### PR TITLE
feat: token-cost cuts + config/doctor hygiene + non-blocking Windows/coverage CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,25 @@ jobs:
       slice_count: 8
     secrets: inherit
 
+  # Non-blocking Windows stable subset. Surfaces win32 regressions Linux
+  # CI never sees; continue-on-error + omitted from all-checks-pass so it
+  # cannot break branch protection while the subset is proven stable.
+  windows-tests:
+    name: Windows tests (stable, non-blocking)
+    needs: detect
+    if: needs.detect.outputs.python == 'true'
+    continue-on-error: true
+    uses: ./.github/workflows/windows-tests.yml
+
+  # Informational pytest-cov report (XML+HTML artifact). No coverage
+  # percentage gate. continue-on-error + omitted from all-checks-pass.
+  coverage:
+    name: Coverage (informational)
+    needs: detect
+    if: needs.detect.outputs.python == 'true'
+    continue-on-error: true
+    uses: ./.github/workflows/coverage.yml
+
   lint:
     name: Python lints
     needs: detect

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,139 @@
+name: Coverage (informational)
+
+# Optional pytest-cov lane. Uploads XML + HTML reports as artifacts.
+# Does NOT enforce a coverage percentage / gate — informational only
+# while a baseline is established. Not listed in all-checks-pass.
+#
+# pytest-cov is installed in this job only (not added to pyproject.toml).
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coverage-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    name: pytest-cov report
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    # Soft-fail: coverage is advisory; install/report issues must not
+    # red-X the required gate.
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install ripgrep (prebuilt binary)
+        run: |
+          set -euo pipefail
+          RG_VERSION=15.1.0
+          RG_SHA256=1c9297be4a084eea7ecaedf93eb03d058d6faae29bbc57ecdaf5063921491599
+          RG_TARBALL=ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl.tar.gz
+          curl -sSfL --retry 3 --retry-delay 5 -o "$RG_TARBALL" \
+            "https://github.com/BurntSushi/ripgrep/releases/download/${RG_VERSION}/${RG_TARBALL}"
+          echo "${RG_SHA256}  ${RG_TARBALL}" | sha256sum -c -
+          tar -xzf "$RG_TARBALL"
+          sudo mv "ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl/rg" /usr/local/bin/rg
+          rm -rf "$RG_TARBALL" "ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl"
+          rg --version
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        uses: ./.github/actions/retry
+        with:
+          command: uv sync --locked --python 3.11 --extra all --extra dev
+
+      - name: Install pytest-cov (job-only; not in pyproject)
+        # Keep pyproject/uv.lock untouched. Install into the project venv
+        # so `python -m pytest` picks up the plugin.
+        run: uv pip install --python .venv pytest-cov
+
+      - name: Minimize uv cache
+        run: uv cache prune --ci
+
+      - name: Run pytest with coverage (no fail-under gate)
+        env:
+          OPENROUTER_API_KEY: ""
+          OPENAI_API_KEY: ""
+          NOUS_API_KEY: ""
+          PYTHONNOUSERSITE: "1"
+          PYTHONHASHSEED: "0"
+          TZ: UTC
+        run: |
+          set -euo pipefail
+          source .venv/bin/activate
+          export PYTHONPATH="${GITHUB_WORKSPACE}${PYTHONPATH:+:${PYTHONPATH}}"
+
+          # Informative subset: core packages Windows + Linux share, plus
+          # CI classifier unit tests. Full 8-slice suite is too heavy for
+          # a single coverage job; expand later once a baseline exists.
+          # No coverage percentage threshold — report only, never gates merge.
+          python -m pytest -q --tb=line \
+            tests/tools/test_delegate.py \
+            tests/tools/test_delegate_composite_toolsets.py \
+            tests/tools/test_delegate_model_router_integration.py \
+            tests/tools/test_delegate_subagent_timeout_diagnostic.py \
+            tests/tools/test_delegate_summary_budget.py \
+            tests/tools/test_delegate_toolset_scope.py \
+            tests/agent/test_async_utils.py \
+            tests/agent/test_prompt_builder.py \
+            tests/agent/test_skill_utils.py \
+            tests/agent/test_skill_commands.py \
+            tests/agent/test_anthropic_keychain.py \
+            tests/hermes_cli/test_config.py \
+            tests/hermes_cli/test_atomic_json_write.py \
+            tests/hermes_cli/test_atomic_yaml_write.py \
+            tests/hermes_cli/test_banner.py \
+            tests/cli/test_slash_confirm_windows.py \
+            tests/ci/ \
+            tests/state/ \
+            --cov=agent \
+            --cov=tools \
+            --cov=hermes_cli \
+            --cov=gateway \
+            --cov-report=term \
+            --cov-report=xml:coverage.xml \
+            --cov-report=html:htmlcov
+
+          echo "## Coverage (informational — no gate)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "XML + HTML reports uploaded as the \`coverage-report\` artifact." >> "$GITHUB_STEP_SUMMARY"
+          if [ -f coverage.xml ]; then
+            python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import xml.etree.ElementTree as ET
+          root = ET.parse("coverage.xml").getroot()
+          line_rate = float(root.attrib.get("line-rate", 0))
+          branch_rate = float(root.attrib.get("branch-rate", 0))
+          lines_valid = root.attrib.get("lines-valid", "?")
+          lines_covered = root.attrib.get("lines-covered", "?")
+          print(f"- **Line rate:** {line_rate:.1%}")
+          print(f"- **Branch rate:** {branch_rate:.1%}")
+          print(f"- **Lines covered:** {lines_covered} / {lines_valid}")
+          PY
+          fi
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-report
+          path: |
+            coverage.xml
+            htmlcov/
+          retention-days: 14
+          if-no-files-found: warn

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -1,0 +1,111 @@
+name: Windows tests (stable subset)
+
+# Non-blocking Windows CI lane. Full suite is slow and many tests are
+# POSIX-only (~46 win32 skip markers). This job runs a curated stable
+# subset that exercises cross-platform pure-Python paths Windows users
+# actually hit (delegate tool, agent core helpers, hermes_cli config /
+# atomic IO, Windows-specific gateway + slash-confirm).
+#
+# Failures do NOT block merge: continue-on-error here and on the ci.yml
+# caller; not listed in all-checks-pass.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows-stable:
+    name: Windows stable subset
+    runs-on: windows-latest
+    timeout-minutes: 30
+    # Soft-fail while Windows stability is proven. Existing pytest
+    # skipif(sys.platform == "win32") markers are honored automatically.
+    continue-on-error: true
+    defaults:
+      run:
+        # GitHub-hosted windows-latest ships Git Bash; keep shell parity
+        # with ubuntu jobs (uv, retry action, path quoting).
+        shell: bash
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        uses: ./.github/actions/retry
+        with:
+          command: uv sync --locked --python 3.11 --extra all --extra dev
+
+      - name: Minimize uv cache
+        run: uv cache prune --ci
+
+      - name: Run Windows-stable pytest subset
+        # scripts/run_tests.sh probes only .venv/bin/activate (POSIX layout)
+        # and is not reliable on native Windows venvs (.venv/Scripts). Invoke
+        # pytest directly with the documented Windows env:
+        #   PYTHONPATH=<repo>  PYTHONNOUSERSITE=1
+        # Prefer the venv interpreter under Scripts/ when present.
+        env:
+          OPENROUTER_API_KEY: ""
+          OPENAI_API_KEY: ""
+          NOUS_API_KEY: ""
+          PYTHONNOUSERSITE: "1"
+          PYTHONHASHSEED: "0"
+          TZ: UTC
+        run: |
+          set -euo pipefail
+          export PYTHONPATH="${GITHUB_WORKSPACE}${PYTHONPATH:+:${PYTHONPATH}}"
+
+          if [ -x .venv/Scripts/python.exe ]; then
+            PY=".venv/Scripts/python.exe"
+          elif [ -x .venv/Scripts/python ]; then
+            PY=".venv/Scripts/python"
+          elif [ -x .venv/bin/python ]; then
+            PY=".venv/bin/python"
+          else
+            echo "::error::no venv python found under .venv/Scripts or .venv/bin"
+            ls -la .venv || true
+            ls -la .venv/Scripts 2>/dev/null || true
+            exit 1
+          fi
+          echo "Using interpreter: $PY"
+          "$PY" -c "import sys; print(sys.platform, sys.executable); print('PYTHONPATH=', __import__('os').environ.get('PYTHONPATH',''))"
+
+          # Curated stable subset — pure-Python / Windows-aware modules.
+          # Globs expand under bash. win32 skip markers still apply.
+          "$PY" -m pytest -v --tb=short \
+            tests/tools/test_delegate.py \
+            tests/tools/test_delegate_composite_toolsets.py \
+            tests/tools/test_delegate_model_router_integration.py \
+            tests/tools/test_delegate_subagent_timeout_diagnostic.py \
+            tests/tools/test_delegate_summary_budget.py \
+            tests/tools/test_delegate_toolset_scope.py \
+            tests/agent/test_async_utils.py \
+            tests/agent/test_prompt_builder.py \
+            tests/agent/test_skill_utils.py \
+            tests/agent/test_skill_commands.py \
+            tests/agent/test_anthropic_keychain.py \
+            tests/hermes_cli/test_config.py \
+            tests/hermes_cli/test_atomic_json_write.py \
+            tests/hermes_cli/test_atomic_yaml_write.py \
+            tests/hermes_cli/test_gateway_windows.py \
+            tests/hermes_cli/test_ensure_utf8_locale.py \
+            tests/hermes_cli/test_banner.py \
+            tests/cli/test_slash_confirm_windows.py \
+            tests/ci/

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1487,6 +1487,78 @@ def _current_session_platform_hint() -> str:
         return ""
 
 
+def _skills_prompt_index_settings() -> tuple[str, int]:
+    """Return ``(prompt_index, index_top_k)`` from config.
+
+    ``prompt_index``:
+      - ``names`` (default) — category + skill names only in the system prompt
+      - ``full`` — legacy per-skill ``name: description`` lines
+
+    ``index_top_k``:
+      - ``0`` (default) — no cap on how many skills appear in the index
+      - ``N > 0`` — after filters, keep at most N skills (stable category/name
+        order); the rest remain loadable via ``skills_list`` / ``skill_view``
+    """
+    mode = "names"
+    top_k = 0
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        skills_cfg = load_config_readonly().get("skills") or {}
+        if isinstance(skills_cfg, dict):
+            raw_mode = str(skills_cfg.get("prompt_index", "names") or "names").strip().lower()
+            if raw_mode in ("full", "descriptions", "description"):
+                mode = "full"
+            else:
+                # names | name | compact | anything unknown → names (safe default)
+                mode = "names"
+            raw_k = skills_cfg.get("index_top_k", 0)
+            try:
+                top_k = int(raw_k)
+            except (TypeError, ValueError):
+                top_k = 0
+            if top_k < 0:
+                top_k = 0
+    except Exception as exc:
+        logger.debug("Could not read skills prompt_index settings: %s", exc)
+    return mode, top_k
+
+
+def _apply_skills_index_top_k(
+    skills_by_category: dict[str, list[tuple[str, str]]],
+    top_k: int,
+) -> tuple[dict[str, list[tuple[str, str]]], int, int]:
+    """Optionally cap the index to *top_k* skills (stable category then name order).
+
+    Returns ``(filtered_map, kept_count, total_before)``. When ``top_k <= 0``
+    the map is unchanged.
+    """
+    total = sum(len(v) for v in skills_by_category.values())
+    if top_k <= 0 or total <= top_k:
+        return skills_by_category, total, total
+
+    kept: dict[str, list[tuple[str, str]]] = {}
+    remaining = top_k
+    for category in sorted(skills_by_category.keys()):
+        if remaining <= 0:
+            break
+        # Deduplicate by name within category, stable sort
+        seen: set[str] = set()
+        ordered: list[tuple[str, str]] = []
+        for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
+            if name in seen:
+                continue
+            seen.add(name)
+            ordered.append((name, desc))
+        if not ordered:
+            continue
+        take = ordered[:remaining]
+        kept[category] = take
+        remaining -= len(take)
+    kept_count = sum(len(v) for v in kept.values())
+    return kept, kept_count, total
+
+
 def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
@@ -1506,17 +1578,30 @@ def build_skills_system_prompt(
     are read-only — they appear in the index but new skills are always created
     in the local dir.  Local skills take precedence when names collide.
 
+    Index density is controlled by ``skills.prompt_index`` (default ``names``):
+      - ``names`` — names-only index; full skill bodies load lazily via
+        ``skill_view`` (token-cheap default).
+      - ``full`` — legacy name+description lines per skill.
+
+    ``skills.index_top_k`` (default ``0`` = uncapped) optionally limits how
+    many skills appear after filters; overflow stays reachable via
+    ``skills_list`` / ``skill_view``.
+
     ``compact_categories`` (e.g. from the coding posture — see
     agent/coding_context.py) demotes whole categories to a names-only line in
-    the rendered index. Nothing is ever hidden: every skill name stays
-    visible and loadable via ``skill_view`` / ``skills_list``; only the
-    descriptions are dropped, and a footer note explains the demotion.
+    the rendered index when ``prompt_index=full``. Nothing is ever hidden:
+    every skill name stays visible and loadable via ``skill_view`` /
+    ``skills_list``; only the descriptions are dropped, and a footer note
+    explains the demotion. Under ``prompt_index=names`` the whole index is
+    already names-only, so category demotion is a no-op for descriptions.
     """
     skills_dir = get_skills_dir()
     external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
 
     if not skills_dir.exists() and not external_dirs:
         return ""
+
+    prompt_index_mode, index_top_k = _skills_prompt_index_settings()
 
     # ── Layer 1: in-process LRU cache ─────────────────────────────────
     # Include the resolved platform so per-platform disabled-skill lists
@@ -1531,6 +1616,8 @@ def build_skills_system_prompt(
         _platform_hint,
         tuple(sorted(disabled)),
         tuple(sorted(compact_categories or ())),
+        prompt_index_mode,
+        index_top_k,
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -1664,27 +1751,52 @@ def build_skills_system_prompt(
             except Exception as e:
                 logger.debug("Could not read external skill description %s: %s", desc_file, e)
 
-    # Posture-driven category demotion (e.g. non-coding skills while pairing
-    # on code). Demoted categories stay in the index as a single names-only
-    # line — descriptions are dropped to cut noise, but every skill name
-    # remains visible so memory-anchored recall ("load <name>") keeps working.
-    # NEVER remove entries entirely: agent-created skills are the model's
-    # project memory, and models don't reach for skills_list to rediscover
-    # what the index stops showing them. Match on the top-level category
-    # segment so nested categories ("social-media/twitter") are demoted with
-    # their parent.
-    demoted = frozenset(
-        cat for cat in skills_by_category
-        if cat.split("/", 1)[0] in (compact_categories or frozenset())
+    # Optional hard cap (skills.index_top_k) after filters — builds on the
+    # existing config key without inventing a parallel limit mechanism.
+    skills_by_category, kept_count, total_before = _apply_skills_index_top_k(
+        skills_by_category, index_top_k
     )
 
-    hidden_note = ""
-    if demoted:
-        hidden_note = (
-            "\n(Categories marked [names only] are outside the current coding "
-            "context, so their descriptions are omitted — the skills work "
-            "normally and load with skill_view(name) as usual.)"
+    # Names-only mode (default): every category is a compact names line.
+    # Full mode: legacy name+description lines, with optional posture demotion.
+    names_only = prompt_index_mode != "full"
+
+    # Posture-driven category demotion (e.g. non-coding skills while pairing
+    # on code). Only meaningful when prompt_index=full — under names mode the
+    # whole index is already names-only. Demoted categories stay in the index
+    # as a single names-only line — descriptions are dropped to cut noise, but
+    # every skill name remains visible so memory-anchored recall ("load <name>")
+    # keeps working. NEVER remove entries entirely: agent-created skills are
+    # the model's project memory, and models don't reach for skills_list to
+    # rediscover what the index stops showing them. Match on the top-level
+    # category segment so nested categories ("social-media/twitter") are
+    # demoted with their parent.
+    demoted = frozenset()
+    if not names_only:
+        demoted = frozenset(
+            cat for cat in skills_by_category
+            if cat.split("/", 1)[0] in (compact_categories or frozenset())
         )
+
+    footer_notes: list[str] = []
+    if names_only:
+        footer_notes.append(
+            "Skill descriptions are omitted from this index "
+            "(skills.prompt_index=names). Load full instructions with "
+            "skill_view(name); use skills_list to browse descriptions."
+        )
+    if demoted:
+        footer_notes.append(
+            "Categories marked [names only] are outside the current coding "
+            "context, so their descriptions are omitted — the skills work "
+            "normally and load with skill_view(name) as usual."
+        )
+    if index_top_k > 0 and total_before > kept_count:
+        footer_notes.append(
+            f"Index capped at {kept_count} of {total_before} skills "
+            f"(skills.index_top_k={index_top_k}); use skills_list for the rest."
+        )
+    hidden_note = ("\n" + " ".join(f"({n})" for n in footer_notes)) if footer_notes else ""
 
     if not skills_by_category:
         result = ""
@@ -1693,9 +1805,12 @@ def build_skills_system_prompt(
         for category in sorted(skills_by_category.keys()):
             # Deduplicate and sort skills within each category
             seen = set()
-            if category in demoted:
+            if names_only or category in demoted:
                 names = sorted({name for name, _ in skills_by_category[category]})
-                index_lines.append(f"  {category} [names only]: {', '.join(names)}")
+                if names_only:
+                    index_lines.append(f"  {category}: {', '.join(names)}")
+                else:
+                    index_lines.append(f"  {category} [names only]: {', '.join(names)}")
                 continue
             cat_desc = category_descriptions.get(category, "")
             if cat_desc:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2416,6 +2416,15 @@ DEFAULT_CONFIG = {
     # always goes to ~/.hermes/skills/.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        # System-prompt skills index density:
+        #   "names" (default) — category + skill names only; full bodies stay
+        #     lazy via skill_view (saves ~descriptions every turn).
+        #   "full" — restore legacy name+description lines per skill.
+        "prompt_index": "names",
+        # Cap how many skills appear in the system-prompt index (0 = no cap).
+        # Applies after platform/disabled/condition filters. Overflow is still
+        # discoverable via skills_list / skill_view.
+        "index_top_k": 0,
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled
@@ -2905,17 +2914,25 @@ DEFAULT_CONFIG = {
     # openclaw-tool-search-report PDF in this PR for the rationale.
     "tools": {
         "tool_search": {
-            # "auto" (default) — activate only when deferrable tool schemas
-            #   exceed ``threshold_pct`` of the active model's context length,
-            #   so small toolsets pay no overhead.
+            # "auto" (default) — activate when deferrable tool schemas meet
+            #   the lower of ``auto_threshold`` (absolute tokens) or
+            #   ``threshold_pct`` of the active model's context length, so
+            #   mid-size MCP/plugin surfaces defer while tiny toolsets pay
+            #   no overhead.
             # "on"  — always activate when there is at least one deferrable
             #   tool. Use when you have many MCP servers and want maximum
             #   token reduction unconditionally.
             # "off" — disable entirely. Tools-array assembly is a pass-through.
             "enabled": "auto",
             # Percentage of context length at which "auto" mode kicks in.
-            # 10 matches the Claude Code default. Range 0..100.
+            # Combined with auto_threshold via min(). Range 0..100.
             "threshold_pct": 10,
+            # Absolute deferrable-schema token floor for "auto" mode.
+            # Default 6000 engages mid-size MCP/plugin setups (5–15k tokens)
+            # that used to stay fully expanded under the old 20k bar.
+            # Set 20000 to restore legacy behaviour; 0 disables the absolute
+            # floor (percentage-only when context length is known).
+            "auto_threshold": 6000,
             # When the model calls tool_search without a ``limit`` argument,
             # how many hits to return. Range 1..max_search_limit.
             "search_default_limit": 5,
@@ -5484,14 +5501,17 @@ def check_config_version() -> Tuple[int, int]:
 # Config structure validation
 # =============================================================================
 
-# Fields that are valid at root level of config.yaml
-_KNOWN_ROOT_KEYS = {
-    "_config_version", "model", "providers", "fallback_model",
-    "fallback_providers", "credential_pool_strategies", "toolsets",
-    "agent", "terminal", "display", "compression", "delegation",
-    "auxiliary", "moa", "custom_providers", "context", "memory", "gateway",
-    "sessions", "streaming", "updates", "mcp_servers",
+# Fields that are valid at root level of config.yaml.
+# DEFAULT_CONFIG is the single source of truth for documented roots; keep this
+# set derived so new defaults (skills, security, browser, …) are accepted
+# automatically. A few optional/legacy roots are valid on disk but intentionally
+# absent from DEFAULT_CONFIG (omitted when unused / alternate schema forms).
+_EXTRA_KNOWN_ROOT_KEYS = {
+    "custom_providers",  # legacy list form; modern equivalent is providers: {}
+    "fallback_model",    # optional single dict or chain list; omitted when disabled
+    "mcp_servers",       # MCP server definitions written by setup/tools flows
 }
+_KNOWN_ROOT_KEYS = frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
@@ -5646,15 +5666,27 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
             "    base_url: https://...",
         ))
 
-    # ── Root-level keys that look misplaced ──────────────────────────────
+    # ── Unknown / misplaced root-level keys ──────────────────────────────
+    # Typos like skillz:/secrity: were previously silent (only provider-like
+    # fields were flagged). Warn on any unknown top-level key so config
+    # hygiene surfaces without breaking startup.
     for key in config:
         if key.startswith("_"):
             continue
-        if key not in _KNOWN_ROOT_KEYS and key in _CUSTOM_PROVIDER_LIKE_FIELDS:
+        if key in _KNOWN_ROOT_KEYS:
+            continue
+        if key in _CUSTOM_PROVIDER_LIKE_FIELDS:
             issues.append(ConfigIssue(
                 "warning",
                 f"Root-level key '{key}' looks misplaced — should it be under 'model:' or inside a 'custom_providers' entry?",
                 f"Move '{key}' under the appropriate section",
+            ))
+        else:
+            issues.append(ConfigIssue(
+                "warning",
+                f"Unknown top-level config key '{key}' — it will be ignored",
+                "Check for typos, or remove the key if it is not a supported config root. "
+                "Run 'hermes doctor' for more detail.",
             ))
 
     return issues

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -201,6 +201,100 @@ def _fail_and_issue(text: str, detail: str, fix: str, issues: list[str]) -> None
     issues.append(fix)
 
 
+# Deprecated / legacy config keys still read for back-compat. Doctor surfaces
+# them as non-failing warnings with the modern replacement — it does not
+# auto-migrate or delete (migrations live in config.py version steps).
+_DEPRECATED_CONFIG_KEYS: tuple[tuple[str, str, str], ...] = (
+    # (section, key, replacement)
+    ("display", "tool_progress_overrides", "display.platforms"),
+    ("delegation", "max_async_children", "delegation.max_concurrent_children"),
+)
+
+# compression.summary_* → auxiliary.compression (model/provider/base_url)
+_DEPRECATED_COMPRESSION_SUMMARY_KEYS: tuple[str, ...] = (
+    "summary_model",
+    "summary_provider",
+    "summary_base_url",
+)
+
+# Deprecated env vars (checked in the .env file, not process env, so config→env
+# bridges like terminal.cwd → TERMINAL_CWD do not false-positive).
+_DEPRECATED_ENV_VARS: tuple[tuple[str, str], ...] = (
+    ("HERMES_TOOL_PROGRESS", "display.tool_progress in config.yaml"),
+    ("HERMES_TOOL_PROGRESS_MODE", "display.tool_progress in config.yaml"),
+    ("TERMINAL_CWD", "terminal.cwd in config.yaml"),
+    ("MESSAGING_CWD", "terminal.cwd in config.yaml"),
+    ("QQ_HOME_CHANNEL", "QQBOT_HOME_CHANNEL"),
+    ("QQ_HOME_CHANNEL_NAME", "QQBOT_HOME_CHANNEL_NAME"),
+)
+
+
+def collect_deprecated_config_keys(raw_config: dict | None) -> list[tuple[str, str]]:
+    """Return ``(legacy_path, replacement)`` for deprecated keys present in *raw_config*.
+
+    Only keys that appear in the on-disk YAML are reported (raw file load, not
+    merged defaults). Empty containers still count — presence of the legacy
+    key is the signal that the user should migrate.
+    """
+    findings: list[tuple[str, str]] = []
+    if not isinstance(raw_config, dict):
+        return findings
+
+    for section, key, replacement in _DEPRECATED_CONFIG_KEYS:
+        section_val = raw_config.get(section)
+        if isinstance(section_val, dict) and key in section_val:
+            findings.append((f"{section}.{key}", replacement))
+
+    compression = raw_config.get("compression")
+    if isinstance(compression, dict):
+        for key in _DEPRECATED_COMPRESSION_SUMMARY_KEYS:
+            if key in compression:
+                findings.append((f"compression.{key}", "auxiliary.compression"))
+
+    return findings
+
+
+def collect_deprecated_env_vars(env_map: dict | None) -> list[tuple[str, str]]:
+    """Return ``(legacy_env, replacement)`` for deprecated vars present in *env_map*.
+
+    *env_map* should come from the on-disk ``.env`` (e.g. ``load_env()``), not
+    ``os.environ``, so bridged runtime vars do not trigger false positives.
+    """
+    findings: list[tuple[str, str]] = []
+    if not isinstance(env_map, dict):
+        return findings
+    for name, replacement in _DEPRECATED_ENV_VARS:
+        val = env_map.get(name)
+        if val is not None and str(val).strip() != "":
+            findings.append((name, replacement))
+    return findings
+
+
+def report_deprecated_config_and_env(
+    raw_config: dict | None = None,
+    env_map: dict | None = None,
+) -> list[tuple[str, str]]:
+    """Emit non-failing doctor warnings for deprecated config keys and env vars.
+
+    Returns the list of ``(legacy, replacement)`` findings that were reported
+    (empty when nothing deprecated is present). Does not mutate config/env and
+    does not append to the blocking ``issues`` list.
+    """
+    findings = collect_deprecated_config_keys(raw_config)
+    findings.extend(collect_deprecated_env_vars(env_map))
+    if not findings:
+        check_ok("No deprecated config keys or env vars")
+        return findings
+
+    for legacy, replacement in findings:
+        check_warn(
+            f"Deprecated: {legacy}",
+            f"(use {replacement} instead)",
+        )
+        check_info(f"Replace {legacy} → {replacement} (warn-only; not auto-migrated here)")
+    return findings
+
+
 def _enabled_cli_toolsets_for_doctor() -> set[str] | None:
     """Return toolsets enabled for the CLI, or None if config resolution fails."""
     try:
@@ -1059,6 +1153,25 @@ def run_doctor(args):
         except Exception:
             pass
 
+        # Surface deprecated/legacy config keys and env vars (warn-only).
+        # Migrations may still live in config.py version steps; doctor does
+        # not auto-delete here — only tells the user the modern replacement.
+        try:
+            import yaml as _yaml_depr
+            from hermes_cli.config import load_env as _load_env_depr
+
+            with open(config_path, encoding="utf-8") as _f_depr:
+                _raw_for_depr = _yaml_depr.safe_load(_f_depr) or {}
+            # Prefer the on-disk .env so bridged process env (e.g. TERMINAL_CWD
+            # from terminal.cwd) does not false-positive.
+            try:
+                _env_for_depr = _load_env_depr()
+            except Exception:
+                _env_for_depr = {}
+            report_deprecated_config_and_env(_raw_for_depr, _env_for_depr)
+        except Exception:
+            pass
+
         # Validate config structure (catches malformed custom_providers, etc.)
         try:
             from hermes_cli.config import validate_config_structure
@@ -1074,6 +1187,19 @@ def run_doctor(args):
                     for hint_line in ci.hint.splitlines():
                         check_info(hint_line)
                     issues.append(ci.message)
+        except Exception:
+            pass
+
+    if not config_path.exists():
+        # No config.yaml — still surface deprecated env vars from .env.
+        try:
+            from hermes_cli.config import load_env as _load_env_depr
+
+            try:
+                _env_for_depr = _load_env_depr()
+            except Exception:
+                _env_for_depr = {}
+            report_deprecated_config_and_env({}, _env_for_depr)
         except Exception:
             pass
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -422,8 +422,11 @@ class TestBuildSkillsSystemPrompt:
         )
         result = build_skills_system_prompt()
         assert "python-debug" in result
-        assert "Debug Python scripts" in result
+        # Default prompt_index=names omits per-skill descriptions.
+        assert "Debug Python scripts" not in result
         assert "available_skills" in result
+        assert "skill_view" in result
+        assert "skills.prompt_index=names" in result
 
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -433,8 +436,12 @@ class TestBuildSkillsSystemPrompt:
             d.mkdir(parents=True, exist_ok=True)
             (d / "SKILL.md").write_text("---\ndescription: Search stuff\n---\n")
         result = build_skills_system_prompt()
-        # "search" should appear only once per category
-        assert result.count("- search") == 1
+        # Isolate the index block so intro text (e.g. "web_search") cannot
+        # inflate the count.
+        start = result.index("<available_skills>")
+        end = result.index("</available_skills>")
+        block = result[start:end]
+        assert block.count("search") == 1
 
     def test_compact_categories_demoted_to_names_only(self, monkeypatch, tmp_path):
         """Posture-driven demotion keeps every skill NAME visible.
@@ -443,8 +450,10 @@ class TestBuildSkillsSystemPrompt:
         full pruning caused silent capability loss in a real workflow
         (agent-created skills are the model's project memory, and models
         don't rediscover them via skills_list once the index goes quiet).
+        Requires prompt_index=full so non-demoted cats still show descriptions.
         """
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("skills:\n  prompt_index: full\n")
         for cat, name in (("social-media", "tweet-stuff"), ("github", "pr-review")):
             d = tmp_path / "skills" / cat / name
             d.mkdir(parents=True)
@@ -468,6 +477,7 @@ class TestBuildSkillsSystemPrompt:
         self, monkeypatch, tmp_path
     ):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("skills:\n  prompt_index: full\n")
         d = tmp_path / "skills" / "social-media" / "twitter" / "thread-writer"
         d.mkdir(parents=True)
         (d / "SKILL.md").write_text(
@@ -516,6 +526,7 @@ class TestBuildSkillsSystemPrompt:
     def test_includes_matching_platform_skills(self, monkeypatch, tmp_path):
         """Skills with platforms: [macos] should appear on macOS."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("skills:\n  prompt_index: full\n")
         skills_dir = tmp_path / "skills" / "apple"
         mac_skill = skills_dir / "imessage"
         mac_skill.mkdir(parents=True)
@@ -634,6 +645,99 @@ class TestBuildSkillsSystemPrompt:
 
         result = build_skills_system_prompt()
         assert "backend-skill" in result
+
+    def test_names_index_smaller_than_full_and_full_restores_descriptions(
+        self, monkeypatch, tmp_path
+    ):
+        """Default names index is strictly smaller; full restores descriptions."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Keep descriptions under the 60-char extract_skill_description cap so
+        # the full index actually embeds them (no "..." truncation).
+        desc_prefix = "Token-heavy skill description pad XX"
+        assert len(desc_prefix) < 57
+        for i in range(12):
+            d = tmp_path / "skills" / "demo" / f"skill-{i}"
+            d.mkdir(parents=True)
+            desc = f"{desc_prefix}{i:02d}"
+            (d / "SKILL.md").write_text(
+                f"---\nname: skill-{i}\ndescription: {desc}\n---\n"
+                f"# Body for skill-{i}\n\nFull instructions live here.\n"
+            )
+
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+
+        def _index_block(text: str) -> str:
+            start = text.index("<available_skills>")
+            end = text.index("</available_skills>")
+            return text[start:end]
+
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+        names = build_skills_system_prompt()
+        assert "skill-0" in names
+        assert desc_prefix not in names
+        assert "skills.prompt_index=names" in names
+
+        (tmp_path / "config.yaml").write_text("skills:\n  prompt_index: full\n")
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+        full = build_skills_system_prompt()
+        assert "skill-0" in full
+        assert desc_prefix in full
+        assert f"skill-0: {desc_prefix}00" in full
+
+        names_block = _index_block(names)
+        full_block = _index_block(full)
+        assert len(names_block) < len(full_block)
+        delta_chars = len(full_block) - len(names_block)
+        # 12 skills × ~40-char descriptions → hundreds of chars (~100+ tokens)
+        assert delta_chars > 300
+        approx_tokens = delta_chars / 4
+        assert approx_tokens > 75
+
+    def test_index_top_k_caps_names_index(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "skills:\n  prompt_index: names\n  index_top_k: 2\n"
+        )
+        for name in ("alpha", "bravo", "charlie"):
+            d = tmp_path / "skills" / "pack" / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: Desc for {name}\n---\n"
+            )
+        result = build_skills_system_prompt()
+        assert "alpha" in result
+        assert "bravo" in result
+        assert "charlie" not in result
+        assert "index_top_k=2" in result
+        assert "skills_list" in result
+
+    def test_skill_view_still_returns_full_body_under_names_index(
+        self, monkeypatch, tmp_path
+    ):
+        """Lazy load path is unchanged: skill_view returns full SKILL.md body."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        body = "# Full skill body\n\nDo the thing with step one and step two.\n"
+        skill_dir = tmp_path / "skills" / "demo" / "lazy-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: lazy-skill\ndescription: Lazy load me\n---\n" + body
+        )
+
+        # Names index must not embed the body or description.
+        index = build_skills_system_prompt()
+        assert "lazy-skill" in index
+        assert "Lazy load me" not in index
+        assert "Do the thing with step one" not in index
+
+        # skill_view still returns the full body (progressive disclosure).
+        import json
+        from tools.skills_tool import skill_view
+
+        viewed = json.loads(skill_view("lazy-skill"))
+        assert viewed.get("error") in (None, False) or "error" not in viewed or not viewed.get("error")
+        content = viewed.get("content") or viewed.get("skill_content") or str(viewed)
+        assert "Do the thing with step one" in content
+        assert "Lazy load me" in content or "lazy-skill" in content
 
 
 class TestBuildNousSubscriptionPrompt:

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -1,7 +1,13 @@
 """Tests for config.yaml structure validation (validate_config_structure)."""
 
 
-from hermes_cli.config import validate_config_structure, ConfigIssue
+from hermes_cli.config import (
+    DEFAULT_CONFIG,
+    _EXTRA_KNOWN_ROOT_KEYS,
+    _KNOWN_ROOT_KEYS,
+    validate_config_structure,
+    ConfigIssue,
+)
 
 
 class TestCustomProvidersValidation:
@@ -205,3 +211,71 @@ class TestConfigIssueDataclass:
         a = ConfigIssue("error", "msg", "hint")
         b = ConfigIssue("error", "msg", "hint")
         assert a == b
+
+
+class TestUnknownTopLevelKeys:
+    """Unknown top-level keys should warn (not error); known roots stay silent."""
+
+    def test_typo_top_level_key_warns_with_key_name(self):
+        """A typo like skillz: must surface as a warning naming the key."""
+        issues = validate_config_structure({
+            "model": {"provider": "openrouter"},
+            "skillz": {"enabled": True},
+            "secrity": {"redact": True},
+        })
+        warnings = [i for i in issues if i.severity == "warning"]
+        unknown = [i for i in warnings if "Unknown top-level config key" in i.message]
+        messages = " ".join(i.message for i in unknown)
+        assert "skillz" in messages
+        assert "secrity" in messages
+        assert all(i.severity == "warning" for i in unknown)
+        assert not any(i.severity == "error" for i in unknown)
+
+    def test_all_default_config_roots_accepted_without_unknown_warning(self):
+        """Every DEFAULT_CONFIG root (and legacy extras) must not warn as unknown."""
+        config = {key: {} if isinstance(DEFAULT_CONFIG.get(key), dict) else DEFAULT_CONFIG.get(key)
+                  for key in DEFAULT_CONFIG}
+        for key in _EXTRA_KNOWN_ROOT_KEYS:
+            if key == "custom_providers":
+                config[key] = [{"name": "x", "base_url": "https://example.com"}]
+                config.setdefault("model", {"provider": "custom", "default": "m"})
+            elif key == "fallback_model":
+                config[key] = {"provider": "openrouter", "model": "test"}
+            else:
+                config[key] = {}
+        issues = validate_config_structure(config)
+        unknown = [i for i in issues if "Unknown top-level config key" in i.message]
+        assert unknown == [], f"Unexpected unknown-key warnings: {[i.message for i in unknown]}"
+
+    def test_known_root_keys_derived_from_default_config(self):
+        """_KNOWN_ROOT_KEYS must be DEFAULT_CONFIG.keys() plus extras — single source of truth."""
+        assert set(DEFAULT_CONFIG.keys()).issubset(_KNOWN_ROOT_KEYS)
+        assert _EXTRA_KNOWN_ROOT_KEYS.issubset(_KNOWN_ROOT_KEYS)
+        assert _KNOWN_ROOT_KEYS == frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
+
+    def test_provider_like_unknown_root_keeps_misplaced_message(self):
+        """Preserve existing base_url/api_key root-level guidance (not generic unknown)."""
+        issues = validate_config_structure({
+            "base_url": "https://example.com/v1",
+            "api_key": "secret",
+        })
+        misplaced = [
+            i for i in issues
+            if i.severity == "warning" and "looks misplaced" in i.message
+        ]
+        generic_unknown = [
+            i for i in issues
+            if "Unknown top-level config key" in i.message
+        ]
+        assert any("base_url" in i.message for i in misplaced)
+        assert any("api_key" in i.message for i in misplaced)
+        assert generic_unknown == []
+
+    def test_private_underscore_keys_not_flagged(self):
+        """Internal keys starting with _ remain ignored (except known defaults)."""
+        issues = validate_config_structure({
+            "_internal_scratch": True,
+            "model": {"provider": "openrouter"},
+        })
+        assert not any("Unknown top-level" in i.message for i in issues)
+        assert not any("_internal_scratch" in i.message for i in issues)

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1488,3 +1488,171 @@ def test_npm_audit_fix_hint_avoids_crashing_workspace_flag(monkeypatch, tmp_path
     assert "build-time tooling" in out
     assert "known npm bug" in out
     assert "lockfile bump" in out
+
+
+class TestDoctorDeprecatedConfigAndEnv:
+    """Doctor must surface deprecated/legacy config keys and env vars with
+    modern replacements as non-failing warnings — without auto-migrating.
+    """
+
+    def test_collect_deprecated_config_keys_flags_legacy(self):
+        raw = {
+            "display": {"tool_progress_overrides": {"telegram": "all"}},
+            "delegation": {"max_async_children": 5, "max_concurrent_children": 3},
+            "compression": {"summary_model": "gpt-4o-mini", "enabled": True},
+        }
+        findings = doctor_mod.collect_deprecated_config_keys(raw)
+        paths = {legacy for legacy, _ in findings}
+        assert "display.tool_progress_overrides" in paths
+        assert "delegation.max_async_children" in paths
+        assert "compression.summary_model" in paths
+        by_key = dict(findings)
+        assert by_key["display.tool_progress_overrides"] == "display.platforms"
+        assert by_key["delegation.max_async_children"] == (
+            "delegation.max_concurrent_children"
+        )
+        assert by_key["compression.summary_model"] == "auxiliary.compression"
+
+    def test_collect_deprecated_config_keys_clean(self):
+        raw = {
+            "display": {"platforms": {"telegram": {"tool_progress": "all"}}},
+            "delegation": {"max_concurrent_children": 3},
+            "compression": {"enabled": True},
+        }
+        assert doctor_mod.collect_deprecated_config_keys(raw) == []
+
+    def test_collect_deprecated_env_vars(self):
+        env = {
+            "HERMES_TOOL_PROGRESS": "true",
+            "TERMINAL_CWD": "/tmp/proj",
+            "QQ_HOME_CHANNEL": "12345",
+            "OPENAI_API_KEY": "sk-test",  # not deprecated
+        }
+        findings = doctor_mod.collect_deprecated_env_vars(env)
+        names = {n for n, _ in findings}
+        assert "HERMES_TOOL_PROGRESS" in names
+        assert "TERMINAL_CWD" in names
+        assert "QQ_HOME_CHANNEL" in names
+        assert "OPENAI_API_KEY" not in names
+        by_name = dict(findings)
+        assert "display.tool_progress" in by_name["HERMES_TOOL_PROGRESS"]
+        assert "terminal.cwd" in by_name["TERMINAL_CWD"]
+        assert by_name["QQ_HOME_CHANNEL"] == "QQBOT_HOME_CHANNEL"
+
+    def test_collect_deprecated_env_vars_ignores_empty(self):
+        assert doctor_mod.collect_deprecated_env_vars({"TERMINAL_CWD": "  "}) == []
+        assert doctor_mod.collect_deprecated_env_vars({}) == []
+        assert doctor_mod.collect_deprecated_env_vars(None) == []
+
+    def _run_doctor_with_config(self, monkeypatch, tmp_path, *, config_yaml: str, env_text: str = ""):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(parents=True)
+        (hermes_home / "config.yaml").write_text(config_yaml, encoding="utf-8")
+        env_body = env_text if env_text else "OPENAI_API_KEY=sk-test\n"
+        (hermes_home / ".env").write_text(env_body, encoding="utf-8")
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", hermes_home)
+        monkeypatch.setattr(doctor_mod, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        # Clear process-level legacy env so tests only see the on-disk .env.
+        for k in (
+            "HERMES_TOOL_PROGRESS",
+            "HERMES_TOOL_PROGRESS_MODE",
+            "TERMINAL_CWD",
+            "MESSAGING_CWD",
+            "QQ_HOME_CHANNEL",
+            "QQ_HOME_CHANNEL_NAME",
+        ):
+            monkeypatch.delenv(k, raising=False)
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: (_ for _ in ()).throw(SystemExit(0)),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf), pytest.raises(SystemExit):
+            doctor_mod.run_doctor(Namespace(fix=False))
+        return buf.getvalue(), hermes_home
+
+    def test_doctor_warns_on_tool_progress_overrides_and_max_async_children(
+        self, monkeypatch, tmp_path
+    ):
+        cfg = """\
+display:
+  tool_progress_overrides:
+    telegram: all
+delegation:
+  max_async_children: 8
+  max_concurrent_children: 3
+"""
+        out, hermes_home = self._run_doctor_with_config(monkeypatch, tmp_path, config_yaml=cfg)
+        assert "Deprecated: display.tool_progress_overrides" in out
+        assert "display.platforms" in out
+        assert "Deprecated: delegation.max_async_children" in out
+        assert "max_concurrent_children" in out
+        # Warn-only: must not mutate config.
+        on_disk = (hermes_home / "config.yaml").read_text(encoding="utf-8")
+        assert "tool_progress_overrides" in on_disk
+        assert "max_async_children" in on_disk
+
+    def test_doctor_warns_on_compression_summary_and_legacy_env(
+        self, monkeypatch, tmp_path
+    ):
+        cfg = """\
+compression:
+  summary_model: gpt-4o-mini
+  summary_provider: openai
+"""
+        env = (
+            "OPENAI_API_KEY=sk-test\n"
+            "HERMES_TOOL_PROGRESS=true\n"
+            "TERMINAL_CWD=/old/path\n"
+            "QQ_HOME_CHANNEL=999\n"
+        )
+        out, _ = self._run_doctor_with_config(
+            monkeypatch, tmp_path, config_yaml=cfg, env_text=env
+        )
+        assert "Deprecated: compression.summary_model" in out
+        assert "auxiliary.compression" in out
+        assert "Deprecated: HERMES_TOOL_PROGRESS" in out
+        assert "display.tool_progress" in out
+        assert "Deprecated: TERMINAL_CWD" in out
+        assert "terminal.cwd" in out
+        assert "Deprecated: QQ_HOME_CHANNEL" in out
+        assert "QQBOT_HOME_CHANNEL" in out
+
+    def test_doctor_clean_config_has_no_deprecated_warning(self, monkeypatch, tmp_path):
+        cfg = """\
+display:
+  platforms:
+    telegram:
+      tool_progress: all
+delegation:
+  max_concurrent_children: 3
+compression:
+  enabled: true
+terminal:
+  cwd: /project
+"""
+        out, _ = self._run_doctor_with_config(monkeypatch, tmp_path, config_yaml=cfg)
+        assert "Deprecated: display.tool_progress_overrides" not in out
+        assert "Deprecated: delegation.max_async_children" not in out
+        assert "Deprecated: compression.summary_model" not in out
+        assert "Deprecated: HERMES_TOOL_PROGRESS" not in out
+        assert "Deprecated: TERMINAL_CWD" not in out
+        assert "Deprecated: QQ_HOME_CHANNEL" not in out
+        assert "No deprecated config keys or env vars" in out
+
+    def test_report_does_not_count_as_blocking_issue(self, monkeypatch, tmp_path, capsys):
+        """report_deprecated_config_and_env is warn-only — no issues list mutation."""
+        findings = doctor_mod.report_deprecated_config_and_env(
+            {"delegation": {"max_async_children": 2}},
+            {"HERMES_TOOL_PROGRESS_MODE": "verbose"},
+        )
+        out = capsys.readouterr().out
+        assert len(findings) == 2
+        assert "Deprecated: delegation.max_async_children" in out
+        assert "Deprecated: HERMES_TOOL_PROGRESS_MODE" in out
+        assert "⚠" in out or "Deprecated" in out

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -41,10 +41,12 @@ def _td(name: str, description: str = "", properties: Dict[str, Any] | None = No
 
 class TestConfigParsing:
     def test_default_when_missing(self):
-        from tools.tool_search import ToolSearchConfig
+        from tools.tool_search import ToolSearchConfig, DEFAULT_AUTO_THRESHOLD
         cfg = ToolSearchConfig.from_raw(None)
         assert cfg.enabled == "auto"
         assert cfg.threshold_pct == 10.0
+        assert cfg.auto_threshold == DEFAULT_AUTO_THRESHOLD
+        assert cfg.auto_threshold == 6_000
 
     def test_bool_true_maps_to_auto(self):
         from tools.tool_search import ToolSearchConfig
@@ -72,6 +74,15 @@ class TestConfigParsing:
         assert cfg.threshold_pct == 100.0
         cfg = ToolSearchConfig.from_raw({"threshold_pct": -5})
         assert cfg.threshold_pct == 0.0
+
+    def test_auto_threshold_configurable_and_clamped(self):
+        from tools.tool_search import ToolSearchConfig
+        cfg = ToolSearchConfig.from_raw({"auto_threshold": 12_000})
+        assert cfg.auto_threshold == 12_000
+        cfg = ToolSearchConfig.from_raw({"auto_threshold": -10})
+        assert cfg.auto_threshold == 0
+        cfg = ToolSearchConfig.from_raw({"auto_threshold": 9_999_999})
+        assert cfg.auto_threshold == 1_000_000
 
     def test_search_limits_clamped(self):
         from tools.tool_search import ToolSearchConfig
@@ -151,22 +162,88 @@ class TestThresholdGate:
 
     def test_auto_below_threshold_does_not_activate(self):
         from tools.tool_search import ToolSearchConfig, should_activate
-        cfg = ToolSearchConfig.from_raw({"enabled": "auto", "threshold_pct": 10})
-        # 5% of 200K = below 10% threshold
+        # Raise absolute floor so this case is percentage-only: 5% of 200K
+        # stays below the 10% bar.
+        cfg = ToolSearchConfig.from_raw({
+            "enabled": "auto",
+            "threshold_pct": 10,
+            "auto_threshold": 0,
+        })
         assert not should_activate(cfg, deferrable_tokens=10_000, context_length=200_000)
 
     def test_auto_at_or_above_threshold_activates(self):
         from tools.tool_search import ToolSearchConfig, should_activate
-        cfg = ToolSearchConfig.from_raw({"enabled": "auto", "threshold_pct": 10})
+        cfg = ToolSearchConfig.from_raw({
+            "enabled": "auto",
+            "threshold_pct": 10,
+            "auto_threshold": 0,
+        })
         assert should_activate(cfg, deferrable_tokens=20_000, context_length=200_000)
         assert should_activate(cfg, deferrable_tokens=50_000, context_length=200_000)
 
-    def test_auto_without_context_length_uses_20k_cutoff(self):
-        """Fallback cutoff used when the active model is unknown."""
-        from tools.tool_search import ToolSearchConfig, should_activate
+    def test_auto_without_context_length_uses_auto_threshold(self):
+        """Absolute floor used when the active model context is unknown."""
+        from tools.tool_search import (
+            ToolSearchConfig, should_activate, DEFAULT_AUTO_THRESHOLD,
+        )
         cfg = ToolSearchConfig.from_raw({"enabled": "auto"})
+        assert cfg.auto_threshold == DEFAULT_AUTO_THRESHOLD
+        assert not should_activate(
+            cfg, deferrable_tokens=DEFAULT_AUTO_THRESHOLD - 1, context_length=0,
+        )
+        assert should_activate(
+            cfg, deferrable_tokens=DEFAULT_AUTO_THRESHOLD, context_length=0,
+        )
+        # Mid-size MCP surface (~10k tokens) now engages under the default.
+        assert should_activate(cfg, deferrable_tokens=10_000, context_length=0)
+
+    def test_auto_mid_token_count_engages_with_large_context(self):
+        """Default auto_threshold engages mid-size setups on large contexts.
+
+        Previously only threshold_pct (10% of 200k = 20k) applied, so a
+        5–15k MCP surface stayed fully expanded every turn.
+        """
+        from tools.tool_search import ToolSearchConfig, should_activate
+        cfg = ToolSearchConfig.from_raw({"enabled": "auto"})  # defaults
+        assert should_activate(cfg, deferrable_tokens=8_000, context_length=200_000)
+        assert should_activate(cfg, deferrable_tokens=6_000, context_length=200_000)
+        assert not should_activate(cfg, deferrable_tokens=5_000, context_length=200_000)
+
+    def test_auto_threshold_configurable(self):
+        from tools.tool_search import ToolSearchConfig, should_activate
+        cfg = ToolSearchConfig.from_raw({
+            "enabled": "auto",
+            "auto_threshold": 12_000,
+            "threshold_pct": 10,
+        })
+        assert not should_activate(cfg, deferrable_tokens=10_000, context_length=200_000)
+        assert should_activate(cfg, deferrable_tokens=12_000, context_length=200_000)
+
+    def test_auto_disabled_absolute_uses_pct_only(self):
+        """auto_threshold: 0 restores percentage-only auto behaviour."""
+        from tools.tool_search import ToolSearchConfig, should_activate
+        cfg = ToolSearchConfig.from_raw({
+            "enabled": "auto",
+            "auto_threshold": 0,
+            "threshold_pct": 10,
+        })
+        # 10k is below 10% of 200k — must not activate.
+        assert not should_activate(cfg, deferrable_tokens=10_000, context_length=200_000)
+        # Without context and no absolute floor, auto stays off.
+        assert not should_activate(cfg, deferrable_tokens=50_000, context_length=0)
+
+    def test_legacy_auto_threshold_restores_old_bar(self):
+        from tools.tool_search import (
+            ToolSearchConfig, should_activate, LEGACY_AUTO_THRESHOLD,
+        )
+        cfg = ToolSearchConfig.from_raw({
+            "enabled": "auto",
+            "auto_threshold": LEGACY_AUTO_THRESHOLD,
+            "threshold_pct": 10,
+        })
+        assert not should_activate(cfg, deferrable_tokens=10_000, context_length=200_000)
         assert not should_activate(cfg, deferrable_tokens=10_000, context_length=0)
-        assert should_activate(cfg, deferrable_tokens=25_000, context_length=0)
+        assert should_activate(cfg, deferrable_tokens=20_000, context_length=0)
 
     def test_token_estimate_proportional_to_schema_size(self):
         from tools.tool_search import estimate_tokens_from_schemas

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -10,8 +10,10 @@ for the full rationale):
 * Core tools defined in ``toolsets._HERMES_CORE_TOOLS`` are *never* deferred.
   Always-load means always-load. No exceptions.
 * The threshold gate runs every assembly: when deferrable tools would consume
-  less than ``threshold_pct`` of the model's context window (default 10%),
-  tool search is a no-op and the tools array passes through unchanged.
+  less than the effective auto bar — the lower of ``auto_threshold``
+  (default 6k absolute tokens) and ``threshold_pct`` of the model's context
+  window (default 10%) — tool search is a no-op and the tools array passes
+  through unchanged. Set ``auto_threshold: 20000`` for the legacy absolute bar.
 * The catalog is stateless across turns and tools-array assemblies. It is
   rebuilt from the current tool-defs list every time. This is the lesson
   from OpenClaw's cron regression (openclaw/openclaw#84141): a session-keyed
@@ -54,6 +56,17 @@ BRIDGE_TOOL_NAMES = frozenset({TOOL_SEARCH_NAME, TOOL_DESCRIBE_NAME, TOOL_CALL_N
 # underestimating, which is the safer default.
 CHARS_PER_TOKEN = 4.0
 
+# Absolute deferrable-schema token floor for ``enabled: auto``. Mid-size
+# MCP/plugin surfaces (roughly 5–15k schema tokens) used to stay fully
+# expanded every turn because the previous 20k fixed cutoff (and 10% of a
+# 200k context) never fired. 6k engages those setups while tiny toolsets
+# still pass through. Restore the old bar with
+# ``tools.tool_search.auto_threshold: 20000``.
+DEFAULT_AUTO_THRESHOLD = 6_000
+# Historical no-context cutoff; kept for docs/tests and as the value users
+# set to recover pre-change auto behaviour.
+LEGACY_AUTO_THRESHOLD = 20_000
+
 
 # ---------------------------------------------------------------------------
 # Configuration plumbing
@@ -66,6 +79,7 @@ class ToolSearchConfig:
 
     enabled: str  # "auto" | "on" | "off"
     threshold_pct: float  # 0..100 — only used when enabled == "auto"
+    auto_threshold: int  # absolute deferrable-token floor for auto mode
     search_default_limit: int
     max_search_limit: int
 
@@ -81,12 +95,15 @@ class ToolSearchConfig:
         """
         if raw is True:
             return cls(enabled="auto", threshold_pct=10.0,
+                       auto_threshold=DEFAULT_AUTO_THRESHOLD,
                        search_default_limit=5, max_search_limit=20)
         if raw is False:
             return cls(enabled="off", threshold_pct=10.0,
+                       auto_threshold=DEFAULT_AUTO_THRESHOLD,
                        search_default_limit=5, max_search_limit=20)
         if not isinstance(raw, dict):
             return cls(enabled="auto", threshold_pct=10.0,
+                       auto_threshold=DEFAULT_AUTO_THRESHOLD,
                        search_default_limit=5, max_search_limit=20)
 
         enabled_raw = str(raw.get("enabled", "auto")).strip().lower()
@@ -102,6 +119,13 @@ class ToolSearchConfig:
         threshold_pct = _safe_float(raw.get("threshold_pct"), 10.0)
         threshold_pct = max(0.0, min(100.0, threshold_pct))
 
+        # Absolute token floor for auto mode. 0 disables the absolute gate
+        # (percentage-only when context is known; no activation without a
+        # known context length). Cap at a generous upper bound so typos
+        # cannot overflow comparisons.
+        auto_threshold = max(0, min(1_000_000, _safe_int(
+            raw.get("auto_threshold"), DEFAULT_AUTO_THRESHOLD)))
+
         max_search_limit = max(1, min(50, _safe_int(raw.get("max_search_limit"), 20)))
         search_default_limit = max(1, min(max_search_limit,
                                           _safe_int(raw.get("search_default_limit"), 5)))
@@ -109,6 +133,7 @@ class ToolSearchConfig:
         return cls(
             enabled=enabled,
             threshold_pct=threshold_pct,
+            auto_threshold=auto_threshold,
             search_default_limit=search_default_limit,
             max_search_limit=max_search_limit,
         )
@@ -218,9 +243,9 @@ def estimate_tokens_from_schemas(tool_defs: Iterable[Dict[str, Any]]) -> int:
     """Estimate the token cost of a tool-defs list via the chars/4 rule.
 
     Cheap and stable across providers. The number doesn't need to be exact —
-    it gates the activate/skip decision, and a typical 200K context with a
-    10% threshold means the decision flips around 20K tokens of schema.
-    Order-of-magnitude precision is fine.
+    it gates the activate/skip decision. With the default absolute floor of
+    6k tokens (or 10% of context, whichever is lower), order-of-magnitude
+    precision is fine.
     """
     total_chars = 0
     for td in tool_defs:
@@ -229,6 +254,35 @@ def estimate_tokens_from_schemas(tool_defs: Iterable[Dict[str, Any]]) -> int:
         except (TypeError, ValueError):
             total_chars += len(str(td))
     return int(math.ceil(total_chars / CHARS_PER_TOKEN))
+
+
+def effective_auto_threshold(
+    config: ToolSearchConfig,
+    context_length: Optional[int],
+) -> Optional[int]:
+    """Return the deferrable-token bar for ``enabled: auto``, or None if none.
+
+    Auto mode uses the *lower* of:
+
+    * ``auto_threshold`` — absolute floor (default 6k) so mid-size MCP/plugin
+      surfaces engage even on large context windows;
+    * ``threshold_pct`` of ``context_length`` — relative gate when the model
+      context size is known.
+
+    Setting ``auto_threshold`` to ``0`` disables the absolute floor (legacy
+    percentage-only behaviour when context is known). Without a known
+    context and with ``auto_threshold == 0``, there is no bar and auto
+    stays inactive. Restore the pre-6k absolute bar with
+    ``auto_threshold: 20000``.
+    """
+    candidates: List[int] = []
+    if config.auto_threshold > 0:
+        candidates.append(config.auto_threshold)
+    if context_length and context_length > 0:
+        candidates.append(int(context_length * (config.threshold_pct / 100.0)))
+    if not candidates:
+        return None
+    return min(candidates)
 
 
 def should_activate(
@@ -240,8 +294,8 @@ def should_activate(
 
     ``"off"`` skips unconditionally. ``"on"`` activates unconditionally
     (as long as there is at least one deferrable tool — there's no point
-    swapping a no-op). ``"auto"`` activates when the deferrable schemas
-    would consume ``threshold_pct`` of context or more.
+    swapping a no-op). ``"auto"`` activates when deferrable schemas meet
+    the effective auto threshold (see ``effective_auto_threshold``).
     """
     if config.enabled == "off":
         return False
@@ -250,11 +304,9 @@ def should_activate(
     if config.enabled == "on":
         return True
     # auto
-    if not context_length or context_length <= 0:
-        # Without a known context size, fall back to a fixed 20K-token cutoff
-        # — the cliff above which Anthropic and OpenAI both saw quality drops.
-        return deferrable_tokens >= 20_000
-    threshold_tokens = int(context_length * (config.threshold_pct / 100.0))
+    threshold_tokens = effective_auto_threshold(config, context_length)
+    if threshold_tokens is None:
+        return False
     return deferrable_tokens >= threshold_tokens
 
 
@@ -556,18 +608,18 @@ def assemble_tool_defs(
         return AssemblyResult(tool_defs=incoming, activated=False)
 
     deferrable_tokens = estimate_tokens_from_schemas(deferrable)
+    threshold_tokens = effective_auto_threshold(config, context_length) or 0
     if not should_activate(config, deferrable_tokens, context_length):
         return AssemblyResult(
             tool_defs=incoming,
             activated=False,
             deferred_count=len(deferrable),
             deferred_tokens=deferrable_tokens,
-            threshold_tokens=int((context_length or 0) * (config.threshold_pct / 100.0)),
+            threshold_tokens=threshold_tokens,
         )
 
     bridge = bridge_tool_schemas(len(deferrable))
     result = visible + bridge
-    threshold_tokens = int((context_length or 0) * (config.threshold_pct / 100.0))
 
     logger.info(
         "tool_search activated: %d core/visible tools kept, %d deferred (~%d tokens, threshold ~%d)",
@@ -722,7 +774,10 @@ __all__ = [
     "is_deferrable_tool_name",
     "classify_tools",
     "estimate_tokens_from_schemas",
+    "effective_auto_threshold",
     "should_activate",
+    "DEFAULT_AUTO_THRESHOLD",
+    "LEGACY_AUTO_THRESHOLD",
     "build_catalog",
     "search_catalog",
     "bridge_tool_schemas",


### PR DESCRIPTION
## Summary
Three related reliability/cost/ops improvements:
1. **Token cost:** earlier `tool_search` auto engagement + names-only skills index by default (~8k tokens/turn saved on a large skill tree).
2. **Config hygiene:** warn on unknown top-level config keys; `hermes doctor` reports deprecated keys/env with modern replacements.
3. **CI:** non-blocking Windows stable-subset job + informational coverage job (no fail-under gate).

## Root cause
- `tool_search` auto only fired at a hard 20k deferrable-token floor — mid-size MCP/plugin setups still paid full schema cost every turn.
- Skills system prompt injected name+description for every skill every session (~steady multi‑k token tax).
- Incomplete `_KNOWN_ROOT_KEYS` let top-level config typos be silently ignored; legacy keys/env had no doctor surface.
- CI was Ubuntu-only with no Windows signal and no coverage artifact.

## Fix
### Cost
- `tools.tool_search.auto_threshold` default **6000** (was hardcoded 20000); `auto_threshold: 20000` restores legacy; `enabled: off` unchanged.
- `skills.prompt_index: names` (default) vs `full`; full bodies remain lazy via `skill_view`; uses existing `index_top_k` / `compact_categories`.

### Config
- Known root keys derived from `DEFAULT_CONFIG.keys()` (+ small extras); unknown top-level keys warn (non-blocking).
- Doctor reports deprecated config keys (`display.tool_progress_overrides`, `delegation.max_async_children`, `compression.summary_*`) and legacy env vars with replacements.

### CI
- `.github/workflows/windows-tests.yml` — `windows-latest`, stable subset, `continue-on-error`, not in `all-checks-pass`.
- `.github/workflows/coverage.yml` — pytest-cov job-only install, XML/HTML artifact, no percentage gate.
- Wired from `ci.yml` as non-blocking callers.

## Footprint
Config defaults change token shape (smaller prompts) but preserve full restore knobs. Doctor/config warnings only. CI additive non-blocking.

## Validation
```text
pytest tests/tools/test_tool_search.py tests/agent/test_prompt_builder.py \
       tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_doctor.py
→ 312 passed, 1 skipped
YAML OK across workflows
Measured skills index: names ≈ 9.6k chars vs full ≈ 42k chars (~8.1k tokens/turn saved)
```

## Tests
tool_search, prompt_builder, config_validation, doctor suites green.