### PR TITLE
[codex] fix(anthropic): validate image media types

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1750,12 +1750,13 @@ def _image_source_from_openai_url(url: str) -> Dict[str, str]:
         sniffed_type = _sniff_mime_from_bytes(raw)
         if sniffed_type in _ANTHROPIC_IMAGE_MEDIA_TYPES:
             media_type = sniffed_type
-        elif media_type not in _ANTHROPIC_IMAGE_MEDIA_TYPES:
+        else:
             transcoded = _transcode_to_png(raw)
             if transcoded is None:
                 raise ValueError(
-                    f"Anthropic does not support image media type {media_type!r}, "
-                    "and the image could not be converted to PNG"
+                    f"Anthropic image payload declared as {media_type!r} has an "
+                    "unsupported or unrecognized byte format and could not be "
+                    "converted to PNG"
                 )
             media_type = "image/png"
             data = base64.b64encode(transcoded).decode("ascii")

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1703,6 +1703,20 @@ def convert_tools_to_anthropic(tools: List[Dict]) -> List[Dict]:
     return result
 
 
+_ANTHROPIC_IMAGE_MEDIA_TYPES = frozenset({
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "image/webp",
+})
+_ANTHROPIC_IMAGE_MEDIA_ALIASES = {
+    "image/jpg": "image/jpeg",
+    "image/jpe": "image/jpeg",
+    "image/jfif": "image/jpeg",
+    "image/pjpeg": "image/jpeg",
+}
+
+
 def _image_source_from_openai_url(url: str) -> Dict[str, str]:
     """Convert an OpenAI-style image URL/data URL into Anthropic image source."""
     url = str(url or "").strip()
@@ -1716,6 +1730,35 @@ def _image_source_from_openai_url(url: str) -> Dict[str, str]:
             mime_part = header[len("data:"):].split(";", 1)[0].strip()
             if mime_part.startswith("image/"):
                 media_type = mime_part
+        media_type = _ANTHROPIC_IMAGE_MEDIA_ALIASES.get(media_type, media_type)
+
+        # Anthropic validates both the declared media type and the actual
+        # bytes. Correct a stale/misreported label when magic bytes identify a
+        # supported format. For unsupported raster formats, transcode instead
+        # of pretending the unchanged payload is JPEG (which still produces a
+        # provider-side 400). Vector/corrupt inputs are rejected locally with
+        # an actionable message.
+        try:
+            import base64
+
+            raw = base64.b64decode(data, validate=True)
+        except Exception as exc:
+            raise ValueError("Anthropic image data URL contains invalid base64 data") from exc
+
+        from agent.image_routing import _sniff_mime_from_bytes, _transcode_to_png
+
+        sniffed_type = _sniff_mime_from_bytes(raw)
+        if sniffed_type in _ANTHROPIC_IMAGE_MEDIA_TYPES:
+            media_type = sniffed_type
+        elif media_type not in _ANTHROPIC_IMAGE_MEDIA_TYPES:
+            transcoded = _transcode_to_png(raw)
+            if transcoded is None:
+                raise ValueError(
+                    f"Anthropic does not support image media type {media_type!r}, "
+                    "and the image could not be converted to PNG"
+                )
+            media_type = "image/png"
+            data = base64.b64encode(transcoded).decode("ascii")
         return {
             "type": "base64",
             "media_type": media_type,

--- a/contributors/emails/reymondmeking@gmail.com
+++ b/contributors/emails/reymondmeking@gmail.com
@@ -1,0 +1,1 @@
+reymondmeking-dot

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -900,12 +900,19 @@ class TestConvertMessages:
         ]
 
     def test_converts_data_url_image_blocks_to_base64_anthropic_image_blocks(self):
+        png_data = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNg"
+            "YAAAAAMAASsJTYQAAAAASUVORK5CYII="
+        )
         messages = [
             {
                 "role": "user",
                 "content": [
                     {"type": "input_text", "text": "What is in this screenshot?"},
-                    {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+                    {
+                        "type": "input_image",
+                        "image_url": f"data:image/png;base64,{png_data}",
+                    },
                 ],
             }
         ]
@@ -922,7 +929,7 @@ class TestConvertMessages:
                         "source": {
                             "type": "base64",
                             "media_type": "image/png",
-                            "data": "AAAA",
+                            "data": png_data,
                         },
                     },
                 ],
@@ -930,6 +937,10 @@ class TestConvertMessages:
         ]
 
     def test_normalizes_jpg_alias_before_anthropic_request(self):
