### PR TITLE
fix(deps): bump lark-oapi to 1.6.9 for Feishu WebSocket extra_ua_tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,7 +249,7 @@ termux-all = [
   "hermes-agent[web]",
 ]
 dingtalk = ["dingtalk-stream==0.24.3", "alibabacloud-dingtalk==2.2.42", "qrcode==7.4.2"]
-feishu = ["lark-oapi==1.6.8", "qrcode==7.4.2"]
+feishu = ["lark-oapi==1.6.9", "qrcode==7.4.2"]
 google = [
   # Required by the google-workspace skill (Gmail, Calendar, Drive, Contacts,
   # Sheets, Docs).  Declared here so packagers (Nix, Homebrew) ship them with

--- a/uv.lock
+++ b/uv.lock
@@ -1794,7 +1794,7 @@ requires-dist = [
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.2.0" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },
-    { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.6.8" },
+    { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.6.9" },
     { name = "markdown", specifier = "==3.10.2" },
     { name = "mautrix", extras = ["encryption"], marker = "extra == 'matrix'", specifier = "==0.21.0" },
     { name = "mcp", marker = "extra == 'computer-use'", specifier = "==1.26.0" },
@@ -2184,7 +2184,7 @@ wheels = [
 
 [[package]]
 name = "lark-oapi"
-version = "1.6.8"
+version = "1.6.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2194,7 +2194,7 @@ dependencies = [
     { name = "websockets" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/ad/1ab04db5d549ad1a7a2cd33682b1c38dee1d65019cb24fd7a23270e6337d/lark_oapi-1.6.8-py3-none-any.whl", hash = "sha256:9b443a5d47a7d204dd42dc40896c8b75087cc35788e45c48c140806d7df7e5e8", size = 7798300, upload-time = "2026-06-02T07:40:05.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b5/00982093154f92ffc2bfe8448367323a07513bd1db1e92672f9573c92ddf/lark_oapi-1.6.9-py3-none-any.whl", hash = "sha256:ebc93c09eba66e3d2d8823d9df4988370b2e0245870b3249b61cdf6d6cd1642c", size = 7801043, upload-time = "2026-06-24T06:15:19.989Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
     `lark-oapi==1.6.8` does not expose the `extra_ua_tags` kwarg on its websocket `Client`, which causes the Feishu adapter in `origin/main` to fail when it passes `extra_ua_tags=["channel"]`.                                                      
                                                                                                                                                                                                                                                       
     Bumping to `1.6.9` adds support for the parameter, so the Feishu WebSocket connection can request the Channel protocol for group @mention delivery without a runtime compatibility shim.                                                          
                                                                                                                                                                                                                                                       
     Changes:                                                                                                                                                                                                                                          
     - `pyproject.toml`: `lark-oapi==1.6.8` → `lark-oapi==1.6.9`                                                                                                                                                                                       
     - `uv.lock`: regenerated via `uv lock`  