### PR TITLE
docs: correct command to set default model in FAQ

### DIFF
--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -269,7 +269,7 @@ Make sure the key matches the provider. An OpenAI key won't work with OpenRouter
 hermes model
 
 # Set a valid model
-hermes config set HERMES_MODEL anthropic/claude-opus-4.7
+hermes config set model.default anthropic/claude-opus-4.7
 
 # Or specify per-session
 hermes chat --model openrouter/meta-llama/llama-3.1-70b-instruct

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/faq.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/faq.md
@@ -288,7 +288,7 @@ hermes config set OPENROUTER_API_KEY sk-or-v1-xxxxxxxxxxxx
 hermes model
 
 # 设置有效的模型
-hermes config set HERMES_MODEL anthropic/claude-opus-4.7
+hermes config set model.default anthropic/claude-opus-4.7
 
 # 或按会话指定
 hermes chat --model openrouter/meta-llama/llama-3.1-70b-instruct


### PR DESCRIPTION
Fixes #65855.

### Problem
The FAQ page instructed users to run  to set their default model. However,  is an environment variable rather than a configuration key, causing the command to set an ignored configuration entry.

### Fix
Updated the FAQ (both English and Chinese translations) to correctly use  key path.