### PR TITLE
feat(desktop): per-job model picker in the cron create/edit dialog

### DIFF
--- a/apps/desktop/src/app/cron/cron-job-model.test.ts
+++ b/apps/desktop/src/app/cron/cron-job-model.test.ts
@@ -35,7 +35,7 @@ describe('cronEditorUpdates', () => {
   it('omits prompt when saving a script-only job with an empty prompt', () => {
     expect(
       cronEditorUpdates(
-        { deliver: 'local', name: 'Weekly', prompt: '', schedule: '0 9 * * 1' },
+        { deliver: 'local', model: '', name: 'Weekly', prompt: '', provider: '', schedule: '0 9 * * 1' },
         { scriptOnlyJob: true }
       )
     ).toEqual({
@@ -48,9 +48,46 @@ describe('cronEditorUpdates', () => {
   it('includes prompt when the user typed one on a script-only job', () => {
     expect(
       cronEditorUpdates(
-        { deliver: 'email', name: 'Weekly', prompt: 'note', schedule: '0 9 * * 1' },
+        { deliver: 'email', model: '', name: 'Weekly', prompt: 'note', provider: '', schedule: '0 9 * * 1' },
         { scriptOnlyJob: true }
       ).prompt
     ).toBe('note')
+  })
+
+  it('writes the model override for agent jobs', () => {
+    const updates = cronEditorUpdates(
+      {
+        deliver: 'local',
+        model: 'claude-sonnet-4',
+        name: 'Daily',
+        prompt: 'go',
+        provider: 'anthropic',
+        schedule: '0 9 * * *'
+      },
+      { scriptOnlyJob: false }
+    )
+
+    expect(updates.model).toBe('claude-sonnet-4')
+    expect(updates.provider).toBe('anthropic')
+  })
+
+  it('clears a previous pin when the override is reset to default', () => {
+    const updates = cronEditorUpdates(
+      { deliver: 'local', model: '', name: 'Daily', prompt: 'go', provider: '', schedule: '0 9 * * *' },
+      { scriptOnlyJob: false }
+    )
+
+    expect(updates.model).toBe(null)
+    expect(updates.provider).toBe(null)
+  })
+
+  it('never touches model fields on script-only jobs', () => {
+    const updates = cronEditorUpdates(
+      { deliver: 'local', model: 'x', name: 'Weekly', prompt: '', provider: 'y', schedule: '0 9 * * 1' },
+      { scriptOnlyJob: true }
+    )
+
+    expect('model' in updates).toBe(false)
+    expect('provider' in updates).toBe(false)
   })
 })

--- a/apps/desktop/src/app/cron/cron-job-model.ts
+++ b/apps/desktop/src/app/cron/cron-job-model.ts
@@ -36,8 +36,12 @@ export function validateCronEditor(input: CronEditorValidationInput): CronEditor
 
 export interface CronEditorSaveValues {
   deliver: string
+  /** Per-job model override ('' = follow the global default at fire time). */
+  model: string
   name: string
   prompt: string
+  /** Provider for the model override ('' = none). Always paired with model. */
+  provider: string
   schedule: string
 }
 
@@ -53,6 +57,15 @@ export function cronEditorUpdates(values: CronEditorSaveValues, options: { scrip
 
   if (!options.scriptOnlyJob || trimmedPrompt) {
     updates.prompt = trimmedPrompt
+  }
+
+  // Script-only jobs never run an agent, so the scheduler ignores model
+  // overrides — leave whatever is stored untouched. For agent jobs, always
+  // write both axes so resetting to "default" clears a previous pin (the
+  // backend normalizes null/'' to "no override").
+  if (!options.scriptOnlyJob) {
+    updates.model = values.model.trim() || null
+    updates.provider = values.provider.trim() || null
   }
 
   return updates

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -1,4 +1,5 @@
 import { useStore } from '@nanostores/react'
+import { useQuery } from '@tanstack/react-query'
 import type * as React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
@@ -14,7 +15,15 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
 import {
   createCronJob,
@@ -30,6 +39,7 @@ import {
 } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
 import { AlertTriangle } from '@/lib/icons'
+import { requestModelOptions } from '@/lib/model-options'
 import { asText } from '@/lib/text'
 import { $cronFocusJobId, $cronJobs, setCronFocusJobId, setCronJobs, updateCronJobs } from '@/store/cron'
 import { notify, notifyError } from '@/store/notifications'
@@ -58,6 +68,10 @@ import { cronEditorUpdates, jobIsScriptOnly, validateCronEditor } from './cron-j
 import { jobState, jobTitle, STATE_DOT } from './job-state'
 
 const DEFAULT_DELIVER = 'local'
+
+// Radix <SelectItem> rejects empty-string values, so the "no override" row in
+// the model picker carries this sentinel and is mapped back to '' on save.
+const MODEL_DEFAULT_VALUE = '__default__'
 
 const DELIVERY_VALUES: readonly string[] = ['local', 'telegram', 'discord', 'slack', 'email']
 
@@ -101,6 +115,14 @@ function jobScheduleExpr(job: CronJob): string {
 
 function jobDeliver(job: CronJob): string {
   return asText(job.deliver) || DEFAULT_DELIVER
+}
+
+function jobModel(job: CronJob): string {
+  return asText(job.model).trim()
+}
+
+function jobProvider(job: CronJob): string {
+  return asText(job.provider).trim()
 }
 
 function cronParts(expr: string): null | string[] {
@@ -391,7 +413,8 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
         prompt: values.prompt,
         schedule: values.schedule,
         name: values.name || undefined,
-        deliver: values.deliver || DEFAULT_DELIVER
+        deliver: values.deliver || DEFAULT_DELIVER,
+        ...(values.model.trim() ? { model: values.model.trim(), provider: values.provider.trim() || undefined } : {})
       })
 
       updateCronJobs(rows => [...rows, created])
@@ -550,6 +573,7 @@ function CronJobDetail({
   const isPaused = state === 'paused'
   const deliver = jobDeliver(job)
   const prompt = jobPrompt(job)
+  const modelOverride = jobModel(job)
 
   return (
     <PanelDetail>
@@ -574,7 +598,8 @@ function CronJobDetail({
             { label: c.frequencyLabel, value: jobScheduleDisplay(job) },
             { label: c.last.replace(/:$/, ''), value: formatTime(job.last_run_at) },
             { label: c.next.replace(/:$/, ''), value: formatTime(job.next_run_at) },
-            { label: c.deliverLabel, value: c.deliveryLabels[deliver] ?? deliver }
+            { label: c.deliverLabel, value: c.deliveryLabels[deliver] ?? deliver },
+            ...(modelOverride ? [{ label: c.modelLabel, value: modelOverride }] : [])
           ]}
         />
 
@@ -717,8 +742,20 @@ function CronEditorDialog({
   const [schedule, setSchedule] = useState('')
   const [schedulePreset, setSchedulePreset] = useState('daily')
   const [deliver, setDeliver] = useState(DEFAULT_DELIVER)
+  // Per-job model override, encoded as `${providerSlug}:${model}` (split on the
+  // first ':' when saving). MODEL_DEFAULT_VALUE = follow the global default.
+  const [modelChoice, setModelChoice] = useState(MODEL_DEFAULT_VALUE)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<null | string>(null)
+
+  // Same catalog the chat model picker uses: configured providers and their
+  // actually-available models only. Script-only jobs never run an agent, so
+  // skip the fetch entirely for them.
+  const modelOptions = useQuery({
+    queryKey: ['model-options', 'global'],
+    queryFn: () => requestModelOptions({}),
+    enabled: open && !scriptOnlyJob
+  })
 
   useEffect(() => {
     if (!open) {
@@ -730,6 +767,7 @@ function CronEditorDialog({
     setSchedule(initial ? jobScheduleExpr(initial) : (SCHEDULE_OPTIONS[0].expr ?? ''))
     setSchedulePreset(initial ? scheduleOptionForExpr(jobScheduleExpr(initial)).value : 'daily')
     setDeliver(initial ? jobDeliver(initial) : DEFAULT_DELIVER)
+    setModelChoice(initial && jobModel(initial) ? `${jobProvider(initial)}:${jobModel(initial)}` : MODEL_DEFAULT_VALUE)
     setError(null)
     setSaving(false)
   }, [initial, open])
@@ -752,6 +790,19 @@ function CronEditorDialog({
 
   const scheduleHint = scheduleSummary(selectedScheduleOption, schedule, c)
 
+  // Configured providers with at least one available model — mirrors the chat
+  // model picker's gate so only actually-selectable models are offered.
+  const modelProviders = (modelOptions.data?.providers ?? []).filter(
+    provider => provider.authenticated !== false && (provider.models ?? []).length > 0
+  )
+
+  // A previously pinned model that has since left the catalog (provider
+  // removed / model retired) would render Radix's blank trigger. Keep the
+  // stored pin visible and re-selectable rather than silently dropping it.
+  const modelChoiceKnown =
+    modelChoice === MODEL_DEFAULT_VALUE ||
+    modelProviders.some(provider => (provider.models ?? []).some(model => `${provider.slug}:${model}` === modelChoice))
+
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault()
 
@@ -773,14 +824,22 @@ function CronEditorDialog({
       return
     }
 
+    // Decode `${providerSlug}:${model}` — the model half may itself contain
+    // ':' (e.g. openrouter 'anthropic/claude-sonnet-4:beta'), so split once.
+    const overrideIndex = modelChoice === MODEL_DEFAULT_VALUE ? -1 : modelChoice.indexOf(':')
+    const overrideProvider = overrideIndex >= 0 ? modelChoice.slice(0, overrideIndex) : ''
+    const overrideModel = overrideIndex >= 0 ? modelChoice.slice(overrideIndex + 1) : ''
+
     setSaving(true)
     setError(null)
 
     try {
       await onSave({
         deliver,
+        model: overrideModel,
         name: name.trim(),
         prompt: prompt.trim(),
+        provider: overrideProvider,
         schedule: schedule.trim()
       })
     } catch (err) {
@@ -857,6 +916,38 @@ function CronEditorDialog({
             </Field>
           </div>
 
+          {!scriptOnlyJob && (
+            <Field htmlFor="cron-model" label={c.modelLabel} optional optionalLabel={c.optional}>
+              <Select onValueChange={setModelChoice} value={modelChoice}>
+                <SelectTrigger className="h-9 rounded-md" id="cron-model">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={MODEL_DEFAULT_VALUE}>{c.modelDefault}</SelectItem>
+                  {!modelChoiceKnown && (
+                    <SelectItem className="font-mono" value={modelChoice}>
+                      {modelChoice.slice(modelChoice.indexOf(':') + 1)}
+                    </SelectItem>
+                  )}
+                  {modelProviders.map(provider => (
+                    <SelectGroup key={provider.slug}>
+                      <SelectLabel>{provider.name}</SelectLabel>
+                      {(provider.models ?? []).map(model => (
+                        <SelectItem
+                          className="font-mono"
+                          key={`${provider.slug}:${model}`}
+                          value={`${provider.slug}:${model}`}
+                        >
+                          {model}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Field>
+          )}
+
           {schedulePreset === 'custom' ? (
             <Field htmlFor="cron-schedule" label={c.customScheduleLabel}>
               <Input
@@ -930,8 +1021,12 @@ type EditorState = { mode: 'closed' } | { mode: 'create' } | { job: CronJob; mod
 
 interface EditorValues {
   deliver: string
+  /** Per-job model override ('' = follow the global default). */
+  model: string
   name: string
   prompt: string
+  /** Provider slug for the model override ('' = none). */
+  provider: string
   schedule: string
 }
 

--- a/apps/desktop/src/components/ui/select.tsx
+++ b/apps/desktop/src/components/ui/select.tsx
@@ -69,6 +69,20 @@ function SelectContent({
   )
 }
 
+function SelectGroup({ ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectLabel({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      className={cn('px-2 py-1.5 text-[0.65rem] font-medium uppercase tracking-wide text-muted-foreground', className)}
+      data-slot="select-label"
+      {...props}
+    />
+  )
+}
+
 function SelectItem({ className, children, ...props }: React.ComponentProps<typeof SelectPrimitive.Item>) {
   return (
     <SelectPrimitive.Item
@@ -89,4 +103,4 @@ function SelectItem({ className, children, ...props }: React.ComponentProps<type
   )
 }
 
-export { Select, SelectContent, SelectItem, SelectTrigger, SelectValue }
+export { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1518,6 +1518,8 @@ export const en: Translations = {
     promptPlaceholder: 'Summarize my unread Slack threads and email me the top 5...',
     frequencyLabel: 'Frequency',
     deliverLabel: 'Deliver to',
+    modelLabel: 'Model',
+    modelDefault: 'Default (global model)',
     customScheduleLabel: 'Custom schedule',
     customPlaceholder: '0 9 * * * or weekdays at 9am',
     customHint: 'Cron expression, or phrases like "every hour" or "weekdays at 9am".',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1445,6 +1445,8 @@ export const ja = defineLocale({
     promptPlaceholder: '実行ごとにエージェントが行う内容は？',
     frequencyLabel: '頻度',
     deliverLabel: '配信先',
+    modelLabel: 'モデル',
+    modelDefault: 'デフォルト（グローバルモデル）',
     customScheduleLabel: 'カスタムスケジュール',
     customPlaceholder: '0 9 * * * または weekdays at 9am',
     customHint: 'Cron 式、または「every hour」「weekdays at 9am」のようなフレーズ。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1249,6 +1249,8 @@ export interface Translations {
     promptPlaceholder: string
     frequencyLabel: string
     deliverLabel: string
+    modelLabel: string
+    modelDefault: string
     customScheduleLabel: string
     customPlaceholder: string
     customHint: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1398,6 +1398,8 @@ export const zhHant = defineLocale({
     promptPlaceholder: '代理每次執行時應做什麼？',
     frequencyLabel: '頻率',
     deliverLabel: '傳遞至',
+    modelLabel: '模型',
+    modelDefault: '預設（全域模型）',
     customScheduleLabel: '自訂排程',
     customPlaceholder: '0 9 * * * 或 weekdays at 9am',
     customHint: 'Cron 表達式，或類似「每小時」「工作日上午 9 點」的短語。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1701,6 +1701,8 @@ export const zh: Translations = {
     promptPlaceholder: '总结我未读的 Slack 话题，并把前 5 条邮件发给我…',
     frequencyLabel: '频率',
     deliverLabel: '投递至',
+    modelLabel: '模型',
+    modelDefault: '默认（全局模型）',
     customScheduleLabel: '自定义排程',
     customPlaceholder: '0 9 * * * 或 weekdays at 9am',
     customHint: 'Cron 表达式，或类似"每小时""工作日上午 9 点"的短语。',

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -572,10 +572,12 @@ export interface CronJob {
   id: string
   last_error?: null | string
   last_run_at?: null | string
+  model?: null | string
   name?: null | string
   next_run_at?: null | string
   no_agent?: boolean
   prompt?: null | string
+  provider?: null | string
   schedule?: CronJobSchedule
   schedule_display?: null | string
   script?: null | string
@@ -584,8 +586,10 @@ export interface CronJob {
 
 export interface CronJobCreatePayload {
   deliver?: string
+  model?: string
   name?: string
   prompt: string
+  provider?: string
   schedule: string
 }
 
@@ -598,8 +602,10 @@ export interface CronJobSchedule {
 export interface CronJobUpdates {
   deliver?: string
   enabled?: boolean
+  model?: null | string
   name?: string
   prompt?: string
+  provider?: null | string
   schedule?: string
 }
 


### PR DESCRIPTION
## Summary
The Desktop app's cron create/edit dialog now lets the user pin a model to each scheduled job, so every cron can run on the model best suited to it (requested by @Da7_Tech). The picker offers only actually-available models — the same `model.options` catalog the chat model picker uses (configured providers with models, curated order). The agent-facing `cronjob` tool schema is deliberately untouched: model selection is a human UX affordance, not a tool parameter.

## Changes
- `apps/desktop/src/app/cron/index.tsx`: optional **Model** select in the editor, grouped by provider (`Default (global model)` first); hidden for script-only (`no_agent`) jobs; a pinned model that later left the catalog stays visible/re-selectable instead of a blank Radix trigger; detail pane shows the pin.
- `apps/desktop/src/app/cron/cron-job-model.ts`: `cronEditorUpdates` writes `model`/`provider` on agent jobs (null clears a previous pin) and never touches them on script-only jobs.
- `apps/desktop/src/components/ui/select.tsx`: adds `SelectGroup` + `SelectLabel` primitives.
- `apps/desktop/src/types/hermes.ts`: `CronJob`/`CronJobCreatePayload`/`CronJobUpdates` carry `model`/`provider`.
- i18n: `modelLabel` + `modelDefault` in en/ja/zh/zh-hant (+ types).

No backend changes needed — `POST/PUT /api/cron/jobs` and `cron/jobs.py` already accept and persist `model`/`provider` (the dashboard web UI uses the same path).

## Validation
| Check | Result |
|---|---|
| `npx tsc --noEmit` (apps/desktop) | clean |
| `npx vitest run` — cron model tests (10, incl. 3 new), i18n runtime/languages, hermes.test, session-list-actions, model-menu-panel | 65/65 pass |
| eslint + prettier on touched files | clean |
| E2E (`execute_code`, temp HERMES_HOME): `create_job(model=, provider=)` → pin stored; `update_job` with nulls → pin cleared; re-pin; reload from disk; `_normalize_dashboard_cron_updates` null/trim handling | all pass |

## Infographic

![per-job-model-picker](https://v3b.fal.media/files/b/0aa2df1a/HKgqJglNmWzRXMudUPcRk_222Czvb5.png)
