### PR TITLE
fix(models): ignore non-USD catalog pricing

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -21,7 +21,12 @@ import yaml
 if TYPE_CHECKING:  # pragma: no cover — runtime import is lazy (see below)
     import requests
 
-from utils import atomic_json_write, base_url_host_matches, base_url_hostname
+from utils import (
+    atomic_json_write,
+    base_url_host_matches,
+    base_url_hostname,
+    pricing_currency_is_usd_or_unspecified,
+)
 
 from hermes_constants import OPENROUTER_MODELS_URL
 
@@ -1047,14 +1052,23 @@ def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
     return result
 
 
-def _iter_nested_dicts(value: Any):
+def _iter_nested_dicts_with_ancestors(
+    value: Any,
+    ancestors: tuple[Dict[str, Any], ...] = (),
+):
     if isinstance(value, dict):
-        yield value
+        yield value, ancestors
+        child_ancestors = (value, *ancestors)
         for nested in value.values():
-            yield from _iter_nested_dicts(nested)
+            yield from _iter_nested_dicts_with_ancestors(nested, child_ancestors)
     elif isinstance(value, list):
         for item in value:
-            yield from _iter_nested_dicts(item)
+            yield from _iter_nested_dicts_with_ancestors(item, ancestors)
+
+
+def _iter_nested_dicts(value: Any):
+    for mapping, _ancestors in _iter_nested_dicts_with_ancestors(value):
+        yield mapping
 
 
 def _coerce_reasonable_int(value: Any, minimum: int = 1024, maximum: int = 10_000_000) -> Optional[int]:
@@ -1095,6 +1109,8 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
     novita_input = payload.get("input_token_price_per_m")
     novita_output = payload.get("output_token_price_per_m")
     if novita_input is not None or novita_output is not None:
+        if not pricing_currency_is_usd_or_unspecified(payload):
+            return {}
         pricing: Dict[str, Any] = {}
         if novita_input is not None:
             pricing["prompt"] = str(float(novita_input) / 10_000 / 1_000_000)
@@ -1111,6 +1127,12 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
     if isinstance(deepinfra_pricing, dict) and any(
         k in deepinfra_pricing for k in ("input_tokens", "output_tokens", "cache_read_tokens")
     ):
+        if not pricing_currency_is_usd_or_unspecified(
+            deepinfra_pricing,
+            metadata,
+            payload,
+        ):
+            return {}
         result: Dict[str, Any] = {}
         if deepinfra_pricing.get("input_tokens") is not None:
             result["prompt"] = str(float(deepinfra_pricing["input_tokens"]) / 1_000_000)
@@ -1127,9 +1149,11 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
         "cache_read": ("cache_read", "cached_prompt", "input_cache_read", "cache_read_cost_per_token"),
         "cache_write": ("cache_write", "cache_creation", "input_cache_write", "cache_write_cost_per_token"),
     }
-    for mapping in _iter_nested_dicts(payload):
+    for mapping, ancestors in _iter_nested_dicts_with_ancestors(payload):
         normalized = {str(key).lower(): value for key, value in mapping.items()}
         if not any(any(alias in normalized for alias in aliases) for aliases in alias_map.values()):
+            continue
+        if not pricing_currency_is_usd_or_unspecified(mapping, *ancestors):
             continue
         pricing: Dict[str, Any] = {}
         for target, aliases in alias_map.items():
