### PR TITLE
fix(cron): re-check the per-profile gateway gate under the tick lock

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -494,6 +494,55 @@ def _profile_name_for_home(profile_home: Path) -> Optional[str]:
     return None
 
 
+def _parse_profile_selector_from_command(
+    command: str,
+) -> tuple[bool, Optional[str], Optional[str]]:
+    """Parse a gateway command line's explicit profile selection.
+
+    Returns ``(has_explicit_profile, profile_value, hermes_home_value)``:
+    ``profile_value`` is the value of ``--profile``/``-p`` (space or ``=`` form),
+    lower-cased; ``hermes_home_value`` is the value of an ``HERMES_HOME=`` token,
+    slash- and case-normalized. Tokenizes quote-aware (``shlex``) so callers can
+    match by EXACT argv token instead of substring — ``--profile work`` must not
+    be read as selecting profile ``worker`` (#66629 amend / Sol #2).
+
+    ``HERMES_HOME=`` is a best-effort signal only: the live command line is a
+    space-joined argv, so a HERMES_HOME path that itself contains spaces cannot
+    be recovered and yields only its first segment. A genuine owner then reads
+    as ``free`` (local dispatch, the fail-safe direction), never a false
+    ``held``. Profile scoping never relies on it when an explicit
+    ``--profile``/``-p`` is present.
+    """
+    try:
+        tokens = shlex.split(command, posix=False)
+    except ValueError:
+        tokens = command.split()
+    tokens = [t.strip("\"'") for t in tokens]
+
+    has_explicit_profile = False
+    profile_value: Optional[str] = None
+    hermes_home_value: Optional[str] = None
+
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        low = tok.lower()
+        if tok in ("--profile", "-p"):
+            has_explicit_profile = True
+            if i + 1 < len(tokens):
+                profile_value = tokens[i + 1].strip("\"'").lower()
+                i += 2
+                continue
+        elif low.startswith("--profile=") or low.startswith("-p="):
+            has_explicit_profile = True
+            profile_value = tok.split("=", 1)[1].strip("\"'").lower()
+        elif low.startswith("hermes_home="):
+            hermes_home_value = tok.split("=", 1)[1].strip("\"'").replace("\\", "/").lower()
+        i += 1
+
+    return has_explicit_profile, profile_value, hermes_home_value
+
+
 def _command_line_belongs_to_profile(command: str, profile_home: Path) -> bool:
     """Return True when a gateway command line belongs to ``profile_home``.
 
@@ -506,30 +555,39 @@ def _command_line_belongs_to_profile(command: str, profile_home: Path) -> bool:
     profile gateway carries ``-p <name>``/``--profile <name>`` (or, rarely, an
     explicit ``HERMES_HOME=<path>``) on its argv; the default/root gateway runs
     bare with no profile flag.
+
+    Matching is by EXACT argv token: the previous substring test let profile
+    ``work`` match a live ``--profile worker`` and (via a stale record whose
+    honest ``hermes_home`` still names ``work`` after PID reuse + a start-time
+    collision) report ``work`` running when only ``worker`` was live (#66629
+    amend / Sol #2).
     """
-    # Normalize separators before the substring match: on Windows,
-    # str(Path) renders backslashes while a HERMES_HOME= value on the argv
-    # may carry forward slashes (Git Bash, JSON configs) — and vice versa.
-    command_lc = command.lower().replace("\\", "/")
     profile_name = _profile_name_for_home(profile_home)
-    home_lc = str(profile_home).lower().replace("\\", "/")
+    home_norm = str(profile_home).replace("\\", "/").lower()
+    has_explicit_profile, profile_value, hermes_home_value = (
+        _parse_profile_selector_from_command(command)
+    )
 
     if profile_name is not None and profile_name != "default":
-        profile_lc = profile_name.lower()
-        return (
-            f"--profile {profile_lc}" in command_lc
-            or f"-p {profile_lc}" in command_lc
-            or f"hermes_home={home_lc}" in command_lc
-        )
+        if has_explicit_profile:
+            # An explicit --profile/-p selector is authoritative — Hermes'
+            # _apply_profile_override consumes it before argparse — so a
+            # HERMES_HOME= token on the SAME argv must not override it. A live
+            # `--profile worker` process is not this "work" profile even if its
+            # argv also carries HERMES_HOME=<work> (Sol #2, second pass).
+            return profile_value is not None and profile_value == profile_name.lower()
+        # No explicit selector: an explicit HERMES_HOME= token is the only
+        # profile evidence the argv can carry.
+        return hermes_home_value is not None and hermes_home_value == home_norm
 
     # Default/root profile: the gateway runs with no profile flag. Accept unless
     # the command advertises *some other* profile (an explicit -p/--profile) or
     # a non-matching explicit HERMES_HOME= on the argv. HERMES_HOME is usually
     # passed via the environment (not visible on the command line), so its mere
     # absence is not disqualifying — only a conflicting explicit value is.
-    if "--profile " in command_lc or " -p " in command_lc:
+    if has_explicit_profile:
         return False
-    if "hermes_home=" in command_lc and f"hermes_home={home_lc}" not in command_lc:
+    if hermes_home_value is not None and hermes_home_value != home_norm:
         return False
     return True
 
@@ -607,7 +665,9 @@ def _read_json_file(path: Path) -> Optional[dict[str, Any]]:
         return None
     try:
         payload = json.loads(raw)
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, RecursionError):
+        # RecursionError: a deeply-nested corrupt file overflows json's
+        # recursive decoder (a RuntimeError subclass, not JSONDecodeError).
         return None
     return payload if isinstance(payload, dict) else None
 
@@ -632,7 +692,11 @@ def _read_pid_record(pid_path: Optional[Path] = None) -> Optional[dict]:
 
     try:
         payload = json.loads(raw)
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, RecursionError):
+        # RecursionError: a deeply-nested corrupt record overflows json's
+        # recursive decoder. It is a RuntimeError subclass, not a
+        # JSONDecodeError, so callers guarding only OSError/JSONDecodeError
+        # would otherwise see it escape as a crash.
         try:
             return {"pid": int(raw)}
         except ValueError:
@@ -977,7 +1041,14 @@ def probe_gateway_runtime_lock(lock_path: Optional[Path] = None) -> str:
             return "free"
     except OSError:
         return "unknown"
-    record = _read_gateway_lock_record(resolved_lock_path)
+    try:
+        # _read_gateway_lock_record -> _read_pid_record does its OWN exists()
+        # check outside its own except, so a TOCTOU permission flip after the
+        # outer exists() above can still raise. Catch here so the probe's
+        # tri-state contract holds (Sol 4th finding 2).
+        record = _read_gateway_lock_record(resolved_lock_path)
+    except OSError:
+        return "unknown"
     if not record:
         # Empty / unparseable: a crashed mid-write, or the sub-millisecond
         # startup window. Fail open (documented 1x degraded-delivery residual).
@@ -987,16 +1058,52 @@ def probe_gateway_runtime_lock(lock_path: Optional[Path] = None) -> str:
         return "unknown"
     if not _pid_exists(pid):
         return "free"  # crash: OS released the lock, record is stale.
+    # Positive live-owner evidence (Sol 4th finding 1). Without every check
+    # below, a stale record whose PID has been recycled onto a live gateway on
+    # a DIFFERENT profile would answer "held" and stall this profile's desktop
+    # cron forever. Every leg must be positively established.
     recorded_start = record.get("start_time")
     live_start = _get_process_start_time(pid)
