### PR TITLE
fix(session): honour reset boundary on absent-key recovery (follow-up to #54878)

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1434,6 +1434,10 @@ class SessionStore:
             display_name=source.chat_name,
             platform=source.platform,
             chat_type=source.chat_type,
+            # Carry the durable reset-boundary flag so callers can tell an
+            # expiry-watcher-finalized session (idle/daily reset already due)
+            # apart from a merely agent_close'd one that is still alive.
+            expiry_finalized=bool(row.get("expiry_finalized")),
         )
 
     def _recover_session_from_db(
@@ -1492,7 +1496,12 @@ class SessionStore:
     def _query_recoverable_session(self, *, session_key, source, now):
         """DB-only half of _recover_session_from_db (no lock needed).
 
-        Returns a SessionEntry or None.  Caller assigns _entries[key] under lock.
+        Returns a SessionEntry or None.  Caller assigns _entries[key] under
+        lock.  Unlike ``_recover_session_from_db`` this does NOT call
+        ``reopen_session``: the single caller (``_get_or_create_session_impl``
+        phase 3) may still decide to honour a reset boundary and create a fresh
+        session instead, in which case reopening the ended row would leave it
+        wrongly resumable.  The caller reopens only when it keeps the row.
         """
         if not self._db:
             return None
@@ -1526,14 +1535,20 @@ class SessionStore:
                 session_key,
             )
             return None
-        try:
-            self._db.reopen_session(str(recovered["id"]))
-        except Exception as exc:
-            logger.debug("Gateway session DB reopen failed for %s: %s",
-                         session_key, exc)
         return self._create_entry_from_recovered_row(
             row=recovered, session_key=session_key, source=source, now=now,
         )
