### PR TITLE
fix(vision): honor routed model tool-message capabilities

### DIFF
--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -73,6 +73,32 @@ def get_provider_profile(name: str) -> ProviderProfile | None:
     return _REGISTRY.get(canonical)
 
 
+def supports_vision_tool_messages(provider: str, model: str = "") -> bool:
+    """Return whether a provider route accepts images in tool messages.
+
+    The active provider profile is not always the model vendor profile.  A
+    routing provider such as OpenRouter can expose ``xiaomi/mimo-v2.5`` while
+    its own generic profile permits multimodal tool results.  In that case the
+    routed model still has Xiaomi's stricter message-schema limitation.
+
+    Only explicit opt-outs are inherited.  Unknown provider/model prefixes
+    retain the backwards-compatible permissive default.
+    """
+    names = [provider]
+    if isinstance(model, str) and "/" in model:
+        names.append(model.split("/", 1)[0])
+
+    for name in names:
+        if not isinstance(name, str) or not name.strip():
+            continue
+        profile = get_provider_profile(name.strip().lower())
+        if profile is not None and not getattr(
+            profile, "supports_vision_tool_messages", True
+        ):
+            return False
+    return True
+
+
 def list_providers() -> list[ProviderProfile]:
     """Return all registered provider profiles (one per canonical name)."""
     if not _discovered:

--- a/run_agent.py
+++ b/run_agent.py
@@ -5395,14 +5395,13 @@ class AIAgent:
 
         Some providers (e.g. Xiaomi MiMo) support multimodal user messages
         but reject list-type tool message content with 400 errors.  This
-        checks the provider profile's ``supports_vision_tool_messages`` field.
+        checks both the active provider and a routed ``vendor/model`` profile.
         """
         try:
-            from providers import get_provider_profile
+            from providers import supports_vision_tool_messages
             provider = (getattr(self, "provider", "") or "").strip()
-            profile = get_provider_profile(provider)
-            if profile is not None:
-                return getattr(profile, "supports_vision_tool_messages", True)
+            model = (getattr(self, "model", "") or "").strip()
+            return supports_vision_tool_messages(provider, model)
         except Exception:
             pass
         return True  # default: assume compatible

--- a/tests/run_agent/test_vision_tool_messages.py
+++ b/tests/run_agent/test_vision_tool_messages.py
@@ -79,6 +79,10 @@ class TestProviderSupportsVisionToolMessages:
         agent = _make_agent("openrouter", "gpt-4o")
         assert agent._provider_supports_vision_tool_messages() is True
 
+    def test_openrouter_inherits_xiaomi_model_opt_out(self):
+        agent = _make_agent("openrouter", "xiaomi/mimo-v2.5")
+        assert agent._provider_supports_vision_tool_messages() is False
+
     def test_anthropic_defaults_true(self):
         agent = _make_agent("anthropic", "claude-sonnet-4")
         assert agent._provider_supports_vision_tool_messages() is True
@@ -124,6 +128,17 @@ class TestToolResultContentProactiveDowngrade:
 
         assert isinstance(content, list)
         assert any(p.get("type") == "image_url" for p in content if isinstance(p, dict))
+
+    def test_openrouter_xiaomi_route_downgrades_to_text_summary(self):
+        """A router profile must not mask the selected model's opt-out."""
+        agent = _make_agent("openrouter", "xiaomi/mimo-v2.5")
+        result = _multimodal_result(text="screenshot captured")
+
+        with patch.object(agent, "_model_supports_vision", return_value=True):
+            content = agent._tool_result_content_for_active_model("vision_analyze", result)
+
+        assert isinstance(content, str)
+        assert "screenshot captured" in content
 
     def test_non_vision_model_gets_text_summary(self):
         """Non-vision model: text summary regardless of provider."""

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -38,6 +38,9 @@ class TestSupportsMediaInToolResults:
     def test_openrouter_yes(self):
         assert _supports_media_in_tool_results("openrouter", "anthropic/claude-opus-4.6") is True
 
+    def test_openrouter_xiaomi_route_no(self):
+        assert _supports_media_in_tool_results("openrouter", "xiaomi/mimo-v2.5") is False
+
     def test_nous_yes(self):
         assert _supports_media_in_tool_results("nous", "anthropic/claude-sonnet-4.6") is True
 
@@ -229,6 +232,31 @@ class TestHandleVisionAnalyzeFastPath:
 
         assert not (isinstance(result, dict) and result.get("_multimodal") is True), \
             "Fast path fired for non-vision model; should have fallen through to aux LLM"
