### PR TITLE
feat(desktop): add profile-scoped launch deep link

### DIFF
--- a/apps/desktop/electron/deep-link.test.ts
+++ b/apps/desktop/electron/deep-link.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict'
+
+import { describe, test } from 'vitest'
+
+import { extractHermesDeepLink, parseHermesDeepLink } from './deep-link'
+
+describe('extractHermesDeepLink', () => {
+  test('finds cold-start and second-instance protocol arguments', () => {
+    assert.equal(
+      extractHermesDeepLink(['/opt/Hermes', '--flag', 'hermes://profile/work?new=1']),
+      'hermes://profile/work?new=1'
+    )
+  })
+
+  test('ignores non-array and unrelated argv input', () => {
+    assert.equal(extractHermesDeepLink(null), null)
+    assert.equal(extractHermesDeepLink(['/opt/Hermes', 'https://example.com']), null)
+  })
+})
+
+describe('parseHermesDeepLink', () => {
+  test('preserves the existing blueprint payload contract', () => {
+    assert.deepEqual(parseHermesDeepLink('hermes://blueprint/morning-brief?time=08%3A00&city=New+York'), {
+      kind: 'blueprint',
+      name: 'morning-brief',
+      params: { city: 'New York', time: '08:00' }
+    })
+  })
+
+  test('accepts an explicit blank-chat request for a safe profile name', () => {
+    assert.deepEqual(parseHermesDeepLink('hermes://profile/research_bot?new=1'), {
+      kind: 'profile',
+      name: 'research_bot',
+      params: { new: '1' }
+    })
+  })
+
+  test('accepts percent-encoding without weakening profile validation', () => {
+    assert.deepEqual(parseHermesDeepLink('hermes://profile/%77ork?new=1'), {
+      kind: 'profile',
+      name: 'work',
+      params: { new: '1' }
+    })
+    assert.equal(parseHermesDeepLink('hermes://profile/%2e%2e%2fwork?new=1'), null)
+  })
+
+  test('rejects profile links that carry another action or prompt-shaped data', () => {
+    assert.equal(parseHermesDeepLink('hermes://profile/work'), null)
+    assert.equal(parseHermesDeepLink('hermes://profile/work?new=0'), null)
+    assert.equal(parseHermesDeepLink('hermes://profile/work?new=1&prompt=hello'), null)
+    assert.equal(parseHermesDeepLink('hermes://profile/work?new=1&new=1'), null)
+  })
+
+  test('rejects unsafe names, extra path segments, fragments, and unsupported routes', () => {
+    assert.equal(parseHermesDeepLink('hermes://profile/Work?new=1'), null)
+    assert.equal(parseHermesDeepLink('hermes://profile/work/chat?new=1'), null)
+    assert.equal(parseHermesDeepLink('hermes://profile/work?new=1#prompt'), null)
+    assert.equal(parseHermesDeepLink('hermes://unknown/work?new=1'), null)
+    assert.equal(parseHermesDeepLink('not a url'), null)
+  })
+})

