### PR TITLE
feat(discord): add keyed task status cards

### DIFF
--- a/gateway/operator_cards.py
+++ b/gateway/operator_cards.py
@@ -191,7 +191,11 @@ class OperatorCard:
             raise OperatorCardValidationError("kind must be operator_card")
         if "version" not in payload:
             raise OperatorCardValidationError("missing required field: version")
-        if isinstance(payload["version"], bool) or payload["version"] != 1:
+        # Require the exact integer 1 — reject bools, floats (``1.0``), and
+        # numeric strings.  ``1.0 == 1`` in Python, so an equality-only check
+        # would silently admit a float version the contract does not define.
+        version = payload["version"]
+        if isinstance(version, bool) or type(version) is not int or version != 1:
             raise OperatorCardValidationError("version must be 1")
 
         card_type = _bounded_string(payload, "card_type", max_length=32)

--- a/gateway/operator_cards.py
+++ b/gateway/operator_cards.py
@@ -1,0 +1,268 @@
+"""Platform-agnostic operator-card contract and plaintext fallback.
+
+Operator cards carry bounded, human-readable control-surface metadata between
+the gateway and platform adapters.  This module intentionally contains no
+Discord (or other platform) dependency; adapters decide whether to render the
+validated contract richly or use :func:`render_operator_card_text`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+from urllib.parse import urlsplit
+
+
+CARD_TYPES = frozenset(
+    {
+        "approval",
+        "task_run",
+        "digest",
+        "deal",
+        "capture",
+        "ops_alert",
+        "thread_header",
+    }
+)
+SEVERITIES = frozenset({"done", "info", "needs_review", "blocked", "critical"})
+ACTION_STYLES = frozenset({"primary", "secondary", "success", "danger", "link"})
+
+_TOP_LEVEL_FIELDS = frozenset(
+    {
+        "kind",
+        "version",
+        "card_type",
+        "title",
+        "severity",
+        "summary",
+        "fields",
+        "actions",
+        "links",
+        "state_ref",
+    }
+)
+_ACTION_ID_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+_STATE_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,199}$")
+
+_SEVERITY_DISPLAY = {
+    "done": ("✅", "Done"),
+    "info": ("🔵", "Info"),
+    "needs_review": ("🟡", "Needs review"),
+    "blocked": ("🔴", "Blocked"),
+    "critical": ("🚨", "Critical"),
+}
+
+
+class OperatorCardValidationError(ValueError):
+    """Raised when untrusted operator-card data violates the contract."""
+
+
+def _mapping(value: Any, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise OperatorCardValidationError(f"{field_name} must be an object")
+    return value
+
+
+def _bounded_string(
+    source: Mapping[str, Any],
+    field_name: str,
+    *,
+    max_length: int,
+) -> str:
+    if field_name not in source:
+        raise OperatorCardValidationError(f"missing required field: {field_name}")
+    value = source[field_name]
+    if not isinstance(value, str) or not value.strip():
+        raise OperatorCardValidationError(f"{field_name} must be a non-empty string")
+    value = value.strip()
+    if len(value) > max_length:
+        raise OperatorCardValidationError(
+            f"{field_name} exceeds the {max_length}-character limit"
+        )
+    return value
+
+
+def _object_list(source: Mapping[str, Any], field_name: str, *, max_items: int) -> list[Mapping[str, Any]]:
+    value = source.get(field_name, [])
+    if not isinstance(value, list):
+        raise OperatorCardValidationError(f"{field_name} must be a list")
+    if len(value) > max_items:
+        raise OperatorCardValidationError(f"{field_name} exceeds the {max_items}-item limit")
+    return [_mapping(item, f"{field_name}[{index}]") for index, item in enumerate(value)]
+
+
+def _reject_unknown_fields(source: Mapping[str, Any], allowed: set[str] | frozenset[str], context: str) -> None:
+    unknown = set(source) - set(allowed)
+    if unknown:
+        rendered = ", ".join(sorted(str(name) for name in unknown))
+        raise OperatorCardValidationError(f"{context} has unknown fields: {rendered}")
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorCardField:
+    label: str
+    value: str
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> "OperatorCardField":
+        _reject_unknown_fields(payload, {"label", "value"}, "field")
+        return cls(
+            label=_bounded_string(payload, "label", max_length=80),
+            value=_bounded_string(payload, "value", max_length=1024),
+        )
+
+    def to_mapping(self) -> dict[str, str]:
+        return {"label": self.label, "value": self.value}
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorCardAction:
+    id: str
+    label: str
+    style: str
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> "OperatorCardAction":
+        _reject_unknown_fields(payload, {"id", "label", "style"}, "action")
+        action_id = _bounded_string(payload, "id", max_length=64)
+        if not _ACTION_ID_RE.fullmatch(action_id):
+            raise OperatorCardValidationError("action id must use lowercase letters, digits, hyphens, or underscores")
+        style = _bounded_string(payload, "style", max_length=16)
+        if style not in ACTION_STYLES:
+            raise OperatorCardValidationError(f"unsupported action style: {style}")
+        return cls(
+            id=action_id,
+            label=_bounded_string(payload, "label", max_length=80),
+            style=style,
+        )
+
+    def to_mapping(self) -> dict[str, str]:
+        return {"id": self.id, "label": self.label, "style": self.style}
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorCardLink:
+    label: str
+    url: str
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> "OperatorCardLink":
+        _reject_unknown_fields(payload, {"label", "url"}, "link")
+        url = _bounded_string(payload, "url", max_length=2048)
+        parsed = urlsplit(url)
+        if (
+            parsed.scheme not in {"http", "https"}
+            or not parsed.netloc
+            or parsed.username is not None
+            or parsed.password is not None
+        ):
+            raise OperatorCardValidationError("link url must be an http(s) URL without credentials")
+        return cls(
+            label=_bounded_string(payload, "label", max_length=80),
+            url=url,
+        )
+
+    def to_mapping(self) -> dict[str, str]:
+        return {"label": self.label, "url": self.url}
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorCard:
+    card_type: str
+    title: str
+    severity: str
+    summary: str
+    fields: tuple[OperatorCardField, ...]
+    actions: tuple[OperatorCardAction, ...]
+    links: tuple[OperatorCardLink, ...]
+    state_ref: str
+    kind: str = "operator_card"
+    version: int = 1
+
+    @classmethod
+    def from_mapping(cls, raw_payload: Mapping[str, Any]) -> "OperatorCard":
+        payload = _mapping(raw_payload, "operator_card")
+        _reject_unknown_fields(payload, _TOP_LEVEL_FIELDS, "operator_card")
+
+        if "kind" not in payload:
+            raise OperatorCardValidationError("missing required field: kind")
+        if payload["kind"] != "operator_card":
+            raise OperatorCardValidationError("kind must be operator_card")
+        if "version" not in payload:
+            raise OperatorCardValidationError("missing required field: version")
+        if isinstance(payload["version"], bool) or payload["version"] != 1:
+            raise OperatorCardValidationError("version must be 1")
+
+        card_type = _bounded_string(payload, "card_type", max_length=32)
+        if card_type not in CARD_TYPES:
+            raise OperatorCardValidationError(f"unsupported card_type: {card_type}")
+        severity = _bounded_string(payload, "severity", max_length=32)
+        if severity not in SEVERITIES:
+            raise OperatorCardValidationError(f"unsupported severity: {severity}")
+
+        fields = tuple(
+            OperatorCardField.from_mapping(item)
+            for item in _object_list(payload, "fields", max_items=12)
+        )
+        actions = tuple(
+            OperatorCardAction.from_mapping(item)
+            for item in _object_list(payload, "actions", max_items=5)
+        )
+        action_ids = [action.id for action in actions]
+        if len(action_ids) != len(set(action_ids)):
+            raise OperatorCardValidationError("action ids must be unique")
+        links = tuple(
+            OperatorCardLink.from_mapping(item)
+            for item in _object_list(payload, "links", max_items=5)
+        )
+
+        state_ref = _bounded_string(payload, "state_ref", max_length=200)
+        if not _STATE_REF_RE.fullmatch(state_ref):
+            raise OperatorCardValidationError("state_ref must be an opaque identifier")
+
+        return cls(
+            card_type=card_type,
+            title=_bounded_string(payload, "title", max_length=120),
+            severity=severity,
+            summary=_bounded_string(payload, "summary", max_length=500),
+            fields=fields,
+            actions=actions,
+            links=links,
+            state_ref=state_ref,
+        )
+
+    def to_mapping(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "version": self.version,
+            "card_type": self.card_type,
+            "title": self.title,
+            "severity": self.severity,
+            "summary": self.summary,
+            "fields": [field.to_mapping() for field in self.fields],
+            "actions": [action.to_mapping() for action in self.actions],
+            "links": [link.to_mapping() for link in self.links],
+            "state_ref": self.state_ref,
+        }
+
+
+def render_operator_card_text(card: OperatorCard, *, max_length: int = 2000) -> str:
+    """Render a compact Markdown fallback shared by non-rich platforms."""
+    emoji, severity_label = _SEVERITY_DISPLAY[card.severity]
+    lines = [f"{emoji} **{severity_label} — {card.title}**", card.summary]
+    lines.extend(f"{field.label}: {field.value}" for field in card.fields)
+    if card.actions:
+        lines.append("Actions: " + " · ".join(action.label for action in card.actions))
+    if card.links:
+        links = " · ".join(f"[{link.label}]({link.url})" for link in card.links)
+        lines.append(f"Links: {links}")
+
+    rendered = "\n".join(lines)
+    if len(rendered) <= max_length:
+        return rendered
+    if max_length <= 0:
+        return ""
+    if max_length == 1:
+        return "…"
+    return rendered[: max_length - 1].rstrip() + "…"

--- a/gateway/operator_cards.py
+++ b/gateway/operator_cards.py
@@ -54,6 +54,11 @@ _SEVERITY_DISPLAY = {
 }
 
 
+def operator_card_severity_display(severity: str) -> tuple[str, str]:
+    """Return the shared emoji and label for a validated severity."""
+    return _SEVERITY_DISPLAY[severity]
+
+
 class OperatorCardValidationError(ValueError):
     """Raised when untrusted operator-card data violates the contract."""
 
@@ -153,7 +158,7 @@ class OperatorCardLink:
         parsed = urlsplit(url)
         if (
             parsed.scheme not in {"http", "https"}
-            or not parsed.netloc
+            or not parsed.hostname
             or parsed.username is not None
             or parsed.password is not None
         ):
@@ -261,7 +266,7 @@ def render_operator_card_text(
     Passing ``None`` returns the complete fallback so an adapter with native
     message chunking can preserve every field and link across messages.
     """
-    emoji, severity_label = _SEVERITY_DISPLAY[card.severity]
+    emoji, severity_label = operator_card_severity_display(card.severity)
     lines = [f"{emoji} **{severity_label} — {card.title}**", card.summary]
     lines.extend(f"{field.label}: {field.value}" for field in card.fields)
     if card.actions:

--- a/gateway/operator_cards.py
+++ b/gateway/operator_cards.py
@@ -251,8 +251,16 @@ class OperatorCard:
         }
 
 
-def render_operator_card_text(card: OperatorCard, *, max_length: int = 2000) -> str:
-    """Render a compact Markdown fallback shared by non-rich platforms."""
+def render_operator_card_text(
+    card: OperatorCard,
+    *,
+    max_length: int | None = 2000,
+) -> str:
+    """Render a compact Markdown fallback shared by non-rich platforms.
+
+    Passing ``None`` returns the complete fallback so an adapter with native
+    message chunking can preserve every field and link across messages.
+    """
     emoji, severity_label = _SEVERITY_DISPLAY[card.severity]
     lines = [f"{emoji} **{severity_label} — {card.title}**", card.summary]
     lines.extend(f"{field.label}: {field.value}" for field in card.fields)
@@ -263,7 +271,7 @@ def render_operator_card_text(card: OperatorCard, *, max_length: int = 2000) -> 
         lines.append(f"Links: {links}")
 
     rendered = "\n".join(lines)
-    if len(rendered) <= max_length:
+    if max_length is None or len(rendered) <= max_length:
         return rendered
     if max_length <= 0:
         return ""

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -92,6 +92,30 @@ def _mark_notify_metadata(metadata: dict | None) -> dict:
     return notify_metadata
 
 
+def status_terminal_metadata(
+    metadata: dict | None,
+    status_key: object,
+    reply_to_message_id: object = None,
+) -> dict:
+    """Clone routing metadata and mark one keyed status as terminal."""
+    terminal_metadata = dict(metadata) if metadata else {}
+    terminal_metadata["notify"] = True
+    terminal_metadata["status_key"] = str(status_key)
+    terminal_metadata["status_terminal"] = True
+    if reply_to_message_id is not None:
+        terminal_metadata["reply_to_message_id"] = str(reply_to_message_id)
+    return terminal_metadata
+
+
+def attachment_delivery_status(delivered_attachment_count: int) -> str:
+    """Return the terminal card text for confirmed attachment delivery."""
+    return (
+        "Attachment delivered."
+        if delivered_attachment_count == 1
+        else "Attachments delivered."
+    )
+
+
 def _reply_anchor_for_event(event) -> str | None:
     """Return reply_to id for platforms that need reply semantics.
 
@@ -5178,10 +5202,14 @@ class BasePlatformAdapter(ABC):
                 _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
                 _attachment_deliveries = 0
                 _status_key = getattr(event, "_status_key", None)
-                if _status_key:
-                    _final_thread_metadata = dict(_final_thread_metadata or {})
-                    _final_thread_metadata["status_key"] = str(_status_key)
-                    _final_thread_metadata["status_terminal"] = True
+                _terminal_thread_metadata = (
+                    status_terminal_metadata(
+                        _final_thread_metadata,
+                        _status_key,
+                    )
+                    if _status_key
+                    else _final_thread_metadata
+                )
 
                 # Auto-TTS: if voice message, generate audio FIRST (before sending text)
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has
@@ -5293,7 +5321,7 @@ class BasePlatformAdapter(ABC):
                         chat_id=event.source.chat_id,
                         content=text_content,
                         reply_to=_reply_anchor,
-                        metadata=_final_thread_metadata,
+                        metadata=_terminal_thread_metadata,
                     )
                     _record_delivery(result)
                     if _obligation_id is not None:
@@ -5459,16 +5487,14 @@ class BasePlatformAdapter(ABC):
                     # explicitly replace the retained running card so it cannot
                     # remain stuck indefinitely.
                     delivery_adapter = self._final_delivery_adapter(event.source)
-                    attachment_label = (
-                        "Attachment delivered."
-                        if _attachment_deliveries == 1
-                        else "Attachments delivered."
-                    )
                     terminal_result = await delivery_adapter._send_with_retry(
                         chat_id=event.source.chat_id,
-                        content=attachment_label,
+                        content=attachment_delivery_status(_attachment_deliveries),
                         reply_to=_reply_anchor_for_event(event),
-                        metadata=_final_thread_metadata,
+                        metadata=status_terminal_metadata(
+                            _final_thread_metadata,
+                            _status_key,
+                        ),
                     )
                     _record_delivery(terminal_result)
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1926,20 +1926,20 @@ class SendResult:
     # ``None`` (unset / not classified).  Producers should set this via
     # :func:`classify_send_error`.
     error_kind: Optional[str] = None
-    # Native batch attachment transports set this to the number of
-    # attachments they can confirm reached the platform.  Keeping the field
+    # Native attachment transports set this to the number of attachments they
+    # can confirm reached the platform.  Keeping the field
     # after all pre-existing fields preserves positional construction, while
     # the default keeps older/custom adapters source-compatible.
     delivered_attachment_count: int = 0
 
 
 def confirmed_attachment_delivery_count(result: Any) -> int:
-    """Return the number of attachments a batch result confirms as delivered.
+    """Return the number of attachments a result confirms as delivered.
 
     ``send_multiple_images`` historically returned ``None``.  Keep that call
     shape harmless for third-party adapters, but never promote an ambiguous
-    legacy return into terminal status.  Migrated batch transports expose an
-    explicit positive count on ``SendResult``.
+    legacy return into terminal status.  Migrated attachment transports expose
+    an explicit positive count on ``SendResult``.
     """
     if not getattr(result, "success", False):
         return 0
@@ -3402,8 +3402,12 @@ class BasePlatformAdapter(ABC):
                         caption=alt_text if alt_text else None,
                         metadata=metadata,
                     )
-                if img_result.success:
-                    delivered_attachment_count += 1
+                confirmed_count = min(
+                    1,
+                    confirmed_attachment_delivery_count(img_result),
+                )
+                if confirmed_count:
+                    delivered_attachment_count += confirmed_count
                     last_message_id = img_result.message_id or last_message_id
                 else:
                     logger.error("[%s] Failed to send image: %s", self.name, img_result.error)
@@ -5413,10 +5417,14 @@ class BasePlatformAdapter(ABC):
                                 metadata=_final_thread_metadata,
                             )
 
-                        if not media_result.success:
+                        confirmed_count = min(
+                            1,
+                            confirmed_attachment_delivery_count(media_result),
+                        )
+                        if not confirmed_count:
                             logger.warning("[%s] Failed to send media (%s): %s", self.name, ext, media_result.error)
                         else:
-                            _attachment_deliveries += 1
+                            _attachment_deliveries += confirmed_count
                     except Exception as media_err:
                         logger.warning("[%s] Error sending media: %s", self.name, media_err)
 
@@ -5438,8 +5446,10 @@ class BasePlatformAdapter(ABC):
                                 file_path=file_path,
                                 metadata=_final_thread_metadata,
                             )
-                        if getattr(file_result, "success", False):
-                            _attachment_deliveries += 1
+                        _attachment_deliveries += min(
+                            1,
+                            confirmed_attachment_delivery_count(file_result),
+                        )
                     except Exception as file_err:
                         logger.error("[%s] Error sending local file %s: %s", self.name, file_path, file_err)
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1926,6 +1926,30 @@ class SendResult:
     # ``None`` (unset / not classified).  Producers should set this via
     # :func:`classify_send_error`.
     error_kind: Optional[str] = None
+    # Native batch attachment transports set this to the number of
+    # attachments they can confirm reached the platform.  Keeping the field
+    # after all pre-existing fields preserves positional construction, while
+    # the default keeps older/custom adapters source-compatible.
+    delivered_attachment_count: int = 0
+
+
+def confirmed_attachment_delivery_count(result: Any) -> int:
+    """Return the number of attachments a batch result confirms as delivered.
+
+    ``send_multiple_images`` historically returned ``None``.  Keep that call
+    shape harmless for third-party adapters, but never promote an ambiguous
+    legacy return into terminal status.  Migrated batch transports expose an
+    explicit positive count on ``SendResult``.
+    """
+    if not getattr(result, "success", False):
+        return 0
+    count = getattr(result, "delivered_attachment_count", 0)
+    if isinstance(count, bool):
+        return 0
+    try:
+        return max(0, int(count))
+    except (TypeError, ValueError):
+        return 0
 
 
 # Machine-readable send-failure categories.  Kept platform-neutral so every
@@ -3329,7 +3353,7 @@ class BasePlatformAdapter(ABC):
         images: List[Tuple[str, str]],
         metadata: Optional[Dict[str, Any]] = None,
         human_delay: float = 0.0,
-    ) -> None:
+    ) -> SendResult:
         """Send a batch of images.
 
         Accepts ``http(s)://``, ``file://`` URIs in the first tuple
@@ -3344,6 +3368,9 @@ class BasePlatformAdapter(ABC):
         """
         from urllib.parse import unquote as _unquote
 
+        delivered_attachment_count = 0
+        last_message_id: Optional[str] = None
+        delivery_errors: List[str] = []
         for image_url, alt_text in images:
             if human_delay > 0:
                 await asyncio.sleep(human_delay)
@@ -3375,10 +3402,29 @@ class BasePlatformAdapter(ABC):
                         caption=alt_text if alt_text else None,
                         metadata=metadata,
                     )
-                if not img_result.success:
+                if img_result.success:
+                    delivered_attachment_count += 1
+                    last_message_id = img_result.message_id or last_message_id
+                else:
                     logger.error("[%s] Failed to send image: %s", self.name, img_result.error)
+                    if img_result.error:
+                        delivery_errors.append(img_result.error)
             except Exception as img_err:
                 logger.error("[%s] Error sending image: %s", self.name, img_err, exc_info=True)
+                delivery_errors.append(str(img_err))
+
+        success = delivered_attachment_count > 0
+        return SendResult(
+            success=success,
+            message_id=last_message_id,
+            error=(
+                None
+                if success
+                else "; ".join(delivery_errors)
+                or "No image attachments were delivered"
+            ),
+            delivered_attachment_count=delivered_attachment_count,
+        )
 
     async def send_image(
         self,
@@ -5292,8 +5338,9 @@ class BasePlatformAdapter(ABC):
                             metadata=_final_thread_metadata,
                             human_delay=human_delay,
                         )
-                        if batch_result is None or getattr(batch_result, "success", False):
-                            _attachment_deliveries += len(images)
+                        _attachment_deliveries += (
+                            confirmed_attachment_delivery_count(batch_result)
+                        )
                     except Exception as batch_err:
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
 
@@ -5336,8 +5383,9 @@ class BasePlatformAdapter(ABC):
                             metadata=_final_thread_metadata,
                             human_delay=human_delay,
                         )
-                        if batch_result is None or getattr(batch_result, "success", False):
-                            _attachment_deliveries += len(_batch)
+                        _attachment_deliveries += (
+                            confirmed_attachment_delivery_count(batch_result)
+                        )
                     except Exception as batch_err:
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5126,6 +5126,7 @@ class BasePlatformAdapter(ABC):
                 # metadata stays unmarked and progress bubbles remain
                 # thread-strict.
                 _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
+                _attachment_deliveries = 0
                 _status_key = getattr(event, "_status_key", None)
                 if _status_key:
                     _final_thread_metadata = dict(_final_thread_metadata or {})
@@ -5176,6 +5177,8 @@ class BasePlatformAdapter(ABC):
                         _tts_caption_delivered = bool(
                             telegram_tts_caption and getattr(tts_result, "success", False)
                         )
+                        if getattr(tts_result, "success", False):
+                            _attachment_deliveries += 1
                     finally:
                         try:
                             os.remove(_tts_path)
@@ -5283,12 +5286,14 @@ class BasePlatformAdapter(ABC):
                 if images:
                     logger.info("[%s] Extracted %d image(s) to send as attachments", self.name, len(images))
                     try:
