### PR TITLE
fix(toolsets): use typing.Any instead of builtin any in get_distribution

### DIFF
--- a/tests/test_toolset_distributions.py
+++ b/tests/test_toolset_distributions.py
@@ -32,6 +32,29 @@ class TestGetDistribution:
             assert get_distribution(name) is not None, f"{name} missing"
 
 
+class TestGetDistributionAnnotation:
+    def test_return_annotation_uses_typing_any_not_builtin(self):
+        """The return annotation must be typing.Any, not the builtin any().
+
+        Regression for the ``Optional[Dict[str, any]]`` typo: the builtin
+        ``any`` is a function, not a type, so the annotation was semantically
+        wrong (and static checkers reject it). This asserts the value nested
+        in the annotation is ``typing.Any``.
+        """
+        import typing
+
+        ann = get_distribution.__annotations__["return"]
+        # return is Optional[Dict[str, X]] == Union[Dict[str, X], None]
+        union_args = typing.get_args(ann)
+        dict_type = next(a for a in union_args if a is not type(None))
+        key_t, val_t = typing.get_args(dict_type)
+        assert val_t is typing.Any, (
+            f"expected typing.Any, got {val_t!r} "
+            "(the builtin any() is not a valid type annotation)"
+        )
+        assert val_t is not any
+
+
 class TestListDistributions:
     def test_returns_copy(self):
         d1 = list_distributions()

--- a/tests/test_toolset_distributions.py
+++ b/tests/test_toolset_distributions.py
@@ -21,6 +21,31 @@ class TestGetDistribution:
 
 
 
+
+
+class TestGetDistributionAnnotation:
+    def test_return_annotation_uses_typing_any_not_builtin(self):
+        """The return annotation must be typing.Any, not the builtin any().
+
+        Regression for the ``Optional[Dict[str, any]]`` typo: the builtin
+        ``any`` is a function, not a type, so the annotation was semantically
+        wrong (and static checkers reject it). This asserts the value nested
+        in the annotation is ``typing.Any``.
+        """
+        import typing
+
+        ann = get_distribution.__annotations__["return"]
+        # return is Optional[Dict[str, X]] == Union[Dict[str, X], None]
+        union_args = typing.get_args(ann)
+        dict_type = next(a for a in union_args if a is not type(None))
+        key_t, val_t = typing.get_args(dict_type)
+        assert val_t is typing.Any, (
+            f"expected typing.Any, got {val_t!r} "
+            "(the builtin any() is not a valid type annotation)"
+        )
+        assert val_t is not any
+
+
 class TestListDistributions:
     def test_returns_copy(self):
         d1 = list_distributions()

--- a/toolset_distributions.py
+++ b/toolset_distributions.py
@@ -19,7 +19,7 @@ Usage:
     all_dists = list_distributions()
 """
 
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 import random
 from toolsets import validate_toolset
 
@@ -214,7 +214,7 @@ DISTRIBUTIONS = {
 }
 
 
-def get_distribution(name: str) -> Optional[Dict[str, any]]:
+def get_distribution(name: str) -> Optional[Dict[str, Any]]:
     """
     Get a toolset distribution by name.
     


### PR DESCRIPTION
## Summary

`get_distribution()` in `toolset_distributions.py` annotated its return type as `Optional[Dict[str, any]]` — using the builtin `any()` function instead of `typing.Any`. The builtin `any` is a callable, not a type, so the annotation is semantically incorrect and rejected by static type checkers.

## Motivation

Salvage of #20812 by @ms-alan onto current main. The original one-line typo fix is still applicable — the annotation on current `main` still reads `Optional[Dict[str, any]]`.

## Changes

- Add `Any` to the `typing` import
- Change `any` → `Any` in the `get_distribution` return annotation
- Add a regression test that introspects `get_distribution.__annotations__` and asserts the nested value is `typing.Any` (fails against the old `any`)

## Verification

```
python3 -m pytest tests/test_toolset_distributions.py -q
16 passed in 0.16s
```

Fail-without-fix confirmed: reverting only the source change makes the new test fail with
`AssertionError: expected typing.Any, got <built-in function any>`.

AI-assisted; human-reviewed. Credit to @ms-alan for the original fix (#20812).