### PR TITLE
fix(desktop): allow slash trigger popover mid-message after whitespace

### DIFF
--- a/apps/desktop/src/app/chat/composer/text-utils.test.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.test.ts
@@ -46,12 +46,22 @@ describe('detectTrigger', () => {
     expect(detectTrigger('/path/to/file')).toBeNull()
   })
 
-  it('does not trigger slash popover mid-message', () => {
-    expect(detectTrigger('hello /')).toBeNull()
-    expect(detectTrigger('hello /skill')).toBeNull()
-    expect(detectTrigger('hello there /personality alic')).toBeNull()
-    expect(detectTrigger('text\n/skill')).toBeNull()
-    expect(detectTrigger('multi word message /')).toBeNull()
+  it('triggers slash popover mid-message after whitespace', () => {
+    expect(detectTrigger('hello /')).toEqual({ kind: '/', query: '', tokenLength: 1 })
+    expect(detectTrigger('hello /skill')).toEqual({ kind: '/', query: 'skill', tokenLength: 6 })
+    expect(detectTrigger('hello there /personality alic')).toEqual({
+      kind: '/',
+      query: 'personality alic',
+      tokenLength: 17
+    })
+    expect(detectTrigger('text\n/skill')).toEqual({ kind: '/', query: 'skill', tokenLength: 6 })
+    expect(detectTrigger('multi word message /')).toEqual({ kind: '/', query: '', tokenLength: 1 })
+  })
+
+  it('still does not trigger slash popover without whitespace before the slash', () => {
+    expect(detectTrigger('hello/skill')).toBeNull()
+    expect(detectTrigger('word/skill')).toBeNull()
+    expect(detectTrigger('some/file')).toBeNull()
   })
 
   it('still anchors at-mention triggers strictly at the token edge', () => {

--- a/apps/desktop/src/app/chat/composer/text-utils.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.ts
@@ -12,11 +12,12 @@ export interface TriggerState {
 // Restricting the slash command name to `[a-zA-Z][\w-]*` avoids matching file
 // paths like `src/foo/bar`.
 //
-// Slash commands only execute at the beginning of a message, so the `/`
-// trigger is anchored strictly at position 0 — not after whitespace — to
-// avoid opening the popover mid-message (e.g. `hello /`).
+// Slash triggers are anchored at a word boundary (start of input or after
+// whitespace) so the popover opens mid-message as well as at position 0.
+// File-style paths (`src/foo`) are still excluded because their `/` is not
+// preceded by whitespace and the following segment starts with `[a-zA-Z]`.
 const AT_TRIGGER_RE = /(?:^|[\s])(@)([^\s@/]*)$/
-const SLASH_TRIGGER_RE = /^(\/)((?:[a-zA-Z][\w-]*(?:\s+\S*)*)?)$/
+const SLASH_TRIGGER_RE = /(?:^|[\s])(\/)((?:[a-zA-Z][\w-]*(?:\s+\S*)*)?)$/
 
 /** Stable key for paste dedupe — `items` and `files` often mirror the same image as different objects. */
 export function blobDedupeKey(blob: Blob): string {


### PR DESCRIPTION
## Summary

Fixes #67316: Skills can only be called at start of the prompt.

## Root Cause

The `SLASH_TRIGGER_RE` regex in `apps/desktop/src/app/chat/composer/text-utils.ts` was anchored strictly at position 0 (`^`), which prevented the slash completion popover from appearing when the user typed `/` after any preceding text. Users had to delete all prior text before typing `/` to make the popover appear.

## Fix

Changed `SLASH_TRIGGER_RE` from `^(\/)...` to `(?:^|[\s])(\/)...` so the trigger fires at the start of input OR after whitespace. This allows the slash popover to appear mid-message while still excluding file-style paths like `src/foo/bar` (where `/` is not preceded by whitespace).

The `SLASH_COMMAND_RE` in `chat-runtime.ts` (submit detection) is intentionally unchanged — slash commands still only **execute** when the entire message starts with `/`. This change only affects the popover/trigger detection for discoverability.

## Changes

- `apps/desktop/src/app/chat/composer/text-utils.ts` — Updated `SLASH_TRIGGER_RE` regex and comment
- `apps/desktop/src/app/chat/composer/text-utils.test.ts` — Updated tests: mid-message triggers now expected to match; added test for no-match without whitespace prefix

## Testing

Manual regex verification against all edge cases:
- `/skill` at position 0 ✅ (still works)
- `hello /skill` mid-message ✅ (now works)
- `hello/skill` file-style path ✅ (still excluded)
- `text\n/skill` across newline ✅ (now works)