### PR TITLE
fix(config): add group_sessions_per_user and known_plugin_toolsets to _EXTRA_KNOWN_ROOT_KEYS

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5519,6 +5519,9 @@ _EXTRA_KNOWN_ROOT_KEYS = {
     "require_mention",       # top-level convenience form honored by the gateway (#3979)
     "unauthorized_dm_behavior",  # top-level form read by gateway/config.py
     "signal",            # Signal settings bridged to env vars by gateway/config.py
+    # Keys read/written by Hermes flows but absent from DEFAULT_CONFIG:
+    "group_sessions_per_user",   # top-level form read by gateway/config.py (#67478)
+    "known_plugin_toolsets",     # written by `hermes tools` (tools_config.py) (#67478)
 }
 _KNOWN_ROOT_KEYS = frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 


### PR DESCRIPTION
Fixes #67478

Both `group_sessions_per_user` and `known_plugin_toolsets` are read/written by Hermes flows but were missing from `_EXTRA_KNOWN_ROOT_KEYS`, causing `hermes doctor` to falsely warn about them as unknown config keys.

- **`group_sessions_per_user`**: top-level form read by `gateway/config.py` (line 1206)
- **`known_plugin_toolsets`**: written by `hermes tools` (`hermes_cli/tools_config.py:2012-2013`) and read back at line 1859

## Verification
On current `main` (`36f2a966c`):
```python
>>> from hermes_cli.config import _EXTRA_KNOWN_ROOT_KEYS
>>> 'group_sessions_per_user' in _EXTRA_KNOWN_ROOT_KEYS
False  # before this PR
>>> 'known_plugin_toolsets' in _EXTRA_KNOWN_ROOT_KEYS
False  # before this PR
```

After this PR, both keys will be recognized as valid config roots.