### PR TITLE
fix(compression): floor safe_pct at small-context threshold before recommending

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -339,6 +339,12 @@ def check_compression_model_feasibility(agent: Any) -> None:
                     new_threshold / main_ctx
                 )
             safe_pct = int((aux_context / main_ctx) * 100) if main_ctx else 50
+            # Account for the small-context floor: models under 512K
+            # are raise-only floored at 75%.
+            from agent.context_compressor import _SMALL_CTX_WINDOW_LIMIT, _SMALL_CTX_THRESHOLD_PERCENT
+            if main_ctx and main_ctx < _SMALL_CTX_WINDOW_LIMIT:
+                floor_pct = int(_SMALL_CTX_THRESHOLD_PERCENT * 100)
+                safe_pct = max(safe_pct, floor_pct)
             # Build human-readable "model (provider)" labels for both
             # the main model and the compression model so users can
             # tell at a glance which provider each side is actually


### PR DESCRIPTION
## Summary

The compression feasibility warning calculates `safe_pct` independently and can recommend a `compression.threshold` below the 75% small-context floor applied by `ContextCompressor._effective_threshold_percent()`. Users who configure the recommended value see the same warning repeat next session because the floor raises it back to 75%.

Fixes #67422

## Root Cause

In `conversation_compression.py`, `safe_pct` is calculated as `int((aux_context / main_ctx) * 100)` without considering the small-context floor. For context windows below 512K, `ContextCompressor` applies a hard-coded 75% raise-only floor, but the warning doesn't account for this.

## Fix

Import `_SMALL_CTX_WINDOW_LIMIT` and `_SMALL_CTX_THRESHOLD_PERCENT` from `context_compressor` and apply `max(safe_pct, floor_pct)` so the warning always recommends a threshold the system will actually honor.

## Changes

- `agent/conversation_compression.py`: Added small-context floor check after `safe_pct` calculation