### PR TITLE
fix(tools): don't block execute() on Windows backgrounded-child stdout close (#67362)

### DIFF
--- a/tests/tools/test_local_background_child_hang.py
+++ b/tests/tools/test_local_background_child_hang.py
@@ -16,6 +16,7 @@ import time
 import pytest
 
 from tools.environments.local import LocalEnvironment
+from tools.environments.base import _should_close_drained_stdout
 
 
 def _pkill(pattern: str) -> None:
@@ -214,3 +215,29 @@ class TestBackgroundChildDoesNotHang:
         assert "before" in result["output"]
         assert "after" in result["output"]
         assert "binary output detected" not in result["output"]
+
+
+class TestShouldCloseDrainedStdout:
+    """Focused unit coverage for the Windows drain-thread close guard (#67362).
+
+    ``BaseEnvironment.execute()`` must skip ``proc.stdout.close()`` when — and
+    only when — running on native Windows with the drain thread still blocked in
+    ``os.read`` (a backgrounded child holding the write end). Closing there would
+    serialize on the same MSVCRT per-fd lock and stall for the child's whole
+    lifetime. This exercises the exact predicate cross-platform without needing a
+    real Windows pipe.
+    """
+
+    def test_windows_live_drain_thread_skips_close(self):
+        # The guarded case: only here is the close skipped.
+        assert _should_close_drained_stdout("nt", True) is False
+
+    def test_windows_finished_drain_thread_closes(self):
+        # Drain thread already exited on Windows → close is safe.
+        assert _should_close_drained_stdout("nt", False) is True
+
+    def test_posix_always_closes(self):
+        # On POSIX close() is independent of a concurrent read, so it always runs
+        # regardless of drain-thread liveness.
+        assert _should_close_drained_stdout("posix", True) is True
+        assert _should_close_drained_stdout("posix", False) is True

--- a/tests/tools/test_local_background_child_hang.py
+++ b/tests/tools/test_local_background_child_hang.py
@@ -16,6 +16,7 @@ import time
 import pytest
 
 from tools.environments.local import LocalEnvironment
+from tools.environments.base import _should_close_drained_stdout
 
 
 def _pkill(pattern: str) -> None:
@@ -138,3 +139,29 @@ class TestBackgroundChildDoesNotHang:
         assert "before" in result["output"]
         assert "after" in result["output"]
         assert "binary output detected" not in result["output"]
+
+
+class TestShouldCloseDrainedStdout:
+    """Focused unit coverage for the Windows drain-thread close guard (#67362).
+
+    ``BaseEnvironment.execute()`` must skip ``proc.stdout.close()`` when — and
+    only when — running on native Windows with the drain thread still blocked in
+    ``os.read`` (a backgrounded child holding the write end). Closing there would
+    serialize on the same MSVCRT per-fd lock and stall for the child's whole
+    lifetime. This exercises the exact predicate cross-platform without needing a
+    real Windows pipe.
+    """
+
+    def test_windows_live_drain_thread_skips_close(self):
+        # The guarded case: only here is the close skipped.
+        assert _should_close_drained_stdout("nt", True) is False
+
+    def test_windows_finished_drain_thread_closes(self):
+        # Drain thread already exited on Windows → close is safe.
+        assert _should_close_drained_stdout("nt", False) is True
+
+    def test_posix_always_closes(self):
+        # On POSIX close() is independent of a concurrent read, so it always runs
+        # regardless of drain-thread liveness.
+        assert _should_close_drained_stdout("posix", True) is True
+        assert _should_close_drained_stdout("posix", False) is True

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -429,6 +429,21 @@ def _export_dump_excluding_session_vars(tmp_path: str) -> str:
     )
 
 
+def _should_close_drained_stdout(os_name: str, drain_thread_alive: bool) -> bool:
+    """Decide whether ``proc.stdout.close()`` is safe after the drain join.
+
+    On native Windows, a still-alive drain thread is blocked in ``os.read`` on
+    the stdout fd (no ``select()`` on pipe fds there). ``close()`` would then
+    serialize on the same per-fd MSVCRT lock and block for the whole lifetime of
+    a backgrounded child that inherited the write end, even though bash already
+    exited and the output is fully captured (#67362). In that one case the close
+    must be skipped and the fd left to the daemon drain thread / GC. Everywhere
+    else — POSIX always, and Windows once the drain thread has exited — closing
+    is safe and desirable.
+    """
+    return not (os_name == "nt" and drain_thread_alive)
+
+
 # ---------------------------------------------------------------------------
 # BaseEnvironment
 # ---------------------------------------------------------------------------
