### PR TITLE
fix(wecom): preserve quoted app message context

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -651,6 +651,32 @@ class WeComAdapter(BasePlatformAdapter):
                 self._pending_text_batch_tasks.pop(key, None)
 
     @staticmethod
+    def _extract_appmsg_text(appmsg: Dict[str, Any]) -> Optional[str]:
+        """Render useful user-visible fields from a WeCom app message.
+
+        Article/link cards and document cards both arrive as ``appmsg``.
+        Quoted cards are nested under ``quote.appmsg`` instead of the top-level
+        body, so treating quotes as text/voice only loses the referenced source.
+        """
+        lines: List[str] = []
+        for keys in (
+            ("title",),
+            ("description", "desc", "digest", "summary"),
+            ("url", "content_url", "page_url", "link_url"),
+        ):
+            value = next(
+                (
+                    str(appmsg.get(key) or "").strip()
+                    for key in keys
+                    if str(appmsg.get(key) or "").strip()
+                ),
+                "",
+            )
+            if value and value not in lines:
+                lines.append(value)
+        return "\n".join(lines) or None
+
+    @staticmethod
     def _extract_text(body: Dict[str, Any]) -> Tuple[str, Optional[str]]:
         """Extract plain text and quoted text from a callback payload."""
         text_parts: List[str] = []
@@ -686,9 +712,9 @@ class WeComAdapter(BasePlatformAdapter):
             # Extract appmsg title (filename) for WeCom AI Bot attachments
             if msgtype == "appmsg":
                 appmsg = body.get("appmsg") if isinstance(body.get("appmsg"), dict) else {}
-                title = str(appmsg.get("title") or "").strip()
-                if title:
-                    text_parts.append(title)
+                appmsg_text = WeComAdapter._extract_appmsg_text(appmsg)
+                if appmsg_text:
+                    text_parts.append(appmsg_text)
 
         quote = body.get("quote") if isinstance(body.get("quote"), dict) else {}
         quote_type = str(quote.get("msgtype") or "").lower()
@@ -698,6 +724,9 @@ class WeComAdapter(BasePlatformAdapter):
         elif quote_type == "voice":
             quote_voice = quote.get("voice") if isinstance(quote.get("voice"), dict) else {}
             reply_text = str(quote_voice.get("content") or "").strip() or None
+        elif quote_type == "appmsg":
+            quote_appmsg = quote.get("appmsg") if isinstance(quote.get("appmsg"), dict) else {}
+            reply_text = WeComAdapter._extract_appmsg_text(quote_appmsg)
 
         return "\n".join(part for part in text_parts if part).strip(), reply_text
 
@@ -738,6 +767,12 @@ class WeComAdapter(BasePlatformAdapter):
             refs.append(("image", quote["image"]))
         elif quote_type == "file" and isinstance(quote.get("file"), dict):
             refs.append(("file", quote["file"]))
+        elif quote_type == "appmsg" and isinstance(quote.get("appmsg"), dict):
+            quote_appmsg = quote["appmsg"]
+            if isinstance(quote_appmsg.get("file"), dict):
+                refs.append(("file", quote_appmsg["file"]))
+            elif isinstance(quote_appmsg.get("image"), dict):
+                refs.append(("image", quote_appmsg["image"]))
 
         for kind, ref in refs:
             cached = await self._cache_media(kind, ref)

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -1503,6 +1503,32 @@ class WeComAdapter(BasePlatformAdapter):
                 self._pending_text_batch_tasks.pop(key, None)
 
     @staticmethod
