### PR TITLE
fix(desktop): avoid stale actions in memoized surfaces

### DIFF
--- a/apps/desktop/src/app/contrib/latest-actions.test.ts
+++ b/apps/desktop/src/app/contrib/latest-actions.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { latestChatActions } from './latest-actions'
+import type { ChatActions } from './types'
+
+function makeActions(onSubmit: ChatActions['onSubmit']): ChatActions {
+  return {
+    onAddContextRef: vi.fn(),
+    onAddUrl: vi.fn(),
+    onAttachDroppedItems: vi.fn(),
+    onAttachImageBlob: vi.fn(),
+    onBranchInNewChat: vi.fn(),
+    onCancel: vi.fn(),
+    onDeleteSelectedSession: vi.fn(),
+    onDismissError: vi.fn(),
+    onEdit: vi.fn(),
+    onPasteClipboardImage: vi.fn(),
+    onPickFiles: vi.fn(),
+    onPickFolders: vi.fn(),
+    onPickImages: vi.fn(),
+    onReload: vi.fn(),
+    onRemoveAttachment: vi.fn(),
+    onRestoreToMessage: vi.fn(),
+    onRetryResume: vi.fn(),
+    onSteer: vi.fn(),
+    onSubmit,
+    onThreadMessagesChange: vi.fn(),
+    onToggleSelectedPin: vi.fn(),
+    onTranscribeAudio: vi.fn()
+  }
+}
+
+describe('latestActions adapters', () => {
+  it('dereferences the latest chat handler from a stable actions object', async () => {
+    const staleSubmit = vi.fn(async () => false)
+    const latestSubmit = vi.fn(async () => true)
+    const actions = makeActions(staleSubmit)
+    const adapted = latestChatActions(actions)
+
+    actions.onSubmit = latestSubmit
+
+    await expect(adapted.onSubmit('continue in selected session')).resolves.toBe(true)
+    expect(staleSubmit).not.toHaveBeenCalled()
+    expect(latestSubmit).toHaveBeenCalledWith('continue in selected session')
+  })
+})

--- a/apps/desktop/src/app/contrib/latest-actions.test.ts
+++ b/apps/desktop/src/app/contrib/latest-actions.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { latestChatActions } from './latest-actions'
-import type { ChatActions } from './types'
+import type { SidebarNavItem } from '../types'
 
