### PR TITLE
docs(links): update moved Agent Client Protocol repo URL

### DIFF
--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -10,7 +10,7 @@ Hermes ships three protocols for driving the agent from external programs — ID
 
 | Protocol | Transport | Best for | Defined by |
 |----------|-----------|----------|------------|
-| **ACP** | JSON-RPC over stdio | IDE clients (VS Code, Zed, JetBrains) that already speak the [Agent Client Protocol](https://github.com/zed-industries/agent-client-protocol) | `acp_adapter/` |
+| **ACP** | JSON-RPC over stdio | IDE clients (VS Code, Zed, JetBrains) that already speak the [Agent Client Protocol](https://github.com/agentclientprotocol/agent-client-protocol) | `acp_adapter/` |
 | **TUI gateway** | JSON-RPC over stdio (or WebSocket) | Custom hosts that want fine-grained control of sessions, slash commands, approvals, and streaming events | `tui_gateway/server.py` |
 | **API server** | HTTP + Server-Sent Events | OpenAI-compatible frontends (Open WebUI, LobeChat, LibreChat…) and language-agnostic web clients | `gateway/platforms/api_server.py` |
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/programmatic-integration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/programmatic-integration.md
@@ -10,7 +10,7 @@ Hermes 提供三种协议，供外部程序驱动 agent——IDE 插件、自定
 
 | 协议 | 传输方式 | 适用场景 | 定义位置 |
 |----------|-----------|----------|------------|
-| **ACP** | JSON-RPC over stdio | 已支持 [Agent Client Protocol](https://github.com/zed-industries/agent-client-protocol) 的 IDE 客户端（VS Code、Zed、JetBrains） | `acp_adapter/` |
+| **ACP** | JSON-RPC over stdio | 已支持 [Agent Client Protocol](https://github.com/agentclientprotocol/agent-client-protocol) 的 IDE 客户端（VS Code、Zed、JetBrains） | `acp_adapter/` |
 | **TUI gateway** | JSON-RPC over stdio（或 WebSocket） | 需要精细控制会话、slash 命令、审批及流式事件的自定义宿主 | `tui_gateway/server.py` |
 | **API server** | HTTP + Server-Sent Events | 兼容 OpenAI 的前端（Open WebUI、LobeChat、LibreChat……）及语言无关的 Web 客户端 | `gateway/platforms/api_server.py` |
 


### PR DESCRIPTION
### Problem

The programmatic-integration guide links the Agent Client Protocol repo at its former location, which now permanently redirects:

```
$ curl -sI https://github.com/zed-industries/agent-client-protocol
HTTP/1.1 301 Moved Permanently
Location: https://github.com/agentclientprotocol/agent-client-protocol
```

The project moved out of the `zed-industries` org into its own `agentclientprotocol` org. The new location is a direct 200:

```
$ curl -sI https://github.com/agentclientprotocol/agent-client-protocol
HTTP/1.1 200 OK
```

### Fix

Point the link at the canonical URL GitHub itself redirects to. The link appears in the English guide and its zh-Hans mirror — nowhere else in the repo — so both are updated for a complete fix.

```diff
-| **ACP** | JSON-RPC over stdio | IDE clients (VS Code, Zed, JetBrains) that already speak the [Agent Client Protocol](https://github.com/zed-industries/agent-client-protocol) | `acp_adapter/` |
+| **ACP** | JSON-RPC over stdio | IDE clients (VS Code, Zed, JetBrains) that already speak the [Agent Client Protocol](https://github.com/agentclientprotocol/agent-client-protocol) | `acp_adapter/` |
```

Docs-only, no runtime or behavior change. The replacement URL is exactly the `Location` header returned by the old URL, so there is no ambiguity about the destination. (The "Zed" IDE reference in the same row is unrelated and left as-is.)
