### PR TITLE
fix(cli): clear inherited HERMES_SERVE_HEADLESS in cmd_dashboard

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12095,6 +12095,13 @@ def cmd_dashboard(args):
     # build gate, and start_server.
     _headless_backend = getattr(args, "headless_backend", False)
 
+    # Prevent Desktop's inherited env vars from hijacking the dashboard
+    # frontend:
+    #   - HERMES_WEB_DIST → Desktop SPA (blank/white page, PR #52947)
+    #   - HERMES_SERVE_HEADLESS = "1" → SPA disabled, "headless backend" error
+    os.environ.pop("HERMES_WEB_DIST", None)
+    os.environ.pop("HERMES_SERVE_HEADLESS", None)
+
     # ── Unified profile launch routing ────────────────────────────────
     # The dashboard is a MACHINE management surface: it can read/write any
     # profile via the per-request ?profile= scoping. Running one dashboard


### PR DESCRIPTION
## Problem

When Hermes Desktop spawns dashboard as a child process, inherits HERMES_SERVE_HEADLESS=1 from parent. mount_spa() in web_server reads it and disables SPA.

HERMES_WEB_DIST was already tracked (PR #52947), but HERMES_SERVE_HEADLESS was overlooked.

## Fix

Pop both at cmd_dashboard() entry, before web_server module import reads HERMES_SERVE_HEADLESS at module level.

## Verification

- Before: GET / returns 404 with headless backend error
- After: GET / returns 200 with SPA HTML
- API endpoints continue working