### PR TITLE
fix(usage): persist Codex telemetry on drifted v22 databases

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2400,6 +2400,39 @@ def run_conversation(
                             f"{cached:,}/{prompt:,} tokens "
                             f"({hit_pct:.0f}% hit, {written:,} written)"
                         )
+                else:
+                    # A completed provider call still counts even when the raw
+                    # Responses stream omits exact token telemetry.  The live
+                    # ChatGPT Codex backend currently emits response.completed
+                    # with response.usage=null; do not invent token estimates,
+                    # but preserve the exact call count and billing route.
+                    agent.session_api_calls += 1
+                    logger.info(
+                        "API call #%d: model=%s provider=%s usage=unavailable latency=%.1fs",
+                        agent.session_api_calls,
+                        agent.model,
+                        agent.provider or "unknown",
+                        api_duration,
+                    )
+                    if agent._session_db and agent.session_id:
+                        try:
+                            if not agent._session_db_created:
+                                agent._ensure_db_session()
+                            agent._session_db.update_token_counts(
+                                agent.session_id,
+                                billing_provider=agent.provider,
+                                billing_base_url=agent.base_url,
+                                billing_mode="subscription_included"
+                                if agent.provider == "openai-codex" else None,
+                                model=agent.model,
+                                api_call_count=1,
+                            )
+                        except Exception as e:
+                            logger.debug(
+                                "API-call persistence without usage failed (session=%s): %s",
+                                agent.session_id,
+                                e,
+                            )
                 
                 _retry.has_retried_429 = False  # Reset on success
                 # Note: don't clear the retry buffer here — an "API call

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -836,6 +837,13 @@ def _to_int(value: Any) -> int:
         return 0
 
 