-                        await self.send_multiple_images(
+                        batch_result = await self.send_multiple_images(
                             chat_id=event.source.chat_id,
                             images=images,
                             metadata=_final_thread_metadata,
                             human_delay=human_delay,
                         )
+                        if batch_result is None or getattr(batch_result, "success", False):
+                            _attachment_deliveries += len(images)
                     except Exception as batch_err:
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
 
@@ -5325,12 +5330,14 @@ class BasePlatformAdapter(ABC):
                 if _image_paths:
                     try:
                         _batch = [(f"file://{_quote(p)}", "") for p in _image_paths]
-                        await self.send_multiple_images(
+                        batch_result = await self.send_multiple_images(
                             chat_id=event.source.chat_id,
                             images=_batch,
                             metadata=_final_thread_metadata,
                             human_delay=human_delay,
                         )
+                        if batch_result is None or getattr(batch_result, "success", False):
+                            _attachment_deliveries += len(_batch)
                     except Exception as batch_err:
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
 
@@ -5360,6 +5367,8 @@ class BasePlatformAdapter(ABC):
 
                         if not media_result.success:
                             logger.warning("[%s] Failed to send media (%s): %s", self.name, ext, media_result.error)
+                        else:
+                            _attachment_deliveries += 1
                     except Exception as media_err:
                         logger.warning("[%s] Error sending media: %s", self.name, media_err)
 
@@ -5370,19 +5379,40 @@ class BasePlatformAdapter(ABC):
                     try:
                         ext = Path(file_path).suffix.lower()
                         if ext in _VIDEO_EXTS:
-                            await self.send_video(
+                            file_result = await self.send_video(
                                 chat_id=event.source.chat_id,
                                 video_path=file_path,
                                 metadata=_final_thread_metadata,
                             )
                         else:
-                            await self.send_document(
+                            file_result = await self.send_document(
                                 chat_id=event.source.chat_id,
                                 file_path=file_path,
                                 metadata=_final_thread_metadata,
                             )
+                        if getattr(file_result, "success", False):
+                            _attachment_deliveries += 1
                     except Exception as file_err:
                         logger.error("[%s] Error sending local file %s: %s", self.name, file_path, file_err)
+
+                if _status_key and not text_content and _attachment_deliveries:
+                    # Discord attachment transports do not own the keyed text
+                    # lifecycle. Once at least one no-text attachment lands,
+                    # explicitly replace the retained running card so it cannot
+                    # remain stuck indefinitely.
+                    delivery_adapter = self._final_delivery_adapter(event.source)
+                    attachment_label = (
+                        "Attachment delivered."
+                        if _attachment_deliveries == 1
+                        else "Attachments delivered."
+                    )
+                    terminal_result = await delivery_adapter._send_with_retry(
+                        chat_id=event.source.chat_id,
+                        content=attachment_label,
+                        reply_to=_reply_anchor_for_event(event),
+                        metadata=_final_thread_metadata,
+                    )
+                    _record_delivery(terminal_result)
 
                 # A3 (#29346): if a non-empty response produced nothing
                 # deliverable, fail loudly rather than dropping it in silence.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5126,6 +5126,11 @@ class BasePlatformAdapter(ABC):
                 # metadata stays unmarked and progress bubbles remain
                 # thread-strict.
                 _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
+                _status_key = getattr(event, "_status_key", None)
+                if _status_key:
+                    _final_thread_metadata = dict(_final_thread_metadata or {})
+                    _final_thread_metadata["status_key"] = str(_status_key)
+                    _final_thread_metadata["status_terminal"] = True
 
                 # Auto-TTS: if voice message, generate audio FIRST (before sending text)
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14575,7 +14575,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # send_multiple_images (Telegram sendPhoto recompresses to ~1280px).
             force_document_attachments = "[[as_document]]" in response
 
-            from gateway.platforms.base import BasePlatformAdapter, should_send_media_as_audio
+            from gateway.platforms.base import (
+                BasePlatformAdapter,
+                confirmed_attachment_delivery_count,
+                should_send_media_as_audio,
+            )
 
             media_files, cleaned = adapter.extract_media(response)
             media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
@@ -14628,8 +14632,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         images=images,
                         metadata=_thread_meta,
                     )
-                    if image_result is None or getattr(image_result, "success", False):
-                        _attachment_deliveries += len(image_paths)
+                    _attachment_deliveries += (
+                        confirmed_attachment_delivery_count(image_result)
+                    )
                 except Exception as e:
                     logger.warning("[%s] Post-stream image batch delivery failed: %s", adapter.name, e)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19129,6 +19129,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Adapter doesn't support deletion — silently disable.
             _cleanup_progress = False
             _cleanup_adapter = None
+        if _task_run_status_key:
+            # Discord's progress/status/heartbeat identity is retained and
+            # becomes the terminal answer. Registering that message for the
+            # temporary-bubble cleanup would delete the completed response.
+            _cleanup_progress = False
+            _cleanup_adapter = None
         _cleanup_msg_ids: List[str] = []
         # First-touch onboarding latch: fires at most once per run, even if
         # several tools exceed the threshold.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -27,6 +27,7 @@ except ModuleNotFoundError:
 import asyncio
 import concurrent.futures
 import dataclasses
+import hashlib
 import inspect
 import json
 import logging
@@ -500,6 +501,31 @@ def render_notice_line(notice) -> str:
     return str(getattr(notice, "text", "") or "").strip()
 
 
+def _discord_task_run_status_key(
+    platform: Any,
+    *,
+    event_message_id: Any = None,
+    session_key: Any = None,
+    run_generation: Any = None,
+) -> Optional[str]:
+    """Return one stable status identity for a single Discord agent run.
+
+    The inbound reply anchor is the best identity because Discord message ids
+    are unique and every seam already receives it. Synthetic/recovery events
+    can lack an anchor; hash their session generation instead so sequential
+    runs in the same thread still never overwrite each other's final answer.
+    """
+    platform_value = getattr(platform, "value", platform)
+    if str(platform_value or "").lower() != "discord":
+        return None
+    anchor = str(event_message_id or "").strip()
+    if anchor:
+        return f"task_run:message:{anchor}"
+    fallback = f"{session_key or 'session'}:{run_generation or 0}"
+    digest = hashlib.sha256(fallback.encode("utf-8")).hexdigest()[:20]
+    return f"task_run:generation:{digest}"
+
+
 async def _send_or_update_status_coro(adapter, chat_id, status_key, content, metadata):
     """Route a status message through adapter.send_or_update_status when supported.
 
@@ -507,9 +533,14 @@ async def _send_or_update_status_coro(adapter, chat_id, status_key, content, met
     Telegram) edit the previous bubble for the same status_key instead of
     appending a new one. Adapters without the method fall back to plain send.
     """
+    routed_status_key = (
+        (metadata or {}).get("status_key")
+        if isinstance(metadata, dict)
+        else None
+    ) or status_key
     sender = getattr(adapter, "send_or_update_status", None)
     if callable(sender):
-        return await sender(chat_id, status_key, content, metadata=metadata)
+        return await sender(chat_id, routed_status_key, content, metadata=metadata)
     return await adapter.send(chat_id, content, metadata=metadata)
 
 
@@ -12851,6 +12882,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # below; a /new or another lifecycle transition may move
             # session_entry.session_id while the old run is still unwinding.
             _run_start_session_id = session_entry.session_id
+            _run_reply_anchor = self._reply_anchor_for_event(event)
+            _task_status_key = _discord_task_run_status_key(
+                source.platform,
+                event_message_id=_run_reply_anchor,
+                session_key=session_key,
+                run_generation=run_generation,
+            )
+            if _task_status_key:
+                # BasePlatformAdapter owns the final send after this handler
+                # returns. Carry the same key used by Discord progress,
+                # streaming, status, and heartbeat paths so that final send
+                # replaces their retained card instead of appending a bubble.
+                event._status_key = _task_status_key
             agent_result = await self._run_agent(
                 message=message_text,
                 context_prompt=context_prompt,
@@ -12859,7 +12903,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_id=_run_start_session_id,
                 session_key=session_key,
                 run_generation=run_generation,
-                event_message_id=self._reply_anchor_for_event(event),
+                event_message_id=_run_reply_anchor,
                 channel_prompt=event.channel_prompt,
                 moa_config=getattr(event, "_moa_config", None),
                 persist_user_message=persist_user_message,
@@ -18464,6 +18508,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
 
         _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
+        _proxy_status_key = _discord_task_run_status_key(
+            source.platform,
+            event_message_id=event_message_id,
+            session_key=session_key,
+            run_generation=run_generation,
+        )
+        if _proxy_status_key:
+            _thread_metadata = dict(_thread_metadata or {})
+            _thread_metadata["status_key"] = _proxy_status_key
 
         if _streaming_enabled:
             try:
@@ -18858,6 +18911,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         user_config = _load_gateway_config()
         platform_key = _platform_config_key(source.platform)
+        _task_run_status_key = _discord_task_run_status_key(
+            source.platform,
+            event_message_id=event_message_id,
+            session_key=session_key,
+            run_generation=run_generation,
+        )
 
         from hermes_cli.tools_config import _get_platform_tools
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
@@ -19335,6 +19394,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else {"thread_id": _progress_thread_id}
         ) if _progress_thread_id else None
         _progress_metadata = _non_conversational_metadata(_progress_metadata, platform=source.platform)
+        if _task_run_status_key:
+            _progress_metadata = dict(_progress_metadata or {})
+            _progress_metadata["status_key"] = _task_run_status_key
         _progress_reply_to = (
             event_message_id
             if source.platform in (Platform.FEISHU, Platform.MATTERMOST) and source.thread_id and event_message_id
@@ -19788,6 +19850,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             }
         else:
             _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id) if _progress_thread_id else None
+        if _task_run_status_key:
+            _status_thread_metadata = dict(_status_thread_metadata or {})
+            _status_thread_metadata["status_key"] = _task_run_status_key
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():
@@ -21326,7 +21391,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 try:
                     _notify_res = None
-                    if _heartbeat_msg_id:
+                    _heartbeat_metadata = _non_conversational_metadata(
+                        _status_thread_metadata,
+                        platform=source.platform,
+                    )
+                    if isinstance(_heartbeat_metadata, dict) and _heartbeat_metadata.get("status_key"):
+                        # Discord's keyed status-card send owns both the edit
+                        # and stale-identity fallback. Calling it on every tick
+                        # keeps heartbeat/progress/stream/final on one message.
+                        _notify_res = await _notify_adapter.send(
+                            source.chat_id,
+                            _heartbeat_text,
+                            metadata=_heartbeat_metadata,
+                        )
+                    elif _heartbeat_msg_id:
                         try:
                             _notify_res = await _notify_adapter.edit_message(
                                 source.chat_id,
@@ -21340,14 +21418,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _notify_res = await _notify_adapter.send(
                             source.chat_id,
                             _heartbeat_text,
-                            metadata=_non_conversational_metadata(_status_thread_metadata, platform=source.platform),
+                            metadata=_heartbeat_metadata,
                         )
-                        if getattr(_notify_res, "success", False) and getattr(
-                            _notify_res, "message_id", None
-                        ):
-                            _heartbeat_msg_id = str(_notify_res.message_id)
-                            if _cleanup_progress:
-                                _cleanup_msg_ids.append(_heartbeat_msg_id)
+                    if getattr(_notify_res, "success", False) and getattr(
+                        _notify_res, "message_id", None
+                    ):
+                        _heartbeat_msg_id = str(_notify_res.message_id)
+                        if _cleanup_progress:
+                            _cleanup_msg_ids.append(_heartbeat_msg_id)
                 except Exception as _ne:
                     logger.debug("Long-running notification error: %s", _ne)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14659,8 +14659,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             file_path=media_path,
                             metadata=_thread_meta,
                         )
-                    if media_result is None or getattr(media_result, "success", False):
-                        _attachment_deliveries += 1
+                    _attachment_deliveries += min(
+                        1,
+                        confirmed_attachment_delivery_count(media_result),
+                    )
                 except Exception as e:
                     logger.warning("[%s] Post-stream media delivery failed: %s", adapter.name, e)
 
@@ -14679,8 +14681,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             file_path=file_path,
                             metadata=_thread_meta,
                         )
-                    if file_result is None or getattr(file_result, "success", False):
-                        _attachment_deliveries += 1
+                    _attachment_deliveries += min(
+                        1,
+                        confirmed_attachment_delivery_count(file_result),
+                    )
                 except Exception as e:
                     logger.warning("[%s] Post-stream file delivery failed: %s", adapter.name, e)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14587,10 +14587,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # producing false-positive bare-path matches with the MEDIA: prefix
             # glued on. This matches the chain order in gateway/platforms/base.py.
             _, cleaned = adapter.extract_images(cleaned)
-            local_files, _ = adapter.extract_local_files(cleaned)
+            local_files, cleaned = adapter.extract_local_files(cleaned)
             local_files = BasePlatformAdapter.filter_local_delivery_paths(local_files)
 
-            _thread_meta = self._thread_metadata_for_source(event.source, self._reply_anchor_for_event(event))
+            _reply_anchor = self._reply_anchor_for_event(event)
+            _thread_meta = self._thread_metadata_for_source(event.source, _reply_anchor)
+            _attachment_deliveries = 0
 
             _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
             _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
@@ -14621,11 +14623,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if image_paths:
                 try:
                     images = [(f"file://{_quote(p)}", "") for p in image_paths]
-                    await adapter.send_multiple_images(
+                    image_result = await adapter.send_multiple_images(
                         chat_id=event.source.chat_id,
                         images=images,
                         metadata=_thread_meta,
                     )
+                    if image_result is None or getattr(image_result, "success", False):
+                        _attachment_deliveries += len(image_paths)
                 except Exception as e:
                     logger.warning("[%s] Post-stream image batch delivery failed: %s", adapter.name, e)
 
@@ -14633,23 +14637,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 try:
                     ext = Path(media_path).suffix.lower()
                     if should_send_media_as_audio(event.source.platform, ext, is_voice=is_voice):
-                        await adapter.send_voice(
+                        media_result = await adapter.send_voice(
                             chat_id=event.source.chat_id,
                             audio_path=media_path,
                             metadata=_thread_meta,
                         )
                     elif ext in _VIDEO_EXTS:
-                        await adapter.send_video(
+                        media_result = await adapter.send_video(
                             chat_id=event.source.chat_id,
                             video_path=media_path,
                             metadata=_thread_meta,
                         )
                     else:
-                        await adapter.send_document(
+                        media_result = await adapter.send_document(
                             chat_id=event.source.chat_id,
                             file_path=media_path,
                             metadata=_thread_meta,
                         )
+                    if media_result is None or getattr(media_result, "success", False):
+                        _attachment_deliveries += 1
                 except Exception as e:
                     logger.warning("[%s] Post-stream media delivery failed: %s", adapter.name, e)
 
@@ -14657,19 +14663,49 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 try:
                     ext = Path(file_path).suffix.lower()
                     if ext in _VIDEO_EXTS:
-                        await adapter.send_video(
+                        file_result = await adapter.send_video(
                             chat_id=event.source.chat_id,
                             video_path=file_path,
                             metadata=_thread_meta,
                         )
                     else:
-                        await adapter.send_document(
+                        file_result = await adapter.send_document(
                             chat_id=event.source.chat_id,
                             file_path=file_path,
                             metadata=_thread_meta,
                         )
+                    if file_result is None or getattr(file_result, "success", False):
+                        _attachment_deliveries += 1
                 except Exception as e:
                     logger.warning("[%s] Post-stream file delivery failed: %s", adapter.name, e)
+
+            _status_key = getattr(event, "_status_key", None)
+            if _status_key and not cleaned.strip() and _attachment_deliveries:
+                # Streaming owns the visible body, but attachment transports do
+                # not own Discord's keyed text lifecycle. For a MEDIA-only final,
+                # replace the retained running card after at least one attachment
+                # succeeds so the run cannot remain visibly stuck.
+                _terminal_metadata = dict(_thread_meta or {})
+                _terminal_metadata.update(
+                    {
+                        "notify": True,
+                        "status_key": str(_status_key),
+                        "status_terminal": True,
+                    }
+                )
+                if _reply_anchor is not None:
+                    _terminal_metadata["reply_to_message_id"] = str(_reply_anchor)
+                attachment_label = (
+                    "Attachment delivered."
+                    if _attachment_deliveries == 1
+                    else "Attachments delivered."
+                )
+                await adapter._send_with_retry(
+                    chat_id=event.source.chat_id,
+                    content=attachment_label,
+                    reply_to=_reply_anchor,
+                    metadata=_terminal_metadata,
+                )
 
         except Exception as e:
             logger.warning("Post-stream media extraction failed: %s", e)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18545,6 +18545,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if _proxy_status_key:
             _thread_metadata = dict(_thread_metadata or {})
             _thread_metadata["status_key"] = _proxy_status_key
+            if event_message_id:
+                _thread_metadata["reply_to_message_id"] = str(event_message_id)
 
         if _streaming_enabled:
             try:
@@ -19431,9 +19433,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if _task_run_status_key:
             _progress_metadata = dict(_progress_metadata or {})
             _progress_metadata["status_key"] = _task_run_status_key
+            if event_message_id:
+                # Progress/status/heartbeat can win the race to create the
+                # retained Discord card. Carry the inbound anchor in shared
+                # metadata so every first-creation seam replies to the user.
+                _progress_metadata["reply_to_message_id"] = str(event_message_id)
         _progress_reply_to = (
             event_message_id
-            if source.platform in (Platform.FEISHU, Platform.MATTERMOST) and source.thread_id and event_message_id
+            if (
+                source.platform == Platform.DISCORD
+                and _task_run_status_key
+                and event_message_id
+            )
+            or (
+                source.platform in (Platform.FEISHU, Platform.MATTERMOST)
+                and source.thread_id
+                and event_message_id
+            )
             else None
         )
 
@@ -19887,6 +19903,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if _task_run_status_key:
             _status_thread_metadata = dict(_status_thread_metadata or {})
             _status_thread_metadata["status_key"] = _task_run_status_key
+            if event_message_id:
+                _status_thread_metadata["reply_to_message_id"] = str(event_message_id)
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14577,8 +14577,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             from gateway.platforms.base import (
                 BasePlatformAdapter,
+                attachment_delivery_status,
                 confirmed_attachment_delivery_count,
                 should_send_media_as_audio,
+                status_terminal_metadata,
             )
 
             media_files, cleaned = adapter.extract_media(response)
@@ -14694,26 +14696,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # not own Discord's keyed text lifecycle. For a MEDIA-only final,
                 # replace the retained running card after at least one attachment
                 # succeeds so the run cannot remain visibly stuck.
-                _terminal_metadata = dict(_thread_meta or {})
-                _terminal_metadata.update(
-                    {
-                        "notify": True,
-                        "status_key": str(_status_key),
-                        "status_terminal": True,
-                    }
-                )
-                if _reply_anchor is not None:
-                    _terminal_metadata["reply_to_message_id"] = str(_reply_anchor)
-                attachment_label = (
-                    "Attachment delivered."
-                    if _attachment_deliveries == 1
-                    else "Attachments delivered."
-                )
                 await adapter._send_with_retry(
                     chat_id=event.source.chat_id,
-                    content=attachment_label,
+                    content=attachment_delivery_status(_attachment_deliveries),
                     reply_to=_reply_anchor,
-                    metadata=_terminal_metadata,
+                    metadata=status_terminal_metadata(
+                        _thread_meta,
+                        _status_key,
+                        _reply_anchor,
+                    ),
                 )
 
         except Exception as e:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -544,6 +544,28 @@ async def _send_or_update_status_coro(adapter, chat_id, status_key, content, met
     return await adapter.send(chat_id, content, metadata=metadata)
 
 
+async def _edit_streamed_transformed_final(
+    stream_consumer: Any,
+    *,
+    message_id: str,
+    content: str,
+) -> bool:
+    """Replace a streamed reply with plugin-transformed terminal content.
+
+    Route through the consumer's metadata-aware edit seam so Discord retains
+    its thread and keyed status identity.  Only report delivery when the
+    adapter explicitly confirms success; otherwise Base delivery remains the
+    fallback for the transformed answer.
+    """
+    result = await stream_consumer._edit_message(
+        message_id=message_id,
+        content=content,
+        finalize=True,
+        status_terminal=True,
+    )
+    return bool(result and result.success)
+
+
 def _resolve_progress_thread_id(platform: Any, source_thread_id: Any, event_message_id: Any) -> Optional[str]:
     """Return thread/root ID that progress/status bubbles should target."""
     platform_value = getattr(platform, "value", platform)
@@ -12909,6 +12931,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
             )
+            if isinstance(agent_result, dict) and agent_result.get("_status_key"):
+                # An in-band queued follow-up may finish under a different
+                # inbound-message identity.  BasePlatformAdapter performs the
+                # final delivery after this handler returns, so hand it the
+                # final turn's key rather than overwriting the first answer.
+                event._status_key = agent_result["_status_key"]
 
             # Stop persistent typing indicator now that the agent is done.
             # Slack AI status is scoped to a thread/workspace, so preserve the
@@ -21841,10 +21869,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "Queued follow-up for session %s: final stream delivery not confirmed; sending first response before continuing.",
                                 session_key or "?",
                             )
+                            _first_response_metadata = dict(
+                                _status_thread_metadata or {}
+                            )
+                            if _task_run_status_key:
+                                _first_response_metadata["status_terminal"] = True
                             await adapter.send(
                                 source.chat_id,
                                 first_response,
-                                metadata=_status_thread_metadata,
+                                metadata=_first_response_metadata or None,
                             )
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)
@@ -21961,6 +21994,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     event_message_id=next_message_id,
                     channel_prompt=next_channel_prompt,
                 )
+                _followup_status_key = _discord_task_run_status_key(
+                    next_source.platform,
+                    event_message_id=next_message_id,
+                    session_key=next_session_key,
+                    run_generation=run_generation,
+                )
+                if _followup_status_key and isinstance(followup_result, dict):
+                    # Preserve a deeper queued turn's identity when recursive
+                    # draining returns through multiple levels.
+                    followup_result = dict(followup_result)
+                    followup_result.setdefault("_status_key", _followup_status_key)
                 return _preserve_queued_followup_history_offset(result, followup_result)
         finally:
             # Stop progress sender, interrupt monitor, and notification task
@@ -22076,17 +22120,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _sc_msg_id = _sc.message_id
                 if _sc_msg_id:
                     try:
-                        await _sc.adapter.edit_message(
-                            chat_id=source.chat_id,
+                        _transformed_delivered = await _edit_streamed_transformed_final(
+                            _sc,
                             message_id=_sc_msg_id,
                             content=response["final_response"],
-                            finalize=True,
                         )
-                        response["already_sent"] = True
-                        logger.info(
-                            "Edited streamed message %s for session %s to include plugin-transformed content.",
-                            _sc_msg_id, session_key or "?",
-                        )
+                        if _transformed_delivered:
+                            response["already_sent"] = True
+                            logger.info(
+                                "Edited streamed message %s for session %s to include plugin-transformed content.",
+                                _sc_msg_id, session_key or "?",
+                            )
+                        else:
+                            logger.warning(
+                                "Failed to confirm transformed streamed edit for session %s; leaving normal final delivery enabled.",
+                                session_key or "?",
+                            )
                     except Exception as _edit_err:
                         logger.warning(
                             "Failed to edit streamed message for session %s: %s",

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -255,6 +255,12 @@ class GatewayStreamConsumer:
         return meta or None
 
     @property
+    def _has_keyed_status(self) -> bool:
+        return bool(
+            isinstance(self.metadata, dict) and self.metadata.get("status_key")
+        )
+
+    @property
     def already_sent(self) -> bool:
         """True if at least one message was sent or edited during the run."""
         return self._already_sent
@@ -678,6 +684,7 @@ class GatewayStreamConsumer:
                     if (
                         _len_fn(self._accumulated) > _safe_limit
                         and self._message_id is None
+                        and not self._has_keyed_status
                     ):
                         # No existing message to edit (first message or after a
                         # segment break).  Use truncate_message — the same
@@ -721,6 +728,7 @@ class GatewayStreamConsumer:
                         _len_fn(self._accumulated) > _safe_limit
                         and self._message_id is not None
                         and self._edit_supported
+                        and not self._has_keyed_status
                     ):
                         _cp_budget = _custom_unit_to_cp(
                             self._accumulated, _safe_limit, _len_fn,
@@ -828,7 +836,11 @@ class GatewayStreamConsumer:
                                 # not duplicate the visible prefix.
                                 await self._send_fallback_final(self._accumulated)
                         elif not self._already_sent:
-                            self._final_response_sent = await self._send_or_edit(self._accumulated)
+                            self._final_response_sent = await self._send_or_edit(
+                                self._accumulated,
+                                finalize=True,
+                                is_turn_final=True,
+                            )
                             if self._final_response_sent:
                                 self._final_content_delivered = True
                     return
@@ -1074,6 +1086,32 @@ class GatewayStreamConsumer:
                 return
 
         raw_limit = getattr(self.adapter, "MAX_MESSAGE_LENGTH", 4096)
+        if self._has_keyed_status:
+            # A keyed Discord fallback replaces the retained card. Sending
+            # pre-split chunks with the same key would edit each chunk over the
+            # previous one and leave only the tail visible. Give the adapter
+            # the complete answer once so its terminal overflow splitter owns
+            # the existing-message edit plus continuation messages.
+            result = await self.adapter.send(
+                chat_id=self.chat_id,
+                content=final_text,
+                metadata=self._metadata_for_send(final=True),
+            )
+            if result.success:
+                if result.message_id:
+                    self._message_id = str(result.message_id)
+                    self._track_preview_ids_from_result(result)
+                self._already_sent = True
+                self._final_response_sent = True
+                self._final_content_delivered = True
+                self._last_sent_text = final_text
+                self._fallback_prefix = ""
+                self._fallback_preserve_partial_messages = False
+            else:
+                self._final_response_sent = False
+                self._final_content_delivered = False
+            return
+
         _len_fn: "Callable[[str], int]" = (
             self.adapter.message_len_fn
             if isinstance(self.adapter, _BasePlatformAdapter)
@@ -1725,7 +1763,11 @@ class GatewayStreamConsumer:
                     # their streaming UI can transition out of the in-
                     # progress state.  Everyone else short-circuits.
                     if text == self._last_sent_text and not (
-                        finalize and self._adapter_requires_finalize
+                        finalize
+                        and (
+                            self._adapter_requires_finalize
+                            or (is_turn_final and self._has_keyed_status)
+                        )
                     ):
                         return True
                     # Fresh-final for long-lived previews: when finalizing

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -321,11 +321,16 @@ class GatewayStreamConsumer:
                     for param in params.values()
                 ):
                     edit_metadata = dict(self.metadata)
-                    if (
-                        (finalize if status_terminal is None else status_terminal)
-                        and edit_metadata.get("status_key")
-                    ):
-                        edit_metadata["status_terminal"] = True
+                    if edit_metadata.get("status_key"):
+                        # ``False`` is meaningful here: a segment break uses
+                        # ``finalize=True`` to remove the cursor, but the run is
+                        # still active.  Preserve that explicit marker so the
+                        # Discord adapter does not infer a terminal transition
+                        # merely from ``finalize``.
+                        if status_terminal is not None:
+                            edit_metadata["status_terminal"] = bool(status_terminal)
+                        elif finalize:
+                            edit_metadata["status_terminal"] = True
                     kwargs["metadata"] = edit_metadata
             except (TypeError, ValueError):
                 pass
@@ -1829,7 +1834,7 @@ class GatewayStreamConsumer:
                         message_id=self._message_id,
                         content=text,
                         finalize=finalize,
-                        status_terminal=finalize and is_turn_final,
+                        status_terminal=(is_turn_final if finalize else None),
                     )
                     if result.success:
                         self._already_sent = True
@@ -1984,7 +1989,7 @@ class GatewayStreamConsumer:
                     metadata=self._metadata_for_send(
                         final=finalize,
                         expect_edits=True,
-                        status_terminal=finalize and is_turn_final,
+                        status_terminal=(is_turn_final if finalize else None),
                     ),
                 )
                 if result.success:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -227,6 +227,7 @@ class GatewayStreamConsumer:
         *,
         final: bool = False,
         expect_edits: bool = False,
+        status_terminal: bool | None = None,
     ) -> dict | None:
         """Return per-send metadata for stream-created messages.
 
@@ -246,6 +247,11 @@ class GatewayStreamConsumer:
             meta["expect_edits"] = True
         if final:
             meta["notify"] = True
+        if (
+            (final if status_terminal is None else status_terminal)
+            and meta.get("status_key")
+        ):
+            meta["status_terminal"] = True
         return meta or None
 
     @property
@@ -289,6 +295,7 @@ class GatewayStreamConsumer:
         message_id: str,
         content: str,
         finalize: bool = False,
+        status_terminal: bool | None = None,
     ):
         """Edit via the adapter, passing routing metadata when supported."""
         kwargs = {
@@ -307,7 +314,13 @@ class GatewayStreamConsumer:
                     param.kind is inspect.Parameter.VAR_KEYWORD
                     for param in params.values()
                 ):
-                    kwargs["metadata"] = self.metadata
+                    edit_metadata = dict(self.metadata)
+                    if (
+                        (finalize if status_terminal is None else status_terminal)
+                        and edit_metadata.get("status_key")
+                    ):
+                        edit_metadata["status_terminal"] = True
+                    kwargs["metadata"] = edit_metadata
             except (TypeError, ValueError):
                 pass
         return await self.adapter.edit_message(**kwargs)
@@ -1774,6 +1787,7 @@ class GatewayStreamConsumer:
                         message_id=self._message_id,
                         content=text,
                         finalize=finalize,
+                        status_terminal=finalize and is_turn_final,
                     )
                     if result.success:
                         self._already_sent = True
@@ -1928,6 +1942,7 @@ class GatewayStreamConsumer:
                     metadata=self._metadata_for_send(
                         final=finalize,
                         expect_edits=True,
+                        status_terminal=finalize and is_turn_final,
                     ),
                 )
                 if result.success:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -175,31 +175,83 @@ _DISCORD_OPERATOR_CARD_SEVERITY_LABELS = {
     "critical": "Critical",
 }
 
+# Discord embed budgets, measured in UTF-16 code units (Discord's own unit for
+# these limits).  A contract-valid operator card can still exceed them — e.g.
+# up to 12 fields at the 1024-char field ceiling, or a link block wider than a
+# single field — and Discord rejects an oversized embed wholesale (HTTP 400,
+# error code 50035), which would drop the entire message.  We bound each part
+# and stop once the running aggregate would overflow.
+_DISCORD_EMBED_TITLE_LIMIT = 256
+_DISCORD_EMBED_DESCRIPTION_LIMIT = 4096
+_DISCORD_EMBED_FOOTER_LIMIT = 2048
+_DISCORD_EMBED_FIELD_NAME_LIMIT = 256
+_DISCORD_EMBED_FIELD_VALUE_LIMIT = 1024
+_DISCORD_EMBED_TOTAL_LIMIT = 6000
+_DISCORD_EMBED_MAX_FIELDS = 25
+
 
 def _build_operator_card_embed(card: OperatorCard) -> Any:
-    """Render a validated operator card as a bounded Discord embed."""
-    embed = discord.Embed(
-        title=card.title,
-        description=card.summary,
-        color=_DISCORD_OPERATOR_CARD_COLORS[card.severity],
+    """Render a validated operator card as an embed bounded to Discord's limits.
+
+    Every part is truncated to its per-element ceiling and fields are dropped
+    once the running aggregate would exceed Discord's 6000-code-unit budget, so
+    the embed is always API-valid.  Nothing the operator needs is lost: the
+    plaintext fallback (``render_operator_card_text``) still carries the full
+    card as the message content alongside this embed.
+    """
+    title = _truncate_discord_component_text(card.title, _DISCORD_EMBED_TITLE_LIMIT)
+    description = _truncate_discord_component_text(
+        card.summary, _DISCORD_EMBED_DESCRIPTION_LIMIT
     )
-    for field in card.fields:
-        embed.add_field(name=field.label, value=field.value, inline=False)
-    if card.actions:
-        embed.add_field(
-            name="Actions",
-            value=" · ".join(action.label for action in card.actions),
-            inline=False,
-        )
-    if card.links:
-        embed.add_field(
-            name="Links",
-            value="\n".join(f"[{link.label}]({link.url})" for link in card.links),
-            inline=False,
-        )
     card_type_label = card.card_type.replace("_", " ").title()
     severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[card.severity]
-    embed.set_footer(text=f"{card_type_label} · {severity_label}")
+    footer = _truncate_discord_component_text(
+        f"{card_type_label} · {severity_label}", _DISCORD_EMBED_FOOTER_LIMIT
+    )
+
+    embed = discord.Embed(
+        title=title,
+        description=description,
+        color=_DISCORD_OPERATOR_CARD_COLORS[card.severity],
+    )
+
+    # Title, description, and footer always count against the 6000 aggregate.
+    remaining = _DISCORD_EMBED_TOTAL_LIMIT - (
+        utf16_len(title) + utf16_len(description) + utf16_len(footer)
+    )
+
+    def _add_bounded_field(name: str, value: str) -> None:
+        nonlocal remaining
+        if len(embed.fields) >= _DISCORD_EMBED_MAX_FIELDS or remaining <= 0:
+            return
+        name = _truncate_discord_component_text(
+            name, min(_DISCORD_EMBED_FIELD_NAME_LIMIT, remaining)
+        )
+        if not name:
+            return
+        remaining -= utf16_len(name)
+        if remaining <= 0:
+            return
+        value = _truncate_discord_component_text(
+            value, min(_DISCORD_EMBED_FIELD_VALUE_LIMIT, remaining)
+        )
+        if not value:
+            return
+        remaining -= utf16_len(value)
+        embed.add_field(name=name, value=value, inline=False)
+
+    for field in card.fields:
+        _add_bounded_field(field.label, field.value)
+    if card.actions:
+        _add_bounded_field(
+            "Actions", " · ".join(action.label for action in card.actions)
+        )
+    if card.links:
+        _add_bounded_field(
+            "Links", "\n".join(f"[{link.label}]({link.url})" for link in card.links)
+        )
+
+    embed.set_footer(text=footer)
     return embed
 
 
@@ -2889,9 +2941,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[
                     operator_card.severity
                 ]
-                operator_card_thread_name = (
-                    f"{severity_label} — {operator_card.title}"
-                )[:100]
+                # Discord's 100-char thread-name cap is measured in UTF-16 code
+                # units; a naive ``[:100]`` slice counts code points and can
+                # emit a name Discord rejects.  Use the shared UTF-16-aware
+                # component truncator like every other Discord label.
+                operator_card_thread_name = _truncate_discord_component_text(
+                    f"{severity_label} — {operator_card.title}", 100
+                )
 
             # Determine target channel: thread_id in metadata takes precedence.
             thread_id = None

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3800,6 +3800,24 @@ class DiscordAdapter(BasePlatformAdapter):
                 channel = await self._client.fetch_channel(int(target_chat_id))
             msg = await channel.fetch_message(int(message_id))
             terminal_status = bool(metadata and metadata.get("status_terminal"))
+
+            async def _record_completed_edit(result: SendResult) -> SendResult:
+                """Persist only complete final edits before returning upstream."""
+                raw_response = result.raw_response
+                partial_overflow = bool(
+                    isinstance(raw_response, dict)
+                    and raw_response.get("partial_overflow")
+                )
+                if finalize and result.success and not partial_overflow:
+                    await asyncio.to_thread(
+                        self._record_discord_response,
+                        reply_to=(metadata or {}).get("reply_to_message_id"),
+                        result=result,
+                        content=content,
+                        final=True,
+                    )
+                return result
+
             operator_card_embed = None
             operator_card_payload = (
                 metadata.get("operator_card") if metadata else None
@@ -3825,12 +3843,14 @@ class DiscordAdapter(BasePlatformAdapter):
             # streaming edits truncate a one-message preview in place.
             if len(formatted) > self.MAX_MESSAGE_LENGTH:
                 if finalize:
-                    return await self._edit_overflow_split(
-                        channel,
-                        msg,
-                        message_id,
-                        content,
-                        clear_embed=terminal_status,
+                    return await _record_completed_edit(
+                        await self._edit_overflow_split(
+                            channel,
+                            msg,
+                            message_id,
+                            content,
+                            clear_embed=terminal_status,
+                        )
                     )
                 formatted = self.truncate_message(
                     formatted, self.MAX_MESSAGE_LENGTH,
@@ -3867,12 +3887,14 @@ class DiscordAdapter(BasePlatformAdapter):
                 # as "error code: 50035 ... Must be 2000 or fewer in length".
                 if self._is_length_overflow_error(edit_err):
                     if finalize:
-                        return await self._edit_overflow_split(
-                            channel,
-                            msg,
-                            message_id,
-                            content,
-                            clear_embed=terminal_status,
+                        return await _record_completed_edit(
+                            await self._edit_overflow_split(
+                                channel,
+                                msg,
+                                message_id,
+                                content,
+                                clear_embed=terminal_status,
+                            )
                         )
                     # Mid-stream: truncate and retry in place (no split).
                     truncated = self.truncate_message(
@@ -3886,15 +3908,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 else:
                     raise
             result = SendResult(success=True, message_id=message_id)
-            if finalize:
-                await asyncio.to_thread(
-                    self._record_discord_response,
-                    reply_to=(metadata or {}).get("reply_to_message_id"),
-                    result=result,
-                    content=content,
-                    final=True,
-                )
-            return result
+            return await _record_completed_edit(result)
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to edit Discord message %s: %s", self.name, message_id, e, exc_info=True)
             return SendResult(success=False, error=str(e))

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -390,6 +390,17 @@ class _DiscordNonConversationalMessageTracker:
         if changed:
             self._save()
 
+    def discard_many(self, message_ids: List[str]) -> None:
+        """Stop treating completed status-card messages as history noise."""
+        changed = False
+        for message_id in message_ids:
+            key = str(message_id or "").strip()
+            if key and key in self._ids:
+                self._ids.pop(key, None)
+                changed = True
+        if changed:
+            self._save()
+
     def __contains__(self, message_id: str) -> bool:
         return str(message_id or "") in self._ids
 
@@ -3253,6 +3264,41 @@ class DiscordAdapter(BasePlatformAdapter):
             self._status_message_users.pop(evict_key, None)
             self._status_message_terminal.pop(evict_key, None)
 
+    def _restore_terminal_status_to_conversation(
+        self,
+        *,
+        chat_id: str,
+        thread_id: str,
+        original_message_id: Optional[str],
+        result: SendResult,
+    ) -> None:
+        """Make a completed card visible to history backfill again.
+
+        Running task cards are deliberately excluded from conversational
+        history.  Once the card becomes the assistant's final answer, every
+        chunk belongs to the conversation and the fast-path history cursor
+        must point at the last visible chunk.
+        """
+        message_ids: list[str] = []
+
+        def _append(message_id: Any) -> None:
+            value = str(message_id or "").strip()
+            if value and value not in message_ids:
+                message_ids.append(value)
+
+        _append(original_message_id)
+        raw_response = result.raw_response
+        if isinstance(raw_response, dict):
+            for message_id in raw_response.get("message_ids", ()) or ():
+                _append(message_id)
+        for message_id in result.continuation_message_ids or ():
+            _append(message_id)
+        _append(result.message_id)
+
+        self._nonconversational_messages.discard_many(message_ids)
+        if message_ids:
+            self._last_self_message_id[thread_id or str(chat_id)] = message_ids[-1]
+
     async def send_or_update_status(
         self,
         chat_id: str,
@@ -3330,6 +3376,13 @@ class DiscordAdapter(BasePlatformAdapter):
                     )
                     if result.success:
                         retained_id = str(result.message_id or cached_id)
+                        if terminal:
+                            self._restore_terminal_status_to_conversation(
+                                chat_id=str(chat_id),
+                                thread_id=thread_id,
+                                original_message_id=cached_id,
+                                result=result,
+                            )
                         self._cache_status_message(
                             key,
                             retained_id,
@@ -3380,6 +3433,13 @@ class DiscordAdapter(BasePlatformAdapter):
                     result = await self.send(**fallback_kwargs)
 
                 if result.success and result.message_id:
+                    if terminal:
+                        self._restore_terminal_status_to_conversation(
+                            chat_id=str(chat_id),
+                            thread_id=thread_id,
+                            original_message_id=cached_id,
+                            result=result,
+                        )
                     self._cache_status_message(
                         key,
                         str(result.message_id),

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4079,7 +4079,7 @@ class DiscordAdapter(BasePlatformAdapter):
         images: List[Tuple[str, str]],
         metadata: Optional[Dict[str, Any]] = None,
         human_delay: float = 0.0,
-    ) -> None:
+    ) -> SendResult:
         """Send a batch of images as a single Discord message with multiple attachments.
 
         Discord permits up to 10 file attachments per message. Batches are
@@ -4090,17 +4090,18 @@ class DiscordAdapter(BasePlatformAdapter):
         fall back to the base per-image loop.
         """
         if not self._client:
-            return
+            return SendResult(success=False, error="Not connected")
         if not images:
-            return
+            return SendResult(success=False, error="No images to send")
 
         try:
             import discord as _discord_mod
             import io as _io
             from urllib.parse import unquote as _unquote
         except Exception:  # pragma: no cover
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
-            return
+            return await super().send_multiple_images(
+                chat_id, images, metadata, human_delay
+            )
 
         try:
             channel = self._client.get_channel(int(chat_id))
@@ -4108,14 +4109,21 @@ class DiscordAdapter(BasePlatformAdapter):
                 channel = await self._client.fetch_channel(int(chat_id))
             if not channel:
                 logger.warning("[%s] Channel %s not found for multi-image send", self.name, chat_id)
-                return
+                return SendResult(
+                    success=False,
+                    error=f"Channel {chat_id} not found",
+                )
         except Exception as e:
             logger.warning("[%s] Failed to resolve channel for multi-image send: %s", self.name, e)
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
-            return
+            return await super().send_multiple_images(
+                chat_id, images, metadata, human_delay
+            )
 
         CHUNK = 10
         chunks = [images[i:i + CHUNK] for i in range(0, len(images), CHUNK)]
+        delivered_attachment_count = 0
+        last_message_id: Optional[str] = None
+        delivery_errors: List[str] = []
 
         for chunk_idx, chunk in enumerate(chunks):
             if human_delay > 0 and chunk_idx > 0:
@@ -4180,26 +4188,57 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
 
                 if self._is_forum_parent(channel):
-                    await self._forum_post_file(
+                    forum_result = await self._forum_post_file(
                         channel,
                         content=(content or "").strip(),
                         files=files,
                     )
+                    if not forum_result.success:
+                        delivery_errors.append(
+                            forum_result.error or "Forum image batch failed"
+                        )
+                        continue
+                    delivered_attachment_count += len(files)
+                    last_message_id = forum_result.message_id
                 else:
-                    await channel.send(content=content, files=files)
+                    message = await channel.send(content=content, files=files)
+                    delivered_attachment_count += len(files)
+                    last_message_id = str(message.id)
             except Exception as e:
                 logger.warning(
                     "[%s] Multi-image Discord send failed (chunk %d/%d), falling back to per-image: %s",
                     self.name, chunk_idx + 1, len(chunks), e,
                     exc_info=True,
                 )
-                await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
+                fallback_result = await super().send_multiple_images(
+                    chat_id, chunk, metadata, human_delay=human_delay
+                )
+                if fallback_result.success:
+                    delivered_attachment_count += (
+                        fallback_result.delivered_attachment_count
+                    )
+                    last_message_id = fallback_result.message_id or last_message_id
+                elif fallback_result.error:
+                    delivery_errors.append(fallback_result.error)
             finally:
                 if aiohttp_session is not None:
                     try:
                         await aiohttp_session.close()
                     except Exception:
                         pass
+
+        success = delivered_attachment_count > 0
+        return SendResult(
+            success=success,
+            message_id=last_message_id,
+            error=(
+                None
+                if success
+                else "; ".join(delivery_errors)
+                or "No image attachments were delivered"
+            ),
+            delivered_attachment_count=delivered_attachment_count,
+        )
 
     async def play_tts(
         self,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1019,6 +1019,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self._status_message_fingerprints: Dict[tuple[str, str, str], str] = {}
         self._status_message_locks: Dict[tuple[str, str, str], asyncio.Lock] = {}
         self._status_message_users: Dict[tuple[str, str, str], int] = {}
+        self._status_message_terminal: Dict[tuple[str, str, str], bool] = {}
         # Persistent typing indicator loops per channel (DMs don't reliably
         # show the standard typing gateway event for bots)
         self._typing_tasks: Dict[str, asyncio.Task] = {}
@@ -3218,6 +3219,8 @@ class DiscordAdapter(BasePlatformAdapter):
         key: tuple[str, str, str],
         message_id: str,
         fingerprint: str,
+        *,
+        terminal: bool = False,
     ) -> None:
         """Cache one identity and evict the oldest inactive status runs.
 
@@ -3229,6 +3232,8 @@ class DiscordAdapter(BasePlatformAdapter):
         self._status_message_fingerprints.pop(key, None)
         self._status_message_ids[key] = message_id
         self._status_message_fingerprints[key] = fingerprint
+        if terminal:
+            self._status_message_terminal[key] = True
 
         while len(self._status_message_ids) > self._STATUS_MESSAGE_CACHE_LIMIT:
             evict_key = next(
@@ -3246,6 +3251,7 @@ class DiscordAdapter(BasePlatformAdapter):
             self._status_message_fingerprints.pop(evict_key, None)
             self._status_message_locks.pop(evict_key, None)
             self._status_message_users.pop(evict_key, None)
+            self._status_message_terminal.pop(evict_key, None)
 
     async def send_or_update_status(
         self,
@@ -3293,10 +3299,24 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
                 cached_id = self._status_message_ids.get(key)
                 if (
+                    not terminal
+                    and cached_id is not None
+                    and self._status_message_terminal.get(key)
+                ):
+                    # Final delivery is monotonic. A late progress callback or
+                    # heartbeat must never turn the complete plaintext answer
+                    # back into a running operator card.
+                    return SendResult(success=True, message_id=cached_id)
+                if (
                     cached_id is not None
                     and self._status_message_fingerprints.get(key) == fingerprint
                 ):
-                    self._cache_status_message(key, cached_id, fingerprint)
+                    self._cache_status_message(
+                        key,
+                        cached_id,
+                        fingerprint,
+                        terminal=terminal,
+                    )
                     return SendResult(success=True, message_id=cached_id)
 
                 edit_failed = False
@@ -3310,7 +3330,12 @@ class DiscordAdapter(BasePlatformAdapter):
                     )
                     if result.success:
                         retained_id = str(result.message_id or cached_id)
-                        self._cache_status_message(key, retained_id, fingerprint)
+                        self._cache_status_message(
+                            key,
+                            retained_id,
+                            fingerprint,
+                            terminal=terminal,
+                        )
                         return result
                     edit_failed = True
                     self._status_message_ids.pop(key, None)
@@ -3359,6 +3384,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         key,
                         str(result.message_id),
                         fingerprint,
+                        terminal=terminal,
                     )
                 return result
         finally:
@@ -3375,6 +3401,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 and remaining_users == 0
             ):
                 self._status_message_locks.pop(key, None)
+                self._status_message_terminal.pop(key, None)
 
     async def _send_with_retry(
         self,
@@ -3561,11 +3588,14 @@ class DiscordAdapter(BasePlatformAdapter):
             # send. Route those updates back through the keyed lifecycle so
             # heartbeat, stream finalization, and BasePlatformAdapter's final
             # delivery share the same lock, fingerprint, and fallback policy.
+            routed_metadata = dict(metadata or {})
+            if finalize and "status_terminal" not in routed_metadata:
+                routed_metadata["status_terminal"] = True
             return await self.send_or_update_status(
                 chat_id,
                 str(status_key),
                 content,
-                metadata=metadata,
+                metadata=routed_metadata,
             )
         if not self._client:
             return SendResult(success=False, error="Not connected")

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -141,6 +141,31 @@ def _truncate_discord_component_text(text: str, limit: int) -> str:
     return _prefix_within_utf16_limit(str(text or ""), max(0, limit))
 
 
+def _chunk_discord_lossless_text(text: str, limit: int) -> list[str]:
+    """Split text on Discord's UTF-16 budget without changing its content.
+
+    Operator-card fallbacks are evidence-bearing data.  Generic message
+    chunking adds page indicators and trims boundary whitespace, which can
+    corrupt a long URL.  These chunks intentionally omit presentation markers
+    so joining them reproduces the exact validated fallback.
+    """
+    text = str(text or "")
+    limit = max(1, int(limit))
+    if utf16_len(text) <= limit:
+        return [text]
+
+    chunks: list[str] = []
+    remaining = text
+    while utf16_len(remaining) > limit:
+        chunk = _prefix_within_utf16_limit(remaining, limit)
+        if not chunk:  # Defensive only: Discord's real limit is 2,000 units.
+            chunk = remaining[0]
+        chunks.append(chunk)
+        remaining = remaining[len(chunk):]
+    chunks.append(remaining)
+    return chunks
+
+
 def _abort_discord_websocket_transport(websocket: Any) -> bool:
     """Abort the active aiohttp transport after a bounded close times out."""
     socket = getattr(websocket, "socket", None)
@@ -2978,6 +3003,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     content,
                     embed=operator_card_embed,
                     thread_name=operator_card_thread_name,
+                    preserve_content=operator_card is not None,
                 )
                 await asyncio.to_thread(
                     self._record_discord_response,
@@ -2990,7 +3016,11 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Format and split message if needed
             formatted = self.format_message(content)
-            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            chunks = (
+                _chunk_discord_lossless_text(formatted, self.MAX_MESSAGE_LENGTH)
+                if operator_card is not None
+                else self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            )
 
             message_ids = []
             reference = None
@@ -3084,6 +3114,7 @@ class DiscordAdapter(BasePlatformAdapter):
         *,
         embed: Any = None,
         thread_name: Optional[str] = None,
+        preserve_content: bool = False,
     ) -> SendResult:
         """Create a thread post in a forum channel with the message as starter content.
 
@@ -3097,7 +3128,11 @@ class DiscordAdapter(BasePlatformAdapter):
         # module — no cross-module import needed.
 
         formatted = self.format_message(content)
-        chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+        chunks = (
+            _chunk_discord_lossless_text(formatted, self.MAX_MESSAGE_LENGTH)
+            if preserve_content
+            else self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+        )
 
         thread_name = thread_name or _derive_forum_thread_name(content)
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1027,6 +1027,9 @@ class DiscordAdapter(BasePlatformAdapter):
         # key).  Discord thread sessions can share a parent chat id, so the
         # thread component is required to prevent cross-workspace edits.
         self._status_message_ids: Dict[tuple[str, str, str], str] = {}
+        self._status_message_groups: Dict[
+            tuple[str, str, str], tuple[str, ...]
+        ] = {}
         self._status_message_fingerprints: Dict[tuple[str, str, str], str] = {}
         self._status_message_locks: Dict[tuple[str, str, str], asyncio.Lock] = {}
         self._status_message_users: Dict[tuple[str, str, str], int] = {}
@@ -3231,6 +3234,7 @@ class DiscordAdapter(BasePlatformAdapter):
         message_id: str,
         fingerprint: str,
         *,
+        message_ids: Optional[tuple[str, ...]] = None,
         terminal: bool = False,
     ) -> None:
         """Cache one identity and evict the oldest inactive status runs.
@@ -3243,6 +3247,8 @@ class DiscordAdapter(BasePlatformAdapter):
         self._status_message_fingerprints.pop(key, None)
         self._status_message_ids[key] = message_id
         self._status_message_fingerprints[key] = fingerprint
+        if message_ids is not None:
+            self._status_message_groups[key] = message_ids
         if terminal:
             self._status_message_terminal[key] = True
 
@@ -3259,26 +3265,19 @@ class DiscordAdapter(BasePlatformAdapter):
             if evict_key is None:
                 break
             self._status_message_ids.pop(evict_key, None)
+            self._status_message_groups.pop(evict_key, None)
             self._status_message_fingerprints.pop(evict_key, None)
             self._status_message_locks.pop(evict_key, None)
             self._status_message_users.pop(evict_key, None)
             self._status_message_terminal.pop(evict_key, None)
 
-    def _restore_terminal_status_to_conversation(
-        self,
-        *,
-        chat_id: str,
-        thread_id: str,
-        original_message_id: Optional[str],
+    @staticmethod
+    def _status_result_message_ids(
         result: SendResult,
-    ) -> None:
-        """Make a completed card visible to history backfill again.
-
-        Running task cards are deliberately excluded from conversational
-        history.  Once the card becomes the assistant's final answer, every
-        chunk belongs to the conversation and the fast-path history cursor
-        must point at the last visible chunk.
-        """
+        *,
+        original_message_id: Optional[str] = None,
+    ) -> tuple[str, ...]:
+        """Return every visible message ID owned by one status result."""
         message_ids: list[str] = []
 
         def _append(message_id: Any) -> None:
@@ -3291,11 +3290,75 @@ class DiscordAdapter(BasePlatformAdapter):
         if isinstance(raw_response, dict):
             for message_id in raw_response.get("message_ids", ()) or ():
                 _append(message_id)
+            for message_id in raw_response.get("continuation_message_ids", ()) or ():
+                _append(message_id)
         for message_id in result.continuation_message_ids or ():
             _append(message_id)
         _append(result.message_id)
+        return tuple(message_ids)
 
-        self._nonconversational_messages.discard_many(message_ids)
+    async def _delete_replaced_status_messages(
+        self,
+        *,
+        chat_id: str,
+        thread_id: str,
+        previous_message_ids: tuple[str, ...],
+        retained_message_ids: tuple[str, ...],
+    ) -> None:
+        """Best-effort remove stale chunks after their replacement succeeds."""
+        retained = set(retained_message_ids)
+        stale = [
+            message_id
+            for message_id in previous_message_ids
+            if message_id not in retained
+        ]
+        if not stale or not self._client:
+            return
+        target_chat_id = thread_id or str(chat_id)
+        try:
+            channel = self._client.get_channel(int(target_chat_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(target_chat_id))
+            if not channel:
+                return
+        except Exception:
+            logger.debug(
+                "[%s] Failed to resolve channel for stale status-chunk cleanup",
+                self.name,
+                exc_info=True,
+            )
+            return
+
+        deleted: list[str] = []
+        for message_id in stale:
+            try:
+                message = await channel.fetch_message(int(message_id))
+                await message.delete()
+                deleted.append(message_id)
+            except Exception:
+                logger.debug(
+                    "[%s] Failed to delete replaced status chunk %s",
+                    self.name,
+                    message_id,
+                    exc_info=True,
+                )
+        self._nonconversational_messages.discard_many(deleted)
+
+    def _restore_terminal_status_to_conversation(
+        self,
+        *,
+        chat_id: str,
+        thread_id: str,
+        message_ids: tuple[str, ...],
+    ) -> None:
+        """Make a completed card visible to history backfill again.
+
+        Running task cards are deliberately excluded from conversational
+        history.  Once the card becomes the assistant's final answer, every
+        chunk belongs to the conversation and the fast-path history cursor
+        must point at the last visible chunk.
+        """
+        self._nonconversational_messages.discard_many(list(message_ids))
         if message_ids:
             self._last_self_message_id[thread_id or str(chat_id)] = message_ids[-1]
 
@@ -3344,6 +3407,10 @@ class DiscordAdapter(BasePlatformAdapter):
                     )
                 )
                 cached_id = self._status_message_ids.get(key)
+                cached_group = self._status_message_groups.get(
+                    key,
+                    (cached_id,) if cached_id is not None else (),
+                )
                 if (
                     not terminal
                     and cached_id is not None
@@ -3366,6 +3433,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     return SendResult(success=True, message_id=cached_id)
 
                 edit_failed = False
+                replaced_message_ids: tuple[str, ...] = ()
                 if cached_id is not None:
                     result = await self.edit_message(
                         chat_id=str(chat_id),
@@ -3379,19 +3447,28 @@ class DiscordAdapter(BasePlatformAdapter):
                         isinstance(raw_response, dict)
                         and raw_response.get("partial_overflow")
                     )
+                    result_group = self._status_result_message_ids(
+                        result,
+                        original_message_id=cached_id,
+                    )
                     if result.success and not partial_overflow:
-                        retained_id = str(result.message_id or cached_id)
+                        await self._delete_replaced_status_messages(
+                            chat_id=str(chat_id),
+                            thread_id=thread_id,
+                            previous_message_ids=cached_group,
+                            retained_message_ids=result_group,
+                        )
                         if terminal:
                             self._restore_terminal_status_to_conversation(
                                 chat_id=str(chat_id),
                                 thread_id=thread_id,
-                                original_message_id=cached_id,
-                                result=result,
+                                message_ids=result_group,
                             )
                         self._cache_status_message(
                             key,
-                            retained_id,
+                            cached_id,
                             fingerprint,
+                            message_ids=result_group,
                             terminal=terminal,
                         )
                         return result
@@ -3402,7 +3479,11 @@ class DiscordAdapter(BasePlatformAdapter):
                     # stale-edit fallback below to make exactly one fresh
                     # plaintext send of the complete answer.
                     edit_failed = True
+                    replaced_message_ids = tuple(
+                        dict.fromkeys((*cached_group, *result_group))
+                    )
                     self._status_message_ids.pop(key, None)
+                    self._status_message_groups.pop(key, None)
                     self._status_message_fingerprints.pop(key, None)
 
                 # Terminal results are deliberately plaintext so the operator gets
@@ -3444,17 +3525,24 @@ class DiscordAdapter(BasePlatformAdapter):
                     result = await self.send(**fallback_kwargs)
 
                 if result.success and result.message_id:
+                    result_group = self._status_result_message_ids(result)
+                    await self._delete_replaced_status_messages(
+                        chat_id=str(chat_id),
+                        thread_id=thread_id,
+                        previous_message_ids=replaced_message_ids,
+                        retained_message_ids=result_group,
+                    )
                     if terminal:
                         self._restore_terminal_status_to_conversation(
                             chat_id=str(chat_id),
                             thread_id=thread_id,
-                            original_message_id=cached_id,
-                            result=result,
+                            message_ids=result_group,
                         )
                     self._cache_status_message(
                         key,
-                        str(result.message_id),
+                        result_group[0],
                         fingerprint,
+                        message_ids=result_group,
                         terminal=terminal,
                     )
                 return result
@@ -3472,6 +3560,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 and remaining_users == 0
             ):
                 self._status_message_locks.pop(key, None)
+                self._status_message_groups.pop(key, None)
                 self._status_message_terminal.pop(key, None)
 
     async def _send_with_retry(

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3234,6 +3234,17 @@ class DiscordAdapter(BasePlatformAdapter):
         }
         return plain or None
 
+    @staticmethod
+    def _status_transport_metadata(
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        """Strip lifecycle-only receipt state before a direct Discord send."""
+        if not metadata:
+            return None
+        transport = dict(metadata)
+        transport.pop("reply_to_message_id", None)
+        return transport or None
+
     def _cache_status_message(
         self,
         key: tuple[str, str, str],
@@ -3399,13 +3410,23 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
                 status_metadata: Optional[Dict[str, Any]] = dict(metadata or {})
                 status_metadata.pop("status_key", None)
-                status_metadata.pop("reply_to_message_id", None)
+                if reply_anchor is not None:
+                    # Direct cached edits do not receive ``reply_to``. Retain the
+                    # originating message identity as lifecycle metadata so a
+                    # terminal edit can complete Discord's recovery receipt.
+                    status_metadata["reply_to_message_id"] = str(reply_anchor)
                 if terminal:
                     status_metadata.pop("operator_card", None)
-                elif "operator_card" not in status_metadata:
-                    status_metadata["operator_card"] = self._task_run_operator_card(
-                        status_key, content
-                    )
+                else:
+                    # Running cards are operational UI, not assistant turns.
+                    # Enforce this at the keyed lifecycle boundary so every
+                    # producer (progress, stream, proxy, status) stays out of
+                    # history/backfill even if its caller omits the marker.
+                    status_metadata["non_conversational"] = True
+                    if "operator_card" not in status_metadata:
+                        status_metadata["operator_card"] = self._task_run_operator_card(
+                            status_key, content
+                        )
                 if not status_metadata:
                     status_metadata = None
 
@@ -3505,7 +3526,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 send_metadata = (
                     self._plain_status_metadata(status_metadata)
                     if terminal or edit_failed
-                    else status_metadata
+                    else self._status_transport_metadata(status_metadata)
                 )
                 send_kwargs: Dict[str, Any] = {
                     "chat_id": str(chat_id),

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -18,6 +18,7 @@ import logging
 import math
 import os
 import re
+import secrets
 import struct
 import subprocess
 import tempfile
@@ -116,6 +117,12 @@ from gateway.operator_cards import (
     OperatorCard,
     operator_card_severity_display,
     render_operator_card_text,
+)
+from plugins.platforms.discord.workspace_headers import (
+    WorkspaceHeaderResult,
+    WorkspaceHeaderState,
+    WorkspaceHeaderStore,
+    WorkspaceHeaderStoreError,
 )
 
 from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker, convert_table_to_bullets
@@ -996,6 +1003,11 @@ class DiscordAdapter(BasePlatformAdapter):
         # in those threads don't require @mention.  Persisted to disk so the
         # set survives gateway restarts.
         self._threads = ThreadParticipationTracker("discord")
+        # One durable header per Discord thread workspace. Identity is
+        # partitioned by canonical guild scope_id; locks close a create/create
+        # race when per-user thread sessions are enabled.
+        self._workspace_headers = WorkspaceHeaderStore()
+        self._workspace_header_locks: Dict[tuple[str, str], asyncio.Lock] = {}
         # Persistent typing indicator loops per channel (DMs don't reliably
         # show the standard typing gateway event for bots)
         self._typing_tasks: Dict[str, asyncio.Task] = {}
@@ -2920,15 +2932,25 @@ class DiscordAdapter(BasePlatformAdapter):
             event,
             outcome,
         )
-        if not self._reactions_enabled():
-            return
-        message = event.raw_message
-        if hasattr(message, "add_reaction"):
-            await self._remove_reaction(message, "👀")
-            if outcome == ProcessingOutcome.SUCCESS:
-                await self._add_reaction(message, "✅")
-            elif outcome == ProcessingOutcome.FAILURE:
-                await self._add_reaction(message, "❌")
+        if self._reactions_enabled():
+            message = event.raw_message
+            if hasattr(message, "add_reaction"):
+                await self._remove_reaction(message, "👀")
+                if outcome == ProcessingOutcome.SUCCESS:
+                    await self._add_reaction(message, "✅")
+                elif outcome == ProcessingOutcome.FAILURE:
+                    await self._add_reaction(message, "❌")
+        if outcome == ProcessingOutcome.SUCCESS:
+            # This hook runs after final delivery, so headers only appear for
+            # completed assistant turns. Header I/O remains non-fatal to chat.
+            try:
+                await self.ensure_workspace_header(event.source)
+            except Exception:
+                logger.debug(
+                    "[%s] Failed to refresh Discord workspace header",
+                    self.name,
+                    exc_info=True,
+                )
 
     async def send(
         self,
@@ -5670,6 +5692,18 @@ class DiscordAdapter(BasePlatformAdapter):
             user_name=interaction.user.display_name,
             thread_id=thread_id,
             chat_topic=chat_topic,
+            scope_id=(str(getattr(interaction, "guild_id", "") or "") or None),
+            parent_chat_id=(
+                str(
+                    getattr(
+                        getattr(interaction, "channel", None),
+                        "parent_id",
+                        "",
+                    )
+                    or ""
+                )
+                or None
+            ),
         )
 
         msg_type = MessageType.COMMAND if text.startswith("/") else MessageType.TEXT
@@ -5764,6 +5798,21 @@ class DiscordAdapter(BasePlatformAdapter):
             user_name=interaction.user.display_name,
             thread_id=thread_id,
             chat_topic=chat_topic,
+            scope_id=(
+                str(getattr(getattr(interaction, "guild", None), "id", "") or "")
+                or None
+            ),
+            parent_chat_id=(
+                str(
+                    getattr(
+                        self._thread_parent_channel(_chan),
+                        "id",
+                        "",
+                    )
+                    or ""
+                )
+                or None
+            ),
         )
 
         _parent_channel = self._thread_parent_channel(getattr(interaction, "channel", None))
@@ -6497,6 +6546,204 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception:
             logger.debug("[%s] Failed to rename Discord thread %s", self.name, thread_id, exc_info=True)
             return False
+
+    @staticmethod
+    def _workspace_header_message_missing(error: BaseException) -> bool:
+        """True only when Discord definitively says the tracked message is gone."""
+        code = getattr(error, "code", None)
+        status = getattr(error, "status", None)
+        text = str(error).casefold()
+        return code == 10008 or (status == 404 and "unknown message" in text)
+
+    def _build_workspace_header_card(
+        self,
+        source: Any,
+        thread: Any,
+        state: WorkspaceHeaderState,
+    ) -> OperatorCard:
+        """Build the standard thread-header operator card."""
+        scope_id = str(source.scope_id)
+        thread_id = str(source.thread_id)
+        thread_name = (
+            " ".join(str(getattr(thread, "name", "") or "").split()) or "Hermes"
+        )
+        return OperatorCard.from_mapping(
+            {
+                "kind": "operator_card",
+                "version": 1,
+                "card_type": "thread_header",
+                "title": f"Workspace · {thread_name}",
+                "severity": "info",
+                "summary": "Persistent Hermes context for this Discord thread.",
+                "fields": [
+                    {"label": "Owner", "value": state.owner},
+                    {"label": "Status", "value": state.status},
+                    {"label": "Thread", "value": f"<#{thread_id}>"},
+                    {
+                        "label": "Linked issue / artifact",
+                        "value": state.linked_issue_or_artifact,
+                    },
+                    {"label": "Last decision", "value": state.last_decision},
+                    {"label": "Next action", "value": state.next_action},
+                ],
+                "actions": [],
+                "links": [],
+                "state_ref": f"discord-workspace:{scope_id}:{thread_id}",
+            }
+        )
+
+    async def ensure_workspace_header(self, source: Any) -> WorkspaceHeaderResult:
+        """Create or edit the one persistent header for a Discord thread.
+
+        The method fails closed when canonical scope is missing/mismatched. A
+        tracked message is recreated only after Discord definitively reports
+        Unknown Message; transient fetch failures never risk a duplicate.
+        """
+        if (
+            getattr(source, "platform", None) != Platform.DISCORD
+            or getattr(source, "chat_type", None) != "thread"
+            or not getattr(source, "scope_id", None)
+            or not getattr(source, "thread_id", None)
+            or self._client is None
+        ):
+            return WorkspaceHeaderResult(
+                False, "skipped", error="not a scoped Discord thread"
+            )
+
+        scope_id = str(source.scope_id)
+        thread_id = str(source.thread_id)
+        try:
+            thread_id_int = int(thread_id)
+            thread = self._client.get_channel(thread_id_int)
+            if thread is None:
+                thread = await self._client.fetch_channel(thread_id_int)
+        except Exception as error:
+            return WorkspaceHeaderResult(False, "failed", error=str(error))
+        live_scope_id = str(
+            getattr(getattr(thread, "guild", None), "id", "") or ""
+        )
+        if live_scope_id != scope_id:
+            return WorkspaceHeaderResult(
+                False, "skipped", error="live guild scope mismatch"
+            )
+
+        lock_key = (scope_id, thread_id)
+        lock = self._workspace_header_locks.setdefault(lock_key, asyncio.Lock())
+        async with lock:
+            try:
+                binding = self._workspace_headers.get(scope_id, thread_id)
+                state = self._workspace_headers.get_state(scope_id, thread_id)
+            except WorkspaceHeaderStoreError as error:
+                return WorkspaceHeaderResult(False, "failed", error=str(error))
+            state = state or WorkspaceHeaderState()
+            card = self._build_workspace_header_card(source, thread, state)
+            content = render_operator_card_text(
+                card, max_length=self.MAX_MESSAGE_LENGTH
+            )
+            embed = _build_operator_card_embed(card)
+            action = "created"
+            expected_message_id: Optional[str] = None
+
+            if binding is not None:
+                if binding.pending or not binding.message_id:
+                    return WorkspaceHeaderResult(
+                        False,
+                        "failed",
+                        error="workspace header creation is pending in the registry",
+                    )
+                try:
+                    message = await thread.fetch_message(int(binding.message_id))
+                except Exception as error:
+                    if not self._workspace_header_message_missing(error):
+                        return WorkspaceHeaderResult(
+                            False,
+                            "failed",
+                            message_id=binding.message_id,
+                            error=str(error),
+                        )
+                    expected_message_id = binding.message_id
+                    action = "recreated"
+                else:
+                    try:
+                        await message.edit(content=content, embed=embed)
+                    except Exception as error:
+                        return WorkspaceHeaderResult(
+                            False,
+                            "failed",
+                            message_id=binding.message_id,
+                            error=str(error),
+                        )
+                    self._nonconversational_messages.mark_many(
+                        [binding.message_id]
+                    )
+                    return WorkspaceHeaderResult(
+                        True, "updated", message_id=binding.message_id
+                    )
+
+            reservation_token = secrets.token_hex(16)
+            try:
+                reserved = self._workspace_headers.reserve_creation(
+                    scope_id,
+                    thread_id,
+                    token=reservation_token,
+                    expected_message_id=expected_message_id,
+                )
+            except WorkspaceHeaderStoreError as error:
+                return WorkspaceHeaderResult(False, "failed", error=str(error))
+            if not reserved:
+                return WorkspaceHeaderResult(
+                    False,
+                    "failed",
+                    error="workspace header identity changed before creation",
+                )
+
+            try:
+                message = await thread.send(content=content, embed=embed)
+            except Exception as error:
+                try:
+                    self._workspace_headers.cancel_creation(
+                        scope_id, thread_id, token=reservation_token
+                    )
+                except WorkspaceHeaderStoreError:
+                    logger.debug(
+                        "[%s] Failed to release Discord workspace header reservation",
+                        self.name,
+                        exc_info=True,
+                    )
+                return WorkspaceHeaderResult(False, "failed", error=str(error))
+            message_id = str(getattr(message, "id", "") or "")
+            if not message_id:
+                try:
+                    self._workspace_headers.cancel_creation(
+                        scope_id, thread_id, token=reservation_token
+                    )
+                except WorkspaceHeaderStoreError:
+                    logger.debug(
+                        "[%s] Failed to release Discord workspace header reservation",
+                        self.name,
+                        exc_info=True,
+                    )
+                return WorkspaceHeaderResult(
+                    False, "failed", error="Discord send returned no message id"
+                )
+            self._nonconversational_messages.mark_many([message_id])
+            try:
+                self._workspace_headers.complete_creation(
+                    scope_id,
+                    thread_id,
+                    token=reservation_token,
+                    message_id=message_id,
+                )
+            except WorkspaceHeaderStoreError as error:
+                # The persisted pending reservation deliberately remains. A
+                # later turn fails closed instead of emitting a duplicate.
+                return WorkspaceHeaderResult(
+                    False,
+                    "failed",
+                    message_id=message_id,
+                    error=str(error),
+                )
+            return WorkspaceHeaderResult(True, action, message_id=message_id)
 
     async def create_handoff_thread(
         self,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3374,7 +3374,12 @@ class DiscordAdapter(BasePlatformAdapter):
                         finalize=terminal,
                         metadata=status_metadata,
                     )
-                    if result.success:
+                    raw_response = result.raw_response
+                    partial_overflow = bool(
+                        isinstance(raw_response, dict)
+                        and raw_response.get("partial_overflow")
+                    )
+                    if result.success and not partial_overflow:
                         retained_id = str(result.message_id or cached_id)
                         if terminal:
                             self._restore_terminal_status_to_conversation(
@@ -3390,6 +3395,12 @@ class DiscordAdapter(BasePlatformAdapter):
                             terminal=terminal,
                         )
                         return result
+                    # Discord deliberately reports a mid-continuation overflow
+                    # failure as partial success so callers know some chunks
+                    # are already visible.  It is not a completed terminal
+                    # delivery: do not fingerprint or latch it.  Reuse the
+                    # stale-edit fallback below to make exactly one fresh
+                    # plaintext send of the complete answer.
                     edit_failed = True
                     self._status_message_ids.pop(key, None)
                     self._status_message_fingerprints.pop(key, None)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -133,6 +133,7 @@ from gateway.platforms.base import (
     MessageType,
     ProcessingOutcome,
     SendResult,
+    confirmed_attachment_delivery_count,
     cache_image_from_url,
     cache_image_from_bytes,
     cache_audio_from_url,
@@ -3066,7 +3067,13 @@ class DiscordAdapter(BasePlatformAdapter):
             if metadata and metadata.get("thread_id"):
                 thread_id = metadata["thread_id"]
             nonconversational = _metadata_marks_nonconversational(metadata)
-            final_delivery = bool(metadata and metadata.get("notify"))
+            final_delivery = bool(
+                metadata
+                and (
+                    metadata.get("notify")
+                    or metadata.get("status_terminal")
+                )
+            )
 
             if thread_id:
                 # Fetch the thread directly — threads are addressed by their own ID.
@@ -3190,7 +3197,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 reply_to=reply_to,
                 result=result,
                 content=content,
-                final=bool(metadata and metadata.get("notify")),
+                final=bool(
+                    metadata
+                    and (
+                        metadata.get("notify")
+                        or metadata.get("status_terminal")
+                    )
+                ),
             )
             return result
 
@@ -3218,7 +3231,7 @@ class DiscordAdapter(BasePlatformAdapter):
     def _plain_status_metadata(
         metadata: Optional[Dict[str, Any]],
     ) -> Optional[Dict[str, Any]]:
-        """Keep routing markers while stripping rich/status-only controls."""
+        """Keep routing/terminal markers while stripping rich controls."""
         if not metadata:
             return None
         plain = {
@@ -3227,7 +3240,6 @@ class DiscordAdapter(BasePlatformAdapter):
             if key
             not in {
                 "operator_card",
-                "status_terminal",
                 "status_key",
                 "reply_to_message_id",
             }
@@ -3752,6 +3764,9 @@ class DiscordAdapter(BasePlatformAdapter):
             success=True,
             message_id=message_id,
             raw_response={"thread_id": thread_id},
+            delivered_attachment_count=(
+                len(files) if files else 1 if file is not None else 0
+            ),
         )
 
     async def edit_message(
@@ -4071,7 +4086,11 @@ class DiscordAdapter(BasePlatformAdapter):
                     file=file,
                 )
             msg = await channel.send(content=caption if caption else None, file=file)
-        return SendResult(success=True, message_id=str(msg.id))
+        return SendResult(
+            success=True,
+            message_id=str(msg.id),
+            delivered_attachment_count=1,
+        )
 
     async def send_multiple_images(
         self,
@@ -4193,12 +4212,15 @@ class DiscordAdapter(BasePlatformAdapter):
                         content=(content or "").strip(),
                         files=files,
                     )
-                    if not forum_result.success:
+                    confirmed_count = confirmed_attachment_delivery_count(
+                        forum_result
+                    )
+                    if not confirmed_count:
                         delivery_errors.append(
                             forum_result.error or "Forum image batch failed"
                         )
                         continue
-                    delivered_attachment_count += len(files)
+                    delivered_attachment_count += confirmed_count
                     last_message_id = forum_result.message_id
                 else:
                     message = await channel.send(content=content, files=files)
@@ -4335,12 +4357,20 @@ class DiscordAdapter(BasePlatformAdapter):
                     discord.http.Route("POST", "/channels/{channel_id}/messages", channel_id=channel.id),
                     form=form,
                 )
-                return SendResult(success=True, message_id=str(msg_data["id"]))
+                return SendResult(
+                    success=True,
+                    message_id=str(msg_data["id"]),
+                    delivered_attachment_count=1,
+                )
             except Exception as voice_err:
                 logger.debug("Voice message flag failed, falling back to file: %s", voice_err)
                 file = discord.File(io.BytesIO(file_data), filename=filename)
                 msg = await channel.send(file=file)
-                return SendResult(success=True, message_id=str(msg.id))
+                return SendResult(
+                    success=True,
+                    message_id=str(msg.id),
+                    delivered_attachment_count=1,
+                )
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to send audio, falling back to base adapter: %s", self.name, e, exc_info=True)
             return await super().send_voice(chat_id, audio_path, caption, reply_to, metadata=metadata)
@@ -5350,7 +5380,11 @@ class DiscordAdapter(BasePlatformAdapter):
                         content=caption if caption else None,
                         file=file,
                     )
