### PR TITLE
fix(agent): scope provider terminal lifecycle per attempt

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2760,6 +2760,7 @@ def create_anthropic_message(
     *,
     log_prefix: str = "",
     prefer_stream: bool = True,
+    on_response_received=None,
 ) -> Any:
     """Create an Anthropic message, aggregating via stream when available.
 
@@ -2769,6 +2770,12 @@ def create_anthropic_message(
     crash on ``.content``.  Prefer ``messages.stream().get_final_message()`` to
     match the main turn path, falling back to ``create()`` only for providers
     that explicitly do not support streaming, such as restricted Bedrock roles.
+
+    ``on_response_received`` (optional zero-arg callback) fires once at the
+    provider-completion boundary — when ``message_stop`` is observed, when a
+    shim stream produces a validated final message, or when ``create()``
+    returns — and never fires before the boundary, so callers can distinguish
+    "provider completed" from "still in flight" without exception-type checks.
     """
     sanitize_anthropic_kwargs(api_kwargs, log_prefix=log_prefix)
 
@@ -2777,10 +2784,28 @@ def create_anthropic_message(
     if prefer_stream and callable(stream_fn):
         stream_kwargs = dict(api_kwargs)
         stream_kwargs.pop("stream", None)
+        terminal_received = False
         try:
             with stream_fn(**stream_kwargs) as stream:
-                return stream.get_final_message()
+                saw_message_stop = False
+                if hasattr(stream, "__iter__"):
+                    for event in stream:
+                        if getattr(event, "type", None) == "message_stop":
+                            saw_message_stop = True
+                            terminal_received = True
+                            if on_response_received is not None:
+                                on_response_received()
+                final_message = stream.get_final_message()
+                # A shim without an explicit message_stop has now produced a
+                # validated final response — the equivalent terminal boundary.
+                if not saw_message_stop:
+                    terminal_received = True
+                    if on_response_received is not None:
+                        on_response_received()
+                return final_message
         except Exception as exc:
+            if terminal_received:
+                raise
             if not _is_stream_unavailable_error(exc):
                 raise
             logger.debug(
@@ -2792,4 +2817,7 @@ def create_anthropic_message(
 
     create_kwargs = dict(api_kwargs)
     create_kwargs.pop("stream", None)
-    return messages_api.create(**create_kwargs)
+    response = messages_api.create(**create_kwargs)
+    if on_response_received is not None:
+        on_response_received()
+    return response

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -366,7 +366,90 @@ def _bedrock_reasoning_stale_floor(model_id: object) -> "float | None":
     return None
 
 
-def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
+# ── Provider response lifecycle boundary ────────────────────────────────────
+# Explicit request-phase tracking (positional, never exception-type based).
+# The retry classification in conversation_loop must distinguish "the provider
+# has not completed" (network errors, timeouts — retry/fallback allowed) from
+# "a terminal response was received" (any later exception is Hermes-local and
+# must never re-request the completed, billable response).
+#
+# Attempt scoping: every provider attempt owns a token
+# (``ProviderAttemptLifecycle``). Transports, terminal callbacks, workers and
+# error classifiers capture the token at attempt start and operate ONLY on
+# their own token — never on shared agent state. The outer exception handlers
+# read only the loop's CURRENT attempt token, so a stale late worker from an
+# older attempt cannot mark the current attempt as terminal. Exception types,
+# error strings and traceback module names are never used as the source of
+# this fact.
+PROVIDER_PHASE_NOT_STARTED = "not_started"
+PROVIDER_PHASE_IN_FLIGHT = "in_flight"
+PROVIDER_PHASE_TERMINAL_RECEIVED = "terminal_received"
+
+
+class ProviderAttemptLifecycle:
+    """Per-attempt provider lifecycle token.
+
+    One instance per provider attempt. Callers that capture it operate on the
+    token itself; there is no writer-side way to touch another attempt's
+    phase through it.
+    """
+
+    __slots__ = ("phase",)
+
+    def __init__(self) -> None:
+        self.phase: str = PROVIDER_PHASE_IN_FLIGHT
+
+    def mark(self, phase: str) -> None:
+        self.phase = phase
+
+    @property
+    def terminal_received(self) -> bool:
+        return self.phase == PROVIDER_PHASE_TERMINAL_RECEIVED
+
+
+def _new_provider_attempt(agent) -> ProviderAttemptLifecycle:
+    """Start a new provider attempt and make it the loop's current one."""
+    attempt = ProviderAttemptLifecycle()
+    agent._provider_attempt = attempt
+    return attempt
+
+
+def _capture_provider_attempt(agent) -> ProviderAttemptLifecycle:
+    """Capture the attempt a transport/worker belongs to, at call time.
+
+    Falls back to a detached token for auxiliary calls outside any
+    conversation attempt, so those paths stay safe without ever writing
+    shared state.
+    """
+    attempt = getattr(agent, "_provider_attempt", None)
+    if attempt is None:
+        attempt = ProviderAttemptLifecycle()
+    return attempt
+
+
+def _detached_provider_attempt() -> ProviderAttemptLifecycle:
+    """Fresh standalone token for AUXILIARY entry points (e.g. iteration-limit
+    summary calls) that were invoked without an explicit attempt.
+
+    Unlike ``_capture_provider_attempt`` this never adopts
+    ``agent._provider_attempt``: an auxiliary request must not inherit the
+    main loop's previous (possibly already terminal) token, or its own
+    pre-terminal transport errors would be misclassified as post-terminal
+    local failures and its internal reconnects wrongly suppressed.
+    """
+    return ProviderAttemptLifecycle()
+
+
+def _provider_terminal_received(agent) -> bool:
+    """True iff the OUTER LOOP'S CURRENT attempt reached its terminal.
+
+    A stale late worker marking its own (older) token can never flip this.
+    """
+    attempt = getattr(agent, "_provider_attempt", None)
+    return bool(attempt and attempt.terminal_received)
+
+
+def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client, attempt):
     """Run one non-streaming LLM request for the active api_mode and return it.
 
     Shared by the interrupt-worker path (``interruptible_api_call``) and the
@@ -381,14 +464,25 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
     bedrock / MoA branches manage their own clients and never call it. All
     interrupt, abort, cancellation, and close semantics stay in the callers —
     this helper only issues the request.
+
+    ``attempt`` is the caller's provider-attempt lifecycle token, captured ONCE
+    at the attempt's main entry. This function must never re-read
+    ``agent._provider_attempt``: a worker that was delayed past a stale-kill
+    would otherwise capture a NEWER attempt's token and mark it terminal.
     """
+    _attempt = attempt
     if agent.api_mode == "codex_responses":
         request_client = make_client("codex_stream_request")
-        return agent._run_codex_stream(
+        response = agent._run_codex_stream(
             api_kwargs,
             client=request_client,
             on_first_delta=getattr(agent, "_codex_on_first_delta", None),
+            attempt=_attempt,
         )
+        # run_codex_stream also marks its own terminal-event boundary; this
+        # covers any post-helper local work as well.
+        _attempt.mark(PROVIDER_PHASE_TERMINAL_RECEIVED)
+        return response
     if agent.api_mode == "anthropic_messages":
         # #67142: use a request-local Anthropic client so the stale/interrupt
         # watchdog aborts sockets from the stranger thread while the worker
@@ -396,7 +490,9 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
         request_client = make_client(
             "anthropic_messages_request", kind="anthropic_messages"
         )
-        return agent._anthropic_messages_create(api_kwargs, client=request_client)
+        response = agent._anthropic_messages_create(api_kwargs, client=request_client, attempt=_attempt)
+        _attempt.mark(PROVIDER_PHASE_TERMINAL_RECEIVED)
+        return response
     if agent.api_mode == "bedrock_converse":
         # Bedrock uses boto3 directly — no OpenAI client needed.
         # normalize_converse_response produces an OpenAI-compatible
@@ -419,14 +515,21 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
             if is_stale_connection_error(_bedrock_exc):
                 invalidate_runtime_client(region)
             raise
+        # The provider has completed a billable inference. Any exception from
+        # normalization below is Hermes-local and must not trigger another call.
+        _attempt.mark(PROVIDER_PHASE_TERMINAL_RECEIVED)
         return normalize_converse_response(raw_response)
     if agent.provider == "moa":
         # MoA is a virtual chat-completions provider backed by the
         # in-process MoAClient facade. Do not rebuild a request-local
         # OpenAI client from the virtual runtime metadata.
-        return agent.client.chat.completions.create(**api_kwargs)
+        response = agent.client.chat.completions.create(**api_kwargs)
+        _attempt.mark(PROVIDER_PHASE_TERMINAL_RECEIVED)
+        return response
     request_client = make_client("chat_completion_request")
-    return request_client.chat.completions.create(**api_kwargs)
+    response = request_client.chat.completions.create(**api_kwargs)
+    _attempt.mark(PROVIDER_PHASE_TERMINAL_RECEIVED)
+    return response
 
 
 def should_use_direct_api_call(agent) -> bool:
@@ -455,6 +558,7 @@ def direct_api_call(agent, api_kwargs: dict):
     a genuinely hung provider — the same bound interactive calls already rely on.
     """
     _check_stale_giveup(agent)
+    _attempt = _capture_provider_attempt(agent)
     agent._touch_activity("waiting for non-streaming API response")
     request_client_holder = {"client": None}
     request_client_lock = threading.Lock()
@@ -479,7 +583,7 @@ def direct_api_call(agent, api_kwargs: dict):
 
     try:
         response = _dispatch_nonstreaming_api_request(
-            agent, api_kwargs, make_client=_make_client
+            agent, api_kwargs, make_client=_make_client, attempt=_attempt
         )
     except Exception:
         if getattr(agent, "_interrupt_requested", False):
@@ -527,6 +631,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
     # subagent / no-stream-consumer sessions take THIS path, and a wedged
     # unattended session here has the same infinite stale-retry class.
     _check_stale_giveup(agent)
+    _attempt = _capture_provider_attempt(agent)
 
     request_client_holder = {"client": None, "owner_tid": None}
     # Transport kind of the registered request client ("openai" or
@@ -598,7 +703,11 @@ def interruptible_api_call(agent, api_kwargs: dict):
             # stranger-thread abort machinery above; the shared dispatch helper
             # builds it via this callback (openai- or anthropic-kind) so the
             # interrupt / stale-call detectors can force-close the worker's
-            # connection without touching the shared client (#67142).
+            # connection without touching the shared client (#67142). The
+            # attempt token was captured ONCE at this call's entry (main
+            # thread, before the worker could ever be delayed) and is passed
+            # down explicitly — nothing below this point re-reads
+            # agent._provider_attempt.
             result["response"] = _dispatch_nonstreaming_api_request(
                 agent,
                 api_kwargs,
@@ -610,6 +719,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     ),
                     kind=kind,
                 ),
+                attempt=_attempt,
             )
         except Exception as e:
             # If the request was cancelled by the main thread's interrupt
@@ -2257,6 +2367,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     if should_use_direct_api_call(agent):
         return agent._interruptible_api_call(api_kwargs)
 
+    # Lifecycle boundary (positional): each streaming branch marks the
+    # CAPTURED attempt token terminal at its provider-completion signal
+    # (finish_reason / message_stop / consumed terminal event). Pre-terminal
+    # failures keep the baseline retry classification untouched.
+    _attempt = _capture_provider_attempt(agent)
+
     if agent.api_mode == "codex_responses":
         # Codex streams internally via _run_codex_stream. The main dispatch
         # in _interruptible_api_call already calls it; we just need to
@@ -2914,6 +3030,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
             if chunk.choices[0].finish_reason:
                 finish_reason = chunk.choices[0].finish_reason
+                # Terminal frame arrived — everything after this assignment
+                # is local aggregation/state work and must not reconnect.
+                _attempt.mark(PROVIDER_PHASE_TERMINAL_RECEIVED)
 
             # Usage in the final chunk
             if hasattr(chunk, "usage") and chunk.usage:
@@ -3151,6 +3270,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
                 event_type = getattr(event, "type", None)
 
+                if event_type == "message_stop":
+                    # Terminal event arrived; any later SDK aggregation or
+                    # callback failure is Hermes-local and must not reconnect.
+                    _attempt.mark(PROVIDER_PHASE_TERMINAL_RECEIVED)
+
                 if event_type == "content_block_start":
                     block = getattr(event, "content_block", None)
                     if block and getattr(block, "type", None) == "tool_use":
@@ -3216,6 +3340,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     "Provider returned an empty stream with no stop_reason "
                     "(possible upstream error or malformed event stream)."
                 )
+            # Completion validated (for shim streams without an explicit
+            # message_stop this is the equivalent terminal boundary).
+            _attempt.mark(PROVIDER_PHASE_TERMINAL_RECEIVED)
             return _final_message
 
     def _call():
@@ -3265,6 +3392,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             "cancellation — exiting without retry.",
                             type(e).__name__,
                         )
+                        return
+                    if _attempt.terminal_received:
+                        # A terminal provider response was already observed
+                        # ON THIS ATTEMPT'S OWN TOKEN. Do not feed a later
+                        # local exception into the stream reconnect
+                        # classifier, regardless of exception type.
+                        result["error"] = e
                         return
                     _is_timeout = isinstance(
                         e, (_httpx.ReadTimeout, _httpx.ConnectTimeout, _httpx.PoolTimeout)
@@ -3732,6 +3866,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     if agent._interrupt_requested:
         raise InterruptedError("Agent interrupted during streaming API call (post-worker)")
     if result["error"] is not None:
+        # Lifecycle boundary: once a terminal provider response was received,
+        # a later error is Hermes-local. It must NOT be converted into a
+        # partial-stream stub (which stamps finish_reason="length" and fires
+        # the continuation machinery, re-requesting a completed, billable
+        # response). Raise it so the outer loop reports a unified local
+        # post-response failure through the finalizer instead.
+        if _attempt.terminal_received:
+            raise result["error"]
         if deltas_were_sent["yes"]:
             # Streaming failed AFTER some tokens were already delivered to
             # the platform.  Re-raising would let the outer retry loop make

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -381,7 +381,6 @@ def _bedrock_reasoning_stale_floor(model_id: object) -> "float | None":
 # older attempt cannot mark the current attempt as terminal. Exception types,
 # error strings and traceback module names are never used as the source of
 # this fact.
-PROVIDER_PHASE_NOT_STARTED = "not_started"
 PROVIDER_PHASE_IN_FLIGHT = "in_flight"
 PROVIDER_PHASE_TERMINAL_RECEIVED = "terminal_received"
 

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -931,6 +931,7 @@ def _consume_codex_event_stream(
     on_first_delta=None,
     on_event=None,
     interrupt_check=None,
+    on_terminal=None,
 ) -> SimpleNamespace:
     """Consume a Codex Responses SSE event stream and return a final response.
 
@@ -1103,6 +1104,10 @@ def _consume_codex_event_stream(
 
         if event_type in _TERMINAL_EVENT_TYPES:
             saw_terminal = True
+            if on_terminal is not None:
+                # Lifecycle boundary: terminal provider response observed.
+                # Fires before any terminal field is read locally.
+                on_terminal()
             resp_obj = _event_field(event, "response")
             if resp_obj is not None:
                 terminal_usage = getattr(resp_obj, "usage", None)
@@ -1176,7 +1181,7 @@ def _consume_codex_event_stream(
     return final
 
 
-def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta=None):
+def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta=None, attempt=None):
     """Execute one streaming Responses API request and return the final response.
 
     Uses ``responses.create(stream=True)`` (low-level raw event iteration)
@@ -1185,6 +1190,23 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     payload shape — we never let the SDK reconstruct a typed object from
     the terminal event's ``output`` field.
     """
+    from agent.chat_completion_helpers import (
+        PROVIDER_PHASE_TERMINAL_RECEIVED,
+        _detached_provider_attempt,
+    )
+
+    # The attempt token arrives explicitly from the attempt's main entry
+    # (dispatch). Auxiliary callers outside any conversation attempt (e.g.
+    # iteration-limit summaries) get a DETACHED token — never the main loop's
+    # current/previous token, which may already be terminal and would
+    # misclassify this auxiliary stream's pre-terminal transport errors and
+    # suppress its internal reconnect. A delayed conversation worker must
+    # NEVER re-read agent._provider_attempt either, so it always passes an
+    # explicit token and never reaches this branch.
+    if attempt is None:
+        attempt = _detached_provider_attempt()
+    _attempt = attempt
+
     import httpx as _httpx
 
     active_client = client or agent._ensure_primary_openai_client(reason="codex_stream_direct")
@@ -1270,8 +1292,13 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                     on_first_delta=on_first_delta,
                     on_event=_on_event,
                     interrupt_check=_interrupt_or_superseded,
+                    on_terminal=lambda: _attempt.mark(
+                        PROVIDER_PHASE_TERMINAL_RECEIVED
+                    ),
                 )
             except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
+                if _attempt.terminal_received:
+                    raise
                 if attempt < max_stream_retries:
                     logger.debug(
                         "Codex Responses stream transport failed mid-iteration "

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1217,8 +1217,21 @@ def run_conversation(
         api_kwargs = None  # Guard against UnboundLocalError in except handler
         api_request_id = f"{turn_id}:api:{api_call_count}"
         agent._current_api_request_id = api_request_id
+        _local_post_response_failure = False
+        _loop_attempt = None  # set at the top of each provider attempt below
 
         while retry_count < max_retries:
+            # Provider response lifecycle (positional, never type-based):
+            # each attempt gets its OWN token; transports/terminal callbacks
+            # mark only the token they captured, so a stale late worker from
+            # an older attempt can never flip the current attempt's phase.
+            # The loop keeps a LOCAL reference: exception handlers and the
+            # _perform_api_call backstop read this variable, never
+            # agent._provider_attempt, so a delayed worker from an older
+            # attempt cannot become this attempt's writer-identity source.
+            from agent.chat_completion_helpers import _new_provider_attempt
+
+            _loop_attempt = _new_provider_attempt(agent)
             # ── Nous Portal rate limit guard ──────────────────────
             # If another session already recorded that Nous is rate-
             # limited, skip the API call entirely.  Each attempt
@@ -1434,6 +1447,10 @@ def run_conversation(
                         _use_streaming = False
 
                 def _perform_api_call(next_api_kwargs):
+                    from agent.chat_completion_helpers import (
+                        PROVIDER_PHASE_TERMINAL_RECEIVED,
+                    )
+
                     if agent.api_mode == "codex_responses":
                         next_api_kwargs = agent._get_transport().preflight_kwargs(
                             next_api_kwargs,
@@ -1441,10 +1458,20 @@ def run_conversation(
                             is_github_responses=agent._is_copilot_url(),
                         )
                     if _use_streaming:
-                        return agent._interruptible_streaming_api_call(
+                        provider_response = agent._interruptible_streaming_api_call(
                             next_api_kwargs, on_first_delta=_stop_spinner
                         )
-                    return agent._interruptible_api_call(next_api_kwargs)
+                    else:
+                        provider_response = agent._interruptible_api_call(next_api_kwargs)
+                    # Backstop boundary: the provider call wrapper returned a
+                    # completed response by any means (real transport or a
+                    # test seam). Transports mark the earlier raw boundary on
+                    # the attempt token themselves; this covers everything
+                    # past this point for THE CURRENT attempt. Read the
+                    # loop-LOCAL token, never agent._provider_attempt.
+                    if _loop_attempt is not None:
+                        _loop_attempt.mark(PROVIDER_PHASE_TERMINAL_RECEIVED)
+                    return provider_response
 
                 from hermes_cli.middleware import run_llm_execution_middleware
 
@@ -2445,6 +2472,41 @@ def run_conversation(
                 break
 
             except Exception as api_error:
+                # Read the loop-LOCAL attempt token first (this attempt's own
+                # identity), never agent._provider_attempt — a delayed worker
+                # from an older attempt may still exist, and the agent-level
+                # reference is only a current-state/diagnostic view.
+                if _loop_attempt is not None and _loop_attempt.terminal_received:
+                    # Lifecycle fact dominates: a terminal provider response
+                    # was already received for this attempt. Whatever failed
+                    # afterwards is Hermes-local and must NOT be reclassified
+                    # into provider retry/fallback/continuation — and must not
+                    # issue another model request, regardless of the
+                    # exception's type.
+                    _local_error_msg = (
+                        "Local post-response processing error after API call "
+                        f"#{api_call_count}: {type(api_error).__name__}: {api_error}"
+                    )
+                    try:
+                        print(f"❌ {_local_error_msg}")
+                    except (OSError, ValueError):
+                        logger.error(_local_error_msg)
+                    logger.exception(
+                        "Local post-response processing failed after API call #%d; "
+                        "provider will not be requested again",
+                        api_call_count,
+                    )
+                    final_response = (
+                        "I apologize, but I encountered an error while processing "
+                        f"the model response: {_local_error_msg}"
+                    )
+                    failed = True
+                    _turn_exit_reason = "local_post_response_error"
+                    messages.append({"role": "assistant", "content": final_response})
+                    agent._persist_session(messages, conversation_history)
+                    _local_post_response_failure = True
+                    break
+
                 # Stop spinner silently — retry status is buffered and
                 # only flushed when every retry+fallback is exhausted.
                 if thinking_spinner:
@@ -4426,6 +4488,12 @@ def run_conversation(
             agent._ephemeral_max_output_tokens = min(_boost, _boost_cap)
             continue
 
+        # Guard: a post-terminal local failure already produced its final
+        # state above — exit the turn loop without touching response
+        # processing or the all-retries-exhausted guard.
+        if _local_post_response_failure:
+            break
+
         # Guard: if all retries exhausted without a successful response
         # (e.g. repeated context-length errors that exhausted retry_count),
         # the `response` variable is still None. Break out cleanly.
@@ -5681,7 +5749,22 @@ def run_conversation(
             _hit_local = bool(tb_module_names & _LOCAL_PROCESSING_MODULES)
             _hit_api = bool(tb_module_names & _API_CALL_MODULES)
 
-            _is_local_processing_error = _hit_local and not _hit_api
+            # Lifecycle dominates: once a terminal provider response was
+            # received, ANY exception here is local post-response processing
+            # (this outer try only runs after a completed provider call).
+            # Read the loop-LOCAL attempt token first — it is this attempt's
+            # own identity, immune to delayed workers from older attempts.
+            # agent._provider_attempt remains only a diagnostic fallback for
+            # paths that never entered the retry loop above.
+            # The traceback classifier remains as defense-in-depth for
+            # pre-terminal local errors only.
+            if _loop_attempt is not None:
+                _lifecycle_terminal = _loop_attempt.terminal_received
+            else:
+                from agent.chat_completion_helpers import _provider_terminal_received
+
+                _lifecycle_terminal = _provider_terminal_received(agent)
+            _is_local_processing_error = _lifecycle_terminal or (_hit_local and not _hit_api)
 
             if _is_local_processing_error:
                 error_msg = (
@@ -5744,8 +5827,15 @@ def run_conversation(
                 or api_call_count >= agent.max_iterations - 1
             ):
                 if _is_local_processing_error:
-                    _turn_exit_reason = f"local_processing_error({error_msg[:80]})"
+                    if _lifecycle_terminal:
+                        _turn_exit_reason = "local_post_response_error"
+                    else:
+                        _turn_exit_reason = f"local_processing_error({error_msg[:80]})"
                     final_response = f"I apologize, but I encountered an error while processing the model response: {error_msg}"
+                    # A deterministic local failure means the turn did not
+                    # complete — keep failed/completed consistent with the
+                    # exit reason for the finalizer and the transcript.
+                    failed = True
                 else:
                     _turn_exit_reason = f"error_near_max_iterations({error_msg[:80]})"
                     final_response = f"I apologize, but I encountered repeated errors: {error_msg}"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -40,6 +40,9 @@ from agent.turn_context import (
 from agent.turn_retry_state import TurnRetryState
 from agent.message_sanitization import (
     close_interrupted_tool_sequence,
+    finalize_local_failure_turn,
+    LOCAL_FAILURE_NOTE,
+    LOCAL_FAILURE_TOOL_NOTE,
     _repair_tool_call_arguments,
     _sanitize_messages_non_ascii,
     _sanitize_messages_surrogates,
@@ -2482,27 +2485,21 @@ def run_conversation(
                     # afterwards is Hermes-local and must NOT be reclassified
                     # into provider retry/fallback/continuation — and must not
                     # issue another model request, regardless of the
-                    # exception's type.
-                    _local_error_msg = (
-                        "Local post-response processing error after API call "
-                        f"#{api_call_count}: {type(api_error).__name__}: {api_error}"
-                    )
+                    # exception's type. The user-visible note is a fixed
+                    # generic string; the exception itself goes to the logs
+                    # only (never into final_response / transcript / stdout).
                     try:
-                        print(f"❌ {_local_error_msg}")
+                        print(f"❌ {LOCAL_FAILURE_NOTE}")
                     except (OSError, ValueError):
-                        logger.error(_local_error_msg)
+                        logger.error(LOCAL_FAILURE_NOTE)
                     logger.exception(
                         "Local post-response processing failed after API call #%d; "
                         "provider will not be requested again",
                         api_call_count,
                     )
-                    final_response = (
-                        "I apologize, but I encountered an error while processing "
-                        f"the model response: {_local_error_msg}"
-                    )
                     failed = True
                     _turn_exit_reason = "local_post_response_error"
-                    messages.append({"role": "assistant", "content": final_response})
+                    final_response = finalize_local_failure_turn(messages)
                     agent._persist_session(messages, conversation_history)
                     _local_post_response_failure = True
                     break
@@ -5773,10 +5770,14 @@ def run_conversation(
                 )
             else:
                 error_msg = f"Error during OpenAI-compatible API call #{api_call_count}: {str(e)}"
+            # User-facing surfaces (stdout, transcript, synthetic tool
+            # results, final_response) only ever carry the fixed generic
+            # note. The detailed error_msg stays in the logs.
             try:
-                print(f"❌ {error_msg}")
+                print(f"❌ {LOCAL_FAILURE_NOTE}")
             except (OSError, ValueError):
-                logger.error(error_msg)
+                logger.error(LOCAL_FAILURE_NOTE)
+            logger.error(error_msg)
 
             # Emit the full traceback at ERROR level so it lands in both
             # agent.log AND errors.log.  Previously this was logged at DEBUG,
@@ -5804,11 +5805,21 @@ def run_conversation(
                     for tc in msg["tool_calls"]:
                         if not tc or not isinstance(tc, dict): continue
                         if tc["id"] not in answered_ids:
+                            # Local post-response failures get the fixed
+                            # generic note (no exception text ever reaches
+                            # the transcript); retryable transport errors
+                            # keep their diagnostic text so the retry loop
+                            # can act on it.
+                            _tool_err_content = (
+                                LOCAL_FAILURE_TOOL_NOTE
+                                if _is_local_processing_error
+                                else f"Error executing tool: {error_msg}"
+                            )
                             err_msg = {
                                 "role": "tool",
                                 "name": _ra().AIAgent._get_tool_call_name_static(tc),
                                 "tool_call_id": tc["id"],
-                                "content": f"Error executing tool: {error_msg}",
+                                "content": _tool_err_content,
                             }
                             messages.append(err_msg)
                 break
@@ -5831,7 +5842,11 @@ def run_conversation(
                         _turn_exit_reason = "local_post_response_error"
                     else:
                         _turn_exit_reason = f"local_processing_error({error_msg[:80]})"
-                    final_response = f"I apologize, but I encountered an error while processing the model response: {error_msg}"
+                    # Role-safe terminal write: preserves an already
+                    # appended plain assistant answer, closes dangling
+                    # tool calls (done above), and only ever surfaces the
+                    # fixed generic note — never the exception text.
+                    final_response = finalize_local_failure_turn(messages)
                     # A deterministic local failure means the turn did not
                     # complete — keep failed/completed consistent with the
                     # exit reason for the finalizer and the transcript.
@@ -5839,9 +5854,9 @@ def run_conversation(
                 else:
                     _turn_exit_reason = f"error_near_max_iterations({error_msg[:80]})"
                     final_response = f"I apologize, but I encountered repeated errors: {error_msg}"
-                # Append as assistant so the history stays valid for
-                # session resume (avoids consecutive user messages).
-                messages.append({"role": "assistant", "content": final_response})
+                    # Append as assistant so the history stays valid for
+                    # session resume (avoids consecutive user messages).
+                    messages.append({"role": "assistant", "content": final_response})
                 break
     
     # Post-loop turn finalization extracted to agent/turn_finalizer.finalize_turn

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5770,13 +5770,20 @@ def run_conversation(
                 )
             else:
                 error_msg = f"Error during OpenAI-compatible API call #{api_call_count}: {str(e)}"
-            # User-facing surfaces (stdout, transcript, synthetic tool
-            # results, final_response) only ever carry the fixed generic
-            # note. The detailed error_msg stays in the logs.
+            # Only deterministic LOCAL post-response failures get the fixed
+            # generic note on user-facing surfaces (stdout, transcript,
+            # final_response). Retryable provider/transport errors keep
+            # their original provider error display semantics — they must
+            # NOT be misreported as a local response-processing error.
             try:
-                print(f"❌ {LOCAL_FAILURE_NOTE}")
+                if _is_local_processing_error:
+                    print(f"❌ {LOCAL_FAILURE_NOTE}")
+                else:
+                    print(f"❌ {error_msg}")
             except (OSError, ValueError):
-                logger.error(LOCAL_FAILURE_NOTE)
+                logger.error(
+                    LOCAL_FAILURE_NOTE if _is_local_processing_error else error_msg
+                )
             logger.error(error_msg)
 
             # Emit the full traceback at ERROR level so it lands in both

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -311,6 +311,61 @@ def close_interrupted_tool_sequence(messages: list, final_response: Any = None) 
     return True
 
 
+# Fixed, fully static strings for the terminal local-failure path. They are
+# the ONLY text this path may surface to the user, the transcript, or
+# synthetic tool results — exception strings, exception types, URLs,
+# payloads, headers and credential material must never appear here.
+LOCAL_FAILURE_NOTE = (
+    "I ran into a local error while processing the model's response. "
+    "The details are in the logs."
+)
+LOCAL_FAILURE_TOOL_NOTE = (
+    "Tool execution was aborted by a local processing error. "
+    "The details are in the logs."
+)
+
+
+def finalize_local_failure_turn(messages: list, note: str = LOCAL_FAILURE_NOTE) -> str:
+    """Close a turn that failed locally with a role-safe, generic note.
+
+    Two terminal ``local_post_response_error`` exits share this helper:
+
+    * If the transcript tail is a plain assistant row (the model's answer
+      was already appended and possibly shown to the user), the fixed note
+      is APPENDED TO THAT ROW's content — the delivered text is preserved
+      and no second, adjacent assistant row is created.
+    * Otherwise a single generic closing assistant row is appended.
+
+    Returns the final user-visible text (the tail's updated content, or
+    the note itself). Everything returned is built exclusively from the
+    caller's original content and the fixed ``note`` — never from any
+    exception object. The note passes through
+    ``redact_sensitive_text(force=True)`` purely as defense-in-depth; it is
+    already static and must stay that way.
+    """
+    try:
+        from agent.redact import redact_sensitive_text
+
+        note = redact_sensitive_text(note, force=True)
+    except Exception:
+        # Redaction is defense-in-depth only; the fixed note is used as-is
+        # if the redactor is unavailable.
+        pass
+    if messages:
+        tail = messages[-1]
+        if (
+            isinstance(tail, dict)
+            and tail.get("role") == "assistant"
+            and not tail.get("tool_calls")
+            and isinstance(tail.get("content"), str)
+            and tail["content"].strip()
+        ):
+            tail["content"] = tail["content"].rstrip() + "\n\n" + note
+            return tail["content"]
+    messages.append({"role": "assistant", "content": note})
+    return note
+
+
 def _strip_non_ascii(text: str) -> str:
     """Remove non-ASCII characters, replacing with closest ASCII equivalent or removing.
 
@@ -464,6 +519,9 @@ def _sanitize_structure_non_ascii(payload: Any) -> bool:
 __all__ = [
     "_SURROGATE_RE",
     "close_interrupted_tool_sequence",
+    "finalize_local_failure_turn",
+    "LOCAL_FAILURE_NOTE",
+    "LOCAL_FAILURE_TOOL_NOTE",
     "_sanitize_surrogates",
     "_sanitize_structure_surrogates",
     "_sanitize_messages_surrogates",

--- a/run_agent.py
+++ b/run_agent.py
@@ -4410,10 +4410,10 @@ class AIAgent:
                 exc,
             )
 
-    def _run_codex_stream(self, api_kwargs: dict, client: Any = None, on_first_delta: callable = None):
+    def _run_codex_stream(self, api_kwargs: dict, client: Any = None, on_first_delta: callable = None, attempt=None):
         """Forwarder — see ``agent.codex_runtime.run_codex_stream``."""
         from agent.codex_runtime import run_codex_stream
-        return run_codex_stream(self, api_kwargs, client, on_first_delta)
+        return run_codex_stream(self, api_kwargs, client, on_first_delta, attempt=attempt)
 
     def _run_codex_create_stream_fallback(self, api_kwargs: dict, client: Any = None):
         """Forwarder — see ``agent.codex_runtime.run_codex_create_stream_fallback``."""
@@ -4795,7 +4795,7 @@ class AIAgent:
             return False
         return pool.has_available()
 
-    def _anthropic_messages_create(self, api_kwargs: dict, *, client: Any = None):
+    def _anthropic_messages_create(self, api_kwargs: dict, *, client: Any = None, attempt=None):
         # When a request-local client is supplied it was already credential-
         # refreshed in ``_create_request_anthropic_client``; only the shared
         # fallback path refreshes here.
@@ -4805,11 +4805,29 @@ class AIAgent:
         # api_mode-flip race (the Anthropic SDK raises a non-retryable
         # TypeError on them). See #31673.
         from agent.anthropic_adapter import create_anthropic_message
+        from agent.chat_completion_helpers import (
+            PROVIDER_PHASE_TERMINAL_RECEIVED,
+            _detached_provider_attempt,
+        )
+
+        # The attempt token arrives explicitly from the attempt's main entry
+        # (dispatch / interruptible_api_call). Auxiliary callers outside any
+        # conversation attempt (e.g. memory/iteration-limit summaries) get a
+        # DETACHED token — never the main loop's current/previous token,
+        # which may already be terminal. A delayed conversation worker must
+        # NEVER re-read agent._provider_attempt, so it always passes an
+        # explicit token and never reaches this branch.
+        if attempt is None:
+            attempt = _detached_provider_attempt()
+
         return create_anthropic_message(
             client or self._anthropic_client,
             api_kwargs,
             log_prefix=getattr(self, "log_prefix", ""),
             prefer_stream=not bool(getattr(self, "_disable_streaming", False)),
+            on_response_received=lambda: attempt.mark(
+                PROVIDER_PHASE_TERMINAL_RECEIVED
+            ),
         )
 
     def _rebuild_anthropic_client(self) -> None:

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -80,7 +80,12 @@ def test_ttfb_kills_when_no_stream_event(tmp_path, monkeypatch):
 
     stop = {"flag": False}
 
-    def fake_hang(api_kwargs, client=None, on_first_delta=None):
+    def fake_hang(
+        api_kwargs,
+        client=None,
+        on_first_delta=None,
+        attempt=None,
+    ):
         # Never set _codex_stream_last_event_ts: simulate zero events arriving.
         deadline = time.time() + 30
         while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
@@ -128,7 +133,12 @@ def test_ttfb_default_tolerates_slow_first_event(tmp_path, monkeypatch):
 
     sentinel = SimpleNamespace(ok=True)
 
-    def fake_slow_first_event(api_kwargs, client=None, on_first_delta=None):
+    def fake_slow_first_event(
+        api_kwargs,
+        client=None,
+        on_first_delta=None,
+        attempt=None,
+    ):
         # Backend is alive but slow to admit: first event lands after ~2s,
         # well under the 120s default cutoff. Mark the first byte so the
         # no-byte detector sees activity, then return the response.
@@ -168,7 +178,12 @@ def test_ttfb_includes_silent_hang_hint_for_gpt_5_5(tmp_path, monkeypatch):
 
     stop = {"flag": False}
 
-    def fake_hang(api_kwargs, client=None, on_first_delta=None):
+    def fake_hang(
+        api_kwargs,
+        client=None,
+        on_first_delta=None,
+        attempt=None,
+    ):
         deadline = time.time() + 30
         while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
             time.sleep(0.02)
@@ -213,7 +228,12 @@ def test_ttfb_high_env_is_capped_for_openai_codex(tmp_path, monkeypatch):
 
     stop = {"flag": False}
 
-    def fake_hang(api_kwargs, client=None, on_first_delta=None):
+    def fake_hang(
+        api_kwargs,
+        client=None,
+        on_first_delta=None,
+        attempt=None,
+    ):
         deadline = time.time() + 30
         while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
             time.sleep(0.02)
@@ -255,7 +275,12 @@ def test_ttfb_does_not_kill_when_events_flow(tmp_path, monkeypatch):
 
     sentinel = SimpleNamespace(ok=True)
 
-    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+    def fake_stream(
+        api_kwargs,
+        client=None,
+        on_first_delta=None,
+        attempt=None,
+    ):
         # Bytes flowing: mark stream activity right away, then keep generating
         # past the 1s TTFB cutoff before returning a real response.
         agent._codex_stream_last_event_ts = time.time()
@@ -297,7 +322,12 @@ def test_event_idle_kills_after_first_event_then_silence(tmp_path, monkeypatch):
 
     stop = {"flag": False}
 
-    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+    def fake_stream(
+        api_kwargs,
+        client=None,
+        on_first_delta=None,
+        attempt=None,
+    ):
         agent._codex_stream_last_event_ts = time.time()
         deadline = time.time() + 30
         while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
@@ -539,7 +569,12 @@ def test_ttfb_disabled_via_env_zero(tmp_path, monkeypatch):
 
     sentinel = SimpleNamespace(ok=True)
 
-    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+    def fake_stream(
+        api_kwargs,
+        client=None,
+        on_first_delta=None,
+        attempt=None,
+    ):
         # No event marker, but only briefly — well under the 60s stale timeout.
         time.sleep(2.0)
         return sentinel
@@ -572,7 +607,12 @@ def test_large_codex_request_waits_instead_of_ttfb_reconnect(tmp_path, monkeypat
 
     sentinel = SimpleNamespace(ok=True)
 
-    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+    def fake_stream(
+        api_kwargs,
+        client=None,
+        on_first_delta=None,
+        attempt=None,
+    ):
         # No event marker for 2s: this would trip the 1s TTFB watchdog on a
         # small request, but should be allowed for a large request.
         time.sleep(2.0)
@@ -607,7 +647,12 @@ def test_large_codex_request_can_still_ttfb_reconnect_when_capped(tmp_path, monk
 
     stop = {"flag": False}
 
-    def fake_hang(api_kwargs, client=None, on_first_delta=None):
+    def fake_hang(
+        api_kwargs,
+        client=None,
+        on_first_delta=None,
+        attempt=None,
+    ):
         deadline = time.time() + 30
         while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
             time.sleep(0.02)
@@ -646,7 +691,12 @@ def test_large_codex_request_strict_ttfb_env_still_reconnects(tmp_path, monkeypa
 
     stop = {"flag": False}
 
-    def fake_hang(api_kwargs, client=None, on_first_delta=None):
+    def fake_hang(
+        api_kwargs,
+        client=None,
+        on_first_delta=None,
+        attempt=None,
+    ):
         deadline = time.time() + 30
         while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
             time.sleep(0.02)
@@ -694,7 +744,12 @@ def test_large_codex_request_hard_ceiling_reclaims_silent_stall(tmp_path, monkey
 
     stop = {"flag": False}
 
-    def fake_hang(api_kwargs, client=None, on_first_delta=None):
+    def fake_hang(
+        api_kwargs,
+        client=None,
+        on_first_delta=None,
+        attempt=None,
+    ):
         # No event marker AND no event ever: the exact issue-64507 stall.
         deadline = time.time() + 120
         while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
@@ -742,7 +797,12 @@ def test_large_codex_request_hard_ceiling_disabled_restores_legacy(tmp_path, mon
 
     sentinel = SimpleNamespace(ok=True)
 
-    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+    def fake_stream(
+        api_kwargs,
+        client=None,
+        on_first_delta=None,
+        attempt=None,
+    ):
         # No event, but only briefly — well under the (here 60s) stale timeout.
         time.sleep(2.0)
         return sentinel
@@ -784,7 +844,12 @@ def test_large_codex_request_hard_ceiling_caps_raised_stale_floor(tmp_path, monk
 
     stop = {"flag": False}
 
-    def fake_hang(api_kwargs, client=None, on_first_delta=None):
+    def fake_hang(
+        api_kwargs,
+        client=None,
+        on_first_delta=None,
+        attempt=None,
+    ):
         deadline = time.time() + 200
         while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
             time.sleep(0.02)

--- a/tests/run_agent/test_post_response_retry_boundary.py
+++ b/tests/run_agent/test_post_response_retry_boundary.py
@@ -1,0 +1,496 @@
+"""Post-response retry boundary regressions (non-streaming transports).
+
+Once the provider has returned a terminal response, any Hermes-local
+processing error must stop the turn through the unified finalizer with
+turn_exit_reason="local_post_response_error" — never another model request,
+no continuation, no length stub. Network/transport failures BEFORE the
+terminal response keep their baseline retry classification.
+
+Boundary flags live at the raw provider call in every dispatch branch; the
+tests use the real AIAgent.run_conversation entry and assert the actual
+provider wire call count.
+"""
+
+from __future__ import annotations
+
+import copy
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+import run_agent
+
+
+def _ns_response(text="ok"):
+    msg = SimpleNamespace(content=text, tool_calls=None)
+    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _ns_agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = run_agent.AIAgent(
+            api_key="test-key",
+            base_url="https://provider.invalid/v1",
+            provider="custom",
+            quiet_mode=True,
+            max_iterations=4,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._cached_system_prompt = "system"
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent._disable_streaming = True
+    agent.client = MagicMock()
+    return agent
+
+
+def _ns_run(agent):
+    with (
+        patch("run_agent.jittered_backoff", return_value=0),
+        patch("time.sleep", return_value=None),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        return agent.run_conversation("ping")
+
+
+def test_chat_raw_return_then_wrapper_local_failure_calls_provider_once():
+    agent = _ns_agent()
+    create = agent.client.chat.completions.create
+    create.return_value = _ns_response("visible")
+
+    with patch(
+        "agent.chat_completion_helpers._reset_stale_streak",
+        side_effect=RuntimeError("post-return local state"),
+    ):
+        result = _ns_run(agent)
+
+    assert create.call_count == 1
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["turn_exit_reason"] == "local_post_response_error"
+    assert result["final_response"]
+
+
+def test_network_error_before_raw_response_still_retries():
+    agent = _ns_agent()
+    create = agent.client.chat.completions.create
+    create.side_effect = [ConnectionError("wire down"), _ns_response("recovered")]
+
+    result = _ns_run(agent)
+
+    assert create.call_count == 2
+    assert result["failed"] is False
+    assert result["completed"] is True
+    assert result["final_response"] == "recovered"
+
+
+def test_bedrock_raw_return_then_local_normalization_failure_calls_once(monkeypatch):
+    agent = _ns_agent()
+    agent.api_mode = "bedrock_converse"
+    agent.provider = "bedrock"
+
+    client = MagicMock()
+    client.converse.return_value = {"output": {"message": {"content": []}}}
+
+    monkeypatch.setattr(
+        "agent.bedrock_adapter._get_bedrock_runtime_client",
+        lambda _region: client,
+    )
+    monkeypatch.setattr(
+        "agent.bedrock_adapter.normalize_converse_response",
+        lambda _raw: (_ for _ in ()).throw(KeyError("local normalization")),
+    )
+    monkeypatch.setattr(
+        agent,
+        "_build_api_kwargs",
+        lambda _messages: {
+            "__bedrock_region__": "us-east-1",
+            "__bedrock_converse__": True,
+        },
+    )
+
+    result = _ns_run(agent)
+
+    assert client.converse.call_count == 1
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["turn_exit_reason"] == "local_post_response_error"
+
+
+def _tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": "test tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _tool_call(name: str, call_id: str = "call-structured-content-1"):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments="{}"),
+    )
+
+
+def _response(content, *, finish_reason: str = "stop", tool_calls=None):
+    message = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=message, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _make_agent(*tool_names: str, interim_callback=None) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            model="test-model",
+            api_key="test-key-not-a-secret",
+            base_url="https://test.invalid/v1",
+            provider="custom",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            interim_assistant_callback=interim_callback,
+        )
+    agent._cached_system_prompt = "You are a test double."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent.valid_tool_names = set(tool_names)
+    agent.max_iterations = 4
+    return agent
+
+
+def _run(agent: AIAgent, request, *, extra_patches=()):
+    with ExitStack() as stack:
+        stack.enter_context(patch.object(agent, "_interruptible_api_call", request))
+        save = stack.enter_context(patch.object(agent, "_save_trajectory"))
+        cleanup = stack.enter_context(patch.object(agent, "_cleanup_task_resources"))
+        persist = stack.enter_context(patch.object(agent, "_persist_session"))
+        for extra_patch in extra_patches:
+            stack.enter_context(extra_patch)
+        result = agent.run_conversation("structured content regression")
+    return result, save, cleanup, persist
+
+
+class _TextPart:
+    type = "output_text"
+    text = "object text"
+
+
+class _TextPartWithExplosiveLegacyContent:
+    type = "output_text"
+    text = "safe object text"
+
+    @property
+    def content(self):
+        raise RuntimeError("legacy content must not be read")
+
+
+class _Opaque:
+    def __str__(self) -> str:
+        return "MUST_NOT_LEAK"
+
+
+class _ExplosiveContentObject:
+    @property
+    def type(self):
+        raise RuntimeError("must be ignored")
+
+
+
+
+@pytest.mark.parametrize(
+    "exc_type",
+    [TypeError, AttributeError, ValueError, KeyError, IndexError, RuntimeError],
+)
+def test_final_materialization_local_errors_stop_after_one_request(exc_type):
+    agent = _make_agent()
+    agent._stream_callback = MagicMock()
+    request = MagicMock(return_value=_response("done"))
+    result, save, cleanup, persist = _run(
+        agent,
+        request,
+        extra_patches=(
+            patch.object(agent, "_build_assistant_message", side_effect=exc_type("injected")),
+        ),
+    )
+
+    assert request.call_count == 1
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == "local_post_response_error"
+    assert result["final_response"]
+    assert result["messages"][-1]["role"] == "assistant"
+    assert save.call_count == cleanup.call_count == 1
+    assert persist.call_count >= 1
+    assert agent._stream_callback is None
+
+
+def test_length_path_local_runtime_error_stops_after_one_request():
+    agent = _make_agent()
+    request = MagicMock(
+        return_value=_response(
+            [{"type": "output_text", "text": "partial"}],
+            finish_reason="length",
+        )
+    )
+    result, _, cleanup, persist = _run(
+        agent,
+        request,
+        extra_patches=(
+            patch.object(agent, "_build_assistant_message", side_effect=RuntimeError("injected")),
+        ),
+    )
+
+    assert request.call_count == 1
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == "local_post_response_error"
+    assert cleanup.call_count == 1
+    assert persist.call_count >= 1
+
+
+def test_early_normalization_runtime_error_stops_after_one_request():
+    agent = _make_agent()
+    request = MagicMock(return_value=_response("done"))
+    result, _, cleanup, persist = _run(
+        agent,
+        request,
+        extra_patches=(
+            patch(
+                "agent.chat_completion_helpers.flatten_message_text",
+                side_effect=RuntimeError("normalization injected"),
+            ),
+        ),
+    )
+
+    assert request.call_count == 1
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == "local_post_response_error"
+    assert cleanup.call_count == 1
+    assert persist.call_count >= 1
+
+
+@pytest.mark.parametrize("interim_enabled", [False, True])
+def test_normal_tool_then_final_text_path_remains_reachable(interim_enabled):
+    callback = MagicMock() if interim_enabled else None
+    agent = _make_agent("review_tool", interim_callback=callback)
+    request = MagicMock(
+        side_effect=[
+            _response(
+                "working",
+                finish_reason="tool_calls",
+                tool_calls=[_tool_call("review_tool")],
+            ),
+            _response("finished"),
+        ]
+    )
+    with patch("run_agent.handle_function_call", return_value="ok") as tool:
+        result, _, cleanup, persist = _run(agent, request)
+
+    assert request.call_count == 2
+    assert tool.call_count == 1
+    assert result["final_response"] == "finished"
+    assert result["completed"] is True
+    assert result["failed"] is False
+    assert result["turn_exit_reason"] == "text_response(finish_reason=stop)"
+    if interim_enabled:
+        callback.assert_called()
+    assert cleanup.call_count == 1
+    assert persist.call_count >= 1
+
+
+def test_tool_materialization_runtime_error_stops_without_executing_tool():
+    agent = _make_agent("review_tool")
+    request = MagicMock(
+        return_value=_response(
+            "working",
+            finish_reason="tool_calls",
+            tool_calls=[_tool_call("review_tool")],
+        )
+    )
+    with patch("run_agent.handle_function_call") as tool:
+        result, _, cleanup, persist = _run(
+            agent,
+            request,
+            extra_patches=(
+                patch.object(
+                    agent,
+                    "_build_assistant_message",
+                    side_effect=RuntimeError("tool materialization injected"),
+                ),
+            ),
+        )
+
+    assert request.call_count == 1
+    assert tool.call_count == 0
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == "local_post_response_error"
+    assert cleanup.call_count == 1
+    assert persist.call_count >= 1
+
+
+def test_response_side_middleware_error_stops_after_one_provider_request():
+    agent = _make_agent()
+    request = MagicMock(return_value=_response("done"))
+
+    def response_side_failure(api_kwargs, call_provider, **_kwargs):
+        call_provider(api_kwargs)
+        raise RuntimeError("response middleware injected")
+
+    result, _, cleanup, persist = _run(
+        agent,
+        request,
+        extra_patches=(
+            patch(
+                "hermes_cli.middleware.run_llm_execution_middleware",
+                side_effect=response_side_failure,
+            ),
+        ),
+    )
+
+    assert request.call_count == 1
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == "local_post_response_error"
+    assert cleanup.call_count == 1
+    assert persist.call_count >= 1
+
+
+@pytest.mark.parametrize("interim_enabled", [False, True])
+def test_interim_visible_text_local_error_stops_after_one_request(interim_enabled):
+    callback = MagicMock() if interim_enabled else None
+    agent = _make_agent("review_tool", interim_callback=callback)
+    request = MagicMock(
+        return_value=_response(
+            "working",
+            finish_reason="tool_calls",
+            tool_calls=[_tool_call("review_tool")],
+        )
+    )
+    with patch("run_agent.handle_function_call") as tool:
+        result, _, cleanup, persist = _run(
+            agent,
+            request,
+            extra_patches=(
+                patch.object(
+                    agent,
+                    "_interim_assistant_visible_text",
+                    side_effect=RuntimeError("interim injected"),
+                ),
+            ),
+        )
+
+    assert request.call_count == 1
+    assert tool.call_count == 0
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == "local_post_response_error"
+    assert cleanup.call_count == 1
+    assert persist.call_count >= 1
+
+
+def test_network_error_then_success_still_retries_provider():
+    agent = _make_agent()
+    request = MagicMock(side_effect=[ConnectionError("transient"), _response("recovered")])
+    result, _, _, _ = _run(
+        agent,
+        request,
+        extra_patches=(
+            patch("agent.conversation_loop.jittered_backoff", return_value=0),
+            patch("agent.conversation_loop.time.sleep"),
+        ),
+    )
+
+    assert request.call_count == 2
+    assert result["final_response"] == "recovered"
+    assert result["completed"] is True
+    assert result["failed"] is False
+
+
+def test_persistent_network_error_honors_retry_limit():
+    agent = _make_agent()
+    agent._api_max_retries = 3
+    request = MagicMock(side_effect=ConnectionError("persistent"))
+    result, _, _, _ = _run(
+        agent,
+        request,
+        extra_patches=(
+            patch("agent.conversation_loop.jittered_backoff", return_value=0),
+            patch("agent.conversation_loop.time.sleep"),
+        ),
+    )
+
+    assert request.call_count == 3
+    assert result["completed"] is False
+    assert result["failed"] is True
+
+
+def test_local_error_after_final_row_keeps_transcript_and_result_aligned():
+    agent = _make_agent()
+    agent.quiet_mode = False
+    request = MagicMock(return_value=_response("model answer"))
+
+    def fail_after_final_append(message, *_args, **_kwargs):
+        if "Conversation completed" in str(message):
+            raise RuntimeError("display completion injected")
+
+    result, _, cleanup, persist = _run(
+        agent,
+        request,
+        extra_patches=(
+            patch.object(agent, "_safe_print", side_effect=fail_after_final_append),
+        ),
+    )
+
+    assert request.call_count == 1
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == "local_post_response_error"
+    assert result["messages"][-1]["role"] == "assistant"
+    assert result["messages"][-1]["content"] == result["final_response"]
+    assert result["messages"][-1].get("tool_calls") is None
+    assert cleanup.call_count == 1
+    assert persist.call_count >= 1
+
+
+def test_finalizer_cleanup_and_persist_failures_do_not_request_provider_again():
+    agent = _make_agent()
+    request = MagicMock(return_value=_response("done"))
+    with (
+        patch.object(agent, "_interruptible_api_call", request),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources", side_effect=RuntimeError("cleanup")),
+        patch.object(agent, "_persist_session", side_effect=RuntimeError("persist")),
+    ):
+        result = agent.run_conversation("cleanup failure regression")
+
+    assert request.call_count == 1
+    assert result["completed"] is True
+    assert result["failed"] is False
+    assert len(result.get("cleanup_errors", [])) == 2

--- a/tests/run_agent/test_post_response_retry_boundary.py
+++ b/tests/run_agent/test_post_response_retry_boundary.py
@@ -756,3 +756,30 @@ def test_partial_visible_text_preserved_after_terminal_local_failure():
     assert "post-terminal materialization failure" not in (result["final_response"] or "")
     for payload in _persisted_payloads(persist):
         assert _adjacent_assistant_pairs(payload) == []
+
+
+def test_non_local_provider_error_does_not_show_local_failure_note(capsys):
+    """Narrow regression: a retryable provider/transport error must keep its
+    original provider error display semantics and must NOT be reported as a
+    local response-processing failure (LOCAL_FAILURE_NOTE)."""
+    from agent.message_sanitization import LOCAL_FAILURE_NOTE
+
+    agent = _make_agent()
+    request = MagicMock(
+        side_effect=[
+            ConnectionError("wire down attempt 1"),
+            ConnectionError("wire down attempt 2"),
+            ConnectionError("wire down attempt 3"),
+        ]
+    )
+    result, _, _, _ = _run(agent, request)
+
+    out = capsys.readouterr().out
+    # Retry classification is unchanged: three attempts were made.
+    assert request.call_count == 3
+    # The provider error display keeps its original semantics...
+    assert "wire down" in out
+    # ...and is NEVER misreported as a local response-processing failure.
+    assert LOCAL_FAILURE_NOTE not in out
+    assert result.get("turn_exit_reason") != "local_post_response_error"
+    assert result.get("turn_exit_reason") != "local_post_response_error"

--- a/tests/run_agent/test_post_response_retry_boundary.py
+++ b/tests/run_agent/test_post_response_retry_boundary.py
@@ -494,3 +494,265 @@ def test_finalizer_cleanup_and_persist_failures_do_not_request_provider_again():
     assert result["completed"] is True
     assert result["failed"] is False
     assert len(result.get("cleanup_errors", [])) == 2
+
+
+# ── terminal local-failure hardening: role-safety + generic surfaces ─────────
+
+def _adjacent_assistant_pairs(messages):
+    roles = [m.get("role") for m in messages if isinstance(m, dict)]
+    return [(i, roles[i]) for i in range(1, len(roles))
+            if roles[i] == "assistant" and roles[i - 1] == "assistant"]
+
+
+def _dangling_tool_call_ids(messages):
+    answered = {
+        m.get("tool_call_id")
+        for m in messages
+        if isinstance(m, dict) and m.get("role") == "tool"
+    }
+    dangling = []
+    for m in messages:
+        if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls"):
+            for tc in m["tool_calls"]:
+                if tc.get("id") not in answered:
+                    dangling.append(tc.get("id"))
+    return dangling
+
+
+def _persisted_payloads(persist):
+    out = []
+    for call in persist.call_args_list:
+        payload = call.args[0] if call.args else []
+        out.append(payload)
+    return out
+
+
+def test_adjacent_assistant_never_persisted_after_terminal_local_failure():
+    """RED->GREEN: a local failure AFTER a plain assistant row was appended
+    must NOT produce assistant->assistant in the transcript. The fixed note
+    is merged into the existing row, preserving the delivered answer."""
+    agent = _make_agent()
+    agent.quiet_mode = False
+    request = MagicMock(return_value=_response("model answer"))
+
+    def fail_after_final_append(message, *_a, **_k):
+        if "Conversation completed" in str(message):
+            raise RuntimeError("display completion injected")
+
+    result, _, _, persist = _run(
+        agent,
+        request,
+        extra_patches=(
+            patch.object(agent, "_safe_print", side_effect=fail_after_final_append),
+        ),
+    )
+
+    assert request.call_count == 1
+    assert result["turn_exit_reason"] == "local_post_response_error"
+    # No adjacent assistant rows in the live transcript...
+    assert _adjacent_assistant_pairs(result["messages"]) == []
+    # ...and none in any persisted payload either.
+    for payload in _persisted_payloads(persist):
+        assert _adjacent_assistant_pairs(payload) == []
+    # The delivered answer is preserved, with the fixed note appended to the
+    # SAME row (no second assistant row).
+    tail = result["messages"][-1]
+    assert tail["role"] == "assistant"
+    assert tail["content"].startswith("model answer")
+    assert "local error" in tail["content"]
+    assert result["final_response"] == tail["content"]
+
+
+def test_local_failure_note_has_no_exception_details_inner_exit():
+    """Inner exit: RuntimeError text never reaches final_response,
+    transcript, or persisted payloads — but DOES stay in the logs."""
+    import io, logging
+
+    log_stream = io.StringIO()
+    handler = logging.StreamHandler(log_stream)
+    logging.getLogger().addHandler(handler)
+    try:
+        agent = _make_agent()
+        request = MagicMock(return_value=_response("done"))
+        result, _, _, persist = _run(
+            agent,
+            request,
+            extra_patches=(
+                patch.object(
+                    agent,
+                    "_build_assistant_message",
+                    side_effect=RuntimeError("sentinel-secret-XYZ"),
+                ),
+            ),
+        )
+    finally:
+        logging.getLogger().removeHandler(handler)
+
+    assert result["turn_exit_reason"] == "local_post_response_error"
+    assert "sentinel-secret-XYZ" not in (result["final_response"] or "")
+    assert "RuntimeError" not in (result["final_response"] or "")
+    for m in result["messages"]:
+        if isinstance(m.get("content"), str):
+            assert "sentinel-secret-XYZ" not in m["content"]
+    for payload in _persisted_payloads(persist):
+        for m in payload:
+            if isinstance(m.get("content"), str):
+                assert "sentinel-secret-XYZ" not in m["content"]
+    # The full exception stays in the logs.
+    assert "sentinel-secret-XYZ" in log_stream.getvalue()
+
+
+def test_local_failure_note_has_no_exception_details_outer_exit():
+    """Outer exit (display completion failure after final append): same
+    secrecy contract."""
+    agent = _make_agent()
+    agent.quiet_mode = False
+    request = MagicMock(return_value=_response("model answer"))
+
+    def fail_after_final_append(message, *_a, **_k):
+        if "Conversation completed" in str(message):
+            raise RuntimeError("sentinel-secret-XYZ")
+
+    result, _, _, persist = _run(
+        agent,
+        request,
+        extra_patches=(
+            patch.object(agent, "_safe_print", side_effect=fail_after_final_append),
+        ),
+    )
+
+    assert result["turn_exit_reason"] == "local_post_response_error"
+    assert "sentinel-secret-XYZ" not in (result["final_response"] or "")
+    assert "RuntimeError" not in (result["final_response"] or "")
+    for m in result["messages"]:
+        if isinstance(m.get("content"), str):
+            assert "sentinel-secret-XYZ" not in m["content"]
+    for payload in _persisted_payloads(persist):
+        for m in payload:
+            if isinstance(m.get("content"), str):
+                assert "sentinel-secret-XYZ" not in m["content"]
+
+
+def test_synthetic_tool_result_is_generic_when_tool_dispatch_fails():
+    """A post-append failure inside the tool dispatcher must synthesize
+    generic tool results (no exception text) and close every tool_call."""
+    agent = _make_agent("review_tool")
+    request = MagicMock(
+        return_value=_response(
+            "working",
+            finish_reason="tool_calls",
+            tool_calls=[_tool_call("review_tool")],
+        )
+    )
+    result, _, _, persist = _run(
+        agent,
+        request,
+        extra_patches=(
+            patch.object(
+                agent,
+                "_execute_tool_calls",
+                side_effect=RuntimeError("sentinel-secret-XYZ"),
+            ),
+        ),
+    )
+
+    assert result["turn_exit_reason"] == "local_post_response_error"
+    # Pairing invariant: every tool_call.id got a matching tool result.
+    assert _dangling_tool_call_ids(result["messages"]) == []
+    # Synthetic tool results carry the fixed generic note only.
+    tool_rows = [m for m in result["messages"] if m.get("role") == "tool"]
+    assert tool_rows, "expected a synthetic tool result"
+    for row in tool_rows:
+        assert "sentinel-secret-XYZ" not in row["content"]
+        assert "RuntimeError" not in row["content"]
+    # No adjacent assistants anywhere (live or persisted).
+    assert _adjacent_assistant_pairs(result["messages"]) == []
+    for payload in _persisted_payloads(persist):
+        assert _adjacent_assistant_pairs(payload) == []
+        for m in payload:
+            if isinstance(m.get("content"), str):
+                assert "sentinel-secret-XYZ" not in m["content"]
+
+
+
+
+def test_cli_visible_output_has_no_exception_details(capsys):
+    """The error line printed to the terminal must be generic."""
+    agent = _make_agent()
+    request = MagicMock(return_value=_response("done"))
+    result, _, _, _ = _run(
+        agent,
+        request,
+        extra_patches=(
+            patch.object(
+                agent,
+                "_build_assistant_message",
+                side_effect=RuntimeError("sentinel-secret-XYZ"),
+            ),
+        ),
+    )
+    out = capsys.readouterr().out
+    assert result["turn_exit_reason"] == "local_post_response_error"
+    assert "sentinel-secret-XYZ" not in out
+    assert "RuntimeError" not in out
+
+
+def test_partial_visible_text_preserved_after_terminal_local_failure():
+    """Text already delivered to the user stays in the transcript; the
+    failure is appended to the SAME row, and the provider is NOT called again."""
+    from types import SimpleNamespace as _SN
+
+    deltas = []
+
+    def _mk_chunk(text=None, finish=None, usage=None):
+        delta = _SN(content=text, reasoning_content=None, reasoning=None, tool_calls=None)
+        return _SN(choices=[_SN(delta=delta, finish_reason=finish)], model="m", usage=usage)
+
+    def _stream():
+        usage = _SN(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+        yield _mk_chunk("visible-part")
+        yield _mk_chunk("-tail", finish="stop", usage=usage)
+
+    class _FakeStreamClient:
+        def __init__(self):
+            self.calls = 0
+            self.chat = _SN(completions=_SN(create=self._create))
+
+        def _create(self, **kw):
+            self.calls += 1
+            return _stream()
+
+        def close(self):
+            pass
+
+    fake = _FakeStreamClient()
+    agent = _make_agent()
+    agent.quiet_mode = False
+    agent._disable_streaming = False
+    agent.stream_delta_callback = lambda text: deltas.append(text)
+    agent.client = fake
+
+    from contextlib import ExitStack as _ES
+    with _ES() as st:
+        st.enter_context(patch("run_agent.jittered_backoff", return_value=0))
+        st.enter_context(patch("time.sleep", return_value=None))
+        persist = st.enter_context(patch.object(agent, "_persist_session"))
+        st.enter_context(patch.object(agent, "_save_trajectory"))
+        st.enter_context(patch.object(agent, "_cleanup_task_resources"))
+        st.enter_context(patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake))
+        # Local failure strictly after the terminal frame.
+        st.enter_context(patch.object(
+            agent, "_build_assistant_message",
+            side_effect=RuntimeError("post-terminal materialization failure"),
+        ))
+        result = agent.run_conversation("visible partial probe")
+
+    assert fake.calls == 1
+    assert result["turn_exit_reason"] == "local_post_response_error"
+    # The streamed text the user saw is still delivered intact.
+    assert "".join(deltas) == "visible-part-tail"
+    # The failure note is present and generic.
+    assert "local error" in (result["final_response"] or "")
+    assert "post-terminal materialization failure" not in (result["final_response"] or "")
+    for payload in _persisted_payloads(persist):
+        assert _adjacent_assistant_pairs(payload) == []

--- a/tests/run_agent/test_provider_attempt_lifecycle.py
+++ b/tests/run_agent/test_provider_attempt_lifecycle.py
@@ -65,9 +65,9 @@ def _agent(fake):
     return agent
 
 
-def _response(text="ok"):
+def _response(text="ok", finish_reason="stop"):
     msg = SimpleNamespace(content=text, tool_calls=None)
-    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
     return SimpleNamespace(choices=[choice], model="test/model", usage=None)
 
 
@@ -339,3 +339,155 @@ def test_aux_anthropic_create_marks_only_detached_token():
     # The callback marked a DETACHED token; the loop's token is untouched.
     assert old_token.phase == cch.PROVIDER_PHASE_IN_FLIGHT
     assert agent._provider_attempt is old_token
+
+
+# ── merge-order independence: continuation / MoA / visible-text ─────────────
+
+def test_legal_length_continuation_uses_fresh_attempt_token():
+    """A legal finish_reason='length' continuation must start a NEW attempt
+    token rather than being choked by the previous attempt's terminal.
+
+    Sequence: response 1 is truncated (finish_reason='length'); response 2
+    completes it (finish_reason='stop'). Assert the full token contract:
+    the first attempt's token IS terminal (its response legitimately
+    completed), the continuation gets a DIFFERENT fresh token that did not
+    inherit terminal state, mutating the old token afterwards cannot
+    contaminate the new one, and the whole flow is continuation — not
+    retry, not fallback, not local_post_response_error.
+    """
+    tokens = []
+
+    real_new = cch._new_provider_attempt
+    def spy_new(agent):
+        tok = real_new(agent)
+        tokens.append(tok)
+        return tok
+
+    replies = [
+        _response("partial", finish_reason="length"),
+        _response("finished", finish_reason="stop"),
+    ]
+    create = MagicMock(side_effect=list(replies))
+
+    agent = _agent(MagicMock())
+    agent._disable_streaming = True
+    agent.client = MagicMock()
+    agent.client.chat.completions.create = create
+
+    with ExitStack() as st:
+        st.enter_context(patch("run_agent.jittered_backoff", return_value=0))
+        st.enter_context(patch("agent.conversation_loop.jittered_backoff", return_value=0))
+        st.enter_context(patch("agent.conversation_loop.time.sleep"))
+        st.enter_context(patch.object(agent, "_save_trajectory"))
+        st.enter_context(patch.object(agent, "_persist_session"))
+        st.enter_context(patch.object(agent, "_cleanup_task_resources"))
+        st.enter_context(patch.object(agent, "_create_request_openai_client", lambda *a, **k: agent.client))
+        st.enter_context(patch.object(cch, "_new_provider_attempt", spy_new))
+        result = agent.run_conversation("continuation probe")
+
+    assert create.call_count == 2
+    assert len(tokens) == 2
+    # First attempt legitimately reached terminal (its response DID return).
+    assert tokens[0].terminal_received
+    # The continuation is a DIFFERENT token object, not the same one reused.
+    assert tokens[1] is not tokens[0]
+    # The second token did not inherit the first's terminal state — it went
+    # through its own in_flight -> terminal lifecycle.
+    assert tokens[1].terminal_received
+    # Late writes to the OLD token cannot pollute the continuation's token:
+    # they are separate objects with separate phase state.
+    tokens[0].mark("in_flight")
+    assert tokens[1].terminal_received
+    # Legal continuation completed: no local_post_response_error anywhere.
+    assert result["completed"] is True
+    assert result["failed"] is False
+    assert result.get("turn_exit_reason") != LOCAL_REASON
+    # Baseline concatenation semantics: truncated fragment is prepended to
+    # the continuation text.
+    assert result["final_response"] == "partialfinished"
+
+
+def test_moa_post_terminal_local_failure_does_not_rerun_facade():
+    """MoA: once the facade's create() returns (all underlying fan-out calls
+    completed), a later Hermes-local failure must NOT re-execute the facade.
+
+    The failure is injected strictly AFTER the provider work — during local
+    usage accounting (consume_reference_usage) — never as a subcall/network
+    failure. Assert: the facade ran exactly once, no fallback, no
+    continuation, turn_exit_reason == local_post_response_error,
+    failed == True.
+    """
+    facade_create = MagicMock(return_value=_response("moa answer"))
+    agent = _agent(MagicMock())
+    agent.provider = "moa"
+    agent._disable_streaming = True
+    agent.client = MagicMock()
+    agent.client.chat.completions.create = facade_create
+
+    with ExitStack() as st:
+        st.enter_context(patch("run_agent.jittered_backoff", return_value=0))
+        st.enter_context(patch.object(agent, "_save_trajectory"))
+        st.enter_context(patch.object(agent, "_persist_session"))
+        st.enter_context(patch.object(agent, "_cleanup_task_resources"))
+        # MoA aggregation into the final assistant message fails AFTER the
+        # facade returned — strictly post-terminal Hermes-local processing
+        # (this is the failure that drives the turn outcome).
+        st.enter_context(patch.object(
+            agent, "_build_assistant_message",
+            side_effect=RuntimeError("moa local aggregation failure"),
+        ))
+        # The MoA usage-accounting call would also throw if reached — it is
+        # patched here to PROVE the facade is not invoked a second time to
+        # recover from post-terminal local work.
+        st.enter_context(patch.object(
+            agent.client,
+            "consume_reference_usage",
+            side_effect=RuntimeError("moa local usage accounting failure"),
+            create=True,
+        ))
+        result = agent.run_conversation("moa probe")
+
+    assert facade_create.call_count == 1
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["turn_exit_reason"] == LOCAL_REASON
+
+
+def test_post_terminal_local_error_after_visible_partial_text():
+    """Partial text already shown to the user + terminal received + later
+    local failure: the shown text must be preserved, a clear local-failure
+    message appended, and NO retry / fallback / continuation / length stub.
+    """
+    deltas = []
+    fake = _FakeStreamClient(lambda _n: iter([
+        _chunk("visible-part"),
+        _chunk("-tail", finish="stop", usage=SimpleNamespace(
+            prompt_tokens=1, completion_tokens=1, total_tokens=2)),
+    ]))
+    agent = _agent(fake)
+    agent.stream_delta_callback = lambda text: deltas.append(text)
+
+    with ExitStack() as st:
+        st.enter_context(patch("run_agent.jittered_backoff", return_value=0))
+        st.enter_context(patch.object(agent, "_save_trajectory"))
+        st.enter_context(patch.object(agent, "_persist_session"))
+        st.enter_context(patch.object(agent, "_cleanup_task_resources"))
+        st.enter_context(patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake))
+        # Local failure strictly after the terminal frame: final assistant
+        # message materialization throws.
+        st.enter_context(patch.object(
+            agent, "_build_assistant_message",
+            side_effect=RuntimeError("post-terminal materialization failure"),
+        ))
+        result = agent.run_conversation("visible partial probe")
+
+    # One wire call only — no retry, no continuation, no length stub.
+    assert fake.calls == 1
+    # The text the user already saw is intact.
+    assert "".join(deltas) == "visible-part-tail"
+    # The turn surfaces an explicit local-processing failure message.
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["turn_exit_reason"] == LOCAL_REASON
+    assert result["final_response"]
+    assert "error" in result["final_response"].lower()

--- a/tests/run_agent/test_provider_attempt_lifecycle.py
+++ b/tests/run_agent/test_provider_attempt_lifecycle.py
@@ -491,3 +491,98 @@ def test_post_terminal_local_error_after_visible_partial_text():
     assert result["turn_exit_reason"] == LOCAL_REASON
     assert result["final_response"]
     assert "error" in result["final_response"].lower()
+
+
+# ── #67923 × attempt lifecycle: partial-stub backstop × fresh continuation ──
+
+def test_partial_stub_backstop_terminal_does_not_poison_fresh_continuation():
+    """Cross-contract: attempt A's stream ends with NO finish_reason after a
+    text delta (#67923 text-only drop). The transport builds a
+    PARTIAL_STREAM_STUB_ID stub with finish_reason='length', and the
+    _perform_api_call backstop marks attempt A's token terminal_received.
+
+    That backstop mark must NOT poison the continuation: the length
+    continuation triggers normally, creates a BRAND NEW attempt B token,
+    B is NOT terminal before its own dispatch, and B completes the turn.
+
+    Asserts the full contract: call_count == 2, token A is not token B,
+    token A terminal, token B not-terminal pre-dispatch, completed, not
+    failed, no local_post_response_error, partial + continuation text
+    preserved exactly once, no LOCAL_FAILURE_NOTE, no adjacent assistant,
+    no dangling tool call.
+    """
+    from agent.message_sanitization import LOCAL_FAILURE_NOTE
+
+    tokens = []
+    real_new = cch._new_provider_attempt
+    def spy_new(agent):
+        tok = real_new(agent)
+        tokens.append(tok)
+        return tok
+
+    calls = {"n": 0}
+    def factory(n):
+        calls["n"] = n
+        if n == 1:
+            # Attempt A: text delta, then clean stream-end with NO
+            # finish_reason — the #67923 text-only drop path.
+            return iter([_chunk("partial")])
+        # Attempt B: normal completion.
+        usage = SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+        return iter([_chunk("finished", finish="stop", usage=usage)])
+
+    fake = _FakeStreamClient(factory)
+    agent = _agent(fake)
+
+    def _capture_dispatch(a, kw, *, make_client, attempt):
+        # Attempt B must NOT be terminal before its own dispatch.
+        if len(tokens) >= 2:
+            assert not tokens[1].terminal_received, (
+                "continuation attempt B inherited terminal state from stubbed A"
+            )
+        return real_dispatch(a, kw, make_client=make_client, attempt=attempt)
+
+    real_dispatch = cch._dispatch_nonstreaming_api_request
+
+    with ExitStack() as st:
+        st.enter_context(patch("run_agent.jittered_backoff", return_value=0))
+        st.enter_context(patch("agent.conversation_loop.jittered_backoff", return_value=0))
+        st.enter_context(patch("agent.conversation_loop.time.sleep"))
+        st.enter_context(patch.object(agent, "_save_trajectory"))
+        st.enter_context(patch.object(agent, "_persist_session"))
+        st.enter_context(patch.object(agent, "_cleanup_task_resources"))
+        st.enter_context(patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake))
+        st.enter_context(patch.object(cch, "_new_provider_attempt", spy_new))
+        st.enter_context(patch.object(cch, "_dispatch_nonstreaming_api_request", _capture_dispatch))
+        result = agent.run_conversation("stub continuation probe")
+
+    # Exact call contract: stub consumed A, continuation was B.
+    assert fake.calls == 2
+    assert calls["n"] == 2
+    assert len(tokens) == 2
+    assert tokens[0] is not tokens[1]
+    # A reached terminal via the wrapper backstop (stub returned a response).
+    assert tokens[0].terminal_received
+    # B went through its own in_flight -> terminal lifecycle.
+    assert tokens[1].terminal_received
+    # Turn completed through legal continuation — NOT a local failure.
+    assert result["completed"] is True
+    assert result["failed"] is False
+    assert result.get("turn_exit_reason") != LOCAL_REASON
+    # Partial + continuation text preserved, exactly once.
+    final = result["final_response"] or ""
+    assert "partial" in final and "finished" in final
+    assert final.count("partial") == 1
+    # No generic local-failure note, no adjacent assistants, no dangling tools.
+    assert LOCAL_FAILURE_NOTE not in final
+    msgs = result["messages"]
+    roles = [m.get("role") for m in msgs if isinstance(m, dict)]
+    assert not any(
+        roles[i] == "assistant" and roles[i - 1] == "assistant"
+        for i in range(1, len(roles))
+    )
+    answered = {m.get("tool_call_id") for m in msgs if isinstance(m, dict) and m.get("role") == "tool"}
+    for m in msgs:
+        if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls"):
+            for tc in m["tool_calls"]:
+                assert tc.get("id") in answered

--- a/tests/run_agent/test_provider_attempt_lifecycle.py
+++ b/tests/run_agent/test_provider_attempt_lifecycle.py
@@ -1,0 +1,341 @@
+"""Attempt-scoped provider lifecycle: stale-worker isolation + detached aux.
+
+Each real provider attempt owns a unique lifecycle token captured ONCE at the
+attempt's main entry. Transports, terminal callbacks and error classifiers
+operate only on the token they captured — a stale late worker from an older
+attempt can never flip the current attempt's phase, and auxiliary calls
+(memory/iteration-limit summaries) run on fresh detached tokens instead of
+inheriting the main loop's (possibly already terminal) token.
+
+Both races here are deterministic: attempt A is abandoned by the stale
+detector while its worker is still alive; attempt B must classify its own
+pre-terminal network error as retryable regardless of A's late terminal.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import agent.chat_completion_helpers as cch
+from run_agent import AIAgent
+
+LOCAL_REASON = "local_post_response_error"
+
+
+def _chunk(text=None, finish=None, usage=None):
+    delta = SimpleNamespace(content=text, reasoning_content=None, reasoning=None, tool_calls=None)
+    return SimpleNamespace(choices=[SimpleNamespace(delta=delta, finish_reason=finish)], model="m", usage=usage)
+
+
+class _FakeStreamClient:
+    def __init__(self, factory):
+        self.calls = 0
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
+        self._factory = factory
+
+    def _create(self, **kw):
+        self.calls += 1
+        return self._factory(self.calls)
+
+    def close(self):
+        pass
+
+
+def _agent(fake):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(model="m", api_key="k", base_url="https://x.invalid/v1",
+                        provider="custom", quiet_mode=False, skip_context_files=True,
+                        skip_memory=True)
+    agent._cached_system_prompt = "s"
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent.max_iterations = 4
+    agent._disable_streaming = False
+    agent.stream_delta_callback = lambda t: None
+    agent.client = fake
+    return agent
+
+
+def _response(text="ok"):
+    msg = SimpleNamespace(content=text, tool_calls=None)
+    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def test_stale_late_worker_cannot_flip_current_attempt():
+    """A stale attempt's LATE terminal report must not flip the CURRENT
+    attempt's phase. Non-streaming path, fully deterministic:
+
+    1. Attempt A's create blocks on a gate — its worker stays alive when the
+       main-side stale-call detector (0.2s) abandons the attempt.
+    2. Attempt B starts in-flight (new token), releases A's gate, waits until
+       A's late terminal mark has REALLY landed on A's token via the actual
+       ``_dispatch_nonstreaming_api_request`` code path, then hits a
+       pre-terminal network error.
+    3. B MUST retry normally (no local_post_response_error) and C succeeds.
+    """
+    gate_a = threading.Event()
+    tokens = []
+
+    real_new = cch._new_provider_attempt
+    def spy_new(agent):
+        tok = real_new(agent)
+        tokens.append(tok)
+        return tok
+
+    fake = MagicMock()
+
+    def create_side_effect(**_kw):
+        n = fake.client.chat.completions.create.call_count
+        if n == 1:
+            # Attempt A: block until B releases us — the worker outlives the
+            # stale kill, then returns normally so the dispatch helper marks
+            # terminal on the token IT captured (tokens[0]).
+            gate_a.wait(timeout=30)
+            return _response("a-late")
+        if n == 2:
+            # Attempt B is now in-flight. Let A's late terminal report land
+            # for real, then fail pre-terminal.
+            gate_a.set()
+            deadline = time.time() + 15
+            while not tokens[0].terminal_received:
+                if time.time() > deadline:
+                    raise AssertionError("A's late terminal mark never landed")
+                time.sleep(0.01)
+            raise ConnectionError("attempt B wire down before terminal")
+        # Attempt C: success.
+        return _response("final")
+
+    fake.client.chat.completions.create.side_effect = create_side_effect
+
+    agent = _agent(fake.client)
+    agent._disable_streaming = True
+    # Shrink the non-streaming stale-call timeout so attempt A is abandoned
+    # quickly while its worker stays blocked on the gate.
+    agent._compute_non_stream_stale_timeout = lambda _payload: 0.2
+
+    with ExitStack() as st:
+        st.enter_context(patch("run_agent.jittered_backoff", return_value=0))
+        st.enter_context(patch.object(agent, "_save_trajectory"))
+        st.enter_context(patch.object(agent, "_persist_session"))
+        st.enter_context(patch.object(agent, "_cleanup_task_resources"))
+        st.enter_context(patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake.client))
+        st.enter_context(patch.object(cch, "_new_provider_attempt", spy_new))
+        try:
+            result = agent.run_conversation("race probe")
+        finally:
+            gate_a.set()
+
+    # Three distinct attempts: A stale, B network error, C success.
+    assert len(tokens) == 3
+    assert tokens[0] is not tokens[1] and tokens[1] is not tokens[2]
+    # The late report landed on A's own token (allowed), never on B's.
+    assert tokens[0].terminal_received
+    assert not tokens[1].terminal_received, (
+        f"stale terminal write leaked into attempt B: {tokens[1].phase}"
+    )
+    # B retried normally: three wire calls, no local post-response error.
+    assert fake.client.chat.completions.create.call_count == 3
+    assert result["completed"] is True
+    assert result["final_response"] == "final"
+    assert result.get("turn_exit_reason") != LOCAL_REASON
+    # The loop's current attempt is C and reached terminal legitimately.
+    assert agent._provider_attempt is tokens[2]
+    assert tokens[2].terminal_received
+
+
+
+def test_worker_delayed_before_dispatch_captures_own_attempt():
+    """Delayed-worker regression. A non-streaming worker that is delayed
+    BEFORE entering ``_dispatch_nonstreaming_api_request`` must still mark
+    ITS OWN attempt token — never the newer attempt's.
+
+    Deterministic sequence:
+
+    1. Attempt A's worker starts but blocks at the dispatch door (gate) —
+       it is still parked there when the main-side stale-call detector
+       (0.2s) abandons the attempt and the loop creates attempt B.
+    2. B runs in-flight, releases A's gate, and waits until A's late
+       terminal mark has REALLY landed (via the real dispatch path).
+    3. Assert A's token is terminal and B's is NOT, then B hits a
+       pre-terminal ConnectionError, retries normally, and C succeeds.
+
+    With the old capture-at-dispatch code, A's delayed worker would re-read
+    agent._provider_attempt inside the dispatch helper, capture B's token,
+    and flip B terminal — B's network error would then be misclassified as
+    local_post_response_error and never retried.
+    """
+    gate_a = threading.Event()
+    tokens = []
+
+    real_new = cch._new_provider_attempt
+    def spy_new(agent):
+        tok = real_new(agent)
+        tokens.append(tok)
+        return tok
+
+    real_dispatch = cch._dispatch_nonstreaming_api_request
+    dispatch_calls = {"n": 0}
+    _tls = threading.local()
+    def gated_dispatch(agent, api_kwargs, *, make_client, attempt):
+        dispatch_calls["n"] += 1
+        ordinal = dispatch_calls["n"]
+        # Tag this thread so create_side_effect knows which ATTEMPT it is
+        # serving — A's worker is parked pre-dispatch, so the create call
+        # ORDER does not match the attempt order.
+        _tls.ordinal = ordinal
+        if ordinal == 1:
+            # Attempt A's worker parks HERE — before any provider I/O and
+            # before any attempt capture inside the dispatch helper.
+            gate_a.wait(timeout=30)
+        return real_dispatch(agent, api_kwargs, make_client=make_client, attempt=attempt)
+
+    fake = MagicMock()
+
+    def create_side_effect(**_kw):
+        ordinal = getattr(_tls, "ordinal", None)
+        if ordinal == 1:
+            # Attempt A (released by B below): returns normally so the real
+            # dispatch path marks terminal on the token it was HANDED at the
+            # attempt entry (tokens[0]).
+            return _response("a-late")
+        if ordinal == 2:
+            # Attempt B is now in-flight with its own token. Release A's
+            # parked worker and wait for A's late terminal mark to land.
+            gate_a.set()
+            deadline = time.time() + 15
+            while not tokens[0].terminal_received:
+                if time.time() > deadline:
+                    raise AssertionError("A's late terminal mark never landed")
+                time.sleep(0.01)
+            # A marked its own token; B's must still be untouched.
+            assert not tokens[1].terminal_received, (
+                f"stale pre-dispatch worker flipped attempt B: {tokens[1].phase}"
+            )
+            raise ConnectionError("attempt B wire down before terminal")
+        # Attempt C: success.
+        return _response("final")
+
+    fake.client.chat.completions.create.side_effect = create_side_effect
+
+    agent = _agent(fake.client)
+    agent._disable_streaming = True
+    agent._compute_non_stream_stale_timeout = lambda _payload: 0.2
+
+    with ExitStack() as st:
+        st.enter_context(patch("run_agent.jittered_backoff", return_value=0))
+        st.enter_context(patch.object(agent, "_save_trajectory"))
+        st.enter_context(patch.object(agent, "_persist_session"))
+        st.enter_context(patch.object(agent, "_cleanup_task_resources"))
+        st.enter_context(patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake.client))
+        st.enter_context(patch.object(cch, "_new_provider_attempt", spy_new))
+        st.enter_context(patch.object(cch, "_dispatch_nonstreaming_api_request", gated_dispatch))
+        try:
+            result = agent.run_conversation("race probe")
+        finally:
+            gate_a.set()
+
+    # Three distinct attempts: A stale (worker parked pre-dispatch), B
+    # pre-terminal network error, C success.
+    assert len(tokens) == 3
+    assert tokens[0] is not tokens[1] and tokens[1] is not tokens[2]
+    assert tokens[0].terminal_received
+    assert not tokens[1].terminal_received, (
+        f"stale terminal write leaked into attempt B: {tokens[1].phase}"
+    )
+    assert fake.client.chat.completions.create.call_count == 3
+    assert result["completed"] is True
+    assert result["final_response"] == "final"
+    assert result.get("turn_exit_reason") != LOCAL_REASON
+    assert agent._provider_attempt is tokens[2]
+    assert tokens[2].terminal_received
+
+
+
+def test_aux_codex_stream_keeps_internal_reconnect_and_does_not_touch_loop_token():
+    """An auxiliary Codex call (e.g. iteration-limit summary) invoked WITHOUT
+    an explicit attempt must run on a detached token:
+
+    - ``agent._provider_attempt`` holds an OLD, already-terminal main-loop
+      token;
+    - the auxiliary stream's FIRST connection dies pre-terminal
+      (ConnectionError) — the codex runtime's one internal reconnect must
+      still fire (wire create_calls == 2);
+    - the old loop token must be left completely untouched.
+    """
+    agent = _agent(MagicMock())
+
+    old_token = cch.ProviderAttemptLifecycle()
+    old_token.mark(cch.PROVIDER_PHASE_TERMINAL_RECEIVED)
+    agent._provider_attempt = old_token
+
+    terminal_event = SimpleNamespace(
+        type="response.completed",
+        response=SimpleNamespace(
+            status="completed", id="r1", model="m",
+            usage=None, incomplete_details=None, error=None,
+        ),
+    )
+
+    class _Stream:
+        def __init__(self, events):
+            self._events = events
+        def __iter__(self):
+            return iter(self._events)
+        def close(self):
+            pass
+
+    create = MagicMock(
+        side_effect=[
+            ConnectionError("aux stream wire down before terminal"),
+            _Stream([terminal_event]),
+        ]
+    )
+    client = SimpleNamespace(responses=SimpleNamespace(create=create), close=lambda: None)
+
+    result = agent._run_codex_stream({"model": "m"}, client=client, attempt=None)
+
+    # Internal reconnect preserved: first pre-terminal failure retried once.
+    assert create.call_count == 2
+    assert getattr(result, "status", "completed") == "completed"
+    # The old main-loop token was never adopted or mutated by the aux call.
+    assert agent._provider_attempt is old_token
+    assert old_token.phase == cch.PROVIDER_PHASE_TERMINAL_RECEIVED
+
+
+
+def test_aux_anthropic_create_marks_only_detached_token():
+    """``_anthropic_messages_create(..., attempt=None)`` (auxiliary path) must
+    fire ``on_response_received`` on a detached token, never on
+    ``agent._provider_attempt``."""
+    captured = {}
+
+    def fake_create_anthropic_message(client, api_kwargs, *, log_prefix="", prefer_stream=False, on_response_received=None):
+        captured["on_response_received"] = on_response_received
+        return SimpleNamespace(content=[SimpleNamespace(text="ok")], stop_reason="end_turn")
+
+    agent = _agent(MagicMock())
+    agent.api_mode = "anthropic_messages"
+    agent._anthropic_client = MagicMock()
+    agent._is_anthropic_oauth = False
+    old_token = cch.ProviderAttemptLifecycle()
+    agent._provider_attempt = old_token
+
+    with patch("agent.anthropic_adapter.create_anthropic_message", fake_create_anthropic_message):
+        agent._anthropic_messages_create({"model": "claude-test", "messages": []})
+
+    cb = captured.get("on_response_received")
+    assert callable(cb)
+    cb()  # simulate the provider terminal callback
+    # The callback marked a DETACHED token; the loop's token is untouched.
+    assert old_token.phase == cch.PROVIDER_PHASE_IN_FLIGHT
+    assert agent._provider_attempt is old_token

--- a/tests/run_agent/test_provider_lifecycle_paths.py
+++ b/tests/run_agent/test_provider_lifecycle_paths.py
@@ -1,0 +1,755 @@
+"""Provider-path terminal boundary tests — real provider identities and
+transport routing (no generic custom-provider substitutes).
+
+Covers: Codex Responses terminal-event boundary, Kimi Coding (anthropic
+messages) message_stop boundary, Kimi API / DeepSeek chat-completions
+finish_reason boundary, and auxiliary Codex/Anthropic calls running on
+detached attempt tokens. Terminal-after local error keeps wire call_count=1;
+pre-terminal network errors keep baseline retry/reconnect.
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import httpx
+import model_tools  # noqa: F401  (triggers plugin discovery)
+import pytest
+
+import run_agent
+from run_agent import AIAgent
+
+LOCAL_REASON = "local_post_response_error"
+
+
+# ── shared fakes ─────────────────────────────────────────────────────────────
+
+def _chunk(text=None, finish=None, usage=None):
+    delta = SimpleNamespace(
+        content=text, reasoning_content=None, reasoning=None, tool_calls=None
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(delta=delta, finish_reason=finish)],
+        model="test/model",
+        usage=usage,
+    )
+
+
+def _good_stream(text="hello"):
+    usage = SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+    return iter([_chunk(text[:2]), _chunk(text[2:], finish="stop", usage=usage)])
+
+
+def _response(content, *, finish_reason="stop", tool_calls=None, reasoning_content=None):
+    message = SimpleNamespace(
+        content=content, tool_calls=tool_calls, reasoning_content=reasoning_content
+    )
+    choice = SimpleNamespace(message=message, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _tool_call(name, call_id="call-provider-path-1"):
+    return SimpleNamespace(
+        id=call_id, type="function",
+        function=SimpleNamespace(name=name, arguments="{}"),
+    )
+
+
+def _tool_defs(*names):
+    return [
+        {"type": "function", "function": {"name": n, "description": "t", "parameters": {"type": "object", "properties": {}}}}
+        for n in names
+    ]
+
+
+class _FakeStreamClient:
+    def __init__(self, factory):
+        self.calls = 0
+        self.kwargs_seen = []
+        self._factory = factory
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
+
+    def _create(self, **kwargs):
+        self.calls += 1
+        self.kwargs_seen.append(kwargs)
+        return self._factory()
+
+    def close(self):
+        pass
+
+
+def _run(agent, extra_patches=(), prompt="provider path probe"):
+    with ExitStack() as stack:
+        stack.enter_context(patch("run_agent.jittered_backoff", return_value=0))
+        stack.enter_context(patch("time.sleep", return_value=None))
+        stack.enter_context(patch.object(agent, "_save_trajectory"))
+        stack.enter_context(patch.object(agent, "_cleanup_task_resources"))
+        stack.enter_context(patch.object(agent, "_persist_session"))
+        for extra in extra_patches:
+            stack.enter_context(extra)
+        return agent.run_conversation(prompt)
+
+
+# ── §A shared streaming terminal blocking ────────────────────────────────────
+
+def _shared_agent(fake, *, quiet=False):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            model="test-model", api_key="test-key-not-a-secret",
+            base_url="https://test.invalid/v1", provider="custom",
+            quiet_mode=quiet, skip_context_files=True, skip_memory=True,
+        )
+    agent._cached_system_prompt = "s"
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent.max_iterations = 4
+    agent._disable_streaming = quiet
+    if not quiet:
+        agent.stream_delta_callback = lambda t: None
+    agent.client = fake
+    return agent
+
+
+def test_a1_terminal_then_runtime_error_no_stub_no_continuation():
+    fake = _FakeStreamClient(lambda: _good_stream())
+    agent = _shared_agent(fake)
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+            patch(
+                "agent.chat_completion_helpers._reset_stale_streak",
+                side_effect=RuntimeError("post-terminal local failure"),
+            ),
+        ),
+    )
+    assert fake.calls == 1
+    assert result["api_calls"] == 1
+    assert result["turn_exit_reason"] == LOCAL_REASON
+    assert result["failed"] is True and result["completed"] is False
+    # no length-stub, no continuation user row
+    roles = [m.get("role") for m in result["messages"]]
+    assert roles.count("user") == 1
+
+
+def test_a2_terminal_then_network_typed_error_is_local():
+    def terminal_then_error():
+        yield _chunk("done", finish="stop")
+        raise httpx.ReadTimeout("network-typed error after terminal")
+
+    fake = _FakeStreamClient(terminal_then_error)
+    agent = _shared_agent(fake)
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+        ),
+    )
+    assert fake.calls == 1
+    assert result["api_calls"] == 1
+    assert result["turn_exit_reason"] == LOCAL_REASON
+
+
+def test_a3_pre_terminal_network_error_then_success_retries():
+    fake = _FakeStreamClient(lambda: _good_stream())
+    agent = _shared_agent(fake)
+    state = {"n": 0}
+
+    def flaky(**kwargs):
+        state["n"] += 1
+        if state["n"] == 1:
+            raise ConnectionError("wire down before terminal")
+        return _good_stream()
+
+    fake.chat.completions.create = flaky
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+        ),
+    )
+    assert state["n"] == 2
+    assert result["completed"] is True
+    assert result["final_response"] == "hello"
+
+
+def test_a4_interruption_stays_interruption():
+    fake = _FakeStreamClient(lambda: _good_stream())
+    agent = _shared_agent(fake)
+
+    def cancel(msg=""):
+        agent._interrupt_requested = True
+
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+            patch.object(agent, "_touch_activity", cancel),
+        ),
+    )
+    reason = str(result.get("turn_exit_reason", ""))
+    assert "interrupt" in reason.lower()
+    assert reason != LOCAL_REASON
+
+
+# ── Codex OAuth / Responses ─────────────────────────────────────────────────
+
+class _FakeCodexClient:
+    def __init__(self, events):
+        self.calls = 0
+        self.kwargs_seen = []
+        self._events = events
+        self.responses = SimpleNamespace(create=self._create)
+
+    def _create(self, **kwargs):
+        self.calls += 1
+        self.kwargs_seen.append(kwargs)
+        assert kwargs.get("stream") is True
+        return list(self._events)
+
+    def close(self):
+        pass
+
+
+def _codex_agent(fake):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs("terminal")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            model="gpt-5-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_key="codex-placeholder",
+            api_mode="codex_responses",
+            provider="openai-codex",
+            quiet_mode=True,
+            max_iterations=4,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._cached_system_prompt = "You are Hermes."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent.max_iterations = 4
+    agent.valid_tool_names = {"terminal"}
+    agent.client = fake
+    return agent
+
+
+def test_b1_codex_oauth_credentials_applied_to_runtime_client():
+    agent = _codex_agent(_FakeCodexClient([]))
+    # session already on singleton tokens (matches resolver output below)
+    agent.api_key = "fake-oauth-access-token"
+    oauth_out = {
+        "provider": "openai-codex",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "api_key": "fake-oauth-access-token",
+        "source": "hermes-auth-store",
+        "auth_mode": "chatgpt",
+        "last_refresh": 1784300000,
+    }
+    with patch(
+        "hermes_cli.auth.resolve_codex_runtime_credentials", return_value=oauth_out
+    ) as resolver:
+        ok = agent._try_refresh_codex_client_credentials(force=True)
+    assert ok is True
+    assert resolver.called
+    assert agent.api_key == "fake-oauth-access-token"
+    assert agent.base_url == "https://chatgpt.com/backend-api/codex"
+
+
+def test_b2_codex_responses_request_shape_and_final_text():
+    events = [
+        SimpleNamespace(type="response.output_text.delta", delta="hel"),
+        SimpleNamespace(type="response.output_text.delta", delta="lo"),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(
+                status="completed",
+                usage=SimpleNamespace(input_tokens=1, output_tokens=1, total_tokens=2),
+                id="r1",
+                incomplete_details=None,
+                error=None,
+            ),
+        ),
+    ]
+    fake = _FakeCodexClient(events)
+    agent = _codex_agent(fake)
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+        ),
+    )
+    assert fake.calls == 1
+    assert result["completed"] is True
+    assert result["final_response"] == "hello"
+    kw = fake.kwargs_seen[0]
+    assert kw["model"] == "gpt-5-codex"
+    assert isinstance(kw.get("instructions"), str) and kw["instructions"]
+    assert isinstance(kw.get("input"), list) and kw["input"]
+    assert kw.get("store") is False
+
+
+def test_b3_codex_reasoning_commentary_toolcall_no_regression():
+    commentary_item = SimpleNamespace(
+        type="message", phase="commentary", status="completed",
+        content=[SimpleNamespace(type="output_text", text="checking first")],
+    )
+    function_item = SimpleNamespace(
+        type="function_call", id="fc_1", call_id="call_1",
+        name="terminal", arguments="{}",
+    )
+    turn1 = [
+        SimpleNamespace(type="response.reasoning_text.delta", delta="private plan"),
+        SimpleNamespace(type="response.output_item.done", item=commentary_item),
+        SimpleNamespace(type="response.output_item.done", item=function_item),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(status="completed", usage=None, id="r1",
+                                     incomplete_details=None, error=None),
+        ),
+    ]
+    turn2 = [
+        SimpleNamespace(type="response.output_text.delta", delta="done"),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(status="completed", usage=None, id="r2",
+                                     incomplete_details=None, error=None),
+        ),
+    ]
+    streams = [turn1, turn2]
+    fake = _FakeCodexClient([])
+    fake._events = None
+
+    def _create(**kwargs):
+        fake.calls += 1
+        fake.kwargs_seen.append(kwargs)
+        return list(streams.pop(0))
+
+    fake.responses = SimpleNamespace(create=_create)
+    agent = _codex_agent(fake)
+    with patch("run_agent.handle_function_call", return_value="tool-out") as tool:
+        result = _run(
+            agent,
+            extra_patches=(
+                patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+            ),
+        )
+    assert tool.call_count == 1
+    assert fake.calls == 2
+    assert result["completed"] is True
+    assert result["final_response"] == "done"
+    # reasoning + commentary preserved on the transcript
+    assistant_rows = [m for m in result["messages"] if m.get("role") == "assistant"]
+    joined = str(assistant_rows)
+    assert "private plan" in joined or "checking first" in joined
+
+
+def test_b4_codex_terminal_then_local_error_once():
+    # Terminal response object whose fields raise locally when Hermes reads
+    # them AFTER the terminal event was observed (on_terminal already fired).
+    class _ExplodingTerminalResponse:
+        def __getattr__(self, name):
+            raise RuntimeError("post-terminal local failure")
+
+    events = [
+        SimpleNamespace(type="response.output_text.delta", delta="hel"),
+        SimpleNamespace(
+            type="response.incomplete",
+            response=_ExplodingTerminalResponse(),
+        ),
+    ]
+    fake = _FakeCodexClient(events)
+    agent = _codex_agent(fake)
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+        ),
+    )
+    assert fake.calls == 1
+    assert result["turn_exit_reason"] == LOCAL_REASON
+
+
+# ── Kimi Coding (api.kimi.com/coding, anthropic wire) ────────────────────────
+
+class _FakeAnthropicStream:
+    def __init__(self, events, final_message=None, final_error=None):
+        self._events = events
+        self._final_message = final_message
+        self._final_error = final_error
+        self.response = None
+
+    def __iter__(self):
+        return iter(self._events)
+
+    def get_final_message(self):
+        if self._final_error is not None:
+            raise self._final_error
+        return self._final_message
+
+
+class _FakeAnthropicCM:
+    def __init__(self, stream):
+        self._s = stream
+
+    def __enter__(self):
+        return self._s
+
+    def __exit__(self, *e):
+        return False
+
+
+def _kimi_coding_agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs("terminal")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            model="kimi-k2.7-code",
+            api_key="sk-kimi-test-not-real",
+            base_url="https://api.kimi.com/coding",
+            provider="kimi-coding",
+            api_mode="anthropic_messages",
+            quiet_mode=False,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._cached_system_prompt = "s"
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent.max_iterations = 4
+    agent.valid_tool_names = {"terminal"}
+    agent._disable_streaming = False
+    agent.stream_delta_callback = lambda t: None
+    return agent
+
+
+def test_b5_kimi_coding_key_prefix_routing_real_resolver():
+    from hermes_cli.auth import _resolve_kimi_base_url
+
+    assert _resolve_kimi_base_url("sk-kimi-abc", "https://api.moonshot.ai/v1", None) == "https://api.kimi.com/coding"
+    assert _resolve_kimi_base_url("sk-legacy", "https://api.moonshot.ai/v1", None) == "https://api.moonshot.ai/v1"
+    assert _resolve_kimi_base_url("sk-kimi-abc", "https://api.moonshot.ai/v1", "https://proxy.invalid/kimi") == "https://proxy.invalid/kimi"
+
+
+def test_b6_kimi_coding_anthropic_client_construction():
+    agent = _kimi_coding_agent()
+    agent._rebuild_anthropic_client()
+    client = agent._anthropic_client
+    assert client.api_key == "sk-kimi-test-not-real"
+    assert "api.kimi.com/coding" in str(client.base_url)
+    headers = getattr(client, "_custom_headers", {}) or {}
+    assert headers.get("User-Agent") == "claude-code/0.1.0"
+
+
+def _kimi_stream_events(with_tool=False):
+    events = [SimpleNamespace(type="message_start")]
+    if with_tool:
+        events += [
+            SimpleNamespace(
+                type="content_block_start",
+                content_block=SimpleNamespace(type="tool_use", id="t1", name="terminal"),
+            ),
+            SimpleNamespace(type="content_block_stop"),
+        ]
+    else:
+        events += [
+            SimpleNamespace(
+                type="content_block_delta",
+                delta=SimpleNamespace(type="text_delta", text="kimi says hi"),
+            ),
+        ]
+    events.append(SimpleNamespace(type="message_stop"))
+    return events
+
+
+def test_b7_kimi_coding_stream_turn_toolcall_and_final_text():
+    final = SimpleNamespace(
+        role="assistant",
+        content=[
+            SimpleNamespace(type="text", text="using tool"),
+            SimpleNamespace(type="tool_use", id="t1", name="terminal", input={}),
+        ],
+        stop_reason="tool_use",
+    )
+    calls = {"n": 0}
+    finals = [
+        final,
+        SimpleNamespace(
+            role="assistant",
+            content=[SimpleNamespace(type="text", text="kimi done")],
+            stop_reason="end_turn",
+        ),
+    ]
+
+    def fake_stream(**kwargs):
+        calls["n"] += 1
+        return _FakeAnthropicCM(
+            _FakeAnthropicStream(_kimi_stream_events(with_tool=calls["n"] == 1), finals.pop(0))
+        )
+
+    agent = _kimi_coding_agent()
+    agent._anthropic_client = SimpleNamespace(messages=SimpleNamespace(stream=fake_stream))
+    with patch("run_agent.handle_function_call", return_value="tool-out") as tool:
+        result = _run(
+            agent,
+            extra_patches=(
+                patch.object(agent, "_try_refresh_anthropic_client_credentials", lambda: None),
+                # #67142: per-request client factory
+                patch.object(
+                    agent,
+                    "_create_request_anthropic_client",
+                    lambda **_: agent._anthropic_client,
+                ),
+            ),
+        )
+    assert tool.call_count == 1
+    assert calls["n"] == 2
+    assert result["completed"] is True
+    assert result["final_response"] == "kimi done"
+
+
+def test_b8_kimi_coding_terminal_then_local_error_once():
+    calls = {"n": 0}
+
+    def fake_stream(**kwargs):
+        calls["n"] += 1
+        return _FakeAnthropicCM(
+            _FakeAnthropicStream(
+                _kimi_stream_events(),
+                final_error=RuntimeError("post-messageStop local failure"),
+            )
+        )
+
+    agent = _kimi_coding_agent()
+    agent._anthropic_client = SimpleNamespace(messages=SimpleNamespace(stream=fake_stream))
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_try_refresh_anthropic_client_credentials", lambda: None),
+            # #67142: per-request client factory
+            patch.object(
+                agent,
+                "_create_request_anthropic_client",
+                lambda **_: agent._anthropic_client,
+            ),
+        ),
+    )
+    assert calls["n"] == 1
+    assert result["turn_exit_reason"] == LOCAL_REASON
+
+
+# ── Kimi API (api.moonshot.ai/v1, chat_completions) ──────────────────────────
+
+def _kimi_api_agent(**overrides):
+    kwargs = dict(
+        model="kimi-k2-thinking",
+        api_key="sk-test-not-real",
+        base_url="https://api.moonshot.ai/v1",
+        provider="kimi-coding",
+        api_mode="chat_completions",
+        quiet_mode=False,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    kwargs.update(overrides)
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs("terminal")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(**kwargs)
+    agent._cached_system_prompt = "s"
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent.max_iterations = 4
+    agent.valid_tool_names = {"terminal"}
+    agent._disable_streaming = False
+    agent.stream_delta_callback = lambda t: None
+    return agent
+
+
+def test_b9_kimi_api_request_construction_and_reasoning_params():
+    fake = _FakeStreamClient(lambda: _good_stream())
+    agent = _kimi_api_agent()
+    agent.client = fake
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+        ),
+    )
+    assert result["completed"] is True
+    # endpoint + key as configured at the agent layer
+    assert agent.base_url == "https://api.moonshot.ai/v1"
+    assert agent.api_key == "sk-test-not-real"
+    # profile extras flow through the real kwargs builder
+    built = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+    assert built["model"] == "kimi-k2-thinking"
+    assert built.get("extra_body", {}).get("thinking") == {"type": "enabled"} or built.get("reasoning_effort")
+    # profile default UA header is registered on the provider profile
+    from providers import get_provider_profile
+
+    profile = get_provider_profile("kimi-coding")
+    assert profile.default_headers.get("User-Agent") == "hermes-agent/1.0"
+
+
+def test_b10_kimi_api_reasoning_toolcall_and_terminal_boundary():
+    seq = [
+        lambda: _response(
+            None,
+            tool_calls=[_tool_call("terminal")],
+            reasoning_content="kimi private reasoning",
+        ),
+        lambda: _response("kimi final"),
+    ]
+
+    def factory():
+        return seq.pop(0)()
+
+    fake = _FakeStreamClient(factory)
+    agent = _kimi_api_agent()
+    agent.client = fake
+    with patch("run_agent.handle_function_call", return_value="tool-out") as tool:
+        result = _run(
+            agent,
+            extra_patches=(
+                patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+            ),
+        )
+    assert tool.call_count == 1
+    assert fake.calls == 2
+    assert result["completed"] is True
+    assert result["final_response"] == "kimi final"
+    rows = str(result["messages"])
+    assert "kimi private reasoning" in rows
+
+
+def test_b11_kimi_api_terminal_then_local_error_once():
+    fake = _FakeStreamClient(lambda: _good_stream())
+    agent = _kimi_api_agent()
+    agent.client = fake
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+            patch(
+                "agent.chat_completion_helpers._reset_stale_streak",
+                side_effect=RuntimeError("post-terminal local failure"),
+            ),
+        ),
+    )
+    assert fake.calls == 1
+    assert result["turn_exit_reason"] == LOCAL_REASON
+
+
+# ── DeepSeek (api.deepseek.com, dedicated profile) ───────────────────────────
+
+def _deepseek_agent(model="deepseek-reasoner", **overrides):
+    kwargs = dict(
+        model=model,
+        api_key="sk-deepseek-test-not-real",
+        base_url="https://api.deepseek.com/v1",
+        provider="deepseek",
+        api_mode="chat_completions",
+        quiet_mode=False,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    kwargs.update(overrides)
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs("terminal")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(**kwargs)
+    agent._cached_system_prompt = "s"
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent.max_iterations = 4
+    agent.valid_tool_names = {"terminal"}
+    agent._disable_streaming = False
+    agent.stream_delta_callback = lambda t: None
+    return agent
+
+
+def test_b12_deepseek_profile_and_reasoning_params():
+    from providers import get_provider_profile
+
+    profile = get_provider_profile("deepseek")
+    assert profile.base_url == "https://api.deepseek.com/v1"
+    extra_body, top = profile.build_api_kwargs_extras(
+        reasoning_config={"effort": "high"}, model="deepseek-reasoner"
+    )
+    assert extra_body["thinking"] == {"type": "enabled"}
+    assert top["reasoning_effort"] == "high"
+    extra_body2, top2 = profile.build_api_kwargs_extras(model="deepseek-chat")
+    assert extra_body2 == {} and top2 == {}
+
+    agent = _deepseek_agent()
+    built = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+    assert built["model"] == "deepseek-reasoner"
+    assert built.get("extra_body", {}).get("thinking") == {"type": "enabled"}
+
+
+def test_b13_deepseek_reasoning_content_toolcall_and_final_text():
+    seq = [
+        lambda: _response(
+            None,
+            tool_calls=[_tool_call("terminal")],
+            reasoning_content="deepseek reasoning_content",
+        ),
+        lambda: _response("deepseek final"),
+    ]
+
+    def factory():
+        return seq.pop(0)()
+
+    fake = _FakeStreamClient(factory)
+    agent = _deepseek_agent()
+    agent.client = fake
+    with patch("run_agent.handle_function_call", return_value="tool-out") as tool:
+        result = _run(
+            agent,
+            extra_patches=(
+                patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+            ),
+        )
+    assert tool.call_count == 1
+    assert fake.calls == 2
+    assert result["completed"] is True
+    assert result["final_response"] == "deepseek final"
+    assert "deepseek reasoning_content" in str(result["messages"])
+
+
+def test_b14_deepseek_terminal_then_local_error_once():
+    fake = _FakeStreamClient(lambda: _good_stream())
+    agent = _deepseek_agent()
+    agent.client = fake
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+            patch(
+                "agent.chat_completion_helpers._reset_stale_streak",
+                side_effect=RuntimeError("post-terminal local failure"),
+            ),
+        ),
+    )
+    assert fake.calls == 1
+    assert result["turn_exit_reason"] == LOCAL_REASON

--- a/tests/run_agent/test_streaming_terminal_boundary.py
+++ b/tests/run_agent/test_streaming_terminal_boundary.py
@@ -1,0 +1,522 @@
+"""Streaming provider-response terminal boundary regressions.
+
+Once a streaming transport reaches its provider terminal (finish_reason /
+message_stop / terminal response event), every later failure is Hermes-local:
+no reconnect, no retry, no partial-stream "length" stub, no continuation —
+the turn ends via the unified finalizer. Pre-terminal network failures keep
+the baseline reconnect/retry behavior. Interruption semantics are unchanged.
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+import run_agent
+from run_agent import AIAgent
+
+LOCAL_REASON = "local_post_response_error"
+
+
+# ── chat_completions streaming fakes ─────────────────────────────────────────
+
+def _chunk(text=None, finish=None, usage=None):
+    delta = SimpleNamespace(
+        content=text, reasoning_content=None, reasoning=None, tool_calls=None
+    )
+    choice = SimpleNamespace(delta=delta, finish_reason=finish)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=usage)
+
+
+class _FakeStreamClient:
+    """Non-Mock fake: passes the production isinstance(client, Mock) guard."""
+
+    def __init__(self, stream_factory):
+        self.calls = 0
+        self._stream_factory = stream_factory
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
+
+    def _create(self, **kwargs):
+        self.calls += 1
+        return self._stream_factory()
+
+    def close(self):
+        pass
+
+
+def _good_stream():
+    usage = SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+    return iter([_chunk("he"), _chunk("llo", finish="stop", usage=usage)])
+
+
+# ── agent construction ───────────────────────────────────────────────────────
+
+def _make_agent(fake, *, api_mode="chat_completions", provider="custom") -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            model="test-model",
+            api_key="test-key-not-a-secret",
+            base_url="https://test.invalid/v1",
+            provider=provider,
+            api_mode=api_mode,
+            quiet_mode=False,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._cached_system_prompt = "You are a test double."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent.max_iterations = 4
+    agent._disable_streaming = False
+    agent.stream_delta_callback = lambda text: None
+    agent.client = fake
+    return agent
+
+
+def _run(agent, extra_patches=()):
+    with ExitStack() as stack:
+        stack.enter_context(patch("run_agent.jittered_backoff", return_value=0))
+        stack.enter_context(patch("time.sleep", return_value=None))
+        stack.enter_context(patch.object(agent, "_save_trajectory"))
+        stack.enter_context(patch.object(agent, "_cleanup_task_resources"))
+        stack.enter_context(patch.object(agent, "_persist_session"))
+        for extra in extra_patches:
+            stack.enter_context(extra)
+        return agent.run_conversation("streaming boundary probe")
+
+
+# ── chat_completions streaming ───────────────────────────────────────────────
+
+def test_chat_streaming_normal_completion_single_call():
+    fake = _FakeStreamClient(_good_stream)
+    agent = _make_agent(fake)
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+        ),
+    )
+    assert fake.calls == 1
+    assert result["completed"] is True
+    assert result["failed"] is False
+    assert result["final_response"] == "hello"
+
+
+def test_chat_streaming_post_terminal_local_error_calls_once():
+    """Local failure after the terminal frame (finish_reason) must not retry."""
+    fake = _FakeStreamClient(_good_stream)
+    agent = _make_agent(fake)
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+            # _reset_stale_streak runs on the streaming success path, after
+            # the terminal frame and final assembly — deterministic
+            # post-boundary local failure.
+            patch(
+                "agent.chat_completion_helpers._reset_stale_streak",
+                side_effect=RuntimeError("injected post-terminal local failure"),
+            ),
+        ),
+    )
+    assert fake.calls == 1
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == LOCAL_REASON
+    assert "API call failed" not in str(result["final_response"])
+
+
+def test_chat_streaming_terminal_then_network_typed_local_error_does_not_retry():
+    """Exception type must not override a position-proven terminal boundary."""
+
+    def terminal_then_error():
+        yield _chunk("done", finish="stop")
+        raise httpx.ReadTimeout("raised after terminal frame")
+
+    fake = _FakeStreamClient(terminal_then_error)
+    agent = _make_agent(fake)
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+        ),
+    )
+    assert fake.calls == 1
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == LOCAL_REASON
+
+
+def test_chat_streaming_mid_stream_transport_error_keeps_baseline_retry(monkeypatch):
+    """Pre-terminal transport failure: baseline retry behavior is preserved.
+
+    The baseline issues 6 raw calls for this shape (3 outer attempts x the
+    error classifier's within-attempt handling); the candidate must produce
+    the same count, not fewer and not more. See BASELINE_COMPARISON.md.
+    """
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+
+    def failing_stream():
+        yield _chunk(None)
+        raise httpx.ReadTimeout("simulated mid-stream transport timeout")
+
+    fake = _FakeStreamClient(failing_stream)
+    agent = _make_agent(fake)
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+        ),
+    )
+    assert fake.calls == 6  # == locked-baseline count for this scenario
+    assert result["failed"] is True
+    assert result.get("turn_exit_reason") != LOCAL_REASON
+
+
+def test_chat_streaming_mid_stream_local_error_keeps_baseline_retry(monkeypatch):
+    """ACCEPTED BOUNDARY SEMANTICS (see ARCHITECTURE_DECISION.md): a
+    Hermes-local failure BEFORE the terminal frame cannot be distinguished
+    from a transport failure without exception-type guessing, so it keeps
+    the baseline retry classification. This test pins that behavior so any
+    future boundary change is deliberate."""
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+    fake = _FakeStreamClient(_good_stream)
+    agent = _make_agent(fake)
+    real_touch = agent._touch_activity
+
+    def picky_touch(msg=""):
+        if msg == "receiving stream response":
+            raise RuntimeError("injected mid-stream local failure")
+        return real_touch(msg)
+
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+            patch.object(agent, "_touch_activity", picky_touch),
+        ),
+    )
+    assert fake.calls > 1  # baseline retry behavior, by design
+    assert result.get("turn_exit_reason") != LOCAL_REASON
+
+
+def test_chat_streaming_network_error_before_boundary_then_success():
+    fake = _FakeStreamClient(_good_stream)
+    agent = _make_agent(fake)
+    state = {"n": 0}
+
+    def flaky(**kwargs):
+        state["n"] += 1
+        if state["n"] == 1:
+            raise ConnectionError("wire down before stream established")
+        return _good_stream()
+
+    fake.chat.completions.create = flaky
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+        ),
+    )
+    assert state["n"] == 2
+    assert result["completed"] is True
+    assert result["final_response"] == "hello"
+
+
+def test_chat_streaming_empty_stream_stays_provider_anomaly(monkeypatch):
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+    fake = _FakeStreamClient(lambda: iter([]))
+    agent = _make_agent(fake)
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+        ),
+    )
+    # EmptyStreamError = provider anomaly without a terminal frame: must not
+    # be reported as a local post-response failure; provider-side retry
+    # classification is preserved.
+    assert fake.calls >= 2
+    assert result.get("turn_exit_reason") != LOCAL_REASON
+
+
+# ── Bedrock streaming ────────────────────────────────────────────────────────
+
+def _bedrock_stream_events():
+    return {
+        "stream": [
+            {"contentBlockDelta": {"delta": {"text": "he"}}},
+            {"messageStop": {"stopReason": "end_turn"}},
+            {"metadata": {"usage": {"inputTokens": 1, "outputTokens": 1}}},
+        ]
+    }
+
+
+class _BedrockTerminalThenLocalError:
+    def __iter__(self):
+        yield {"messageStop": {"stopReason": "end_turn"}}
+        raise RuntimeError("local event handling failed after messageStop")
+
+
+
+
+
+
+
+# ── Anthropic streaming ──────────────────────────────────────────────────────
+
+class _FakeAnthropicStream:
+    def __init__(self, events, final_message=None, final_error=None):
+        self._events = events
+        self._final_message = final_message
+        self._final_error = final_error
+        self.response = None
+
+    def __iter__(self):
+        return iter(self._events)
+
+    def get_final_message(self):
+        if self._final_error is not None:
+            raise self._final_error
+        return self._final_message
+
+
+class _AnthropicTerminalThenLocalError:
+    response = None
+
+    def __iter__(self):
+        yield SimpleNamespace(type="message_stop")
+        raise RuntimeError("local event handling failed after message_stop")
+
+    def get_final_message(self):
+        raise AssertionError("must not reach final assembly")
+
+
+class _NonIterableAnthropicStream:
+    response = None
+
+    def __init__(self, final_message):
+        self._final_message = final_message
+
+    def get_final_message(self):
+        return self._final_message
+
+
+def _anthropic_final_message(text="hello"):
+    return SimpleNamespace(
+        content=[SimpleNamespace(type="text", text=text)],
+        stop_reason="end_turn",
+        usage=SimpleNamespace(input_tokens=1, output_tokens=1),
+        model="test-model",
+    )
+
+
+class _FakeAnthropicStreamCM:
+    def __init__(self, stream):
+        self._stream = stream
+
+    def __enter__(self):
+        return self._stream
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _anthropic_events_with_stop():
+    return [
+        SimpleNamespace(type="message_start"),
+        SimpleNamespace(type="message_stop"),
+    ]
+
+
+def test_anthropic_streaming_post_messagestop_local_error_calls_once():
+    agent = _make_agent(None, api_mode="anthropic_messages", provider="custom")
+    stream_calls = {"n": 0}
+
+    def fake_stream(**kwargs):
+        stream_calls["n"] += 1
+        return _FakeAnthropicStreamCM(
+            _FakeAnthropicStream(
+                _anthropic_events_with_stop(),
+                final_error=RuntimeError("injected final-assembly local failure"),
+            )
+        )
+
+    agent._anthropic_client = SimpleNamespace(
+        messages=SimpleNamespace(stream=fake_stream)
+    )
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_try_refresh_anthropic_client_credentials", lambda: None),
+            # #67142: the streaming path builds a per-request client via this
+            # factory instead of using the shared _anthropic_client.
+            patch.object(
+                agent,
+                "_create_request_anthropic_client",
+                lambda **_: agent._anthropic_client,
+            ),
+        ),
+    )
+    assert stream_calls["n"] == 1
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == LOCAL_REASON
+    assert "API call failed" not in str(result["final_response"])
+
+
+
+
+def test_anthropic_terminal_event_marks_before_later_iterator_error():
+    agent = _make_agent(None, api_mode="anthropic_messages", provider="custom")
+    stream_calls = {"n": 0}
+
+    def fake_stream(**kwargs):
+        stream_calls["n"] += 1
+        return _FakeAnthropicStreamCM(_AnthropicTerminalThenLocalError())
+
+    agent._anthropic_client = SimpleNamespace(
+        messages=SimpleNamespace(stream=fake_stream)
+    )
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_try_refresh_anthropic_client_credentials", lambda: None),
+            # #67142: per-request client factory — see test above.
+            patch.object(
+                agent,
+                "_create_request_anthropic_client",
+                lambda **_: agent._anthropic_client,
+            ),
+        ),
+    )
+    assert stream_calls["n"] == 1
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == LOCAL_REASON
+
+
+
+
+
+
+# ── Codex Responses streaming ────────────────────────────────────────────────
+
+class _FakeCodexClient:
+    def __init__(self, events):
+        self.calls = 0
+        self._events = events
+        self.responses = SimpleNamespace(create=self._create)
+
+    def _create(self, **kwargs):
+        self.calls += 1
+        assert kwargs.get("stream") is True
+        return list(self._events)
+
+    def close(self):
+        pass
+
+
+def _codex_events_terminal(status="completed"):
+    return [
+        SimpleNamespace(type="response.output_text.delta", delta="hel"),
+        SimpleNamespace(type="response.output_text.delta", delta="lo"),
+        SimpleNamespace(
+            type=f"response.{status}",
+            response=SimpleNamespace(
+                status=status,
+                usage=SimpleNamespace(input_tokens=1, output_tokens=1, total_tokens=2),
+                id="resp-1",
+                incomplete_details=(
+                    SimpleNamespace(reason="max_output_tokens")
+                    if status == "incomplete"
+                    else None
+                ),
+                error=SimpleNamespace(message="boom") if status == "failed" else None,
+            ),
+        ),
+    ]
+
+
+class _ExplosiveCodexTerminalResponse:
+    status = "incomplete"
+    id = "resp-explosive"
+    incomplete_details = SimpleNamespace(reason="max_output_tokens")
+    error = None
+
+    @property
+    def usage(self):
+        raise RuntimeError("injected terminal-field local failure")
+
+
+def _codex_events_terminal_field_error():
+    return [
+        SimpleNamespace(type="response.output_text.delta", delta="partial"),
+        SimpleNamespace(
+            type="response.incomplete",
+            response=_ExplosiveCodexTerminalResponse(),
+        ),
+    ]
+
+
+def _make_codex_agent(fake):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            model="gpt-5-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_key="codex-token",
+            api_mode="codex_responses",
+            provider="openai-codex",
+            quiet_mode=True,
+            max_iterations=4,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._cached_system_prompt = "You are Hermes."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent.max_iterations = 4
+    agent.client = fake
+    return agent
+
+
+def test_codex_streaming_normal_completion_single_call():
+    fake = _FakeCodexClient(_codex_events_terminal("completed"))
+    agent = _make_codex_agent(fake)
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+        ),
+    )
+    assert fake.calls == 1
+    assert result["completed"] is True
+    assert result["final_response"] == "hello"
+
+
+def test_codex_streaming_post_terminal_local_error_calls_once():
+    """Terminal callback fires before local terminal-field materialization."""
+    fake = _FakeCodexClient(_codex_events_terminal_field_error())
+    agent = _make_codex_agent(fake)
+    result = _run(
+        agent,
+        extra_patches=(
+            patch.object(agent, "_create_request_openai_client", lambda *a, **k: fake),
+        ),
+    )
+    assert fake.calls == 1
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == LOCAL_REASON
+    assert "API call failed" not in str(result["final_response"])

