### PR TITLE
fix(desktop): support voice barge-in during TTS

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
@@ -4,6 +4,7 @@ type BrowserAudioContext = typeof AudioContext
 
 export interface MicRecorderOptions {
   onLevel?: (level: number) => void
+  onSpeech?: () => void
   onError?: (error: Error) => void
   onSilence?: () => void
   silenceLevel?: number
@@ -138,8 +139,12 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
 
         if (speechThreshold > 0 && options.onSilence && !silenceTriggeredRef.current) {
           if (normalized >= speechThreshold) {
+            const wasSpeaking = heardSpeechRef.current
             heardSpeechRef.current = true
             silenceStartedAtRef.current = null
+            if (!wasSpeaking) {
+              options.onSpeech?.()
+            }
           } else if (heardSpeechRef.current && silenceMs > 0) {
             silenceStartedAtRef.current ??= now
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -225,6 +225,19 @@ export function useVoiceConversation({
       setStatus('speaking')
 
       try {
+        // Keep a microphone capture alive while TTS is playing so the user can
+        // barge in. The first detected speech stops playback and hands the
+        // same recorder to the normal turn-closing path.
+        await handle.start({
+          silenceLevel: 0.075,
+          silenceMs: 1_250,
+          idleSilenceMs: 12_000,
+          onSpeech: () => {
+            stopVoicePlayback()
+            void handleTurn(true)
+          },
+          onSilence: () => void handleTurn()
+        })
         await playSpeechText(text, { source: 'voice-conversation' })
       } catch (error) {
         notifyError(error, voiceCopy.playbackFailed)
@@ -237,7 +250,7 @@ export function useVoiceConversation({
         }
       }
     },
-    [voiceCopy.playbackFailed]
+    [handle, handleTurn, voiceCopy.playbackFailed]
   )
 
   const start = useCallback(async () => {


### PR DESCRIPTION
## Summary
- expose first-speech detection from the microphone recorder
- keep a microphone recorder active while voice-conversation TTS is playing
- stop TTS and close the current turn when the user starts speaking

## Root cause
The previous voice-conversation implementation waited for `playSpeechText()` to finish before starting the next recorder. As a result, users could not barge in during TTS, and the next turn depended on a later UI interaction. The recorder now observes the first speech threshold during playback and interrupts the current TTS path.

## Test plan
- `git diff --check` passed
- source-level lifecycle review completed
- full Desktop TypeScript/lint tests are blocked in this checkout because `apps/desktop/node_modules` does not contain executable `tsc`/`eslint`; no dependency installation was performed
- requires Desktop manual verification for TTS interruption, consecutive turns, and microphone cleanup
