### PR TITLE
feat(delegation): dynamic provider-aware subagent model router (default OFF)

### DIFF
--- a/agent/model_router.py
+++ b/agent/model_router.py
@@ -1,0 +1,374 @@
+"""Deterministic, provider-aware model router for subagent delegation.
+
+Phase03. Instead of the parent forcing one fixed model onto every subagent,
+this module selects a ``(provider, model)`` pair *dynamically* from the
+providers the user actually holds credentials for, scoring candidates by
+task-type capability hints and preferring paid/preferred models first, then
+free/local models as a final fallback tier. It also produces a
+provider-diverse fallback chain so a child can recover from rate-limit /
+credential-exhaustion exactly like the top-level agent does.
+
+Design constraints (see AGENTS.md):
+
+  * Pure, deterministic, stdlib-only. No LLM calls; nothing hits the network
+    at import time. Every external lookup (provider inventory, model catalog,
+    pricing, credential health) is *injected* so tests never touch live APIs.
+  * Never hardcodes which model to use for a task type (no fixed model names).
+    Scoring matches generic capability words against each model's own catalog
+    id/description — brand names are deliberately absent from the keyword sets.
+  * Zero effect unless ``delegation.model_router.enabled`` is true, so current
+    behaviour and prompt caching stay byte-stable by default.
+  * Explicit per-task ``model`` / ``provider`` always wins — the router steps
+    aside entirely when the caller pinned a model.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Capability-hint keywords per route. These match against a MODEL's own
+# catalog id/description — they are NOT a map to fixed model names. Keeping
+# brand names out of this table is what makes the router "without fixed model
+# names": the parent expresses *what kind of work* the task is, never *which
+# model* must run it.
+ROUTE_KEYWORDS: Dict[str, Tuple[str, ...]] = {
+    "coding": ("code", "coder", "coding", "program", "debug", "engineer", "swe", "dev"),
+    "research": ("research", "search", "analy", "reason", "think", "deep", "web"),
+    "writing": ("write", "writer", "author", "doc", "summar", "report", "prose", "chat"),
+    "architecture": ("architect", "design", "system", "plan", "reason", "engineer"),
+    "default": ("instruct", "chat", "general", "assistant", "reason"),
+}
+
+# Goal/context intent terms that pick the route. Ordered most-specific first so
+# a tie prefers the earlier (more specific) route.
+_ROUTE_INTENT: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
+    (
+        "coding",
+        (
+            "code", "coding", "implement", "bug", "fix", "refactor", "function",
+            "script", "test", "pytest", "compile", "build", "patch", "lint",
+        ),
+    ),
+    (
+        "architecture",
+        (
+            "architect", "design", "system", "schema", "orchestr", "pipeline",
+            "plan", "structure", "diagram",
+        ),
+    ),
+    (
+        "research",
+        (
+            "research", "search", "investigate", "analy", "find", "compare",
+            "gather", "study", "review", "benchmark",
+        ),
+    ),
+    (
+        "writing",
+        (
+            "write", "draft", "summar", "report", "document", "blog", "article",
+            "memo", "letter", "translate",
+        ),
+    ),
+)
+
+# Providers whose models are always treated as the free/local fallback tier
+# regardless of pricing metadata (local runtimes have no per-token price).
+_LOCAL_PROVIDERS = {"lmstudio", "ollama", "ollama-cloud", "llamacpp", "llama-cpp", "custom"}
+
+# Generic quality adjectives (no model names) used only as a soft tie-breaker.
+_STRONG_HINTS = ("pro", "max", "large", "ultra", "advanced", "opus", "plus")
+_LIGHT_HINTS = ("mini", "small", "lite", "fast", "flash", "turbo", "nano", "air")
+
+
+def _truthy(value: Any) -> bool:
+    if value is True:
+        return True
+    return str(value).strip().lower() in ("1", "true", "yes", "on")
+
+
+def infer_route_key(goal: str = "", context: str = "") -> str:
+    """Classify a task into a route from its goal/context text.
+
+    Returns one of ``coding``, ``research``, ``writing``, ``architecture`` or
+    ``default``. Deterministic: counts keyword hits per route and returns the
+    highest, ties broken by the ``_ROUTE_INTENT`` ordering.
+    """
+    blob = f"{goal or ''} {context or ''}".lower()
+    best = "default"
+    best_hits = 0
+    for route, terms in _ROUTE_INTENT:
+        hits = sum(1 for t in terms if t in blob)
+        if hits > best_hits:
+            best_hits = hits
+            best = route
+    return best
+
+
+def is_local_provider(provider: str) -> bool:
+    return (provider or "").strip().lower() in _LOCAL_PROVIDERS
+
+
+def candidate_is_free(
+    provider: str,
+    model: str,
+    description: str = "",
+    pricing: Optional[Dict[str, Any]] = None,
+    free_providers: Sequence[str] = (),
+) -> bool:
+    """Best-effort free/local classification for the final fallback tier."""
+    provider_l = (provider or "").strip().lower()
+    free_set = {str(p).strip().lower() for p in (free_providers or ()) if str(p).strip()}
+    if provider_l in free_set or is_local_provider(provider):
+        return True
+    pricing = pricing or {}
+    price = pricing.get(model)
+    if price is None:
+        price = pricing.get((model or "").lower())
+    if isinstance(price, dict):
+        # NOTE: do not use ``float(x or 1)`` here — a genuine 0.0 price is
+        # falsy and would collapse to the fallback, misclassifying a free
+        # model as paid. Only claim "free" when BOTH sides are explicitly 0.
+        prompt_raw = price.get("prompt")
+        completion_raw = price.get("completion")
+        try:
+            if prompt_raw is not None and completion_raw is not None:
+                if float(prompt_raw) == 0.0 and float(completion_raw) == 0.0:
+                    return True
+        except (TypeError, ValueError):
+            pass
+    blob = f"{provider} {model} {description}".lower()
+    return ":free" in blob or "(free)" in blob or blob.rstrip().endswith(" free")
+
+
+def score_candidate(candidate: Dict[str, Any], route_key: str) -> int:
+    """Deterministic capability score for one candidate against a route."""
+    blob = (
+        f"{candidate.get('provider', '')} "
+        f"{candidate.get('model', '')} "
+        f"{candidate.get('description', '')}"
+    ).lower()
+    route = route_key if route_key in ROUTE_KEYWORDS else "default"
+    score = 0
+    for kw in ROUTE_KEYWORDS[route]:
+        if kw in blob:
+            score += 10
+    for kw in ROUTE_KEYWORDS["default"]:
+        if kw in blob:
+            score += 2
+    for kw in _STRONG_HINTS:
+        if kw in blob:
+            score += 3
+    for kw in _LIGHT_HINTS:
+        if kw in blob:
+            score += 1
+    # Preserve provider catalog ordering as a small, stable tie-breaker.
+    try:
+        score -= int(candidate.get("model_index", 0) or 0)
+    except (TypeError, ValueError):
+        pass
+    return score
+
+
+def build_candidates(
+    route_key: str,
+    providers: Sequence[str],
+    *,
+    catalog_fn: Callable[[str], Sequence[Any]],
+    pricing_fn: Optional[Callable[[str], Dict[str, Any]]] = None,
+    credential_ok_fn: Optional[Callable[[str], bool]] = None,
+    free_providers: Sequence[str] = (),
+    priority_providers: Sequence[str] = (),
+    max_models_per_provider: int = 60,
+    max_candidates: int = 12,
+) -> List[Dict[str, Any]]:
+    """Build an ordered candidate list across providers.
+
+    Paid/preferred candidates come first (highest score first), free/local
+    candidates form the tail as the final fallback tier. Providers whose
+    credential pool reports no availability (``credential_ok_fn`` returns
+    False) are skipped so an exhausted provider is never selected.
+
+    ``priority_providers`` (earlier = higher priority) applies a strong
+    *within-tier* score boost so a user-preferred provider surfaces first,
+    without letting a preferred free/local provider jump ahead of the paid
+    tier (the tier split is applied before sorting).
+    """
+    # Map provider -> priority bonus (earlier in the list = larger bonus).
+    # The weight is large enough to dominate route/capability scoring within a
+    # tier, so "prefer this provider" is honoured, but the paid/free tier split
+    # below still holds because it partitions before this score is used.
+    prio_rank: Dict[str, int] = {}
+    plist = [str(p).strip().lower() for p in (priority_providers or ()) if str(p).strip()]
+    for i, p in enumerate(plist):
+        prio_rank[p] = (len(plist) - i) * 1000
+
+    candidates: List[Dict[str, Any]] = []
+    for provider in providers:
+        provider = (provider or "").strip()
+        if not provider:
+            continue
+        if credential_ok_fn is not None:
+            try:
+                if not credential_ok_fn(provider):
+                    logger.debug("model_router: skip provider (no available credentials): %s", provider)
+                    continue
+            except Exception:
+                logger.debug("model_router: credential check failed for %s", provider, exc_info=True)
+        try:
+            catalog = list(catalog_fn(provider) or [])
+        except Exception:
+            logger.debug("model_router: catalog lookup failed for %s", provider, exc_info=True)
+            catalog = []
+        if not catalog:
+            continue
+        pricing: Dict[str, Any] = {}
+        if pricing_fn is not None:
+            try:
+                pricing = pricing_fn(provider) or {}
+            except Exception:
+                pricing = {}
+        prio_bonus = prio_rank.get(provider.lower(), 0)
+        for idx, item in enumerate(catalog[: max(1, max_models_per_provider)]):
+            if isinstance(item, (list, tuple)):
+                model = str(item[0] or "").strip()
+                description = str(item[1] or "") if len(item) > 1 else ""
+            else:
+                model = str(item or "").strip()
+                description = ""
+            if not model:
+                continue
+            cand: Dict[str, Any] = {
+                "provider": provider,
+                "model": model,
+                "description": description,
+                "model_index": idx,
+                "is_free": candidate_is_free(provider, model, description, pricing, free_providers),
+                "is_local": is_local_provider(provider),
+            }
+            cand["score"] = score_candidate(cand, route_key) + prio_bonus
+            candidates.append(cand)
+
+    paid = [c for c in candidates if not (c["is_free"] or c["is_local"])]
+    free_local = [c for c in candidates if c["is_free"] or c["is_local"]]
+    paid.sort(key=lambda c: (int(c["score"]), -int(c["model_index"])), reverse=True)
+    free_local.sort(key=lambda c: (int(c["score"]), -int(c["model_index"])), reverse=True)
+    ordered = paid + free_local
+
+    result: List[Dict[str, Any]] = []
+    seen: set[Tuple[str, str]] = set()
+    for c in ordered:
+        key = (c["provider"].lower(), c["model"].lower())
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(c)
+        if len(result) >= max(1, max_candidates):
+            break
+    return result
+
+
+def router_enabled(router_cfg: Optional[Dict[str, Any]]) -> bool:
+    """Whether the dynamic router should act. Default OFF."""
+    if not isinstance(router_cfg, dict):
+        return False
+    return _truthy(router_cfg.get("enabled", False))
+
+
+def task_has_explicit_model(task: Optional[Dict[str, Any]]) -> bool:
+    """True when the caller pinned a per-task model/provider (router steps aside)."""
+    if not isinstance(task, dict):
+        return False
+    return bool(task.get("model")) or bool(task.get("provider"))
+
+
+def select_delegation_model(
+    task: Optional[Dict[str, Any]],
+    router_cfg: Optional[Dict[str, Any]],
+    *,
+    provider_inventory_fn: Callable[[], Sequence[str]],
+    catalog_fn: Callable[[str], Sequence[Any]],
+    pricing_fn: Optional[Callable[[str], Dict[str, Any]]] = None,
+    credential_ok_fn: Optional[Callable[[str], bool]] = None,
+    goal: str = "",
+    context: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Select a provider/model for one delegated task.
+
+    Returns a dict::
+
+        {
+          "selected": {"provider": ..., "model": ...},
+          "candidates": [ {provider, model, score, is_free, is_local, ...}, ... ],
+          "fallback_chain": [ {provider, model}, ... ],   # excludes selected
+          "route": "coding" | "research" | ...,
+        }
+
+    or ``None`` when the router is disabled, the task pinned a model, or no
+    usable candidate exists (caller then keeps inherited/default credentials).
+    """
+    if not router_enabled(router_cfg):
+        return None
+    if task_has_explicit_model(task):
+        return None
+
+    assert isinstance(router_cfg, dict)  # narrowed by router_enabled
+
+    try:
+        providers = [str(p).strip() for p in (provider_inventory_fn() or []) if str(p).strip()]
+    except Exception:
+        logger.debug("model_router: provider inventory lookup failed", exc_info=True)
+        return None
+    if not providers:
+        return None
+
+    priority = router_cfg.get("provider_priority") or []
+    priority_providers: List[str] = []
+    if isinstance(priority, (list, tuple)) and priority:
+        priority_providers = [str(p).strip() for p in priority if str(p).strip()]
+        providers = priority_providers + [p for p in providers if p not in priority_providers]
+
+    task_goal = goal or (task or {}).get("goal", "") or ""
+    task_context = context or (task or {}).get("context", "") or ""
+    route = infer_route_key(task_goal, task_context)
+
+    try:
+        max_per_provider = int(router_cfg.get("max_models_per_provider", 60) or 60)
+    except (TypeError, ValueError):
+        max_per_provider = 60
+    try:
+        max_candidates = int(router_cfg.get("max_candidates", 12) or 12)
+    except (TypeError, ValueError):
+        max_candidates = 12
+
+    candidates = build_candidates(
+        route,
+        providers,
+        catalog_fn=catalog_fn,
+        pricing_fn=pricing_fn,
+        credential_ok_fn=credential_ok_fn,
+        free_providers=router_cfg.get("free_providers") or (),
+        priority_providers=priority_providers,
+        max_models_per_provider=max_per_provider,
+        max_candidates=max_candidates,
+    )
+    if not candidates:
+        return None
+
+    selected = candidates[0]
+    fallback_chain = [
+        {"provider": c["provider"], "model": c["model"]} for c in candidates[1:]
+    ]
+    logger.info(
+        "model_router: route=%s selected=%s/%s candidates=%d",
+        route, selected["provider"], selected["model"], len(candidates),
+    )
+    return {
+        "selected": {"provider": selected["provider"], "model": selected["model"]},
+        "candidates": candidates,
+        "fallback_chain": fallback_chain,
+        "route": route,
+    }

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1109,11 +1109,19 @@ code_execution:
 # Supports single tasks and batch mode (default 3 parallel, configurable).
 delegation:
   max_iterations: 50                          # Max tool-calling turns per child (default: 50)
