### PR TITLE
fix(nix): include apps/shared in TUI source filter (#67079)

### DIFF
--- a/nix/tui.nix
+++ b/nix/tui.nix
@@ -1,7 +1,12 @@
 # nix/tui.nix — Hermes TUI (Ink/React) compiled with tsc and bundled
 { pkgs, hermesNpmLib, ... }:
 let
-  npm = hermesNpmLib.mkNpmPassthru { dirs = [ "ui-tui" ]; };
+  npm = hermesNpmLib.mkNpmPassthru {
+    dirs = [
+      "ui-tui"
+      "apps/shared"
+    ];
+  };
 
   packageJson = builtins.fromJSON (builtins.readFile (npm.src + "/ui-tui/package.json"));
   version = packageJson.version;


### PR DESCRIPTION
## Description

The TUI imports from `@hermes/shared/charge-settlement` (added in PR #61067), but the Nix TUI source filter in `nix/tui.nix` only included `ui-tui`. The `apps/shared` workspace dependency was missing, causing esbuild to fail when resolving the `@hermes/shared/charge-settlement` import.

`nix/web.nix` and `nix/desktop.nix` already include `apps/shared` in their `dirs` list for the same reason — this fix adds it to `nix/tui.nix` to match.

Fixes #67079, #67056