+
+    def _reopen_recovered_session(self, session_id: str) -> None:
+        """Clear the ended markers so a kept recovered row is resumable."""
+        if not self._db:
+            return
+        try:
+            self._db.reopen_session(str(session_id))
+        except Exception as exc:
+            logger.debug("Gateway session DB reopen failed for %s: %s",
+                         session_id, exc)
+
     def _record_gateway_session_peer(
         self,
         session_id: str,
@@ -2029,7 +2044,42 @@ class SessionStore:
             recovered = self._query_recoverable_session(
                 session_key=session_key, source=source, now=now,
             )
+            # Reset-boundary guard for the absent-key recovery path (#54878
+            # follow-up).  The in-memory stale branch already honours the reset
+            # decision, but a gateway restart *prunes* the routing entry: the
+            # next message then arrives with the key absent and falls straight
+            # into recovery, which would resurrect a session the expiry watcher
+            # had already finalized (idle/daily reset was due) — reusing the
+            # expired conversation with its full transcript.  ``expiry_finalized``
+            # is durable (``reopen_session`` clears only ended_at/end_reason, not
+            # this flag), so it is the reliable signal that the reset boundary
+            # was already crossed.  Honour it: drop the recovered row and create
+            # a fresh session, unless the user has opted out of resets
+            # (mode == "none") or an active background process still pins it.
+            if (
+                recovered is not None
+                and recovered.expiry_finalized
+                and not self._has_active_processes_safe(
+                    session_key, context="recover"
+                )
+            ):
+                _policy = self.config.get_reset_policy(
+                    platform=source.platform,
+                    session_type=source.chat_type,
+                )
+                if _policy.mode != "none":
+                    was_auto_reset = True
+                    auto_reset_reason = (
+                        "idle" if _policy.mode in {"idle", "both"} else "daily"
+                    )
+                    reset_had_activity = True
+                    db_end_session_id = recovered.session_id
+                    recovered = None
             if recovered is not None:
+                # Keeping the recovered row → reopen it so the ended markers are
+                # cleared (deferred out of _query_recoverable_session so the
+                # reset-boundary branch above can skip reopening).
+                self._reopen_recovered_session(recovered.session_id)
                 with self._lock:
                     published = self._entries.get(session_key)
                     if published is None:

--- a/tests/gateway/test_session_store_runtime_stale_guard.py
+++ b/tests/gateway/test_session_store_runtime_stale_guard.py
@@ -267,3 +267,82 @@ class TestRuntimeStaleGuard:
         db.reopen_session.assert_not_called()
         # A brand-new session row was created.
         db.create_session.assert_called_once()
+
+    def test_absent_key_recovery_of_finalized_session_creates_fresh(
+        self, tmp_path,
+    ):
+        """Restart-pruned key + expiry-finalized DB row → fresh session.
+
+        The #54878 in-memory stale branch only guards keys still present in
+        ``_entries``.  A gateway restart *prunes* the routing entry
+        (``_prune_stale_sessions_locked``), so the next message arrives with
+        the key ABSENT and falls straight into ``_query_recoverable_session``.
+        Before this follow-up fix, recovery reopened the same session_id even
+        though the expiry watcher had already finalized it (idle/daily reset
+        was due) — resurrecting the expired transcript.  ``expiry_finalized``
+        is the durable signal (``reopen_session`` does not clear it) that the
+        reset boundary was crossed, so recovery of a finalized row must yield a
+        fresh session instead.
+        """
+        source = _source()
+        config = GatewayConfig(
+            default_reset_policy=SessionResetPolicy(mode="idle", idle_minutes=60),
+        )
+        db = _db_returning({})
+        # The recoverable row is expiry_finalized=1 (watcher already reset it),
+        # and reopen_session cleared end_reason so the finder still returns it.
+        db.find_latest_gateway_session_for_peer.return_value = {
+            "id": "sid_finalized",
+            "started_at": (datetime.now() - timedelta(hours=3)).timestamp(),
+            "expiry_finalized": 1,
+            "end_reason": None,
+        }
+
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = db
+        store._loaded = True
+
+        # Key is ABSENT from _entries (pruned by the restart) → recovery path.
+        result = store.get_or_create_session(source)
+
+        assert result.session_id != "sid_finalized"
+        assert result.was_auto_reset is True
+        assert result.auto_reset_reason == "idle"
+        # Recovery was consulted, but the finalized row was NOT reopened.
+        db.find_latest_gateway_session_for_peer.assert_called_once()
+        db.reopen_session.assert_not_called()
+        db.create_session.assert_called_once()
+
+    def test_absent_key_recovery_of_non_finalized_session_resumes(
+        self, tmp_path,
+    ):
+        """Restart-pruned key + NON-finalized agent_close row → resume same id.
+
+        The crash-recovery negative case must still work: an ``agent_close``
+        row that was NOT expiry-finalized (a genuinely-live session whose agent
+        was merely evicted, reset not due) is still resumed with its original
+        session_id and transcript.
+        """
+        source = _source()
+        config = GatewayConfig(
+            default_reset_policy=SessionResetPolicy(mode="idle", idle_minutes=60),
+        )
+        db = _db_returning({})
+        db.find_latest_gateway_session_for_peer.return_value = {
+            "id": "sid_live",
+            "started_at": (datetime.now() - timedelta(minutes=5)).timestamp(),
+            "expiry_finalized": 0,
+            "end_reason": "agent_close",
+        }
+
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = db
+        store._loaded = True
+
+        result = store.get_or_create_session(source)
+
+        assert result.session_id == "sid_live"
+        db.reopen_session.assert_called_once_with("sid_live")
+        db.create_session.assert_not_called()


### PR DESCRIPTION
## Problem

Hermes' session idle/daily auto-reset is bypassed after a gateway restart. An idle-overdue session that already crossed a reset boundary gets silently resumed with its full prior context instead of starting fresh.

#54878 fixed the in-memory stale-recovery branch of `SessionStore.get_or_create_session` to honour the reset policy. But that guard only fires when the routing key is still present in `_entries`. On restart, `_prune_stale_sessions_locked` removes the key, so the next inbound message arrives with the key **absent** and skips the stale branch entirely.

## Root cause

With the key absent, routing falls into the Phase 3 absent-key recovery path: `_query_recoverable_session` -> `find_latest_gateway_session_for_peer` + `reopen_session`. This resurrects the most-recent recoverable session row **without ever calling `_should_reset`**. `reopen_session` clears `end_reason` but not the durable `expiry_finalized` flag, and `_create_entry_from_recovered_row` stamps `updated_at=now`, so a session that already crossed a reset boundary is resumed as if live.

## Fix

- Carry `expiry_finalized` from the recovered DB row into the reconstructed `SessionEntry`.
- Move `reopen_session` out of `_query_recoverable_session` into a `_reopen_recovered_session` helper that the caller invokes only when it actually keeps the row.
- In Phase 3, if the recovered row is `expiry_finalized`, has no active processes, and `policy.mode != none`, treat it as an auto-reset: create a fresh session (`was_auto_reset=True`, `auto_reset_reason=idle|daily`) and promote the old row to `session_reset`, instead of resuming.
- `mode:none` and sessions with active background processes still resume unchanged, preserving the #54878 crash-recovery behaviour.

## Testing

Added two tests to `tests/gateway/test_session_store_runtime_stale_guard.py`:

- `test_absent_key_recovery_of_finalized_session_creates_fresh` - finalized row under an active reset policy yields a fresh session.
- `test_absent_key_recovery_of_non_finalized_session_resumes` - non-finalized `agent_close` row still resumes the same session.

`python -m pytest tests/gateway/test_session_store_runtime_stale_guard.py tests/gateway/test_session.py -q` -> 137 passed.