### PR TITLE
fix(gateway): treat Feishu/Lark WebSocket close as transient (#67358)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -259,6 +259,14 @@ def _is_transient_network_error(exc: BaseException) -> bool:
         "ServerDisconnectedError",
         "ClientConnectorError",
         "ClientOSError",
+        # websockets clean / unclean peer closes from platform WS clients
+        # (Feishu/Lark lark_oapi receive loop — issue #67358). A normal
+        # close frame must not kill the entire gateway process via the
+        # asyncio "Task exception was never retrieved" default path.
+        "ConnectionClosed",
+        "ConnectionClosedOK",
+        "ConnectionClosedError",
+        "ConnectionClosedException",  # lark_oapi wrapper name
     }
     while cur is not None and depth < 12:
         ident = id(cur)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -606,6 +606,14 @@ def _is_transient_network_error(exc: BaseException) -> bool:
         "ServerDisconnectedError",
         "ClientConnectorError",
         "ClientOSError",
+        # websockets clean / unclean peer closes from platform WS clients
+        # (Feishu/Lark lark_oapi receive loop — issue #67358). A normal
+        # close frame must not kill the entire gateway process via the
+        # asyncio "Task exception was never retrieved" default path.
+        "ConnectionClosed",
+        "ConnectionClosedOK",
+        "ConnectionClosedError",
+        "ConnectionClosedException",  # lark_oapi wrapper name
     }
     while cur is not None and depth < 12:
         ident = id(cur)

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1295,6 +1295,37 @@ def _strip_edge_self_mentions(
             return remaining
 
 
+def _feishu_ws_loop_exception_handler(
+    loop: "asyncio.AbstractEventLoop", context: Dict[str, Any]
+) -> None:
+    """Worker-loop safety net for the Lark receive task (issue #67358).
+
+    The SDK's ``_receive_message_loop`` task lives on this thread-local
+    worker loop, so a normal close (1000) or transient disconnect surfaces
+    here rather than on the gateway loop. Reuse the gateway's transient
+    classifier so classification stays consistent, and only swallow the
+    close/reconnect path — genuine bugs fall through to the default handler.
+    """
+    exc = context.get("exception")
+    is_transient = False
+    if exc is not None:
+        try:
+            from gateway.run import _is_transient_network_error
+
+            is_transient = _is_transient_network_error(exc)
+        except Exception:
+            is_transient = False
+    if exc is not None and is_transient:
+        logger.warning(
+            "[Feishu] Swallowed transient WS error on worker loop: %s: %s",
+            type(exc).__name__,
+            exc,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+        return
+    loop.default_exception_handler(context)
+
+
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     """Run the official Lark WS client in its own thread-local event loop."""
     import lark_oapi.ws.client as ws_client_module
@@ -1303,6 +1334,14 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     asyncio.set_event_loop(loop)
     ws_client_module.loop = loop
     adapter._ws_thread_loop = loop
+    # The Lark SDK schedules its own `_receive_message_loop` task on THIS
+    # worker loop (lark_oapi/ws/client.py), not on the gateway loop where
+    # `_gateway_loop_exception_handler` is installed. A normal close (1000)
+    # surfacing from that task therefore reaches the worker loop's default
+    # handler and can escalate. Install the same transient classifier here so
+    # the close/reconnect path is swallowed-with-logging on the loop that
+    # actually owns the receive task (see #67358 review).
+    loop.set_exception_handler(_feishu_ws_loop_exception_handler)
 
     original_connect = ws_client_module.websockets.connect
     original_configure = getattr(ws_client, "_configure", None)

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1336,8 +1336,17 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     _apply_runtime_ws_overrides()
     try:
         ws_client.start()
-    except Exception:
-        pass
+    except Exception as exc:
+        # Normal WebSocket close frames (1000 OK) and transient disconnects
+        # must not escape the worker thread as unhandled loop task crashes
+        # (see #67358). Auto-reconnect is owned by the Lark client when
+        # enabled; we only log so gateway systemd does not see TEMPFAIL.
+        logger.warning(
+            "[Feishu] WebSocket client exited: %s: %s",
+            type(exc).__name__,
+            exc,
+            exc_info=True,
+        )
     finally:
         ws_client_module.websockets.connect = original_connect
         if original_configure is not None:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1322,6 +1322,37 @@ def _strip_edge_self_mentions(
             return remaining
 
 
+def _feishu_ws_loop_exception_handler(
+    loop: "asyncio.AbstractEventLoop", context: Dict[str, Any]
+) -> None:
+    """Worker-loop safety net for the Lark receive task (issue #67358).
+
+    The SDK's ``_receive_message_loop`` task lives on this thread-local
+    worker loop, so a normal close (1000) or transient disconnect surfaces
+    here rather than on the gateway loop. Reuse the gateway's transient
+    classifier so classification stays consistent, and only swallow the
+    close/reconnect path — genuine bugs fall through to the default handler.
+    """
+    exc = context.get("exception")
+    is_transient = False
+    if exc is not None:
+        try:
+            from gateway.run import _is_transient_network_error
+
+            is_transient = _is_transient_network_error(exc)
+        except Exception:
+            is_transient = False
+    if exc is not None and is_transient:
+        logger.warning(
+            "[Feishu] Swallowed transient WS error on worker loop: %s: %s",
+            type(exc).__name__,
+            exc,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+        return
+    loop.default_exception_handler(context)
+
+
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     """Run the official Lark WS client in its own thread-local event loop."""
     import lark_oapi.ws.client as ws_client_module
@@ -1330,6 +1361,14 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     asyncio.set_event_loop(loop)
     ws_client_module.loop = loop
     adapter._ws_thread_loop = loop
+    # The Lark SDK schedules its own `_receive_message_loop` task on THIS
+    # worker loop (lark_oapi/ws/client.py), not on the gateway loop where
+    # `_gateway_loop_exception_handler` is installed. A normal close (1000)
+    # surfacing from that task therefore reaches the worker loop's default
+    # handler and can escalate. Install the same transient classifier here so
+    # the close/reconnect path is swallowed-with-logging on the loop that
+    # actually owns the receive task (see #67358 review).
+    loop.set_exception_handler(_feishu_ws_loop_exception_handler)
 
     original_connect = ws_client_module.websockets.connect
     original_configure = getattr(ws_client, "_configure", None)
@@ -1363,8 +1402,17 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     _apply_runtime_ws_overrides()
     try:
         ws_client.start()
-    except Exception:
-        pass
+    except Exception as exc:
+        # Normal WebSocket close frames (1000 OK) and transient disconnects
+        # must not escape the worker thread as unhandled loop task crashes
+        # (see #67358). Auto-reconnect is owned by the Lark client when
+        # enabled; we only log so gateway systemd does not see TEMPFAIL.
+        logger.warning(
+            "[Feishu] WebSocket client exited: %s: %s",
+            type(exc).__name__,
+            exc,
+            exc_info=True,
+        )
     finally:
         ws_client_module.websockets.connect = original_connect
         if original_configure is not None:

--- a/tests/gateway/test_feishu_ws_worker_loop.py
+++ b/tests/gateway/test_feishu_ws_worker_loop.py
@@ -1,0 +1,75 @@
+"""Regression tests for the Feishu/Lark WS worker-loop exception handler.
+
+The Lark SDK schedules its ``_receive_message_loop`` task on the adapter's
+own thread-local worker loop, not on the gateway loop. A normal close (1000)
+or transient disconnect surfacing from that task must be swallowed-with-logging
+on the worker loop so it never escalates to a gateway TEMPFAIL (issue #67358,
+sweeper review of PR #67366).
+"""
+
+import asyncio
+
+from plugins.platforms.feishu.adapter import _feishu_ws_loop_exception_handler
+
+
+class ConnectionClosedOK(Exception):
+    """Stand-in for websockets ConnectionClosedOK (normal close 1000)."""
+
+
+class _RealBug(Exception):
+    """A non-transient error that must fall through to default handling."""
+
+
+def _make_context(exc):
+    return {"message": "Task exception was never retrieved", "exception": exc}
+
+
+def test_worker_loop_swallows_normal_close(monkeypatch):
+    loop = asyncio.new_event_loop()
+    try:
+        forwarded = {"called": False}
+        monkeypatch.setattr(
+            loop,
+            "default_exception_handler",
+            lambda ctx: forwarded.__setitem__("called", True),
+        )
+        _feishu_ws_loop_exception_handler(
+            loop, _make_context(ConnectionClosedOK("1000 (OK)"))
+        )
+        # Transient close is swallowed; default handler NOT invoked.
+        assert forwarded["called"] is False
+    finally:
+        loop.close()
+
+
+def test_worker_loop_forwards_real_bug(monkeypatch):
+    loop = asyncio.new_event_loop()
+    try:
+        forwarded = {"ctx": None}
+        monkeypatch.setattr(
+            loop,
+            "default_exception_handler",
+            lambda ctx: forwarded.__setitem__("ctx", ctx),
+        )
+        _feishu_ws_loop_exception_handler(loop, _make_context(_RealBug("boom")))
+        # Non-transient error is forwarded to the default handler.
+        assert forwarded["ctx"] is not None
+        assert isinstance(forwarded["ctx"]["exception"], _RealBug)
+    finally:
+        loop.close()
+
+
+def test_worker_loop_no_exception_forwards(monkeypatch):
+    """A context without an exception must not be swallowed."""
+    loop = asyncio.new_event_loop()
+    try:
+        forwarded = {"called": False}
+        monkeypatch.setattr(
+            loop,
+            "default_exception_handler",
+            lambda ctx: forwarded.__setitem__("called", True),
+        )
+        _feishu_ws_loop_exception_handler(loop, {"message": "no exc"})
+        assert forwarded["called"] is True
+    finally:
+        loop.close()

--- a/tests/gateway/test_loop_exception_handler.py
+++ b/tests/gateway/test_loop_exception_handler.py
@@ -52,6 +52,14 @@ class ClientConnectorError(Exception):
     """Stand-in for ``aiohttp.ClientConnectorError``."""
 
 
+class ConnectionClosedOK(Exception):
+    """Stand-in for ``websockets.exceptions.ConnectionClosedOK`` (Feishu/Lark)."""
+
+
+class ConnectionClosedException(Exception):
+    """Stand-in for ``lark_oapi`` ConnectionClosedException."""
+
+
 class SomeUnrelatedBug(Exception):
     """A non-transient error that should NOT be swallowed."""
 
@@ -70,6 +78,8 @@ class SomeUnrelatedBug(Exception):
         ReadTimeout,
         PoolTimeout,
         ClientConnectorError,
+        ConnectionClosedOK,
+        ConnectionClosedException,
     ],
 )
 def test_transient_classifier_matches_known_network_errors(exc_cls):


### PR DESCRIPTION
## Summary

Closes #67358.

When the Feishu/Lark WebSocket receives a normal close (`ConnectionClosedOK` / 1000 bye), `lark_oapi`'s `_receive_message_loop` can leave an unretrieved asyncio task exception. The gateway loop safety net only classified HTTP/Telegram-style network errors as transient, so Feishu flaps could still escalate and leave systemd at **status 75/TEMPFAIL**.

## Motivation

Production log pattern from the issue:

```
[Lark] receive message loop exit, err: sent 1000 (OK); then received 1000 (OK) bye
ERROR asyncio: Task exception was never retrieved
… ConnectionClosedOK …
hermes-gateway.service: Main process exited, code=exited, status=75/TEMPFAIL
```

Other messaging platforms already benefit from `_gateway_loop_exception_handler` / `_is_transient_network_error` (#31066 / #31110). WebSocket close classes were missing from that set.

## Root cause

1. Unhandled (or task-orphaned) `ConnectionClosedOK` / peer close on the Feishu WS thread.
2. Loop default handler path for unmatched exceptions — not treated as the same transient class as `TimedOut` / `ConnectError`.

## Fix

1. **`gateway/run.py`**: classify `ConnectionClosed`, `ConnectionClosedOK`, `ConnectionClosedError`, and `ConnectionClosedException` (lark_oapi name) as transient network errors so the existing loop handler logs-and-swallows them.
2. **`plugins/platforms/feishu/adapter.py`**: when `_run_official_feishu_ws_client` sees `ws_client.start()` raise, log a structured warning (instead of a bare `except: pass`) so disconnects stay diagnosable without becoming silent.

Lark's own `_auto_reconnect` path remains the reconnect owner when enabled; this change prevents *process death* on close flaps.

## Tests

- Extended `tests/gateway/test_loop_exception_handler.py` parametrize coverage for the new class names.
- `pytest tests/gateway/test_loop_exception_handler.py -q` → **16 passed**.

## Verification

```bash
pytest tests/gateway/test_loop_exception_handler.py -q
```

Live: Feishu WS 1000 close should warn at most and leave the gateway process up (other channels untouched).