### PR TITLE
fix: skip blocking proc.stdout.close() on Windows when drain thread is alive (#67362)

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -959,10 +959,19 @@ class BaseEnvironment(ABC):
         # it means the non-blocking loop itself stopped cooperating.
         drain_thread.join(timeout=2)
 
-        try:
-            proc.stdout.close()
-        except Exception:
-            pass
+        # On Windows, closing the fd while a backgrounded child still holds
+        # the write-end of the pipe serializes on the same fd lock as the
+        # blocking os.read() in the drain thread — close() itself blocks until
+        # that child exits (issue #67362).  When the drain thread is still
+        # alive we leave the fd to the daemon thread; it reaches EOF when the
+        # child exits and the fd is then reclaimed by GC or Popen.__del__.
+        # On POSIX, close() and read() on the same fd are independent, so
+        # this guard is only needed on Windows.
+        if not (os.name == "nt" and drain_thread.is_alive()):
+            try:
+                proc.stdout.close()
+            except Exception:
+                pass
 
         if _DEBUG_INTERRUPT:
             logger.info(


### PR DESCRIPTION
## Summary

On native Windows, when a foreground terminal command backgrounds a child
(e.g. `cmd &`), the drain thread's blocking `os.read()` on the stdout pipe
never sees EOF until the backgrounded grandchild exits — because it inherited
the write-end of our pipe via `fork()`. After `proc.poll()` reports the main
process exited, the existing `drain_thread.join(timeout=2)` correctly times
out, **but** the subsequent `proc.stdout.close()` then blocks: on Windows,
`close()` serializes on the same fd lock that the blocked `read()` is
holding, so `close()` cannot return until the child exits.

This means the `execute()` call blocks for the full lifetime of the
backgrounded child (e.g., 60s for a `time.sleep(60) &`), even though the
command's timeout (15s) has long passed.

## Root cause

Two threads, captured with `faulthandler` (see #67362):

```
drain thread:  tools/environments/base.py:794  os.read(fd, 4096)
main thread:   tools/environments/base.py:963  proc.stdout.close()
```

The `close()` goes through MSVCRT fd machinery, which serializes on the same
per-fd lock that the blocked `os.read` is holding. On POSIX, `close()` and
`read()` on the same fd are independent — this is Windows-specific.

## Fix

In `_wait_for_process`, guard `proc.stdout.close()` so it is skipped on
Windows when the drain thread is still alive:

```python
if not (os.name == "nt" and drain_thread.is_alive()):
    try:
        proc.stdout.close()
    except Exception:
        pass
```

The fd is left to the daemon drain thread, which reaches EOF when the child
exits and is reclaimed by GC or `Popen.__del__`.

## Testing

- `tests/tools/test_local_background_child_hang.py` already provides a
  regression test suite (from the original #8340 fix). These tests are
  expected to pass on native Windows after this fix.
- No behavior changes on POSIX — the guard is Windows-only.
- Timeout, interrupt, and kill paths are unaffected because they call
  `_kill_process()` which causes the drain thread to see EOF promptly.

Closes #67362