### PR TITLE
feat(gateway): configure opt-in event-loop watchdog

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -712,6 +712,47 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
 
 
 @dataclass
+class EventLoopWatchdogConfig:
+    """Configuration for the supervised gateway event-loop liveness probe."""
+
+    enabled: bool = False
+    interval_seconds: float = 60.0
+    timeout_seconds: float = 30.0
+    failure_threshold: int = 3
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "EventLoopWatchdogConfig":
+        data = _coerce_dict(data)
+
+        def positive_number(key: str, default: float) -> float:
+            try:
+                value = float(data.get(key, default))
+            except (TypeError, ValueError):
+                return default
+            return value if value > 0 else default
+
+        try:
+            threshold = int(data.get("failure_threshold", 3))
+        except (TypeError, ValueError):
+            threshold = 3
+
+        return cls(
+            enabled=_coerce_bool(data.get("enabled"), False),
+            interval_seconds=positive_number("interval_seconds", 60.0),
+            timeout_seconds=positive_number("timeout_seconds", 30.0),
+            failure_threshold=threshold if threshold > 0 else 3,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "interval_seconds": self.interval_seconds,
+            "timeout_seconds": self.timeout_seconds,
+            "failure_threshold": self.failure_threshold,
+        }
+
+
+@dataclass
 class GatewayConfig:
     """
     Main gateway configuration.
@@ -760,6 +801,11 @@ class GatewayConfig:
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available
     thread_sessions_per_user: bool = False  # When False (default), threads are shared across all participants
     max_concurrent_sessions: Optional[int] = None  # Positive int caps simultaneous active chat sessions
+
+    # Opt-in event-loop liveness probe for supervised deployments.
+    event_loop_watchdog: EventLoopWatchdogConfig = field(
+        default_factory=EventLoopWatchdogConfig
+    )
 
     # Multi-profile multiplexing (opt-in; default off preserves one-gateway-per-profile).
     # When True, the default profile's gateway serves inbound messages for every
@@ -888,6 +934,7 @@ class GatewayConfig:
             "group_sessions_per_user": self.group_sessions_per_user,
             "thread_sessions_per_user": self.thread_sessions_per_user,
             "max_concurrent_sessions": self.max_concurrent_sessions,
+            "event_loop_watchdog": self.event_loop_watchdog.to_dict(),
             "multiplex_profiles": self.multiplex_profiles,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
@@ -1011,6 +1058,11 @@ class GatewayConfig:
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),
             max_concurrent_sessions=max_concurrent_sessions,
+            event_loop_watchdog=EventLoopWatchdogConfig.from_dict(
+                data.get("event_loop_watchdog")
+                or nested_gateway.get("event_loop_watchdog")
+                or {}
+            ),
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
@@ -1145,6 +1197,8 @@ def load_gateway_config() -> GatewayConfig:
                     gw_data["multiplex_profiles"] = gateway_section["multiplex_profiles"]
                 if "max_concurrent_sessions" in gateway_section:
                     gw_data["max_concurrent_sessions"] = gateway_section["max_concurrent_sessions"]
+                if "event_loop_watchdog" in gateway_section:
+                    gw_data["event_loop_watchdog"] = gateway_section["event_loop_watchdog"]
 
             if "max_concurrent_sessions" in yaml_cfg:
                 gw_data["max_concurrent_sessions"] = yaml_cfg["max_concurrent_sessions"]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21149,6 +21149,74 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
     logger.info("Gateway housekeeping stopped")
 
 
+async def _event_loop_watchdog_probe() -> float:
+    return time.monotonic()
+
+
+def _start_event_loop_watchdog(
+    stop_event: threading.Event,
+    loop: asyncio.AbstractEventLoop,
+    *,
+    interval: float = 60.0,
+    timeout: float = 30.0,
+    max_failures: int = 3,
+) -> None:
+    """Exit for supervisor recovery when the live loop stops dispatching work."""
+    interval, timeout, max_failures = max(interval, 1.0), max(timeout, 1.0), max(max_failures, 1)
+    failures = 0
+    while not stop_event.wait(interval):
+        future = safe_schedule_threadsafe(
+            _event_loop_watchdog_probe(), loop,
+            logger=logger,
+            log_message="Gateway event-loop watchdog scheduling error",
+            log_level=logging.WARNING,
+        )
+        reason = "scheduling failed"
+        if future is not None:
+            try:
+                future.result(timeout=timeout)
+                failures = 0
+                continue
+            except concurrent.futures.TimeoutError:
+                reason = "probe timed out before dispatch" if future.cancel() else "probe did not complete"
+            except Exception as exc:
+                reason = f"probe failed: {exc}"
+        failures += 1
+        logger.warning("Gateway event-loop watchdog failure %d/%d: %s", failures, max_failures, reason)
+        if failures >= max_failures:
+            logger.critical("Gateway event loop is unresponsive; exiting for service restart")
+            try:
+                from gateway.status import write_runtime_status
+                write_runtime_status(
+                    gateway_state="degraded",
+                    exit_reason="event_loop_watchdog_unresponsive",
+                )
+            except Exception:
+                pass
+            _exit_after_graceful_shutdown(GATEWAY_SERVICE_RESTART_EXIT_CODE)
+
+
+def _build_event_loop_watchdog_thread(
+    stop_event: threading.Event,
+    loop: asyncio.AbstractEventLoop,
+    config: Any,
+) -> Optional[threading.Thread]:
+    """Build the watchdog thread when enabled by gateway config."""
+    if not config.enabled:
+        return None
+    return threading.Thread(
+        target=_start_event_loop_watchdog,
+        args=(stop_event, loop),
+        kwargs={
+            "interval": config.interval_seconds,
+            "timeout": config.timeout_seconds,
+            "max_failures": config.failure_threshold,
+        },
+        daemon=True,
+        name="gateway-loop-watchdog",
+    )
+
+
 def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, interval: int = 60):
     """DEPRECATED shim — preserved for backward compatibility.
 
