### PR TITLE
feat(pricing): add Z.AI (GLM) first-party pricing + route resolution

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -808,6 +808,54 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://docs.fireworks.ai/serverless/pricing",
         pricing_version="fireworks-pricing-2026-07",
     ),
+    # Z.AI / Zhipu GLM — official docs (docs.z.ai/guides/overview/pricing).
+    # Z.AI's first-party API uses dot-notation model ids (glm-5.2), distinct
+    # from the Fireworks "p" slugs above. Both forms are handled so a session
+    # using either naming resolves. Rates verified July 2026.
+    (
+        "zai",
+        "glm-5.2",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.40"),
+        output_cost_per_million=Decimal("4.40"),
+        cache_read_cost_per_million=Decimal("0.26"),
+        source="official_docs_snapshot",
+        source_url="https://docs.z.ai/guides/overview/pricing",
+        pricing_version="zai-pricing-2026-07",
+    ),
+    (
+        "zai",
+        "glm-5.1",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.40"),
+        output_cost_per_million=Decimal("4.40"),
+        cache_read_cost_per_million=Decimal("0.26"),
+        source="official_docs_snapshot",
+        source_url="https://docs.z.ai/guides/overview/pricing",
+        pricing_version="zai-pricing-2026-07",
+    ),
+    (
+        "zai",
+        "glm-5-turbo",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.20"),
+        output_cost_per_million=Decimal("4.00"),
+        cache_read_cost_per_million=Decimal("0.24"),
+        source="official_docs_snapshot",
+        source_url="https://docs.z.ai/guides/overview/pricing",
+        pricing_version="zai-pricing-2026-07",
+    ),
+    (
+        "zai",
+        "glm-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.00"),
+        output_cost_per_million=Decimal("3.20"),
+        cache_read_cost_per_million=Decimal("0.20"),
+        source="official_docs_snapshot",
+        source_url="https://docs.z.ai/guides/overview/pricing",
+        pricing_version="zai-pricing-2026-07",
+    ),
 }
 
 # GPT-5.6 "-pro" high-effort variants bill at the same per-token rates as
