### PR TITLE
fix(moonshot): inject required: [] on object schemas missing it

### DIFF
--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -130,6 +130,12 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
             else:
                 repaired.pop("enum")
 
+    # Moonshot requires every object schema to carry an explicit ``required``
+    # array, even when empty.  Standard JSON Schema allows omitting it.
+    if (repaired.get("type") == "object" or "properties" in repaired) and "required" not in repaired:
+        repaired["required"] = []
+    if "required" in repaired and not isinstance(repaired["required"], list):
+        repaired["required"] = []
     return repaired
 
 


### PR DESCRIPTION
## Summary

Moonshot/Kimi's tool-parameter validator requires every object schema to carry an explicit `required` array, even when empty. Standard JSON Schema allows omitting `required`, but Moonshot rejects this with HTTP 400:

```
required must be an array
```

Fixes #66835

## Root Cause

Hermes's `agent/moonshot_schema.py` sanitizer handles several Moonshot-specific rules but does not inject `"required": []` on object schemas that lack the key. Any tool with zero required parameters (browser_back, browser_console, delegate_task, session_search, etc.) triggers this.

## Fix

In `_repair_schema()`, after all existing repairs:
- If the node has `type: "object"` or `properties` but no `required` → inject `"required": []`
- If `required` exists but is not a list → coerce to `[]`

This aligns with the existing sanitizer philosophy: conservative, only modifies shapes the backend couldn't use anyway.

## Changes

- `agent/moonshot_schema.py`: Added `required` injection rule in `_repair_schema()`