-  # max_concurrent_children: 3                # Max parallel child agents per batch (default: 3, floor: 1, no ceiling).
+  # max_concurrent_children: 3                # Max parallel child agents per batch (default: 3, floor: 1).
                                               # WARNING: values above 10 multiply API cost linearly.
-  # max_spawn_depth: 1                        # Delegation tree depth cap (range: 1-3, default: 1 = flat).
+                                              # When enforce_safe_caps is on (default), values above the hard
+                                              # cap are clamped with a warning.
+  # max_concurrent_children_hard_cap: 16      # Safe upper bound for max_concurrent_children (default: 16).
+  # max_spawn_depth: 1                        # Delegation tree depth cap (default: 1 = flat).
                                               # Raise to 2 to allow workers to spawn their own subagents.
                                               # Requires role="orchestrator" on intermediate agents.
+                                              # When enforce_safe_caps is on (default), values above the hard
+                                              # cap are clamped with a warning.
+  # max_spawn_depth_hard_cap: 3               # Safe upper bound for max_spawn_depth (default: 3).
+  # enforce_safe_caps: true                   # Clamp absurd concurrency/depth (default: true). Set false
+                                              # only if you knowingly want unbounded fan-out (cost risk).
   # orchestrator_enabled: true                # Kill switch for role="orchestrator" children (default: true).
   # subagent_auto_approve: false              # When a subagent hits a dangerous-command approval prompt, auto-deny (default: false)
                                               # or auto-approve "once" (true) instead of blocking on stdin.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2361,6 +2361,26 @@ DEFAULT_CONFIG = {
         # Flip to true only if you trust delegated work to run dangerous cmds
         # without human review (cron pipelines, batch automation, etc.).
         "subagent_auto_approve": False,
+
+        # Phase03 dynamic model router (default OFF). When enabled, the parent
+        # does NOT force one fixed model on every subagent. Instead it selects a
+        # provider/model per task from the providers you actually hold
+        # credentials for, scored by task type, preferring paid/preferred models
+        # first and free/local models as the final fallback tier, and builds a
+        # provider-diverse fallback chain so a child recovers from
+        # rate-limit/exhaustion just like the top-level agent. Explicit
+        # tasks[].model / tasks[].provider and a forced
+        # delegation.provider/base_url both bypass the router. No fixed model
+        # names live in code — routing matches capability words against each
+        # provider's own live model catalog. OFF keeps behaviour + prompt
+        # caching byte-stable.
+        "model_router": {
+            "enabled": False,          # master switch; OFF preserves current behaviour
+            "provider_priority": [],   # optional provider slugs to surface first (within tier)
+            "free_providers": [],      # extra providers to treat as the free/local fallback tier
+            "max_models_per_provider": 60,
+            "max_candidates": 12,
+        },
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts

