### PR TITLE
fix(agent): harden structured message text projection

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -748,27 +748,17 @@ def strip_think_blocks(agent, content: str) -> str:
     # object, got 'list'``, which the outer conversation loop swallows and
     # retries forever (observed as an infinite "preparing terminal…" loop on
     # Anthropic models via OpenRouter).  Flatten here so every caller is safe.
+    #
+    # This helper intentionally delegates all content-shape handling to the
+    # canonical projector in ``agent.message_content`` (single owner): typed
+    # text parts are concatenated with no inserted separator (``sep=""``) so
+    # provider-split tags like ``<thi`` + ``nk>`` are reassembled exactly
+    # before the scrubber runs, and unknown objects return "" instead of
+    # being stringified into visible text.
     if not isinstance(content, str):
-        if isinstance(content, list):
-            _parts: list[str] = []
-            for _part in content:
-                if isinstance(_part, str):
-                    _parts.append(_part)
-                elif isinstance(_part, dict):
-                    _ptype = str(_part.get("type") or "").strip().lower()
-                    # Drop reasoning/thinking blocks outright — this function's
-                    # whole job is to strip them, and their text lives under
-                    # different keys ("thinking", "reasoning") per provider.
-                    if _ptype in {"thinking", "reasoning", "redacted_thinking"}:
-                        continue
-                    _text = _part.get("text")
-                    if isinstance(_text, str) and _text:
-                        _parts.append(_text)
-            content = "".join(_parts)
-        elif isinstance(content, dict):
-            content = str(content.get("text") or content.get("content") or "")
-        else:
-            content = str(content)
+        from agent.message_content import flatten_message_text
+
+        content = flatten_message_text(content, sep="")
         if not content:
             return ""
     # 1. Closed tag pairs — case-insensitive for all variants so

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1252,7 +1252,7 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     # reasoning fields are present (some models/providers embed thinking
     # directly in the content rather than returning separate API fields).
     if not reasoning_text:
-        content = flatten_message_text(getattr(assistant_message, "content", None))
+        content = flatten_message_text(getattr(assistant_message, "content", None), sep="")
         think_blocks = re.findall(r'<think>(.*?)</think>', content, flags=re.DOTALL)
         if think_blocks:
             combined = "\n\n".join(b.strip() for b in think_blocks if b.strip())
@@ -1278,7 +1278,7 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
 
     # Sanitize surrogates from API response — some models (e.g. Kimi/GLM via Ollama)
     # can return invalid surrogate code points that crash json.dumps() on persist.
-    _raw_content = flatten_message_text(getattr(assistant_message, "content", None))
+    _raw_content = flatten_message_text(getattr(assistant_message, "content", None), sep="")
     _san_content = _sanitize_surrogates(_raw_content)
     if reasoning_text:
         reasoning_text = _sanitize_surrogates(reasoning_text)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1796,7 +1796,11 @@ def run_conversation(
                         )
                     else:
                         _refusal_result = _refusal_transport.normalize_response(response)
-                    _refusal_text = (getattr(_refusal_result, "content", None) or "").strip()
+                    from agent.message_content import flatten_message_text
+
+                    _refusal_text = flatten_message_text(
+                        getattr(_refusal_result, "content", None), sep=""
+                    ).strip()
                     # Some refusals carry the explanation only in the reasoning
                     # channel; fall back to it so the user sees *something*.
                     if not _refusal_text:
