### PR TITLE
fix(config): stop doctor flagging Hermes-written known_plugin_toolsets

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5512,7 +5512,10 @@ _EXTRA_KNOWN_ROOT_KEYS = {
     "plugins",           # plugin enable/disable lists (hermes_cli/plugins_cmd.py)
     "smart_model_routing",   # written by the setup wizard (hermes_cli/setup.py)
     "platform_toolsets",     # written by the setup wizard (hermes_cli/setup.py)
+    "known_plugin_toolsets", # written/read by hermes_cli/tools_config.py toolset-save flow
     "session_reset",         # top-level form read by gateway/config.py + setup
+    "group_sessions_per_user",   # top-level form bridged by gateway/config.py
+    "thread_sessions_per_user",  # top-level form bridged by gateway/config.py
     "multiplex_profiles",    # top-level form accepted alongside gateway.multiplex_profiles
     "profile_routes",        # top-level form accepted alongside gateway.profile_routes
     "platforms",             # top-level per-platform map merged by gateway/config.py

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -253,6 +253,20 @@ class TestUnknownTopLevelKeys:
         assert _EXTRA_KNOWN_ROOT_KEYS.issubset(_KNOWN_ROOT_KEYS)
         assert _KNOWN_ROOT_KEYS == frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 
+    def test_hermes_written_roots_not_flagged_as_unknown(self):
+        """Roots Hermes itself writes/reads must not warn as unknown (#67397)."""
+        issues = validate_config_structure({
+            "model": {"provider": "openrouter"},
+            "known_plugin_toolsets": {"cli": ["spotify"]},
+            "group_sessions_per_user": True,
+            "thread_sessions_per_user": False,
+        })
+        unknown = [i for i in issues if "Unknown top-level config key" in i.message]
+        messages = " ".join(i.message for i in unknown)
+        assert "known_plugin_toolsets" not in messages
+        assert "group_sessions_per_user" not in messages
+        assert "thread_sessions_per_user" not in messages
+
     def test_provider_like_unknown_root_keeps_misplaced_message(self):
         """Preserve existing base_url/api_key root-level guidance (not generic unknown)."""
         issues = validate_config_structure({


### PR DESCRIPTION
## Summary
- `hermes doctor` falsely warned that top-level `known_plugin_toolsets` (and `group_sessions_per_user`) were unknown, even though Hermes itself writes/reads those keys.
- Add both roots to `_EXTRA_KNOWN_ROOT_KEYS` so config validation matches runtime behavior.
- Add a regression test so the false-positive cannot return unnoticed.

Fixes the allowlist mismatch reported in #67397 (sweeper closed as `cannot_reproduce`, but the warning is still reproducible on current `main`).

## Test plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_config_validation.py -q`
- [ ] With a config that contains `known_plugin_toolsets:` (e.g. after `hermes tools` save), run `hermes doctor` and confirm the unknown-key warning is gone
- [ ] Confirm a real typo root (e.g. `skillz:`) still warns