-    if (
-        recorded_start is not None
-        and live_start is not None
-        and recorded_start != live_start
-    ):
-        return "free"  # PID reused by an unrelated process.
-    if not _record_matches_live_gateway_pid(record, pid):
-        return "free"  # live PID, but not a gateway (foreign process using the same PID).
+    if recorded_start is None or live_start is None:
+        # Can't confirm identity from start_time (missing side). Fail open to
+        # unknown -> dispatch + warning; a desktop-only cron never stalls on
+        # an unverifiable record.
+        return "unknown"
+    if recorded_start != live_start:
+        return "free"  # PID reuse: same pid, different process.
+    # Same pid + start_time -> this live process IS the one that wrote the
+    # record. Profile identity now rests on the HERMES_HOME the record persisted
+    # about itself matching THIS lock's home (the lock lives directly under
+    # HERMES_HOME). Require positive, canonical home evidence: without it we do
+    # NOT fall through to the argv matcher, whose profile-name substring test
+    # (a profile named "work" matches a live "--profile worker") cannot by
+    # itself prove identity. A pre-fix or corrupt record that omits a usable
+    # home is indeterminate ownership, not proof of it. The matcher's own
+    # substring bug is a separate fix(status) follow-up; this probe simply
+    # never depends on it to scope a profile.
+    recorded_home = record.get("hermes_home")
+    if not isinstance(recorded_home, str) or not recorded_home.strip():
+        return "unknown"  # no usable home to prove profile identity -> fail open.
+    try:
+        probed_home = _canonical_hermes_home(resolved_lock_path.parent)
+        # Compare with the host's path + case semantics, not raw string
+        # equality: representations differing only in case (Windows) or
+        # normalization still name the same directory.
+        home_matches = _same_hermes_home(recorded_home, probed_home)
+    except (OSError, ValueError, TypeError, RuntimeError):
+        # Either side unresolvable: a bad HOME (RuntimeError from expanduser),
+        # non-path garbage that slipped past the str check (TypeError), or a
+        # transient FS error. Fail open to unknown so a desktop-only cron is
+        # never stalled on an unverifiable record.
+        return "unknown"
+    if not home_matches:
+        return "free"  # record belongs to a different HERMES_HOME.
+    # Home has proved profile identity. The live-cmdline match below is now
+    # defense-in-depth only: reached solely after an exact home match, it can
+    # withhold a "held" (fail-safe -> local dispatch) but can never manufacture
+    # one for the wrong profile.
+    if not _record_matches_live_gateway_pid(record, pid, expected_home=probed_home):
+        return "free"
     return "held"
 
 

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -12,6 +12,7 @@ concurrently under distinct configurations).
 """
 
 import copy
+import errno
 import hashlib
 import json
 import logging
@@ -944,6 +945,89 @@ def is_gateway_runtime_lock_active(lock_path: Optional[Path] = None) -> bool:
             _release_file_lock(handle)
             return False
         return True
+    finally:
+        try:
+            handle.close()
+        except OSError:
+            pass
+
+
+def _probe_file_lock(handle) -> str:
+    """Non-mutating, tri-state probe of an already-open lock handle.
+
+    Returns ``"free"`` (the lock could be taken, so no live process owns it),
+    ``"held"`` (contention — a live owner), or ``"unknown"`` (a non-contention
+    error left ownership indeterminate). Unlike :func:`_try_acquire_file_lock`,
+    this NEVER writes to the file (stays strictly read-only) and distinguishes
+    lock CONTENTION (EACCES / EAGAIN) from other OS errors — the desktop cron
+    gate must fail open on the latter rather than mistake it for a live owner
+    (#66629).
+    """
+    try:
+        if _IS_WINDOWS:
+            # msvcrt byte-range locks need a byte at the lock offset. A live
+            # gateway lock is non-empty (it holds a JSON record); an empty file
+            # means no owner has recorded yet. Report it indeterminate rather
+            # than writing a byte to make it lockable — keep the probe read-only.
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                return "unknown"
+            handle.seek(_WINDOWS_LOCK_OFFSET)
+            try:
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            except OSError as e:
+                # Contention on Windows surfaces as EACCES (measured); any other
+                # errno (ENOTSUP, EIO, ...) is a real error, not a live owner.
+                return "held" if e.errno == errno.EACCES else "unknown"
+            try:
+                handle.seek(_WINDOWS_LOCK_OFFSET)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            except OSError:
+                pass
+            return "free"
+        else:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError as e:
+                # Contention is EAGAIN (== EWOULDBLOCK); some platforms report
+                # EACCES. Anything else (ENOLCK, ENOTSUP, EIO) is a real error,
+                # not proof of a live owner.
+                return "held" if e.errno in (errno.EACCES, errno.EAGAIN) else "unknown"
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
+            return "free"
+    except OSError:
+        return "unknown"
+
+
+def probe_gateway_runtime_lock(lock_path: Optional[Path] = None) -> str:
+    """Read-only probe of the gateway runtime lock: ``"held"``, ``"free"`` or ``"unknown"``.
+
+    Unlike :func:`is_gateway_runtime_lock_active`, this never creates the lock
+    file (opens ``"r+"``, not ``"a+"``), never unlinks it, and never writes to it
+    — so a frequent caller (the desktop cron gate, #66629) cannot mutate the
+    gateway's own lock. ``"unknown"`` means the owner could not be determined (a
+    permission or stat error, an unsupported filesystem, or a not-yet-recorded
+    empty lock); such callers must fail open (never stall a desktop-only cron)
+    and should surface a warning.
+    """
+    global _gateway_lock_handle
+    try:
+        resolved_lock_path = lock_path or _get_gateway_lock_path()
+        # This process already holds it (in-process gateway on the same HERMES_HOME).
+        if _gateway_lock_handle is not None and resolved_lock_path == _get_gateway_lock_path():
+            return "held"
+        if not resolved_lock_path.exists():
+            return "free"
+        handle = open(resolved_lock_path, "r+", encoding="utf-8")
+    except OSError:
+        # Path inspection or open failed (permission, unsupported FS): ownership
+        # is indeterminate. Never create or unlink the lock here.
+        return "unknown"
+    try:
+        return _probe_file_lock(handle)
     finally:
         try:
             handle.close()

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -12,7 +12,6 @@ concurrently under distinct configurations).
 """
 
 import copy
-import errno
 import hashlib
 import json
 import logging
@@ -952,87 +951,53 @@ def is_gateway_runtime_lock_active(lock_path: Optional[Path] = None) -> bool:
             pass
 
 
-def _probe_file_lock(handle) -> str:
-    """Non-mutating, tri-state probe of an already-open lock handle.
-
-    Returns ``"free"`` (the lock could be taken, so no live process owns it),
-    ``"held"`` (contention — a live owner), or ``"unknown"`` (a non-contention
-    error left ownership indeterminate). Unlike :func:`_try_acquire_file_lock`,
-    this NEVER writes to the file (stays strictly read-only) and distinguishes
-    lock CONTENTION (EACCES / EAGAIN) from other OS errors — the desktop cron
-    gate must fail open on the latter rather than mistake it for a live owner
-    (#66629).
-    """
-    try:
-        if _IS_WINDOWS:
-            # msvcrt byte-range locks need a byte at the lock offset. A live
-            # gateway lock is non-empty (it holds a JSON record); an empty file
-            # means no owner has recorded yet. Report it indeterminate rather
-            # than writing a byte to make it lockable — keep the probe read-only.
-            handle.seek(0, os.SEEK_END)
-            if handle.tell() == 0:
-                return "unknown"
-            handle.seek(_WINDOWS_LOCK_OFFSET)
-            try:
-                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
-            except OSError as e:
-                # Contention on Windows surfaces as EACCES (measured); any other
-                # errno (ENOTSUP, EIO, ...) is a real error, not a live owner.
-                return "held" if e.errno == errno.EACCES else "unknown"
-            try:
-                handle.seek(_WINDOWS_LOCK_OFFSET)
-                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
-            except OSError:
-                pass
-            return "free"
-        else:
-            try:
-                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except OSError as e:
-                # Contention is EAGAIN (== EWOULDBLOCK); some platforms report
-                # EACCES. Anything else (ENOLCK, ENOTSUP, EIO) is a real error,
-                # not proof of a live owner.
-                return "held" if e.errno in (errno.EACCES, errno.EAGAIN) else "unknown"
-            try:
-                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
-            except OSError:
-                pass
-            return "free"
-    except OSError:
-        return "unknown"
-
-
 def probe_gateway_runtime_lock(lock_path: Optional[Path] = None) -> str:
-    """Read-only probe of the gateway runtime lock: ``"held"``, ``"free"`` or ``"unknown"``.
+    """Read-only owner probe of the gateway runtime lock: ``"held"``, ``"free"``, or ``"unknown"``.
 
-    Unlike :func:`is_gateway_runtime_lock_active`, this never creates the lock
-    file (opens ``"r+"``, not ``"a+"``), never unlinks it, and never writes to it
-    — so a frequent caller (the desktop cron gate, #66629) cannot mutate the
-    gateway's own lock. ``"unknown"`` means the owner could not be determined (a
-    permission or stat error, an unsupported filesystem, or a not-yet-recorded
-    empty lock); such callers must fail open (never stall a desktop-only cron)
-    and should surface a warning.
+    Classifies ownership from the JSON lock record (pid + start_time + argv) and
+    a live-PID check with a PID-reuse guard — the same 4-step verification the
+    dashboard's :func:`get_running_pid` already uses (``:2105-2150``). NEVER
+    touches the OS lock, so a frequent caller (the desktop cron gate, #66629)
+    cannot serialize against :func:`acquire_gateway_runtime_lock` and cannot
+    make gateway startup lose its own lock. Observer-kills-owner is impossible
+    by construction, not by timing.
+
+    ``"unknown"`` means the record is empty or unreadable (a crashed mid-write,
+    or the ~1 ms startup window between ``_try_acquire_file_lock`` succeeding
+    and ``_write_gateway_lock_record`` completing). Callers must fail open
+    (never stall a desktop-only cron) and should surface a warning.
     """
     global _gateway_lock_handle
+    resolved_lock_path = lock_path or _get_gateway_lock_path()
+    # In-process fast path: this process already holds it.
+    if _gateway_lock_handle is not None and resolved_lock_path == _get_gateway_lock_path():
+        return "held"
     try:
-        resolved_lock_path = lock_path or _get_gateway_lock_path()
-        # This process already holds it (in-process gateway on the same HERMES_HOME).
-        if _gateway_lock_handle is not None and resolved_lock_path == _get_gateway_lock_path():
-            return "held"
         if not resolved_lock_path.exists():
             return "free"
-        handle = open(resolved_lock_path, "r+", encoding="utf-8")
     except OSError:
-        # Path inspection or open failed (permission, unsupported FS): ownership
-        # is indeterminate. Never create or unlink the lock here.
         return "unknown"
-    try:
-        return _probe_file_lock(handle)
-    finally:
-        try:
-            handle.close()
-        except OSError:
-            pass
+    record = _read_gateway_lock_record(resolved_lock_path)
+    if not record:
+        # Empty / unparseable: a crashed mid-write, or the sub-millisecond
+        # startup window. Fail open (documented 1x degraded-delivery residual).
+        return "unknown"
+    pid = _pid_from_record(record)
+    if pid is None:
+        return "unknown"
+    if not _pid_exists(pid):
+        return "free"  # crash: OS released the lock, record is stale.
+    recorded_start = record.get("start_time")
+    live_start = _get_process_start_time(pid)
+    if (
+        recorded_start is not None
+        and live_start is not None
+        and recorded_start != live_start
+    ):
+        return "free"  # PID reused by an unrelated process.
+    if not _record_matches_live_gateway_pid(record, pid):
+        return "free"  # live PID, but not a gateway (foreign process using the same PID).
+    return "held"
 
 
 def write_pid_file() -> None:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -147,6 +147,38 @@ _log = logging.getLogger(__name__)
 # when the same module is used across TestClient instances or uvicorn reloads.
 # ---------------------------------------------------------------------------
 
+def _no_live_gateway() -> bool:
+    """#66629 dispatch gate for the desktop cron ticker.
+
+    Return True (dispatch) only when no live gateway owns the gateway runtime
+    lock on this HERMES_HOME. When a gateway is live, return False so the tick is
+    left for it: the gateway has live platform adapters and renders Feishu
+    interactive cards, whereas the desktop standalone path silently degrades them
+    to plain text. Fails open (dispatch) on an indeterminate probe so a
+    desktop-only cron is never stalled, logging a warning for observability.
+    """
+    try:
+        from gateway.status import probe_gateway_runtime_lock
+
+        state = probe_gateway_runtime_lock()
+    except Exception:
+        _log.warning(
+            "Desktop cron: gateway runtime lock probe raised unexpectedly; "
+            "dispatching locally (#66629).",
+            exc_info=True,
+        )
+        return True
+    if state == "held":
+        return False
+    if state == "unknown":
+        _log.warning(
+            "Desktop cron: gateway runtime lock probe was indeterminate; "
+            "dispatching locally. If a gateway is in fact live, interactive-card "
+            "jobs may degrade to plain text (#66629)."
+        )
+    return True
+
+
 def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60) -> None:
     """Tick the cron scheduler from inside the desktop dashboard backend.
 
@@ -165,7 +197,18 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
 
     provider = resolve_cron_scheduler()
     _log.info("Desktop cron scheduler started (provider=%s, interval=%ds)", provider.name, interval)
-    provider.start(stop_event, interval=interval)
+    # #66629: only dispatch when no live gateway owns this HERMES_HOME, so cron
+    # delivery uses the gateway's live adapters (which render Feishu interactive
+    # cards) instead of the desktop standalone path (which silently degrades
+    # cards to plain text). Pass the gate only to providers that accept it — the
+    # built-in in-process scheduler does; an external provider may not.
+    start_kwargs = {"interval": interval}
+    try:
+        if "can_dispatch" in inspect.signature(provider.start).parameters:
+            start_kwargs["can_dispatch"] = _no_live_gateway
+    except (TypeError, ValueError):
+        pass
+    provider.start(stop_event, **start_kwargs)
 
 
 def _warm_gateway_module() -> None:

--- a/tests/cron/test_desktop_cron_gateway_gate.py
+++ b/tests/cron/test_desktop_cron_gateway_gate.py
@@ -293,3 +293,342 @@ def test_probe_reports_unknown_when_path_inspection_raises(monkeypatch, tmp_path
 
     monkeypatch.setattr("pathlib.Path.exists", deny)
     assert status.probe_gateway_runtime_lock() == "unknown"
+
+
+def test_probe_reports_unknown_when_second_exists_raises_after_first_succeeds(
+    monkeypatch, tmp_path,
+):
+    """Sol 4th finding 2 — TOCTOU. The outer Path.exists() succeeds; then
+    permissions flip before _read_pid_record's OWN exists() runs, and its
+    PermissionError escapes an inner "if not exists()" that lives outside the
+    inner try. probe_gateway_runtime_lock() must catch it and stay tri-state."""
+    import pathlib
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    lock = tmp_path / "gateway.lock"
+    lock.write_text(json.dumps({"pid": 1, "kind": status._GATEWAY_KIND}), encoding="utf-8")
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock)
+
+    real_exists = pathlib.Path.exists
+    calls = {"n": 0}
+
+    def flipping_exists(self, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return True  # outer probe check: file is there.
+        raise PermissionError("simulated permission flip")
+
+    monkeypatch.setattr(pathlib.Path, "exists", flipping_exists)
+    try:
+        assert status.probe_gateway_runtime_lock() == "unknown"
+    finally:
+        monkeypatch.setattr(pathlib.Path, "exists", real_exists)
+
+
+def test_probe_reports_unknown_when_recorded_start_time_is_null(monkeypatch, tmp_path):
+    """Sol 4th finding 1 — a null recorded start_time cannot positively
+    establish identity. probe must return "unknown" (fail open, dispatch), not
+    "held", so a dead profile's stale record whose PID got recycled onto a
+    live gateway on another profile does NOT stall this profile's cron."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    lock = tmp_path / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock)
+    _write_record(lock, {
+        "pid": os.getpid(),
+        "kind": status._GATEWAY_KIND,
+        "argv": ["hermes", "gateway", "run"],
+        "start_time": None,  # a record that never received an OS timestamp.
+        "hermes_home": str(tmp_path),
+    })
+
+    assert status.probe_gateway_runtime_lock() == "unknown"
+
+
+def test_probe_reports_unknown_when_live_start_time_is_none(monkeypatch, tmp_path):
+    """The live PID exists but its start_time cannot be read (permission,
+    unsupported platform). Identity is unconfirmable -> "unknown"."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    lock = tmp_path / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock)
+    _write_record(lock, _make_live_gateway_record(tmp_path))
+    # Force _get_process_start_time() to return None for this pid.
+    monkeypatch.setattr(status, "_get_process_start_time", lambda _pid: None)
+
+    assert status.probe_gateway_runtime_lock() == "unknown"
+
+
+def test_probe_reports_free_when_record_hermes_home_differs_from_probed(
+    monkeypatch, tmp_path,
+):
+    """Sol 4th finding 1 (part 2) — cross-profile: the record's stored
+    hermes_home does not match the probed lock's HERMES_HOME. This means the
+    record was written by a gateway on a different profile (either a foreign
+    write, or the record survived a profile move). The probe must NOT trust
+    it; return "free"."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    lock = tmp_path / "gateway.lock"
+    other_home = tmp_path / "other-profile"
+    other_home.mkdir()
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock)
+    # Record is authentic for the CURRENT process but was written for a
+    # different HERMES_HOME than this lock's parent (tmp_path).
+    rec = _make_live_gateway_record(tmp_path)
+    rec["hermes_home"] = str(other_home)
+    _write_record(lock, rec)
+    # Force the fingerprint check to pass so this test isolates the
+    # hermes_home mismatch check itself. Without this pin, the pre-fix
+    # implementation would return "free" via the fingerprint path (pytest
+    # is not a gateway), producing a false-green.
+    monkeypatch.setattr(
+        status,
+        "_record_matches_live_gateway_pid",
+        lambda record, pid, *, expected_home=None: True,
+    )
+
+    assert status.probe_gateway_runtime_lock() == "free"
+
+
+def test_probe_passes_expected_home_to_gateway_fingerprint(monkeypatch, tmp_path):
+    """Sol 4th finding 1 (part 3) — the live-cmdline fingerprint check must be
+    called with expected_home derived from the probed lock. Without it, a PID
+    recycled onto another profile's live gateway would still pass the "is a
+    gateway" check and return "held". Assert the argument is passed."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    lock = tmp_path / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock)
+    _write_record(lock, _make_live_gateway_record(tmp_path))
+
+    captured = {}
+
+    def fake_match(record, pid, *, expected_home=None):
+        captured["expected_home"] = expected_home
+        return True
+
+    monkeypatch.setattr(status, "_record_matches_live_gateway_pid", fake_match)
+
+    assert status.probe_gateway_runtime_lock() == "held"
+    assert captured["expected_home"] is not None, (
+        "probe must pass expected_home so cross-profile PID reuse does not falsely fingerprint"
+    )
+    assert str(captured["expected_home"]) == str(status._canonical_hermes_home(tmp_path))
+
+
+def test_probe_reports_unknown_when_recorded_home_is_not_a_usable_string(
+    monkeypatch, tmp_path,
+):
+    """Sol 5th #1 — a record whose ``hermes_home`` is missing, empty, or not a
+    string (a corrupt record, or one written before the field existed) cannot
+    positively prove profile identity. The probe must return "unknown" (fail
+    open) rather than fall through to the argv matcher. Pinned with the matcher
+    forced True: pre-fix a homeless record reached it and answered "held"."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    lock = tmp_path / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock)
+    monkeypatch.setattr(
+        status,
+        "_record_matches_live_gateway_pid",
+        lambda record, pid, *, expected_home=None: True,
+    )
+
+    base = _make_live_gateway_record(tmp_path)
+    for bad in ("__missing__", "", "   ", 12345, ["/x"], {"p": 1}):
+        rec = dict(base)
+        if bad == "__missing__":
+            rec.pop("hermes_home", None)
+        else:
+            rec["hermes_home"] = bad
+        _write_record(lock, rec)
+        assert status.probe_gateway_runtime_lock() == "unknown", (
+            f"homeless/garbage record (hermes_home={bad!r}) must be indeterminate, "
+            "not trusted as held"
+        )
+
+
+def test_probe_delegates_hermes_home_equality_to_platform_comparator(
+    monkeypatch, tmp_path,
+):
+    """Sol 5th #3 — HERMES_HOME identity must be compared with the host's
+    path + case semantics (``_same_hermes_home``), not raw string equality, so
+    representations that differ only in case (Windows) or normalization still
+    name the same directory. Proven by forcing the comparator's verdict on a
+    record whose home is raw-equal to the probed home and asserting the probe
+    honors it — pre-fix used ``str(...) != str(...)`` and ignored the patch."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    lock = tmp_path / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock)
+    _write_record(lock, _make_live_gateway_record(tmp_path))
+    monkeypatch.setattr(
+        status,
+        "_record_matches_live_gateway_pid",
+        lambda record, pid, *, expected_home=None: True,
+    )
+
+    # Comparator says "different" for a raw-equal pair -> a probe that honors the
+    # comparator returns "free"; one still using raw `==` ignores it and wrongly
+    # returns "held".
+    monkeypatch.setattr(status, "_same_hermes_home", lambda a, b: False)
+    assert status.probe_gateway_runtime_lock() == "free"
+    # Inverse: comparator says "same" -> held.
+    monkeypatch.setattr(status, "_same_hermes_home", lambda a, b: True)
+    assert status.probe_gateway_runtime_lock() == "held"
+
+
+def test_probe_survives_recursion_error_from_deeply_nested_record(
+    monkeypatch, tmp_path,
+):
+    """Sol 5th #4 — a deeply-nested corrupt JSON lock record makes ``json.loads``
+    raise ``RecursionError`` (a RuntimeError subclass, NOT JSONDecodeError or
+    OSError), which escaped the probe's ``except OSError``. The record read must
+    treat it as unreadable and the probe must return "unknown" (fail open),
+    not crash."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    lock = tmp_path / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock)
+    depth = 20000  # well past the interpreter recursion limit for json's decoder
+    lock.write_text("[" * depth + "]" * depth, encoding="utf-8")
+
+    assert status.probe_gateway_runtime_lock() == "unknown"
+
+
+def test_command_line_belongs_to_profile_requires_an_exact_profile_token(tmp_path):
+    """Sol 5th #2 (root) — profile scoping must match an EXACT argv token, not a
+    substring. ``work`` must not match a live ``--profile worker``; the real
+    ``work`` selector (space / ``=`` / ``-p`` forms, and an explicit
+    ``HERMES_HOME=``) must match."""
+    import gateway.status as status
+
+    work_home = tmp_path / "profiles" / "work"
+    m = status._command_line_belongs_to_profile
+    # The substring trap: sibling profile whose name has "work" as a prefix.
+    assert m("hermes gateway run --profile worker", work_home) is False
+    assert m("hermes gateway run -p worker", work_home) is False
+    assert m("hermes gateway run --profile=worker", work_home) is False
+    # Genuine selectors for "work" in every accepted form.
+    assert m("hermes gateway run --profile work", work_home) is True
+    assert m("hermes gateway run -p work", work_home) is True
+    assert m("hermes gateway run --profile=work", work_home) is True
+    assert m(f"HERMES_HOME={work_home} hermes gateway run", work_home) is True
+    # A named profile with no selector at all does not match.
+    assert m("hermes gateway run", work_home) is False
+
+
+def test_command_line_belongs_to_profile_treats_explicit_profile_as_authoritative(tmp_path):
+    """Sol 6th #2 (second pass) — an explicit ``--profile``/``-p`` selector is
+    authoritative (Hermes' ``_apply_profile_override`` consumes it); a
+    conflicting ``HERMES_HOME=`` token on the SAME argv must not override it. A
+    live ``--profile worker`` process is not the "work" profile even if its argv
+    also carries ``HERMES_HOME=<work>``."""
+    import gateway.status as status
+
+    work_home = tmp_path / "profiles" / "work"
+    worker_home = tmp_path / "profiles" / "worker"
+    m = status._command_line_belongs_to_profile
+    cmd = f"HERMES_HOME={work_home} hermes gateway run --profile worker"
+    assert m(cmd, work_home) is False   # explicit --profile worker wins over HERMES_HOME=work
+    assert m(cmd, worker_home) is True  # it genuinely belongs to worker
+
+
+def test_probe_reports_free_when_live_argv_names_a_sibling_profile(
+    monkeypatch, tmp_path,
+):
+    """Sol 5th #2 (the exact reproduction) — probe profile "work" whose lock
+    holds a record that HONESTLY recorded ``hermes_home=work`` (written by
+    work's now-dead gateway) with a pid + start_time that, after PID reuse and a
+    start-time collision, now identify a LIVE process running ``--profile
+    worker``. Home matches (both work); pre-fix the substring matcher confirmed
+    via ``--profile work`` ⊂ ``--profile worker`` and the probe answered "held",
+    stalling work's cron. With exact-token matching the live sibling gateway is
+    rejected and the probe returns "free" (work has no live gateway)."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    work_home = tmp_path / "profiles" / "work"
+    work_home.mkdir(parents=True)
+    lock = work_home / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock)
+    # The live process (this pid) is a gateway for the sibling profile "worker".
+    monkeypatch.setattr(
+        status, "_read_process_cmdline", lambda pid: "hermes gateway run --profile worker"
+    )
+    # Honest stale record: home=work, pid+start now collide with the live worker.
+    rec = {
+        "pid": os.getpid(),
+        "kind": status._GATEWAY_KIND,
+        "argv": ["hermes", "gateway", "run", "--profile", "work"],
+        "start_time": status._get_process_start_time(os.getpid()),
+        "hermes_home": str(work_home),
+    }
+    _write_record(lock, rec)
+
+    assert status.probe_gateway_runtime_lock() == "free"
+
+
+def test_probe_reports_unknown_when_a_homeless_record_cannot_scope_a_profile(
+    monkeypatch, tmp_path,
+):
+    """A record that omits ``hermes_home`` cannot positively scope a profile, so
+    the probe returns "unknown" (fail open) before the argv matcher is even
+    consulted — independent of whatever the live argv looks like."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    work_home = tmp_path / "profiles" / "work"
+    work_home.mkdir(parents=True)
+    lock = work_home / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock)
+    monkeypatch.setattr(
+        status, "_read_process_cmdline", lambda pid: "hermes gateway run --profile work"
+    )
+    rec = {
+        "pid": os.getpid(),
+        "kind": status._GATEWAY_KIND,
+        "argv": ["hermes", "gateway", "run", "--profile", "work"],
+        "start_time": status._get_process_start_time(os.getpid()),
+        # deliberately no hermes_home
+    }
+    _write_record(lock, rec)
+
+    assert status.probe_gateway_runtime_lock() == "unknown"
+
+
+def test_probe_holds_for_a_named_profile_when_home_confirms_identity(
+    monkeypatch, tmp_path,
+):
+    """The fix must not over-tighten. A record that DOES carry this named
+    profile's ``hermes_home``, written by a live gateway-shaped process on the
+    same profile, still resolves to "held"."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    work_home = tmp_path / "profiles" / "work"
+    work_home.mkdir(parents=True)
+    lock = work_home / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock)
+    monkeypatch.setattr(
+        status, "_read_process_cmdline", lambda pid: "hermes gateway run --profile work"
+    )
+    rec = {
+        "pid": os.getpid(),
+        "kind": status._GATEWAY_KIND,
+        "argv": ["hermes", "gateway", "run", "--profile", "work"],
+        "start_time": status._get_process_start_time(os.getpid()),
+        "hermes_home": str(work_home),
+    }
+    _write_record(lock, rec)
+
+    assert status.probe_gateway_runtime_lock() == "held"

--- a/tests/cron/test_desktop_cron_gateway_gate.py
+++ b/tests/cron/test_desktop_cron_gateway_gate.py
@@ -8,13 +8,20 @@ gateway owns this HERMES_HOME, and resumes on its own if the gateway stops.
 
 The headline test is behavioral, through the public ticker entry point
 (``hermes_cli.web_server._start_desktop_cron_ticker``): it fails before the fix
-(the ungated ticker fires regardless of the gateway lock) and passes after. The
-probe unit tests pin the read-only contract of the lock probe.
+(the ungated ticker fires regardless of the gateway lock) and passes after.
+The probe unit tests pin its owner-aware classification (held / free / unknown)
+and, critically, the by-construction guarantee that the probe never touches the
+OS lock — so a probe collision can never make gateway startup lose its own
+lock (#66629 amend: observer must not kill owner, enforced by construction not
+by timing).
 """
-import errno
+import json
+import os
 import threading
 import time
 from unittest.mock import patch
+
+import pytest
 
 
 def _wait_until(predicate, timeout=10.0, interval=0.005):
@@ -26,24 +33,49 @@ def _wait_until(predicate, timeout=10.0, interval=0.005):
     return bool(predicate())
 
 
+def _make_live_gateway_record(hermes_home):
+    """Build a record for the current process framed as a running gateway."""
+    import gateway.status as status
+    pid = os.getpid()
+    return {
+        "pid": pid,
+        "kind": status._GATEWAY_KIND,
+        "argv": ["hermes", "gateway", "run"],
+        "start_time": status._get_process_start_time(pid),
+        "hermes_home": str(hermes_home),
+    }
+
+
+def _write_record(lock_path, record):
+    lock_path.write_text(json.dumps(record), encoding="utf-8")
+
+
 def test_desktop_ticker_defers_to_a_live_gateway_then_resumes(monkeypatch, tmp_path):
     """RED before the gate, GREEN after. While a live gateway owns the runtime
-    lock on this HERMES_HOME the desktop ticker must not drive cron.scheduler.tick
-    (its standalone path degrades interactive cards). It resumes once the gateway
-    releases the lock."""
+    lock on this HERMES_HOME the desktop ticker must not drive
+    ``cron.scheduler.tick`` (its standalone path degrades interactive cards).
+    It resumes once the record disappears."""
     import gateway.status as status
     from hermes_cli.web_server import _start_desktop_cron_ticker
+    from hermes_cli import web_server as ws
 
-    # Keep everything inside tmp: the lock the probe reads and the HERMES_HOME
-    # the ticker heartbeats into.
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setattr(status, "_gateway_lock_handle", None)
     lock_path = tmp_path / "gateway.lock"
     monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock_path)
 
-    # A second real OS lock stands in for a live gateway holding the lock.
-    holder = open(lock_path, "a+", encoding="utf-8")
-    assert status._try_acquire_file_lock(holder) is True
+    # Stand in for a live gateway by writing a record matching THIS pid — the
+    # probe uses _pid_exists() + start_time + argv fingerprint to classify held.
+    _write_record(lock_path, _make_live_gateway_record(tmp_path))
+
+    # Force the argv fingerprint check to pass on this test process (we are
+    # pytest, not hermes gateway run), keeping the test independent of live
+    # cmdline shape while still exercising every other probe branch.
+    monkeypatch.setattr(
+        status,
+        "_record_matches_live_gateway_pid",
+        lambda record, pid, *, expected_home=None: True,
+    )
 
     ticks = []
     stop = threading.Event()
@@ -51,6 +83,19 @@ def test_desktop_ticker_defers_to_a_live_gateway_then_resumes(monkeypatch, tmp_p
     def fake_tick(*args, **kwargs):
         ticks.append(kwargs)
         return 0
+
+    # Count gate calls so the quiet-interval assertion is guaranteed to run
+    # AFTER the ticker started deciding to defer. Without this, a delayed
+    # provider thread could reach its first tick only after the record is
+    # removed and pass the quiet check without ever exercising the held path.
+    gate_calls = []
+    real_gate = ws._no_live_gateway
+
+    def counting_gate():
+        gate_calls.append(1)
+        return real_gate()
+
+    monkeypatch.setattr(ws, "_no_live_gateway", counting_gate)
 
     with patch("cron.scheduler.tick", side_effect=fake_tick):
         t = threading.Thread(
@@ -61,17 +106,20 @@ def test_desktop_ticker_defers_to_a_live_gateway_then_resumes(monkeypatch, tmp_p
         )
         t.start()
         try:
-            # A live gateway owns the lock -> the desktop ticker must stay quiet.
+            assert _wait_until(lambda: len(gate_calls) >= 2, timeout=2.0), (
+                "provider loop never consulted the gate within 2 s — the quiet "
+                "interval assertion would be vacuous"
+            )
+            # A live gateway holds this HERMES_HOME -> the desktop ticker must stay quiet.
             time.sleep(0.2)
             assert ticks == [], (
                 f"desktop ticker fired {len(ticks)} tick(s) while a live gateway "
-                "owned the runtime lock (interactive cards would degrade to text)"
+                "was recorded (interactive cards would degrade to text)"
             )
-            # Gateway stops -> lock released -> desktop cron resumes on its own.
-            status._release_file_lock(holder)
-            holder.close()
+            # Gateway stops -> record removed -> desktop cron resumes on its own.
+            lock_path.unlink()
             assert _wait_until(lambda: len(ticks) >= 1), (
-                "desktop ticker did not resume after the gateway released the lock"
+                "desktop ticker did not resume after the gateway record was cleared"
             )
         finally:
             stop.set()
@@ -79,117 +127,169 @@ def test_desktop_ticker_defers_to_a_live_gateway_then_resumes(monkeypatch, tmp_p
     assert not t.is_alive()
 
 
-def test_probe_reports_free_without_creating_the_lock(tmp_path, monkeypatch):
-    """No lock file -> "free", and the read-only probe must not create one."""
+def test_probe_never_touches_the_os_lock(monkeypatch, tmp_path):
+    """By-construction guarantee (#66629 amend, Sol 3rd finding). The probe
+    must never call ``_try_acquire_file_lock`` / ``msvcrt.locking`` /
+    ``fcntl.flock`` on the runtime lock — an OS-lock probe would serialize
+    against ``acquire_gateway_runtime_lock`` for microseconds and, under
+    scheduler pressure, arbitrarily longer, making the observer kill the
+    owner. Any future change that reintroduces such a probe fails this test
+    deterministically (no timing dependency)."""
     import gateway.status as status
 
     monkeypatch.setattr(status, "_gateway_lock_handle", None)
-    lock_path = tmp_path / "gateway.lock"
-    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock_path)
+    lock = tmp_path / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock)
+    _write_record(lock, _make_live_gateway_record(tmp_path))
+    monkeypatch.setattr(
+        status,
+        "_record_matches_live_gateway_pid",
+        lambda record, pid, *, expected_home=None: True,
+    )
 
-    assert status.probe_gateway_runtime_lock() == "free"
-    assert not lock_path.exists(), "probe must not create the lock file (opens r+, not a+)"
+    def _explode(_handle):
+        pytest.fail(
+            "probe must not call _try_acquire_file_lock (#66629 regression: "
+            "an OS-lock probe would race gateway startup)"
+        )
 
-
-def test_probe_reports_held_then_free_across_a_real_lock(tmp_path, monkeypatch):
-    """A held OS lock reads as "held"; once released it reads as "free"."""
-    import gateway.status as status
-
-    monkeypatch.setattr(status, "_gateway_lock_handle", None)
-    lock_path = tmp_path / "gateway.lock"
-    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock_path)
-
-    holder = open(lock_path, "a+", encoding="utf-8")
-    try:
-        assert status._try_acquire_file_lock(holder) is True
-        assert status.probe_gateway_runtime_lock() == "held"
-    finally:
-        status._release_file_lock(holder)
-        holder.close()
-    assert status.probe_gateway_runtime_lock() == "free"
-
-
-def test_probe_reports_unknown_on_non_contention_lock_error(tmp_path, monkeypatch):
-    """A non-contention lock error (ENOTSUP / ENOLCK / EIO) must report
-    "unknown", NOT "held" (Sol REQUEST-CHANGES finding 1). Collapsing every
-    OSError to "held" would stall a desktop-only cron indefinitely on an
-    unsupported filesystem — a fail-open contract violation."""
-    import gateway.status as status
-
-    monkeypatch.setattr(status, "_gateway_lock_handle", None)
-    lock_path = tmp_path / "gateway.lock"
-    lock_path.write_text("owner-record", encoding="utf-8")
-    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock_path)
-
-    def raise_enotsup(*args, **kwargs):
-        raise OSError(errno.ENOTSUP, "operation not supported by this filesystem")
-
+    monkeypatch.setattr(status, "_try_acquire_file_lock", _explode)
     if status._IS_WINDOWS:
