### PR TITLE
fix(acp_adapter): soft-archive live SessionDB rows on /reset

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2338,6 +2338,10 @@ class HermesACPAgent(acp.Agent):
         ``load_session`` / ``resume_session`` does not revive the discarded
         transcript. Rows stay on disk for audit; compaction archives
         (``compacted=1``) are untouched.
+
+        Legacy compression may rotate ``state.agent.session_id`` to a child
+        while the ACP handle stays put — archive both distinct ids so the
+        durable live set is empty before the flush cursor resets.
         """
         state.history.clear()
 
@@ -2346,7 +2350,14 @@ class HermesACPAgent(acp.Agent):
             try:
                 # Soft-archive only — never DELETE. Matches rewind/undo
                 # durability; compaction archives remain searchable.
-                db.archive_live_messages(state.session_id)
+                # Archive the stable ACP handle and, when compression has
+                # rotated the agent head, the current agent session id too.
+                ids_to_archive = {state.session_id}
+                agent_sid = getattr(state.agent, "session_id", None)
+                if isinstance(agent_sid, str) and agent_sid.strip():
+                    ids_to_archive.add(agent_sid.strip())
+                for sid in ids_to_archive:
+                    db.archive_live_messages(sid)
             except Exception:
                 logger.warning(
                     "Failed to soft-archive live SessionDB messages for ACP reset %s",

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2330,19 +2330,44 @@ class HermesACPAgent(acp.Agent):
         return "\n".join(lines)
 
     def _cmd_reset(self, args: str, state: SessionState) -> str:
+        """Clear the live conversation under the same ACP session id.
+
+        ACP clients hold a stable session handle, so we cannot rotate to a new
+        id the way CLI ``/new`` does. Clear in-memory history, then soft-archive
+        live SessionDB rows (``active=1 → 0``, rewind-style) so a later
+        ``load_session`` / ``resume_session`` does not revive the discarded
+        transcript. Rows stay on disk for audit; compaction archives
+        (``compacted=1``) are untouched.
+        """
         state.history.clear()
-        reset_failed = False
-        try:
-            reset_session_state = getattr(state.agent, "reset_session_state", None)
-            if callable(reset_session_state):
-                reset_session_state()
-        except Exception:
-            reset_failed = True
-            logger.warning("ACP session state reset failed for %s", state.session_id, exc_info=True)
-        finally:
-            self.session_manager.save_session(state.session_id)
-        if reset_failed:
-            return "Conversation history cleared. Agent session state reset failed; see logs."
+
+        db = self.session_manager._get_db()
+        if db is not None:
+            try:
+                # Soft-archive only — never DELETE. Matches rewind/undo
+                # durability; compaction archives remain searchable.
+                db.archive_live_messages(state.session_id)
+            except Exception:
+                logger.warning(
+                    "Failed to soft-archive live SessionDB messages for ACP reset %s",
+                    state.session_id,
+                    exc_info=True,
+                )
+
+        agent = state.agent
+        if agent is not None:
+            # Match CLI /new: next turns must flush from an empty live set.
+            if hasattr(agent, "_last_flushed_db_idx"):
+                agent._last_flushed_db_idx = 0
+            if hasattr(agent, "reset_session_state"):
+                try:
+                    agent.reset_session_state()
+                except Exception:
+                    logger.debug(
+                        "reset_session_state failed during ACP /reset",
+                        exc_info=True,
+                    )
+
         return "Conversation history cleared."
 
     def _cmd_compress(self, args: str, state: SessionState) -> str:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6187,6 +6187,40 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
             return cursor.fetchone() is not None
 
+    def archive_live_messages(self, session_id: str) -> int:
+        """Soft-archive every live (``active = 1``) message for *session_id*.
+
+        Rewind-style durability: flip ``active → 0`` without setting
+        ``compacted = 1``, so rows stay on disk for audit but are excluded from
+        :meth:`get_messages` / :meth:`get_messages_as_conversation` and from
+        default :meth:`search_messages`. Compaction archives (already
+        ``active = 0``, ``compacted = 1``) are untouched and remain searchable.
+
+        Zeros ``sessions.message_count`` / ``tool_call_count`` to match an empty
+        live set. Returns the number of rows newly flipped inactive.
+        """
+
+        def _do(conn):
+            cursor = conn.execute(
+                "SELECT id FROM messages WHERE session_id = ? AND active = 1",
+                (session_id,),
+            )
+            ids = [r[0] for r in cursor.fetchall()]
+            if ids:
+                placeholders = ",".join("?" for _ in ids)
+                conn.execute(
+                    f"UPDATE messages SET active = 0 WHERE id IN ({placeholders})",
+                    ids,
+                )
+            conn.execute(
+                "UPDATE sessions SET message_count = 0, tool_call_count = 0 "
+                "WHERE id = ?",
+                (session_id,),
+            )
+            return len(ids)
+
+        return self._execute_write(_do)
+
     def archive_and_compact(
         self, session_id: str, compacted_messages: List[Dict[str, Any]]
     ) -> int:

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -560,6 +560,7 @@ class TestSlashCommands:
         manager = SessionManager(agent_factory=factory, db=db)
         acp_agent = HermesACPAgent(session_manager=manager)
         state = manager.create_session(cwd="/tmp")
+        state.agent.session_id = state.session_id
         db.append_message(state.session_id, "user", "discard me")
         db.append_message(state.session_id, "assistant", "old reply")
         db.archive_and_compact(
@@ -589,6 +590,77 @@ class TestSlashCommands:
         assert int(inactive["live after compact"].get("compacted") or 0) == 0
         hits = {r["session_id"] for r in db.search_messages("discard")}
         assert state.session_id in hits
+
+        # Restart contract: evict memory and restore via SessionManager._restore
+        # (load_session / resume_session path) — restored history must stay empty.
+        session_id = state.session_id
+        with manager._lock:
+            manager._sessions.pop(session_id, None)
+        restored = manager.get_session(session_id)
+        assert restored is not None
+        assert restored.history == []
+        assert db.get_messages_as_conversation(session_id) == []
+
+    def test_reset_soft_archives_compression_rotated_child(self, tmp_path):
+        """Legacy compression rotates agent.session_id to a child; /reset must
+        soft-archive both the stable ACP id and the live child head.
+        """
+        db = SessionDB(tmp_path / "state.db")
+
+        def factory(**_kwargs):
+            agent = MagicMock(name="MockAIAgent")
+            agent.model = "test-model"
+            agent.provider = "openrouter"
+            agent._session_db = db
+            agent._session_db_created = True
+            agent._last_flushed_db_idx = 3
+            agent.reset_session_state = MagicMock()
+            return agent
+
+        manager = SessionManager(agent_factory=factory, db=db)
+        acp_agent = HermesACPAgent(session_manager=manager)
+        state = manager.create_session(cwd="/tmp")
+        parent_id = state.session_id
+        child_id = "20260719_120000_abc123"
+
+        db.append_message(parent_id, "user", "parent live leftover")
+        db.create_session(
+            session_id=child_id,
+            source="acp",
+            parent_session_id=parent_id,
+        )
+        db.append_message(child_id, "user", "child live after rotation")
+        db.append_message(child_id, "assistant", "child reply")
+        state.agent.session_id = child_id
+        state.history = [
+            {"role": "user", "content": "child live after rotation"},
+            {"role": "assistant", "content": "child reply"},
+        ]
+
+        result = acp_agent._handle_slash_command("/reset", state)
+
+        assert "cleared" in result.lower()
+        assert state.history == []
+        assert state.agent._last_flushed_db_idx == 0
+        assert db.get_messages_as_conversation(parent_id) == []
+        assert db.get_messages_as_conversation(child_id) == []
+        parent_inactive = {
+            m["content"]: m
+            for m in db.get_messages(parent_id, include_inactive=True)
+        }
+        child_inactive = {
+            m["content"]: m
+            for m in db.get_messages(child_id, include_inactive=True)
+        }
+        assert parent_inactive["parent live leftover"]["active"] == 0
+        assert child_inactive["child live after rotation"]["active"] == 0
+        assert child_inactive["child reply"]["active"] == 0
+
+        with manager._lock:
+            manager._sessions.pop(parent_id, None)
+        restored = manager.get_session(parent_id)
+        assert restored is not None
+        assert restored.history == []
 
     def test_version(self, agent, mock_manager):
         state = self._make_state(mock_manager)

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -514,8 +514,86 @@ class TestSlashCommands:
         assert "cleared" in result.lower()
         assert len(state.history) == 0
 
+    def test_reset_resets_agent_session_state(self, agent, mock_manager):
+        state = self._make_state(mock_manager)
+        state.history = [{"role": "user", "content": "hello"}]
+        state.agent.reset_session_state = MagicMock()
+        state.agent._last_flushed_db_idx = 7
 
+        result = agent._handle_slash_command("/reset", state)
 
+        assert "cleared" in result.lower()
+        assert state.history == []
+        assert state.agent._last_flushed_db_idx == 0
+        state.agent.reset_session_state.assert_called_once_with()
+
+    def test_reset_continues_when_agent_state_reset_fails(self, agent, mock_manager):
+        state = self._make_state(mock_manager)
+        state.history = [{"role": "user", "content": "hello"}]
+        state.agent.reset_session_state = MagicMock(side_effect=RuntimeError("boom"))
+
+        with patch("acp_adapter.server.logger") as mock_logger:
+            result = agent._handle_slash_command("/reset", state)
+
+        assert "cleared" in result.lower()
+        assert "state reset failed" not in result.lower()
+        assert state.history == []
+        state.agent.reset_session_state.assert_called_once_with()
+        mock_logger.debug.assert_called()
+
+    def test_reset_soft_archives_live_sessiondb_rows(self, tmp_path):
+        """ACP keeps a stable session id — /reset must soft-archive live rows
+        so load/resume after restart does not revive the discarded transcript.
+        """
+        db = SessionDB(tmp_path / "state.db")
+
+        def factory(**_kwargs):
+            agent = MagicMock(name="MockAIAgent")
+            agent.model = "test-model"
+            agent.provider = "openrouter"
+            agent._session_db = db
+            agent._session_db_created = True
+            agent._last_flushed_db_idx = 4
+            agent.reset_session_state = MagicMock()
+            return agent
+
+        manager = SessionManager(agent_factory=factory, db=db)
+        acp_agent = HermesACPAgent(session_manager=manager)
+        state = manager.create_session(cwd="/tmp")
+        db.append_message(state.session_id, "user", "discard me")
+        db.append_message(state.session_id, "assistant", "old reply")
+        db.archive_and_compact(
+            state.session_id,
+            [{"role": "user", "content": "compacted keep"}],
+        )
+        db.append_message(state.session_id, "assistant", "live after compact")
+        state.history = [
+            {"role": "user", "content": "compacted keep"},
+            {"role": "assistant", "content": "live after compact"},
+        ]
+
+        result = acp_agent._handle_slash_command("/reset", state)
+
+        assert "cleared" in result.lower()
+        assert state.history == []
+        assert state.agent._last_flushed_db_idx == 0
+        state.agent.reset_session_state.assert_called_once_with()
+        assert db.get_messages_as_conversation(state.session_id) == []
+        inactive = {
+            m["content"]: m
+            for m in db.get_messages(state.session_id, include_inactive=True)
+        }
+        assert "discard me" in inactive
+        assert inactive["discard me"]["compacted"] == 1
+        assert inactive["live after compact"]["active"] == 0
+        assert int(inactive["live after compact"].get("compacted") or 0) == 0
+        hits = {r["session_id"] for r in db.search_messages("discard")}
+        assert state.session_id in hits
+
+    def test_version(self, agent, mock_manager):
+        state = self._make_state(mock_manager)
+        result = agent._handle_slash_command("/version", state)
+        assert HERMES_VERSION in result
 
     def test_compact_compresses_context(self, agent, mock_manager):
         state = self._make_state(mock_manager)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2712,6 +2712,65 @@ class TestGetMessagesPagination:
 
 
 # =========================================================================
+# archive_live_messages (ACP /reset soft-archive)
+# =========================================================================
+
+class TestArchiveLiveMessages:
+    """Soft-archive live rows rewind-style without touching compaction archives."""
+
+    def test_soft_archives_live_rows_without_deleting(self, db):
+        db.create_session("s1", source="acp")
+        db.append_message("s1", "user", "keep for audit")
+        db.append_message("s1", "assistant", "reply")
+
+        archived = db.archive_live_messages("s1")
+
+        assert archived == 2
+        assert db.get_messages("s1") == []
+        assert db.get_messages_as_conversation("s1") == []
+        inactive = db.get_messages("s1", include_inactive=True)
+        assert [m["content"] for m in inactive] == ["keep for audit", "reply"]
+        assert all(m["active"] == 0 for m in inactive)
+        # Rewind-style: not compacted=1 (those stay searchable as summaries).
+        assert all(int(m.get("compacted") or 0) == 0 for m in inactive)
+        session = db.get_session("s1")
+        assert session["message_count"] == 0
+        assert session["tool_call_count"] == 0
+
+    def test_leaves_compaction_archives_untouched(self, db):
+        db.create_session("s1", source="acp")
+        db.append_message("s1", "user", "pre-compact needle")
+        db.archive_and_compact(
+            "s1", [{"role": "user", "content": "live summary"}]
+        )
+        db.append_message("s1", "assistant", "after compact")
+
+        archived = db.archive_live_messages("s1")
+
+        assert archived == 2  # summary + after compact
+        live = db.get_messages("s1")
+        assert live == []
+        all_rows = {
+            m["content"]: m for m in db.get_messages("s1", include_inactive=True)
+        }
+        assert all_rows["pre-compact needle"]["compacted"] == 1
+        assert all_rows["pre-compact needle"]["active"] == 0
+        assert all_rows["live summary"]["compacted"] == 0
+        assert all_rows["live summary"]["active"] == 0
+        assert all_rows["after compact"]["active"] == 0
+        # Compaction archives remain discoverable via session_search.
+        hits = {r["session_id"] for r in db.search_messages("needle")}
+        assert "s1" in hits
+
+    def test_idempotent_when_no_live_rows(self, db):
+        db.create_session("s1", source="acp")
+        db.append_message("s1", "user", "once")
+        assert db.archive_live_messages("s1") == 1
+        assert db.archive_live_messages("s1") == 0
+        assert len(db.get_messages("s1", include_inactive=True)) == 1
+
+
+# =========================================================================
 # Lone-surrogate persistence
 # =========================================================================
 


### PR DESCRIPTION
## What does this PR do?

ACP clients hold a stable session id, so `/reset` cannot rotate to a new id the way CLI `/new` does. Before this change, `_cmd_reset` only cleared in-memory `state.history` (and optionally called `reset_session_state`). Live SessionDB rows stayed `active=1`, so after restart a `load_session` / `resume_session` could revive the discarded transcript.

This PR soft-archives live rows rewind-style (`active=1 → 0`, no `DELETE`), leaves compaction archives (`compacted=1`) searchable, zeros session live counters, and resets `_last_flushed_db_idx` so the next turn flushes from an empty live set.

## Related Issue

Follow-on durability gap after #65538 (which cleared counters / agent session state on `/reset`, but left live SessionDB rows loadable after restart). No dedicated issue for this soft-archive path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: add `SessionDB.archive_live_messages(session_id)` — flip live rows inactive, zero `message_count` / `tool_call_count`, leave compaction archives untouched
- `acp_adapter/server.py`: `_cmd_reset` clears history, soft-archives via SessionDB, resets `_last_flushed_db_idx`, then best-effort `reset_session_state`
- `tests/test_hermes_state.py`: `TestArchiveLiveMessages` — soft-archive, compaction-archive untouched + searchable, idempotent empty live set
- `tests/acp/test_server.py`: `/reset` soft-archives live rows across restart/load invariants; continues when agent reset fails

## How to Test

1. Unit — SessionDB helper:
   ```bash
   scripts/run_tests.sh tests/test_hermes_state.py -k ArchiveLiveMessages -q
   ```
2. Unit — ACP `/reset` path:
   ```bash
   scripts/run_tests.sh tests/acp/test_server.py -k 'reset_soft_archives or reset_resets_agent or reset_continues_when' -q
   ```
3. Manual ACP (stable session id):
   - Chat a few turns so SessionDB has live rows
   - Run `/reset` → in-memory history empty; `get_messages_as_conversation(session_id)` empty
   - Restart / resume the same ACP session id → discarded live transcript must **not** revive
   - Prior live rows remain on disk as `active=0`, `compacted=0`; pre-existing compaction archives stay searchable via `search_messages`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 14.3.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — SessionDB soft-archive behavior covered by unit tests above.
