### PR TITLE
fix(gateway): bypass proxies for launchd loopback traffic

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3942,6 +3942,8 @@ def _launchd_fallback_to_detached(reason: str, *, exit_on_failure: bool = True) 
 
 
 def generate_launchd_plist() -> str:
+    from xml.sax.saxutils import escape
+
     python_path = get_python_path()
     # Stable cwd anchor — never the volatile source checkout. See
     # _stable_service_working_dir() for the rationale (same rot risk applies
@@ -3978,6 +3980,14 @@ def generate_launchd_plist() -> str:
             priority_dirs + [p for p in os.environ.get("PATH", "").split(":") if p]
         )
     )
+    no_proxy_entries = [
+        entry.strip()
+        for name in ("NO_PROXY", "no_proxy")
+        for entry in os.environ.get(name, "").split(",")
+        if entry.strip()
+    ]
+    no_proxy_entries.extend(("127.0.0.1", "localhost", "::1"))
+    no_proxy = escape(",".join(dict.fromkeys(no_proxy_entries)))
 
     # Build ProgramArguments array, including --profile when using a named profile
     prog_args = [
@@ -4020,6 +4030,10 @@ def generate_launchd_plist() -> str:
         <string>{venv_dir}</string>
         <key>HERMES_HOME</key>
         <string>{hermes_home}</string>
+        <key>NO_PROXY</key>
+        <string>{no_proxy}</string>
+        <key>no_proxy</key>
+        <string>{no_proxy}</string>
     </dict>
 
     <key>LimitLoadToSessionType</key>

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,6 +1,7 @@
 """Tests for gateway service management helpers."""
 
 import os
+import plistlib
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -2605,6 +2606,45 @@ class TestProfileArg:
         assert "<key>LimitLoadToSessionType</key>" in plist
         assert "<string>Aqua</string>" in plist
         assert "<string>Background</string>" in plist
+
+    @pytest.mark.parametrize(
+        ("upper", "lower", "expected"),
+        [
+            (None, None, "127.0.0.1,localhost,::1"),
+            ("example.com", None, "example.com,127.0.0.1,localhost,::1"),
+            (None, "example.net", "example.net,127.0.0.1,localhost,::1"),
+            (
+                "shared.example,upper.example",
+                "lower.example,shared.example",
+                "shared.example,upper.example,lower.example,127.0.0.1,localhost,::1",
+            ),
+        ],
+    )
+    def test_launchd_plist_includes_loopback_no_proxy(self, monkeypatch, upper, lower, expected):
+        for name, value in (("NO_PROXY", upper), ("no_proxy", lower)):
+            if value is None:
+                monkeypatch.delenv(name, raising=False)
+            else:
+                monkeypatch.setenv(name, value)
+
+        environment = plistlib.loads(
+            gateway_cli.generate_launchd_plist().encode("utf-8")
+        )["EnvironmentVariables"]
+
+        assert environment["NO_PROXY"] == expected
+        assert environment["no_proxy"] == expected
+
+    def test_launchd_plist_escapes_no_proxy_xml_special_characters(self, monkeypatch):
+        monkeypatch.setenv("NO_PROXY", "host&name")
+        monkeypatch.setenv("no_proxy", "<local>")
+
+        environment = plistlib.loads(
+            gateway_cli.generate_launchd_plist().encode("utf-8")
+        )["EnvironmentVariables"]
+
+        expected = "host&name,<local>,127.0.0.1,localhost,::1"
+        assert environment["NO_PROXY"] == expected
+        assert environment["no_proxy"] == expected
 
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):
         profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"


### PR DESCRIPTION
## Architecture reset

This draft now uses a generator-only fix: generated macOS launchd plists set both `NO_PROXY` and `no_proxy`, preserving existing entries from both casings, deduplicating them, appending `127.0.0.1`, `localhost`, and `::1`, and XML-escaping the emitted value.

There are no `env_loader` changes in this revision. This keeps proxy bypass scoped to launchd-managed loopback traffic and avoids mutating process-wide or authoritative managed proxy policy.

## Related issues

- Relates to #41913: launchd gateway loopback traffic must bypass configured proxies.
- Relates to #18821: preserves the launchd service-generation architecture while fixing the loopback proxy path.

## Validation

- RED on clean `main`: 5/5 new cases failed.
- GREEN: 5/5 new cases passed.
- Launchd-focused verification: 11/11 passed.
- Full module: 190 passed, with the same 4 pre-existing macOS/systemd failures.
- `compileall`, `git diff --check`, and exact two-file scope check passed.

## Review

Independent Codex review: **APPROVE**, with no actionable regressions.

Draft remains open for maintainer review; do not merge yet.