### PR TITLE
fix(update): add venv_holder_allowlist + pre_update_command (#66933)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3241,6 +3241,30 @@ DEFAULT_CONFIG = {
         # upstream installer is not appropriate for the machine, for example
         # on non-admin accounts where `/Applications` is not writable.
         "refresh_cua_driver": True,
+        # Optional shell command (string) or argv (list) executed by
+        # ``hermes update`` BEFORE the venv-holder guard runs. Use it to
+        # release resources held by an external service that runs from
+        # this install's venv interpreter (e.g. an NSSM- or systemd-
+        # supervised Python daemon) so the guard can re-check after the
+        # release. Exit code 0 -> update continues; non-zero -> the
+        # update is aborted with a clear message, NOT a raw traceback.
+        # Strings are passed to the user's shell (cmd.exe on Windows,
+        # /bin/sh elsewhere). Lists are exec'd directly without a shell.
+        # See #66933 (supervised venv holders deadlock the updater).
+        "pre_update_command": None,
+        # Seconds to wait for ``pre_update_command`` to complete before
+        # treating it as a failure. Floored to 0; set to 0 to disable
+        # the timeout (NOT recommended for unattended deploys).
+        "pre_update_command_timeout": 60,
+        # Names or cmdline substrings (case-insensitive) the deployment
+        # owner attests are SAFE to keep running while ``hermes update``
+        # mutates the venv. Each entry is matched as a substring against
+        # both the detected holder's process name AND its full command
+        # line; any hit drops the holder from the refusal list. Plain
+        # strings only — no glob, no regex (operators attest to exact
+        # names they trust). Default empty: the guard's strict refuse
+        # behavior is preserved.
+        "venv_holder_allowlist": [],
     },
 
     # Language Server Protocol — semantic diagnostics from real

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9255,7 +9255,9 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
 
 
 def _detect_venv_python_processes(
-    *, exclude_pids: set[int] | None = None
+    *,
+    exclude_pids: set[int] | None = None,
+    allowlist: list[str] | None = None,
 ) -> list[tuple[int, str, str]]:
     """Find live processes running from the project venv's interpreter.
 
@@ -9272,6 +9274,14 @@ def _detect_venv_python_processes(
     tuples; empty off-Windows / without psutil / when nothing matches. The
     calling process and its ancestors are always excluded (a CLI ``hermes
     update`` itself runs from the venv python). Never raises.
+
+    ``allowlist`` is an opt-in deployment-owner attestation (#66933): a
+    list of case-insensitive substrings matched against both the holder's
+    process name AND its full command line. Any holder matching an
+    allowlist entry is dropped from the returned matches — the operator
+    has explicitly said "I know this process is safe to leave running
+    while the venv mutates." Plain strings only (no glob, no regex); the
+    list is intended to be short and operator-curated, not pattern-rich.
     """
     if not _is_windows():
         return []
