### PR TITLE
fix(cli): recognize whitespace around '=' in .env save/remove

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -7894,11 +7894,21 @@ def _env_line_defines_key(line: str, key: str) -> bool:
     (#6659), so the writers must recognise the same shape. Otherwise a
     hand-added ``export`` line is invisible to save (duplicate appended) and
     remove (line survives → the value resurrects on the next load, #40041).
+
+    The same applies to whitespace around the ``=``: ``load_env()`` splits on
+    the first ``=`` and ``.strip()``s the name, so ``KEY = value`` is a live
+    assignment.  Matching on the ``KEY=`` prefix alone missed it, leaving the
+    identical resurrection hole for that form.  Mirror ``load_env()``'s parse
+    instead of prefix-matching so the writers recognise exactly what the
+    reader accepts.
     """
     stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in stripped:
+        return False
     if stripped.startswith("export "):
-        stripped = stripped[7:].lstrip()
-    return stripped.startswith(f"{key}=")
+        stripped = stripped[7:]
+    name, _, _ = stripped.partition("=")
+    return name.strip() == key
 
 
 def save_env_value(key: str, value: str):

--- a/tests/hermes_cli/test_env_export_line_lifecycle.py
+++ b/tests/hermes_cli/test_env_export_line_lifecycle.py
@@ -123,3 +123,74 @@ def test_export_line_with_comment_untouched(hermes_home):
     env_text = hermes_home.joinpath(".env").read_text(encoding="utf-8")
     assert "# export GITHUB_TOKEN=" in env_text
     assert "OTHER_KEY=value" in env_text
+
+
+# -- whitespace around '=' (same resurrection hole, other line form) ----------
+
+
+def test_remove_token_written_with_spaces_around_equals(hermes_home):
+    """DELETE must clear a ``KEY = value`` line, not 404 on it.
+
+    ``load_env()`` splits on the first ``=`` and strips the name, so this is a
+    live assignment and every UI shows the token as set — the writers have to
+    recognise it for the same reason they recognise ``export`` (#40041).
+    """
+    _write_env_raw(hermes_home, f"GITHUB_TOKEN = {OLD_PAT}\n")
+
+    from hermes_cli.config import load_env
+
+    assert load_env()["GITHUB_TOKEN"] == OLD_PAT, "precondition: token is live"
+
+    resp = client.request(
+        "DELETE", "/api/env", json={"key": "GITHUB_TOKEN"}, headers=HEADERS
+    )
+    assert resp.status_code == 200, resp.text
+
+    env_text = hermes_home.joinpath(".env").read_text(encoding="utf-8")
+    assert OLD_PAT not in env_text
+    assert "GITHUB_TOKEN" not in load_env()
+
+
+def test_spaced_token_rotate_then_delete_does_not_resurrect(hermes_home):
+    """Rotating over a spaced line must replace it, not shadow it.
+
+    Otherwise the save appends a second line and a later delete removes only
+    that one — silently restoring the key the user rotated away from.
+    """
+    _write_env_raw(hermes_home, f"GITHUB_TOKEN = {OLD_PAT}\n")
+
+    resp = client.put(
+        "/api/env", json={"key": "GITHUB_TOKEN", "value": NEW_PAT}, headers=HEADERS
+    )
+    assert resp.status_code == 200
+    env_text = hermes_home.joinpath(".env").read_text(encoding="utf-8")
+    assert OLD_PAT not in env_text, "the rotated-away token must not survive"
+    assert env_text.count("GITHUB_TOKEN") == 1
+
+    from hermes_cli.config import load_env
+
+    assert load_env()["GITHUB_TOKEN"] == NEW_PAT
+
+    client.request("DELETE", "/api/env", json={"key": "GITHUB_TOKEN"}, headers=HEADERS)
+    assert "GITHUB_TOKEN" not in load_env(), "the old token must not resurrect"
+
+
+def test_writer_matches_exactly_what_load_env_accepts(hermes_home):
+    """Parity: the writers must recognise a line iff ``load_env()`` does."""
+    from hermes_cli.config import _env_line_defines_key, load_env
+
+    for line, expected in [
+        (f"GITHUB_TOKEN={OLD_PAT}", True),
+        (f"export GITHUB_TOKEN={OLD_PAT}", True),
+        (f"GITHUB_TOKEN = {OLD_PAT}", True),
+        (f"GITHUB_TOKEN\t=\t{OLD_PAT}", True),
+        (f"export GITHUB_TOKEN = {OLD_PAT}", True),
+        (f"# GITHUB_TOKEN={OLD_PAT}", False),
+        (f"GITHUB_TOKEN_EXTRA={OLD_PAT}", False),
+        (f"MY_GITHUB_TOKEN={OLD_PAT}", False),
+    ]:
+        _write_env_raw(hermes_home, line + "\n")
+        assert _env_line_defines_key(line, "GITHUB_TOKEN") is expected, line
+        assert ("GITHUB_TOKEN" in load_env()) is expected, (
+            f"writer and load_env disagree on: {line!r}"
+        )


### PR DESCRIPTION
## Summary

`_env_line_defines_key()` decides which `.env` lines the writers are allowed to
rewrite or drop. It matched on the `KEY=` prefix:

```python
stripped = line.strip()
if stripped.startswith("export "):
    stripped = stripped[7:].lstrip()
return stripped.startswith(f"{key}=")
```

But `load_env()` splits on the first `=` and strips the name:

```python
key, _, value = line.partition('=')
env_vars[key.strip()] = _parse_env_value(value)
```

So `OPENAI_API_KEY = sk-...` **is** a live assignment — the key resolves, the
provider authenticates, and every UI shows it as set. The writers never saw it.

This is the same resurrection hole #40041 just fixed for `export KEY=`, still
open for the whitespace form.

## Impact

A credential the user revokes through the UI is **not actually revoked**:

| step | observed |
|---|---|
| `.env` contains `OPENAI_API_KEY = sk-COMPROMISED` | key is live; UI shows it set |
| `DELETE /api/env` | 404 *"not found in .env"* — key stays active |
| `PUT /api/env` (rotate) | appends a **second** line; the old line survives |
| later `DELETE` | removes only the appended line → **old key comes back** |

Reproduced end-to-end against the real endpoint handlers:

```
after rotate : sk-ROTATED
after delete : sk-COMPROMISED     <-- rotated-away credential resurrected
```

## Fix

Mirror `load_env()`'s parse instead of prefix-matching, so the writers accept
precisely what the reader accepts — skip blank/comment/no-`=` lines, strip an
`export ` prefix, then compare the stripped name:

```python
stripped = line.strip()
if not stripped or stripped.startswith("#") or "=" not in stripped:
    return False
if stripped.startswith("export "):
    stripped = stripped[7:]
name, _, _ = stripped.partition("=")
return name.strip() == key
```

Both writers (`save_env_value`, `remove_env_value`) go through this one helper,
so the single change covers save and remove together.

Parity after the fix — writer matches a line **iff** `load_env()` accepts it:

| line | `load_env()` | writer |
|---|---|---|
| `KEY=v` | ✅ | ✅ |
| `export KEY=v` | ✅ | ✅ |
| `KEY = v` | ✅ | ✅ *(was ❌)* |
| `KEY\t=\tv` | ✅ | ✅ *(was ❌)* |
| `export KEY = v` | ✅ | ✅ *(was ❌)* |
| `# KEY=v` | ❌ | ❌ |
| `KEY_EXTRA=v` | ❌ | ❌ |
| `MY_KEY=v` | ❌ | ❌ |

Commented-out lines are still left untouched, and no prefix/substring key
collides.

## Testing

Three tests added to `tests/hermes_cli/test_env_export_line_lifecycle.py`,
driving the real dashboard endpoints against a temp `HERMES_HOME` (fake tokens
constructed at runtime, matching the file's existing convention):

- `test_remove_token_written_with_spaces_around_equals`
- `test_spaced_token_rotate_then_delete_does_not_resurrect`
- `test_writer_matches_exactly_what_load_env_accepts`

All three **fail on `main`** with the resurrection above and pass with this
change. The 5 existing `export`-line tests are unaffected.

```
tests/hermes_cli/  env + credential suites .......... 80 passed
```

Config and managed-scope suites compared against a clean `origin/main`
worktree (`09109fec9`): identical pre-existing failure set
(`TestGetHermesHome::test_default_path`, two `SaveEnvValueSecure` quoting
tests), no new failures.

## Checklist

- [x] Bug is reproducible on `main` and covered by a failing-before/passing-after test
- [x] No regressions in the surrounding suite (baseline-compared against `origin/main`)
- [x] Change is scoped to the defect — no unrelated refactoring
- [x] Tested on Ubuntu 24.04