### PR TITLE
fix(telegram): respect HERMES_TELEGRAM_DISABLE_FALLBACK_IPS for DoH discovery

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3117,7 +3117,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
             disable_fallback = (os.getenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "").strip().lower() in {"1", "true", "yes", "on"})
             fallback_ips = self._fallback_ips()
-            if not fallback_ips:
+            if not fallback_ips and not disable_fallback:
                 logger.warning("[%s] Discovering Telegram API fallback IPs via DNS-over-HTTPS…", self.name)
                 fallback_ips = await discover_fallback_ips()
                 logger.info(


### PR DESCRIPTION
## Problem

When `HERMES_TELEGRAM_DISABLE_FALLBACK_IPS=true` is set, the DNS-over-HTTPS fallback IP discovery still runs. On networks where Google/Cloudflare DoH is blocked, this hangs startup indefinitely because the discovery call never returns.

The env var currently only skips the IP-rewriting transport — it does not skip the DoH discovery call that feeds the transport.

## Fix

One-line change: add `and not disable_fallback` to the condition that gates the DoH discovery call.



This makes the env var do what it claims — disable the **entire** fallback mechanism, not just the transport.

## Test Plan

- [x] With `HERMES_TELEGRAM_DISABLE_FALLBACK_IPS=true` on a network where DoH is blocked, gateway connects successfully
- [x] Without the env var, existing behavior unchanged (DoH discovery runs as before)

## Related

A separate issue exists with `_await_with_thread_deadline` — the `threading.Timer`-based timeout fails to fire in some environments, causing `app.initialize()` to hang even after the DoH bypass. This PR doesn't address that; will file a follow-up issue.