### PR TITLE
fix(mcp): don't count tool-level errors toward the circuit breaker (#11113)

### DIFF
--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -170,6 +170,131 @@ def test_circuit_breaker_half_opens_after_cooldown(monkeypatch, tmp_path):
         _cleanup(mcp_tool, "srv")
 
 
+def test_tool_level_error_does_not_trip_breaker(monkeypatch, tmp_path):
+    """Tool-level errors (result.isError: DNS failure, HTTP 4xx/5xx, page
+    crash) prove the transport is ALIVE — they must not count toward the
+    breaker. Under the old counting, three bad URLs branded a healthy
+    Playwright server "unreachable" and short-circuited every tool on it
+    (#11113)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    call_count = {"n": 0}
+
+    async def _call_tool_dns_error(*a, **kw):
+        call_count["n"] += 1
+        result = MagicMock()
+        result.isError = True
+        block = MagicMock()
+        block.text = "net::ERR_NAME_NOT_RESOLVED navigating to https://bad.example"
+        result.content = [block]
+        result.structuredContent = None
+        return result
+
+    _install_stub_server(mcp_tool, "srv", _call_tool_dns_error)
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        handler = _make_tool_handler("srv", "browser_navigate", 10.0)
+
+        attempts = mcp_tool._CIRCUIT_BREAKER_THRESHOLD + 2
+        for i in range(attempts):
+            parsed = json.loads(handler({}))
+            # Every call must reach the session and surface the real tool
+            # error — never the breaker's "unreachable" short-circuit.
+            assert "error" in parsed, parsed
+            assert "unreachable" not in parsed["error"].lower(), (
+                f"breaker tripped on tool-level errors after {i + 1} calls"
+            )
+            assert "ERR_NAME_NOT_RESOLVED" in parsed["error"], parsed
+
+        assert call_count["n"] == attempts, "every call should reach the session"
+        assert mcp_tool._server_error_counts.get("srv", 0) == 0, (
+            "tool-level errors must not accumulate breaker strikes"
+        )
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
+def test_tool_level_error_resets_prior_transport_strikes(monkeypatch, tmp_path):
+    """A completed round-trip — even one carrying a tool error — is evidence
+    of reachability, so it resets strikes accumulated from earlier transport
+    failures ("consecutive failures" semantics)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    async def _call_tool_http_500(*a, **kw):
+        result = MagicMock()
+        result.isError = True
+        block = MagicMock()
+        block.text = "HTTP 500 from upstream API"
+        result.content = [block]
+        result.structuredContent = None
+        return result
+
+    _install_stub_server(mcp_tool, "srv", _call_tool_http_500)
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        # Two transport strikes already on the board (one below threshold).
+        mcp_tool._server_error_counts["srv"] = (
+            mcp_tool._CIRCUIT_BREAKER_THRESHOLD - 1
+        )
+
+        handler = _make_tool_handler("srv", "tool1", 10.0)
+        parsed = json.loads(handler({}))
+        assert "HTTP 500" in parsed.get("error", ""), parsed
+
+        assert mcp_tool._server_error_counts.get("srv", 0) == 0, (
+            "a completed round-trip must reset consecutive-failure strikes"
+        )
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
+def test_transport_exceptions_still_trip_breaker(monkeypatch, tmp_path):
+    """Transport-level failures (exceptions out of the call, timeouts,
+    connection loss) remain the breaker's business: threshold consecutive
+    failures short-circuit subsequent calls (#10447 retry-burn protection)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    call_count = {"n": 0}
+
+    async def _call_tool_transport_dead(*a, **kw):
+        call_count["n"] += 1
+        raise ConnectionError("connection lost")
+
+    _install_stub_server(mcp_tool, "srv", _call_tool_transport_dead)
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        handler = _make_tool_handler("srv", "tool1", 10.0)
+
+        for _ in range(mcp_tool._CIRCUIT_BREAKER_THRESHOLD):
+            parsed = json.loads(handler({}))
+            assert "error" in parsed
+
+        assert (
+            mcp_tool._server_error_counts.get("srv", 0)
+            >= mcp_tool._CIRCUIT_BREAKER_THRESHOLD
+        )
+
+        # Next call short-circuits without touching the session.
+        before = call_count["n"]
+        parsed = json.loads(handler({}))
+        assert "unreachable" in parsed.get("error", "").lower(), parsed
+        assert call_count["n"] == before, "tripped breaker must short-circuit"
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
 def test_circuit_breaker_reopens_on_probe_failure(monkeypatch, tmp_path):
     """If the half-open probe fails, the breaker must re-arm the
     cooldown (not let every subsequent call through).

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4270,15 +4270,15 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
 
         try:
             result = _call_once()
