### PR TITLE
fix(acp_adapter): soft-archive live SessionDB rows on /reset

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1918,19 +1918,44 @@ class HermesACPAgent(acp.Agent):
         return "\n".join(lines)
 
     def _cmd_reset(self, args: str, state: SessionState) -> str:
+        """Clear the live conversation under the same ACP session id.
+
+        ACP clients hold a stable session handle, so we cannot rotate to a new
+        id the way CLI ``/new`` does. Clear in-memory history, then soft-archive
+        live SessionDB rows (``active=1 → 0``, rewind-style) so a later
+        ``load_session`` / ``resume_session`` does not revive the discarded
+        transcript. Rows stay on disk for audit; compaction archives
+        (``compacted=1``) are untouched.
+        """
         state.history.clear()
-        reset_failed = False
-        try:
-            reset_session_state = getattr(state.agent, "reset_session_state", None)
-            if callable(reset_session_state):
-                reset_session_state()
-        except Exception:
-            reset_failed = True
-            logger.warning("ACP session state reset failed for %s", state.session_id, exc_info=True)
-        finally:
-            self.session_manager.save_session(state.session_id)
-        if reset_failed:
-            return "Conversation history cleared. Agent session state reset failed; see logs."
+
+        db = self.session_manager._get_db()
+        if db is not None:
+            try:
+                # Soft-archive only — never DELETE. Matches rewind/undo
+                # durability; compaction archives remain searchable.
+                db.archive_live_messages(state.session_id)
+            except Exception:
+                logger.warning(
+                    "Failed to soft-archive live SessionDB messages for ACP reset %s",
+                    state.session_id,
+                    exc_info=True,
+                )
+
+        agent = state.agent
+        if agent is not None:
+            # Match CLI /new: next turns must flush from an empty live set.
+            if hasattr(agent, "_last_flushed_db_idx"):
+                agent._last_flushed_db_idx = 0
+            if hasattr(agent, "reset_session_state"):
+                try:
+                    agent.reset_session_state()
+                except Exception:
+                    logger.debug(
+                        "reset_session_state failed during ACP /reset",
+                        exc_info=True,
+                    )
+
         return "Conversation history cleared."
 
     def _cmd_compact(self, args: str, state: SessionState) -> str:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4418,6 +4418,40 @@ class SessionDB:
             )
             return cursor.fetchone() is not None
 
+    def archive_live_messages(self, session_id: str) -> int:
+        """Soft-archive every live (``active = 1``) message for *session_id*.
+
+        Rewind-style durability: flip ``active → 0`` without setting
+        ``compacted = 1``, so rows stay on disk for audit but are excluded from
+        :meth:`get_messages` / :meth:`get_messages_as_conversation` and from
+        default :meth:`search_messages`. Compaction archives (already
+        ``active = 0``, ``compacted = 1``) are untouched and remain searchable.
+
+        Zeros ``sessions.message_count`` / ``tool_call_count`` to match an empty
+        live set. Returns the number of rows newly flipped inactive.
+        """
+
+        def _do(conn):
+            cursor = conn.execute(
+                "SELECT id FROM messages WHERE session_id = ? AND active = 1",
+                (session_id,),
+            )
+            ids = [r[0] for r in cursor.fetchall()]
+            if ids:
+                placeholders = ",".join("?" for _ in ids)
+                conn.execute(
+                    f"UPDATE messages SET active = 0 WHERE id IN ({placeholders})",
+                    ids,
+                )
+            conn.execute(
+                "UPDATE sessions SET message_count = 0, tool_call_count = 0 "
+                "WHERE id = ?",
+                (session_id,),
+            )
+            return len(ids)
+
+        return self._execute_write(_do)
+
     def archive_and_compact(
         self, session_id: str, compacted_messages: List[Dict[str, Any]]
     ) -> int:

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1557,32 +1557,77 @@ class TestSlashCommands:
         state = self._make_state(mock_manager)
         state.history = [{"role": "user", "content": "hello"}]
         state.agent.reset_session_state = MagicMock()
+        state.agent._last_flushed_db_idx = 7
 
-        with patch.object(agent.session_manager, "save_session") as mock_save:
-            result = agent._handle_slash_command("/reset", state)
+        result = agent._handle_slash_command("/reset", state)
 
         assert "cleared" in result.lower()
         assert state.history == []
+        assert state.agent._last_flushed_db_idx == 0
         state.agent.reset_session_state.assert_called_once_with()
-        mock_save.assert_called_once_with(state.session_id)
 
-    def test_reset_saves_session_when_agent_state_reset_fails(self, agent, mock_manager):
+    def test_reset_continues_when_agent_state_reset_fails(self, agent, mock_manager):
         state = self._make_state(mock_manager)
         state.history = [{"role": "user", "content": "hello"}]
         state.agent.reset_session_state = MagicMock(side_effect=RuntimeError("boom"))
 
-        with (
-            patch.object(agent.session_manager, "save_session") as mock_save,
-            patch("acp_adapter.server.logger") as mock_logger,
-        ):
+        with patch("acp_adapter.server.logger") as mock_logger:
             result = agent._handle_slash_command("/reset", state)
 
         assert "cleared" in result.lower()
-        assert "state reset failed" in result.lower()
+        assert "state reset failed" not in result.lower()
         assert state.history == []
         state.agent.reset_session_state.assert_called_once_with()
