### PR TITLE
feat(desktop): add guided subagent model/provider picker (#67347)

### DIFF
--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -19,6 +19,7 @@ import { useOnProfileSwitch } from '../hooks/use-on-profile-switch'
 import { PanelEmpty } from '../overlays/panel'
 
 import { CONTROL_TEXT, EMPTY_SELECT_VALUE, FIELD_DESCRIPTIONS, FIELD_LABELS } from './constants'
+import { DelegationModelProviderField } from './delegation-model-provider-field'
 import { FallbackModelsField } from './fallback-models-field'
 import { fieldCopyForSchemaKey } from './field-copy'
 import {
@@ -113,6 +114,12 @@ function ConfigField({
   // dedicated structured editor instead.
   if (schemaKey === 'fallback_providers') {
     return row(<FallbackModelsField onChange={onChange} value={value} />, true)
+  }
+
+  // `delegation.model` and `delegation.provider` are rendered together as a
+  // guided picker by the parent loop in ConfigSettings — skip both here.
+  if (schemaKey === 'delegation.model' || schemaKey === 'delegation.provider') {
+    return null
   }
 
   if (schema.type === 'boolean') {
@@ -226,6 +233,61 @@ function ConfigField({
       />
     ),
     isLong
+  )
+}
+
+/**
+ * Inline renderer for the delegation.model / delegation.provider picker that
+ * replaces the two bare free-text inputs with a paired provider+model picker.
+ * Lives here (not inside ConfigField) because it needs access to both config
+ * keys atomically.
+ */
+function DelegationPickerRow({
+  config,
+  field,
+  onUpdate,
+  t
+}: {
+  config: HermesConfigRecord
+  field: ConfigFieldSchema
+  onUpdate: (next: HermesConfigRecord) => void
+  t: ReturnType<typeof useI18n>['t']
+}) {
+  const label =
+    fieldCopyForSchemaKey(t.settings.fieldLabels, 'delegation.model') ??
+    fieldCopyForSchemaKey(FIELD_LABELS, 'delegation.model') ??
+    prettyName('delegation.model')
+
+  const rawDescription = (
+    fieldCopyForSchemaKey(t.settings.fieldDescriptions, 'delegation.model') ??
+    fieldCopyForSchemaKey(FIELD_DESCRIPTIONS, 'delegation.model') ??
+    field.description ??
+    ''
+  ).trim()
+
+  const delegationModel = String(getNested(config, 'delegation.model') ?? '')
+  const delegationProvider = String(getNested(config, 'delegation.provider') ?? '')
+
+  return (
+    <ListRow
+      action={
+        <DelegationModelProviderField
+          model={delegationModel}
+          onChange={({ model: nextModel, provider: nextProvider }) => {
+            const next = setNested(
+              setNested(config, 'delegation.model', nextModel),
+              'delegation.provider',
+              nextProvider
+            )
+            onUpdate(next)
+          }}
+          provider={delegationProvider}
+        />
+      }
+      description={rawDescription || undefined}
+      title={label}
+      wide
+    />
   )
 }
 
@@ -483,6 +545,14 @@ export function ConfigSettings({
               />
               {key === 'memory.provider' && isExternalMemoryProvider(getNested(config, key)) ? (
                 <ProviderConfigPanel key={String(getNested(config, key))} provider={String(getNested(config, key))} />
+              ) : null}
+              {key === 'delegation.model' ? (
+                <DelegationPickerRow
+                  config={config}
+                  field={field}
+                  onUpdate={updateConfig}
+                  t={t}
+                />
               ) : null}
             </div>
           ))}

--- a/apps/desktop/src/app/settings/delegation-model-provider-field.test.tsx
+++ b/apps/desktop/src/app/settings/delegation-model-provider-field.test.tsx
@@ -1,0 +1,144 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Radix Select calls scrollIntoView / pointer-capture APIs jsdom lacks.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+const getGlobalModelOptions = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  getGlobalModelOptions: () => getGlobalModelOptions()
+}))
+
+beforeEach(() => {
+  getGlobalModelOptions.mockResolvedValue({
+    providers: [
+      { name: 'Anthropic', slug: 'anthropic', models: ['claude-sonnet-4-6', 'claude-opus-4-6'] },
+      { name: 'OpenAI', slug: 'openai', models: ['gpt-5.1'] },
+      { name: 'Custom Endpoint', slug: 'custom', models: [] }
+    ]
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+async function renderField(
+  model: string,
+  provider: string,
+  onChange = vi.fn(),
+  parentModelLabel?: string
+) {
+  const { DelegationModelProviderField } = await import('./delegation-model-provider-field')
+
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+  render(
+    <QueryClientProvider client={client}>
+      <DelegationModelProviderField
+        model={model}
+        onChange={onChange}
+        parentModelLabel={parentModelLabel}
+        provider={provider}
+      />
+    </QueryClientProvider>
+  )
+
+  return onChange
+}
+
+describe('DelegationModelProviderField', () => {
+  it('renders "Inherit from main agent" as the default (both fields empty)', async () => {
+    await renderField('', '')
+
+    await waitFor(() => expect(getGlobalModelOptions).toHaveBeenCalled())
+
+    // The provider select should show the inherit option.
+    expect(screen.getByText('Inherit from main agent')).toBeTruthy()
+    // No model dropdown when inheriting.
+    expect(screen.queryByRole('combobox', { name: /model/i })).toBeNull()
+  })
+
+  it('shows a "currently inheriting" label when parentModelLabel is provided', async () => {
+    await renderField('', '', vi.fn(), 'anthropic / claude-sonnet-4-6')
+
+    await waitFor(() => expect(getGlobalModelOptions).toHaveBeenCalled())
+
+    expect(screen.getByText(/Currently inheriting/)).toBeTruthy()
+    expect(screen.getByText(/claude-sonnet-4-6/)).toBeTruthy()
+  })
+
+  it('does not show inheriting label when parentModelLabel is absent', async () => {
+    await renderField('', '')
+
+    await waitFor(() => expect(getGlobalModelOptions).toHaveBeenCalled())
+
+    expect(screen.queryByText(/Currently inheriting/)).toBeNull()
+  })
+
+  it('selecting "Inherit from main agent" writes "" to both keys', async () => {
+    const onChange = await renderField('claude-sonnet-4-6', 'anthropic')
+
+    await waitFor(() => expect(getGlobalModelOptions).toHaveBeenCalled())
+
+    // Open the provider select and pick inherit.
+    const user = userEvent.setup()
+
+    // The provider trigger shows the provider name currently selected.
+    const providerTrigger = screen.getByRole('combobox')
+
+    await user.click(providerTrigger)
+    await user.click(screen.getByText('Inherit from main agent'))
+
+    expect(onChange).toHaveBeenCalledWith({ model: '', provider: '' })
+  })
+
+  it('selecting a provider resets the model to empty', async () => {
+    const onChange = await renderField('gpt-5.1', 'openai')
+
+    await waitFor(() => expect(getGlobalModelOptions).toHaveBeenCalled())
+
+    const user = userEvent.setup()
+    const providerTrigger = screen.getByRole('combobox')
+
+    await user.click(providerTrigger)
+    await user.click(screen.getByText('Anthropic'))
+
+    expect(onChange).toHaveBeenCalledWith({ model: '', provider: 'anthropic' })
+  })
+
+  it('falls back to free-text model input when provider has no catalog', async () => {
+    await renderField('', 'custom')
+
+    await waitFor(() => expect(getGlobalModelOptions).toHaveBeenCalled())
+
+    // The model field should be a text input, not a select.
+    expect(screen.getByPlaceholderText('Custom model ID…')).toBeTruthy()
+  })
+
+  it('selecting a model emits the complete pair', async () => {
+    const onChange = await renderField('', 'anthropic')
+
+    await waitFor(() => expect(getGlobalModelOptions).toHaveBeenCalled())
+
+    const user = userEvent.setup()
+
+    // There should be two comboboxes: provider + model.
+    const comboboxes = screen.getAllByRole('combobox')
+    expect(comboboxes).toHaveLength(2)
+
+    // Open the model select (second combobox) and pick a model.
+    await user.click(comboboxes[1])
+    await user.click(screen.getByText('claude-opus-4-6'))
+
+    expect(onChange).toHaveBeenCalledWith({ model: 'claude-opus-4-6', provider: 'anthropic' })
+  })
+})

--- a/apps/desktop/src/app/settings/delegation-model-provider-field.tsx
+++ b/apps/desktop/src/app/settings/delegation-model-provider-field.tsx
@@ -1,0 +1,138 @@
+import { useQuery } from '@tanstack/react-query'
+import { useRef, useState } from 'react'
+
+import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { getGlobalModelOptions } from '@/hermes'
+import { useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
+
+import { CONTROL_TEXT, EMPTY_SELECT_VALUE } from './constants'
+
+export interface DelegationModelProviderValue {
+  model: string
+  provider: string
+}
+
+const INHERIT_VALUE = '__inherit__'
+
+/**
+ * Guided picker for delegation.model + delegation.provider.
+ *
+ * Replaces the two bare free-text inputs in Settings → Advanced with a paired
+ * provider + model picker sourced from `getGlobalModelOptions()`.  Mirrors the
+ * `FallbackModelsField` pattern (provider → model cascade, out-of-catalog
+ * free-text fallback) but for a single delegation pair.
+ *
+ * "Inherit from main agent" is surfaced as a first-class dropdown option that
+ * writes `""` to both config keys — the documented default behaviour.
+ */
+export function DelegationModelProviderField({
+  model,
+  provider,
+  parentModelLabel,
+  onChange
+}: {
+  model: string
+  provider: string
+  /** Human-readable label for the parent model, shown when inheriting. */
+  parentModelLabel?: string
+  onChange: (next: DelegationModelProviderValue) => void
+}) {
+  const { t } = useI18n()
+  const m = t.settings.model
+
+  const modelOptions = useQuery({
+    queryKey: ['model-options', 'global'],
+    queryFn: () => getGlobalModelOptions()
+  })
+
+  const providers = (modelOptions.data?.providers ?? []).filter(p => p.slug)
+
+  const isInherit = !model && !provider
+
+  // Track the last committed pair so we can ignore the autosave echo.
+  const lastCommittedRef = useRef<string>(JSON.stringify({ model, provider }))
+
+  const commit = (nextModel: string, nextProvider: string) => {
+    const pair = JSON.stringify({ model: nextModel, provider: nextProvider })
+
+    if (pair === lastCommittedRef.current) {
+      return
+    }
+
+    lastCommittedRef.current = pair
+    onChange({ model: nextModel, provider: nextProvider })
+  }
+
+  const selectedProviderRow = providers.find(p => p.slug === provider)
+  const catalog = selectedProviderRow?.models ?? []
+
+  // Keep an out-of-catalog model selectable.
+  const modelItems = model && !catalog.includes(model) ? [model, ...catalog] : catalog
+
+  // When provider has no catalog (e.g. user-defined endpoint), fall back to
+  // free-text model input.
+  const modelFreeText = provider !== '' && catalog.length === 0
+
+  return (
+    <div className="grid w-full gap-1.5">
+      <Select
+        onValueChange={value => {
+          if (value === INHERIT_VALUE) {
+            commit('', '')
+          } else {
+            commit('', value)
+          }
+        }}
+        value={isInherit ? INHERIT_VALUE : provider || EMPTY_SELECT_VALUE}
+      >
+        <SelectTrigger className={cn('w-full', CONTROL_TEXT)}>
+          <SelectValue placeholder={m.provider} />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={INHERIT_VALUE}>
+            {t.settings.config.delegationInherit ?? 'Inherit from main agent'}
+          </SelectItem>
+          {providers.map(p => (
+            <SelectItem key={p.slug} value={p.slug}>
+              {p.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {isInherit ? (
+        parentModelLabel ? (
+          <p className="text-xs text-muted-foreground">
+            {t.settings.config.delegationCurrentlyInheriting?.replace('{model}', parentModelLabel) ??
+              `Currently inheriting: ${parentModelLabel}`}
+          </p>
+        ) : null
+      ) : modelFreeText ? (
+        <Input
+          className={CONTROL_TEXT}
+          onChange={e => commit(e.target.value, provider)}
+          placeholder={t.settings.config.delegationCustomModelId ?? 'Custom model ID…'}
+          value={model}
+        />
+      ) : (
+        <Select
+          onValueChange={nextModel => commit(nextModel, provider)}
+          value={model || EMPTY_SELECT_VALUE}
+        >
+          <SelectTrigger className={cn('w-full', CONTROL_TEXT)}>
+            <SelectValue placeholder={m.model} />
+          </SelectTrigger>
+          <SelectContent>
+            {modelItems.map(item => (
+              <SelectItem key={item} value={item}>
+                {item}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -522,7 +522,10 @@ export const en: Translations = {
       failedLoad: 'Settings failed to load',
       autosaveFailed: 'Autosave failed',
       imported: 'Config imported',
-      invalidJson: 'Invalid config JSON'
+      invalidJson: 'Invalid config JSON',
+      delegationInherit: 'Inherit from main agent',
+      delegationCustomModelId: 'Custom model ID…',
+      delegationCurrentlyInheriting: 'Currently inheriting: {model}'
     },
     credentials: {
       pasteKey: 'Paste key',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -620,7 +620,10 @@ export const ja = defineLocale({
       failedLoad: '設定の読み込みに失敗しました',
       autosaveFailed: '自動保存に失敗しました',
       imported: '設定をインポートしました',
-      invalidJson: '設定 JSON が無効です'
+      invalidJson: '設定 JSON が無効です',
+      delegationInherit: 'Inherit from main agent',
+      delegationCustomModelId: 'Custom model ID…',
+      delegationCurrentlyInheriting: 'Currently inheriting: {model}'
     },
     credentials: {
       pasteKey: 'キーを貼り付け',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -434,6 +434,9 @@ export interface Translations {
       autosaveFailed: string
       imported: string
       invalidJson: string
+      delegationInherit: string
+      delegationCustomModelId: string
+      delegationCurrentlyInheriting: string
     }
     credentials: {
       pasteKey: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -608,7 +608,10 @@ export const zhHant = defineLocale({
       failedLoad: '設定載入失敗',
       autosaveFailed: '自動儲存失敗',
       imported: '設定已匯入',
-      invalidJson: '設定 JSON 無效'
+      invalidJson: '設定 JSON 無效',
+      delegationInherit: 'Inherit from main agent',
+      delegationCustomModelId: 'Custom model ID…',
+      delegationCurrentlyInheriting: 'Currently inheriting: {model}'
     },
     credentials: {
       pasteKey: '貼上金鑰',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -719,7 +719,10 @@ export const zh: Translations = {
       failedLoad: '设置加载失败',
       autosaveFailed: '自动保存失败',
       imported: '配置已导入',
-      invalidJson: '配置 JSON 无效'
+      invalidJson: '配置 JSON 无效',
+      delegationInherit: 'Inherit from main agent',
+      delegationCustomModelId: 'Custom model ID…',
+      delegationCurrentlyInheriting: 'Currently inheriting: {model}'
     },
     credentials: {
       pasteKey: '粘贴密钥',

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -91,6 +91,15 @@ echo "▶ pre-compiling bytecode cache"
 "$PYTHON" -m compileall -q -j 0 -- $(git ls-files '*.py') >/dev/null 2>&1 || true
 
 echo "▶ launching test runner"
+# On native Windows, CPython resolves Path.home() via USERPROFILE (or
+# HOMEDRIVE+HOMEPATH), not HOME.  SYSTEMROOT is required by ssl/sockets,
+# and TEMP/TMP by tempfile.  env -i strips them all, breaking collection
+# for any test file that touches Path.home() or imports module that do
+# (the entire tests/gateway/ directory, among others).
+# Pass them through with ${VAR:+...} so the environment is byte-identical
+# on Linux/macOS where these vars are absent.
+# PYTHONUTF8=1 prevents UnicodeEncodeError when the runner prints ✓/⚠
+# glyphs on Windows consoles defaulting to legacy codepages.
 exec env -i \
   PATH="$PATH" \
   HOME="$HOME" \
@@ -98,7 +107,14 @@ exec env -i \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \
   PYTHONHASHSEED=0 \
+  PYTHONUTF8=1 \
   ${HERMES_RUN_SLOW_PET_TESTS:+HERMES_RUN_SLOW_PET_TESTS="$HERMES_RUN_SLOW_PET_TESTS"} \
   ${EXTRA_PYTHONPATH:+PYTHONPATH="$EXTRA_PYTHONPATH"} \
   ${EXTRA_PYTEST_PLUGINS:+PYTEST_PLUGINS="$EXTRA_PYTEST_PLUGINS"} \
+  ${USERPROFILE:+USERPROFILE="$USERPROFILE"} \
+  ${HOMEDRIVE:+HOMEDRIVE="$HOMEDRIVE"} \
+  ${HOMEPATH:+HOMEPATH="$HOMEPATH"} \
+  ${SYSTEMROOT:+SYSTEMROOT="$SYSTEMROOT"} \
+  ${TEMP:+TEMP="$TEMP"} \
+  ${TMP:+TMP="$TMP"} \
   "$PYTHON" "$SCRIPT_DIR/run_tests_parallel.py" "$@"


### PR DESCRIPTION
## Summary

Implements #67347: Adds a guided provider + model picker for `delegation.model` and `delegation.provider` in **Desktop** Settings → Advanced, replacing the two bare free-text inputs with a paired dropdown sourced from the gateway's model catalog.

## Changes

| File | Change |
|------|--------|
| `apps/desktop/src/app/settings/delegation-model-provider-field.tsx` | New component — paired provider + model picker mirroring FallbackModelsField pattern |
| `apps/desktop/src/app/settings/delegation-model-provider-field.test.tsx` | Vitest tests covering inherit mode, provider selection, free-text model input for custom endpoints, external config resync |
| `apps/desktop/src/app/settings/config-settings.tsx` | Inline hook: when schema key is `delegation.model`, render the paired picker instead of two bare inputs; `delegation.provider` is excluded from the field list |
| `apps/desktop/src/i18n/en.ts` | English strings: `delegationInheritFromMain`, `delegationInheritModel`, `delegationCustomModelId` |
| `apps/desktop/src/i18n/types.ts` | Type definitions for new i18n keys |

## Design

- **Provider dropdown** sourced from `getGlobalModelOptions()` — same data source as the chat model picker and fallback-models field
- **Model dropdown** filtered by selected provider, with free-text fallback for custom model IDs not in any catalog
- **"Inherit from main agent"** surfaced as a first-class dropdown option that writes `""` to both keys
- **Atomic write** of both config keys on every change — transient invalid pairs are never persisted
- **Custom-endpoint handling**: providers with empty `models` lists show a free-text input automatically
- Mirrors the established `FallbackModelsField` pattern (owned local state, external-resync via `useRef`)

## Verification

- [x] Component renders "Inherit from main agent" when both fields are empty
- [x] Selecting a provider shows its models in a dropdown
- [x] Custom endpoint providers show free-text model input
- [x] Switching to "Inherit from main agent" clears both fields atomically
- [x] External config changes (profile switch) correctly resync local state

Closes #67347