### PR TITLE
feat(redact): mask 1Password service-account tokens (ops_ prefix)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -110,6 +110,7 @@ _PREFIX_PATTERNS = [
     r"fw-[A-Za-z0-9]{30,}",             # Fireworks AI API key
     r"fw_[A-Za-z0-9]{30,}",             # Fireworks AI API key
     r"fpk_[A-Za-z0-9]{30,}",            # Fireworks AI project key
+    r"ops_[A-Za-z0-9._=-]{30,}",        # 1Password service-account token
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name.

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -36,6 +36,13 @@ class TestKnownPrefixes:
         result = redact_sensitive_text("github_pat_abc123def456ghi789jklmno")
         assert "abc123def456" not in result
 
+    def test_1password_service_account_token(self):
+        # 1Password service-account tokens: "ops_" prefix + long base64url body
+        token = "ops_" + "abcdEFGH1234" * 6
+        result = redact_sensitive_text(token)
+        assert "abcdEFGH1234abcdEFGH1234" not in result
+        assert "..." in result
+
     def test_slack_token(self):
         token = "xoxb-" + "0" * 12 + "-" + "a" * 14
         result = redact_sensitive_text(token)


### PR DESCRIPTION
## What
Add the 1Password **service-account** token prefix `ops_` to `agent/redact.py` `_PREFIX_PATTERNS`, so these tokens are masked in logs/output like the vendor keys already covered (`sk-`, `ghp_`, `xai-`, `ntn_`, `fpk_`, …).

## Why
1Password service-account tokens (`ops_` + long base64url body) are the **master credential** for `op://` secret resolution. They can surface in env dumps, error output or tool results, and were leaking verbatim because no prefix pattern matched them.

## Change
- `agent/redact.py`: `+ r"ops_[A-Za-z0-9._=-]{30,}"` (min length 30 avoids false positives on short `ops_…` words).
- `tests/agent/test_redact.py`: `test_1password_service_account_token`.

Verified locally: `redact_sensitive_text("ops_" + <token>)` masks the body and keeps the `ops_` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)