### PR TITLE
docs: surface dashboard quick start in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Use any model you want — [Nous Portal](https://portal.nousresearch.com), OpenR
 
 <table>
 <tr><td><b>A real terminal interface</b></td><td>Full TUI with multiline editing, slash-command autocomplete, conversation history, interrupt-and-redirect, and streaming tool output.</td></tr>
+<tr><td><b>Local web dashboard</b></td><td>Browser UI for managing config, API keys, sessions, tools, skills, and the embedded Chat tab. Launch it with <code>hermes dashboard</code>; install the <code>[web]</code> extra first if you are running from source.</td></tr>
 <tr><td><b>Lives where you do</b></td><td>Telegram, Discord, Slack, WhatsApp, Signal, and CLI — all from a single gateway process. Voice memo transcription, cross-platform conversation continuity.</td></tr>
 <tr><td><b>A closed learning loop</b></td><td>Agent-curated memory with periodic nudges. Autonomous skill creation after complex tasks. Skills self-improve during use. FTS5 session search with LLM summarization for cross-session recall. <a href="https://github.com/plastic-labs/honcho">Honcho</a> dialectic user modeling. Compatible with the <a href="https://agentskills.io">agentskills.io</a> open standard.</td></tr>
 <tr><td><b>Scheduled automations</b></td><td>Built-in cron scheduler with delivery to any platform. Daily reports, nightly backups, weekly audits — all in natural language, running unattended.</td></tr>
@@ -170,6 +171,7 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 | [CLI Usage](https://hermes-agent.nousresearch.com/docs/user-guide/cli)                              | Commands, keybindings, personalities, sessions             |
 | [Configuration](https://hermes-agent.nousresearch.com/docs/user-guide/configuration)                | Config file, providers, models, all options                |
 | [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging)                | Telegram, Discord, Slack, WhatsApp, Signal, Home Assistant |
+| [Web Dashboard](https://hermes-agent.nousresearch.com/docs/user-guide/features/web-dashboard)       | Browser UI, Chat tab, install extras, and remote access    |
 | [Security](https://hermes-agent.nousresearch.com/docs/user-guide/security)                          | Command approval, DM pairing, container isolation          |
 | [Tools & Toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools)            | 40+ tools, toolset system, terminal backends               |
 | [Skills System](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills)              | Procedural memory, Skills Hub, creating skills             |


### PR DESCRIPTION
## Problem
The README points users to CLI, messaging, config, and other feature docs, but the web dashboard is easy to miss from the first page even though the full dashboard guide already exists.

This replaces #31603 against current main and keeps the guidance aligned with the current dashboard behavior.

## Before / after
Before:
- The top feature table did not mention the local web dashboard.
- The documentation table did not link directly to the Web Dashboard guide.

After:
- The feature table includes a concise `hermes dashboard` quick-start mention.
- The documentation table links to the existing Web Dashboard guide for install extras, Chat tab behavior, and remote access details.
- No stale `--tui` guidance is included.

## Verification
- Reviewed README diff locally.
- Confirmed the linked Web Dashboard docs already document `[web]` / `[pty]` prerequisites and platform-specific details.