--- a/tests/agent/test_model_router.py
+++ b/tests/agent/test_model_router.py
@@ -1,0 +1,263 @@
+"""Unit tests for the Phase03 deterministic delegation model router.
+
+Everything is faked (inventory / catalog / pricing / credential health) so
+these tests never touch live provider APIs. They assert *behaviour contracts*
+(route inference, paid-before-free ordering, exhausted-provider skipping,
+explicit-override precedence, provider-diverse fallback), not frozen model
+lists — there are no hardcoded model names in the production path under test.
+"""
+
+import pytest
+
+from agent.model_router import (
+    build_candidates,
+    candidate_is_free,
+    infer_route_key,
+    router_enabled,
+    score_candidate,
+    select_delegation_model,
+    task_has_explicit_model,
+)
+
+
+# --- Fake inventory --------------------------------------------------------
+
+FAKE_CATALOG = {
+    "paidcoder": [
+        ("acme-coder-pro", "strong coding and debugging model"),
+        ("acme-chat", "general chat assistant"),
+    ],
+    "paidresearch": [
+        ("beta-reason-max", "deep research and reasoning model"),
+        ("beta-write", "long-form writing and summaries"),
+    ],
+    "localfree": [
+        ("local-generalist", "runs locally, general instruct model"),
+    ],
+}
+
+FAKE_PRICING = {
+    "paidcoder": {
+        "acme-coder-pro": {"prompt": 3.0, "completion": 9.0},
+        "acme-chat": {"prompt": 1.0, "completion": 2.0},
+    },
+    "paidresearch": {
+        "beta-reason-max": {"prompt": 2.0, "completion": 6.0},
+        "beta-write": {"prompt": 1.0, "completion": 3.0},
+    },
+    "localfree": {
+        "local-generalist": {"prompt": 0.0, "completion": 0.0},
+    },
+}
+
+
+def _catalog_fn(provider):
+    return FAKE_CATALOG.get(provider, [])
+
+
+def _pricing_fn(provider):
+    return FAKE_PRICING.get(provider, {})
+
+
+def _inventory_fn():
+    return ["paidcoder", "paidresearch", "localfree"]
+
+
+def _router_cfg(**over):
+    cfg = {"enabled": True, "free_providers": ["localfree"], "max_candidates": 12}
+    cfg.update(over)
+    return cfg
+
+
+# --- Route inference -------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "goal,expected",
+    [
+        ("Implement the function and fix the failing pytest", "coding"),
+        ("Research and compare the latest agent frameworks", "research"),
+        ("Draft a summary report of the findings", "writing"),
+        ("Design the overall system architecture and pipeline", "architecture"),
+        ("Say hello", "default"),
+    ],
+)
+def test_infer_route_key(goal, expected):
+    assert infer_route_key(goal) == expected
+
+
+# --- Enable / override gating ---------------------------------------------
+
+def test_router_disabled_by_default():
+    assert router_enabled(None) is False
+    assert router_enabled({}) is False
+    assert router_enabled({"enabled": False}) is False
+
+
+@pytest.mark.parametrize("val", [True, "true", "yes", "on", "1"])
+def test_router_enabled_truthy(val):
+    assert router_enabled({"enabled": val}) is True
+
+
+def test_disabled_router_returns_none():
+    out = select_delegation_model(
+        {"goal": "write code"},
+        {"enabled": False},
+        provider_inventory_fn=_inventory_fn,
+        catalog_fn=_catalog_fn,
+        pricing_fn=_pricing_fn,
+    )
+    assert out is None
+
+
+def test_explicit_model_override_wins():
+    assert task_has_explicit_model({"model": "x/y"}) is True
+    assert task_has_explicit_model({"provider": "x"}) is True
+    out = select_delegation_model(
+        {"goal": "write code", "model": {"provider": "x", "model": "y"}},
+        _router_cfg(),
+        provider_inventory_fn=_inventory_fn,
+        catalog_fn=_catalog_fn,
+        pricing_fn=_pricing_fn,
+    )
+    assert out is None
+
+
+# --- Selection & scoring ---------------------------------------------------
+
+def test_coding_task_prefers_coding_capable_model():
+    out = select_delegation_model(
+        {"goal": "Implement and debug the parser function"},
+        _router_cfg(),
+        provider_inventory_fn=_inventory_fn,
+        catalog_fn=_catalog_fn,
+        pricing_fn=_pricing_fn,
+    )
+    assert out is not None
+    assert out["route"] == "coding"
+    assert out["selected"] == {"provider": "paidcoder", "model": "acme-coder-pro"}
+
+
+def test_research_task_prefers_reasoning_model():
+    out = select_delegation_model(
+        {"goal": "Research and analyze prior art, compare approaches"},
+        _router_cfg(),
+        provider_inventory_fn=_inventory_fn,
+        catalog_fn=_catalog_fn,
+        pricing_fn=_pricing_fn,
+    )
+    assert out is not None
+    assert out["route"] == "research"
+    assert out["selected"]["provider"] == "paidresearch"
+    assert out["selected"]["model"] == "beta-reason-max"
+
+
+def test_free_local_is_last_tier():
+    cands = build_candidates(
+        "default",
+        _inventory_fn(),
+        catalog_fn=_catalog_fn,
+        pricing_fn=_pricing_fn,
+        free_providers=["localfree"],
+    )
+    # Free/local candidate must not be first while any paid candidate exists.
+    assert not (cands[0]["is_free"] or cands[0]["is_local"])
+    assert any(c["is_free"] or c["is_local"] for c in cands)
+    last = cands[-1]
+    assert last["provider"] == "localfree"
+
+
+def test_zero_priced_model_detected_free():
+    assert candidate_is_free(
+        "paidresearch", "beta-write",
+        pricing={"beta-write": {"prompt": 0.0, "completion": 0.0}},
+    ) is True
+
+
+def test_local_provider_is_free_tier():
+    assert candidate_is_free("ollama", "anything") is True
+    assert candidate_is_free("lmstudio", "anything") is True
+
+
+# --- Credential exhaustion -------------------------------------------------
+
+def test_exhausted_provider_is_skipped():
+    def credential_ok(provider):
+        return provider != "paidcoder"  # paidcoder is exhausted
+
+    out = select_delegation_model(
+        {"goal": "Implement and debug the parser function"},  # coding task
+        _router_cfg(),
+        provider_inventory_fn=_inventory_fn,
+        catalog_fn=_catalog_fn,
+        pricing_fn=_pricing_fn,
+        credential_ok_fn=credential_ok,
+    )
+    assert out is not None
+    # paidcoder skipped -> selection must come from another provider
+    assert out["selected"]["provider"] != "paidcoder"
+    assert all(c["provider"] != "paidcoder" for c in out["candidates"])
+
+
+def test_all_providers_exhausted_returns_none():
+    out = select_delegation_model(
+        {"goal": "write code"},
+        _router_cfg(),
+        provider_inventory_fn=_inventory_fn,
+        catalog_fn=_catalog_fn,
+        pricing_fn=_pricing_fn,
+        credential_ok_fn=lambda p: False,
+    )
+    assert out is None
+
+
+# --- Fallback chain --------------------------------------------------------
+
+def test_fallback_chain_excludes_selected_and_is_provider_diverse():
+    out = select_delegation_model(
+        {"goal": "Implement and debug the parser function"},
+        _router_cfg(),
+        provider_inventory_fn=_inventory_fn,
+        catalog_fn=_catalog_fn,
+        pricing_fn=_pricing_fn,
+    )
+    assert out is not None
+    selected = out["selected"]
+    chain = out["fallback_chain"]
+    # selected pair not repeated in the fallback chain
+    assert {"provider": selected["provider"], "model": selected["model"]} not in chain
+    # chain contains at least one different provider (provider diversity)
+    providers_in_chain = {c["provider"] for c in chain}
+    assert providers_in_chain - {selected["provider"]}
+    # a free/local option is reachable somewhere in the full ordering
+    assert any(c["is_free"] or c["is_local"] for c in out["candidates"])
+
+
+def test_empty_inventory_returns_none():
+    out = select_delegation_model(
+        {"goal": "write code"},
+        _router_cfg(),
+        provider_inventory_fn=lambda: [],
+        catalog_fn=_catalog_fn,
+        pricing_fn=_pricing_fn,
+    )
+    assert out is None
+
+
+def test_provider_priority_reorders_inventory():
+    out = select_delegation_model(
+        {"goal": "Say hello"},  # default route, weak signal
+        _router_cfg(provider_priority=["paidresearch"]),
+        provider_inventory_fn=_inventory_fn,
+        catalog_fn=_catalog_fn,
+        pricing_fn=_pricing_fn,
+    )
+    assert out is not None
+    # With a weak route signal, priority should surface paidresearch first.
+    assert out["candidates"][0]["provider"] == "paidresearch"
+
+
+def test_score_is_deterministic():
+    cand = {"provider": "paidcoder", "model": "acme-coder-pro", "description": "coding", "model_index": 0}
+    assert score_candidate(cand, "coding") == score_candidate(cand, "coding")
+    # coding route scores a coding model higher than the writing route does
+    assert score_candidate(cand, "coding") > score_candidate(cand, "writing")

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2542,7 +2542,14 @@ class TestDelegateEventEnum(unittest.TestCase):
 
 
 class TestConcurrencyDefaults(unittest.TestCase):
-    """Tests for the concurrency default and no hard ceiling."""
+    """Tests for concurrency defaults and safe hard-cap clamping."""
+
+    def setUp(self):
+        import tools.delegate_tool as dt
+        # Clamp warnings are one-shot per process; reset so log assertions are stable.
+        dt._SAFE_CAP_CONCURRENT_CLAMP_WARNED = False
+        dt._SAFE_CAP_SPAWN_DEPTH_CLAMP_WARNED = False
+        dt._HIGH_CONCURRENCY_WARNED = False
 
     def test_load_config_prefers_active_persistent_config_over_cli_defaults(self):
         stale_cli = types.ModuleType("cli")
@@ -2568,7 +2575,8 @@ class TestConcurrencyDefaults(unittest.TestCase):
                 "hermes_cli.config.load_config_readonly", return_value=active_config
             ):
                 self.assertEqual(_load_config()["max_concurrent_children"], 50)
-                self.assertEqual(_get_max_concurrent_children(), 50)
+                # Raw config is 50; effective value is clamped by enforce_safe_caps.
+                self.assertEqual(_get_max_concurrent_children(), 16)
 
     def test_load_config_falls_back_to_cli_config_when_persistent_load_fails(self):
         fallback_cli = types.ModuleType("cli")
@@ -2617,14 +2625,19 @@ class TestConcurrencyDefaults(unittest.TestCase):
 
     @patch("tools.delegate_tool._load_config",
            return_value={"max_concurrent_children": 10})
-    def test_no_upper_ceiling(self, mock_cfg):
-        """Users can raise concurrency as high as they want — no hard cap."""
+    def test_values_at_or_below_hard_cap_pass_through(self, mock_cfg):
+        """Values at the soft-advisory threshold still pass under default hard cap 16."""
         self.assertEqual(_get_max_concurrent_children(), 10)
 
     @patch("tools.delegate_tool._load_config",
            return_value={"max_concurrent_children": 100})
