### PR TITLE
fix(compression): don't recommend a threshold the small-context floor will ignore

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -458,6 +458,20 @@ def check_compression_model_feasibility(agent: Any) -> None:
                     new_threshold / main_ctx
                 )
             safe_pct = int((aux_context / main_ctx) * 100) if main_ctx else 50
+            # The "lower the threshold" suggestion must survive the
+            # compressor's raise-only small-context floor (#67422): for main
+            # windows under 512K, _effective_threshold_percent() raises any
+            # configured value below 75% back up, so recommending e.g. 0.40
+            # would be silently ignored and this warning would reappear every
+            # session. Only offer the option when the floored value still
+            # fits the auxiliary model's context.
+            from agent.context_compressor import ContextCompressor as _CC
+
+            threshold_suggestion_viable = (
+                not main_ctx
+                or _CC._effective_threshold_percent(main_ctx, safe_pct / 100) * main_ctx
+                <= aux_context
+            )
             # Build human-readable "model (provider)" labels for both
             # the main model and the compression model so users can
             # tell at a glance which provider each side is actually
@@ -491,15 +505,30 @@ def check_compression_model_feasibility(agent: Any) -> None:
                 f"{old_threshold:,} tokens. "
                 f"Auto-lowered this session's threshold to "
                 f"{new_threshold:,} tokens so compression can run.\n"
-                f"  To make this permanent, edit config.yaml — either:\n"
-                f"  1. Use a larger compression model:\n"
-                f"       auxiliary:\n"
-                f"         compression:\n"
-                f"           model: <model-with-{old_threshold:,}+-context>\n"
-                f"  2. Lower the compression threshold:\n"
-                f"       compression:\n"
-                f"         threshold: 0.{safe_pct:02d}"
             )
+            if threshold_suggestion_viable:
+                msg += (
+                    f"  To make this permanent, edit config.yaml — either:\n"
+                    f"  1. Use a larger compression model:\n"
+                    f"       auxiliary:\n"
+                    f"         compression:\n"
+                    f"           model: <model-with-{old_threshold:,}+-context>\n"
+                    f"  2. Lower the compression threshold:\n"
+                    f"       compression:\n"
+                    f"         threshold: 0.{safe_pct:02d}"
+                )
+            else:
+                msg += (
+                    f"  To make this permanent, use a larger compression "
+                    f"model in config.yaml:\n"
+                    f"       auxiliary:\n"
+                    f"         compression:\n"
+                    f"           model: <model-with-{old_threshold:,}+-context>\n"
+                    f"  (Lowering compression.threshold cannot help here — "
+                    f"{_main_label}'s {main_ctx:,}-token window is under "
+                    f"512K, where Hermes floors the compression trigger at "
+                    f"75% and raises any lower configured value back up.)"
+                )
             agent._compression_warning = msg
             agent._emit_status(msg)
             logger.warning(

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -458,19 +458,28 @@ def check_compression_model_feasibility(agent: Any) -> None:
                     new_threshold / main_ctx
                 )
             safe_pct = int((aux_context / main_ctx) * 100) if main_ctx else 50
-            # The "lower the threshold" suggestion must survive the
-            # compressor's raise-only small-context floor (#67422): for main
-            # windows under 512K, _effective_threshold_percent() raises any
-            # configured value below 75% back up, so recommending e.g. 0.40
-            # would be silently ignored and this warning would reappear every
-            # session. Only offer the option when the floored value still
-            # fits the auxiliary model's context.
+            # The "lower the threshold" suggestion must survive the built-in
+            # trigger recomputation (#67422): _effective_threshold_percent()
+            # raises sub-75% values back up for main windows under 512K, and
+            # _compute_threshold_tokens() further applies the output-token
+            # reservation, the 64K floor, and the degenerate-window guard.
+            # Recommending a value those would override is silently ignored
+            # and this warning would reappear every session — so mirror the
+            # compressor's own math and only offer the option when the
+            # recomputed trigger actually fits the auxiliary model's context.
+            # External engines own compaction policy (#44439); the built-in
+            # floor doesn't apply to them, so keep the plain suggestion.
             from agent.context_compressor import ContextCompressor as _CC
 
