### PR TITLE
fix(file_operations): correct total_lines for files without trailing newline

### DIFF
--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine Mac Studio local email on Bartok9 PR tips (per-PR attribution; Teknium/Daniel 2026-08-01)

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -386,6 +386,54 @@ class TestShellFileOpsHelpers:
         assert result.error is None
         assert result.content == "alpha\n"
 
+    def test_no_trailing_newline_counts_final_line(self, mock_env):
+        """wc -l undercounts when the final line has no trailing newline."""
+        content = "alpha\nbravo\ncharlie"  # 3 lines, no final LF
+
+        def side_effect(command, **kwargs):
+            if command.startswith("wc -c"):
+                return {"output": f"{len(content)}\n", "returncode": 0}
+            if command.startswith("head -c"):
+                return {"output": content[:1000], "returncode": 0}
+            if command.startswith("sed -n"):
+                return {"output": content + "\n", "returncode": 0}
+            if command.startswith("wc -l"):
+                # newline count only — two LF characters
+                return {"output": "2\n", "returncode": 0}
+            if command.startswith("tail -c 1"):
+                # last byte is 'e' (0x65), not 0x0a
+                return {"output": "65\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file("/tmp/test/no_nl.txt")
+        assert result.error is None
+        assert result.total_lines == 3
+
+    def test_trailing_newline_does_not_double_count(self, mock_env):
+        """Files that already end in LF must keep wc -l's count."""
+        content = "alpha\nbravo\ncharlie\n"
+
+        def side_effect(command, **kwargs):
+            if command.startswith("wc -c"):
+                return {"output": f"{len(content)}\n", "returncode": 0}
+            if command.startswith("head -c"):
+                return {"output": content[:1000], "returncode": 0}
+            if command.startswith("sed -n"):
+                return {"output": content, "returncode": 0}
+            if command.startswith("wc -l"):
+                return {"output": "3\n", "returncode": 0}
+            if command.startswith("tail -c 1"):
+                return {"output": "0a\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file("/tmp/test/with_nl.txt")
+        assert result.error is None
+        assert result.total_lines == 3
+
 
 class TestSearchPathValidation:
     """Test that search() returns an error for non-existent paths."""

--- a/tests/tools/test_file_tools_live.py
+++ b/tests/tools/test_file_tools_live.py
@@ -145,6 +145,20 @@ class TestReadFile:
         assert result.error is None
         _assert_clean(result.content)
 
+    def test_total_lines_no_trailing_newline(self, ops, tmp_path):
+        # Live LocalEnvironment-backed check: a file whose final line has no
+        # trailing LF must still be counted. Exercises the real
+        # `tail -c 1 | od | tr` pipeline through the shell backend rather
+        # than a stubbed _exec.
+        f = tmp_path / "no_trailing_lf.txt"
+        f.write_bytes(b"alpha\nbravo\ncharlie")  # note: no final newline
+        result = ops.read_file(str(f))
+        assert result.error is None
+        assert "alpha" in result.content
+        assert "charlie" in result.content
+        assert result.total_lines == 3
+        _assert_clean(result.content)
+
 
 # ── write_file ───────────────────────────────────────────────────────────
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1177,7 +1177,20 @@ class ShellFileOperations(FileOperations):
             total_lines = int(wc_output.strip())
         except ValueError:
             total_lines = 0
-        
+
+        # wc -l counts newline characters, not lines. A file whose final line
+        # has no trailing newline therefore has one more line of content than
+        # wc -l reports. Detect this by inspecting the last byte of the file
+        # and, when it is not 0x0a (\n), account for the uncounted final line.
+        if file_size > 0:
+            tail_cmd = (
+                f"tail -c 1 {self._escape_shell_arg(path)} | od -An -tx1 | tr -d ' '"
+            )
+            tail_result = self._exec(tail_cmd)
+            last_byte = _strip_terminal_fence_leaks(tail_result.stdout).strip()
+            if last_byte and last_byte != "0a":
+                total_lines += 1
+
         # Check if truncated
         truncated = total_lines > end_line
         hint = None


### PR DESCRIPTION
## Summary

`read_file()` derived `total_lines` from `wc -l`, which counts newline characters rather than lines. A file whose final line has no trailing newline is therefore undercounted by one, producing incorrect pagination hints and truncation flags.

## Motivation

Salvage of #20814 by @ms-alan onto current main. The bug is still present: `main` reads `total_lines` straight from `wc -l` with no correction for a missing trailing newline.

## Changes

- After reading `wc -l`, inspect the file's last byte with `tail -c 1 | od`. When the final byte is not `0x0a` (\\n), increment `total_lines` to account for the uncounted final line.
- Guarded by `file_size > 0` so empty files are unaffected.
- Add regression tests covering both the no-trailing-newline (undercount) and trailing-newline (no double count) cases via a command-routed `_exec` stub.

## Verification

```
python3 -m pytest tests/tools/test_file_operations.py -q
96 passed in 0.87s
```

Fail-without-fix confirmed: reverting only the source change makes
`test_no_trailing_newline_counts_final_line` fail with `assert 2 == 3`.

AI-assisted; human-reviewed. Credit to @ms-alan for the original fix (#20814).