### PR TITLE
feat: add cross-process turn serialization with DB-level leases (#67442)

### DIFF
--- a/gateway/turn_lease.py
+++ b/gateway/turn_lease.py
@@ -300,3 +300,244 @@ class SessionTurnLeaseRegistry:
         if lease.lock.locked():
             lease.lock.release()
         return True
+
+
+# ---------------------------------------------------------------------------
+# DB-level turn lease — cross-process serialization (#67442)
+# ---------------------------------------------------------------------------
+
+# Default total wait for the DB lease poll loop.  Shorter than the
+# in-process DEFAULT_LEASE_WAIT because a DB-held lease that outlives its
+# TTL is reclaimed automatically (the stale row is deleted on the next
+# acquire attempt), so a stuck holder wedges the session for at most
+# TURN_LEASE_TTL_SECONDS, not indefinitely.
+DEFAULT_DB_LEASE_WAIT = 300.0
+
+# Initial backoff interval between DB poll attempts (seconds).
+DEFAULT_DB_LEASE_POLL = 0.25
+
+# Maximum backoff interval (capped exponential).
+DEFAULT_DB_LEASE_POLL_MAX = 2.0
+
+# Backoff multiplier per retry.
+DEFAULT_DB_LEASE_BACKOFF = 1.5
+
+# Default lease TTL (seconds).  Must be longer than the longest expected
+# turn.  The HermesState default of 120 s covers all but the most extreme
+# tool loops; callers with known-long runs should pass a longer TTL or
+# enable background refresh.
+DEFAULT_DB_LEASE_TTL = 120.0
+
+
+class TurnLease:
+    """DB-level async context manager for cross-process turn serialization.
+
+    Uses the ``turn_leases`` table in ``HermesState`` as the coordination
+    point, so a CLI process and a gateway process sharing the same session
+    (CLI-continuity) serialize against the same DB row (#67442).  The
+    in-process :class:`SessionTurnLeaseRegistry` cannot see across process
+    boundaries — this closes that gap.
+
+    Usage::
+
+        async with TurnLease(
+            state, session_id, holder, surface="cli", run_generation=gen,
+        ) as acquired:
+            if not acquired:
+                # Timed out — proceed unserialized (fail-open).
+                ...
+            # Critical section: load history → run → flush.
+            ...
+
+    .. rubric:: Protocol
+
+    On enter, polls :meth:`HermesState.try_acquire_turn_lease` with
+    exponential backoff until the lease is acquired or the overall
+    ``wait_timeout`` expires.  Returns ``True`` when the lease was
+    acquired, ``False`` on timeout (fail-open — the caller proceeds
+    unserialized rather than wedging the session).
+
+    On exit, calls :meth:`HermesState.release_turn_lease`.  Guaranteed on
+    every exit path: normal return, exception, and cancellation.  If a
+    background refresh task was running it is cancelled first.
+
+    .. rubric:: Background refresh
+
+    Set ``refresh_interval`` (seconds) to periodically bump the lease
+    expiry during long turns.  The refresh calls
+    :meth:`HermesState.refresh_turn_lease` and is cancelled on exit.
+    Without it, a turn that runs longer than ``ttl_seconds`` will see its
+    lease expire — the next acquirer reclaims the stale row and the two
+    turns interleave.
+
+    .. rubric:: Safety properties
+
+    - **Fail-open on timeout.**  Returns ``False`` after ``wait_timeout``
+      — the caller proceeds unserialized with a loud ERROR log, never a
+      wedged session.
+    - **Guaranteed release.**  ``__aexit__`` is called on every path,
+      including cancellation.  The DB row is deleted iff this holder still
+      owns it (identity-checked by ``HermesState.release_turn_lease``).
+    - **Expired-lease reclamation.**  The DB layer deletes stale rows
+      transparently, so a crashed holder wedges the session for at most
+      ``ttl_seconds``, not indefinitely.
+    """
+
+    def __init__(
+        self,
+        state,  # HermesState
+        session_id: str,
+        holder: str,
+        *,
+        surface: str = "",
+        run_generation: int = 0,
+        ttl_seconds: float = DEFAULT_DB_LEASE_TTL,
+        wait_timeout: float = DEFAULT_DB_LEASE_WAIT,
+        poll_interval: float = DEFAULT_DB_LEASE_POLL,
+        refresh_interval: Optional[float] = None,
+    ) -> None:
+        self._state = state
+        self._session_id = session_id
+        self._holder = holder
+        self._surface = surface
+        self._run_generation = int(run_generation)
+        self._ttl_seconds = float(ttl_seconds)
+        self._wait_timeout = float(wait_timeout)
+        self._poll_interval = float(poll_interval)
+        self._refresh_interval = refresh_interval
+        self._acquired = False
+        self._refresh_task: Optional[asyncio.Task] = None
+
+    async def __aenter__(self) -> bool:
+        """Acquire the DB turn lease with polling backoff.
+
+        Returns ``True`` on success, ``False`` on timeout (fail-open).
+        """
+        if not self._session_id:
+            self._acquired = False
+            return False
+
+        deadline = time.time() + self._wait_timeout
+        backoff = self._poll_interval
+        attempts = 0
+
+        while True:
+            attempts += 1
+            if self._state.try_acquire_turn_lease(
+                session_id=self._session_id,
+                holder=self._holder,
+                surface=self._surface,
+                run_generation=self._run_generation,
+                ttl_seconds=self._ttl_seconds,
+            ):
+                self._acquired = True
+                logger.debug(
+                    "DB turn lease acquired for session %s (holder=%s, "
+                    "gen=%s, attempts=%s, ttl=%.0fs)",
+                    self._session_id,
+                    self._holder,
+                    self._run_generation,
+                    attempts,
+                    self._ttl_seconds,
+                )
+                break
+
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                logger.error(
+                    "DB turn lease wait timed out after %.1fs on session "
+                    "%s (holder=%s, attempts=%s) — failing open: this turn "
+                    "runs UNSERIALIZED; transcript writes may interleave "
+                    "with another process (#67442)",
+                    self._wait_timeout,
+                    self._session_id,
+                    self._holder,
+                    attempts,
+                )
+                self._acquired = False
+                break
+
+            # Log contention at WARNING on the first attempt only (avoid
+            # log spam during poll loop).
+            if attempts == 1:
+                logger.warning(
+                    "DB turn lease contention on session %s: holder=%s "
+                    "waiting to acquire (ttl=%.0fs, wait=%.0fs) — another "
+                    "process holds the lease (#67442)",
+                    self._session_id,
+                    self._holder,
+                    self._ttl_seconds,
+                    self._wait_timeout,
+                )
+
+            sleep = min(backoff, remaining)
+            await asyncio.sleep(sleep)
+            backoff = min(backoff * DEFAULT_DB_LEASE_BACKOFF,
+                          DEFAULT_DB_LEASE_POLL_MAX)
+
+        if self._acquired and self._refresh_interval is not None:
+            self._start_refresh()
+
+        return self._acquired
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Release the DB turn lease.  Guaranteed on every exit path."""
+        try:
+            if self._refresh_task is not None:
+                self._refresh_task.cancel()
+                try:
+                    await self._refresh_task
+                except asyncio.CancelledError:
+                    pass
+                self._refresh_task = None
+
+            if self._acquired and self._session_id:
+                self._state.release_turn_lease(
+                    session_id=self._session_id,
+                    holder=self._holder,
+                )
+                logger.debug(
+                    "DB turn lease released for session %s (holder=%s)",
+                    self._session_id,
+                    self._holder,
+                )
+        except Exception:
+            logger.debug(
+                "DB turn lease release error for session %s",
+                self._session_id,
+                exc_info=True,
+            )
+        finally:
+            self._acquired = False
+
+    def _start_refresh(self) -> None:
+        """Launch a background task that refreshes the lease periodically."""
+        if self._refresh_interval is None or self._refresh_interval <= 0:
+            return
+
+        async def _refresh_loop() -> None:
+            interval = self._refresh_interval
+            while True:
+                await asyncio.sleep(interval)
+                try:
+                    ok = self._state.refresh_turn_lease(
+                        session_id=self._session_id,
+                        holder=self._holder,
+                        ttl_seconds=self._ttl_seconds,
+                    )
+                    if not ok:
+                        logger.warning(
+                            "DB turn lease refresh failed for session %s "
+                            "(holder=%s) — lease may have been reclaimed "
+                            "by another process (#67442)",
+                            self._session_id,
+                            self._holder,
+                        )
+                except Exception:
+                    logger.debug(
+                        "DB turn lease refresh error for session %s",
+                        self._session_id,
+                        exc_info=True,
+                    )
+
+        self._refresh_task = asyncio.create_task(_refresh_loop())

--- a/gateway/turn_lease.py
+++ b/gateway/turn_lease.py
@@ -50,6 +50,7 @@ Known limits (deliberate, flagged on #64934):
 
 import asyncio
 import logging
+import sqlite3
 import time
 from typing import Dict, Optional
 
@@ -350,3 +351,291 @@ class SessionTurnLeaseRegistry:
         if lease.lock.locked():
             lease.lock.release()
         return True
+
+
+
+# ---------------------------------------------------------------------------
+# DB-level turn lease — async wrapper over the merged cross-process lease
+# ---------------------------------------------------------------------------
+#
+# The storage substrate (``session_turn_leases`` table, lineage-root key,
+# dead-PID reclaim, holder fencing via ``SessionTurnLeaseLostError``) landed
+# in ``6e929a9694`` ("fix(sessions): serialize turns across processes") and
+# follow-ups; the sync ``AIAgent`` consumer lives in ``run_agent.py``.  This
+# section is the async adapter for event-loop contexts (gateway dispatch
+# layer): the same acquire/refresh/release protocol exposed as a context
+# manager that never blocks the loop.
+
+# Default lease TTL (seconds).  Matches the merged storage default and the
+# ``run_agent`` consumer's ``_lease_ttl`` (300.0), so an async wrapper turn
+# and a sync AIAgent turn serialize on the same clock.
+DEFAULT_DB_LEASE_TTL = 300.0
+
+# Default total wait for the DB lease poll loop (seconds).  Mirrors the
+# merged ``acquire_session_turn_lease`` wait budget.  A DB-held lease that
+# outlives its TTL is reclaimed by the next acquirer (expired rows and rows
+# whose local holder PID is known dead are deleted inside the same write
+# transaction), so a crashed holder wedges the session for at most
+# ``ttl_seconds`` — the wait budget only bounds how long this caller polls
+# before failing open.
+DEFAULT_DB_LEASE_WAIT = 1800.0
+
+# Initial backoff interval between DB poll attempts (seconds).
+DEFAULT_DB_LEASE_POLL = 0.25
+
+# Maximum backoff interval (capped exponential).
+DEFAULT_DB_LEASE_POLL_MAX = 2.0
+
+# Backoff multiplier per retry.
+DEFAULT_DB_LEASE_BACKOFF = 1.5
+
+
+class TurnLease:
+    """Async context manager over the merged cross-process session turn lease.
+
+    ``async with TurnLease(state, session_id, holder) as acquired:``
+    serializes the [load history → run → flush] region against the merged
+    ``session_turn_leases`` table (``6e929a9694``, #67442), so a CLI process,
+    a gateway process, or two ``hermes serve`` backends sharing one
+    ``HERMES_HOME`` coordinate through the same DB row.  The in-process
+    :class:`SessionTurnLeaseRegistry` above cannot see across process
+    boundaries — this closes that gap for async callers.
+
+    The storage layer is sync
+    (``HermesState.try_acquire_session_turn_lease`` /
+    ``refresh_session_turn_lease`` / ``release_session_turn_lease``); this
+    wrapper adapts it to the event loop: each attempt is a short SQLite write
+    and the wait between attempts is ``asyncio.sleep``, so the loop never
+    blocks.
+
+    Usage::
+
+        async with TurnLease(
+            state, session_id,
+            holder=f"pid={os.getpid()}:turn={gen}:surface={surface}",
+        ) as acquired:
+            if not acquired:
+                # Timed out — fail-open: proceed unserialized.
+                ...
+            # Critical section: load history → run → flush.
+            ...
+
+    .. rubric:: Protocol
+
+    On enter, polls :meth:`HermesState.try_acquire_session_turn_lease` with
+    capped exponential backoff until the lease is acquired or the overall
+    ``wait_timeout`` expires.  Returns ``True`` when the lease was acquired,
+    ``False`` on timeout (fail-open — the caller proceeds unserialized rather
+    than wedging the session).  ``degraded`` is ``True`` exactly when
+    exclusivity was NOT proven.
+
+    On exit, calls :meth:`HermesState.release_session_turn_lease`.  Guaranteed
+    on every exit path: normal return, exception, and cancellation.  If a
+    background refresh task is running it is cancelled first.
+
+    .. rubric:: Holder contract
+
+    ``holder`` is the fence identity: the merged flush layer raises
+    :class:`hermes_state.SessionTurnLeaseLostError` when a transcript write
+    presents a holder that no longer owns the lease, and the dead-PID reclaim
+    parses ``pid=`` out of the holder string to reap crashed holders without
+    waiting for the TTL.  Pass a holder embedding the local PID (same
+    convention as the merged ``run_agent`` consumer's
+    ``f"pid={os.getpid()}:turn=<id>:platform=<...>"``).
+
+    .. rubric:: Background refresh
+
+    Set ``refresh_interval`` (seconds) to periodically bump the lease expiry
+    during long turns via :meth:`HermesState.refresh_session_turn_lease`.  The
+    refresh task is cancelled on exit.  Without it, a turn that runs longer
+    than ``ttl_seconds`` will see its lease expire — the next acquirer
+    reclaims the stale row and the two turns interleave.
+
+    .. rubric:: Safety properties
+
+    - **Fail-open on timeout.**  Returns ``False`` after ``wait_timeout``
+      with a loud ERROR log, never a wedged session.  Posture per #67442:
+      interactive user turns wait with a bounded budget; machine-initiated
+      paths should choose the storage layer's fail-closed semantics instead.
+    - **Guaranteed release.**  ``__aexit__`` is called on every path,
+      including cancellation.  The DB row is deleted iff this holder still
+      owns it (identity-checked by ``release_session_turn_lease``).
+    - **Expired/dead-holder reclamation.**  The storage layer deletes stale
+      rows transparently, so a crashed holder wedges the session for at most
+      ``ttl_seconds``, not indefinitely.
+    """
+
+    def __init__(
+        self,
+        state,  # HermesState / SessionDB
+        session_id: str,
+        holder: str,
+        *,
+        ttl_seconds: float = DEFAULT_DB_LEASE_TTL,
+        wait_timeout: float = DEFAULT_DB_LEASE_WAIT,
+        poll_interval: float = DEFAULT_DB_LEASE_POLL,
+        refresh_interval: Optional[float] = None,
+    ) -> None:
+        self._state = state
+        self._session_id = session_id
+        self._holder = holder
+        self._ttl_seconds = float(ttl_seconds)
+        self._wait_timeout = float(wait_timeout)
+        self._poll_interval = float(poll_interval)
+        self._refresh_interval = refresh_interval
+        self._acquired = False
+        self._refresh_task: Optional[asyncio.Task] = None
+
+    @property
+    def degraded(self) -> bool:
+        """True when exclusivity was NOT proven (fail-open timeout).
+
+        Posture contract from #67442: report whether the lease was proven,
+        let each caller class decide how to react.
+        """
+        return not self._acquired
+
+    async def __aenter__(self) -> bool:
+        """Acquire the DB turn lease with non-blocking polling backoff.
+
+        Returns ``True`` on success, ``False`` on timeout (fail-open).
+        """
+        if not self._session_id:
+            self._acquired = False
+            return False
+
+        deadline = time.time() + self._wait_timeout
+        backoff = self._poll_interval
+        attempts = 0
+
+        while True:
+            attempts += 1
+            try:
+                if self._state.try_acquire_session_turn_lease(
+                    self._session_id,
+                    self._holder,
+                    ttl_seconds=self._ttl_seconds,
+                ):
+                    self._acquired = True
+                    logger.debug(
+                        "DB turn lease acquired for session %s (holder=%s, "
+                        "attempts=%s, ttl=%.0fs)",
+                        self._session_id,
+                        self._holder,
+                        attempts,
+                        self._ttl_seconds,
+                    )
+                    break
+            except sqlite3.Error as exc:
+                # A holder's long write transaction (compression publish,
+                # large flush) can exhaust a single write-patience budget.
+                # Keep polling until the wait budget expires — same posture
+                # as the merged sync ``acquire_session_turn_lease`` loop.
+                logger.debug(
+                    "DB turn lease poll attempt %s on session %s hit sqlite "
+                    "error %s — retrying",
+                    attempts,
+                    self._session_id,
+                    exc,
+                )
+
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                logger.error(
+                    "DB turn lease wait timed out after %.1fs on session %s "
+                    "(holder=%s, attempts=%s) — failing open: this turn runs "
+                    "UNSERIALIZED; transcript writes may interleave with "
+                    "another process (#67442)",
+                    self._wait_timeout,
+                    self._session_id,
+                    self._holder,
+                    attempts,
+                )
+                self._acquired = False
+                break
+
+            # Log contention at WARNING on the first attempt only (avoid log
+            # spam during the poll loop).
+            if attempts == 1:
+                logger.warning(
+                    "DB turn lease contention on session %s: holder=%s "
+                    "waiting to acquire (ttl=%.0fs, wait=%.0fs) — another "
+                    "process holds the lease (#67442)",
+                    self._session_id,
+                    self._holder,
+                    self._ttl_seconds,
+                    self._wait_timeout,
+                )
+
+            sleep = min(backoff, remaining)
+            await asyncio.sleep(sleep)
+            backoff = min(backoff * DEFAULT_DB_LEASE_BACKOFF,
+                          DEFAULT_DB_LEASE_POLL_MAX)
+
+        if self._acquired and self._refresh_interval is not None:
+            self._start_refresh()
+
+        return self._acquired
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Release the DB turn lease.  Guaranteed on every exit path."""
+        try:
+            if self._refresh_task is not None:
+                self._refresh_task.cancel()
+                try:
+                    await self._refresh_task
+                except asyncio.CancelledError:
+                    pass
+                self._refresh_task = None
+
+            if self._acquired and self._session_id:
+                self._state.release_session_turn_lease(
+                    self._session_id,
+                    self._holder,
+                )
+                logger.debug(
+                    "DB turn lease released for session %s (holder=%s)",
+                    self._session_id,
+                    self._holder,
+                )
+        except Exception:
+            logger.debug(
+                "DB turn lease release error for session %s",
+                self._session_id,
+                exc_info=True,
+            )
+        finally:
+            self._acquired = False
+
+    def _start_refresh(self) -> None:
+        """Launch a background task that refreshes the lease periodically."""
+        if self._refresh_interval is None or self._refresh_interval <= 0:
+            return
+
+        async def _refresh_loop() -> None:
+            interval = self._refresh_interval
+            while True:
+                await asyncio.sleep(interval)
+                try:
+                    ok = self._state.refresh_session_turn_lease(
+                        self._session_id,
+                        self._holder,
+                        ttl_seconds=self._ttl_seconds,
+                    )
+                    if not ok:
+                        logger.warning(
+                            "DB turn lease refresh failed for session %s "
+                            "(holder=%s) — lease may have been reclaimed by "
+                            "another process (#67442)",
+                            self._session_id,
+                            self._holder,
+                        )
+                except Exception:
+                    logger.debug(
+                        "DB turn lease refresh error for session %s",
+                        self._session_id,
+                        exc_info=True,
+                    )
+
+        self._refresh_task = asyncio.create_task(_refresh_loop())
+

--- a/tests/gateway/test_turn_lease_db_async.py
+++ b/tests/gateway/test_turn_lease_db_async.py
@@ -1,0 +1,274 @@
+"""Async ``TurnLease`` wrapper over the merged cross-process turn lease.
+
+The storage substrate (``session_turn_leases`` table, lineage-root key,
+dead-PID reclaim, ``SessionTurnLeaseLostError`` fencing) is covered by
+``tests/state/test_session_turn_lease.py``, and the sync ``AIAgent`` consumer
+by ``tests/run_agent/test_cross_process_turn_lease.py``.  This file covers
+only the async adapter in ``gateway/turn_lease.py``: non-blocking polling with
+backoff, fail-open timeout, guaranteed release on every exit path (including
+exception and cancellation), and the background refresh loop — unit-tested
+against a fake state, plus one real-DB integration test proving it stacks on
+the merged substrate (#67442).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from gateway.turn_lease import TurnLease
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class _FakeState:
+    """Minimal sync surface the wrapper needs (merged API names)."""
+
+    def __init__(self, acquire_results=None):
+        # The LAST element is repeated forever, so [True] acquires
+        # immediately and [False] never does.
+        self.acquire_results = list(acquire_results or [True])
+        self.acquire_calls = []
+        self.refresh_calls = []
+        self.release_calls = []
+
+    def try_acquire_session_turn_lease(self, session_id, holder, **kwargs):
+        self.acquire_calls.append((session_id, holder, kwargs))
+        return (
+            self.acquire_results[-1]
+            if len(self.acquire_results) == 1
+            else self.acquire_results.pop(0)
+        )
+
+    def refresh_session_turn_lease(self, session_id, holder, **kwargs):
+        self.refresh_calls.append((session_id, holder, kwargs))
+        return True
+
+    def release_session_turn_lease(self, session_id, holder):
+        self.release_calls.append((session_id, holder))
+
+
+# ---------------------------------------------------------------------------
+# Acquisition / release
+# ---------------------------------------------------------------------------
+
+
+def test_acquire_immediate_success_and_release():
+    """A free lease is taken on the first attempt and released on exit."""
+    state = _FakeState([True])
+
+    async def scenario():
+        lease = TurnLease(state, "s1", "pid=1:turn=a")
+        async with lease as acquired:
+            assert acquired is True
+            assert lease.degraded is False
+
+    _run(scenario())
+    assert [c[0] for c in state.acquire_calls] == ["s1"]
+    assert state.acquire_calls[0][1] == "pid=1:turn=a"
+    assert state.acquire_calls[0][2] == {"ttl_seconds": 300.0}
+    assert state.release_calls == [("s1", "pid=1:turn=a")]
+
+
+def test_degraded_flag_reflects_exclusivity():
+    """``degraded`` is True only when the lease was NOT proven exclusive."""
+    state_ok = _FakeState([True])
+    lease_ok = TurnLease(state_ok, "s1", "pid=1:turn=a")
+    assert _run(lease_ok.__aenter__()) is True
+    assert lease_ok.degraded is False
+    _run(lease_ok.__aexit__(None, None, None))
+
+    state_busy = _FakeState([False])
+    lease_busy = TurnLease(
+        state_busy, "s1", "pid=1:turn=b",
+        wait_timeout=0.05, poll_interval=0.01,
+    )
+    assert _run(lease_busy.__aenter__()) is False
+    assert lease_busy.degraded is True
+    _run(lease_busy.__aexit__(None, None, None))
+
+
+def test_polls_with_backoff_until_lease_is_free():
+    """A contended lease is polled (non-blocking) until the holder releases."""
+    state = _FakeState([False, False, True])
+
+    async def scenario():
+        async with TurnLease(
+            state, "s1", "pid=1:turn=a",
+            wait_timeout=2.0, poll_interval=0.01,
+        ) as acquired:
+            return acquired
+
+    assert _run(scenario()) is True
+    assert len(state.acquire_calls) == 3
+    # No release before acquisition completes.
+    assert state.release_calls == [("s1", "pid=1:turn=a")]
+
+
+def test_timeout_fails_open_without_release():
+    """A lease held past the wait budget returns False and releases nothing."""
+    state = _FakeState([False])
+
+    async def scenario():
+        async with TurnLease(
+            state, "s1", "pid=1:turn=a",
+            wait_timeout=0.05, poll_interval=0.01,
+        ) as acquired:
+            return acquired
+
+    assert _run(scenario()) is False
+    assert len(state.acquire_calls) >= 2  # polled, then gave up
+    assert state.release_calls == []  # never held → nothing to release
+
+
+def test_empty_session_id_never_acquires():
+    """A falsy session_id short-circuits to fail-open with no storage calls."""
+    state = _FakeState([True])
+
+    async def scenario():
+        async with TurnLease(state, "", "pid=1:turn=a") as acquired:
+            return acquired
+
+    assert _run(scenario()) is False
+    assert state.acquire_calls == []
+    assert state.release_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Guaranteed release
+# ---------------------------------------------------------------------------
+
+
+def test_release_on_exception():
+    """An exception inside the body still releases the lease."""
+    state = _FakeState([True])
+
+    async def scenario():
+        try:
+            async with TurnLease(state, "s1", "pid=1:turn=a"):
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+
+    _run(scenario())
+    assert state.release_calls == [("s1", "pid=1:turn=a")]
+
+
+def test_release_on_cancellation():
+    """Cancelling the task mid-body releases the lease (aexit runs)."""
+    state = _FakeState([True])
+
+    async def scenario():
+        async with TurnLease(state, "s1", "pid=1:turn=a"):
+            await asyncio.sleep(30)
+
+    async def driver():
+        task = asyncio.create_task(scenario())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    _run(driver())
+    assert state.release_calls == [("s1", "pid=1:turn=a")]
+
+
+# ---------------------------------------------------------------------------
+# Background refresh
+# ---------------------------------------------------------------------------
+
+
+def test_background_refresh_extends_and_stops_on_exit():
+    """refresh_interval spawns a loop that bumps expiry; exit cancels it."""
+    state = _FakeState([True])
+
+    async def scenario():
+        async with TurnLease(
+            state, "s1", "pid=1:turn=a",
+            ttl_seconds=1.0, refresh_interval=0.02,
+        ) as acquired:
+            assert acquired is True
+            await asyncio.sleep(0.09)
+        return len(state.refresh_calls)
+
+    refreshes = _run(scenario())
+    assert refreshes >= 2  # loop ran at ~0.02/0.04/0.06/0.08
+    assert all(c[0] == "s1" and c[1] == "pid=1:turn=a" for c in state.refresh_calls)
+    assert state.release_calls == [("s1", "pid=1:turn=a")]
+
+
+def test_no_refresh_without_refresh_interval():
+    state = _FakeState([True])
+
+    async def scenario():
+        async with TurnLease(state, "s1", "pid=1:turn=a"):
+            await asyncio.sleep(0.03)
+
+    _run(scenario())
+    assert state.refresh_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Integration on the merged substrate
+# ---------------------------------------------------------------------------
+
+
+def test_real_db_serializes_two_handles(tmp_path):
+    """The async wrapper acquires the same row the merged storage exposes."""
+    from hermes_state import SessionDB
+
+    path = tmp_path / "state.db"
+    db1 = SessionDB(path)
+    db2 = SessionDB(path)
+    db1.create_session("shared", source="test")
+
+    h1 = f"pid={os.getpid()}:turn=async1"
+    h2 = f"pid={os.getpid()}:turn=async2"
+
+    async def scenario():
+        async with TurnLease(db1, "shared", h1, ttl_seconds=5) as acquired:
+            assert acquired is True
+            # Second handle sees the lease held (cross-process shape).
+            assert not db2.try_acquire_session_turn_lease("shared", h2, ttl_seconds=5)
+        # Released on exit → the second handle can now take it.
+        assert db2.try_acquire_session_turn_lease("shared", h2, ttl_seconds=5)
+        db2.release_session_turn_lease("shared", h2)
+
+    _run(scenario())
+
+
+def test_real_db_async_waiter_polls_until_contention_clears(tmp_path):
+    """A second async wrapper waits (non-blocking) and wins after release."""
+    from hermes_state import SessionDB
+
+    path = tmp_path / "state.db"
+    db1 = SessionDB(path)
+    db2 = SessionDB(path)
+    db1.create_session("shared", source="test")
+
+    h1 = f"pid={os.getpid()}:turn=holder"
+    h2 = f"pid={os.getpid()}:turn=waiter"
+    results = {}
+
+    async def holder():
+        async with TurnLease(db1, "shared", h1, ttl_seconds=5):
+            await asyncio.sleep(0.15)  # simulate a turn
+
+    async def waiter():
+        async with TurnLease(
+            db2, "shared", h2,
+            ttl_seconds=5, wait_timeout=3.0, poll_interval=0.01,
+        ) as acquired:
+            results["waiter"] = acquired
+
+    async def main():
+        await asyncio.gather(holder(), waiter())
+
+    _run(main())
+    assert results["waiter"] is True


### PR DESCRIPTION
## Summary

Adds `TurnLease`, a DB-level async context manager for cross-process turn serialization, to `gateway/turn_lease.py`.

Closes #67442.

## Problem

The existing in-process `SessionTurnLeaseRegistry` (#64934, #67401) serializes
the `[load history → run → flush]` region per resolved session_id, preventing
interleaved transcript writes when two routing keys are mapped to one
session_id via `switch_session()`. However, it is process-local — a CLI
process and a gateway process sharing the same session (CLI-continuity)
cannot coordinate through an in-process lock.

## Solution

`TurnLease` uses the `turn_leases` table in `HermesState` (schema v23) as the
coordination point, so any process with access to the state DB serializes
against the same row.

### Design

- **Async context manager.** `async with TurnLease(state, ...) as acquired:` —
  the critical section is the body of the `with` block.
- **Polling with exponential backoff.** On enter, calls
  `state.try_acquire_turn_lease()` in a loop with capped exponential backoff
  until acquired or the overall `wait_timeout` is reached.
- **Fail-open on timeout.** Returns `False` (with a loud ERROR log) — the
  caller proceeds unserialized rather than wedging the session.
- **Guaranteed release.** `__aexit__` calls `state.release_turn_lease()` on
  every exit path: normal return, exception, and cancellation.
- **Optional background refresh.** Set `refresh_interval` to periodically
  bump the lease expiry during long turns via `state.refresh_turn_lease()`.
  The refresh task is cancelled on exit.
- **Expired-lease reclamation.** The DB layer deletes stale rows
  transparently, so a crashed holder wedges the session for at most the TTL,
  not indefinitely.

## Usage

```python
async with TurnLease(
    state, session_id, holder="cli:pid",
    surface="cli", run_generation=gen,
) as acquired:
    if not acquired:
        # Timed out — proceed unserialized (fail-open)
        ...
    # Critical section: load history → run → flush
    ...
```

## Testing

- [ ] All existing tests pass
- [ ] Manual cross-process serialization verified