### PR TITLE
fix: Moonshot/Kimi 'assistant must not be empty' session wedge — four-layer protection

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2688,6 +2688,35 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             dropped_empty_tool_calls,
         )
 
+    # --- Drop fully-empty assistant messages ---
+    # An assistant turn with no visible content, no tool_calls, and no
+    # reasoning payload carries nothing for any provider, and strict
+    # OpenAI-compatible backends (Kimi/Moonshot, ZAI) reject the whole request
+    # with HTTP 400 "the message at position N with role 'assistant' must not
+    # be empty". Such shells reach here from interrupted/aborted generations
+    # flushed into the history; when one lands in the compaction-protected
+    # tail, every subsequent call replays it and the session wedges
+    # permanently. Runs AFTER the empty-tool_calls normalization above (an
+    # assistant turn whose only payload was ``tool_calls: []`` is exactly this
+    # case once the key is dropped) and BEFORE the tool_call/result pairing
+    # passes below, so surviving-id bookkeeping sees the cleaned list.
+    # Thinking-only turns (reasoning but no text) are NOT dropped here —
+    # ``drop_thinking_only_and_merge_users`` owns that per-provider decision.
+    # Per-call wire copy only; the stored trajectory is never rewritten.
+    cleaned: List[Dict[str, Any]] = []
+    dropped_empty_assistant = 0
+    for msg in messages:
+        if _ra().AIAgent._is_empty_assistant(msg):
+            dropped_empty_assistant += 1
+            continue
+        cleaned.append(msg)
+    if dropped_empty_assistant:
+        messages = cleaned
+        _ra().logger.debug(
+            "Pre-call sanitizer: dropped %d fully-empty assistant message(s)",
+            dropped_empty_assistant,
+        )
+
     # --- Repair tool_calls whose function.name is empty/missing ---
     # Some providers (and partially-streamed responses) emit a tool_call with
     # id="call_xxx" but function.name="". Downstream Responses-API adapters

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1966,6 +1966,16 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         # turns so Anthropic-family providers don't 400 the summary call.
         api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
 
+        # Mirror the transport's last-line guard: drop assistant messages that
+        # are empty AS SERIALIZED. The summary path bypasses
+        # ChatCompletionsTransport.convert_messages(), so without this an
+        # empty shell that slipped the semantic filters (unknown block types,
+        # junk tool_calls, stripped scaffolding) wedges the summary request on
+        # strict providers with HTTP 400 "assistant must not be empty" —
+        # observed live 2026-07-19 at max-iterations summary, position 3.
+        from agent.transports.chat_completions import _drop_wire_empty_assistants
+        api_messages = _drop_wire_empty_assistants(api_messages)
+
         summary_extra_body = {}
         try:
             from agent.auxiliary_client import _fixed_temperature_for_model, OMIT_TEMPERATURE as _OMIT_TEMP

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -9,6 +9,7 @@ which has provider-specific conditionals for max_tokens defaults,
 reasoning configuration, temperature handling, and extra_body assembly.
 """
 
+import logging
 from typing import Any, Dict
 
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
@@ -16,6 +17,68 @@ from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
+
+logger = logging.getLogger(__name__)
+
+
+def _wire_empty_assistant(msg: Any) -> bool:
+    """True if ``msg`` is an assistant message that is empty AS SERIALIZED.
+
+    Last line of defense against the Moonshot/Kimi/ZAI HTTP 400 "message at
+    position N with role 'assistant' must not be empty" session wedge. The
+    semantic pre-call filters (``sanitize_api_messages`` +
+    ``drop_thinking_only_and_merge_users``) judge INTERNAL message shapes and
+    deliberately keep anything that looks like payload — but exotic shapes
+    (unknown content-block types, junk tool_calls entries, stripped
+    scaffolding) can serialize to nothing, and each new variant re-wedges
+    sessions (observed live 2026-07-19, request dumps ..._063158_ca3fef and
+    ..._074429_daef41). At the transport boundary "empty on the wire" is
+    finally decidable, so judge the FINAL shape here.
+
+    A message with a truthy reasoning payload is NOT dropped: require-side
+    providers (Kimi thinking, DeepSeek) need reasoning_content echo-back.
+    """
+    if not isinstance(msg, dict) or msg.get("role") != "assistant":
+        return False
+    if msg.get("tool_calls"):
+        return False
+    for key in ("reasoning_content", "reasoning", "reasoning_details"):
+        value = msg.get(key)
+        if isinstance(value, str) and value.strip():
+            return False
+        if isinstance(value, list) and value:
+            return False
+    content = msg.get("content")
+    if content is None or content == [] or (isinstance(content, str) and not content.strip()):
+        return True
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict):
+                if str(block.get("text") or "").strip():
+                    return False
+            elif block:
+                return False
+        return True
+    return False
+
+
+def _drop_wire_empty_assistants(messages: list) -> list:
+    """Remove assistant messages that would serialize empty (see above).
+
+    Returns the input list unchanged (same object) when nothing is empty.
+    Consecutive same-role messages left behind by a drop are legal in the
+    Chat Completions schema, so no merging is needed here.
+    """
+    dropped = [i for i, m in enumerate(messages) if _wire_empty_assistant(m)]
+    if not dropped:
+        return messages
+    logger.warning(
+        "chat_completions: dropped %d wire-empty assistant message(s) at "
+        "position(s) %s — strict providers reject them with HTTP 400",
+        len(dropped), dropped,
+    )
+    kept = set(range(len(messages))) - set(dropped)
+    return [m for i, m in enumerate(messages) if i in kept]
 
 
 def _reasoning_config_for_model(model: str, reasoning_config: dict | None) -> dict | None:
@@ -208,7 +271,7 @@ class ChatCompletionsTransport(ProviderTransport):
                     break
 
         if not needs_sanitize:
-            return messages
+            return _drop_wire_empty_assistants(messages)
 
         sanitized = list(messages)
         for msg_idx, msg in enumerate(messages):
@@ -271,7 +334,7 @@ class ChatCompletionsTransport(ProviderTransport):
                             copied_tool_calls[tc_idx] = copied_tc
                 if copied_tool_calls is not None:
                     mutable_msg()["tool_calls"] = copied_tool_calls
-        return sanitized
+        return _drop_wire_empty_assistants(sanitized)
 
     def convert_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Tools are already in OpenAI format — identity."""

