### PR TITLE
fix(tests): make run_tests.sh work on native Windows (#67385)

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -91,6 +91,19 @@ echo "▶ pre-compiling bytecode cache"
 "$PYTHON" -m compileall -q -j 0 -- $(git ls-files '*.py') >/dev/null 2>&1 || true
 
 echo "▶ launching test runner"
+# Windows (native, via Git Bash): CPython on Windows ignores HOME —
+# Path.home()/expanduser need USERPROFILE (or HOMEDRIVE+HOMEPATH), ssl and
+# sockets need SystemRoot, and tempfile needs TEMP/TMP.  With env -i
+# stripping them, every test that touches Path.home() dies at collection
+# with "RuntimeError: Could not determine home directory."  None of these
+# carry secrets, so passing them through preserves the hermetic intent
+# (credential vars stay stripped).  All are guarded on being set, so the
+# Linux/macOS environment is byte-identical to before.
+#
+# PYTHONUTF8=1: the runner and per-file subprocesses print ✓/⚠ glyphs;
+# Windows consoles default to a legacy codepage (cp1252) and crash with
+# UnicodeEncodeError.  UTF-8 mode is a no-op on Linux/macOS, where
+# LANG=C.UTF-8 already forces UTF-8.
 exec env -i \
   PATH="$PATH" \
   HOME="$HOME" \
@@ -98,6 +111,13 @@ exec env -i \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \
   PYTHONHASHSEED=0 \
+  PYTHONUTF8=1 \
+  ${USERPROFILE:+USERPROFILE="$USERPROFILE"} \
+  ${HOMEDRIVE:+HOMEDRIVE="$HOMEDRIVE"} \
+  ${HOMEPATH:+HOMEPATH="$HOMEPATH"} \
+  ${SYSTEMROOT:+SYSTEMROOT="$SYSTEMROOT"} \
+  ${TEMP:+TEMP="$TEMP"} \
+  ${TMP:+TMP="$TMP"} \
   ${HERMES_RUN_SLOW_PET_TESTS:+HERMES_RUN_SLOW_PET_TESTS="$HERMES_RUN_SLOW_PET_TESTS"} \
   ${EXTRA_PYTHONPATH:+PYTHONPATH="$EXTRA_PYTHONPATH"} \
   ${EXTRA_PYTEST_PLUGINS:+PYTEST_PLUGINS="$EXTRA_PYTEST_PLUGINS"} \

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -42,15 +42,27 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # (HERMES_PYTHON is exported by the devShell hook and ships [dev] extras:
 # pytest, pytest-asyncio, pytest-timeout, ruff, ty).
 VENV=""
+VENV_PYTHON=""
 for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
   if [ -f "$candidate/bin/activate" ]; then
     VENV="$candidate"
+    VENV_PYTHON="$candidate/bin/python"
+    break
+  fi
+  # Native Windows venv layout: python.exe and activate live under
+  # Scripts/, and there is no bin/. Anyone running this script from
+  # Git Bash / MSYS with a `python -m venv`- or uv-created venv hits
+  # this branch — without it the canonical runner refuses to start.
+  # (Probe shape from #66496.)
+  if [ -f "$candidate/Scripts/activate" ]; then
+    VENV="$candidate"
+    VENV_PYTHON="$candidate/Scripts/python.exe"
     break
   fi
 done
 
 if [ -n "$VENV" ]; then
-  PYTHON="$VENV/bin/python"
+  PYTHON="$VENV_PYTHON"
 elif [ -n "${HERMES_PYTHON:-}" ] && [ -x "$HERMES_PYTHON" ] \
     && "$HERMES_PYTHON" -c 'import pytest' 2>/dev/null; then
   # Guard with an import check: HERMES_PYTHON may point at the RELEASE


### PR DESCRIPTION
## What does this PR do?

Makes the canonical test runner usable on native Windows. `env -i`'s allowlist was POSIX-centric: it passed `HOME`, which CPython on Windows never reads — `Path.home()`/`expanduser` resolve via `USERPROFILE` (or `HOMEDRIVE`+`HOMEPATH`), `ssl`/sockets need `SystemRoot`, and `tempfile` needs `TEMP`/`TMP`. With those stripped, every test file touching `Path.home()` died at collection with `RuntimeError: Could not determine home directory` — all of `tests/gateway/` included. Full traceback and analysis in #67385.

Also sets `PYTHONUTF8=1`: the runner and per-file subprocesses print `✓`/`⚠` glyphs, which crash with `UnicodeEncodeError` under legacy Windows codepages (cp1252).

**Hermetic intent preserved**: none of the six passed-through vars carry secrets — credential vars stay stripped. All six are guarded on being set (`${VAR:+...}`), so the **Linux/macOS environment is byte-identical to before**; `PYTHONUTF8=1` is a no-op there since `LANG=C.UTF-8` already forces UTF-8. CI is unaffected either way — the workflows invoke `run_tests_parallel.py` directly, not this wrapper.

## Related Issue

Fixes #67385.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/run_tests.sh` — guarded passthrough of `USERPROFILE`, `HOMEDRIVE`, `HOMEPATH`, `SYSTEMROOT`, `TEMP`, `TMP` in the `env -i` block + `PYTHONUTF8=1`, with a comment documenting why each is needed on Windows.

## How to Test

1. Native Windows, Git Bash — **no workarounds, ordinary uv/`python -m venv` `.venv`** (post-consolidation, commit `97ce96b2e`): `bash scripts/run_tests.sh tests/gateway/test_42039_duplicate_user_message.py tests/agent/test_turn_overlap_tripwire.py`
   - Before this PR: `error: no virtualenv found` at startup (Scripts/ layout unprobed); with `HERMES_PYTHON` supplied, `RuntimeError: Could not determine home directory` at collection (0 collected).
   - After: probe finds `.venv/Scripts/python.exe`, collection succeeds, **16/16 pass**, no UnicodeEncodeError.
2. Linux/macOS: no behavior change — the added vars are unset there (`${VAR:+...}`-guarded), `bin/activate` is still probed first, and UTF-8 mode was already in effect via `LANG`.

**Regression guard**: the fix is shell-level, so the guard is the reproducible command above rather than a test file. If maintainers want it mechanized, a small CI job running that exact command under `windows-latest` + Git Bash would lock both failure modes permanently — happy to add it here or as a follow-up.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] I searched existing PRs and issues for prior attempts (none — mechanism + keyword search)
- [x] Single-topic diff
- [x] Test suite exercised — see How to Test (this PR is itself about making that possible on Windows)
- [x] Tested on my platform: Windows 11 (native); Linux env is provably byte-identical (guarded expansions)

### Documentation & Housekeeping

- [x] Documentation — in-file comment added; no docs pages reference the env allowlist — or N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md / AGENTS.md — N/A (behavior now matches what they already document)
- [x] Cross-platform impact — the entire point; see hermetic-intent note above