-        monkeypatch.setattr(status.msvcrt, "locking", raise_enotsup)
+        class _Explode:
+            def locking(self, *a, **kw):
+                pytest.fail("probe must not call msvcrt.locking (#66629 regression)")
+        monkeypatch.setattr(status, "msvcrt", _Explode(), raising=False)
     else:
-        monkeypatch.setattr(status.fcntl, "flock", raise_enotsup)
+        class _Explode:
+            LOCK_EX = 2
+            LOCK_NB = 4
+            LOCK_UN = 8
+            LOCK_SH = 1
+            def flock(self, *a, **kw):
+                pytest.fail("probe must not call fcntl.flock (#66629 regression)")
+        monkeypatch.setattr(status, "fcntl", _Explode(), raising=False)
 
+    assert status.probe_gateway_runtime_lock() == "held"
+
+
+def test_probe_reports_free_when_no_lock_file_exists(monkeypatch, tmp_path):
+    """No lock file -> "free" (no live process owns it). The probe must not
+    create the lock as a side effect."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    lock = tmp_path / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock)
+
+    assert status.probe_gateway_runtime_lock() == "free"
+    assert not lock.exists(), "probe must not create the lock file as a side effect"
+
+
+def test_probe_reports_free_for_a_stale_record_from_a_dead_pid(monkeypatch, tmp_path):
+    """After a crash the OS releases the lock; the JSON record is stale (pid
+    dead). ``_pid_exists`` returns False -> probe returns "free" so the desktop
+    cron takes over correctly."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    lock = tmp_path / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock)
+    # Deliberately unassignable pid: max signed 32-bit minus one. Even on
+    # systems that allow larger pids, no process will match this.
+    _write_record(lock, {
+        "pid": 2**31 - 2,
+        "kind": status._GATEWAY_KIND,
+        "argv": ["hermes", "gateway", "run"],
+        "start_time": 1,
+    })
+
+    assert status.probe_gateway_runtime_lock() == "free"
+
+
+def test_probe_reports_free_when_pid_reused_by_another_process(monkeypatch, tmp_path):
+    """The record's pid is alive but the ``start_time`` in the record does not
+    match the live process — the pid was recycled onto an unrelated process
+    after the original gateway crashed. Return "free" so the desktop cron does
+    not stall on a phantom gateway."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    lock = tmp_path / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock)
+    # Point the record at the pytest process itself, but with a wrong
+    # start_time so the PID-reuse guard fires.
+    _write_record(lock, {
+        "pid": os.getpid(),
+        "kind": status._GATEWAY_KIND,
+        "argv": ["hermes", "gateway", "run"],
+        "start_time": 1,  # deliberately not the real start_time
+    })
+
+    assert status.probe_gateway_runtime_lock() == "free"
+
+
+def test_probe_reports_free_when_live_pid_is_not_a_gateway(monkeypatch, tmp_path):
+    """The pid is alive, the start_time matches, but the process is NOT a
+    gateway (a PID was recycled and the fingerprint check
+    ``_record_matches_live_gateway_pid`` rejects it). Return "free"."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    lock = tmp_path / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock)
+    _write_record(lock, _make_live_gateway_record(tmp_path))
+    monkeypatch.setattr(
+        status,
+        "_record_matches_live_gateway_pid",
+        lambda record, pid, *, expected_home=None: False,
+    )
+
+    assert status.probe_gateway_runtime_lock() == "free"
+
+
+def test_probe_reports_unknown_for_empty_or_unparseable_record(monkeypatch, tmp_path):
+    """An empty file, or a file whose JSON cannot be parsed, means the record
+    is unreadable — either a crashed mid-write or the sub-millisecond startup
+    window between the OS lock and the record write. Return "unknown" so the
+    gate fails open (dispatch + warning) and never stalls a desktop-only
+    cron."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    lock = tmp_path / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock)
+
+    lock.write_text("", encoding="utf-8")
+    assert status.probe_gateway_runtime_lock() == "unknown"
+
+    lock.write_text("not-json{", encoding="utf-8")
     assert status.probe_gateway_runtime_lock() == "unknown"
 
 
-def test_probe_reports_unknown_when_path_inspection_raises(tmp_path, monkeypatch):
-    """A stat / permission error from Path.exists() must be caught as "unknown",
-    not escape the documented three-valued API (Sol REQUEST-CHANGES finding 2)."""
+def test_probe_reports_held_when_this_process_holds_the_in_process_lock(monkeypatch, tmp_path):
+    """Fast path: the in-process module global says this process is holding
+    the lock. No file I/O; no OS lock touched."""
+    import gateway.status as status
+
+    lock = tmp_path / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock)
+    # Simulate 'this process holds it' by installing any non-None handle.
+    monkeypatch.setattr(status, "_gateway_lock_handle", object())
+
+    assert status.probe_gateway_runtime_lock() == "held"
+
+
+def test_probe_reports_unknown_when_path_inspection_raises(monkeypatch, tmp_path):
+    """A stat / permission error from ``Path.exists()`` must be caught as
+    "unknown", not escape the documented three-valued API."""
     import gateway.status as status
 
     monkeypatch.setattr(status, "_gateway_lock_handle", None)
-    lock_path = tmp_path / "gateway.lock"
-    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock_path)
+    lock = tmp_path / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock)
 
     def deny(self, *args, **kwargs):
         raise PermissionError("simulated stat denied")
 
     monkeypatch.setattr("pathlib.Path.exists", deny)
     assert status.probe_gateway_runtime_lock() == "unknown"
-
-
-def test_probe_stays_read_only_on_empty_windows_lock(tmp_path, monkeypatch):
-    """On Windows an empty existing lock must report "unknown" WITHOUT writing
-    a byte to it (Sol REQUEST-CHANGES finding 3 — strict read-only contract).
-    On POSIX an empty file locks fine, so it reports "free"."""
-    import gateway.status as status
-
-    monkeypatch.setattr(status, "_gateway_lock_handle", None)
-    lock_path = tmp_path / "gateway.lock"
-    lock_path.touch()
-    assert lock_path.stat().st_size == 0
-    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock_path)
-
-    result = status.probe_gateway_runtime_lock()
-    if status._IS_WINDOWS:
-        assert result == "unknown"
-        assert lock_path.stat().st_size == 0, "probe wrote to an empty lock file"
-    else:
-        assert result == "free"
-
-
-def test_probe_reports_unknown_without_unlinking_on_permission_error(tmp_path, monkeypatch):
-    """A permission error reading an existing lock -> "unknown", and the probe
-    must NOT unlink the lock (is_gateway_runtime_lock_active does; the probe must
-    not, or a desktop cron could delete a live gateway's lock — #66629)."""
-    import builtins
-    import gateway.status as status
-
-    monkeypatch.setattr(status, "_gateway_lock_handle", None)
-    lock_path = tmp_path / "gateway.lock"
-    lock_path.write_text("owner-record", encoding="utf-8")
-    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock_path)
-
-    real_open = builtins.open
-
-    def denying_open(path, *args, **kwargs):
-        if str(path) == str(lock_path):
-            raise PermissionError("simulated denied read")
-        return real_open(path, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "open", denying_open)
-    try:
-        assert status.probe_gateway_runtime_lock() == "unknown"
-    finally:
-        monkeypatch.setattr(builtins, "open", real_open)
-    assert lock_path.exists(), "probe must not unlink the lock on a permission error"