--- a/run_agent.py
+++ b/run_agent.py
@@ -3874,7 +3874,15 @@ class AIAgent:
             return False
         if msg.get("tool_calls"):
             return False
-        # Does it have any actual output?
+        # Does it have any actual output? Track reasoning seen as
+        # Anthropic-style content thinking-blocks: a turn whose ONLY content
+        # is thinking blocks is thinking-only even without a top-level
+        # reasoning field. (Previously such a turn fell through BOTH this
+        # predicate and _is_empty_assistant, reached the chat-completions
+        # wire converter, had its thinking blocks stripped, and hit strict
+        # providers as an empty assistant → HTTP 400 wedge; observed live
+        # with Kimi/Moonshot via OpenRouter on 2026-07-19.)
+        saw_thinking_block = False
         content = msg.get("content")
         if isinstance(content, str):
             if content.strip():
@@ -3887,6 +3895,7 @@ class AIAgent:
                     continue
                 btype = block.get("type")
                 if btype in {"thinking", "redacted_thinking"}:
+                    saw_thinking_block = True
                     continue
                 if btype == "text":
                     text = block.get("text", "")
@@ -3898,6 +3907,8 @@ class AIAgent:
         elif content is not None and content != "":
             return False
         # Content is empty-ish. Is there reasoning to make it thinking-only?
+        if saw_thinking_block:
+            return True
         reasoning = msg.get("reasoning_content") or msg.get("reasoning")
         if isinstance(reasoning, str) and reasoning.strip():
             return True
@@ -3916,6 +3927,62 @@ class AIAgent:
                 for item in codex_items
             )
         return False
