### PR TITLE
fix(cli): suppress CPR on POSIX local TTYs under load

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3224,28 +3224,28 @@ def _disable_prompt_toolkit_cpr_warning(app) -> None:
         pass
 
 
-def _terminal_may_leak_cpr() -> bool:
-    """Detect terminals where CPR (ESC[6n) replies are likely to leak.
+def _terminal_may_leak_cpr(*, platform: str | None = None) -> bool:
+    """Whether classic CLI should suppress prompt_toolkit CPR (ESC[6n) queries.
 
-    The CPR leak in #13870 is environment-specific: it shows up over SSH +
-    cloudflared/mux tunnels and slow PTYs, where the terminal's
-    ``ESC[<row>;<col>R`` reply round-trips slowly enough to race past the input
-    parser and land in the display as raw ``20;1R`` text (and the pending-CPR
-    future can stall the renderer, freezing the prompt). On a local terminal the
-    reply returns instantly and cleanly, so CPR works fine and there is nothing
-    to fix — we leave prompt_toolkit's default behavior untouched there.
+    Delayed CPR replies (``ESC[<row>;<col>R`` / visible ``^[[<row>;<col>R``)
+    leak into the status line and can freeze input when the reply is slow
+    (#13870 on SSH/slow PTYs). The same race hits **local POSIX** TTYs under
+    heavy subagent / status-line load — deterministic delayed-CPR PTY harness
+    in ``tests/cli/test_cpr_local_leak.py``.
 
-    We only suppress CPR on a remote/tunneled link (SSH env vars) or when the
-    user has explicitly opted out via prompt_toolkit's own ``PROMPT_TOOLKIT_NO_CPR``
-    escape hatch. Keeping this narrow (not the broader WSL/Ghostty/Windows set
-    that ``_preserve_ctrl_enter_newline`` keys on) means the only behavior change
-    lands exactly where the bug reproduces.
+    Policy:
+    - ``PROMPT_TOOLKIT_NO_CPR=1`` → always suppress
+    - native Windows (``win32``) → keep prompt_toolkit's default for now
+      (no native-Windows Application coverage yet); still honor NO_CPR
+    - all other platforms → suppress (CPR is only a layout hint; heuristic
+      height is enough). SSH env is no longer required to trigger this.
     """
     if os.environ.get("PROMPT_TOOLKIT_NO_CPR", "") == "1":
         return True
-    if any(os.environ.get(v) for v in ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY")):
-        return True
-    return False
+    plat = sys.platform if platform is None else platform
+    if plat == "win32":
+        return False
+    return True
 
 
 def _build_cpr_disabled_output(stdout):
@@ -3253,23 +3253,14 @@ def _build_cpr_disabled_output(stdout):
 
     prompt_toolkit's renderer sends ``ESC[6n`` (Device Status Report) to learn
     the cursor row before painting in non-fullscreen mode; the terminal replies
-    ``ESC[<row>;<col>R``. Over SSH + cloudflared/mux tunnels and some slow PTYs
-    these replies race past the input parser and land in the display as raw text
-    like ``20;1R21;1R``, and the pending-CPR future can stall the renderer so the
-    prompt appears frozen after the agent's final answer (see #13870).
+    ``ESC[<row>;<col>R``. When that reply is delayed it races into the display
+    as raw ``^[[39;1R`` and can stall the renderer's pending-CPR future
+    (#13870; also local POSIX under heavy subagent load).
 
-    Constructing the output with ``enable_cpr=False`` makes the renderer mark CPR
-    ``NOT_SUPPORTED`` up front, so ``ESC[6n`` is never sent and no CPR response
-    can leak. This is the root-cause counterpart to the input-side scrubbing in
-    ``_strip_leaked_terminal_responses`` — that cleans leaks after the fact; this
-    stops them at the source. The UI is otherwise identical (prompt_toolkit uses
-    its heuristic available-height fallback, which it already relies on whenever a
-    terminal doesn't answer CPR).
-
-    This is only invoked on terminals flagged by ``_terminal_may_leak_cpr()`` —
-    CPR is a layout hint, not a speed optimization, and it works fine locally, so
-    we leave the upstream default in place on local terminals and only suppress it
-    where the leak actually reproduces.
+    Constructing the output with ``enable_cpr=False`` marks CPR
+    ``NOT_SUPPORTED`` so ``ESC[6n`` is never sent. prompt_toolkit then uses its
+    heuristic available-height fallback. Input-side
+    ``_strip_leaked_terminal_responses`` remains belt-and-suspenders.
 
     Note: ``Vt100_Output.from_pty()`` does NOT expose ``enable_cpr`` in
     prompt_toolkit 3.x, so we reproduce its ``get_size`` setup and call the
@@ -3293,6 +3284,18 @@ def _build_cpr_disabled_output(stdout):
         return Vt100_Output(stdout, _get_term_size, enable_cpr=False)
     except Exception:
         return None
+
+
+def _select_classic_cli_pt_output(stdout):
+    """Select prompt_toolkit Output for classic-CLI Application construction.
+
+    Returns a CPR-disabled ``Vt100_Output`` when ``_terminal_may_leak_cpr()``
+    is true, otherwise ``None`` so Application keeps prompt_toolkit's default
+    output (Windows preserve-default path).
+    """
+    if not _terminal_may_leak_cpr():
+        return None
+    return _build_cpr_disabled_output(stdout)
 
 
 def _strip_leaked_terminal_responses_with_meta(text: str) -> tuple[str, bool]:
@@ -14632,22 +14635,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         }
         style = PTStyle.from_dict(self._build_tui_style_dict())
 
-        # Disable CPR (Cursor Position Report) at the source so prompt_toolkit
-        # never sends ESC[6n cursor-position queries — but only on terminals
-        # where the reply is likely to leak. Over SSH/cloudflared tunnels and
-        # slow PTYs the CPR replies (ESC[<row>;<col>R) leak into the display as
-        # raw "20;1R21;1R" text and can stall the renderer's pending-CPR future,
-        # freezing the prompt after the agent's final answer (#13870). CPR is a
-        # layout hint, not a speed optimization, and it works fine locally, so we
-        # leave prompt_toolkit's default untouched on local terminals and only
-        # suppress it where the bug reproduces. None (local, or build failure)
-        # falls back to the default output; the input-side scrubbing in
-        # _strip_leaked_terminal_responses still guards against any leaks.
-        _cpr_disabled_output = (
-            _build_cpr_disabled_output(sys.stdout)
-            if _terminal_may_leak_cpr()
-            else None
-        )
+        # Select CPR-disabled output when _terminal_may_leak_cpr() says so
+        # (POSIX local + SSH; Windows keeps PT default — see helper docs).
+        # None falls back to prompt_toolkit's default output; input scrubbing
+        # in _strip_leaked_terminal_responses still guards residual leaks.
+        _cpr_disabled_output = _select_classic_cli_pt_output(sys.stdout)
 
         # Create the application
         app = Application(

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -289,30 +289,23 @@ class TestPromptToolkitTerminalCompatibility:
         result = _build_cpr_disabled_output(_NoFileno())
         assert result is None or result.enable_cpr is False
 
-    def test_cpr_gating_local_vs_tunnel(self, monkeypatch):
-        """CPR is only suppressed on tunneled links / explicit opt-out.
+    def test_cpr_gating_posix_local_and_windows_preserve(self, monkeypatch):
+        """POSIX suppresses CPR without SSH; native Windows keeps PT default.
 
-        CPR works fine on local terminals and is only a layout hint, so the fix
-        for #13870 must not change default behavior locally — it gates on
-        _terminal_may_leak_cpr(). Local (no SSH env) -> CPR left enabled;
-        SSH session or PROMPT_TOOLKIT_NO_CPR=1 -> CPR suppressed.
+        Broader coverage (Application wiring + delayed-CPR PTY repro) lives in
+        ``tests/cli/test_cpr_local_leak.py``.
         """
         from cli import _terminal_may_leak_cpr
 
         for var in ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY", "PROMPT_TOOLKIT_NO_CPR"):
             monkeypatch.delenv(var, raising=False)
 
-        # Local terminal: leave prompt_toolkit's default (CPR on) untouched.
-        assert _terminal_may_leak_cpr() is False
+        assert _terminal_may_leak_cpr(platform="linux") is True
+        assert _terminal_may_leak_cpr(platform="darwin") is True
+        assert _terminal_may_leak_cpr(platform="win32") is False
 
-        # SSH session: the tunnel where the leak reproduces.
-        monkeypatch.setenv("SSH_CONNECTION", "10.0.0.1 22 10.0.0.2 51234")
-        assert _terminal_may_leak_cpr() is True
-        monkeypatch.delenv("SSH_CONNECTION", raising=False)
-
-        # prompt_toolkit's own explicit opt-out is honored.
         monkeypatch.setenv("PROMPT_TOOLKIT_NO_CPR", "1")
-        assert _terminal_may_leak_cpr() is True
+        assert _terminal_may_leak_cpr(platform="win32") is True
 
 
 class TestSingleQueryState:

--- a/tests/cli/test_cpr_local_leak.py
+++ b/tests/cli/test_cpr_local_leak.py
@@ -1,0 +1,174 @@
+"""Local CPR leak reproduction + classic-CLI Application output selection.
+
+Addresses review on #67377:
+
+* Deterministic local-PTY proof that delayed CPR replies leak as
+  ``ESC[row;colR`` / ``^[[row;colR`` when ``enable_cpr=True`` (no SSH).
+* Integration-level assertion that, with no SSH env vars, classic CLI
+  output selection wires a CPR-disabled Output into Application on POSIX.
+* Native Windows keeps prompt_toolkit's default output selection.
+"""
+
+from __future__ import annotations
+
+import os
+import select
+import sys
+import threading
+import time
+
+import pytest
+
+from cli import (
+    _build_cpr_disabled_output,
+    _select_classic_cli_pt_output,
+    _terminal_may_leak_cpr,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cpr_env(monkeypatch):
+    for var in ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY", "PROMPT_TOOLKIT_NO_CPR"):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestClassicCliOutputSelection:
+    def test_posix_local_without_ssh_selects_cpr_disabled_output(self, monkeypatch):
+        """Changed contract: no SSH vars, still CPR-disabled on POSIX."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        assert _terminal_may_leak_cpr() is True
+        out = _select_classic_cli_pt_output(sys.stdout)
+        assert out is not None
+        assert out.enable_cpr is False
+
+    def test_application_receives_cpr_not_supported_without_ssh(self, monkeypatch):
+        """Classic-CLI Application construction must get CPR-disabled output."""
+        from prompt_toolkit.application import Application
+        from prompt_toolkit.layout import FormattedTextControl, Layout, Window
+        from prompt_toolkit.renderer import CPR_Support
+
+        monkeypatch.setattr(sys, "platform", "linux")
+        out = _select_classic_cli_pt_output(sys.stdout)
+        assert out is not None
+
+        app = Application(
+            layout=Layout(Window(FormattedTextControl("x"))),
+            output=out,
+            full_screen=False,
+        )
+        assert app.renderer.cpr_support == CPR_Support.NOT_SUPPORTED
+
+    def test_windows_preserves_default_output_selection(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        assert _terminal_may_leak_cpr() is False
+        assert _select_classic_cli_pt_output(sys.stdout) is None
+
+    def test_windows_honors_explicit_no_cpr(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setenv("PROMPT_TOOLKIT_NO_CPR", "1")
+        assert _terminal_may_leak_cpr() is True
+        out = _select_classic_cli_pt_output(sys.stdout)
+        # Build may return None if stdout is not a real tty in CI; if it
+        # succeeds it must be CPR-disabled.
+        assert out is None or out.enable_cpr is False
+
+
+def _openpty_or_skip():
+    import pty
+
+    try:
+        return pty.openpty()
+    except OSError as exc:
+        pytest.skip(f"no PTY devices available: {exc}")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX PTY harness")
+class TestDelayedCprLocalPtyLeak:
+    def test_delayed_cpr_reply_leaks_when_enable_cpr_true(self):
+        """Local (no SSH) delayed ESC[6n reply lands as ESC[39;1R on stdin."""
+        import tty
+
+        from prompt_toolkit.data_structures import Size
+        from prompt_toolkit.output.vt100 import Vt100_Output
+
+        master, slave = _openpty_or_skip()
+        tty.setraw(slave)
+        slave_w = os.fdopen(os.dup(slave), "w", buffering=1)
+        stop = threading.Event()
+        queries = 0
+
+        def terminal() -> None:
+            nonlocal queries
+            buf = b""
+            while not stop.is_set():
+                r, _, _ = select.select([master], [], [], 0.05)
+                if not r:
+                    continue
+                try:
+                    chunk = os.read(master, 4096)
+                except OSError:
+                    break
+                if not chunk:
+                    break
+                buf += chunk
+                while True:
+                    idx = buf.find(b"\x1b[6n")
+                    if idx < 0:
+                        buf = buf[-8:] if len(buf) > 8 else buf
+                        break
+                    buf = buf[idx + 4 :]
+                    queries += 1
+                    time.sleep(0.12)
+                    os.write(master, b"\x1b[39;1R")
+
+        threading.Thread(target=terminal, daemon=True).start()
+        out = Vt100_Output(
+            slave_w, lambda: Size(rows=40, columns=80), enable_cpr=True
+        )
+        out.ask_for_cpr()
+        out.flush()
+        for i in range(4):
+            slave_w.write(f"\rgpt-5.6-sol Q {i}\n")
+            slave_w.flush()
+            time.sleep(0.02)
+        time.sleep(0.3)
+
+        data = b""
+        while True:
+            r, _, _ = select.select([slave], [], [], 0.05)
+            if not r:
+                break
+            data += os.read(slave, 4096)
+
+        stop.set()
+        slave_w.close()
+        os.close(slave)
+        os.close(master)
+
+        assert queries >= 1
+        assert b"\x1b[39;1R" in data
+
+    def test_cpr_disabled_output_sends_no_query(self):
+        """Hermes CPR-disabled builder must not emit ESC[6n."""
+        master, slave = _openpty_or_skip()
+        slave_w = os.fdopen(slave, "w", buffering=1)
+        out = _build_cpr_disabled_output(slave_w)
+        assert out is not None
+        assert out.enable_cpr is False
+
+        seen = b""
+
+        def reader() -> None:
+            nonlocal seen
+            r, _, _ = select.select([master], [], [], 0.25)
+            if r:
+                seen = os.read(master, 4096)
+
+        threading.Thread(target=reader, daemon=True).start()
+        slave_w.write("status ok\n")
+        slave_w.flush()
+        # Do not call ask_for_cpr — renderer skips it when NOT_SUPPORTED.
+        time.sleep(0.3)
+        slave_w.close()
+        os.close(master)
+        assert b"\x1b[6n" not in seen


### PR DESCRIPTION
## Summary
- Delayed CPR replies (`ESC[6n` → `^[[row;colR`) leak into classic CLI on SSH/slow PTYs (#13870) **and** on local POSIX TTYs under heavy subagent/status-line load (deterministic delayed-CPR PTY harness; reporter screencast shows `^[[38;1R` / `^[[40;1R`).
- Suppress CPR on non-Windows platforms via `_select_classic_cli_pt_output` (CPR is only a layout hint). **Preserve native Windows** prompt_toolkit default pending native coverage; still honor `PROMPT_TOOLKIT_NO_CPR=1`.
- Address review: Application-level wiring assertion without SSH env; no duplicate sanitizer-only coverage as the primary proof.

## Test plan
- [x] `scripts/run_tests.sh tests/cli/test_cpr_local_leak.py tests/cli/test_cli_init.py -q -k 'cpr or Cpr or ClassicCli or Delayed'`
- [ ] Classic CLI on Linux: large parallel `delegate_task` — status line should not show `^[[…R`
