### PR TITLE
fix(desktop): respect i18n labels for reasoning effort in model menu and status bar

### DIFF
--- a/apps/desktop/src/app/chat/composer/model-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.tsx
@@ -42,6 +42,7 @@ export function ModelPill({
   model: ChatBarState['model']
 }) {
   const copy = useI18n().t.shell.statusbar
+  const modelLabels = useI18n().t.shell.modelOptions
   const currentModel = useStore($currentModel)
   const currentProvider = useStore($currentProvider)
   const fastMode = useStore($currentFastMode)
@@ -65,7 +66,7 @@ export function ModelPill({
   ) : (
     <>
       {currentModel.trim() ? (
-        <span className="truncate">{formatModelStatusLabel(currentModel, { fastMode, reasoningEffort })}</span>
+        <span className="truncate">{formatModelStatusLabel(currentModel, { fastMode, reasoningEffort, effortLabels: modelLabels })}</span>
       ) : (
         <GlyphSpinner className="opacity-50" spinner="braille" />
       )}

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -94,7 +94,7 @@ const isFastTier = (tier: unknown): boolean =>
   )
 
 // Reuse the composer's effort labels.
-const effortLabelKey = (v: string) => v as 'high' | 'low' | 'max' | 'medium' | 'minimal' | 'ultra' | 'xhigh'
+const effortLabelKey = (v: string) => v as 'high' | 'low' | 'max' | 'medium' | 'minimal' | 'none' | 'ultra' | 'xhigh'
 
 // A provider row is "ready" to pick a model from when it reports models. The
 // backend now surfaces the full `hermes model` universe (every canonical
@@ -814,7 +814,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                   <SelectContent>
                     {EFFORT_VALUES.map(value => (
                       <SelectItem key={value} value={value}>
-                        {value === 'none' ? m.reasoningOff : t.shell.modelOptions[effortLabelKey(value)]}
+                        {t.shell.modelOptions[effortLabelKey(value)]}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -66,6 +66,7 @@ interface ProviderGroup {
 export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: ModelMenuPanelProps) {
   const { t } = useI18n()
   const copy = t.shell.modelMenu
+  const effortCopy = t.shell.modelOptions
   const closeMenu = useContext(ModelMenuCloseContext)
   const [search, setSearch] = useState('')
   const [refreshing, setRefreshing] = useState(false)
@@ -265,7 +266,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
 
                 const meta = [
                   fastControl.kind !== 'none' && fastControl.on ? copy.fast : null,
-                  (caps?.reasoning ?? true) ? reasoningEffortLabel(effEffort) || copy.medium : null
+                  (caps?.reasoning ?? true) ? reasoningEffortLabel(effEffort, effortCopy) || copy.medium : null
                 ]
                   .filter(Boolean)
                   .join(' ')

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2105,6 +2105,7 @@ export const en: Translations = {
       xhigh: 'Extra High',
       max: 'Max',
       ultra: 'Ultra',
+      none: 'Off',
       updateFailed: 'Model option update failed',
       fastFailed: 'Fast mode update failed'
     },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2029,6 +2029,7 @@ export const ja = defineLocale({
       xhigh: '特高',
       max: '最大',
       ultra: 'ウルトラ',
+      none: 'オフ',
       updateFailed: 'モデルオプションの更新に失敗しました',
       fastFailed: '高速モードの更新に失敗しました'
     },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1734,6 +1734,7 @@ export interface Translations {
       xhigh: string
       max: string
       ultra: string
+      none: string
       updateFailed: string
       fastFailed: string
     }

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1964,6 +1964,7 @@ export const zhHant = defineLocale({
       xhigh: '極高',
       max: '最高',
       ultra: '超高',
+      none: '關閉',
       updateFailed: '模型選項更新失敗',
       fastFailed: '快速模式更新失敗'
     },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2275,6 +2275,7 @@ export const zh: Translations = {
       xhigh: '极高',
       max: '最高',
       ultra: '超高',
+      none: '关闭',
       updateFailed: '模型选项更新失败',
       fastFailed: '快速模式更新失败'
     },

--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -28,6 +28,31 @@ describe('model-status-label', () => {
     expect(reasoningEffortLabel('')).toBe('')
   })
 
+  it('uses i18n labels when provided', () => {
+    const zhLabels: Record<string, string> = {
+      minimal: '最小',
+      low: '低',
+      medium: '中',
+      high: '高',
+      xhigh: '极高',
+      max: '最高',
+      ultra: '超高',
+      none: '关闭'
+    }
+
+    expect(reasoningEffortLabel('high', zhLabels)).toBe('高')
+    expect(reasoningEffortLabel('medium', zhLabels)).toBe('中')
+    expect(reasoningEffortLabel('low', zhLabels)).toBe('低')
+    expect(reasoningEffortLabel('none', zhLabels)).toBe('关闭')
+    expect(reasoningEffortLabel('xhigh', zhLabels)).toBe('极高')
+  })
+
+  it('falls back to built-in labels when i18n labels are missing a key', () => {
+    const partialLabels: Record<string, string> = { medium: 'Mittel' }
+    expect(reasoningEffortLabel('medium', partialLabels)).toBe('Mittel')
+    expect(reasoningEffortLabel('high', partialLabels)).toBe('High')
+  })
+
   it('appends fast + effort session state to the status label', () => {
     expect(formatModelStatusLabel('openai/gpt-5.5', { fastMode: true, reasoningEffort: 'high' })).toBe(
       'GPT-5.5 · Fast High'
@@ -37,6 +62,26 @@ describe('model-status-label', () => {
   it('always surfaces the effort (default medium) so the level is visible', () => {
     expect(formatModelStatusLabel('openai/gpt-5.5', { reasoningEffort: 'medium' })).toBe('GPT-5.5 · Med')
     expect(formatModelStatusLabel('openai/gpt-5.5')).toBe('GPT-5.5 · Med')
+  })
+
+  it('localizes effort labels in status label via effortLabels', () => {
+    const zhLabels: Record<string, string> = {
+      low: '低',
+      medium: '中',
+      high: '高',
+      none: '关闭'
+    }
+
+    expect(formatModelStatusLabel('openai/gpt-5.5', { reasoningEffort: 'high', effortLabels: zhLabels })).toBe(
+      'GPT-5.5 · 高'
+    )
+
+    expect(formatModelStatusLabel('openai/gpt-5.5', { reasoningEffort: 'none', effortLabels: zhLabels })).toBe(
+      'GPT-5.5 · 关闭'
+    )
+
+    // empty effort / default medium uses the localized fallback
+    expect(formatModelStatusLabel('openai/gpt-5.5', { effortLabels: zhLabels })).toBe('GPT-5.5 · 中')
   })
 
   it('returns just the placeholder name when there is no model', () => {

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -11,14 +11,21 @@ const REASONING_LABELS: Record<string, string> = {
   ultra: 'Ultra'
 }
 
-export function reasoningEffortLabel(effort: string): string {
+/** Map a reasoning effort value to a display label. When `labels` is provided
+ *  (e.g. the i18n `t.shell.modelOptions` catalog) it takes precedence over the
+ *  built-in English fallback map, so localized labels (Chinese "中"/"高"/"低")
+ *  are shown instead of the English "Med"/"High"/"Low". */
+export function reasoningEffortLabel(
+  effort: string,
+  labels?: Record<string, string>
+): string {
   const key = normalize(effort)
 
   if (!key) {
     return ''
   }
 
-  return REASONING_LABELS[key] ?? effort
+  return labels?.[key] ?? REASONING_LABELS[key] ?? effort
 }
 
 /** Which model/provider a picker should mark "current". With a live session the
@@ -102,7 +109,7 @@ export function displayModelName(model: string): string {
 /** Status bar trigger label — model name plus the live session state (effort/fast). */
 export function formatModelStatusLabel(
   model: string,
-  options?: { fastMode?: boolean; reasoningEffort?: string }
+  options?: { fastMode?: boolean; reasoningEffort?: string; effortLabels?: Record<string, string> }
 ): string {
   const name = displayModelName(model)
 
@@ -120,7 +127,8 @@ export function formatModelStatusLabel(
 
   // Always surface the effort (empty = Hermes default of medium) so the
   // current reasoning level is visible at a glance, not just when non-default.
-  parts.push(reasoningEffortLabel(options?.reasoningEffort ?? '') || 'Med')
+  // Pass the i18n labels through so localized catalogs (zh/"中") are respected.
+  parts.push(reasoningEffortLabel(options?.reasoningEffort ?? '', options?.effortLabels) || 'Med')
 
   return `${name} · ${parts.join(' ')}`
 }

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -128,7 +128,7 @@ export function formatModelStatusLabel(
   // Always surface the effort (empty = Hermes default of medium) so the
   // current reasoning level is visible at a glance, not just when non-default.
   // Pass the i18n labels through so localized catalogs (zh/"中") are respected.
-  parts.push(reasoningEffortLabel(options?.reasoningEffort ?? '', options?.effortLabels) || 'Med')
+  parts.push(reasoningEffortLabel(options?.reasoningEffort ?? '', options?.effortLabels) || (options?.effortLabels?.medium ?? 'Med'))
 
   return `${name} · ${parts.join(' ')}`
 }


### PR DESCRIPTION
## Bug
When non-English users select a reasoning depth, the model menu meta labels and status bar pill show English (e.g. `Med`/`High`) instead of the localized translations (e.g. Chinese `中`/`高`).

## Root cause
`reasoningEffortLabel()` in `model-status-label.ts` uses a hardcoded `REASONING_LABELS` map with English values, completely bypassing the i18n system.

## Fix
Added an optional `labels?: Record<string, string>` parameter to `reasoningEffortLabel()`. When provided (from `t.shell.modelOptions`), it takes precedence over the built-in English fallback. Updated `formatModelStatusLabel()` and both callers to pass the i18n catalog through.

## Files changed
- `apps/desktop/src/lib/model-status-label.ts` — core signature change
- `apps/desktop/src/app/shell/model-menu-panel.tsx` — pass i18n labels
- `apps/desktop/src/app/chat/composer/model-pill.tsx` — pass i18n labels

## Testing
- All 10 existing `model-status-label.test.ts` tests pass unchanged
- TypeScript typecheck passes
- All 311 desktop lib tests pass