### PR TITLE
fix(dashboard): bracket IPv6 addresses in dashboard URLs (#67367)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12399,7 +12399,10 @@ def cmd_dashboard(args):
         # Desktop pool backends are intentionally per-profile.
         and os.environ.get("HERMES_DESKTOP") != "1"
     ):
-        url = f"http://{args.host or '127.0.0.1'}:{args.port}/?profile={_launch_profile}"
+        from hermes_cli.url_utils import format_url_host
+
+        url_host = format_url_host(args.host or "127.0.0.1")
+        url = f"http://{url_host}:{args.port}/?profile={_launch_profile}"
         if _dashboard_listening(args.host, args.port):
             print(f"Machine dashboard already running on port {args.port}.")
             print(f"  Managing profile '{_launch_profile}': {url}")

--- a/hermes_cli/url_utils.py
+++ b/hermes_cli/url_utils.py
@@ -1,0 +1,13 @@
+"""Small helpers for composing URLs from configured network hosts."""
+
+
+def format_url_host(host: str) -> str:
+    """Return *host* in HTTP URL-authority form.
+
+    IPv6 literals require brackets when followed by a port. Already-bracketed
+    values are preserved so callers can safely pass either representation.
+    """
+    host = host.strip()
+    if ":" in host and not (host.startswith("[") and host.endswith("]")):
+        return f"[{host}]"
+    return host

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17809,8 +17809,10 @@ def _maybe_open_browser(
         )
         return
 
+    from hermes_cli.url_utils import format_url_host
+
     _display_host = host if host not in ("0.0.0.0", "::") else "127.0.0.1"
-    _open_url = f"http://{_display_host}:{actual_port}"
+    _open_url = f"http://{format_url_host(_display_host)}:{actual_port}"
     if initial_profile:
         from urllib.parse import quote
         _open_url += f"/?profile={quote(initial_profile)}"
@@ -18035,7 +18037,9 @@ def start_server(
                 # advertise a paste-and-connect URL, just announce the bind.
                 print(f"  Hermes backend listening on {host}:{actual_port}")
             else:
-                print(f"  Hermes Web UI → http://{host}:{actual_port}")
+                from hermes_cli.url_utils import format_url_host
+
+                print(f"  Hermes Web UI → http://{format_url_host(host)}:{actual_port}")
             _maybe_open_browser(host, actual_port, open_browser, initial_profile)
 
             # Collapse the peer-hangup teardown flood (#50005). When the Desktop


### PR DESCRIPTION
Closes #67367

When dashboard binds to IPv6, the URL was constructed as http://::1:9119 which is invalid. IPv6 hosts with ports must be bracketed: http://[::1]:9119.

Adds hermes_cli/url_utils.py with format_url_host() helper.