### PR TITLE
fix(redactor): detect bare AQ.-format Gemini authorization keys

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -79,6 +79,8 @@ _PREFIX_PATTERNS = [
     r"xapp-\d+-[A-Za-z0-9-]{10,}",      # Slack app-Level token
     r"xox[baprs]-[A-Za-z0-9-]{10,}",    # Slack bot/app/user tokens
     r"AIza[A-Za-z0-9_-]{30,}",          # Google API keys
+    r"AQ\.[A-Za-z0-9_-]{40,}",         # Google Gemini authorization keys
+    r"AQ\\.[A-Za-z0-9_-]{40,}",         # Google Gemini authorization keys
     r"pplx-[A-Za-z0-9]{10,}",           # Perplexity
     r"fal_[A-Za-z0-9_-]{10,}",          # Fal.ai
     r"fc-[A-Za-z0-9]{10,}",             # Firecrawl


### PR DESCRIPTION
## Summary

The secret redactor misses Google Gemini authorization keys using the newer `AQ.` prefix. Bare unlabelled keys in tool output, provider errors, or pasted text pass through unchanged and can reach `state.db`.

Fixes #66920 (security)

## Root Cause

`agent/redact.py` `_PREFIX_PATTERNS` covers standard Google API keys (`AIza...`) but not the newer `AQ.` authorization-key format.

## Fix

Add explicit pattern `AQ\\.[A-Za-z0-9_-]{40,}` to `_PREFIX_PATTERNS` alongside the existing `AIza` pattern.

## Changes

- `agent/redact.py`: Added Gemini `AQ.` key pattern to `_PREFIX_PATTERNS`