--- a/tests/cron/test_desktop_cron_gateway_gate.py
+++ b/tests/cron/test_desktop_cron_gateway_gate.py
@@ -1,0 +1,195 @@
+"""#66629 — the desktop cron ticker must defer to a live gateway.
+
+When ``hermes gateway run`` and ``hermes serve`` (desktop) share a HERMES_HOME,
+the desktop ticker's standalone delivery path has no live platform adapters, so
+Feishu interactive cards silently degrade to plain text. The fix gates the
+desktop ticker on the gateway runtime lock: it dispatches only when no live
+gateway owns this HERMES_HOME, and resumes on its own if the gateway stops.
+
+The headline test is behavioral, through the public ticker entry point
+(``hermes_cli.web_server._start_desktop_cron_ticker``): it fails before the fix
+(the ungated ticker fires regardless of the gateway lock) and passes after. The
+probe unit tests pin the read-only contract of the lock probe.
+"""
+import errno
+import threading
+import time
+from unittest.mock import patch
+
+
+def _wait_until(predicate, timeout=10.0, interval=0.005):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return bool(predicate())
+
+
+def test_desktop_ticker_defers_to_a_live_gateway_then_resumes(monkeypatch, tmp_path):
+    """RED before the gate, GREEN after. While a live gateway owns the runtime
+    lock on this HERMES_HOME the desktop ticker must not drive cron.scheduler.tick
+    (its standalone path degrades interactive cards). It resumes once the gateway
+    releases the lock."""
+    import gateway.status as status
+    from hermes_cli.web_server import _start_desktop_cron_ticker
+
+    # Keep everything inside tmp: the lock the probe reads and the HERMES_HOME
+    # the ticker heartbeats into.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    lock_path = tmp_path / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock_path)
+
+    # A second real OS lock stands in for a live gateway holding the lock.
+    holder = open(lock_path, "a+", encoding="utf-8")
+    assert status._try_acquire_file_lock(holder) is True
+
+    ticks = []
+    stop = threading.Event()
+
+    def fake_tick(*args, **kwargs):
+        ticks.append(kwargs)
+        return 0
+
+    with patch("cron.scheduler.tick", side_effect=fake_tick):
+        t = threading.Thread(
+            target=_start_desktop_cron_ticker,
+            args=(stop,),
+            kwargs={"interval": 0.01},
+            daemon=True,
+        )
+        t.start()
+        try:
+            # A live gateway owns the lock -> the desktop ticker must stay quiet.
+            time.sleep(0.2)
+            assert ticks == [], (
+                f"desktop ticker fired {len(ticks)} tick(s) while a live gateway "
+                "owned the runtime lock (interactive cards would degrade to text)"
+            )
+            # Gateway stops -> lock released -> desktop cron resumes on its own.
+            status._release_file_lock(holder)
+            holder.close()
+            assert _wait_until(lambda: len(ticks) >= 1), (
+                "desktop ticker did not resume after the gateway released the lock"
+            )
+        finally:
+            stop.set()
+            t.join(timeout=5)
+    assert not t.is_alive()
+
+
+def test_probe_reports_free_without_creating_the_lock(tmp_path, monkeypatch):
+    """No lock file -> "free", and the read-only probe must not create one."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    lock_path = tmp_path / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock_path)
+
+    assert status.probe_gateway_runtime_lock() == "free"
+    assert not lock_path.exists(), "probe must not create the lock file (opens r+, not a+)"
+
+
+def test_probe_reports_held_then_free_across_a_real_lock(tmp_path, monkeypatch):
+    """A held OS lock reads as "held"; once released it reads as "free"."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    lock_path = tmp_path / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock_path)
+
+    holder = open(lock_path, "a+", encoding="utf-8")
+    try:
+        assert status._try_acquire_file_lock(holder) is True
+        assert status.probe_gateway_runtime_lock() == "held"
+    finally:
+        status._release_file_lock(holder)
+        holder.close()
+    assert status.probe_gateway_runtime_lock() == "free"
+
+
+def test_probe_reports_unknown_on_non_contention_lock_error(tmp_path, monkeypatch):
+    """A non-contention lock error (ENOTSUP / ENOLCK / EIO) must report
+    "unknown", NOT "held" (Sol REQUEST-CHANGES finding 1). Collapsing every
+    OSError to "held" would stall a desktop-only cron indefinitely on an
+    unsupported filesystem — a fail-open contract violation."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    lock_path = tmp_path / "gateway.lock"
+    lock_path.write_text("owner-record", encoding="utf-8")
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock_path)
+
+    def raise_enotsup(*args, **kwargs):
+        raise OSError(errno.ENOTSUP, "operation not supported by this filesystem")
+
+    if status._IS_WINDOWS:
+        monkeypatch.setattr(status.msvcrt, "locking", raise_enotsup)
+    else:
+        monkeypatch.setattr(status.fcntl, "flock", raise_enotsup)
+
+    assert status.probe_gateway_runtime_lock() == "unknown"
+
+
+def test_probe_reports_unknown_when_path_inspection_raises(tmp_path, monkeypatch):
+    """A stat / permission error from Path.exists() must be caught as "unknown",
+    not escape the documented three-valued API (Sol REQUEST-CHANGES finding 2)."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    lock_path = tmp_path / "gateway.lock"
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock_path)
+
+    def deny(self, *args, **kwargs):
+        raise PermissionError("simulated stat denied")
+
+    monkeypatch.setattr("pathlib.Path.exists", deny)
+    assert status.probe_gateway_runtime_lock() == "unknown"
+
+
+def test_probe_stays_read_only_on_empty_windows_lock(tmp_path, monkeypatch):
+    """On Windows an empty existing lock must report "unknown" WITHOUT writing
+    a byte to it (Sol REQUEST-CHANGES finding 3 — strict read-only contract).
+    On POSIX an empty file locks fine, so it reports "free"."""
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    lock_path = tmp_path / "gateway.lock"
+    lock_path.touch()
+    assert lock_path.stat().st_size == 0
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock_path)
+
+    result = status.probe_gateway_runtime_lock()
+    if status._IS_WINDOWS:
+        assert result == "unknown"
+        assert lock_path.stat().st_size == 0, "probe wrote to an empty lock file"
+    else:
+        assert result == "free"
+
+
+def test_probe_reports_unknown_without_unlinking_on_permission_error(tmp_path, monkeypatch):
+    """A permission error reading an existing lock -> "unknown", and the probe
+    must NOT unlink the lock (is_gateway_runtime_lock_active does; the probe must
+    not, or a desktop cron could delete a live gateway's lock — #66629)."""
+    import builtins
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "_gateway_lock_handle", None)
+    lock_path = tmp_path / "gateway.lock"
+    lock_path.write_text("owner-record", encoding="utf-8")
+    monkeypatch.setattr(status, "_get_gateway_lock_path", lambda *a, **k: lock_path)
+
+    real_open = builtins.open
+
+    def denying_open(path, *args, **kwargs):
+        if str(path) == str(lock_path):
+            raise PermissionError("simulated denied read")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", denying_open)
+    try:
+        assert status.probe_gateway_runtime_lock() == "unknown"
+    finally:
+        monkeypatch.setattr(builtins, "open", real_open)
+    assert lock_path.exists(), "probe must not unlink the lock on a permission error"


