### PR TITLE
fix(context): revalidate compression state under session lock (salvages #64511)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1593,6 +1593,16 @@ class ContextCompressor(ContextEngine):
         # and re-evaluate so a stale local block cannot outlive the durable
         # state that justified it. The unblocked hot path above never pays
         # for the DB reads.
+        if (
+            self._summary_failure_cooldown_until <= time.monotonic()
+            and self._fallback_compression_streak < 2
+        ):
+            # Blocked solely by the in-memory ineffective-compression
+            # counter, which is not durable — there is nothing in the DB
+            # that could unblock it, so skip the refresh (otherwise this
+            # branch would re-read the DB on every gate check for the rest
+            # of the session).
+            return True
         self._refresh_durable_guards()
         return self._automatic_compression_blocked_locally()
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -889,6 +889,7 @@ class ContextCompressor(ContextEngine):
         self._verify_compaction_cleared_threshold = False
         self._last_compression_made_progress = False
         self._summary_failure_cooldown_until = 0.0  # transient errors must not block a fresh session
+        self._cooldown_persist_failed = False
         self._last_summary_error = None
         self._last_compress_aborted = False
         self.last_real_prompt_tokens = 0
@@ -928,6 +929,7 @@ class ContextCompressor(ContextEngine):
         self._verify_compaction_cleared_threshold = False
         self._last_compression_made_progress = False
         self._summary_failure_cooldown_until = 0.0
+        self._cooldown_persist_failed = False
         self._last_compress_aborted = False
         self._context_probed = False
         self._context_probe_persistable = False
@@ -941,6 +943,7 @@ class ContextCompressor(ContextEngine):
         self._session_db = session_db
         self._session_id = session_id or ""
         self._summary_failure_cooldown_until = 0.0
+        self._cooldown_persist_failed = False
         self._last_summary_error = None
         self._consecutive_timeout_failures = 0
         self._fallback_compression_streak = 0
@@ -1058,6 +1061,14 @@ class ContextCompressor(ContextEngine):
             return local_state
         if not state:
             if refresh:
+                if local_state is not None and self._cooldown_persist_failed:
+                    # The live local cooldown never made it to the DB (persist
+                    # failed), so the empty row is not evidence that another
+                    # agent cleared it. Honouring the DB here would re-enable
+                    # auto-compress mid-cooldown and reopen the #11529 thrash
+                    # window. Keep the local timer authoritative until it
+                    # expires or a successful DB read supersedes it.
+                    return local_state
                 self._summary_failure_cooldown_until = 0.0
                 self._last_summary_error = None
             return None
@@ -1065,12 +1076,15 @@ class ContextCompressor(ContextEngine):
         remaining_seconds = float(state.get("remaining_seconds") or 0.0)
         if remaining_seconds <= 0:
             if refresh:
+                if local_state is not None and self._cooldown_persist_failed:
+                    return local_state
                 self._summary_failure_cooldown_until = 0.0
                 self._last_summary_error = None
             return None
 
         self._summary_failure_cooldown_until = now_mono + remaining_seconds
         self._last_summary_error = state.get("error")
+        self._cooldown_persist_failed = False
         return {
             "cooldown_until": float(state.get("cooldown_until") or 0.0),
             "remaining_seconds": remaining_seconds,
@@ -1093,18 +1107,23 @@ class ContextCompressor(ContextEngine):
 
         recorder = getattr(session_db, "record_compression_failure_cooldown", None)
         if recorder is None:
+            self._cooldown_persist_failed = True
             return
         try:
             recorder(session_id, cooldown_until, error)
+            self._cooldown_persist_failed = False
         except sqlite3.Error as exc:
+            self._cooldown_persist_failed = True
             logger.debug("compression failure cooldown persist failed: %s", exc)
         except Exception as exc:
+            self._cooldown_persist_failed = True
             logger.debug("compression failure cooldown persist failed (non-sqlite): %s", exc)
 
     def _clear_compression_failure_cooldown(self) -> None:
         self._summary_failure_cooldown_until = 0.0
         self._last_summary_error = None
         self._consecutive_timeout_failures = 0
+        self._cooldown_persist_failed = False
 
         session_db = getattr(self, "_session_db", None)
         session_id = getattr(self, "_session_id", "")
@@ -1398,6 +1417,10 @@ class ContextCompressor(ContextEngine):
         # no-op/abort without inferring progress from message-list length.
         self._last_compression_made_progress: bool = False
         self._summary_failure_cooldown_until: float = 0.0
+        # True while the live local cooldown failed to persist to the DB;
+        # a refresh must then treat an empty durable row as unknown, not
+        # cleared (see get_active_compression_failure_cooldown).
+        self._cooldown_persist_failed: bool = False
         self._last_summary_error: Optional[str] = None
         # When summary generation fails and a static fallback is inserted,
         # record how many turns were unrecoverably dropped so callers
@@ -1543,8 +1566,38 @@ class ContextCompressor(ContextEngine):
             return False
         return not self._automatic_compression_blocked()
 
+    def _refresh_durable_guards(self) -> None:
+        """Re-read durable cooldown + fallback-streak state from the DB.
+
+        Cheap, best-effort, and only called when a gate is about to say
+        "blocked": another agent on the same session may have cleared the
+        durable rows (successful boundary, forced retry) after this
+        compressor was bound, and a fallback streak has no timer — without
+        a re-read the stale in-memory snapshot blocks forever.
+        """
+        try:
+            self.get_active_compression_failure_cooldown(refresh=True)
+        except Exception as exc:
+            logger.debug("compression cooldown refresh failed: %s", exc)
+        try:
+            self._load_fallback_compression_streak()
+        except Exception as exc:
+            logger.debug("compression fallback-streak refresh failed: %s", exc)
+
     def _automatic_compression_blocked(self) -> bool:
         """Return whether automatic compaction is in cooldown or tripped."""
+        if not self._automatic_compression_blocked_locally():
+            return False
+        # Blocked on the in-memory snapshot. Durable guard rows may have
+        # been cleared by another agent since bind_session_state(); refresh
+        # and re-evaluate so a stale local block cannot outlive the durable
+        # state that justified it. The unblocked hot path above never pays
+        # for the DB reads.
+        self._refresh_durable_guards()
+        return self._automatic_compression_blocked_locally()
+
+    def _automatic_compression_blocked_locally(self) -> bool:
+        """Evaluate the automatic-compaction gate on in-memory state only."""
         # Do not trigger compression while the summary LLM is in cooldown.
         # On a 429/transient failure _generate_summary() sets a cooldown and
         # returns None; compress() then inserts a static fallback marker and

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1022,38 +1022,51 @@ class ContextCompressor(ContextEngine):
             self._fallback_compression_streak = 0
         self._persist_fallback_compression_streak()
 
-    def get_active_compression_failure_cooldown(self) -> Optional[Dict[str, Any]]:
+    def get_active_compression_failure_cooldown(
+        self,
+        *,
+        refresh: bool = False,
+    ) -> Optional[Dict[str, Any]]:
         """Return the live compression-failure cooldown for the bound session."""
         now_mono = time.monotonic()
+        local_state = None
         if self._summary_failure_cooldown_until > now_mono:
-            return {
+            local_state = {
                 "cooldown_until": time.time() + (
                     self._summary_failure_cooldown_until - now_mono
                 ),
                 "remaining_seconds": self._summary_failure_cooldown_until - now_mono,
                 "error": self._last_summary_error,
             }
+            if not refresh:
+                return local_state
 
         session_db = getattr(self, "_session_db", None)
         session_id = getattr(self, "_session_id", "")
         if not session_db or not session_id:
-            return None
+            return local_state
 
         getter = getattr(session_db, "get_compression_failure_cooldown", None)
         if getter is None:
-            return None
+            return local_state
         try:
             state = getter(session_id)
         except sqlite3.Error as exc:
             logger.debug("compression failure cooldown lookup failed: %s", exc)
-            return None
+            return local_state
         except Exception:
-            return None
+            return local_state
         if not state:
+            if refresh:
+                self._summary_failure_cooldown_until = 0.0
+                self._last_summary_error = None
             return None
 
         remaining_seconds = float(state.get("remaining_seconds") or 0.0)
         if remaining_seconds <= 0:
+            if refresh:
+                self._summary_failure_cooldown_until = 0.0
+                self._last_summary_error = None
             return None
 
         self._summary_failure_cooldown_until = now_mono + remaining_seconds

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -76,6 +76,35 @@ def _lock_api_is_absent_on_session_db(lock_db: Any) -> bool:
         return False
 
 
+def _refresh_persisted_compression_guards(compressor: Any) -> None:
+    """Refresh durable automatic-compression guards on a built-in compressor."""
+    method_calls = (
+        ("get_active_compression_failure_cooldown", {"refresh": True}),
+        ("_load_fallback_compression_streak", {}),
+    )
+    for method_name, kwargs in method_calls:
+        method = getattr(type(compressor), method_name, None)
+        if not callable(method):
+            continue
+        try:
+            method(compressor, **kwargs)
+        except Exception as exc:
+            logger.debug("compression guard refresh failed (%s): %s", method_name, exc)
+
+
+def _session_was_rotated_by_compression(session_db: Any, session_id: str) -> bool:
+    """Return whether another path already rotated this compression parent."""
+    getter = getattr(type(session_db), "get_session", None)
+    if not callable(getter):
+        return False
+    session = getter(session_db, session_id)
+    return bool(
+        session
+        and session.get("ended_at") is not None
+        and session.get("end_reason") == "compression"
+    )
+
+
 def _compression_lock_holder(agent: Any) -> str:
     """Build a unique holder id for the lock: pid:tid:agent-instance:uuid.
 
@@ -612,6 +641,7 @@ def compress_context(
     # breaker state. Gateway hygiene constructs a fresh AIAgent, so the
     # persisted fallback streak is loaded by bind_session_state() before this.
     if not force:
+        _refresh_persisted_compression_guards(agent.context_compressor)
         blocked = getattr(
             type(agent.context_compressor),
             "_automatic_compression_blocked",
@@ -813,6 +843,58 @@ def compress_context(
                 _lock_db.release_compression_lock(_lock_sid, _lock_holder)
             except Exception as _rel_err:
                 logger.debug("compression lock release failed: %s", _rel_err)
+
+    # A delayed contender can acquire the parent lock after the winning path
+    # has released it and completed rotation. The lock serializes work but does
+    # not by itself prove that this stale agent still owns a live parent.
+    if _lock_db is not None and _lock_sid:
+        try:
+            _parent_already_rotated = _session_was_rotated_by_compression(
+                _lock_db, _lock_sid
+            )
+        except Exception as _session_err:
+            logger.warning(
+                "compression session ownership lookup failed for session=%s "
+                "(%s: %s) - skipping compression this cycle",
+                _lock_sid,
+                type(_session_err).__name__,
+                _session_err,
+            )
+            _release_lock()
+            _existing_sp = getattr(agent, "_cached_system_prompt", None)
+            if not _existing_sp:
+                _existing_sp = agent._build_system_prompt(system_message)
+            return messages, _existing_sp
+        if _parent_already_rotated:
+            logger.info(
+                "compression skipped: session=%s was already rotated by "
+                "another compression path",
+                _lock_sid,
+            )
+            _release_lock()
+            _existing_sp = getattr(agent, "_cached_system_prompt", None)
+            if not _existing_sp:
+                _existing_sp = agent._build_system_prompt(system_message)
+            return messages, _existing_sp
+
+    # The agent may have been constructed before another path completed an
+    # in-place compaction on the same session. Re-read durable breaker state
+    # after acquiring the session lock so this final gate cannot act on the
+    # stale snapshot loaded by bind_session_state().
+    if not force:
+        compressor = agent.context_compressor
+        _refresh_persisted_compression_guards(compressor)
+        blocked = getattr(
+            type(compressor),
+            "_automatic_compression_blocked",
+            None,
+        )
+        if callable(blocked) and blocked(compressor):
+            _release_lock()
+            existing_prompt = getattr(agent, "_cached_system_prompt", None)
+            if not existing_prompt:
+                existing_prompt = agent._build_system_prompt(system_message)
+            return messages, existing_prompt
 
     # Notify external memory provider before compression discards context
     if agent._memory_manager:

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -577,3 +577,22 @@ class TestCooldownPersistFailureIsNotAClearedRow:
         db.clear_compression_failure_cooldown(session_id)
         assert compressor.get_active_compression_failure_cooldown(refresh=True) is None
         assert compressor._summary_failure_cooldown_until == 0.0
+
+    def test_ineffective_count_only_block_skips_durable_refresh(
+        self,
+        refresh_state_db: SessionDB,
+    ):
+        """A block owed solely to the in-memory ineffective counter (which is
+        not durable) must not re-read the DB on every gate check."""
+        db = refresh_state_db
+        session_id = "INEFFECTIVE_ONLY_BLOCK"
+        db.create_session(session_id, source="telegram")
+        compressor = _bound_context_compressor(db, session_id)
+        compressor._ineffective_compression_count = 2
+
+        with patch.object(
+            compressor,
+            "_refresh_durable_guards",
+            side_effect=AssertionError("nothing durable to refresh"),
+        ):
+            assert compressor._automatic_compression_blocked() is True

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -18,8 +18,11 @@ These tests drive the real ``compress_context`` path against a real SessionDB.
 from __future__ import annotations
 
 import os
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from agent.context_compressor import ContextCompressor
 from hermes_state import SessionDB
@@ -63,6 +66,31 @@ def _build_agent_with_db(db: SessionDB, session_id: str, platform: str = "telegr
 
 def _msgs(n=20):
     return [{"role": "user", "content": f"m{i}"} for i in range(n)]
+
+
+def _bound_context_compressor(db: SessionDB, session_id: str) -> ContextCompressor:
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=100_000,
+    ):
+        compressor = ContextCompressor(
+            model="test/model",
+            threshold_percent=0.85,
+            protect_first_n=2,
+            protect_last_n=2,
+            quiet_mode=True,
+        )
+    compressor.bind_session_state(db, session_id)
+    return compressor
+
+
+@pytest.fixture
+def refresh_state_db(tmp_path: Path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        yield db
+    finally:
+        db.close()
 
 
 class TestGoalMigratesOnRotation:
@@ -224,3 +252,245 @@ class TestFallbackStreakFollowsRotation:
         assert child != parent
         assert compressor._fallback_compression_streak == 1
         assert db.get_compression_fallback_streak(child) == 1
+
+
+class TestAutomaticCompressionStateRefreshAfterLock:
+    def test_prebound_agent_rejects_parent_rotated_before_lock_acquisition(
+        self,
+        refresh_state_db: SessionDB,
+    ):
+        db = refresh_state_db
+        parent_id = "STALE_ROTATED_PARENT"
+        child_id = "CANONICAL_COMPRESSION_CHILD"
+        db.create_session(parent_id, source="telegram")
+        agent = _build_agent_with_db(db, parent_id, platform="telegram")
+        compressor = _bound_context_compressor(db, parent_id)
+
+        # A competing path completes rotation after this call's initial checks
+        # but before it acquires the parent lock.
+        real_acquire = db.try_acquire_compression_lock
+
+        def _acquire_after_rotation(*args, **kwargs):
+            db.end_session(parent_id, "compression")
+            db.create_session(
+                child_id,
+                source="telegram",
+                parent_session_id=parent_id,
+            )
+            return real_acquire(*args, **kwargs)
+
+        db.try_acquire_compression_lock = _acquire_after_rotation
+        agent.context_compressor = compressor
+        agent.compression_in_place = False
+        agent._compression_feasibility_checked = True
+        messages = _msgs()
+
+        with patch.object(
+            compressor,
+            "compress",
+            side_effect=AssertionError("stale parent was compressed again"),
+        ) as compress:
+            returned, _ = agent._compress_context(
+                messages,
+                "sys",
+                approx_tokens=120_000,
+                force=True,
+            )
+
+        children = db._conn.execute(
+            "SELECT id FROM sessions WHERE parent_session_id = ?",
+            (parent_id,),
+        ).fetchall()
+        assert returned is messages
+        assert agent.session_id == parent_id
+        assert [row["id"] for row in children] == [child_id]
+        compress.assert_not_called()
+        assert db.get_compression_lock_holder(parent_id) is None
+
+    def test_prebound_agent_reloads_persisted_streak_before_compressing(
+        self,
+        refresh_state_db: SessionDB,
+    ):
+        db = refresh_state_db
+        session_id = "STALE_FALLBACK_BREAKER"
+        db.create_session(session_id, source="telegram")
+        db.set_compression_fallback_streak(session_id, 1)
+        agent = _build_agent_with_db(db, session_id, platform="telegram")
+        compressor = _bound_context_compressor(db, session_id)
+        assert compressor._fallback_compression_streak == 1
+
+        # A second agent finishes an in-place fallback boundary after this
+        # call's initial gate but while it is acquiring the session lock.
+        real_acquire = db.try_acquire_compression_lock
+
+        def _acquire_after_fallback(*args, **kwargs):
+            db.set_compression_fallback_streak(session_id, 2)
+            return real_acquire(*args, **kwargs)
+
+        db.try_acquire_compression_lock = _acquire_after_fallback
+        agent.context_compressor = compressor
+        agent.compression_in_place = True
+        agent._compression_feasibility_checked = True
+        messages = _msgs()
+
+        with patch.object(
+            compressor,
+            "compress",
+            side_effect=AssertionError("stale agent bypassed fallback breaker"),
+        ) as compress:
+            returned, _ = agent._compress_context(
+                messages,
+                "sys",
+                approx_tokens=120_000,
+            )
+
+        assert returned is messages
+        assert compressor._fallback_compression_streak == 2
+        compress.assert_not_called()
+        assert db.get_compression_lock_holder(session_id) is None
+
+    def test_prebound_agent_reloads_persisted_cooldown_before_compressing(
+        self,
+        refresh_state_db: SessionDB,
+    ):
+        db = refresh_state_db
+        session_id = "STALE_COMPRESSION_COOLDOWN"
+        db.create_session(session_id, source="telegram")
+        agent = _build_agent_with_db(db, session_id, platform="telegram")
+        compressor = _bound_context_compressor(db, session_id)
+        assert compressor.get_active_compression_failure_cooldown() is None
+
+        # Another agent records a provider cooldown after this call's initial
+        # gate but while it is acquiring the session lock.
+        real_acquire = db.try_acquire_compression_lock
+
+        def _acquire_after_cooldown(*args, **kwargs):
+            db.record_compression_failure_cooldown(
+                session_id,
+                time.time() + 60,
+                "rate limited",
+            )
+            return real_acquire(*args, **kwargs)
+
+        db.try_acquire_compression_lock = _acquire_after_cooldown
+        agent.context_compressor = compressor
+        agent.compression_in_place = True
+        agent._compression_feasibility_checked = True
+        messages = _msgs()
+
+        with patch.object(
+            compressor,
+            "compress",
+            side_effect=AssertionError("stale agent bypassed compression cooldown"),
+        ) as compress:
+            returned, _ = agent._compress_context(
+                messages,
+                "sys",
+                approx_tokens=120_000,
+            )
+
+        assert returned is messages
+        assert compressor.get_active_compression_failure_cooldown() is not None
+        compress.assert_not_called()
+        assert db.get_compression_lock_holder(session_id) is None
+
+    def test_prebound_agent_drops_stale_blocker_before_initial_gate(
+        self,
+        refresh_state_db: SessionDB,
+    ):
+        db = refresh_state_db
+        session_id = "CLEARED_FALLBACK_BREAKER"
+        db.create_session(session_id, source="telegram")
+        db.set_compression_fallback_streak(session_id, 2)
+        agent = _build_agent_with_db(db, session_id, platform="telegram")
+        compressor = _bound_context_compressor(db, session_id)
+        assert compressor._fallback_compression_streak == 2
+
+        # A healthy boundary on another agent clears the durable breaker after
+        # this compressor was bound. The initial gate must not remain stuck on
+        # its stale in-memory snapshot.
+        db.set_compression_fallback_streak(session_id, 0)
+        agent.context_compressor = compressor
+        agent.compression_in_place = True
+        agent._compression_feasibility_checked = True
+        messages = _msgs()
+
+        with patch.object(compressor, "compress", return_value=messages) as compress:
+            returned, _ = agent._compress_context(
+                messages,
+                "sys",
+                approx_tokens=120_000,
+            )
+
+        assert returned is messages
+        assert compressor._fallback_compression_streak == 0
+        compress.assert_called_once()
+        assert db.get_compression_lock_holder(session_id) is None
+
+    def test_prebound_agent_drops_stale_cooldown_before_initial_gate(
+        self,
+        refresh_state_db: SessionDB,
+    ):
+        db = refresh_state_db
+        session_id = "CLEARED_COMPRESSION_COOLDOWN"
+        db.create_session(session_id, source="telegram")
+        db.record_compression_failure_cooldown(
+            session_id,
+            time.time() + 60,
+            "rate limited",
+        )
+        agent = _build_agent_with_db(db, session_id, platform="telegram")
+        compressor = _bound_context_compressor(db, session_id)
+        assert compressor.get_active_compression_failure_cooldown() is not None
+
+        # A successful forced retry on another agent clears the durable row.
+        # This prebound compressor must not keep honoring its stale local timer.
+        db.clear_compression_failure_cooldown(session_id)
+        agent.context_compressor = compressor
+        agent.compression_in_place = True
+        agent._compression_feasibility_checked = True
+        messages = _msgs()
+
+        with patch.object(compressor, "compress", return_value=messages) as compress:
+            returned, _ = agent._compress_context(
+                messages,
+                "sys",
+                approx_tokens=120_000,
+            )
+
+        assert returned is messages
+        assert compressor.get_active_compression_failure_cooldown() is None
+        compress.assert_called_once()
+        assert db.get_compression_lock_holder(session_id) is None
+
+    def test_force_still_bypasses_refreshed_persisted_breaker(
+        self,
+        refresh_state_db: SessionDB,
+    ):
+        db = refresh_state_db
+        session_id = "FORCED_FALLBACK_RETRY"
+        db.create_session(session_id, source="telegram")
+        db.set_compression_fallback_streak(session_id, 2)
+        agent = _build_agent_with_db(db, session_id, platform="telegram")
+        compressor = _bound_context_compressor(db, session_id)
+        agent.context_compressor = compressor
+        agent.compression_in_place = True
+        agent._compression_feasibility_checked = True
+        messages = _msgs()
+
+        with patch.object(compressor, "compress", return_value=messages) as compress:
+            returned, _ = agent._compress_context(
+                messages,
+                "sys",
+                approx_tokens=120_000,
+                force=True,
+            )
+
+        assert returned is messages
+        compress.assert_called_once_with(
+            messages,
+            current_tokens=120_000,
+            focus_topic=None,
+            force=True,
+        )
+        assert db.get_compression_lock_holder(session_id) is None

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -494,3 +494,86 @@ class TestAutomaticCompressionStateRefreshAfterLock:
             force=True,
         )
         assert db.get_compression_lock_holder(session_id) is None
+
+
+class TestGateLevelGuardRefresh:
+    """The unblock direction must work from the should_compress() pre-gates.
+
+    compress_context refreshes durable guards internally, but the automatic
+    paths (preflight/turn gates) consult should_compress() first — if a stale
+    in-memory fallback streak (which has no expiry timer) blocks there, the
+    refresh inside compress_context is never reached and the agent stays
+    blocked forever.
+    """
+
+    def test_should_compress_unblocks_after_another_agent_clears_streak(
+        self,
+        refresh_state_db: SessionDB,
+    ):
+        db = refresh_state_db
+        session_id = "GATE_LEVEL_STREAK_CLEAR"
+        db.create_session(session_id, source="telegram")
+        db.set_compression_fallback_streak(session_id, 2)
+        compressor = _bound_context_compressor(db, session_id)
+        assert compressor._fallback_compression_streak == 2
+
+        # Another agent's healthy boundary clears the durable breaker.
+        db.set_compression_fallback_streak(session_id, 0)
+
+        assert compressor.should_compress(10**9) is True
+        assert compressor._fallback_compression_streak == 0
+
+    def test_unblocked_gate_does_not_touch_the_db(
+        self,
+        refresh_state_db: SessionDB,
+    ):
+        db = refresh_state_db
+        session_id = "GATE_LEVEL_HOT_PATH"
+        db.create_session(session_id, source="telegram")
+        compressor = _bound_context_compressor(db, session_id)
+
+        with patch.object(
+            compressor,
+            "_refresh_durable_guards",
+            side_effect=AssertionError("hot path must not refresh"),
+        ):
+            assert compressor._automatic_compression_blocked() is False
+
+
+class TestCooldownPersistFailureIsNotAClearedRow:
+    def test_refresh_keeps_local_cooldown_when_persist_failed(
+        self,
+        refresh_state_db: SessionDB,
+    ):
+        """An empty durable row is not evidence of a clear when OUR write failed.
+
+        _record_compression_failure_cooldown sets the local timer first and
+        persists best-effort. If that persist failed, a later refresh=True
+        finding no DB row must keep the local cooldown (otherwise the #11529
+        thrash guard silently re-opens), until it expires or a successful
+        DB round-trip supersedes it.
+        """
+        db = refresh_state_db
+        session_id = "PERSIST_FAILED_COOLDOWN"
+        db.create_session(session_id, source="telegram")
+        compressor = _bound_context_compressor(db, session_id)
+
+        with patch.object(
+            db,
+            "record_compression_failure_cooldown",
+            side_effect=Exception("disk full"),
+        ):
+            compressor._record_compression_failure_cooldown(60, "rate limited")
+        assert compressor._cooldown_persist_failed is True
+
+        state = compressor.get_active_compression_failure_cooldown(refresh=True)
+        assert state is not None
+        assert compressor._summary_failure_cooldown_until > 0
+        assert compressor._automatic_compression_blocked() is True
+
+        # Once a durable round-trip succeeds, the DB is authoritative again.
+        compressor._record_compression_failure_cooldown(30, "retry later")
+        assert compressor._cooldown_persist_failed is False
+        db.clear_compression_failure_cooldown(session_id)
+        assert compressor.get_active_compression_failure_cooldown(refresh=True) is None
+        assert compressor._summary_failure_cooldown_until == 0.0


### PR DESCRIPTION
Salvages #64511 by @ljy-2000 — cherry-picked to preserve authorship, with one follow-up commit closing the two gaps found in review.

## What changed (salvaged commit)

- Refresh persisted cooldown and fallback-streak state before the initial automatic gate in `compress_context`, and again after acquiring the per-session compression lock, so a prebound agent cannot act on a stale in-memory snapshot another agent has since updated or cleared (TOCTOU window between gate and lock).
- `get_active_compression_failure_cooldown(refresh=True)`: the DB wins on any successful read (shorten and clear both propagate); local state wins only on read failure (conservative).
- After lock acquisition, reject a parent already ended with `end_reason='compression'` — a delayed contender that grabs the lock after the winner released it can no longer rotate the ended parent into a second child (the orphan-fork incident class). Ownership check applies even under `force=True`; breaker/cooldown bypass for manual `/compress` is preserved.
- Six production-seam regressions driving real `SessionDB` through the lock-acquisition hook.

## Follow-up (second commit)

- **Unblock direction at the pre-gates:** the refresh lived only inside `compress_context`, but the automatic paths consult `should_compress()` first — and a stale in-memory fallback streak has no expiry timer, so a durable row cleared by another agent could never unblock a prebound agent. `_automatic_compression_blocked()` now re-reads durable guards when (and only when) the in-memory snapshot says blocked, then re-evaluates — one chokepoint covers every pre-gate, and the unblocked hot path pays zero DB reads (guard test asserts the DB is never touched when unblocked).
- **Persist-failure is not a cleared row:** `_record_compression_failure_cooldown` sets the local timer first and persists best-effort. If that persist failed, a later `refresh=True` finding no DB row must not clear the live local cooldown (that would silently reopen the #11529 thrash window) — tracked via `_cooldown_persist_failed`, reset at every session boundary and superseded by any successful durable round-trip.

## Validation

- 14/14 rotation-state tests (11 salvaged + 3 new guard tests; new tests verified red on the pre-fix head).
- Consumers of the changed gates: `test_api_content_sidecar.py`, `test_context_engine_host_contract.py` — green.
- Scoped suites: 245 targeted compression/compaction tests, 561 agent-scope (`compress or cooldown or breaker or fallback or rotation`), 117 run_agent-scope — zero failures.
- Live probes against real `SessionDB`: stale-parent fence (including `force=True`), interaction with #67275's durable child persistence (mutually reinforcing — the new check detects exactly the state the durable rotation persists), refresh semantics (clear propagates, DB-error conservative), legacy no-lock-API path still fences, two real threads → exactly one child, no lock leaks.
- Ruff clean; `py_compile` clean.

Based on #64511 by @ljy-2000 — commit cherry-picked to preserve authorship. Closes #64511.