+    def _extract_appmsg_text(appmsg: Dict[str, Any]) -> Optional[str]:
+        """Render useful user-visible fields from a WeCom app message.
+
+        Article/link cards and document cards both arrive as ``appmsg``.
+        Quoted cards are nested under ``quote.appmsg`` instead of the top-level
+        body, so treating quotes as text/voice only loses the referenced source.
+        """
+        lines: List[str] = []
+        for keys in (
+            ("title",),
+            ("description", "desc", "digest", "summary"),
+            ("url", "content_url", "page_url", "link_url"),
+        ):
+            value = next(
+                (
+                    str(appmsg.get(key) or "").strip()
+                    for key in keys
+                    if str(appmsg.get(key) or "").strip()
+                ),
+                "",
+            )
+            if value and value not in lines:
+                lines.append(value)
+        return "\n".join(lines) or None
+
+    @staticmethod
     def _extract_text(body: Dict[str, Any]) -> Tuple[str, Optional[str]]:
         """Extract plain text and quoted text from a callback payload."""
         text_parts: List[str] = []
@@ -1538,9 +1564,9 @@ class WeComAdapter(BasePlatformAdapter):
             # Extract appmsg title (filename) for WeCom AI Bot attachments
             if msgtype == "appmsg":
                 appmsg = body.get("appmsg") if isinstance(body.get("appmsg"), dict) else {}
-                title = str(appmsg.get("title") or "").strip()
-                if title:
-                    text_parts.append(title)
+                appmsg_text = WeComAdapter._extract_appmsg_text(appmsg)
+                if appmsg_text:
+                    text_parts.append(appmsg_text)
 
         quote = body.get("quote") if isinstance(body.get("quote"), dict) else {}
         quote_type = str(quote.get("msgtype") or "").lower()
@@ -1550,6 +1576,9 @@ class WeComAdapter(BasePlatformAdapter):
         elif quote_type == "voice":
             quote_voice = quote.get("voice") if isinstance(quote.get("voice"), dict) else {}
             reply_text = str(quote_voice.get("content") or "").strip() or None
+        elif quote_type == "appmsg":
+            quote_appmsg = quote.get("appmsg") if isinstance(quote.get("appmsg"), dict) else {}
+            reply_text = WeComAdapter._extract_appmsg_text(quote_appmsg)
 
         return "\n".join(part for part in text_parts if part).strip(), reply_text
 
@@ -1590,6 +1619,12 @@ class WeComAdapter(BasePlatformAdapter):
             refs.append(("image", quote["image"]))
         elif quote_type == "file" and isinstance(quote.get("file"), dict):
             refs.append(("file", quote["file"]))
+        elif quote_type == "appmsg" and isinstance(quote.get("appmsg"), dict):
+            quote_appmsg = quote["appmsg"]
+            if isinstance(quote_appmsg.get("file"), dict):
+                refs.append(("file", quote_appmsg["file"]))
+            elif isinstance(quote_appmsg.get("image"), dict):
+                refs.append(("image", quote_appmsg["image"]))
 
         for kind, ref in refs:
             cached = await self._cache_media(kind, ref)

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -260,6 +260,77 @@ class TestExtractText:
         assert text == "spoken text"
         assert reply_text == "quoted"
 
