### PR TITLE
fix(session_search): replace exact-match title search with LIKE-based substring matching

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5412,6 +5412,10 @@ class SessionDB:
         if not query or not query.strip():
             return []
 
+        # Save the raw (unsanitized) query for title search supplement
+        # and CJK paths. The sanitized form is safe for FTS5 MATCH but
+        # strips/preserves syntax that LIKE/trigram won't understand.
+        raw_query = query.strip()
         query = self._sanitize_fts5_query(query)
         if not query:
             return []
@@ -5493,15 +5497,15 @@ class SessionDB:
         # bytes = 3 CJK chars), so we fall back to LIKE.
         is_cjk = self._contains_cjk(query)
         if is_cjk:
-            raw_query = query.strip('"').strip()
-            cjk_count = self._count_cjk(raw_query)
+            cjk_raw_query = query.strip('"').strip()
+            cjk_count = self._count_cjk(cjk_raw_query)
 
             # Per-token CJK length check (#20494): trigram needs >=3 CJK chars
             # per token. A query like "广西 OR 桂林 OR 漓江" has cjk_count=6
             # (>=3) but each individual token is only 2 chars — trigram returns 0.
             # Route to LIKE when any non-operator CJK token is <3 CJK chars.
             _tokens_for_check = [
-                t for t in raw_query.split()
+                t for t in cjk_raw_query.split()
                 if t.upper() not in {"AND", "OR", "NOT"} and self._contains_cjk(t)
             ]
             _any_short_cjk = any(
@@ -5513,7 +5517,7 @@ class SessionDB:
                 # Trigram FTS5 path — quote each non-operator token to handle
                 # FTS5 special chars (%, *, etc.) while preserving boolean
                 # operators (AND, OR, NOT) for multi-term queries.
-                tokens = raw_query.split()
+                tokens = cjk_raw_query.split()
                 parts = []
                 for tok in tokens:
                     if tok.upper() in {"AND", "OR", "NOT"}:
@@ -5570,9 +5574,9 @@ class SessionDB:
                 # build one LIKE condition per non-operator token so each term
                 # is matched independently (#20494).
                 non_op_tokens = [
-                    t for t in raw_query.split()
+                    t for t in cjk_raw_query.split()
                     if t.upper() not in {"AND", "OR", "NOT"}
-                ] or [raw_query]
+                ] or [cjk_raw_query]
                 token_clauses = []
                 like_params: list = []
                 for tok in non_op_tokens:
@@ -5615,10 +5619,95 @@ class SessionDB:
                 try:
                     cursor = self._conn.execute(sql, params)
                 except sqlite3.OperationalError:
-                    # FTS5 query syntax error despite sanitization — return empty
-                    return []
+                    # FTS5 query syntax error despite sanitization.
+                    # Fall through to the title search supplement below
+                    # rather than returning early — the raw query terms
+                    # may still match session titles via LIKE.
+                    matches = []
                 else:
                     matches = [dict(row) for row in cursor.fetchall()]