-            # Check if the MCP tool itself returned an error
-            try:
-                parsed = json.loads(result)
-                if "error" in parsed:
-                    _bump_server_error(server_name)
-                else:
-                    _reset_server_error(server_name)  # success — reset
-            except (json.JSONDecodeError, TypeError):
-                _reset_server_error(server_name)  # non-JSON = success
+            # A completed tools/call round-trip is direct evidence the
+            # transport is alive — even when the payload is a tool-level
+            # error (result.isError: a DNS failure, HTTP 4xx/5xx, a crashed
+            # page). Those are the tool's business errors, not server
+            # unreachability; counting them branded a healthy server
+            # "unreachable" after three bad URLs and short-circuited every
+            # other tool on it (#11113). Only transport-level failures
+            # (the except paths below) feed the breaker.
+            _reset_server_error(server_name)
             return result
         except InterruptedError:
             return _interrupted_call_result()


### PR DESCRIPTION
## What does this PR do?

Stops the MCP circuit breaker from counting **tool-level errors** as server failures.

`_make_tool_handler`'s success path bumped the consecutive-failure count for any `{"error": ...}` payload — which is exactly what a completed `tools/call` with `result.isError` (a DNS failure, an HTTP 4xx/5xx, a crashed page) serializes to. Three bad URLs therefore branded a healthy Playwright server "unreachable" and short-circuited **every** tool on that server, returning a message that actively steers the model away from a working server. Reported with a precise repro in #11113 (P2, `tool/mcp`).

The fix is structural rather than heuristic: **a completed RPC round-trip is itself the reachability proof.** If `session.call_tool` returned at all — even with `isError=True` — the transport is alive, so the handler resets the breaker and surfaces the tool's real error text (which the model can act on). Only transport-level failures — exceptions out of the call: timeouts, connection loss, a dead stdio subprocess — feed the breaker, which is precisely the retry-burn case it was introduced for in #10447. The half-open/cooldown machinery (#26892, #16788) is untouched.

Relation to #11128 (open, stale since April): same diagnosis, different mechanism — it classifies exception *strings* into infrastructure-vs-tool via an `_is_infrastructure_error()` heuristic, which needs a pattern list maintained as new MCP servers appear, and its base predates the half-open/cooldown rework of this file. This change needs no classification at all.

## Related Issue

Fixes #11113.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py` — in `_make_tool_handler`, the completed-call path now always resets the consecutive-failure count instead of parsing the payload for an `"error"` key; the exception paths (transport failures) still bump. The other `{"error": ...}` returns in the handler (not-connected, transport-down) already bump explicitly before returning and are unaffected.
- `tests/tools/test_mcp_circuit_breaker.py` — 3 new behavior tests: tool-level errors never trip the breaker across threshold+2 calls (the real error text surfaces every time, never "unreachable"); a completed round-trip resets strikes accumulated from earlier transport failures (consecutive-failure semantics); transport exceptions still trip the breaker and short-circuit (locks in the #10447 contract).

## How to Test

1. `scripts/run_tests.sh tests/tools/test_mcp_circuit_breaker.py` — 10 passed (7 existing + 3 new).
2. Full MCP surface: `scripts/run_tests.sh tests/tools/test_mcp_*.py` — failing set on native Windows is identical to a pristine `main` worktree baseline (6 pre-existing platform failures: tilde expansion, image caching, Windows env vars); zero failures attributable to this change.
3. Live repro from the issue: configure a Playwright MCP server, navigate to 3 unresolvable URLs, then a valid one — the valid navigation now executes instead of short-circuiting with "unreachable".

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — #11128 addresses the same issue with a string-classifier approach on a pre-rework base; differences explained above and on the issue
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the test suite — see "How to Test"
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (native)

### Documentation & Housekeeping

- [x] Documentation — N/A (behavioral fix; comments updated in place)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — pure-Python control flow; developed and tested on native Windows
