### PR TITLE
fix(web): stabilize model picker provider search

### DIFF
--- a/web/src/components/ModelPickerDialog.tsx
+++ b/web/src/components/ModelPickerDialog.tsx
@@ -11,7 +11,10 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { cn, themedBody } from "@/lib/utils";
 import { fuzzyRank } from "@/lib/fuzzy";
-import { queryMatchesProviderOnly } from "@/lib/model-picker-filter";
+import {
+  filterModelPickerProviders,
+  modelQueryForSelectedProvider,
+} from "@/lib/model-picker-filter";
 
 /**
  * Two-stage model picker modal.
@@ -214,43 +217,30 @@ export function ModelPickerDialog(props: Props) {
 
   const trimmedQuery = query.trim();
 
-  // Fuzzy-ranked providers: match on name + slug + the provider's model ids so
-  // typing a model name surfaces its provider (preserves the prior behaviour
-  // where a model match also revealed its provider).
+  // Fuzzy-ranked providers: rank provider identity matches first, then include
+  // model-id-only matches in backend order. The model column filters model ids
+  // separately; ranking providers by concatenated model ids makes shared model
+  // names reorder providers unpredictably (e.g. `glm-5.2` under multiple
+  // providers), which can apply the right model through the wrong provider.
   const filteredProviders = useMemo(
-    () =>
-      fuzzyRank(
-        providers,
-        trimmedQuery,
-        (p) => `${p.name} ${p.slug} ${(p.models ?? []).join(" ")}`,
-      ).map((r) => r.item),
+    () => filterModelPickerProviders(providers, trimmedQuery),
     [providers, trimmedQuery],
   );
 
-  // A query that matched the SELECTED provider by name/slug (not its models)
-  // located that provider — it shouldn't also hide that provider's models
-  // just because their ids don't share a substring with the provider name
-  // (e.g. typing "aws" to find "AWS Build" then finding zero of its Claude
-  // model ids contain "aws"). Fall back to an unfiltered model list in that
-  // case; a query that also matches a model id keeps filtering normally.
-  const queryMatchesSelectedProviderOnly = useMemo(
-    () => queryMatchesProviderOnly(selectedProvider, models, trimmedQuery),
-    [trimmedQuery, selectedProvider, models],
+  const modelQuery = useMemo(
+    () => modelQueryForSelectedProvider(selectedProvider, models, trimmedQuery),
+    [selectedProvider, models, trimmedQuery],
   );
 
   // Fuzzy-ranked models carrying the matched character positions so the model
   // list can highlight why each entry matched.
   const filteredModels = useMemo(
     () =>
-      fuzzyRank(
-        models,
-        queryMatchesSelectedProviderOnly ? "" : trimmedQuery,
-        (m) => m,
-      ).map((r) => ({
+      fuzzyRank(models, modelQuery, (m) => m).map((r) => ({
         model: r.item,
         positions: r.positions,
       })),
-    [models, trimmedQuery, queryMatchesSelectedProviderOnly],
+    [models, modelQuery],
   );
 
   const canConfirm = !!selectedProvider && !!selectedModel && !applying;

--- a/web/src/lib/model-picker-filter.test.ts
+++ b/web/src/lib/model-picker-filter.test.ts
@@ -1,5 +1,91 @@
 import { describe, it, expect } from "vitest";
-import { queryMatchesProviderOnly } from "./model-picker-filter";
+import { fuzzyRank } from "./fuzzy";
+import {
+  filterModelPickerProviders,
+  modelQueryForSelectedProvider,
+  queryMatchesProviderOnly,
+} from "./model-picker-filter";
+
+const providers = [
+  {
+    name: "Custom GLM Gateway",
+    slug: "custom-glm",
+    models: [
+      "glm-4-flash",
+      "glm-4-plus",
+      "glm-5.2",
+      "glm-5.2-thinking",
+      "qwen-2.5-72b",
+    ],
+  },
+  {
+    name: "NVIDIA NIM",
+    slug: "nvidia-nim",
+    models: [
+      "llama-3.1-8b-instruct",
+      "mistral-7b-instruct",
+      "glm-5.2",
+      "deepseek-r1-distill-llama-70b",
+    ],
+  },
+  {
+    name: "OpenRouter",
+    slug: "openrouter",
+    models: ["claude-sonnet-4", "gpt-4o", "glm-5.2"],
+  },
+];
+
+describe("filterModelPickerProviders", () => {
+  it("keeps model-only provider matches in backend order", () => {
+    expect(
+      filterModelPickerProviders(providers, "glm-5.2").map((p) => p.slug),
+    ).toEqual(["custom-glm", "nvidia-nim", "openrouter"]);
+  });
+
+  it("still ranks provider identity matches", () => {
+    expect(
+      filterModelPickerProviders(providers, "nvidia").map((p) => p.slug),
+    ).toEqual(["nvidia-nim"]);
+  });
+
+  it("does not include providers without provider or model matches", () => {
+    expect(
+      filterModelPickerProviders(providers, "claude").map((p) => p.slug),
+    ).toEqual(["openrouter"]);
+  });
+});
+
+describe("modelQueryForSelectedProvider", () => {
+  it("keeps normal model-only filtering", () => {
+    expect(
+      modelQueryForSelectedProvider(providers[0], providers[0].models, "glm-5.2"),
+    ).toBe("glm-5.2");
+  });
+
+  it("returns an empty query when the query only locates the selected provider", () => {
+    const provider = { name: "AWS Build", slug: "aws-build" };
+    const models = ["claude-sonnet-4.5", "claude-sonnet-4", "claude-haiku-4.5"];
+
+    expect(modelQueryForSelectedProvider(provider, models, "aws")).toBe("");
+  });
+
+  it("supports mixed provider and model queries in the provider and model columns", () => {
+    const [provider] = filterModelPickerProviders(providers, "nvidia glm-5.2");
+    const modelQuery = modelQueryForSelectedProvider(
+      provider,
+      provider.models,
+      "nvidia glm-5.2",
+    );
+
+    expect(provider.slug).toBe("nvidia-nim");
+    expect(modelQuery).toBe("glm-5.2");
+    expect(
+      fuzzyRank(provider.models, modelQuery, (model) => model).map(
+        (r) => r.item,
+      ),
+    ).toEqual(["glm-5.2"]);
+  });
+});
 
 describe("queryMatchesProviderOnly", () => {
   it("returns true when the query finds the provider but no model id (issue #65374)", () => {

--- a/web/src/lib/model-picker-filter.ts
+++ b/web/src/lib/model-picker-filter.ts
@@ -1,4 +1,101 @@
-import { fuzzyScoreMulti } from "@/lib/fuzzy";
+import { fuzzyRank, fuzzyScoreMulti } from "@/lib/fuzzy";
+
+interface ModelPickerSearchProvider {
+  name: string;
+  slug: string;
+  models?: string[];
+}
+
+function providerSearchText(provider: ModelPickerSearchProvider): string {
+  return `${provider.name} ${provider.slug}`;
+}
+
+function queryTokens(query: string): string[] {
+  return query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+function tokenMatchesAnyModel(models: readonly string[], token: string): boolean {
+  return models.some((model) => fuzzyScoreMulti(model, token) != null);
+}
+
+/**
+ * Filter providers for the model picker without letting model-id matches
+ * reshuffle provider identity.
+ *
+ * Provider name/slug matches are still ranked normally. Model-only matches are
+ * included so typing a model id still surfaces providers that offer it, but
+ * those rows keep the backend order. This avoids shared model ids (for example
+ * `glm-5.2`) jumping to a different provider just because one concatenated
+ * search string scored better than another.
+ */
+export function filterModelPickerProviders<T extends ModelPickerSearchProvider>(
+  providers: readonly T[],
+  query: string,
+): T[] {
+  const trimmed = query.trim();
+
+  if (!trimmed) {
+    return [...providers];
+  }
+
+  const identityMatches = fuzzyRank(providers, trimmed, providerSearchText);
+  const identitySlugs = new Set(identityMatches.map((r) => r.item.slug));
+  const tokens = queryTokens(trimmed);
+  const modelOrMixedMatches = providers.filter((provider) => {
+    if (identitySlugs.has(provider.slug)) {
+      return false;
+    }
+
+    const identityText = providerSearchText(provider);
+    const models = provider.models ?? [];
+
+    return tokens.every(
+      (token) =>
+        fuzzyScoreMulti(identityText, token) ||
+        tokenMatchesAnyModel(models, token),
+    );
+  });
+
+  return [...identityMatches.map((r) => r.item), ...modelOrMixedMatches];
+}
+
+/**
+ * Derive the query used by the model column for the selected provider.
+ *
+ * If the query matches only the selected provider's identity, return an empty
+ * query so that provider's model list stays visible. For mixed provider+model
+ * searches like `nvidia glm-5.2`, strip the selected provider's identity terms
+ * before filtering models so the model column still shows `glm-5.2` instead of
+ * going empty on the provider token.
+ */
+export function modelQueryForSelectedProvider(
+  selectedProvider: ModelPickerSearchProvider | null,
+  models: readonly string[],
+  query: string,
+): string {
+  const trimmed = query.trim();
+
+  if (!trimmed || !selectedProvider) {
+    return trimmed;
+  }
+
+  const tokens = queryTokens(trimmed);
+
+  if (!tokens.length || tokens.every((token) => tokenMatchesAnyModel(models, token))) {
+    return trimmed;
+  }
+
+  const identityText = providerSearchText(selectedProvider);
+  const modelTokens = tokens.filter((token) => {
+    if (tokenMatchesAnyModel(models, token)) {
+      return true;
+    }
+
+    return fuzzyScoreMulti(identityText, token) == null;
+  });
+
+  return modelTokens.join(" ");
+}
 
 /**
  * True when `trimmedQuery` located the selected provider by name/slug but
@@ -12,12 +109,7 @@ export function queryMatchesProviderOnly(
   models: readonly string[],
   trimmedQuery: string,
 ): boolean {
-  if (!trimmedQuery || !selectedProvider) return false;
+  if (!trimmedQuery) return false;
 
-  const matchesProvider =
-    fuzzyScoreMulti(`${selectedProvider.name} ${selectedProvider.slug}`, trimmedQuery) !=
-    null;
-  const matchesAnyModel = models.some((m) => fuzzyScoreMulti(m, trimmedQuery) != null);
-
-  return matchesProvider && !matchesAnyModel;
+  return modelQueryForSelectedProvider(selectedProvider, models, trimmedQuery) === "";
 }


### PR DESCRIPTION
## Summary
- keep provider identity matches fuzzy-ranked in the WebUI model picker
- keep model-id-only provider matches in backend order instead of ranking providers by concatenated model ids
- add regression coverage for shared model ids like `glm-5.2` appearing under multiple providers

## Why
Typing a shared model id in the picker search, such as `glm-5.2`, could reorder providers by fuzzy-score artifacts from each provider's concatenated model list. That made it easy to select the same model under a different provider than intended (for example NVIDIA NIM instead of a custom/insert-provider-here provider).

## Test plan
- `cd web && PATH=/home/rumoto/.hermes/node/bin:$PATH npm test -- --run src/lib/model-picker-search.test.ts`
- `cd web && PATH=/home/rumoto/.hermes/node/bin:$PATH npm run check`
- `cd web && PATH=/home/rumoto/.hermes/node/bin:$PATH npm run build`