--- a/tests/run_agent/test_wait_state_visibility.py
+++ b/tests/run_agent/test_wait_state_visibility.py
@@ -98,7 +98,7 @@ def test_nonstream_wait_loop_emits_explained_notice(tmp_path, monkeypatch):
 
     stop = {"flag": False}
 
-    def fake_hang(api_kwargs, client=None, on_first_delta=None):
+    def fake_hang(api_kwargs, client=None, on_first_delta=None, attempt=None):
         deadline = time.time() + 10
         while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
             time.sleep(0.02)


### PR DESCRIPTION
## Problem

Current main distinguishes "provider request failed" from "Hermes-local
post-processing failed" by inspecting traceback module names. That is not a
reliable source of lifecycle truth:

1. **Post-terminal local errors can re-request the model.** Once the
   provider has delivered a terminal response, a later local exception
   (aggregation, usage handling, normalization) can still be converted into
   a partial-stream `length` stub and trigger a continuation, or fall into
   provider retry/fallback — re-issuing an already-completed, billable
   request. Even an exception whose *type* looks like a network error (e.g.
   an iterator-tail `RemoteProtocolError`) is misclassified the same way.

2. **Shared lifecycle state has a cross-attempt race.** With phase stored on
   the agent, a stale-killed but still-alive worker can report its terminal
   late and contaminate a *newer* attempt's classification — and a worker
   delayed before its first dispatch can capture the newer attempt's
   identity entirely.