--- a/apps/desktop/electron/deep-link.ts
+++ b/apps/desktop/electron/deep-link.ts
@@ -1,0 +1,93 @@
+export interface HermesDeepLinkPayload {
+  kind: 'blueprint' | 'profile'
+  name: string
+  params: Record<string, string>
+}
+
+const HERMES_PROTOCOL = 'hermes:'
+const PROFILE_LINK_RE = /^hermes:\/\/profile\/([^/?#]+)\?([^#]*)$/i
+const PROFILE_NAME_RE = /^(?:default|[a-z0-9][a-z0-9_-]{0,63})$/
+
+export function extractHermesDeepLink(argv: unknown): null | string {
+  if (!Array.isArray(argv)) {
+    return null
+  }
+
+  return argv.find(value => typeof value === 'string' && value.startsWith('hermes://')) ?? null
+}
+
+/**
+ * Parse the public hermes:// surface at the native protocol boundary.
+ *
+ * Profile links are deliberately narrower than blueprint links: they carry
+ * only an installed profile identifier plus the explicit new-chat intent.
+ * They cannot transport prompt text or another action for the renderer to run.
+ */
+export function parseHermesDeepLink(raw: unknown): HermesDeepLinkPayload | null {
+  if (typeof raw !== 'string') {
+    return null
+  }
+
+  let parsed: URL
+
+  try {
+    parsed = new URL(raw)
+  } catch {
+    return null
+  }
+
+  if (parsed.protocol !== HERMES_PROTOCOL) {
+    return null
+  }
+
+  const kind = parsed.hostname.toLowerCase()
+
+  if (kind === 'profile') {
+    const match = PROFILE_LINK_RE.exec(raw)
+
+    if (!match) {
+      return null
+    }
+
+    let name: string
+
+    try {
+      name = decodeURIComponent(match[1])
+    } catch {
+      return null
+    }
+
+    const keys = [...parsed.searchParams.keys()]
+
+    if (
+      !PROFILE_NAME_RE.test(name) ||
+      keys.length !== 1 ||
+      keys[0] !== 'new' ||
+      parsed.searchParams.getAll('new').length !== 1 ||
+      parsed.searchParams.get('new') !== '1'
+    ) {
+      return null
+    }
+
+    return { kind: 'profile', name, params: { new: '1' } }
+  }
+
+  if (kind !== 'blueprint') {
+    return null
+  }
+
+  let name: string
+
+  try {
+    name = decodeURIComponent((parsed.pathname || '').replace(/^\//, ''))
+  } catch {
+    return null
+  }
+
+  const params: Record<string, string> = {}
+  parsed.searchParams.forEach((value, key) => {
+    params[key] = value
+  })
+
+  return { kind: 'blueprint', name, params }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -67,6 +67,7 @@ import {
 } from './connection-config'
 import { adoptServedDashboardToken } from './dashboard-token'
 import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
+import { extractHermesDeepLink, type HermesDeepLinkPayload, parseHermesDeepLink } from './deep-link'
 import {
   buildPosixCleanupScript,
   buildWindowsCleanupScript,
@@ -10237,40 +10238,23 @@ ipcMain.handle('hermes:vscode-theme:search', async (_event, query) => searchMark
 // Win/Linux running-app 'second-instance' (argv), Win/Linux cold-start argv.
 // ---------------------------------------------------------------------------
 const HERMES_PROTOCOL = 'hermes'
-let _pendingDeepLink = null
+let _pendingDeepLink: HermesDeepLinkPayload | null = null
 let _rendererReadyForDeepLink = false
 
-function _extractDeepLink(argv) {
-  if (!Array.isArray(argv)) {
-    return null
+function handleDeepLink(url) {
+  const payload = parseHermesDeepLink(url)
+
+  if (!payload) {
+    rememberLog('[deeplink] ignoring malformed or unsupported url')
+
+    return
   }
 
-  return argv.find(a => typeof a === 'string' && a.startsWith(`${HERMES_PROTOCOL}://`)) || null
+  deliverDeepLink(payload)
 }
 
-function handleDeepLink(url) {
-  if (!url || typeof url !== 'string') {
-    return
-  }
-
-  let parsed
-
-  try {
-    parsed = new URL(url)
-  } catch {
-    rememberLog(`[deeplink] ignoring malformed url: ${url}`)
-
-    return
-  }
-
-  // hermes://blueprint/<key>?slot=val  -> host="blueprint", path="/<key>"
-  const kind = parsed.hostname || ''
-  const name = decodeURIComponent((parsed.pathname || '').replace(/^\//, ''))
-  const params = {}
-  parsed.searchParams.forEach((v, k) => {
-    params[k] = v
-  })
-  const payload = { kind, name, params }
+function deliverDeepLink(payload: HermesDeepLinkPayload) {
+  const { kind, name } = payload
 
   if (!_rendererReadyForDeepLink || !mainWindow || mainWindow.isDestroyed()) {
     _pendingDeepLink = payload
@@ -10299,10 +10283,7 @@ ipcMain.handle('hermes:deep-link-ready', () => {
   if (_pendingDeepLink) {
     const queued = _pendingDeepLink
     _pendingDeepLink = null
-    handleDeepLink(
-      `${HERMES_PROTOCOL}://${queued.kind}/${encodeURIComponent(queued.name)}` +
-        (Object.keys(queued.params).length ? '?' + new URLSearchParams(queued.params).toString() : '')
-    )
+    deliverDeepLink(queued)
   }
 
   return { ok: true }
@@ -10331,7 +10312,7 @@ if (!_gotSingleInstanceLock) {
   app.quit()
 } else {
   app.on('second-instance', (_event, argv) => {
-    const url = _extractDeepLink(argv)
+    const url = extractHermesDeepLink(argv)
 
     if (url) {
       handleDeepLink(url)
@@ -10382,7 +10363,7 @@ app.whenReady().then(() => {
   createWindow()
 
   // Win/Linux cold start: the launching hermes:// URL is in our own argv.
-  const _coldStartLink = _extractDeepLink(process.argv)
+  const _coldStartLink = extractHermesDeepLink(process.argv)
 
   if (_coldStartLink) {
     handleDeepLink(_coldStartLink)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -66,8 +66,8 @@ import {
   tokenPreview
 } from './connection-config'
 import { adoptServedDashboardToken } from './dashboard-token'
-import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
 import { extractHermesDeepLink, type HermesDeepLinkPayload, parseHermesDeepLink } from './deep-link'
+import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
 import {
   buildPosixCleanupScript,
   buildWindowsCleanupScript,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -79,6 +79,7 @@ import {
 import { describeCrashReason, installCrashForensics } from './crash-forensics'
 import { adoptServedDashboardToken } from './dashboard-token'
 import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
+import { extractHermesDeepLink, type HermesDeepLinkPayload, parseHermesDeepLink } from './deep-link'
 import {
   buildPosixCleanupScript,
   buildWindowsCleanupScript,
@@ -12191,40 +12192,23 @@ ipcMain.handle('hermes:vscode-theme:search', async (_event, query) => searchMark
 // Win/Linux running-app 'second-instance' (argv), Win/Linux cold-start argv.
 // ---------------------------------------------------------------------------
 const HERMES_PROTOCOL = 'hermes'
-let _pendingDeepLink = null
+let _pendingDeepLink: HermesDeepLinkPayload | null = null
 let _rendererReadyForDeepLink = false
 
-function _extractDeepLink(argv) {
-  if (!Array.isArray(argv)) {
-    return null
+function handleDeepLink(url) {
+  const payload = parseHermesDeepLink(url)
+
+  if (!payload) {
+    rememberLog('[deeplink] ignoring malformed or unsupported url')
+
+    return
   }
 
-  return argv.find(a => typeof a === 'string' && a.startsWith(`${HERMES_PROTOCOL}://`)) || null
+  deliverDeepLink(payload)
 }
 
-function handleDeepLink(url) {
-  if (!url || typeof url !== 'string') {
-    return
-  }
-
-  let parsed
-
-  try {
-    parsed = new URL(url)
-  } catch {
-    rememberLog(`[deeplink] ignoring malformed url: ${url}`)
-
-    return
-  }
-
-  // hermes://blueprint/<key>?slot=val  -> host="blueprint", path="/<key>"
-  const kind = parsed.hostname || ''
-  const name = decodeURIComponent((parsed.pathname || '').replace(/^\//, ''))
-  const params = {}
-  parsed.searchParams.forEach((v, k) => {
-    params[k] = v
-  })
-  const payload = { kind, name, params }
+function deliverDeepLink(payload: HermesDeepLinkPayload) {
+  const { kind, name } = payload
 
   if (!_rendererReadyForDeepLink || !mainWindow || mainWindow.isDestroyed()) {
     _pendingDeepLink = payload
@@ -12253,10 +12237,7 @@ ipcMain.handle('hermes:deep-link-ready', () => {
   if (_pendingDeepLink) {
     const queued = _pendingDeepLink
     _pendingDeepLink = null
-    handleDeepLink(
-      `${HERMES_PROTOCOL}://${queued.kind}/${encodeURIComponent(queued.name)}` +
-        (Object.keys(queued.params).length ? '?' + new URLSearchParams(queued.params).toString() : '')
-    )
+    deliverDeepLink(queued)
   }
 
   return { ok: true }
@@ -12285,7 +12266,7 @@ if (!_gotSingleInstanceLock) {
   app.quit()
 } else {
   app.on('second-instance', (_event, argv) => {
-    const url = _extractDeepLink(argv)
+    const url = extractHermesDeepLink(argv)
 
     if (url) {
       handleDeepLink(url)
@@ -12351,7 +12332,7 @@ app.whenReady().then(() => {
   createWindow()
 
   // Win/Linux cold start: the launching hermes:// URL is in our own argv.
-  const _coldStartLink = _extractDeepLink(process.argv)
+  const _coldStartLink = extractHermesDeepLink(process.argv)
 
   if (_coldStartLink) {
     handleDeepLink(_coldStartLink)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -78,8 +78,8 @@ import {
 } from './connection-config'
 import { describeCrashReason, installCrashForensics } from './crash-forensics'
 import { adoptServedDashboardToken } from './dashboard-token'
-import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
 import { extractHermesDeepLink, type HermesDeepLinkPayload, parseHermesDeepLink } from './deep-link'
+import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
 import {
   buildPosixCleanupScript,
   buildWindowsCleanupScript,

--- a/apps/desktop/src/app/contrib/deep-link.test.ts
+++ b/apps/desktop/src/app/contrib/deep-link.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { handleDesktopDeepLink } from './deep-link'
+
+vi.mock('@/i18n', () => ({
+  translateNow: (key: string, ...args: unknown[]) => `${key}:${args.join('|')}`
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+vi.mock('@/store/profile', () => ({
+  newSessionInProfile: vi.fn(),
+  normalizeProfileKey: (name: string | null | undefined) => name?.trim() || 'default',
+  refreshProfiles: vi.fn(),
+  switchProfile: vi.fn()
+}))
+
+vi.mock('@/app/chat/composer/focus', () => ({
+  requestComposerFocus: vi.fn(),
+  requestComposerInsert: vi.fn(),
+  requestComposerSubmit: vi.fn()
+}))
+
+const notifications = await import('@/store/notifications')
+const notify = vi.mocked(notifications.notify)
+const notifyError = vi.mocked(notifications.notifyError)
+const profileStore = await import('@/store/profile')
+const newSessionInProfile = vi.mocked(profileStore.newSessionInProfile)
+const refreshProfiles = vi.mocked(profileStore.refreshProfiles)
+const switchProfile = vi.mocked(profileStore.switchProfile)
+const composer = await import('@/app/chat/composer/focus')
+const requestComposerFocus = vi.mocked(composer.requestComposerFocus)
+const requestComposerInsert = vi.mocked(composer.requestComposerInsert)
+const requestComposerSubmit = vi.mocked(composer.requestComposerSubmit)
+
+const profile = (name: string, isDefault = false) => ({
+  has_env: true,
+  is_default: isDefault,
+  model: null,
+  name,
+  path: `/profiles/${name}`,
+  provider: null,
+  skill_count: 0
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('handleDesktopDeepLink', () => {
+  it('keeps blueprint links reviewable in the composer without submitting', async () => {
+    await handleDesktopDeepLink({
+      kind: 'blueprint',
+      name: 'morning-brief',
+      params: { city: 'New York', time: '08:00' }
+    })
+
+    expect(requestComposerInsert).toHaveBeenCalledWith('/blueprint morning-brief city="New York" time=08:00', {
+      mode: 'block',
+      target: 'main'
+    })
+    expect(requestComposerFocus).toHaveBeenCalledWith('main')
+    expect(refreshProfiles).not.toHaveBeenCalled()
+    expect(newSessionInProfile).not.toHaveBeenCalled()
+  })
+
+  it('opens a blank chat through the live per-session profile route', async () => {
+    refreshProfiles.mockResolvedValue([profile('default', true), profile('research')])
+
+    await handleDesktopDeepLink({ kind: 'profile', name: 'research', params: { new: '1' } })
+
+    expect(refreshProfiles).toHaveBeenCalledTimes(1)
+    expect(newSessionInProfile).toHaveBeenCalledWith('research')
+    expect(switchProfile).not.toHaveBeenCalled()
+    expect(requestComposerFocus).toHaveBeenCalledWith('main')
+    expect(requestComposerInsert).not.toHaveBeenCalled()
+    expect(requestComposerSubmit).not.toHaveBeenCalled()
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  it('shows a durable error and leaves the current chat untouched when the profile is missing', async () => {
+    refreshProfiles.mockResolvedValue([profile('default', true), profile('work')])
+
+    await handleDesktopDeepLink({ kind: 'profile', name: 'missing', params: { new: '1' } })
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'deep-link-profile-missing:missing',
+        kind: 'error',
+        title: 'desktop.unknownProfile:',
+        message: 'desktop.noProfileNamed:missing|default, work'
+      })
+    )
+    expect(newSessionInProfile).not.toHaveBeenCalled()
+    expect(requestComposerFocus).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when installed profiles cannot be validated', async () => {
+    const error = new Error('profiles unavailable')
+    refreshProfiles.mockRejectedValue(error)
+
+    await handleDesktopDeepLink({ kind: 'profile', name: 'research', params: { new: '1' } })
+
+    expect(notifyError).toHaveBeenCalledWith(error, 'desktop.setProfileFailed:')
+    expect(newSessionInProfile).not.toHaveBeenCalled()
+    expect(requestComposerFocus).not.toHaveBeenCalled()
+  })
+
+  it('ignores profile payloads that do not request a new chat', async () => {
+    await handleDesktopDeepLink({ kind: 'profile', name: 'research', params: { prompt: 'hello' } })
+
+    expect(refreshProfiles).not.toHaveBeenCalled()
+    expect(newSessionInProfile).not.toHaveBeenCalled()
+    expect(requestComposerInsert).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/contrib/deep-link.test.ts
+++ b/apps/desktop/src/app/contrib/deep-link.test.ts
@@ -46,6 +46,16 @@ const profile = (name: string, isDefault = false) => ({
   skill_count: 0
 })
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
 })
@@ -79,6 +89,31 @@ describe('handleDesktopDeepLink', () => {
     expect(requestComposerInsert).not.toHaveBeenCalled()
     expect(requestComposerSubmit).not.toHaveBeenCalled()
     expect(notify).not.toHaveBeenCalled()
+  })
+
+  it('does not let a slower earlier profile link replace a newer link', async () => {
+    const earlierRefresh = deferred<ReturnType<typeof profile>[]>()
+    const newerRefresh = deferred<ReturnType<typeof profile>[]>()
+    refreshProfiles
+      .mockImplementationOnce(() => earlierRefresh.promise)
+      .mockImplementationOnce(() => newerRefresh.promise)
+
+    const earlierLink = handleDesktopDeepLink({ kind: 'profile', name: 'research', params: { new: '1' } })
+    const newerLink = handleDesktopDeepLink({ kind: 'profile', name: 'work', params: { new: '1' } })
+
+    newerRefresh.resolve([profile('default', true), profile('work')])
+    await newerLink
+
+    expect(newSessionInProfile).toHaveBeenCalledTimes(1)
+    expect(newSessionInProfile).toHaveBeenCalledWith('work')
+
+    earlierRefresh.resolve([profile('default', true), profile('research')])
+    await earlierLink
+
+    expect(newSessionInProfile).toHaveBeenCalledTimes(1)
+    expect(requestComposerFocus).toHaveBeenCalledTimes(1)
+    expect(notify).not.toHaveBeenCalled()
+    expect(notifyError).not.toHaveBeenCalled()
   })
 
   it('shows a durable error and leaves the current chat untouched when the profile is missing', async () => {

--- a/apps/desktop/src/app/contrib/deep-link.ts
+++ b/apps/desktop/src/app/contrib/deep-link.ts
@@ -1,0 +1,70 @@
+import { translateNow } from '@/i18n'
+import { notify, notifyError } from '@/store/notifications'
+import { newSessionInProfile, normalizeProfileKey, refreshProfiles } from '@/store/profile'
+
+import { requestComposerFocus, requestComposerInsert } from '../chat/composer/focus'
+
+interface DesktopDeepLinkPayload {
+  kind: string
+  name: string
+  params: Record<string, string>
+}
+
+const PROFILE_NAME_RE = /^(?:default|[a-z0-9][a-z0-9_-]{0,63})$/
+
+export async function handleDesktopDeepLink(payload: DesktopDeepLinkPayload | null | undefined): Promise<void> {
+  if (!payload?.name) {
+    return
+  }
+
+  if (payload.kind === 'blueprint') {
+    const slots = Object.entries(payload.params || {})
+      .map(([key, value]) => {
+        const stringValue = /\s/.test(value) ? `"${value.replace(/"/g, '\\"')}"` : value
+
+        return `${key}=${stringValue}`
+      })
+      .join(' ')
+
+    const command = `/blueprint ${payload.name}${slots ? ' ' + slots : ''}`
+    requestComposerInsert(command, { mode: 'block', target: 'main' })
+    requestComposerFocus('main')
+
+    return
+  }
+
+  if (payload.kind !== 'profile' || payload.params?.new !== '1' || !PROFILE_NAME_RE.test(payload.name)) {
+    return
+  }
+
+  let profiles
+
+  try {
+    profiles = await refreshProfiles()
+  } catch (error) {
+    notifyError(error, translateNow('desktop.setProfileFailed'))
+
+    return
+  }
+
+  const target = normalizeProfileKey(payload.name)
+  const installed = profiles.some(profile => normalizeProfileKey(profile.name) === target)
+
+  if (!installed) {
+    const available = profiles.map(profile => profile.name).join(', ') || '—'
+
+    notify({
+      id: `deep-link-profile-missing:${target}`,
+      kind: 'error',
+      title: translateNow('desktop.unknownProfile'),
+      message: translateNow('desktop.noProfileNamed', target, available)
+    })
+
+    return
+  }
+
+  // This is intentionally the live per-session route. It does not call the
+  // persistent profile setter and never changes the CLI's sticky default.
+  newSessionInProfile(target)
+  requestComposerFocus('main')
+}

--- a/apps/desktop/src/app/contrib/deep-link.ts
+++ b/apps/desktop/src/app/contrib/deep-link.ts
@@ -11,6 +11,7 @@ interface DesktopDeepLinkPayload {
 }
 
 const PROFILE_NAME_RE = /^(?:default|[a-z0-9][a-z0-9_-]{0,63})$/
+let latestDeliveryGeneration = 0
 
 export async function handleDesktopDeepLink(payload: DesktopDeepLinkPayload | null | undefined): Promise<void> {
   if (!payload?.name) {
@@ -18,6 +19,8 @@ export async function handleDesktopDeepLink(payload: DesktopDeepLinkPayload | nu
   }
 
   if (payload.kind === 'blueprint') {
+    latestDeliveryGeneration += 1
+
     const slots = Object.entries(payload.params || {})
       .map(([key, value]) => {
         const stringValue = /\s/.test(value) ? `"${value.replace(/"/g, '\\"')}"` : value
@@ -37,13 +40,22 @@ export async function handleDesktopDeepLink(payload: DesktopDeepLinkPayload | nu
     return
   }
 
+  const deliveryGeneration = ++latestDeliveryGeneration
   let profiles
 
   try {
     profiles = await refreshProfiles()
   } catch (error) {
-    notifyError(error, translateNow('desktop.setProfileFailed'))
+    if (deliveryGeneration === latestDeliveryGeneration) {
+      notifyError(error, translateNow('desktop.setProfileFailed'))
+    }
 
+    return
+  }
+
+  // Profile discovery is asynchronous. A newer external link owns the user's
+  // navigation intent, so a stale lookup must not replace its draft or error.
+  if (deliveryGeneration !== latestDeliveryGeneration) {
     return
   }
 

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -8,8 +8,8 @@ import { onSessionsChanged } from '@/store/session-sync'
 import { openUpdatesWindow, startUpdatePoller, stopUpdatePoller } from '@/store/updates'
 import { isSecondaryWindow } from '@/store/windows'
 
-import { requestComposerFocus, requestComposerInsert } from '../../chat/composer/focus'
 import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, sessionRoute } from '../../routes'
+import { handleDesktopDeepLink } from '../deep-link'
 
 interface DesktopIntegrationsParams {
   chatOpen: boolean
@@ -125,24 +125,11 @@ export function useDesktopIntegrations({
     return () => unsubscribe?.()
   }, [])
 
-  // hermes:// deep links -> a reviewable /blueprint command in the composer.
+  // hermes:// deep links -> a reviewable blueprint command or a blank chat in
+  // an already-installed profile. Neither route auto-sends a prompt.
   useEffect(() => {
     const unsubscribe = window.hermesDesktop?.onDeepLink?.(payload => {
-      if (!payload || payload.kind !== 'blueprint' || !payload.name) {
-        return
-      }
-
-      const slots = Object.entries(payload.params || {})
-        .map(([k, v]) => {
-          const sval = /\s/.test(v) ? `"${v.replace(/"/g, '\\"')}"` : v
-
-          return `${k}=${sval}`
-        })
-        .join(' ')
-
-      const command = `/blueprint ${payload.name}${slots ? ' ' + slots : ''}`
-      requestComposerInsert(command, { mode: 'block', target: 'main' })
-      requestComposerFocus('main')
+      void handleDesktopDeepLink(payload)
     })
 
     void window.hermesDesktop?.signalDeepLinkReady?.()

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -17,8 +17,8 @@ import { openUpdatesWindow, startUpdatePoller, stopUpdatePoller } from '@/store/
 import { isHudWindow, isSecondaryWindow } from '@/store/windows'
 import type { SessionInfo } from '@/types/hermes'
 
-import { requestComposerFocus, requestComposerInsert } from '../../chat/composer/focus'
 import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, routeSessionId, sessionRoute } from '../../routes'
+import { handleDesktopDeepLink } from '../deep-link'
 
 type RememberedSession = Pick<SessionInfo, '_lineage_root_id' | 'id' | 'profile'>
 
@@ -187,24 +187,11 @@ export function useDesktopIntegrations({
     return () => unsubscribe?.()
   }, [])
 
-  // hermes:// deep links -> a reviewable /blueprint command in the composer.
+  // hermes:// deep links -> a reviewable blueprint command or a blank chat in
+  // an already-installed profile. Neither route auto-sends a prompt.
   useEffect(() => {
     const unsubscribe = window.hermesDesktop?.onDeepLink?.(payload => {
-      if (!payload || payload.kind !== 'blueprint' || !payload.name) {
-        return
-      }
-
-      const slots = Object.entries(payload.params || {})
-        .map(([k, v]) => {
-          const sval = /\s/.test(v) ? `"${v.replace(/"/g, '\\"')}"` : v
-
-          return `${k}=${sval}`
-        })
-        .join(' ')
-
-      const command = `/blueprint ${payload.name}${slots ? ' ' + slots : ''}`
-      requestComposerInsert(command, { mode: 'block', target: 'main' })
-      requestComposerFocus('main')
+      void handleDesktopDeepLink(payload)
     })
 
     void window.hermesDesktop?.signalDeepLinkReady?.()

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -123,6 +123,31 @@ The app also surfaces the broader Hermes management surface so you don't have to
 - **Search sessions by id** — find a specific session directly by its id.
 - **Concurrent multi-profile sessions** — run sessions across multiple [profiles](./profiles.md) at the same time, and reference a session in another profile with cross-profile `@session` links.
 
+#### Launch a blank chat in an installed profile
+
+Local integrations can ask Hermes Desktop to focus and open a new, blank chat
+in an already-installed profile:
+
+```text
+hermes://profile/<profile-name>?new=1
+```
+
+Percent-encode the profile path segment when constructing the URL. The name
+must be a valid Hermes profile identifier and must already appear in the local
+profile list. A missing profile produces a visible error and leaves the current
+chat untouched.
+
+This link selects the profile only for the new Desktop chat. It does not change
+Desktop's persistent primary profile, does not run `hermes profile use`, and
+does not change the CLI's sticky default. It also cannot carry or send a prompt:
+the only accepted query is exactly `new=1`. Treat `hermes://` URLs as untrusted
+external input; Desktop allow-lists the route, validates the identifier at the
+native boundary, verifies that the profile is installed, and then uses the
+existing live multi-profile session/gateway path.
+
+Existing `hermes://blueprint/...` links continue to preload a reviewable
+`/blueprint` command in the composer without sending it.
+
 ## Updating
 
 The app checks for updates in the background and offers a one-click update when one is ready.

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -166,6 +166,31 @@ The app also surfaces the broader Hermes management surface so you don't have to
 - **Search sessions by id** — find a specific session directly by its id.
 - **Concurrent multi-profile sessions** — run sessions across multiple [profiles](./profiles.md) at the same time, and reference a session in another profile with cross-profile `@session` links.
 
+#### Launch a blank chat in an installed profile
+
+Local integrations can ask Hermes Desktop to focus and open a new, blank chat
+in an already-installed profile:
+
+```text
+hermes://profile/<profile-name>?new=1
+```
+
+Percent-encode the profile path segment when constructing the URL. The name
+must be a valid Hermes profile identifier and must already appear in the local
+profile list. A missing profile produces a visible error and leaves the current
+chat untouched.
+
+This link selects the profile only for the new Desktop chat. It does not change
+Desktop's persistent primary profile, does not run `hermes profile use`, and
+does not change the CLI's sticky default. It also cannot carry or send a prompt:
+the only accepted query is exactly `new=1`. Treat `hermes://` URLs as untrusted
+external input; Desktop allow-lists the route, validates the identifier at the
+native boundary, verifies that the profile is installed, and then uses the
+existing live multi-profile session/gateway path.
+
+Existing `hermes://blueprint/...` links continue to preload a reviewable
+`/blueprint` command in the composer without sending it.
+
 ## Updating
 
 The app checks for updates in the background and offers a one-click update when one is ready.


### PR DESCRIPTION
## What does this PR do?

Adds a public `hermes://profile/<profile-name>?new=1` deep link that focuses Hermes Desktop and opens a blank new chat in an already-installed profile.

The renderer uses the existing live `newSessionInProfile` gateway/session path. It does not change Desktop's persistent primary profile, call the persistent profile setter, or change the CLI sticky default. The link cannot carry or submit a prompt, and existing `hermes://blueprint/...` behavior remains unchanged.

The contract is intended for local integrations that install or target specialized Hermes profiles and need to hand users into the correct context without changing their broader defaults.

## Related Issue

Closes #67375

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a native deep-link parser shared by cold-start and running-app delivery on macOS, Windows, and Linux.
- Strictly allow-listed the profile route, profile identifier, and exact `new=1` query; malformed links, extra actions, fragments, and prompt parameters fail closed without logging the raw URL.
- Revalidated external payloads in the renderer and refreshed the authoritative installed-profile list before opening a chat.
- Guarded asynchronous profile discovery with a delivery generation so stale links cannot overwrite newer navigation intent.
- Used `newSessionInProfile` for per-session profile routing without changing persistent Desktop or CLI profile state.
- Preserved the existing reviewable, non-submitting blueprint deep-link behavior.
- Added focused native and renderer tests plus public Desktop documentation.

## How to Test

1. Install or create a profile such as `research`.
2. Open `hermes://profile/research?new=1` with Desktop stopped and verify Desktop opens a blank chat scoped to `research`.
3. Repeat while Desktop is running and minimized; verify it focuses and opens another blank `research` chat.
4. Open a link for a missing profile and verify a visible error appears without changing the current chat.
5. Verify `hermes://profile/research?new=1&prompt=hello`, malformed names, fragments, and additional paths are ignored.
6. Verify an existing `hermes://blueprint/...` link still preloads a reviewable command without submitting it.

Automated validation on macOS:

- `npm run fix`
- `npm run lint` (0 errors; 9 pre-existing warnings)
- `npm run typecheck`
- Focused deep-link tests: 13 passed
- `npm run test:ui`: 1,850 passed, 1 skipped; 2 unrelated tests timed out under concurrent validation, and both affected files pass alone (10 passed)
- `npm run test:desktop:platforms`: 669 passed, 2 skipped
- `python3 scripts/check-windows-footguns.py --all`: passed
- `npm run pack`: passed (unsigned local macOS app)
- Packaged macOS manual test with an isolated disposable `HERMES_HOME`: cold start, running/minimized delivery, missing-profile error, and blueprint compatibility passed; profile chats remained blank and unsent
- `npm --prefix website run build`: passed with existing documentation warnings

The canonical `scripts/run_tests.sh` repository suite was also run: 42,945 tests passed and 56 failed across 22 unrelated Python files, with one additional collection/timeout file and three flakes passing on retry. The Python failures do not touch Desktop or files changed by this PR. The focused deep-link and native Desktop suites pass; the full UI run has the two unrelated load-sensitive timeouts disclosed above, with both affected files passing in isolation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — canonical suite ran with the unrelated baseline failures documented above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (automated suites plus packaged cold start, running/minimized delivery, missing-profile error, and blueprint compatibility)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no contributor architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — shared delivery paths are covered by native tests and the Windows footgun checker
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool behavior changed

## Screenshots / Logs

Not applicable; this contribution adds protocol behavior without a new visual surface.