+    def test_extracts_direct_appmsg_article_fields(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        body = {
+            "msgtype": "appmsg",
+            "appmsg": {
+                "title": "Quarterly update",
+                "digest": "Latest data and evidence",
+                "url": "https://example.com/article",
+            },
+        }
+
+        text, reply_text = WeComAdapter._extract_text(body)
+
+        assert text == (
+            "Quarterly update\n"
+            "Latest data and evidence\n"
+            "https://example.com/article"
+        )
+        assert reply_text is None
+
+    def test_extracts_quoted_appmsg_article_fields(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        body = {
+            "msgtype": "text",
+            "text": {"content": "Please analyze this article"},
+            "quote": {
+                "msgtype": "appmsg",
+                "appmsg": {
+                    "title": "Quarterly update",
+                    "description": "Latest data and evidence",
+                    "content_url": "https://example.com/article",
+                },
+            },
+        }
+
+        text, reply_text = WeComAdapter._extract_text(body)
+
+        assert text == "Please analyze this article"
+        assert reply_text == (
+            "Quarterly update\n"
+            "Latest data and evidence\n"
+            "https://example.com/article"
+        )
+
+    @pytest.mark.asyncio
+    async def test_extracts_media_from_quoted_appmsg(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._cache_media = AsyncMock(
+            return_value=("/tmp/quoted.pdf", "application/pdf")
+        )
+        body = {
+            "msgtype": "text",
+            "text": {"content": "Review this"},
+            "quote": {
+                "msgtype": "appmsg",
+                "appmsg": {"file": {"url": "https://example.com/quoted.pdf"}},
+            },
+        }
+
+        paths, media_types = await adapter._extract_media(body)
+
+        adapter._cache_media.assert_awaited_once_with(
+            "file", {"url": "https://example.com/quoted.pdf"}
+        )
+        assert paths == ["/tmp/quoted.pdf"]
+        assert media_types == ["application/pdf"]
+
 
 class TestCallbackDispatch:
     @pytest.mark.asyncio

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -307,29 +307,44 @@ class TestExtractText:
         )
 
     @pytest.mark.asyncio
-    async def test_extracts_media_from_quoted_appmsg(self):
+    @pytest.mark.parametrize(
+        ("kind", "url", "cached_path", "media_type"),
+        [
+            (
+                "file",
+                "https://example.com/quoted.pdf",
+                "/tmp/quoted.pdf",
+                "application/pdf",
+            ),
+            (
+                "image",
+                "https://example.com/quoted.png",
+                "/tmp/quoted.png",
+                "image/png",
+            ),
+        ],
+    )
+    async def test_extracts_media_from_quoted_appmsg(
+        self, kind, url, cached_path, media_type
+    ):
         from plugins.platforms.wecom.adapter import WeComAdapter
 
         adapter = WeComAdapter(PlatformConfig(enabled=True))
-        adapter._cache_media = AsyncMock(
-            return_value=("/tmp/quoted.pdf", "application/pdf")
-        )
+        adapter._cache_media = AsyncMock(return_value=(cached_path, media_type))
         body = {
             "msgtype": "text",
             "text": {"content": "Review this"},
             "quote": {
                 "msgtype": "appmsg",
-                "appmsg": {"file": {"url": "https://example.com/quoted.pdf"}},
+                "appmsg": {kind: {"url": url}},
             },
         }
 
         paths, media_types = await adapter._extract_media(body)
 
-        adapter._cache_media.assert_awaited_once_with(
-            "file", {"url": "https://example.com/quoted.pdf"}
-        )
-        assert paths == ["/tmp/quoted.pdf"]
-        assert media_types == ["application/pdf"]
+        adapter._cache_media.assert_awaited_once_with(kind, {"url": url})
+        assert paths == [cached_path]
+        assert media_types == [media_type]
 
 
 class TestCallbackDispatch:

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -238,6 +238,76 @@ class TestExtractText:
         text, _reply_text = WeComAdapter._extract_text(body)
         assert text == "part1\npart2"
 
+    def test_extracts_direct_appmsg_article_fields(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        body = {
+            "msgtype": "appmsg",
+            "appmsg": {
+                "title": "Quarterly update",
+                "digest": "Latest data and evidence",
+                "url": "https://example.com/article",
+            },
+        }
+
+        text, reply_text = WeComAdapter._extract_text(body)
+
+        assert text == (
+            "Quarterly update\n"
+            "Latest data and evidence\n"
+            "https://example.com/article"
+        )
+        assert reply_text is None
+
+    def test_extracts_quoted_appmsg_article_fields(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        body = {
+            "msgtype": "text",
+            "text": {"content": "Please analyze this article"},
+            "quote": {
+                "msgtype": "appmsg",
+                "appmsg": {
+                    "title": "Quarterly update",
+                    "description": "Latest data and evidence",
+                    "content_url": "https://example.com/article",
+                },
+            },
+        }
+
+        text, reply_text = WeComAdapter._extract_text(body)
+
+        assert text == "Please analyze this article"
+        assert reply_text == (
+            "Quarterly update\n"
+            "Latest data and evidence\n"
+            "https://example.com/article"
+        )
+
+    @pytest.mark.asyncio
+    async def test_extracts_media_from_quoted_appmsg(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._cache_media = AsyncMock(
+            return_value=("/tmp/quoted.pdf", "application/pdf")
+        )
+        body = {
+            "msgtype": "text",
+            "text": {"content": "Review this"},
+            "quote": {
+                "msgtype": "appmsg",
+                "appmsg": {"file": {"url": "https://example.com/quoted.pdf"}},
+            },
+        }
+
+        paths, media_types = await adapter._extract_media(body)
+
+        adapter._cache_media.assert_awaited_once_with(
+            "file", {"url": "https://example.com/quoted.pdf"}
+        )
+        assert paths == ["/tmp/quoted.pdf"]
+        assert media_types == ["application/pdf"]
 
 class TestCallbackDispatch:
     @pytest.mark.asyncio
@@ -693,7 +763,6 @@ class TestTextBatchFlushRace:
         assert adapter._pending_text_batches.get(key) is event, (
             "superseded task must not pop the event"
         )
-
     @pytest.mark.asyncio
     async def test_active_task_processes_event_normally(self):
         """When the task is not superseded it must still process the event."""

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -285,29 +285,44 @@ class TestExtractText:
         )
 
     @pytest.mark.asyncio
-    async def test_extracts_media_from_quoted_appmsg(self):
+    @pytest.mark.parametrize(
+        ("kind", "url", "cached_path", "media_type"),
+        [
+            (
+                "file",
+                "https://example.com/quoted.pdf",
+                "/tmp/quoted.pdf",
+                "application/pdf",
+            ),
+            (
+                "image",
+                "https://example.com/quoted.png",
+                "/tmp/quoted.png",
+                "image/png",
+            ),
+        ],
+    )
+    async def test_extracts_media_from_quoted_appmsg(
+        self, kind, url, cached_path, media_type
+    ):
         from plugins.platforms.wecom.adapter import WeComAdapter
 
         adapter = WeComAdapter(PlatformConfig(enabled=True))
-        adapter._cache_media = AsyncMock(
-            return_value=("/tmp/quoted.pdf", "application/pdf")
-        )
+        adapter._cache_media = AsyncMock(return_value=(cached_path, media_type))
         body = {
             "msgtype": "text",
             "text": {"content": "Review this"},
             "quote": {
                 "msgtype": "appmsg",
-                "appmsg": {"file": {"url": "https://example.com/quoted.pdf"}},
+                "appmsg": {kind: {"url": url}},
             },
         }
 
         paths, media_types = await adapter._extract_media(body)
 
-        adapter._cache_media.assert_awaited_once_with(
-            "file", {"url": "https://example.com/quoted.pdf"}
-        )
-        assert paths == ["/tmp/quoted.pdf"]
-        assert media_types == ["application/pdf"]
+        adapter._cache_media.assert_awaited_once_with(kind, {"url": url})
+        assert paths == [cached_path]
+        assert media_types == [media_type]
 
 class TestCallbackDispatch:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- extract title, description/digest, and canonical URL fields from WeCom
  `appmsg` article and document cards
- preserve those fields when an app message is nested under `quote.appmsg`
- cache file or image media referenced by quoted app messages through the
  existing media path
- keep duplicate visible fields out of the generated text

## Bug

Current main handles top-level app-message attachments and direct quoted
file/image payloads, but quoted `appmsg` text and nested media are still lost.
A reply such as “analyze this article” therefore reaches the agent without the
referenced title, summary, URL, or attachment.

## Current-main verification

- compatibly replayed onto `73f68362b` (2026-09-02), preserving new upstream
  WeCom batching tests
- `scripts/run_tests.sh tests/gateway/test_wecom.py -q`: 67 passed, 3 skipped
- Ruff and `git diff --check`: passed
