### PR TITLE
fix(cron): add cron.drift_guard config to bypass provider/model drift guard

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3237,7 +3237,8 @@ def run_job(
             _cfg if isinstance(_cfg, dict) else {}, str(model)
         )
 
-        # Provider/model-drift fail-closed guard (#44585).
+        # Provider/model-drift fail-closed guard (#44585), skippable via
+        # config.yaml ``cron.drift_guard: false`` (#67490).
         #
         # An UNPINNED job (no explicit job["provider"]/["model"]) follows the
         # global default, which can change after the job was created — a switch
@@ -3257,41 +3258,46 @@ def run_job(
         # any axis whose creation-time resolution failed) behaves exactly as
         # before — the guard never engages for it. Pinned axes are unaffected.
         _drift: list[str] = []
-        _provider_snapshot = (job.get("provider_snapshot") or "").strip().lower()
-        if _provider_snapshot and not (job.get("provider") or "").strip():
-            _current_provider = str(
-                primary_provider_for_drift or runtime.get("provider") or ""
-            ).strip().lower()
-            if _current_provider and _current_provider != _provider_snapshot:
-                _drift.append(
-                    f"provider '{_provider_snapshot}' -> '{_current_provider}'"
+        _cron_cfg = _cfg.get("cron", {}) if isinstance(_cfg, dict) else {}
+        _drift_guard_enabled = bool(
+            _cron_cfg.get("drift_guard", True)
+        )
+        if _drift_guard_enabled:
+            _provider_snapshot = (job.get("provider_snapshot") or "").strip().lower()
+            if _provider_snapshot and not (job.get("provider") or "").strip():
+                _current_provider = str(
+                    primary_provider_for_drift or runtime.get("provider") or ""
+                ).strip().lower()
+                if _current_provider and _current_provider != _provider_snapshot:
+                    _drift.append(
+                        f"provider '{_provider_snapshot}' -> '{_current_provider}'"
+                    )
+            _model_snapshot = (job.get("model_snapshot") or "").strip().lower()
+            if _model_snapshot and not (job.get("model") or "").strip():
+                _current_model = str(primary_model_for_drift or "").strip().lower()
+                if _current_model and _current_model != _model_snapshot:
+                    _drift.append(
+                        f"model '{_model_snapshot}' -> '{_current_model}'"
+                    )
+            if _drift:
+                _changes = "; ".join(_drift)
+                logger.warning(
+                    "Job '%s': SKIPPED — global inference config drifted since "
+                    "creation (%s) and this job is unpinned. Skipped to prevent "
+                    "unintended spend. Pin explicitly to proceed: "
+                    "`cronjob action=update job_id=%s provider=<p> model=<m>`.",
+                    job_id,
+                    _changes,
+                    job_id,
                 )
-        _model_snapshot = (job.get("model_snapshot") or "").strip().lower()
-        if _model_snapshot and not (job.get("model") or "").strip():
-            _current_model = str(primary_model_for_drift or "").strip().lower()
-            if _current_model and _current_model != _model_snapshot:
-                _drift.append(
-                    f"model '{_model_snapshot}' -> '{_current_model}'"
+                raise RuntimeError(
+                    f"Skipped to prevent unintended spend: global inference config "
+                    f"drifted since this job was created ({_changes}), and this job "
+                    f"is unpinned. No inference call was made. To run on the new "
+                    f"config, pin it explicitly: `cronjob action=update "
+                    f"job_id={job_id} provider=<provider> model=<model>` "
+                    f"(or pin the original values to keep them). See #44585."
                 )
-        if _drift:
-            _changes = "; ".join(_drift)
-            logger.warning(
-                "Job '%s': SKIPPED — global inference config drifted since "
-                "creation (%s) and this job is unpinned. Skipped to prevent "
-                "unintended spend. Pin explicitly to proceed: "
-                "`cronjob action=update job_id=%s provider=<p> model=<m>`.",
-                job_id,
-                _changes,
-                job_id,
-            )
-            raise RuntimeError(
-                f"Skipped to prevent unintended spend: global inference config "
-                f"drifted since this job was created ({_changes}), and this job "
-                f"is unpinned. No inference call was made. To run on the new "
-                f"config, pin it explicitly: `cronjob action=update "
-                f"job_id={job_id} provider=<provider> model=<model>` "
-                f"(or pin the original values to keep them). See #44585."
-            )
 
         fallback_model = get_fallback_chain(_cfg) or None
         credential_pool = None

--- a/tests/cron/test_cron_provider_pin.py
+++ b/tests/cron/test_cron_provider_pin.py
@@ -334,3 +334,87 @@ class TestModelDriftGuard:
             )
         assert agent_constructed is True
         assert success is True
+
+
+def _run_with_disabled_drift_guard(job, current_provider, tmp_path):
+    """Drive run_job with cron.drift_guard: false in config.yaml.
+
+    The drift guard must be bypassed even when the snapshot differs from
+    the currently-resolved provider.
+    """
+    (tmp_path / "config.yaml").write_text(
+        "cron:\n  drift_guard: false\n"
+    )
+    fake_db = MagicMock()
+    with patch("cron.scheduler._hermes_home", tmp_path), \
+         patch("cron.scheduler._get_hermes_home", return_value=tmp_path), \
+         patch("cron.scheduler._resolve_origin", return_value=None), \
+         patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+         patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+         patch("hermes_state.SessionDB", return_value=fake_db), \
+         patch(
+             "hermes_cli.runtime_provider.resolve_runtime_provider",
+             return_value={
+                 "api_key": "test-key",
+                 "base_url": "https://example.invalid/v1",
+                 "provider": current_provider,
+                 "api_mode": "chat_completions",
+             },
+         ), \
+         patch("run_agent.AIAgent") as mock_agent_cls:
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        mock_agent_cls.return_value = mock_agent
+        success, output, final_response, error = run_job(job)
+        agent_constructed = mock_agent_cls.called
+    return success, output, final_response, error, agent_constructed
+
+
+class TestDriftGuardDisabled:
+    """When cron.drift_guard: false, unpinned jobs follow the global default
+    regardless of snapshot mismatch (#67490)."""
+
+    def test_disabled_allows_provider_drift(self, tmp_path):
+        """cron.drift_guard: false → unpinned provider drift is allowed."""
+        job = _base_job(provider_snapshot="openrouter")
+        success, output, final_response, error, agent_constructed = \
+            _run_with_disabled_drift_guard(job, "nous", tmp_path)
+        assert agent_constructed is True
+        assert success is True
+        assert error is None
+
+    def test_disabled_allows_model_drift(self, tmp_path):
+        """cron.drift_guard: false → unpinned model drift is allowed."""
+        job = _base_job(
+            provider_snapshot="openrouter",
+            model_snapshot="llama-3.3-70b-instruct:free",
+        )
+        (tmp_path / "config.yaml").write_text(
+            "cron:\n  drift_guard: false\n"
+            "model:\n  default: claude-fable-5\n"
+        )
+        fake_db = MagicMock()
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._get_hermes_home", return_value=tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, output, final_response, error = run_job(job)
+            agent_constructed = mock_agent_cls.called
+        assert agent_constructed is True
+        assert success is True
+        assert error is None


### PR DESCRIPTION
Closes #67490

## Problem

The provider/model drift guard (#44585) snapshots the global default provider/model at cron job creation and fails closed at fire time if the global default changes. This prevents unintended spend (the $7.73 incident), but it breaks users who change their base model frequently — every unpinned cron job stops firing until manually updated.

## Solution

Add a `cron.drift_guard` config option (default: `true`, preserving existing behavior). When set to `false` in `config.yaml`, the drift guard is disabled and unpinned cron jobs follow the global default at fire time:

```yaml
cron:
  drift_guard: false
```

## Changes

1. **cron/scheduler.py**: Read `cron.drift_guard` from `_cfg` and wrap the drift guard block in a conditional. Default is `true` (backward compatible).
2. **tests/cron/test_cron_provider_pin.py**: Add `TestDriftGuardDisabled` with two test cases verifying provider drift and model drift are allowed when the config is disabled.

## Testing

- All 14 existing tests pass unchanged.
- 2 new tests pass: `test_disabled_allows_provider_drift` and `test_disabled_allows_model_drift`.