### PR TITLE
fix(config): add group_sessions_per_user + known_plugin_toolsets to _EXTRA_KNOWN_ROOT_KEYS (#67478)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5516,6 +5516,9 @@ _EXTRA_KNOWN_ROOT_KEYS = {
     "require_mention",       # top-level convenience form honored by the gateway (#3979)
     "unauthorized_dm_behavior",  # top-level form read by gateway/config.py
     "signal",            # Signal settings bridged to env vars by gateway/config.py
+    # Keys read/written by Hermes flows but absent from DEFAULT_CONFIG:
+    "group_sessions_per_user",   # top-level form read by gateway/config.py:1206
+    "known_plugin_toolsets",     # written by `hermes tools` (tools_config.py:1859,2012-2013)
 }
 _KNOWN_ROOT_KEYS = frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5518,6 +5518,7 @@ _EXTRA_KNOWN_ROOT_KEYS = {
     "signal",            # Signal settings bridged to env vars by gateway/config.py
     # Keys read/written by Hermes flows but absent from DEFAULT_CONFIG:
     "group_sessions_per_user",   # top-level form read by gateway/config.py:1206
+    "thread_sessions_per_user",  # immediately after group_sessions_per_user at gateway/config.py:1209
     "known_plugin_toolsets",     # written by `hermes tools` (tools_config.py:1859,2012-2013)
 }
 _KNOWN_ROOT_KEYS = frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -253,6 +253,15 @@ class TestUnknownTopLevelKeys:
         assert _EXTRA_KNOWN_ROOT_KEYS.issubset(_KNOWN_ROOT_KEYS)
         assert _KNOWN_ROOT_KEYS == frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 
+    def test_group_sessions_per_user_known_root_accepted(self):
+        """group_sessions_per_user, thread_sessions_per_user, and known_plugin_toolsets
+        must NOT produce unknown-key warnings — they are live read/write roots."""
+        for key in ("group_sessions_per_user", "thread_sessions_per_user", "known_plugin_toolsets"):
+            config = {key: {}}
+            issues = validate_config_structure(config)
+            unknown = [i for i in issues if "Unknown top-level config key" in i.message]
+            assert unknown == [], f"{key} produced unknown-key warning: {unknown}"
+
     def test_provider_like_unknown_root_keeps_misplaced_message(self):
         """Preserve existing base_url/api_key root-level guidance (not generic unknown)."""
         issues = validate_config_structure({


### PR DESCRIPTION
Fixes #67478.

The previous fix (4f67c333) added `_EXTRA_KNOWN_ROOT_KEYS` but missed two keys that Hermes itself reads and writes at the config root:

- **`group_sessions_per_user`** — top-level form read by `gateway/config.py:1206` 
- **`known_plugin_toolsets`** — written by `hermes tools` (`tools_config.py:1859,2012-2013`)

Without these entries, `hermes doctor` still warns:

> ⚠ Unknown top-level config key 'known_plugin_toolsets' — it will be ignored

The warning is self-defeating: deleting the key to silence it is not a viable workaround since `hermes tools` writes it back on every run.

Both are confirmed live read/write sites on current `main` (`19527db73`).

## Diff

`hermes_cli/config.py`: +3 lines adding both keys to the existing `_EXTRA_KNOWN_ROOT_KEYS` set. Existing tests auto-cover the contract (`test_all_default_config_roots_accepted_without_unknown_warning` iterates every entry).

## Tests

```
$ python -m pytest tests/hermes_cli/test_config_validation.py -q
26 passed in 0.77s
```