### PR DESCRIPTION
## What does this PR do?

Re-scope of the original PR. Main already has the Desktop gateway gate: 62a4599f89 (#100489) introduced `profile_gate(name, home)` on the multiplex ticker and wired the Desktop ticker to `_check_gateway_running`, and later commits extended it to single-profile installations and to profiles served by the default multiplexer. That covers what this PR originally did with its own lock-record probe, so the branch now uses the upstream gate instead of its custom probe and dispatch API.

What is left is one gap. `_start_multiplex` applies `profile_gate` once per cycle while enumerating profiles, but each profile's `tick()` only receives the global `can_dispatch`. `tick()` re-evaluates `can_dispatch` after it acquires `cron/.tick.lock`, so a gateway that comes up for a profile between the enumeration filter and that profile's tick is not seen, and the Desktop ticker can still win the lock race and deliver through the standalone path (#66629).

This commit composes the profile gate into the per-profile `can_dispatch`, so the check also runs under the tick lock. The enumeration filter is unchanged. With `profile_gate=None` the original `can_dispatch` object is passed through untouched, so the single-store ticker and non-Desktop providers behave as before. A gate that raises at lock time lands in the existing per-profile error handling and does not stop the ticker thread.

## Related Issue

Refs #66629

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler_provider.py`: `_start_multiplex` builds a per-profile `can_dispatch` that requires both the global gate and `profile_gate(name, home)`; passed to `cron_tick` for that profile only when `profile_gate` is set. Docstring updated.
- `tests/cron/test_cron_multiplex_desktop_ticker_scope.py`: new `test_multiplex_ticker_recheck_gate_under_tick_for_each_profile`.

## How to Test

1. `scripts/run_tests.sh tests/cron/test_cron_multiplex_desktop_ticker_scope.py`. The new test flips the gate for one profile between enumeration and tick, and checks that the callback passed to the mocked `tick()` returns false for that profile and true for its sibling. It fails on the parent commit `d4625b593d` and passes at HEAD.
2. `scripts/run_tests.sh tests/cron/test_scheduler_provider.py tests/cron/test_ticker_startup_survival.py tests/cron/test_estop.py tests/test_no_shadowed_test_definitions.py` (77 passed together with step 1).
3. `python scripts/ci/check_public_surface.py --base d4625b593d --head HEAD --strict` reports no dropped public names or tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (ran the cron suites listed above, not the full tree)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