+        image_module = pytest.importorskip("PIL.Image")
+        buffer = BytesIO()
+        image_module.new("RGB", (1, 1), color="red").save(buffer, format="JPEG")
+        jpeg_data = base64.b64encode(buffer.getvalue()).decode("ascii")
         messages = [
             {
                 "role": "user",
@@ -937,7 +948,7 @@ class TestConvertMessages:
                     {"type": "input_text", "text": "Describe this image"},
                     {
                         "type": "input_image",
-                        "image_url": "data:image/jpg;base64,QUJD",
+                        "image_url": f"data:image/jpg;base64,{jpeg_data}",
                     },
                 ],
             }
@@ -948,7 +959,7 @@ class TestConvertMessages:
         assert result[0]["content"][1]["source"] == {
             "type": "base64",
             "media_type": "image/jpeg",
-            "data": "QUJD",
+            "data": jpeg_data,
         }
 
     def test_uses_magic_bytes_when_data_url_label_is_wrong(self):
@@ -975,7 +986,7 @@ class TestConvertMessages:
         assert source["media_type"] == "image/png"
         assert source["data"] == png_data
 
-    def test_transcodes_unsupported_raster_image_to_png(self):
+    def test_transcodes_raster_bytes_even_when_declared_type_is_native(self):
         image_module = pytest.importorskip("PIL.Image")
         buffer = BytesIO()
         image_module.new("RGB", (1, 1), color="red").save(buffer, format="BMP")
@@ -987,7 +998,7 @@ class TestConvertMessages:
                     {"type": "input_text", "text": "Describe this image"},
                     {
                         "type": "input_image",
-                        "image_url": f"data:image/bmp;base64,{bmp_data}",
+                        "image_url": f"data:image/png;base64,{bmp_data}",
                     },
                 ],
             }
@@ -999,9 +1010,17 @@ class TestConvertMessages:
         assert source["media_type"] == "image/png"
         assert base64.b64decode(source["data"]).startswith(b"\x89PNG\r\n\x1a\n")
 
-    def test_rejects_unsupported_vector_image_without_mime_spoofing(self):
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            b'<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>',
+            b"not an image",
+        ],
+        ids=["svg", "corrupt"],
+    )
+    def test_rejects_unconvertible_bytes_even_when_declared_type_is_native(self, raw):
         svg_data = base64.b64encode(
-            b'<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>'
+            raw
         ).decode("ascii")
         messages = [
             {
@@ -1010,13 +1029,13 @@ class TestConvertMessages:
                     {"type": "input_text", "text": "Describe this image"},
                     {
                         "type": "input_image",
-                        "image_url": f"data:image/svg+xml;base64,{svg_data}",
+                        "image_url": f"data:image/png;base64,{svg_data}",
                     },
                 ],
             }
         ]
 
-        with pytest.raises(ValueError, match="does not support image media type"):
+        with pytest.raises(ValueError, match="could not be converted to PNG"):
             convert_messages_to_anthropic(messages)
 
     def test_converts_tool_calls(self):
@@ -1335,6 +1354,10 @@ class TestConvertMessages:
         assert assistant_blocks[1]["type"] == "tool_use"
 
     def test_converts_data_url_image_to_anthropic_image_block(self):
+        png_data = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNg"
+            "YAAAAAMAASsJTYQAAAAASUVORK5CYII="
+        )
         messages = [
             {
                 "role": "user",
@@ -1342,7 +1365,7 @@ class TestConvertMessages:
                     {"type": "text", "text": "Describe this image"},
                     {
                         "type": "image_url",
-                        "image_url": {"url": "data:image/png;base64,ZmFrZQ=="},
+                        "image_url": {"url": f"data:image/png;base64,{png_data}"},
                     },
                 ],
             }
@@ -1356,7 +1379,7 @@ class TestConvertMessages:
             "source": {
                 "type": "base64",
                 "media_type": "image/png",
-                "data": "ZmFrZQ==",
+                "data": png_data,
             },
         }
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1,5 +1,7 @@
 """Tests for agent/anthropic_adapter.py — Anthropic Messages API adapter."""
 
+import base64
+from io import BytesIO
 import json
 import sys
 import time
@@ -926,6 +928,96 @@ class TestConvertMessages:
                 ],
             }
         ]