-    def test_very_high_values_honored(self, mock_cfg):
-        self.assertEqual(_get_max_concurrent_children(), 100)
+    def test_very_high_values_clamped_to_hard_cap(self, mock_cfg):
+        """Absurd values are clamped to max_concurrent_children_hard_cap (default 16)."""
+        import logging
+        with self.assertLogs("tools.delegate_tool", level=logging.WARNING) as cm:
+            result = _get_max_concurrent_children()
+        self.assertEqual(result, 16)
+        self.assertTrue(any("hard cap" in m and "clamping" in m for m in cm.output))
 
     @patch("tools.delegate_tool._load_config",
            return_value={"max_concurrent_children": 0})
@@ -2633,7 +2646,7 @@ class TestConcurrencyDefaults(unittest.TestCase):
         self.assertEqual(_get_max_concurrent_children(), 1)
 
     @patch("tools.delegate_tool._load_config", return_value={})
-    def test_env_var_honored_uncapped(self, mock_cfg):
+    def test_env_var_honored_within_hard_cap(self, mock_cfg):
         with patch.dict(os.environ, {"DELEGATION_MAX_CONCURRENT_CHILDREN": "12"}):
             self.assertEqual(_get_max_concurrent_children(), 12)
 
@@ -2641,6 +2654,37 @@ class TestConcurrencyDefaults(unittest.TestCase):
            return_value={"max_concurrent_children": 6})
     def test_configured_value_returned(self, mock_cfg):
         self.assertEqual(_get_max_concurrent_children(), 6)
+
+    @patch("tools.delegate_tool._load_config",
+           return_value={"max_concurrent_children": 3})
+    def test_normal_value_unchanged(self, mock_cfg):
+        """Byte-stable: default-like normal value 3 passes through unchanged."""
+        self.assertEqual(_get_max_concurrent_children(), 3)
+
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={
+            "max_concurrent_children": 100,
+            "enforce_safe_caps": False,
+        },
+    )
+    def test_enforce_safe_caps_false_disables_concurrent_clamp(self, mock_cfg):
+        """enforce_safe_caps: false restores floor-only unbounded behaviour."""
+        self.assertEqual(_get_max_concurrent_children(), 100)
+
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={
+            "max_concurrent_children": 100,
+            "max_concurrent_children_hard_cap": 8,
+        },
+    )
+    def test_custom_hard_cap_used_when_clamping(self, mock_cfg):
+        import logging
+        with self.assertLogs("tools.delegate_tool", level=logging.WARNING) as cm:
+            result = _get_max_concurrent_children()
+        self.assertEqual(result, 8)
+        self.assertTrue(any("hard cap 8" in m for m in cm.output))
 
 
 class TestAsyncCapUnified(unittest.TestCase):
@@ -2673,6 +2717,11 @@ class TestAsyncCapUnified(unittest.TestCase):
 class TestMaxSpawnDepth(unittest.TestCase):
     """Tests for _get_max_spawn_depth clamping and fallback behavior."""
 
+    def setUp(self):
+        import tools.delegate_tool as dt
+        dt._SAFE_CAP_CONCURRENT_CLAMP_WARNED = False
+        dt._SAFE_CAP_SPAWN_DEPTH_CLAMP_WARNED = False
+
     @patch("tools.delegate_tool._load_config", return_value={})
     def test_max_spawn_depth_defaults_to_1(self, mock_cfg):
         from tools.delegate_tool import _get_max_spawn_depth
@@ -2690,10 +2739,45 @@ class TestMaxSpawnDepth(unittest.TestCase):
 
     @patch("tools.delegate_tool._load_config",
            return_value={"max_spawn_depth": 99})
-    def test_max_spawn_depth_no_upper_ceiling(self, mock_cfg):
-        """No upper ceiling — high values pass through unchanged (cost is the limiter)."""
+    def test_max_spawn_depth_clamped_to_hard_cap(self, mock_cfg):
+        """Default enforce_safe_caps clamps absurd depth to max_spawn_depth_hard_cap (3)."""
+        import logging
+        from tools.delegate_tool import _get_max_spawn_depth
+        with self.assertLogs("tools.delegate_tool", level=logging.WARNING) as cm:
+            result = _get_max_spawn_depth()
+        self.assertEqual(result, 3)
+        self.assertTrue(any("hard cap" in m and "clamping" in m for m in cm.output))
+
+    @patch("tools.delegate_tool._load_config",
+           return_value={"max_spawn_depth": 2})
+    def test_max_spawn_depth_normal_value_unchanged(self, mock_cfg):
+        """Byte-stable: documented normal values (1–3) pass through under default cap."""
+        from tools.delegate_tool import _get_max_spawn_depth
+        self.assertEqual(_get_max_spawn_depth(), 2)
+
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={"max_spawn_depth": 99, "enforce_safe_caps": False},
+    )
+    def test_max_spawn_depth_enforce_safe_caps_false(self, mock_cfg):
+        """enforce_safe_caps: false restores floor-only (no upper ceiling)."""
         from tools.delegate_tool import _get_max_spawn_depth
         self.assertEqual(_get_max_spawn_depth(), 99)
+
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={
+            "max_spawn_depth": 99,
+            "max_spawn_depth_hard_cap": 5,
+        },
+    )
+    def test_max_spawn_depth_custom_hard_cap(self, mock_cfg):
+        import logging
+        from tools.delegate_tool import _get_max_spawn_depth
+        with self.assertLogs("tools.delegate_tool", level=logging.WARNING) as cm:
+            result = _get_max_spawn_depth()
+        self.assertEqual(result, 5)
+        self.assertTrue(any("hard cap 5" in m for m in cm.output))
 
     @patch("tools.delegate_tool._load_config",
            return_value={"max_spawn_depth": "not-a-number"})

--- a/tests/tools/test_delegate_model_router_integration.py
+++ b/tests/tools/test_delegate_model_router_integration.py
@@ -7,6 +7,8 @@ with every external resolver monkeypatched, so no live provider APIs are hit.
 Contract coverage:
   * router OFF (default) → inherited creds returned unchanged, no fallback
   * explicit tasks[].model / tasks[].provider → bypass router, resolve override
+  * explicit provider+model that fails resolution → ValueError (no parent-auth merge)
+  * model-only override → inherit parent auth, swap model id only
   * forced delegation.provider → bypass router
   * router ON → dynamic selection + provider-diverse fallback chain
   * router ON but resolution fails → safe fallback to inherited creds
@@ -103,23 +105,71 @@ def test_explicit_model_string_without_provider_keeps_inherited_auth(monkeypatch
         dt, "_resolve_provider_model_bundle",
         lambda p, m: (_ for _ in ()).throw(AssertionError("should not resolve")),
     )
+    parent = dict(
+        DEFAULT_CREDS,
+        provider="openrouter",
+        api_key="parent-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="parent-model",
+    )
     cfg = {"model_router": {"enabled": True}}
     creds, chain = dt._resolve_task_credentials(
-        {"goal": "x", "model": "just-a-model"}, cfg, DEFAULT_CREDS
+        {"goal": "x", "model": "just-a-model"}, cfg, parent
     )
     assert creds["model"] == "just-a-model"
-    assert creds["provider"] is None
+    # parent auth bundle preserved (model-only override is legitimate)
+    assert creds["provider"] == "openrouter"
+    assert creds["api_key"] == "parent-key"
+    assert creds["base_url"] == "https://openrouter.ai/api/v1"
     assert chain is None
 
 
-def test_explicit_override_resolution_failure_falls_back(monkeypatch):
+def test_explicit_provider_model_resolution_failure_raises(monkeypatch):
+    """Regression: failed explicit provider must NOT merge model onto parent auth.
+
+    Pre-fix behaviour swapped only the model id onto the parent's credentials,
+    which ran a foreign model id against the wrong provider's API key → 401.
+    """
     monkeypatch.setattr(dt, "_resolve_provider_model_bundle", lambda p, m: None)
