### PR TITLE
fix(api-server): stream run reasoning deltas

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1707,6 +1707,7 @@ class APIServerAdapter(BasePlatformAdapter):
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
+        reasoning_delta_callback=None,
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
@@ -1824,6 +1825,7 @@ class APIServerAdapter(BasePlatformAdapter):
             session_id=session_id,
             platform="api_server",
             stream_delta_callback=stream_delta_callback,
+            reasoning_callback=reasoning_delta_callback,
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,
             tool_complete_callback=tool_complete_callback,
@@ -4786,6 +4788,19 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception:
                 pass
 
+        def _reasoning_cb(delta: Optional[str]) -> None:
+            if not delta or run_id not in self._run_streams:
+                return
+            try:
+                loop.call_soon_threadsafe(_put_event_if_active, {
+                    "event": "reasoning.delta",
+                    "run_id": run_id,
+                    "timestamp": time.time(),
+                    "delta": delta,
+                })
+            except Exception:
+                pass
+
         self._set_run_status(
             run_id,
             "queued",
@@ -4820,6 +4835,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         ephemeral_system_prompt=ephemeral_system_prompt,
                         session_id=session_id,
                         stream_delta_callback=_text_cb,
+                        reasoning_delta_callback=_reasoning_cb,
                         tool_progress_callback=event_cb,
                         gateway_session_key=gateway_session_key,
                         route=route,

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -9,6 +9,7 @@ Covers:
 """
 
 import asyncio
+import json
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -297,6 +298,45 @@ class TestRunStatus:
 
 
 class TestRunEvents:
+    @pytest.mark.asyncio
+    async def test_events_streams_reasoning_deltas_before_completion(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            def create_agent(**kwargs):
+                mock_agent = MagicMock()
+
+                def run_conversation(**_run_kwargs):
+                    kwargs["reasoning_delta_callback"]("先分析需求")
+                    kwargs["reasoning_delta_callback"]("，再调用工具")
+                    return {"final_response": "完成"}
+
+                mock_agent.run_conversation.side_effect = run_conversation
+                mock_agent.session_prompt_tokens = 10
+                mock_agent.session_completion_tokens = 5
+                mock_agent.session_total_tokens = 15
+                return mock_agent
+
+            with patch.object(adapter, "_create_agent", side_effect=create_agent):
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await resp.json())["run_id"]
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                body = await events_resp.text()
+
+        events = [
+            json.loads(line.removeprefix("data: "))
+            for line in body.splitlines()
+            if line.startswith("data: ")
+        ]
+        assert [event["event"] for event in events] == [
+            "reasoning.delta",
+            "reasoning.delta",
+            "run.completed",
+        ]
+        assert [event["delta"] for event in events[:2]] == [
+            "先分析需求",
+            "，再调用工具",
+        ]
+
     @pytest.mark.asyncio
     async def test_events_stream_returns_completed(self, adapter):
         """Events stream should receive run.completed when agent finishes."""


### PR DESCRIPTION
## Summary

- wire the agent reasoning callback into the `/v1/runs` execution path
- emit additive `reasoning.delta` SSE events for structured reasoning chunks
- preserve the existing message, tool, error, and completion event behavior
- add regression coverage proving reasoning frames arrive before `run.completed`

## Root cause

The provider stream already invokes the agent's reasoning callback, but the API server's runs adapter did not pass such a callback when constructing `AIAgent`. As a result, reasoning could be persisted and visible in session history after the run while remaining absent from the live runs SSE stream.

## Compatibility

This is an additive SSE event. Existing clients that ignore unknown event types continue to behave as before.

## Validation

- `scripts/run_tests.sh tests/gateway/test_api_server_runs.py`
- 34 tests passed

Fixes #60634