@@ -1181,7 +1205,7 @@ def fetch_model_metadata(force_refresh: bool = False) -> Dict[str, Dict[str, Any
                 "context_length": model.get("context_length", 128000),
                 "max_completion_tokens": model.get("top_provider", {}).get("max_completion_tokens", 4096),
                 "name": model.get("name", model_id),
-                "pricing": model.get("pricing", {}),
+                "pricing": _extract_pricing(model),
             }
             _add_model_aliases(cache, model_id, entry)
             canonical = model.get("canonical_slug", "")

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
 from hermes_cli import __version__ as _HERMES_VERSION
 from hermes_cli.urllib_security import open_credentialed_url
+from utils import pricing_currency_is_usd_or_unspecified
 
 logger = logging.getLogger(__name__)
 
@@ -1852,9 +1853,15 @@ def fetch_models_with_pricing(
 
     result: dict[str, dict[str, Any]] = {}
     for item in payload.get("data", []):
+        if not isinstance(item, dict):
+            continue
         mid = item.get("id")
         pricing = item.get("pricing")
-        if mid and isinstance(pricing, dict):
+        if (
+            mid
+            and isinstance(pricing, dict)
+            and pricing_currency_is_usd_or_unspecified(pricing, item)
+        ):
             entry: dict[str, Any] = {
                 "prompt": str(pricing.get("prompt", "")),
                 "completion": str(pricing.get("completion", "")),
@@ -2121,6 +2128,8 @@ def _fetch_novita_pricing(
         inp = item.get("input_token_price_per_m")
         out = item.get("output_token_price_per_m")
         if inp is None and out is None:
+            continue
+        if not pricing_currency_is_usd_or_unspecified(item):
             continue
         result[str(mid)] = {
             "prompt": str(float(inp or 0) / 10_000 / 1_000_000),
@@ -4587,6 +4596,8 @@ def _fetch_deepinfra_pricing(
         metadata = item.get("metadata") or {}
         pricing = metadata.get("pricing") if isinstance(metadata, dict) else None
         if not isinstance(pricing, dict):
+            continue
+        if not pricing_currency_is_usd_or_unspecified(pricing, metadata, item):
             continue
         entry: dict[str, str] = {}
         inp = pricing.get("input_tokens")

--- a/tests/agent/test_model_metadata_pricing_currency.py
+++ b/tests/agent/test_model_metadata_pricing_currency.py
@@ -1,0 +1,206 @@
+"""Currency handling for model-catalog pricing metadata."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import agent.model_metadata as model_metadata
+from agent.model_metadata import (
+    _extract_pricing,
+    fetch_endpoint_model_metadata,
+    fetch_model_metadata,
+)
+
+
+@pytest.mark.parametrize(
+    ("has_currency_field", "currency", "expected"),
+    (
+        (False, None, {"prompt": "0.000001", "completion": "0.000002"}),
+        (True, None, {"prompt": "0.000001", "completion": "0.000002"}),
+        (True, "", {"prompt": "0.000001", "completion": "0.000002"}),
+        (True, "   ", {"prompt": "0.000001", "completion": "0.000002"}),
+        (True, "USD", {"prompt": "0.000001", "completion": "0.000002"}),
+        (True, "usd", {"prompt": "0.000001", "completion": "0.000002"}),
+        (True, " USD ", {"prompt": "0.000001", "completion": "0.000002"}),
+        (True, "$", {"prompt": "0.000001", "completion": "0.000002"}),
+        (True, "IDR", {}),
+        (True, "EUR", {}),
+    ),
+)
+def test_extract_pricing_currency_matrix(has_currency_field, currency, expected):
+    pricing = {"prompt": "0.000001", "completion": "0.000002"}
+    if has_currency_field:
+        pricing["currency"] = currency
+
+    assert _extract_pricing({"pricing": pricing}) == expected
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {
+            "currency": "IDR",
+            "input_token_price_per_m": 1000,
+            "output_token_price_per_m": 2000,
+        },
+        {
+            "metadata": {
+                "pricing": {
+                    "currency": "EUR",
+                    "input_tokens": 1,
+                    "output_tokens": 2,
+                }
+            }
+        },
+    ),
+)
+def test_non_usd_currency_rejected_for_special_pricing_shapes(payload):
+    assert _extract_pricing(payload) == {}
+
+
+def test_unrelated_non_usd_currency_does_not_suppress_usd_pricing():
+    payload = {
+        "regional_metadata": {"currency": "EUR"},
+        "pricing": {
+            "currency": "USD",
+            "prompt": "0.000001",
+            "completion": "0.000002",
+        },
+    }
+
+    assert _extract_pricing(payload) == {
+        "prompt": "0.000001",
+        "completion": "0.000002",
+    }
+
+
+@pytest.mark.parametrize("currency", (None, "", "   "))
+def test_empty_child_currency_inherits_non_usd_parent(currency):
+    payload = {
+        "currency": "IDR",
+        "pricing": {
+            "currency": currency,
+            "prompt": "1",
+            "completion": "2",
+        },
+    }
+
+    assert _extract_pricing(payload) == {}
+
+
+def test_generic_pricing_inherits_non_usd_parent_currency():
+    payload = {
+        "currency": "IDR",
+        "pricing": {
+            "prompt": "1",
+            "completion": "2",
+        },
+    }
+
+    assert _extract_pricing(payload) == {}
+
+
+def test_deepinfra_pricing_inherits_metadata_currency():
+    payload = {
+        "metadata": {
+            "currency": "IDR",
+            "pricing": {
+                "input_tokens": 1,
+                "output_tokens": 2,
+            },
+        }
+    }
+
+    assert _extract_pricing(payload) == {}
+
+
+def test_child_usd_currency_overrides_non_usd_parent():
+    payload = {
+        "currency": "IDR",
+        "pricing": {
+            "currency": "USD",
+            "prompt": "0.000001",
+            "completion": "0.000002",
+        },
+    }
+
+    assert _extract_pricing(payload) == {
+        "prompt": "0.000001",
+        "completion": "0.000002",
+    }
+
+
+def test_endpoint_catalog_keeps_usd_model_when_sibling_is_non_usd():
+    response = MagicMock()
+    response.json.return_value = {
+        "data": [
+            {
+                "id": "usd-model",
+                "pricing": {
+                    "currency": "USD",
+                    "prompt": "0.000001",
+                    "completion": "0.000002",
+                },
+            },
+            {
+                "id": "non-usd-model",
+                "pricing": {
+                    "currency": "IDR",
+                    "prompt": "1",
+                    "completion": "2",
+                },
+            },
+        ]
+    }
+    response.raise_for_status.return_value = None
+
+    with patch("agent.model_metadata.requests.get", return_value=response):
+        metadata = fetch_endpoint_model_metadata(
+            "https://currency-matrix.example/v1",
+            force_refresh=True,
+        )
+
+    assert metadata["usd-model"]["pricing"] == {
+        "prompt": "0.000001",
+        "completion": "0.000002",
+    }
+    assert "pricing" not in metadata["non-usd-model"]
+
+
+def test_openrouter_cache_filters_non_usd_pricing(monkeypatch):
+    response = MagicMock()
+    response.json.return_value = {
+        "data": [
+            {
+                "id": "usd-model",
+                "pricing": {
+                    "currency": "USD",
+                    "prompt": "0.000001",
+                    "completion": "0.000002",
+                },
+            },
+            {
+                "id": "non-usd-model",
+                "pricing": {
+                    "currency": "IDR",
+                    "prompt": "1",
+                    "completion": "2",
+                },
+            },
+        ]
+    }
+    response.raise_for_status.return_value = None
+    monkeypatch.setattr(model_metadata, "_model_metadata_cache", {})
+    monkeypatch.setattr(model_metadata, "_model_metadata_cache_time", 0)
+    monkeypatch.setattr(
+        model_metadata, "_save_model_metadata_disk_cache", lambda _cache: None
+    )
+
+    with patch("agent.model_metadata.requests.get", return_value=response):
+        metadata = fetch_model_metadata(force_refresh=True)
+
+    assert metadata["usd-model"]["pricing"] == {
+        "prompt": "0.000001",
+        "completion": "0.000002",
+    }
+    assert metadata["non-usd-model"]["pricing"] == {}

--- a/tests/hermes_cli/test_model_pricing_currency.py
+++ b/tests/hermes_cli/test_model_pricing_currency.py
@@ -1,0 +1,133 @@
+"""Currency handling for model-picker pricing catalogs."""
+
+import json
+from unittest.mock import MagicMock
+
+from hermes_cli import models
+
+
+def _catalog_response(payload):
+    response = MagicMock()
+    response.read.return_value = json.dumps(payload).encode()
+    response.__enter__.return_value = response
+    response.__exit__.return_value = False
+    return response
+
+
+def test_generic_picker_keeps_only_usd_compatible_pricing(monkeypatch):
+    payload = {
+        "data": [
+            {
+                "id": "usd",
+                "pricing": {"currency": "USD", "prompt": "1e-6", "completion": "2e-6"},
+            },
+            {
+                "id": "inherited-idr",
+                "currency": "IDR",
+                "pricing": {"prompt": "1", "completion": "2"},
+            },
+            {
+                "id": "overridden-usd",
+                "currency": "IDR",
+                "pricing": {"currency": "$", "prompt": "3e-6", "completion": "4e-6"},
+            },
+            {
+                "id": "direct-idr",
+                "pricing": {"currency": "IDR", "prompt": "5", "completion": "6"},
+            },
+        ]
+    }
+    monkeypatch.setattr(
+        models,
+        "_urlopen_model_catalog_request",
+        lambda *_args, **_kwargs: _catalog_response(payload),
+    )
+
+    result = models.fetch_models_with_pricing(
+        base_url="https://currency-picker.example/api",
+        force_refresh=True,
+    )
+
+    assert set(result) == {"usd", "overridden-usd"}
+
+
+def test_novita_picker_keeps_only_usd_compatible_pricing(monkeypatch):
+    payload = {
+        "data": [
+            {
+                "id": "currencyless",
+                "input_token_price_per_m": 10_000,
+                "output_token_price_per_m": 20_000,
+            },
+            {
+                "id": "usd",
+                "currency": "USD",
+                "input_token_price_per_m": 10_000,
+                "output_token_price_per_m": 20_000,
+            },
+            {
+                "id": "idr",
+                "currency": "IDR",
+                "input_token_price_per_m": 10_000,
+                "output_token_price_per_m": 20_000,
+            },
+        ]
+    }
+    monkeypatch.setenv("NOVITA_API_KEY", "test-key")
+    monkeypatch.setenv("NOVITA_BASE_URL", "https://currency-novita.example/v1")
+    monkeypatch.setattr(
+        models,
+        "_urlopen_model_catalog_request",
+        lambda *_args, **_kwargs: _catalog_response(payload),
+    )
+
+    result = models._fetch_novita_pricing(force_refresh=True)
+
+    assert set(result) == {"currencyless", "usd"}
+
+
+def test_deepinfra_picker_uses_nearest_currency_declaration(monkeypatch):
+    items = [
+        {
+            "id": "metadata-idr",
+            "metadata": {
+                "currency": "IDR",
+                "pricing": {"input_tokens": 1, "output_tokens": 2},
+            },
+        },
+        {
+            "id": "child-usd",
+            "metadata": {
+                "currency": "IDR",
+                "pricing": {
+                    "currency": "USD",
+                    "input_tokens": 1,
+                    "output_tokens": 2,
+                },
+            },
+        },
+        {
+            "id": "child-empty-inherits-idr",
+            "metadata": {
+                "currency": "IDR",
+                "pricing": {
+                    "currency": "   ",
+                    "input_tokens": 1,
+                    "output_tokens": 2,
+                },
+            },
+        },
+        {
+            "id": "currencyless",
+            "metadata": {"pricing": {"input_tokens": 1, "output_tokens": 2}},
+        },
+    ]
+    monkeypatch.setattr(
+        models,
+        "_fetch_deepinfra_models_by_tag",
+        lambda *_args, **_kwargs: items,
+    )
+
+    result = models._fetch_deepinfra_pricing(force_refresh=True)
+
+    assert set(result) == {"child-usd", "currencyless"}

--- a/utils.py
+++ b/utils.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import stat
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Union
 from urllib.parse import urlparse
@@ -17,6 +18,26 @@ logger = logging.getLogger(__name__)
 
 
 TRUTHY_STRINGS = frozenset({"1", "true", "yes", "on"})
+
+
+def pricing_currency_is_usd_or_unspecified(
+    mapping: Mapping[str, Any],
+    *ancestors: Mapping[str, Any],
+) -> bool:
+    """Return whether the nearest declared pricing currency is USD-compatible.
+
+    ``mapping`` is the pricing object and ``ancestors`` must be ordered from
+    nearest to farthest. Empty currency values inherit from the next object;
+    no declaration preserves the historical assumption that prices are USD.
+    """
+    for candidate in (mapping, *ancestors):
+        for key, value in candidate.items():
+            if str(key).lower() != "currency":
+                continue
+            normalized = "" if value is None else str(value).strip().upper()
+            if normalized:
+                return normalized in {"USD", "$"}
+    return True
 
 
 def is_truthy_value(value: Any, default: bool = False) -> bool:


### PR DESCRIPTION
## Summary

- ignore model-catalog prices that declare a non-USD currency
- apply the same rule to agent metadata, the OpenRouter cache, and generic, Novita, and DeepInfra picker pricing
- use the nearest non-empty currency declaration so a price object can override its parent
- preserve existing behavior for `USD`, `$`, missing, null, empty, and whitespace currency values

## Problem

Hermes formats model pricing as USD. An OpenRouter-compatible endpoint can return numeric prices with an explicit non-USD currency. Copying those values into the pricing cache makes a valid amount in another currency appear as a dollar amount.

The fix omits that pricing block instead of converting it or treating it as zero. Model discovery and context metadata remain available.

## Decision table

| Nearest non-empty currency | Result |
|---|---|
| `USD`, `usd`, padded `USD`, `$` | keep pricing |
| missing, null, empty, whitespace | keep legacy behavior |
| any other explicit currency | omit pricing |

Sibling model metadata cannot affect another model. A child pricing declaration overrides a parent model or metadata declaration.

## Verification

- 62 focused and adjacent tests passed
- generic, Novita, and DeepInfra picker paths covered
- OpenRouter memory and disk cache path covered
- 34 existing local model-metadata tests passed
- Ruff check passed
- changed test format check passed
- Python compile check passed
- diff check passed
