### PR TITLE
fix(redact): add Google Gemini AQ. key prefix pattern to redactor

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -110,6 +110,7 @@ _PREFIX_PATTERNS = [
     r"fw-[A-Za-z0-9]{30,}",             # Fireworks AI API key
     r"fw_[A-Za-z0-9]{30,}",             # Fireworks AI API key
     r"fpk_[A-Za-z0-9]{30,}",            # Fireworks AI project key
+    r"AQ\.[A-Za-z0-9_-]{40,}",          # Google Gemini authorization keys
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name.

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -51,6 +51,10 @@ class TestKnownPrefixes:
         result = redact_sensitive_text("AIzaSyB-abc123def456ghi789jklmno012345")
         assert "abc123def456" not in result
 
+    def test_gemini_aq_api_key(self):
+        result = redact_sensitive_text("AQ.B1234567890123456789012345678901234567890123")
+        assert "B1234567890" not in result
+
     def test_perplexity_key(self):
         result = redact_sensitive_text("pplx-abcdef123456789012345")
         assert "abcdef12345" not in result


### PR DESCRIPTION
Fixes #66920.

### Problem
The secret redactor in  misses bare Google Gemini authorization keys that start with the newer  prefix. They only get scrubbed if they are labelled as  through the env assignment pattern. Unlabelled keys in logs, tool outputs, or tracebacks remain unredacted.

### Fix
- Appended the pattern  to  in  to match bare Gemini authorization keys.
- Added regression test  to .
- Verified test execution locally ().