+def _usage_field(value: Any, name: str, default: Any = None) -> Any:
+    """Read usage fields from SDK objects or raw Responses JSON mappings."""
+    if isinstance(value, Mapping):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
 def resolve_billing_route(
     model_name: str,
     provider: Optional[str] = None,
@@ -1048,32 +1056,36 @@ def normalize_usage(
     mode = (api_mode or "").strip().lower()
 
     if mode == "anthropic_messages" or provider_name == "anthropic":
-        input_tokens = _to_int(getattr(response_usage, "input_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "output_tokens", 0))
-        cache_read_tokens = _to_int(getattr(response_usage, "cache_read_input_tokens", 0))
-        cache_write_tokens = _to_int(getattr(response_usage, "cache_creation_input_tokens", 0))
+        input_tokens = _to_int(_usage_field(response_usage, "input_tokens", 0))
+        output_tokens = _to_int(_usage_field(response_usage, "output_tokens", 0))
+        cache_read_tokens = _to_int(_usage_field(response_usage, "cache_read_input_tokens", 0))
+        cache_write_tokens = _to_int(_usage_field(response_usage, "cache_creation_input_tokens", 0))
     elif mode == "codex_responses":
-        input_total = _to_int(getattr(response_usage, "input_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "output_tokens", 0))
-        details = getattr(response_usage, "input_tokens_details", None)
-        cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
+        input_total = _to_int(_usage_field(response_usage, "input_tokens", 0))
+        output_tokens = _to_int(_usage_field(response_usage, "output_tokens", 0))
+        details = _usage_field(response_usage, "input_tokens_details", None)
+        cache_read_tokens = _to_int(_usage_field(details, "cached_tokens", 0) if details else 0)
         cache_write_tokens = _to_int(
-            getattr(details, "cache_creation_tokens", 0) if details else 0
+            _usage_field(details, "cache_write_tokens", 0) if details else 0
         )
+        if not cache_write_tokens:
+            cache_write_tokens = _to_int(
+                _usage_field(details, "cache_creation_tokens", 0) if details else 0
+            )
         input_tokens = max(0, input_total - cache_read_tokens - cache_write_tokens)
     else:
-        prompt_total = _to_int(getattr(response_usage, "prompt_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "completion_tokens", 0))
-        details = getattr(response_usage, "prompt_tokens_details", None)
+        prompt_total = _to_int(_usage_field(response_usage, "prompt_tokens", 0))
+        output_tokens = _to_int(_usage_field(response_usage, "completion_tokens", 0))
+        details = _usage_field(response_usage, "prompt_tokens_details", None)
         # Primary: OpenAI-style prompt_tokens_details. Fallback: Anthropic-style
         # top-level fields that some OpenAI-compatible proxies (OpenRouter, Cline)
         # expose when routing Claude models — without this
         # fallback, cache writes are undercounted as 0 and cache reads can be
         # missed when the proxy only surfaces them at the top level.
         # Port of cline/cline#10266.
-        cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
+        cache_read_tokens = _to_int(_usage_field(details, "cached_tokens", 0) if details else 0)
         if not cache_read_tokens:
-            cache_read_tokens = _to_int(getattr(response_usage, "cache_read_input_tokens", 0))
+            cache_read_tokens = _to_int(_usage_field(response_usage, "cache_read_input_tokens", 0))
         if not cache_read_tokens:
             # DeepSeek's native API (api.deepseek.com) reports context-cache
             # hits as top-level prompt_cache_hit_tokens (+ the complementary
@@ -1081,14 +1093,14 @@ def normalize_usage(
             # OpenAI nested shape. Without this, direct DeepSeek sessions
             # always showed 0 cache-hit tokens (#61871).
             cache_read_tokens = _to_int(
-                getattr(response_usage, "prompt_cache_hit_tokens", 0)
+                _usage_field(response_usage, "prompt_cache_hit_tokens", 0)
             )
         cache_write_tokens = _to_int(
-            getattr(details, "cache_write_tokens", 0) if details else 0
+            _usage_field(details, "cache_write_tokens", 0) if details else 0
         )
         if not cache_write_tokens:
             cache_write_tokens = _to_int(
-                getattr(response_usage, "cache_creation_input_tokens", 0)
+                _usage_field(response_usage, "cache_creation_input_tokens", 0)
             )
         input_tokens = max(0, prompt_total - cache_read_tokens - cache_write_tokens)
 
@@ -1100,14 +1112,14 @@ def normalize_usage(
     # hidden thinking was invisible in session accounting even though it
     # dominates output spend on models like deepseek-v4-flash (measured:
     # single calls burning 21K reasoning tokens to emit 500 visible tokens).
-    output_details = getattr(response_usage, "output_tokens_details", None)
+    output_details = _usage_field(response_usage, "output_tokens_details", None)
     if output_details:
-        reasoning_tokens = _to_int(getattr(output_details, "reasoning_tokens", 0))
+        reasoning_tokens = _to_int(_usage_field(output_details, "reasoning_tokens", 0))
     if not reasoning_tokens:
-        completion_details = getattr(response_usage, "completion_tokens_details", None)
+        completion_details = _usage_field(response_usage, "completion_tokens_details", None)
         if completion_details:
             reasoning_tokens = _to_int(
-                getattr(completion_details, "reasoning_tokens", 0)
+                _usage_field(completion_details, "reasoning_tokens", 0)
             )
 
     return CanonicalUsage(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1535,6 +1535,90 @@ class SessionDB:
                             "reconcile %s.%s: %s", table_name, col_name, exc,
                         )
 
+    @staticmethod
+    def _repair_session_model_usage_primary_key(cursor: sqlite3.Cursor) -> None:
+        """Ensure task is the sixth component of the live usage primary key."""
+        expected_pk = [
+            "session_id",
+            "model",
+            "billing_provider",
+            "billing_base_url",
+            "billing_mode",
+            "task",
+        ]
+        table_info = cursor.execute(
+            "PRAGMA table_info('session_model_usage')"
+        ).fetchall()
+        live_pk = [
+            row[1]
+            for row in sorted(table_info, key=lambda row: row[5] or len(table_info) + 1)
+            if row[5]
+        ]
+        if live_pk == expected_pk:
+            return
+
+        cursor.execute("SAVEPOINT repair_session_model_usage_pk")
+        try:
+            cursor.execute(
+                "ALTER TABLE session_model_usage RENAME TO session_model_usage_old_pk"
+            )
+            cursor.execute(
+                """CREATE TABLE session_model_usage (
+                       session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                       model TEXT NOT NULL,
+                       billing_provider TEXT NOT NULL DEFAULT '',
+                       billing_base_url TEXT NOT NULL DEFAULT '',
+                       billing_mode TEXT NOT NULL DEFAULT '',
+                       task TEXT NOT NULL DEFAULT '',
+                       api_call_count INTEGER NOT NULL DEFAULT 0,
+                       input_tokens INTEGER NOT NULL DEFAULT 0,
+                       output_tokens INTEGER NOT NULL DEFAULT 0,
+                       cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+                       cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+                       reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+                       estimated_cost_usd REAL NOT NULL DEFAULT 0,
+                       actual_cost_usd REAL NOT NULL DEFAULT 0,
+                       cost_status TEXT,
+                       cost_source TEXT,
+                       first_seen REAL,
+                       last_seen REAL,
+                       PRIMARY KEY (
+                           session_id, model, billing_provider,
+                           billing_base_url, billing_mode, task
+                       )
+                   )"""
+            )
+            cursor.execute(
+                """INSERT INTO session_model_usage (
+                       session_id, model, billing_provider, billing_base_url,
+                       billing_mode, task, api_call_count, input_tokens,
+                       output_tokens, cache_read_tokens, cache_write_tokens,
+                       reasoning_tokens, estimated_cost_usd, actual_cost_usd,
+                       cost_status, cost_source, first_seen, last_seen
+                   )
+                   SELECT session_id, model, billing_provider, billing_base_url,
+                          billing_mode, COALESCE(task, ''), api_call_count,
+                          input_tokens, output_tokens, cache_read_tokens,
+                          cache_write_tokens, reasoning_tokens,
+                          estimated_cost_usd, actual_cost_usd, cost_status,
+                          cost_source, first_seen, last_seen
+                   FROM session_model_usage_old_pk"""
+            )
+            cursor.execute("DROP TABLE session_model_usage_old_pk")
+            cursor.execute(
+                "CREATE INDEX idx_session_model_usage_session "
+                "ON session_model_usage(session_id)"
+            )
+            cursor.execute(
+                "CREATE INDEX idx_session_model_usage_model "
+                "ON session_model_usage(model)"
+            )
+            cursor.execute("RELEASE SAVEPOINT repair_session_model_usage_pk")
+        except sqlite3.Error:
+            cursor.execute("ROLLBACK TO SAVEPOINT repair_session_model_usage_pk")
+            cursor.execute("RELEASE SAVEPOINT repair_session_model_usage_pk")
+            raise
+
     def _init_schema(self):
         """Create tables and FTS if they don't exist, reconcile columns.
 
@@ -1558,6 +1642,10 @@ class SessionDB:
         # migration was skipped (e.g. due to version renumbering), the
         # column gets created here.
         self._reconcile_columns(cursor)
+        # schema_version alone cannot prove that a reconciler-added ``task``
+        # column participates in the primary key. Inspect and repair the live
+        # key on every startup; the common correct-schema path is read-only.
+        self._repair_session_model_usage_primary_key(cursor)
 
         # Indexes that reference reconciler-added columns must be created
         # AFTER _reconcile_columns runs — declaring them in SCHEMA_SQL
@@ -1790,72 +1878,6 @@ class SessionDB:
                     )
                 except sqlite3.OperationalError:
                     pass
-            if current_version < 22:
-                # v22: task-dimension usage attribution (issue #23270).
-                # session_model_usage gains a ``task`` column ('' = main agent
-                # loop; 'vision'/'compression'/'title_generation'/... =
-                # auxiliary calls) so aux model spend is visible in analytics.
-                # The column participates in the PRIMARY KEY and SQLite cannot
-                # ALTER a PK, so rebuild the table. The reconciler will have
-                # already ADDed the plain column on legacy DBs (harmless);
-                # the rebuild bakes it into the PK properly. Existing rows are
-                # main-loop accounting by definition → task=''.
-                try:
-                    legacy_pk = cursor.execute(
-                        "SELECT COUNT(*) FROM pragma_table_info('session_model_usage') "
-                        "WHERE name = 'task' AND pk > 0"
-                    ).fetchone()[0]
-                    if not legacy_pk:
-                        cursor.execute("ALTER TABLE session_model_usage RENAME TO session_model_usage_v21")
-                        cursor.execute(
-                            """CREATE TABLE session_model_usage (
-                                   session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
-                                   model TEXT NOT NULL,
-                                   billing_provider TEXT NOT NULL DEFAULT '',
-                                   billing_base_url TEXT NOT NULL DEFAULT '',
-                                   billing_mode TEXT NOT NULL DEFAULT '',
-                                   task TEXT NOT NULL DEFAULT '',
-                                   api_call_count INTEGER NOT NULL DEFAULT 0,
-                                   input_tokens INTEGER NOT NULL DEFAULT 0,
-                                   output_tokens INTEGER NOT NULL DEFAULT 0,
-                                   cache_read_tokens INTEGER NOT NULL DEFAULT 0,
-                                   cache_write_tokens INTEGER NOT NULL DEFAULT 0,
-                                   reasoning_tokens INTEGER NOT NULL DEFAULT 0,
-                                   estimated_cost_usd REAL NOT NULL DEFAULT 0,
-                                   actual_cost_usd REAL NOT NULL DEFAULT 0,
-                                   cost_status TEXT,
-                                   cost_source TEXT,
-                                   first_seen REAL,
-                                   last_seen REAL,
-                                   PRIMARY KEY (session_id, model, billing_provider, billing_base_url, billing_mode, task)
-                               )"""
-                        )
-                        cursor.execute(
-                            """INSERT INTO session_model_usage (
-                                   session_id, model, billing_provider, billing_base_url,
-                                   billing_mode, task, api_call_count, input_tokens,
-                                   output_tokens, cache_read_tokens, cache_write_tokens,
-                                   reasoning_tokens, estimated_cost_usd, actual_cost_usd,
-                                   cost_status, cost_source, first_seen, last_seen
-                               )
-                               SELECT session_id, model, billing_provider, billing_base_url,
-                                      billing_mode, '', api_call_count, input_tokens,
-                                      output_tokens, cache_read_tokens, cache_write_tokens,
-                                      reasoning_tokens, estimated_cost_usd, actual_cost_usd,
-                                      cost_status, cost_source, first_seen, last_seen
-                               FROM session_model_usage_v21"""
-                        )
-                        cursor.execute("DROP TABLE session_model_usage_v21")
-                        cursor.execute(
-                            "CREATE INDEX IF NOT EXISTS idx_session_model_usage_session "
-                            "ON session_model_usage(session_id)"
-                        )
-                        cursor.execute(
-                            "CREATE INDEX IF NOT EXISTS idx_session_model_usage_model "
-                            "ON session_model_usage(model)"
-                        )
-                except sqlite3.OperationalError as exc:
-                    logger.debug("v22 session_model_usage rebuild skipped: %s", exc)
             if current_version < SCHEMA_VERSION and fts_migrations_complete:
                 cursor.execute(
                     "UPDATE schema_version SET version = ?",
@@ -3054,9 +3076,6 @@ class SessionDB:
             eff_base_url = billing_base_url or sess_base_url or ""
             eff_billing_mode = billing_mode or sess_billing_mode or ""
         now = time.time()
-        # Omit the conflict target for compatibility with drifted v22 databases
-        # where ``task`` exists but was not rebuilt into the primary key. The
-        # explicit six-column target makes SQLite reject the entire usage write.
         conn.execute(
             """INSERT INTO session_model_usage (
                    session_id, model, billing_provider, billing_base_url, billing_mode,
@@ -3065,7 +3084,10 @@ class SessionDB:
                    estimated_cost_usd, actual_cost_usd, cost_status, cost_source,
                    first_seen, last_seen
                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-               ON CONFLICT DO UPDATE SET
+               ON CONFLICT(
+                   session_id, model, billing_provider,
+                   billing_base_url, billing_mode, task
+               ) DO UPDATE SET
                    api_call_count = api_call_count + excluded.api_call_count,
                    input_tokens = input_tokens + excluded.input_tokens,
                    output_tokens = output_tokens + excluded.output_tokens,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3054,6 +3054,9 @@ class SessionDB:
             eff_base_url = billing_base_url or sess_base_url or ""
             eff_billing_mode = billing_mode or sess_billing_mode or ""
         now = time.time()
+        # Omit the conflict target for compatibility with drifted v22 databases
+        # where ``task`` exists but was not rebuilt into the primary key. The
+        # explicit six-column target makes SQLite reject the entire usage write.
         conn.execute(
             """INSERT INTO session_model_usage (
                    session_id, model, billing_provider, billing_base_url, billing_mode,
@@ -3062,8 +3065,7 @@ class SessionDB:
                    estimated_cost_usd, actual_cost_usd, cost_status, cost_source,
                    first_seen, last_seen
                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-               ON CONFLICT(session_id, model, billing_provider, billing_base_url, billing_mode, task)
-               DO UPDATE SET
+               ON CONFLICT DO UPDATE SET
                    api_call_count = api_call_count + excluded.api_call_count,
                    input_tokens = input_tokens + excluded.input_tokens,
                    output_tokens = output_tokens + excluded.output_tokens,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1536,7 +1536,17 @@ class SessionDB:
                         )
 
     @staticmethod
-    def _repair_session_model_usage_primary_key(cursor: sqlite3.Cursor) -> None:
+    def _session_model_usage_primary_key(cursor: sqlite3.Cursor) -> List[str]:
+        table_info = cursor.execute(
+            "PRAGMA table_info('session_model_usage')"
+        ).fetchall()
+        return [
+            row[1]
+            for row in sorted(table_info, key=lambda row: row[5] or len(table_info) + 1)
+            if row[5]
+        ]
+
+    def _repair_session_model_usage_primary_key(self, cursor: sqlite3.Cursor) -> None:
         """Ensure task is the sixth component of the live usage primary key."""
         expected_pk = [
             "session_id",
@@ -1546,78 +1556,109 @@ class SessionDB:
             "billing_mode",
             "task",
         ]
-        table_info = cursor.execute(
-            "PRAGMA table_info('session_model_usage')"
-        ).fetchall()
-        live_pk = [
-            row[1]
-            for row in sorted(table_info, key=lambda row: row[5] or len(table_info) + 1)
-            if row[5]
-        ]
-        if live_pk == expected_pk:
+        if self._session_model_usage_primary_key(cursor) == expected_pk:
             return
 
-        cursor.execute("SAVEPOINT repair_session_model_usage_pk")
-        try:
-            cursor.execute(
-                "ALTER TABLE session_model_usage RENAME TO session_model_usage_old_pk"
-            )
-            cursor.execute(
-                """CREATE TABLE session_model_usage (
-                       session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
-                       model TEXT NOT NULL,
-                       billing_provider TEXT NOT NULL DEFAULT '',
-                       billing_base_url TEXT NOT NULL DEFAULT '',
-                       billing_mode TEXT NOT NULL DEFAULT '',
-                       task TEXT NOT NULL DEFAULT '',
-                       api_call_count INTEGER NOT NULL DEFAULT 0,
-                       input_tokens INTEGER NOT NULL DEFAULT 0,
-                       output_tokens INTEGER NOT NULL DEFAULT 0,
-                       cache_read_tokens INTEGER NOT NULL DEFAULT 0,
-                       cache_write_tokens INTEGER NOT NULL DEFAULT 0,
-                       reasoning_tokens INTEGER NOT NULL DEFAULT 0,
-                       estimated_cost_usd REAL NOT NULL DEFAULT 0,
-                       actual_cost_usd REAL NOT NULL DEFAULT 0,
-                       cost_status TEXT,
-                       cost_source TEXT,
-                       first_seen REAL,
-                       last_seen REAL,
-                       PRIMARY KEY (
-                           session_id, model, billing_provider,
-                           billing_base_url, billing_mode, task
+        connection = cursor.connection
+        for attempt in range(self._WRITE_MAX_RETRIES):
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+            except sqlite3.OperationalError as exc:
+                err_msg = str(exc).lower()
+                if "locked" not in err_msg and "busy" not in err_msg:
+                    raise
+                if attempt >= self._WRITE_MAX_RETRIES - 1:
+                    raise
+                time.sleep(random.uniform(
+                    self._WRITE_RETRY_MIN_S,
+                    self._WRITE_RETRY_MAX_S,
+                ))
+                continue
+
+            savepoint_active = False
+            try:
+                # A concurrent process may have repaired the key while this
+                # connection waited for the migration write lock.
+                if self._session_model_usage_primary_key(cursor) == expected_pk:
+                    connection.commit()
+                    return
+
+                cursor.execute("SAVEPOINT repair_session_model_usage_pk")
+                savepoint_active = True
+                cursor.execute(
+                    "ALTER TABLE session_model_usage RENAME TO session_model_usage_old_pk"
+                )
+                cursor.execute(
+                    """CREATE TABLE session_model_usage (
+                           session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                           model TEXT NOT NULL,
+                           billing_provider TEXT NOT NULL DEFAULT '',
+                           billing_base_url TEXT NOT NULL DEFAULT '',
+                           billing_mode TEXT NOT NULL DEFAULT '',
+                           task TEXT NOT NULL DEFAULT '',
+                           api_call_count INTEGER NOT NULL DEFAULT 0,
+                           input_tokens INTEGER NOT NULL DEFAULT 0,
+                           output_tokens INTEGER NOT NULL DEFAULT 0,
+                           cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+                           cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+                           reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+                           estimated_cost_usd REAL NOT NULL DEFAULT 0,
+                           actual_cost_usd REAL NOT NULL DEFAULT 0,
+                           cost_status TEXT,
+                           cost_source TEXT,
+                           first_seen REAL,
+                           last_seen REAL,
+                           PRIMARY KEY (
+                               session_id, model, billing_provider,
+                               billing_base_url, billing_mode, task
+                           )
+                       )"""
+                )
+                cursor.execute(
+                    """INSERT INTO session_model_usage (
+                           session_id, model, billing_provider, billing_base_url,
+                           billing_mode, task, api_call_count, input_tokens,
+                           output_tokens, cache_read_tokens, cache_write_tokens,
+                           reasoning_tokens, estimated_cost_usd, actual_cost_usd,
+                           cost_status, cost_source, first_seen, last_seen
                        )
-                   )"""
-            )
-            cursor.execute(
-                """INSERT INTO session_model_usage (
-                       session_id, model, billing_provider, billing_base_url,
-                       billing_mode, task, api_call_count, input_tokens,
-                       output_tokens, cache_read_tokens, cache_write_tokens,
-                       reasoning_tokens, estimated_cost_usd, actual_cost_usd,
-                       cost_status, cost_source, first_seen, last_seen
-                   )
-                   SELECT session_id, model, billing_provider, billing_base_url,
-                          billing_mode, COALESCE(task, ''), api_call_count,
-                          input_tokens, output_tokens, cache_read_tokens,
-                          cache_write_tokens, reasoning_tokens,
-                          estimated_cost_usd, actual_cost_usd, cost_status,
-                          cost_source, first_seen, last_seen
-                   FROM session_model_usage_old_pk"""
-            )
-            cursor.execute("DROP TABLE session_model_usage_old_pk")
-            cursor.execute(
-                "CREATE INDEX idx_session_model_usage_session "
-                "ON session_model_usage(session_id)"
-            )
-            cursor.execute(
-                "CREATE INDEX idx_session_model_usage_model "
-                "ON session_model_usage(model)"
-            )
-            cursor.execute("RELEASE SAVEPOINT repair_session_model_usage_pk")
-        except sqlite3.Error:
-            cursor.execute("ROLLBACK TO SAVEPOINT repair_session_model_usage_pk")
-            cursor.execute("RELEASE SAVEPOINT repair_session_model_usage_pk")
-            raise
+                       SELECT session_id, model, billing_provider, billing_base_url,
+                              billing_mode, COALESCE(task, ''), api_call_count,
+                              input_tokens, output_tokens, cache_read_tokens,
+                              cache_write_tokens, reasoning_tokens,
+                              estimated_cost_usd, actual_cost_usd, cost_status,
+                              cost_source, first_seen, last_seen
+                       FROM session_model_usage_old_pk"""
+                )
+                cursor.execute("DROP TABLE session_model_usage_old_pk")
+                cursor.execute(
+                    "CREATE INDEX idx_session_model_usage_session "
+                    "ON session_model_usage(session_id)"
+                )
+                cursor.execute(
+                    "CREATE INDEX idx_session_model_usage_model "
+                    "ON session_model_usage(model)"
+                )
+                cursor.execute("RELEASE SAVEPOINT repair_session_model_usage_pk")
+                savepoint_active = False
+                connection.commit()
+                return
+            except BaseException:
+                if savepoint_active:
+                    try:
+                        cursor.execute(
+                            "ROLLBACK TO SAVEPOINT repair_session_model_usage_pk"
+                        )
+                        cursor.execute(
+                            "RELEASE SAVEPOINT repair_session_model_usage_pk"
+                        )
+                    except sqlite3.Error:
+                        pass
+                try:
+                    connection.rollback()
+                except sqlite3.Error:
+                    pass
+                raise
 
     def _init_schema(self):
         """Create tables and FTS if they don't exist, reconcile columns.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1067,8 +1067,33 @@ class SessionDB:
                 self._conn.execute("PRAGMA foreign_keys=ON")
                 self._init_schema()
 
+            def _connect_and_init_with_retry():
+                """Retry schema initialization while another process holds the writer lock."""
+                for attempt in range(self._WRITE_MAX_RETRIES):
+                    try:
+                        _connect_and_init()
+                        return
+                    except sqlite3.OperationalError as exc:
+                        err_msg = str(exc).lower()
+                        if "locked" not in err_msg and "busy" not in err_msg:
+                            raise
+                        try:
+                            if self._conn is not None:
+                                self._conn.rollback()
+                                self._conn.close()
+                        except sqlite3.Error:
+                            pass
+                        finally:
+                            self._conn = None
+                        if attempt >= self._WRITE_MAX_RETRIES - 1:
+                            raise
+                        time.sleep(random.uniform(
+                            self._WRITE_RETRY_MIN_S,
+                            self._WRITE_RETRY_MAX_S,
+                        ))
+
             try:
-                _connect_and_init()
+                _connect_and_init_with_retry()
             except sqlite3.DatabaseError as exc:
                 # The malformed-schema class (e.g. a duplicate sqlite_master
                 # row for messages_fts) fails on the very first statement —
@@ -1091,7 +1116,7 @@ class SessionDB:
                 report = repair_state_db_schema(self.db_path)
                 if not report.get("repaired"):
                     raise
-                _connect_and_init()
+                _connect_and_init_with_retry()
         except Exception as exc:
             # Capture the cause so /resume and friends can surface WHY the
             # session DB is unavailable instead of a bare "Session database
@@ -1530,7 +1555,11 @@ class SessionDB:
                         # Expected: "duplicate column name" from a race or
                         # re-run.  Unexpected: "Cannot add a NOT NULL column
                         # with default value NULL" from a schema mistake.
-                        # Log at DEBUG so it's visible in agent.log.
+                        # Locked/busy must escape so constructor-level retry
+                        # can restart reconciliation on a clean connection.
+                        err_msg = str(exc).lower()
+                        if "locked" in err_msg or "busy" in err_msg:
+                            raise
                         logger.debug(
                             "reconcile %s.%s: %s", table_name, col_name, exc,
                         )

--- a/tests/cli/test_single_query_usage_persistence.py
+++ b/tests/cli/test_single_query_usage_persistence.py
@@ -70,15 +70,9 @@ def _create_v22_db_with_legacy_usage_key(db_path: Path) -> None:
         conn.close()
 
 
-def test_single_query_exact_usage_survives_process_exit_on_legacy_v22_key(tmp_path):
-    """Run the real one-shot CLI turn/finalizer, then reopen and read state.db."""
-    hermes_home = tmp_path / "hermes-home"
-    hermes_home.mkdir()
-    db_path = hermes_home / "state.db"
-    _create_v22_db_with_legacy_usage_key(db_path)
-
+def _run_single_query_child(hermes_home: Path, usage_expression: str) -> subprocess.CompletedProcess:
     child = textwrap.dedent(
-        """
+        f"""
         from types import SimpleNamespace
 
         import cli
@@ -87,7 +81,7 @@ def test_single_query_exact_usage_survives_process_exit_on_legacy_v22_key(tmp_pa
         cli._run_state_db_auto_maintenance = lambda _db: None
         cli._run_checkpoint_auto_maintenance = lambda: None
         run_agent.get_tool_definitions = lambda **_kwargs: []
-        run_agent.check_toolset_requirements = lambda: {}
+        run_agent.check_toolset_requirements = lambda: {{}}
 
         real_agent_factory = cli.AIAgent
 
@@ -100,16 +94,7 @@ def test_single_query_exact_usage_survives_process_exit_on_legacy_v22_key(tmp_pa
                     type="message",
                     content=[SimpleNamespace(type="output_text", text="OK")],
                 )],
-                usage=SimpleNamespace(
-                    input_tokens=26,
-                    input_tokens_details=SimpleNamespace(
-                        cached_tokens=5,
-                        cache_write_tokens=2,
-                    ),
-                    output_tokens=9,
-                    output_tokens_details=SimpleNamespace(reasoning_tokens=3),
-                    total_tokens=35,
-                ),
+                usage={usage_expression},
                 status="completed",
                 model="gpt-5.6-sol",
             )
@@ -138,8 +123,7 @@ def test_single_query_exact_usage_survives_process_exit_on_legacy_v22_key(tmp_pa
     )
     env.pop("HERMES_KANBAN_TASK", None)
     env.pop("HERMES_KANBAN_GOAL_MODE", None)
-
-    proc = subprocess.run(
+    return subprocess.run(
         [sys.executable, "-c", child],
         cwd=Path(__file__).resolve().parents[2],
         env=env,
@@ -147,6 +131,28 @@ def test_single_query_exact_usage_survives_process_exit_on_legacy_v22_key(tmp_pa
         text=True,
         timeout=60,
         check=False,
+    )
+
+
+def test_single_query_exact_usage_survives_process_exit_on_legacy_v22_key(tmp_path):
+    """Run the real one-shot CLI turn/finalizer, then reopen and read state.db."""
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    db_path = hermes_home / "state.db"
+    _create_v22_db_with_legacy_usage_key(db_path)
+
+    proc = _run_single_query_child(
+        hermes_home,
+        """SimpleNamespace(
+            input_tokens=26,
+            input_tokens_details=SimpleNamespace(
+                cached_tokens=5,
+                cache_write_tokens=2,
+            ),
+            output_tokens=9,
+            output_tokens_details=SimpleNamespace(reasoning_tokens=3),
+            total_tokens=35,
+        )""",
     )
     assert proc.returncode == 0, proc.stderr
     assert "OK" in proc.stdout
@@ -177,3 +183,33 @@ def test_single_query_exact_usage_survives_process_exit_on_legacy_v22_key(tmp_pa
     assert dict(session) == EXPECTED_USAGE
     assert model_usage is not None
     assert dict(model_usage) == EXPECTED_USAGE
+
+
+def test_single_query_without_usage_persists_api_call_across_process_exit(tmp_path):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+
+    proc = _run_single_query_child(hermes_home, "None")
+    assert proc.returncode == 0, proc.stderr
+    assert "OK" in proc.stdout
+
+    reopened = SessionDB(db_path=hermes_home / "state.db")
+    try:
+        session = reopened._conn.execute(
+            "SELECT id, api_call_count, input_tokens, output_tokens, "
+            "cache_read_tokens, cache_write_tokens, reasoning_tokens "
+            "FROM sessions ORDER BY started_at DESC LIMIT 1"
+        ).fetchone()
+        assert session is not None
+        usage = reopened._conn.execute(
+            "SELECT api_call_count, input_tokens, output_tokens, "
+            "cache_read_tokens, cache_write_tokens, reasoning_tokens "
+            "FROM session_model_usage WHERE session_id = ?",
+            (session["id"],),
+        ).fetchone()
+    finally:
+        reopened.close()
+
+    assert tuple(session)[1:] == (1, 0, 0, 0, 0, 0)
+    assert usage is not None
+    assert tuple(usage) == (1, 0, 0, 0, 0, 0)

--- a/tests/cli/test_single_query_usage_persistence.py
+++ b/tests/cli/test_single_query_usage_persistence.py
@@ -1,0 +1,179 @@
+"""Process-level regression coverage for exact CLI usage persistence."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+from hermes_state import SessionDB
+
+
+EXPECTED_USAGE = {
+    "input_tokens": 19,
+    "output_tokens": 9,
+    "cache_read_tokens": 5,
+    "cache_write_tokens": 2,
+    "reasoning_tokens": 3,
+    "api_call_count": 1,
+    "model": "gpt-5.6-sol",
+    "billing_provider": "openai-codex",
+}
+
+
+def _create_v22_db_with_legacy_usage_key(db_path: Path) -> None:
+    """Model a v22 DB whose task column was added without rebuilding its PK."""
+    db = SessionDB(db_path=db_path)
+    db.close()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            DROP TABLE session_model_usage;
+            CREATE TABLE session_model_usage (
+                session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                model TEXT NOT NULL,
+                billing_provider TEXT NOT NULL DEFAULT '',
+                billing_base_url TEXT NOT NULL DEFAULT '',
+                billing_mode TEXT NOT NULL DEFAULT '',
+                api_call_count INTEGER NOT NULL DEFAULT 0,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+                reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+                estimated_cost_usd REAL NOT NULL DEFAULT 0,
+                actual_cost_usd REAL NOT NULL DEFAULT 0,
+                cost_status TEXT,
+                cost_source TEXT,
+                first_seen REAL,
+                last_seen REAL,
+                task TEXT DEFAULT '',
+                PRIMARY KEY (
+                    session_id, model, billing_provider,
+                    billing_base_url, billing_mode
+                )
+            );
+            CREATE INDEX idx_session_model_usage_session
+                ON session_model_usage(session_id);
+            CREATE INDEX idx_session_model_usage_model
+                ON session_model_usage(model);
+            UPDATE schema_version SET version = 22;
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_single_query_exact_usage_survives_process_exit_on_legacy_v22_key(tmp_path):
+    """Run the real one-shot CLI turn/finalizer, then reopen and read state.db."""
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    db_path = hermes_home / "state.db"
+    _create_v22_db_with_legacy_usage_key(db_path)
+
+    child = textwrap.dedent(
+        """
+        from types import SimpleNamespace
+
+        import cli
+        import run_agent
+
+        cli._run_state_db_auto_maintenance = lambda _db: None
+        cli._run_checkpoint_auto_maintenance = lambda: None
+        run_agent.get_tool_definitions = lambda **_kwargs: []
+        run_agent.check_toolset_requirements = lambda: {}
+
+        real_agent_factory = cli.AIAgent
+
+        def deterministic_agent(*args, **kwargs):
+            agent = real_agent_factory(*args, **kwargs)
+            agent._cleanup_task_resources = lambda _task_id: None
+            agent._save_trajectory = lambda *_args, **_kwargs: None
+            response = SimpleNamespace(
+                output=[SimpleNamespace(
+                    type="message",
+                    content=[SimpleNamespace(type="output_text", text="OK")],
+                )],
+                usage=SimpleNamespace(
+                    input_tokens=26,
+                    input_tokens_details=SimpleNamespace(
+                        cached_tokens=5,
+                        cache_write_tokens=2,
+                    ),
+                    output_tokens=9,
+                    output_tokens_details=SimpleNamespace(reasoning_tokens=3),
+                    total_tokens=35,
+                ),
+                status="completed",
+                model="gpt-5.6-sol",
+            )
+            agent._interruptible_api_call = lambda _api_kwargs: response
+            return agent
+
+        cli.AIAgent = deterministic_agent
+        cli.main(
+            query="Say OK",
+            quiet=True,
+            model="gpt-5.6-sol",
+            provider="openai-codex",
+            api_key="test-token",
+            base_url="https://chatgpt.com/backend-api/codex",
+            toolsets="terminal",
+            max_turns=1,
+            ignore_rules=True,
+        )
+        """
+    )
+    env = os.environ.copy()
+    env.update(
+        HERMES_HOME=str(hermes_home),
+        HERMES_EXIT_WATCHDOG_S="0",
+        PYTHONPATH=str(Path(__file__).resolve().parents[2]),
+    )
+    env.pop("HERMES_KANBAN_TASK", None)
+    env.pop("HERMES_KANBAN_GOAL_MODE", None)
+
+    proc = subprocess.run(
+        [sys.executable, "-c", child],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "OK" in proc.stdout
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        session = conn.execute(
+            """SELECT input_tokens, output_tokens, cache_read_tokens,
+                      cache_write_tokens, reasoning_tokens, api_call_count,
+                      model, billing_provider
+               FROM sessions ORDER BY started_at DESC LIMIT 1"""
+        ).fetchone()
+        assert session is not None
+        session_id = conn.execute(
+            "SELECT id FROM sessions ORDER BY started_at DESC LIMIT 1"
+        ).fetchone()["id"]
+        model_usage = conn.execute(
+            """SELECT input_tokens, output_tokens, cache_read_tokens,
+                      cache_write_tokens, reasoning_tokens, api_call_count,
+                      model, billing_provider
+               FROM session_model_usage WHERE session_id = ?""",
+            (session_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert dict(session) == EXPECTED_USAGE
+    assert model_usage is not None
+    assert dict(model_usage) == EXPECTED_USAGE

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1088,6 +1088,93 @@ def test_run_conversation_codex_plain_text(monkeypatch):
     assert result["messages"][-1]["content"] == "OK"
 
 
+def test_codex_raw_stream_usage_updates_agent_and_session_accounting(monkeypatch, tmp_path):
+    """Raw Responses events must retain exact provider usage through persistence."""
+    from agent.codex_runtime import _consume_codex_event_stream
+    from hermes_state import SessionDB
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream([
+            SimpleNamespace(
+                type="response.output_item.done",
+                item=SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    content=[SimpleNamespace(type="output_text", text="OK")],
+                ),
+            ),
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_usage",
+                    "status": "completed",
+                    "usage": {
+                        "input_tokens": 26,
+                        "input_tokens_details": {
+                            "cached_tokens": 5,
+                            "cache_write_tokens": 2,
+                        },
+                        "output_tokens": 9,
+                        "output_tokens_details": {"reasoning_tokens": 3},
+                        "total_tokens": 35,
+                    },
+                },
+            },
+        ]),
+        model="gpt-5.6-sol",
+    )
+
+    agent = _build_agent(monkeypatch)
+    agent.model = "gpt-5.6-sol"
+    agent.provider = "openai-codex"
+    agent.api_mode = "codex_responses"
+    agent.session_id = "codex-usage"
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session(agent.session_id, "cli", model=agent.model)
+    agent._session_db = db
+    agent._session_db_created = True
+    monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: response)
+
+    result = agent.run_conversation("Say OK")
+
+    assert result["completed"] is True
+    assert agent.session_input_tokens == 19
+    assert agent.session_cache_read_tokens == 5
+    assert agent.session_cache_write_tokens == 2
+    assert agent.session_output_tokens == 9
+    assert agent.session_reasoning_tokens == 3
+    assert agent.session_api_calls == 1
+
+    session = db._conn.execute(
+        "SELECT * FROM sessions WHERE id = ?", (agent.session_id,)
+    ).fetchone()
+    assert session["input_tokens"] == 19
+    assert session["cache_read_tokens"] == 5
+    assert session["cache_write_tokens"] == 2
+    assert session["output_tokens"] == 9
+    assert session["reasoning_tokens"] == 3
+    assert session["api_call_count"] == 1
+    assert session["model"] == "gpt-5.6-sol"
+    assert session["billing_provider"] == "openai-codex"
+    assert session["billing_mode"] == "subscription_included"
+
+    usage = db._conn.execute(
+        "SELECT * FROM session_model_usage WHERE session_id = ?",
+        (agent.session_id,),
+    ).fetchone()
+    assert usage is not None
+    assert usage["input_tokens"] == 19
+    assert usage["cache_read_tokens"] == 5
+    assert usage["cache_write_tokens"] == 2
+    assert usage["output_tokens"] == 9
+    assert usage["reasoning_tokens"] == 3
+    assert usage["api_call_count"] == 1
+    assert usage["model"] == "gpt-5.6-sol"
+    assert usage["billing_provider"] == "openai-codex"
+    assert usage["billing_mode"] == "subscription_included"
+
+
 def test_copilot_final_preflight_sanitizes_both_middleware_layers(monkeypatch):
     """The dispatch chokepoint must sanitize after every mutable layer."""
     agent = _build_copilot_agent(monkeypatch)

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1175,6 +1175,70 @@ def test_codex_raw_stream_usage_updates_agent_and_session_accounting(monkeypatch
     assert usage["billing_mode"] == "subscription_included"
 
 
+def test_codex_raw_stream_without_usage_still_persists_api_call(monkeypatch, tmp_path):
+    """Live Codex can complete a raw Responses stream without exact usage telemetry."""
+    from agent.codex_runtime import _consume_codex_event_stream
+    from hermes_state import SessionDB
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream([
+            SimpleNamespace(
+                type="response.output_item.done",
+                item=SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    content=[SimpleNamespace(type="output_text", text="OK")],
+                ),
+            ),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(
+                    id="resp_without_usage",
+                    status="completed",
+                    usage=None,
+                ),
+            ),
+        ]),
+        model="gpt-5.6-sol",
+    )
+
+    agent = _build_agent(monkeypatch)
+    agent.model = "gpt-5.6-sol"
+    agent.provider = "openai-codex"
+    agent.api_mode = "codex_responses"
+    agent.session_id = "codex-without-usage"
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session(agent.session_id, "cli", model=agent.model)
+    agent._session_db = db
+    agent._session_db_created = True
+    monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: response)
+
+    result = agent.run_conversation("Say OK")
+
+    assert result["completed"] is True
+    assert result["api_calls"] == 1
+    assert agent.session_api_calls == 1
+
+    session = db._conn.execute(
+        "SELECT * FROM sessions WHERE id = ?", (agent.session_id,)
+    ).fetchone()
+    assert session["api_call_count"] == 1
+    assert session["billing_provider"] == "openai-codex"
+    assert session["billing_mode"] == "subscription_included"
+    assert session["input_tokens"] == 0
+    assert session["output_tokens"] == 0
+
+    usage = db._conn.execute(
+        "SELECT * FROM session_model_usage WHERE session_id = ?",
+        (agent.session_id,),
+    ).fetchone()
+    assert usage is not None
+    assert usage["api_call_count"] == 1
+    assert usage["model"] == "gpt-5.6-sol"
+    assert usage["billing_provider"] == "openai-codex"
+
+
 def test_copilot_final_preflight_sanitizes_both_middleware_layers(monkeypatch):
     """The dispatch chokepoint must sanitize after every mutable layer."""
     agent = _build_copilot_agent(monkeypatch)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,7 +1,9 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
 import sqlite3
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 import json
 import pytest
 
@@ -73,6 +75,44 @@ def db(tmp_path):
     session_db = SessionDB(db_path=db_path)
     yield session_db
     session_db.close()
+
+
+def _create_drifted_usage_table(conn, rows):
+    conn.executescript("""
+        DROP TABLE IF EXISTS session_model_usage;
+        CREATE TABLE session_model_usage (
+            session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            model TEXT NOT NULL,
+            billing_provider TEXT NOT NULL DEFAULT '',
+            billing_base_url TEXT NOT NULL DEFAULT '',
+            billing_mode TEXT NOT NULL DEFAULT '',
+            task TEXT DEFAULT '',
+            api_call_count INTEGER NOT NULL DEFAULT 0,
+            input_tokens INTEGER NOT NULL DEFAULT 0,
+            output_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+            reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+            estimated_cost_usd REAL NOT NULL DEFAULT 0,
+            actual_cost_usd REAL NOT NULL DEFAULT 0,
+            cost_status TEXT,
+            cost_source TEXT,
+            first_seen REAL,
+            last_seen REAL,
+            PRIMARY KEY (
+                session_id, model, billing_provider,
+                billing_base_url, billing_mode
+            )
+        );
+    """)
+    conn.executemany(
+        """INSERT INTO session_model_usage (
+               session_id, model, billing_provider, billing_base_url,
+               billing_mode, task, api_call_count, input_tokens
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        rows,
+    )
+    conn.commit()
 
 
 # =========================================================================
@@ -647,6 +687,267 @@ class TestSessionLifecycle:
             assert tuple(row) == (7, 1)
         finally:
             reopened.close()
+
+    def test_usage_primary_key_repair_after_task_column_reconciliation(self, tmp_path):
+        """A pre-task table must commit reconciliation before BEGIN IMMEDIATE."""
+        db_path = tmp_path / "pre-task-v22.db"
+        db = SessionDB(db_path=db_path)
+        db.close()
+
+        conn = sqlite3.connect(db_path)
+        conn.executescript("""
+            DROP TABLE session_model_usage;
+            CREATE TABLE session_model_usage (
+                session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                model TEXT NOT NULL,
+                billing_provider TEXT NOT NULL DEFAULT '',
+                billing_base_url TEXT NOT NULL DEFAULT '',
+                billing_mode TEXT NOT NULL DEFAULT '',
+                api_call_count INTEGER NOT NULL DEFAULT 0,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+                reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+                estimated_cost_usd REAL NOT NULL DEFAULT 0,
+                actual_cost_usd REAL NOT NULL DEFAULT 0,
+                cost_status TEXT,
+                cost_source TEXT,
+                first_seen REAL,
+                last_seen REAL,
+                PRIMARY KEY (
+                    session_id, model, billing_provider,
+                    billing_base_url, billing_mode
+                )
+            );
+            UPDATE schema_version SET version = 22;
+        """)
+        conn.commit()
+        conn.close()
+
+        repaired = SessionDB(db_path=db_path)
+        try:
+            assert repaired._session_model_usage_primary_key(
+                repaired._conn.cursor()
+            ) == [
+                "session_id", "model", "billing_provider",
+                "billing_base_url", "billing_mode", "task",
+            ]
+        finally:
+            repaired.close()
+
+    def test_concurrent_usage_primary_key_repair_retries_and_rechecks(
+        self, tmp_path, monkeypatch,
+    ):
+        db_path = tmp_path / "concurrent-drifted-v22.db"
+        db = SessionDB(db_path=db_path)
+        db.create_session(session_id="usage", source="cli")
+        db.close()
+
+        conn = sqlite3.connect(db_path)
+        _create_drifted_usage_table(conn, [(
+            "usage", "shared-model", "custom", "https://example.test/v1",
+            "api_key", "vision", 2, 20,
+        )])
+        conn.close()
+
+        opener_count = 4
+        observed_drift = threading.Barrier(opener_count + 1)
+        rebuild_count = 0
+        rebuild_count_lock = threading.Lock()
+        real_connect = sqlite3.connect
+
+        def instrumented_connect(*args, **kwargs):
+            nonlocal rebuild_count
+            opened_conn = real_connect(*args, **kwargs)
+            if args and str(args[0]) == str(db_path):
+                saw_initial_inspection = False
+
+                def trace(sql):
+                    nonlocal saw_initial_inspection, rebuild_count
+                    normalized = " ".join(sql.lower().split())
+                    if (
+                        not saw_initial_inspection
+                        and normalized.startswith("pragma table_info")
+                        and "session_model_usage" in normalized
+                    ):
+                        saw_initial_inspection = True
+                        observed_drift.wait(timeout=5)
+                    if normalized.startswith(
+                        "alter table session_model_usage rename to"
+                    ):
+                        with rebuild_count_lock:
+                            rebuild_count += 1
+
+                opened_conn.set_trace_callback(trace)
+            return opened_conn
+
+        def repair_only(session_db):
+            session_db._repair_session_model_usage_primary_key(
+                session_db._conn.cursor()
+            )
+
+        monkeypatch.setattr(hermes_state.sqlite3, "connect", instrumented_connect)
+        monkeypatch.setattr(SessionDB, "_init_schema", repair_only)
+
+        blocker = real_connect(db_path, timeout=1.0, isolation_level=None)
+        blocker.execute("BEGIN IMMEDIATE")
+        opened_dbs = []
+
+        def open_db():
+            session_db = SessionDB(db_path=db_path)
+            opened_dbs.append(session_db)
+            return session_db
+
+        try:
+            with ThreadPoolExecutor(max_workers=opener_count) as executor:
+                futures = [executor.submit(open_db) for _ in range(opener_count)]
+                observed_drift.wait(timeout=5)
+                time.sleep(1.2)
+                blocker.commit()
+                results = [future.result(timeout=10) for future in futures]
+
+            assert len(results) == opener_count
+            assert rebuild_count == 1
+            assert all(
+                result._conn is not None and not result._conn.in_transaction
+                for result in results
+            )
+        finally:
+            if blocker.in_transaction:
+                blocker.rollback()
+            blocker.close()
+            for session_db in opened_dbs:
+                session_db.close()
+
+        check = real_connect(db_path)
+        try:
+            pk_columns = [
+                row[1]
+                for row in check.execute(
+                    "PRAGMA table_info('session_model_usage')"
+                ).fetchall()
+                if row[5]
+            ]
+            assert pk_columns == [
+                "session_id", "model", "billing_provider",
+                "billing_base_url", "billing_mode", "task",
+            ]
+            assert check.execute(
+                "SELECT task, api_call_count, input_tokens "
+                "FROM session_model_usage"
+            ).fetchone() == ("vision", 2, 20)
+        finally:
+            check.close()
+
+    def test_usage_primary_key_repair_has_bounded_lock_retries(
+        self, tmp_path, monkeypatch,
+    ):
+        db_path = tmp_path / "retry-exhaustion.db"
+        conn = sqlite3.connect(db_path)
+        _create_drifted_usage_table(conn, [(
+            "usage", "model", "", "", "", "vision", 0, 20,
+        )])
+        conn.close()
+
+        class CountingConnection(sqlite3.Connection):
+            begin_attempts = 0
+
+            def execute(self, sql, parameters=()):
+                if sql.strip().upper() == "BEGIN IMMEDIATE":
+                    self.begin_attempts += 1
+                return super().execute(sql, parameters)
+
+        repair_conn = sqlite3.connect(
+            db_path, timeout=0, isolation_level=None,
+            factory=CountingConnection,
+        )
+        blocker = sqlite3.connect(db_path, timeout=0, isolation_level=None)
+        blocker.execute("BEGIN IMMEDIATE")
+        repair_db = SessionDB.__new__(SessionDB)
+        monkeypatch.setattr(SessionDB, "_WRITE_MAX_RETRIES", 3)
+        monkeypatch.setattr(hermes_state.time, "sleep", lambda _delay: None)
+
+        try:
+            with pytest.raises(sqlite3.OperationalError, match="locked"):
+                repair_db._repair_session_model_usage_primary_key(
+                    repair_conn.cursor()
+                )
+            assert repair_conn.begin_attempts == 3
+            assert not repair_conn.in_transaction
+        finally:
+            blocker.rollback()
+            blocker.close()
+            repair_conn.close()
+
+        check = sqlite3.connect(db_path)
+        try:
+            assert [
+                row[1]
+                for row in check.execute(
+                    "PRAGMA table_info('session_model_usage')"
+                ).fetchall()
+                if row[5]
+            ] == [
+                "session_id", "model", "billing_provider",
+                "billing_base_url", "billing_mode",
+            ]
+            assert check.execute(
+                "SELECT task, input_tokens FROM session_model_usage"
+            ).fetchone() == ("vision", 20)
+        finally:
+            check.close()
+
+    def test_usage_primary_key_copy_failure_rolls_back_transaction(
+        self, tmp_path,
+    ):
+        db_path = tmp_path / "copy-failure.db"
+        conn = sqlite3.connect(db_path)
+        _create_drifted_usage_table(conn, [(
+            "usage", "model", "", "", "", "vision", 0, 20,
+        )])
+        conn.close()
+
+        class FailingCopyCursor(sqlite3.Cursor):
+            def execute(self, sql, parameters=()):
+                normalized = " ".join(sql.lower().split())
+                if normalized.startswith("insert into session_model_usage"):
+                    raise sqlite3.OperationalError("injected copy failure")
+                return super().execute(sql, parameters)
+
+        class FailingCopyConnection(sqlite3.Connection):
+            def cursor(self, factory=None):
+                return super().cursor(factory or FailingCopyCursor)
+
+        repair_conn = sqlite3.connect(
+            db_path, isolation_level=None, factory=FailingCopyConnection,
+        )
+        repair_db = SessionDB.__new__(SessionDB)
+        try:
+            with pytest.raises(sqlite3.OperationalError, match="copy failure"):
+                repair_db._repair_session_model_usage_primary_key(
+                    repair_conn.cursor()
+                )
+            assert not repair_conn.in_transaction
+            assert repair_conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+                "AND name = 'session_model_usage_old_pk'"
+            ).fetchone() is None
+            assert repair_conn.execute(
+                "SELECT task, input_tokens FROM session_model_usage"
+            ).fetchone() == ("vision", 20)
+            assert [
+                row[1]
+                for row in repair_conn.execute(
+                    "PRAGMA table_info('session_model_usage')"
+                ).fetchall()
+                if row[5]
+            ] == [
+                "session_id", "model", "billing_provider",
+                "billing_base_url", "billing_mode",
+            ]
+        finally:
+            repair_conn.close()
 
     def test_metadata_only_update_does_not_replace_requested_route(self, db):
         db.create_session(session_id="metadata", source="cli", model="primary")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -506,6 +506,148 @@ class TestSessionLifecycle:
             ("https://two.example/v1", "subscription_included", 20),
         ]
 
+    def test_v22_drifted_usage_primary_key_is_repaired_from_live_schema(self, tmp_path):
+        db_path = tmp_path / "drifted-v22.db"
+        db = SessionDB(db_path=db_path)
+        db.create_session(session_id="usage", source="cli")
+        db.close()
+
+        conn = sqlite3.connect(db_path)
+        conn.executescript("""
+            DROP TABLE session_model_usage;
+            CREATE TABLE session_model_usage (
+                session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                model TEXT NOT NULL,
+                billing_provider TEXT NOT NULL DEFAULT '',
+                billing_base_url TEXT NOT NULL DEFAULT '',
+                billing_mode TEXT NOT NULL DEFAULT '',
+                task TEXT DEFAULT '',
+                api_call_count INTEGER NOT NULL DEFAULT 0,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+                reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+                estimated_cost_usd REAL NOT NULL DEFAULT 0,
+                actual_cost_usd REAL NOT NULL DEFAULT 0,
+                cost_status TEXT,
+                cost_source TEXT,
+                first_seen REAL,
+                last_seen REAL,
+                PRIMARY KEY (
+                    session_id, model, billing_provider,
+                    billing_base_url, billing_mode
+                )
+            );
+            CREATE INDEX idx_session_model_usage_session
+                ON session_model_usage(session_id);
+            CREATE INDEX idx_session_model_usage_model
+                ON session_model_usage(model);
+            INSERT INTO session_model_usage (
+                session_id, model, billing_provider, billing_base_url,
+                billing_mode, task, api_call_count, input_tokens
+            ) VALUES (
+                'usage', 'shared-model', 'custom', 'https://example.test/v1',
+                'api_key', 'vision', 2, 20
+            );
+            INSERT INTO session_model_usage (
+                session_id, model, billing_provider, billing_base_url,
+                billing_mode, task, api_call_count, input_tokens
+            ) VALUES (
+                'usage', 'null-task-model', 'custom', 'https://example.test/v1',
+                'api_key', NULL, 1, 4
+            );
+            UPDATE schema_version SET version = 22;
+        """)
+        conn.commit()
+        conn.close()
+
+        repaired = SessionDB(db_path=db_path)
+        try:
+            pk_columns = [
+                row["name"]
+                for row in repaired._conn.execute(
+                    "PRAGMA table_info('session_model_usage')"
+                ).fetchall()
+                if row["pk"]
+            ]
+            assert pk_columns == [
+                "session_id", "model", "billing_provider",
+                "billing_base_url", "billing_mode", "task",
+            ]
+            assert {
+                row["name"]
+                for row in repaired._conn.execute(
+                    "PRAGMA index_list('session_model_usage')"
+                ).fetchall()
+            } >= {
+                "idx_session_model_usage_session",
+                "idx_session_model_usage_model",
+            }
+
+            repaired.update_token_counts(
+                "usage", input_tokens=10, output_tokens=3,
+                model="shared-model", billing_provider="custom",
+                billing_base_url="https://example.test/v1",
+                billing_mode="api_key", api_call_count=1,
+            )
+            rows = repaired._conn.execute(
+                "SELECT task, api_call_count, input_tokens, output_tokens "
+                "FROM session_model_usage WHERE session_id = 'usage' "
+                "AND model = 'shared-model' ORDER BY task"
+            ).fetchall()
+            assert [tuple(row) for row in rows] == [
+                ("", 1, 10, 3),
+                ("vision", 2, 20, 0),
+            ]
+            normalized = repaired._conn.execute(
+                "SELECT task, input_tokens FROM session_model_usage "
+                "WHERE session_id = 'usage' AND model = 'null-task-model'"
+            ).fetchone()
+            assert tuple(normalized) == ("", 4)
+        finally:
+            repaired.close()
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            pk_columns = [
+                row["name"]
+                for row in reopened._conn.execute(
+                    "PRAGMA table_info('session_model_usage')"
+                ).fetchall()
+                if row["pk"]
+            ]
+            assert pk_columns[-1] == "task"
+        finally:
+            reopened.close()
+
+    def test_correct_usage_primary_key_startup_does_not_rebuild_table(self, tmp_path):
+        db_path = tmp_path / "correct-v22.db"
+        db = SessionDB(db_path=db_path)
+        db.create_session(session_id="usage", source="cli")
+        db.update_token_counts(
+            "usage", input_tokens=7, model="model", api_call_count=1,
+        )
+        db._conn.execute(
+            "CREATE INDEX usage_startup_sentinel ON session_model_usage(last_seen)"
+        )
+        db._conn.commit()
+        db.close()
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert reopened._conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'index' "
+                "AND name = 'usage_startup_sentinel'"
+            ).fetchone() is not None
+            row = reopened._conn.execute(
+                "SELECT input_tokens, api_call_count FROM session_model_usage "
+                "WHERE session_id = 'usage'"
+            ).fetchone()
+            assert tuple(row) == (7, 1)
+        finally:
+            reopened.close()
+
     def test_metadata_only_update_does_not_replace_requested_route(self, db):
         db.create_session(session_id="metadata", source="cli", model="primary")
         db.update_token_counts(

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -736,6 +736,66 @@ class TestSessionLifecycle:
         finally:
             repaired.close()
 
+    def test_pre_task_usage_repair_retries_after_reconciliation_lock(self, tmp_path):
+        """A locked pre-task table must add task inside the serialized repair."""
+        db_path = tmp_path / "locked-pre-task-v22.db"
+        db = SessionDB(db_path=db_path)
+        db.close()
+
+        conn = sqlite3.connect(db_path)
+        conn.executescript("""
+            DROP TABLE session_model_usage;
+            CREATE TABLE session_model_usage (
+                session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                model TEXT NOT NULL,
+                billing_provider TEXT NOT NULL DEFAULT '',
+                billing_base_url TEXT NOT NULL DEFAULT '',
+                billing_mode TEXT NOT NULL DEFAULT '',
+                api_call_count INTEGER NOT NULL DEFAULT 0,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+                reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+                estimated_cost_usd REAL NOT NULL DEFAULT 0,
+                actual_cost_usd REAL NOT NULL DEFAULT 0,
+                cost_status TEXT,
+                cost_source TEXT,
+                first_seen REAL,
+                last_seen REAL,
+                PRIMARY KEY (
+                    session_id, model, billing_provider,
+                    billing_base_url, billing_mode
+                )
+            );
+            UPDATE schema_version SET version = 22;
+        """)
+        conn.commit()
+        conn.close()
+
+        blocker = sqlite3.connect(db_path, timeout=1.0, isolation_level=None)
+        blocker.execute("BEGIN IMMEDIATE")
+        try:
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(SessionDB, db_path=db_path)
+                time.sleep(1.2)
+                blocker.commit()
+                repaired = future.result(timeout=10)
+        finally:
+            if blocker.in_transaction:
+                blocker.rollback()
+            blocker.close()
+
+        try:
+            assert repaired._session_model_usage_primary_key(
+                repaired._conn.cursor()
+            ) == [
+                "session_id", "model", "billing_provider",
+                "billing_base_url", "billing_mode", "task",
+            ]
+        finally:
+            repaired.close()
+
     def test_concurrent_usage_primary_key_repair_retries_and_rechecks(
         self, tmp_path, monkeypatch,
     ):


### PR DESCRIPTION
## What does this PR do?

This PR restores exact OpenAI Codex Responses usage accounting and prevents valid session counters from being rolled back on databases whose `session_model_usage` table drifted during the v22 migration.

There are three parts to the same persistence chain:

1. Normalize raw Codex Responses usage whether the SDK/runtime exposes it as an object or a mapping.
2. Count a completed Codex API call once even when the provider omits token telemetry, without inventing token values.
3. Make `session_model_usage` upserts compatible with both legacy and current uniqueness layouts.

The database failure is reproducible when a v22-era table has a `task` column but still retains the original five-column primary key. The six-column conflict target does not match any unique constraint, so SQLite rejects `_record_model_usage()` and rolls back the surrounding session token update.

The fix now inspects the live primary key on every startup, independent of `schema_version`. A drifted table is rebuilt transactionally with `task` as the sixth key component, existing rows are preserved, and NULL tasks are normalized to `''`. The normal write path keeps the explicit six-column conflict target, preserving task attribution and compatibility with SQLite versions that predate targetless UPSERT.

Concurrent startup repair is serialized with `BEGIN IMMEDIATE`. After acquiring the write lock, each process rechecks the live key so only one process rebuilds; lock acquisition uses the existing bounded jittered retry policy rather than failing after SQLite's one-second busy timeout. Schema initialization itself also retries locked/busy failures on a fresh connection, covering pre-`task` databases where `SCHEMA_SQL` or column reconciliation encounters a concurrent writer before primary-key repair begins.

## Related Issue

No matching issue or duplicate PR was found after searching for `session_model_usage`, Codex usage persistence, and v22 schema drift.

Related but non-overlapping open PRs: #47935 (account usage guard) and #64584 (session source repair after lock races).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/usage_pricing.py`
  - normalize usage fields and nested details from both object-shaped and mapping-shaped provider telemetry;
  - preserve exact input, output, cache, and reasoning counters when supplied.
- `agent/conversation_loop.py`
  - account for raw Codex Responses stream telemetry;
  - count a completed request once when usage is unavailable, without estimating tokens.
- `hermes_state.py`
  - detect the actual `session_model_usage` primary-key order with `PRAGMA table_info`, independent of the stored schema version;
  - transactionally repair a drifted table under a savepoint, preserve rows/tasks, and recreate its indexes;
  - serialize concurrent repair with `BEGIN IMMEDIATE`, post-lock schema recheck, and bounded locked/busy retry;
  - retry locked/busy schema initialization on a fresh connection instead of silently losing a reconciler-added `task` column;
  - keep the explicit six-column `ON CONFLICT(..., task) DO UPDATE` write path so main-loop and auxiliary task usage remain separate.
- `tests/run_agent/test_run_agent_codex_responses.py`
  - cover raw stream usage and completed calls without usage.
- `tests/cli/test_single_query_usage_persistence.py`
  - reproduce the drifted v22 schema with a temporary SQLite DB;
  - run the single-query persistence path, close the process-owned DB, reopen it, and verify both aggregate and per-model usage rows;
  - verify a completed request with `usage=None` persists one API call after process exit without inventing token values.
- `tests/test_hermes_state.py`
  - verify drifted-v22 primary-key repair, index recreation, NULL-task normalization, and correct-schema idempotency;
  - verify main-loop and `vision` usage on the same route remain separate rows;
  - deterministically hold the SQLite writer lock while four connections observe drift, then verify all openers succeed and only one rebuild occurs;
  - cover the combined pre-`task` schema plus concurrent-writer path that previously failed before or during column reconciliation;
  - verify bounded retry exhaustion and copy-failure rollback leave the original table/data intact.

## How to Test

1. Run the affected SessionDB, CLI, and Codex Responses suites:

   ```bash
   python -m pytest -q \
     tests/cli/test_single_query_usage_persistence.py \
     tests/run_agent/test_run_agent_codex_responses.py \
     tests/test_hermes_state.py
   ```

   Observed: `489 passed in 48.53s`.

2. Check patch hygiene and changed-file lint:

   ```bash
   git diff --check origin/main...HEAD
   ruff check \
     hermes_state.py \
     tests/cli/test_single_query_usage_persistence.py \
     tests/test_hermes_state.py
   ```

   Observed: `git diff --check` exited 0 and Ruff reported `All checks passed!`.

3. Manual provider smoke on Linux using `openai-codex / gpt-5.6-sol`:

   - the provider request completed once;
   - `sessions` persisted non-zero exact input/output tokens, provider, billing mode, and API call count;
   - `session_model_usage` persisted the corresponding per-model row;
   - reopening the SQLite database retained the values.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full repository suite not run locally; 481 affected tests passed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.17 aarch64, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; internal accounting/persistence fix
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — SQLite and provider-shape handling only; no platform-specific process or path behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No UI change. The regression suite uses only synthetic provider responses and temporary SQLite databases; no prompts, credentials, or user database contents are included.