+
+        # ── Title search supplement ──────────────────────────────────
+        # Session titles are not in the FTS5 index (the triggers only
+        # cover messages.content/tool_name/tool_calls).  Run a separate
+        # LIKE pass over sessions.title so renamed sessions are findable
+        # by their title (#66242).
+        #
+        # Unlike the earlier resolve_session_by_title() path
+        # (4efec63a3) which required an EXACT title match, this uses
+        # substring matching so partial-title / keyword searches work.
+        #
+        # Results are appended to matches and flow through the same
+        # context-enrichment and dedup-by-lineage pipeline below,
+        # returning properly formatted discovery results with anchored
+        # views and bookends rather than a bespoke "session_title" path.
+        if raw_query:
+            _FTS5_BOOLS = {"AND", "OR", "NOT"}
+            title_terms = [
+                t for t in re.sub(r"[^\w\s]", " ", raw_query).split()
+                if len(t) >= 2 and t.upper() not in _FTS5_BOOLS
+            ]
+            if title_terms:
+                existing_ids = {m.get("id") for m in matches if m.get("id") is not None}
+                with self._lock:
+                    for term in title_terms[:5]:  # cap to 5 terms
+                        esc = (
+                            term.replace("\\", "\\\\")
+                            .replace("%", "\\%")
+                            .replace("_", "\\_")
+                        )
+                        try:
+                            title_cursor = self._conn.execute(
+                                """
+                                SELECT s.id AS session_id,
+                                       (SELECT m2.id FROM messages m2
+                                        WHERE m2.session_id = s.id
+                                        ORDER BY m2.timestamp DESC
+                                        LIMIT 1) AS msg_id
+                                FROM sessions s
+                                WHERE s.title IS NOT NULL
+                                  AND s.title LIKE ? ESCAPE '\\'
+                                LIMIT ?
+                                """,
+                                (f"%{esc}%", limit),
+                            )
+                        except sqlite3.OperationalError:
+                            continue
+                        for row in title_cursor.fetchall():
+                            msg_id = row["msg_id"]
+                            if msg_id is None or msg_id in existing_ids:
+                                continue
+                            try:
+                                msg_cursor = self._conn.execute(
+                                    """
+                                    SELECT m.id, m.session_id, m.role,
+                                           m.content, m.timestamp, m.tool_name,
+                                           s.source, s.model, s.started_at AS session_started
+                                    FROM messages m
+                                    JOIN sessions s ON s.id = m.session_id
+                                    WHERE m.id = ?
+                                    """,
+                                    (msg_id,),
+                                )
+                                msg_row = msg_cursor.fetchone()
+                            except sqlite3.OperationalError:
+                                continue
+                            if msg_row is None:
+                                continue
+                            match = dict(msg_row)
+                            decoded = self._decode_content(match.get("content") or "")
+                            if isinstance(decoded, list):
+                                text_parts = [
+                                    p.get("text", "") for p in decoded
+                                    if isinstance(p, dict) and p.get("type") == "text"
+                                ]
+                                match["snippet"] = " ".join(t for t in text_parts if t)[:120]
+                            elif isinstance(decoded, str):
+                                match["snippet"] = decoded[:120]
+                            else:
+                                match["snippet"] = ""
+                            matches.append(match)
+                            existing_ids.add(msg_id)
 
         # Add surrounding context (1 message before + after each match).
         # Done outside the lock so we don't hold it across N sequential queries.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5637,10 +5637,9 @@ class SessionDB:
         # (4efec63a3) which required an EXACT title match, this uses
         # substring matching so partial-title / keyword searches work.
         #
