### PR TITLE
fix(skills): merge owner bits in _rmtree_writable error handler instead of replacing mode (#67496)

### DIFF
--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -759,9 +759,15 @@ def _rmtree_writable(path: Path) -> None:
     def _on_error(func, fpath, exc_info):
         # Unlinking a child requires the parent dir to be writable, so chmod
         # the parent as well as the failing path, then retry.
+        # Merge owner-write into the existing mode instead of replacing it,
+        # so group/other permissions survive (#67496).
         for target in (os.path.dirname(fpath), fpath):
+            # Never widen the skills root itself — it must not need mode
+            # changes to delete a child's contents (#67496).
+            if Path(target).resolve() == skills_root:
+                continue
             try:
-                os.chmod(target, stat.S_IRWXU)
+                os.chmod(target, os.stat(target).st_mode | stat.S_IRWXU)
             except OSError:
                 pass
         func(fpath)


### PR DESCRIPTION
## Summary

`_rmtree_writable`'s error handler `_on_error` used `os.chmod(target, stat.S_IRWXU)` which **replaces** the mode with `0700`, discarding all group/other permissions. When `fpath` is a direct child of the skills root, `dirname(fpath)` **is** the skills root — so the chmod permanently clamps the root to `0700`, breaking every non-owner role in group-shared installs.

## Root Cause

`os.chmod(target, stat.S_IRWXU)` is an assignment, not a merge — it discards all group and other bits, and nothing restores them afterward.

The existing #48200 scope guard protects the root from **deletion** but `_on_error` chmods `os.path.dirname(fpath)` — when `fpath` is a direct child of the skills root, that chmod reaches exactly the directory the guard exists to protect.

## Change

- **Merge** owner-write into the existing mode (`os.stat(target).st_mode | stat.S_IRWXU`) instead of replacing it, so group/other permissions survive.
- **Skip** the chmod entirely when the target resolves to the skills root, mirroring the #48200 scope guard's intent — the root should never need mode changes to delete a child's contents.

## Verification

```diff
 for target in (os.path.dirname(fpath), fpath):
+    if Path(target).resolve() == skills_root:
+        continue
     try:
-        os.chmod(target, stat.S_IRWXU)
+        os.chmod(target, os.stat(target).st_mode | stat.S_IRWXU)
     except OSError:
         pass
```

Closes #67496