### PR TITLE
fix(terminal): intercept long foreground sleep commands that block the agent

### DIFF
--- a/tests/tools/test_terminal_sleep_guard.py
+++ b/tests/tools/test_terminal_sleep_guard.py
@@ -1,0 +1,58 @@
+"""Regression tests for the long foreground `sleep` interceptor.
+
+A foreground `sleep N` (N > 30) holds the executor worker thread hostage for
+the whole duration, risking upstream timeouts. While interruptible on main,
+the guard rejects such commands early to enforce the asynchronous 
+background + process(poll) pattern instead.
+"""
+
+import json
+
+from tools.terminal_tool import terminal_tool
+
+def test_long_foreground_sleep_is_rejected():
+    result = json.loads(terminal_tool("sleep 120"))
+
+    assert result["exit_code"] == -1
+    assert result["status"] == "error"
+    assert "sleep 120" in result["error"]
+    assert "background=true" in result["error"]
+
+def test_long_foreground_sleep_with_whitespace_is_rejected():
+    result = json.loads(terminal_tool("  sleep   90  "))
+
+    assert result["exit_code"] == -1
+    assert "background=true" in result["error"]
+
+def test_short_sleep_is_not_intercepted(monkeypatch):
+    import tools.terminal_tool as tt
+
+    def _boom():
+        raise RuntimeError("env-config-reached")
+
+    monkeypatch.setattr(tt, "_get_env_config", _boom)
+    result = json.loads(terminal_tool("sleep 5"))
+    assert "env-config-reached" in result["error"]
+    assert "background=true" not in result["error"]
+
+def test_background_sleep_is_not_intercepted(monkeypatch):
+    import tools.terminal_tool as tt
+
+    def _boom():
+        raise RuntimeError("env-config-reached")
+
+    monkeypatch.setattr(tt, "_get_env_config", _boom)
+    result = json.loads(terminal_tool("sleep 300", background=True))
+    assert "env-config-reached" in result["error"]
+    assert "background=true" not in result["error"]
+
+def test_command_containing_sleep_substring_is_not_intercepted(monkeypatch):
+    import tools.terminal_tool as tt
+
+    def _boom():
+        raise RuntimeError("env-config-reached")
+
+    monkeypatch.setattr(tt, "_get_env_config", _boom)
+    result = json.loads(terminal_tool("./run_sleep_test.sh 120"))
+    assert "env-config-reached" in result["error"]
+    assert "background=true" not in result["error"]

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2153,6 +2153,31 @@ def terminal_tool(
                 "status": "error",
             }, ensure_ascii=False)
 
+        # Intercept long foreground `sleep N` commands. A multi-minute foreground 
+        # sleep holds the executor worker thread hostage for the full duration. 
+        # While it is interruptible on current main (the poll loop checks the 
+        # interrupt flag), it wastes concurrent executor capacity and risks 
+        # hitting upstream API network or inactivity timeouts before returning 
+        # to the LLM. Reject sleeps > 30s so the agent uses the non-blocking 
+        # background + process(poll) pattern instead.
+        _sleep_match = re.match(r"^\s*sleep\s+(\d+)\s*$", command)
+        if _sleep_match and int(_sleep_match.group(1)) > 30 and not background:
+            _sleep_secs = int(_sleep_match.group(1))
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": (
+                    f"Rejected: 'sleep {_sleep_secs}' would hold the executor "
+                    f"worker thread hostage for {_sleep_secs}s. "
+                    "While interruptible, this wastes executor capacity and "
+                    "risks upstream network timeouts. Instead: run your "
+                    "long process with background=true, then use "
+                    "process(action='poll', session_id=...) to check progress. "
+                    "For short waits, use sleep values <= 30."
+                ),
+                "status": "error",
+            }, ensure_ascii=False)
+
         # Get configuration
         config = _get_env_config()
         env_type = config["env_type"]


### PR DESCRIPTION
## Summary

A foreground `sleep N` with `N > 30` holds the executor worker thread hostage for the full duration. While such commands ARE properly interruptible on current main (the shared wait loop checks the interrupt flag during execution, so the agent isn't 'blocked' from interrupting), allowing them wastes concurrent executor capacity and risks hitting upstream network or inactivity timeouts before returning to the LLM. 

## Motivation

Salvage of #8612 by @SHL0MS, updated for current main. The original motivation ('user cannot interact and agent hangs blockingly') is no longer accurate since full interrupt routing was added in `AIAgent.interrupt()`, but enforcing the background pattern for multi-minute waits is still important to protect executor threads and network boundaries.

## Changes

- Reject a bare foreground `sleep N` where `N > 30` early in `terminal_tool()`, with an error that enforces the non-blocking `background=true` + `process(action='poll')` pattern.
- Only bare `sleep N` commands are affected — background sleeps, short (`<= 30s`) sleeps, and commands that merely mention 'sleep' fall through untouched.
- Re-targeted to the current `terminal_tool()` entry point with updated justification.

## Verification

```
python3 -m pytest tests/tools/test_terminal_sleep_guard.py -q
5 passed in 0.18s
```

Confirmed that `terminal_tool("sleep 120")` now bounces immediately with instructions on how to wait asynchronously.

AI-assisted; human-reviewed. Credit to @SHL0MS for the original PR (#8612).