### PR TITLE
fix(config): 添加 group_sessions_per_user 和 known_plugin_toolsets 到白名单

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5406,6 +5406,9 @@ _KNOWN_ROOT_KEYS = {
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "moa", "custom_providers", "context", "memory", "gateway",
     "sessions", "streaming", "updates", "mcp_servers",
+    # Keys read/written by Hermes flows but absent from DEFAULT_CONFIG:
+    "group_sessions_per_user",      # top-level form read by gateway/config.py:1206
+    "known_plugin_toolsets",        # written by `hermes tools` (tools_config.py:2012-2013)
 }
 
 # Valid fields inside a custom_providers list entry


### PR DESCRIPTION
## 背景

修复 #67478: _KNOWN_ROOT_KEYS 缺少 group_sessions_per_user + known_plugin_toolsets

## 根因分析

之前的修复 (#4f67c3338) 只添加了部分缺失的 key，但遗漏了：
- `group_sessions_per_user` — gateway/config.py:1206 读取的顶层配置项
- `known_plugin_toolsets` — hermes tools (tools_config.py:2012-2013) 写入/读取的配置项

这导致 `hermes doctor` 持续警告 'Unknown top-level config key'，且该 key 会被自动写回形成循环。

## 修复方式

在 `hermes_cli/config.py` 的 `_KNOWN_ROOT_KEYS` 集合中添加这两个 key。

## 验证

- [x] 语法检查通过
- [x] 遵循项目 AGENTS.md 贡献规范
- [x] 无破坏性变更（仅添加白名单）

Closes #67478