@@ -1908,6 +1912,14 @@ def run_conversation(
                     _trunc_msg = _trunc_result
 
                     _trunc_content = getattr(_trunc_msg, "content", None) if _trunc_msg else None
+                    if _trunc_content is not None and not isinstance(_trunc_content, str):
+                        # Project structured content to visible text via the
+                        # canonical projector before any regex/strip sink —
+                        # typed parts join without separators, unknown
+                        # structures drop out instead of crashing here.
+                        from agent.message_content import flatten_message_text
+
+                        _trunc_content = flatten_message_text(_trunc_content, sep="")
                     _trunc_has_tool_calls = bool(getattr(_trunc_msg, "tool_calls", None)) if _trunc_msg else False
 
                     # ── Detect thinking-budget exhaustion ──────────────
@@ -2027,8 +2039,18 @@ def run_conversation(
                             length_continue_retries += 1
                             interim_msg = agent._build_assistant_message(assistant_message, finish_reason)
                             messages.append(interim_msg)
-                            if assistant_message.content:
-                                truncated_response_parts.append(assistant_message.content)
+                            # Project the raw content to visible text via the
+                            # canonical projector (no TypeError on list), but
+                            # WITHOUT build_assistant_message's .strip() — the
+                            # continuation join must preserve the truncated
+                            # fragment byte-for-byte (e.g. trailing spaces).
+                            from agent.message_content import flatten_message_text
+
+                            _trunc_partial = flatten_message_text(
+                                getattr(assistant_message, "content", None), sep=""
+                            )
+                            if _trunc_partial:
+                                truncated_response_parts.append(_trunc_partial)
 
                             if length_continue_retries < 4:
                                 _is_partial_stream_stub = (
@@ -4444,26 +4466,23 @@ def run_conversation(
             assistant_message = normalized
             finish_reason = normalized.finish_reason
             
-            # Normalize content to string — some OpenAI-compatible servers
-            # (llama-server, etc.) return content as a dict or list instead
-            # of a plain string, which crashes downstream .strip() calls.
+            # Normalize visible content to a string BEFORE any downstream
+            # string sink — some OpenAI-compatible servers return content as
+            # a dict or list instead of a plain string, which crashes
+            # downstream .strip()/regex calls. This goes through the canonical
+            # projector in agent.message_content (single owner): typed text
+            # parts are concatenated without inserting separators, and
+            # images, metadata and unknown structures are dropped instead of
+            # being stringified into visible text.
             if assistant_message.content is not None and not isinstance(assistant_message.content, str):
-                raw = assistant_message.content
-                if isinstance(raw, dict):
-                    assistant_message.content = raw.get("text", "") or raw.get("content", "") or json.dumps(raw)
-                elif isinstance(raw, list):
-                    # Multimodal content list — extract text parts
-                    parts = []
-                    for part in raw:
-                        if isinstance(part, str):
-                            parts.append(part)
-                        elif isinstance(part, dict) and part.get("type") == "text":
-                            parts.append(part.get("text", ""))
-                        elif isinstance(part, dict) and "text" in part:
-                            parts.append(str(part["text"]))
-                    assistant_message.content = "\n".join(parts)
-                else:
-                    assistant_message.content = str(raw)
+                from agent.message_content import flatten_message_text
+                # Preserve structured reasoning BEFORE projecting, otherwise
+                # thinking/reasoning blocks die here before
+                # build_assistant_message can capture them.
+                _extracted_reasoning = agent._extract_reasoning(assistant_message)
+                if _extracted_reasoning and not getattr(assistant_message, "reasoning", None):
+                    assistant_message.reasoning = _extracted_reasoning
+                assistant_message.content = flatten_message_text(assistant_message.content, sep="")
 
             try:
                 from hermes_cli.plugins import (
@@ -4593,7 +4612,10 @@ def run_conversation(
                     # dedup and causes message storms (#52711).
                     last_interim_visible = (
                         agent._interim_assistant_visible_text(last_msg)
-                        if isinstance(last_msg, dict)
+                        if (
+                            isinstance(last_msg, dict)
+                            and last_msg.get("role") == "assistant"
+                        )
                         else ""
                     )
                     current_interim_visible = agent._interim_assistant_visible_text(interim_msg)
@@ -4992,7 +5014,10 @@ def run_conversation(
                 current_interim_visible = agent._interim_assistant_visible_text(assistant_msg)
                 previous_interim_visible = (
                     agent._interim_assistant_visible_text(previous_msg)
-                    if isinstance(previous_msg, dict)
+                    if (
+                        isinstance(previous_msg, dict)
+                        and previous_msg.get("role") == "assistant"
+                    )
                     else ""
                 )
                 duplicate_previous_interim = (

--- a/agent/message_content.py
+++ b/agent/message_content.py
@@ -4,35 +4,105 @@ from collections.abc import Mapping
 from typing import Any
 
 
-_NON_TEXT_PART_TYPES = {"image", "image_url", "input_image", "audio", "input_audio"}
-_TEXT_KEYS = ("text", "content", "input_text", "output_text", "summary_text")
+# Canonical structured-content text projection (single owner).  Everything
+# that needs the *visible text* of a message — reasoning scrubbers, interim
+# dedup, assistant-message building, MoA aggregation — must go through this
+# module instead of maintaining its own coercion logic.
+#
+# Contract:
+#   known visible text      -> extracted
+#   known non-text content  -> ignored
+#   unknown structure       -> "" (never stringified, never reflectively read)
+#
+# Only these part shapes contribute text:
+#   * plain ``str`` items
+#   * typed text parts whose ``type`` is in ``_TEXT_PART_TYPES`` (typed
+#     Mappings or provider SDK objects exposing ``.type``/``.text``)
+#   * explicitly allowed summary parts (``_SUMMARY_PART_TYPES``)
+#   * untyped PURE legacy wrapper Mappings — every key is in
+#     ``_LEGACY_WRAPPER_KEYS`` (``{"text": str}`` / ``{"content": str}``,
+#     in any position). An untyped Mapping carrying ANY extra
+#     provider/tool/metadata/unknown field is not a wrapper and yields "".
+# Images, URLs, base64, audio, files, tool results, encrypted/redacted
+# reasoning, provider metadata, unknown typed parts and unknown objects
+# contribute nothing.
+
+_TEXT_PART_TYPES = frozenset({"text", "input_text", "output_text"})
+_SUMMARY_PART_TYPES = frozenset({"summary_text"})
+_LEGACY_WRAPPER_KEYS = ("text", "content")
 
 
-def _field(value: Any, key: str) -> Any:
-    if isinstance(value, Mapping):
-        return value.get(key)
-    return getattr(value, key, None)
+def _part_type(part: Any) -> Any:
+    if isinstance(part, Mapping):
+        try:
+            return part.get("type")
+        except Exception:
+            return None
+    try:
+        return getattr(part, "type", None)
+    except Exception:
+        return None
+
+
+def _part_text(part: Any) -> Any:
+    if isinstance(part, Mapping):
+        try:
+            return part.get("text")
+        except Exception:
+            return None
+    try:
+        return getattr(part, "text", None)
+    except Exception:
+        return None
 
 
 def _text_from_part(part: Any) -> str:
+    """Extract visible text from one explicitly textual content part.
+
+    Returns "" for anything not in the allowlist — no ``str()`` fallback and
+    no reflective attribute reads on unknown objects. Hostile Mappings whose
+    accessors raise also yield "" (never propagated).
+    """
     if part is None:
         return ""
     if isinstance(part, str):
         return part
 
-    part_type = str(_field(part, "type") or "").strip().lower()
-    if part_type in _NON_TEXT_PART_TYPES:
+    part_type = _part_type(part)
+    if isinstance(part_type, str):
+        normalized = part_type.strip().lower()
+        if normalized in _TEXT_PART_TYPES or normalized in _SUMMARY_PART_TYPES:
+            text = _part_text(part)
+            if isinstance(text, str):
+                return text
         return ""
 
-    for key in _TEXT_KEYS:
-        text = _field(part, key)
-        if isinstance(text, str):
-            return text
+    if part_type is None and isinstance(part, Mapping):
+        # Untyped Mappings count as legacy text wrappers ONLY when they are
+        # PURE wrappers: every key is one of the wrapper keys. Any extra
+        # provider/tool/metadata/unknown field disqualifies the shape —
+        # otherwise provider metadata or tool-call payloads would leak into
+        # visible text.
+        try:
+            if not set(part.keys()) <= set(_LEGACY_WRAPPER_KEYS):
+                return ""
+            for key in _LEGACY_WRAPPER_KEYS:
+                value = part.get(key)
+                if isinstance(value, str):
+                    return value
+        except Exception:
+            return ""
     return ""
 
 
 def flatten_message_text(content: Any, *, sep: str = "\n") -> str:
-    """Return the visible text from common chat/Responses message content shapes."""
+    """Return the visible text from common chat/Responses message content shapes.
+
+    ``sep`` joins multiple visible parts (default "\n" for display-oriented
+    callers).  Pipelines that must reassemble provider-split tokens or tags
+    exactly (reasoning scrubbers, regex sinks) pass ``sep=""`` so no
+    character that was absent from the original content is inserted.
+    """
     if content is None:
         return ""
     if isinstance(content, str):
@@ -41,10 +111,5 @@ def flatten_message_text(content: Any, *, sep: str = "\n") -> str:
         chunks = [_text_from_part(part) for part in content]
         return sep.join(chunk for chunk in chunks if chunk)
 
-    text = _text_from_part(content)
-    if text:
-        return text
-    try:
-        return str(content)
-    except Exception:
-        return ""
+    # Top-level single part / legacy wrapper position.
+    return _text_from_part(content)

--- a/run_agent.py
+++ b/run_agent.py
@@ -4986,7 +4986,7 @@ class AIAgent:
         if visible:
             return visible
         content = assistant_msg.get("content")
-        return self._strip_think_blocks(flatten_message_text(content)).strip()
+        return self._strip_think_blocks(flatten_message_text(content, sep="")).strip()
 
     def _interim_text_was_delivered(self, text: str) -> bool:
         normalized = self._normalize_interim_visible_text(text)

--- a/tests/run_agent/test_structured_content_projection.py
+++ b/tests/run_agent/test_structured_content_projection.py
@@ -1,0 +1,488 @@
+"""Structured message content projection regressions.
+
+Canonical owner: ``agent.message_content.flatten_message_text`` — string
+pass-through, ordered concatenation of confirmed textual parts
+(text / input_text / output_text) without inserted separators, and no
+str()/repr()/json.dumps() fallback for images, base64, reasoning metadata,
+provider state, or unknown objects. Assistant and tool-role list content
+must never reach a string-only sink unnormalized.
+
+The length-continuation assertion follows the baseline concatenation
+semantics ("partial" + "finished" == "partialfinished").
+"""
+
+from __future__ import annotations
+
+import copy
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Adapted for upstream main: the canonical projector in agent.message_content
+# joins typed parts without a separator on the scrub path (sep="").
+from functools import partial as _partial
+from agent.message_content import flatten_message_text as _flatten_message_text
+visible_text_from_content = _partial(_flatten_message_text, sep="")
+from run_agent import AIAgent
+
+
+def _tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": "test tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _tool_call(name: str, call_id: str = "call-structured-content-1"):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments="{}"),
+    )
+
+
+def _response(content, *, finish_reason: str = "stop", tool_calls=None):
+    message = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=message, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _make_agent(*tool_names: str, interim_callback=None) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            model="test-model",
+            api_key="test-key-not-a-secret",
+            base_url="https://test.invalid/v1",
+            provider="custom",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            interim_assistant_callback=interim_callback,
+        )
+    agent._cached_system_prompt = "You are a test double."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent.valid_tool_names = set(tool_names)
+    agent.max_iterations = 4
+    return agent
+
+
+def _run(agent: AIAgent, request, *, extra_patches=()):
+    with ExitStack() as stack:
+        stack.enter_context(patch.object(agent, "_interruptible_api_call", request))
+        save = stack.enter_context(patch.object(agent, "_save_trajectory"))
+        cleanup = stack.enter_context(patch.object(agent, "_cleanup_task_resources"))
+        persist = stack.enter_context(patch.object(agent, "_persist_session"))
+        for extra_patch in extra_patches:
+            stack.enter_context(extra_patch)
+        result = agent.run_conversation("structured content regression")
+    return result, save, cleanup, persist
+
+
+class _TextPart:
+    type = "output_text"
+    text = "object text"
+
+
+class _TextPartWithExplosiveLegacyContent:
+    type = "output_text"
+    text = "safe object text"
+
+    @property
+    def content(self):
+        raise RuntimeError("legacy content must not be read")
+
+
+class _Opaque:
+    def __str__(self) -> str:
+        return "MUST_NOT_LEAK"
+
+
+class _ExplosiveContentObject:
+    @property
+    def type(self):
+        raise RuntimeError("must be ignored")
+
+
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        (None, ""),
+        ("plain", "plain"),
+        ({"type": "output_text", "text": "typed dict"}, "typed dict"),
+        ({"type": " OUTPUT_TEXT ", "text": "normalized type"}, "normalized type"),
+        ({"text": "legacy text"}, "legacy text"),
+        ({"content": "legacy content"}, "legacy content"),
+        ({"type": "input_image", "text": "MUST_NOT_LEAK"}, ""),
+        (_TextPart(), "object text"),
+        (_TextPartWithExplosiveLegacyContent(), "safe object text"),
+        (_Opaque(), ""),
+        (_ExplosiveContentObject(), ""),
+        (b"MUST_NOT_LEAK", ""),
+        (7, ""),
+    ],
+)
+def test_visible_text_scalar_and_wrapper_contract(content, expected):
+    assert visible_text_from_content(content) == expected
+
+
+def test_visible_text_list_preserves_order_boundaries_and_ignores_non_text():
+    content = [
+        "hel",
+        {"type": "text", "text": "lo"},
+        {"type": "input_text", "text": " "},
+        {"type": "output_text", "text": "world"},
+        SimpleNamespace(type="output_text", text="!"),
+        {"type": "input_image", "image_url": "data:image/png;base64,MUST_NOT_LEAK"},
+        {"type": "reasoning", "encrypted_content": "MUST_NOT_LEAK"},
+        {"type": "unknown", "text": "MUST_NOT_LEAK"},
+        {"text": "legacy list text"},
+        {"content": "legacy list content"},
+        {"type": "text", "text": {"nested": "MUST_NOT_LEAK"}},
+        _Opaque(),
+    ]
+    # Untyped legacy dict wrappers ({"text": str} / {"content": str}) are
+    # accepted in any position — same contract as upstream's
+    # test_message_content.py. Typed-unknown parts and unknown objects
+    # still contribute nothing.
+    assert visible_text_from_content(content) == "hello world!legacy list textlegacy list content"
+
+
+def test_cross_part_reasoning_tag_is_reassembled_before_scrubbing():
+    agent = _make_agent()
+    content = [
+        {"type": "text", "text": "<thi"},
+        {"type": "text", "text": "nk>secret</think>visible"},
+    ]
+    assert agent._strip_think_blocks(content) == "visible"
+
+
+def test_build_assistant_message_normalizes_visible_text_after_reasoning_capture():
+    agent = _make_agent()
+    message = _response(
+        [
+            {"type": "thinking", "thinking": "private plan"},
+            {"type": "output_text", "text": "visible answer"},
+        ]
+    ).choices[0].message
+
+    built = agent._build_assistant_message(message, "stop")
+
+    assert built["content"] == "visible answer"
+    assert built["reasoning"] == "private plan"
+
+
+def test_normal_loop_preserves_structured_reasoning_while_projecting_visible_text():
+    agent = _make_agent()
+    request = MagicMock(
+        return_value=_response(
+            [
+                {"type": "thinking", "thinking": "private plan"},
+                {"type": "output_text", "text": "visible answer"},
+            ]
+        )
+    )
+
+    result, _, _, _ = _run(agent, request)
+
+    assert request.call_count == 1
+    assert result["final_response"] == "visible answer"
+    assert result["last_reasoning"] == "private plan"
+    assistant_rows = [
+        row for row in result["messages"] if row.get("role") == "assistant"
+    ]
+    assert assistant_rows[-1]["content"] == "visible answer"
+    assert assistant_rows[-1]["reasoning"] == "private plan"
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        [{"type": "output_text", "text": "list visible"}],
+        {"type": "output_text", "text": "dict visible"},
+        {"text": "legacy visible"},
+    ],
+)
+def test_structured_normal_response_completes_after_one_provider_request(content):
+    agent = _make_agent()
+    request = MagicMock(return_value=_response(content))
+    result, _, cleanup, persist = _run(agent, request)
+    assert request.call_count == 1
+    assert result["api_calls"] == 1
+    assert result["final_response"].endswith("visible")
+    assert result["completed"] is True
+    assert result["failed"] is False
+    assert result["turn_exit_reason"] == "text_response(finish_reason=stop)"
+    assert cleanup.call_count == 1
+    assert persist.call_count >= 1
+
+
+def test_length_list_uses_continuation_instead_of_provider_error_retry():
+    agent = _make_agent()
+    replies = [
+        _response(
+            [
+                {"type": "thinking", "thinking": "private continuation plan"},
+                {"type": "output_text", "text": "partial"},
+            ],
+            finish_reason="length",
+        ),
+        _response("finished"),
+    ]
+    captured = []
+
+    def fake_request(api_kwargs):
+        captured.append(copy.deepcopy(api_kwargs))
+        return replies.pop(0)
+
+    request = MagicMock(side_effect=fake_request)
+    result, _, _, _ = _run(
+        agent,
+        request,
+        extra_patches=(
+            patch("agent.conversation_loop.jittered_backoff", return_value=0),
+            patch("agent.conversation_loop.time.sleep"),
+        ),
+    )
+
+    second_messages = captured[1].get("messages", [])
+    roles = [m.get("role") for m in second_messages if isinstance(m, dict)]
+    assert request.call_count == 2
+    assert result["api_calls"] == 2
+    assert "assistant" in roles and roles[-1] == "user"
+    # Baseline concatenation semantics (conversation_loop.py:
+    # final_response = "".join(truncated_response_parts) + final_response):
+    # the truncated fragment is preserved and prepended to the continuation.
+    assert result["final_response"] == "partialfinished"
+    assert result["completed"] is True
+    assert result["failed"] is False
+    partial_rows = [
+        row
+        for row in result["messages"]
+        if row.get("role") == "assistant"
+        and row.get("reasoning") == "private continuation plan"
+    ]
+    assert partial_rows
+    assert partial_rows[-1]["content"] == "partial"
+
+
+def test_content_filter_list_is_terminal_and_not_retried():
+    agent = _make_agent()
+    request = MagicMock(
+        side_effect=[
+            _response(
+                [{"type": "output_text", "text": "declined"}],
+                finish_reason="content_filter",
+            ),
+            _response("must not be requested"),
+        ]
+    )
+    result, _, _, _ = _run(
+        agent,
+        request,
+        extra_patches=(
+            patch("agent.conversation_loop.jittered_backoff", return_value=0),
+            patch("agent.conversation_loop.time.sleep"),
+        ),
+    )
+
+    assert request.call_count == 1
+    assert result["api_calls"] == 1
+    assert "declined" in (result["final_response"] or "")
+    assert "must not be requested" not in (result["final_response"] or "")
+    assert result["completed"] is False
+
+
+def test_content_filter_reasoning_only_explanation_is_preserved():
+    agent = _make_agent()
+    request = MagicMock(
+        return_value=_response(
+            [{"type": "thinking", "thinking": "policy explanation"}],
+            finish_reason="content_filter",
+        )
+    )
+
+    result, _, _, _ = _run(agent, request)
+
+    assert request.call_count == 1
+    assert result["api_calls"] == 1
+    assert "policy explanation" in (result["final_response"] or "")
+    assert result["completed"] is False
+
+
+def test_tool_role_vision_result_reaches_interim_processing_without_crash():
+    """Issue #66267: a tool-role message whose content is a vision list must
+    not crash interim visible-text processing (the role gate historically
+    came after the text extraction)."""
+    agent = _make_agent()
+    vision_result = [
+        {"type": "image_url", "image_url": {"url": "https://img.invalid/x.png"}},
+        {"type": "text", "text": "tool saw a diagram"},
+    ]
+    # Direct hit on the exact crash point from the issue traceback — any role,
+    # including non-assistant roles, must be safe.
+    out = agent._interim_assistant_visible_text({"role": "tool", "content": vision_result})
+    assert "tool saw a diagram" in out
+    assert "img.invalid" not in out
+
+
+def test_tool_role_list_content_full_turn_completes_without_assistant_interim_probe():
+    agent = _make_agent("vision_tool")
+    request = MagicMock(
+        side_effect=[
+            _response(None, tool_calls=[_tool_call("vision_tool")]),
+            _response("done after vision tool"),
+        ]
+    )
+    original = agent._interim_assistant_visible_text
+    probed_roles = []
+
+    def _record_interim_probe(message):
+        probed_roles.append(message.get("role") if isinstance(message, dict) else None)
+        return original(message)
+
+    with (
+        patch(
+            "run_agent.handle_function_call",
+            return_value=[
+                {"type": "image_url", "image_url": {"url": "https://img.invalid/y.png"}},
+                {"type": "text", "text": "pixels"},
+            ],
+        ),
+        patch.object(
+            agent,
+            "_interim_assistant_visible_text",
+            side_effect=_record_interim_probe,
+        ),
+    ):
+        result, _, _, _ = _run(agent, request)
+    assert request.call_count == 2
+    assert result["completed"] is True
+    assert result["final_response"] == "done after vision tool"
+    assert "tool" not in probed_roles
+
+
+def test_image_only_list_produces_no_visible_text_and_no_crash():
+    """An image-only assistant response normalizes to empty visible text.
+
+    The turn must not crash with a TypeError and no URL/base64 may leak; the
+    loop's pre-existing empty-response retry budget applies exactly as it
+    would for a string-empty response (baseline-consistent behavior).
+    """
+    agent = _make_agent()
+    request = MagicMock(
+        return_value=_response(
+            [{"type": "input_image", "image_url": "https://img.invalid/z.png"}]
+        )
+    )
+    result, _, _, _ = _run(agent, request)
+    assert request.call_count >= 2  # empty-response retry budget, not a crash loop
+    assert result.get("turn_exit_reason") == "empty_response_exhausted"
+    assert "img.invalid" not in (result["final_response"] or "")
+
+
+# ── unknown objects must never be read reflectively into text ─────────────
+
+class _UnknownWithText:
+    def __init__(self):
+        self.text = "ATTR-TEXT-MUST-NOT-LEAK"
+
+
+class _UnknownWithContent:
+    def __init__(self):
+        self.content = "ATTR-CONTENT-MUST-NOT-LEAK"
+
+
+class _UnknownWithStr:
+    def __str__(self):
+        return "STR-REPR-MUST-NOT-LEAK"
+
+
+class _UnknownNested:
+    def __init__(self):
+        self.inner = _UnknownWithText()
+        self.payload = {"type": "output_text", "text": "NESTED-MUST-NOT-LEAK"}
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        _UnknownWithText(),
+        _UnknownWithContent(),
+        _UnknownWithStr(),
+        _UnknownNested(),
+        [_UnknownWithText(), _UnknownWithContent(), _UnknownWithStr()],
+        {"outer": _UnknownNested()},
+    ],
+)
+def test_unknown_objects_return_empty_text_and_never_leak(content):
+    out = visible_text_from_content(content)
+    assert out == ""
+    assert "LEAK" not in out
+
+
+# ── hostile Mappings: accessor failures must yield "", never propagate ──────
+
+class _HostileGetMapping(dict):
+    """Mapping whose .get() always raises."""
+
+    def get(self, key, default=None):
+        raise RuntimeError("hostile get")
+
+
+class _HostileKeysMapping(dict):
+    """Mapping whose keys()/iteration always raises."""
+
+    def keys(self):
+        raise RuntimeError("hostile keys")
+
+    def __iter__(self):
+        raise RuntimeError("hostile iter")
+
+
+@pytest.mark.parametrize(
+    "mapping",
+    [
+        _HostileGetMapping({"text": "SECRET"}),
+        _HostileGetMapping({"content": "SECRET"}),
+        _HostileKeysMapping({"text": "SECRET"}),
+        _HostileKeysMapping({"content": "SECRET"}),
+    ],
+)
+def test_hostile_mapping_top_level_returns_empty_without_propagating(mapping):
+    out = visible_text_from_content(mapping)
+    assert out == ""
+    assert "SECRET" not in out
+
+
+@pytest.mark.parametrize(
+    "mapping",
+    [
+        _HostileGetMapping({"text": "SECRET"}),
+        _HostileKeysMapping({"text": "SECRET"}),
+    ],
+)
+def test_hostile_mapping_inside_list_returns_empty_without_propagating(mapping):
+    out = visible_text_from_content([mapping])
+    assert out == ""
+    assert "SECRET" not in out
+    # A hostile item must not poison its neighbours either.
+    out = visible_text_from_content([{"type": "text", "text": "ok"}, mapping])
+    assert out == "ok"


