### PR TITLE
feat: add Sference as model-provider plugin

### DIFF
--- a/plugins/model-providers/sference/__init__.py
+++ b/plugins/model-providers/sference/__init__.py
@@ -1,0 +1,28 @@
+"""Sference provider profile.
+
+Sference — hosted LLM inference on bare-metal GPUs (B200/B300/AMD BW100).
+OpenAI-compatible API at https://api.sference.com/v1, EMEA region.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+sference = ProviderProfile(
+    name="sference",
+    aliases=("sference",),
+    display_name="Sference",
+    description="Sference — hosted LLM inference on bare-metal GPUs (EMEA)",
+    signup_url="https://sference.com",
+    env_vars=("SFERENCE_API_KEY", "SFERENCE_BASE_URL"),
+    base_url="https://api.sference.com/v1",
+    auth_type="api_key",
+    fallback_models=(
+        "zai-org/GLM-5.2",
+        "deepseek-ai/DeepSeek-V4-Flash",
+        "Qwen/Qwen3.6-35B-A3B",
+        "bottlecapai/ThinkingCap-Qwen3.6-27B",
+    ),
+    default_aux_model="Qwen/Qwen3.6-35B-A3B",
+)
+
+register_provider(sference)

--- a/plugins/model-providers/sference/plugin.yaml
+++ b/plugins/model-providers/sference/plugin.yaml
@@ -1,0 +1,5 @@
+name: sference-provider
+kind: model-provider
+version: 1.0.0
+description: Sference — hosted LLM inference on bare-metal GPUs
+author: Sference

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -47,6 +47,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **AWS Bedrock** | `hermes model` → "AWS Bedrock" (provider: `bedrock`; standard AWS credentials chain via boto3) |
 | **NVIDIA Build** | `NVIDIA_API_KEY` in `~/.hermes/.env` (provider: `nvidia`; NIM-hosted models on build.nvidia.com) |
 | **Ollama Cloud** | `hermes model` → "Ollama Cloud" (provider: `ollama-cloud`; cloud-hosted Ollama API) |
+| **Sference** | `SFERENCE_API_KEY` in `~/.hermes/.env` (provider: `sference`; hosted LLM inference on bare-metal GPUs, EMEA region) |
 | **Qwen OAuth** | `hermes model` → "Qwen OAuth" (provider: `qwen-oauth`; browser PKCE login) |
 | **MiniMax OAuth** | `hermes model` → "MiniMax (OAuth)" (provider: `minimax-oauth`; browser PKCE login) |
 | **StepFun** | `STEPFUN_API_KEY` in `~/.hermes/.env` (provider: `stepfun`) |
@@ -263,6 +264,10 @@ hermes chat --provider arcee --model trinity-large-thinking
 # Use the exact model ID returned by GMI's /v1/models endpoint.
 hermes chat --provider gmi --model zai-org/GLM-5.1-FP8
 # Requires: GMI_API_KEY in ~/.hermes/.env
+
+# Sference (hosted LLM inference on bare-metal GPUs, EMEA region)
+hermes chat --provider sference --model zai-org/GLM-5.2
+# Requires: SFERENCE_API_KEY in ~/.hermes/.env
 ```
 
 Fireworks uses its native slash-form catalog IDs, such as `accounts/fireworks/models/kimi-k2p6`. Run `hermes model`, choose **Fireworks AI**, and select from the live catalog or enter another Fireworks model ID. The default endpoint is `https://api.fireworks.ai/inference/v1`; configure a different endpoint through `model.base_url` in `config.yaml`, not `.env`.


### PR DESCRIPTION
## Summary

Adds [Sference](https://sference.com) — hosted LLM inference on bare-metal GPUs (B200/B300/AMD BW100), EMEA region — as a standalone model-provider plugin. No core tree edits.

Sference exposes an OpenAI-compatible API at `https://api.sference.com/v1`. Users set `SFERENCE_API_KEY` in `~/.hermes/.env` and select the provider via `hermes model` or `--provider sference`.

### Changes

- **`plugins/model-providers/sference/__init__.py`** — `ProviderProfile` with `register_provider()`. API-key auth, `SFERENCE_API_KEY` env var, `SFERENCE_BASE_URL` override, fallback models (GLM-5.2, DeepSeek V4 Flash, Qwen3.6, ThinkingCap).
- **`plugins/model-providers/sference/plugin.yaml`** — plugin manifest (`kind: model-provider`).
- **`website/docs/integrations/providers.md`** — provider table entry + CLI usage example.

### What auto-wires (zero core edits)

Per the [model-provider plugin docs](https://hermes-agent.nousresearch.com/docs/developer-guide/model-provider-plugin), the `ProviderProfile` registration auto-wires:
- `PROVIDER_REGISTRY` entry in `hermes_cli/auth.py` (credential resolution)
- `--provider sference` CLI flag
- `hermes model` picker entry
- `hermes setup` wizard entry
- `hermes doctor` health check
- Runtime resolution (`base_url` + `api_key` + `chat_completions` api_mode)
- Auxiliary model defaults
- URL reverse-mapping for auto-detection

### Usage

```bash
# Set API key
echo "SFERENCE_API_KEY=sk_..." >> ~/.hermes/.env

# Use via CLI
hermes chat --provider sference --model zai-org/GLM-5.2

# Or via hermes model
hermes model  # select "Sference"
```

### Test plan

- [x] Plugin discovered by `list_providers()` — `name=sference`, `base_url=https://api.sference.com/v1`
- [x] `PROVIDER_REGISTRY` auto-extended with correct `api_key_env_vars` and `base_url_env_var`
- [x] `scripts/run_tests.sh tests/hermes_cli/test_auth_commands.py tests/hermes_cli/test_auth_provider_gate.py tests/agent/test_credential_pool.py` — 152 passed, 0 failed