### PR TITLE
fix(anthropic): preserve signed thinking blocks on Kimi-family replay (#66948 salvage)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2276,13 +2276,6 @@ def _manage_thinking_signatures(
     """
     _THINKING_TYPES = frozenset(("thinking", "redacted_thinking"))
     _is_third_party = _is_third_party_anthropic_endpoint(base_url)
-    # Kimi / DeepSeek share a contract: strip signed Anthropic blocks
-    # (neither upstream can validate Anthropic signatures), preserve unsigned
-    # ones synthesised from reasoning_content.  See #13848, #16748.
-    _preserve_unsigned_thinking = (
-        _is_kimi_family_endpoint(base_url, model)
-        or _is_deepseek_anthropic_endpoint(base_url)
-    )
 
     last_assistant_idx = None
     for i in range(len(result) - 1, -1, -1):
@@ -2294,8 +2287,12 @@ def _manage_thinking_signatures(
         if m.get("role") != "assistant" or not isinstance(m.get("content"), list):
             continue
 
-        if _preserve_unsigned_thinking:
-            # Kimi / DeepSeek: strip signed, preserve unsigned.
+        if _is_kimi_family_endpoint(base_url, model):
+            # Kimi does not enforce thinking signatures — replay as-is
+            # (shared cleanup below still strips cache markers + the internal flag).
+            pass
+        elif _is_deepseek_anthropic_endpoint(base_url):
+            # DeepSeek: strip signed, preserve unsigned.
             new_content = []
             for b in m["content"]:
                 if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:

--- a/contributors/emails/fanyu@moonshot.cn
+++ b/contributors/emails/fanyu@moonshot.cn
@@ -1,0 +1,1 @@
+FuryMartin

--- a/tests/agent/test_anthropic_kimi_signed_thinking_replay.py
+++ b/tests/agent/test_anthropic_kimi_signed_thinking_replay.py
@@ -1,0 +1,107 @@
+"""Kimi-family endpoints don't need thinking blocks stripped on replay; DeepSeek does."""
+
+from types import SimpleNamespace
+
+from agent.transports import get_transport
+from agent.anthropic_adapter import convert_messages_to_anthropic
+
+SIG = "sig-k3"
+
+KIMI = "https://api.kimi.com/coding"
+MOONSHOT = "https://api.moonshot.cn/anthropic"
+DEEPSEEK = "https://api.deepseek.com/anthropic"
+
+
+def _thinking_on_replay(base_url, signature=SIG):
+    """Normalize a thinking+text turn, store it, convert to the next-turn request,
+    and return its thinking blocks."""
+    response = SimpleNamespace(
+        content=[
+            SimpleNamespace(type="thinking", thinking="five: 5 11 27 63 88", signature=signature),
+            SimpleNamespace(type="text", text="5 27 88"),
+        ],
+        stop_reason="end_turn",
+        usage=None,
+    )
+    normalized = get_transport("anthropic_messages").normalize_response(response)
+    stored = {
+        "role": "assistant",
+        "content": normalized.content or "",
+        "reasoning_details": (normalized.provider_data or {}).get("reasoning_details"),
+    }
+    messages = [
+        {"role": "user", "content": "q1"},
+        stored,
+        {"role": "user", "content": "q2"},
+    ]
+    _sys, out = convert_messages_to_anthropic(messages, base_url=base_url, model="k3")
+    assistant = [m for m in out if m.get("role") == "assistant"][0]
+    return [b for b in assistant["content"] if isinstance(b, dict) and b.get("type") == "thinking"]
+
+
+def test_kimi_coding_keeps_signed_thinking():
+    thinking = _thinking_on_replay(KIMI)
+    assert thinking and thinking[0].get("signature") == SIG
+
+
+def test_kimi_coding_keeps_unsigned_thinking():
+    assert _thinking_on_replay(KIMI, signature="")
+
+
+def test_moonshot_keeps_signed_thinking():
+    thinking = _thinking_on_replay(MOONSHOT)
+    assert thinking and thinking[0].get("signature") == SIG
+
+
+def test_deepseek_still_strips_signed_thinking():
+    assert not _thinking_on_replay(DEEPSEEK)
+
+
+def test_direct_anthropic_keeps_signed_on_latest():
+    assert _thinking_on_replay(None)
+
+
+def test_orphan_tool_turn_demotes_and_leaks_no_internal_marker():
+    """Signed thinking + parallel tool batch interrupted mid-flight (one orphan):
+    the internal _thinking_signature_invalidated marker must be popped —
+    never leak into the Kimi payload — while the thinking block itself
+    replays as-is (Kimi does not enforce signatures)."""
+    response = SimpleNamespace(
+        content=[
+            SimpleNamespace(type="thinking", thinking="plan both reads", signature=SIG),
+            SimpleNamespace(type="tool_use", id="toolu_1", name="read_file", input={"path": "a.py"}),
+            SimpleNamespace(type="tool_use", id="toolu_2", name="read_file", input={"path": "b.py"}),
+        ],
+        stop_reason="tool_use",
+        usage=None,
+    )
+    normalized = get_transport("anthropic_messages").normalize_response(response)
+    provider_data = normalized.provider_data or {}
+    stored = {
+        "role": "assistant",
+        "content": normalized.content or "",
+        "reasoning_details": provider_data.get("reasoning_details"),
+        "tool_calls": [
+            {"id": tc.id, "type": "function", "function": {"name": tc.name, "arguments": tc.arguments}}
+            for tc in (normalized.tool_calls or [])
+        ],
+    }
+    if provider_data.get("anthropic_content_blocks"):
+        stored["anthropic_content_blocks"] = provider_data["anthropic_content_blocks"]
+    messages = [
+        {"role": "user", "content": "inspect both"},
+        stored,
+        {"role": "tool", "tool_call_id": "toolu_1", "content": "a.py: ok"},
+        # toolu_2 interrupted: no tool result follows (orphan)
+        {"role": "user", "content": "continue"},
+    ]
+    _sys, out = convert_messages_to_anthropic(messages, base_url=KIMI, model="k3")
+    assistant = [m for m in out if m.get("role") == "assistant"][0]
+    assert "_thinking_signature_invalidated" not in assistant, (
+        f"internal marker leaked into Kimi payload: {assistant.keys()}"
+    )
+    types = [b.get("type") for b in assistant["content"] if isinstance(b, dict)]
+    assert "thinking" in types, (
+        "Kimi does not enforce signatures — even orphan-invalidated blocks "
+        f"must replay as-is: {types}"
+    )


### PR DESCRIPTION
## Summary

Salvage of #66948 by @FuryMartin — Kimi-family Anthropic endpoints now replay thinking blocks as-is (signed and unsigned) instead of stripping signed ones, restoring cross-turn reasoning recall on Kimi For Coding / Moonshot.

Root cause: the #13848-era contract assumed Kimi cannot validate Anthropic thinking signatures and stripped every signed block on replay. Live probes show the whole Kimi family accepts signed blocks (HTTP 200 even with mutated signatures) — the strip silently deleted the model's prior reasoning each turn.

## Changes

- `agent/anthropic_adapter.py`: `_manage_thinking_signatures` splits the shared Kimi/DeepSeek branch — Kimi family replays thinking unchanged; DeepSeek keeps strip-signed/keep-unsigned (#16748); third-party and direct Anthropic untouched.
- `tests/agent/test_anthropic_kimi_signed_thinking_replay.py`: 6 new regression tests, incl. orphan-tool-turn case verifying the internal `_thinking_signature_invalidated` marker never reaches the wire.
- `contributors/emails/fanyu@moonshot.cn`: contributor mapping for @FuryMartin.

## Validation

| Check | Result |
|---|---|
| Targeted tests (new + thinking-block-order + adapter) | 186 passed, 0 failed |
| OpenRouter Kimi (chat_completions path) wire A/B | byte-identical request hash, main vs PR |
| Live OpenRouter kimi-k3 two-turn recall probe | HTTP 200, model recalls prior-turn reasoning |
| Contributor's live probes (KFC + Moonshot /anthropic) | 200 on verbatim AND mutated signed blocks |

Cherry-picked with @FuryMartin's authorship preserved; rebase-merge.

Closes #66948.

## Infographic

![kimi-signed-thinking-replay](https://v3b.fal.media/files/b/0aa2daca/DV3hlPRVzZKxVvZXdmQYY_bwbM93ja.png)