### PR DESCRIPTION
## What

Follow-up to #66267 / #66945. Those fixes stopped the immediate crashes from
multimodal list content, but three gaps remain reproducible on current main:

1. **Split reasoning tags break the scrubber.** `flatten_message_text` joins
   parts with `"\n"` by default. When a provider splits `<think>` across two
   parts (`"<thi"` + `"nk>secret</think>visible"`), the reassembled string
   contains a newline the original never had, the `<think>...</think>` regex
   no longer matches, and reasoning leaks into the visible reply.

2. **Unknown shapes leak into visible text.** Untyped Mappings are read for
   `text`/`content` regardless of extra fields
   (`{"provider": "x", "content": "SECRET"}` → `"SECRET"`;
   `[{"tool_call_id": "abc", "content": "SECRET"}]` → `"SECRET"`); objects of
   unknown type contribute attribute values; top-level `str(content)`
   stringifies unknown objects; Mappings whose accessors raise propagate the
   exception instead of yielding `""`.

3. **Interim dedup has no role gate.** The assistant-visible-text extractor
   runs on any dict message — user, tool, system — before checking whether it
   is an assistant turn at all.

There are also multiple slightly different list-flattening implementations
across call sites with divergent contracts.

## How

- `agent/message_content.py` becomes the single canonical projector with a
  strict allowlist: plain `str`; typed text parts
  (`text`/`input_text`/`output_text`); explicit `summary_text`; and **pure**
  legacy wrappers (untyped Mappings whose keys are a subset of
  `{text, content}`). Everything else — unknown typed parts, images, base64,
  audio, tool metadata, encrypted/redacted reasoning, unknown objects,
  hostile Mappings — yields `""`.