@@ -866,6 +914,13 @@ def resolve_billing_route(
         return BillingRoute(provider="openai", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"minimax", "minimax-cn"}:
         return BillingRoute(provider=provider_name, model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
+    # Z.AI / Zhipu (api.z.ai) — first-party GLM provider. "zai", "z-ai", and
+    # "z.ai" are all accepted provider aliases (normalized upstream in
+    # hermes_cli/auth.py); "glm"/"zhipu" also collapse to "zai". Price off the
+    # official docs snapshot, not OpenRouter, so token-plan sessions see the
+    # equivalent first-party metered cost.
+    if provider_name in {"zai", "z-ai", "z.ai", "glm", "zhipu"} or base_url_host_matches(base_url or "", "api.z.ai"):
+        return BillingRoute(provider="zai", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     # Vertex AI hosts the same Gemini models as Google AI Studio; price them
     # off the gemini official-docs snapshot. Strip the "google/" vendor prefix
     # the OpenAI-compat endpoint requires so the pricing key matches.

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -5,6 +5,7 @@ from agent.usage_pricing import (
     estimate_usage_cost,
     get_pricing_entry,
     normalize_usage,
+    resolve_billing_route,
 )
 
 
@@ -519,3 +520,75 @@ def test_deepseek_v4_flash_estimate_usage_cost():
     assert result.amount_usd is not None
     # 1M input × $0.14/M + 500K output × $0.28/M = $0.14 + $0.14 = $0.28
     assert float(result.amount_usd) == 0.28
+
+
+def test_zai_glm_5_2_pricing_entry_exists():
+    """Regression test: Z.AI GLM-5.2 must have a first-party pricing entry.
+
+    Before this fix, Z.AI/GLM sessions showed as $0.00 / unknown cost because
+    resolve_billing_route had no "zai" branch — it fell through to the
+    billing_mode="unknown" default, so get_pricing_entry() returned None.
+    The GLM-5.2 row existed only under the Fireworks ("fireworks","glm-5p2")
+    slug and was unreachable from the first-party Z.AI route.
+    """
+    entry = get_pricing_entry("glm-5.2", provider="zai")
+
+    assert entry is not None
+    assert entry.input_cost_per_million is not None
+    assert entry.output_cost_per_million is not None
+    assert entry.cache_read_cost_per_million is not None
+    assert float(entry.input_cost_per_million) == 1.40
+    assert float(entry.output_cost_per_million) == 4.40
+    assert float(entry.cache_read_cost_per_million) == 0.26
+    # Source must be the official Z.AI docs, not a reseller snapshot.
+    assert entry.source == "official_docs_snapshot"
+    assert entry.source_url is not None and "z.ai" in entry.source_url
+
+
+def test_zai_glm_5_2_estimate_usage_cost():
+    """Ensure Z.AI GLM-5.2 sessions get a dollar estimate, not unknown."""
+    result = estimate_usage_cost(
+        "glm-5.2",
+        CanonicalUsage(input_tokens=1_000_000, output_tokens=500_000, cache_read_tokens=2_000_000),
+        provider="zai",
+    )
+
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    # 1M × $1.40 + 0.5M × $4.40 + 2M × $0.26 = 1.40 + 2.20 + 0.52 = 4.12
+    assert float(result.amount_usd) == 4.12
+
+
+def test_zai_provider_aliases_collapse_to_zai():
+    """Invariant: the documented Z.AI provider aliases (z-ai, z.ai, glm, zhipu)
+    and api.z.ai base_url all resolve to the "zai" billing route, so pricing
+    is found regardless of how the user configured the provider name."""
+    for alias in ("zai", "z-ai", "z.ai", "glm", "zhipu"):
+        route = resolve_billing_route("glm-5.2", provider=alias)
+        assert route.provider == "zai", alias
+        assert route.billing_mode == "official_docs_snapshot", alias
+
+
+def test_zai_base_url_detected_without_provider_name():
+    """Invariant: a session whose provider name is empty/unknown but whose
+    base_url is on api.z.ai still routes to Z.AI pricing — the host check must
+    not depend on the provider name being set."""
+    route = resolve_billing_route("glm-5.2", provider="", base_url="https://api.z.ai/api/paas/v4")
+    assert route.provider == "zai"
+    assert route.billing_mode == "official_docs_snapshot"
+
+
+def test_zai_rows_all_carry_cache_read_pricing():
+    """Invariant: Z.AI publishes a cached-input rate for every current GLM
+    model; every zai snapshot row must carry cache_read < input so cached
+    sessions estimate correctly instead of billing reads at full price."""
+    from agent.usage_pricing import _OFFICIAL_DOCS_PRICING
+
+    zai_rows = [k for k in _OFFICIAL_DOCS_PRICING if k[0] == "zai"]
+    assert zai_rows, "expected at least one zai pricing row"
+    for key in zai_rows:
+        entry = _OFFICIAL_DOCS_PRICING[key]
+        assert entry.cache_read_cost_per_million is not None, key
+        assert entry.input_cost_per_million is not None, key
+        assert entry.cache_read_cost_per_million < entry.input_cost_per_million, key
+


### PR DESCRIPTION
## Summary

Z.AI / Zhipu (api.z.ai) GLM sessions resolved to `billing_mode="unknown"` and showed **`$0.00` / `cost_status=unknown`** in cost analytics because `resolve_billing_route()` had no `"zai"` branch — it fell through to the unknown-billing default, so `get_pricing_entry()` returned `None`. GLM-5.2 pricing already existed in `_OFFICIAL_DOCS_PRICING`, but only under the **Fireworks** provider (`("fireworks", "glm-5p2")`) with the Fireworks `p`-notation slug, unreachable from the first-party Z.AI route.

Two changes to `agent/usage_pricing.py` close the gap.

## What changed

### 1. Route resolution — `resolve_billing_route()`

Z.AI is now a recognized provider, matched two ways (mirroring the existing MiniMax / Fireworks / Nous patterns):

- **By name** — `zai`, `z-ai`, `z.ai`, `glm`, `zhipu`. These match the alias normalization in `hermes_cli/auth.py` (`"glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai"`), so a session billed under any documented alias resolves.
- **By base_url host** — `api.z.ai`, via the existing `base_url_host_matches()` helper. Catches sessions whose provider name is empty/unknown but whose endpoint is Z.AI's first-party API.

Returns `BillingRoute(provider="zai", billing_mode="official_docs_snapshot")`.

### 2. First-party pricing entries — `_OFFICIAL_DOCS_PRICING`

Added official Z.AI rows for the four current GLM text models, sourced from `docs.z.ai/guides/overview/pricing` (`pricing_version="zai-pricing-2026-07"`). Every row carries a `cache_read` rate — Z.AI publishes cached-input pricing for all current GLM models.

| Model | Input | Output | Cache read | (all per 1M tokens) |
| --- | --- | --- | --- | --- |
| GLM-5.2 | $1.40 | $4.40 | $0.26 | |
| GLM-5.1 | $1.40 | $4.40 | $0.26 | |
| GLM-5-Turbo | $1.20 | $4.00 | $0.24 | |
| GLM-5 | $1.00 | $3.20 | $0.20 | |

Rates verified July 2026 from the official Z.AI developer docs.

### Why first-party rates, not OpenRouter

OpenRouter's `z-ai/glm-5.2` cache_read rate ($0.048/Mtok) is ~5× cheaper than Z.AI's first-party rate ($0.26/Mtok). For users on Z.AI's **GLM Coding Plan** (token subscription, like OpenAI's ChatGPT Pro), the honest "shadow cost" is the first-party metered rate the plan subsidizes — that's the number that answers "would I be cheaper on pay-per-token?". This matches the existing convention: `openai-codex` subscription routes report the pay-per-token equivalent, not $0.

## Behavior contract (what this fixes)

Before:
```
>>> get_pricing_entry("glm-5.2", provider="zai") is None
True
>>> resolve_billing_route("glm-5.2", provider="zai").billing_mode
'unknown'
```

After:
```
>>> entry = get_pricing_entry("glm-5.2", provider="zai")
>>> entry.input_cost_per_million, entry.output_cost_per_million, entry.cache_read_cost_per_million
(Decimal('1.40'), Decimal('4.40'), Decimal('0.26'))
>>> resolve_billing_route("glm-5.2", provider="zai").billing_mode
'official_docs_snapshot'
```

## Tests

5 new tests in `tests/agent/test_usage_pricing.py`, mirroring the established DeepSeek regression-test pattern:

| Test | Asserts |
| --- | --- |
| `test_zai_glm_5_2_pricing_entry_exists` | entry present with correct rates + source attribution to `z.ai` |
| `test_zai_glm_5_2_estimate_usage_cost` | `estimate_usage_cost()` returns `status="estimated"` with correct dollar amount (1M in + 0.5M out + 2M cache_read = $4.12) |
| `test_zai_provider_aliases_collapse_to_zai` | `zai`, `z-ai`, `z.ai`, `glm`, `zhipu` all route to `provider="zai"` |
| `test_zai_base_url_detected_without_provider_name` | `api.z.ai` base_url routes correctly even with empty provider |
| `test_zai_rows_all_carry_cache_read_pricing` | invariant: every zai row has `cache_read < input` |

```
tests/agent/test_usage_pricing.py ... 32 passed
```

Plus a broader sweep across the pricing/cost surface:
```
tests/agent/test_usage_pricing.py
tests/hermes_cli/test_inventory_pricing.py
tests/hermes_cli/test_model_cost_guard.py
tests/hermes_state/test_aux_usage_accounting.py
... 60 passed in 3.72s
```

## Real-world validation

Verified against a live Hermes install (v0.18.2, `glm-5.2` via Z.AI provider): previously every Z.AI session recorded `estimated_cost_usd=0.00, cost_status=unknown` in `state.db`; after this patch, the same config resolves correctly and produces accurate estimates.

## Scope

- No new env vars, no new config keys, no core-tool changes.
- No prompt-cache or message-alternation impact.
- Purely additive: 4 pricing rows + 1 route branch + 5 tests.

<!-- This is an upstream contribution from a Hermes user (MLcogTech), not a Nous Research internal PR. -->