## Change

Make the lifecycle explicit and attempt-scoped:

- `ProviderAttemptLifecycle` token (`in_flight` → `terminal_received`) per
  real provider attempt, created by the conversation retry loop and held as
  a loop-local reference.
- Transports capture the token **once** at the attempt's main entry
  (`interruptible_api_call` / `direct_api_call` /
  `interruptible_streaming_api_call`, on the calling thread, before any
  worker starts) and pass it down through explicit parameters or bound
  closures: `_dispatch_nonstreaming_api_request(..., attempt=...)`,
  `_run_codex_stream(..., attempt=...)`,
  `_anthropic_messages_create(..., attempt=...)`,
  `on_terminal` / `on_response_received` callbacks, and the loop backstop.
  Nothing past worker start re-reads `agent._provider_attempt` for writer
  identity; that field remains only a current-state/diagnostic view.
- Auxiliary entry points invoked without an attempt (Codex iteration-limit
  summaries, Anthropic auxiliary calls) run on a **fresh detached token**,
  so they never inherit the main loop's terminal state and keep their own
  internal reconnect.
- Terminal boundary marks: non-streaming raw return on every dispatch
  branch; Chat `finish_reason`; Anthropic `message_stop` (including shim);
  Codex terminal response event.
- **After terminal**: no retry, no reconnect, no fallback, no continuation,
  no `length` partial stub — the turn ends through the unified finalizer as
  `local_post_response_error` with `failed=True` and the real `api_calls`.