-                    return SendResult(success=True, message_id=str(msg.id))
+                    return SendResult(
+                        success=True,
+                        message_id=str(msg.id),
+                        delivered_attachment_count=1,
+                    )
 
         except ImportError:
             logger.warning(
@@ -5419,7 +5453,11 @@ class DiscordAdapter(BasePlatformAdapter):
                         content=caption if caption else None,
                         file=file,
                     )
-                    return SendResult(success=True, message_id=str(msg.id))
+                    return SendResult(
+                        success=True,
+                        message_id=str(msg.id),
+                        delivered_attachment_count=1,
+                    )
 
         except ImportError:
             logger.warning(

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2940,17 +2940,46 @@ class DiscordAdapter(BasePlatformAdapter):
                     await self._add_reaction(message, "✅")
                 elif outcome == ProcessingOutcome.FAILURE:
                     await self._add_reaction(message, "❌")
-        if outcome == ProcessingOutcome.SUCCESS:
-            # This hook runs after final delivery, so headers only appear for
-            # completed assistant turns. Header I/O remains non-fatal to chat.
-            try:
-                await self.ensure_workspace_header(event.source)
-            except Exception:
-                logger.debug(
-                    "[%s] Failed to refresh Discord workspace header",
-                    self.name,
-                    exc_info=True,
+        # The processing lifecycle is the concrete status producer for the
+        # persistent workspace card. Successful turns may create the header;
+        # failures and cancellations only edit an already-tracked message.
+        # Header I/O remains non-fatal to chat.
+        try:
+            source = event.source
+            binding = None
+            if (
+                source is not None
+                and source.scope_id
+                and source.thread_id
+            ):
+                binding = self._workspace_headers.get(
+                    source.scope_id,
+                    source.thread_id,
                 )
+            if outcome == ProcessingOutcome.SUCCESS or binding is not None:
+                if outcome == ProcessingOutcome.SUCCESS:
+                    status = "Active"
+                    next_action = "Awaiting next assistant turn"
+                elif outcome == ProcessingOutcome.FAILURE:
+                    status = "Needs attention"
+                    next_action = "Retry the last request"
+                else:
+                    status = "Paused"
+                    next_action = "Awaiting next instruction"
+                if source is not None and source.scope_id and source.thread_id:
+                    self._workspace_headers.update_state(
+                        source.scope_id,
+                        source.thread_id,
+                        status=status,
+                        next_action=next_action,
+                    )
+                await self.ensure_workspace_header(source)
+        except Exception:
+            logger.debug(
+                "[%s] Failed to refresh Discord workspace header",
+                self.name,
+                exc_info=True,
+            )
 
     async def send(
         self,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -959,6 +959,10 @@ class DiscordAdapter(BasePlatformAdapter):
     # Discord message limits
     MAX_MESSAGE_LENGTH = 2000
     _SPLIT_THRESHOLD = 1900  # near the 2000-char split point
+    # Status identity is process-local delivery state, not history. Keep recent
+    # run identities for retries/final replacement without retaining every run
+    # for the lifetime of a busy gateway process.
+    _STATUS_MESSAGE_CACHE_LIMIT = 512
     supports_code_blocks = True  # Discord markdown renders fenced code blocks natively
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
 
@@ -1008,6 +1012,13 @@ class DiscordAdapter(BasePlatformAdapter):
         # race when per-user thread sessions are enabled.
         self._workspace_headers = WorkspaceHeaderStore()
         self._workspace_header_locks: Dict[tuple[str, str], asyncio.Lock] = {}
+        # One mutable task-run card per (parent chat, routed thread, status
+        # key).  Discord thread sessions can share a parent chat id, so the
+        # thread component is required to prevent cross-workspace edits.
+        self._status_message_ids: Dict[tuple[str, str, str], str] = {}
+        self._status_message_fingerprints: Dict[tuple[str, str, str], str] = {}
+        self._status_message_locks: Dict[tuple[str, str, str], asyncio.Lock] = {}
+        self._status_message_users: Dict[tuple[str, str, str], int] = {}
         # Persistent typing indicator loops per channel (DMs don't reliably
         # show the standard typing gateway event for bots)
         self._typing_tasks: Dict[str, asyncio.Task] = {}
@@ -2996,6 +3007,20 @@ class DiscordAdapter(BasePlatformAdapter):
         Forum channels (type 15) reject direct messages — a thread post is
         created automatically.
         """
+        status_key = (metadata or {}).get("status_key")
+        if status_key:
+            # Gateway progress, heartbeat, streaming, and final-delivery seams
+            # all use normal send/edit calls. A metadata key lets those paths
+            # share the keyed-card lifecycle without platform checks at every
+            # call site. send_or_update_status strips the key before its direct
+            # transport write, preventing recursion.
+            return await self.send_or_update_status(
+                chat_id,
+                str(status_key),
+                content,
+                metadata=metadata,
+                reply_to=reply_to,
+            )
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
@@ -3154,6 +3179,229 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             return result
 
+    @staticmethod
+    def _task_run_operator_card(status_key: str, content: str) -> Dict[str, Any]:
+        """Build the bounded rich presentation for a non-terminal run update."""
+        summary = str(content or "").strip() or "Task is still running."
+        if len(summary) > 500:
+            summary = summary[:499].rstrip() + "…"
+        identity = hashlib.sha256(str(status_key).encode("utf-8")).hexdigest()[:20]
+        return {
+            "kind": "operator_card",
+            "version": 1,
+            "card_type": "task_run",
+            "title": "Task running",
+            "severity": "info",
+            "summary": summary,
+            "fields": [],
+            "actions": [],
+            "links": [],
+            "state_ref": f"discord-task-run:{identity}",
+        }
+
+    @staticmethod
+    def _plain_status_metadata(
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        """Keep routing markers while stripping rich/status-only controls."""
+        if not metadata:
+            return None
+        plain = {
+            key: value
+            for key, value in metadata.items()
+            if key not in {"operator_card", "status_terminal", "status_key"}
+        }
+        return plain or None
+
+    def _cache_status_message(
+        self,
+        key: tuple[str, str, str],
+        message_id: str,
+        fingerprint: str,
+    ) -> None:
+        """Cache one identity and evict the oldest inactive status runs.
+
+        Dict insertion order supplies a small LRU without another dependency.
+        A locked key may be sending or editing, so eviction skips it even when
+        that means temporarily exceeding the cap until a later successful run.
+        """
+        self._status_message_ids.pop(key, None)
+        self._status_message_fingerprints.pop(key, None)
+        self._status_message_ids[key] = message_id
+        self._status_message_fingerprints[key] = fingerprint
+
+        while len(self._status_message_ids) > self._STATUS_MESSAGE_CACHE_LIMIT:
+            evict_key = next(
+                (
+                    candidate
+                    for candidate in self._status_message_ids
+                    if candidate != key
+                    and self._status_message_users.get(candidate, 0) == 0
+                ),
+                None,
+            )
+            if evict_key is None:
+                break
+            self._status_message_ids.pop(evict_key, None)
+            self._status_message_fingerprints.pop(evict_key, None)
+            self._status_message_locks.pop(evict_key, None)
+            self._status_message_users.pop(evict_key, None)
+
+    async def send_or_update_status(
+        self,
+        chat_id: str,
+        status_key: str,
+        content: str,
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: Optional[str] = None,
+    ) -> SendResult:
+        """Create or update one Discord task-run card for a routed status key.
+
+        Running updates use the operator-card renderer. A terminal update
+        replaces the retained message with the complete plaintext result and
+        removes the embed. Any stale-message edit failure gets exactly one
+        fresh plaintext send; a first rich-send/embed failure does the same.
+        """
+        thread_id = str((metadata or {}).get("thread_id") or "")
+        key = (str(chat_id), thread_id, str(status_key))
+        lock = self._status_message_locks.setdefault(key, asyncio.Lock())
+        # Register before awaiting the lock. The count covers the acquired
+        # caller and queued callers, making eviction/removal safe without
+        # relying on private asyncio.Lock waiter internals.
+        self._status_message_users[key] = self._status_message_users.get(key, 0) + 1
+        try:
+            async with lock:
+                terminal = bool((metadata or {}).get("status_terminal"))
+                status_metadata: Optional[Dict[str, Any]] = dict(metadata or {})
+                status_metadata.pop("status_key", None)
+                if terminal:
+                    status_metadata.pop("operator_card", None)
+                elif "operator_card" not in status_metadata:
+                    status_metadata["operator_card"] = self._task_run_operator_card(
+                        status_key, content
+                    )
+                if not status_metadata:
+                    status_metadata = None
+
+                fingerprint = repr(
+                    (
+                        str(content),
+                        terminal,
+                        (status_metadata or {}).get("operator_card"),
+                    )
+                )
+                cached_id = self._status_message_ids.get(key)
+                if (
+                    cached_id is not None
+                    and self._status_message_fingerprints.get(key) == fingerprint
+                ):
+                    self._cache_status_message(key, cached_id, fingerprint)
+                    return SendResult(success=True, message_id=cached_id)
+
+                edit_failed = False
+                if cached_id is not None:
+                    result = await self.edit_message(
+                        chat_id=str(chat_id),
+                        message_id=cached_id,
+                        content=content,
+                        finalize=terminal,
+                        metadata=status_metadata,
+                    )
+                    if result.success:
+                        retained_id = str(result.message_id or cached_id)
+                        self._cache_status_message(key, retained_id, fingerprint)
+                        return result
+                    edit_failed = True
+                    self._status_message_ids.pop(key, None)
+                    self._status_message_fingerprints.pop(key, None)
+
+                # Terminal results are deliberately plaintext so the operator gets
+                # the full answer rather than the card summary's 500-character cap.
+                # After a stale edit, go straight to one plaintext send as well.
+                send_metadata = (
+                    self._plain_status_metadata(status_metadata)
+                    if terminal or edit_failed
+                    else status_metadata
+                )
+                send_kwargs: Dict[str, Any] = {
+                    "chat_id": str(chat_id),
+                    "content": content,
+                    "metadata": send_metadata,
+                }
+                if reply_to is not None:
+                    send_kwargs["reply_to"] = reply_to
+                result = await self.send(
+                    **send_kwargs,
+                )
+
+                # A first rich send can fail because Discord rejected the embed.
+                # Retry exactly once without the rich payload; never recursively
+                # enter this method or the generic send retry loop.
+                if (
+                    not result.success
+                    and not terminal
+                    and not edit_failed
+                    and status_metadata
+                    and "operator_card" in status_metadata
+                ):
+                    fallback_kwargs: Dict[str, Any] = {
+                        "chat_id": str(chat_id),
+                        "content": content,
+                        "metadata": self._plain_status_metadata(status_metadata),
+                    }
+                    if reply_to is not None:
+                        fallback_kwargs["reply_to"] = reply_to
+                    result = await self.send(**fallback_kwargs)
+
+                if result.success and result.message_id:
+                    self._cache_status_message(
+                        key,
+                        str(result.message_id),
+                        fingerprint,
+                    )
+                return result
+        finally:
+            remaining_users = self._status_message_users.get(key, 1) - 1
+            if remaining_users > 0:
+                self._status_message_users[key] = remaining_users
+            else:
+                self._status_message_users.pop(key, None)
+            # Failed first sends have no useful retained identity. Remove their
+            # now-unlocked lock so repeated failures cannot grow the lock map.
+            if (
+                key not in self._status_message_ids
+                and self._status_message_locks.get(key) is lock
+                and remaining_users == 0
+            ):
+                self._status_message_locks.pop(key, None)
+
+    async def _send_with_retry(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Any = None,
+        max_retries: int = 2,
+        base_delay: float = 2.0,
+    ) -> SendResult:
+        """Keep keyed-card fallback single-shot; retain normal send retries."""
+        if metadata and metadata.get("status_key"):
+            return await self.send(
+                chat_id=chat_id,
+                content=content,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+        return await super()._send_with_retry(
+            chat_id=chat_id,
+            content=content,
+            reply_to=reply_to,
+            metadata=metadata,
+            max_retries=max_retries,
+            base_delay=base_delay,
+        )
+
     async def _send_to_forum(
         self,
         forum_channel: Any,
@@ -3307,14 +3555,40 @@ class DiscordAdapter(BasePlatformAdapter):
         re-split, looping forever (the Telegram #48648 lesson).  The complete
         text is delivered when ``finalize=True`` via ``_edit_overflow_split``.
         """
+        status_key = (metadata or {}).get("status_key")
+        if status_key:
+            # Stream consumers call edit_message directly after their first
+            # send. Route those updates back through the keyed lifecycle so
+            # heartbeat, stream finalization, and BasePlatformAdapter's final
+            # delivery share the same lock, fingerprint, and fallback policy.
+            return await self.send_or_update_status(
+                chat_id,
+                str(status_key),
+                content,
+                metadata=metadata,
+            )
         if not self._client:
             return SendResult(success=False, error="Not connected")
         try:
-            channel = self._client.get_channel(int(chat_id))
+            target_chat_id = (metadata or {}).get("thread_id") or chat_id
+            channel = self._client.get_channel(int(target_chat_id))
             if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
+                channel = await self._client.fetch_channel(int(target_chat_id))
             msg = await channel.fetch_message(int(message_id))
-            formatted = self.format_message(content)
+            terminal_status = bool(metadata and metadata.get("status_terminal"))
+            operator_card_embed = None
+            operator_card_payload = (
+                metadata.get("operator_card") if metadata else None
+            )
+            if operator_card_payload is not None:
+                operator_card = OperatorCard.from_mapping(operator_card_payload)
+                formatted = render_operator_card_text(
+                    operator_card,
+                    max_length=self.MAX_MESSAGE_LENGTH,
+                )
+                operator_card_embed = _build_operator_card_embed(operator_card)
+            else:
+                formatted = self.format_message(content)
 
             _preview_key = (str(chat_id), str(message_id))
             _saturated_preview = False
@@ -3328,7 +3602,11 @@ class DiscordAdapter(BasePlatformAdapter):
             if len(formatted) > self.MAX_MESSAGE_LENGTH:
                 if finalize:
                     return await self._edit_overflow_split(
-                        channel, msg, message_id, content,
+                        channel,
+                        msg,
+                        message_id,
+                        content,
+                        clear_embed=terminal_status,
                     )
                 formatted = self.truncate_message(
                     formatted, self.MAX_MESSAGE_LENGTH,
@@ -3348,7 +3626,14 @@ class DiscordAdapter(BasePlatformAdapter):
                 self._last_overflow_preview.pop(_preview_key, None)
 
             try:
-                await msg.edit(content=formatted)
+                edit_kwargs: Dict[str, Any] = {"content": formatted}
+                if terminal_status:
+                    # A final result replaces the card; omitting embed=None
+                    # would leave the stale running embed attached.
+                    edit_kwargs["embed"] = None
+                elif operator_card_embed is not None:
+                    edit_kwargs["embed"] = operator_card_embed
+                await msg.edit(**edit_kwargs)
                 if _saturated_preview:
                     self._last_overflow_preview[_preview_key] = formatted
             except Exception as edit_err:
@@ -3359,7 +3644,11 @@ class DiscordAdapter(BasePlatformAdapter):
                 if self._is_length_overflow_error(edit_err):
                     if finalize:
                         return await self._edit_overflow_split(
-                            channel, msg, message_id, content,
+                            channel,
+                            msg,
+                            message_id,
+                            content,
+                            clear_embed=terminal_status,
                         )
                     # Mid-stream: truncate and retry in place (no split).
                     truncated = self.truncate_message(
@@ -3406,6 +3695,8 @@ class DiscordAdapter(BasePlatformAdapter):
         msg: Any,
         message_id: str,
         content: str,
+        *,
+        clear_embed: bool = False,
     ) -> SendResult:
         """Deliver an oversized final edit across message + continuations.
 
@@ -3429,12 +3720,20 @@ class DiscordAdapter(BasePlatformAdapter):
         if len(chunks) <= 1:
             # Defensive: caller's pre-flight should guarantee >1 chunk, but if
             # not, just edit normally.
-            await msg.edit(content=chunks[0] if chunks else formatted)
+            edit_kwargs: Dict[str, Any] = {
+                "content": chunks[0] if chunks else formatted
+            }
+            if clear_embed:
+                edit_kwargs["embed"] = None
+            await msg.edit(**edit_kwargs)
             return SendResult(success=True, message_id=message_id)
 
         # Step 1 — edit the existing message with the first chunk.
         try:
-            await msg.edit(content=chunks[0])
+            edit_kwargs: Dict[str, Any] = {"content": chunks[0]}
+            if clear_embed:
+                edit_kwargs["embed"] = None
+            await msg.edit(**edit_kwargs)
         except Exception as e:
             logger.error(
                 "[%s] Overflow split: first-chunk edit failed: %s",

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2935,7 +2935,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 operator_card = OperatorCard.from_mapping(metadata["operator_card"])
                 content = render_operator_card_text(
                     operator_card,
-                    max_length=self.MAX_MESSAGE_LENGTH,
+                    max_length=None,
                 )
                 operator_card_embed = _build_operator_card_embed(operator_card)
                 severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[
@@ -8959,13 +8959,13 @@ def _probe_is_forum_cached(chat_id: str) -> Optional[bool]:
 
 
 def _derive_forum_thread_name(message: str) -> str:
-    """Derive a thread name from the first line of the message, capped at 100 chars."""
+    """Derive a thread name within Discord's 100 UTF-16-unit limit."""
     first_line = message.strip().split("\n", 1)[0].strip()
     # Strip common markdown heading prefixes
     first_line = first_line.lstrip("#").strip()
     if not first_line:
         first_line = "New Post"
-    return first_line[:100]
+    return _truncate_discord_component_text(first_line, 100)
 
 
 def _standalone_sanitize_error(text) -> str:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -112,7 +112,11 @@ from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
-from gateway.operator_cards import OperatorCard, render_operator_card_text
+from gateway.operator_cards import (
+    OperatorCard,
+    operator_card_severity_display,
+    render_operator_card_text,
+)
 
 from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker, convert_table_to_bullets
 from utils import atomic_json_write, env_float, env_int
@@ -192,14 +196,6 @@ _DISCORD_OPERATOR_CARD_COLORS = {
     "blocked": 0xE74C3C,
     "critical": 0x992D22,
 }
-_DISCORD_OPERATOR_CARD_SEVERITY_LABELS = {
-    "done": "Done",
-    "info": "Info",
-    "needs_review": "Needs review",
-    "blocked": "Blocked",
-    "critical": "Critical",
-}
-
 # Discord embed budgets, measured in UTF-16 code units (Discord's own unit for
 # these limits).  A contract-valid operator card can still exceed them — e.g.
 # up to 12 fields at the 1024-char field ceiling, or a link block wider than a
@@ -229,7 +225,7 @@ def _build_operator_card_embed(card: OperatorCard) -> Any:
         card.summary, _DISCORD_EMBED_DESCRIPTION_LIMIT
     )
     card_type_label = card.card_type.replace("_", " ").title()
-    severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[card.severity]
+    _, severity_label = operator_card_severity_display(card.severity)
     footer = _truncate_discord_component_text(
         f"{card_type_label} · {severity_label}", _DISCORD_EMBED_FOOTER_LIMIT
     )
@@ -2963,9 +2959,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     max_length=None,
                 )
                 operator_card_embed = _build_operator_card_embed(operator_card)
-                severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[
+                _, severity_label = operator_card_severity_display(
                     operator_card.severity
-                ]
+                )
                 # Discord's 100-char thread-name cap is measured in UTF-16 code
                 # units; a naive ``[:100]`` slice counts code points and can
                 # emit a name Discord rejects.  Use the shared UTF-16-aware

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3224,7 +3224,13 @@ class DiscordAdapter(BasePlatformAdapter):
         plain = {
             key: value
             for key, value in metadata.items()
-            if key not in {"operator_card", "status_terminal", "status_key"}
+            if key
+            not in {
+                "operator_card",
+                "status_terminal",
+                "status_key",
+                "reply_to_message_id",
+            }
         }
         return plain or None
 
@@ -3388,8 +3394,12 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             async with lock:
                 terminal = bool((metadata or {}).get("status_terminal"))
+                reply_anchor = reply_to or (metadata or {}).get(
+                    "reply_to_message_id"
+                )
                 status_metadata: Optional[Dict[str, Any]] = dict(metadata or {})
                 status_metadata.pop("status_key", None)
+                status_metadata.pop("reply_to_message_id", None)
                 if terminal:
                     status_metadata.pop("operator_card", None)
                 elif "operator_card" not in status_metadata:
@@ -3399,13 +3409,16 @@ class DiscordAdapter(BasePlatformAdapter):
                 if not status_metadata:
                     status_metadata = None
 
-                fingerprint = repr(
+                fingerprint_payload = repr(
                     (
                         str(content),
                         terminal,
                         (status_metadata or {}).get("operator_card"),
                     )
                 )
+                fingerprint = hashlib.sha256(
+                    fingerprint_payload.encode("utf-8")
+                ).hexdigest()
                 cached_id = self._status_message_ids.get(key)
                 cached_group = self._status_message_groups.get(
                     key,
@@ -3499,8 +3512,8 @@ class DiscordAdapter(BasePlatformAdapter):
                     "content": content,
                     "metadata": send_metadata,
                 }
-                if reply_to is not None:
-                    send_kwargs["reply_to"] = reply_to
+                if reply_anchor is not None:
+                    send_kwargs["reply_to"] = str(reply_anchor)
                 result = await self.send(
                     **send_kwargs,
                 )
@@ -3520,8 +3533,8 @@ class DiscordAdapter(BasePlatformAdapter):
                         "content": content,
                         "metadata": self._plain_status_metadata(status_metadata),
                     }
-                    if reply_to is not None:
-                        fallback_kwargs["reply_to"] = reply_to
+                    if reply_anchor is not None:
+                        fallback_kwargs["reply_to"] = str(reply_anchor)
                     result = await self.send(**fallback_kwargs)
 
                 if result.success and result.message_id:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -112,6 +112,7 @@ from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
+from gateway.operator_cards import OperatorCard, render_operator_card_text
 
 from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker, convert_table_to_bullets
 from utils import atomic_json_write, env_float, env_int
@@ -157,6 +158,49 @@ def _abort_discord_websocket_transport(websocket: Any) -> bool:
         return False
     abort()
     return True
+
+
+_DISCORD_OPERATOR_CARD_COLORS = {
+    "done": 0x2ECC71,
+    "info": 0x3498DB,
+    "needs_review": 0xF1C40F,
+    "blocked": 0xE74C3C,
+    "critical": 0x992D22,
+}
+_DISCORD_OPERATOR_CARD_SEVERITY_LABELS = {
+    "done": "Done",
+    "info": "Info",
+    "needs_review": "Needs review",
+    "blocked": "Blocked",
+    "critical": "Critical",
+}
+
+
+def _build_operator_card_embed(card: OperatorCard) -> Any:
+    """Render a validated operator card as a bounded Discord embed."""
+    embed = discord.Embed(
+        title=card.title,
+        description=card.summary,
+        color=_DISCORD_OPERATOR_CARD_COLORS[card.severity],
+    )
+    for field in card.fields:
+        embed.add_field(name=field.label, value=field.value, inline=False)
+    if card.actions:
+        embed.add_field(
+            name="Actions",
+            value=" · ".join(action.label for action in card.actions),
+            inline=False,
+        )
+    if card.links:
+        embed.add_field(
+            name="Links",
+            value="\n".join(f"[{link.label}]({link.url})" for link in card.links),
+            inline=False,
+        )
+    card_type_label = card.card_type.replace("_", " ").title()
+    severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[card.severity]
+    embed.set_footer(text=f"{card_type_label} · {severity_label}")
+    return embed
 
 
 async def _wait_for_ready_or_bot_exit(
@@ -2832,6 +2876,23 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
+            operator_card = None
+            operator_card_embed = None
+            operator_card_thread_name = None
+            if metadata and "operator_card" in metadata:
+                operator_card = OperatorCard.from_mapping(metadata["operator_card"])
+                content = render_operator_card_text(
+                    operator_card,
+                    max_length=self.MAX_MESSAGE_LENGTH,
+                )
+                operator_card_embed = _build_operator_card_embed(operator_card)
+                severity_label = _DISCORD_OPERATOR_CARD_SEVERITY_LABELS[
+                    operator_card.severity
+                ]
+                operator_card_thread_name = (
+                    f"{severity_label} — {operator_card.title}"
+                )[:100]
+
             # Determine target channel: thread_id in metadata takes precedence.
             thread_id = None
             if metadata and metadata.get("thread_id"):
@@ -2856,7 +2917,12 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Forum channels reject channel.send() — create a thread post instead.
             if self._is_forum_parent(channel):
-                result = await self._send_to_forum(channel, content)
+                result = await self._send_to_forum(
+                    channel,
+                    content,
+                    embed=operator_card_embed,
+                    thread_name=operator_card_thread_name,
+                )
                 await asyncio.to_thread(
                     self._record_discord_response,
                     reply_to=reply_to,
@@ -2889,10 +2955,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 else:  # "first" (default) or "off"
                     chunk_reference = reference if i == 0 else None
                 try:
-                    msg = await channel.send(
-                        content=chunk,
-                        reference=chunk_reference,
-                    )
+                    send_kwargs: Dict[str, Any] = {
+                        "content": chunk,
+                        "reference": chunk_reference,
+                    }
+                    if i == 0 and operator_card_embed is not None:
+                        send_kwargs["embed"] = operator_card_embed
+                    msg = await channel.send(**send_kwargs)
                 except Exception as e:
                     err_text = str(e)
                     if (
@@ -2911,10 +2980,8 @@ class DiscordAdapter(BasePlatformAdapter):
                             reply_to,
                         )
                         reference = None
-                        msg = await channel.send(
-                            content=chunk,
-                            reference=None,
-                        )
+                        send_kwargs["reference"] = None
+                        msg = await channel.send(**send_kwargs)
                     else:
                         raise
                 message_ids.append(str(msg.id))
@@ -2954,7 +3021,14 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             return result
 
-    async def _send_to_forum(self, forum_channel: Any, content: str) -> SendResult:
+    async def _send_to_forum(
+        self,
+        forum_channel: Any,
+        content: str,
+        *,
+        embed: Any = None,
+        thread_name: Optional[str] = None,
+    ) -> SendResult:
         """Create a thread post in a forum channel with the message as starter content.
 
         Forum channels (type 15) don't support direct messages.  Instead we
@@ -2969,15 +3043,18 @@ class DiscordAdapter(BasePlatformAdapter):
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
-        thread_name = _derive_forum_thread_name(content)
+        thread_name = thread_name or _derive_forum_thread_name(content)
 
         starter_content = chunks[0] if chunks else thread_name
 
         try:
-            thread = await forum_channel.create_thread(
-                name=thread_name,
-                content=starter_content,
-            )
+            create_kwargs: Dict[str, Any] = {
+                "name": thread_name,
+                "content": starter_content,
+            }
+            if embed is not None:
+                create_kwargs["embed"] = embed
+            thread = await forum_channel.create_thread(**create_kwargs)
         except Exception as e:
             logger.error("[%s] Failed to create forum thread in %s: %s", self.name, forum_channel.id, e)
             return SendResult(success=False, error=f"Forum thread creation failed: {e}")

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -980,6 +980,61 @@ class DiscordAdapter(BasePlatformAdapter):
 
     # Auto-disconnect from voice channel after this many seconds of inactivity
     VOICE_TIMEOUT = 300
+    _ATTACHMENT_FALLBACK_TERMINAL_KEYS = frozenset(
+        {"notify", "status_key", "status_terminal"}
+    )
+
+    @staticmethod
+    def _attachment_target_id(
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]],
+    ) -> str:
+        """Return the routed Discord destination for an attachment send."""
+        return str((metadata or {}).get("thread_id") or chat_id)
+
+    @classmethod
+    def _attachment_fallback_metadata(
+        cls,
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        """Keep fallback routing without falsely terminalizing a status card."""
+        if not metadata:
+            return None
+        fallback_metadata = {
+            key: value
+            for key, value in metadata.items()
+            if key not in cls._ATTACHMENT_FALLBACK_TERMINAL_KEYS
+        }
+        return fallback_metadata or None
+
+    async def _resolve_attachment_channel(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]],
+    ) -> tuple[Any, str]:
+        target_id = self._attachment_target_id(chat_id, metadata)
+        channel = self._client.get_channel(int(target_id))
+        if not channel:
+            channel = await self._client.fetch_channel(int(target_id))
+        return channel, target_id
+
+    async def _attachment_reply_reference(
+        self,
+        channel: Any,
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> Any:
+        anchor = reply_to or (metadata or {}).get("reply_to_message_id")
+        if not anchor or self._reply_to_mode == "off":
+            return None
+        try:
+            message = await channel.fetch_message(int(anchor))
+            if hasattr(message, "to_reference"):
+                return message.to_reference(fail_if_not_exists=False)
+            return message
+        except Exception as exc:
+            logger.debug("Could not fetch attachment reply target: %s", exc)
+            return None
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.DISCORD)
@@ -4061,6 +4116,8 @@ class DiscordAdapter(BasePlatformAdapter):
         file_path: str,
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a local file as a Discord attachment.
 
@@ -4070,11 +4127,12 @@ class DiscordAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
-        channel = self._client.get_channel(int(chat_id))
+        channel, target_id = await self._resolve_attachment_channel(
+            chat_id,
+            metadata,
+        )
         if not channel:
-            channel = await self._client.fetch_channel(int(chat_id))
-        if not channel:
-            return SendResult(success=False, error=f"Channel {chat_id} not found")
+            return SendResult(success=False, error=f"Channel {target_id} not found")
 
         filename = file_name or os.path.basename(file_path)
         with open(file_path, "rb") as fh:
@@ -4085,7 +4143,18 @@ class DiscordAdapter(BasePlatformAdapter):
                     content=(caption or "").strip(),
                     file=file,
                 )
-            msg = await channel.send(content=caption if caption else None, file=file)
+            send_kwargs: Dict[str, Any] = {
+                "content": caption if caption else None,
+                "file": file,
+            }
+            reference = await self._attachment_reply_reference(
+                channel,
+                reply_to,
+                metadata,
+            )
+            if reference is not None:
+                send_kwargs["reference"] = reference
+            msg = await channel.send(**send_kwargs)
         return SendResult(
             success=True,
             message_id=str(msg.id),
@@ -4119,24 +4188,37 @@ class DiscordAdapter(BasePlatformAdapter):
             from urllib.parse import unquote as _unquote
         except Exception:  # pragma: no cover
             return await super().send_multiple_images(
-                chat_id, images, metadata, human_delay
+                chat_id,
+                images,
+                self._attachment_fallback_metadata(metadata),
+                human_delay,
             )
 
         try:
-            channel = self._client.get_channel(int(chat_id))
+            channel, target_id = await self._resolve_attachment_channel(
+                chat_id,
+                metadata,
+            )
             if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-            if not channel:
-                logger.warning("[%s] Channel %s not found for multi-image send", self.name, chat_id)
+                logger.warning("[%s] Channel %s not found for multi-image send", self.name, target_id)
                 return SendResult(
                     success=False,
-                    error=f"Channel {chat_id} not found",
+                    error=f"Channel {target_id} not found",
                 )
         except Exception as e:
             logger.warning("[%s] Failed to resolve channel for multi-image send: %s", self.name, e)
             return await super().send_multiple_images(
-                chat_id, images, metadata, human_delay
+                chat_id,
+                images,
+                self._attachment_fallback_metadata(metadata),
+                human_delay,
             )
+
+        reference = await self._attachment_reply_reference(
+            channel,
+            None,
+            metadata,
+        )
 
         CHUNK = 10
         chunks = [images[i:i + CHUNK] for i in range(0, len(images), CHUNK)]
@@ -4223,7 +4305,13 @@ class DiscordAdapter(BasePlatformAdapter):
                     delivered_attachment_count += confirmed_count
                     last_message_id = forum_result.message_id
                 else:
-                    message = await channel.send(content=content, files=files)
+                    send_kwargs: Dict[str, Any] = {
+                        "content": content,
+                        "files": files,
+                    }
+                    if reference is not None and chunk_idx == 0:
+                        send_kwargs["reference"] = reference
+                    message = await channel.send(**send_kwargs)
                     delivered_attachment_count += len(files)
                     last_message_id = str(message.id)
             except Exception as e:
@@ -4233,7 +4321,10 @@ class DiscordAdapter(BasePlatformAdapter):
                     exc_info=True,
                 )
                 fallback_result = await super().send_multiple_images(
-                    chat_id, chunk, metadata, human_delay=human_delay
+                    chat_id,
+                    chunk,
+                    self._attachment_fallback_metadata(metadata),
+                    human_delay=human_delay,
                 )
                 if fallback_result.success:
                     delivered_attachment_count += (
@@ -4293,11 +4384,12 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             import io
 
-            channel = self._client.get_channel(int(chat_id))
+            channel, target_id = await self._resolve_attachment_channel(
+                chat_id,
+                metadata,
+            )
             if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-            if not channel:
-                return SendResult(success=False, error=f"Channel {chat_id} not found")
+                return SendResult(success=False, error=f"Channel {target_id} not found")
 
             if not os.path.exists(audio_path):
                 return SendResult(success=False, error=f"Audio file not found: {audio_path}")
@@ -4344,6 +4436,16 @@ class DiscordAdapter(BasePlatformAdapter):
                         "waveform": waveform_b64,
                     }],
                 })
+                reply_anchor = reply_to or (metadata or {}).get(
+                    "reply_to_message_id"
+                )
+                if reply_anchor and self._reply_to_mode != "off":
+                    payload_data = _json.loads(payload)
+                    payload_data["message_reference"] = {
+                        "message_id": str(reply_anchor),
+                        "fail_if_not_exists": False,
+                    }
+                    payload = _json.dumps(payload_data)
                 form = [
                     {"name": "payload_json", "value": payload},
                     {
@@ -4365,7 +4467,15 @@ class DiscordAdapter(BasePlatformAdapter):
             except Exception as voice_err:
                 logger.debug("Voice message flag failed, falling back to file: %s", voice_err)
                 file = discord.File(io.BytesIO(file_data), filename=filename)
-                msg = await channel.send(file=file)
+                send_kwargs: Dict[str, Any] = {"file": file}
+                reference = await self._attachment_reply_reference(
+                    channel,
+                    reply_to,
+                    metadata,
+                )
+                if reference is not None:
+                    send_kwargs["reference"] = reference
+                msg = await channel.send(**send_kwargs)
                 return SendResult(
                     success=True,
                     message_id=str(msg.id),
@@ -4373,7 +4483,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to send audio, falling back to base adapter: %s", self.name, e, exc_info=True)
-            return await super().send_voice(chat_id, audio_path, caption, reply_to, metadata=metadata)
+            return await super().send_voice(
+                chat_id,
+                audio_path,
+                caption,
+                reply_to,
+                metadata=self._attachment_fallback_metadata(metadata),
+            )
 
     # ------------------------------------------------------------------
     # Voice channel methods (join / leave / play)
@@ -5312,12 +5428,24 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a local image file natively as a Discord file attachment."""
         try:
-            return await self._send_file_attachment(chat_id, image_path, caption)
+            return await self._send_file_attachment(
+                chat_id,
+                image_path,
+                caption,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
         except FileNotFoundError:
             return SendResult(success=False, error=f"Image file not found: {image_path}")
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to send local image, falling back to base adapter: %s", self.name, e, exc_info=True)
-            return await super().send_image_file(chat_id, image_path, caption, reply_to, metadata=metadata)
+            return await super().send_image_file(
+                chat_id,
+                image_path,
+                caption,
+                reply_to,
+                metadata=self._attachment_fallback_metadata(metadata),
+            )
 
     async def send_image(
         self,
@@ -5333,16 +5461,23 @@ class DiscordAdapter(BasePlatformAdapter):
 
         if not is_safe_url(image_url):
             logger.warning("[%s] Blocked unsafe image URL during Discord send_image", self.name)
-            return await super().send_image(chat_id, image_url, caption, reply_to, metadata=metadata)
+            return await super().send_image(
+                chat_id,
+                image_url,
+                caption,
+                reply_to,
+                metadata=self._attachment_fallback_metadata(metadata),
+            )
 
         try:
             import aiohttp
 
-            channel = self._client.get_channel(int(chat_id))
+            channel, target_id = await self._resolve_attachment_channel(
+                chat_id,
+                metadata,
+            )
             if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-            if not channel:
-                return SendResult(success=False, error=f"Channel {chat_id} not found")
+                return SendResult(success=False, error=f"Channel {target_id} not found")
 
             # Download the image and send as a Discord file attachment
             # (Discord renders attachments inline, unlike plain URLs)
@@ -5376,10 +5511,18 @@ class DiscordAdapter(BasePlatformAdapter):
                             file=file,
                         )
 
-                    msg = await channel.send(
-                        content=caption if caption else None,
-                        file=file,
+                    send_kwargs: Dict[str, Any] = {
+                        "content": caption if caption else None,
+                        "file": file,
+                    }
+                    reference = await self._attachment_reply_reference(
+                        channel,
+                        reply_to,
+                        metadata,
                     )
+                    if reference is not None:
+                        send_kwargs["reference"] = reference
+                    msg = await channel.send(**send_kwargs)
                     return SendResult(
                         success=True,
                         message_id=str(msg.id),
@@ -5392,7 +5535,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 self.name,
                 exc_info=True,
             )
-            return await super().send_image(chat_id, image_url, caption, reply_to)
+            return await super().send_image(
+                chat_id,
+                image_url,
+                caption,
+                reply_to,
+                metadata=self._attachment_fallback_metadata(metadata),
+            )
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error(
                 "[%s] Failed to send image attachment, falling back to URL: %s",
@@ -5400,7 +5549,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 e,
                 exc_info=True,
             )
-            return await super().send_image(chat_id, image_url, caption, reply_to)
+            return await super().send_image(
+                chat_id,
+                image_url,
+                caption,
+                reply_to,
+                metadata=self._attachment_fallback_metadata(metadata),
+            )
 
     async def send_animation(
         self,
@@ -5416,16 +5571,23 @@ class DiscordAdapter(BasePlatformAdapter):
 
         if not is_safe_url(animation_url):
             logger.warning("[%s] Blocked unsafe animation URL during Discord send_animation", self.name)
-            return await super().send_animation(chat_id, animation_url, caption, reply_to, metadata=metadata)
+            return await super().send_animation(
+                chat_id,
+                animation_url,
+                caption,
+                reply_to,
+                metadata=self._attachment_fallback_metadata(metadata),
+            )
 
         try:
             import aiohttp
 
-            channel = self._client.get_channel(int(chat_id))
+            channel, target_id = await self._resolve_attachment_channel(
+                chat_id,
+                metadata,
+            )
             if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
-            if not channel:
-                return SendResult(success=False, error=f"Channel {chat_id} not found")
+                return SendResult(success=False, error=f"Channel {target_id} not found")
 
             # Download the GIF and send as a Discord file attachment
             # (Discord renders .gif attachments as auto-playing animations inline)
@@ -5449,10 +5611,18 @@ class DiscordAdapter(BasePlatformAdapter):
                             file=file,
                         )
 
-                    msg = await channel.send(
-                        content=caption if caption else None,
-                        file=file,
+                    send_kwargs: Dict[str, Any] = {
+                        "content": caption if caption else None,
+                        "file": file,
+                    }
+                    reference = await self._attachment_reply_reference(
+                        channel,
+                        reply_to,
+                        metadata,
                     )
+                    if reference is not None:
+                        send_kwargs["reference"] = reference
+                    msg = await channel.send(**send_kwargs)
                     return SendResult(
                         success=True,
                         message_id=str(msg.id),
@@ -5465,7 +5635,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 self.name,
                 exc_info=True,
             )
-            return await super().send_animation(chat_id, animation_url, caption, reply_to, metadata=metadata)
+            return await super().send_animation(
+                chat_id,
+                animation_url,
+                caption,
+                reply_to,
+                metadata=self._attachment_fallback_metadata(metadata),
+            )
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error(
                 "[%s] Failed to send animation attachment, falling back to URL: %s",
@@ -5473,7 +5649,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 e,
                 exc_info=True,
             )
-            return await super().send_animation(chat_id, animation_url, caption, reply_to, metadata=metadata)
+            return await super().send_animation(
+                chat_id,
+                animation_url,
+                caption,
+                reply_to,
+                metadata=self._attachment_fallback_metadata(metadata),
+            )
 
     async def send_video(
         self,
@@ -5485,12 +5667,24 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a local video file natively as a Discord attachment."""
         try:
-            return await self._send_file_attachment(chat_id, video_path, caption)
+            return await self._send_file_attachment(
+                chat_id,
+                video_path,
+                caption,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
         except FileNotFoundError:
             return SendResult(success=False, error=f"Video file not found: {video_path}")
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to send local video, falling back to base adapter: %s", self.name, e, exc_info=True)
-            return await super().send_video(chat_id, video_path, caption, reply_to, metadata=metadata)
+            return await super().send_video(
+                chat_id,
+                video_path,
+                caption,
+                reply_to,
+                metadata=self._attachment_fallback_metadata(metadata),
+            )
 
     async def send_document(
         self,
@@ -5503,12 +5697,26 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send an arbitrary file natively as a Discord attachment."""
         try:
-            return await self._send_file_attachment(chat_id, file_path, caption, file_name=file_name)
+            return await self._send_file_attachment(
+                chat_id,
+                file_path,
+                caption,
+                file_name=file_name,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
         except FileNotFoundError:
             return SendResult(success=False, error=f"File not found: {file_path}")
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to send document, falling back to base adapter: %s", self.name, e, exc_info=True)
-            return await super().send_document(chat_id, file_path, caption, file_name, reply_to, metadata=metadata)
+            return await super().send_document(
+                chat_id,
+                file_path,
+                caption,
+                file_name,
+                reply_to,
+                metadata=self._attachment_fallback_metadata(metadata),
+            )
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Start a persistent typing indicator for a channel.

--- a/plugins/platforms/discord/workspace_headers.py
+++ b/plugins/platforms/discord/workspace_headers.py
@@ -1,0 +1,522 @@
+"""Persistent identity and safe backfill planning for Discord workspaces.
+
+A Discord thread is the user-visible workspace. Header identity and the small
+workspace context map are profile-local and partitioned first by canonical
+Discord guild ``SessionSource.scope_id`` and then by thread id. Registry reads
+fail closed, and every read-modify-write transaction holds both an in-process
+lock and an OS file lock so gateway and backfill processes cannot lose each
+other's bindings.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Optional
+
+from utils import atomic_json_write
+
+if os.name == "nt":
+    import msvcrt
+else:
+    import fcntl
+
+
+_STATE_VERSION = 1
+_STATE_FILENAME = "discord_workspace_headers.json"
+_KNOWN_HERMES_PLACEHOLDER_TITLES = frozenset(
+    {"hermes", "hermes chat", "new post"}
+)
+_LOCAL_LOCKS_GUARD = threading.Lock()
+_LOCAL_LOCKS: dict[str, threading.RLock] = {}
+
+
+class WorkspaceHeaderStoreError(RuntimeError):
+    """Raised when registry identity cannot be read or safely persisted."""
+
+
+def _clean_id(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _clean_workspace_text(value: Any, field_name: str) -> str:
+    text = " ".join(str(value or "").split())
+    if not text:
+        raise ValueError(f"{field_name} must be non-empty")
+    if len(text) > 1024:
+        raise ValueError(f"{field_name} exceeds the 1024-character limit")
+    return text
+
+
+def _thread_scope_id(thread: Any) -> str:
+    guild = getattr(thread, "guild", None)
+    return _clean_id(getattr(guild, "id", None))
+
+
+def is_known_hermes_placeholder_title(title: Any) -> bool:
+    """Return whether a title is one of Hermes' exact generic placeholders."""
+    normalized = " ".join(str(title or "").split()).casefold()
+    return normalized in _KNOWN_HERMES_PLACEHOLDER_TITLES
+
+
+def _local_registry_lock(path: Path) -> threading.RLock:
+    key = str(path.resolve())
+    with _LOCAL_LOCKS_GUARD:
+        return _LOCAL_LOCKS.setdefault(key, threading.RLock())
+
+
+@contextmanager
+def _exclusive_registry_lock(path: Path) -> Iterator[None]:
+    """Hold a blocking cross-process lock for one registry transaction."""
+    lock_path = path.with_name(f".{path.name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with _local_registry_lock(lock_path):
+        with lock_path.open("a+b") as handle:
+            if os.name == "nt":
+                handle.seek(0, os.SEEK_END)
+                if handle.tell() == 0:
+                    handle.write(b"\0")
+                    handle.flush()
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                if os.name == "nt":
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceHeaderState:
+    owner: str = "Hermes"
+    status: str = "Active"
+    linked_issue_or_artifact: str = "Not linked"
+    last_decision: str = "No decision recorded"
+    next_action: str = "Awaiting next assistant turn"
+
+    @classmethod
+    def from_mapping(cls, payload: Any) -> "WorkspaceHeaderState":
+        if payload is None:
+            return cls()
+        if not isinstance(payload, dict):
+            raise WorkspaceHeaderStoreError("workspace state must be an object")
+        unknown = set(payload) - {
+            "owner",
+            "status",
+            "linked_issue_or_artifact",
+            "last_decision",
+            "next_action",
+        }
+        if unknown:
+            raise WorkspaceHeaderStoreError(
+                "workspace state has unknown fields: " + ", ".join(sorted(unknown))
+            )
+        defaults = cls()
+        try:
+            return cls(
+                owner=_clean_workspace_text(payload.get("owner", defaults.owner), "owner"),
+                status=_clean_workspace_text(payload.get("status", defaults.status), "status"),
+                linked_issue_or_artifact=_clean_workspace_text(
+                    payload.get(
+                        "linked_issue_or_artifact",
+                        defaults.linked_issue_or_artifact,
+                    ),
+                    "linked_issue_or_artifact",
+                ),
+                last_decision=_clean_workspace_text(
+                    payload.get("last_decision", defaults.last_decision),
+                    "last_decision",
+                ),
+                next_action=_clean_workspace_text(
+                    payload.get("next_action", defaults.next_action),
+                    "next_action",
+                ),
+            )
+        except ValueError as error:
+            raise WorkspaceHeaderStoreError(str(error)) from error
+
+    def to_mapping(self) -> dict[str, str]:
+        return {
+            "owner": self.owner,
+            "status": self.status,
+            "linked_issue_or_artifact": self.linked_issue_or_artifact,
+            "last_decision": self.last_decision,
+            "next_action": self.next_action,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceHeaderBinding:
+    scope_id: str
+    thread_id: str
+    message_id: Optional[str]
+    pending: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceHeaderResult:
+    success: bool
+    action: str
+    message_id: Optional[str] = None
+    error: Optional[str] = None
+
+
+_WorkspaceRecord = dict[str, Any]
+_WorkspaceRegistry = dict[str, dict[str, _WorkspaceRecord]]
+
+
+class WorkspaceHeaderStore:
+    """Locked atomic registry for header identity and tiny workspace state."""
+
+    def __init__(self, path: Optional[Path] = None):
+        if path is None:
+            from hermes_constants import get_hermes_home
+
+            path = get_hermes_home() / "gateway" / _STATE_FILENAME
+        self.path = Path(path)
+
+    @staticmethod
+    def _default_record() -> _WorkspaceRecord:
+        return {
+            "message_id": None,
+            "pending_token": None,
+            "state": WorkspaceHeaderState().to_mapping(),
+        }
+
+    def _read_unlocked(self) -> _WorkspaceRegistry:
+        if not self.path.exists():
+            return {}
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except Exception as error:
+            raise WorkspaceHeaderStoreError(
+                f"workspace header registry is unreadable: {type(error).__name__}"
+            ) from error
+        if not isinstance(payload, dict):
+            raise WorkspaceHeaderStoreError("workspace header registry must be an object")
+        if payload.get("version") != _STATE_VERSION:
+            raise WorkspaceHeaderStoreError("workspace header registry version is unsupported")
+        raw_workspaces = payload.get("workspaces")
+        if not isinstance(raw_workspaces, dict):
+            raise WorkspaceHeaderStoreError("workspace header registry has invalid workspaces")
+
+        workspaces: _WorkspaceRegistry = {}
+        for raw_scope_id, raw_threads in raw_workspaces.items():
+            scope_id = _clean_id(raw_scope_id)
+            if not scope_id or not isinstance(raw_threads, dict):
+                raise WorkspaceHeaderStoreError("workspace header registry has invalid scope")
+            threads: dict[str, _WorkspaceRecord] = {}
+            for raw_thread_id, raw_record in raw_threads.items():
+                thread_id = _clean_id(raw_thread_id)
+                if not thread_id:
+                    raise WorkspaceHeaderStoreError("workspace header registry has invalid thread id")
+                # Accept the initial message-id-only shape written by early
+                # OE-178 builds, but always rewrite it in the richer shape.
+                if isinstance(raw_record, str):
+                    message_id = _clean_id(raw_record)
+                    if not message_id:
+                        raise WorkspaceHeaderStoreError(
+                            "workspace header registry has an empty message id"
+                        )
+                    record = self._default_record()
+                    record["message_id"] = message_id
+                elif isinstance(raw_record, dict):
+                    unknown = set(raw_record) - {
+                        "message_id",
+                        "pending_token",
+                        "state",
+                    }
+                    if unknown:
+                        raise WorkspaceHeaderStoreError(
+                            "workspace header registry record has unknown fields"
+                        )
+                    message_id = _clean_id(raw_record.get("message_id")) or None
+                    pending_token = _clean_id(raw_record.get("pending_token")) or None
+                    if message_id and pending_token:
+                        raise WorkspaceHeaderStoreError(
+                            "workspace header registry record has conflicting identity"
+                        )
+                    state = WorkspaceHeaderState.from_mapping(
+                        raw_record.get("state")
+                    )
+                    record = {
+                        "message_id": message_id,
+                        "pending_token": pending_token,
+                        "state": state.to_mapping(),
+                    }
+                else:
+                    raise WorkspaceHeaderStoreError(
+                        "workspace header registry record must be an object"
+                    )
+                threads[thread_id] = record
+            if threads:
+                workspaces[scope_id] = threads
+        return workspaces
+
+    def _write_unlocked(self, workspaces: _WorkspaceRegistry) -> None:
+        try:
+            atomic_json_write(
+                self.path,
+                {"version": _STATE_VERSION, "workspaces": workspaces},
+                indent=2,
+            )
+        except Exception as error:
+            raise WorkspaceHeaderStoreError(
+                f"workspace header registry write failed: {type(error).__name__}"
+            ) from error
+
+    @staticmethod
+    def _keys(scope_id: Any, thread_id: Any) -> tuple[str, str]:
+        scope_key = _clean_id(scope_id)
+        thread_key = _clean_id(thread_id)
+        if not scope_key or not thread_key:
+            raise ValueError("scope_id and thread_id are required")
+        return scope_key, thread_key
+
+    @staticmethod
+    def _record(
+        workspaces: _WorkspaceRegistry,
+        scope_key: str,
+        thread_key: str,
+    ) -> Optional[_WorkspaceRecord]:
+        return workspaces.get(scope_key, {}).get(thread_key)
+
+    def get(self, scope_id: Any, thread_id: Any) -> Optional[WorkspaceHeaderBinding]:
+        scope_key, thread_key = self._keys(scope_id, thread_id)
+        with _exclusive_registry_lock(self.path):
+            record = self._record(self._read_unlocked(), scope_key, thread_key)
+        if record is None:
+            return None
+        message_id = record.get("message_id")
+        pending = bool(record.get("pending_token"))
+        if not message_id and not pending:
+            return None
+        return WorkspaceHeaderBinding(scope_key, thread_key, message_id, pending)
+
+    def get_state(
+        self, scope_id: Any, thread_id: Any
+    ) -> Optional[WorkspaceHeaderState]:
+        scope_key, thread_key = self._keys(scope_id, thread_id)
+        with _exclusive_registry_lock(self.path):
+            record = self._record(self._read_unlocked(), scope_key, thread_key)
+        if record is None:
+            return None
+        return WorkspaceHeaderState.from_mapping(record.get("state"))
+
+    def put(
+        self, scope_id: Any, thread_id: Any, message_id: Any
+    ) -> WorkspaceHeaderBinding:
+        scope_key, thread_key = self._keys(scope_id, thread_id)
+        message_key = _clean_id(message_id)
+        if not message_key:
+            raise ValueError("message_id is required")
+        with _exclusive_registry_lock(self.path):
+            workspaces = self._read_unlocked()
+            record = self._record(workspaces, scope_key, thread_key)
+            if record is None:
+                record = self._default_record()
+                workspaces.setdefault(scope_key, {})[thread_key] = record
+            record["message_id"] = message_key
+            record["pending_token"] = None
+            self._write_unlocked(workspaces)
+        return WorkspaceHeaderBinding(scope_key, thread_key, message_key)
+
+    def update_state(
+        self,
+        scope_id: Any,
+        thread_id: Any,
+        *,
+        owner: Any = None,
+        status: Any = None,
+        linked_issue_or_artifact: Any = None,
+        last_decision: Any = None,
+        next_action: Any = None,
+    ) -> WorkspaceHeaderState:
+        scope_key, thread_key = self._keys(scope_id, thread_id)
+        with _exclusive_registry_lock(self.path):
+            workspaces = self._read_unlocked()
+            record = self._record(workspaces, scope_key, thread_key)
+            if record is None:
+                record = self._default_record()
+                workspaces.setdefault(scope_key, {})[thread_key] = record
+            current = WorkspaceHeaderState.from_mapping(record.get("state"))
+            changes = {
+                "owner": current.owner if owner is None else owner,
+                "status": current.status if status is None else status,
+                "linked_issue_or_artifact": (
+                    current.linked_issue_or_artifact
+                    if linked_issue_or_artifact is None
+                    else linked_issue_or_artifact
+                ),
+                "last_decision": (
+                    current.last_decision if last_decision is None else last_decision
+                ),
+                "next_action": current.next_action if next_action is None else next_action,
+            }
+            state = WorkspaceHeaderState.from_mapping(changes)
+            record["state"] = state.to_mapping()
+            self._write_unlocked(workspaces)
+        return state
+
+    def reserve_creation(
+        self,
+        scope_id: Any,
+        thread_id: Any,
+        *,
+        token: Any,
+        expected_message_id: Any = None,
+    ) -> bool:
+        """Reserve one create/recreate before Discord receives a send."""
+        scope_key, thread_key = self._keys(scope_id, thread_id)
+        token_key = _clean_id(token)
+        expected_key = _clean_id(expected_message_id) or None
+        if not token_key:
+            raise ValueError("reservation token is required")
+        with _exclusive_registry_lock(self.path):
+            workspaces = self._read_unlocked()
+            record = self._record(workspaces, scope_key, thread_key)
+            if record is None:
+                if expected_key is not None:
+                    return False
+                record = self._default_record()
+                workspaces.setdefault(scope_key, {})[thread_key] = record
+            current_message_id = record.get("message_id")
+            if record.get("pending_token") or current_message_id != expected_key:
+                return False
+            record["message_id"] = None
+            record["pending_token"] = token_key
+            self._write_unlocked(workspaces)
+        return True
+
+    def complete_creation(
+        self,
+        scope_id: Any,
+        thread_id: Any,
+        *,
+        token: Any,
+        message_id: Any,
+    ) -> WorkspaceHeaderBinding:
+        scope_key, thread_key = self._keys(scope_id, thread_id)
+        token_key = _clean_id(token)
+        message_key = _clean_id(message_id)
+        if not token_key or not message_key:
+            raise ValueError("reservation token and message_id are required")
+        with _exclusive_registry_lock(self.path):
+            workspaces = self._read_unlocked()
+            record = self._record(workspaces, scope_key, thread_key)
+            if record is None or record.get("pending_token") != token_key:
+                raise WorkspaceHeaderStoreError(
+                    "workspace header creation reservation was lost"
+                )
+            record["message_id"] = message_key
+            record["pending_token"] = None
+            self._write_unlocked(workspaces)
+        return WorkspaceHeaderBinding(scope_key, thread_key, message_key)
+
+    def cancel_creation(
+        self, scope_id: Any, thread_id: Any, *, token: Any
+    ) -> bool:
+        scope_key, thread_key = self._keys(scope_id, thread_id)
+        token_key = _clean_id(token)
+        with _exclusive_registry_lock(self.path):
+            workspaces = self._read_unlocked()
+            record = self._record(workspaces, scope_key, thread_key)
+            if record is None or record.get("pending_token") != token_key:
+                return False
+            record["pending_token"] = None
+            self._write_unlocked(workspaces)
+        return True
+
+    def remove(self, scope_id: Any, thread_id: Any) -> None:
+        scope_key, thread_key = self._keys(scope_id, thread_id)
+        with _exclusive_registry_lock(self.path):
+            workspaces = self._read_unlocked()
+            threads = workspaces.get(scope_key)
+            if not threads or thread_key not in threads:
+                return
+            del threads[thread_key]
+            if not threads:
+                workspaces.pop(scope_key, None)
+            self._write_unlocked(workspaces)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceHeaderCandidate:
+    scope_id: str
+    thread_id: str
+    observed_title: str
+    reasons: tuple[str, ...]
+    proposed_title: None = None
+
+
+def collect_workspace_header_candidates(
+    threads: Iterable[Any],
+    *,
+    participated_thread_ids: Iterable[Any],
+    store: WorkspaceHeaderStore,
+) -> list[WorkspaceHeaderCandidate]:
+    """Plan only known Hermes workspaces; never propose a title mutation."""
+    participated = {_clean_id(value) for value in participated_thread_ids}
+    candidates: list[WorkspaceHeaderCandidate] = []
+    for thread in threads:
+        thread_id = _clean_id(getattr(thread, "id", None))
+        scope_id = _thread_scope_id(thread)
+        if not thread_id or not scope_id or thread_id not in participated:
+            continue
+        title = " ".join(str(getattr(thread, "name", "") or "").split())
+        reasons: list[str] = []
+        if is_known_hermes_placeholder_title(title):
+            reasons.append("placeholder_title")
+        if store.get(scope_id, thread_id) is None:
+            reasons.append("header_missing")
+        if reasons:
+            candidates.append(
+                WorkspaceHeaderCandidate(
+                    scope_id=scope_id,
+                    thread_id=thread_id,
+                    observed_title=title,
+                    reasons=tuple(reasons),
+                )
+            )
+    candidates.sort(key=lambda item: (item.scope_id, item.thread_id))
+    return candidates
+
+
+def revalidate_workspace_header_candidate(
+    candidate: WorkspaceHeaderCandidate,
+    *,
+    live_thread: Any,
+    participated_thread_ids: Iterable[Any],
+    store: WorkspaceHeaderStore,
+) -> bool:
+    """Fail closed if any live fact changed since the dry-run observation."""
+    thread_id = _clean_id(getattr(live_thread, "id", None))
+    scope_id = _thread_scope_id(live_thread)
+    live_title = " ".join(str(getattr(live_thread, "name", "") or "").split())
+    participated = {_clean_id(value) for value in participated_thread_ids}
+    if (
+        thread_id != candidate.thread_id
+        or scope_id != candidate.scope_id
+        or thread_id not in participated
+        or live_title != candidate.observed_title
+    ):
+        return False
+    if "placeholder_title" in candidate.reasons and not is_known_hermes_placeholder_title(
+        live_title
+    ):
+        return False
+    if (
+        "header_missing" in candidate.reasons
+        and store.get(scope_id, thread_id) is not None
+    ):
+        return False
+    return True

--- a/scripts/backfill_discord_workspace_headers.py
+++ b/scripts/backfill_discord_workspace_headers.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Safely backfill persistent headers for known Hermes Discord workspaces.
+
+The default is a read-only dry run. ``--apply`` is required for message
+creation/editing, and every planned candidate is re-fetched and revalidated
+immediately before that write. This script never renames threads.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from typing import Any
+
+from gateway.config import Platform, load_gateway_config
+from gateway.session import SessionSource
+from hermes_constants import get_hermes_home
+from plugins.platforms.discord.adapter import DiscordAdapter, discord
+from plugins.platforms.discord.workspace_headers import (
+    WorkspaceHeaderStore,
+    collect_workspace_header_candidates,
+    revalidate_workspace_header_candidate,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Plan or apply Discord workspace-header backfill."
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Create/edit headers after live revalidation (default: dry run).",
+    )
+    parser.add_argument(
+        "--guild-id",
+        action="append",
+        default=[],
+        help="Limit reads/writes to this Discord guild id (repeatable).",
+    )
+    return parser
+
+
+def _load_participated_thread_ids() -> set[str]:
+    path = get_hermes_home() / "discord_threads.json"
+    if not path.exists():
+        return set()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return set()
+    if not isinstance(payload, list):
+        return set()
+    return {str(value) for value in payload if str(value).strip()}
+
+
+def _active_threads(client: Any, allowed_guild_ids: set[str]) -> list[Any]:
+    threads: list[Any] = []
+    for guild in list(getattr(client, "guilds", []) or []):
+        guild_id = str(getattr(guild, "id", "") or "")
+        if allowed_guild_ids and guild_id not in allowed_guild_ids:
+            continue
+        threads.extend(list(getattr(guild, "threads", []) or []))
+    return threads
+
+
+async def _run(args: argparse.Namespace) -> int:
+    config = load_gateway_config()
+    discord_config = config.platforms.get(Platform.DISCORD)
+    token = str(getattr(discord_config, "token", "") or "").strip()
+    if discord_config is None or not token:
+        print(json.dumps({"ok": False, "error": "Discord is not configured"}))
+        return 2
+
+    intents = getattr(discord, "Intents").none()
+    intents.guilds = True
+    client = getattr(discord, "Client")(intents=intents)
+    store = WorkspaceHeaderStore()
+    adapter = DiscordAdapter(discord_config)
+    adapter._client = client
+    allowed_guild_ids = {str(value) for value in args.guild_id}
+    outcome: dict[str, Any] = {
+        "mode": "apply" if args.apply else "dry-run",
+        "candidates": [],
+        "results": [],
+    }
+
+    @client.event
+    async def on_ready() -> None:
+        participated = _load_participated_thread_ids()
+        candidates = collect_workspace_header_candidates(
+            _active_threads(client, allowed_guild_ids),
+            participated_thread_ids=participated,
+            store=store,
+        )
+        outcome["candidates"] = [
+            {
+                "scope_id": candidate.scope_id,
+                "thread_id": candidate.thread_id,
+                "observed_title": candidate.observed_title,
+                "reasons": list(candidate.reasons),
+                "proposed_title": candidate.proposed_title,
+            }
+            for candidate in candidates
+        ]
+
+        if args.apply:
+            for candidate in candidates:
+                try:
+                    live_thread = client.get_channel(int(candidate.thread_id))
+                    if live_thread is None:
+                        live_thread = await client.fetch_channel(
+                            int(candidate.thread_id)
+                        )
+                except Exception as error:
+                    outcome["results"].append(
+                        {
+                            "thread_id": candidate.thread_id,
+                            "action": "skipped",
+                            "error": f"live fetch failed: {type(error).__name__}",
+                        }
+                    )
+                    continue
+
+                participated_now = _load_participated_thread_ids()
+                if not revalidate_workspace_header_candidate(
+                    candidate,
+                    live_thread=live_thread,
+                    participated_thread_ids=participated_now,
+                    store=store,
+                ):
+                    outcome["results"].append(
+                        {
+                            "thread_id": candidate.thread_id,
+                            "action": "skipped",
+                            "error": "live state changed after planning",
+                        }
+                    )
+                    continue
+
+                source = SessionSource(
+                    platform=Platform.DISCORD,
+                    chat_id=candidate.thread_id,
+                    chat_name=candidate.observed_title,
+                    chat_type="thread",
+                    thread_id=candidate.thread_id,
+                    scope_id=candidate.scope_id,
+                    parent_chat_id=(
+                        str(getattr(live_thread, "parent_id", "") or "") or None
+                    ),
+                )
+                result = await adapter.ensure_workspace_header(source)
+                outcome["results"].append(
+                    {
+                        "thread_id": candidate.thread_id,
+                        "action": result.action,
+                        "success": result.success,
+                        "message_id": result.message_id,
+                        "error": result.error,
+                    }
+                )
+
+        await client.close()
+
+    try:
+        await client.start(token, reconnect=False)
+    finally:
+        if not client.is_closed():
+            await client.close()
+
+    outcome["ok"] = True
+    outcome["candidate_count"] = len(outcome["candidates"])
+    print(json.dumps(outcome, indent=2, sort_keys=True))
+    return 0
+
+
+def main() -> int:
+    return asyncio.run(_run(build_parser().parse_args()))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/gateway/test_discord_operator_cards_real.py
+++ b/tests/gateway/test_discord_operator_cards_real.py
@@ -1,0 +1,60 @@
+"""Integration coverage for operator cards with the real discord.py types."""
+
+import importlib
+import sys
+
+from gateway.operator_cards import OperatorCard
+
+
+def _load_real_discord_adapter():
+    """Replace the gateway test shim with the installed discord.py package."""
+    for module_name in tuple(sys.modules):
+        if module_name == "discord" or module_name.startswith("discord."):
+            sys.modules.pop(module_name)
+    sys.modules.pop("plugins.platforms.discord.adapter", None)
+    discord_module = importlib.import_module("discord")
+    adapter_module = importlib.import_module("plugins.platforms.discord.adapter")
+    return discord_module, adapter_module
+
+
+def test_operator_card_serializes_through_real_discord_embed():
+    discord_module, adapter_module = _load_real_discord_adapter()
+    card = OperatorCard.from_mapping(
+        {
+            "kind": "operator_card",
+            "version": 1,
+            "card_type": "approval",
+            "title": "Approve source sync",
+            "severity": "needs_review",
+            "summary": "A second source is ready to normalize.",
+            "fields": [{"label": "Issue", "value": "OE-222"}],
+            "actions": [
+                {"id": "approve", "label": "Approve", "style": "success"}
+            ],
+            "links": [
+                {
+                    "label": "Open issue",
+                    "url": "https://linear.app/example/issue/OE-222",
+                }
+            ],
+            "state_ref": "oe-222:approval:1",
+        }
+    )
+
+    embed = adapter_module._build_operator_card_embed(card)
+    serialized = embed.to_dict()
+
+    assert isinstance(embed, discord_module.Embed)
+    assert serialized["title"] == "Approve source sync"
+    assert serialized["description"] == "A second source is ready to normalize."
+    assert serialized["fields"] == [
+        {"inline": False, "name": "Issue", "value": "OE-222"},
+        {"inline": False, "name": "Actions", "value": "Approve"},
+        {
+            "inline": False,
+            "name": "Links",
+            "value": "[Open issue](https://linear.app/example/issue/OE-222)",
+        },
+    ]
+    assert serialized["footer"]["text"] == "Approval · Needs review"
+    assert serialized["color"] == 0xF1C40F

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -281,6 +281,49 @@ async def test_send_operator_card_creates_forum_thread_with_embed(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_send_operator_card_forum_chunks_preserve_maximum_length_url(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    thread_channel = SimpleNamespace(
+        id=889,
+        send=AsyncMock(return_value=SimpleNamespace(id=7004)),
+    )
+    thread = SimpleNamespace(
+        id=889,
+        message=SimpleNamespace(id=7003),
+        thread=thread_channel,
+    )
+    forum_channel = _discord_mod.ForumChannel()
+    forum_channel.id = 999
+    forum_channel.create_thread = AsyncMock(return_value=thread)
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: forum_channel,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(_discord_mod, "Embed", _FakeEmbed)
+
+    payload = _operator_card_payload()
+    payload["fields"] = [
+        {"label": f"Field {index}", "value": str(index) * 1024}
+        for index in range(3)
+    ]
+    url_prefix = "https://example.com/"
+    trailing_url = url_prefix + "u" * (2048 - len(url_prefix))
+    payload["links"] = [{"label": "Trailing link", "url": trailing_url}]
+
+    result = await adapter.send(
+        "999",
+        "ignored",
+        metadata={"operator_card": payload},
+    )
+
+    assert result.success is True
+    sent_chunks = [forum_channel.create_thread.await_args.kwargs["content"]]
+    sent_chunks.extend(call.kwargs["content"] for call in thread_channel.send.await_args_list)
+    assert all(len(chunk) <= adapter.MAX_MESSAGE_LENGTH for chunk in sent_chunks)
+    assert trailing_url in "".join(sent_chunks)
+
+
+@pytest.mark.asyncio
 async def test_send_rejects_invalid_operator_card_without_platform_write():
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
     channel = SimpleNamespace(send=AsyncMock())
@@ -366,7 +409,8 @@ async def test_send_chunks_full_operator_card_fallback_without_losing_trailing_l
         {"label": f"Field {index}", "value": str(index) * 1024}
         for index in range(3)
     ]
-    trailing_url = "https://example.com/operator-card-tail"
+    url_prefix = "https://example.com/"
+    trailing_url = url_prefix + "u" * (2048 - len(url_prefix))
     payload["links"] = [{"label": "Trailing link", "url": trailing_url}]
 
     result = await adapter.send(

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -161,6 +161,145 @@ async def test_send_does_not_retry_on_unrelated_errors():
 
 
 # ---------------------------------------------------------------------------
+# Operator card rendering
+# ---------------------------------------------------------------------------
+
+
+def _operator_card_payload():
+    return {
+        "kind": "operator_card",
+        "version": 1,
+        "card_type": "approval",
+        "title": "Approve source sync",
+        "severity": "needs_review",
+        "summary": "A second source is ready to normalize.",
+        "fields": [{"label": "Issue", "value": "OE-222"}],
+        "actions": [{"id": "approve", "label": "Approve", "style": "success"}],
+        "links": [{"label": "Open issue", "url": "https://linear.app/example/issue/OE-222"}],
+        "state_ref": "oe-222:approval:1",
+    }
+
+
+class _FakeEmbed:
+    def __init__(self, *, title, description, color):
+        self.title = title
+        self.description = description
+        self.color = color
+        self.fields = []
+        self.footer = None
+
+    def add_field(self, *, name, value, inline):
+        self.fields.append({"name": name, "value": value, "inline": inline})
+
+    def set_footer(self, *, text):
+        self.footer = text
+
+
+@pytest.mark.asyncio
+async def test_send_renders_valid_operator_card_as_embed_with_text_fallback(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    channel = SimpleNamespace(
+        send=AsyncMock(return_value=SimpleNamespace(id=7001)),
+        fetch_message=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(_discord_mod, "Embed", _FakeEmbed)
+
+    result = await adapter.send(
+        "555",
+        "untrusted presentation text",
+        metadata={"operator_card": _operator_card_payload()},
+    )
+
+    assert result.success is True
+    kwargs = channel.send.await_args.kwargs
+    assert kwargs["content"].startswith("🟡 **Needs review — Approve source sync**")
+    assert len(kwargs["content"]) <= adapter.MAX_MESSAGE_LENGTH
+    assert kwargs["embed"].title == "Approve source sync"
+    assert kwargs["embed"].description == "A second source is ready to normalize."
+    assert kwargs["embed"].fields[0] == {"name": "Issue", "value": "OE-222", "inline": False}
+    assert kwargs["embed"].footer == "Approval · Needs review"
+
+
+@pytest.mark.asyncio
+async def test_send_operator_card_targets_requested_thread(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    parent = SimpleNamespace(send=AsyncMock())
+    thread = SimpleNamespace(
+        send=AsyncMock(return_value=SimpleNamespace(id=7002)),
+        fetch_message=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda channel_id: thread if channel_id == 777 else parent,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(_discord_mod, "Embed", _FakeEmbed)
+
+    result = await adapter.send(
+        "555",
+        "ignored",
+        metadata={"thread_id": "777", "operator_card": _operator_card_payload()},
+    )
+
+    assert result.success is True
+    assert thread.send.await_count == 1
+    assert parent.send.await_count == 0
+    assert isinstance(thread.send.await_args.kwargs["embed"], _FakeEmbed)
+
+
+@pytest.mark.asyncio
+async def test_send_operator_card_creates_forum_thread_with_embed(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    thread_channel = SimpleNamespace(id=888, send=AsyncMock())
+    thread = SimpleNamespace(id=888, message=SimpleNamespace(id=7003), thread=thread_channel)
+    forum_channel = _discord_mod.ForumChannel()
+    forum_channel.id = 999
+    forum_channel.create_thread = AsyncMock(return_value=thread)
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: forum_channel,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(_discord_mod, "Embed", _FakeEmbed)
+
+    result = await adapter.send(
+        "999",
+        "ignored",
+        metadata={"operator_card": _operator_card_payload()},
+    )
+
+    assert result.success is True
+    kwargs = forum_channel.create_thread.await_args.kwargs
+    assert kwargs["name"] == "Needs review — Approve source sync"
+    assert isinstance(kwargs["embed"], _FakeEmbed)
+    assert len(kwargs["content"]) <= adapter.MAX_MESSAGE_LENGTH
+
+
+@pytest.mark.asyncio
+async def test_send_rejects_invalid_operator_card_without_platform_write():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    channel = SimpleNamespace(send=AsyncMock())
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    payload = _operator_card_payload()
+    payload["unexpected"] = "fail closed"
+
+    result = await adapter.send(
+        "555",
+        "must not be sent",
+        metadata={"operator_card": payload},
+    )
+
+    assert result.success is False
+    assert "unknown fields" in (result.error or "")
+    assert channel.send.await_count == 0
+
+
+# ---------------------------------------------------------------------------
 # Forum channel tests
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -42,7 +42,10 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
-from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+from plugins.platforms.discord.adapter import (  # noqa: E402
+    DiscordAdapter,
+    _derive_forum_thread_name,
+)
 
 
 @pytest.mark.asyncio
@@ -329,7 +332,8 @@ async def test_send_bounds_contract_valid_but_oversized_card_to_discord_limits(m
 
     # The card is delivered (safe fallback), not dropped by a Discord 400.
     assert result.success is True
-    embed = channel.send.await_args.kwargs["embed"]
+    first_send = channel.send.await_args_list[0]
+    embed = first_send.kwargs["embed"]
     # Per-field invariants.
     assert all(len(field["value"]) <= 1024 for field in embed.fields)
     assert all(0 < len(field["name"]) <= 256 for field in embed.fields)
@@ -338,7 +342,46 @@ async def test_send_bounds_contract_valid_but_oversized_card_to_discord_limits(m
     total += sum(len(field["name"]) + len(field["value"]) for field in embed.fields)
     assert total <= 6000
     # The full card still reaches the operator via the plaintext content.
-    assert channel.send.await_args.kwargs["content"].startswith("🟡")
+    assert first_send.kwargs["content"].startswith("🟡")
+    assert "https://example.com/" in "".join(
+        call.kwargs["content"] for call in channel.send.await_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_chunks_full_operator_card_fallback_without_losing_trailing_links(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    channel = SimpleNamespace(
+        send=AsyncMock(return_value=SimpleNamespace(id=7010)),
+        fetch_message=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(_discord_mod, "Embed", _FakeEmbed)
+
+    payload = _operator_card_payload()
+    payload["fields"] = [
+        {"label": f"Field {index}", "value": str(index) * 1024}
+        for index in range(3)
+    ]
+    trailing_url = "https://example.com/operator-card-tail"
+    payload["links"] = [{"label": "Trailing link", "url": trailing_url}]
+
+    result = await adapter.send(
+        "555",
+        "ignored",
+        metadata={"operator_card": payload},
+    )
+
+    assert result.success is True
+    assert channel.send.await_count >= 2
+    sent_chunks = [call.kwargs["content"] for call in channel.send.await_args_list]
+    assert all(len(chunk) <= adapter.MAX_MESSAGE_LENGTH for chunk in sent_chunks)
+    assert trailing_url in "".join(sent_chunks)
+    assert "embed" in channel.send.await_args_list[0].kwargs
+    assert all("embed" not in call.kwargs for call in channel.send.await_args_list[1:])
 
 
 # ---------------------------------------------------------------------------
@@ -404,6 +447,15 @@ async def test_send_to_forum_creates_thread_post():
     assert result.success is True
     assert result.message_id == "500"
     forum_channel.create_thread.assert_awaited_once()
+
+
+def test_forum_thread_name_obeys_discord_utf16_limit_for_astral_text():
+    title = "🚀" * 60
+
+    thread_name = _derive_forum_thread_name(title)
+
+    assert thread_name == "🚀" * 50
+    assert len(thread_name.encode("utf-16-le")) // 2 <= 100
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -299,6 +299,48 @@ async def test_send_rejects_invalid_operator_card_without_platform_write():
     assert channel.send.await_count == 0
 
 
+@pytest.mark.asyncio
+async def test_send_bounds_contract_valid_but_oversized_card_to_discord_limits(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    channel = SimpleNamespace(
+        send=AsyncMock(return_value=SimpleNamespace(id=7009)),
+        fetch_message=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    monkeypatch.setattr(_discord_mod, "Embed", _FakeEmbed)
+
+    # Every part below is within the operator-card contract, yet the embed it
+    # would naively produce blows past Discord's 1024 per-field and 6000
+    # aggregate ceilings (12 fields at the field limit + a wide link block).
+    payload = _operator_card_payload()
+    payload["fields"] = [{"label": f"Field {i}", "value": "x" * 1024} for i in range(12)]
+    payload["links"] = [
+        {"label": "L" * 80, "url": "https://example.com/" + "y" * 2000} for _ in range(5)
+    ]
+
+    result = await adapter.send(
+        "555",
+        "ignored",
+        metadata={"operator_card": payload},
+    )
+
+    # The card is delivered (safe fallback), not dropped by a Discord 400.
+    assert result.success is True
+    embed = channel.send.await_args.kwargs["embed"]
+    # Per-field invariants.
+    assert all(len(field["value"]) <= 1024 for field in embed.fields)
+    assert all(0 < len(field["name"]) <= 256 for field in embed.fields)
+    # Aggregate invariant: whole embed stays within the 6000 budget.
+    total = len(embed.title) + len(embed.description) + len(embed.footer or "")
+    total += sum(len(field["name"]) + len(field["value"]) for field in embed.fields)
+    assert total <= 6000
+    # The full card still reaches the operator via the plaintext content.
+    assert channel.send.await_args.kwargs["content"].startswith("🟡")
+
+
 # ---------------------------------------------------------------------------
 # Forum channel tests
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_discord_status_cards.py
+++ b/tests/gateway/test_discord_status_cards.py
@@ -8,8 +8,9 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from gateway.config import PlatformConfig
-from gateway.platforms.base import SendResult
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, SendResult
+from gateway.session import SessionSource, build_session_key
 from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
 from plugins.platforms.discord.adapter import DiscordAdapter
 
@@ -571,6 +572,77 @@ async def test_stream_edit_and_base_final_share_one_real_discord_message(
             "final": True,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_failed_image_only_final_keeps_real_card_and_receipt_nonterminal(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter._build_operator_card_embed",
+        lambda card: {"kind": card.card_type},
+    )
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter.is_safe_url",
+        lambda _url: False,
+    )
+    instance = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    record_response = Mock()
+    instance._record_discord_response = record_response
+    retained = SimpleNamespace(id=7001, edit=AsyncMock())
+    thread = SimpleNamespace(
+        send=AsyncMock(return_value=retained),
+        fetch_message=AsyncMock(return_value=retained),
+    )
+    instance._client = SimpleNamespace(
+        get_channel=lambda channel_id: thread if channel_id in {555, 777} else None,
+        fetch_channel=AsyncMock(),
+    )
+
+    await instance.send(
+        "555",
+        "Working",
+        metadata={
+            "thread_id": "777",
+            "status_key": "task_run:message:42",
+        },
+    )
+    record_response.reset_mock()
+    retained.edit.reset_mock()
+
+    async def handler(event):
+        event._status_key = "task_run:message:42"
+        return "![report](https://example.com/blocked.png)"
+
+    async def hold_typing(_chat_id, interval=2.0, metadata=None):
+        await asyncio.Event().wait()
+
+    instance.set_message_handler(handler)
+    instance._keep_typing = hold_typing
+    event = MessageEvent(
+        text="Send the report",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="555",
+            chat_type="thread",
+            thread_id="777",
+        ),
+        message_id="42",
+    )
+
+    await instance._process_message_background(
+        event,
+        build_session_key(event.source),
+    )
+
+    retained.edit.assert_not_awaited()
+    terminal_receipts = [
+        call.kwargs
+        for call in record_response.call_args_list
+        if call.kwargs.get("final")
+    ]
+    assert terminal_receipts == []
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_status_cards.py
+++ b/tests/gateway/test_discord_status_cards.py
@@ -1,0 +1,478 @@
+"""Behavior contracts for keyed Discord task-run status cards (OE-180)."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+@pytest.fixture
+def adapter(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    instance = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    instance.send = AsyncMock()
+    instance.edit_message = AsyncMock()
+    return instance
+
+
+@pytest.mark.asyncio
+async def test_status_card_first_send_caches_then_same_key_edits(adapter):
+    adapter.send.return_value = SendResult(success=True, message_id="7001")
+    adapter.edit_message.return_value = SendResult(success=True, message_id="7001")
+
+    first = await adapter.send_or_update_status(
+        "555", "run-1", "Starting", metadata={"thread_id": "777"}
+    )
+    second = await adapter.send_or_update_status(
+        "555", "run-1", "Checking files", metadata={"thread_id": "777"}
+    )
+
+    assert first.message_id == second.message_id == "7001"
+    adapter.send.assert_awaited_once()
+    adapter.edit_message.assert_awaited_once()
+    assert adapter.send.await_args.kwargs["metadata"]["operator_card"]["card_type"] == "task_run"
+    edit_kwargs = adapter.edit_message.await_args.kwargs
+    assert edit_kwargs["chat_id"] == "555"
+    assert edit_kwargs["message_id"] == "7001"
+    assert edit_kwargs["content"] == "Checking files"
+    assert edit_kwargs["finalize"] is False
+    assert edit_kwargs["metadata"]["thread_id"] == "777"
+    assert edit_kwargs["metadata"]["operator_card"]["card_type"] == "task_run"
+
+
+@pytest.mark.asyncio
+async def test_status_card_identity_isolated_by_thread_and_status_key(adapter):
+    adapter.send.side_effect = [
+        SendResult(success=True, message_id="7001"),
+        SendResult(success=True, message_id="7002"),
+        SendResult(success=True, message_id="7003"),
+    ]
+
+    await adapter.send_or_update_status(
+        "555", "run-1", "Thread A", metadata={"thread_id": "777"}
+    )
+    await adapter.send_or_update_status(
+        "555", "run-1", "Thread B", metadata={"thread_id": "778"}
+    )
+    await adapter.send_or_update_status(
+        "555", "run-2", "Other run", metadata={"thread_id": "777"}
+    )
+
+    assert adapter.send.await_count == 3
+    adapter.edit_message.assert_not_awaited()
+    assert adapter._status_message_ids == {
+        ("555", "777", "run-1"): "7001",
+        ("555", "778", "run-1"): "7002",
+        ("555", "777", "run-2"): "7003",
+    }
+
+
+@pytest.mark.asyncio
+async def test_sequential_runs_in_one_thread_keep_distinct_final_messages(adapter):
+    adapter.send.side_effect = [
+        SendResult(success=True, message_id="7001"),
+        SendResult(success=True, message_id="7002"),
+    ]
+
+    async def edit_same_message(*, message_id, **_kwargs):
+        return SendResult(success=True, message_id=message_id)
+
+    adapter.edit_message.side_effect = edit_same_message
+
+    await adapter.send_or_update_status(
+        "555", "task_run:message:42", "Run one working", metadata={"thread_id": "777"}
+    )
+    first_final = await adapter.send_or_update_status(
+        "555",
+        "task_run:message:42",
+        "Run one complete",
+        metadata={"thread_id": "777", "status_terminal": True},
+    )
+    await adapter.send_or_update_status(
+        "555", "task_run:message:43", "Run two working", metadata={"thread_id": "777"}
+    )
+    second_final = await adapter.send_or_update_status(
+        "555",
+        "task_run:message:43",
+        "Run two complete",
+        metadata={"thread_id": "777", "status_terminal": True},
+    )
+
+    assert first_final.message_id == "7001"
+    assert second_final.message_id == "7002"
+    assert adapter.send.await_count == 2
+    assert adapter.edit_message.await_count == 2
+    assert adapter._status_message_ids[("555", "777", "task_run:message:42")] == "7001"
+    assert adapter._status_message_ids[("555", "777", "task_run:message:43")] == "7002"
+
+
+@pytest.mark.asyncio
+async def test_terminal_result_replaces_retained_card_as_plaintext(adapter):
+    adapter.send.return_value = SendResult(success=True, message_id="7001")
+    adapter.edit_message.return_value = SendResult(success=True, message_id="7001")
+
+    await adapter.send_or_update_status(
+        "555", "run-1", "Working", metadata={"thread_id": "777"}
+    )
+    result = await adapter.send_or_update_status(
+        "555",
+        "run-1",
+        "Done. Here is the complete final result.",
+        metadata={"thread_id": "777", "status_terminal": True},
+    )
+
+    assert result.success is True
+    adapter.send.assert_awaited_once()
+    adapter.edit_message.assert_awaited_once_with(
+        chat_id="555",
+        message_id="7001",
+        content="Done. Here is the complete final result.",
+        finalize=True,
+        metadata={"thread_id": "777", "status_terminal": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_edit_failure_sends_exactly_one_fresh_plaintext_final_and_recaches(adapter):
+    adapter.send.side_effect = [
+        SendResult(success=True, message_id="7001"),
+        SendResult(success=True, message_id="7002"),
+    ]
+    adapter.edit_message.return_value = SendResult(success=False, error="Unknown Message")
+
+    await adapter.send_or_update_status(
+        "555", "run-1", "Working", metadata={"thread_id": "777"}
+    )
+    result = await adapter.send_or_update_status(
+        "555",
+        "run-1",
+        "Final result",
+        metadata={"thread_id": "777", "status_terminal": True},
+    )
+
+    assert result.message_id == "7002"
+    assert adapter.send.await_count == 2
+    assert adapter.send.await_args.kwargs == {
+        "chat_id": "555",
+        "content": "Final result",
+        "metadata": {"thread_id": "777"},
+    }
+    assert adapter._status_message_ids[("555", "777", "run-1")] == "7002"
+
+
+@pytest.mark.asyncio
+async def test_embed_send_failure_falls_back_once_to_plaintext_and_recaches(adapter):
+    adapter.send.side_effect = [
+        SendResult(success=False, error="Invalid Form Body: embed"),
+        SendResult(success=True, message_id="7002"),
+    ]
+
+    result = await adapter.send_or_update_status(
+        "555", "run-1", "Working", metadata={"thread_id": "777"}
+    )
+
+    assert result.message_id == "7002"
+    assert adapter.send.await_count == 2
+    assert "operator_card" in adapter.send.await_args_list[0].kwargs["metadata"]
+    assert adapter.send.await_args_list[1].kwargs == {
+        "chat_id": "555",
+        "content": "Working",
+        "metadata": {"thread_id": "777"},
+    }
+    assert adapter._status_message_ids[("555", "777", "run-1")] == "7002"
+
+
+@pytest.mark.asyncio
+async def test_repeated_identical_heartbeat_does_not_send_or_edit_again(adapter):
+    adapter.send.return_value = SendResult(success=True, message_id="7001")
+
+    first = await adapter.send_or_update_status(
+        "555", "run-1", "Still working", metadata={"thread_id": "777"}
+    )
+    second = await adapter.send_or_update_status(
+        "555", "run-1", "Still working", metadata={"thread_id": "777"}
+    )
+
+    assert first.message_id == second.message_id == "7001"
+    adapter.send.assert_awaited_once()
+    adapter.edit_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_identical_first_updates_create_only_one_message(adapter):
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def delayed_send(**_kwargs):
+        entered.set()
+        await release.wait()
+        return SendResult(success=True, message_id="7001")
+
+    adapter.send.side_effect = delayed_send
+    first = asyncio.create_task(
+        adapter.send_or_update_status(
+            "555", "run-1", "Starting", metadata={"thread_id": "777"}
+        )
+    )
+    await entered.wait()
+    second = asyncio.create_task(
+        adapter.send_or_update_status(
+            "555", "run-1", "Starting", metadata={"thread_id": "777"}
+        )
+    )
+    release.set()
+
+    first_result, second_result = await asyncio.gather(first, second)
+
+    assert first_result.message_id == second_result.message_id == "7001"
+    adapter.send.assert_awaited_once()
+    adapter.edit_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_status_identity_cache_evicts_oldest_inactive_runs(adapter):
+    adapter._STATUS_MESSAGE_CACHE_LIMIT = 3
+    adapter.send.side_effect = [
+        SendResult(success=True, message_id=str(7000 + index))
+        for index in range(1, 6)
+    ]
+
+    for index in range(1, 6):
+        await adapter.send_or_update_status(
+            "555",
+            f"run-{index}",
+            f"Run {index}",
+            metadata={"thread_id": "777", "status_terminal": True},
+        )
+
+    expected_keys = {
+        ("555", "777", "run-3"),
+        ("555", "777", "run-4"),
+        ("555", "777", "run-5"),
+    }
+    assert set(adapter._status_message_ids) == expected_keys
+    assert set(adapter._status_message_fingerprints) == expected_keys
+    assert set(adapter._status_message_locks) == expected_keys
+    assert adapter._status_message_users == {}
+
+
+@pytest.mark.asyncio
+async def test_status_identity_cache_never_evicts_locked_inflight_run(adapter):
+    adapter._STATUS_MESSAGE_CACHE_LIMIT = 2
+    locked_key = ("555", "777", "run-1")
+    locked = asyncio.Lock()
+    await locked.acquire()
+    adapter._status_message_ids[locked_key] = "7001"
+    adapter._status_message_fingerprints[locked_key] = "old"
+    adapter._status_message_locks[locked_key] = locked
+    adapter._status_message_users[locked_key] = 1
+    adapter._status_message_ids[("555", "777", "run-2")] = "7002"
+    adapter._status_message_fingerprints[("555", "777", "run-2")] = "old"
+    adapter._status_message_locks[("555", "777", "run-2")] = asyncio.Lock()
+    adapter.send.return_value = SendResult(success=True, message_id="7003")
+
+    await adapter.send_or_update_status(
+        "555",
+        "run-3",
+        "Run 3",
+        metadata={"thread_id": "777", "status_terminal": True},
+    )
+
+    assert locked_key in adapter._status_message_ids
+    assert ("555", "777", "run-2") not in adapter._status_message_ids
+    assert ("555", "777", "run-3") in adapter._status_message_ids
+    locked.release()
+
+
+@pytest.mark.asyncio
+async def test_failed_new_status_does_not_retain_an_orphan_lock(adapter):
+    adapter.send.return_value = SendResult(success=False, error="offline")
+
+    result = await adapter.send_or_update_status(
+        "555",
+        "run-1",
+        "Final",
+        metadata={"thread_id": "777", "status_terminal": True},
+    )
+
+    assert result.success is False
+    assert adapter._status_message_ids == {}
+    assert adapter._status_message_fingerprints == {}
+    assert adapter._status_message_locks == {}
+    assert adapter._status_message_users == {}
+
+
+@pytest.mark.asyncio
+async def test_failed_first_send_keeps_lock_while_same_key_caller_is_queued(adapter):
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    second_started = asyncio.Event()
+    second_entered = asyncio.Event()
+    release_second = asyncio.Event()
+    third_started = asyncio.Event()
+    send_count = 0
+
+    async def controlled_send(**_kwargs):
+        nonlocal send_count
+        send_count += 1
+        if send_count == 1:
+            first_entered.set()
+            await release_first.wait()
+            return SendResult(success=False, error="offline")
+        if send_count == 2:
+            second_entered.set()
+            await release_second.wait()
+            return SendResult(success=True, message_id="7002")
+        raise AssertionError("same-key caller escaped the retained lock")
+
+    adapter.send.side_effect = controlled_send
+    async def call(started=None):
+        if started is not None:
+            started.set()
+        return await adapter.send_or_update_status(
+            "555",
+            "run-1",
+            "Final",
+            metadata={"thread_id": "777", "status_terminal": True},
+        )
+    key = ("555", "777", "run-1")
+
+    first = asyncio.create_task(call())
+    await first_entered.wait()
+    retained_lock = adapter._status_message_locks[key]
+    second = asyncio.create_task(call(second_started))
+    await second_started.wait()
+    release_first.set()
+    await second_entered.wait()
+
+    assert adapter._status_message_locks[key] is retained_lock
+    third = asyncio.create_task(call(third_started))
+    await third_started.wait()
+    assert send_count == 2
+    assert third.done() is False
+
+    release_second.set()
+    first_result, second_result, third_result = await asyncio.gather(
+        first,
+        second,
+        third,
+    )
+    assert first_result.success is False
+    assert second_result.message_id == third_result.message_id == "7002"
+    assert send_count == 2
+
+
+@pytest.mark.asyncio
+async def test_stream_edit_and_base_final_share_one_real_discord_message(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter._build_operator_card_embed",
+        lambda card: {"kind": card.card_type, "summary": card.summary},
+    )
+    instance = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    retained = SimpleNamespace(id=7001, edit=AsyncMock())
+    thread = SimpleNamespace(
+        send=AsyncMock(return_value=retained),
+        fetch_message=AsyncMock(return_value=retained),
+    )
+    instance._client = SimpleNamespace(
+        get_channel=lambda channel_id: thread if channel_id == 777 else None,
+        fetch_channel=AsyncMock(),
+    )
+
+    running = await instance.send(
+        "555",
+        "Checking files",
+        metadata={"thread_id": "777", "status_key": "task_run"},
+    )
+    stream_final = await instance.edit_message(
+        "555",
+        "7001",
+        "Complete final result",
+        metadata={
+            "thread_id": "777",
+            "status_key": "task_run",
+            "status_terminal": True,
+            "expect_edits": True,
+            "notify": True,
+        },
+    )
+    base_final = await instance.send(
+        "555",
+        "Complete final result",
+        metadata={
+            "thread_id": "777",
+            "status_key": "task_run",
+            "status_terminal": True,
+            "notify": True,
+        },
+    )
+
+    assert (
+        running.message_id
+        == stream_final.message_id
+        == base_final.message_id
+        == "7001"
+    )
+    assert thread.send.await_count == 1
+    assert thread.send.await_args.kwargs["embed"] == {
+        "kind": "task_run",
+        "summary": "Checking files",
+    }
+    thread.fetch_message.assert_awaited_once_with(7001)
+    retained.edit.assert_awaited_once_with(
+        content="Complete final result",
+        embed=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_style_running_edit_refreshes_embed_in_routed_thread(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter._build_operator_card_embed",
+        lambda card: {"kind": card.card_type, "summary": card.summary},
+    )
+    instance = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    retained = SimpleNamespace(id=7001, edit=AsyncMock())
+    thread = SimpleNamespace(
+        send=AsyncMock(return_value=retained),
+        fetch_message=AsyncMock(return_value=retained),
+    )
+    instance._client = SimpleNamespace(
+        get_channel=lambda channel_id: thread if channel_id == 777 else None,
+        fetch_channel=AsyncMock(),
+    )
+
+    await instance.send(
+        "555",
+        "Starting",
+        metadata={"thread_id": "777", "status_key": "task_run"},
+    )
+    result = await instance.edit_message(
+        "555",
+        "7001",
+        "Still working",
+        metadata={"thread_id": "777", "status_key": "task_run"},
+    )
+
+    assert result.success is True
+    retained.edit.assert_awaited_once()
+    assert retained.edit.await_args.kwargs["embed"] == {
+        "kind": "task_run",
+        "summary": "Still working",
+    }
+    assert retained.edit.await_args.kwargs["content"].startswith(
+        "🔵 **Info — Task running**"
+    )

--- a/tests/gateway/test_discord_status_cards.py
+++ b/tests/gateway/test_discord_status_cards.py
@@ -421,8 +421,13 @@ async def test_stream_edit_and_base_final_share_one_real_discord_message(
     running = await instance.send(
         "555",
         "Checking files",
-        metadata={"thread_id": "777", "status_key": "task_run"},
+        metadata={
+            "thread_id": "777",
+            "status_key": "task_run",
+            "non_conversational": True,
+        },
     )
+    assert "7001" in instance._nonconversational_messages
     stream_final = await instance.edit_message(
         "555",
         "7001",
@@ -453,6 +458,8 @@ async def test_stream_edit_and_base_final_share_one_real_discord_message(
         == "7001"
     )
     assert thread.send.await_count == 1
+    assert "7001" not in instance._nonconversational_messages
+    assert instance._last_self_message_id["777"] == "7001"
     assert thread.send.await_args.kwargs["embed"] == {
         "kind": "task_run",
         "summary": "Checking files",
@@ -579,7 +586,11 @@ async def test_keyed_consumer_fallback_oversized_final_preserves_all_chunks(
     running = await instance.send(
         "555",
         "Working",
-        metadata={"thread_id": "777", "status_key": "task_run:message:42"},
+        metadata={
+            "thread_id": "777",
+            "status_key": "task_run:message:42",
+            "non_conversational": True,
+        },
     )
     retained = sent[0][1]
     thread.fetch_message.return_value = retained
@@ -600,3 +611,9 @@ async def test_keyed_consumer_fallback_oversized_final_preserves_all_chunks(
     assert retained.edit.await_args.kwargs["content"].startswith("A" * 100)
     assert len(sent) >= 2
     assert "B" * 100 in sent[-1][0]["content"]
+    visible_ids = [str(message.id) for _kwargs, message in sent]
+    assert all(
+        message_id not in instance._nonconversational_messages
+        for message_id in visible_ids
+    )
+    assert instance._last_self_message_id["777"] == visible_ids[-1]

--- a/tests/gateway/test_discord_status_cards.py
+++ b/tests/gateway/test_discord_status_cards.py
@@ -195,6 +195,52 @@ async def test_edit_failure_sends_exactly_one_fresh_plaintext_final_and_recaches
 
 
 @pytest.mark.asyncio
+async def test_partial_terminal_overflow_falls_back_once_before_latching(adapter):
+    adapter.send.side_effect = [
+        SendResult(success=True, message_id="7001"),
+        SendResult(
+            success=True,
+            message_id="8001",
+            raw_response={"message_ids": ["8001", "8002"]},
+        ),
+    ]
+    adapter.edit_message.return_value = SendResult(
+        success=True,
+        message_id="7002",
+        continuation_message_ids=("7002",),
+        raw_response={
+            "partial_overflow": True,
+            "delivered_chunks": 2,
+            "total_chunks": 3,
+            "last_message_id": "7002",
+            "continuation_message_ids": ("7002",),
+        },
+    )
+
+    await adapter.send_or_update_status(
+        "555", "run-1", "Working", metadata={"thread_id": "777"}
+    )
+    result = await adapter.send_or_update_status(
+        "555",
+        "run-1",
+        "Complete final result " * 300,
+        metadata={"thread_id": "777", "status_terminal": True},
+    )
+
+    assert result.message_id == "8001"
+    assert adapter.edit_message.await_count == 1
+    assert adapter.send.await_count == 2
+    fallback = adapter.send.await_args_list[1].kwargs
+    assert fallback["chat_id"] == "555"
+    assert fallback["content"] == "Complete final result " * 300
+    assert fallback["metadata"] == {"thread_id": "777"}
+    key = ("555", "777", "run-1")
+    assert adapter._status_message_ids[key] == "8001"
+    assert adapter._status_message_terminal[key] is True
+    assert adapter._last_self_message_id["777"] == "8002"
+
+
+@pytest.mark.asyncio
 async def test_embed_send_failure_falls_back_once_to_plaintext_and_recaches(adapter):
     adapter.send.side_effect = [
         SendResult(success=False, error="Invalid Form Body: embed"),
@@ -617,3 +663,76 @@ async def test_keyed_consumer_fallback_oversized_final_preserves_all_chunks(
         for message_id in visible_ids
     )
     assert instance._last_self_message_id["777"] == visible_ids[-1]
+
+
+@pytest.mark.asyncio
+async def test_keyed_oversized_terminal_continuation_failure_falls_back_fresh_once(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter._build_operator_card_embed",
+        lambda card: {"kind": card.card_type},
+    )
+    instance = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    retained = SimpleNamespace(
+        id=7001,
+        edit=AsyncMock(),
+        to_reference=lambda **_kwargs: object(),
+    )
+    send_calls = []
+
+    async def send_message(**kwargs):
+        send_calls.append(kwargs)
+        call_number = len(send_calls)
+        if call_number == 1:
+            return retained
+        if call_number == 2:
+            return SimpleNamespace(
+                id=7002,
+                to_reference=lambda **_kwargs: object(),
+            )
+        if call_number in {3, 4}:
+            raise RuntimeError("continuation send failed")
+        return SimpleNamespace(
+            id=8000 + call_number,
+            to_reference=lambda **_kwargs: object(),
+        )
+
+    thread = SimpleNamespace(
+        id=777,
+        send=AsyncMock(side_effect=send_message),
+        fetch_message=AsyncMock(return_value=retained),
+    )
+    instance._client = SimpleNamespace(
+        get_channel=lambda channel_id: thread if channel_id == 777 else None,
+        fetch_channel=AsyncMock(),
+    )
+
+    await instance.send(
+        "555",
+        "Working",
+        metadata={"thread_id": "777", "status_key": "task_run:message:42"},
+    )
+    final_text = "Complete final result " * 300
+    result = await instance.send(
+        "555",
+        final_text,
+        metadata={
+            "thread_id": "777",
+            "status_key": "task_run:message:42",
+            "status_terminal": True,
+        },
+    )
+
+    fallback_ids = result.raw_response["message_ids"]
+    assert result.success is True
+    assert result.message_id == fallback_ids[0]
+    assert fallback_ids[0].startswith("800")
+    assert len(send_calls) == 4 + len(fallback_ids)
+    assert retained.edit.await_count == 1
+    key = ("555", "777", "task_run:message:42")
+    assert instance._status_message_ids[key] == fallback_ids[0]
+    assert instance._status_message_terminal[key] is True
+    assert instance._last_self_message_id["777"] == fallback_ids[-1]

--- a/tests/gateway/test_discord_status_cards.py
+++ b/tests/gateway/test_discord_status_cards.py
@@ -49,6 +49,24 @@ async def test_status_card_first_send_caches_then_same_key_edits(adapter):
 
 
 @pytest.mark.asyncio
+async def test_status_card_first_creation_uses_metadata_reply_anchor(adapter):
+    adapter.send.return_value = SendResult(success=True, message_id="7001")
+
+    await adapter.send_or_update_status(
+        "555",
+        "run-1",
+        "Starting",
+        metadata={
+            "thread_id": "777",
+            "reply_to_message_id": "42",
+        },
+    )
+
+    assert adapter.send.await_args.kwargs["reply_to"] == "42"
+    assert "reply_to_message_id" not in adapter.send.await_args.kwargs["metadata"]
+
+
+@pytest.mark.asyncio
 async def test_status_card_identity_isolated_by_thread_and_status_key(adapter):
     adapter.send.side_effect = [
         SendResult(success=True, message_id="7001"),
@@ -276,6 +294,21 @@ async def test_repeated_identical_heartbeat_does_not_send_or_edit_again(adapter)
     assert first.message_id == second.message_id == "7001"
     adapter.send.assert_awaited_once()
     adapter.edit_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_status_fingerprint_is_fixed_size_digest(adapter):
+    adapter.send.return_value = SendResult(success=True, message_id="7001")
+    content = "x" * 100_000
+
+    await adapter.send_or_update_status(
+        "555", "run-1", content, metadata={"thread_id": "777"}
+    )
+
+    fingerprint = adapter._status_message_fingerprints[("555", "777", "run-1")]
+    assert len(fingerprint) == 64
+    assert set(fingerprint) <= set("0123456789abcdef")
+    assert content not in fingerprint
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_status_cards.py
+++ b/tests/gateway/test_discord_status_cards.py
@@ -331,6 +331,7 @@ async def test_status_identity_cache_evicts_oldest_inactive_runs(adapter):
         ("555", "777", "run-5"),
     }
     assert set(adapter._status_message_ids) == expected_keys
+    assert set(adapter._status_message_groups) == expected_keys
     assert set(adapter._status_message_fingerprints) == expected_keys
     assert set(adapter._status_message_locks) == expected_keys
     assert set(adapter._status_message_terminal) == expected_keys
@@ -378,6 +379,7 @@ async def test_failed_new_status_does_not_retain_an_orphan_lock(adapter):
 
     assert result.success is False
     assert adapter._status_message_ids == {}
+    assert adapter._status_message_groups == {}
     assert adapter._status_message_fingerprints == {}
     assert adapter._status_message_locks == {}
     assert adapter._status_message_terminal == {}
@@ -736,3 +738,96 @@ async def test_keyed_oversized_terminal_continuation_failure_falls_back_fresh_on
     assert instance._status_message_ids[key] == fallback_ids[0]
     assert instance._status_message_terminal[key] is True
     assert instance._last_self_message_id["777"] == fallback_ids[-1]
+
+
+@pytest.mark.asyncio
+async def test_oversized_streamed_terminal_transform_removes_prior_chunks(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter._build_operator_card_embed",
+        lambda card: {"kind": card.card_type},
+    )
+    instance = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    retained = SimpleNamespace(
+        id=7001,
+        edit=AsyncMock(),
+        delete=AsyncMock(),
+        to_reference=lambda **_kwargs: object(),
+    )
+    messages = {7001: retained}
+    next_message_id = 7002
+
+    async def send_message(**_kwargs):
+        nonlocal next_message_id
+        message = SimpleNamespace(
+            id=next_message_id,
+            edit=AsyncMock(),
+            delete=AsyncMock(),
+            to_reference=lambda **_kwargs: object(),
+        )
+        messages[next_message_id] = message
+        next_message_id += 1
+        return message
+
+    async def fetch_message(message_id):
+        return messages[int(message_id)]
+
+    thread = SimpleNamespace(
+        id=777,
+        send=AsyncMock(side_effect=send_message),
+        fetch_message=AsyncMock(side_effect=fetch_message),
+    )
+    instance._client = SimpleNamespace(
+        get_channel=lambda channel_id: thread if channel_id == 777 else None,
+        fetch_channel=AsyncMock(),
+    )
+
+    # Seed the retained running card without consuming the continuation ID
+    # allocator used by the oversized terminal edit below.
+    instance._status_message_ids[("555", "777", "task_run:message:42")] = "7001"
+    instance._status_message_groups[("555", "777", "task_run:message:42")] = (
+        "7001",
+    )
+    raw_final = "Raw streamed answer " * 300
+    first_terminal = await instance.send(
+        "555",
+        raw_final,
+        metadata={
+            "thread_id": "777",
+            "status_key": "task_run:message:42",
+            "status_terminal": True,
+        },
+    )
+    key = ("555", "777", "task_run:message:42")
+    raw_group = instance._status_message_groups[key]
+
+    assert first_terminal.success is True
+    assert len(raw_group) > 1
+    assert raw_group[0] == "7001"
+    assert instance._status_message_ids[key] == "7001"
+
+    transformed = "Plugin-transformed complete answer"
+    transformed_terminal = await instance.send(
+        "555",
+        transformed,
+        metadata={
+            "thread_id": "777",
+            "status_key": "task_run:message:42",
+            "status_terminal": True,
+        },
+    )
+
+    assert transformed_terminal.success is True
+    assert instance._status_message_ids[key] == "7001"
+    assert instance._status_message_groups[key] == ("7001",)
+    assert retained.edit.await_args.kwargs == {
+        "content": transformed,
+        "embed": None,
+    }
+    for stale_id in raw_group[1:]:
+        messages[int(stale_id)].delete.assert_awaited_once()
+    retained.delete.assert_not_awaited()
+    assert instance._last_self_message_id["777"] == "7001"

--- a/tests/gateway/test_discord_status_cards.py
+++ b/tests/gateway/test_discord_status_cards.py
@@ -10,6 +10,7 @@ import pytest
 
 from gateway.config import PlatformConfig
 from gateway.platforms.base import SendResult
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
 from plugins.platforms.discord.adapter import DiscordAdapter
 
 
@@ -140,6 +141,32 @@ async def test_terminal_result_replaces_retained_card_as_plaintext(adapter):
 
 
 @pytest.mark.asyncio
+async def test_late_running_update_cannot_downgrade_terminal_card(adapter):
+    adapter.send.return_value = SendResult(success=True, message_id="7001")
+    adapter.edit_message.return_value = SendResult(success=True, message_id="7001")
+
+    await adapter.send_or_update_status(
+        "555", "run-1", "Working", metadata={"thread_id": "777"}
+    )
+    terminal = await adapter.send_or_update_status(
+        "555",
+        "run-1",
+        "Complete final result",
+        metadata={"thread_id": "777", "status_terminal": True},
+    )
+    late = await adapter.send_or_update_status(
+        "555", "run-1", "Still working", metadata={"thread_id": "777"}
+    )
+
+    assert terminal.message_id == late.message_id == "7001"
+    adapter.send.assert_awaited_once()
+    adapter.edit_message.assert_awaited_once()
+    assert adapter._status_message_terminal == {
+        ("555", "777", "run-1"): True,
+    }
+
+
+@pytest.mark.asyncio
 async def test_edit_failure_sends_exactly_one_fresh_plaintext_final_and_recaches(adapter):
     adapter.send.side_effect = [
         SendResult(success=True, message_id="7001"),
@@ -260,6 +287,7 @@ async def test_status_identity_cache_evicts_oldest_inactive_runs(adapter):
     assert set(adapter._status_message_ids) == expected_keys
     assert set(adapter._status_message_fingerprints) == expected_keys
     assert set(adapter._status_message_locks) == expected_keys
+    assert set(adapter._status_message_terminal) == expected_keys
     assert adapter._status_message_users == {}
 
 
@@ -306,6 +334,7 @@ async def test_failed_new_status_does_not_retain_an_orphan_lock(adapter):
     assert adapter._status_message_ids == {}
     assert adapter._status_message_fingerprints == {}
     assert adapter._status_message_locks == {}
+    assert adapter._status_message_terminal == {}
     assert adapter._status_message_users == {}
 
 
@@ -476,3 +505,98 @@ async def test_gateway_style_running_edit_refreshes_embed_in_routed_thread(
     assert retained.edit.await_args.kwargs["content"].startswith(
         "🔵 **Info — Task running**"
     )
+
+
+@pytest.mark.asyncio
+async def test_keyed_consumer_fresh_oversized_final_preserves_all_chunks(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    instance = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sent = []
+
+    async def send_message(**kwargs):
+        message = SimpleNamespace(id=7001 + len(sent), edit=AsyncMock())
+        sent.append((kwargs, message))
+        return message
+
+    thread = SimpleNamespace(
+        id=777,
+        send=AsyncMock(side_effect=send_message),
+        fetch_message=AsyncMock(),
+    )
+    instance._client = SimpleNamespace(
+        get_channel=lambda channel_id: thread if channel_id == 777 else None,
+        fetch_channel=AsyncMock(),
+    )
+    final_text = "A" * 2200 + "B" * 2200
+    consumer = GatewayStreamConsumer(
+        adapter=instance,
+        chat_id="555",
+        config=StreamConsumerConfig(cursor="", buffer_only=True),
+        metadata={"thread_id": "777", "status_key": "task_run:message:42"},
+    )
+    consumer.on_delta(final_text)
+    consumer.finish()
+
+    await consumer.run()
+
+    assert consumer.final_response_sent is True
+    assert len(sent) >= 2
+    assert sent[0][0]["content"].startswith("A" * 100)
+    assert "B" * 100 in sent[-1][0]["content"]
+    assert all(message.edit.await_count == 0 for _kwargs, message in sent)
+
+
+@pytest.mark.asyncio
+async def test_keyed_consumer_fallback_oversized_final_preserves_all_chunks(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter._build_operator_card_embed",
+        lambda card: {"kind": card.card_type},
+    )
+    instance = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sent = []
+
+    async def send_message(**kwargs):
+        message = SimpleNamespace(id=7001 + len(sent), edit=AsyncMock())
+        sent.append((kwargs, message))
+        return message
+
+    thread = SimpleNamespace(
+        id=777,
+        send=AsyncMock(side_effect=send_message),
+        fetch_message=AsyncMock(),
+    )
+    instance._client = SimpleNamespace(
+        get_channel=lambda channel_id: thread if channel_id == 777 else None,
+        fetch_channel=AsyncMock(),
+    )
+    running = await instance.send(
+        "555",
+        "Working",
+        metadata={"thread_id": "777", "status_key": "task_run:message:42"},
+    )
+    retained = sent[0][1]
+    thread.fetch_message.return_value = retained
+    final_text = "A" * 2200 + "B" * 2200
+    consumer = GatewayStreamConsumer(
+        adapter=instance,
+        chat_id="555",
+        config=StreamConsumerConfig(cursor=""),
+        metadata={"thread_id": "777", "status_key": "task_run:message:42"},
+    )
+    consumer._message_id = running.message_id
+    consumer._fallback_final_send = True
+
+    await consumer._send_fallback_final(final_text)
+
+    assert consumer.final_response_sent is True
+    assert retained.edit.await_count == 1
+    assert retained.edit.await_args.kwargs["content"].startswith("A" * 100)
+    assert len(sent) >= 2
+    assert "B" * 100 in sent[-1][0]["content"]

--- a/tests/gateway/test_discord_status_cards.py
+++ b/tests/gateway/test_discord_status_cards.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -275,7 +275,10 @@ async def test_embed_send_failure_falls_back_once_to_plaintext_and_recaches(adap
     assert adapter.send.await_args_list[1].kwargs == {
         "chat_id": "555",
         "content": "Working",
-        "metadata": {"thread_id": "777"},
+        "metadata": {
+            "thread_id": "777",
+            "non_conversational": True,
+        },
     }
     assert adapter._status_message_ids[("555", "777", "run-1")] == "7002"
 
@@ -489,6 +492,8 @@ async def test_stream_edit_and_base_final_share_one_real_discord_message(
         lambda card: {"kind": card.card_type, "summary": card.summary},
     )
     instance = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    record_response = Mock()
+    instance._record_discord_response = record_response
     retained = SimpleNamespace(id=7001, edit=AsyncMock())
     thread = SimpleNamespace(
         send=AsyncMock(return_value=retained),
@@ -505,7 +510,7 @@ async def test_stream_edit_and_base_final_share_one_real_discord_message(
         metadata={
             "thread_id": "777",
             "status_key": "task_run",
-            "non_conversational": True,
+            "reply_to_message_id": "42",
         },
     )
     assert "7001" in instance._nonconversational_messages
@@ -519,6 +524,7 @@ async def test_stream_edit_and_base_final_share_one_real_discord_message(
             "status_terminal": True,
             "expect_edits": True,
             "notify": True,
+            "reply_to_message_id": "42",
         },
     )
     base_final = await instance.send(
@@ -545,11 +551,26 @@ async def test_stream_edit_and_base_final_share_one_real_discord_message(
         "kind": "task_run",
         "summary": "Checking files",
     }
-    thread.fetch_message.assert_awaited_once_with(7001)
+    assert thread.fetch_message.await_count == 2
+    assert thread.fetch_message.await_args_list[0].args == (42,)
+    assert thread.fetch_message.await_args_list[1].args == (7001,)
     retained.edit.assert_awaited_once_with(
         content="Complete final result",
         embed=None,
     )
+    terminal_receipts = [
+        call.kwargs
+        for call in record_response.call_args_list
+        if call.kwargs.get("final")
+    ]
+    assert terminal_receipts == [
+        {
+            "reply_to": "42",
+            "result": SendResult(success=True, message_id="7001"),
+            "content": "Complete final result",
+            "final": True,
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_status_cards.py
+++ b/tests/gateway/test_discord_status_cards.py
@@ -208,7 +208,7 @@ async def test_edit_failure_sends_exactly_one_fresh_plaintext_final_and_recaches
     assert adapter.send.await_args.kwargs == {
         "chat_id": "555",
         "content": "Final result",
-        "metadata": {"thread_id": "777"},
+        "metadata": {"thread_id": "777", "status_terminal": True},
     }
     assert adapter._status_message_ids[("555", "777", "run-1")] == "7002"
 
@@ -252,7 +252,10 @@ async def test_partial_terminal_overflow_falls_back_once_before_latching(adapter
     fallback = adapter.send.await_args_list[1].kwargs
     assert fallback["chat_id"] == "555"
     assert fallback["content"] == "Complete final result " * 300
-    assert fallback["metadata"] == {"thread_id": "777"}
+    assert fallback["metadata"] == {
+        "thread_id": "777",
+        "status_terminal": True,
+    }
     key = ("555", "777", "run-1")
     assert adapter._status_message_ids[key] == "8001"
     assert adapter._status_message_terminal[key] is True
@@ -646,6 +649,130 @@ async def test_failed_image_only_final_keeps_real_card_and_receipt_nonterminal(
 
 
 @pytest.mark.asyncio
+async def test_double_native_image_failure_text_fallback_keeps_card_nonterminal(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_MISSED_MESSAGE_BACKFILL", "true")
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter._build_operator_card_embed",
+        lambda card: {"kind": card.card_type},
+    )
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter.is_safe_url",
+        lambda _url: True,
+    )
+
+    class _ImageResponse:
+        status = 200
+        headers = {"content-type": "image/png"}
+
+        async def read(self):
+            return b"\x89PNG" + b"\x00" * 20
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    class _ImageSession:
+        def get(self, *_args, **_kwargs):
+            return _ImageResponse()
+
+        async def close(self):
+            return None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    monkeypatch.setattr("aiohttp.ClientSession", lambda **_kwargs: _ImageSession())
+
+    instance = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    incoming = SimpleNamespace(
+        id=42,
+        channel=SimpleNamespace(id=777, parent_id=555),
+        author=SimpleNamespace(id=99),
+        created_at=None,
+        to_reference=lambda **_kwargs: object(),
+    )
+    instance._record_discord_message_seen(incoming, status="processing")
+    retained = SimpleNamespace(id=7001, edit=AsyncMock())
+    fallback_text = SimpleNamespace(id=7002)
+
+    async def send_message(**kwargs):
+        if kwargs.get("embed") is not None:
+            return retained
+        if "files" in kwargs or "file" in kwargs:
+            raise RuntimeError("native attachment unavailable")
+        return fallback_text
+
+    thread = SimpleNamespace(
+        id=777,
+        send=AsyncMock(side_effect=send_message),
+        fetch_message=AsyncMock(return_value=incoming),
+    )
+    instance._client = SimpleNamespace(
+        get_channel=lambda channel_id: thread if channel_id in {555, 777} else None,
+        fetch_channel=AsyncMock(),
+    )
+    await instance.send(
+        "555",
+        "Working",
+        metadata={
+            "thread_id": "777",
+            "status_key": "task_run:message:42",
+            "reply_to_message_id": "42",
+        },
+    )
+
+    async def handler(event):
+        event._status_key = "task_run:message:42"
+        return "![report](https://example.com/report.png)"
+
+    async def hold_typing(_chat_id, interval=2.0, metadata=None):
+        await asyncio.Event().wait()
+
+    instance.set_message_handler(handler)
+    instance._keep_typing = hold_typing
+    event = MessageEvent(
+        text="Send the report",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="555",
+            chat_type="thread",
+            thread_id="777",
+        ),
+        message_id="42",
+    )
+
+    await instance._process_message_background(
+        event,
+        build_session_key(event.source),
+    )
+
+    receipt = instance._with_discord_recovery_db(
+        lambda conn: conn.execute(
+            "SELECT status, replied FROM discord_messages WHERE message_id='42'"
+        ).fetchone()
+    )
+    sent_text = [
+        call.kwargs.get("content")
+        for call in thread.send.await_args_list
+        if "file" not in call.kwargs and "files" not in call.kwargs
+    ]
+    assert len(sent_text) == 2
+    assert sent_text[0].endswith("\nWorking")
+    assert sent_text[1] == "report\nhttps://example.com/report.png"
+    assert receipt == ("failed", 0)
+    retained.edit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_oversized_cached_terminal_edit_records_durable_completion(
     tmp_path, monkeypatch
 ):
@@ -727,6 +854,75 @@ async def test_oversized_cached_terminal_edit_records_durable_completion(
             "final": True,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_cached_terminal_edit_plaintext_recovery_records_durable_completion(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_MISSED_MESSAGE_BACKFILL", "true")
+    instance = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    incoming = SimpleNamespace(
+        id=42,
+        channel=SimpleNamespace(id=777, parent_id=555),
+        author=SimpleNamespace(id=99),
+        created_at=None,
+        to_reference=lambda **_kwargs: object(),
+    )
+    instance._record_discord_message_seen(incoming, status="processing")
+    sent_ids = iter((7001, 7002))
+    thread = SimpleNamespace(
+        id=777,
+        send=AsyncMock(
+            side_effect=lambda **_kwargs: SimpleNamespace(id=next(sent_ids))
+        ),
+        fetch_message=AsyncMock(return_value=incoming),
+    )
+    instance._client = SimpleNamespace(
+        get_channel=lambda channel_id: thread if channel_id == 777 else None,
+        fetch_channel=AsyncMock(),
+    )
+
+    await instance.send(
+        "555",
+        "Working",
+        metadata={
+            "thread_id": "777",
+            "status_key": "task_run:message:42",
+            "reply_to_message_id": "42",
+        },
+    )
+    instance.edit_message = AsyncMock(
+        return_value=SendResult(success=False, error="stale message")
+    )
+
+    result = await instance.send(
+        "555",
+        "Complete final result",
+        metadata={
+            "thread_id": "777",
+            "status_key": "task_run:message:42",
+            "status_terminal": True,
+            "reply_to_message_id": "42",
+        },
+    )
+
+    receipt = instance._with_discord_recovery_db(
+        lambda conn: conn.execute(
+            "SELECT status, replied, response_message_id "
+            "FROM discord_messages WHERE message_id='42'"
+        ).fetchone()
+    )
+    assert result == SendResult(
+        success=True,
+        message_id="7002",
+        raw_response={"message_ids": ["7002"]},
+    )
+    assert receipt == ("responded", 1, "7002")
+    instance.edit_message.assert_awaited_once()
+    assert thread.send.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_status_cards.py
+++ b/tests/gateway/test_discord_status_cards.py
@@ -574,6 +574,129 @@ async def test_stream_edit_and_base_final_share_one_real_discord_message(
 
 
 @pytest.mark.asyncio
+async def test_oversized_cached_terminal_edit_records_durable_completion(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter._build_operator_card_embed",
+        lambda card: {"kind": card.card_type},
+    )
+    instance = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    record_response = Mock()
+    instance._record_discord_response = record_response
+    retained = SimpleNamespace(
+        id=7001,
+        edit=AsyncMock(),
+        to_reference=lambda **_kwargs: object(),
+    )
+    next_message_id = 7002
+
+    async def send_message(**_kwargs):
+        nonlocal next_message_id
+        if next_message_id == 7002:
+            next_message_id += 1
+            return retained
+        message = SimpleNamespace(
+            id=next_message_id,
+            to_reference=lambda **_kwargs: object(),
+        )
+        next_message_id += 1
+        return message
+
+    thread = SimpleNamespace(
+        id=777,
+        send=AsyncMock(side_effect=send_message),
+        fetch_message=AsyncMock(
+            side_effect=lambda message_id: retained
+            if int(message_id) in {42, 7001}
+            else None
+        ),
+    )
+    instance._client = SimpleNamespace(
+        get_channel=lambda channel_id: thread if channel_id == 777 else None,
+        fetch_channel=AsyncMock(),
+    )
+
+    await instance.send(
+        "555",
+        "Working",
+        metadata={
+            "thread_id": "777",
+            "status_key": "task_run",
+            "reply_to_message_id": "42",
+        },
+    )
+    final_text = "Complete final result " * 300
+    result = await instance.send(
+        "555",
+        final_text,
+        metadata={
+            "thread_id": "777",
+            "status_key": "task_run",
+            "status_terminal": True,
+            "notify": True,
+            "reply_to_message_id": "42",
+        },
+    )
+
+    assert result.success is True
+    assert result.continuation_message_ids
+    terminal_receipts = [
+        call.kwargs
+        for call in record_response.call_args_list
+        if call.kwargs.get("final")
+    ]
+    assert terminal_receipts == [
+        {
+            "reply_to": "42",
+            "result": result,
+            "content": final_text,
+            "final": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_partial_oversized_terminal_edit_does_not_record_completion(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    instance = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    record_response = Mock()
+    instance._record_discord_response = record_response
+    retained = SimpleNamespace(id=7001, edit=AsyncMock())
+    thread = SimpleNamespace(fetch_message=AsyncMock(return_value=retained))
+    instance._client = SimpleNamespace(
+        get_channel=lambda channel_id: thread if channel_id == 777 else None,
+        fetch_channel=AsyncMock(),
+    )
+    partial_result = SendResult(
+        success=True,
+        message_id="7001",
+        continuation_message_ids=["7002"],
+        raw_response={"partial_overflow": True},
+    )
+    instance._edit_overflow_split = AsyncMock(return_value=partial_result)
+
+    result = await instance.edit_message(
+        "555",
+        "7001",
+        "Incomplete final result " * 300,
+        finalize=True,
+        metadata={
+            "thread_id": "777",
+            "status_terminal": True,
+            "reply_to_message_id": "42",
+        },
+    )
+
+    assert result is partial_result
+    instance._edit_overflow_split.assert_awaited_once()
+    record_response.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_gateway_style_running_edit_refreshes_embed_in_routed_thread(
     tmp_path, monkeypatch
 ):

--- a/tests/gateway/test_discord_status_cards.py
+++ b/tests/gateway/test_discord_status_cards.py
@@ -578,6 +578,150 @@ async def test_stream_edit_and_base_final_share_one_real_discord_message(
 
 
 @pytest.mark.asyncio
+async def test_attachment_reaches_thread_before_retained_card_terminalizes(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter._build_operator_card_embed",
+        lambda card: {"kind": card.card_type},
+    )
+    image_path = tmp_path / "report.png"
+    image_path.write_bytes(b"\x89PNG" + b"\x00" * 20)
+
+    instance = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    retained = SimpleNamespace(id=7001, edit=AsyncMock())
+    attachment = SimpleNamespace(id=7002)
+    delivery_order = []
+
+    async def send_to_thread(**kwargs):
+        if kwargs.get("embed") is not None:
+            delivery_order.append("status")
+            return retained
+        if kwargs.get("file") is not None:
+            delivery_order.append("attachment")
+            return attachment
+        raise AssertionError(f"unexpected thread send: {kwargs}")
+
+    parent = SimpleNamespace(id=555, send=AsyncMock())
+    thread = SimpleNamespace(
+        id=777,
+        send=AsyncMock(side_effect=send_to_thread),
+        fetch_message=AsyncMock(return_value=retained),
+    )
+    instance._client = SimpleNamespace(
+        get_channel=lambda channel_id: {555: parent, 777: thread}.get(channel_id),
+        fetch_channel=AsyncMock(),
+    )
+
+    await instance.send(
+        "555",
+        "Working",
+        metadata={"thread_id": "777", "status_key": "task_run:message:42"},
+    )
+    attachment_result = await instance.send_image_file(
+        "555",
+        str(image_path),
+        metadata={
+            "thread_id": "777",
+            "status_key": "task_run:message:42",
+            "status_terminal": True,
+        },
+    )
+    await instance.send(
+        "555",
+        "Attachment delivered.",
+        metadata={
+            "thread_id": "777",
+            "status_key": "task_run:message:42",
+            "status_terminal": True,
+        },
+    )
+
+    assert attachment_result.delivered_attachment_count == 1
+    assert delivery_order == ["status", "attachment"]
+    parent.send.assert_not_awaited()
+    retained.edit.assert_awaited_once_with(
+        content="Attachment delivered.",
+        embed=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_attachment_warning_fallback_stays_in_thread_without_terminal_receipt(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter._build_operator_card_embed",
+        lambda card: {"kind": card.card_type},
+    )
+    image_path = tmp_path / "report.png"
+    image_path.write_bytes(b"\x89PNG" + b"\x00" * 20)
+
+    instance = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    record_response = Mock()
+    instance._record_discord_response = record_response
+    retained = SimpleNamespace(id=7001, edit=AsyncMock())
+    warning = SimpleNamespace(id=7002)
+
+    async def send_to_thread(**kwargs):
+        if kwargs.get("embed") is not None:
+            return retained
+        if kwargs.get("file") is not None:
+            raise RuntimeError("native attachment unavailable")
+        if kwargs.get("content") == "⚠️ Couldn't deliver the image attachment.":
+            return warning
+        raise AssertionError(f"unexpected thread send: {kwargs}")
+
+    parent = SimpleNamespace(id=555, send=AsyncMock())
+    thread = SimpleNamespace(
+        id=777,
+        send=AsyncMock(side_effect=send_to_thread),
+        fetch_message=AsyncMock(return_value=retained),
+    )
+    instance._client = SimpleNamespace(
+        get_channel=lambda channel_id: {555: parent, 777: thread}.get(channel_id),
+        fetch_channel=AsyncMock(),
+    )
+    await instance.send(
+        "555",
+        "Working",
+        metadata={"thread_id": "777", "status_key": "task_run:message:42"},
+    )
+    record_response.reset_mock()
+    retained.edit.reset_mock()
+
+    fallback_result = await instance.send_image_file(
+        "555",
+        str(image_path),
+        reply_to="42",
+        metadata={
+            "thread_id": "777",
+            "reply_to_message_id": "42",
+            "notify": True,
+            "status_key": "task_run:message:42",
+            "status_terminal": True,
+        },
+    )
+
+    assert fallback_result.success is True
+    assert fallback_result.delivered_attachment_count == 0
+    parent.send.assert_not_awaited()
+    retained.edit.assert_not_awaited()
+    text_sends = [
+        call.kwargs.get("content")
+        for call in thread.send.await_args_list
+        if call.kwargs.get("file") is None
+    ]
+    assert text_sends[-1] == "⚠️ Couldn't deliver the image attachment."
+    assert [
+        call.kwargs for call in record_response.call_args_list
+        if call.kwargs.get("final")
+    ] == []
+
+
+@pytest.mark.asyncio
 async def test_failed_image_only_final_keeps_real_card_and_receipt_nonterminal(
     tmp_path, monkeypatch
 ):

--- a/tests/gateway/test_discord_workspace_headers.py
+++ b/tests/gateway/test_discord_workspace_headers.py
@@ -1,0 +1,370 @@
+"""Behavior contracts for persistent Discord thread workspace headers."""
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
+from gateway.session import SessionSource
+from plugins.platforms.discord.adapter import DiscordAdapter
+from plugins.platforms.discord.workspace_headers import (
+    WorkspaceHeaderStore,
+    WorkspaceHeaderStoreError,
+    collect_workspace_header_candidates,
+    revalidate_workspace_header_candidate,
+)
+
+
+def _source(*, scope_id="111", thread_id="222") -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id=thread_id,
+        chat_name="MMG / launch-plan",
+        chat_type="thread",
+        user_id="333",
+        user_name="Martin",
+        thread_id=thread_id,
+        scope_id=scope_id,
+        parent_chat_id="444",
+    )
+
+
+@pytest.fixture
+def adapter(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    instance = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter._build_operator_card_embed",
+        lambda card: {
+            "card_type": card.card_type,
+            "state_ref": card.state_ref,
+            "fields": {field.label: field.value for field in card.fields},
+        },
+    )
+    return instance
+
+
+@pytest.mark.asyncio
+async def test_workspace_header_creates_once_then_edits_same_message(adapter, tmp_path):
+    header_message = SimpleNamespace(id=7001, edit=AsyncMock())
+    thread = SimpleNamespace(
+        id=222,
+        name="launch-plan",
+        guild=SimpleNamespace(id=111),
+        send=AsyncMock(return_value=header_message),
+        fetch_message=AsyncMock(return_value=header_message),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda channel_id: thread if channel_id == 222 else None,
+        fetch_channel=AsyncMock(),
+    )
+
+    created = await adapter.ensure_workspace_header(_source())
+    updated = await adapter.ensure_workspace_header(_source())
+
+    assert created.success is True
+    assert created.action == "created"
+    assert updated.success is True
+    assert updated.action == "updated"
+    assert thread.send.await_count == 1
+    thread.fetch_message.assert_awaited_once_with(7001)
+    assert header_message.edit.await_count == 1
+    assert header_message.edit.await_args.kwargs["embed"]["card_type"] == "thread_header"
+    assert header_message.edit.await_args.kwargs["content"].startswith("🔵")
+    assert header_message.edit.await_args.kwargs["embed"]["state_ref"] == "discord-workspace:111:222"
+    assert header_message.edit.await_args.kwargs["embed"]["fields"] == {
+        "Owner": "Hermes",
+        "Status": "Active",
+        "Thread": "<#222>",
+        "Linked issue / artifact": "Not linked",
+        "Last decision": "No decision recorded",
+        "Next action": "Awaiting next assistant turn",
+    }
+
+    persisted = WorkspaceHeaderStore().get("111", "222")
+    assert persisted is not None
+    assert persisted.message_id == "7001"
+    assert (tmp_path / "gateway" / "discord_workspace_headers.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_workspace_header_identity_survives_adapter_restart(adapter, tmp_path, monkeypatch):
+    adapter._workspace_headers.put("111", "222", "7001")
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    restarted = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    binding = restarted._workspace_headers.get("111", "222")
+    assert binding is not None
+    assert binding.message_id == "7001"
+
+
+@pytest.mark.asyncio
+async def test_workspace_header_persists_and_renders_thread_context(adapter, tmp_path, monkeypatch):
+    adapter._workspace_headers.update_state(
+        "111",
+        "222",
+        owner="Martin + Hermes",
+        status="Needs review",
+        linked_issue_or_artifact="OE-178 · docs/proofs/header.md",
+        last_decision="Keep the human-renamed thread title",
+        next_action="Review the backfill dry run",
+    )
+    header_message = SimpleNamespace(id=7001)
+    thread = SimpleNamespace(
+        id=222,
+        name="launch-plan",
+        guild=SimpleNamespace(id=111),
+        send=AsyncMock(return_value=header_message),
+    )
+    adapter._client = SimpleNamespace(get_channel=lambda _id: thread, fetch_channel=AsyncMock())
+
+    created = await adapter.ensure_workspace_header(_source())
+
+    assert created.success is True
+    fields = thread.send.await_args.kwargs["embed"]["fields"]
+    assert fields["Owner"] == "Martin + Hermes"
+    assert fields["Status"] == "Needs review"
+    assert fields["Linked issue / artifact"] == "OE-178 · docs/proofs/header.md"
+    assert fields["Last decision"] == "Keep the human-renamed thread title"
+    assert fields["Next action"] == "Review the backfill dry run"
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    restarted = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    state = restarted._workspace_headers.get_state("111", "222")
+    assert state is not None
+    assert state.linked_issue_or_artifact == "OE-178 · docs/proofs/header.md"
+    assert state.last_decision == "Keep the human-renamed thread title"
+    assert state.next_action == "Review the backfill dry run"
+
+
+@pytest.mark.asyncio
+async def test_workspace_header_requires_canonical_scope_and_matching_live_guild(adapter):
+    thread = SimpleNamespace(
+        id=222,
+        name="launch-plan",
+        guild=SimpleNamespace(id=999),
+        send=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(get_channel=lambda _id: thread, fetch_channel=AsyncMock())
+
+    missing_scope = await adapter.ensure_workspace_header(_source(scope_id=None))
+    mismatched_scope = await adapter.ensure_workspace_header(_source(scope_id="111"))
+
+    assert missing_scope.success is False
+    assert missing_scope.action == "skipped"
+    assert mismatched_scope.success is False
+    assert mismatched_scope.action == "skipped"
+    thread.send.assert_not_awaited()
+
+
+class _UnknownMessage(RuntimeError):
+    status = 404
+    code = 10008
+
+
+@pytest.mark.asyncio
+async def test_deleted_header_is_recreated_but_transient_fetch_failure_never_duplicates(adapter):
+    adapter._workspace_headers.put("111", "222", "7001")
+    replacement = SimpleNamespace(id=7002)
+    thread = SimpleNamespace(
+        id=222,
+        name="launch-plan",
+        guild=SimpleNamespace(id=111),
+        send=AsyncMock(return_value=replacement),
+        fetch_message=AsyncMock(side_effect=_UnknownMessage("Unknown Message")),
+    )
+    adapter._client = SimpleNamespace(get_channel=lambda _id: thread, fetch_channel=AsyncMock())
+
+    recreated = await adapter.ensure_workspace_header(_source())
+
+    assert recreated.success is True
+    assert recreated.action == "recreated"
+    assert thread.send.await_count == 1
+    assert adapter._workspace_headers.get("111", "222").message_id == "7002"
+
+    adapter._workspace_headers.put("111", "222", "7003")
+    thread.fetch_message = AsyncMock(side_effect=RuntimeError("temporary transport failure"))
+    thread.send.reset_mock()
+
+    failed = await adapter.ensure_workspace_header(_source())
+
+    assert failed.success is False
+    assert failed.action == "failed"
+    thread.send.assert_not_awaited()
+    assert adapter._workspace_headers.get("111", "222").message_id == "7003"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "registry_payload",
+    ["not json", '{"version": 999, "workspaces": {}}'],
+)
+async def test_corrupt_or_unknown_registry_fails_closed_without_duplicate(
+    adapter, tmp_path, registry_payload
+):
+    registry = tmp_path / "gateway" / "discord_workspace_headers.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(registry_payload, encoding="utf-8")
+    thread = SimpleNamespace(
+        id=222,
+        name="launch-plan",
+        guild=SimpleNamespace(id=111),
+        send=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(get_channel=lambda _id: thread, fetch_channel=AsyncMock())
+
+    result = await adapter.ensure_workspace_header(_source())
+
+    assert result.success is False
+    assert result.action == "failed"
+    assert "registry" in (result.error or "")
+    thread.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_send_persistence_failure_leaves_reservation_and_never_duplicates(
+    adapter, monkeypatch
+):
+    sent = SimpleNamespace(id=7001)
+    thread = SimpleNamespace(
+        id=222,
+        name="launch-plan",
+        guild=SimpleNamespace(id=111),
+        send=AsyncMock(return_value=sent),
+    )
+    adapter._client = SimpleNamespace(get_channel=lambda _id: thread, fetch_channel=AsyncMock())
+    monkeypatch.setattr(
+        adapter._workspace_headers,
+        "complete_creation",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            WorkspaceHeaderStoreError("simulated persistence failure")
+        ),
+    )
+
+    first = await adapter.ensure_workspace_header(_source())
+    second = await adapter.ensure_workspace_header(_source())
+
+    assert first.success is False
+    assert first.message_id == "7001"
+    assert second.success is False
+    assert "pending" in (second.error or "")
+    assert thread.send.await_count == 1
+
+
+def test_two_store_instances_serialize_read_modify_write_without_lost_binding(tmp_path, monkeypatch):
+    path = tmp_path / "headers.json"
+    first = WorkspaceHeaderStore(path=path)
+    second = WorkspaceHeaderStore(path=path)
+    first_read = Event()
+    allow_first_write = Event()
+    original_read = first._read_unlocked
+
+    def delayed_read():
+        payload = original_read()
+        first_read.set()
+        assert allow_first_write.wait(timeout=2)
+        return payload
+
+    monkeypatch.setattr(first, "_read_unlocked", delayed_read)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first_put = executor.submit(first.put, "111", "222", "7001")
+        assert first_read.wait(timeout=2)
+        second_put = executor.submit(second.put, "111", "333", "7002")
+        assert second_put.done() is False
+        allow_first_write.set()
+        first_put.result(timeout=2)
+        second_put.result(timeout=2)
+
+    assert WorkspaceHeaderStore(path=path).get("111", "222").message_id == "7001"
+    assert WorkspaceHeaderStore(path=path).get("111", "333").message_id == "7002"
+
+
+@pytest.mark.asyncio
+async def test_successful_turn_refreshes_header_without_changing_participation(adapter):
+    adapter.ensure_workspace_header = AsyncMock()
+    source = _source()
+    event = MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=source,
+        raw_message=SimpleNamespace(id=123),
+    )
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    adapter.ensure_workspace_header.assert_awaited_once_with(source)
+    assert "222" not in adapter._threads
+
+    adapter.ensure_workspace_header.reset_mock()
+    await adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
+    adapter.ensure_workspace_header.assert_not_awaited()
+
+
+def test_backfill_candidates_are_known_workspaces_and_do_not_propose_title_changes(tmp_path):
+    store = WorkspaceHeaderStore(path=tmp_path / "headers.json")
+    store.put("111", "10", "9000")
+    store.put("111", "13", "9003")
+    threads = [
+        SimpleNamespace(id=10, name="Hermes", guild=SimpleNamespace(id=111)),
+        SimpleNamespace(id=11, name="Human-renamed launch", guild=SimpleNamespace(id=111)),
+        SimpleNamespace(id=12, name="Hermes", guild=SimpleNamespace(id=111)),
+        SimpleNamespace(id=13, name="Human-renamed retained", guild=SimpleNamespace(id=111)),
+    ]
+
+    candidates = collect_workspace_header_candidates(
+        threads,
+        participated_thread_ids={"10", "11", "13"},
+        store=store,
+    )
+
+    assert [(item.thread_id, item.reasons) for item in candidates] == [
+        ("10", ("placeholder_title",)),
+        ("11", ("header_missing",)),
+    ]
+    assert all(item.proposed_title is None for item in candidates)
+
+
+def test_backfill_apply_revalidates_title_participation_scope_and_missing_state(tmp_path):
+    store = WorkspaceHeaderStore(path=tmp_path / "headers.json")
+    planned_thread = SimpleNamespace(id=22, name="Hermes", guild=SimpleNamespace(id=111))
+    candidate = collect_workspace_header_candidates(
+        [planned_thread], participated_thread_ids={"22"}, store=store
+    )[0]
+
+    assert revalidate_workspace_header_candidate(
+        candidate,
+        live_thread=planned_thread,
+        participated_thread_ids={"22"},
+        store=store,
+    ) is True
+    assert revalidate_workspace_header_candidate(
+        candidate,
+        live_thread=SimpleNamespace(id=22, name="Human renamed", guild=SimpleNamespace(id=111)),
+        participated_thread_ids={"22"},
+        store=store,
+    ) is False
+    assert revalidate_workspace_header_candidate(
+        candidate,
+        live_thread=planned_thread,
+        participated_thread_ids=set(),
+        store=store,
+    ) is False
+    assert revalidate_workspace_header_candidate(
+        candidate,
+        live_thread=SimpleNamespace(id=22, name="Hermes", guild=SimpleNamespace(id=999)),
+        participated_thread_ids={"22"},
+        store=store,
+    ) is False
+
+    store.put("111", "22", "9000")
+    assert revalidate_workspace_header_candidate(
+        candidate,
+        live_thread=planned_thread,
+        participated_thread_ids={"22"},
+        store=store,
+    ) is False

--- a/tests/gateway/test_discord_workspace_headers.py
+++ b/tests/gateway/test_discord_workspace_headers.py
@@ -305,6 +305,53 @@ async def test_successful_turn_refreshes_header_without_changing_participation(a
     adapter.ensure_workspace_header.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_processing_outcome_updates_existing_workspace_header_before_edit(adapter):
+    adapter._workspace_headers.put("111", "222", "7001")
+    header_message = SimpleNamespace(id=7001, edit=AsyncMock())
+    thread = SimpleNamespace(
+        id=222,
+        name="launch-plan",
+        guild=SimpleNamespace(id=111),
+        fetch_message=AsyncMock(return_value=header_message),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda channel_id: thread if channel_id == 222 else None,
+        fetch_channel=AsyncMock(),
+    )
+    source = _source()
+    event = MessageEvent(
+        text="ship the reviewed plan",
+        message_type=MessageType.TEXT,
+        source=source,
+        raw_message=SimpleNamespace(id=123),
+    )
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
+
+    persisted = adapter._workspace_headers.get_state("111", "222")
+    assert persisted is not None
+    assert persisted.status == "Needs attention"
+    assert persisted.next_action == "Retry the last request"
+    header_message.edit.assert_awaited_once()
+    assert header_message.edit.await_args.kwargs["embed"]["fields"] == {
+        "Owner": "Hermes",
+        "Status": "Needs attention",
+        "Thread": "<#222>",
+        "Linked issue / artifact": "Not linked",
+        "Last decision": "No decision recorded",
+        "Next action": "Retry the last request",
+    }
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    recovered = adapter._workspace_headers.get_state("111", "222")
+    assert recovered is not None
+    assert recovered.status == "Active"
+    assert recovered.next_action == "Awaiting next assistant turn"
+    assert header_message.edit.await_count == 2
+
+
 def test_backfill_candidates_are_known_workspaces_and_do_not_propose_title_changes(tmp_path):
     store = WorkspaceHeaderStore(path=tmp_path / "headers.json")
     store.put("111", "10", "9000")

--- a/tests/gateway/test_operator_cards.py
+++ b/tests/gateway/test_operator_cards.py
@@ -84,6 +84,7 @@ def test_every_severity_has_a_mobile_readable_label(severity, label):
         ({"state_ref": ""}, "state_ref"),
         ({"actions": [{"id": "approve", "label": "Approve", "style": "neon"}]}, "style"),
         ({"links": [{"label": "Bad", "url": "javascript:alert(1)"}]}, "url"),
+        ({"links": [{"label": "Bad", "url": "https://:443"}]}, "url"),
     ],
 )
 def test_invalid_values_fail_closed(change, message):

--- a/tests/gateway/test_operator_cards.py
+++ b/tests/gateway/test_operator_cards.py
@@ -1,0 +1,129 @@
+"""Behavior contract for platform-agnostic operator cards."""
+
+import pytest
+
+from gateway.operator_cards import (
+    CARD_TYPES,
+    SEVERITIES,
+    OperatorCard,
+    OperatorCardValidationError,
+    render_operator_card_text,
+)
+
+
+def _payload(**overrides):
+    payload = {
+        "kind": "operator_card",
+        "version": 1,
+        "card_type": "approval",
+        "title": "Contract redlines",
+        "severity": "needs_review",
+        "summary": "Legal language changed in the indemnity section.",
+        "fields": [
+            {"label": "Impact", "value": "The liability boundary changed."},
+            {"label": "Next", "value": "Approve or ask for revision."},
+        ],
+        "actions": [
+            {"id": "approve", "label": "Approve", "style": "success"},
+            {"id": "revise", "label": "Revise", "style": "secondary"},
+            {"id": "escalate", "label": "Escalate", "style": "danger"},
+        ],
+        "links": [{"label": "Linear", "url": "https://linear.app/example"}],
+        "state_ref": "opaque-state-ref",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_round_trip_preserves_the_contract_without_platform_fields():
+    card = OperatorCard.from_mapping(_payload())
+
+    assert card.to_mapping() == _payload()
+    assert "discord" not in repr(card).lower()
+
+
+@pytest.mark.parametrize("card_type", sorted(CARD_TYPES))
+def test_every_card_type_uses_the_same_plaintext_contract(card_type):
+    rendered = render_operator_card_text(OperatorCard.from_mapping(_payload(card_type=card_type)))
+
+    assert "Contract redlines" in rendered
+    assert "Legal language changed" in rendered
+    assert "Impact: The liability boundary changed." in rendered
+    assert "Actions: Approve · Revise · Escalate" in rendered
+    assert "[Linear](https://linear.app/example)" in rendered
+
+
+@pytest.mark.parametrize(
+    ("severity", "label"),
+    [
+        ("done", "Done"),
+        ("info", "Info"),
+        ("needs_review", "Needs review"),
+        ("blocked", "Blocked"),
+        ("critical", "Critical"),
+    ],
+)
+def test_every_severity_has_a_mobile_readable_label(severity, label):
+    rendered = render_operator_card_text(OperatorCard.from_mapping(_payload(severity=severity)))
+
+    assert label in rendered.splitlines()[0]
+
+
+@pytest.mark.parametrize(
+    ("change", "message"),
+    [
+        ({"kind": "message"}, "kind"),
+        ({"version": 2}, "version"),
+        ({"card_type": "unknown"}, "card_type"),
+        ({"severity": "warning"}, "severity"),
+        ({"title": ""}, "title"),
+        ({"summary": ""}, "summary"),
+        ({"state_ref": ""}, "state_ref"),
+        ({"actions": [{"id": "approve", "label": "Approve", "style": "neon"}]}, "style"),
+        ({"links": [{"label": "Bad", "url": "javascript:alert(1)"}]}, "url"),
+    ],
+)
+def test_invalid_values_fail_closed(change, message):
+    with pytest.raises(OperatorCardValidationError, match=message):
+        OperatorCard.from_mapping(_payload(**change))
+
+
+@pytest.mark.parametrize("missing", ["kind", "version", "card_type", "title", "severity", "summary", "state_ref"])
+def test_missing_required_fields_fail_closed(missing):
+    payload = _payload()
+    payload.pop(missing)
+
+    with pytest.raises(OperatorCardValidationError, match=missing):
+        OperatorCard.from_mapping(payload)
+
+
+def test_unknown_top_level_fields_cannot_leak_to_downstream_renderers():
+    payload = _payload(provider_payload={"private": "must-not-pass"})
+
+    with pytest.raises(OperatorCardValidationError, match="unknown fields"):
+        OperatorCard.from_mapping(payload)
+
+
+def test_plaintext_renderer_is_bounded_without_splitting_the_status_header():
+    card = OperatorCard.from_mapping(
+        _payload(summary="x" * 500, fields=[{"label": "Impact", "value": "y" * 1000}])
+    )
+
+    rendered = render_operator_card_text(card, max_length=240)
+
+    assert len(rendered) <= 240
+    assert rendered.startswith("🟡 **Needs review — Contract redlines**")
+    assert rendered.endswith("…")
+
+
+def test_constant_sets_match_the_values_accepted_by_the_parser():
+    assert CARD_TYPES == {
+        "approval",
+        "task_run",
+        "digest",
+        "deal",
+        "capture",
+        "ops_alert",
+        "thread_header",
+    }
+    assert SEVERITIES == {"done", "info", "needs_review", "blocked", "critical"}

--- a/tests/gateway/test_operator_cards.py
+++ b/tests/gateway/test_operator_cards.py
@@ -74,6 +74,9 @@ def test_every_severity_has_a_mobile_readable_label(severity, label):
     [
         ({"kind": "message"}, "kind"),
         ({"version": 2}, "version"),
+        ({"version": 1.0}, "version"),
+        ({"version": True}, "version"),
+        ({"version": "1"}, "version"),
         ({"card_type": "unknown"}, "card_type"),
         ({"severity": "warning"}, "severity"),
         ({"title": ""}, "title"),
@@ -116,14 +119,23 @@ def test_plaintext_renderer_is_bounded_without_splitting_the_status_header():
     assert rendered.endswith("…")
 
 
-def test_constant_sets_match_the_values_accepted_by_the_parser():
-    assert CARD_TYPES == {
-        "approval",
-        "task_run",
-        "digest",
-        "deal",
-        "capture",
-        "ops_alert",
-        "thread_header",
-    }
-    assert SEVERITIES == {"done", "info", "needs_review", "blocked", "critical"}
+@pytest.mark.parametrize("card_type", sorted(CARD_TYPES))
+def test_every_declared_card_type_is_accepted_by_the_parser(card_type):
+    # Invariant: the accept-list constant and the parser agree — each declared
+    # card_type round-trips instead of being frozen against a literal set.
+    assert OperatorCard.from_mapping(_payload(card_type=card_type)).card_type == card_type
+
+
+@pytest.mark.parametrize("severity", sorted(SEVERITIES))
+def test_every_declared_severity_is_accepted_by_the_parser(severity):
+    assert OperatorCard.from_mapping(_payload(severity=severity)).severity == severity
+
+
+def test_parser_rejects_values_outside_the_declared_sets():
+    assert "totally-made-up" not in CARD_TYPES
+    with pytest.raises(OperatorCardValidationError, match="card_type"):
+        OperatorCard.from_mapping(_payload(card_type="totally-made-up"))
+
+    assert "totally-made-up" not in SEVERITIES
+    with pytest.raises(OperatorCardValidationError, match="severity"):
+        OperatorCard.from_mapping(_payload(severity="totally-made-up"))

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -1,11 +1,13 @@
 """Tests for gateway proxy mode — forwarding messages to a remote API server."""
 
+import asyncio
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from gateway.config import Platform, StreamingConfig
-from gateway.platforms.base import resolve_proxy_url
+from gateway.platforms.base import SendResult, resolve_proxy_url
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
 
@@ -279,6 +281,98 @@ class TestRunAgentViaProxy:
 
         # Verify response was assembled
         assert result["final_response"] == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_discord_proxy_stream_uses_per_run_status_identity(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        runner = _make_runner()
+        source = _make_source(Platform.DISCORD)
+        source.chat_id = "555"
+        source.thread_id = "777"
+        adapter = MagicMock()
+        adapter.SUPPORTS_MESSAGE_EDITING = True
+        adapter.send_typing = AsyncMock()
+        adapter.send = AsyncMock(
+            return_value=SendResult(success=True, message_id="7001")
+        )
+        runner.adapters[Platform.DISCORD] = adapter
+        runner._session_run_generation["discord:555:thread:777"] = 4
+        runner.config.streaming.enabled = True
+        runner.config.streaming.transport = "edit"
+
+        captured = {}
+
+        class _CapturingConsumer:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.metadata = kwargs["metadata"]
+                self.adapter = kwargs["adapter"]
+                self.chat_id = kwargs["chat_id"]
+                self.content = ""
+                self._finished = asyncio.Event()
+
+            async def run(self):
+                await self._finished.wait()
+                final_metadata = dict(self.metadata)
+                if final_metadata.get("status_key"):
+                    final_metadata["status_terminal"] = True
+                await self.adapter.send(
+                    self.chat_id,
+                    self.content,
+                    metadata=final_metadata,
+                )
+
+            def on_delta(self, content):
+                self.content += content
+
+            def finish(self):
+                self._finished.set()
+
+        resp = _FakeSSEResponse(
+            status=200,
+            sse_chunks=[
+                b'data: {"choices":[{"delta":{"content":"done"}}]}\n\n'
+                b'data: [DONE]\n\n'
+            ],
+        )
+        session = _FakeSession(resp)
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout"):
+                    with patch(
+                        "gateway.display_config.resolve_display_setting",
+                        return_value=True,
+                    ):
+                        with patch(
+                            "gateway.stream_consumer.GatewayStreamConsumer",
+                            _CapturingConsumer,
+                        ):
+                            result = await runner._run_agent_via_proxy(
+                                message="hi",
+                                context_prompt="",
+                                history=[],
+                                source=source,
+                                session_id="sess-123",
+                                session_key="discord:555:thread:777",
+                                run_generation=4,
+                                event_message_id="42",
+                            )
+
+        assert result["final_response"] == "done"
+        assert captured["metadata"] == {
+            "thread_id": "777",
+            "status_key": "task_run:message:42",
+        }
+        adapter.send.assert_awaited_once_with(
+            "555",
+            "done",
+            metadata={
+                "thread_id": "777",
+                "status_key": "task_run:message:42",
+                "status_terminal": True,
+            },
+        )
 
     @pytest.mark.asyncio
     async def test_handles_http_error(self, monkeypatch):

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -363,6 +363,7 @@ class TestRunAgentViaProxy:
         assert captured["metadata"] == {
             "thread_id": "777",
             "status_key": "task_run:message:42",
+            "reply_to_message_id": "42",
         }
         adapter.send.assert_awaited_once_with(
             "555",
@@ -370,6 +371,7 @@ class TestRunAgentViaProxy:
             metadata={
                 "thread_id": "777",
                 "status_key": "task_run:message:42",
+                "reply_to_message_id": "42",
                 "status_terminal": True,
             },
         )

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -166,7 +166,13 @@ def _make_runner(adapter):
     return runner
 
 
-def _install_fakes(monkeypatch, agent_cls, *, cleanup_on: bool):
+def _install_fakes(
+    monkeypatch,
+    agent_cls,
+    *,
+    cleanup_on: bool,
+    platform_key: str = "telegram",
+):
     """Wire up the module stubs every _run_agent test needs."""
     monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
 
@@ -187,7 +193,7 @@ def _install_fakes(monkeypatch, agent_cls, *, cleanup_on: bool):
     cfg = {
         "display": {
             "platforms": {
-                "telegram": {"cleanup_progress": True},
+                platform_key: {"cleanup_progress": True},
             }
         }
     } if cleanup_on else {}
@@ -272,6 +278,48 @@ async def test_cleanup_registers_callback_and_deletes_on_success(monkeypatch, tm
     assert len(adapter.deleted) >= 1, f"deleted={adapter.deleted} sent={adapter.sent}"
     for entry in adapter.deleted:
         assert entry["chat_id"] == "-1001"
+
+
+@pytest.mark.asyncio
+async def test_discord_keyed_card_is_never_registered_for_progress_cleanup(
+    monkeypatch,
+    tmp_path,
+):
+    """The retained Discord progress identity becomes the final answer."""
+    adapter = CleanupCaptureAdapter(Platform.DISCORD)
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(
+        monkeypatch,
+        ProgressAgent,
+        cleanup_on=True,
+        platform_key="discord",
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    source = SessionSource(platform=Platform.DISCORD, chat_id="555", thread_id="777")
+    session_key = "agent:main:discord:channel:555:thread:777"
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key=session_key,
+        event_message_id="42",
+    )
+
+    assert result["final_response"] == "done"
+    assert any(
+        (entry["metadata"] or {}).get("status_key") == "task_run:message:42"
+        for entry in adapter.sent
+    )
+    callback = adapter.pop_post_delivery_callback(session_key)
+    if callback is not None:
+        await _fire_post_delivery_cb(callback)
+        for _ in range(10):
+            await asyncio.sleep(0.01)
+    assert adapter.deleted == []
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_keyed_status_cards.py
+++ b/tests/gateway/test_run_keyed_status_cards.py
@@ -412,3 +412,62 @@ async def test_base_final_delivery_carries_terminal_status_identity():
             },
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_attachment_only_final_explicitly_terminalizes_status_card():
+    adapter = _FinalDeliveryAdapter()
+    adapter.extract_media = lambda _response: ([('/tmp/report.pdf', False)], "")
+    adapter.filter_media_delivery_paths = lambda media: media
+    adapter.send_document = AsyncMock(
+        return_value=SendResult(success=True, message_id="attachment-1")
+    )
+
+    async def handler(event):
+        event._status_key = "task_run:message:42"
+        return "MEDIA:/tmp/report.pdf"
+
+    async def hold_typing(_chat_id, interval=2.0, metadata=None):
+        await asyncio.Event().wait()
+
+    adapter.set_message_handler(handler)
+    adapter._keep_typing = hold_typing
+    event = MessageEvent(
+        text="Send the report",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="555",
+            chat_type="thread",
+            thread_id="777",
+        ),
+        message_id="42",
+    )
+
+    await adapter._process_message_background(
+        event,
+        build_session_key(event.source),
+    )
+
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="555",
+        file_path="/tmp/report.pdf",
+        metadata={
+            "thread_id": "777",
+            "notify": True,
+            "status_key": "task_run:message:42",
+            "status_terminal": True,
+        },
+    )
+    assert adapter.sent == [
+        {
+            "chat_id": "555",
+            "content": "Attachment delivered.",
+            "reply_to": "42",
+            "metadata": {
+                "thread_id": "777",
+                "notify": True,
+                "status_key": "task_run:message:42",
+                "status_terminal": True,
+            },
+        }
+    ]

--- a/tests/gateway/test_run_keyed_status_cards.py
+++ b/tests/gateway/test_run_keyed_status_cards.py
@@ -10,7 +10,11 @@ import pytest
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
-from gateway.run import _discord_task_run_status_key, _send_or_update_status_coro
+from gateway.run import (
+    _discord_task_run_status_key,
+    _edit_streamed_transformed_final,
+    _send_or_update_status_coro,
+)
 from gateway.session import SessionSource, build_session_key
 from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
 
@@ -129,6 +133,108 @@ async def test_stream_terminal_metadata_is_copied_not_shared_with_heartbeat():
             "status_terminal": True,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_segment_break_finalize_keeps_keyed_card_running():
+    calls = []
+
+    class _Adapter:
+        async def edit_message(
+            self,
+            chat_id,
+            message_id,
+            content,
+            *,
+            finalize=False,
+            metadata=None,
+        ):
+            calls.append({"finalize": finalize, "metadata": metadata})
+            return SendResult(success=True, message_id=message_id)
+
+    consumer = GatewayStreamConsumer(
+        adapter=_Adapter(),
+        chat_id="555",
+        config=StreamConsumerConfig(cursor=""),
+        metadata={"thread_id": "777", "status_key": "task_run:message:42"},
+    )
+    consumer._message_id = "7001"
+    consumer._last_sent_text = "Earlier text"
+
+    await consumer._send_or_edit(
+        "Segment complete",
+        finalize=True,
+        is_turn_final=False,
+    )
+
+    assert calls == [
+        {
+            "finalize": True,
+            "metadata": {
+                "thread_id": "777",
+                "status_key": "task_run:message:42",
+                "status_terminal": False,
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transformed_stream_edit_keeps_routing_and_requires_success():
+    calls = []
+
+    class _Adapter:
+        async def edit_message(
+            self,
+            chat_id,
+            message_id,
+            content,
+            *,
+            finalize=False,
+            metadata=None,
+        ):
+            calls.append(
+                {
+                    "chat_id": chat_id,
+                    "message_id": message_id,
+                    "content": content,
+                    "finalize": finalize,
+                    "metadata": metadata,
+                }
+            )
+            return SendResult(success=len(calls) == 2, message_id=message_id)
+
+    consumer = GatewayStreamConsumer(
+        adapter=_Adapter(),
+        chat_id="555",
+        config=StreamConsumerConfig(),
+        metadata={"thread_id": "777", "status_key": "task_run:message:42"},
+    )
+
+    failed = await _edit_streamed_transformed_final(
+        consumer,
+        message_id="7001",
+        content="Transformed final",
+    )
+    delivered = await _edit_streamed_transformed_final(
+        consumer,
+        message_id="7001",
+        content="Transformed final",
+    )
+
+    assert failed is False
+    assert delivered is True
+    assert calls[0] == calls[1] == {
+        "chat_id": "555",
+        "message_id": "7001",
+        "content": "Transformed final",
+        "finalize": True,
+        "metadata": {
+            "thread_id": "777",
+            "status_key": "task_run:message:42",
+            "status_terminal": True,
+        },
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_keyed_status_cards.py
+++ b/tests/gateway/test_run_keyed_status_cards.py
@@ -1,0 +1,210 @@
+"""Gateway seam coverage for Discord's retained task-run status card."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
+from gateway.run import _discord_task_run_status_key, _send_or_update_status_coro
+from gateway.session import SessionSource, build_session_key
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+@pytest.mark.asyncio
+async def test_status_callback_prefers_routed_metadata_status_key():
+    adapter = SimpleNamespace(
+        send_or_update_status=AsyncMock(
+            return_value=SendResult(success=True, message_id="7001")
+        ),
+        send=AsyncMock(),
+    )
+
+    result = await _send_or_update_status_coro(
+        adapter,
+        "555",
+        "compression",
+        "Still working",
+        {"thread_id": "777", "status_key": "task_run"},
+    )
+
+    assert result.message_id == "7001"
+    adapter.send_or_update_status.assert_awaited_once_with(
+        "555",
+        "task_run",
+        "Still working",
+        metadata={"thread_id": "777", "status_key": "task_run"},
+    )
+    adapter.send.assert_not_awaited()
+
+
+def test_discord_task_run_key_is_stable_within_run_and_distinct_across_runs():
+    first = _discord_task_run_status_key(
+        Platform.DISCORD,
+        event_message_id="42",
+        session_key="discord:555:thread:777",
+        run_generation=1,
+    )
+    same_first = _discord_task_run_status_key(
+        Platform.DISCORD,
+        event_message_id="42",
+        session_key="discord:555:thread:777",
+        run_generation=1,
+    )
+    second = _discord_task_run_status_key(
+        Platform.DISCORD,
+        event_message_id="43",
+        session_key="discord:555:thread:777",
+        run_generation=2,
+    )
+
+    assert first == same_first == "task_run:message:42"
+    assert second == "task_run:message:43"
+    assert first != second
+
+
+def test_discord_task_run_key_fallback_is_generation_scoped():
+    first = _discord_task_run_status_key(
+        Platform.DISCORD,
+        session_key="discord:555:thread:777",
+        run_generation=1,
+    )
+    second = _discord_task_run_status_key(
+        Platform.DISCORD,
+        session_key="discord:555:thread:777",
+        run_generation=2,
+    )
+
+    assert first.startswith("task_run:generation:")
+    assert second.startswith("task_run:generation:")
+    assert first != second
+    assert _discord_task_run_status_key(Platform.TELEGRAM) is None
+
+
+@pytest.mark.asyncio
+async def test_stream_terminal_metadata_is_copied_not_shared_with_heartbeat():
+    calls = []
+
+    class _Adapter:
+        async def edit_message(
+            self,
+            chat_id,
+            message_id,
+            content,
+            *,
+            finalize=False,
+            metadata=None,
+        ):
+            calls.append(metadata)
+            return SendResult(success=True, message_id=message_id)
+
+    shared = {"thread_id": "777", "status_key": "task_run:message:42"}
+    consumer = GatewayStreamConsumer(
+        adapter=_Adapter(),
+        chat_id="555",
+        config=StreamConsumerConfig(),
+        metadata=shared,
+    )
+
+    final_send_metadata = consumer._metadata_for_send(final=True)
+    await consumer._edit_message(
+        message_id="7001",
+        content="Complete",
+        finalize=True,
+    )
+
+    assert shared == {
+        "thread_id": "777",
+        "status_key": "task_run:message:42",
+    }
+    assert final_send_metadata["status_terminal"] is True
+    assert calls == [
+        {
+            "thread_id": "777",
+            "status_key": "task_run:message:42",
+            "status_terminal": True,
+        }
+    ]
+
+
+class _FinalDeliveryAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(
+            PlatformConfig(enabled=True, token="fake-token"),
+            Platform.DISCORD,
+        )
+        self.sent = []
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id="7001")
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        return None
+
+    async def stop_typing(self, chat_id: str, metadata=None) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+@pytest.mark.asyncio
+async def test_base_final_delivery_carries_terminal_status_identity():
+    adapter = _FinalDeliveryAdapter()
+
+    async def handler(event):
+        event._status_key = "task_run"
+        return "Complete final result"
+
+    async def hold_typing(_chat_id, interval=2.0, metadata=None):
+        await asyncio.Event().wait()
+
+    adapter.set_message_handler(handler)
+    adapter._keep_typing = hold_typing
+    event = MessageEvent(
+        text="Do the work",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="555",
+            chat_type="thread",
+            thread_id="777",
+        ),
+        message_id="42",
+    )
+
+    await adapter._process_message_background(
+        event,
+        build_session_key(event.source),
+    )
+
+    assert adapter.sent == [
+        {
+            "chat_id": "555",
+            "content": "Complete final result",
+            "reply_to": "42",
+            "metadata": {
+                "thread_id": "777",
+                "notify": True,
+                "status_key": "task_run",
+                "status_terminal": True,
+            },
+        }
+    ]

--- a/tests/gateway/test_run_keyed_status_cards.py
+++ b/tests/gateway/test_run_keyed_status_cards.py
@@ -458,8 +458,6 @@ async def test_attachment_only_final_explicitly_terminalizes_status_card():
         metadata={
             "thread_id": "777",
             "notify": True,
-            "status_key": "task_run:message:42",
-            "status_terminal": True,
         },
     )
     assert adapter.sent == [

--- a/tests/gateway/test_run_keyed_status_cards.py
+++ b/tests/gateway/test_run_keyed_status_cards.py
@@ -131,6 +131,104 @@ async def test_stream_terminal_metadata_is_copied_not_shared_with_heartbeat():
     ]
 
 
+@pytest.mark.asyncio
+async def test_identical_empty_cursor_final_still_terminalizes_keyed_card():
+    calls = []
+
+    class _Adapter:
+        async def edit_message(
+            self,
+            chat_id,
+            message_id,
+            content,
+            *,
+            finalize=False,
+            metadata=None,
+        ):
+            calls.append(
+                {
+                    "chat_id": chat_id,
+                    "message_id": message_id,
+                    "content": content,
+                    "finalize": finalize,
+                    "metadata": metadata,
+                }
+            )
+            return SendResult(success=True, message_id=message_id)
+
+    final_text = "Complete final result " * 40
+    consumer = GatewayStreamConsumer(
+        adapter=_Adapter(),
+        chat_id="555",
+        config=StreamConsumerConfig(cursor=""),
+        metadata={"thread_id": "777", "status_key": "task_run:message:42"},
+    )
+    consumer._message_id = "7001"
+    consumer._last_sent_text = final_text
+
+    delivered = await consumer._send_or_edit(
+        final_text,
+        finalize=True,
+        is_turn_final=True,
+    )
+
+    assert delivered is True
+    assert calls == [
+        {
+            "chat_id": "555",
+            "message_id": "7001",
+            "content": final_text,
+            "finalize": True,
+            "metadata": {
+                "thread_id": "777",
+                "status_key": "task_run:message:42",
+                "status_terminal": True,
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_recovered_done_send_keeps_terminal_metadata():
+    calls = []
+
+    class _Adapter:
+        async def send(self, chat_id, content, reply_to=None, metadata=None):
+            calls.append(metadata)
+            if len(calls) == 1:
+                return SendResult(success=False, error="temporary")
+            return SendResult(success=True, message_id="7001")
+
+    consumer = GatewayStreamConsumer(
+        adapter=_Adapter(),
+        chat_id="555",
+        config=StreamConsumerConfig(cursor="", buffer_only=True),
+        metadata={"thread_id": "777", "status_key": "task_run:message:42"},
+    )
+    consumer.on_delta("Complete final result")
+    consumer.finish()
+
+    await consumer.run()
+
+    assert consumer.final_response_sent is True
+    assert calls == [
+        {
+            "thread_id": "777",
+            "status_key": "task_run:message:42",
+            "expect_edits": True,
+            "notify": True,
+            "status_terminal": True,
+        },
+        {
+            "thread_id": "777",
+            "status_key": "task_run:message:42",
+            "expect_edits": True,
+            "notify": True,
+            "status_terminal": True,
+        },
+    ]
+
+
 class _FinalDeliveryAdapter(BasePlatformAdapter):
     def __init__(self):
         super().__init__(

--- a/tests/gateway/test_run_keyed_status_cards.py
+++ b/tests/gateway/test_run_keyed_status_cards.py
@@ -420,7 +420,11 @@ async def test_attachment_only_final_explicitly_terminalizes_status_card():
     adapter.extract_media = lambda _response: ([('/tmp/report.pdf', False)], "")
     adapter.filter_media_delivery_paths = lambda media: media
     adapter.send_document = AsyncMock(
-        return_value=SendResult(success=True, message_id="attachment-1")
+        return_value=SendResult(
+            success=True,
+            message_id="attachment-1",
+            delivered_attachment_count=1,
+        )
     )
 
     async def handler(event):
@@ -471,6 +475,67 @@ async def test_attachment_only_final_explicitly_terminalizes_status_card():
             },
         }
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("media_path", "is_voice", "warning"),
+    [
+        pytest.param(
+            "/tmp/report.pdf",
+            False,
+            "⚠️ Couldn't deliver the file attachment.",
+            id="document",
+        ),
+        pytest.param(
+            "/tmp/clip.mp4",
+            False,
+            "⚠️ Couldn't deliver the video attachment.",
+            id="video",
+        ),
+        pytest.param(
+            "/tmp/voice.ogg",
+            True,
+            "⚠️ Couldn't deliver the audio attachment.",
+            id="voice",
+        ),
+    ],
+)
+async def test_warning_fallback_does_not_claim_attachment_delivery(
+    media_path,
+    is_voice,
+    warning,
+):
+    adapter = _FinalDeliveryAdapter()
+    adapter.extract_media = lambda _response: ([(media_path, is_voice)], "")
+    adapter.filter_media_delivery_paths = lambda media: media
+
+    async def handler(event):
+        event._status_key = "task_run:message:42"
+        return f"MEDIA:{media_path}"
+
+    async def hold_typing(_chat_id, interval=2.0, metadata=None):
+        await asyncio.Event().wait()
+
+    adapter.set_message_handler(handler)
+    adapter._keep_typing = hold_typing
+    event = MessageEvent(
+        text="Send the report",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="555",
+            chat_type="thread",
+            thread_id="777",
+        ),
+        message_id="42",
+    )
+
+    await adapter._process_message_background(
+        event,
+        build_session_key(event.source),
+    )
+
+    assert [item["content"] for item in adapter.sent] == [warning]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_keyed_status_cards.py
+++ b/tests/gateway/test_run_keyed_status_cards.py
@@ -471,3 +471,93 @@ async def test_attachment_only_final_explicitly_terminalizes_status_card():
             },
         }
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "batch_result",
+    [
+        pytest.param(None, id="legacy-none"),
+        pytest.param(
+            SendResult(success=True, delivered_attachment_count=0),
+            id="explicit-zero",
+        ),
+    ],
+)
+async def test_unconfirmed_image_only_final_does_not_terminalize_status_card(
+    batch_result,
+):
+    adapter = _FinalDeliveryAdapter()
+    adapter.send_multiple_images = AsyncMock(return_value=batch_result)
+
+    async def handler(event):
+        event._status_key = "task_run:message:42"
+        return "![report](https://example.com/report.png)"
+
+    async def hold_typing(_chat_id, interval=2.0, metadata=None):
+        await asyncio.Event().wait()
+
+    adapter.set_message_handler(handler)
+    adapter._keep_typing = hold_typing
+    event = MessageEvent(
+        text="Send the report",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="555",
+            chat_type="thread",
+            thread_id="777",
+        ),
+        message_id="42",
+    )
+
+    await adapter._process_message_background(
+        event,
+        build_session_key(event.source),
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_partial_image_only_final_uses_confirmed_delivery_count():
+    adapter = _FinalDeliveryAdapter()
+    adapter.send_multiple_images = AsyncMock(
+        return_value=SendResult(
+            success=True,
+            message_id="attachment-1",
+            delivered_attachment_count=1,
+        )
+    )
+
+    async def handler(event):
+        event._status_key = "task_run:message:42"
+        return "\n".join(
+            [
+                "![first](https://example.com/first.png)",
+                "![second](https://example.com/second.png)",
+            ]
+        )
+
+    async def hold_typing(_chat_id, interval=2.0, metadata=None):
+        await asyncio.Event().wait()
+
+    adapter.set_message_handler(handler)
+    adapter._keep_typing = hold_typing
+    event = MessageEvent(
+        text="Send the reports",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="555",
+            chat_type="thread",
+            thread_id="777",
+        ),
+        message_id="42",
+    )
+
+    await adapter._process_message_background(
+        event,
+        build_session_key(event.source),
+    )
+
+    assert adapter.sent[0]["content"] == "Attachment delivered."

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1091,6 +1091,36 @@ async def test_run_agent_queued_message_does_not_treat_commentary_as_final(monke
 
 
 @pytest.mark.asyncio
+async def test_discord_queued_followup_terminalizes_each_run_key(monkeypatch, tmp_path):
+    """Two queued turns in one thread keep two completed status identities."""
+    QueuedCommentaryAgent.calls = 0
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        QueuedCommentaryAgent,
+        session_id="sess-discord-queued-status-keys",
+        pending_text="queued follow-up",
+        config_data={"display": {"interim_assistant_messages": False}},
+        platform=Platform.DISCORD,
+        chat_id="555",
+        chat_type="thread",
+        thread_id="777",
+        adapter_cls=MetadataEditProgressCaptureAdapter,
+    )
+
+    first_delivery = next(
+        call for call in adapter.sent if call["content"] == "final response 1"
+    )
+    assert first_delivery["metadata"]["status_terminal"] is True
+    assert first_delivery["metadata"]["status_key"].startswith(
+        "task_run:generation:"
+    )
+    assert result["final_response"] == "final response 2"
+    assert result["_status_key"] == "task_run:message:queued-1"
+    assert result["_status_key"] != first_delivery["metadata"]["status_key"]
+
+
+@pytest.mark.asyncio
 async def test_run_agent_defers_background_review_notification_until_release(monkeypatch, tmp_path):
     adapter, result = await _run_with_agent(
         monkeypatch,

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -145,6 +145,22 @@ class FakeAgent:
         }
 
 
+class StatusOnlyAgent:
+    def __init__(self, **_kwargs):
+        self.status_callback = None
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        assert self.status_callback is not None
+        self.status_callback("context", "Preparing context")
+        time.sleep(0.1)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class ThinkingAgent:
     """Agent that emits _thinking scratch text (no tool calls).
 
@@ -746,6 +762,7 @@ async def _run_with_agent(
     chat_type="group",
     thread_id="17585",
     adapter_cls=ProgressCaptureAdapter,
+    event_message_id=None,
 ):
     if config_data:
         import yaml
@@ -791,6 +808,7 @@ async def _run_with_agent(
         source=source,
         session_id=session_id,
         session_key=session_key,
+        event_message_id=event_message_id,
     )
     return adapter, result
 
@@ -826,6 +844,65 @@ async def test_run_agent_rolls_progress_bubble_before_platform_limit(monkeypatch
     assert adapter.oversized_edits == []
     all_bubbles = [call["content"] for call in adapter.sent + adapter.edits]
     assert all(len(text) <= adapter.MAX_MESSAGE_LENGTH for text in all_bubbles)
+
+
+@pytest.mark.asyncio
+async def test_discord_first_progress_card_keeps_inbound_reply_anchor(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        FakeAgent,
+        session_id="sess-discord-progress-anchor",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "interim_assistant_messages": False,
+            }
+        },
+        platform=Platform.DISCORD,
+        chat_id="555",
+        chat_type="thread",
+        thread_id="777",
+        event_message_id="42",
+    )
+
+    assert result["final_response"] == "done"
+    first_progress = adapter.sent[0]
+    assert first_progress["reply_to"] == "42"
+    assert first_progress["metadata"]["status_key"] == "task_run:message:42"
+    assert first_progress["metadata"]["reply_to_message_id"] == "42"
+
+
+@pytest.mark.asyncio
+async def test_discord_status_and_heartbeat_metadata_keep_inbound_reply_anchor(
+    monkeypatch,
+    tmp_path,
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StatusOnlyAgent,
+        session_id="sess-discord-status-anchor",
+        config_data={
+            "display": {
+                "tool_progress": "off",
+                "interim_assistant_messages": False,
+            }
+        },
+        platform=Platform.DISCORD,
+        chat_id="555",
+        chat_type="thread",
+        thread_id="777",
+        event_message_id="42",
+    )
+
+    assert result["final_response"] == "done"
+    status = next(call for call in adapter.sent if call["content"] == "Preparing context")
+    assert status["metadata"] == {
+        "thread_id": "777",
+        "status_key": "task_run:message:42",
+        "reply_to_message_id": "42",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_send_multiple_images.py
+++ b/tests/gateway/test_send_multiple_images.py
@@ -19,7 +19,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from gateway.config import PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter
+from gateway.platforms.base import BasePlatformAdapter, SendResult
 
 
 def _run(coro):
@@ -48,26 +48,34 @@ class _StubAdapter(BasePlatformAdapter):
         return None
 
     async def send(self, chat_id, content, reply_to=None, **kwargs):
-        from gateway.platforms.base import SendResult
         return SendResult(success=True)
 
     async def get_chat_info(self, chat_id):
         return {}
 
     async def send_image(self, chat_id, image_url, caption=None, **kwargs):
-        from gateway.platforms.base import SendResult
         self.sent_images.append((chat_id, image_url, caption))
-        return SendResult(success=True, message_id=str(len(self.sent_images)))
+        return SendResult(
+            success=True,
+            message_id=str(len(self.sent_images)),
+            delivered_attachment_count=1,
+        )
 
     async def send_animation(self, chat_id, animation_url, caption=None, **kwargs):
-        from gateway.platforms.base import SendResult
         self.sent_animations.append((chat_id, animation_url, caption))
-        return SendResult(success=True, message_id=str(len(self.sent_animations)))
+        return SendResult(
+            success=True,
+            message_id=str(len(self.sent_animations)),
+            delivered_attachment_count=1,
+        )
 
     async def send_image_file(self, chat_id, image_path, caption=None, **kwargs):
-        from gateway.platforms.base import SendResult
         self.sent_files.append((chat_id, image_path, caption))
-        return SendResult(success=True, message_id=str(len(self.sent_files)))
+        return SendResult(
+            success=True,
+            message_id=str(len(self.sent_files)),
+            delivered_attachment_count=1,
+        )
 
 
 class TestBaseDefaultLoop:
@@ -353,6 +361,7 @@ class TestDiscordMultiImage:
                 success=True,
                 message_id="fallback-1",
                 error=None,
+                delivered_attachment_count=1,
             )
         )
 
@@ -391,6 +400,35 @@ class TestDiscordMultiImage:
             )
         )
 
+        assert result.success is False
+        assert result.delivered_attachment_count == 0
+
+    def test_failed_batch_and_text_only_per_image_fallback_report_zero_deliveries(
+        self, adapter, tmp_path
+    ):
+        image = tmp_path / "report.png"
+        image.write_bytes(b"\x89PNG" + b"\x00" * 20)
+        mock_channel = MagicMock()
+        mock_channel.send = AsyncMock(side_effect=RuntimeError("native unavailable"))
+        adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        adapter._is_forum_parent = MagicMock(return_value=False)
+        adapter.send = AsyncMock(
+            return_value=SendResult(success=True, message_id="warning-text")
+        )
+
+        result = _run(
+            adapter.send_multiple_images(
+                "67890",
+                [(f"file://{image}", "")],
+            )
+        )
+
+        adapter.send.assert_awaited_once_with(
+            chat_id="67890",
+            content="⚠️ Couldn't deliver the image attachment.",
+            reply_to=None,
+            metadata=None,
+        )
         assert result.success is False
         assert result.delivered_attachment_count == 0
 

--- a/tests/gateway/test_send_multiple_images.py
+++ b/tests/gateway/test_send_multiple_images.py
@@ -79,12 +79,14 @@ class TestBaseDefaultLoop:
             ("file:///tmp/foo.png", "local"),
             ("https://x.com/c.gif", ""),
         ]
-        _run(a.send_multiple_images("chat1", images))
+        result = _run(a.send_multiple_images("chat1", images))
         # 2 URL images + 1 animation + 1 local file
         assert len(a.sent_images) == 2
         assert len(a.sent_animations) == 1
         assert len(a.sent_files) == 1
         assert a.sent_files[0][1] == "/tmp/foo.png"
+        assert result.success is True
+        assert result.delivered_attachment_count == 4
 
     def test_empty_batch_is_noop(self):
         a = _StubAdapter()
@@ -235,10 +237,162 @@ class TestDiscordMultiImage:
         adapter._is_forum_parent = MagicMock(return_value=False)
 
         images = [(f"file://{p}", "") for p in paths]
-        _run(adapter.send_multiple_images("67890", images))
+        result = _run(adapter.send_multiple_images("67890", images))
 
         mock_channel.send.assert_awaited_once()
         assert len(mock_channel.send.call_args.kwargs["files"]) == 3
+        assert result.success is True
+        assert result.delivered_attachment_count == 3
+
+    def test_all_missing_images_report_zero_deliveries(self, adapter, tmp_path):
+        """A skipped batch must not claim that any attachment reached Discord."""
+        mock_channel = MagicMock()
+        mock_channel.send = AsyncMock(return_value=MagicMock(id=1))
+        adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        adapter._is_forum_parent = MagicMock(return_value=False)
+
+        missing = tmp_path / "missing.png"
+        result = _run(
+            adapter.send_multiple_images(
+                "67890",
+                [(f"file://{missing}", "")],
+            )
+        )
+
+        assert result.success is False
+        assert result.delivered_attachment_count == 0
+        mock_channel.send.assert_not_awaited()
+
+    def test_all_unsafe_images_report_zero_deliveries(self, adapter):
+        mock_channel = MagicMock()
+        mock_channel.send = AsyncMock(return_value=MagicMock(id=1))
+        adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        adapter._is_forum_parent = MagicMock(return_value=False)
+
+        with patch(
+            "plugins.platforms.discord.adapter.is_safe_url",
+            return_value=False,
+        ):
+            result = _run(
+                adapter.send_multiple_images(
+                    "67890",
+                    [("https://example.com/blocked.png", "")],
+                )
+            )
+
+        assert result.success is False
+        assert result.delivered_attachment_count == 0
+        mock_channel.send.assert_not_awaited()
+
+    def test_all_failed_downloads_report_zero_deliveries(self, adapter):
+        mock_channel = MagicMock()
+        mock_channel.send = AsyncMock(return_value=MagicMock(id=1))
+        adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        adapter._is_forum_parent = MagicMock(return_value=False)
+        response = MagicMock(status=503)
+        response_context = MagicMock()
+        response_context.__aenter__ = AsyncMock(return_value=response)
+        response_context.__aexit__ = AsyncMock(return_value=False)
+        session = MagicMock()
+        session.get.return_value = response_context
+        session.close = AsyncMock()
+
+        with (
+            patch(
+                "plugins.platforms.discord.adapter.is_safe_url",
+                return_value=True,
+            ),
+            patch("aiohttp.ClientSession", return_value=session),
+        ):
+            result = _run(
+                adapter.send_multiple_images(
+                    "67890",
+                    [("https://example.com/unavailable.png", "")],
+                )
+            )
+
+        assert result.success is False
+        assert result.delivered_attachment_count == 0
+        mock_channel.send.assert_not_awaited()
+
+    def test_missing_client_or_channel_reports_zero_deliveries(self, adapter):
+        adapter._client = None
+        disconnected = _run(
+            adapter.send_multiple_images(
+                "67890",
+                [("https://example.com/report.png", "")],
+            )
+        )
+
+        adapter._client = MagicMock()
+        adapter._client.get_channel.return_value = None
+        adapter._client.fetch_channel = AsyncMock(return_value=None)
+        missing_channel = _run(
+            adapter.send_multiple_images(
+                "67890",
+                [("https://example.com/report.png", "")],
+            )
+        )
+
+        assert disconnected.success is False
+        assert disconnected.delivered_attachment_count == 0
+        assert missing_channel.success is False
+        assert missing_channel.delivered_attachment_count == 0
+
+    def test_failed_batch_preserves_successful_per_image_fallback(
+        self, adapter, tmp_path
+    ):
+        image = tmp_path / "report.png"
+        image.write_bytes(b"\x89PNG" + b"\x00" * 20)
+        mock_channel = MagicMock()
+        mock_channel.send = AsyncMock(side_effect=RuntimeError("batch unavailable"))
+        adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        adapter._is_forum_parent = MagicMock(return_value=False)
+        adapter.send_image_file = AsyncMock(
+            return_value=MagicMock(
+                success=True,
+                message_id="fallback-1",
+                error=None,
+            )
+        )
+
+        result = _run(
+            adapter.send_multiple_images(
+                "67890",
+                [(f"file://{image}", "")],
+            )
+        )
+
+        assert result.success is True
+        assert result.message_id == "fallback-1"
+        assert result.delivered_attachment_count == 1
+
+    def test_failed_batch_and_fallback_report_zero_deliveries(
+        self, adapter, tmp_path
+    ):
+        image = tmp_path / "report.png"
+        image.write_bytes(b"\x89PNG" + b"\x00" * 20)
+        mock_channel = MagicMock()
+        mock_channel.send = AsyncMock(side_effect=RuntimeError("batch unavailable"))
+        adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        adapter._is_forum_parent = MagicMock(return_value=False)
+        adapter.send_image_file = AsyncMock(
+            return_value=MagicMock(
+                success=False,
+                message_id=None,
+                error="fallback unavailable",
+            )
+        )
+
+        result = _run(
+            adapter.send_multiple_images(
+                "67890",
+                [(f"file://{image}", "")],
+            )
+        )
+
+        assert result.success is False
+        assert result.delivered_attachment_count == 0
 
     def test_batch_over_10_chunks_into_two_messages(self, adapter, tmp_path):
         """15 local images → two channel.send calls (10 + 5)."""
@@ -254,11 +408,13 @@ class TestDiscordMultiImage:
         adapter._is_forum_parent = MagicMock(return_value=False)
 
         images = [(f"file://{p}", "") for p in paths]
-        _run(adapter.send_multiple_images("67890", images))
+        result = _run(adapter.send_multiple_images("67890", images))
 
         assert mock_channel.send.await_count == 2
         sizes = [len(c.kwargs["files"]) for c in mock_channel.send.await_args_list]
         assert sizes == [10, 5]
+        assert result.success is True
+        assert result.delivered_attachment_count == 15
 
     def test_empty_noop(self, adapter):
         adapter._client = MagicMock()

--- a/tests/gateway/test_send_multiple_images.py
+++ b/tests/gateway/test_send_multiple_images.py
@@ -252,6 +252,135 @@ class TestDiscordMultiImage:
         assert result.success is True
         assert result.delivered_attachment_count == 3
 
+    def test_batch_routes_to_metadata_thread_instead_of_parent(
+        self, adapter, tmp_path
+    ):
+        image = tmp_path / "thread-report.png"
+        image.write_bytes(b"\x89PNG" + b"\x00" * 20)
+        parent = MagicMock(id=67890)
+        parent.send = AsyncMock()
+        thread = MagicMock(id=777)
+        thread.send = AsyncMock(return_value=MagicMock(id=1))
+        adapter._client.get_channel = MagicMock(
+            side_effect=lambda channel_id: {67890: parent, 777: thread}.get(
+                channel_id
+            )
+        )
+        adapter._is_forum_parent = MagicMock(return_value=False)
+
+        result = _run(
+            adapter.send_multiple_images(
+                "67890",
+                [(f"file://{image}", "")],
+                metadata={"thread_id": "777"},
+            )
+        )
+
+        assert result.delivered_attachment_count == 1
+        thread.send.assert_awaited_once()
+        parent.send.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        "method_name,path_kwarg",
+        [
+            ("send_image_file", "image_path"),
+            ("send_video", "video_path"),
+            ("send_document", "file_path"),
+            ("send_voice", "audio_path"),
+        ],
+    )
+    def test_local_attachment_transport_routes_to_metadata_thread(
+        self,
+        adapter,
+        tmp_path,
+        method_name,
+        path_kwarg,
+    ):
+        attachment_path = tmp_path / f"{method_name}.bin"
+        attachment_path.write_bytes(b"attachment")
+        parent = MagicMock(id=67890)
+        parent.send = AsyncMock()
+        thread = MagicMock(id=777)
+        thread.send = AsyncMock(return_value=MagicMock(id=1))
+        adapter._client.get_channel = MagicMock(
+            side_effect=lambda channel_id: {67890: parent, 777: thread}.get(
+                channel_id
+            )
+        )
+        adapter._client.http.request = AsyncMock(
+            side_effect=RuntimeError("use regular file transport")
+        )
+        adapter._is_forum_parent = MagicMock(return_value=False)
+
+        result = _run(
+            getattr(adapter, method_name)(
+                chat_id="67890",
+                **{path_kwarg: str(attachment_path)},
+                metadata={"thread_id": "777"},
+            )
+        )
+
+        assert result.delivered_attachment_count == 1
+        thread.send.assert_awaited_once()
+        parent.send.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        "method_name,url_kwarg",
+        [
+            ("send_image", "image_url"),
+            ("send_animation", "animation_url"),
+        ],
+    )
+    def test_remote_attachment_transport_routes_to_metadata_thread(
+        self,
+        adapter,
+        method_name,
+        url_kwarg,
+    ):
+        parent = MagicMock(id=67890)
+        parent.send = AsyncMock()
+        thread = MagicMock(id=777)
+        thread.send = AsyncMock(return_value=MagicMock(id=1))
+        adapter._client.get_channel = MagicMock(
+            side_effect=lambda channel_id: {67890: parent, 777: thread}.get(
+                channel_id
+            )
+        )
+        adapter._is_forum_parent = MagicMock(return_value=False)
+
+        response = MagicMock(
+            status=200,
+            headers={"content-type": "image/gif"},
+        )
+        response.read = AsyncMock(return_value=b"GIF89a")
+        response_context = MagicMock()
+        response_context.__aenter__ = AsyncMock(return_value=response)
+        response_context.__aexit__ = AsyncMock(return_value=False)
+        session = MagicMock()
+        session.get.return_value = response_context
+        session_context = MagicMock()
+        session_context.__aenter__ = AsyncMock(return_value=session)
+        session_context.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "plugins.platforms.discord.adapter.is_safe_url",
+                return_value=True,
+            ),
+            patch("aiohttp.ClientSession", return_value=session_context),
+        ):
+            result = _run(
+                getattr(adapter, method_name)(
+                    chat_id="67890",
+                    **{url_kwarg: "https://example.com/report.gif"},
+                    metadata={"thread_id": "777"},
+                )
+            )
+
+        assert result.delivered_attachment_count == 1
+        thread.send.assert_awaited_once()
+        parent.send.assert_not_awaited()
+
     def test_all_missing_images_report_zero_deliveries(self, adapter, tmp_path):
         """A skipped batch must not claim that any attachment reached Discord."""
         mock_channel = MagicMock()

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -19,8 +19,9 @@ from gateway.session import SessionSource, build_session_key
 
 
 class _MediaRoutingAdapter(BasePlatformAdapter):
-    def __init__(self):
-        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(PlatformConfig(enabled=True, token="test"), platform)
+        self.sent_messages = []
 
     async def connect(self, *, is_reconnect: bool = False):
         return True
@@ -29,6 +30,9 @@ class _MediaRoutingAdapter(BasePlatformAdapter):
         pass
 
     async def send(self, chat_id, content=None, **kwargs):
+        self.sent_messages.append(
+            {"chat_id": chat_id, "content": content, **kwargs}
+        )
         return SendResult(success=True, message_id="text")
 
     async def get_chat_info(self, chat_id):
@@ -132,6 +136,57 @@ def _fake_runner(thread_meta, *, reply_anchor=None):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("file_name", "is_voice", "warning"),
+    [
+        pytest.param(
+            "report.pdf",
+            False,
+            "⚠️ Couldn't deliver the file attachment.",
+            id="document",
+        ),
+        pytest.param(
+            "clip.mp4",
+            False,
+            "⚠️ Couldn't deliver the video attachment.",
+            id="video",
+        ),
+        pytest.param(
+            "voice.ogg",
+            True,
+            "⚠️ Couldn't deliver the audio attachment.",
+            id="voice",
+        ),
+    ],
+)
+async def test_streamed_warning_fallback_does_not_claim_attachment_delivery(
+    tmp_path,
+    monkeypatch,
+    file_name,
+    is_voice,
+    warning,
+):
+    event = _event(thread_id="topic-1", platform=Platform.DISCORD)
+    event._status_key = "task_run:message:msg-1"
+    media_file = _allowed_media_path(tmp_path, monkeypatch, file_name)
+    adapter = _MediaRoutingAdapter(platform=Platform.DISCORD)
+    media_tag = (
+        f"[[audio_as_voice]]\nMEDIA:{media_file}"
+        if is_voice
+        else f"MEDIA:{media_file}"
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({"thread_id": "topic-1"}, reply_anchor="msg-1"),
+        media_tag,
+        event,
+        adapter,
+    )
+
+    assert [item["content"] for item in adapter.sent_messages] == [warning]
+
+
+@pytest.mark.asyncio
 async def test_streamed_media_only_final_terminalizes_keyed_status_card(
     tmp_path, monkeypatch
 ):
@@ -145,7 +200,11 @@ async def test_streamed_media_only_final_terminalizes_keyed_status_card(
         extract_local_files=BasePlatformAdapter.extract_local_files,
         send_voice=AsyncMock(),
         send_document=AsyncMock(
-            return_value=SendResult(success=True, message_id="document")
+            return_value=SendResult(
+                success=True,
+                message_id="document",
+                delivered_attachment_count=1,
+            )
         ),
         send_multiple_images=AsyncMock(),
         send_video=AsyncMock(),

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -35,9 +35,9 @@ class _MediaRoutingAdapter(BasePlatformAdapter):
         return {"id": chat_id, "type": "dm"}
 
 
-def _event(thread_id=None):
+def _event(thread_id=None, *, platform=Platform.TELEGRAM):
     source = SessionSource(
-        platform=Platform.TELEGRAM,
+        platform=platform,
         chat_id="chat-1",
         chat_type="dm",
         thread_id=thread_id,
@@ -121,14 +121,63 @@ async def test_base_adapter_routes_voice_tagged_telegram_ogg_media_tag_to_voice_
     adapter.send_document.assert_not_awaited()
 
 
-def _fake_runner(thread_meta):
+def _fake_runner(thread_meta, *, reply_anchor=None):
     """Build a fake GatewayRunner-like object with the helper methods needed by
     _deliver_media_from_response."""
     runner = SimpleNamespace(
         _thread_metadata_for_source=lambda source, anchor=None: thread_meta,
-        _reply_anchor_for_event=lambda event: None,
+        _reply_anchor_for_event=lambda event: reply_anchor,
     )
     return runner
+
+
+@pytest.mark.asyncio
+async def test_streamed_media_only_final_terminalizes_keyed_status_card(
+    tmp_path, monkeypatch
+):
+    event = _event(thread_id="topic-1", platform=Platform.DISCORD)
+    event._status_key = "task_run:message:msg-1"
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "report.pdf")
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_voice=AsyncMock(),
+        send_document=AsyncMock(
+            return_value=SendResult(success=True, message_id="document")
+        ),
+        send_multiple_images=AsyncMock(),
+        send_video=AsyncMock(),
+        _send_with_retry=AsyncMock(
+            return_value=SendResult(success=True, message_id="status")
+        ),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({"thread_id": "topic-1"}, reply_anchor="msg-1"),
+        f"MEDIA:{media_file}",
+        event,
+        adapter,
+    )
+
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="chat-1",
+        file_path=str(media_file),
+        metadata={"thread_id": "topic-1"},
+    )
+    adapter._send_with_retry.assert_awaited_once_with(
+        chat_id="chat-1",
+        content="Attachment delivered.",
+        reply_to="msg-1",
+        metadata={
+            "thread_id": "topic-1",
+            "notify": True,
+            "status_key": "task_run:message:msg-1",
+            "status_terminal": True,
+            "reply_to_message_id": "msg-1",
+        },
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -181,6 +181,79 @@ async def test_streamed_media_only_final_terminalizes_keyed_status_card(
 
 
 @pytest.mark.asyncio
+async def test_streamed_unconfirmed_image_only_final_stays_nonterminal(
+    tmp_path, monkeypatch
+):
+    event = _event(thread_id="topic-1", platform=Platform.DISCORD)
+    event._status_key = "task_run:message:msg-1"
+    image_file = _allowed_media_path(tmp_path, monkeypatch, "report.png")
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_voice=AsyncMock(),
+        send_document=AsyncMock(),
+        send_multiple_images=AsyncMock(return_value=None),
+        send_video=AsyncMock(),
+        _send_with_retry=AsyncMock(
+            return_value=SendResult(success=True, message_id="status")
+        ),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({"thread_id": "topic-1"}, reply_anchor="msg-1"),
+        f"MEDIA:{image_file}",
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    adapter._send_with_retry.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_streamed_partial_image_batch_uses_confirmed_delivery_count(
+    tmp_path, monkeypatch
+):
+    event = _event(thread_id="topic-1", platform=Platform.DISCORD)
+    event._status_key = "task_run:message:msg-1"
+    first = _allowed_media_path(tmp_path, monkeypatch, "first.png")
+    second = first.with_name("second.png")
+    second.write_bytes(b"media")
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_voice=AsyncMock(),
+        send_document=AsyncMock(),
+        send_multiple_images=AsyncMock(
+            return_value=SendResult(
+                success=True,
+                message_id="attachment-1",
+                delivered_attachment_count=1,
+            )
+        ),
+        send_video=AsyncMock(),
+        _send_with_retry=AsyncMock(
+            return_value=SendResult(success=True, message_id="status")
+        ),
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({"thread_id": "topic-1"}, reply_anchor="msg-1"),
+        f"MEDIA:{first}\nMEDIA:{second}",
+        event,
+        adapter,
+    )
+
+    assert adapter._send_with_retry.await_args.kwargs["content"] == (
+        "Attachment delivered."
+    )
+
+
+@pytest.mark.asyncio
 async def test_streaming_delivery_routes_telegram_flac_media_tag_to_document_sender(tmp_path, monkeypatch):
     event = _event(thread_id="topic-1")
     media_file = _allowed_media_path(tmp_path, monkeypatch, "speech.flac")

--- a/tests/scripts/test_backfill_discord_workspace_headers.py
+++ b/tests/scripts/test_backfill_discord_workspace_headers.py
@@ -1,0 +1,15 @@
+"""CLI safety contract for the Discord workspace-header backfill."""
+
+from scripts.backfill_discord_workspace_headers import build_parser
+
+
+def test_backfill_defaults_to_read_only_dry_run():
+    args = build_parser().parse_args([])
+
+    assert args.apply is False
+
+
+def test_backfill_requires_explicit_apply_flag_for_mutation():
+    args = build_parser().parse_args(["--apply"])
+
+    assert args.apply is True


### PR DESCRIPTION
## Summary

- keep one Discord task-status card per `(chat_id, thread_id, status_key)`
- edit the retained card for progress and replace it with the final result
- recover safely from stale messages, partial overflow, transformed chunks, and failed image delivery
- route every native attachment transport through `metadata.thread_id` before terminalizing the retained card
- preserve thread/reply routing while stripping terminal lifecycle markers from warning fallbacks, preventing false edits or final receipts when zero attachments were delivered

## Stack

Depends on operator-card PR #67224 and workspace-header PR #67333. This branch is restacked onto exact OE-178 head `bcf5e7e254bbdb0f3423c2c7479d6e208d4d48b0`.

Exact OE-180 head: `f7a243f892344f8cf685122b3afa4b1daf4b48b6`.

## Verification

- original ten OE-180 commits remain exact `=` matches by `git range-diff`
- relevant keyed-status/attachment slice: 158 passed
- full Discord gateway slice: 645 passed
- root replay of the core status/multi-image/run slice: 78 passed
- Ruff, bytecode compilation, Windows-footgun scan, diff, and ancestry checks passed
- independent Spec and Standards reviews approved the exact final head with zero findings

The added remediation uses real fake-client transport behavior across local image/video/document/voice, remote image/animation, and multi-image paths. It verifies delivery reaches the intended thread before terminalization and that warning fallbacks produce neither retained-card edits nor terminal receipts.

Fork CI remains `action_required` with zero jobs until a NousResearch maintainer approves the workflow run.