### PR TITLE
fix: handle multimodal content in think scrubber

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -639,8 +639,12 @@ def repair_message_sequence_with_cursor(agent, messages: List[Dict]) -> int:
 
 
 
-def strip_think_blocks(agent, content: str) -> str:
+def strip_think_blocks(agent, content: Any) -> str:
     """Remove reasoning/thinking blocks from content, returning only visible text.
+
+    Multimodal OpenAI-style content arrays are reduced to their text parts
+    before the regex scrubber runs. Image and other non-text blocks are
+    intentionally ignored here because this helper only produces display text.
 
     Handles four cases:
       1. Closed tag pairs (``<think>…</think>``) — the common path when
@@ -670,6 +674,21 @@ def strip_think_blocks(agent, content: str) -> str:
     after punctuation and carries a ``name="..."`` attribute) so prose
     mentions like "Use <function> in JavaScript" are preserved.
     """
+    if isinstance(content, list):
+        text_parts = []
+        for part in content:
+            if isinstance(part, str):
+                text_parts.append(part)
+            elif isinstance(part, dict) and part.get("type") in {
+                "text",
+                "input_text",
+                "output_text",
+            }:
+                text = part.get("text")
+                if isinstance(text, str):
+                    text_parts.append(text)
+        content = "\n".join(text_parts)
+
     if not content:
         return ""
     # 1. Closed tag pairs — case-insensitive for all variants so

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -445,6 +445,40 @@ class TestStripThinkBlocks:
     def test_none_returns_empty(self, agent):
         assert agent._strip_think_blocks(None) == ""
 
+    def test_multimodal_content_extracts_visible_text(self, agent):
+        content = [
+            {"type": "text", "text": "Borderô com imagem"},
+            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}},
+        ]
+
+        assert agent._strip_think_blocks(content) == "Borderô com imagem"
+
+    def test_multimodal_content_supports_openai_text_block_variants(self, agent):
+        content = [
+            {"type": "input_text", "text": "entrada"},
+            {"type": "output_text", "text": "saída"},
+        ]
+
+        assert agent._strip_think_blocks(content) == "entrada\nsaída"
+
+    def test_multimodal_content_preserves_string_parts(self, agent):
+        assert agent._strip_think_blocks(["primeiro", "segundo"]) == "primeiro\nsegundo"
+
+    def test_image_only_multimodal_content_returns_empty(self, agent):
+        content = [
+            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}},
+        ]
+
+        assert agent._strip_think_blocks(content) == ""
+
+    def test_multimodal_text_still_strips_think_blocks(self, agent):
+        content = [
+            {"type": "text", "text": "<think>segredo</think> resposta"},
+            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}},
+        ]
+
+        assert agent._strip_think_blocks(content).strip() == "resposta"
+
     def test_no_blocks_unchanged(self, agent):
         assert agent._strip_think_blocks("hello world") == "hello world"
 


### PR DESCRIPTION
## Summary
- normalize OpenAI-style multimodal content arrays to visible text before regex scrubbing
- ignore image/non-text blocks in the display-text helper
- cover text/input_text/output_text, string parts, image-only content, and think tags

## Reproduction
A Telegram user message containing native image content is stored as a list. `_interim_assistant_visible_text()` passes that list to `strip_think_blocks()`, which called `re.sub()` directly and raised `TypeError: expected string or bytes-like object, got list`. The outer conversation loop retried repeatedly.

## Verification
- `pytest tests/run_agent/test_run_agent.py::TestStripThinkBlocks -q` → 30 passed
- `ruff check agent/agent_runtime_helpers.py tests/run_agent/test_run_agent.py` → passed
- live Telegram image → follow-up tool call completed with no new TypeError
