### PR TITLE
fix(email): connect reliably on very large mailboxes

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -46,6 +46,18 @@ from gateway.config import Platform, PlatformConfig
 from utils import env_int, env_bool
 
 logger = logging.getLogger(__name__)
+
+# imaplib caps a single IMAP *response line* at ``_MAXLINE`` (1 MB by default).
+# ``UID SEARCH ALL`` / ``UID SEARCH UNSEEN`` return every matching UID on one
+# space-separated line; on a large mailbox that line exceeds 1 MB and imaplib
+# raises "command: UID => got more than 1000000 bytes". That fires inside
+# connect(), which then returns False and wedges the platform in an endless
+# reconnect loop (observed on a 420k-message Gmail INBOX → ~2.8 MB UID line).
+# Raise the cap so large mailboxes work. Message bodies are read as IMAP
+# literals, not lines, so they are unaffected by this limit.
+if getattr(imaplib, "_MAXLINE", 0) < 100_000_000:
+    imaplib._MAXLINE = 100_000_000
+
 # Automated sender patterns — emails from these are silently ignored
 _NOREPLY_PATTERNS = (
     "noreply", "no-reply", "no_reply", "donotreply", "do-not-reply",
@@ -585,13 +597,33 @@ class EmailAdapter(BasePlatformAdapter):
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
             imap.login(self._address, self._password)
             _send_imap_id(imap)
-            # Mark all existing messages as seen so we only process new ones
-            imap.select("INBOX")
-            status, data = imap.uid("search", None, "ALL")
-            if status == "OK" and data and data[0]:
-                for uid in data[0].split():
-                    self._seen_uids.add(uid)
-            # Keep only the most recent UIDs to prevent unbounded growth
+            # Seed the seen-UID set with the most recent messages so we only
+            # dispatch genuinely new mail. We fetch just the most recent
+            # ``_seen_uids_max`` UIDs by *sequence number* rather than issuing
+            # ``UID SEARCH ALL``: on a large INBOX the latter returns every UID
+            # on one multi-MB line (a 420k-message Gmail INBOX → ~2.8 MB) which
+            # is wasteful and can overflow imaplib's line cap — and we only keep
+            # the recent slice anyway. Sequence numbers are position-ordered, so
+            # ``lo:count`` is exactly the newest ``_seen_uids_max`` messages.
+            sel_status, sel_data = imap.select("INBOX")
+            count = 0
+            if sel_status == "OK" and sel_data and sel_data[0]:
+                try:
+                    count = int(sel_data[0])
+                except (ValueError, TypeError):
+                    count = 0
+            if count > 0:
+                lo = max(1, count - self._seen_uids_max + 1)
+                fetch_status, fetch_data = imap.fetch(f"{lo}:{count}", "(UID)")
+                if fetch_status == "OK" and fetch_data:
+                    for item in fetch_data:
+                        raw = item[0] if isinstance(item, tuple) else item
+                        if not isinstance(raw, (bytes, bytearray)):
+                            continue
+                        m = re.search(rb"UID (\d+)", raw)
+                        if m:
+                            self._seen_uids.add(m.group(1))
+            # Defensive: keep memory bounded even if the server over-returns.
             self._trim_seen_uids()
             imap.logout()
             logger.info("[Email] IMAP connection test passed. %d existing messages skipped.", len(self._seen_uids))

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -447,6 +447,31 @@ class TestSendMethods(unittest.TestCase):
         self.assertEqual(info["subject"], "Test")
 
 
+def _configure_seed_imap(mock_imap, *, count, uids=()):
+    """Configure a mock IMAP connection for connect()'s seen-UID seeding.
+
+    connect() seeds ``_seen_uids`` by SELECTing INBOX (whose response carries
+    the message count) and then FETCHing the most recent ``_seen_uids_max``
+    *sequence numbers* to read their UIDs — it deliberately does not issue
+    ``UID SEARCH ALL``, which returns every UID on one multi-MB line.
+
+    ``count`` is the mailbox size reported by SELECT; ``uids`` are the UIDs the
+    FETCH should report, numbered from the start of the fetched range.
+    """
+    mock_imap.select.return_value = ("OK", [str(count).encode()])
+    start = max(1, count - len(uids) + 1) if uids else 1
+    mock_imap.fetch.return_value = (
+        "OK",
+        [b"%d (UID %s)" % (start + i, u) for i, u in enumerate(uids)],
+    )
+    # Also answer UID SEARCH the way a real server would. connect() must not
+    # use it, but serving it keeps the "no UID SEARCH ALL" assertions honest:
+    # a regression back to the search path fails on that assertion rather than
+    # on an unconfigured-mock error.
+    mock_imap.uid.return_value = ("OK", [b" ".join(uids)])
+    return mock_imap
+
+
 class TestConnectDisconnect(unittest.TestCase):
     """Test IMAP/SMTP connection lifecycle."""
 
@@ -468,7 +493,7 @@ class TestConnectDisconnect(unittest.TestCase):
         adapter = self._make_adapter()
 
         mock_imap = MagicMock()
-        mock_imap.uid.return_value = ("OK", [b"1 2 3"])
+        _configure_seed_imap(mock_imap, count=3, uids=(b"101", b"102", b"103"))
 
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
              patch("smtplib.SMTP") as mock_smtp:
@@ -479,12 +504,113 @@ class TestConnectDisconnect(unittest.TestCase):
 
             self.assertTrue(result)
             self.assertTrue(adapter._running)
-            # Should have skipped existing messages
-            self.assertEqual(len(adapter._seen_uids), 3)
+            # Existing messages are seeded as "seen" so they are not dispatched.
+            self.assertEqual(adapter._seen_uids, {b"101", b"102", b"103"})
             # Cleanup
             adapter._running = False
             if adapter._poll_task:
                 adapter._poll_task.cancel()
+
+    def test_connect_seeds_only_recent_window_on_large_mailbox(self):
+        """A mailbox larger than _seen_uids_max seeds via a bounded FETCH range.
+
+        Regression test for the endless reconnect loop on large INBOXes:
+        ``UID SEARCH ALL`` returned every UID on a single line, overflowing
+        imaplib's 1 MB ``_MAXLINE`` cap (a 423k-message Gmail INBOX produced a
+        ~2.8 MB line) and aborting connect(). connect() must instead FETCH only
+        the newest ``_seen_uids_max`` sequence numbers.
+        """
+        import asyncio
+        adapter = self._make_adapter()
+
+        count = 423832
+        window = adapter._seen_uids_max
+        seeded = tuple(str(431000 + i).encode() for i in range(window))
+
+        mock_imap = MagicMock()
+        _configure_seed_imap(mock_imap, count=count, uids=seeded)
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+
+            result = asyncio.run(adapter.connect())
+
+            self.assertTrue(result)
+            adapter._running = False
+            if adapter._poll_task:
+                adapter._poll_task.cancel()
+
+        # The bounded range covers exactly the newest _seen_uids_max messages.
+        expected_lo = count - window + 1
+        mock_imap.fetch.assert_called_once_with(f"{expected_lo}:{count}", "(UID)")
+
+        # And the unbounded whole-mailbox search must not be issued at all.
+        search_all_calls = [
+            c for c in mock_imap.uid.call_args_list
+            if c.args and c.args[0] == "search" and "ALL" in c.args
+        ]
+        self.assertEqual(
+            search_all_calls, [],
+            "connect() must not issue UID SEARCH ALL — on a large mailbox its "
+            "single-line response overflows imaplib._MAXLINE and wedges the "
+            "platform in a reconnect loop.",
+        )
+        self.assertEqual(len(adapter._seen_uids), window)
+
+    def test_connect_seeds_whole_small_mailbox_from_first_message(self):
+        """A mailbox smaller than _seen_uids_max is fetched from sequence 1."""
+        import asyncio
+        adapter = self._make_adapter()
+
+        mock_imap = MagicMock()
+        _configure_seed_imap(mock_imap, count=5, uids=(b"1", b"2", b"3", b"4", b"5"))
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+            result = asyncio.run(adapter.connect())
+            self.assertTrue(result)
+            adapter._running = False
+            if adapter._poll_task:
+                adapter._poll_task.cancel()
+
+        # lo clamps to 1 rather than going negative.
+        mock_imap.fetch.assert_called_once_with("1:5", "(UID)")
+
+    def test_connect_empty_mailbox_skips_fetch(self):
+        """An empty INBOX seeds nothing and issues no FETCH."""
+        import asyncio
+        adapter = self._make_adapter()
+
+        mock_imap = MagicMock()
+        _configure_seed_imap(mock_imap, count=0)
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+            result = asyncio.run(adapter.connect())
+            self.assertTrue(result)
+            adapter._running = False
+            if adapter._poll_task:
+                adapter._poll_task.cancel()
+
+        mock_imap.fetch.assert_not_called()
+        self.assertEqual(adapter._seen_uids, set())
+
+    def test_connect_smtp_failure(self):
+        """SMTP connection failure returns False."""
+        import asyncio
+        adapter = self._make_adapter()
+
+        mock_imap = MagicMock()
+        # IMAP must genuinely succeed so the failure under test is SMTP's.
+        _configure_seed_imap(mock_imap, count=0)
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP", side_effect=Exception("SMTP down")):
+            result = asyncio.run(adapter.connect())
+            self.assertFalse(result)
 
 
 class TestFetchNewMessages(unittest.TestCase):
@@ -724,7 +850,8 @@ class TestImapIdExtensionForNetEase(unittest.TestCase):
         adapter = self._make_adapter()
 
         mock_imap = MagicMock()
-        mock_imap.uid.return_value = ("OK", [b""])
+        # Let the IMAP phase run to completion so ordering is exercised fully.
+        _configure_seed_imap(mock_imap, count=0)
 
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
              patch("smtplib.SMTP") as mock_smtp:

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -658,6 +658,110 @@ class TestFetchNewMessages(unittest.TestCase):
         self.assertIn(b"3", adapter._seen_uids)
 
 
+class TestSeedDeliveryNeutrality(unittest.TestCase):
+    """The bounded connect() seed must not change delivery.
+
+    Addresses the message-delivery risk of switching connect() from
+    ``UID SEARCH ALL`` to a bounded ``FETCH`` window: the seed exists purely to
+    mark pre-existing mail as already-seen so it is not re-dispatched as "new".
+    Delivery must stay neutral in both directions —
+
+      * no *suppression*: mail arriving after connect is still delivered;
+      * no *duplication / re-delivery*: mail that existed at connect and was
+        seeded is not dispatched on a later poll.
+
+    Both properties hold because the poll dispatches exactly
+    ``UNSEEN ∧ uid ∉ _seen_uids``, and the bounded seed populates the highest
+    (most recent) UIDs — a superset of what the old trimmed ``SEARCH ALL``
+    retained (``_seen_uids_max`` vs ``_seen_uids_max // 2``), never a subset.
+    """
+
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }):
+            from plugins.platforms.email.adapter import EmailAdapter
+            return EmailAdapter(PlatformConfig(enabled=True))
+
+    def test_seeded_message_not_redispatched_but_new_mail_is(self):
+        import asyncio
+        adapter = self._make_adapter()
+
+        # --- connect(): a 3-message inbox; the seed marks all three seen ---
+        seed_imap = MagicMock()
+        _configure_seed_imap(seed_imap, count=3, uids=(b"101", b"102", b"103"))
+        with patch("imaplib.IMAP4_SSL", return_value=seed_imap), \
+             patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+            self.assertTrue(asyncio.run(adapter.connect()))
+            adapter._running = False
+            if adapter._poll_task:
+                adapter._poll_task.cancel()
+        self.assertEqual(adapter._seen_uids, {b"101", b"102", b"103"})
+
+        # --- a new message (UID 104) arrives; 103 is still UNSEEN server-side ---
+        new_mail = MIMEText("fresh", "plain", "utf-8")
+        new_mail["From"] = "sender@test.com"
+        new_mail["Subject"] = "New"
+        new_mail["Message-ID"] = "<104@test.com>"
+
+        poll_imap = MagicMock()
+
+        def uid_handler(command, *args):
+            if command == "search":            # UNSEEN returns a seeded one + the new one
+                return ("OK", [b"103 104"])
+            if command == "fetch":
+                return ("OK", [(args[0], new_mail.as_bytes())])
+            return ("NO", [])
+
+        poll_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=poll_imap):
+            results = adapter._fetch_new_messages()
+
+        # 103 was seeded at connect → not re-delivered (no duplicate).
+        # 104 is genuinely new → delivered (no suppression).
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["message_id"], "<104@test.com>")
+        self.assertIn(b"104", adapter._seen_uids)
+
+    def test_bounded_seed_covers_at_least_the_old_trimmed_window(self):
+        """The recent-window seed is a superset of the old trimmed SEARCH ALL.
+
+        Old path: SEARCH ALL then _trim_seen_uids() → the top ``_seen_uids_max
+        // 2`` UIDs survive. New path seeds the most recent ``_seen_uids_max``.
+        Any UID the old path would have suppressed, the new path also seeds, so
+        the change cannot newly re-dispatch a recent message.
+        """
+        adapter = self._make_adapter()
+        cap = adapter._seen_uids_max
+        count = cap * 3  # mailbox far larger than the window
+
+        seed_imap = MagicMock()
+        seeded = tuple(str(500_000 + i).encode() for i in range(cap))
+        _configure_seed_imap(seed_imap, count=count, uids=seeded)
+        import asyncio
+        with patch("imaplib.IMAP4_SSL", return_value=seed_imap), \
+             patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+            self.assertTrue(asyncio.run(adapter.connect()))
+            adapter._running = False
+            if adapter._poll_task:
+                adapter._poll_task.cancel()
+
+        new_seed = adapter._seen_uids
+        old_trimmed = set(sorted(seeded, key=int)[-(cap // 2):])  # what SEARCH ALL+trim kept
+        self.assertTrue(
+            old_trimmed.issubset(new_seed),
+            "new bounded seed must cover every UID the old trimmed path retained",
+        )
+        self.assertGreaterEqual(len(new_seed), len(old_trimmed))
+
+
 class TestPollLoop(unittest.TestCase):
     """Test the async polling loop."""
 


### PR DESCRIPTION
## Problem

The email platform could not connect for accounts with a very large INBOX and
got stuck in an endless reconnect loop. `connect()` seeds its seen-UID set with
`UID SEARCH ALL`, which returns every UID on a single space-separated line.
Python's `imaplib` caps a response line at `_MAXLINE` (1 MB), so a large mailbox
overflows it and raises:

```
[Email] IMAP connection failed: command: UID => got more than 1000000 bytes
```

The exception aborts `connect()`, which returns `False`, so the platform never
comes up and retries forever. Reproduced against a live account: a
**423,832-message Gmail INBOX** yields a ~2.8 MB UID line.

## Fix

- **Seed from the most recent `_seen_uids_max` messages by *sequence number***
  (`FETCH lo:count (UID)`) instead of `UID SEARCH ALL`. The adapter only keeps
  the recent slice anyway, so there's no reason to download 420k UIDs (~2.8 MB)
  to retain 2000. The bounded fetch is ~38 KB and ~0.1 s.
- **Raise `imaplib._MAXLINE` to 100 MB** as defense-in-depth for the poll
  path's `UID SEARCH UNSEEN` (unbounded by nature). Message bodies are read as
  IMAP literals and are unaffected by this limit.

## Verification

Against the live 423k-message account, the platform now connects cleanly:

```
[Email] IMAP connection test passed. 2000 existing messages skipped.
[Email] SMTP connection test passed.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)