### PR TITLE
fix(skills): preserve existing permissions in _rmtree_writable (#67496)

### DIFF
--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -759,9 +759,11 @@ def _rmtree_writable(path: Path) -> None:
     def _on_error(func, fpath, exc_info):
         # Unlinking a child requires the parent dir to be writable, so chmod
         # the parent as well as the failing path, then retry.
+        # Merge owner rwx into the existing mode instead of replacing it, so
+        # group/other permissions survive (see #67496).
         for target in (os.path.dirname(fpath), fpath):
             try:
-                os.chmod(target, stat.S_IRWXU)
+                os.chmod(target, os.stat(target).st_mode | stat.S_IRWXU)
             except OSError:
                 pass
         func(fpath)


### PR DESCRIPTION
## Summary

`tools/skills_sync.py::_rmtree_writable()` error handler replaces a directory's full mode with `stat.S_IRWXU` (0o700), stripping all group and other permission bits. When a failure occurs on a direct child of the skills root, `os.path.dirname(fpath)` resolves to the skills root itself, so the root gets clamped to `drwx------` on every `hermes update`.

On group-shared installs (multi-user / per-role UNIX isolation), this locks out every non-owner role: they can no longer traverse the skills directory, and each agent turn dies with `PermissionError` during system-prompt construction.

## Fix

Merge owner rwx into the existing mode instead of replacing it:

```python
os.chmod(target, os.stat(target).st_mode | stat.S_IRWXU)
```

This still satisfies the original goal (making read-only entries writable enough to remove, per #34860 / #34972) while preserving group and other permissions.

## Testing

- All 69 existing `tests/tools/test_skills_sync.py` tests pass
- `py_compile` clean

Fixes #67496