+
+    def test_normalizes_jpg_alias_before_anthropic_request(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Describe this image"},
+                    {
+                        "type": "input_image",
+                        "image_url": "data:image/jpg;base64,QUJD",
+                    },
+                ],
+            }
+        ]
+
+        _, result = convert_messages_to_anthropic(messages)
+
+        assert result[0]["content"][1]["source"] == {
+            "type": "base64",
+            "media_type": "image/jpeg",
+            "data": "QUJD",
+        }
+
+    def test_uses_magic_bytes_when_data_url_label_is_wrong(self):
+        png_data = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNg"
+            "YAAAAAMAASsJTYQAAAAASUVORK5CYII="
+        )
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Describe this image"},
+                    {
+                        "type": "input_image",
+                        "image_url": f"data:image/svg+xml;base64,{png_data}",
+                    },
+                ],
+            }
+        ]
+
+        _, result = convert_messages_to_anthropic(messages)
+
+        source = result[0]["content"][1]["source"]
+        assert source["media_type"] == "image/png"
+        assert source["data"] == png_data
+
+    def test_transcodes_unsupported_raster_image_to_png(self):
+        image_module = pytest.importorskip("PIL.Image")
+        buffer = BytesIO()
+        image_module.new("RGB", (1, 1), color="red").save(buffer, format="BMP")
+        bmp_data = base64.b64encode(buffer.getvalue()).decode("ascii")
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Describe this image"},
+                    {
+                        "type": "input_image",
+                        "image_url": f"data:image/bmp;base64,{bmp_data}",
+                    },
+                ],
+            }
+        ]
+
+        _, result = convert_messages_to_anthropic(messages)
+
+        source = result[0]["content"][1]["source"]
+        assert source["media_type"] == "image/png"
+        assert base64.b64decode(source["data"]).startswith(b"\x89PNG\r\n\x1a\n")
+
+    def test_rejects_unsupported_vector_image_without_mime_spoofing(self):
+        svg_data = base64.b64encode(
+            b'<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>'
+        ).decode("ascii")
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Describe this image"},
+                    {
+                        "type": "input_image",
+                        "image_url": f"data:image/svg+xml;base64,{svg_data}",
+                    },
+                ],
+            }
+        ]
+
+        with pytest.raises(ValueError, match="does not support image media type"):
+            convert_messages_to_anthropic(messages)
 
     def test_converts_tool_calls(self):
         messages = [


### PR DESCRIPTION
## Summary

Fix Anthropic Messages image conversion so common JPEG aliases and unsupported image formats do not produce provider-side HTTP 400 errors.

Closes #55432.

This incorporates the useful JPEG alias handling from #55440 while addressing its review feedback: unsupported SVG/TIFF/ICO payloads are never relabeled as JPEG without changing their bytes.

## Root cause

`_image_source_from_openai_url()` forwarded the media type from an OpenAI-format data URL verbatim. Anthropic only accepts `image/jpeg`, `image/png`, `image/gif`, and `image/webp`, and it also validates that the declared type matches the actual bytes.

Consequently:

- `image/jpg` was rejected even for valid JPEG data.
- stale or incorrect labels were forwarded unchanged.
- blindly defaulting unsupported formats to `image/jpeg` would still fail because the payload bytes remained SVG/TIFF/ICO/etc.

## Fix

- Normalize JPEG-equivalent aliases such as `image/jpg` to `image/jpeg`.
- Inspect magic bytes and prefer the detected supported media type when the data URL label is wrong.
- Transcode decodable unsupported raster formats to PNG before changing the declared type.
- Reject invalid base64, vector images, corrupt data, or formats that cannot be converted with a clear local error instead of sending a doomed Anthropic request.
- Add end-to-end message-conversion regressions for aliases, mismatched labels, BMP-to-PNG conversion, and SVG rejection.

## Validation

- `python -m pytest tests/agent/test_anthropic_adapter.py -q` — 179 passed, 1 skipped
- `python -m pytest tests/agent/test_image_routing.py -k "sniff or transcode or data_url" -q` — 13 passed
- `python -m pytest tests/scripts/test_contributor_map.py -q` — 12 passed
- `python -m ruff check agent/anthropic_adapter.py tests/agent/test_anthropic_adapter.py` — passed
- `python scripts/check-windows-footguns.py agent/anthropic_adapter.py tests/agent/test_anthropic_adapter.py` — passed
- `git diff --check` — passed

The complete `test_image_routing.py` file still has seven unrelated existing Windows absolute-path extraction failures; all image MIME/sniff/transcode tests pass.

## Platform

- Windows 11
- Python 3.11+