- **Before terminal**: upstream retry/fallback behavior is unchanged. The
  traceback classifier remains only as pre-terminal defense-in-depth.
- Interruption semantics unchanged.

Scope: Chat Completions (streaming/non-streaming), Codex Responses,
Anthropic Messages (streaming/non-streaming, including the Kimi Coding
path), DeepSeek chat-completions, and the Bedrock **non-streaming**
raw-return boundary. **Bedrock streaming (converse_stream messageStop) is
explicitly out of scope.**

## Tests

New deterministic wire-seam suites (fake transports through the real
`AIAgent.run_conversation` entry, asserting actual provider call counts):

- `test_post_response_retry_boundary.py` — non-streaming: post-return local
  error `call_count=1` with `local_post_response_error`; pre-terminal
  network error `call_count=2` (retry preserved); Bedrock raw-return
  boundary.
- `test_streaming_terminal_boundary.py` — `finish_reason` / `message_stop` /
  terminal event then local failure: `call_count=1`, no stub, no
  continuation; pre-terminal reconnect preserved; interruption intact.
- `test_provider_lifecycle_paths.py` — real provider identities and
  transport routing: Codex Responses, Kimi Coding, Kimi API, DeepSeek, plus
  detached-token auxiliary calls (pre-terminal failure of an auxiliary
  stream still reconnects: `call_count=2`, and never touches the loop's
  token).
