### PR TITLE
test: isolate Qwen provider resolution from local pools

### DIFF
--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -303,6 +303,14 @@ def test_resolve_runtime_provider_codex(monkeypatch):
 
 def test_resolve_runtime_provider_qwen_oauth(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "qwen-oauth")
+    # This test exercises the singleton Qwen credential resolver, not the
+    # higher-priority credential pool.  Keep it independent of any real
+    # ~/.qwen credentials present under the HOME preserved by the test runner.
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda _provider: SimpleNamespace(has_credentials=lambda: False),
+    )
     monkeypatch.setattr(
         rp,
         "resolve_qwen_runtime_credentials",
@@ -363,6 +371,14 @@ def test_qwen_oauth_auto_fallthrough_on_auth_failure(monkeypatch):
     from hermes_cli.auth import AuthError
 
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "qwen-oauth")
+    # A real Qwen pool entry would correctly win before the singleton resolver
+    # and prevent this auth-failure branch from running.  Force the empty-pool
+    # precondition that this test is specifically asserting.
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda _provider: SimpleNamespace(has_credentials=lambda: False),
+    )
     monkeypatch.setattr(
         rp,
         "resolve_qwen_runtime_credentials",

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -160,6 +160,14 @@ def test_qwen_oauth_auto_fallthrough_on_auth_failure(monkeypatch):
     from hermes_cli.auth import AuthError
 
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "qwen-oauth")
+    # A real Qwen pool entry would correctly win before the singleton resolver
+    # and prevent this auth-failure branch from running. Force the empty-pool
+    # precondition that this test is specifically asserting.
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda _provider: SimpleNamespace(has_credentials=lambda: False),
+    )
     monkeypatch.setattr(
         rp,
         "resolve_qwen_runtime_credentials",


### PR DESCRIPTION
## Summary

- isolate the Qwen singleton credential resolver test from the higher-priority credential pool
- force an empty-pool precondition in the Qwen auto-fallthrough test
- keep both tests deterministic when the canonical runner preserves a developer's real `HOME`

## Why

`resolve_runtime_provider()` correctly checks the credential pool before the singleton Qwen resolver. On machines with Qwen credentials under `~/.qwen`, these tests can resolve the real pool entry instead of exercising their mocked resolver or auth-failure path.

The production priority is correct; the tests were missing the empty-pool precondition.

## Test plan

- [x] `scripts/run_tests.sh -j 2 tests/hermes_cli/test_models.py tests/hermes_cli/test_runtime_provider_resolution.py -q --tb=short`
- [x] 235 tests passed, 0 failed on current `origin/main`
- [x] `git diff --check origin/main...HEAD`

## Scope

Test-only change. No runtime provider behavior is modified.