+            recomputed_threshold = None
+            if main_ctx and isinstance(agent.context_compressor, _CC):
+                recomputed_threshold = _CC._compute_threshold_tokens(
+                    main_ctx,
+                    _CC._effective_threshold_percent(main_ctx, safe_pct / 100),
+                    getattr(agent.context_compressor, "max_tokens", None),
+                )
             threshold_suggestion_viable = (
-                not main_ctx
-                or _CC._effective_threshold_percent(main_ctx, safe_pct / 100) * main_ctx
-                <= aux_context
+                recomputed_threshold is None or recomputed_threshold <= aux_context
             )
             # Build human-readable "model (provider)" labels for both
             # the main model and the compression model so users can
@@ -525,9 +534,11 @@ def check_compression_model_feasibility(agent: Any) -> None:
                     f"         compression:\n"
                     f"           model: <model-with-{old_threshold:,}+-context>\n"
                     f"  (Lowering compression.threshold cannot help here — "
-                    f"{_main_label}'s {main_ctx:,}-token window is under "
-                    f"512K, where Hermes floors the compression trigger at "
-                    f"75% and raises any lower configured value back up.)"
+                    f"with {_main_label}'s {main_ctx:,}-token window, "
+                    f"Hermes's small-context floor and output reservation "
+                    f"would recompute the trigger to "
+                    f"{recomputed_threshold:,} tokens, still above the "
+                    f"compression model's {aux_context:,}.)"
                 )
             agent._compression_warning = msg
             agent._emit_status(msg)

--- a/contributors/emails/sora.bluesky.dev@gmail.com
+++ b/contributors/emails/sora.bluesky.dev@gmail.com
@@ -1,0 +1,1 @@
+Sora-bluesky

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -95,7 +95,12 @@ def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_clien
     assert "config.yaml" in messages[0]
     assert "auxiliary:" in messages[0]
     assert "compression:" in messages[0]
-    assert "threshold:" in messages[0]
+    # 200K main is under the 512K small-context limit and 80K/200K = 40% sits
+    # below the 75% floor — a `threshold:` suggestion would be raised back to
+    # 75% and ignored (#67422), so the message must not offer one and must
+    # explain the floor instead.
+    assert "threshold:" not in messages[0]
+    assert "75%" in messages[0]
     # Warning stored for gateway replay
     assert agent._compression_warning is not None
     # Threshold on the live compressor was actually lowered to aux_context.