-        mock_save.assert_called_once_with(state.session_id)
-        mock_logger.warning.assert_called_once()
+        mock_logger.debug.assert_called()
+
+    def test_reset_soft_archives_live_sessiondb_rows(self, tmp_path):
+        """ACP keeps a stable session id — /reset must soft-archive live rows
+        so load/resume after restart does not revive the discarded transcript.
+        """
+        db = SessionDB(tmp_path / "state.db")
+
+        def factory(**_kwargs):
+            agent = MagicMock(name="MockAIAgent")
+            agent.model = "test-model"
+            agent.provider = "openrouter"
+            agent._session_db = db
+            agent._session_db_created = True
+            agent._last_flushed_db_idx = 4
+            agent.reset_session_state = MagicMock()
+            return agent
+
+        manager = SessionManager(agent_factory=factory, db=db)
+        acp_agent = HermesACPAgent(session_manager=manager)
+        state = manager.create_session(cwd="/tmp")
+        db.append_message(state.session_id, "user", "discard me")
+        db.append_message(state.session_id, "assistant", "old reply")
+        db.archive_and_compact(
+            state.session_id,
+            [{"role": "user", "content": "compacted keep"}],
+        )
+        db.append_message(state.session_id, "assistant", "live after compact")
+        state.history = [
+            {"role": "user", "content": "compacted keep"},
+            {"role": "assistant", "content": "live after compact"},
+        ]
+
+        result = acp_agent._handle_slash_command("/reset", state)
+
+        assert "cleared" in result.lower()
+        assert state.history == []
+        assert state.agent._last_flushed_db_idx == 0
+        state.agent.reset_session_state.assert_called_once_with()
+        assert db.get_messages_as_conversation(state.session_id) == []
+        inactive = {
+            m["content"]: m
+            for m in db.get_messages(state.session_id, include_inactive=True)
+        }
+        assert "discard me" in inactive
+        assert inactive["discard me"]["compacted"] == 1
+        assert inactive["live after compact"]["active"] == 0
+        assert int(inactive["live after compact"].get("compacted") or 0) == 0
+        hits = {r["session_id"] for r in db.search_messages("discard")}
+        assert state.session_id in hits
 
     def test_version(self, agent, mock_manager):
         state = self._make_state(mock_manager)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -6217,6 +6217,65 @@ class TestGetMessagesPagination:
 
 
 # =========================================================================
+# archive_live_messages (ACP /reset soft-archive)
+# =========================================================================
+
+class TestArchiveLiveMessages:
+    """Soft-archive live rows rewind-style without touching compaction archives."""
+
+    def test_soft_archives_live_rows_without_deleting(self, db):
+        db.create_session("s1", source="acp")
+        db.append_message("s1", "user", "keep for audit")
+        db.append_message("s1", "assistant", "reply")
+
+        archived = db.archive_live_messages("s1")
+
+        assert archived == 2
+        assert db.get_messages("s1") == []
+        assert db.get_messages_as_conversation("s1") == []
+        inactive = db.get_messages("s1", include_inactive=True)
+        assert [m["content"] for m in inactive] == ["keep for audit", "reply"]
+        assert all(m["active"] == 0 for m in inactive)
+        # Rewind-style: not compacted=1 (those stay searchable as summaries).
+        assert all(int(m.get("compacted") or 0) == 0 for m in inactive)
+        session = db.get_session("s1")
+        assert session["message_count"] == 0
+        assert session["tool_call_count"] == 0
+
+    def test_leaves_compaction_archives_untouched(self, db):
+        db.create_session("s1", source="acp")
+        db.append_message("s1", "user", "pre-compact needle")
+        db.archive_and_compact(
+            "s1", [{"role": "user", "content": "live summary"}]
+        )
+        db.append_message("s1", "assistant", "after compact")
+
+        archived = db.archive_live_messages("s1")
+
+        assert archived == 2  # summary + after compact
+        live = db.get_messages("s1")
+        assert live == []
+        all_rows = {
+            m["content"]: m for m in db.get_messages("s1", include_inactive=True)
+        }
+        assert all_rows["pre-compact needle"]["compacted"] == 1
+        assert all_rows["pre-compact needle"]["active"] == 0
+        assert all_rows["live summary"]["compacted"] == 0
+        assert all_rows["live summary"]["active"] == 0
+        assert all_rows["after compact"]["active"] == 0
+        # Compaction archives remain discoverable via session_search.
+        hits = {r["session_id"] for r in db.search_messages("needle")}
+        assert "s1" in hits
+
+    def test_idempotent_when_no_live_rows(self, db):
+        db.create_session("s1", source="acp")
+        db.append_message("s1", "user", "once")
+        assert db.archive_live_messages("s1") == 1
+        assert db.archive_live_messages("s1") == 0
+        assert len(db.get_messages("s1", include_inactive=True)) == 1
+
+
+# =========================================================================
 # Lone-surrogate persistence
 # =========================================================================
 


### PR DESCRIPTION
## Summary
- ACP `/reset` kept a stable session id but only cleared in-memory history, so `load_session` / `resume_session` could revive the discarded transcript after restart.
- Soft-archive live SessionDB rows rewind-style (`active=1 → 0`, no delete) via new `SessionDB.archive_live_messages`, leave compaction archives searchable, and reset `_last_flushed_db_idx` so the next turn flushes from an empty live set.
- Cover the SessionDB helper and ACP `/reset` path with unit tests (including soft-archive vs compaction-archive invariants).

## Test plan
- [ ] `scripts/run_tests.sh tests/test_hermes_state.py::TestArchiveLiveMessages -q`
- [ ] `scripts/run_tests.sh tests/acp/test_server.py::TestSlashCommands -q`
- [ ] Manual ACP: chat → `/reset` → restart/resume same session id → transcript stays empty; prior live rows remain on disk as inactive and compaction archives still searchable

