### PR TITLE
fix(agent): recover Codex reasoning-only stalls

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -665,6 +665,7 @@ def init_agent(
     # models to "give up" prematurely on complex tasks (#7915).
     agent._budget_exhausted_injected = False
     agent._budget_grace_call = False
+    agent._codex_incomplete_fallback_grace_used = False
 
     # Activity tracking — updated on each API call, tool execution, and
     # stream chunk.  Used by the gateway timeout handler to report what the

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1133,7 +1133,7 @@ def drop_thinking_only_and_merge_users(
     *,
     drop_codex_reasoning_items: bool = True,
 ) -> List[Dict[str, Any]]:
-    """Drop thinking-only assistant turns; merge any adjacent user messages left behind.
+    """Drop thinking-only turns and Codex-only nudges; merge adjacent users.
 
     Runs on the per-call ``api_messages`` copy only. The stored
     conversation history (``agent.messages``) is never mutated, so the
@@ -1152,12 +1152,22 @@ def drop_thinking_only_and_merge_users(
     if not messages:
         return messages
 
-    # Pass 1: drop thinking-only assistant turns.
+    # Pass 1: drop thinking-only assistant turns.  When leaving Codex
+    # Responses, also drop the synthetic continuation nudge: after opaque
+    # reasoning is removed it can otherwise land directly after a tool result
+    # (tool → user), which strict Chat Completions providers reject.  The
+    # fallback already has the original tool result and can answer from it.
     kept = [
         m for m in messages
-        if not _ra().AIAgent._is_thinking_only_assistant(
-            m,
-            drop_codex_reasoning_items=drop_codex_reasoning_items,
+        if not (
+            _ra().AIAgent._is_thinking_only_assistant(
+                m,
+                drop_codex_reasoning_items=drop_codex_reasoning_items,
+            )
+            or (
+                drop_codex_reasoning_items
+                and m.get("_codex_incomplete_nudge") is True
+            )
         )
     ]
     dropped = len(messages) - len(kept)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4570,13 +4570,28 @@ def run_conversation(
             agent._incomplete_scratchpad_retries = 0
 
             if agent.api_mode == "codex_responses" and finish_reason == "incomplete":
-                agent._codex_incomplete_retries += 1
-
                 interim_msg = agent._build_assistant_message(assistant_message, finish_reason)
                 interim_has_content = bool((interim_msg.get("content") or "").strip())
                 interim_has_reasoning = bool(interim_msg.get("reasoning", "").strip()) if isinstance(interim_msg.get("reasoning"), str) else False
                 interim_has_codex_reasoning = bool(interim_msg.get("codex_reasoning_items"))
                 interim_has_codex_message_items = bool(interim_msg.get("codex_message_items"))
+                interim_reasoning_only = (
+                    interim_has_codex_reasoning
+                    and not interim_has_content
+                    and not interim_has_codex_message_items
+                )
+                if interim_reasoning_only:
+                    agent._codex_reasoning_only_streak += 1
+                else:
+                    agent._codex_reasoning_only_streak = 0
+                if interim_has_content or interim_has_codex_message_items:
+                    # Visible/replayable message progress starts a fresh local
+                    # continuation budget.  The turn-wide iteration budget
+                    # remains the hard bound, so repeated partial progress
+                    # cannot create an unbounded loop.
+                    agent._codex_incomplete_retries = 0
+                else:
+                    agent._codex_incomplete_retries += 1
 
                 if (
                     interim_has_content
@@ -4646,7 +4661,19 @@ def run_conversation(
                         or interim_has_codex_reasoning
                         or interim_has_codex_message_items
                     )
-                    if not interim_replayable:
+                    # Replaying encrypted reasoning is worthwhile once, but a
+                    # second consecutive reasoning-only completion means that
+                    # replay has stalled: the provider consumed another turn
+                    # without producing visible content or a tool call. Nudge
+                    # that replay explicitly before spending the final retry.
+                    should_nudge = (
+                        not interim_replayable
+                        or (
+                            agent._codex_reasoning_only_streak >= 2
+                            and interim_reasoning_only
+                        )
+                    )
+                    if should_nudge:
                         _last_msg = messages[-1] if messages else None
                         _already_nudged = (
                             isinstance(_last_msg, dict)
@@ -4668,6 +4695,7 @@ def run_conversation(
                             messages.append({
                                 "role": "user",
                                 "content": _CODEX_INCOMPLETE_NUDGE,
+                                "_codex_incomplete_nudge": True,
                             })
                     if not agent.quiet_mode:
                         agent._vprint(f"{agent.log_prefix}↻ Codex response incomplete; continuing turn ({agent._codex_incomplete_retries}/3)")
@@ -4684,7 +4712,38 @@ def run_conversation(
                     agent._session_messages = messages
                     continue
 
+                if (
+                    agent._codex_reasoning_only_streak >= 3
+                    and agent._try_activate_fallback(
+                        reason=FailoverReason.incomplete_response
+                    )
+                ):
+                    active_system_prompt = _sync_failover_system_message(
+                        agent, api_messages, active_system_prompt
+                    )
+                    logger.warning(
+                        "Codex continuation budget exhausted; activated fallback "
+                        "provider=%s model=%s session=%s",
+                        agent.provider,
+                        agent.model,
+                        agent.session_id,
+                    )
+                    agent._codex_incomplete_retries = 0
+                    agent._codex_reasoning_only_streak = 0
+                    if (
+                        (
+                            api_call_count >= agent.max_iterations
+                            or agent.iteration_budget.remaining <= 0
+                        )
+                        and not agent._codex_incomplete_fallback_grace_used
+                    ):
+                        agent._budget_grace_call = True
+                        agent._codex_incomplete_fallback_grace_used = True
+                    agent._session_messages = messages
+                    continue
+
                 agent._codex_incomplete_retries = 0
+                agent._codex_reasoning_only_streak = 0
                 agent._persist_session(messages, conversation_history)
                 return {
                     "final_response": "Codex response remained incomplete after 3 continuation attempts",
@@ -4696,6 +4755,7 @@ def run_conversation(
                 }
             elif hasattr(agent, "_codex_incomplete_retries"):
                 agent._codex_incomplete_retries = 0
+                agent._codex_reasoning_only_streak = 0
             
             # Check for tool calls
             if assistant_message.tool_calls:

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -54,6 +54,7 @@ class FailoverReason(enum.Enum):
 
     # Model / provider policy
     model_not_found = "model_not_found"  # 404 or invalid model — fallback to different model
+    incomplete_response = "incomplete_response"  # Provider exhausted continuation budget without final content/tool call — fallback
     provider_policy_blocked = "provider_policy_blocked"  # Aggregator (e.g. OpenRouter) blocked the only endpoint due to account data/privacy policy
     content_policy_blocked = "content_policy_blocked"  # Provider safety filter rejected this prompt — deterministic per-request, don't retry unchanged
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -342,6 +342,8 @@ def build_turn_context(
     agent._empty_content_retries = 0
     agent._incomplete_scratchpad_retries = 0
     agent._codex_incomplete_retries = 0
+    agent._codex_reasoning_only_streak = 0
+    agent._codex_incomplete_fallback_grace_used = False
     agent._thinking_prefill_retries = 0
     agent._post_tool_empty_retried = False
     agent._last_content_with_tools = None

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -57,7 +57,7 @@ class TestFailoverReason:
             "overloaded", "server_error", "timeout",
             "ssl_cert_verification",
             "context_overflow", "payload_too_large", "image_too_large",
-            "model_not_found", "format_error",
+            "model_not_found", "incomplete_response", "format_error",
             "invalid_encrypted_content",
             "multimodal_tool_content_unsupported",
             "provider_policy_blocked",

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -3505,6 +3505,315 @@ def test_run_conversation_codex_nudges_after_unreplayable_reasoning_only_interim
     )
 
 
+def test_run_conversation_codex_nudges_after_repeated_replayable_reasoning_only_interims(monkeypatch):
+    """A second encrypted reasoning-only response needs an explicit nudge.
+
+    Replaying encrypted reasoning is useful once, but if the provider returns
+    another reasoning-only completion the bare replay has stalled.  The next
+    request must ask for a final answer instead of repeating provider state
+    until the continuation budget is exhausted.
+    """
+    agent = _build_agent(monkeypatch)
+    requests = []
+    responses = [
+        _codex_reasoning_only_response(
+            encrypted_content="enc_first",
+            summary_text="Inspecting the tool output...",
+        ),
+        _codex_reasoning_only_response(
+            encrypted_content="enc_second",
+            summary_text="Still inspecting the tool output...",
+        ),
+        _codex_message_response("Recovered final answer."),
+    ]
+
+    def _fake_api_call(api_kwargs):
+        requests.append(api_kwargs)
+        return responses.pop(0)
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    result = agent.run_conversation("summarize the tool output")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered final answer."
+    assert len(requests) == 3
+
+    first_retry_nudges = [
+        item for item in requests[1]["input"]
+        if isinstance(item, dict)
+        and item.get("role") == "user"
+        and "only internal reasoning" in str(item.get("content"))
+    ]
+    second_retry_nudges = [
+        item for item in requests[2]["input"]
+        if isinstance(item, dict)
+        and item.get("role") == "user"
+        and "only internal reasoning" in str(item.get("content"))
+    ]
+    assert first_retry_nudges == []
+    assert len(second_retry_nudges) == 1
+
+
+def test_run_conversation_codex_fails_over_after_reasoning_only_budget(monkeypatch):
+    """Three reasoning-only responses should try the configured fallback."""
+    from agent.error_classifier import FailoverReason
+
+    agent = _build_agent(monkeypatch)
+    responses = [
+        _codex_reasoning_only_response(encrypted_content="enc_first"),
+        _codex_reasoning_only_response(encrypted_content="enc_second"),
+        _codex_reasoning_only_response(encrypted_content="enc_third"),
+        _codex_message_response("Fallback recovered the turn."),
+    ]
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_api_call",
+        lambda api_kwargs: responses.pop(0),
+    )
+
+    failover_reasons = []
+
+    def _fake_activate_fallback(reason=None):
+        failover_reasons.append(reason)
+        return True
+
+    monkeypatch.setattr(agent, "_try_activate_fallback", _fake_activate_fallback)
+
+    result = agent.run_conversation("finish the answer")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Fallback recovered the turn."
+    assert failover_reasons == [FailoverReason.incomplete_response]
+
+
+def test_run_conversation_codex_reasoning_stall_fallback_grace_is_single_use(monkeypatch):
+    """A stalled fallback cannot renew the iteration grace indefinitely."""
+    from agent.error_classifier import FailoverReason
+
+    agent = _build_agent(monkeypatch)
+    setattr(agent, "max_iterations", 3)
+    requests = []
+    responses = [
+        _codex_reasoning_only_response(encrypted_content="enc_first"),
+        _codex_reasoning_only_response(encrypted_content="enc_second"),
+        _codex_reasoning_only_response(encrypted_content="enc_third"),
+        _codex_reasoning_only_response(encrypted_content="enc_fallback"),
+    ]
+
+    def _fake_api_call(api_kwargs):
+        requests.append(api_kwargs)
+        return responses.pop(0)
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+    failover_reasons = []
+
+    def _fake_activate_fallback(reason=None):
+        failover_reasons.append(reason)
+        return True
+
+    monkeypatch.setattr(agent, "_try_activate_fallback", _fake_activate_fallback)
+
+    result = agent.run_conversation("finish the answer")
+
+    assert result["completed"] is False
+    assert len(requests) == 4
+    assert failover_reasons == [FailoverReason.incomplete_response]
+    assert getattr(agent, "_budget_grace_call") is False
+    assert getattr(agent, "_codex_incomplete_fallback_grace_used") is True
+
+
+def test_run_conversation_codex_visible_partial_then_reasoning_stall_still_fails_over(monkeypatch):
+    """Visible progress resets the stall budget without disabling recovery."""
+    from agent.error_classifier import FailoverReason
+
+    agent = _build_agent(monkeypatch)
+    setattr(agent, "max_iterations", 4)
+    requests = []
+    responses = [
+        _codex_incomplete_message_response("Visible partial answer."),
+        _codex_reasoning_only_response(encrypted_content="enc_first"),
+        _codex_reasoning_only_response(encrypted_content="enc_second"),
+        _codex_reasoning_only_response(encrypted_content="enc_third"),
+        _codex_message_response("Fallback recovered after visible progress."),
+    ]
+
+    def _fake_api_call(api_kwargs):
+        requests.append(api_kwargs)
+        return responses.pop(0)
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+    failover_reasons = []
+
+    def _fake_activate_fallback(reason=None):
+        failover_reasons.append(reason)
+        return True
+
+    monkeypatch.setattr(agent, "_try_activate_fallback", _fake_activate_fallback)
+
+    result = agent.run_conversation("finish the answer")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Fallback recovered after visible progress."
+    assert len(requests) == 5
+    assert failover_reasons == [FailoverReason.incomplete_response]
+    assert not any(
+        "only internal reasoning" in str(item.get("content"))
+        for request in requests[:3]
+        for item in request["input"]
+        if isinstance(item, dict)
+    )
+    assert any(
+        "only internal reasoning" in str(item.get("content"))
+        for item in requests[3]["input"]
+        if isinstance(item, dict)
+    )
+
+
+def test_run_conversation_codex_reasoning_only_failover_sanitizes_replay(monkeypatch):
+    """Post-tool reasoning stall gets one safe, sanitized fallback call."""
+    import json
+
+    agent = _build_agent(monkeypatch)
+    setattr(agent, "max_iterations", 4)
+    fallback = {
+        "provider": "zai",
+        "model": "glm-5.2",
+        "base_url": "https://api.z.ai/api/paas/v4",
+    }
+    setattr(agent, "_fallback_chain", [fallback])
+    setattr(agent, "_fallback_model", fallback)
+    setattr(agent, "_fallback_index", 0)
+    setattr(agent, "_fallback_activated", False)
+    setattr(agent, "_credential_pool", None)
+
+    requests = []
+    responses = [
+        _codex_tool_call_response(),
+        _codex_reasoning_only_response(encrypted_content="enc_first"),
+        _codex_reasoning_only_response(encrypted_content="enc_second"),
+        _codex_reasoning_only_response(encrypted_content="enc_third"),
+        SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content="GLM recovered the turn.",
+                    tool_calls=None,
+                ),
+                finish_reason="stop",
+            )],
+            model="glm-5.2",
+            usage=None,
+        ),
+    ]
+
+    def _fake_api_call(api_kwargs):
+        requests.append((getattr(agent, "provider", ""), api_kwargs))
+        return responses.pop(0)
+
+    def _fake_streaming_api_call(api_kwargs, *, on_first_delta=None):
+        requests.append((getattr(agent, "provider", ""), api_kwargs))
+        return responses.pop(0)
+
+    def _fake_execute_tool_calls(
+        assistant_message,
+        messages,
+        effective_task_id,
+        api_call_count=0,
+    ):
+        for call in assistant_message.tool_calls:
+            messages.append({
+                "role": "tool",
+                "tool_call_id": call.id,
+                "content": "tool evidence for fallback",
+            })
+
+    fallback_client = SimpleNamespace(
+        api_key=None,
+        base_url="https://api.z.ai/api/paas/v4",
+        _custom_headers=None,
+        default_headers=None,
+    )
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_streaming_api_call",
+        _fake_streaming_api_call,
+    )
+    monkeypatch.setattr(agent, "_execute_tool_calls", _fake_execute_tool_calls)
+    monkeypatch.setattr(
+        "agent.auxiliary_client.resolve_provider_client",
+        lambda *args, **kwargs: (fallback_client, "glm-5.2"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_normalize.normalize_model_for_provider",
+        lambda model, provider: model,
+    )
+    monkeypatch.setattr(
+        "agent.credential_pool.load_pool",
+        lambda provider: None,
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *args, **kwargs: 200_000,
+    )
+    monkeypatch.setattr(
+        "agent.chat_completion_helpers.get_provider_request_timeout",
+        lambda provider, model: None,
+    )
+
+    result = agent.run_conversation("finish the answer")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "GLM recovered the turn."
+    assert [provider for provider, _ in requests] == [
+        "openai-codex",
+        "openai-codex",
+        "openai-codex",
+        "openai-codex",
+        "zai",
+    ]
+
+    fallback_messages = requests[-1][1]["messages"]
+    assert "Provider: zai" in fallback_messages[0]["content"]
+    assert "Model: glm-5.2" in fallback_messages[0]["content"]
+    assert "Provider: openai-codex" not in fallback_messages[0]["content"]
+
+    roles = [message.get("role") for message in fallback_messages]
+    assert all(
+        not (previous == "tool" and current == "user")
+        for previous, current in zip(roles, roles[1:])
+    )
+    assert any(
+        message.get("role") == "tool"
+        and message.get("content") == "tool evidence for fallback"
+        for message in fallback_messages
+    )
+
+    def _all_keys(value):
+        if isinstance(value, dict):
+            for key, child in value.items():
+                yield key
+                yield from _all_keys(child)
+        elif isinstance(value, list):
+            for child in value:
+                yield from _all_keys(child)
+
+    forbidden = {
+        "codex_reasoning_items",
+        "codex_message_items",
+        "encrypted_content",
+        "response_item_id",
+        "phase",
+        "reasoning_details",
+        "reasoning_content",
+    }
+    assert forbidden.isdisjoint(set(_all_keys(fallback_messages)))
+    assert "enc_first" not in json.dumps(fallback_messages)
+    assert "enc_second" not in json.dumps(fallback_messages)
+    assert "enc_third" not in json.dumps(fallback_messages)
+
+
 def test_run_conversation_codex_no_nudge_for_replayable_interim(monkeypatch):
     """An interim that carries visible content replays fine — the nudge
     must not fire and pollute the conversation."""


### PR DESCRIPTION
## What does this PR do?

Recovers Codex Responses turns that repeatedly return encrypted reasoning state without final text or a tool call.

The conversation loop now:

1. tracks a dedicated consecutive reasoning-only streak separately from visible/replayable progress;
2. replays encrypted reasoning once, then adds an explicit continuation nudge after the second no-progress response;
3. activates the configured provider fallback after the third consecutive reasoning-only response;
4. grants at most one fallback grace call when the triggering response consumed `max_iterations` / `IterationBudget`;
5. synchronizes the fallback model/provider identity in the system prompt; and
6. strips opaque Codex state plus the Codex-only nudge from cross-protocol wire replay while preserving tool results and valid role ordering.

The local no-progress counter resets when an incomplete response contains visible content or replayable message items. The turn-wide iteration budget remains the hard bound, so partial progress cannot create an unbounded loop.

This complements #61128, which sanitizes internal terminal status text for gateway delivery but does not recover the stalled turn.

## Related Issue

Fixes #67321

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_loop.py`
  - distinguish consecutive encrypted reasoning-only stalls from ordinary incomplete progress;
  - nudge after streak 2 and fail over after streak 3;
  - synchronize fallback identity and add a single-use budget grace call.
- `agent/agent_runtime_helpers.py`
  - remove the marked Codex-only continuation nudge when crossing to Chat Completions, preventing a post-sanitization `tool → user` sequence.
- `agent/agent_init.py` / `agent/turn_context.py`
  - initialize and reset bounded per-turn recovery state.
- `agent/error_classifier.py`
  - add semantic `FailoverReason.incomplete_response` telemetry.
- Tests cover:
  - repeated replayable reasoning-only output;
  - visible partial progress followed by a later three-response stall;
  - bounded single-use fallback grace;
  - exact `tool call → tool result → reasoning-only ×3 → non-Codex fallback final` flow;
  - provider/model identity rewrite, tool evidence retention, role ordering, and recursive absence of opaque Codex fields.

## How to Test

1. Run the full Codex Responses test module:

   ```bash
   python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q -o 'addopts='
   ```

   Result: `110 passed`.

2. Run classifier, identity, and fallback coverage:

   ```bash
   python -m pytest \
     tests/agent/test_error_classifier.py \
     tests/agent/test_failover_identity.py \
     tests/run_agent/test_provider_fallback.py \
     tests/run_agent/test_fallback_credential_isolation.py \
     -q -o 'addopts='
   ```

   Result: `239 passed`.

3. Run sanitizer, runtime-restore, partial-stream, and approvals fail-closed coverage:

   ```bash
   python -m pytest \
     tests/run_agent/test_thinking_only_sanitizer.py \
     tests/run_agent/test_primary_runtime_restore.py \
     tests/run_agent/test_32646_fallback_429_after_timeout.py \
     tests/run_agent/test_partial_stream_finish_reason.py \
     tests/run_agent/test_codex_app_server_integration.py::TestRunConversationCodexPath::test_manual_approvals_keep_codex_server_requests_fail_closed \
     -q -o 'addopts='
   ```

   Result: `84 passed`.

4. Run static checks:

   ```bash
   git diff --check upstream/main...HEAD
   ruff check agent/agent_init.py agent/turn_context.py agent/agent_runtime_helpers.py agent/conversation_loop.py agent/error_classifier.py tests/agent/test_error_classifier.py tests/run_agent/test_run_agent_codex_responses.py
   ```

   Result: pass.

5. Canonical runner:

   ```bash
   ./scripts/run_tests.sh
   ```

   All changed/related tests passed. The repository-wide run reported 13 failures in five unrelated files:

   - `tests/agent/test_copilot_acp_client.py`
   - `tests/gateway/test_complete_path_at_filter.py`
   - `tests/hermes_cli/test_tui_resume_flow.py`
   - `tests/hermes_cli/test_web_server.py`
   - `tests/tools/test_voice_mode.py`

   These files and their implementations are unchanged by this PR. The same failure categories reproduce in a clean detached worktree of the exact base SHA (`ffc69c184`); the isolated clean-base run produced 20 failures across those same five files. The focused changed-path matrix is 433/433 green after rebasing onto current `main` (`e598cef87`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing issues and PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (repository baseline failures are documented above; changed-path matrix is green)
- [x] I've added tests for my changes
- [x] I've tested on Kali GNU/Linux 2026.2, Python 3.11.15

### Documentation & Housekeeping

- [x] Relevant inline documentation/docstrings updated; no user documentation change required
- [x] `cli-config.yaml.example` N/A: no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A: no workflow change
- [x] Cross-platform impact considered: pure Python state/message handling, no OS-specific behavior added
- [x] Tool descriptions/schemas N/A: no tool schema changed

## Screenshots / Logs

The regression tests are deterministic and use mocked provider responses. No credentials, private session logs, or machine configuration are included.