@@ -514,3 +519,48 @@ def test_run_conversation_clears_warning_after_replay(mock_get_client, mock_ctx_
         agent._compression_warning = None
 
     assert len(callback_events) == 0
+
+
+# ── #67422: threshold suggestion must survive the small-context floor ────────
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_threshold_suggestion_kept_when_at_or_above_floor(mock_get_client, mock_ctx_len):
+    """Small-context main, but aux/main = 80% >= the 75% floor — the
+    `threshold:` suggestion is still viable and must be offered."""
+    agent = _make_agent(main_context=100_000, threshold_percent=0.85)
+    # threshold = 85,000 — aux has 80,000 (above 64K floor, below threshold)
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+
+    agent._check_compression_model_feasibility()
+
+    assert len(messages) == 1
+    assert "threshold: 0.80" in messages[0]
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=300_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_threshold_suggestion_kept_for_large_context_main(mock_get_client, mock_ctx_len):
+    """Main window >= 512K has no floor — any suggestion is honored, so the
+    `threshold:` option stays even below 75%."""
+    agent = _make_agent(main_context=1_000_000, threshold_percent=0.50)
+    # threshold = 500,000 — aux has 300,000
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+
+    agent._check_compression_model_feasibility()
+
+    assert len(messages) == 1
+    assert "threshold: 0.30" in messages[0]

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -98,9 +98,9 @@ def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_clien
     # 200K main is under the 512K small-context limit and 80K/200K = 40% sits
     # below the 75% floor — a `threshold:` suggestion would be raised back to
     # 75% and ignored (#67422), so the message must not offer one and must
-    # explain the floor instead.
+    # explain the recomputed trigger instead (0.75 * 200K = 150K).
     assert "threshold:" not in messages[0]
-    assert "75%" in messages[0]
+    assert "150,000" in messages[0]
     # Warning stored for gateway replay
     assert agent._compression_warning is not None
     # Threshold on the live compressor was actually lowered to aux_context.
@@ -564,3 +564,52 @@ def test_threshold_suggestion_kept_for_large_context_main(mock_get_client, mock_
 
     assert len(messages) == 1
     assert "threshold: 0.30" in messages[0]
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_threshold_suggestion_kept_when_reservation_shrinks_trigger(mock_get_client, mock_ctx_len):
+    """Output-token reservation can make a floored suggestion viable again:
+    with max_tokens=120K on a 200K window, the recomputed trigger is
+    max(0.75 * 80K, 64K) = 64K, which fits the 80K aux — so the suggestion
+    must NOT be suppressed by the raw-window percentage check (sweeper
+    regression for #67422)."""
+    agent = _make_agent(main_context=200_000, threshold_percent=0.50)
+    agent.context_compressor.max_tokens = 120_000
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+
+    agent._check_compression_model_feasibility()
+
+    assert len(messages) == 1
+    assert "threshold: 0.40" in messages[0]
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_plugin_engine_keeps_plain_suggestion(mock_get_client, mock_ctx_len):
+    """External context engines own compaction policy (#44439) — the built-in
+    small-context floor must not suppress the threshold suggestion when the
+    active compressor is not the built-in ContextCompressor."""
+    agent = _make_agent(main_context=200_000, threshold_percent=0.50)
+    plugin_engine = MagicMock()  # not spec'd — fails isinstance(ContextCompressor)
+    plugin_engine.context_length = 200_000
+    plugin_engine.threshold_tokens = 100_000
+    agent.context_compressor = plugin_engine
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+
+    agent._check_compression_model_feasibility()
+
+    assert len(messages) == 1
+    assert "threshold: 0.40" in messages[0]


### PR DESCRIPTION
## What does this PR do?

The auxiliary-compression feasibility warning computes its `compression.threshold` suggestion as `aux_context / main_context` (`agent/conversation_compression.py`), independently of `ContextCompressor._effective_threshold_percent()`'s raise-only small-context floor (`agent/context_compressor.py:1261-1262`). For main windows under 512K the floor raises any configured value below 75% back up, so a suggestion like `threshold: 0.40` is silently ignored and the identical warning returns every session — an advice loop the user cannot exit by following the advice.

This PR derives the suggestion's viability through the compressor's **own** floor logic (the `_effective_threshold_percent` staticmethod, so the two can't drift): the "lower the threshold" option is offered only when the floored value still fits the auxiliary model's context; otherwise the message recommends only a larger compression model and explains the floor. This is the issue's first two suggested fixes — no new config surface.

## Related Issue

Fixes #67422

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_compression.py` — compute `threshold_suggestion_viable` via `ContextCompressor._effective_threshold_percent()`; branch the persistence-guidance section of the warning on it. Unknown main context keeps the legacy message (the floor can't be evaluated without a window size).
- `tests/run_agent/test_compression_feasibility.py` — the existing auto-correct test (200K main, 40% suggestion → floored) now pins the new branch: no `threshold:` suggestion, floor explained. Two new tests pin the surviving suggestion at/above the floor on a small window (100K main, 80% ≥ 75%) and below 75% on a 512K+ window where no floor applies (1M main, 30%).

## How to Test

1. `scripts/run_tests.sh tests/run_agent/test_compression_feasibility.py -q`
2. Manual repro (from the issue): main model with a <512K window + aux compression model below 75% of it → the warning no longer suggests a sub-0.75 `compression.threshold`; it explains the floor and recommends a larger aux model. Previously, applying the suggested value changed nothing and the warning repeated every session.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (topic search + issue timeline: none; triage relates #66249 as adjacent but distinct)
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the compression suites (`tests/run_agent/test_compression_feasibility.py`, `tests/agent/test_context_compressor.py`) — 201 passed, zero failures on my platform
- [x] I've added tests for my changes (the updated floored-branch test fails against the previous code)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Docstrings/comments — the viability rationale is documented at the computation site — or N/A
- [x] `cli-config.yaml.example` — N/A (no config surface added)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure string/arithmetic logic)
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

```
$ pytest tests/run_agent/test_compression_feasibility.py tests/agent/test_context_compressor.py -q  (Windows 11)
201 passed

# Against the unfixed code (regression proof, changed test):
1 failed (test_auto_corrects_threshold_when_aux_context_below_threshold), new pinning tests pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)