### PR TITLE
fix(nix): derive npm workspace source closure from file: deps

### DIFF
--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -17,14 +17,9 @@
   ...
 }:
 let
-  # apps/shared ships as a file: workspace dep of apps/desktop, so its
-  # source must be in the filtered src tree too.
-  npm = hermesNpmLib.mkNpmPassthru {
-    dirs = [
-      "apps/desktop"
-      "apps/shared"
-    ];
-  };
+  # apps/desktop pulls @hermes/shared (apps/shared) in via a file: dep;
+  # workspaceClosure derives its dir so the source scope can't drift.
+  npm = hermesNpmLib.mkNpmPassthru { dirs = hermesNpmLib.workspaceClosure "apps/desktop"; };
 
   packageJson = builtins.fromJSON (builtins.readFile (npm.src + "/apps/desktop/package.json"));
   version = packageJson.version;

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -64,6 +64,49 @@ let
   # apps/desktop + apps/shared + ui-tui + web → [ "apps" "ui-tui" "web" ].
   jsWorkspaceTopDirs = lib.unique (map (d: builtins.head (lib.splitString "/" d)) workspaceMemberDirs);
 
+  # Transitive `file:` dependency closure of a workspace member: the member's
+  # own dir plus every workspace member it pulls in via a `file:` specifier,
+  # recursively.  That is exactly the set of dirs whose source must be present
+  # for the member to bundle, so a caller passes `workspaceClosure "ui-tui"`
+  # instead of hand-maintaining the list — which silently breaks the build the
+  # moment a new `file:` dep is added but not mirrored here (see mkNpmPassthru).
+  # Derived from each package.json, matching this file's single-source-of-truth
+  # philosophy.  Self is always first, so it stays the packageJsonPath dir.
+  workspaceClosure =
+    startDir:
+    let
+      # Collapse "." / ".." segments in a slash-joined relative path, e.g.
+      # "ui-tui/../apps/shared" → "apps/shared".
+      normalize =
+        p:
+        lib.concatStringsSep "/" (
+          lib.foldl' (acc: seg: if seg == ".." then lib.init acc else acc ++ [ seg ]) [ ] (
+            lib.filter (s: s != "" && s != ".") (lib.splitString "/" p)
+          )
+        );
+      # Dirs of a member's direct `file:` deps, resolved relative to its dir.
+      # Specs are gathered across every dependency map (not merged) so a
+      # `file:` dep can't slip through by living in optionalDependencies etc.
+      fileDepDirs =
+        dir:
+        let
+          pkg = builtins.fromJSON (builtins.readFile (repoRoot + "/${dir}/package.json"));
+          specs = lib.concatMap (m: lib.attrValues (pkg.${m} or { })) [
+            "dependencies"
+            "devDependencies"
+            "optionalDependencies"
+            "peerDependencies"
+          ];
+        in
+        map (v: normalize "${dir}/${lib.removePrefix "file:" v}") (
+          lib.filter (lib.hasPrefix "file:") specs
+        );
+      go =
+        seen: dir:
+        if lib.elem dir seen then seen else lib.foldl' go (seen ++ [ dir ]) (fileDepDirs dir);
+    in
+    go [ ] startDir;
+
   # ── Source filters for reducing rebuild scope ──────────────────────
   # Changing a .tsx/.mjs file should NOT trigger a Python venv rebuild,
   # and changing a .py file should NOT trigger a TUI/Web/Desktop rebuild.