-function makeActions(onSubmit: ChatActions['onSubmit']): ChatActions {
+import { latestChatActions, latestSidebarActions } from './latest-actions'
+import type { ChatActions, SidebarActions } from './types'
+
+function makeChatActions(): ChatActions {
   return {
     onAddContextRef: vi.fn(),
     onAddUrl: vi.fn(),
@@ -23,24 +25,57 @@ function makeActions(onSubmit: ChatActions['onSubmit']): ChatActions {
     onRestoreToMessage: vi.fn(),
     onRetryResume: vi.fn(),
     onSteer: vi.fn(),
-    onSubmit,
+    onSubmit: vi.fn(),
     onThreadMessagesChange: vi.fn(),
     onToggleSelectedPin: vi.fn(),
     onTranscribeAudio: vi.fn()
   }
 }
 
+function makeSidebarActions(): SidebarActions {
+  return {
+    onArchiveSession: vi.fn(),
+    onBranchSession: vi.fn(),
+    onDeleteSession: vi.fn(),
+    onLoadMoreMessaging: vi.fn(),
+    onLoadMoreProfileSessions: vi.fn(),
+    onLoadMoreSessions: vi.fn(),
+    onManageCronJob: vi.fn(),
+    onNavigate: vi.fn(),
+    onNewSessionInWorkspace: vi.fn(),
+    onNewSessionSplit: vi.fn(),
+    onResumeSession: vi.fn(),
+    onTriggerCronJob: vi.fn()
+  }
+}
+
 describe('latestActions adapters', () => {
-  it('dereferences the latest chat handler from a stable actions object', async () => {
-    const staleSubmit = vi.fn(async () => false)
-    const latestSubmit = vi.fn(async () => true)
-    const actions = makeActions(staleSubmit)
+  it('dereferences the latest steer handler from a stable actions object', async () => {
+    const staleSteer = vi.fn(async () => false)
+    const latestSteer = vi.fn(async () => true)
+    const actions = makeChatActions()
+    actions.onSteer = staleSteer
     const adapted = latestChatActions(actions)
 
-    actions.onSubmit = latestSubmit
+    actions.onSteer = latestSteer
 
-    await expect(adapted.onSubmit('continue in selected session')).resolves.toBe(true)
-    expect(staleSubmit).not.toHaveBeenCalled()
-    expect(latestSubmit).toHaveBeenCalledWith('continue in selected session')
+    await expect(adapted.onSteer('continue in selected session')).resolves.toBe(true)
+    expect(staleSteer).not.toHaveBeenCalled()
+    expect(latestSteer).toHaveBeenCalledWith('continue in selected session')
+  })
+
+  it('dereferences the latest sidebar handler from a stable actions object', () => {
+    const staleNavigate = vi.fn()
+    const latestNavigate = vi.fn()
+    const item = { id: 'settings', icon: vi.fn(), label: 'Settings', route: '/settings' } satisfies SidebarNavItem
+    const actions = makeSidebarActions()
+    actions.onNavigate = staleNavigate
+    const adapted = latestSidebarActions(actions)
+
+    actions.onNavigate = latestNavigate
+    adapted.onNavigate(item)
+
+    expect(staleNavigate).not.toHaveBeenCalled()
+    expect(latestNavigate).toHaveBeenCalledWith(item)
   })
 })

--- a/apps/desktop/src/app/contrib/latest-actions.ts
+++ b/apps/desktop/src/app/contrib/latest-actions.ts
@@ -1,0 +1,52 @@
+import type { ChatActions, SidebarActions } from './types'
+
+/**
+ * Surfaces receive one stable `actions` object whose fields are mutated by the
+ * wiring controller each render. If a memoized surface passes `actions.foo`
+ * directly, the child keeps the function from the surface's last render and can
+ * submit/click against a stale session closure. These adapters keep a stable
+ * wrapper but dereference the latest field at call time.
+ */
+export function latestChatActions(actions: ChatActions): ChatActions {
+  return {
+    onAddContextRef: (...args) => actions.onAddContextRef(...args),
+    onAddUrl: (...args) => actions.onAddUrl(...args),
+    onAttachDroppedItems: (...args) => actions.onAttachDroppedItems(...args),
+    onAttachImageBlob: (...args) => actions.onAttachImageBlob(...args),
+    onBranchInNewChat: (...args) => actions.onBranchInNewChat(...args),
+    onCancel: (...args) => actions.onCancel(...args),
+    onDeleteSelectedSession: (...args) => actions.onDeleteSelectedSession(...args),
+    onDismissError: (...args) => actions.onDismissError?.(...args),
+    onEdit: (...args) => actions.onEdit(...args),
+    onPasteClipboardImage: (...args) => actions.onPasteClipboardImage(...args),
+    onPickFiles: (...args) => actions.onPickFiles(...args),
+    onPickFolders: (...args) => actions.onPickFolders(...args),
+    onPickImages: (...args) => actions.onPickImages(...args),
+    onReload: (...args) => actions.onReload(...args),
+    onRemoveAttachment: (...args) => actions.onRemoveAttachment(...args),
+    onRestoreToMessage: (...args) => actions.onRestoreToMessage?.(...args) ?? Promise.resolve(),
+    onRetryResume: (...args) => actions.onRetryResume(...args),
+    onSteer: (...args) => actions.onSteer(...args),
+    onSubmit: (...args) => actions.onSubmit(...args),
+    onThreadMessagesChange: (...args) => actions.onThreadMessagesChange(...args),
+    onToggleSelectedPin: (...args) => actions.onToggleSelectedPin(...args),
+    onTranscribeAudio: (...args) => actions.onTranscribeAudio?.(...args) ?? Promise.resolve('')
+  }
+}
+
+export function latestSidebarActions(actions: SidebarActions): SidebarActions {
+  return {
+    onArchiveSession: (...args) => actions.onArchiveSession(...args),
+    onBranchSession: (...args) => actions.onBranchSession(...args),
+    onDeleteSession: (...args) => actions.onDeleteSession(...args),
+    onLoadMoreMessaging: (...args) => actions.onLoadMoreMessaging?.(...args),
+    onLoadMoreProfileSessions: (...args) => actions.onLoadMoreProfileSessions?.(...args),
+    onLoadMoreSessions: (...args) => actions.onLoadMoreSessions(...args),
+    onManageCronJob: (...args) => actions.onManageCronJob(...args),
+    onNavigate: (...args) => actions.onNavigate(...args),
+    onNewSessionInWorkspace: (...args) => actions.onNewSessionInWorkspace(...args),
+    onNewSessionSplit: (...args) => actions.onNewSessionSplit(...args),
+    onResumeSession: (...args) => actions.onResumeSession(...args),
+    onTriggerCronJob: (...args) => actions.onTriggerCronJob(...args)
+  }
+}

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -24,6 +24,7 @@ import { useStatusbarItems } from '../shell/hooks/use-statusbar-items'
 import { ModelMenuPanel } from '../shell/model-menu-panel'
 import { StatusbarControls } from '../shell/statusbar-controls'
 
+import { latestChatActions, latestSidebarActions } from './latest-actions'
 import { setStatusbarItemGroup, useStatusbarContributions } from './panes'
 import type { SidebarActions, WiringActions } from './types'
 
@@ -47,7 +48,9 @@ export const SidebarSurface = memo(function SidebarSurface({
   actions: SidebarActions
   currentView: ComponentProps<typeof ChatSidebar>['currentView']
 }) {
-  return <ChatSidebar currentView={currentView} {...actions} />
+  const latestActions = useMemo(() => latestSidebarActions(actions), [actions])
+
+  return <ChatSidebar currentView={currentView} {...latestActions} />
 })
 
 export const TerminalSurface = memo(function TerminalSurface() {
@@ -134,33 +137,13 @@ export const ChatRoutesSurface = memo(function ChatRoutesSurface({
     [actions, gateway, gatewayState]
   )
 
+  const chatActions = useMemo(() => latestChatActions(actions), [actions])
   const chatView = (
     <ChatView
       gateway={gateway}
       maxVoiceRecordingSeconds={maxVoiceRecordingSeconds}
       modelMenuContent={modelMenuContent}
-      onAddContextRef={actions.onAddContextRef}
-      onAddUrl={actions.onAddUrl}
-      onAttachDroppedItems={actions.onAttachDroppedItems}
-      onAttachImageBlob={actions.onAttachImageBlob}
-      onBranchInNewChat={actions.onBranchInNewChat}
-      onCancel={actions.onCancel}
-      onDeleteSelectedSession={actions.onDeleteSelectedSession}
-      onDismissError={actions.onDismissError}
-      onEdit={actions.onEdit}
-      onPasteClipboardImage={actions.onPasteClipboardImage}
-      onPickFiles={actions.onPickFiles}
-      onPickFolders={actions.onPickFolders}
-      onPickImages={actions.onPickImages}
-      onReload={actions.onReload}
-      onRemoveAttachment={actions.onRemoveAttachment}
-      onRestoreToMessage={actions.onRestoreToMessage}
-      onRetryResume={actions.onRetryResume}
-      onSteer={actions.onSteer}
-      onSubmit={actions.onSubmit}
-      onThreadMessagesChange={actions.onThreadMessagesChange}
-      onToggleSelectedPin={actions.onToggleSelectedPin}
-      onTranscribeAudio={actions.onTranscribeAudio}
+      {...chatActions}
     />
   )
 


### PR DESCRIPTION
## Summary
- add latest-action wrappers for memoized Desktop chat/sidebar surfaces
- route ChatView and ChatSidebar callbacks through wrappers that dereference the current actions object at call time
- cover the stale-handler regression with a focused unit test

## Why
`ContribWiring` intentionally keeps a stable `actions` object and mutates its fields each render so memoized pane surfaces do not re-render on ordinary session churn. `ChatRoutesSurface` and `SidebarSurface` were passing fields such as `actions.onSubmit` directly into children. If the surface did not re-render after a session switch, the child could keep a stale submit/navigation closure and route input to the previously selected session.

This keeps the stable-actions performance contract while making the child callbacks late-bind to the latest action field.

## Test Plan
- [x] `npm run test:ui -- src/app/contrib/latest-actions.test.ts src/app/session/hooks/use-prompt-actions/index.test.tsx`
- [x] `npm run typecheck --workspace apps/desktop`