@@ -21692,6 +21760,15 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         name="gateway-housekeeping",
     )
     housekeeping_thread.start()
+
+    watchdog_config = runner.config.event_loop_watchdog
+    loop_watchdog_thread = _build_event_loop_watchdog_thread(
+        cron_stop,
+        asyncio.get_running_loop(),
+        watchdog_config,
+    )
+    if loop_watchdog_thread is not None:
+        loop_watchdog_thread.start()
     
     # Wait for shutdown
     await runner.wait_for_shutdown()
@@ -21730,6 +21807,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     await _await_thread_exit(
         housekeeping_thread, timeout=_HOUSEKEEPING_SHUTDOWN_DRAIN_TIMEOUT
     )
+    await _await_thread_exit(loop_watchdog_thread, timeout=5.0)
 
     # Stop the planned-stop watcher (daemon=True so this is belt-and-suspenders).
     _planned_stop_watcher_stop.set()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2921,6 +2921,16 @@ DEFAULT_CONFIG = {
     # Gateway settings — control how messaging platforms (Telegram, Discord,
     # Slack, etc.) deliver agent-produced files as native attachments.
     "gateway": {
+        # Optional liveness probe for supervised long-running gateways. When
+        # enabled, a daemon thread exits with the service-restart code after
+        # the asyncio loop fails to dispatch several consecutive probes.
+        "event_loop_watchdog": {
+            "enabled": False,
+            "interval_seconds": 60.0,
+            "timeout_seconds": 30.0,
+            "failure_threshold": 3,
+        },
+
         # Seconds the gateway waits for a single messaging platform to finish
         # connecting during startup (and on reconnect). Discord in particular
         # can blow past the old fixed 30s when an account has many slash

--- a/tests/gateway/test_event_loop_watchdog.py
+++ b/tests/gateway/test_event_loop_watchdog.py
@@ -1,0 +1,112 @@
+import concurrent.futures
+
+import pytest
+
+import gateway.run as gateway_run
+import gateway.status as gateway_status
+from gateway.config import GatewayConfig
+
+
+class _ExitCalled(Exception):
+    def __init__(self, code: int):
+        super().__init__(code)
+        self.code = code
+
+
+class _NeverStops:
+    def wait(self, timeout=None):
+        return False
+
+
+class _TimedOutFuture:
+    def result(self, timeout=None):
+        raise concurrent.futures.TimeoutError()
+
+    def cancel(self):
+        return True
+
+
+def test_event_loop_watchdog_exits_after_consecutive_undispatched_probes(monkeypatch):
+    def fake_schedule(coro, *args, **kwargs):
+        coro.close()
+        return _TimedOutFuture()
+
+    monkeypatch.setattr(
+        gateway_run,
+        "safe_schedule_threadsafe",
+        fake_schedule,
+    )
+    monkeypatch.setattr(gateway_status, "write_runtime_status", lambda **kwargs: None)
+
+    def fake_exit(code):
+        raise _ExitCalled(code)
+
+    monkeypatch.setattr(gateway_run, "_exit_after_graceful_shutdown", fake_exit)
+
+    with pytest.raises(_ExitCalled) as exc_info:
+        gateway_run._start_event_loop_watchdog(
+            _NeverStops(),
+            loop=object(),
+            interval=1,
+            timeout=1,
+            max_failures=2,
+        )
+
+    assert exc_info.value.code == gateway_run.GATEWAY_SERVICE_RESTART_EXIT_CODE
+
+
+def test_watchdog_config_parses_nested_gateway_values():
+    config = GatewayConfig.from_dict(
+        {
+            "gateway": {
+                "event_loop_watchdog": {
+                    "enabled": True,
+                    "interval_seconds": 12.5,
+                    "timeout_seconds": 4,
+                    "failure_threshold": 5,
+                }
+            }
+        }
+    )
+
+    watchdog = config.event_loop_watchdog
+    assert watchdog.enabled is True
+    assert watchdog.interval_seconds == 12.5
+    assert watchdog.timeout_seconds == 4
+    assert watchdog.failure_threshold == 5
+
+
+def test_watchdog_config_invalid_values_fall_back_to_safe_defaults():
+    config = GatewayConfig.from_dict(
+        {
+            "event_loop_watchdog": {
+                "enabled": "yes",
+                "interval_seconds": 0,
+                "timeout_seconds": "invalid",
+                "failure_threshold": -1,
+            }
+        }
+    )
+
+    watchdog = config.event_loop_watchdog
+    assert watchdog.enabled is True
+    assert watchdog.interval_seconds == 60.0
+    assert watchdog.timeout_seconds == 30.0
+    assert watchdog.failure_threshold == 3
+
+
+def test_watchdog_thread_is_built_only_when_config_enabled():
+    disabled = GatewayConfig.from_dict({}).event_loop_watchdog
+    assert gateway_run._build_event_loop_watchdog_thread(
+        _NeverStops(), object(), disabled
+    ) is None
+
+    enabled = GatewayConfig.from_dict(
+        {"event_loop_watchdog": {"enabled": True}}
+    ).event_loop_watchdog
+    thread = gateway_run._build_event_loop_watchdog_thread(
+        _NeverStops(), object(), enabled
+    )
+    assert thread is not None
+    assert thread.name == "gateway-loop-watchdog"
+    assert thread.daemon is True

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1661,6 +1661,27 @@ voice:
 
 Use `/voice on` in the CLI to enable microphone mode, `record_key` to start/stop recording, and `/voice tts` to toggle spoken replies. See [Voice Mode](/user-guide/features/voice-mode) for end-to-end setup and platform-specific behavior.
 
+## Gateway Event-Loop Watchdog
+
+Supervised gateway deployments can opt into an event-loop liveness probe:
+
+```yaml
+gateway:
+  event_loop_watchdog:
+    enabled: false
+    interval_seconds: 60
+    timeout_seconds: 30
+    failure_threshold: 3
+```
+
+When enabled, a daemon thread schedules probes on the gateway asyncio loop. If
+the loop fails to dispatch the configured number of consecutive probes, Hermes
+records a degraded runtime status and exits with the service-restart code so
+the existing supervisor can recover it. The watchdog is disabled by default.
+
+All intervals and thresholds must be positive. Invalid values fall back to the
+defaults shown above.
+
 ## Streaming
 
 Stream tokens to the terminal or messaging platforms as they arrive, instead of waiting for the full response.


### PR DESCRIPTION
## Summary

- add an opt-in daemon-thread probe for a gateway event loop that remains alive but stops dispatching callbacks
- configure the feature under gateway.event_loop_watchdog in config.yaml
- parse and validate the settings through GatewayConfig with safe defaults
- record degraded runtime status and exit with the existing service-restart code after consecutive failures
- document the config surface and cover parsing, enablement, and failure behavior

## Configuration

gateway.event_loop_watchdog.enabled defaults to false. The nested config also accepts positive interval_seconds, timeout_seconds, and failure_threshold values. Invalid values fall back to safe defaults.

This supersedes #66721 and directly addresses its maintainer feedback: there are no new user-facing HERMES environment variables, and the feature uses the existing config.yaml model and UX.

## Tests

- scripts/run_tests.sh tests/gateway/test_event_loop_watchdog.py tests/gateway/test_config.py -q
- 108 passed
- ruff check on changed Python files: passed