### PR TITLE
fix(tools): skip stdout close on Windows when drain thread still active (#67362)

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -959,10 +959,16 @@ class BaseEnvironment(ABC):
         # it means the non-blocking loop itself stopped cooperating.
         drain_thread.join(timeout=2)
 
-        try:
-            proc.stdout.close()
-        except Exception:
-            pass
+        # On Windows, closing the fd while the drain thread is still blocked
+        # in os.read() serializes on the same MSVCRT per-fd lock, causing
+        # proc.stdout.close() to hang until the backgrounded child exits.
+        # Skip the close when the drain thread hasn't finished — the fd is
+        # left to the daemon thread / GC / Popen.__del__ (see #67362).
+        if not (os.name == "nt" and drain_thread.is_alive()):
+            try:
+                proc.stdout.close()
+            except Exception:
+                pass
 
         if _DEBUG_INTERRUPT:
             logger.info(


### PR DESCRIPTION
## Summary

On native Windows, `proc.stdout.close()` in `_wait_for_process` blocks until the backgrounded child exits, because it serializes on the same MSVCRT per-fd lock that the drain thread holds in `os.read()`. This makes foreground commands that background children (e.g. `cmd &`) hang for the full lifetime of the background process, even though bash has already exited and output is captured.

The POSIX path doesn't have this issue because `close()` on a pipe fd is independent of a concurrent `read()` there.

## Fix

Skip `proc.stdout.close()` on Windows when the drain thread is still alive. The fd is left to the daemon drain thread (which reaches EOF when the child eventually exits) or is reclaimed by GC / `Popen.__del__`.

```python
if not (os.name == "nt" and drain_thread.is_alive()):
    try:
        proc.stdout.close()
    except Exception:
        pass
```

## Testing

- All 11 existing `tests/tools/test_local_background_child_hang.py` tests pass
- `py_compile` clean
- The fix is Windows-only behavior; POSIX path is unchanged

Fixes #67362