- **No unrestricted text/content reads from untyped unknown objects.** Only
  explicitly allowlisted shapes contribute text.
- **SDK-style provider objects are read only after their type is an
  allowlisted textual type** (`.type` ∈ text/input_text/output_text);
  non-textual or unknown types are never read.
- **No `str()`/`repr()` fallback** anywhere in the projection path; Mappings
  whose accessors raise yield `""` without propagating.
- The scrub pipeline (`strip_think_blocks`, `build_assistant_message`,
  interim visible text, refusal/length normalization) joins parts with
  `sep=""` so provider-split tags reassemble byte-exactly before scrubbing.
- Interim dedup gates on `role == "assistant"` before text extraction.
- Structured reasoning is captured before projecting assistant content so
  thinking blocks are not silently dropped.

## Tests

- New `tests/run_agent/test_structured_content_projection.py`: typed parts,
  multi-part order, empty text, non-string text fields, unknown part types,
  unknown objects (`.text`/`.content`/custom `__str__`/nested), image/base64/
  reasoning/metadata non-leakage, split `<think>` reassembly, tool-role
  guard, refusal/`length` normalization, pure legacy wrappers, and hostile
  Mappings (raising `get`/`keys`/iteration, top-level and in-list, never
  propagating).
- Red→green on main: the leakage/hostile/role cases fail before this change.
- Existing `test_66267_multimodal_interim.py`, `test_message_content.py`,
  think/streaming-context scrubber suites and related Codex/Kimi/DeepSeek
  suites continue to pass.