-    cfg = {"model_router": {"enabled": True}}
-    creds, chain = dt._resolve_task_credentials(
-        {"goal": "x", "model": {"provider": "acme", "model": "x"}}, cfg, DEFAULT_CREDS
+    parent = dict(
+        DEFAULT_CREDS,
+        provider="openrouter",
+        api_key="parent-openrouter-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="parent-model",
     )
-    # resolution failed → inherited creds, model id still applied
-    assert creds["model"] == "x"
+    cfg = {"model_router": {"enabled": True}}
+    with pytest.raises(ValueError) as excinfo:
+        dt._resolve_task_credentials(
+            {"goal": "x", "model": {"provider": "acme", "model": "acme-x"}},
+            cfg,
+            parent,
+        )
+    msg = str(excinfo.value).lower()
+    assert "cannot resolve" in msg
+    assert "acme" in msg
+    # Must not return parent-key + acme-x (the 401-prone merge).
+    # (ValueError path — no return value to inspect; raise is the contract.)
+
+
+def test_explicit_provider_only_resolution_failure_raises(monkeypatch):
+    """Provider-only override that fails resolution also errors (no silent inherit)."""
+    monkeypatch.setattr(dt, "_resolve_provider_model_bundle", lambda p, m: None)
+    parent = dict(DEFAULT_CREDS, provider="openrouter", api_key="parent-key")
+    with pytest.raises(ValueError) as excinfo:
+        dt._resolve_task_credentials(
+            {"goal": "x", "provider": "bad-provider"},
+            {},
+            parent,
+        )
+    assert "bad-provider" in str(excinfo.value)
+
+
+def test_no_override_inherits_unchanged():
+    """No tasks[].model/provider → default_creds object identity preserved."""
+    parent = dict(DEFAULT_CREDS, provider="openrouter", api_key="k", model="m")
+    creds, chain = dt._resolve_task_credentials({"goal": "x"}, {}, parent)
+    assert creds is parent
     assert chain is None
 
 

--- a/tests/tools/test_delegate_model_router_integration.py
+++ b/tests/tools/test_delegate_model_router_integration.py
@@ -1,0 +1,279 @@
+"""Phase03 integration tests for the delegate_tool per-task credential path.
+
+These exercise ``_resolve_task_credentials`` / ``_parse_task_model_override``
+— the glue between the deterministic model router and ``_build_child_agent`` —
+with every external resolver monkeypatched, so no live provider APIs are hit.
+
+Contract coverage:
+  * router OFF (default) → inherited creds returned unchanged, no fallback
+  * explicit tasks[].model / tasks[].provider → bypass router, resolve override
+  * forced delegation.provider → bypass router
+  * router ON → dynamic selection + provider-diverse fallback chain
+  * router ON but resolution fails → safe fallback to inherited creds
+"""
+
+import pytest
+
+import tools.delegate_tool as dt
+
+
+DEFAULT_CREDS = {
+    "model": None,
+    "provider": None,
+    "base_url": None,
+    "api_key": None,
+    "api_mode": None,
+    "request_overrides": None,
+    "max_output_tokens": None,
+}
+
+
+def _bundle(provider, model):
+    return {
+        "model": model,
+        "provider": provider,
+        "base_url": f"https://{provider}.example/v1",
+        "api_key": "[REDACTED]",
+        "api_mode": "chat_completions",
+        "request_overrides": {},
+        "max_output_tokens": None,
+        "command": None,
+        "args": [],
+    }
+
+
+# --- _parse_task_model_override -------------------------------------------
+
+def test_parse_override_string_model():
+    assert dt._parse_task_model_override({"model": "acme/x"}) == (None, "acme/x")
+
+
+def test_parse_override_dict_model():
+    assert dt._parse_task_model_override(
+        {"model": {"provider": "acme", "model": "x"}}
+    ) == ("acme", "x")
+
+
+def test_parse_override_provider_only():
+    assert dt._parse_task_model_override({"provider": "acme"}) == ("acme", None)
+
+
+def test_parse_override_none():
+    assert dt._parse_task_model_override({"goal": "hi"}) == (None, None)
+
+
+# --- router OFF (default) --------------------------------------------------
+
+def test_router_off_returns_inherited_creds():
+    cfg = {"model_router": {"enabled": False}}
+    creds, chain = dt._resolve_task_credentials({"goal": "write code"}, cfg, DEFAULT_CREDS)
+    assert creds is DEFAULT_CREDS
+    assert chain is None
+
+
+def test_no_router_key_returns_inherited_creds():
+    creds, chain = dt._resolve_task_credentials({"goal": "write code"}, {}, DEFAULT_CREDS)
+    assert creds is DEFAULT_CREDS
+    assert chain is None
+
+
+# --- explicit override bypasses router ------------------------------------
+
+def test_explicit_provider_model_resolves(monkeypatch):
+    calls = {}
+
+    def fake_bundle(provider, model):
+        calls["args"] = (provider, model)
+        return _bundle(provider, model)
+
+    monkeypatch.setattr(dt, "_resolve_provider_model_bundle", fake_bundle)
+    cfg = {"model_router": {"enabled": True}}
+    creds, chain = dt._resolve_task_credentials(
+        {"goal": "x", "model": {"provider": "acme", "model": "x"}}, cfg, DEFAULT_CREDS
+    )
+    assert calls["args"] == ("acme", "x")
+    assert creds["provider"] == "acme"
+    assert creds["model"] == "x"
+    assert chain is None  # explicit override doesn't build a router chain
+
+
+def test_explicit_model_string_without_provider_keeps_inherited_auth(monkeypatch):
+    # model string alone, no provider → inherit auth, just swap the model id
+    monkeypatch.setattr(
+        dt, "_resolve_provider_model_bundle",
+        lambda p, m: (_ for _ in ()).throw(AssertionError("should not resolve")),
+    )
+    cfg = {"model_router": {"enabled": True}}
+    creds, chain = dt._resolve_task_credentials(
+        {"goal": "x", "model": "just-a-model"}, cfg, DEFAULT_CREDS
+    )
+    assert creds["model"] == "just-a-model"
+    assert creds["provider"] is None
+    assert chain is None
+
+
+def test_explicit_override_resolution_failure_falls_back(monkeypatch):
+    monkeypatch.setattr(dt, "_resolve_provider_model_bundle", lambda p, m: None)
+    cfg = {"model_router": {"enabled": True}}
+    creds, chain = dt._resolve_task_credentials(
+        {"goal": "x", "model": {"provider": "acme", "model": "x"}}, cfg, DEFAULT_CREDS
+    )
+    # resolution failed → inherited creds, model id still applied
+    assert creds["model"] == "x"
+    assert chain is None
+
+
+# --- forced delegation provider bypasses router ---------------------------
+
+def test_forced_delegation_provider_bypasses_router(monkeypatch):
+    forced = dict(DEFAULT_CREDS, provider="forced", model="forced-model")
+
+    def _boom(*a, **k):
+        raise AssertionError("router must not run when provider is forced")
+
+    monkeypatch.setattr(dt, "_resolve_provider_model_bundle", _boom)
+    cfg = {"model_router": {"enabled": True}}
+    creds, chain = dt._resolve_task_credentials({"goal": "x"}, cfg, forced)
+    assert creds is forced
+    assert chain is None
+
+
+# --- router ON: dynamic selection -----------------------------------------
+
+def _install_fake_router(monkeypatch, selection):
+    """Patch the lazy imports inside _resolve_task_credentials."""
+    import agent.model_router as mr
+    import hermes_cli.models as models
+
+    monkeypatch.setattr(mr, "router_enabled", lambda cfg: bool(cfg.get("enabled")))
+    monkeypatch.setattr(mr, "select_delegation_model", lambda *a, **k: selection)
+    monkeypatch.setattr(models, "list_available_providers",
+                        lambda: [{"id": "acme", "authenticated": True}])
+    monkeypatch.setattr(models, "curated_models_for_provider",
+                        lambda p, **k: [("x", "desc")])
+    monkeypatch.setattr(models, "get_pricing_for_provider", lambda p, **k: {})
+
+
+def test_router_on_selects_and_builds_fallback_chain(monkeypatch):
+    selection = {
+        "selected": {"provider": "acme", "model": "x"},
+        "candidates": [],
+        "fallback_chain": [
+            {"provider": "beta", "model": "y"},
+            {"provider": "gamma", "model": "z"},
+        ],
+        "route": "coding",
+    }
+    _install_fake_router(monkeypatch, selection)
+    monkeypatch.setattr(dt, "_resolve_provider_model_bundle",
+                        lambda p, m: _bundle(p, m))
+
+    cfg = {"model_router": {"enabled": True}}
+    creds, chain = dt._resolve_task_credentials(
+        {"goal": "Implement and debug the parser"}, cfg, DEFAULT_CREDS
+    )
+    assert creds["provider"] == "acme"
+    assert creds["model"] == "x"
+    assert chain == [
+        {"provider": "beta", "model": "y"},
+        {"provider": "gamma", "model": "z"},
+    ]
+
+
+def test_router_on_no_selection_falls_back(monkeypatch):
+    _install_fake_router(monkeypatch, None)
+    cfg = {"model_router": {"enabled": True}}
+    creds, chain = dt._resolve_task_credentials({"goal": "x"}, cfg, DEFAULT_CREDS)
+    assert creds is DEFAULT_CREDS
+    assert chain is None
+
+
+def test_router_on_bundle_failure_falls_back(monkeypatch):
+    selection = {
+        "selected": {"provider": "acme", "model": "x"},
+        "candidates": [],
+        "fallback_chain": [],
+        "route": "coding",
+    }
+    _install_fake_router(monkeypatch, selection)
+    monkeypatch.setattr(dt, "_resolve_provider_model_bundle", lambda p, m: None)
+    cfg = {"model_router": {"enabled": True}}
+    creds, chain = dt._resolve_task_credentials({"goal": "x"}, cfg, DEFAULT_CREDS)
+    assert creds is DEFAULT_CREDS
+    assert chain is None
+
+
+def test_router_end_to_end_unmocked_select(monkeypatch):
+    """Exercise the REAL ``agent.model_router.select_delegation_model`` (no mock).
+
+    Only the boundary dependencies are faked — provider inventory, model
+    catalog, pricing, credential availability, and the credential-bundle
+    resolver — so the router's own route inference, scoring, and
+    provider-diverse fallback-chain construction all run for real. This is the
+    one test that would catch a wiring/signature drift between the glue and
+    the router, which the mocked variants above cannot.
+    """
+    import agent.model_router as mr  # noqa: F401  (real, NOT monkeypatched)
+    import hermes_cli.models as models
+
+    monkeypatch.setattr(
+        dt, "_load_config",
+        lambda: {"model_router": {"enabled": True, "provider_priority": ["beta"]}},
+    )
+    monkeypatch.setattr(
+        models, "list_available_providers",
+        lambda: [
+            {"id": "acme", "authenticated": True},
+            {"id": "beta", "authenticated": True},
+            {"id": "freeco", "authenticated": True},
+        ],
+    )
+    monkeypatch.setattr(
+        models, "curated_models_for_provider",
+        lambda p, **k: {
+            "acme": [("acme/coder-pro", "d"), ("acme/writer", "d")],
+            "beta": [("beta/coder", "d")],
+            "freeco": [("freeco/oss-coder", "d")],
+        }.get(p, []),
+    )
+    monkeypatch.setattr(
+        models, "get_pricing_for_provider",
+        lambda p, **k: {
+            "acme": {"acme/coder-pro": {"prompt": "1", "completion": "2"}},
+            "beta": {"beta/coder": {"prompt": "0.5", "completion": "1"}},
+            "freeco": {"freeco/oss-coder": {"prompt": "0.0", "completion": "0.0"}},
+        }.get(p, {}),
+    )
+    monkeypatch.setattr(dt, "_provider_has_available_credentials", lambda p: True)
+    monkeypatch.setattr(dt, "_resolve_provider_model_bundle", lambda p, m: _bundle(p, m))
+
+    cfg = {"model_router": {"enabled": True, "provider_priority": ["beta"]}}
+    task = {"goal": "Implement and debug the parser module in python, write pytest"}
+    creds, chain = dt._resolve_task_credentials(task, cfg, DEFAULT_CREDS)
+
+    # Real router must produce a selection (provider_priority pins beta first).
+    assert creds["provider"] == "beta"
+    assert creds["model"] == "beta/coder"
+    # Fallback chain excludes the selected pair.
+    assert chain is not None and len(chain) >= 1
+    chain_pairs = {(c["provider"], c["model"]) for c in chain}
+    assert ("beta", "beta/coder") not in chain_pairs
+
+
+# --- model-facing schema ---------------------------------------------------
+
+def test_delegate_schema_exposes_per_task_model_and_provider():
+    """Regression: internal override support must be visible to the model."""
+    props = dt.DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"]["properties"]
+    assert "model" in props
+    assert "provider" in props
+    assert "explicit model override" in props["model"]["description"]
+    assert "explicit provider override" in props["provider"]["description"]
+
+    dynamic = dt._build_dynamic_schema_overrides()
+    dynamic_props = dynamic["parameters"]["properties"]["tasks"]["items"]["properties"]
+    assert "model" in dynamic_props
+    assert "provider" in dynamic_props
+    assert "tasks[].model" in dynamic["description"]
+    assert "tasks[].provider" in dynamic["description"]
+    assert "Subagent model is NOT selectable per call" not in dynamic["description"]

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1082,6 +1082,9 @@ def _build_child_agent(
     # ACP transport overrides from trusted delegation config.
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
+    # Phase03: explicit provider-diverse fallback chain from the model router.
+    # None (default) → inherit the parent's chain (byte-stable prior behaviour).
+    override_fallback_chain: Optional[List[Dict[str, Any]]] = None,
     # Per-call role controlling whether the child can further delegate.
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
@@ -1321,7 +1324,13 @@ def _build_child_agent(
     # from rate-limits and credential exhaustion exactly like the top-level
     # agent does.  _fallback_chain is a list accepted by AIAgent's
     # fallback_model parameter (which handles both list and dict forms).
-    parent_fallback = getattr(parent_agent, "_fallback_chain", None) or None
+    # Phase03: when the model router supplies an explicit provider-diverse
+    # chain for this task, use it instead of the parent's (still a plain
+    # [{provider, model}, ...] list AIAgent filters on construction).
+    if override_fallback_chain:
+        parent_fallback = list(override_fallback_chain)
+    else:
+        parent_fallback = getattr(parent_agent, "_fallback_chain", None) or None
 
     # Inherit the parent's OpenRouter provider-preference filters by default
     # (so subagents routed to the same provider honour the same routing
@@ -2571,6 +2580,15 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            # Phase03: resolve per-task credentials. Honours explicit
+            # tasks[].model/provider first, then a forced delegation provider,
+            # then the opt-in dynamic model router, else inherits `creds`
+            # unchanged (router OFF → byte-identical to prior behaviour).
+            try:
+                task_creds, task_fallback_chain = _resolve_task_credentials(t, cfg, creds)
+            except Exception:
+                logger.debug("model_router: per-task credential resolution failed", exc_info=True)
+                task_creds, task_fallback_chain = creds, None
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
@@ -2578,18 +2596,19 @@ def delegate_task(
                 # Subagents always inherit the parent's toolsets; the model
                 # cannot choose or narrow them (no model-facing toolsets arg).
                 toolsets=None,
-                model=creds["model"],
+                model=task_creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
-                override_request_overrides=creds.get("request_overrides"),
-                override_max_tokens=creds.get("max_output_tokens"),
-                override_acp_command=creds.get("command"),
-                override_acp_args=creds.get("args"),
+                override_provider=task_creds["provider"],
+                override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
+                override_request_overrides=task_creds.get("request_overrides"),
+                override_max_tokens=task_creds.get("max_output_tokens"),
+                override_acp_command=task_creds.get("command"),
+                override_acp_args=task_creds.get("args"),
+                override_fallback_chain=task_fallback_chain,
                 role=effective_role,
             )
             # Override with correct parent tool names (before child construction mutated global)
@@ -3226,6 +3245,196 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     }
 
 
+def _parse_task_model_override(task: Any) -> tuple[Optional[str], Optional[str]]:
+    """Return ``(provider, model)`` from an explicit per-task override.
+
+    Accepts the two documented shapes:
+      * ``task["model"] = "model-id"``            → (task.provider or None, "model-id")
+      * ``task["model"] = {"provider", "model"}`` → (provider, model)
+      * ``task["provider"] = "slug"`` alone       → (slug, None)
+
+    Returns ``(None, None)`` when the task pinned nothing.
+    """
+    if not isinstance(task, dict):
+        return None, None
+    prov = str(task.get("provider") or "").strip() or None
+    m = task.get("model")
+    if isinstance(m, dict):
+        return (
+            str(m.get("provider") or prov or "").strip() or None,
+            str(m.get("model") or "").strip() or None,
+        )
+    if isinstance(m, str) and m.strip():
+        return (prov, m.strip())
+    return (prov, None)
+
+
+def _provider_has_available_credentials(provider: str) -> bool:
+    """Credential-pool health gate. True when the provider can still be used.
+
+    Best-effort and fail-open: if the pool cannot be inspected we assume the
+    provider is usable (the child's own credential rotation / fallback chain is
+    the real backstop). A provider whose pool reports it has credentials but
+    none currently available (all rate-limited/exhausted) returns False so the
+    router skips it.
+    """
+    provider = (provider or "").strip()
+    if not provider:
+        return False
+    try:
+        from agent.credential_pool import load_pool
+
+        pool = load_pool(provider)
+        if pool is not None and pool.has_credentials():
+            return pool.has_available()
+    except Exception:
+        logger.debug("model_router: credential pool check failed for %s", provider, exc_info=True)
+    return True
+
+
+def _resolve_provider_model_bundle(provider: str, model: Optional[str]) -> Optional[dict]:
+    """Resolve a full credential bundle for a chosen ``provider``/``model``.
+
+    Uses the same runtime provider resolution as ``_resolve_delegation_credentials``
+    so a routed/explicit provider gets the correct base_url/api_key/api_mode.
+    Returns ``None`` (caller then inherits parent credentials) when resolution
+    fails or the provider has no usable key.
+    """
+    provider = (provider or "").strip()
+    if not provider:
+        return None
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(requested=provider, target_model=model)
+    except Exception:
+        logger.debug("model_router: runtime resolve failed for %s", provider, exc_info=True)
+        return None
+    api_key = runtime.get("api_key", "")
+    if not api_key:
+        logger.debug("model_router: provider %s resolved without api key; skipping", provider)
+        return None
+    resolved_provider = (
+        provider
+        if runtime.get("provider") == _RUNTIME_PROVIDER_CUSTOM
+        else runtime.get("provider")
+    )
+    return {
+        "model": model or runtime.get("model") or None,
+        "provider": resolved_provider,
+        "base_url": runtime.get("base_url"),
+        "api_key": api_key,
+        "api_mode": runtime.get("api_mode"),
+        "request_overrides": dict(runtime.get("request_overrides") or {}),
+        "max_output_tokens": runtime.get("max_output_tokens"),
+        "command": runtime.get("command"),
+        "args": list(runtime.get("args") or []),
+    }
+
+
+def _resolve_task_credentials(task: dict, cfg: dict, default_creds: dict) -> tuple[dict, Optional[List[dict]]]:
+    """Per-task credential resolution (Phase03).
+
+    Precedence (highest first):
+      1. Explicit per-task ``model`` / ``provider`` override → resolve + apply.
+      2. A globally forced ``delegation.provider`` / ``delegation.base_url``
+         (already baked into ``default_creds``) → keep as-is, router steps aside.
+      3. ``delegation.model_router.enabled`` → dynamic provider/model selection
+         from the providers the user actually holds credentials for.
+      4. Otherwise → inherit ``default_creds`` unchanged.
+
+    Returns ``(effective_creds, fallback_chain_or_None)``. When the router is
+    disabled and no explicit override is present this returns
+    ``(default_creds, None)`` byte-for-byte, preserving current behaviour.
+    """
+    # 1. Explicit per-task override always wins — resolve it to a full bundle.
+    exp_provider, exp_model = _parse_task_model_override(task)
+    if exp_provider or exp_model:
+        if exp_provider:
+            bundle = _resolve_provider_model_bundle(exp_provider, exp_model)
+            if bundle is not None:
+                return bundle, None
+            # Resolution failed → fall through to inherited creds but swap model
+            # so an explicit model id at least applies against inherited auth.
+        merged = dict(default_creds)
+        if exp_model:
+            merged["model"] = exp_model
+        return merged, None
+
+    # 2. Forced global delegation provider/endpoint → respect it, no routing.
+    if default_creds.get("provider") or default_creds.get("base_url"):
+        return default_creds, None
+
+    # 3. Dynamic model router (opt-in).
+    router_cfg = cfg.get("model_router") or {}
+    try:
+        from agent.model_router import router_enabled, select_delegation_model
+    except Exception:
+        return default_creds, None
+    if not router_enabled(router_cfg):
+        return default_creds, None
+
+    try:
+        from hermes_cli.models import (
+            curated_models_for_provider,
+            get_pricing_for_provider,
+            list_available_providers,
+        )
+    except Exception:
+        return default_creds, None
+
+    def _inventory() -> List[str]:
+        return [
+            str(p.get("id"))
+            for p in list_available_providers()
+            if isinstance(p, dict) and p.get("authenticated") and p.get("id")
+        ]
+
+    def _catalog(provider: str):
+        try:
+            return curated_models_for_provider(provider, force_refresh=False)
+        except TypeError:
+            return curated_models_for_provider(provider)
+
+    def _pricing(provider: str):
+        try:
+            return get_pricing_for_provider(provider, force_refresh=False)
+        except TypeError:
+            return get_pricing_for_provider(provider)
+
+    selection = select_delegation_model(
+        task,
+        router_cfg,
+        provider_inventory_fn=_inventory,
+        catalog_fn=_catalog,
+        pricing_fn=_pricing,
+        credential_ok_fn=_provider_has_available_credentials,
+        goal=str(task.get("goal") or ""),
+        context=str(task.get("context") or ""),
+    )
+    if not selection:
+        return default_creds, None
+
+    sel = selection["selected"]
+    bundle = _resolve_provider_model_bundle(sel.get("provider"), sel.get("model"))
+    if bundle is None:
+        return default_creds, None
+
+    # Convert the router's provider-diverse fallback chain into resolved
+    # {provider, model} entries AIAgent accepts (it filters unusable ones).
+    fallback_chain = [
+        {"provider": c["provider"], "model": c["model"]}
+        for c in selection.get("fallback_chain", [])
+        if c.get("provider") and c.get("model")
+    ] or None
+    logger.info(
+        "model_router: task routed → %s/%s (route=%s, %d fallbacks)",
+        bundle.get("provider"), bundle.get("model"),
+        selection.get("route"), len(fallback_chain or []),
+    )
+    return bundle, fallback_chain
+
+
 def _load_config() -> dict:
     """Load delegation config from the active Hermes config.
 
@@ -3367,7 +3576,7 @@ def _build_top_level_description() -> str:
         f"Orchestrators are bounded by max_spawn_depth={max_depth} for this "
         f"user and can be disabled globally via "
         "delegation.orchestrator_enabled=false.\n"
-        "- Subagent model is NOT selectable per call: children inherit the parent model (plus its fallback chain) unless you pin all subagents to a model via delegation.provider / delegation.model in config.yaml.\n"
+        "- Subagent model selection: by default children inherit the parent/global delegation model. If delegation.model_router.enabled=true, Hermes selects a provider/model per task from available credentials. For explicit per-task routing, pass tasks[].model (string model id, or {provider, model}) and/or tasks[].provider; explicit overrides beat the router and global delegation.provider/model.\n"
         "- Each subagent gets its own terminal session (separate working directory and state).\n"
         "- Results are always returned as an array, one entry per task."
     )
@@ -3490,6 +3699,23 @@ DELEGATE_TASK_SCHEMA = {
                         "context": {
                             "type": "string",
                             "description": "Task-specific context",
+                        },
+                        "model": {
+                            "description": (
+                                "Optional explicit model override for this task. "
+                                "Use a string model id to keep inherited/provider-global auth, "
+                                "or an object like {'provider': 'openrouter', 'model': '...'} "
+                                "to pin both provider and model. Explicit overrides bypass "
+                                "delegation.model_router."
+                            )
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": (
+                                "Optional explicit provider override for this task. "
+                                "Use with 'model' to pin a provider/model pair, or alone "
+                                "to use that provider's configured/default model."
+                            ),
                         },
                         "role": {
                             "type": "string",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -117,19 +117,32 @@ def _get_subagent_approval_callback():
 # — the model has no toolsets argument. Subagents inherit the parent's toolsets.
 
 _DEFAULT_MAX_CONCURRENT_CHILDREN = 3
+# Hard upper bound when delegation.enforce_safe_caps is on (default). Configurable
+# via delegation.max_concurrent_children_hard_cap. Normal configs (3–10) pass
+# through unchanged; only absurd values are clamped.
+_DEFAULT_MAX_CONCURRENT_CHILDREN_HARD_CAP = 16
 # One-shot guard: the high-concurrency cost advisory is emitted at most once
 # per process. _get_max_concurrent_children() runs on every get_definitions()
 # schema rebuild (via _build_top_level_description / _build_tasks_param_description),
 # so without this flag a config of max_concurrent_children>10 spams the log on
 # every turn / agent spawn even when delegate_task is never called.
 _HIGH_CONCURRENCY_WARNED = False
+# One-shot guards for safe-cap clamp warnings (same spam risk as above).
+_SAFE_CAP_CONCURRENT_CLAMP_WARNED = False
+_SAFE_CAP_SPAWN_DEPTH_CLAMP_WARNED = False
 MAX_DEPTH = 1  # flat by default: parent (0) -> child (1); grandchild rejected unless max_spawn_depth raised.
 # Configurable depth cap consulted by _get_max_spawn_depth; MAX_DEPTH
 # stays as the default fallback and is still the symbol tests import.
 _MIN_SPAWN_DEPTH = 1
-# No upper ceiling on spawn depth — like max_concurrent_children, depth has a
-# floor of 1 and no ceiling. Deeper trees multiply API cost, so the default
-# stays flat (MAX_DEPTH = 1); raising the config knob is an explicit opt-in.
+# Hard upper bound on spawn depth when enforce_safe_caps is on (default).
+# Documented range in cli-config is 1–3; absurd values (e.g. 99) fan out API
+# cost exponentially with nested orchestrators. Configurable via
+# delegation.max_spawn_depth_hard_cap. Default tree stays flat (MAX_DEPTH = 1).
+_DEFAULT_MAX_SPAWN_DEPTH_HARD_CAP = 3
+# When True (default), clamp max_concurrent_children / max_spawn_depth to their
+# hard caps and warn. Set delegation.enforce_safe_caps: false to restore
+# floor-only behaviour for power users who knowingly want unbounded fan-out.
+_DEFAULT_ENFORCE_SAFE_CAPS = True
 
 
 # ---------------------------------------------------------------------------
@@ -352,11 +365,108 @@ def _normalize_role(r: Optional[str]) -> str:
     return "leaf"
 
 
+def _enforce_safe_caps_enabled(cfg: Optional[Dict[str, Any]] = None) -> bool:
+    """Whether to clamp absurd concurrency/depth values (default True).
+
+    Config key: ``delegation.enforce_safe_caps``. When false, only the floor
+    of 1 is enforced (legacy unbounded behaviour).
+    """
+    if cfg is None:
+        cfg = _load_config()
+    return is_truthy_value(
+        cfg.get("enforce_safe_caps", _DEFAULT_ENFORCE_SAFE_CAPS),
+        default=_DEFAULT_ENFORCE_SAFE_CAPS,
+    )
+
+
+def _get_max_concurrent_children_hard_cap(cfg: Optional[Dict[str, Any]] = None) -> int:
+    """Hard ceiling for max_concurrent_children when safe caps are enforced."""
+    if cfg is None:
+        cfg = _load_config()
+    val = cfg.get("max_concurrent_children_hard_cap")
+    if val is not None:
+        try:
+            return max(1, int(val))
+        except (TypeError, ValueError):
+            logger.warning(
+                "delegation.max_concurrent_children_hard_cap=%r is not a valid "
+                "integer; using default %d",
+                val,
+                _DEFAULT_MAX_CONCURRENT_CHILDREN_HARD_CAP,
+            )
+    return _DEFAULT_MAX_CONCURRENT_CHILDREN_HARD_CAP
+
+
+def _get_max_spawn_depth_hard_cap(cfg: Optional[Dict[str, Any]] = None) -> int:
+    """Hard ceiling for max_spawn_depth when safe caps are enforced."""
+    if cfg is None:
+        cfg = _load_config()
+    val = cfg.get("max_spawn_depth_hard_cap")
+    if val is not None:
+        try:
+            return max(_MIN_SPAWN_DEPTH, int(val))
+        except (TypeError, ValueError):
+            logger.warning(
+                "delegation.max_spawn_depth_hard_cap=%r is not a valid integer; "
+                "using default %d",
+                val,
+                _DEFAULT_MAX_SPAWN_DEPTH_HARD_CAP,
+            )
+    return _DEFAULT_MAX_SPAWN_DEPTH_HARD_CAP
+
+
+def _apply_concurrent_children_safe_cap(result: int, cfg: Dict[str, Any]) -> int:
+    """Clamp max_concurrent_children to the hard cap when enforce_safe_caps is on."""
+    global _SAFE_CAP_CONCURRENT_CLAMP_WARNED
+    if not _enforce_safe_caps_enabled(cfg):
+        return result
+    hard_cap = _get_max_concurrent_children_hard_cap(cfg)
+    if result <= hard_cap:
+        return result
+    if not _SAFE_CAP_CONCURRENT_CLAMP_WARNED:
+        _SAFE_CAP_CONCURRENT_CLAMP_WARNED = True
+        logger.warning(
+            "delegation.max_concurrent_children=%d exceeds hard cap %d "
+            "(delegation.max_concurrent_children_hard_cap); clamping to %d. "
+            "Set delegation.enforce_safe_caps: false to disable, or raise "
+            "max_concurrent_children_hard_cap deliberately.",
+            result,
+            hard_cap,
+            hard_cap,
+        )
+    return hard_cap
+
+
+def _apply_spawn_depth_safe_cap(result: int, cfg: Dict[str, Any]) -> int:
+    """Clamp max_spawn_depth to the hard cap when enforce_safe_caps is on."""
+    global _SAFE_CAP_SPAWN_DEPTH_CLAMP_WARNED
+    if not _enforce_safe_caps_enabled(cfg):
+        return result
+    hard_cap = _get_max_spawn_depth_hard_cap(cfg)
+    if result <= hard_cap:
+        return result
+    if not _SAFE_CAP_SPAWN_DEPTH_CLAMP_WARNED:
+        _SAFE_CAP_SPAWN_DEPTH_CLAMP_WARNED = True
+        logger.warning(
+            "delegation.max_spawn_depth=%d exceeds hard cap %d "
+            "(delegation.max_spawn_depth_hard_cap); clamping to %d. "
+            "Set delegation.enforce_safe_caps: false to disable, or raise "
+            "max_spawn_depth_hard_cap deliberately. Deep trees multiply API cost "
+            "exponentially with nested orchestrators.",
+            result,
+            hard_cap,
+            hard_cap,
+        )
+    return hard_cap
+
+
 def _get_max_concurrent_children() -> int:
     """Read delegation.max_concurrent_children from config, falling back to
     DELEGATION_MAX_CONCURRENT_CHILDREN env var, then the default (3).
 
-    Users can raise this as high as they want; only the floor (1) is enforced.
+    Floor of 1 is always enforced. When ``delegation.enforce_safe_caps`` is
+    on (default), values above ``max_concurrent_children_hard_cap`` (default
+    16) are clamped with a one-shot warning. Normal configs are byte-stable.
 
     Uses the same ``_load_config()`` path that the rest of ``delegate_task``
     uses, keeping config priority consistent (config.yaml > env > default).
@@ -375,7 +485,7 @@ def _get_max_concurrent_children() -> int:
                         "independently. High values multiply cost linearly.",
                         result,
                     )
-            return result
+            return _apply_concurrent_children_safe_cap(result, cfg)
         except (TypeError, ValueError):
             logger.warning(
                 "delegation.max_concurrent_children=%r is not a valid integer; "
@@ -387,7 +497,8 @@ def _get_max_concurrent_children() -> int:
     env_val = os.getenv("DELEGATION_MAX_CONCURRENT_CHILDREN")
     if env_val:
         try:
-            return max(1, int(env_val))
+            result = max(1, int(env_val))
+            return _apply_concurrent_children_safe_cap(result, cfg)
         except (TypeError, ValueError):
             return _DEFAULT_MAX_CONCURRENT_CHILDREN
     return _DEFAULT_MAX_CONCURRENT_CHILDREN
@@ -466,7 +577,7 @@ def _get_child_timeout() -> Optional[float]:
 
 
 def _get_max_spawn_depth() -> int:
-    """Read delegation.max_spawn_depth from config, floored at 1 (no ceiling).
+    """Read delegation.max_spawn_depth from config, floored at 1.
 
     depth 0 = parent agent.  max_spawn_depth = N means agents at depths
     0..N-1 can spawn; depth N is the leaf floor.  Default 1 is flat:
@@ -477,8 +588,11 @@ def _get_max_spawn_depth() -> int:
     Raise to 2+ to unlock nested orchestration. role="orchestrator"
     removes the toolset strip for spawning children when
     max_spawn_depth >= 2, enabling them to spawn their own workers.
-    Like max_concurrent_children, there is no upper ceiling — but each
-    extra level multiplies API cost, so raise it deliberately.
+
+    When ``delegation.enforce_safe_caps`` is on (default), values above
+    ``max_spawn_depth_hard_cap`` (default 3) are clamped with a one-shot
+    warning — deep trees multiply API cost exponentially. Normal configs
+    (1–3) are byte-stable.
     """
     cfg = _load_config()
     val = cfg.get("max_spawn_depth")
@@ -501,7 +615,7 @@ def _get_max_spawn_depth() -> int:
             _MIN_SPAWN_DEPTH,
             floored,
         )
-    return floored
+    return _apply_spawn_depth_safe_cap(floored, cfg)
 
 
 def _get_orchestrator_enabled() -> bool:
@@ -2490,8 +2604,8 @@ def delegate_task(
                     f"Delegation depth limit reached (depth={depth}, "
                     f"max_spawn_depth={max_spawn}). Raise "
                     f"delegation.max_spawn_depth in config.yaml if deeper "
-                    f"nesting is required (no hard ceiling, but each level "
-                    f"multiplies API cost)."
+                    f"nesting is required (safe hard cap applies by default; "
+                    f"each level multiplies API cost)."
                 )
             }
         )
@@ -2584,8 +2698,13 @@ def delegate_task(
             # tasks[].model/provider first, then a forced delegation provider,
             # then the opt-in dynamic model router, else inherits `creds`
             # unchanged (router OFF → byte-identical to prior behaviour).
+            # ValueError from an explicit override that failed to resolve must
+            # surface as tool_error — never fall back to parent auth with a
+            # mismatched model id (that produces opaque 401s at call time).
             try:
                 task_creds, task_fallback_chain = _resolve_task_credentials(t, cfg, creds)
+            except ValueError as exc:
+                return tool_error(str(exc))
             except Exception:
                 logger.debug("model_router: per-task credential resolution failed", exc_info=True)
                 task_creds, task_fallback_chain = creds, None
@@ -3346,6 +3465,12 @@ def _resolve_task_credentials(task: dict, cfg: dict, default_creds: dict) -> tup
     Returns ``(effective_creds, fallback_chain_or_None)``. When the router is
     disabled and no explicit override is present this returns
     ``(default_creds, None)`` byte-for-byte, preserving current behaviour.
+
+    Raises:
+        ValueError: when the task pins an explicit ``provider`` (with or without
+        a model) and that provider/model cannot be resolved to a usable
+        credential bundle. Callers must surface this (e.g. ``tool_error``) and
+        must not fall back to parent auth with a mismatched model id.
     """
     # 1. Explicit per-task override always wins — resolve it to a full bundle.
     exp_provider, exp_model = _parse_task_model_override(task)
@@ -3354,8 +3479,22 @@ def _resolve_task_credentials(task: dict, cfg: dict, default_creds: dict) -> tup
             bundle = _resolve_provider_model_bundle(exp_provider, exp_model)
             if bundle is not None:
                 return bundle, None
-            # Resolution failed → fall through to inherited creds but swap model
-            # so an explicit model id at least applies against inherited auth.
+            # Explicit provider was requested but could not be resolved (unknown
+            # provider, missing API key, runtime error). Do NOT merge the model
+            # id onto the parent's credentials — that pairs a foreign model with
+            # the wrong provider's auth and surfaces as a confusing 401 later.
+            # Surface a clear error now (caller maps ValueError → tool_error).
+            detail = f"provider '{exp_provider}'"
+            if exp_model:
+                detail += f" / model '{exp_model}'"
+            raise ValueError(
+                f"Cannot resolve explicit task override ({detail}). "
+                f"Check that the provider name is valid and has credentials "
+                f"(API key set / hermes auth), or omit tasks[].provider to "
+                f"inherit the parent's provider."
+            )
+        # Model-only override (no provider): legitimately inherit parent auth
+        # and swap the model id — same provider, different model.
         merged = dict(default_creds)
         if exp_model:
             merged["model"] = exp_model


### PR DESCRIPTION
## Summary
Adds an optional, provider-aware **dynamic model router** for subagent delegation (default **OFF**), plus two reliability fixes on the same path:
1. failed explicit `tasks[].provider`/`model` no longer falls back to parent auth with a mismatched model (401),
2. safe upper caps on `max_concurrent_children` / `max_spawn_depth` (default ON, byte-stable for normal configs).

## Root cause
`delegate_task` could only inherit the parent model or honor an explicit override — no availability/capability-aware choice and no per-task fallback chain. Separately, a failed explicit override merged the model onto parent credentials (wrong provider auth → 401), and concurrency/depth knobs had no hard ceiling against exponential fan-out.

## Fix
- **`agent/model_router.py`:** deterministic, stdlib-only router; `enabled` default false; scores from injected inventory/catalog/pricing/credential gates — no network at import, no fixed model brand names.
- **`tools/delegate_tool.py`:** `(creds, fallback_chain)` with precedence **explicit → forced delegation.provider/base_url → router → inherit**; schema exposes `tasks[].model` + `tasks[].provider`; `override_fallback_chain` into `_build_child_agent`.
- **401 fix:** explicit provider resolve failure → `ValueError` → `tool_error` (model-only override still inherits parent auth).
- **Safe caps:** `delegation.enforce_safe_caps` (default true) clamps concurrent children (hard cap 16) and spawn depth (hard cap 3); opt-out via `false` or higher `*_hard_cap`.
- **`hermes_cli/config.py`:** `delegation.model_router` block default OFF + cap knobs documented in `cli-config.yaml.example`.

## Footprint
Focused on delegation routing/reliability. Feature off by default for the router; caps only clamp absurd values under default config.

## Validation
```text
pytest tests/agent/test_model_router.py \
       tests/tools/test_delegate_model_router_integration.py \
       tests/tools/test_delegate.py -o addopts=
→ 205 passed
Includes REAL end-to-end router test (unmocked select_delegation_model) + 401/caps regressions.
Zero live API calls (inventory/catalog/pricing/bundle mocked at the boundary).
```

## Tests
Unit router suite + integration (schema, override, forced provider, fallback chain, E2E unmocked select) + full `test_delegate*.py` regression.