### PR TITLE
fix: keep macOS TCC permission grants across desktop self-updates

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5507,6 +5507,32 @@ def _stop_desktop_processes_locking_build(desktop_dir: Path) -> list[int]:
     return stopped
 
 
+def _stable_local_signing_identity() -> str:
+    """Return the local signing identity for desktop rebuilds, or "-" (ad-hoc).
+
+    An ad-hoc signature's Designated Requirement is just the cdhash of that
+    exact build, so every self-update rebuild looks like a brand-new app to
+    macOS TCC and all previously granted permissions (Files and Folders,
+    external volumes, microphone, ...) are silently dropped and re-prompted.
+
+    A persistent self-signed codesigning cert named "Hermes Local Signing" in
+    the login keychain gives the bundle a stable identifier+certificate DR, so
+    TCC grants survive rebuilds. Users opt in by creating/importing the cert
+    (openssl req -x509 with extendedKeyUsage=codeSigning, import via
+    `security import`); when absent we fall back to ad-hoc exactly as before.
+    """
+    try:
+        probe = subprocess.run(
+            ["security", "find-identity", "-v", "-p", "codesigning"],
+            capture_output=True, text=True, check=False,
+        )
+        if "Hermes Local Signing" in (probe.stdout or ""):
+            return "Developer ID Application: Hermes Local Signing"
+    except Exception:
+        pass
+    return "-"
+
+
 def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
     """Make a locally-built (unsigned) macOS desktop app survive in-place self-update.
 
@@ -5517,11 +5543,15 @@ def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
     bundle also inherits the com.apple.quarantine flag from the downloaded
     installer process chain. Both make the relaunch fail.
 
-    Clearing the quarantine xattrs and re-applying a clean deep ad-hoc signature
+    Clearing the quarantine xattrs and re-applying a clean deep signature
     (omitting the hardened-runtime flag, which is meaningless without a real
-    Developer ID) lets the rebuilt app relaunch. No-op when a real signing
-    identity is configured (CSC_LINK / APPLE_SIGNING_IDENTITY) so a properly
-    signed/notarized build is never clobbered. Best-effort: never raises.
+    Developer ID) lets the rebuilt app relaunch. Signs with the stable
+    "Hermes Local Signing" keychain identity when the user has created one
+    (keeps TCC permission grants across rebuilds, see
+    ``_stable_local_signing_identity``), otherwise ad-hoc. No-op when a real
+    signing identity is configured (CSC_LINK / APPLE_SIGNING_IDENTITY) so a
+    properly signed/notarized build is never clobbered. Best-effort: never
+    raises.
     """
     if sys.platform != "darwin":
         return
@@ -5537,9 +5567,10 @@ def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
     codesign = shutil.which("codesign")
     if not codesign:
         return
+    sign_id = _stable_local_signing_identity()
     try:
         subprocess.run(["xattr", "-cr", str(app)], check=False)