No behavior change for plain-string content; no prompt, config, or transport
changes.

## Compatibility contract

Preserved:

- plain string content
- typed text / input_text / output_text parts
- explicit summary_text
- pure untyped legacy wrappers whose keys are limited to text/content

Intentionally rejected:

- untyped mappings carrying provider, tool, metadata, or unknown fields
- unknown SDK object types
- images, audio, base64, files, and tool-result shapes
- encrypted or redacted reasoning
- arbitrary str()/repr() fallback
- mappings whose accessors raise

This is a visible-text projection contract, not a general message
serialization or history-schema migration.

## Related defense: #67411

#67380 removes the concrete structured-content projection failure.

#67411 independently prevents a provider request from being reissued when
a Hermes-local processing failure occurs after a terminal provider response.

The PRs share no commits, are independently mergeable, and may land in
either order.

Merge-order matrix:

| Order | Outcome |
| --- | --- |
| #67380 first | The concrete projector failure is removed; the generic post-terminal lifecycle defense waits for #67411. |
| #67411 first | The concrete failure becomes one `local_post_response_error` without a repeated provider request; #67380 later removes the root cause. |
| Both | The concrete content-shape failure is removed AND the generic post-terminal lifecycle boundary is enforced. |

## Current-main validation

Rebased onto `e702a45b5` (current main) and semantically revalidated:

- clean current main still reproduces the residual gaps (22 RED failures:
  unknown-object/hostile-mapping leaks, split `<think>` scrub miss,
  non-assistant interim extraction, structured reasoning loss);
- typed visible-text parts remain supported; unknown / metadata / tool /
  media / hostile shapes stay fail-closed;
- provider-split reasoning tags are reassembled with `sep=""` before scrubbing;
- structured reasoning is preserved before visible-text projection;
- interim dedup extracts text only from assistant-role messages;
- plain-string behavior is unchanged;
- Anthropic / Kimi / DeepSeek / Codex and adjacent continuation suites pass.