+
+    @staticmethod
+    def _is_empty_assistant(msg: Dict[str, Any]) -> bool:
+        """Return True if ``msg`` is an assistant turn with no payload at all.
+
+        No visible text, no tool_calls, and no reasoning of any form.
+        Interrupted/aborted generations can flush such an empty shell into the
+        history, and a compaction window whose protected tail contains one
+        replays it forever. Strict OpenAI-compatible providers (Kimi/Moonshot,
+        ZAI) then reject every subsequent request with HTTP 400 "the message at
+        position N with role 'assistant' must not be empty" — wedging the
+        session. Distinct from ``_is_thinking_only_assistant``, which requires
+        a reasoning payload: a thinking-only turn is dropped per-provider by
+        ``drop_thinking_only_and_merge_users``; a fully-empty turn carries
+        nothing for any provider and is safe to drop from the wire copy
+        unconditionally.
+        """
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            return False
+        if msg.get("tool_calls"):
+            return False
+        content = msg.get("content")
+        if isinstance(content, str):
+            if content.strip():
+                return False
+        elif isinstance(content, list):
+            for block in content:
+                if not isinstance(block, dict):
+                    if block:  # non-empty non-dict string etc.
+                        return False
+                    continue
+                btype = block.get("type")
+                if btype in {"thinking", "redacted_thinking"}:
+                    return False  # reasoning payload — thinking-only, not empty
+                if btype == "text":
+                    text = block.get("text", "")
+                    if isinstance(text, str) and text.strip():
+                        return False
+                    continue
+                # tool_use, image, document, etc. — real payload
+                return False
+        elif content is not None and content != "":
+            return False
+        # Content is empty-ish — any reasoning payload makes it thinking-only
+        # (another filter's decision), not fully empty.
+        for key in ("reasoning", "reasoning_content"):
+            val = msg.get(key)
+            if isinstance(val, str) and val.strip():
+                return False
+        rd = msg.get("reasoning_details")
+        if isinstance(rd, list) and rd:
+            return False
+        codex_items = msg.get("codex_reasoning_items")
+        if isinstance(codex_items, list) and codex_items:
+            return False
+        return True
 
     @staticmethod
     def _drop_thinking_only_and_merge_users(

--- a/tests/providers/test_wire_empty_assistant_guard.py
+++ b/tests/providers/test_wire_empty_assistant_guard.py
@@ -1,0 +1,90 @@
+"""Transport-boundary guard against wire-empty assistant messages.
+
+Strict OpenAI-compatible providers (Moonshot/Kimi, ZAI) reject any request
+containing an assistant message that serializes empty with HTTP 400 "the
+message at position N with role 'assistant' must not be empty" — permanently
+wedging the session. The semantic pre-call filters judge INTERNAL shapes and
+keep anything payload-like, but exotic shapes (unknown content-block types,
+junk tool_calls, stripped scaffolding) can serialize to nothing. Two live
+wedges on 2026-07-19 (request dumps ..._063158_ca3fef and ..._074429_daef41)
+each slipped a different variant past the filters, so convert_messages() now
+drops anything empty AS SERIALIZED — the last line of defense.
+"""
+
+from agent.transports.chat_completions import (
+    ChatCompletionsTransport,
+    _drop_wire_empty_assistants,
+    _wire_empty_assistant,
+)
+
+
+def test_predicate_catches_serialized_empty_variants():
+    empties = [
+        {"role": "assistant", "content": "", "tool_calls": []},   # both live wedges
+        {"role": "assistant", "content": None},
+        {"role": "assistant", "content": "   "},
+        {"role": "assistant", "content": []},
+        {"role": "assistant", "content": [{}]},                    # unknown block, no text
+        {"role": "assistant", "content": [{"type": "output_text", "text": ""}]},
+        {"role": "assistant", "content": "", "reasoning": "", "reasoning_details": []},
+    ]
+    for msg in empties:
+        assert _wire_empty_assistant(msg) is True, msg
+
+
+def test_predicate_keeps_payload_bearing_messages():
+    kept = [
+        {"role": "assistant", "content": "real text"},
+        {"role": "assistant", "content": [{"type": "text", "text": "hi"}]},
+        # reasoning replay is load-bearing for require-side providers
+        {"role": "assistant", "content": "", "reasoning_content": "thinking..."},
+        {"role": "assistant", "content": "", "reasoning_details": [{"type": "reasoning.text"}]},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "c1", "type": "function",
+                         "function": {"name": "f", "arguments": "{}"}}]},
+        {"role": "user", "content": ""},   # only assistant messages are judged
+        {"role": "tool", "content": ""},
+    ]
+    for msg in kept:
+        assert _wire_empty_assistant(msg) is False, msg
+
+
+def test_convert_messages_drops_empty_tail_on_both_exit_paths():
+    transport = ChatCompletionsTransport()
+    shell = {"role": "assistant", "content": "", "tool_calls": []}
+    base = [
+        {"role": "user", "content": "do the thing"},
+        {"role": "assistant", "content": "working on it"},
+    ]
+    # Fast path (no field-level sanitize needed).
+    out = transport.convert_messages(base + [dict(shell)], model="moonshotai/kimi-k3")
+    assert all(not _wire_empty_assistant(m) for m in out)
+    assert len(out) == 2
+    # Sanitize path (message carries a stripped internal marker).
+    marked = dict(shell)
+    marked["_empty_recovery_synthetic"] = True
+    out2 = transport.convert_messages(base + [marked], model="moonshotai/kimi-k3")
+    assert all(not _wire_empty_assistant(m) for m in out2)
+    assert len(out2) == 2
+
+
+def test_drop_returns_same_object_when_nothing_is_empty():
+    msgs = [{"role": "user", "content": "q"}, {"role": "assistant", "content": "a"}]
+    assert _drop_wire_empty_assistants(msgs) is msgs
+
+
+def test_summary_path_helper_is_importable_and_drops_shells():
+    """The max-iterations summary path bypasses the transport and mirrors its
+    sanitization by hand (chat_completion_helpers). It must apply the same
+    wire-empty guard — a shell at any position wedges the summary request on
+    Moonshot/Kimi (observed live 2026-07-19, 'position 3')."""
+    import inspect
+
+    from agent import chat_completion_helpers as helpers
+
+    src = inspect.getsource(helpers)
+    at = src.index('_drop_wire_empty_assistants')
+    assert at > -1, 'summary path must apply the wire-empty guard'
+    # Guard runs AFTER the semantic filters in the same build.
+    semantic = src.index('_drop_thinking_only_and_merge_users(api_messages)')
+    assert semantic < at

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -770,3 +770,107 @@ def test_sanitize_preserves_populated_tool_calls():
     out = sanitize_api_messages(list(messages))
     assistant = [m for m in out if m.get("role") == "assistant"][0]
     assert [tc["id"] for tc in assistant["tool_calls"]] == ["call_Z"]
