### PR TITLE
fix(cli): run -w/--worktree in one-shot mode instead of silently ignoring it (#67458)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -171,6 +171,7 @@ def _run_and_exit_oneshot(
     provider: object = None,
     toolsets: object = None,
     usage_file: object = None,
+    worktree: bool = False,
 ) -> None:
     try:
         from hermes_cli.oneshot import run_oneshot
@@ -181,6 +182,7 @@ def _run_and_exit_oneshot(
             provider=provider,
             toolsets=toolsets,
             usage_file=usage_file,
+            worktree=worktree,
         )
     except KeyboardInterrupt:
         rc = 130
@@ -10764,6 +10766,7 @@ def _try_termux_fast_cli_launch() -> bool:
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
             usage_file=getattr(args, "usage_file", None),
+            worktree=getattr(args, "worktree", False),
         )
 
     if (args.resume or args.continue_last) and args.command is None:
@@ -12368,6 +12371,7 @@ def main():
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
             usage_file=getattr(args, "usage_file", None),
+            worktree=getattr(args, "worktree", False),
         )
 
     # Handle top-level --resume / --continue as shortcut to chat

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -182,6 +182,7 @@ def _run_and_exit_oneshot(
     toolsets: object = None,
     skills: object = None,
     usage_file: object = None,
+    worktree: bool = False,
 ) -> None:
     try:
         from hermes_cli.oneshot import run_oneshot
@@ -193,6 +194,7 @@ def _run_and_exit_oneshot(
             toolsets=toolsets,
             skills=skills,
             usage_file=usage_file,
+            worktree=worktree,
         )
     except KeyboardInterrupt:
         rc = 130
@@ -12242,6 +12244,7 @@ def _try_fast_chat_launch() -> bool:
             toolsets=getattr(args, "toolsets", None),
             skills=getattr(args, "skills", None),
             usage_file=getattr(args, "usage_file", None),
+            worktree=getattr(args, "worktree", False),
         )
 
     if (args.resume or args.continue_last) and args.command is None:
@@ -12300,6 +12303,7 @@ def _try_termux_fast_cli_launch() -> bool:
             toolsets=getattr(args, "toolsets", None),
             skills=getattr(args, "skills", None),
             usage_file=getattr(args, "usage_file", None),
+            worktree=getattr(args, "worktree", False),
         )
 
     if (args.resume or args.continue_last) and args.command is None:
@@ -14233,6 +14237,7 @@ def main():
             toolsets=getattr(args, "toolsets", None),
             skills=getattr(args, "skills", None),
             usage_file=getattr(args, "usage_file", None),
