### PR TITLE
fix(agent): sanitize null assistant wire paths

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1966,6 +1966,14 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         # turns so Anthropic-family providers don't 400 the summary call.
         api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
 
+        # This path calls chat.completions.create() directly and therefore
+        # bypasses ChatCompletionsTransport.build_kwargs(). Internal fields may
+        # already have been stripped from an otherwise empty assistant row.
+        if agent.api_mode == "chat_completions":
+            from agent.transports.chat_completions import _drop_null_assistant_messages
+
+            api_messages = _drop_null_assistant_messages(api_messages)
+
         summary_extra_body = {}
         try:
             from agent.auxiliary_client import _fixed_temperature_for_model, OMIT_TEMPERATURE as _OMIT_TEMP

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -202,6 +202,19 @@ def _drop_null_assistant_messages(
                 )
             elif isinstance(previous_content, list) and isinstance(current_content, list):
                 previous_copy["content"] = list(previous_content) + list(current_content)
+            elif isinstance(previous_content, list) and isinstance(current_content, str):
+                previous_copy["content"] = list(previous_content)
+                if current_content:
+                    previous_copy["content"].append(
+                        {"type": "text", "text": current_content}
+                    )
+            elif isinstance(previous_content, str) and isinstance(current_content, list):
+                previous_copy["content"] = []
+                if previous_content:
+                    previous_copy["content"].append(
+                        {"type": "text", "text": previous_content}
+                    )
+                previous_copy["content"].extend(current_content)
             else:
                 merged.append(message)
                 continue

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -128,6 +128,89 @@ def _model_consumes_thought_signature(model: Any) -> bool:
     return "gemini" in m or "gemma" in m
 
 