@@ -186,7 +229,7 @@ let
     };
 in
 {
-  inherit pythonSrc;
+  inherit pythonSrc workspaceClosure;
 
   # Regenerate the shared root lockfile from scratch and verify all npm
   # packages still build.  Exposed as a runnable package — `nix run
@@ -222,10 +265,12 @@ in
   # its first entry is the package's own folder (→ packageJsonPath), and
   # all entries scope the filtered src.  Packages that import source from
   # another workspace member (file: deps) must list that member's dir too,
-  # e.g. apps/desktop depends on apps/shared.
+  # e.g. apps/desktop depends on apps/shared.  Prefer `workspaceClosure
+  # "<dir>"` over a hand-written list: it derives that closure from the
+  # package.json `file:` deps, so adding a dep can't silently break the build.
   #
   # Usage:
-  #   npm = hermesNpmLib.mkNpmPassthru { dirs = [ "ui-tui" ]; };
+  #   npm = hermesNpmLib.mkNpmPassthru { dirs = workspaceClosure "ui-tui"; };
   #   npm = hermesNpmLib.mkNpmPassthru { dirs = [ "apps/desktop" "apps/shared" ]; };
   #   pkgs.buildNpmPackage (npm // {
   #     pname = "hermes-tui";

--- a/nix/tui.nix
+++ b/nix/tui.nix
@@ -1,7 +1,9 @@
 # nix/tui.nix — Hermes TUI (Ink/React) compiled with tsc and bundled
 { pkgs, hermesNpmLib, ... }:
 let
-  npm = hermesNpmLib.mkNpmPassthru { dirs = [ "ui-tui" ]; };
+  # ui-tui pulls @hermes/shared (apps/shared) and @hermes/ink in via file:
+  # deps; workspaceClosure derives their dirs so the source scope can't drift.
+  npm = hermesNpmLib.mkNpmPassthru { dirs = hermesNpmLib.workspaceClosure "ui-tui"; };
 
   packageJson = builtins.fromJSON (builtins.readFile (npm.src + "/ui-tui/package.json"));
   version = packageJson.version;

--- a/nix/web.nix
+++ b/nix/web.nix
@@ -1,14 +1,9 @@
 # nix/web.nix — Hermes Web Dashboard (Vite/React) frontend build
 { pkgs, hermesNpmLib, ... }:
 let
-  # @hermes/shared ships as a file: workspace dep of web, so its source
-  # must be in the filtered src tree too.
-  npm = hermesNpmLib.mkNpmPassthru {
-    dirs = [
-      "web"
-      "apps/shared"
-    ];
-  };
+  # web pulls @hermes/shared (apps/shared) in via a file: dep; workspaceClosure
+  # derives its dir so the source scope can't drift.
+  npm = hermesNpmLib.mkNpmPassthru { dirs = hermesNpmLib.workspaceClosure "web"; };
 
   packageJson = builtins.fromJSON (builtins.readFile (npm.src + "/web/package.json"));
   version = packageJson.version;


### PR DESCRIPTION
## Problem

`.#tui` has been red on `main` since #51639 landed `/topup`. `ui-tui/src/app/slash/commands/topup.ts` imports `@hermes/shared/charge-settlement`, but `nix/tui.nix` scoped its source to `dirs = [ "ui-tui" ]`, so esbuild can't resolve `apps/shared` in the build sandbox:

```
ui-tui/src/app/slash/commands/topup.ts:1:62: ERROR: Could not resolve "@hermes/shared/charge-settlement"
```

## Root cause

`mkNpmPassthru`'s `dirs` is a hand-maintained allowlist that must mirror each package's `file:` deps, with nothing enforcing it. `web.nix` and `desktop.nix` had already hit this and hardcoded `apps/shared`; `tui.nix` never did — so the moment `topup.ts` pulled in `@hermes/shared`, the build broke.

## Fix

Add `workspaceClosure` to `nix/lib.nix`: it derives a member's transitive `file:`-dependency dir closure from `package.json` (gathered across every dependency map, so a `file:` dep can't slip through via `optionalDependencies` etc.). This matches the single-source-of-truth topology the rest of the file already uses (`workspaceMemberDirs`, `jsWorkspaceTopDirs`). Point `tui`/`web`/`desktop` at it.

The derived closure is **identical** to the current explicit lists for the two packages that already worked:

| package | derived closure | previous explicit `dirs` |
|---|---|---|
| web | `[web, apps/shared]` | `[web, apps/shared]` ✅ |
| desktop | `[apps/desktop, apps/shared]` | `[apps/desktop, apps/shared]` ✅ |
| tui | `[ui-tui, ui-tui/packages/hermes-ink, apps/shared]` | `[ui-tui]` ← **was broken** |

So this is a no-op for `web`/`desktop` and the fix for `tui`. New `file:` deps can no longer silently break the source scope.

## Verification

`nix build .#tui .#web .#desktop` all succeed; the built `hermes-tui` bundle now contains the `charge-settlement` code that previously failed to resolve.

Supersedes #67082 / #67090, which patch only this one instance.
