### PR TITLE
fix(cli): forward --worktree to run_oneshot so -z -w works (#67458)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12982,6 +12982,7 @@ def _try_termux_fast_cli_launch() -> bool:
                 provider=getattr(args, "provider", None),
                 toolsets=getattr(args, "toolsets", None),
                 usage_file=getattr(args, "usage_file", None),
+                worktree=getattr(args, "worktree", False),
             )
         )
 
@@ -15139,6 +15140,7 @@ def main():
                 provider=getattr(args, "provider", None),
                 toolsets=getattr(args, "toolsets", None),
                 usage_file=getattr(args, "usage_file", None),
+                worktree=getattr(args, "worktree", False),
             )
         )
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -173,6 +173,7 @@ def run_oneshot(
     provider: Optional[str] = None,
     toolsets: object = None,
     usage_file: Optional[str] = None,
+    worktree: bool = False,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -187,6 +188,9 @@ def run_oneshot(
             cost, token counts, model, api_calls) is written there after the
             run — even when the run fails — so pipelines can account for
             spend per invocation.
+        worktree: When True, create an isolated git worktree so the agent's
+            commits don't land on the current branch (same as ``-w`` in
+            interactive mode).
 
     Returns the exit code.  Caller should sys.exit() with the return.
     """
@@ -230,6 +234,34 @@ def run_oneshot(
     # to its inline/synchronous path. See declare_stateless_channel().
     declare_stateless_channel()
 
+    # Set up isolated git worktree when -w/--worktree is requested.
+    _wt_info = None
+    if worktree:
+        try:
+            from cli import (
+                _cleanup_worktree,
+                _git_repo_root,
+                _prune_stale_worktrees,
+                _setup_worktree,
+            )
+
+            repo = _git_repo_root()
+            if repo:
+                _prune_stale_worktrees(repo)
+            _wt_info = _setup_worktree()
+            if not _wt_info:
+                sys.stderr.write(
+                    "hermes -z: --worktree failed (are you inside a git repo?).\n"
+                )
+                return 1
+            os.environ["HERMES_CWD"] = _wt_info["path"]
+            os.environ["TERMINAL_CWD"] = _wt_info["path"]
+        except Exception as exc:
+            sys.stderr.write(
+                f"hermes -z: --worktree setup failed: {exc}\n"
+            )
+            return 1
+
     # Redirect stderr AND stdout to devnull for the entire call tree.
     # We'll print the final response to the real stdout at the end.
     real_stdout = sys.stdout
@@ -263,6 +295,14 @@ def run_oneshot(
             devnull.close()
         except Exception:
             pass
+        # Clean up worktree on exit (unless it has unpushed commits — same
+        # policy as interactive mode).
+        if _wt_info is not None:
+            try:
+                from cli import _cleanup_worktree
+                _cleanup_worktree(_wt_info)
+            except Exception:
+                pass
 
     if failure is not None:
         # Re-raise control-flow exceptions so the parent handles them as usual


### PR DESCRIPTION
Closes #67458.

## Problem
The `--worktree` / `-w` flag was silently ignored in one-shot mode (`-z`). Running `hermes -z "make a commit" -w` would commit directly to the current branch instead of using an isolated git worktree.

## Root cause
`run_oneshot()` in `hermes_cli/oneshot.py` didn't accept a `worktree` parameter, and neither call site in `hermes_cli/main.py` forwarded the parsed `worktree` flag.

## Fix
- Added `worktree: bool = False` parameter to `run_oneshot()` 
- Wired worktree setup (imports from `cli.py`: `_git_repo_root`, `_prune_stale_worktrees`, `_setup_worktree`) and cleanup (`_cleanup_worktree`) — mirroring the interactive-mode path
- Set `HERMES_CWD` and `TERMINAL_CWD` env vars so the agent runs inside the worktree
- Clean up the worktree in the `finally` block (preserving it when it has unpushed commits — same policy as interactive mode)
- Forward `worktree=getattr(args, "worktree", False)` from both `run_oneshot()` call sites in `main.py`

## Testing
- Verified the fix compiles and the diff is minimal (only 42 lines added across 2 files)
- The worktree functions reused from `cli.py` are already covered by `tests/cli/test_worktree.py`