+def _drop_null_assistant_messages(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Drop assistant rows that have no provider-visible payload.
+
+    Internal fields such as ``codex_message_items`` can be the only content on
+    an assistant row. ``convert_messages()`` correctly strips those fields,
+    but strict Chat Completions providers then reject the resulting empty row.
+    Preserve rows that still carry tool calls, reasoning, or non-text content.
+    """
+
+    def _content_is_empty(content: Any) -> bool:
+        if content is None:
+            return True
+        if isinstance(content, str):
+            return not content.strip()
+        if not isinstance(content, list):
+            return False
+
+        for block in content:
+            if not isinstance(block, dict):
+                if block:
+                    return False
+                continue
+            block_type = block.get("type")
+            if block_type in {"text", "input_text", "output_text"}:
+                if str(block.get("text") or "").strip():
+                    return False
+            else:
+                # Images, audio, and unknown provider blocks are real payloads.
+                return False
+        return True
+
+    def _is_null_assistant(message: dict[str, Any]) -> bool:
+        if message.get("role") != "assistant":
+            return False
+        if not _content_is_empty(message.get("content")):
+            return False
+        if message.get("tool_calls"):
+            return False
+        return not any(
+            message.get(field)
+            for field in ("reasoning", "reasoning_content", "reasoning_details")
+        )
+
+    kept = [
+        message
+        for message in messages
+        if not (isinstance(message, dict) and _is_null_assistant(message))
+    ]
+    if len(kept) == len(messages):
+        return messages
+
+    # Removing an assistant row can make two user turns adjacent. Merge them
+    # on the per-call copy to preserve strict provider role alternation.
+    merged: list[dict[str, Any]] = []
+    for message in kept:
+        previous = merged[-1] if merged else None
+        if (
+            isinstance(previous, dict)
+            and isinstance(message, dict)
+            and previous.get("role") == "user"
+            and message.get("role") == "user"
+        ):
+            previous_content = previous.get("content", "")
+            current_content = message.get("content", "")
+            previous_copy = dict(previous)
+            if isinstance(previous_content, str) and isinstance(current_content, str):
+                separator = "\n\n" if previous_content and current_content else ""
+                previous_copy["content"] = (
+                    previous_content + separator + current_content
+                )
+            elif isinstance(previous_content, list) and isinstance(current_content, list):
+                previous_copy["content"] = list(previous_content) + list(current_content)
+            else:
+                merged.append(message)
+                continue
+            merged[-1] = previous_copy
+        else:
+            merged.append(message)
+    return merged
+
+
 class ChatCompletionsTransport(ProviderTransport):
     """Transport for api_mode='chat_completions'.
 
@@ -332,6 +415,9 @@ class ChatCompletionsTransport(ProviderTransport):
         # Pass model so the Gemini thought_signature (extra_content) is kept for
         # Gemini targets and stripped for strict non-Gemini providers.
         sanitized = self.convert_messages(messages, model=model)
+        # Internal Codex fields may have been the assistant row's only payload.
+        # Drop such rows only after conversion so the final wire shape is valid.
+        sanitized = _drop_null_assistant_messages(sanitized)
 
         # ── Provider profile: single-path when present ──────────────────
         _profile = params.get("provider_profile")

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -889,6 +889,53 @@ class TestMaxIterationsSummaryReplay:
         assert messages[0]["content"] == "q1"
         assert messages[0]["api_content"] == "q1\n\nPLUGIN-CTX"
 
+    def test_summary_request_drops_codex_only_assistant_prefill(self):
+        from run_agent import AIAgent
+        from agent.chat_completion_helpers import handle_max_iterations
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="http://127.0.0.1:1/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.prefill_messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "codex_message_items": [{"type": "message"}],
+            }
+        ]
+        captured = {}
+
+        class _Completions:
+            def create(self, **kwargs):
+                captured.update(kwargs)
+                return "RAW-RESPONSE"
+
+        client = types.SimpleNamespace(
+            chat=types.SimpleNamespace(completions=_Completions())
+        )
+        transport = types.SimpleNamespace(
+            normalize_response=lambda _r: types.SimpleNamespace(content="SUMMARY")
+        )
+
+        messages = [{"role": "user", "content": "investigate"}]
+        with patch.object(
+            agent, "_ensure_primary_openai_client", return_value=client
+        ), patch.object(agent, "_get_transport", return_value=transport):
+            out = handle_max_iterations(agent, messages, 5)
+
+        assert out == "SUMMARY"
+        assert not any(
+            message.get("role") == "assistant"
+            and not str(message.get("content") or "").strip()
+            and not message.get("tool_calls")
+            and not message.get("reasoning_content")
+            for message in captured["messages"]
+        )
+
 
 class TestSessionRowExistsBeforePreflightCompaction:
     """Moving the crash persist after prefetch/pre_llm_call (one write with

--- a/tests/plugins/model_providers/test_kimi_profile.py
+++ b/tests/plugins/model_providers/test_kimi_profile.py
@@ -15,6 +15,11 @@ import json
 
 import pytest
 
+_IMAGE_BLOCK = {
+    "type": "image_url",
+    "image_url": {"url": "data:image/png;base64,AA=="},
+}
+
 
 @pytest.fixture
 def kimi_profile():
@@ -173,6 +178,52 @@ class TestKimiFullKwargsIntegration:
 
         assert kwargs["messages"] == [
             {"role": "user", "content": "ping\n\npong"}
+        ]
+
+    @pytest.mark.parametrize(
+        ("first_content", "second_content", "expected_content"),
+        [
+            (
+                [_IMAGE_BLOCK],
+                "then continue",
+                [_IMAGE_BLOCK, {"type": "text", "text": "then continue"}],
+            ),
+            (
+                "inspect this",
+                [_IMAGE_BLOCK],
+                [{"type": "text", "text": "inspect this"}, _IMAGE_BLOCK],
+            ),
+        ],
+        ids=["list-then-string", "string-then-list"],
+    )
+    def test_null_assistant_merge_preserves_mixed_multimodal_users(
+        self,
+        kimi_profile,
+        first_content,
+        second_content,
+        expected_content,
+    ):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="kimi-k2-turbo-preview",
+            messages=[
+                {"role": "user", "content": first_content},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "codex_message_items": [{"type": "message"}],
+                },
+                {"role": "user", "content": second_content},
+            ],
+            tools=None,
+            provider_profile=kimi_profile,
+            base_url="https://api.moonshot.ai/v1",
+            provider_name="kimi-coding",
+        )
+
+        assert kwargs["messages"] == [
+            {"role": "user", "content": expected_content}
         ]
 
     def test_non_text_assistant_payloads_remain_on_wire(self, kimi_profile):

--- a/tests/plugins/model_providers/test_kimi_profile.py
+++ b/tests/plugins/model_providers/test_kimi_profile.py
@@ -11,6 +11,8 @@ This mirrors the kimi-k2 handling already shipped for the opencode-go relay
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 
@@ -176,6 +178,13 @@ class TestKimiFullKwargsIntegration:
     def test_non_text_assistant_payloads_remain_on_wire(self, kimi_profile):
         from agent.transports.chat_completions import ChatCompletionsTransport
 
+        script = """python3 - <<'PY'
+import json
+payload = {"nested": {"quote": "it's still intact"}}
+print(json.dumps(payload))
+PY
+""" + ("# preserve this long tool argument\n" * 100)
+        arguments = json.dumps({"cmd": script, "timeout": 120})
         messages = [
             {
                 "role": "assistant",
@@ -184,7 +193,10 @@ class TestKimiFullKwargsIntegration:
                     {
                         "id": "call-1",
                         "type": "function",
-                        "function": {"name": "status", "arguments": "{}"},
+                        "function": {
+                            "name": "execute_code",
+                            "arguments": arguments,
+                        },
                     }
                 ],
             },
@@ -204,3 +216,6 @@ class TestKimiFullKwargsIntegration:
         )
 
         assert kwargs["messages"] == messages
+        assert kwargs["messages"][0]["tool_calls"][0]["function"][
+            "arguments"
+        ] == arguments

--- a/tests/plugins/model_providers/test_kimi_profile.py
+++ b/tests/plugins/model_providers/test_kimi_profile.py
@@ -148,3 +148,59 @@ class TestKimiFullKwargsIntegration:
         kwargs = self._build(kimi_profile, None)
         assert "reasoning_effort" not in kwargs
         assert kwargs["extra_body"] == {"thinking": {"type": "enabled"}}
+
+    def test_codex_only_assistant_is_absent_from_wire(self, kimi_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="kimi-k2-turbo-preview",
+            messages=[
+                {"role": "user", "content": "ping"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "codex_message_items": [{"type": "message"}],
+                },
+                {"role": "user", "content": "pong"},
+            ],
+            tools=None,
+            provider_profile=kimi_profile,
+            base_url="https://api.moonshot.ai/v1",
+            provider_name="kimi-coding",
+        )
+
+        assert kwargs["messages"] == [
+            {"role": "user", "content": "ping\n\npong"}
+        ]
+
+    def test_non_text_assistant_payloads_remain_on_wire(self, kimi_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {"name": "status", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": None,
+                "reasoning_content": "checking",
+            },
+        ]
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="kimi-k2-turbo-preview",
+            messages=messages,
+            tools=None,
+            provider_profile=kimi_profile,
+            base_url="https://api.moonshot.ai/v1",
+            provider_name="kimi-coding",
+        )
+
+        assert kwargs["messages"] == messages


### PR DESCRIPTION
## What does this PR do?

Prevents strict Chat Completions providers from receiving assistant messages with no provider-visible payload.

The existing early sanitizer does not cover two downstream paths:

1. `ChatCompletionsTransport.convert_messages()` can strip an assistant row's only internal `codex_message_items` payload after the earlier sanitizer has run.
2. `handle_max_iterations()` builds its summary request directly and bypasses `ChatCompletionsTransport.build_kwargs()`.

This change validates the final wire shape in both paths. It drops only assistant rows without text, tool calls, reasoning, or non-text content, then merges user turns that become adjacent so strict role alternation is preserved. The stored conversation is not mutated.

## Related Issue

Related to #66429 and complements #66509.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Sanitize the final Chat Completions message list after internal Codex fields are stripped.
- Preserve real tool-call, reasoning, and multimodal assistant payloads.
- Merge user messages that become adjacent after a null assistant row is removed.
- Preserve both mixed multimodal merge orders (`list + str` and `str + list`).
- Apply the same final-wire guard to the direct max-iterations summary request.
- Add behavioral regression coverage for Kimi/Moonshot transport kwargs, including long nested/heredoc tool arguments, and the summary path.

## How to Test

1. Run `scripts/run_tests.sh tests/plugins/model_providers/test_kimi_profile.py -q`.
2. Run `scripts/run_tests.sh tests/agent/test_api_content_sidecar.py -q -k summary_request_drops_codex_only_assistant_prefill --file-timeout 60 --file-retries 0`.
3. Run `scripts/run_tests.sh tests/agent/transports/test_chat_completions.py -q` and `python scripts/check-windows-footguns.py agent/transports/chat_completions.py agent/chat_completion_helpers.py tests/plugins/model_providers/test_kimi_profile.py tests/agent/test_api_content_sidecar.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 (focused upstream tests) and Kali Linux/Python 3.11 (sanitized live reproduction and fix verification)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing configuration or workflow changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); the Windows footgun check passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Sanitized live failure before the fix:

```text
HTTP 400 invalid_request_error: assistant message at position 76 must not be empty
```

Focused verification:

```text
Kimi profile tests: 24 passed
Max-iterations regression: 1 passed
Chat Completions transport tests: 90 passed
Ruff: passed
Windows footgun scan: passed (4 files)
```

The full `test_api_content_sidecar.py` file was also attempted with the canonical runner. An unchanged socket-based test stalled twice at the runner's 300-second per-file limit on this macOS host; the new summary regression passes in isolation in 0.8 seconds.