+
+
+def test_sanitize_drops_fully_empty_assistant_message():
+    """sanitize_api_messages drops an assistant turn with no content, no
+    tool_calls, and no reasoning.
+
+    Interrupted generations can flush an empty assistant shell into the
+    history; strict providers (Kimi/Moonshot, ZAI) then reject every request
+    with HTTP 400 "the message at position N with role 'assistant' must not
+    be empty", wedging the session when the shell sits in the
+    compaction-protected tail.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": ""},
+        {"role": "user", "content": "proceed"},
+        {"role": "assistant", "content": None},
+        {"role": "assistant", "content": "real answer"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assistants = [m for m in out if m.get("role") == "assistant"]
+    assert len(assistants) == 1
+    assert assistants[0]["content"] == "real answer"
+
+
+def test_sanitize_empty_assistant_with_empty_tool_calls_is_dropped():
+    """An assistant turn whose only payload was ``tool_calls: []`` becomes
+    fully empty once the key is normalized away, and is dropped too."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "", "tool_calls": []},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assert [m["role"] for m in out] == ["user"]
+
+
+def test_sanitize_keeps_thinking_only_and_tool_call_assistants():
+    """Negative controls: reasoning-bearing and tool_call-bearing assistant
+    turns with empty visible content must NOT be dropped here — thinking-only
+    turns belong to drop_thinking_only_and_merge_users (per-provider), and
+    tool_call turns are load-bearing for tool-result pairing."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "", "reasoning_content": "thinking..."},
+        {"role": "assistant", "content": None,
+         "tool_calls": [{"id": "call_E", "type": "function",
+                         "function": {"name": "foo", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_E", "content": "r"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assistants = [m for m in out if m.get("role") == "assistant"]
+    assert len(assistants) == 2
+    assert assistants[0].get("reasoning_content") == "thinking..."
+    assert [tc["id"] for tc in assistants[1]["tool_calls"]] == ["call_E"]
+
+
+def test_thinking_block_only_assistant_is_thinking_only():
+    """A turn whose ONLY content is Anthropic-style thinking blocks (no
+    top-level reasoning field) must classify as thinking-only. Previously it
+    fell through BOTH _is_thinking_only_assistant (verdict consulted only
+    top-level reasoning fields) and _is_empty_assistant (thinking block =
+    payload), reached the chat-completions wire converter, lost its thinking
+    blocks, and hit strict providers (Kimi/Moonshot) as an empty assistant —
+    HTTP 400 "must not be empty", wedging the session (observed 2026-07-19
+    via OpenRouter; request dump 20260719_063158_ca3fef)."""
+    from run_agent import AIAgent
+
+    shell = {"role": "assistant",
+             "content": [{"type": "thinking", "thinking": "planning..."}]}
+    assert AIAgent._is_thinking_only_assistant(shell) is True
+    assert AIAgent._is_empty_assistant(shell) is False  # division of labor
+
+
+def test_drop_thinking_only_drops_thinking_block_shell_and_merges():
+    from agent.agent_runtime_helpers import drop_thinking_only_and_merge_users
+
+    messages = [
+        {"role": "user", "content": "do the thing"},
+        {"role": "assistant",
+         "content": [{"type": "thinking", "thinking": "planning..."}]},
+        {"role": "user", "content": "go"},
+    ]
+    out = drop_thinking_only_and_merge_users(list(messages))
+    assert all(m.get("role") != "assistant" for m in out)
+    assert len([m for m in out if m.get("role") == "user"]) == 1  # merged
+
+
+def test_mixed_thinking_and_text_assistant_is_kept():
+    """Thinking blocks alongside real text are normal output — must be kept."""
+    from run_agent import AIAgent
+    from agent.agent_runtime_helpers import drop_thinking_only_and_merge_users
+
+    msg = {"role": "assistant",
+           "content": [{"type": "thinking", "thinking": "hmm"},
+                       {"type": "text", "text": "Here is the answer."}]}
+    assert AIAgent._is_thinking_only_assistant(msg) is False
+    out = drop_thinking_only_and_merge_users([{"role": "user", "content": "q"}, msg])
+    assert msg in out


### PR DESCRIPTION
## Problem

Strict OpenAI-compatible providers (Moonshot/Kimi, ZAI) reject any request containing an assistant message that serializes empty with HTTP 400 `the message at position N with role 'assistant' must not be empty`. Once such a shell lands in the compaction-protected tail of a session, **every subsequent request replays it and the session is permanently wedged** — compression retries shrink the context but re-send the shell, then the client aborts as non-retryable.

We hit this **four times in one day** on kimi-k3 via OpenRouter, each time via a different entry path (request dumps preserved locally for each):

1. A fully-empty assistant shell (`content:"", tool_calls:[]`) from an interrupted generation, replayed from the compaction tail.
2. A turn whose reasoning lived in Anthropic-style **content thinking-blocks**: `_is_thinking_only_assistant` skipped the blocks while scanning for output but based its verdict only on top-level reasoning fields — both filters kept it, the wire converter stripped the blocks, Moonshot got an empty message.
3. A third internal shape that passed both semantic filters yet serialized empty (unknown block types / junk tool_calls are 'payload' to the filters, nothing on the wire).
4. The **max-iterations summary request** — it hand-builds messages and bypasses the transport entirely, so wire-level protection never ran.

## Fix — four layers for four distinct call paths

1. `sanitize_api_messages` drops fully-empty assistant shells (no text, no tool_calls, no reasoning of any form) from the wire copy; stored history untouched.
2. `_is_thinking_only_assistant` now counts content thinking-blocks as reasoning, so blocks-only turns are handled by the existing per-provider thinking-only drop.
3. `ChatCompletionsTransport.convert_messages` gains a shape-agnostic last line of defense: drop any assistant message that is **empty as serialized** (reasoning-bearing messages are kept — require-side providers need `reasoning_content` echo-back). Fires with a logged warning + positions.
4. The iteration-limit summary path mirrors the same guard (it already mirrors other transport shaping by hand).

Layers 1–2 keep semantics clean at the source; 3–4 guarantee the class of wedge cannot recur regardless of future internal shapes. They protect distinct call paths and are deliberately not collapsed — until all entry points route through one canonical message-shaping function, each path needs its own guard.

## Tests

- New `tests/providers/test_wire_empty_assistant_guard.py` (predicate matrix incl. both live wire shapes, both convert_messages exits, summary-path coverage).
- Extended `tests/run_agent/test_message_sequence_repair.py` (empty-shell drop, thinking-block classification, drop+merge, negative controls for tool_calls / reasoning_content / mixed-content turns).
- `tests/providers/ + tests/run_agent/`: **2232 passed** on this branch.
- Both original failing request payloads replay clean through the patched transport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)