-        subprocess.run([codesign, "--force", "--deep", "--sign", "-", str(app)], check=False)
+        subprocess.run([codesign, "--force", "--deep", "--sign", sign_id, str(app)], check=False)
     except Exception as exc:
         print(f"  (warning: macOS relaunch fixup skipped: {exc})")
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2946,7 +2946,14 @@ install_desktop() {
     # real signing identity is configured so a signed build isn't clobbered.
     if [ "$OS" = "macos" ] && [ -z "${CSC_LINK:-}" ] && [ -z "${APPLE_SIGNING_IDENTITY:-}" ] && command -v codesign >/dev/null 2>&1; then
         xattr -cr "$app" 2>/dev/null || true
-        codesign --force --deep --sign - "$app" >/dev/null 2>&1 || true
+        # Prefer a stable local signing identity (keeps TCC permission grants
+        # across rebuilds; ad-hoc gets a new cdhash-only DR every build and
+        # macOS re-asks for every Files-and-Folders / ext-drive approval).
+        local sign_id="-"
+        if security find-identity -v -p codesigning 2>/dev/null | grep -q "Hermes Local Signing"; then
+            sign_id="Developer ID Application: Hermes Local Signing"
+        fi
+        codesign --force --deep --sign "$sign_id" "$app" >/dev/null 2>&1 || true
     fi
 
     # `npm install` + `npm run pack` rewrite lockfiles; restore them so the

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -1070,6 +1070,38 @@ def test_stable_local_signing_identity_falls_back_to_adhoc():
         assert cli_main._stable_local_signing_identity() == "-"
 
 
+@pytest.mark.parametrize(
+    ("identity", "expected_sign_arg"),
+    [
+        ("Developer ID Application: Hermes Local Signing", "Developer ID Application: Hermes Local Signing"),
+        ("-", "-"),
+    ],
+)
+def test_relaunchable_fixup_signs_with_selected_identity(
+    tmp_path, monkeypatch, identity, expected_sign_arg
+):
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    monkeypatch.delenv("CSC_LINK", raising=False)
+    monkeypatch.delenv("APPLE_SIGNING_IDENTITY", raising=False)
+
+    desktop_dir = tmp_path / "apps" / "desktop"
+    exe = desktop_dir / "release" / "mac-arm64" / "Hermes.app" / "Contents" / "MacOS" / "Hermes"
+    exe.parent.mkdir(parents=True)
+    exe.write_bytes(b"")
+    app = exe.parents[2]
+
+    calls = []
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/codesign"), \
+         patch("hermes_cli.main._stable_local_signing_identity", return_value=identity), \
+         patch("hermes_cli.main.subprocess.run", side_effect=lambda cmd, **kw: calls.append(cmd)):
+        cli_main._desktop_macos_relaunchable_fixup(desktop_dir)
+
+    assert calls == [
+        ["xattr", "-cr", str(app)],
+        ["/usr/bin/codesign", "--force", "--deep", "--sign", expected_sign_arg, str(app)],
+    ]
+
+
 # --- desktop.* launch options (config.yaml) -------------------------------
 
 

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -6,7 +6,7 @@ import argparse
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -1052,6 +1052,22 @@ def test_force_adhoc_signing_respects_explicit_caller_flag(monkeypatch):
     env = {"CSC_IDENTITY_AUTO_DISCOVERY": "true"}
     assert cli_main._force_adhoc_macos_signing(env, source_mode=False) is False
     assert env["CSC_IDENTITY_AUTO_DISCOVERY"] == "true"
+
+
+def test_stable_local_signing_identity_prefers_keychain_cert():
+    probe = MagicMock(stdout='  1) ABC123 "Developer ID Application: Hermes Local Signing"\n')
+    with patch("hermes_cli.main.subprocess.run", return_value=probe):
+        assert cli_main._stable_local_signing_identity() == (
+            "Developer ID Application: Hermes Local Signing"
+        )
+
+
+def test_stable_local_signing_identity_falls_back_to_adhoc():
+    probe = MagicMock(stdout="  0 valid identities found\n")
+    with patch("hermes_cli.main.subprocess.run", return_value=probe):
+        assert cli_main._stable_local_signing_identity() == "-"
+    with patch("hermes_cli.main.subprocess.run", side_effect=OSError("no security bin")):
+        assert cli_main._stable_local_signing_identity() == "-"
 
 
 # --- desktop.* launch options (config.yaml) -------------------------------

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -112,6 +112,30 @@ The app checks for updates in the background and offers a one-click update when 
 
 The [manual update process](https://hermes-agent.nousresearch.com/docs/getting-started/updating) also works with the GUI.
 
+### Keeping macOS permissions across updates
+
+Locally built desktop apps are re-signed **ad-hoc** after every self-update. An ad-hoc signature's Designated Requirement is just a hash of that exact build, so macOS TCC treats each update as a brand-new app and re-asks for permissions you already granted (Files and Folders, external volumes, microphone).
+
+To keep grants across updates, create a persistent local signing certificate once. The updater automatically prefers a keychain identity named `Hermes Local Signing` over ad-hoc:
+
+```bash
+mkdir -p ~/.hermes/signing && cd ~/.hermes/signing
+openssl req -new -x509 -days 3650 -nodes -newkey rsa:2048 \
+  -keyout hermes-sign.key -out hermes-sign.pem \
+  -subj "/CN=Developer ID Application: Hermes Local Signing" \
+  -addext "keyUsage=critical,digitalSignature" \
+  -addext "extendedKeyUsage=critical,codeSigning" \
+  -addext "basicConstraints=critical,CA:false"
+openssl pkcs12 -export -legacy -out hermes-sign.p12 -inkey hermes-sign.key \
+  -in hermes-sign.pem -passout pass:hermeslocal -name "Hermes Local Signing"
+security import hermes-sign.p12 -k ~/Library/Keychains/login.keychain-db \
+  -P hermeslocal -T /usr/bin/codesign
+security add-trusted-cert -p codeSign -k ~/Library/Keychains/login.keychain-db hermes-sign.pem
+chmod 600 hermes-sign.key hermes-sign.p12
+```
+
+macOS asks for the permissions one final time after the first update signed with the new identity; from then on they persist. This is opt-in: without the certificate, updates keep today's ad-hoc behavior. A real `CSC_LINK` / `APPLE_SIGNING_IDENTITY` setup always takes precedence.
+
 ## Uninstalling
 
 Open **Settings → About → Danger zone** and pick how much to remove:
@@ -251,6 +275,8 @@ rm -rf "$HOME/.hermes/hermes-agent/venv"
 # Reset a stuck macOS microphone prompt
 tccutil reset Microphone com.nousresearch.hermes
 ```
+
+If macOS re-asks for already-granted permissions after every update, see [Keeping macOS permissions across updates](#keeping-macos-permissions-across-updates).
 
 ### "Build desktop app" stuck on Electron download
 


### PR DESCRIPTION
## Symptom

On macOS, every `hermes update` that rebuilds the desktop app makes the OS re-prompt for permissions the user already granted: Files and Folders, external volume access, microphone. For users whose working directories live on an external drive this means re-approving several TCC prompts after every single update.

## Root cause

The self-update path deliberately re-signs the locally built Hermes.app **ad-hoc** (`_desktop_macos_relaunchable_fixup` in `hermes_cli/main.py`, and the equivalent block in `scripts/install.sh`). That re-sign is needed so the rebuilt bundle can relaunch, but an ad-hoc signature's Designated Requirement is just the cdhash of that exact build:

```
designated => cdhash H"51bf8c33034c1923b14ebb53a478e535e28af54b"
```

macOS TCC ties permission grants to the DR, so each rebuild = new cdhash = new identity = all grants silently dropped.

## Fix

Both re-sign sites now prefer a self-signed codesigning cert named **"Hermes Local Signing"** from the login keychain when the user has created one. A cert-based signature has a stable identifier+certificate DR:

```
designated => identifier "com.nousresearch.hermes" and certificate leaf = H"affe..."
```

which survives rebuilds, so TCC grants persist. Verified on macOS 26.5: signed with the local cert, `codesign --verify --deep --strict` passes, and the DR stays stable across re-signs.

- Opt-in and fully backwards compatible: no cert in the keychain means the exact same ad-hoc behavior as today.
- `CSC_LINK` / `APPLE_SIGNING_IDENTITY` short-circuit exactly as before, a real notarized build is never touched.
- Probe extracted into `_stable_local_signing_identity()` with unit tests (keychain hit, miss, and `security` binary missing).

Users opt in with a one-time cert creation (could later be offered by `hermes doctor --fix`, kept out of scope here):

```bash
openssl req -new -x509 -days 3650 -nodes -newkey rsa:2048 \
  -keyout hermes-sign.key -out hermes-sign.pem \
  -subj "/CN=Developer ID Application: Hermes Local Signing" \
  -addext "keyUsage=critical,digitalSignature" \
  -addext "extendedKeyUsage=critical,codeSigning" \
  -addext "basicConstraints=critical,CA:false"
openssl pkcs12 -export -legacy -out hermes-sign.p12 -inkey hermes-sign.key -in hermes-sign.pem -passout pass:PW -name "Hermes Local Signing"
security import hermes-sign.p12 -k ~/Library/Keychains/login.keychain-db -P PW -T /usr/bin/codesign
security add-trusted-cert -p codeSign -k ~/Library/Keychains/login.keychain-db hermes-sign.pem
```

## Tests

`pytest tests/hermes_cli/test_gui_command.py -k 'signing or adhoc'` : 9 passed (7 existing + 2 new).