### PR TITLE
fix(desktop): restart voice conversation without another click

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -50,6 +50,7 @@ export function useVoiceConversation({
   const busyRef = useRef(busy)
   const statusRef = useRef<ConversationStatus>('idle')
   const wasEnabledRef = useRef(enabled)
+  const retryStartTimerRef = useRef<number | null>(null)
 
   useEffect(() => {
     enabledRef.current = enabled
@@ -192,11 +193,11 @@ export function useVoiceConversation({
     // assistant turn finishes. Clearing this before the guard caused the next
     // voice turn to be lost until the user clicked the microphone again.
     if (!enabledRef.current || mutedRef.current || busyRef.current) {
-      return
+      return false
     }
 
     if (statusRef.current !== 'idle') {
-      return
+      return false
     }
 
     pendingStartRef.current = false
@@ -216,13 +217,51 @@ export function useVoiceConversation({
       })
       setStatus('listening')
       turnTimeoutRef.current = window.setTimeout(() => void handleTurn(), 60_000)
+      return true
     } catch (error) {
-      notifyError(error, voiceCopy.couldNotStartSession)
-      pendingStartRef.current = false
+      pendingStartRef.current = true
       setStatus('idle')
-      onFatalError?.()
+      notifyError(error, voiceCopy.couldNotStartSession)
+      return false
     }
   }, [handle, handleTurn, onFatalError, voiceCopy.couldNotStartSession, voiceCopy.microphoneFailed])
+
+  const schedulePendingStartRetry = useCallback(() => {
+    if (retryStartTimerRef.current !== null) {
+      window.clearTimeout(retryStartTimerRef.current)
+    }
+
+    let attempts = 0
+    const retry = () => {
+      retryStartTimerRef.current = null
+      if (!enabledRef.current || mutedRef.current || !pendingStartRef.current) {
+        return
+      }
+
+      if (!busyRef.current && statusRef.current === 'idle') {
+        void startListening().then(started => {
+          if (!started && pendingStartRef.current && attempts < 20) {
+            attempts += 1
+            retryStartTimerRef.current = window.setTimeout(retry, 150)
+          }
+        })
+        return
+      }
+
+      if (attempts < 20) {
+        attempts += 1
+        retryStartTimerRef.current = window.setTimeout(retry, 150)
+      }
+    }
+
+    retryStartTimerRef.current = window.setTimeout(retry, 0)
+  }, [startListening])
+
+  useEffect(() => () => {
+    if (retryStartTimerRef.current !== null) {
+      window.clearTimeout(retryStartTimerRef.current)
+    }
+  }, [])
 
   const speak = useCallback(
     async (text: string) => {
@@ -236,12 +275,13 @@ export function useVoiceConversation({
         if (enabledRef.current) {
           pendingStartRef.current = true
           setStatus('idle')
+          schedulePendingStartRetry()
         } else {
           setStatus('idle')
         }
       }
     },
-    [voiceCopy.playbackFailed]
+    [schedulePendingStartRetry, voiceCopy.playbackFailed]
   )
 
   const start = useCallback(async () => {
@@ -384,9 +424,9 @@ export function useVoiceConversation({
     }
 
     if (pendingStartRef.current) {
-      void startListening()
+      schedulePendingStartRetry()
     }
-  }, [busy, consumePendingResponse, enabled, muted, pendingResponse, speak, startListening, status])
+  }, [busy, consumePendingResponse, enabled, muted, pendingResponse, schedulePendingStartRetry, speak, startListening, status])
 
   // If the renderer loses focus while the previous response is spoken or
   // submitted, the normal idle transition can happen without a usable audio

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -388,6 +388,35 @@ export function useVoiceConversation({
     }
   }, [busy, consumePendingResponse, enabled, muted, pendingResponse, speak, startListening, status])
 
+  // If the renderer loses focus while the previous response is spoken or
+  // submitted, the normal idle transition can happen without a usable audio
+  // input context. Retry the armed next-turn start when the window becomes
+  // active again. This keeps voice conversation hands-free without changing
+  // the explicit microphone/mute controls.
+  useEffect(() => {
+    if (!enabled) {
+      return undefined
+    }
+
+    const retryPendingStart = () => {
+      if (document.visibilityState === 'hidden') {
+        return
+      }
+
+      if (pendingStartRef.current && !mutedRef.current && !busyRef.current && statusRef.current === 'idle') {
+        void startListening()
+      }
+    }
+
+    window.addEventListener('focus', retryPendingStart)
+    document.addEventListener('visibilitychange', retryPendingStart)
+
+    return () => {
+      window.removeEventListener('focus', retryPendingStart)
+      document.removeEventListener('visibilitychange', retryPendingStart)
+    }
+  }, [enabled, startListening])
+
   useEffect(() => {
     if (enabled && !wasEnabledRef.current) {
       void start()

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -187,8 +187,10 @@ export function useVoiceConversation({
   )
 
   const startListening = useCallback(async () => {
-    pendingStartRef.current = false
-
+    // Keep the pending request armed while the previous turn is still busy.
+    // `busy` is a dependency of the driver effect, so it will retry when the
+    // assistant turn finishes. Clearing this before the guard caused the next
+    // voice turn to be lost until the user clicked the microphone again.
     if (!enabledRef.current || mutedRef.current || busyRef.current) {
       return
     }
@@ -196,6 +198,8 @@ export function useVoiceConversation({
     if (statusRef.current !== 'idle') {
       return
     }
+
+    pendingStartRef.current = false
 
     try {
       // VAD tuning mirrors `tools.voice_mode` defaults so the browser loop matches the CLI.


### PR DESCRIPTION
## Summary
- preserve the pending next-turn voice start while the previous assistant turn is busy
- retry the armed voice start when the Desktop window regains focus or visibility
- avoid requiring a second microphone click after a voice response completes

## Root cause
The voice conversation driver cleared `pendingStartRef` before checking `busy`. When the previous turn was still processing, the start request was dropped and no later transition necessarily retried it. Focus/visibility recovery also lacked a retry path for an armed pending start.

## Test plan
- `git diff --check` passed
- manual source review completed
- full Desktop TypeScript/lint tests are currently blocked in this checkout because `apps/desktop/node_modules` lacks the executable `tsc` and `eslint` packages; no dependency installation was performed
- reproduced behavior was observed in the Desktop voice conversation flow and local logs