-        # Results are appended to matches and flow through the same
-        # context-enrichment and dedup-by-lineage pipeline below,
-        # returning properly formatted discovery results with anchored
-        # views and bookends rather than a bespoke "session_title" path.
+        # The title query carries the same source/role/active filters as
+        # the FTS5 query above.  Results respect offset/limit and are
+        # prepended to FTS5 matches (title hits outrank content hits).
         if raw_query:
             _FTS5_BOOLS = {"AND", "OR", "NOT"}
             title_terms = [
@@ -5650,29 +5649,74 @@ class SessionDB:
             if title_terms:
                 existing_ids = {m.get("id") for m in matches if m.get("id") is not None}
                 with self._lock:
-                    for term in title_terms[:5]:  # cap to 5 terms
+                    # Build LIKE clauses — one per term, OR'd together.
+                    like_clauses: list = []
+                    like_params: list = []
+                    for term in title_terms[:5]:
                         esc = (
                             term.replace("\\", "\\\\")
                             .replace("%", "\\%")
                             .replace("_", "\\_")
                         )
-                        try:
-                            title_cursor = self._conn.execute(
-                                """
-                                SELECT s.id AS session_id,
-                                       (SELECT m2.id FROM messages m2
-                                        WHERE m2.session_id = s.id
-                                        ORDER BY m2.timestamp DESC
-                                        LIMIT 1) AS msg_id
-                                FROM sessions s
-                                WHERE s.title IS NOT NULL
-                                  AND s.title LIKE ? ESCAPE '\\'
-                                LIMIT ?
-                                """,
-                                (f"%{esc}%", limit),
-                            )
-                        except sqlite3.OperationalError:
-                            continue
+                        like_clauses.append("s.title LIKE ? ESCAPE '\\'")
+                        like_params.append(f"%{esc}%")
+
+                    # Session-level source filters (mirror FTS5 query).
+                    session_where: list = [
+                        f"({' OR '.join(like_clauses)})",
+                        "s.title IS NOT NULL",
+                    ]
+                    if exclude_sources is not None:
+                        marks = ",".join("?" for _ in exclude_sources)
+                        session_where.append(f"s.source NOT IN ({marks})")
+                        like_params.extend(exclude_sources)
+                    if source_filter is not None:
+                        marks = ",".join("?" for _ in source_filter)
+                        session_where.append(f"s.source IN ({marks})")
+                        like_params.extend(source_filter)
+
+                    # Anchor-message sub-select filters.
+                    anchor_where: list = ["m2.session_id = s.id"]
+                    if not include_inactive:
+                        anchor_where.append(
+                            "(m2.active = 1 OR m2.compacted = 1)"
+                        )
+                    if role_filter:
+                        marks = ",".join("?" for _ in role_filter)
+                        anchor_where.append(f"m2.role IN ({marks})")
+                        # role_filter params are bound separately below;
+                        # they mirror the FTS5 role_filter params.
+
+                    title_sql = f"""
+                        SELECT s.id AS session_id,
+                               (SELECT m2.id FROM messages m2
+                                WHERE {' AND '.join(anchor_where)}
+                                ORDER BY m2.timestamp DESC
+                                LIMIT 1) AS msg_id
+                        FROM sessions s
+                        WHERE {' AND '.join(session_where)}
+                        ORDER BY s.started_at DESC
+                        LIMIT ? OFFSET ?
+                    """
+                    # Build final param list: role_filter params come
+                    # FIRST (they bind to the sub-select's m2.role IN (?,?)
+                    # which appears earliest in the SQL text), then LIKE
+                    # params, then source params, then limit/offset.
+                    final_params: list = []
+                    if role_filter:
+                        final_params.extend(role_filter)
+                    final_params.extend(like_params)
+                    final_params.extend([limit, offset])
+
+                    try:
+                        title_cursor = self._conn.execute(
+                            title_sql, final_params
+                        )
+                    except sqlite3.OperationalError:
+                        title_cursor = None
+
+                    title_matches: list = []
+                    if title_cursor is not None:
                         for row in title_cursor.fetchall():
                             msg_id = row["msg_id"]
                             if msg_id is None or msg_id in existing_ids:
@@ -5706,8 +5750,13 @@ class SessionDB:
                                 match["snippet"] = decoded[:120]
                             else:
                                 match["snippet"] = ""
-                            matches.append(match)
+                            title_matches.append(match)
                             existing_ids.add(msg_id)
+
+                # Prepend title matches (higher relevance) and trim
+                # FTS5 matches to maintain the total ≤ limit.
+                if title_matches:
+                    matches = title_matches + matches[: max(0, limit - len(title_matches))]
 
         # Add surrounding context (1 message before + after each match).
         # Done outside the lock so we don't hold it across N sequential queries.

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -190,6 +190,11 @@ class TestDiscoveryShape:
         assert result["count"] == 0
 
     def test_query_can_match_session_title_without_message_hit(self, db):
+        """A query that matches only a session title (not message content) is found
+        via LIKE-based title search in search_messages().  The match is returned
+        through the normal discovery pipeline with anchored views and bookends.
+        matched_role reflects the actual matched message role, not a synthetic
+        "session_title"."""
         db.create_session("s_fingerprint", source="cli")
         db.set_session_title("s_fingerprint", "fingerprint-login")
         db.append_message("s_fingerprint", role="user", content="Let's configure PAM for biometric auth")
@@ -202,10 +207,29 @@ class TestDiscoveryShape:
         hit = result["results"][0]
         assert hit["session_id"] == "s_fingerprint"
         assert hit["title"] == "fingerprint-login"
-        assert hit["matched_role"] == "session_title"
-        assert "Session title matched" in hit["snippet"]
+        # matched_role comes from the most recent message, not a synthetic label
+        assert hit["matched_role"] in ("user", "assistant")
+
+    def test_title_like_substring_match(self, db):
+        """Partial title terms match via LIKE (substring), not just exact title match."""
+        db.create_session("s_sub", source="cli")
+        db.set_session_title("s_sub", "Building the Modpack Server")
+        db.append_message("s_sub", role="user", content="Let's start the modpack build.")
+        db.append_message("s_sub", role="assistant", content="Checking dependencies for modpack.")
+
+        # "Modpack" appears in the title but not via FTS5 of messages?  Actually
+        # it also appears in message content.  Search for just "Server" which
+        # is in the title only.
+        result = json.loads(session_search(query="Server", db=db))
+
+        assert result["success"] is True
+        assert result["count"] >= 1
+        hit = result["results"][0]
+        assert hit["session_id"] == "s_sub"
+        assert "Server" in (hit.get("title") or "")
 
     def test_title_query_strips_common_model_quoting(self, db):
+        """Backtick-quoted titles still match via LIKE after non-word-char stripping."""
         db.create_session("s_fingerprint", source="cli")
         db.set_session_title("s_fingerprint", "fingerprint-login")
         db.append_message("s_fingerprint", role="user", content="PAM auth setup")
@@ -214,7 +238,8 @@ class TestDiscoveryShape:
 
         assert result["success"] is True
         assert result["results"][0]["session_id"] == "s_fingerprint"
-        assert result["results"][0]["matched_role"] == "session_title"
+        # matched_role is the actual message role, not "session_title"
+        assert result["results"][0]["matched_role"] in ("user", "assistant")
 
     def test_title_match_respects_current_session_filter(self, db):
         db.create_session("s_current", source="cli")

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -256,6 +256,81 @@ class TestDiscoveryShape:
         assert result["results"] == []
         assert result["count"] == 0
 
+    def test_title_match_hides_subagent_source(self, db):
+        """Title matches must not surface sessions from excluded sources (subagent)."""
+        db.create_session("s_sub", source="subagent")
+        db.set_session_title("s_sub", "find-me-title")
+        db.append_message("s_sub", role="user", content="subagent work")
+
+        db.create_session("s_cli", source="cli")
+        db.set_session_title("s_cli", "find-me-title-cli")
+        db.append_message("s_cli", role="user", content="cli work")
+
+        # _discover() passes exclude_sources=['subagent', 'tool']
+        result = json.loads(session_search(query="find-me-title", db=db))
+        assert result["success"] is True
+        sids = [r["session_id"] for r in result["results"]]
+        assert "s_sub" not in sids, "subagent source should be excluded"
+        assert "s_cli" in sids
+
+    def test_title_match_respects_role_filter(self, db):
+        """Title anchor must not pick a message whose role is excluded."""
+        db.create_session("s_rf", source="cli")
+        db.set_session_title("s_rf", "tool-heavy-session")
+        db.append_message("s_rf", role="tool", content="tool output only", tool_name="x")
+        # No user/assistant messages — so default role_filter=['user','assistant']
+        # should find nothing
+
+        result = json.loads(session_search(query="tool-heavy", db=db))
+        assert result["count"] == 0
+
+        # With explicit tool role inclusion, should find it
+        result2 = json.loads(session_search(
+            query="tool-heavy", role_filter="tool", db=db
+        ))
+        assert result2["count"] >= 1
+        assert result2["results"][0]["session_id"] == "s_rf"
+
+    def test_title_match_hides_inactive_messages(self, db):
+        """Title search should not anchor on inactive (rewound) messages."""
+        db.create_session("s_inactive", source="cli")
+        db.set_session_title("s_inactive", "rewind-session")
+        msg_id = db.append_message("s_inactive", role="user", content="original message")
+
+        # Rewind the message
+        with db._lock:
+            db._conn.execute(
+                "UPDATE messages SET active = 0 WHERE id = ?", (msg_id,)
+            )
+
+        result = json.loads(session_search(query="rewind-session", db=db))
+        # The only message is inactive; title search should not return it
+        assert result["count"] == 0
+
+    def test_title_match_respects_offset_pagination(self, db):
+        """Title matches must respect pagination — offset skips early results.
+        Tested via search_messages() directly since session_search tool
+        does not expose offset."""
+        db.create_session("s_a", source="cli")
+        db.set_session_title("s_a", "paginate-alpha")
+        db.append_message("s_a", role="user", content="alpha content")
+        db.create_session("s_b", source="cli")
+        db.set_session_title("s_b", "paginate-beta")
+        db.append_message("s_b", role="user", content="beta content")
+
+        # Page 1: offset=0, limit=1
+        page1 = db.search_messages(query="paginate", limit=1, offset=0)
+        assert len(page1) == 1, f"expected 1, got {len(page1)}"
+
+        # Page 2: offset=1, limit=1
+        page2 = db.search_messages(query="paginate", limit=1, offset=1)
+        assert len(page2) == 1, f"expected 1, got {len(page2)}"
+
+        # Should get different sessions on each page
+        sids_page1 = {r["session_id"] for r in page1}
+        sids_page2 = {r["session_id"] for r in page2}
+        assert sids_page1 != sids_page2, "offset should paginate across title results"
+
     def test_limit_clamped_to_max_10(self, db):
         _seed_modpack_sessions(db)
         # Pass huge limit; should not error and should cap

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -424,78 +424,6 @@ def _scroll(
     return json.dumps(response, ensure_ascii=False)
 
 
-def _normalize_title_query(query: str) -> str:
-    """Strip common quoting the model may include around a remembered title."""
-    return query.strip().strip("`'\"")
-
-
-def _title_match_result(
-    db,
-    query: str,
-    current_lineage_root: Optional[str],
-) -> Optional[Dict[str, Any]]:
-    """Return a discovery-shaped result when the query matches a session title."""
-    title_query = _normalize_title_query(query)
-    if not title_query:
-        return None
-
-    try:
-        session_id = db.resolve_session_by_title(title_query)
-    except Exception:
-        logging.debug("resolve_session_by_title failed for %r", title_query, exc_info=True)
-        return None
-    if not session_id:
-        return None
-
-    lineage_root = _resolve_to_parent(db, session_id)
-    if current_lineage_root and lineage_root == current_lineage_root:
-        return None
-
-    try:
-        session_meta = db.get_session(lineage_root) or db.get_session(session_id) or {}
-    except Exception:
-        logging.debug("get_session failed for title match %s", session_id, exc_info=True)
-        session_meta = {}
-    if session_meta.get("source") in _HIDDEN_SESSION_SOURCES:
-        return None
-
-    try:
-        messages = db.get_messages(session_id)
-    except Exception:
-        logging.debug("get_messages failed for title match %s", session_id, exc_info=True)
-        messages = []
-
-    anchor_id = messages[0].get("id") if messages else None
-    if anchor_id is not None:
-        try:
-            view = db.get_anchored_view(session_id, anchor_id, window=5, bookend=3)
-        except Exception:
-            logging.debug("get_anchored_view failed for title match %s/%s", session_id, anchor_id, exc_info=True)
-            view = {}
-    else:
-        view = {}
-
-    entry = {
-        "session_id": session_id,
-        "when": _format_timestamp(session_meta.get("started_at")),
-        "source": session_meta.get("source", "unknown"),
-        "model": session_meta.get("model") or "unknown",
-        "title": session_meta.get("title") or title_query,
-        "matched_role": "session_title",
-        "match_message_id": anchor_id,
-        "snippet": f"Session title matched: {session_meta.get('title') or title_query}",
-        "bookend_start": [_shape_message(m) for m in (view.get("bookend_start") or messages[:3])],
-        "messages": [_shape_message(m, anchor_id=anchor_id) for m in (view.get("window") or messages[:5])],
-        "bookend_end": [_shape_message(m) for m in (view.get("bookend_end") or messages[-3:])],
-        "messages_before": view.get("messages_before", 0),
-        "messages_after": view.get("messages_after", max(len(messages) - 5, 0)),
-        "_lineage_root": lineage_root,
-    }
-    if lineage_root and lineage_root != session_id:
-        entry["parent_session_id"] = lineage_root
-    return entry
-
-
 def _discover(
     db,
     query: str,
@@ -507,7 +435,6 @@ def _discover(
     """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
     role_list = role_filter if role_filter else ["user", "assistant"]
     current_lineage_root = _resolve_to_parent(db, current_session_id) if current_session_id else None
-    title_result = _title_match_result(db, query, current_lineage_root)
 
     try:
         raw_results = db.search_messages(
@@ -530,7 +457,7 @@ def _discover(
     # within each class.
     raw_results = _order_for_recall(raw_results)
 
-    if not raw_results and not title_result:
+    if not raw_results:
         return json.dumps({
             "success": True,
             "mode": "discover",
@@ -545,12 +472,6 @@ def _discover(
     # window. parent_session_id is exposed separately when different.
     seen_sessions = {}
     results = []
-
-    if title_result:
-        title_lineage = title_result.pop("_lineage_root", None)
-        if title_lineage:
-            seen_sessions[title_lineage] = {"_title_only": True}
-        results.append(title_result)
 
     for r in raw_results:
         if len(seen_sessions) >= limit:
@@ -570,8 +491,6 @@ def _discover(
             break
 
     for lineage_root, match_info in seen_sessions.items():
-        if match_info.get("_title_only"):
-            continue
         hit_sid = match_info.get("session_id") or lineage_root
         msg_id = match_info.get("id")
         try:


### PR DESCRIPTION
## Problem

Session title search via `session_search()` is incomplete on `main`. The existing fix (4efec63a3) only handles **exact** title matches, not the substring/partial-term matching users actually expect.

**4efec63a3** (`fix(tools): let session_search match session titles`) added title-first discovery in the tool layer via `resolve_session_by_title()`, which does `WHERE title = ?` — exact match only. A session titled "Building the Modpack Server" cannot be found by searching "Server" or "Modpack" — only by repeating the full title verbatim. A separate fix (a3f68fb11, submitted as #66247) added proper LIKE-based substring matching at the data layer but was not merged.

This PR unifies both approaches into a single correct implementation: LIKE-based substring matching in `search_messages()`, with the redundant tool-layer exact-match code removed.

## What this does

### Removes the tool-layer `_title_match_result()` / `_normalize_title_query()` (from 4efec63a3)

- These are the tool-layer exact-match approach added by 4efec63a3.
- They call `db.resolve_session_by_title()` which does `WHERE title = ?` — **exact match only**.
- They construct a bespoke result with synthetic `matched_role: "session_title"` and `snippet: "Session title matched: …"` — a separate code path duplicating anchored-view / bookend construction.

### Adds LIKE-based title search in `search_messages()` (data layer)

- The correct place — `search_messages()` already powers all session search.
- Uses `WHERE s.title LIKE '%term%'` for proper **substring** matching.
- Results flow through the **same** discovery pipeline as FTS5 results — anchored views, bookends, dedup-by-lineage, cron demotion, etc. No duplicate formatting.
- `matched_role` and `snippet` now reflect actual message metadata, not synthetic labels.

### Fixes FTS5 syntax error early-return

The FTS5 path caught `sqlite3.OperationalError` and returned `[]` immediately — before the title supplement could run. Queries containing characters FTS5 can't parse (e.g., backtick-quoted terms like `` `fingerprint-login` ``) were silently empty. Now the method falls through to the title supplement on FTS5 errors.

### Tests

- Updated existing title tests for the new semantics.
- Added `test_title_like_substring_match` — the core case the old code couldn't handle (partial title term match).

## Files changed

| File | Change |
|---|---|
| `hermes_state.py` | +105/-7: LIKE title supplement + FTS5 error fall-through |
| `session_search_tool.py` | +0/-83: remove redundant `_title_match_result()` + `_normalize_title_query()` |
| `tests/tools/test_session_search.py` | +21/-7: updated assertions + new LIKE test |

Closes #66242