### PR TITLE
fix(mcp): guard against RuntimeError on closed event loop during shutdown

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2188,6 +2188,15 @@ class MCPServerTask:
             before returning so the next park cycle starts from a fresh
             signal. Shutdown takes precedence.
         """
+        # Guard against closed event loop during shutdown — trying to
+        # ensure_future on a closed loop raises RuntimeError.
+        try:
+            loop = asyncio.get_running_loop()
+            if loop.is_closed():
+                return "shutdown"
+        except RuntimeError:
+            return "shutdown"
+
         shutdown_task = asyncio.ensure_future(self._shutdown_event.wait())
         reconnect_task = asyncio.ensure_future(self._reconnect_event.wait())
         try:
@@ -3145,6 +3154,15 @@ class MCPServerTask:
 
     async def _wait_for_lazy_reconnect(self) -> None:
         """Wait while an intentionally recycled stdio server is dormant."""
+        # Guard against closed event loop during shutdown — creating
+        # tasks on a closed loop raises RuntimeError.
+        try:
+            loop = asyncio.get_running_loop()
+            if loop.is_closed():
+                return
+        except RuntimeError:
+            return
+
         shutdown_task = asyncio.create_task(self._shutdown_event.wait())
         reconnect_task = asyncio.create_task(self._reconnect_event.wait())
         try:


### PR DESCRIPTION
When Hermes shuts down, the MCP event loop may close before lingering `MCPServerTask.run()` coroutines exit their final park cycle. Both `_wait_for_reconnect_or_shutdown` and `_wait_for_lazy_reconnect` call `asyncio.ensure_future()` / `asyncio.create_task()` on the running loop, which raises `RuntimeError('Event loop is closed')` when the loop is already shut down.

**What happens:** the error is caught by the `Exception ignored in: <coroutine object ...>` handler and printed as a noisy traceback on stderr. The shutdown itself succeeds, but the output is ugly and can confuse users.

**The fix:** check `loop.is_closed()` at the top of both methods, and return immediately (with `"shutdown"` for the reconnect variant) so the `run()` coroutine exits cleanly. Both call sites already handle the `"shutdown"` return correctly.

**Impact:** zero behavioral change during normal operation — the guard only triggers when the loop is already shutting down, which is a transient condition that lasts for ~one sheduled tick during `shutdown_mcp_servers()`.

**Testing:** the fix is trivial — a read-only check followed by an early return. The existing test suite covers the normal-path behaviour of both methods unchanged.