### PR TITLE
fix(auth): parse Retry-After HTTP dates

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -28,6 +28,7 @@ import stat
 import sys
 import base64
 import hashlib
+import math
 import subprocess
 import threading
 import time
@@ -36,6 +37,7 @@ import webbrowser
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Tuple
@@ -792,8 +794,9 @@ def is_rate_limited_auth_error(error: Exception) -> bool:
 def _parse_retry_after_seconds(headers: Any) -> Optional[int]:
     """Best-effort parse of a ``Retry-After`` header into whole seconds.
 
-    Supports the delta-seconds form (e.g. ``"120"``). HTTP-date forms and
-    missing/unparseable values return ``None`` rather than guessing.
+    Supports the delta-seconds form (e.g. ``"120"``) and the HTTP-date form
+    allowed by RFC 9110. Missing/unparseable values return ``None`` rather
+    than guessing.
     """
     if headers is None:
         return None
@@ -806,7 +809,16 @@ def _parse_retry_after_seconds(headers: Any) -> Optional[int]:
     try:
         seconds = int(str(raw).strip())
     except (TypeError, ValueError):
-        return None
+        try:
+            retry_at = parsedate_to_datetime(str(raw).strip())
+        except (TypeError, ValueError, IndexError, OverflowError):
+            return None
+        if retry_at.tzinfo is None:
+            retry_at = retry_at.replace(tzinfo=timezone.utc)
+        delta = (
+            retry_at.astimezone(timezone.utc) - datetime.now(timezone.utc)
+        ).total_seconds()
+        return max(0, math.ceil(delta))
     return seconds if seconds >= 0 else None
 
 

--- a/hermes_cli/nous_billing.py
+++ b/hermes_cli/nous_billing.py
@@ -26,10 +26,13 @@ Design rules:
 from __future__ import annotations
 
 import json
+import math
 import os
 import urllib.error
 import urllib.parse
 import urllib.request
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import Any, Optional
 
 DEFAULT_PORTAL_BASE_URL = "https://portal.nousresearch.com"
@@ -296,7 +299,7 @@ def _resolve_token_and_base(*, use_cache: bool = True) -> tuple[str, str]:
 
 
 def _retry_after_seconds(headers: Any) -> Optional[int]:
-    """Parse a ``Retry-After`` header (integer seconds) — None if absent/bad."""
+    """Parse a ``Retry-After`` header into whole seconds, if possible."""
     if headers is None:
         return None
     try:
@@ -308,7 +311,16 @@ def _retry_after_seconds(headers: Any) -> Optional[int]:
     try:
         return int(str(raw).strip())
     except (TypeError, ValueError):
-        return None
+        try:
+            retry_at = parsedate_to_datetime(str(raw).strip())
+        except (TypeError, ValueError, IndexError, OverflowError):
+            return None
+        if retry_at.tzinfo is None:
+            retry_at = retry_at.replace(tzinfo=timezone.utc)
+        delta = (
+            retry_at.astimezone(timezone.utc) - datetime.now(timezone.utc)
+        ).total_seconds()
+        return max(0, math.ceil(delta))
 
 
 def _raise_for_error(

--- a/tests/agent/test_billing_view.py
+++ b/tests/agent/test_billing_view.py
@@ -14,7 +14,9 @@ request function for the builder.
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+from email.utils import format_datetime
 
 import pytest
 
@@ -320,6 +322,20 @@ def test_rate_limited_maps_with_retry_after(status):
     assert ei.value.retry_after == 60
     # Critically: a rate limit is NOT a generic BillingError-only — surfaces branch on type.
     assert isinstance(ei.value, BillingRateLimited)
+
+
+def test_rate_limited_maps_with_retry_after_http_date():
+    retry_at = datetime.now(timezone.utc) + timedelta(seconds=60)
+
+    with pytest.raises(BillingRateLimited) as ei:
+        _raise_for_error(
+            429,
+            {"error": "rate_limited"},
+            _Headers({"Retry-After": format_datetime(retry_at, usegmt=True)}),
+        )
+
+    assert ei.value.retry_after is not None
+    assert 0 <= ei.value.retry_after <= 60
 
 
 @pytest.mark.parametrize(

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -3,6 +3,8 @@
 import json
 import time
 import base64
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -953,6 +955,28 @@ def test_refresh_429_without_retry_after_header(monkeypatch):
     assert err.code == CODEX_RATE_LIMITED_CODE
     assert err.relogin_required is False
     assert "quota exhausted" in str(err).lower()
+
+
+def test_parse_retry_after_http_date():
+    """Retry-After may be an HTTP-date, not only delta-seconds."""
+    from hermes_cli.auth import _parse_retry_after_seconds
+
+    retry_at = datetime.now(timezone.utc) + timedelta(seconds=90)
+    header = format_datetime(retry_at, usegmt=True)
+
+    parsed = _parse_retry_after_seconds({"retry-after": header})
+
+    assert parsed is not None
+    assert 0 < parsed <= 90
+
+
+def test_parse_retry_after_past_http_date_returns_zero():
+    from hermes_cli.auth import _parse_retry_after_seconds
+
+    retry_at = datetime.now(timezone.utc) - timedelta(seconds=30)
+    header = format_datetime(retry_at, usegmt=True)
+
+    assert _parse_retry_after_seconds({"retry-after": header}) == 0
 
 
 def test_is_rate_limited_auth_error_distinguishes_credential_errors():


### PR DESCRIPTION
## Problem
Some Hermes rate-limit paths read `Retry-After` headers, but only handled integer second values. `Retry-After` also allows HTTP-date values, so valid rate-limit responses could lose retry timing guidance.

This replaces #38701 without force-pushing the old branch, and includes the billing parser gap called out in review.

## Before / after
Before:
- Codex auth quota handling returned no retry delay for non-integer `Retry-After` headers.
- The billing client also returned no retry delay for HTTP-date `Retry-After` values on `BillingRateLimited` errors.

After:
- Codex auth quota handling accepts integer seconds and HTTP-date values.
- Billing rate-limit errors expose `retry_after` for integer seconds and HTTP-date values.
- Malformed values still return `None`; past HTTP dates clamp to `0` seconds.

## Verification
- `python -m pytest tests/hermes_cli/test_auth_codex_provider.py tests/agent/test_billing_view.py -q`
- Result: `112 passed`