### PR TITLE
fix(cli): honor -w/--worktree in one-shot mode instead of silently ignoring it

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -171,6 +171,7 @@ def _run_and_exit_oneshot(
     provider: object = None,
     toolsets: object = None,
     usage_file: object = None,
+    worktree: bool = False,
 ) -> None:
     try:
         from hermes_cli.oneshot import run_oneshot
@@ -181,6 +182,7 @@ def _run_and_exit_oneshot(
             provider=provider,
             toolsets=toolsets,
             usage_file=usage_file,
+            worktree=worktree,
         )
     except KeyboardInterrupt:
         rc = 130
@@ -10743,6 +10745,7 @@ def _try_termux_fast_cli_launch() -> bool:
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
             usage_file=getattr(args, "usage_file", None),
+            worktree=getattr(args, "worktree", False),
         )
 
     if (args.resume or args.continue_last) and args.command is None:
@@ -12347,6 +12350,7 @@ def main():
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
             usage_file=getattr(args, "usage_file", None),
+            worktree=getattr(args, "worktree", False),
         )
 
     # Handle top-level --resume / --continue as shortcut to chat

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -234,6 +234,19 @@ def run_oneshot(
     wt_info = None
     _cleanup_worktree = None
     if worktree:
+        # Capture BEFORE importing cli: the import bridges config → env and
+        # force-exports TERMINAL_CWD (cli.py's config bridge), which would
+        # clobber the in-process caller's original value we mean to restore.
+        _prev_terminal_cwd = os.environ.get("TERMINAL_CWD")
+
+        def _restore_terminal_cwd() -> None:
+            # Every exit path after the cli import must run this: the import
+            # already force-exported TERMINAL_CWD even when setup then fails.
+            if _prev_terminal_cwd is None:
+                os.environ.pop("TERMINAL_CWD", None)
+            else:
+                os.environ["TERMINAL_CWD"] = _prev_terminal_cwd
+
         try:
             from cli import (
                 CLI_CONFIG,
@@ -243,21 +256,27 @@ def run_oneshot(
                 _setup_worktree,
             )
 
-            repo = _git_repo_root()
-            if repo:
-                _prune_stale_worktrees(repo)
-            wt_info = _setup_worktree(sync_base=CLI_CONFIG.get("worktree_sync", True))
+            # The helpers print() their setup progress ("✓ Worktree
+            # created: ..."); one-shot's stdout must carry ONLY the final
+            # response, so route helper output to stderr — same contract as
+            # the cleanup path in the finally below.
+            with redirect_stdout(sys.stderr):
+                repo = _git_repo_root()
+                if repo:
+                    _prune_stale_worktrees(repo)
+                wt_info = _setup_worktree(sync_base=CLI_CONFIG.get("worktree_sync", True))
         except Exception as exc:
+            _restore_terminal_cwd()
             sys.stderr.write(f"hermes -z: failed to create worktree: {exc}\n")
             return 2
         if not wt_info:
+            _restore_terminal_cwd()
             sys.stderr.write(
                 "hermes -z: -w/--worktree was requested but worktree setup "
                 "failed (not a git repository?). Refusing to run without "
                 "isolation.\n"
             )
             return 2
-        _prev_terminal_cwd = os.environ.get("TERMINAL_CWD")
         os.environ["TERMINAL_CWD"] = wt_info["path"]
 
     # Auto-approve any shell / tool approvals.  Non-interactive by
@@ -323,10 +342,7 @@ def run_oneshot(
             # Restore the caller's terminal cwd: the worktree path is gone
             # now, and in-process callers (tests, embedding) shouldn't keep
             # inheriting a dangling TERMINAL_CWD.
-            if _prev_terminal_cwd is None:
-                os.environ.pop("TERMINAL_CWD", None)
-            else:
-                os.environ["TERMINAL_CWD"] = _prev_terminal_cwd
+            _restore_terminal_cwd()
 
     if failure is not None:
         # Re-raise control-flow exceptions so the parent handles them as usual

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -173,6 +173,7 @@ def run_oneshot(
     provider: Optional[str] = None,
     toolsets: object = None,
     usage_file: Optional[str] = None,
+    worktree: bool = False,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -187,6 +188,13 @@ def run_oneshot(
             cost, token counts, model, api_calls) is written there after the
             run — even when the run fails — so pipelines can account for
             spend per invocation.
+        worktree: Run the agent in a disposable git worktree on a dedicated
+            branch (same isolation as ``-w`` in interactive chat) instead of
+            the current checkout. Setup failure is a hard error — a script
+            that asked for isolation must never silently write to the live
+            branch (#67458). Unlike interactive chat, the ``worktree: true``
+            config default is NOT honored here: one-shot is script-facing,
+            so isolation is opt-in per invocation via the explicit flag.
 
     Returns the exit code.  The caller owns process termination.
     """
@@ -215,6 +223,42 @@ def run_oneshot(
         sys.stderr.write(toolsets_error)
         return 2
     use_config_toolsets = _normalize_toolsets(toolsets) is None
+
+    # ── Git worktree isolation (#67458) ──
+    # Mirrors interactive chat (cli.main): prune stale worktrees, create a
+    # fresh one, and point TERMINAL_CWD at it so the terminal/file tools
+    # operate inside the isolated checkout. Runs BEFORE the stdout/stderr
+    # redirect so setup errors reach the terminal. When the flag was given
+    # but setup fails, refuse to run — silently falling back to the live
+    # branch is the exact failure mode this flag exists to prevent.
+    wt_info = None
+    _cleanup_worktree = None
+    if worktree:
+        try:
+            from cli import (
+                CLI_CONFIG,
+                _cleanup_worktree,
+                _git_repo_root,
+                _prune_stale_worktrees,
+                _setup_worktree,
+            )
+
+            repo = _git_repo_root()
+            if repo:
+                _prune_stale_worktrees(repo)
+            wt_info = _setup_worktree(sync_base=CLI_CONFIG.get("worktree_sync", True))
+        except Exception as exc:
+            sys.stderr.write(f"hermes -z: failed to create worktree: {exc}\n")
+            return 2
+        if not wt_info:
+            sys.stderr.write(
+                "hermes -z: -w/--worktree was requested but worktree setup "
+                "failed (not a git repository?). Refusing to run without "
+                "isolation.\n"
+            )
+            return 2
+        _prev_terminal_cwd = os.environ.get("TERMINAL_CWD")
+        os.environ["TERMINAL_CWD"] = wt_info["path"]
 
     # Auto-approve any shell / tool approvals.  Non-interactive by
     # definition — a prompt would hang forever.
@@ -263,6 +307,26 @@ def run_oneshot(
             devnull.close()
         except Exception:
             pass
+        if wt_info is not None and _cleanup_worktree is not None:
+            # Same lifecycle as interactive chat's atexit hook: remove the
+            # disposable worktree, keeping the branch with any commits. The
+            # helper print()s its outcome ("cleaned up" / "has unpushed
+            # commits, keeping") — route that to stderr: one-shot's contract
+            # is that stdout carries ONLY the final response, and the
+            # unpushed-commits notice fires precisely in -w's main use case
+            # (the agent committed something).
+            try:
+                with redirect_stdout(real_stderr):
+                    _cleanup_worktree(wt_info)
+            except Exception:
+                pass
+            # Restore the caller's terminal cwd: the worktree path is gone
+            # now, and in-process callers (tests, embedding) shouldn't keep
+            # inheriting a dangling TERMINAL_CWD.
+            if _prev_terminal_cwd is None:
+                os.environ.pop("TERMINAL_CWD", None)
+            else:
+                os.environ["TERMINAL_CWD"] = _prev_terminal_cwd
 
     if failure is not None:
         # Re-raise control-flow exceptions so the parent handles them as usual

--- a/tests/hermes_cli/test_oneshot_worktree.py
+++ b/tests/hermes_cli/test_oneshot_worktree.py
@@ -43,28 +43,39 @@ def test_worktree_success_retargets_terminal_cwd_and_cleans_up(tmp_path, capsys)
         # "has unpushed commits, keeping" notice in -w's main use case.
         print(f"⚠ Worktree has unpushed commits, keeping: {info['path']}")
 
+    def fake_setup(**kwargs):
+        # The real helper print()s its setup progress too.
+        print(f"✓ Worktree created: {wt_path}")
+        return wt_info
+
     with patch("cli.CLI_CONFIG", {}, create=True), \
          patch("cli._git_repo_root", return_value=str(tmp_path)), \
          patch("cli._prune_stale_worktrees") as prune, \
-         patch("cli._setup_worktree", return_value=wt_info), \
+         patch("cli._setup_worktree", side_effect=fake_setup), \
          patch("cli._cleanup_worktree", side_effect=fake_cleanup), \
          patch("hermes_cli.oneshot._run_agent", side_effect=fake_run_agent):
+        # Entering the patch context imported `cli`, whose config bridge
+        # force-exports TERMINAL_CWD; re-pin the caller's value afterward so
+        # the exact-restore assertion below is meaningful. (In production the
+        # first `import cli` happens inside run_oneshot, AFTER its capture —
+        # which is exactly why the capture sits before the import.)
+        os.environ["TERMINAL_CWD"] = "/original/cwd"
         rc = run_oneshot("make a commit", worktree=True)
 
     assert rc == 0
     assert seen["terminal_cwd"] == wt_path, "agent did not run inside the worktree"
     assert cleaned == [wt_info], "worktree was not cleaned up after the run"
     prune.assert_called_once()
-    # One-shot's stdout contract: ONLY the final response. The cleanup
-    # helper's output must land on stderr, never before the response on
-    # stdout.
+    # One-shot's stdout contract: ONLY the final response. Both the setup
+    # helper's "Worktree created" print and the cleanup helper's output must
+    # land on stderr, never on stdout.
     captured = capsys.readouterr()
     assert captured.out == "done\n"
+    assert "Worktree created" in captured.err
     assert "unpushed commits" in captured.err
-    # The dangling (now-deleted) worktree path must not leak into the
-    # caller's env. (The exact restored value is whatever cli.py's config
-    # bridge exported at import time, so pin only the non-dangling part.)
-    assert os.environ.get("TERMINAL_CWD") != wt_path
+    # TERMINAL_CWD is captured BEFORE the cli import (whose config bridge
+    # force-exports it), so the caller's original value is restored exactly.
+    assert os.environ.get("TERMINAL_CWD") == "/original/cwd"
 
 
 def test_worktree_setup_failure_refuses_to_run(capsys):
@@ -74,12 +85,16 @@ def test_worktree_setup_failure_refuses_to_run(capsys):
          patch("cli._setup_worktree", return_value=None), \
          patch("cli._cleanup_worktree"), \
          patch("hermes_cli.oneshot._run_agent") as run_agent:
+        os.environ["TERMINAL_CWD"] = "/original/cwd"  # re-pin after cli import
         rc = run_oneshot("make a commit", worktree=True)
 
     assert rc == 2
     run_agent.assert_not_called()
     err = capsys.readouterr().err
     assert "Refusing to run without" in err
+    # The early-return path must also restore the caller's TERMINAL_CWD —
+    # the cli import already force-exported it before setup failed.
+    assert os.environ.get("TERMINAL_CWD") == "/original/cwd"
 
 
 def test_worktree_setup_exception_is_a_hard_error(capsys):
@@ -96,6 +111,7 @@ def test_worktree_setup_exception_is_a_hard_error(capsys):
 def test_default_run_does_not_touch_worktree_machinery():
     with patch("cli._setup_worktree") as setup, \
          patch("hermes_cli.oneshot._run_agent", return_value=("done", {})):
+        os.environ["TERMINAL_CWD"] = "/original/cwd"  # re-pin after cli import
         rc = run_oneshot("hello")
 
     assert rc == 0

--- a/tests/hermes_cli/test_oneshot_worktree.py
+++ b/tests/hermes_cli/test_oneshot_worktree.py
@@ -1,0 +1,103 @@
+"""Tests for hermes -z -w — worktree isolation in one-shot mode (#67458).
+
+The flag was previously accepted but silently ignored: run_oneshot() never
+received it, so the agent ran in the current checkout and its commits landed
+on the live branch. These tests pin the forwarded behavior: TERMINAL_CWD is
+retargeted at the disposable worktree for the duration of the run, cleanup
+runs afterward, and a requested-but-failed setup refuses to run instead of
+silently dropping isolation.
+"""
+
+import logging
+import os
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.oneshot import run_oneshot
+
+
+@pytest.fixture(autouse=True)
+def _restore_global_state(monkeypatch):
+    """run_oneshot mutates process-global state; keep it test-local."""
+    monkeypatch.setenv("HERMES_YOLO_MODE", "0")
+    monkeypatch.setenv("HERMES_ACCEPT_HOOKS", "0")
+    monkeypatch.setenv("TERMINAL_CWD", "/original/cwd")
+    yield
+    logging.disable(logging.NOTSET)
+
+
+def test_worktree_success_retargets_terminal_cwd_and_cleans_up(tmp_path, capsys):
+    wt_path = str(tmp_path / "wt")
+    wt_info = {"path": wt_path, "branch": "hermes/wt-test"}
+    seen = {}
+    cleaned = []
+
+    def fake_run_agent(prompt, **kwargs):
+        seen["terminal_cwd"] = os.environ.get("TERMINAL_CWD")
+        return "done", {}
+
+    def fake_cleanup(info):
+        cleaned.append(info)
+        # The real helper print()s its outcome — including the
+        # "has unpushed commits, keeping" notice in -w's main use case.
+        print(f"⚠ Worktree has unpushed commits, keeping: {info['path']}")
+
+    with patch("cli.CLI_CONFIG", {}, create=True), \
+         patch("cli._git_repo_root", return_value=str(tmp_path)), \
+         patch("cli._prune_stale_worktrees") as prune, \
+         patch("cli._setup_worktree", return_value=wt_info), \
+         patch("cli._cleanup_worktree", side_effect=fake_cleanup), \
+         patch("hermes_cli.oneshot._run_agent", side_effect=fake_run_agent):
+        rc = run_oneshot("make a commit", worktree=True)
+
+    assert rc == 0
+    assert seen["terminal_cwd"] == wt_path, "agent did not run inside the worktree"
+    assert cleaned == [wt_info], "worktree was not cleaned up after the run"
+    prune.assert_called_once()
+    # One-shot's stdout contract: ONLY the final response. The cleanup
+    # helper's output must land on stderr, never before the response on
+    # stdout.
+    captured = capsys.readouterr()
+    assert captured.out == "done\n"
+    assert "unpushed commits" in captured.err
+    # The dangling (now-deleted) worktree path must not leak into the
+    # caller's env. (The exact restored value is whatever cli.py's config
+    # bridge exported at import time, so pin only the non-dangling part.)
+    assert os.environ.get("TERMINAL_CWD") != wt_path
+
+
+def test_worktree_setup_failure_refuses_to_run(capsys):
+    with patch("cli.CLI_CONFIG", {}, create=True), \
+         patch("cli._git_repo_root", return_value=None), \
+         patch("cli._prune_stale_worktrees"), \
+         patch("cli._setup_worktree", return_value=None), \
+         patch("cli._cleanup_worktree"), \
+         patch("hermes_cli.oneshot._run_agent") as run_agent:
+        rc = run_oneshot("make a commit", worktree=True)
+
+    assert rc == 2
+    run_agent.assert_not_called()
+    err = capsys.readouterr().err
+    assert "Refusing to run without" in err
+
+
+def test_worktree_setup_exception_is_a_hard_error(capsys):
+    with patch("cli.CLI_CONFIG", {}, create=True), \
+         patch("cli._git_repo_root", side_effect=RuntimeError("git exploded")), \
+         patch("hermes_cli.oneshot._run_agent") as run_agent:
+        rc = run_oneshot("make a commit", worktree=True)
+
+    assert rc == 2
+    run_agent.assert_not_called()
+    assert "failed to create worktree" in capsys.readouterr().err
+
+
+def test_default_run_does_not_touch_worktree_machinery():
+    with patch("cli._setup_worktree") as setup, \
+         patch("hermes_cli.oneshot._run_agent", return_value=("done", {})):
+        rc = run_oneshot("hello")
+
+    assert rc == 0
+    setup.assert_not_called()
+    assert os.environ.get("TERMINAL_CWD") == "/original/cwd"

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -286,3 +286,125 @@ def test_make_tui_argv_dev_prebuilds_hermes_ink(monkeypatch, main_mod, tmp_path)
 
 
 
+def test_print_tui_exit_summary_prefers_actual_active_session_file(
+    monkeypatch, capsys, tmp_path
+):
+    import hermes_cli.main as main_mod
+
+    seen = []
+
+    class _FakeDB:
+        def get_session(self, session_id):
+            seen.append(session_id)
+            return {
+                "message_count": 1,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+            }
+
+        def get_session_title(self, _session_id):
+            return "actual"
+
+        def close(self):
+            return None
+
+    active = tmp_path / "active.json"
+    active.write_text('{"session_id":"actual_session"}', encoding="utf-8")
+    monkeypatch.setitem(
+        sys.modules, "hermes_state", types.SimpleNamespace(SessionDB=lambda: _FakeDB())
+    )
+
+    main_mod._print_tui_exit_summary("startup_resume", str(active))
+    out = capsys.readouterr().out
+
+    assert seen == ["actual_session"]
+    assert "hermes --tui --resume actual_session" in out
+    assert "startup_resume" not in out
+
+
+def test_termux_fast_cli_launch_oneshot_forwards_worktree(monkeypatch, main_mod):
+    """-z with -w must forward worktree=True through the Termux fast path
+    too (#67458 — both dispatches used to drop the flag)."""
+    captured = {}
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.delenv("HERMES_TUI", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "-z", "hello", "--model", "gpt-test", "--provider", "openai", "-w"],
+    )
+    monkeypatch.setattr(main_mod, "_prepare_agent_startup", lambda args: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.oneshot",
+        types.SimpleNamespace(
+            run_oneshot=lambda prompt, **kwargs: captured.update(
+                {"prompt": prompt, **kwargs}
+            )
+            or 0
+        ),
+    )
+
+    def _fake_exit(rc):
+        raise SystemExit(rc)
+
+    monkeypatch.setattr(main_mod.os, "_exit", _fake_exit)
+
+    with pytest.raises(SystemExit):
+        main_mod._try_termux_fast_cli_launch()
+
+    assert captured["worktree"] is True
+
+
+def test_main_top_level_oneshot_forwards_worktree(monkeypatch, main_mod):
+    """-z with -w must forward worktree=True to run_oneshot (#67458 — the
+    flag used to be accepted but silently dropped at this dispatch)."""
+    captured = {}
+
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(sys, "argv", ["hermes", "-z", "hello", "-w"])
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=lambda: None),
+    )
+    monkeypatch.setattr(config_mod, "load_config", lambda: {})
+    monkeypatch.setattr(config_mod, "get_container_exec_info", lambda: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(
+            register_from_config=lambda _cfg, accept_hooks=False: None
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.oneshot",
+        types.SimpleNamespace(
+            run_oneshot=lambda prompt, **kwargs: captured.update(
+                {"prompt": prompt, **kwargs}
+            )
+            or 0
+        ),
+    )
+
+    def _fake_exit(rc):
+        raise SystemExit(rc)
+
+    monkeypatch.setattr(main_mod.os, "_exit", _fake_exit)
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main()
+
+    assert exc.value.code == 0
+    assert captured["worktree"] is True

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -49,6 +49,386 @@ def main_mod(monkeypatch):
 
 
 
+    assert calls == ["tui", "cli"]
+    assert captured["resume"] == "20260408_235959_d4e5f6"
+
+
+def test_cmd_chat_tui_resume_resolves_title_before_launch(monkeypatch, main_mod):
+    captured = {}
+
+    def fake_launch(
+        resume_session_id=None,
+        tui_dev=False,
+        model=None,
+        provider=None,
+        toolsets=None,
+        **kwargs,
+    ):
+        captured["resume"] = resume_session_id
+        raise SystemExit(0)
+
+    monkeypatch.setattr(
+        main_mod, "_resolve_session_by_name_or_id", lambda val: "20260409_000000_aa11bb"
+    )
+    monkeypatch.setattr(main_mod, "_launch_tui", fake_launch)
+
+    with pytest.raises(SystemExit):
+        main_mod.cmd_chat(_args(resume="my t0p session"))
+
+    assert captured["resume"] == "20260409_000000_aa11bb"
+
+
+def test_cmd_chat_tui_passes_model_and_provider(monkeypatch, main_mod):
+    captured = {}
+
+    def fake_launch(
+        resume_session_id=None,
+        tui_dev=False,
+        model=None,
+        provider=None,
+        toolsets=None,
+        **kwargs,
+    ):
+        captured.update(
+            {
+                "model": model,
+                "provider": provider,
+                "resume": resume_session_id,
+                "toolsets": toolsets,
+                "tui_dev": tui_dev,
+            }
+        )
+        raise SystemExit(0)
+
+    monkeypatch.setattr(main_mod, "_launch_tui", fake_launch)
+
+    with pytest.raises(SystemExit):
+        main_mod.cmd_chat(
+            _args(model="anthropic/claude-sonnet-4.6", provider="anthropic")
+        )
+
+    assert captured == {
+        "model": "anthropic/claude-sonnet-4.6",
+        "provider": "anthropic",
+        "resume": None,
+        "toolsets": None,
+        "tui_dev": False,
+    }
+
+
+def test_cmd_chat_tui_passes_toolsets(monkeypatch, main_mod):
+    captured = {}
+
+    def fake_launch(
+        resume_session_id=None,
+        tui_dev=False,
+        model=None,
+        provider=None,
+        toolsets=None,
+        **kwargs,
+    ):
+        captured["toolsets"] = toolsets
+        raise SystemExit(0)
+
+    monkeypatch.setattr(main_mod, "_launch_tui", fake_launch)
+
+    with pytest.raises(SystemExit):
+        main_mod.cmd_chat(_args(toolsets="web,terminal"))
+
+    assert captured["toolsets"] == "web,terminal"
+
+
+def test_cmd_chat_tui_forwards_chat_flags(monkeypatch, main_mod):
+    captured = {}
+
+    def fake_launch(resume_session_id=None, **kwargs):
+        captured["resume_session_id"] = resume_session_id
+        captured.update(kwargs)
+        raise SystemExit(0)
+
+    monkeypatch.setattr(main_mod, "_launch_tui", fake_launch)
+
+    with pytest.raises(SystemExit):
+        main_mod.cmd_chat(
+            _args(
+                skills=["foo,bar"],
+                verbose=True,
+                quiet=True,
+                query="hello",
+                image="/tmp/cat.png",
+                worktree=True,
+                checkpoints=True,
+                pass_session_id=True,
+                max_turns=7,
+                accept_hooks=True,
+            )
+        )
+
+    assert captured["skills"] == ["foo,bar"]
+    assert captured["verbose"] is True
+    assert captured["quiet"] is True
+    assert captured["query"] == "hello"
+    assert captured["image"] == "/tmp/cat.png"
+    assert captured["worktree"] is True
+    assert captured["checkpoints"] is True
+    assert captured["pass_session_id"] is True
+    assert captured["max_turns"] == 7
+    assert captured["accept_hooks"] is True
+
+
+def test_main_top_level_tui_accepts_toolsets(monkeypatch, main_mod):
+    captured = {}
+
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(sys, "argv", ["hermes", "--tui", "--toolsets", "web,terminal"])
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=lambda: None),
+    )
+    monkeypatch.setattr(config_mod, "load_config", lambda: {})
+    monkeypatch.setattr(config_mod, "get_container_exec_info", lambda: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(
+            register_from_config=lambda _cfg, accept_hooks=False: None
+        ),
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "cmd_chat",
+        lambda args: captured.update({"toolsets": args.toolsets, "tui": args.tui}),
+    )
+
+    main_mod.main()
+
+    assert captured == {"toolsets": "web,terminal", "tui": True}
+
+
+def test_termux_fast_tui_launch_uses_light_parser(monkeypatch, main_mod):
+    captured = {}
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setattr(
+        sys, "argv", ["hermes", "--tui", "--toolsets", "web,terminal"]
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "cmd_chat",
+        lambda args: captured.update({"toolsets": args.toolsets, "tui": args.tui}),
+    )
+
+    assert main_mod._try_termux_fast_tui_launch() is True
+    assert captured == {"toolsets": "web,terminal", "tui": True}
+
+
+def test_termux_fast_tui_launch_skips_help(monkeypatch, main_mod):
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setattr(sys, "argv", ["hermes", "--tui", "--help"])
+
+    assert main_mod._try_termux_fast_tui_launch() is False
+
+
+def test_fast_tui_launch_is_termux_only(monkeypatch, main_mod):
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(sys, "argv", ["hermes", "--tui"])
+
+    assert main_mod._try_termux_fast_tui_launch() is False
+
+
+def test_termux_fast_cli_launch_chat_uses_light_parser(monkeypatch, main_mod):
+    captured = {}
+    prepared = []
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.delenv("HERMES_TUI", raising=False)
+    monkeypatch.setattr(
+        sys, "argv", ["hermes", "chat", "-q", "hello", "--toolsets", "web,terminal"]
+    )
+    monkeypatch.setattr(
+        main_mod, "_prepare_agent_startup", lambda args: prepared.append(args.command)
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "cmd_chat",
+        lambda args: captured.update(
+            {"query": args.query, "toolsets": args.toolsets, "command": args.command}
+        ),
+    )
+
+    assert main_mod._try_termux_fast_cli_launch() is True
+    assert prepared == ["chat"]
+    assert captured == {
+        "query": "hello",
+        "toolsets": "web,terminal",
+        "command": "chat",
+    }
+
+
+def test_termux_fast_cli_launch_bare_defers_agent_startup(monkeypatch, main_mod):
+    captured = {}
+    prepared = []
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.delenv("HERMES_TUI", raising=False)
+    monkeypatch.delenv("HERMES_DEFER_AGENT_STARTUP", raising=False)
+    monkeypatch.delenv("HERMES_FAST_STARTUP_BANNER", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes"])
+    monkeypatch.setattr(
+        main_mod, "_prepare_agent_startup", lambda args: prepared.append(args.command)
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "cmd_chat",
+        lambda args: captured.update(
+            {
+                "query": args.query,
+                "command": args.command,
+                "compact": getattr(args, "compact", False),
+            }
+        ),
+    )
+
+    assert main_mod._try_termux_fast_cli_launch() is True
+    assert prepared == []
+    assert captured == {"query": None, "command": None, "compact": True}
+    assert os.environ["HERMES_DEFER_AGENT_STARTUP"] == "1"
+    assert os.environ["HERMES_FAST_STARTUP_BANNER"] == "1"
+
+
+def test_termux_fast_cli_launch_oneshot_uses_light_parser(monkeypatch, main_mod):
+    captured = {}
+    prepared = []
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.delenv("HERMES_TUI", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hermes",
+            "-z",
+            "hello",
+            "--model",
+            "gpt-test",
+            "--provider",
+            "openai",
+            "--usage-file",
+            "usage.json",
+        ],
+    )
+    monkeypatch.setattr(
+        main_mod, "_prepare_agent_startup", lambda args: prepared.append(args.command)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.oneshot",
+        types.SimpleNamespace(
+            run_oneshot=lambda prompt, **kwargs: captured.update(
+                {"prompt": prompt, **kwargs}
+            )
+            or 17
+        ),
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "_exit_after_oneshot",
+        _raise_exit,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod._try_termux_fast_cli_launch()
+
+    assert exc.value.code == 17
+    assert prepared == [None]
+    assert captured == {
+        "prompt": "hello",
+        "model": "gpt-test",
+        "provider": "openai",
+        "toolsets": None,
+        "usage_file": "usage.json",
+        "worktree": False,
+    }
+
+
+def test_termux_fast_cli_launch_version_skips_update_check(monkeypatch, main_mod):
+    captured = []
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.delenv("HERMES_TUI", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "version"])
+    monkeypatch.setattr(
+        main_mod, "_print_version_info", lambda *, check_updates: captured.append(check_updates)
+    )
+
+    assert main_mod._try_termux_fast_cli_launch() is True
+    assert captured == [False]
+
+
+def test_termux_ultrafast_version_runs_before_heavy_startup(
+    monkeypatch, capsys, main_mod
+):
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.delenv("HERMES_TERMUX_DISABLE_FAST_CLI", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "--version"])
+
+    assert main_mod._try_termux_ultrafast_version() is True
+
+    out = capsys.readouterr().out
+    assert "Hermes Agent v" in out
+    assert "Install directory:" in out
+    assert "Python:" in out
+    assert "OpenAI SDK:" in out
+
+
+def test_read_openai_version_fast(monkeypatch, tmp_path, main_mod):
+    package_dir = tmp_path / "openai"
+    package_dir.mkdir()
+    (package_dir / "_version.py").write_text(
+        '__version__ = "9.8.7"  # x-release-please-version\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(sys, "path", [str(tmp_path)])
+
+    assert main_mod._read_openai_version_fast() == "9.8.7"
+
+
+def test_termux_fast_cli_launch_skips_help(monkeypatch, main_mod):
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.delenv("HERMES_TUI", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "chat", "--help"])
+
+    assert main_mod._try_termux_fast_cli_launch() is False
+
+
+def test_termux_fast_cli_launch_can_be_disabled(monkeypatch, main_mod):
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setenv("HERMES_TERMUX_DISABLE_FAST_CLI", "1")
+    monkeypatch.delenv("HERMES_TUI", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "version"])
+
+    assert main_mod._try_termux_fast_cli_launch() is False
+
+
+def test_termux_bundled_skills_stamp_controls_sync(monkeypatch, tmp_path, main_mod):
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setattr(main_mod, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(main_mod, "_termux_bundled_skills_fingerprint", lambda: "fp1")
+
+    assert main_mod._termux_bundled_skills_sync_needed() is True
+    main_mod._mark_termux_bundled_skills_synced()
+    assert main_mod._termux_bundled_skills_sync_needed() is False
+
+    monkeypatch.setenv("HERMES_TERMUX_FORCE_SKILLS_SYNC", "1")
+    assert main_mod._termux_bundled_skills_sync_needed() is True
 
 
 def test_termux_skips_bundled_skill_sync_when_stamp_fresh(monkeypatch, tmp_path, main_mod):
@@ -70,6 +450,153 @@ def test_termux_skips_bundled_skill_sync_when_stamp_fresh(monkeypatch, tmp_path,
 
 
 
+def test_read_git_revision_fingerprint_resolves_packed_refs(tmp_path, main_mod):
+    repo = tmp_path / "repo"
+    git_dir = repo / ".git"
+    git_dir.mkdir(parents=True)
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    packed_sha = "1234567890abcdef1234567890abcdef12345678"
+    (git_dir / "packed-refs").write_text(
+        "# pack-refs with: peeled fully-peeled sorted\n"
+        f"{packed_sha} refs/heads/main\n"
+        "abcdef0000000000000000000000000000000000 refs/tags/v1.0\n"
+        "^99999999aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",
+        encoding="utf-8",
+    )
+
+    fingerprint = main_mod._read_git_revision_fingerprint(repo)
+
+    assert fingerprint == f"git:refs/heads/main:{packed_sha}"
+
+
+def test_read_git_revision_fingerprint_packed_refs_in_worktree_common_dir(
+    tmp_path, main_mod
+):
+    main_repo = tmp_path / "repo"
+    common_git = main_repo / ".git"
+    common_git.mkdir(parents=True)
+    packed_sha = "fedcba9876543210fedcba9876543210fedcba98"
+    (common_git / "packed-refs").write_text(
+        f"{packed_sha} refs/heads/main\n",
+        encoding="utf-8",
+    )
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    wt_gitdir = common_git / "worktrees" / "wt"
+    wt_gitdir.mkdir(parents=True)
+    (wt_gitdir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    (wt_gitdir / "commondir").write_text("../..\n", encoding="utf-8")
+    (worktree / ".git").write_text(f"gitdir: {wt_gitdir}\n", encoding="utf-8")
+
+    fingerprint = main_mod._read_git_revision_fingerprint(worktree)
+
+    assert fingerprint == f"git:refs/heads/main:{packed_sha}"
+
+
+def test_read_git_revision_fingerprint_loose_ref_in_worktree_common_dir(
+    tmp_path, main_mod
+):
+    """`git worktree add -b NAME` writes the new branch ref to the common dir,
+    not the per-worktree gitdir. The fingerprint must still resolve it."""
+    main_repo = tmp_path / "repo"
+    common_git = main_repo / ".git"
+    common_git.mkdir(parents=True)
+    loose_sha = "0123456789abcdef0123456789abcdef01234567"
+    (common_git / "refs" / "heads").mkdir(parents=True)
+    (common_git / "refs" / "heads" / "feature").write_text(
+        loose_sha + "\n", encoding="utf-8"
+    )
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    wt_gitdir = common_git / "worktrees" / "wt"
+    wt_gitdir.mkdir(parents=True)
+    (wt_gitdir / "HEAD").write_text("ref: refs/heads/feature\n", encoding="utf-8")
+    (wt_gitdir / "commondir").write_text("../..\n", encoding="utf-8")
+    (worktree / ".git").write_text(f"gitdir: {wt_gitdir}\n", encoding="utf-8")
+
+    fingerprint = main_mod._read_git_revision_fingerprint(worktree)
+
+    assert fingerprint == f"git:refs/heads/feature:{loose_sha}"
+
+
+def test_read_git_revision_fingerprint_unresolved_ref_is_stable(tmp_path, main_mod):
+    repo = tmp_path / "repo"
+    git_dir = repo / ".git"
+    git_dir.mkdir(parents=True)
+    (git_dir / "HEAD").write_text("ref: refs/heads/missing\n", encoding="utf-8")
+
+    fingerprint = main_mod._read_git_revision_fingerprint(repo)
+
+    assert fingerprint == "git:refs/heads/missing:unresolved"
+
+
+def test_main_top_level_oneshot_accepts_toolsets(monkeypatch, main_mod):
+    captured = {}
+
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hermes",
+            "-z",
+            "hello",
+            "--toolsets",
+            "web,terminal",
+            "--usage-file",
+            "usage.json",
+        ],
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=lambda: None),
+    )
+    monkeypatch.setattr(config_mod, "load_config", lambda: {})
+    monkeypatch.setattr(config_mod, "get_container_exec_info", lambda: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(
+            register_from_config=lambda _cfg, accept_hooks=False: None
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.oneshot",
+        types.SimpleNamespace(
+            run_oneshot=lambda prompt, **kwargs: captured.update(
+                {"prompt": prompt, **kwargs}
+            )
+            or 0
+        ),
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "_exit_after_oneshot",
+        _raise_exit,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main()
+
+    assert exc.value.code == 0
+    assert captured == {
+        "prompt": "hello",
+        "model": None,
+        "provider": None,
+        "toolsets": "web,terminal",
+        "usage_file": "usage.json",
+        "worktree": False,
+    }
 
 
 def test_exit_after_oneshot_flushes_stdio_and_calls_os_exit(
@@ -354,9 +881,10 @@ def test_termux_fast_cli_launch_oneshot_forwards_worktree(monkeypatch, main_mod)
 
     monkeypatch.setattr(main_mod.os, "_exit", _fake_exit)
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as exc:
         main_mod._try_termux_fast_cli_launch()
 
+    assert exc.value.code == 0
     assert captured["worktree"] is True
 
 


### PR DESCRIPTION
## What does this PR do?

`hermes -z "..." -w` accepted the worktree flag but silently ignored it: **both** `run_oneshot(...)` call sites dropped it — the main dispatch (`hermes_cli/main.py`) and the Termux fast-CLI path — so the agent ran in the current checkout and its commits landed directly on the live branch. That's data-loss-adjacent for scripts that relied on `-z ... -w` for isolation, and it's the exact surprise the flag exists to prevent.

This PR forwards the flag from both call sites and mirrors interactive chat's worktree lifecycle inside `run_oneshot()`: prune stale worktrees → create the disposable worktree → retarget `TERMINAL_CWD` at it for the run → clean up in the `finally` (which also covers `KeyboardInterrupt`/`SystemExit`, since they re-raise after it). Setup runs **before** the stdout/stderr redirect so errors reach the terminal, and a requested-but-failed setup exits 2 instead of silently running without isolation — the same refusal interactive chat makes (`cli.py` returns rather than run unisolated).

Two deliberate divergences from interactive, documented in the docstring:

- **The cleanup helper's output is routed to stderr.** One-shot's contract is that stdout carries ONLY the final response, and `_cleanup_worktree`'s "has unpushed commits, keeping" notice fires precisely in `-w`'s main use case (the agent committed something) — unredirected it would corrupt `out=$(hermes -z ... -w)` pipelines.
- **The `worktree: true` config default is not honored.** One-shot is script-facing; isolation stays opt-in per invocation via the explicit flag.

`TERMINAL_CWD` is restored afterward so in-process callers don't inherit a dangling path to the removed worktree.

## Related Issue

Fixes #67458

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/oneshot.py` — `worktree` parameter on `run_oneshot()`; setup/refusal before the output redirect; stderr-routed cleanup + `TERMINAL_CWD` restore in the `finally`.
- `hermes_cli/main.py` — forward `worktree=getattr(args, "worktree", False)` at both `run_oneshot(...)` call sites (main dispatch and Termux fast path).
- `tests/hermes_cli/test_oneshot_worktree.py` — new: success path (agent runs with `TERMINAL_CWD` retargeted, cleanup called, stdout carries only the response, no dangling env), requested-but-failed refusal (exit 2, agent never runs), setup-exception hard error, and default-off passthrough (worktree machinery untouched). The first three fail against the previous code.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_oneshot_worktree.py tests/hermes_cli/test_oneshot_usage_file.py -q`
2. Manual repro (from the issue): in a git repo, `hermes -z "make a commit adding a line to README" -w` → the commit lands on a dedicated `hermes/wt-*` branch in a disposable worktree; the checked-out branch is untouched; stdout contains only the agent's final response.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (topic search: worktree × one-shot — none; no linked PRs on the issue)
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `scripts/run_tests.sh tests/hermes_cli/test_oneshot_worktree.py tests/hermes_cli/test_oneshot_usage_file.py` — 10/10 pass on my platform
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11. Branch is based on current `main`; `scripts/check-windows-footguns.py --diff` is clean.

### Documentation & Housekeeping

- [x] Docstrings updated (`run_oneshot` documents the isolation contract and both divergences) — or N/A
- [x] `cli-config.yaml.example` — N/A (no config surface added; the config default's non-application is documented in the docstring)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — reuses the existing cross-platform worktree helpers from `cli.py`; no new OS-touching code
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/hermes_cli/test_oneshot_worktree.py tests/hermes_cli/test_oneshot_usage_file.py -q
=== Summary: 2 files, 10 tests passed, 0 failed (100% complete) ===

# Against the unfixed code (regression proof):
3 failed, 1 passed  (only the default-off passthrough passes, as expected)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)