### PR TITLE
fix: keep LM Studio (llama.cpp) on-model instead of falling back on grammar errors

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4025,19 +4025,19 @@ def run_conversation(
                     if _stripped:
                         agent._vprint(
                             f"{agent.log_prefix}⚠️  llama.cpp rejected tool schema grammar — "
-                            f"stripped {_stripped} pattern/format keyword(s), retrying...",
+                            f"stripped {_stripped} grammar-hostile keyword(s), retrying...",
                             force=True,
                         )
                         logger.warning(
                             "%sllama.cpp grammar recovery: stripped %d "
-                            "pattern/format keyword(s) from tool schemas",
+                            "grammar-hostile keyword(s) from tool schemas",
                             agent.log_prefix, _stripped,
                         )
                         continue
                     # No keywords found to strip — fall through to normal
                     # retry path rather than loop forever on the same error.
                     logger.warning(
-                        "%sllama.cpp grammar error but no pattern/format "
+                        "%sllama.cpp grammar error but no grammar-hostile "
                         "keywords to strip — falling through to normal retry",
                         agent.log_prefix,
                     )

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -782,6 +782,7 @@ def classify_api_error(
         and (
             "error parsing grammar" in error_msg
             or "json-schema-to-grammar" in error_msg
+            or "failed to parse grammar" in error_msg
             or (
                 "unable to generate parser" in error_msg
                 and "template" in error_msg

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -771,14 +771,23 @@ def classify_api_error(
 
     # llama.cpp's ``json-schema-to-grammar`` converter (used by its OAI
     # server to build GBNF tool-call parsers) rejects regex escape classes
-    # like ``\d``/``\w``/``\s`` and most ``format`` values. MCP servers
-    # routinely emit ``"pattern": "\\d{4}-\\d{2}-\\d{2}"`` for date/phone/
-    # email params. llama.cpp surfaces this as HTTP 400 with one of a few
-    # recognizable phrases; on match we strip ``pattern``/``format`` from
-    # ``self.tools`` in the retry loop and retry once. Cloud providers are
-    # unaffected — they accept these keywords and we never hit this branch.
+    # like ``\d``/``\w``/``\s``, most ``format`` values, AND large bounded
+    # repetition such as ``"maxLength": 2000`` on array-item strings (it
+    # expands the char rule 2000× into a grammar that fails to parse). MCP
+    # servers routinely emit these (``"pattern": "\\d{4}-\\d{2}-\\d{2}"`` for
+    # date params; ``maxLength``/``maxItems`` bounds on batch-id arrays).
+    # llama.cpp surfaces this as HTTP 400 with one of a few recognizable
+    # phrases; on match we strip the hostile keywords from ``self.tools`` in
+    # the retry loop and retry once. Cloud providers are unaffected — they
+    # accept these keywords and we never hit this branch.
+    #
+    # ``status_code`` may be ``None`` on the *streaming* path: LM Studio's
+    # error arrives as a bare ``APIError`` (status_code unset) rather than a
+    # ``BadRequestError``, but the "400 ... failed to parse grammar" text is
+    # still in the message. The phrases below are llama.cpp-specific, so we
+    # match them whether the status code is 400 or absent.
     if (
-        status_code == 400
+        status_code in (400, None)
         and (
             "error parsing grammar" in error_msg
             or "json-schema-to-grammar" in error_msg

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -459,6 +459,33 @@ class TestClassifyApiError:
         result = classify_api_error(e, provider="openai-compatible")
         assert result.reason == FailoverReason.llama_cpp_grammar_pattern
 
+    def test_llama_cpp_grammar_error_without_status_code(self):
+        """The streaming path carries no status_code — still a grammar failure.
+
+        On a non-streaming request the OpenAI SDK raises BadRequestError with
+        status_code=400. On a *streaming* request LM Studio's identical error
+        surfaces as a bare APIError whose status_code is None. Gating the
+        predicate on ``status_code == 400`` therefore missed every streamed
+        request: the recovery branch never ran, the tool schemas were never
+        stripped, and the turn fell through to the fallback model instead of
+        staying on the local model.
+        """
+        e = MockAPIError(
+            'Engine protocol predict request returned 400: '
+            '{"error":{"code":400,"message":"Failed to initialize samplers: '
+            'failed to parse grammar","type":"invalid_request_error"}}',
+            status_code=None,
+        )
+        result = classify_api_error(e, provider="openai-compatible")
+        assert result.reason == FailoverReason.llama_cpp_grammar_pattern
+        assert result.retryable is True
+
+    def test_unrelated_error_without_status_code_is_not_grammar(self):
+        """Relaxing the status gate must not swallow unrelated errors."""
+        e = MockAPIError("connection reset by peer", status_code=None)
+        result = classify_api_error(e, provider="openai-compatible")
+        assert result.reason != FailoverReason.llama_cpp_grammar_pattern
+
     def test_llama_cpp_grammar_requires_400(self):
         """A 500 with the same phrase isn't the llama.cpp grammar case."""
         e = MockAPIError("error parsing grammar", status_code=500)

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -450,9 +450,20 @@ class TestClassifyApiError:
 
     # ── Provider-specific: llama.cpp grammar-parse ──
 
+    def test_llama_cpp_failed_to_parse_grammar_phrase(self):
+        """LM Studio's engine surfaces this as 'failed to initialize samplers: failed to parse grammar'."""
+        e = MockAPIError(
+            "Failed to initialize samplers: failed to parse grammar",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="openai-compatible")
+        assert result.reason == FailoverReason.llama_cpp_grammar_pattern
 
-
-
+    def test_llama_cpp_grammar_requires_400(self):
+        """A 500 with the same phrase isn't the llama.cpp grammar case."""
+        e = MockAPIError("error parsing grammar", status_code=500)
+        result = classify_api_error(e, provider="openai-compatible")
+        assert result.reason != FailoverReason.llama_cpp_grammar_pattern
 
     # ── Provider-specific: Anthropic long-context tier ──
 

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -346,3 +346,71 @@ def test_dependent_schemas_still_recursively_sanitized():
     assert dep_schemas["owner"] == {"type": "object", "properties": {}}, (
         f"dependentSchemas['owner'] was not fully sanitized: {dep_schemas['owner']!r}"
     )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Bounded-repetition keywords. llama.cpp expands maxLength/maxItems literally
+# into GBNF; a large bound (an MCP tool's "maxLength": 2000 on array items)
+# produces a grammar the parser rejects outright — HTTP 400 "failed to parse
+# grammar". Observed against LM Studio with apple-notes' batch-delete-notes.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_strip_removes_max_length_on_array_items():
+    """The real-world trigger: large maxLength nested in array items."""
+    tools = [_tool("batch_delete", {
+        "type": "object",
+        "properties": {
+            "ids": {
+                "type": "array",
+                "items": {"type": "string", "maxLength": 2000},
+                "maxItems": 500,
+            },
+        },
+        "required": ["ids"],
+    })]
+    _, stripped = strip_pattern_and_format(tools)
+    assert stripped == 2, "both items.maxLength and the array's maxItems are hostile"
+    ids = tools[0]["function"]["parameters"]["properties"]["ids"]
+    assert "maxItems" not in ids
+    assert "maxLength" not in ids["items"]
+    # Structure the model still needs must survive.
+    assert ids["type"] == "array"
+    assert ids["items"]["type"] == "string"
+    assert tools[0]["function"]["parameters"]["required"] == ["ids"]
+
+
+def test_strip_removes_min_bounds():
+    """minLength/minItems are expanded the same way and are equally hostile."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "minLength": 3},
+            "tags": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+        },
+    })]
+    _, stripped = strip_pattern_and_format(tools)
+    assert stripped == 2
+    props = tools[0]["function"]["parameters"]["properties"]
+    assert "minLength" not in props["name"]
+    assert "minItems" not in props["tags"]
+
+
+def test_strip_preserves_property_named_max_length():
+    """A property *named* maxLength is data, not a schema keyword — keep it.
+
+    Schema keywords are siblings of ``type``; property names live inside
+    ``properties`` and must survive, exactly as for the ``pattern`` case.
+    """
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "maxLength": {"type": "integer"},
+            "maxItems": {"type": "integer"},
+        },
+    })]
+    _, stripped = strip_pattern_and_format(tools)
+    assert stripped == 0
+    props = tools[0]["function"]["parameters"]["properties"]
+    assert props["maxLength"] == {"type": "integer"}
+    assert props["maxItems"] == {"type": "integer"}

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -448,21 +448,39 @@ def _sanitize_node(node: Any, path: str) -> Any:
 # Reactive strip — only invoked when llama.cpp rejects a schema
 # =============================================================================
 
-_STRIP_ON_RECOVERY_KEYS = frozenset({"pattern", "format"})
+# Keywords llama.cpp's json-schema-to-grammar converter can't express and
+# that make it reject the whole request. Two families:
+#   * regex/format: ``pattern`` (escape classes ``\d``/``\w``/``\s``) and
+#     ``format`` (``date-time``, ``email``, ...).
+#   * bounded repetition: ``maxLength``/``minLength`` on strings and
+#     ``maxItems``/``minItems`` on arrays. A large bound (e.g. an MCP tool's
+#     ``"maxLength": 2000`` on array-item strings) is expanded literally into
+#     the GBNF — the generated grammar is too large / malformed and llama.cpp
+#     returns 400 "failed to parse grammar" / "unable to generate parser".
+_STRIP_ON_RECOVERY_KEYS = frozenset(
+    {"pattern", "format", "maxLength", "minLength", "maxItems", "minItems"}
+)
 
 
 def strip_pattern_and_format(tools: list[dict]) -> tuple[list[dict], int]:
-    """Strip ``pattern`` and ``format`` JSON Schema keywords from tool schemas.
+    """Strip grammar-hostile JSON Schema keywords from tool schemas.
 
     This is a *reactive* sanitizer invoked only when llama.cpp's
     ``json-schema-to-grammar`` converter has rejected a tool schema with an
-    HTTP 400 grammar-parse error.  llama.cpp's regex engine supports only a
-    small subset of ECMAScript regex (literals, ``.``, ``[...]``, ``|``,
-    ``*``, ``+``, ``?``, ``{n,m}``) — it rejects escape classes like ``\\d``,
-    ``\\w``, ``\\s`` and most ``format`` values.  Cloud providers (OpenAI,
-    Anthropic, OpenRouter, Gemini) accept these keywords fine and rely on
-    them as prompting hints, so we keep them in the default schema and only
-    strip on demand.
+    HTTP 400 grammar-parse error.  It removes two families of keywords the
+    converter can't handle (see :data:`_STRIP_ON_RECOVERY_KEYS`):
+
+    * ``pattern`` / ``format`` — llama.cpp's regex engine supports only a
+      small subset of ECMAScript regex (literals, ``.``, ``[...]``, ``|``,
+      ``*``, ``+``, ``?``, ``{n,m}``) and rejects escape classes like ``\\d``,
+      ``\\w``, ``\\s`` and most ``format`` values.
+    * ``maxLength`` / ``minLength`` / ``maxItems`` / ``minItems`` — bounded
+      repetition expanded literally into GBNF; large bounds (an MCP tool's
+      ``"maxLength": 2000`` on array items) overflow the grammar parser.
+
+    Cloud providers (OpenAI, Anthropic, OpenRouter, Gemini) accept these
+    keywords fine and rely on them as prompting hints, so we keep them in the
+    default schema and only strip on demand.
 
     The strip operates on a sibling of ``type`` (so schema keywords are
     removed) — a property literally *named* ``pattern`` (e.g. the first arg
@@ -521,7 +539,8 @@ def strip_pattern_and_format(tools: list[dict]) -> tuple[list[dict], int]:
 
     if stripped:
         logger.info(
-            "schema_sanitizer: stripped %d pattern/format keyword(s) from "
+            "schema_sanitizer: stripped %d grammar-hostile keyword(s) "
+            "(pattern/format/maxLength/minLength/maxItems/minItems) from "
             "tool schemas (llama.cpp grammar-parse recovery)",
             stripped,
         )


### PR DESCRIPTION
## Problem

With a local LM Studio / llama.cpp provider as the primary model, every agent
turn that loaded certain tool schemas failed at request time with

```
400 — Failed to initialize samplers: failed to parse grammar
```

and, after 3 retries, silently fell through to the cloud fallback model. The
network and server were fine — LM Studio was rejecting the *grammar* llama.cpp
builds from the tool schemas.

## Root cause

An MCP tool schema (in our case apple-notes' `batch-delete-notes` /
`batch-move-notes`) carried **`"maxLength": 2000` on array-item strings**.
llama.cpp expands that into a GBNF rule repeating a char class up to 2000×
inside array repetition; the generated grammar is too large/malformed and the
whole request 400s. (`maxItems` alone and top-level `maxLength` are fine — it's
large `maxLength` **nested in array `items`**.)

Hermes already had a reactive recovery for llama.cpp grammar rejections, but it
never helped here, for **two independent reasons**:

1. **Streaming path** — LM Studio's error surfaces as a bare `APIError` with
   `status_code=None` (not `BadRequestError`/400), so the classifier's
   `status_code == 400` guard never matched and the error wasn't recognized as
   a grammar failure at all.
2. **Non-stream path** — it *was* recognized, but the strip only removed
   `pattern`/`format`, and these schemas have neither, so 0 keywords were
   stripped and it fell through to fallback.

## Changes

- **`agent/error_classifier.py`** — recognize the grammar error when
  `status_code` is `400` **or `None`** (fixes the streaming path). The phrases
  are llama.cpp-specific and safe to match without a status code.
- **`tools/schema_sanitizer.py`** — broaden the reactive strip to also remove
  `maxLength` / `minLength` / `maxItems` / `minItems`, not just
  `pattern` / `format`.
- **`agent/conversation_loop.py`** — recovery log wording.

Cloud providers still receive the full schema hints; the strip runs only after
a llama.cpp backend actually rejects the request.

## Verification

End-to-end against a live LM Studio server with the real apple-notes tool set,
both transports:

| Path | attempt 1 | recovery | attempt 2 |
|------|-----------|----------|-----------|
| non-stream | `BadRequestError` 400 → classified | stripped 93 keywords | **succeeds, no fallback** |
| stream | `APIError` sc=None → **now classified** | stripped 93 keywords | **succeeds, no fallback** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)