+
+    def test_routed_xiaomi_model_falls_through_to_aux(self, tmp_path):
+        """A router must not mask a model vendor's tool-message opt-out."""
+        img = tmp_path / "x.png"
+        img.write_bytes(_TINY_PNG)
+
+        async def _aux_sentinel(*args, **kwargs):
+            return '{"sentinel": "aux-path"}'
+
+        from agent.auxiliary_client import set_runtime_main, clear_runtime_main
+        set_runtime_main("openrouter", "xiaomi/mimo-v2.5")
+        try:
+            with patch(
+                "agent.image_routing.decide_image_input_mode", return_value="native",
+            ), patch(
+                "tools.vision_tools.vision_analyze_tool", side_effect=_aux_sentinel,
+            ) as mock_aux:
+                coro = _handle_vision_analyze({"image_url": str(img), "question": "?"})
+                result = asyncio.get_event_loop().run_until_complete(coro)
+        finally:
+            clear_runtime_main()
+
+        assert isinstance(result, str)
+        assert json.loads(result) == {"sentinel": "aux-path"}
+        mock_aux.assert_called_once()
 
     def test_fast_path_disabled_for_unsupported_provider(self, tmp_path, monkeypatch):
         """Even with vision-capable model, unknown provider → fall through."""

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -783,6 +783,16 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
     if not p:
         return False
 
+    # A routing provider's generic transport may support image content while
+    # the selected model vendor does not.  Respect explicit profile opt-outs
+    # before applying the transport allowlist below.
+    try:
+        from providers import supports_vision_tool_messages
+        if not supports_vision_tool_messages(p, model):
+            return False
+    except Exception:
+        pass
+
     # Aggregators that route to multiple vendors — assume support since
     # users on these aggregators are typically using vision-capable
     # frontier models. Falling back to text would be a regression for
@@ -849,6 +859,9 @@ def _should_use_native_vision_fast_path() -> bool:
         model = _read_main_model()
         cfg = load_config()
         if decide_image_input_mode(provider, model, cfg) != "native":
+            return False
+        from providers import supports_vision_tool_messages
+        if not supports_vision_tool_messages(provider, model):
             return False
         return (
             _supports_media_in_tool_results(provider, model)


### PR DESCRIPTION
## What does this PR do?

Makes multimodal tool-message capability model-route-aware.

A routing provider such as OpenRouter exposes its own permissive `ProviderProfile`, so `xiaomi/mimo-v2.5` was treated as accepting images inside `tool` messages even though the Xiaomi profile explicitly opts out. `vision_analyze` then selected its native tool-result fast path; MiMo either rejected that schema or processed the image unreliably. Direct user-message image input works and remains unchanged.

The resolver now combines the active provider profile with a recognized `vendor/model` profile. Only explicit opt-outs are inherited, so unknown/custom routes keep the existing permissive default.

## Related Issue

Fixes #57766
Fixes #49388

This overlaps #49389 and #57770, but covers the gap between them: #49389 fixes direct-provider fast-path selection, while #57770 adds a MiMo-name predicate only in the agent-loop downgrade. This PR uses the existing provider capability as the source of truth and applies it to both fast-path selection and final tool-result conversion, including routed models.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `providers.supports_vision_tool_messages(provider, model)` to resolve explicit incompatibilities from both the transport provider and a routed vendor prefix.
- Use the resolver in `AIAgent._provider_supports_vision_tool_messages()` so OpenRouter/other proxy routes downgrade incompatible multimodal tool results.
- Gate the `vision_analyze` native fast path with the same resolver so routed MiMo uses the auxiliary vision request (where the image is a user message) instead of losing the pixels to a text-only downgrade.
- Add regression coverage for OpenRouter + `xiaomi/mimo-v2.5`, while retaining OpenRouter + Claude/GPT native behavior.

## How to Test

1. Configure `provider: openrouter`, `model: xiaomi/mimo-v2.5`, and native/auto image routing.
2. Call `vision_analyze` on an image. It should use the auxiliary path and return an actual description, not place the image in a tool-result message.
3. Run:
   - `scripts/run_tests.sh tests/run_agent/test_vision_tool_messages.py tests/tools/test_vision_native_fast_path.py -q` (42 passed)
   - `scripts/run_tests.sh tests/tools/test_computer_use_vision_routing.py tests/tools/test_computer_use_capture_routing.py -q` (44 passed)
   - `ruff check providers/__init__.py run_agent.py tools/vision_tools.py tests/run_agent/test_vision_tool_messages.py tests/tools/test_vision_native_fast_path.py`
   - `python scripts/check-windows-footguns.py --diff origin/main`

A broader Windows run of `tests/tools/test_computer_use.py` had 214 passes and 2 unrelated environment/fixture failures (`pywintypes` absent from the test venv; a fixture emits an unescaped Windows path as JSON).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and described the overlap above
- [x] My PR contains only changes related to this fix
- [ ] I've run the full test suite
- [x] I've added tests for my changes
- [x] I've tested on Windows 11 / Python 3.11

### Documentation & Housekeeping

- [x] Documentation/docstrings updated where relevant; standalone docs N/A
- [x] `cli-config.yaml.example` N/A (no config changes)
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A (no workflow changes)
- [x] Cross-platform impact considered; no OS-specific production code added
- [x] Tool descriptions/schemas N/A (no public schema change)