### PR TITLE
fix(moa): route MoA provider through in-process facade in streaming path

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2631,22 +2631,28 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # 'stream_options'`), so omit it only for that endpoint.
         if not is_native_gemini_base_url(agent.base_url):
             stream_kwargs["stream_options"] = {"include_usage": True}
-        request_client = _set_request_client(
-            agent._create_request_openai_client(
-                reason="chat_completion_stream_request",
-                api_kwargs=stream_kwargs,
+        
+        # MoA provider special handling: route through the in-process facade
+        # to support custom reference models and aggregators without hitting
+        # the virtual "moa://local" HTTP endpoint.
+        if agent.provider == "moa":
+            last_chunk_time["t"] = time.time()
+            agent._touch_activity("waiting for MoA aggregator response (streaming)")
+            _diag = agent._stream_diag_init()
+            request_client_holder["diag"] = _diag
+            stream = agent.client.chat.completions.create(**stream_kwargs)
+        else:
+            request_client = _set_request_client(
+                agent._create_request_openai_client(
+                    reason="chat_completion_stream_request",
+                    api_kwargs=stream_kwargs,
+                )
             )
-        )
-        # Reset stale-stream timer so the detector measures from this
-        # attempt's start, not a previous attempt's last chunk.
-        last_chunk_time["t"] = time.time()
-        agent._touch_activity("waiting for provider response (streaming)")
-        # Initialize per-attempt stream diagnostics so the retry block can
-        # reach for them after the stream dies.  Lives on
-        # ``request_client_holder["diag"]`` for closure access.
-        _diag = agent._stream_diag_init()
-        request_client_holder["diag"] = _diag
-        stream = request_client.chat.completions.create(**stream_kwargs)
+            last_chunk_time["t"] = time.time()
+            agent._touch_activity("waiting for provider response (streaming)")
+            _diag = agent._stream_diag_init()
+            request_client_holder["diag"] = _diag
+            stream = request_client.chat.completions.create(**stream_kwargs)
         # Claim the delta sink for THIS attempt (#65991). If a prior attempt's
         # stream is somehow still alive (a stale-stream reconnect whose socket
         # abort raced), this claim supersedes it so its late chunks are fenced

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,7 +249,7 @@ termux-all = [
   "hermes-agent[web]",
 ]
 dingtalk = ["dingtalk-stream==0.24.3", "alibabacloud-dingtalk==2.2.42", "qrcode==7.4.2"]
-feishu = ["lark-oapi==1.6.8", "qrcode==7.4.2"]
+feishu = ["lark-oapi==1.6.9", "qrcode==7.4.2"]
 google = [
   # Required by the google-workspace skill (Gmail, Calendar, Drive, Contacts,
   # Sheets, Docs).  Declared here so packagers (Nix, Homebrew) ship them with

--- a/uv.lock
+++ b/uv.lock
@@ -1794,7 +1794,7 @@ requires-dist = [
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.2.0" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },
-    { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.6.8" },
+    { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.6.9" },
     { name = "markdown", specifier = "==3.10.2" },
     { name = "mautrix", extras = ["encryption"], marker = "extra == 'matrix'", specifier = "==0.21.0" },
     { name = "mcp", marker = "extra == 'computer-use'", specifier = "==1.26.0" },
@@ -2184,7 +2184,7 @@ wheels = [
 
 [[package]]
 name = "lark-oapi"
-version = "1.6.8"
+version = "1.6.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2194,7 +2194,7 @@ dependencies = [
     { name = "websockets" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/ad/1ab04db5d549ad1a7a2cd33682b1c38dee1d65019cb24fd7a23270e6337d/lark_oapi-1.6.8-py3-none-any.whl", hash = "sha256:9b443a5d47a7d204dd42dc40896c8b75087cc35788e45c48c140806d7df7e5e8", size = 7798300, upload-time = "2026-06-02T07:40:05.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b5/00982093154f92ffc2bfe8448367323a07513bd1db1e92672f9573c92ddf/lark_oapi-1.6.9-py3-none-any.whl", hash = "sha256:ebc93c09eba66e3d2d8823d9df4988370b2e0245870b3249b61cdf6d6cd1642c", size = 7801043, upload-time = "2026-06-24T06:15:19.989Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The non-streaming code path (chat_completion_helpers.py line ~423) already
handles provider='moa' correctly by calling agent.client.chat.completions.create()
through the MoAClient facade. The streaming path in interruptible_streaming_api_call
was missing this check, causing it to build an HTTP client targeting the
virtual 'moa://local' URL, resulting in 404 errors on platforms with stream
consumers (Feishu, WeChat).

This fix adds the same provider=='moa' guard to the streaming path, making
MoA work consistently across both streaming and non-streaming scenarios.