### PR TITLE
fix(dashboard): bracket IPv6 browser URLs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10250,7 +10250,10 @@ def cmd_dashboard(args):
         # Desktop pool backends are intentionally per-profile.
         and os.environ.get("HERMES_DESKTOP") != "1"
     ):
-        url = f"http://{args.host or '127.0.0.1'}:{args.port}/?profile={_launch_profile}"
+        from hermes_cli.url_utils import format_url_host
+
+        url_host = format_url_host(args.host or "127.0.0.1")
+        url = f"http://{url_host}:{args.port}/?profile={_launch_profile}"
         if _dashboard_listening(args.host, args.port):
             print(f"Machine dashboard already running on port {args.port}.")
             print(f"  Managing profile '{_launch_profile}': {url}")

--- a/hermes_cli/url_utils.py
+++ b/hermes_cli/url_utils.py
@@ -1,0 +1,13 @@
+"""Small helpers for composing URLs from configured network hosts."""
+
+
+def format_url_host(host: str) -> str:
+    """Return *host* in HTTP URL-authority form.
+
+    IPv6 literals require brackets when followed by a port. Already-bracketed
+    values are preserved so callers can safely pass either representation.
+    """
+    host = host.strip()
+    if ":" in host and not (host.startswith("[") and host.endswith("]")):
+        return f"[{host}]"
+    return host