@@ -9336,6 +9346,17 @@ def _detect_venv_python_processes(
         if not is_holder:
             continue
         name = info.get("name") or Path(exe).name
+        # Operator-curated allowlist (updates.venv_holder_allowlist):
+        # a holder matching any allowlist substring against its name OR
+        # cmdline is dropped, on the operator's attestation that it is
+        # safe to keep running while the venv mutates. See #66933.
+        if allowlist:
+            name_low = str(name).lower()
+            if any(
+                (isinstance(s, str) and (s in name_low or s in cmdline_low))
+                for s in allowlist
+            ):
+                continue
         matches.append((int(pid), str(name), cmdline_raw[:120]))
     return matches
 
@@ -9368,6 +9389,86 @@ def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> 
     lines.append("    hermes update")
     lines.append("  (or use `hermes update --force-venv` to proceed anyway at your own risk)")
     return "\n".join(lines)
+
+
+def _run_pre_update_hook(args) -> bool:
+    """Run the operator-configured ``updates.pre_update_command`` hook.
+
+    Opt-in config (#66933): in supervised deployments an external daemon
+    (NSSM service, systemd unit, supervisor-script) may run from this
+    install's venv interpreter, holding ``.pyd`` files mapped while
+    ``hermes update`` tries to mutate the venv. The refuse-and-exit
+    behavior of the venv-holder guard then deadlocks against the
+    supervisor's respawn loop. The hook gives the operator a place to
+    release those resources BEFORE the guard re-checks.
+
+    Returns ``True`` to continue the update, ``False`` to abort.
+    Aborts (returns False) on:
+
+    * hook's exit code != 0
+    * hook times out (configurable; default 60s, 0 disables)
+    * hook fails to start
+
+    No configuration → noop → returns True. Never raises.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = (load_config() or {}).get("updates", {})
+    except Exception as exc:
+        logger.debug("Could not read updates.pre_update_command: %s", exc)
+        return True
+    if not isinstance(cfg, dict):
+        return True
+    cmd = cfg.get("pre_update_command")
+    if not cmd:
+        return True
+    try:
+        timeout_f = float(cfg.get("pre_update_command_timeout", 60))
+    except (TypeError, ValueError):
+        timeout_f = 60.0
+    if timeout_f < 0:
+        timeout_f = 0
+    rendered = cmd if isinstance(cmd, str) else list(cmd)
+    label = rendered if isinstance(rendered, str) else " ".join(rendered)
+    print(f"⚙ Running pre-update hook ({timeout_f:g}s timeout): {label}")
+    try:
+        if isinstance(cmd, str):
+            result = subprocess.run(
+                cmd,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=timeout_f or None,
+            )
+        else:
+            result = subprocess.run(
+                [str(x) for x in cmd],
+                capture_output=True,
+                text=True,
+                timeout=timeout_f or None,
+            )
+    except subprocess.TimeoutExpired:
+        print(f"✗ Pre-update hook timed out after {timeout_f:g}s; aborting update.")
+        return False
+    except Exception as exc:
+        print(f"✗ Pre-update hook failed to start: {exc!r}; aborting update.")
+        return False
+    if result.stdout:
+        sys.stdout.write(result.stdout)
+        if not result.stdout.endswith("\n"):
+            sys.stdout.write("\n")
+        sys.stdout.flush()
+    if result.stderr:
+        sys.stderr.write(result.stderr)
+        if not result.stderr.endswith("\n"):
+            sys.stderr.write("\n")
+        sys.stderr.flush()
+    if result.returncode != 0:
+        print(
+            f"✗ Pre-update hook exited with code {result.returncode}; aborting update."
+        )
+        return False
+    return True
 
 
 def _pause_windows_gateways_for_update() -> dict | None:
@@ -9852,8 +9953,31 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # and app.asar — a non-desktop venv python holding a .pyd would sail
     # through and corrupt the sync (the exact failure this guard exists for).
     # --force-venv is the explicit escape hatch.
+    #
+    # --force-venv is a global bypass; #66933 adds two narrower opt-ins
+    # that the deployment owner can use to break the supervised-holder
+    # deadlock without disabling the guard entirely:
+    #   * updates.pre_update_command  — release external locks first.
+    #   * updates.venv_holder_allowlist — attest these holders are safe.
+    if not _run_pre_update_hook(args):
+        _resume_windows_gateways_after_update(_windows_gateway_resume)
+        sys.exit(2)
+    _holder_allowlist: list[str] = []
+    try:
+        from hermes_cli.config import load_config
+        _raw_allowlist = (
+            (load_config() or {}).get("updates", {}).get("venv_holder_allowlist", [])
+            or []
+        )
+    except Exception as exc:
+        logger.debug("Could not read updates.venv_holder_allowlist: %s", exc)
+        _raw_allowlist = []
+    if isinstance(_raw_allowlist, list):
+        _holder_allowlist = [
+            str(s).lower() for s in _raw_allowlist if isinstance(s, (str, int))
+        ]
     if _is_windows() and not getattr(args, "force_venv", False):
-        _venv_holders = _detect_venv_python_processes()
+        _venv_holders = _detect_venv_python_processes(allowlist=_holder_allowlist)
         if _venv_holders:
             print(_format_venv_python_holders_message(_venv_holders))
             _resume_windows_gateways_after_update(_windows_gateway_resume)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9350,10 +9350,17 @@ def _detect_venv_python_processes(
         # a holder matching any allowlist substring against its name OR
         # cmdline is dropped, on the operator's attestation that it is
         # safe to keep running while the venv mutates. See #66933.
+        # Empty entries are silently skipped — `""` is a substring of
+        # every holder and would silently disable the guard. Callers
+        # filter up front as well; this is defense-in-depth.
         if allowlist:
             name_low = str(name).lower()
             if any(
-                (isinstance(s, str) and (s in name_low or s in cmdline_low))
+                (
+                    isinstance(s, str)
+                    and s  # empty string is not a usable allowlist entry
+                    and (s in name_low or s in cmdline_low)
+                )
                 for s in allowlist
             ):
                 continue
@@ -9422,19 +9429,54 @@ def _run_pre_update_hook(args) -> bool:
     cmd = cfg.get("pre_update_command")
     if not cmd:
         return True
+    # Strict type validation. Setting `pre_update_command: 123` (int) or
+    # `pre_update_command: {x: y}` (dict) used to silently coerce — `str(x)`
+    # gave `"None"` for None entries, etc. The "Never raises" contract on
+    # this helper means we must catch malformed config here, not at the
+    # subprocess invocation. See sweeper review on #67398.
+    if isinstance(cmd, str):
+        if not cmd.strip():
+            logger.warning(
+                "updates.pre_update_command: empty string; skipping hook run"
+            )
+            return True
+        cmd_argv: tuple[str, ...] | str = cmd
+        label = cmd
+    elif isinstance(cmd, list):
+        argv_list: list[str] = []
+        for entry in cmd:
+            if not isinstance(entry, (str, int)):
+                logger.warning(
+                    "updates.pre_update_command: non-string argv entry %r (%s); skipping hook run",
+                    entry,
+                    type(entry).__name__,
+                )
+                return True
+            argv_list.append(str(entry))
+        if not argv_list:
+            logger.warning(
+                "updates.pre_update_command: empty argv list; skipping hook run"
+            )
+            return True
+        cmd_argv = tuple(argv_list)
+        label = " ".join(argv_list)
+    else:
+        logger.warning(
+            "updates.pre_update_command: unsupported type %s (expected str or list); skipping hook run",
+            type(cmd).__name__,
+        )
+        return True
     try:
         timeout_f = float(cfg.get("pre_update_command_timeout", 60))
     except (TypeError, ValueError):
         timeout_f = 60.0
     if timeout_f < 0:
         timeout_f = 0
-    rendered = cmd if isinstance(cmd, str) else list(cmd)
-    label = rendered if isinstance(rendered, str) else " ".join(rendered)
     print(f"⚙ Running pre-update hook ({timeout_f:g}s timeout): {label}")
     try:
-        if isinstance(cmd, str):
+        if isinstance(cmd_argv, str):
             result = subprocess.run(
-                cmd,
+                cmd_argv,
                 shell=True,
                 capture_output=True,
                 text=True,
@@ -9442,7 +9484,7 @@ def _run_pre_update_hook(args) -> bool:
             )
         else:
             result = subprocess.run(
-                [str(x) for x in cmd],
+                list(cmd_argv),
                 capture_output=True,
                 text=True,
                 timeout=timeout_f or None,
@@ -9973,9 +10015,25 @@ def _cmd_update_impl(args, gateway_mode: bool):
         logger.debug("Could not read updates.venv_holder_allowlist: %s", exc)
         _raw_allowlist = []
     if isinstance(_raw_allowlist, list):
-        _holder_allowlist = [
-            str(s).lower() for s in _raw_allowlist if isinstance(s, (str, int))
-        ]
+        # Drop empty / whitespace-only entries BEFORE lowercasing — an empty
+        # string is a substring of every holder name+cmdline, which silently
+        # disables the safety guard. Operators get a one-shot warning so the
+        # config mistake is visible. See sweeper review on #67398.
+        _holder_allowlist: list[str] = []
+        for s in _raw_allowlist:
+            if not isinstance(s, (str, int)):
+                logger.warning(
+                    "updates.venv_holder_allowlist: skipping non-string entry %r",
+                    type(s).__name__,
+                )
+                continue
+            lowered = str(s).strip().lower()
+            if not lowered:
+                logger.warning(
+                    "updates.venv_holder_allowlist: skipping empty/whitespace-only entry"
+                )
+                continue
+            _holder_allowlist.append(lowered)
     if _is_windows() and not getattr(args, "force_venv", False):
         _venv_holders = _detect_venv_python_processes(allowlist=_holder_allowlist)
         if _venv_holders:

--- a/tests/hermes_cli/test_update_venv_health.py
+++ b/tests/hermes_cli/test_update_venv_health.py
@@ -667,9 +667,9 @@ def test_venv_holder_guard_wiring_lowercases_and_filters_invalid_entries():
     )
     assert result == "past_guard"
     # strings are lower-cased; ints are str()'d and lowercased; None and dict
-    # are filtered; "" passes through (its substring-match-everything pitfall
-    # is the operator's responsibility, not enforced here).
-    assert captured["allowlist"] == ["ok", "123", "", "alsook"]
+    # are filtered; "" is dropped because empty matches every holder (silent
+    # safety-guard neutralization — see sweeper review 2026-07-19).
+    assert captured["allowlist"] == ["ok", "123", "alsook"]
 
 
 def test_venv_holder_guard_wiring_config_load_failure_keeps_existing_behavior():
@@ -710,3 +710,198 @@ def test_venv_holder_guard_wiring_config_load_failure_keeps_existing_behavior():
     assert det.call_args.kwargs.get("allowlist") == []
     # Gateways were either resumed or never registered (either is fine here).
     assert resume.call_count >= 0
+
+
+# ---------------------------------------------------------------------------
+# Sweeper-review follow-ups on #67398 (2026-07-19):
+# 1. Empty/whitespace allowlist entries silently disable the safety guard
+#    because "" is a substring of every holder name+cmdline. Operators
+#    deserve a warning + the entry dropped, not silent neutralization.
+# 2. pre_update_command must reject malformed config (int, dict, mixed
+#    argv) BEFORE subprocess.run is invoked, else the helper's
+#    "Never raises" contract is broken on operator typos.
+# ---------------------------------------------------------------------------
+
+
+class _PastGuardSweep(Exception):
+    pass
+
+
+class _ProjectRootSentinelSweep:
+    def __truediv__(self, _other):
+        raise _PastGuardSweep
+
+
+def _sweep_update_args():
+    return SimpleNamespace(
+        gateway=False,
+        check=False,
+        no_backup=True,
+        backup=False,
+        yes=True,
+        branch=None,
+        force=False,
+        force_venv=False,
+    )
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+@patch.object(cli_main, "_venv_scripts_dir", return_value=None)
+@patch.object(cli_main, "_run_pre_update_backup")
+@patch.object(cli_main, "_pause_windows_gateways_for_update", return_value=None)
+@patch.object(cli_main, "_resume_windows_gateways_after_update")
+@patch.object(cli_main, "_run_pre_update_hook", return_value=True)
+def test_allowlist_empty_string_entries_are_dropped(
+    _hk, _rw, _pwgw, _rub, _vsd, _isw
+):
+    # venv_holder_allowlist: [""] used to silently include every holder
+    # because "" is a substring of every cmdline. Fix: drop with a warning.
+    detected = [(101, "ecosystem_bridge.exe", "ecosystem_bridge.exe --profile worker")]
+    with patch.object(
+        cli_main, "_detect_venv_python_processes", return_value=detected
+    ) as det, patch.object(
+        cli_main, "PROJECT_ROOT", _ProjectRootSentinelSweep()
+    ), patch(
+        "hermes_cli.config.load_config",
+        return_value={"updates": {"venv_holder_allowlist": [""]}},
+    ):
+        try:
+            cli_main._cmd_update_impl(_sweep_update_args(), gateway_mode=False)
+        except SystemExit as exc:
+            assert exc.code == 2
+        except _PastGuardSweep:
+            pass
+    det.assert_called_once()
+    assert det.call_args.kwargs.get("allowlist") == []
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+@patch.object(cli_main, "_venv_scripts_dir", return_value=None)
+@patch.object(cli_main, "_run_pre_update_backup")
+@patch.object(cli_main, "_pause_windows_gateways_for_update", return_value=None)
+@patch.object(cli_main, "_resume_windows_gateways_after_update")
+@patch.object(cli_main, "_run_pre_update_hook", return_value=True)
+def test_allowlist_mixed_types_filter_ints_drop_none_dict_empty(
+    _hk, _rw, _pwgw, _rub, _vsd, _isw
+):
+    detected = [(101, "x.exe", "x")]
+    with patch.object(
+        cli_main, "_detect_venv_python_processes", return_value=detected
+    ) as det, patch.object(
+        cli_main, "PROJECT_ROOT", _ProjectRootSentinelSweep()
+    ), patch(
+        "hermes_cli.config.load_config",
+        return_value={
+            "updates": {
+                "venv_holder_allowlist": [
+                    "okprocess",
+                    123,
+                    None,
+                    {"x": "y"},
+                    "",
+                    "  ",
+                    "alsogood",
+                ]
+            }
+        },
+    ):
+        try:
+            cli_main._cmd_update_impl(_sweep_update_args(), gateway_mode=False)
+        except (SystemExit, _PastGuardSweep):
+            pass
+    det.assert_called_once()
+    allowed = det.call_args.kwargs.get("allowlist")
+    assert "okprocess" in allowed
+    assert "alsogood" in allowed
+    assert "123" in allowed
+    assert "" not in allowed
+    assert len([a for a in allowed if a.strip()]) == len(allowed)
+
+
+def test_pre_update_hook_rejects_int_command():
+    args = SimpleNamespace(force_venv=False)
+    cfg = {"updates": {"pre_update_command": 123}}
+    with patch("hermes_cli.config.load_config", return_value=cfg), patch.object(
+        cli_main.subprocess, "run"
+    ) as run:
+        assert cli_main._run_pre_update_hook(args) is True
+    run.assert_not_called()
+
+
+def test_pre_update_hook_rejects_dict_command():
+    args = SimpleNamespace(force_venv=False)
+    cfg = {"updates": {"pre_update_command": {"x": "y"}}}
+    with patch("hermes_cli.config.load_config", return_value=cfg), patch.object(
+        cli_main.subprocess, "run"
+    ) as run:
+        assert cli_main._run_pre_update_hook(args) is True
+    run.assert_not_called()
+
+
+def test_pre_update_hook_rejects_list_with_non_string_entries():
+    args = SimpleNamespace(force_venv=False)
+    cfg = {"updates": {"pre_update_command": ["sc", None]}}
+    with patch("hermes_cli.config.load_config", return_value=cfg), patch.object(
+        cli_main.subprocess, "run"
+    ) as run:
+        assert cli_main._run_pre_update_hook(args) is True
+    run.assert_not_called()
+
+
+def test_pre_update_hook_accepts_int_inside_list():
+    args = SimpleNamespace(force_venv=False)
+    cfg = {
+        "updates": {
+            "pre_update_command": ["sc", "stop", 123],
+            "pre_update_command_timeout": 5,
+        }
+    }
+    fake = SimpleNamespace(returncode=0, stdout="", stderr="")
+    with patch("hermes_cli.config.load_config", return_value=cfg), patch.object(
+        cli_main.subprocess, "run", return_value=fake
+    ) as run:
+        assert cli_main._run_pre_update_hook(args) is True
+    args_used, _ = run.call_args
+    assert args_used[0] == ["sc", "stop", "123"]
+
+
+def test_pre_update_hook_rejects_empty_string():
+    args = SimpleNamespace(force_venv=False)
+    cfg = {"updates": {"pre_update_command": ""}}
+    with patch("hermes_cli.config.load_config", return_value=cfg), patch.object(
+        cli_main.subprocess, "run"
+    ) as run:
+        assert cli_main._run_pre_update_hook(args) is True
+    run.assert_not_called()
+
+
+def test_pre_update_hook_rejects_whitespace_string():
+    args = SimpleNamespace(force_venv=False)
+    cfg = {"updates": {"pre_update_command": "   "}}
+    with patch("hermes_cli.config.load_config", return_value=cfg), patch.object(
+        cli_main.subprocess, "run"
+    ) as run:
+        assert cli_main._run_pre_update_hook(args) is True
+    run.assert_not_called()
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_detect_venv_python_skips_empty_allowlist_entries_internally(_winp, tmp_path):
+    """Defense in depth: even if a caller hands us ['', '  ', None], empty
+    entries are silently skipped — they never match every holder."""
+    venv_py = str(tmp_path / "venv" / "Scripts" / "python.exe")
+    me = MagicMock()
+    me.parents.return_value = []
+    fake_psutil = types.SimpleNamespace(
+        process_iter=lambda attrs: iter(
+            [_proc(101, venv_py, "ecosystem_bridge.exe", [])]
+        ),
+        Process=lambda *a, **k: me,
+    )
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.dict(
+        sys.modules, {"psutil": fake_psutil}
+    ):
+        matches = cli_main._detect_venv_python_processes(
+            allowlist=["", "  ", None]
+        )
+    assert [m[0] for m in matches] == [101]

--- a/tests/hermes_cli/test_update_venv_health.py
+++ b/tests/hermes_cli/test_update_venv_health.py
@@ -1,13 +1,17 @@
 """Tests for the Windows half-updated-venv hardening (July 2026 incident).
 
-Covers three additions to ``hermes update``:
+Covers four additions to ``hermes update``:
 
 1. ``_venv_core_imports_healthy`` — the venv health probe that lets an
    "Already up to date" checkout still repair a broken dependency install.
 2. ``_detect_venv_python_processes`` — the venv-interpreter process guard
    that refuses to mutate the venv while a desktop backend / stray python
-   holds .pyd files mapped.
-3. The commit_count == 0 repair branch wiring in ``_cmd_update_impl``.
+   holds .pyd files mapped. With the ``allowlist`` keyword it honors
+   ``updates.venv_holder_allowlist`` (#66933).
+3. ``_run_pre_update_hook`` — the operator-configured pre-guard hook
+   (#66933) that lets supervised deployments release external venv
+   holders before the guard re-checks.
+4. The commit_count == 0 repair branch wiring in ``_cmd_update_impl``.
 
 All Windows-specific paths are exercised via ``_is_windows`` patching so
 they run on any host (same approach as test_update_concurrent_quarantine).
@@ -24,6 +28,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from hermes_cli import main as cli_main
+from hermes_cli.config import load_config
 
 
 # ---------------------------------------------------------------------------
@@ -344,3 +349,364 @@ def _run_update_until_guard(args):
 def test_venv_holder_guard_force_semantics(force, force_venv, expected, capsys):
     result = _run_update_until_guard(_update_args(force=force, force_venv=force_venv))
     assert result == expected, capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# _detect_venv_python_processes allowlist parameter (updates.venv_holder_allowlist)
+# See #66933.
+# ---------------------------------------------------------------------------
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_detect_venv_python_allowlist_filters_cmdline_substring(_winp, tmp_path):
+    """A holder whose cmdline contains an allowlisted substring is dropped."""
+    venv_py = str(tmp_path / "venv" / "Scripts" / "python.exe")
+    me = MagicMock()
+    me.parents.return_value = []
+    fake_psutil = types.SimpleNamespace(
+        process_iter=lambda attrs: iter(
+            [
+                _proc(
+                    301,
+                    venv_py,
+                    "python.exe",
+                    ["python.exe", "ecosystem_bridge.py"],
+                    cwd=str(tmp_path),
+                ),
+                _proc(
+                    302,
+                    venv_py,
+                    "python.exe",
+                    ["python.exe", "-m", "hermes_cli.main", "gateway", "run"],
+                    cwd=str(tmp_path),
+                ),
+            ]
+        ),
+        Process=lambda *a, **k: me,
+    )
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.dict(
+        sys.modules, {"psutil": fake_psutil}
+    ):
+        matches = cli_main._detect_venv_python_processes(
+            allowlist=["ecosystem_bridge"]
+        )
+
+    assert [m[0] for m in matches] == [302]
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_detect_venv_python_allowlist_filters_process_name(_winp, tmp_path):
+    """A holder whose process NAME contains an allowlisted substring is dropped."""
+    venv_py = str(tmp_path / "venv" / "Scripts" / "python.exe")
+    me = MagicMock()
+    me.parents.return_value = []
+    fake_psutil = types.SimpleNamespace(
+        process_iter=lambda attrs: iter(
+            [
+                _proc(
+                    401,
+                    venv_py,
+                    "ecosystem_bridge.exe",
+                    [],
+                    cwd=str(tmp_path),
+                ),
+                _proc(402, venv_py, "pythonw.exe", ["pythonw.exe", "monitor.exe"]),
+            ]
+        ),
+        Process=lambda *a, **k: me,
+    )
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.dict(
+        sys.modules, {"psutil": fake_psutil}
+    ):
+        matches = cli_main._detect_venv_python_processes(allowlist=["bridge"])
+
+    assert [m[0] for m in matches] == [402]
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_detect_venv_python_allowlist_is_case_insensitive(_winp, tmp_path):
+    """Allowlist matching is case-insensitive against both name and cmdline."""
+    venv_py = str(tmp_path / "venv" / "Scripts" / "python.exe")
+    me = MagicMock()
+    me.parents.return_value = []
+    fake_psutil = types.SimpleNamespace(
+        process_iter=lambda attrs: iter(
+            [_proc(501, venv_py, "ECOSYSTEM_BRIDGE.EXE", ["PYTHON.EXE", "Bridge.py"])]
+        ),
+        Process=lambda *a, **k: me,
+    )
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.dict(
+        sys.modules, {"psutil": fake_psutil}
+    ):
+        matches = cli_main._detect_venv_python_processes(allowlist=["bridge"])
+
+    assert matches == []
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_detect_venv_python_empty_or_none_allowlist_keeps_all(_winp, tmp_path):
+    """allowlist=None or [] preserves the original strict behavior (none dropped)."""
+    venv_py = str(tmp_path / "venv" / "Scripts" / "python.exe")
+    me = MagicMock()
+    me.parents.return_value = []
+    fake_psutil = types.SimpleNamespace(
+        process_iter=lambda attrs: iter(
+            [_proc(601, venv_py, "ecosystem_bridge.exe", [])]
+        ),
+        Process=lambda *a, **k: me,
+    )
+    base_patches = (
+        patch.object(cli_main, "PROJECT_ROOT", tmp_path),
+        patch.dict(sys.modules, {"psutil": fake_psutil}),
+    )
+    with base_patches[0], base_patches[1]:
+        first = cli_main._detect_venv_python_processes(allowlist=None)
+    with base_patches[0], base_patches[1]:
+        second = cli_main._detect_venv_python_processes(allowlist=[])
+    assert [m[0] for m in first] == [601]
+    assert [m[0] for m in second] == [601]  # noqa: explicit assertion
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_detect_venv_python_allowlist_non_matching_entry_does_not_relax(_winp, tmp_path):
+    """Allowlist entries that don't match any holder must not silently empty the
+    refusal list — the guard must still fire on the un-matched holders."""
+    venv_py = str(tmp_path / "venv" / "Scripts" / "python.exe")
+    me = MagicMock()
+    me.parents.return_value = []
+    fake_psutil = types.SimpleNamespace(
+        process_iter=lambda attrs: iter(
+            [
+                _proc(701, venv_py, "ecosystem_bridge.exe", []),
+                _proc(
+                    702,
+                    venv_py,
+                    "python.exe",
+                    ["python.exe", "-m", "hermes_cli.main", "serve"],
+                ),
+            ]
+        ),
+        Process=lambda *a, **k: me,
+    )
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.dict(
+        sys.modules, {"psutil": fake_psutil}
+    ):
+        matches = cli_main._detect_venv_python_processes(allowlist=["completely_unrelated"])
+
+    assert sorted(m[0] for m in matches) == [701, 702]
+
+
+# ---------------------------------------------------------------------------
+# _run_pre_update_hook
+# ---------------------------------------------------------------------------
+
+
+def test_pre_update_hook_returns_true_when_unconfigured():
+    """No updates.pre_update_command -> noop -> True, regardless of args."""
+    args = SimpleNamespace(force_venv=False)
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value={"updates": {"pre_update_backup": "quick"}},
+    ):
+        assert cli_main._run_pre_update_hook(args) is True
+
+
+def test_pre_update_hook_runs_string_command():
+    """String cmd -> shell=True; exit 0 -> True."""
+    args = SimpleNamespace(force_venv=False)
+    cfg = {"updates": {"pre_update_command": "echo release", "pre_update_command_timeout": 5}}
+    fake = SimpleNamespace(returncode=0, stdout="release\n", stderr="")
+    with patch("hermes_cli.config.load_config", return_value=cfg), patch.object(
+        cli_main.subprocess, "run", return_value=fake
+    ) as run:
+        assert cli_main._run_pre_update_hook(args) is True
+    args_used, kwargs = run.call_args
+    assert args_used[0] == "echo release"
+    assert kwargs["shell"] is True
+
+
+def test_pre_update_hook_runs_argv_list_without_shell():
+    """List cmd -> exec'd directly (shell=False)."""
+    args = SimpleNamespace(force_venv=False)
+    cfg = {"updates": {"pre_update_command": ["sc", "stop", "MySvc"], "pre_update_command_timeout": 5}}
+    fake = SimpleNamespace(returncode=0, stdout="", stderr="")
+    with patch("hermes_cli.config.load_config", return_value=cfg), patch.object(
+        cli_main.subprocess, "run", return_value=fake
+    ) as run:
+        assert cli_main._run_pre_update_hook(args) is True
+    args_used, kwargs = run.call_args
+    assert args_used[0] == ["sc", "stop", "MySvc"]
+    # shell defaults to False for argv lists; either explicit False or omitted is fine
+    assert kwargs.get("shell", False) is False
+
+
+def test_pre_update_hook_aborts_on_nonzero_exit(capsys):
+    args = SimpleNamespace(force_venv=False)
+    cfg = {"updates": {"pre_update_command": "false", "pre_update_command_timeout": 1}}
+    fake = SimpleNamespace(returncode=1, stdout="", stderr="boom\n")
+    with patch("hermes_cli.config.load_config", return_value=cfg), patch.object(
+        cli_main.subprocess, "run", return_value=fake
+    ):
+        assert cli_main._run_pre_update_hook(args) is False
+    out = capsys.readouterr().out + capsys.readouterr().err
+    assert "exited" in out.lower() or "exit code" in out.lower()
+
+
+def test_pre_update_hook_aborts_on_timeout(capsys):
+    args = SimpleNamespace(force_venv=False)
+    cfg = {"updates": {"pre_update_command": "sleep 99", "pre_update_command_timeout": 1}}
+    with patch("hermes_cli.config.load_config", return_value=cfg), patch.object(
+        cli_main.subprocess,
+        "run",
+        side_effect=subprocess.TimeoutExpired(cmd="sleep 99", timeout=1),
+    ):
+        assert cli_main._run_pre_update_hook(args) is False
+    out = capsys.readouterr().out
+    assert "timed out" in out.lower()
+
+
+def test_pre_update_hook_handles_subprocess_start_failure(capsys):
+    args = SimpleNamespace(force_venv=False)
+    cfg = {"updates": {"pre_update_command": "no-such-cmd", "pre_update_command_timeout": 5}}
+    with patch("hermes_cli.config.load_config", return_value=cfg), patch.object(
+        cli_main.subprocess, "run", side_effect=OSError("not found")
+    ):
+        assert cli_main._run_pre_update_hook(args) is False
+    out = capsys.readouterr().out
+    assert "failed to start" in out.lower() or "aborting" in out.lower()
+
+
+def test_pre_update_hook_returns_true_when_load_config_raises():
+    """A load_config failure must not abort the update — fail-open to defaults."""
+    args = SimpleNamespace(force_venv=False)
+    with patch(
+        "hermes_cli.config.load_config", side_effect=RuntimeError("disk full")
+    ):
+        assert cli_main._run_pre_update_hook(args) is True
+
+
+def test_pre_update_hook_clamps_invalid_timeout():
+    """Negative / non-numeric timeouts fall back to safe defaults."""
+    args = SimpleNamespace(force_venv=False)
+    cfg = {"updates": {"pre_update_command": "noop", "pre_update_command_timeout": -5}}
+    fake = SimpleNamespace(returncode=0, stdout="", stderr="")
+    with patch("hermes_cli.config.load_config", return_value=cfg), patch.object(
+        cli_main.subprocess, "run", return_value=fake
+    ) as run:
+        assert cli_main._run_pre_update_hook(args) is True
+    assert run.call_args.kwargs["timeout"] is None  # clamped to 0 -> no timeout
+
+
+# ---------------------------------------------------------------------------
+# Wiring: _cmd_update_impl calls hook + passes allowlist to detector.
+# ---------------------------------------------------------------------------
+
+
+def _run_update_until_guard_with_allowlist(args, *, allowlist, hook_return=True, detected=None):
+    """Variant of _run_update_until_guard that patches load_config and lets
+    us assert what allowlist the detector actually received."""
+    if detected is None:
+        detected = []
+
+    class _PastGuard(Exception):
+        pass
+
+    class _RootSentinel:
+        def __truediv__(self, _other):
+            raise _PastGuard
+
+    captured: dict = {}
+
+    def _capture(**kwargs):
+        captured["allowlist"] = kwargs.get("allowlist")
+        captured["kw"] = kwargs
+        return detected
+
+    with patch.object(cli_main, "_is_windows", return_value=True), patch.object(
+        cli_main, "_venv_scripts_dir", return_value=None
+    ), patch.object(cli_main, "_run_pre_update_backup"), patch.object(
+        cli_main, "_pause_windows_gateways_for_update", return_value=None
+    ), patch.object(
+        cli_main, "_resume_windows_gateways_after_update"
+    ), patch.object(
+        cli_main, "_run_pre_update_hook", return_value=hook_return
+    ), patch.object(
+        cli_main, "_detect_venv_python_processes", side_effect=_capture
+    ), patch.object(
+        cli_main, "PROJECT_ROOT", _RootSentinel()
+    ), patch(
+        "hermes_cli.config.load_config",
+        return_value={"updates": {"venv_holder_allowlist": allowlist}},
+    ):
+        try:
+            cli_main._cmd_update_impl(args, gateway_mode=False)
+        except _PastGuard:
+            return "past_guard", captured
+        except SystemExit as exc:
+            return f"exit_{exc.code}", captured
+    return "returned", captured
+
+
+def test_venv_holder_guard_wiring_reads_allowlist_from_config():
+    """The allowlist from updates.venv_holder_allowlist is forwarded to the
+    detector with each entry lower-cased."""
+    args = _update_args()
+    result, captured = _run_update_until_guard_with_allowlist(
+        args, allowlist=["MyBridge", "ECOSYSTEM_DAEMON"], detected=[]
+    )
+    assert result == "past_guard"
+    assert captured["allowlist"] == ["mybridge", "ecosystem_daemon"]
+
+
+def test_venv_holder_guard_wiring_lowercases_and_filters_invalid_entries():
+    args = _update_args()
+    result, captured = _run_update_until_guard_with_allowlist(
+        args,
+        allowlist=["ok", 123, None, {"x": "y"}, "", "AlsoOk"],
+        detected=[],
+    )
+    assert result == "past_guard"
+    # strings are lower-cased; ints are str()'d and lowercased; None and dict
+    # are filtered; "" passes through (its substring-match-everything pitfall
+    # is the operator's responsibility, not enforced here).
+    assert captured["allowlist"] == ["ok", "123", "", "alsook"]
+
+
+def test_venv_holder_guard_wiring_config_load_failure_keeps_existing_behavior():
+    """If load_config raises, allowlist defaults to [] (strict guard preserved)."""
+
+    class _PastGuard(Exception):
+        pass
+
+    class _RootSentinel:
+        def __truediv__(self, _other):
+            raise _PastGuard
+
+    with patch.object(cli_main, "_is_windows", return_value=True), patch.object(
+        cli_main, "_venv_scripts_dir", return_value=None
+    ), patch.object(cli_main, "_run_pre_update_backup"), patch.object(
+        cli_main, "_pause_windows_gateways_for_update", return_value=None
+    ), patch.object(
+        cli_main, "_resume_windows_gateways_after_update"
+    ) as resume, patch.object(
+        cli_main, "_run_pre_update_hook", return_value=True
+    ), patch.object(
+        cli_main,
+        "_detect_venv_python_processes",
+        return_value=[(1, "x.exe", "x")],
+    ) as det, patch.object(
+        cli_main, "PROJECT_ROOT", _RootSentinel()
+    ), patch(
+        "hermes_cli.config.load_config", side_effect=RuntimeError("boom")
+    ):
+        try:
+            cli_main._cmd_update_impl(_update_args(), gateway_mode=False)
+        except _PastGuard:
+            pass  # acceptable
+        except SystemExit:
+            pass  # also acceptable — guard fired because allowlist=[] strict mode
+    # The Detector was called exactly once and saw allowlist=[] (the safe default).
+    det.assert_called_once()
+    assert det.call_args.kwargs.get("allowlist") == []
+    # Gateways were either resumed or never registered (either is fine here).
+    assert resume.call_count >= 0

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -102,7 +102,18 @@ $ hermes update
 
 Close the listed processes and re-run. If you're sure the concurrent process won't interfere (rare — usually only useful when an antivirus shim is mis-attributed), pass `--force` to skip the check. In that case the updater will still retry the `.exe` rename with exponential backoff and, on stubborn locks, schedule the replacement for next reboot via `MoveFileEx(MOVEFILE_DELAY_UNTIL_REBOOT)` so the update can complete.
 
-A second, separate guard refuses to touch the venv while any process is running from its Python interpreter (the Desktop app's backend, a gateway, a Python REPL). Those processes keep native extension files (`.pyd`) locked, and a dependency sync that dies partway on an access-denied error strands the install between versions. This guard is **not** bypassed by `--force`; if you're certain the detected holders are false positives, use the explicit `hermes update --force-venv`.
+A second, separate guard refuses to touch the venv while any process is running from its Python interpreter (the Desktop app's backend, a gateway, a Python REPL). Those processes keep native extension files (`.pyd`) locked, and a dependency sync that dies partway on an access-denied error strands the install between versions. This guard is **not** bypassed by `--force`; if you're certain the detected holders are false positives, use the explicit `hermes update --force-venv`. For supervised deployments where the holders are *external* (NSSM services, systemd units, supervisor scripts) and cannot be paused by the updater, configure two opt-in keys under `updates:`:
+
+```yaml
+updates:
+  pre_update_command: ["Stop-Service", "MyBridgeDaemon"]   # or a shell string
+  pre_update_command_timeout: 30
+  venv_holder_allowlist:
+    - "mybridgedaemon"                                    # case-insensitive substring
+                                                          # vs. process name + cmdline
+```
+
+`pre_update_command` runs *before* the guard re-checks (use it to release external locks). Matching entries in `venv_holder_allowlist` are dropped from the refusal list on the operator's attestation that they are safe to keep running. Both keys default to absent (strict refusal preserved). The one-off `hermes update --force-venv` flag remains available for ad-hoc overrides when you do not want a permanent config change.
 
 Expected output looks like:
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -104,7 +104,55 @@ updates:
   pre_update_backup: quick       # quick (state snapshot, default) | full (snapshot + HERMES_HOME zip) | off
   backup_keep: 5                 # Keep this many full pre-update backup zips
   non_interactive_local_changes: stash  # stash | discard
+
+  # Optional opt-in escape hatches for supervised venv deployments
+  # where an external service (NSSM / systemd / supervisor) runs from
+  # the install's venv interpreter and would otherwise deadlock the
+  # update. See "Supervised venv holders" below. Both default off.
+  pre_update_command: null      # shell cmd (string) or argv (list) — runs
+                                  # BEFORE the venv-holder guard re-checks.
+                                  # Use to release external locks (e.g.
+                                  # `Stop-Service MyBridge`). Non-zero exit
+                                  # OR timeout -> update aborted cleanly
+                                  # with a clear message.
+  pre_update_command_timeout: 60   # seconds; 0 disables the timeout
+  venv_holder_allowlist: []         # case-insensitive substring list
+                                     # matched against each detected
+                                     # holder's process name AND full
+                                     # command line. Empty entries are
+                                     # ignored (and warned) so a
+                                     # spurious "" never disables the
+                                     # safety guard for all holders.
 ```
+
+### Supervised venv holders
+
+By default the Windows update guard *refuses* any update whose install
+has other processes running from its Python interpreter — those holders
+keep native extension files (`.pyd`) mapped and a dependency sync that
+dies partway on access-denied strands the install between versions.
+
+If an external process (NSSM service, systemd unit, supervisor script)
+runs from this install's venv interpreter and cannot be paused by the
+updater, supervised deployments have two ways to break the resulting
+deadlock without disabling the guard for everyone:
+
+- `updates.pre_update_command` — runs *before* the guard re-checks. Use
+  it to release external locks (e.g. `Stop-Service MyBridge` /
+  `systemctl stop my-bridge`). The hook's exit code is honored: 0
+  proceeds, non-zero aborts the update with a clear message. A timeout
+  (default 60s, configurable) bounds unattended deploys.
+- `updates.venv_holder_allowlist` — a list of case-insensitive substrings
+  matched against each detected holder's process name and command line.
+  Holders matching any entry are dropped from the refusal list.
+
+Both keys are independently opt-in. Use the hook to release external
+locks first, then list the supervised holder in the allowlist so the
+guard recognizes it as safe to leave running while the venv mutates.
+The one-off `hermes update --force-venv` flag remains available for
+ad-hoc overrides.
+
+Leaving both unset preserves the strict refusal behavior unchanged.
 
 `pre_update_backup` is the single pre-update safety knob: `quick` (default) snapshots critical state files (pairing data, cron jobs, config, auth; files over 1 GiB are skipped) into `state-snapshots/`; `full` additionally zips all of `HERMES_HOME` into `backups/` and can add minutes on large homes; `off` disables both. Legacy booleans are honored (`true` → `full`, `false` → `off`).
 


### PR DESCRIPTION
Fixes #66933.

The venv-holder guard at `hermes_cli/main.py:9956` refuses any `hermes update` whose install has other processes running from its interpreter, on the grounds that those holders keep `.pyd` files mapped and would corrupt a mid-update dependency sync. In supervised deployments (Windows NSSM service, systemd unit, supervisor-script) the holder respawns the moment `hermes update` exits, deadlocking the updater:

    [H] holder running
    [H] -> update aborts (sys.exit(2))
    [H] <- supervisor respawns
    [H] -> update aborts (sys.exit(2))
    …

`--force-venv` is the existing global bypass; this PR adds two narrower opt-ins under `updates:` that the operator can use to break the deadlock **without** disabling the guard:

- `pre_update_command: null` — shell cmd (string) or argv (list). Runs FIRST, before the guard re-checks. Use to release external locks (`Stop-Service MyBridge`, `systemctl stop my-bridge`, etc.). Non-zero exit / timeout / start-failure → update aborted cleanly with a clear message.
- `pre_update_command_timeout: 60` — seconds; floored to 0 (disable the timeout — NOT recommended for unattended deploys).
- `venv_holder_allowlist: []` — case-insensitive substring list, matched against holder process name AND cmdline. Holders matching any entry are dropped from the refusal list.

Default behaviour is unchanged (empty allowlist, null hook) — existing strict guard preserved (#65502 path).

## Design notes

- The two keys are additive; each can be used independently. Typical supervised-deployment recipe: `pre_update_command` to release external locks + `venv_holder_allowlist` to attest the supervised process is safe to leave running.
- The allowlist uses substring match (not glob, not regex) because operators attest to exact names they trust; making it pattern-rich invites foot-gunning. Plain strings only.
- All config reads are wrapped in try/except; a `load_config` failure during the update flow defaults to `allowlist=[]` and a no-op hook (fail-open to defaults, never worse).
- `--force-venv` remains the explicit one-off escape hatch for cases that aren't worth a config-driven solution.

## Test coverage

16 new tests in `tests/hermes_cli/test_update_venv_health.py`:

**Detector allowlist (5 tests)** — substring match against cmdline, against name, case-insensitivity, empty/None allowlist preserves strict behavior, non-matching allowlist entries never silently empty the refusal list.

**Pre-update hook (8 tests)** — noop when unconfigured, shell string vs argv list, nonzero exit / timeout / start failure / invalid timeout all abort cleanly, `load_config` failure during read returns True (fail-open).

**Wiring (3 tests)** — allowlist flows from `updates.venv_holder_allowlist` to the detector (with case fold + invalid-entry filtering), `load_config` failure preserves default strict guard with `allowlist=[]`.

Local: 32/32 in the venv-health suite (16 new + 16 pre-existing on this branch).

## Diff scope

- `hermes_cli/config.py` — 3 new keys (`+24/-0`) under the existing `updates` block.
- `hermes_cli/main.py` — `+128/-5`: `_detect_venv_python_processes` gains an `allowlist` kwarg; new helper `_run_pre_update_hook`; `_cmd_update_impl` runs the hook before the venv-holder guard and passes the allowlist through.
- `tests/hermes_cli/test_update_venv_health.py` — `+372/-0`: new sections for allowlist matching, the pre-update hook, and the wiring.

No changes to public CLI args, no schema migration, no new dependencies.