@@ -1022,7 +1037,7 @@ class BaseEnvironment(ABC):
         # to the daemon drain thread, which reaches EOF (or is torn down with the
         # interpreter) and is reclaimed by GC / ``Popen.__del__``.  On POSIX this
         # is a no-op — ``close()`` there is independent of a concurrent read.
-        if not (os.name == "nt" and drain_thread.is_alive()):
+        if _should_close_drained_stdout(os.name, drain_thread.is_alive()):
             try:
                 proc.stdout.close()
             except Exception:

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -1012,10 +1012,21 @@ class BaseEnvironment(ABC):
         # it means the non-blocking loop itself stopped cooperating.
         drain_thread.join(timeout=2)
 
-        try:
-            proc.stdout.close()
-        except Exception:
-            pass
+        # On Windows, if the drain thread is still alive it is blocked in a
+        # ``os.read`` on the stdout fd (no ``select()`` on pipe fds there), which
+        # only unblocks when a backgrounded child that inherited the write end
+        # finally closes it.  ``proc.stdout.close()`` then serializes on the same
+        # per-fd lock via the MSVCRT machinery and blocks for the child's whole
+        # lifetime — even though bash has exited and the output is fully captured
+        # (issue #67362).  Skip the blocking close in that case: the fd is left
+        # to the daemon drain thread, which reaches EOF (or is torn down with the
+        # interpreter) and is reclaimed by GC / ``Popen.__del__``.  On POSIX this
+        # is a no-op — ``close()`` there is independent of a concurrent read.
+        if not (os.name == "nt" and drain_thread.is_alive()):
+            try:
+                proc.stdout.close()
+            except Exception:
+                pass
 
         if _DEBUG_INTERRUPT:
             logger.info(

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -417,10 +417,22 @@ class BaseEnvironment(ABC):
         # The drain thread exits promptly after bash does (~300ms idle check);
         # a long join here would itself indicate a bug in the drain loop.
         drain_thread.join(timeout=2)
-        try:
-            proc.stdout.close()
-        except Exception:
-            pass
+
+        # On Windows, if the drain thread is still alive it is blocked in a
+        # ``os.read`` on the stdout fd (no ``select()`` on pipe fds there), which
+        # only unblocks when a backgrounded child that inherited the write end
+        # finally closes it.  ``proc.stdout.close()`` then serializes on the same
+        # per-fd lock via the MSVCRT machinery and blocks for the child's whole
+        # lifetime — even though bash has exited and the output is fully captured
+        # (issue #67362).  Skip the blocking close in that case: the fd is left
+        # to the daemon drain thread, which reaches EOF (or is torn down with the
+        # interpreter) and is reclaimed by GC / ``Popen.__del__``.  On POSIX this
+        # is a no-op — ``close()`` there is independent of a concurrent read.
+        if not (os.name == "nt" and drain_thread.is_alive()):
+            try:
+                proc.stdout.close()
+            except Exception:
+                pass
         trace.natural_exit(proc.returncode)
 
         # Join the stdin writer before reading its error list: a child that exits without

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -139,6 +139,21 @@ def _file_mtime_key(host_path: str) -> tuple[float, int] | None:
         return None
 
 
+def _should_close_drained_stdout(os_name: str, drain_thread_alive: bool) -> bool:
+    """Decide whether ``proc.stdout.close()`` is safe after the drain join.
+
+    On native Windows, a still-alive drain thread is blocked in ``os.read`` on
+    the stdout fd (no ``select()`` on pipe fds there). ``close()`` would then
+    serialize on the same per-fd MSVCRT lock and block for the whole lifetime of
+    a backgrounded child that inherited the write end, even though bash already
+    exited and the output is fully captured (#67362). In that one case the close
+    must be skipped and the fd left to the daemon drain thread / GC. Everywhere
+    else — POSIX always, and Windows once the drain thread has exited — closing
+    is safe and desirable.
+    """
+    return not (os_name == "nt" and drain_thread_alive)
+
+
 class BaseEnvironment(ABC):
     """Common interface and unified execution flow for all Hermes backends. Subclasses
     implement ``_run_bash()`` and ``cleanup()``; the base provides ``execute()`` with
@@ -428,7 +443,7 @@ class BaseEnvironment(ABC):
         # to the daemon drain thread, which reaches EOF (or is torn down with the
         # interpreter) and is reclaimed by GC / ``Popen.__del__``.  On POSIX this
         # is a no-op — ``close()`` there is independent of a concurrent read.
-        if not (os.name == "nt" and drain_thread.is_alive()):
+        if _should_close_drained_stdout(os.name, drain_thread.is_alive()):
             try:
                 proc.stdout.close()
             except Exception:


### PR DESCRIPTION
## What does this PR do?

On native Windows, a foreground terminal command that backgrounds a child (e.g. `cmd &`, `setsid ... & disown`) makes `BaseEnvironment.execute()` block for the **entire lifetime of the backgrounded child** — even though bash has already exited, the output is fully captured, and the command's own timeout has long passed. The result is correct, just delivered arbitrarily late.

Root cause (natural-exit path of `_wait_for_process` in `tools/environments/base.py`):

1. The Windows drain path has no `select()` on pipe fds, so the daemon drain thread blocks in `os.read(fd, 4096)`. The backgrounded child inherited the stdout **write** end, so no EOF arrives until that child exits.
2. bash exits, the poll loop finishes, and `drain_thread.join(timeout=2)` correctly gives up after 2s.
3. The subsequent `proc.stdout.close()` then serializes on the same per-fd lock the blocked `os.read` holds (MSVCRT fd machinery), so `close()` cannot return until the child exits. On POSIX, `close()` is independent of a concurrent `read()`, so the stall is Windows-only.

Fix: skip the blocking `proc.stdout.close()` while the Windows drain thread is still alive. The fd is left to the daemon drain thread, which reaches EOF (or is torn down with the interpreter) and is reclaimed by GC / `Popen.__del__`. This is a strict **no-op on POSIX** (`os.name != "nt"`), so the existing `select()`-based drain and its `close()` are unchanged there.

## Related Issue

Fixes #67362

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/base.py` — in the natural-exit branch of `_wait_for_process`, guard `proc.stdout.close()` with `if not (os.name == "nt" and drain_thread.is_alive())`, with a comment explaining the Windows per-fd-lock stall. Interrupt (130), timeout (124), and exception-exit paths are untouched (they already only `join`, never `close`).

## How to Test

The reporter's ready-made regression test `tests/tools/test_local_background_child_hang.py::TestBackgroundChildDoesNotHang::test_plain_background_returns_promptly` reproduces the hang on Windows (currently deselected there) and asserts the command returns in well under 10s while the backgrounded child still runs.

POSIX no-regression (the fix is a no-op here, so all capture/streaming/UTF-8/timeout paths must be unchanged):

```
scripts/run_tests.sh tests/tools/test_local_background_child_hang.py tests/tools/test_base_environment.py tests/tools/test_local_env_blocklist.py
```

Result on macOS: `test_local_background_child_hang.py` 11 passed; `test_base_environment.py` 33 passed; `test_local_env_blocklist.py` 51 passed.

Note: I'm on macOS and cannot exercise the native-Windows path directly. The change is deliberately scoped so it only alters behavior when `os.name == "nt"` and the drain thread is still blocked — the exact condition described in the issue's faulthandler capture — and is inert on POSIX.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tools):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (single 15-line change)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the affected files via `scripts/run_tests.sh` (see How to Test); did not run the full suite
- [ ] I've added tests for my changes — the reporter's existing regression test already covers this (deselected on Windows); no new test added
- [x] I've tested on my platform: macOS 15.5 (POSIX no-regression only; Windows path is the fix target)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (comment added at the change site; no external docs affected)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — Windows-only behavior change, POSIX is a no-op
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (internal behavior only)