- `test_provider_attempt_lifecycle.py` — two deterministic stale-worker
  races: a worker alive past its stale-kill, and a worker delayed before
  dispatch; in both, the late terminal lands only on its own token and the
  current attempt's pre-terminal error still retries (`call_count=3`, no
  `local_post_response_error`).

Existing related suites (Codex Responses adapter, Kimi/DeepSeek thinking,
DeepSeek reasoning echo, #66267 multimodal) continue to pass.

No prompt, config, theme, provider-selection, or wire-format changes.

## Related defense: #67380

- #67380 removes the known structured-content projection failure.
- #67411 prevents any post-terminal local processing failure from reissuing
  an already completed provider request.
- The PRs are independently mergeable and merge-order independent.

Merge-order matrix:

| Order | Outcome |
| --- | --- |
| #67380 first | The known structured-content failure is removed; other post-terminal local errors may still be misclassified until #67411. |
| #67411 first | The observed post-response list-processing failure becomes one `local_post_response_error` with no repeated provider request; #67380 later removes the concrete projection root cause. |
| Both | The concrete content-shape root cause is removed AND the generic post-terminal lifecycle boundary is enforced. |

## Conscious non-goals / follow-ups

These boundaries are deliberately scoped out — identified and consciously
deferred, not omissions:

- A three-phase (pre-dispatch) lifecycle for local errors before the
  provider attempt starts is a separate design task, not this PR.
- Gateway / cron / kanban retryable or `failure_class` protocols are not
  part of this PR.
- No new telemetry/counter subsystem is introduced here.
- The Bedrock streaming (`converse_stream` messageStop) terminal boundary
  remains out of scope.

## Current-main validation

Rebased onto `e89bc58a5` (current main, includes merged #67923) and
revalidated:

- **Compatibility with merged #67923 verified**: a text-only stream that
  ends with no `finish_reason` still produces the shared
  `_build_partial_stream_stub()` stub (`finish_reason="length"`), the
  `_perform_api_call` backstop closes that attempt (terminal), and the
  legal continuation starts a FRESH attempt that is NOT terminal before
  its own dispatch. `call_count == 2`, tokens are distinct, partial and
  continuation text are preserved exactly once, and the turn completes.
- **Post-terminal real local failures still cannot** create a stub,
  retry, fallback, or continuation — `call_count == 1`, turn ends as
  `local_post_response_error` with `failed=True`.
- **Role-safe persistence and generic error surfaces remain intact**:
  no adjacent durable assistant rows, plain assistant tails keep their
  delivered text with the fixed note merged into the SAME row, every
  `tool_call.id` keeps its matching tool result, and exception details
  stay in logs only.
- **Non-local provider/transport errors keep their original provider
  error display** — they are never misreported as local
  response-processing failures; retry/fallback classification is
  unchanged.
- No equivalent attempt-scoped lifecycle exists on current main.

### Tests (final numbers, real `AIAgent.run_conversation` entries)

- Attempt-lifecycle suites (incl. the #67923 cross-contract and two
  deterministic stale-worker races): **51 passed**
- Post-response retry boundary (incl. no-adjacent-assistant invariant,
  tool_call/result pairing invariant, exception-secrecy, and non-local
  error display preservation): **28 passed**
- Codex watchdog / Responses / Anthropic / Kimi / DeepSeek / MoA /
  continuation / interruption related suites: **295 passed**
- ruff, compileall, `git diff --check`: clean