+            worktree=getattr(args, "worktree", False),
         )
 
     # Handle top-level --resume / --continue as shortcut to chat

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -167,12 +167,55 @@ def _write_usage_file(path: Optional[str], result: dict, failure: Optional[str] 
         pass
 
 
+def _setup_oneshot_worktree() -> Optional[dict]:
+    """Create an isolated git worktree for ``hermes -z -w``.
+
+    Reuses the interactive ``hermes -w`` lifecycle (``cli._setup_worktree``): a
+    disposable worktree under ``.worktrees/`` on a dedicated ``hermes/...``
+    branch, branched from the freshly-fetched remote tip. Returns the worktree
+    info dict, or ``None`` on failure (the underlying helper prints the reason).
+
+    ``_setup_worktree`` writes its progress/error notices to stdout, but the
+    oneshot contract is that stdout carries only the agent's final response — so
+    those notices are redirected to stderr here.
+    """
+    try:
+        from cli import _git_repo_root, _prune_stale_worktrees, _setup_worktree
+    except Exception as exc:  # pragma: no cover - defensive import guard
+        sys.stderr.write(f"hermes -z: worktree support is unavailable ({exc}).\n")
+        return None
+    with redirect_stdout(sys.stderr):
+        repo_root = _git_repo_root()
+        if repo_root:
+            _prune_stale_worktrees(repo_root)
+        return _setup_worktree()
+
+
+def _cleanup_oneshot_worktree(info: dict) -> None:
+    """Tear down the oneshot worktree on exit (kept if it has unpushed commits).
+
+    Delegates to ``cli._cleanup_worktree``; its stdout notices are routed to
+    stderr so they never contaminate the oneshot response on stdout. Fail-soft:
+    cleanup must never turn a successful run into a failure.
+    """
+    try:
+        from cli import _cleanup_worktree
+    except Exception:  # pragma: no cover - defensive import guard
+        return
+    with redirect_stdout(sys.stderr):
+        try:
+            _cleanup_worktree(info)
+        except Exception:
+            pass
+
+
 def run_oneshot(
     prompt: str,
     model: Optional[str] = None,
     provider: Optional[str] = None,
     toolsets: object = None,
     usage_file: Optional[str] = None,
+    worktree: bool = False,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -187,6 +230,11 @@ def run_oneshot(
             cost, token counts, model, api_calls) is written there after the
             run — even when the run fails — so pipelines can account for
             spend per invocation.
+        worktree: When True (``hermes -z -w``), run the agent inside a
+            disposable git worktree on a dedicated ``hermes/...`` branch —
+            mirroring interactive ``hermes -w`` — so commits never land on the
+            caller's checked-out branch. The worktree is removed on exit unless
+            it has unpushed commits. Returns 2 if the worktree cannot be created.
 
     Returns the exit code.  The caller owns process termination.
     """
@@ -216,82 +264,107 @@ def run_oneshot(
         return 2
     use_config_toolsets = _normalize_toolsets(toolsets) is None
 
-    # Auto-approve any shell / tool approvals.  Non-interactive by
-    # definition — a prompt would hang forever.
-    os.environ["HERMES_YOLO_MODE"] = "1"
-    os.environ["HERMES_ACCEPT_HOOKS"] = "1"
+    # `hermes -z -w`: create the isolated worktree BEFORE any agent work and
+    # chdir into it so the whole run (file edits, commits) happens on the
+    # dedicated branch, not the caller's checked-out branch. Fail loudly (exit
+    # 2) if it can't be created rather than silently running in the live repo.
+    wt_info = None
+    prev_cwd = None
+    if worktree:
+        wt_info = _setup_oneshot_worktree()
+        if not wt_info:
+            return 2
+        prev_cwd = os.getcwd()
+        os.chdir(wt_info["path"])
 
-    # One-shot prints a single final response and exits: there is no later turn
-    # for a detached subagent's completion to re-enter, and nothing here drains
-    # process_registry.completion_queue (only cli.py's interactive process_loop
-    # and the gateway watchers do). Left unbound, async_delivery_supported()
-    # defaults True, delegate_task is forced background, and every subagent
-    # result is discarded. Declaring the channel stateless routes delegate_task
-    # to its inline/synchronous path. See declare_stateless_channel().
-    declare_stateless_channel()
-
-    # Redirect stderr AND stdout to devnull for the entire call tree.
-    # We'll print the final response to the real stdout at the end.
-    real_stdout = sys.stdout
-    real_stderr = sys.stderr
-    devnull = open(os.devnull, "w", encoding="utf-8")
-
-    response: Optional[str] = None
-    result: dict = {}
-    failure: BaseException | None = None
     try:
-        with redirect_stdout(devnull), redirect_stderr(devnull):
-            try:
-                response, result = _run_agent(
-                    prompt,
-                    model=model,
-                    provider=provider,
-                    toolsets=explicit_toolsets,
-                    use_config_toolsets=use_config_toolsets,
-                )
-            except BaseException as exc:  # noqa: BLE001
-                # Capture anything that escapes the agent (including OSError
-                # from prompt_toolkit/Vt100 when stdout is a non-TTY pipe,
-                # KeyboardInterrupt, SystemExit, etc.) so we can surface it on
-                # the real stderr instead of crashing past the redirect with a
-                # traceback that the caller never sees. A silent exit in a
-                # cron / SSH / subprocess context is the worst failure mode.
-                # See #30623.
-                failure = exc
-    finally:
+        # Auto-approve any shell / tool approvals.  Non-interactive by
+        # definition — a prompt would hang forever.
+        os.environ["HERMES_YOLO_MODE"] = "1"
+        os.environ["HERMES_ACCEPT_HOOKS"] = "1"
+
+        # One-shot prints a single final response and exits: there is no later
+        # turn for a detached subagent's completion to re-enter, and nothing
+        # here drains process_registry.completion_queue (only cli.py's
+        # interactive process_loop and the gateway watchers do). Left unbound,
+        # async_delivery_supported() defaults True, delegate_task is forced
+        # background, and every subagent result is discarded. Declaring the
+        # channel stateless routes delegate_task to its inline/synchronous
+        # path. See declare_stateless_channel().
+        declare_stateless_channel()
+
+        # Redirect stderr AND stdout to devnull for the entire call tree.
+        # We'll print the final response to the real stdout at the end.
+        real_stdout = sys.stdout
+        real_stderr = sys.stderr
+        devnull = open(os.devnull, "w", encoding="utf-8")
+
+        response: Optional[str] = None
+        result: dict = {}
+        failure: BaseException | None = None
         try:
-            devnull.close()
-        except Exception:
-            pass
+            with redirect_stdout(devnull), redirect_stderr(devnull):
+                try:
+                    response, result = _run_agent(
+                        prompt,
+                        model=model,
+                        provider=provider,
+                        toolsets=explicit_toolsets,
+                        use_config_toolsets=use_config_toolsets,
+                    )
+                except BaseException as exc:  # noqa: BLE001
+                    # Capture anything that escapes the agent (including OSError
+                    # from prompt_toolkit/Vt100 when stdout is a non-TTY pipe,
+                    # KeyboardInterrupt, SystemExit, etc.) so we can surface it
+                    # on the real stderr instead of crashing past the redirect
+                    # with a traceback that the caller never sees. A silent exit
+                    # in a cron / SSH / subprocess context is the worst failure
+                    # mode. See #30623.
+                    failure = exc
+        finally:
+            try:
+                devnull.close()
+            except Exception:
+                pass
 
-    if failure is not None:
-        # Re-raise control-flow exceptions so the parent handles them as usual
-        # (Ctrl-C / explicit sys.exit() inside the agent).
-        if isinstance(failure, (KeyboardInterrupt, SystemExit)):
-            _write_usage_file(usage_file, result, failure=repr(failure))
-            raise failure
-        _write_usage_file(usage_file, result, failure=str(failure))
-        real_stderr.write(f"hermes -z: agent failed: {failure}\n")
-        real_stderr.flush()
-        return 1
+        if failure is not None:
+            # Re-raise control-flow exceptions so the parent handles them as
+            # usual (Ctrl-C / explicit sys.exit() inside the agent).
+            if isinstance(failure, (KeyboardInterrupt, SystemExit)):
+                _write_usage_file(usage_file, result, failure=repr(failure))
+                raise failure
+            _write_usage_file(usage_file, result, failure=str(failure))
+            real_stderr.write(f"hermes -z: agent failed: {failure}\n")
+            real_stderr.flush()
+            return 1
 
-    _write_usage_file(usage_file, result)
+        _write_usage_file(usage_file, result)
 
-    if response:
-        real_stdout.write(response)
-        if not response.endswith("\n"):
-            real_stdout.write("\n")
-        real_stdout.flush()
+        if response:
+            real_stdout.write(response)
+            if not response.endswith("\n"):
+                real_stdout.write("\n")
+            real_stdout.flush()
 
-    if (result.get("failed") or result.get("partial")) and not (response or "").strip():
-        return 2
+        if (result.get("failed") or result.get("partial")) and not (response or "").strip():
+            return 2
 
-    if not (response or "").strip():
-        real_stderr.write("hermes -z: no final response was produced; treating the run as failed.\n")
-        real_stderr.flush()
-        return 1
+        if not (response or "").strip():
+            real_stderr.write("hermes -z: no final response was produced; treating the run as failed.\n")
+            real_stderr.flush()
+            return 1
 
-    return 0
+        return 0
+    finally:
+        # Restore the original cwd and tear down the worktree (kept only if it
+        # has unpushed commits) regardless of how the run exited.
+        if prev_cwd is not None:
+            try:
+                os.chdir(prev_cwd)
+            except OSError:
+                pass
+        if wt_info is not None:
+            _cleanup_oneshot_worktree(wt_info)
 
 
 def _create_session_db_for_oneshot():

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -199,6 +199,48 @@ def _write_usage_file(path: Optional[str], result: dict, failure: Optional[str] 
         pass
 
 
+def _setup_oneshot_worktree() -> Optional[dict]:
+    """Create an isolated git worktree for ``hermes -z -w``.
+
+    Reuses the interactive ``hermes -w`` lifecycle (``cli._setup_worktree``): a
+    disposable worktree under ``.worktrees/`` on a dedicated ``hermes/...``
+    branch, branched from the freshly-fetched remote tip. Returns the worktree
+    info dict, or ``None`` on failure (the underlying helper prints the reason).
+
+    ``_setup_worktree`` writes its progress/error notices to stdout, but the
+    oneshot contract is that stdout carries only the agent's final response — so
+    those notices are redirected to stderr here.
+    """
+    try:
+        from cli import _git_repo_root, _prune_stale_worktrees, _setup_worktree
+    except Exception as exc:  # pragma: no cover - defensive import guard
+        sys.stderr.write(f"hermes -z: worktree support is unavailable ({exc}).\n")
+        return None
+    with redirect_stdout(sys.stderr):
+        repo_root = _git_repo_root()
+        if repo_root:
+            _prune_stale_worktrees(repo_root)
+        return _setup_worktree()
+
+
+def _cleanup_oneshot_worktree(info: dict) -> None:
+    """Tear down the oneshot worktree on exit (kept if it has unpushed commits).
+
+    Delegates to ``cli._cleanup_worktree``; its stdout notices are routed to
+    stderr so they never contaminate the oneshot response on stdout. Fail-soft:
+    cleanup must never turn a successful run into a failure.
+    """
+    try:
+        from cli import _cleanup_worktree
+    except Exception:  # pragma: no cover - defensive import guard
+        return
+    with redirect_stdout(sys.stderr):
+        try:
+            _cleanup_worktree(info)
+        except Exception:
+            pass
+
+
 def run_oneshot(
     prompt: str,
     model: Optional[str] = None,
@@ -206,6 +248,7 @@ def run_oneshot(
     toolsets: object = None,
     skills: object = None,
     usage_file: Optional[str] = None,
+    worktree: bool = False,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -221,6 +264,11 @@ def run_oneshot(
             cost, token counts, model, api_calls) is written there after the
             run — even when the run fails — so pipelines can account for
             spend per invocation.
+        worktree: When True (``hermes -z -w``), run the agent inside a
+            disposable git worktree on a dedicated ``hermes/...`` branch —
+            mirroring interactive ``hermes -w`` — so commits never land on the
+            caller's checked-out branch. The worktree is removed on exit unless
+            it has unpushed commits. Returns 2 if the worktree cannot be created.
 
     Returns the exit code.  The caller owns process termination.
     """
@@ -250,92 +298,117 @@ def run_oneshot(
         return 2
     use_config_toolsets = _normalize_toolsets(toolsets) is None
 
-    # Auto-approve any shell / tool approvals.  Non-interactive by
-    # definition — a prompt would hang forever.
-    os.environ["HERMES_YOLO_MODE"] = "1"
-    os.environ["HERMES_ACCEPT_HOOKS"] = "1"
+    # `hermes -z -w`: create the isolated worktree BEFORE any agent work and
+    # chdir into it so the whole run (file edits, commits) happens on the
+    # dedicated branch, not the caller's checked-out branch. Fail loudly (exit
+    # 2) if it can't be created rather than silently running in the live repo.
+    wt_info = None
+    prev_cwd = None
+    if worktree:
+        wt_info = _setup_oneshot_worktree()
+        if not wt_info:
+            return 2
+        prev_cwd = os.getcwd()
+        os.chdir(wt_info["path"])
 
-    # One-shot prints a single final response and exits: there is no later turn
-    # for a detached subagent's completion to re-enter, and nothing here drains
-    # process_registry.completion_queue (only cli.py's interactive process_loop
-    # and the gateway watchers do). Left unbound, async_delivery_supported()
-    # defaults True, delegate_task is forced background, and every subagent
-    # result is discarded. Declaring the channel stateless routes delegate_task
-    # to its inline/synchronous path. See declare_stateless_channel().
-    declare_stateless_channel()
-
-    # Redirect stderr AND stdout to devnull for the entire call tree.
-    # We'll print the final response to the real stdout at the end.
-    real_stdout = sys.stdout
-    real_stderr = sys.stderr
-    devnull = open(os.devnull, "w", encoding="utf-8")
-
-    response: Optional[str] = None
-    result: dict = {}
-    failure: BaseException | None = None
     try:
-        with redirect_stdout(devnull), redirect_stderr(devnull):
-            try:
-                response, result = _run_agent(
-                    prompt,
-                    model=model,
-                    provider=provider,
-                    toolsets=explicit_toolsets,
-                    use_config_toolsets=use_config_toolsets,
-                    skills=skills,
-                )
-            except BaseException as exc:  # noqa: BLE001
-                # Capture anything that escapes the agent (including OSError
-                # from prompt_toolkit/Vt100 when stdout is a non-TTY pipe,
-                # KeyboardInterrupt, SystemExit, etc.) so we can surface it on
-                # the real stderr instead of crashing past the redirect with a
-                # traceback that the caller never sees. A silent exit in a
-                # cron / SSH / subprocess context is the worst failure mode.
-                # See #30623.
-                failure = exc
-    finally:
+        # Auto-approve any shell / tool approvals.  Non-interactive by
+        # definition — a prompt would hang forever.
+        os.environ["HERMES_YOLO_MODE"] = "1"
+        os.environ["HERMES_ACCEPT_HOOKS"] = "1"
+
+        # One-shot prints a single final response and exits: there is no later
+        # turn for a detached subagent's completion to re-enter, and nothing
+        # here drains process_registry.completion_queue (only cli.py's
+        # interactive process_loop and the gateway watchers do). Left unbound,
+        # async_delivery_supported() defaults True, delegate_task is forced
+        # background, and every subagent result is discarded. Declaring the
+        # channel stateless routes delegate_task to its inline/synchronous
+        # path. See declare_stateless_channel().
+        declare_stateless_channel()
+
+        # Redirect stderr AND stdout to devnull for the entire call tree.
+        # We'll print the final response to the real stdout at the end.
+        real_stdout = sys.stdout
+        real_stderr = sys.stderr
+        devnull = open(os.devnull, "w", encoding="utf-8")
+
+        response: Optional[str] = None
+        result: dict = {}
+        failure: BaseException | None = None
         try:
-            devnull.close()
-        except Exception:
-            pass
+            with redirect_stdout(devnull), redirect_stderr(devnull):
+                try:
+                    response, result = _run_agent(
+                        prompt,
+                        model=model,
+                        provider=provider,
+                        toolsets=explicit_toolsets,
+                        use_config_toolsets=use_config_toolsets,
+                        skills=skills,
+                    )
+                except BaseException as exc:  # noqa: BLE001
+                    # Capture anything that escapes the agent (including OSError
+                    # from prompt_toolkit/Vt100 when stdout is a non-TTY pipe,
+                    # KeyboardInterrupt, SystemExit, etc.) so we can surface it
+                    # on the real stderr instead of crashing past the redirect
+                    # with a traceback that the caller never sees. A silent exit
+                    # in a cron / SSH / subprocess context is the worst failure
+                    # mode. See #30623.
+                    failure = exc
+        finally:
+            try:
+                devnull.close()
+            except Exception:
+                pass
 
-    if failure is not None:
-        # Re-raise control-flow exceptions so the parent handles them as usual
-        # (Ctrl-C / explicit sys.exit() inside the agent).
-        if isinstance(failure, (KeyboardInterrupt, SystemExit)):
-            _write_usage_file(usage_file, result, failure=repr(failure))
-            raise failure
-        _write_usage_file(usage_file, result, failure=str(failure))
-        real_stderr.write(f"hermes -z: agent failed: {failure}\n")
-        real_stderr.flush()
-        return 1
+        if failure is not None:
+            # Re-raise control-flow exceptions so the parent handles them as
+            # usual (Ctrl-C / explicit sys.exit() inside the agent).
+            if isinstance(failure, (KeyboardInterrupt, SystemExit)):
+                _write_usage_file(usage_file, result, failure=repr(failure))
+                raise failure
+            _write_usage_file(usage_file, result, failure=str(failure))
+            real_stderr.write(f"hermes -z: agent failed: {failure}\n")
+            real_stderr.flush()
+            return 1
 
-    _write_usage_file(usage_file, result)
+        _write_usage_file(usage_file, result)
 
-    # Model text can contain lone UTF-16 surrogates (invalid in UTF-8). Writing
-    # those to a real stdout TextIO raises UnicodeEncodeError and aborts with
-    # exit 1 after the turn already completed — scrub to U+FFFD first.
-    # See #80366.
-    if response:
-        from agent.message_sanitization import _sanitize_surrogates
+        # Model text can contain lone UTF-16 surrogates (invalid in UTF-8).
+        # Writing those to a real stdout TextIO raises UnicodeEncodeError and
+        # aborts with exit 1 after the turn already completed — scrub to U+FFFD
+        # first. See #80366.
+        if response:
+            from agent.message_sanitization import _sanitize_surrogates
 
-        response = _sanitize_surrogates(response)
+            response = _sanitize_surrogates(response)
 
-    if response:
-        real_stdout.write(response)
-        if not response.endswith("\n"):
-            real_stdout.write("\n")
-        real_stdout.flush()
+        if response:
+            real_stdout.write(response)
+            if not response.endswith("\n"):
+                real_stdout.write("\n")
+            real_stdout.flush()
 
-    if (result.get("failed") or result.get("partial")) and not (response or "").strip():
-        return 2
+        if (result.get("failed") or result.get("partial")) and not (response or "").strip():
+            return 2
 
-    if not (response or "").strip():
-        real_stderr.write("hermes -z: no final response was produced; treating the run as failed.\n")
-        real_stderr.flush()
-        return 1
+        if not (response or "").strip():
+            real_stderr.write("hermes -z: no final response was produced; treating the run as failed.\n")
+            real_stderr.flush()
+            return 1
 
-    return 0
+        return 0
+    finally:
+        # Restore the original cwd and tear down the worktree (kept only if it
+        # has unpushed commits) regardless of how the run exited.
+        if prev_cwd is not None:
+            try:
+                os.chdir(prev_cwd)
+            except OSError:
+                pass
+        if wt_info is not None:
+            _cleanup_oneshot_worktree(wt_info)
 
 
 def _create_session_db_for_oneshot():

--- a/tests/hermes_cli/test_oneshot_worktree.py
+++ b/tests/hermes_cli/test_oneshot_worktree.py
@@ -1,0 +1,127 @@
+"""`hermes -z -w` (one-shot) must run inside a disposable git worktree.
+
+One-shot mode used to silently drop `-w`: the agent ran in the caller's cwd and
+its commits landed on the checked-out branch. It now mirrors interactive
+`hermes -w` — set up a worktree, chdir into it, run, and tear it down. See
+issue #67458.
+"""
+
+import os
+
+import pytest
+
+
+def _stub_agent(monkeypatch, oneshot_mod, sink):
+    """Make `_run_agent` record the cwd it saw and return a canned response."""
+
+    def _fake_run_agent(prompt, **_kwargs):
+        sink["agent_cwd"] = os.getcwd()
+        return "done", {}
+
+    monkeypatch.setattr(oneshot_mod, "_run_agent", _fake_run_agent)
+
+
+def test_worktree_runs_agent_in_worktree_and_cleans_up(monkeypatch, tmp_path, capsys):
+    import hermes_cli.oneshot as oneshot_mod
+
+    wt_path = tmp_path / "wt"
+    wt_path.mkdir()
+    wt_info = {"path": str(wt_path), "branch": "hermes/test", "repo_root": str(tmp_path)}
+    sink = {}
+    cleaned = []
+
+    monkeypatch.setattr(oneshot_mod, "_setup_oneshot_worktree", lambda: wt_info)
+    monkeypatch.setattr(
+        oneshot_mod, "_cleanup_oneshot_worktree", lambda info: cleaned.append(info)
+    )
+    _stub_agent(monkeypatch, oneshot_mod, sink)
+
+    start_cwd = os.getcwd()
+    try:
+        rc = oneshot_mod.run_oneshot("hello", worktree=True)
+    finally:
+        os.chdir(start_cwd)
+
+    assert rc == 0
+    # Agent ran inside the worktree, not the caller's cwd.
+    assert os.path.realpath(sink["agent_cwd"]) == os.path.realpath(str(wt_path))
+    # cwd is restored and the worktree is torn down exactly once.
+    assert os.getcwd() == start_cwd
+    assert cleaned == [wt_info]
+    # stdout carries only the final response.
+    assert capsys.readouterr().out.strip() == "done"
+
+
+def test_worktree_setup_failure_returns_2_without_running_agent(monkeypatch):
+    import hermes_cli.oneshot as oneshot_mod
+
+    ran = {"agent": False}
+
+    def _boom_agent(*_args, **_kwargs):
+        ran["agent"] = True
+        return "should-not-run", {}
+
+    monkeypatch.setattr(oneshot_mod, "_setup_oneshot_worktree", lambda: None)
+    monkeypatch.setattr(oneshot_mod, "_run_agent", _boom_agent)
+    # If setup fails we must not attempt cleanup on a nonexistent worktree.
+    monkeypatch.setattr(
+        oneshot_mod,
+        "_cleanup_oneshot_worktree",
+        lambda info: pytest.fail("cleanup ran without a worktree"),
+    )
+
+    start_cwd = os.getcwd()
+    rc = oneshot_mod.run_oneshot("hello", worktree=True)
+
+    assert rc == 2
+    assert ran["agent"] is False
+    assert os.getcwd() == start_cwd
+
+
+def test_worktree_cleanup_runs_even_when_agent_fails(monkeypatch, tmp_path, capsys):
+    import hermes_cli.oneshot as oneshot_mod
+
+    wt_path = tmp_path / "wt"
+    wt_path.mkdir()
+    wt_info = {"path": str(wt_path), "branch": "hermes/test", "repo_root": str(tmp_path)}
+    cleaned = []
+
+    monkeypatch.setattr(oneshot_mod, "_setup_oneshot_worktree", lambda: wt_info)
+    monkeypatch.setattr(
+        oneshot_mod, "_cleanup_oneshot_worktree", lambda info: cleaned.append(info)
+    )
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("agent exploded")
+
+    monkeypatch.setattr(oneshot_mod, "_run_agent", _boom)
+
+    start_cwd = os.getcwd()
+    try:
+        rc = oneshot_mod.run_oneshot("hello", worktree=True)
+    finally:
+        os.chdir(start_cwd)
+
+    assert rc == 1
+    # Worktree is still torn down and cwd restored on the failure path.
+    assert cleaned == [wt_info]
+    assert os.getcwd() == start_cwd
+
+
+def test_no_worktree_by_default_does_not_touch_cwd(monkeypatch):
+    import hermes_cli.oneshot as oneshot_mod
+
+    sink = {}
+    monkeypatch.setattr(
+        oneshot_mod,
+        "_setup_oneshot_worktree",
+        lambda: pytest.fail("worktree setup ran without -w"),
+    )
+    _stub_agent(monkeypatch, oneshot_mod, sink)
+
+    start_cwd = os.getcwd()
+    rc = oneshot_mod.run_oneshot("hello")
+
+    assert rc == 0
+    assert sink["agent_cwd"] == start_cwd
+    assert os.getcwd() == start_cwd

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -49,6 +49,386 @@ def main_mod(monkeypatch):
 
 
 
+    assert calls == ["tui", "cli"]
+    assert captured["resume"] == "20260408_235959_d4e5f6"
+
+
+def test_cmd_chat_tui_resume_resolves_title_before_launch(monkeypatch, main_mod):
+    captured = {}
+
+    def fake_launch(
+        resume_session_id=None,
+        tui_dev=False,
+        model=None,
+        provider=None,
+        toolsets=None,
+        **kwargs,
+    ):
+        captured["resume"] = resume_session_id
+        raise SystemExit(0)
+
+    monkeypatch.setattr(
+        main_mod, "_resolve_session_by_name_or_id", lambda val: "20260409_000000_aa11bb"
+    )
+    monkeypatch.setattr(main_mod, "_launch_tui", fake_launch)
+
+    with pytest.raises(SystemExit):
+        main_mod.cmd_chat(_args(resume="my t0p session"))
+
+    assert captured["resume"] == "20260409_000000_aa11bb"
+
+
+def test_cmd_chat_tui_passes_model_and_provider(monkeypatch, main_mod):
+    captured = {}
+
+    def fake_launch(
+        resume_session_id=None,
+        tui_dev=False,
+        model=None,
+        provider=None,
+        toolsets=None,
+        **kwargs,
+    ):
+        captured.update(
+            {
+                "model": model,
+                "provider": provider,
+                "resume": resume_session_id,
+                "toolsets": toolsets,
+                "tui_dev": tui_dev,
+            }
+        )
+        raise SystemExit(0)
+
+    monkeypatch.setattr(main_mod, "_launch_tui", fake_launch)
+
+    with pytest.raises(SystemExit):
+        main_mod.cmd_chat(
+            _args(model="anthropic/claude-sonnet-4.6", provider="anthropic")
+        )
+
+    assert captured == {
+        "model": "anthropic/claude-sonnet-4.6",
+        "provider": "anthropic",
+        "resume": None,
+        "toolsets": None,
+        "tui_dev": False,
+    }
+
+
+def test_cmd_chat_tui_passes_toolsets(monkeypatch, main_mod):
+    captured = {}
+
+    def fake_launch(
+        resume_session_id=None,
+        tui_dev=False,
+        model=None,
+        provider=None,
+        toolsets=None,
+        **kwargs,
+    ):
+        captured["toolsets"] = toolsets
+        raise SystemExit(0)
+
+    monkeypatch.setattr(main_mod, "_launch_tui", fake_launch)
+
+    with pytest.raises(SystemExit):
+        main_mod.cmd_chat(_args(toolsets="web,terminal"))
+
+    assert captured["toolsets"] == "web,terminal"
+
+
+def test_cmd_chat_tui_forwards_chat_flags(monkeypatch, main_mod):
+    captured = {}
+
+    def fake_launch(resume_session_id=None, **kwargs):
+        captured["resume_session_id"] = resume_session_id
+        captured.update(kwargs)
+        raise SystemExit(0)
+
+    monkeypatch.setattr(main_mod, "_launch_tui", fake_launch)
+
+    with pytest.raises(SystemExit):
+        main_mod.cmd_chat(
+            _args(
+                skills=["foo,bar"],
+                verbose=True,
+                quiet=True,
+                query="hello",
+                image="/tmp/cat.png",
+                worktree=True,
+                checkpoints=True,
+                pass_session_id=True,
+                max_turns=7,
+                accept_hooks=True,
+            )
+        )
+
+    assert captured["skills"] == ["foo,bar"]
+    assert captured["verbose"] is True
+    assert captured["quiet"] is True
+    assert captured["query"] == "hello"
+    assert captured["image"] == "/tmp/cat.png"
+    assert captured["worktree"] is True
+    assert captured["checkpoints"] is True
+    assert captured["pass_session_id"] is True
+    assert captured["max_turns"] == 7
+    assert captured["accept_hooks"] is True
+
+
+def test_main_top_level_tui_accepts_toolsets(monkeypatch, main_mod):
+    captured = {}
+
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(sys, "argv", ["hermes", "--tui", "--toolsets", "web,terminal"])
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=lambda: None),
+    )
+    monkeypatch.setattr(config_mod, "load_config", lambda: {})
+    monkeypatch.setattr(config_mod, "get_container_exec_info", lambda: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(
+            register_from_config=lambda _cfg, accept_hooks=False: None
+        ),
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "cmd_chat",
+        lambda args: captured.update({"toolsets": args.toolsets, "tui": args.tui}),
+    )
+
+    main_mod.main()
+
+    assert captured == {"toolsets": "web,terminal", "tui": True}
+
+
+def test_termux_fast_tui_launch_uses_light_parser(monkeypatch, main_mod):
+    captured = {}
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setattr(
+        sys, "argv", ["hermes", "--tui", "--toolsets", "web,terminal"]
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "cmd_chat",
+        lambda args: captured.update({"toolsets": args.toolsets, "tui": args.tui}),
+    )
+
+    assert main_mod._try_termux_fast_tui_launch() is True
+    assert captured == {"toolsets": "web,terminal", "tui": True}
+
+
+def test_termux_fast_tui_launch_skips_help(monkeypatch, main_mod):
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setattr(sys, "argv", ["hermes", "--tui", "--help"])
+
+    assert main_mod._try_termux_fast_tui_launch() is False
+
+
+def test_fast_tui_launch_is_termux_only(monkeypatch, main_mod):
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(sys, "argv", ["hermes", "--tui"])
+
+    assert main_mod._try_termux_fast_tui_launch() is False
+
+
+def test_termux_fast_cli_launch_chat_uses_light_parser(monkeypatch, main_mod):
+    captured = {}
+    prepared = []
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.delenv("HERMES_TUI", raising=False)
+    monkeypatch.setattr(
+        sys, "argv", ["hermes", "chat", "-q", "hello", "--toolsets", "web,terminal"]
+    )
+    monkeypatch.setattr(
+        main_mod, "_prepare_agent_startup", lambda args: prepared.append(args.command)
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "cmd_chat",
+        lambda args: captured.update(
+            {"query": args.query, "toolsets": args.toolsets, "command": args.command}
+        ),
+    )
+
+    assert main_mod._try_termux_fast_cli_launch() is True
+    assert prepared == ["chat"]
+    assert captured == {
+        "query": "hello",
+        "toolsets": "web,terminal",
+        "command": "chat",
+    }
+
+
+def test_termux_fast_cli_launch_bare_defers_agent_startup(monkeypatch, main_mod):
+    captured = {}
+    prepared = []
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.delenv("HERMES_TUI", raising=False)
+    monkeypatch.delenv("HERMES_DEFER_AGENT_STARTUP", raising=False)
+    monkeypatch.delenv("HERMES_FAST_STARTUP_BANNER", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes"])
+    monkeypatch.setattr(
+        main_mod, "_prepare_agent_startup", lambda args: prepared.append(args.command)
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "cmd_chat",
+        lambda args: captured.update(
+            {
+                "query": args.query,
+                "command": args.command,
+                "compact": getattr(args, "compact", False),
+            }
+        ),
+    )
+
+    assert main_mod._try_termux_fast_cli_launch() is True
+    assert prepared == []
+    assert captured == {"query": None, "command": None, "compact": True}
+    assert os.environ["HERMES_DEFER_AGENT_STARTUP"] == "1"
+    assert os.environ["HERMES_FAST_STARTUP_BANNER"] == "1"
+
+
+def test_termux_fast_cli_launch_oneshot_uses_light_parser(monkeypatch, main_mod):
+    captured = {}
+    prepared = []
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.delenv("HERMES_TUI", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hermes",
+            "-z",
+            "hello",
+            "--model",
+            "gpt-test",
+            "--provider",
+            "openai",
+            "--usage-file",
+            "usage.json",
+        ],
+    )
+    monkeypatch.setattr(
+        main_mod, "_prepare_agent_startup", lambda args: prepared.append(args.command)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.oneshot",
+        types.SimpleNamespace(
+            run_oneshot=lambda prompt, **kwargs: captured.update(
+                {"prompt": prompt, **kwargs}
+            )
+            or 17
+        ),
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "_exit_after_oneshot",
+        _raise_exit,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod._try_termux_fast_cli_launch()
+
+    assert exc.value.code == 17
+    assert prepared == [None]
+    assert captured == {
+        "prompt": "hello",
+        "model": "gpt-test",
+        "provider": "openai",
+        "toolsets": None,
+        "usage_file": "usage.json",
+        "worktree": False,
+    }
+
+
+def test_termux_fast_cli_launch_version_skips_update_check(monkeypatch, main_mod):
+    captured = []
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.delenv("HERMES_TUI", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "version"])
+    monkeypatch.setattr(
+        main_mod, "_print_version_info", lambda *, check_updates: captured.append(check_updates)
+    )
+
+    assert main_mod._try_termux_fast_cli_launch() is True
+    assert captured == [False]
+
+
+def test_termux_ultrafast_version_runs_before_heavy_startup(
+    monkeypatch, capsys, main_mod
+):
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.delenv("HERMES_TERMUX_DISABLE_FAST_CLI", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "--version"])
+
+    assert main_mod._try_termux_ultrafast_version() is True
+
+    out = capsys.readouterr().out
+    assert "Hermes Agent v" in out
+    assert "Install directory:" in out
+    assert "Python:" in out
+    assert "OpenAI SDK:" in out
+
+
+def test_read_openai_version_fast(monkeypatch, tmp_path, main_mod):
+    package_dir = tmp_path / "openai"
+    package_dir.mkdir()
+    (package_dir / "_version.py").write_text(
+        '__version__ = "9.8.7"  # x-release-please-version\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(sys, "path", [str(tmp_path)])
+
+    assert main_mod._read_openai_version_fast() == "9.8.7"
+
+
+def test_termux_fast_cli_launch_skips_help(monkeypatch, main_mod):
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.delenv("HERMES_TUI", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "chat", "--help"])
+
+    assert main_mod._try_termux_fast_cli_launch() is False
+
+
+def test_termux_fast_cli_launch_can_be_disabled(monkeypatch, main_mod):
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setenv("HERMES_TERMUX_DISABLE_FAST_CLI", "1")
+    monkeypatch.delenv("HERMES_TUI", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "version"])
+
+    assert main_mod._try_termux_fast_cli_launch() is False
+
+
+def test_termux_bundled_skills_stamp_controls_sync(monkeypatch, tmp_path, main_mod):
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setattr(main_mod, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(main_mod, "_termux_bundled_skills_fingerprint", lambda: "fp1")
+
+    assert main_mod._termux_bundled_skills_sync_needed() is True
+    main_mod._mark_termux_bundled_skills_synced()
+    assert main_mod._termux_bundled_skills_sync_needed() is False
+
+    monkeypatch.setenv("HERMES_TERMUX_FORCE_SKILLS_SYNC", "1")
+    assert main_mod._termux_bundled_skills_sync_needed() is True
 
 
 def test_termux_skips_bundled_skill_sync_when_stamp_fresh(monkeypatch, tmp_path, main_mod):
@@ -70,6 +450,203 @@ def test_termux_skips_bundled_skill_sync_when_stamp_fresh(monkeypatch, tmp_path,
 
 
 
+def test_read_git_revision_fingerprint_resolves_packed_refs(tmp_path, main_mod):
+    repo = tmp_path / "repo"
+    git_dir = repo / ".git"
+    git_dir.mkdir(parents=True)
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    packed_sha = "1234567890abcdef1234567890abcdef12345678"
+    (git_dir / "packed-refs").write_text(
+        "# pack-refs with: peeled fully-peeled sorted\n"
+        f"{packed_sha} refs/heads/main\n"
+        "abcdef0000000000000000000000000000000000 refs/tags/v1.0\n"
+        "^99999999aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",
+        encoding="utf-8",
+    )
+
+    fingerprint = main_mod._read_git_revision_fingerprint(repo)
+
+    assert fingerprint == f"git:refs/heads/main:{packed_sha}"
+
+
+def test_read_git_revision_fingerprint_packed_refs_in_worktree_common_dir(
+    tmp_path, main_mod
+):
+    main_repo = tmp_path / "repo"
+    common_git = main_repo / ".git"
+    common_git.mkdir(parents=True)
+    packed_sha = "fedcba9876543210fedcba9876543210fedcba98"
+    (common_git / "packed-refs").write_text(
+        f"{packed_sha} refs/heads/main\n",
+        encoding="utf-8",
+    )
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    wt_gitdir = common_git / "worktrees" / "wt"
+    wt_gitdir.mkdir(parents=True)
+    (wt_gitdir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    (wt_gitdir / "commondir").write_text("../..\n", encoding="utf-8")
+    (worktree / ".git").write_text(f"gitdir: {wt_gitdir}\n", encoding="utf-8")
+
+    fingerprint = main_mod._read_git_revision_fingerprint(worktree)
+
+    assert fingerprint == f"git:refs/heads/main:{packed_sha}"
+
+
+def test_read_git_revision_fingerprint_loose_ref_in_worktree_common_dir(
+    tmp_path, main_mod
+):
+    """`git worktree add -b NAME` writes the new branch ref to the common dir,
+    not the per-worktree gitdir. The fingerprint must still resolve it."""
+    main_repo = tmp_path / "repo"
+    common_git = main_repo / ".git"
+    common_git.mkdir(parents=True)
+    loose_sha = "0123456789abcdef0123456789abcdef01234567"
+    (common_git / "refs" / "heads").mkdir(parents=True)
+    (common_git / "refs" / "heads" / "feature").write_text(
+        loose_sha + "\n", encoding="utf-8"
+    )
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    wt_gitdir = common_git / "worktrees" / "wt"
+    wt_gitdir.mkdir(parents=True)
+    (wt_gitdir / "HEAD").write_text("ref: refs/heads/feature\n", encoding="utf-8")
+    (wt_gitdir / "commondir").write_text("../..\n", encoding="utf-8")
+    (worktree / ".git").write_text(f"gitdir: {wt_gitdir}\n", encoding="utf-8")
+
+    fingerprint = main_mod._read_git_revision_fingerprint(worktree)
+
+    assert fingerprint == f"git:refs/heads/feature:{loose_sha}"
+
+
+def test_read_git_revision_fingerprint_unresolved_ref_is_stable(tmp_path, main_mod):
+    repo = tmp_path / "repo"
+    git_dir = repo / ".git"
+    git_dir.mkdir(parents=True)
+    (git_dir / "HEAD").write_text("ref: refs/heads/missing\n", encoding="utf-8")
+
+    fingerprint = main_mod._read_git_revision_fingerprint(repo)
+
+    assert fingerprint == "git:refs/heads/missing:unresolved"
+
+
+def test_main_top_level_oneshot_accepts_toolsets(monkeypatch, main_mod):
+    captured = {}
+
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hermes",
+            "-z",
+            "hello",
+            "--toolsets",
+            "web,terminal",
+            "--usage-file",
+            "usage.json",
+        ],
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=lambda: None),
+    )
+    monkeypatch.setattr(config_mod, "load_config", lambda: {})
+    monkeypatch.setattr(config_mod, "get_container_exec_info", lambda: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(
+            register_from_config=lambda _cfg, accept_hooks=False: None
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.oneshot",
+        types.SimpleNamespace(
+            run_oneshot=lambda prompt, **kwargs: captured.update(
+                {"prompt": prompt, **kwargs}
+            )
+            or 0
+        ),
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "_exit_after_oneshot",
+        _raise_exit,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main()
+
+    assert exc.value.code == 0
+    assert captured == {
+        "prompt": "hello",
+        "model": None,
+        "provider": None,
+        "toolsets": "web,terminal",
+        "usage_file": "usage.json",
+        "worktree": False,
+    }
+
+
+def test_main_top_level_oneshot_forwards_worktree(monkeypatch, main_mod):
+    # `hermes -z ... -w` through the main dispatch must forward worktree=True to
+    # run_oneshot (issue #67458 — the flag used to be silently dropped).
+    captured = {}
+
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(sys, "argv", ["hermes", "-z", "hello", "-w"])
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=lambda: None),
+    )
+    monkeypatch.setattr(config_mod, "load_config", lambda: {})
+    monkeypatch.setattr(config_mod, "get_container_exec_info", lambda: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(
+            register_from_config=lambda _cfg, accept_hooks=False: None
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.oneshot",
+        types.SimpleNamespace(
+            run_oneshot=lambda prompt, **kwargs: captured.update(
+                {"prompt": prompt, **kwargs}
+            )
+            or 0
+        ),
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "_exit_after_oneshot",
+        _raise_exit,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main()
+
+    assert exc.value.code == 0
+    assert captured["worktree"] is True
 
 
 def test_exit_after_oneshot_flushes_stdio_and_calls_os_exit(

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -49,6 +49,389 @@ def main_mod(monkeypatch):
 
 
 
+    assert calls == ["tui", "cli"]
+    assert captured["resume"] == "20260408_235959_d4e5f6"
+
+
+def test_cmd_chat_tui_resume_resolves_title_before_launch(monkeypatch, main_mod):
+    captured = {}
+
+    def fake_launch(
+        resume_session_id=None,
+        tui_dev=False,
+        model=None,
+        provider=None,
+        toolsets=None,
+        **kwargs,
+    ):
+        captured["resume"] = resume_session_id
+        raise SystemExit(0)
+
+    monkeypatch.setattr(
+        main_mod, "_resolve_session_by_name_or_id", lambda val: "20260409_000000_aa11bb"
+    )
+    monkeypatch.setattr(main_mod, "_launch_tui", fake_launch)
+
+    with pytest.raises(SystemExit):
+        main_mod.cmd_chat(_args(resume="my t0p session"))
+
+    assert captured["resume"] == "20260409_000000_aa11bb"
+
+
+def test_cmd_chat_tui_passes_model_and_provider(monkeypatch, main_mod):
+    captured = {}
+
+    def fake_launch(
+        resume_session_id=None,
+        tui_dev=False,
+        model=None,
+        provider=None,
+        toolsets=None,
+        **kwargs,
+    ):
+        captured.update(
+            {
+                "model": model,
+                "provider": provider,
+                "resume": resume_session_id,
+                "toolsets": toolsets,
+                "tui_dev": tui_dev,
+            }
+        )
+        raise SystemExit(0)
+
+    monkeypatch.setattr(main_mod, "_launch_tui", fake_launch)
+
+    with pytest.raises(SystemExit):
+        main_mod.cmd_chat(
+            _args(model="anthropic/claude-sonnet-4.6", provider="anthropic")
+        )
+
+    assert captured == {
+        "model": "anthropic/claude-sonnet-4.6",
+        "provider": "anthropic",
+        "resume": None,
+        "toolsets": None,
+        "tui_dev": False,
+    }
+
+
+def test_cmd_chat_tui_passes_toolsets(monkeypatch, main_mod):
+    captured = {}
+
+    def fake_launch(
+        resume_session_id=None,
+        tui_dev=False,
+        model=None,
+        provider=None,
+        toolsets=None,
+        **kwargs,
+    ):
+        captured["toolsets"] = toolsets
+        raise SystemExit(0)
+
+    monkeypatch.setattr(main_mod, "_launch_tui", fake_launch)
+
+    with pytest.raises(SystemExit):
+        main_mod.cmd_chat(_args(toolsets="web,terminal"))
+
+    assert captured["toolsets"] == "web,terminal"
+
+
+def test_cmd_chat_tui_forwards_chat_flags(monkeypatch, main_mod):
+    captured = {}
+
+    def fake_launch(resume_session_id=None, **kwargs):
+        captured["resume_session_id"] = resume_session_id
+        captured.update(kwargs)
+        raise SystemExit(0)
+
+    monkeypatch.setattr(main_mod, "_launch_tui", fake_launch)
+
+    with pytest.raises(SystemExit):
+        main_mod.cmd_chat(
+            _args(
+                skills=["foo,bar"],
+                verbose=True,
+                quiet=True,
+                query="hello",
+                image="/tmp/cat.png",
+                worktree=True,
+                checkpoints=True,
+                pass_session_id=True,
+                max_turns=7,
+                accept_hooks=True,
+            )
+        )
+
+    assert captured["skills"] == ["foo,bar"]
+    assert captured["verbose"] is True
+    assert captured["quiet"] is True
+    assert captured["query"] == "hello"
+    assert captured["image"] == "/tmp/cat.png"
+    assert captured["worktree"] is True
+    assert captured["checkpoints"] is True
+    assert captured["pass_session_id"] is True
+    assert captured["max_turns"] == 7
+    assert captured["accept_hooks"] is True
+
+
+def test_main_top_level_tui_accepts_toolsets(monkeypatch, main_mod):
+    captured = {}
+
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(sys, "argv", ["hermes", "--tui", "--toolsets", "web,terminal"])
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=lambda: None),
+    )
+    monkeypatch.setattr(config_mod, "load_config", lambda: {})
+    monkeypatch.setattr(config_mod, "get_container_exec_info", lambda: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(
+            register_from_config=lambda _cfg, accept_hooks=False: None
+        ),
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "cmd_chat",
+        lambda args: captured.update({"toolsets": args.toolsets, "tui": args.tui}),
+    )
+
+    main_mod.main()
+
+    assert captured == {"toolsets": "web,terminal", "tui": True}
+
+
+def test_termux_fast_tui_launch_uses_light_parser(monkeypatch, main_mod):
+    captured = {}
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setattr(
+        sys, "argv", ["hermes", "--tui", "--toolsets", "web,terminal"]
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "cmd_chat",
+        lambda args: captured.update({"toolsets": args.toolsets, "tui": args.tui}),
+    )
+
+    assert main_mod._try_termux_fast_tui_launch() is True
+    assert captured == {"toolsets": "web,terminal", "tui": True}
+
+
+def test_termux_fast_tui_launch_skips_help(monkeypatch, main_mod):
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setattr(sys, "argv", ["hermes", "--tui", "--help"])
+
+    assert main_mod._try_termux_fast_tui_launch() is False
+
+
+def test_fast_tui_launch_is_termux_only(monkeypatch, main_mod):
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(sys, "argv", ["hermes", "--tui"])
+
+    assert main_mod._try_termux_fast_tui_launch() is False
+
+
+def test_termux_fast_cli_launch_chat_uses_light_parser(monkeypatch, main_mod):
+    captured = {}
+    prepared = []
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.delenv("HERMES_TUI", raising=False)
+    monkeypatch.setattr(
+        sys, "argv", ["hermes", "chat", "-q", "hello", "--toolsets", "web,terminal"]
+    )
+    monkeypatch.setattr(
+        main_mod, "_prepare_agent_startup", lambda args: prepared.append(args.command)
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "cmd_chat",
+        lambda args: captured.update(
+            {"query": args.query, "toolsets": args.toolsets, "command": args.command}
+        ),
+    )
+
+    assert main_mod._try_termux_fast_cli_launch() is True
+    assert prepared == ["chat"]
+    assert captured == {
+        "query": "hello",
+        "toolsets": "web,terminal",
+        "command": "chat",
+    }
+
+
+def test_termux_fast_cli_launch_bare_defers_agent_startup(monkeypatch, main_mod):
+    captured = {}
+    prepared = []
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.delenv("HERMES_TUI", raising=False)
+    monkeypatch.delenv("HERMES_DEFER_AGENT_STARTUP", raising=False)
+    monkeypatch.delenv("HERMES_FAST_STARTUP_BANNER", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes"])
+    monkeypatch.setattr(
+        main_mod, "_prepare_agent_startup", lambda args: prepared.append(args.command)
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "cmd_chat",
+        lambda args: captured.update(
+            {
+                "query": args.query,
+                "command": args.command,
+                "compact": getattr(args, "compact", False),
+            }
+        ),
+    )
+
+    assert main_mod._try_termux_fast_cli_launch() is True
+    assert prepared == []
+    assert captured == {"query": None, "command": None, "compact": True}
+    assert os.environ["HERMES_DEFER_AGENT_STARTUP"] == "1"
+    assert os.environ["HERMES_FAST_STARTUP_BANNER"] == "1"
+
+
+def test_termux_fast_cli_launch_oneshot_uses_light_parser(monkeypatch, main_mod):
+    captured = {}
+    prepared = []
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.delenv("HERMES_TUI", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hermes",
+            "-z",
+            "hello",
+            "--model",
+            "gpt-test",
+            "--provider",
+            "openai",
+            "--usage-file",
+            "usage.json",
+        ],
+    )
+    monkeypatch.setattr(
+        main_mod, "_prepare_agent_startup", lambda args: prepared.append(args.command)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.oneshot",
+        types.SimpleNamespace(
+            run_oneshot=lambda prompt, **kwargs: captured.update(
+                {"prompt": prompt, **kwargs}
+            )
+            or 17
+        ),
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "_exit_after_oneshot",
+        _raise_exit,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod._try_termux_fast_cli_launch()
+
+    assert exc.value.code == 17
+    assert prepared == [None]
+    assert captured == {
+        "prompt": "hello",
+        "model": "gpt-test",
+        "provider": "openai",
+        "toolsets": None,
+        "skills": None,
+        "usage_file": "usage.json",
+        "worktree": False,
+    }
+
+
+def test_termux_fast_cli_launch_version_runs_update_check(monkeypatch, main_mod):
+    captured = []
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.delenv("HERMES_TUI", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "--version"])
+    monkeypatch.setattr(
+        main_mod, "_print_version_info", lambda *, check_updates: captured.append(check_updates)
+    )
+
+    # The Termux fast-path recognizes ``--version`` / ``-V`` on the light parser
+    # and prints version info with the update check enabled.
+    assert main_mod._try_termux_fast_cli_launch() is True
+    assert captured == [True]
+
+
+def test_termux_ultrafast_version_runs_before_heavy_startup(
+    monkeypatch, capsys, main_mod
+):
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.delenv("HERMES_TERMUX_DISABLE_FAST_CLI", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "--version"])
+
+    assert main_mod._try_termux_ultrafast_version() is True
+
+    out = capsys.readouterr().out
+    assert "Hermes Agent v" in out
+    assert "Install directory:" in out
+    assert "Python:" in out
+    assert "OpenAI SDK:" in out
+
+
+def test_read_openai_version_fast(monkeypatch, tmp_path, main_mod):
+    package_dir = tmp_path / "openai"
+    package_dir.mkdir()
+    (package_dir / "_version.py").write_text(
+        '__version__ = "9.8.7"  # x-release-please-version\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(sys, "path", [str(tmp_path)])
+
+    assert main_mod._read_openai_version_fast() == "9.8.7"
+
+
+def test_termux_fast_cli_launch_skips_help(monkeypatch, main_mod):
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.delenv("HERMES_TUI", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "chat", "--help"])
+
+    assert main_mod._try_termux_fast_cli_launch() is False
+
+
+def test_termux_fast_cli_launch_can_be_disabled(monkeypatch, main_mod):
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setenv("HERMES_TERMUX_DISABLE_FAST_CLI", "1")
+    monkeypatch.delenv("HERMES_TUI", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "version"])
+
+    assert main_mod._try_termux_fast_cli_launch() is False
+
+
+def test_termux_bundled_skills_stamp_controls_sync(monkeypatch, tmp_path, main_mod):
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setattr(main_mod, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(main_mod, "_termux_bundled_skills_fingerprint", lambda: "fp1")
+
+    assert main_mod._termux_bundled_skills_sync_needed() is True
+    main_mod._mark_termux_bundled_skills_synced()
+    assert main_mod._termux_bundled_skills_sync_needed() is False
+
+    monkeypatch.setenv("HERMES_TERMUX_FORCE_SKILLS_SYNC", "1")
+    assert main_mod._termux_bundled_skills_sync_needed() is True
 
 
 def test_termux_skips_bundled_skill_sync_when_stamp_fresh(monkeypatch, tmp_path, main_mod):
@@ -70,6 +453,204 @@ def test_termux_skips_bundled_skill_sync_when_stamp_fresh(monkeypatch, tmp_path,
 
 
 
+def test_read_git_revision_fingerprint_resolves_packed_refs(tmp_path, main_mod):
+    repo = tmp_path / "repo"
+    git_dir = repo / ".git"
+    git_dir.mkdir(parents=True)
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    packed_sha = "1234567890abcdef1234567890abcdef12345678"
+    (git_dir / "packed-refs").write_text(
+        "# pack-refs with: peeled fully-peeled sorted\n"
+        f"{packed_sha} refs/heads/main\n"
+        "abcdef0000000000000000000000000000000000 refs/tags/v1.0\n"
+        "^99999999aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",
+        encoding="utf-8",
+    )
+
+    fingerprint = main_mod._read_git_revision_fingerprint(repo)
+
+    assert fingerprint == f"git:refs/heads/main:{packed_sha}"
+
+
+def test_read_git_revision_fingerprint_packed_refs_in_worktree_common_dir(
+    tmp_path, main_mod
+):
+    main_repo = tmp_path / "repo"
+    common_git = main_repo / ".git"
+    common_git.mkdir(parents=True)
+    packed_sha = "fedcba9876543210fedcba9876543210fedcba98"
+    (common_git / "packed-refs").write_text(
+        f"{packed_sha} refs/heads/main\n",
+        encoding="utf-8",
+    )
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    wt_gitdir = common_git / "worktrees" / "wt"
+    wt_gitdir.mkdir(parents=True)
+    (wt_gitdir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    (wt_gitdir / "commondir").write_text("../..\n", encoding="utf-8")
+    (worktree / ".git").write_text(f"gitdir: {wt_gitdir}\n", encoding="utf-8")
+
+    fingerprint = main_mod._read_git_revision_fingerprint(worktree)
+
+    assert fingerprint == f"git:refs/heads/main:{packed_sha}"
+
+
+def test_read_git_revision_fingerprint_loose_ref_in_worktree_common_dir(
+    tmp_path, main_mod
+):
+    """`git worktree add -b NAME` writes the new branch ref to the common dir,
+    not the per-worktree gitdir. The fingerprint must still resolve it."""
+    main_repo = tmp_path / "repo"
+    common_git = main_repo / ".git"
+    common_git.mkdir(parents=True)
+    loose_sha = "0123456789abcdef0123456789abcdef01234567"
+    (common_git / "refs" / "heads").mkdir(parents=True)
+    (common_git / "refs" / "heads" / "feature").write_text(
+        loose_sha + "\n", encoding="utf-8"
+    )
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    wt_gitdir = common_git / "worktrees" / "wt"
+    wt_gitdir.mkdir(parents=True)
+    (wt_gitdir / "HEAD").write_text("ref: refs/heads/feature\n", encoding="utf-8")
+    (wt_gitdir / "commondir").write_text("../..\n", encoding="utf-8")
+    (worktree / ".git").write_text(f"gitdir: {wt_gitdir}\n", encoding="utf-8")
+
+    fingerprint = main_mod._read_git_revision_fingerprint(worktree)
+
+    assert fingerprint == f"git:refs/heads/feature:{loose_sha}"
+
+
+def test_read_git_revision_fingerprint_unresolved_ref_is_stable(tmp_path, main_mod):
+    repo = tmp_path / "repo"
+    git_dir = repo / ".git"
+    git_dir.mkdir(parents=True)
+    (git_dir / "HEAD").write_text("ref: refs/heads/missing\n", encoding="utf-8")
+
+    fingerprint = main_mod._read_git_revision_fingerprint(repo)
+
+    assert fingerprint == "git:refs/heads/missing:unresolved"
+
+
+def test_main_top_level_oneshot_accepts_toolsets(monkeypatch, main_mod):
+    captured = {}
+
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hermes",
+            "-z",
+            "hello",
+            "--toolsets",
+            "web,terminal",
+            "--usage-file",
+            "usage.json",
+        ],
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=lambda: None),
+    )
+    monkeypatch.setattr(config_mod, "load_config", lambda: {})
+    monkeypatch.setattr(config_mod, "get_container_exec_info", lambda: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(
+            register_from_config=lambda _cfg, accept_hooks=False: None
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.oneshot",
+        types.SimpleNamespace(
+            run_oneshot=lambda prompt, **kwargs: captured.update(
+                {"prompt": prompt, **kwargs}
+            )
+            or 0
+        ),
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "_exit_after_oneshot",
+        _raise_exit,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main()
+
+    assert exc.value.code == 0
+    assert captured == {
+        "prompt": "hello",
+        "model": None,
+        "provider": None,
+        "toolsets": "web,terminal",
+        "skills": None,
+        "usage_file": "usage.json",
+        "worktree": False,
+    }
+
+
+def test_main_top_level_oneshot_forwards_worktree(monkeypatch, main_mod):
+    # `hermes -z ... -w` through the main dispatch must forward worktree=True to
+    # run_oneshot (issue #67458 — the flag used to be silently dropped).
+    captured = {}
+
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(sys, "argv", ["hermes", "-z", "hello", "-w"])
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=lambda: None),
+    )
+    monkeypatch.setattr(config_mod, "load_config", lambda: {})
+    monkeypatch.setattr(config_mod, "get_container_exec_info", lambda: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(
+            register_from_config=lambda _cfg, accept_hooks=False: None
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.oneshot",
+        types.SimpleNamespace(
+            run_oneshot=lambda prompt, **kwargs: captured.update(
+                {"prompt": prompt, **kwargs}
+            )
+            or 0
+        ),
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "_exit_after_oneshot",
+        _raise_exit,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main()
+
+    assert exc.value.code == 0
+    assert captured["worktree"] is True
 
 
 def test_exit_after_oneshot_flushes_stdio_and_calls_os_exit(


### PR DESCRIPTION
## What does this PR do?

`hermes -z "…" -w` accepts `-w/--worktree` but silently ignores it. One-shot mode
had no worktree lifecycle — `run_oneshot` (`hermes_cli/oneshot.py`) never set one
up, and both `-z` dispatch sites in `hermes_cli/main.py` forwarded neither the flag
nor any isolation. So the agent runs in the caller's cwd and its commits land on
the checked-out branch, instead of the isolated branch `-w` implies — a
data-loss-adjacent surprise for scripts that rely on `-z … -w` for isolation.

This PR **honors** `-w` in one-shot mode instead of dropping it, matching the
documented contract (`website/docs/user-guide/git-worktrees.md`, `cli.md` both
advertise `hermes -w -z`) and the interactive `hermes -w` behavior. It reuses the
existing worktree lifecycle rather than adding a parallel one.

## Related Issue

Fixes #67458

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/oneshot.py`: `run_oneshot()` gains a `worktree: bool` parameter. When
  set, it creates a disposable worktree on a dedicated `hermes/…` branch, `chdir`s
  into it for the run, and tears it down on exit (kept only if it has unpushed
  commits) — reusing `cli._setup_worktree` / `_cleanup_worktree`, the same helpers
  the interactive path uses. Setup/cleanup notices are routed to **stderr** so
  stdout still carries only the final response; a setup failure exits `2` without
  running the agent.
- `hermes_cli/main.py`: both one-shot dispatch sites (Termux fast-CLI path and main
  dispatch) now forward `worktree=getattr(args, "worktree", False)`. The previous
  hard-reject helper is removed.
- Tests:
  - `tests/hermes_cli/test_oneshot_worktree.py` (new): lifecycle coverage — agent
    runs inside the worktree, cwd restored afterward, cleanup runs even when the
    agent raises, setup failure returns `2` without running the agent, and no-op
    when `-w` is absent.
  - `tests/hermes_cli/test_tui_resume_flow.py`: dispatch-level coverage that `-w`
    forwards `worktree=True` through **both** the main and Termux one-shot routes.

## How to Test

1. `hermes -z "make a commit adding a line to README" -w` now runs the agent in a
   fresh `.worktrees/hermes-<hash>` worktree on branch `hermes/hermes-<hash>`; the
   caller's checked-out branch is left untouched. If the run produces unpushed
   commits, the worktree is preserved and its path printed to stderr.
2. `scripts/run_tests.sh tests/hermes_cli/test_oneshot_worktree.py tests/hermes_cli/test_tui_resume_flow.py` → all pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (this makes the already-documented `hermes -w -z` behavior actually work; no doc change needed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] I've considered cross-platform impact — reuses the existing cross-platform worktree helpers
- [x] I've updated tool descriptions/schemas — N/A