--- a/hermes_cli/url_utils.py
+++ b/hermes_cli/url_utils.py
@@ -8,6 +8,11 @@ def format_url_host(host: str) -> str:
     values are preserved so callers can safely pass either representation.
     """
     host = host.strip()
-    if ":" in host and not (host.startswith("[") and host.endswith("]")):
-        return f"[{host}]"
+    if host.startswith("[") and host.endswith("]"):
+        inner_host = host[1:-1]
+        if ":" in inner_host:
+            return f"[{inner_host.replace('%', '%25')}]"
+        return host
+    if ":" in host:
+        return f"[{host.replace('%', '%25')}]"
     return host

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17277,7 +17277,9 @@ def start_server(
                 # advertise a paste-and-connect URL, just announce the bind.
                 print(f"  Hermes backend listening on {host}:{actual_port}")
             else:
-                print(f"  Hermes Web UI → http://{host}:{actual_port}")
+                from hermes_cli.url_utils import format_url_host
+
+                print(f"  Hermes Web UI → http://{format_url_host(host)}:{actual_port}")
             _maybe_open_browser(host, actual_port, open_browser, initial_profile)
 
             # Collapse the peer-hangup teardown flood (#50005). When the Desktop

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17040,8 +17040,10 @@ def _maybe_open_browser(
         )
         return
 
+    from hermes_cli.url_utils import format_url_host
+
     _display_host = host if host not in ("0.0.0.0", "::") else "127.0.0.1"
-    _open_url = f"http://{_display_host}:{actual_port}"
+    _open_url = f"http://{format_url_host(_display_host)}:{actual_port}"
     if initial_profile:
         from urllib.parse import quote
         _open_url += f"/?profile={quote(initial_profile)}"

--- a/tests/hermes_cli/test_dashboard_unified_launch.py
+++ b/tests/hermes_cli/test_dashboard_unified_launch.py
@@ -29,6 +29,22 @@ def _args(**kw):
 class TestUnifiedDashboardRouting:
 
 
+    def test_profile_launch_attach_brackets_ipv6_host_in_browser_url(self, main_mod, monkeypatch):
+        """IPv6 literals must be bracketed before adding a dashboard port."""
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "worker_x"
+        )
+        monkeypatch.setattr(main_mod, "_dashboard_listening", lambda host, port: True)
+        opened = []
+        import webbrowser
+        monkeypatch.setattr(webbrowser, "open", lambda url: opened.append(url))
+
+        with pytest.raises(SystemExit) as exc:
+            main_mod.cmd_dashboard(_args(host="::1", no_open=False))
+
+        assert exc.value.code == 0
+        assert opened == ["http://[::1]:9119/?profile=worker_x"]
+
     def test_profile_launch_reexecs_machine_dashboard(self, main_mod, monkeypatch):
         monkeypatch.delenv("HERMES_HOME", raising=False)
         monkeypatch.setattr(

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -85,6 +85,29 @@ def test_start_server_applies_process_local_ssh_bootstrap_state(monkeypatch):
     assert captured["port"] == 0
 
 
+def test_maybe_open_browser_brackets_ipv6_loopback(monkeypatch):
+    """A browser URL needs brackets around an IPv6 literal authority."""
+    import webbrowser
+
+    opened = []
+
+    class _ImmediateThread:
+        def __init__(self, *, target, daemon):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    monkeypatch.setattr(web_server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(web_server.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(webbrowser, "open", lambda url: opened.append(url))
+    monkeypatch.setenv("DISPLAY", ":0")
+
+    web_server._maybe_open_browser("::1", 9119, True, "worker_x")
+
+    assert opened == ["http://[::1]:9119/?profile=worker_x"]
+
+
 def test_start_server_disables_ws_ping_on_loopback(monkeypatch):
     """Loopback binds (the Desktop case) MUST disable uvicorn's protocol-level
     keepalive ping so an event-loop stall can never trigger a false disconnect.

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -144,6 +144,15 @@ def test_start_server_accepts_base64_desktop_attachments_above_preview_limit(mon
     assert captured["ws_max_size"] > base64_bytes
 
 
+def test_start_server_prints_bracketed_ipv6_dashboard_url(monkeypatch, capsys):
+    """The no-browser startup banner must still show a valid IPv6 URL."""
+    _stub_uvicorn(monkeypatch)
+
+    web_server.start_server(host="::1", port=9119, open_browser=False)
+
+    assert "Hermes Web UI → http://[::1]:9119" in capsys.readouterr().out
+
+
 def test_start_server_enables_ws_ping_for_half_open_detection(monkeypatch):
     """Non-loopback (public) binds MUST keep the ws ping enabled so half-open
     connections (reverse-proxy 524, dropped Cloudflare Tunnel) raise

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -85,6 +85,14 @@ def test_start_server_applies_process_local_ssh_bootstrap_state(monkeypatch):
     assert captured["port"] == 0
 
 
+def test_format_url_host_escapes_ipv6_zone_identifier():
+    """An IPv6 zone delimiter must be percent-encoded inside URL authority."""
+    from hermes_cli.url_utils import format_url_host
+
+    assert format_url_host("fe80::1%eth0") == "[fe80::1%25eth0]"
+    assert format_url_host("[fe80::1%eth0]") == "[fe80::1%25eth0]"
+
+
 def test_maybe_open_browser_brackets_ipv6_loopback(monkeypatch):
     """A browser URL needs brackets around an IPv6 literal authority."""
     import webbrowser


### PR DESCRIPTION
## Summary

- format IPv6 literals as bracketed URL authorities before adding Dashboard browser ports
- apply the formatter to both named-profile attach and initial auto-open flows
- cover `::1` browser URLs in both paths

## Validation

- `./scripts/run_tests.sh tests/hermes_cli/test_dashboard_unified_launch.py tests/test_web_server.py tests/hermes_cli/test_web_server_host_header.py tests/dashboard/test_ws_client_host.py -q` — 53 passed
- `ruff check hermes_cli/url_utils.py hermes_cli/main.py hermes_cli/web_server.py tests/hermes_cli/test_dashboard_unified_launch.py tests/test_web_server.py`
- `python3 -m py_compile hermes_cli/url_utils.py hermes_cli/main.py hermes_cli/web_server.py`
- `git diff --check`
- `./scripts/run_tests.sh -q` — 40,124 tests run; 8 known failures, all in pre-existing `tests/tools/test_execute_code_approval_cluster.py` (also reproduces in isolation); no failures in changed Dashboard paths.

## Reproduction

With `hermes dashboard --host ::1`, the previous browser URL was `http://::1:9119`, which is an invalid IPv6 authority. It is now `http://[::1]:9119`.

Related issue (created after this PR): #67367
