### PR TITLE
fix(verification): allow passing ad-hoc evidence when verifyCommands exist

### DIFF
--- a/agent/verification_evidence.py
+++ b/agent/verification_evidence.py
@@ -223,6 +223,22 @@ def _equivalent_needles(needle: list[str]) -> list[list[str]]:
     return candidates
 
 
+def _command_basename(token: str) -> str:
+    """Return an executable token's basename across POSIX/Windows spellings."""
+
+    name = token.replace("\\", "/").rsplit("/", 1)[-1]
+    return name[:-4] if name.lower().endswith(".exe") else name
+
+
+def _executable_basename_variant(tokens: list[str]) -> list[str]:
+    if not tokens:
+        return []
+    first = _command_basename(tokens[0])
+    if first == tokens[0]:
+        return tokens
+    return [first, *tokens[1:]]
+
+
 def _find_canonical_match(command: str, canonical_commands: list[str]) -> Optional[tuple[str, list[str]]]:
     """Return ``(canonical, trailing_args)`` for the first detected command."""
 
@@ -233,9 +249,14 @@ def _find_canonical_match(command: str, canonical_commands: list[str]) -> Option
             continue
         for tokens in segments:
             candidate_tokens = _strip_command_prefix(tokens)
-            for candidate in _equivalent_needles(needle):
-                if candidate_tokens[:len(candidate)] == candidate:
-                    return canonical, candidate_tokens[len(candidate):]
+            token_variants = [candidate_tokens]
+            basename_variant = _executable_basename_variant(candidate_tokens)
+            if basename_variant != candidate_tokens:
+                token_variants.append(basename_variant)
+            for candidate_tokens in token_variants:
+                for candidate in _equivalent_needles(needle):
+                    if candidate_tokens[:len(candidate)] == candidate:
+                        return canonical, candidate_tokens[len(candidate):]
     return None
 
 
@@ -435,7 +456,13 @@ def classify_verification_command(
     verify_commands = list(facts.get("verifyCommands") or [])
     match = _find_canonical_match(command, verify_commands)
     is_ad_hoc = False
-    if match is None and not verify_commands:
+    # Allow ad-hoc evidence even when canonical verifyCommands exist.
+    # A passing ad-hoc run (tempfile.mkstemp + hermes-verify-* prefix) is valid
+    # evidence that the workspace verification is green. We gate on exit_code==0
+    # (not on heredoc-wrapper shape) because the intent is "passed = valid",
+    # not "specific implementation shape = valid". This fixes #47237 where
+    # passing ad-hoc runs were silently dropped when verifyCommands were present.
+    if match is None and (not verify_commands or int(exit_code) == 0):
         ad_hoc_args = _find_ad_hoc_match(command, facts.get("root"))
         if ad_hoc_args is not None:
             match = ("ad-hoc verification script", ad_hoc_args)
@@ -640,6 +667,9 @@ def verification_status(
         status = "stale"
     else:
         status = evidence["status"]
+        verify_commands = [str(cmd).strip() for cmd in (facts.get("verifyCommands") or []) if str(cmd).strip()]
+        if status == "passed" and evidence.get("kind") == "ad_hoc" and verify_commands:
+            status = "targeted_passed"
     return {
         "status": status,
         "evidence": evidence,

--- a/agent/verification_stop.py
+++ b/agent/verification_stop.py
@@ -232,6 +232,9 @@ def build_verify_on_stop_nudge(
     if state == "passed":
         return None
 
+    if state == "targeted_passed" and verify_commands and attempts > 0:
+        return None
+
     # Optional shipped coding guidance, only paid when this evidence gate fires.
     try:
         from agent.verify_hooks import coding_verify_guidance
@@ -241,7 +244,16 @@ def build_verify_on_stop_nudge(
         guidance = None
     addendum = f"\n\n{guidance}" if guidance else ""
 
-    if verify_commands:
+    if state == "targeted_passed" and verify_commands:
+        command_instruction = (
+            "Targeted ad-hoc verification passed, but the detected canonical "
+            "verification command has not run yet. Run the relevant canonical "
+            "command now ("
+            + ", ".join(f"`{cmd}`" for cmd in verify_commands[:3])
+            + (", ..." if len(verify_commands) > 3 else "")
+            + "), or explicitly say that only targeted ad-hoc verification passed."
+        )
+    elif verify_commands:
         command_instruction = (
             "Run the relevant verification command now ("
             + ", ".join(f"`{cmd}`" for cmd in verify_commands[:3])

--- a/tests/agent/test_verification_evidence.py
+++ b/tests/agent/test_verification_evidence.py
@@ -28,8 +28,93 @@ def _python_project(root: Path) -> None:
 
 
 
+def test_classifies_python_module_pytest_as_detected_pytest(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _python_project(tmp_path)
+
+    evidence = classify_verification_command(
+        "python -m pytest tests/test_calc.py::test_even -q",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=1,
+        output="failed",
+    )
+
+    assert evidence is not None
+    assert evidence.canonical_command == "pytest"
+    assert evidence.kind == "test"
+    assert evidence.scope == "targeted"
+    assert evidence.status == "failed"
 
 
+def test_classifies_venv_pytest_spellings_as_detected_pytest(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _python_project(tmp_path)
+
+    commands = [
+        ".venv/bin/pytest -q",
+        str(tmp_path / ".venv" / "bin" / "pytest") + " -q",
+        ".venv/bin/python -m pytest -q",
+        str(tmp_path / ".venv" / "bin" / "python") + " -m pytest -q",
+    ]
+
+    for command in commands:
+        evidence = classify_verification_command(
+            command,
+            cwd=tmp_path,
+            session_id="s1",
+            exit_code=0,
+            output="15 passed",
+        )
+
+        assert evidence is not None, command
+        assert evidence.canonical_command == "pytest"
+        assert evidence.kind == "test"
+        assert evidence.scope == "full"
+        assert evidence.status == "passed"
+
+
+def test_records_venv_pytest_as_fresh_suite_evidence(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _python_project(tmp_path)
+    mark_workspace_edited(session_id="s1", cwd=tmp_path, paths=[str(tmp_path / "app.py")])
+
+    event = record_terminal_result(
+        command=".venv/bin/pytest -q",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+        output="15 passed",
+    )
+
+    assert event is not None
+    assert verification_status(session_id="s1", cwd=tmp_path)["status"] == "passed"
+
+
+def test_records_passed_then_marks_stale_after_edit(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+
+    event = record_terminal_result(
+        command="scripts/run_tests.sh",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+        output="all green",
+    )
+
+    assert event is not None
+    assert verification_status(session_id="s1", cwd=tmp_path)["status"] == "passed"
+
+    mark_workspace_edited(
+        session_id="s1",
+        cwd=tmp_path,
+        paths=[str(tmp_path / "src" / "app.ts")],
+    )
+
+    status = verification_status(session_id="s1", cwd=tmp_path)
+    assert status["status"] == "stale"
+    assert status["changed_paths"] == [str(tmp_path / "src" / "app.ts")]
 
 
 def test_lint_and_typecheck_are_not_reported_as_full_tests(tmp_path, monkeypatch):
@@ -107,14 +192,165 @@ def test_temp_script_records_ad_hoc_evidence_without_canonical_suite(tmp_path, m
     assert evidence.status == "passed"
 
 
+def test_unprefixed_temp_script_is_not_ad_hoc_evidence(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+    script = Path(tempfile.gettempdir()) / f"random-check-{tmp_path.name}.py"
+    script.write_text("print('ok')\n", encoding="utf-8")
+    try:
+        evidence = classify_verification_command(
+            f"python {script}",
+            cwd=tmp_path,
+            session_id="s1",
+            exit_code=0,
+            output="ok",
+        )
+    finally:
+        script.unlink(missing_ok=True)
+
+    assert evidence is None
 
 
+def test_temp_script_does_not_replace_detected_suite(tmp_path, monkeypatch):
+    # A passing temporary script is worth recording as targeted evidence, but
+    # it must not masquerade as the detected canonical suite.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    script = Path(tempfile.gettempdir()) / f"hermes-ad-hoc-{tmp_path.name}.py"
+    script.write_text("print('ok')\n", encoding="utf-8")
+    try:
+        evidence = classify_verification_command(
+            f"python {script}",
+            cwd=tmp_path,
+            session_id="s1",
+            exit_code=0,
+            output="ok",
+        )
+    finally:
+        script.unlink(missing_ok=True)
+
+    assert evidence is not None
+    assert evidence.kind == "ad_hoc"
+    assert evidence.canonical_command == "ad-hoc verification script"
+    assert evidence.scope == "targeted"
+    assert evidence.status == "passed"
 
 
+def test_passed_ad_hoc_with_verify_commands_is_targeted_not_suite_green(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    mark_workspace_edited(session_id="s1", cwd=tmp_path, paths=[str(tmp_path / "src/index.ts")])
+    script = Path(tempfile.gettempdir()) / f"hermes-verify-{tmp_path.name}.py"
+    script.write_text("print('ok')\n", encoding="utf-8")
+    try:
+        record_terminal_result(
+            command=f"python {script}",
+            cwd=tmp_path,
+            session_id="s1",
+            exit_code=0,
+            output="ok",
+        )
+        status = verification_status(session_id="s1", cwd=tmp_path)
+    finally:
+        script.unlink(missing_ok=True)
+
+    assert status["status"] == "targeted_passed"
+    assert status["evidence"] is not None
+    assert status["evidence"]["kind"] == "ad_hoc"
 
 
+def test_failed_ad_hoc_is_skipped_when_verify_commands_exist(tmp_path, monkeypatch):
+    # Regression: a *failing* ad-hoc run in a workspace with canonical
+    # verifyCommands does not prove the workspace is green, so it must
+    # still be dropped.  The exit_code==0 gate in classify_verification_command
+    # is what separates the passing case (recorded) from the failing case (skipped).
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    script = Path(tempfile.gettempdir()) / f"hermes-ad-hoc-{tmp_path.name}.py"
+    script.write_text("import sys; sys.exit(1)\n", encoding="utf-8")
+    try:
+        evidence = classify_verification_command(
+            f"python {script}",
+            cwd=tmp_path,
+            session_id="s1",
+            exit_code=1,
+            output="assertion failed",
+        )
+    finally:
+        script.unlink(missing_ok=True)
+
+    assert evidence is None
 
 
+def test_passed_ad_hoc_recorded_when_verify_commands_exist_clears_stale_to_targeted(
+    tmp_path, monkeypatch,
+):
+    # End-to-end verification_status() behavior: after mark_workspace_edited()
+    # on the node project, a passing ad-hoc run (with verifyCommands present)
+    # records targeted evidence so verification_status() reports
+    # "targeted_passed", not full suite "passed".
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    mark_workspace_edited(session_id="s1", cwd=tmp_path, paths=[str(tmp_path / "src/index.ts")])
+    script = Path(tempfile.gettempdir()) / f"hermes-verify-{tmp_path.name}.py"
+    script.write_text("print('ok')\n", encoding="utf-8")
+    try:
+        record_terminal_result(
+            command=f"python {script}",
+            cwd=tmp_path,
+            session_id="s1",
+            exit_code=0,
+            output="ok",
+        )
+        status = verification_status(session_id="s1", cwd=tmp_path)
+    finally:
+        script.unlink(missing_ok=True)
+
+    assert status["status"] == "targeted_passed"
+    assert status["evidence"] is not None
+    assert status["evidence"]["kind"] == "ad_hoc"
+
+
+def test_non_temp_script_is_not_ad_hoc_evidence(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+    script = tmp_path / "scripts" / "repro.py"
+    script.parent.mkdir()
+    script.write_text("print('ok')\n", encoding="utf-8")
+
+    evidence = classify_verification_command(
+        f"python {script}",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+        output="ok",
+    )
+
+    assert evidence is None
+
+
+def test_status_is_unverified_without_evidence(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+
+    assert verification_status(session_id="s1", cwd=tmp_path)["status"] == "unverified"
+
+
+def test_edit_without_prior_evidence_stays_unverified(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+
+    mark_workspace_edited(
+        session_id="s1",
+        cwd=tmp_path,
+        paths=[str(tmp_path / "src" / "app.ts")],
+    )
+
+    status = verification_status(session_id="s1", cwd=tmp_path)
+    assert status["status"] == "unverified"
+    assert status["changed_paths"] == [str(tmp_path / "src" / "app.ts")]
 
 
 def test_file_tool_stales_evidence_by_session_id_for_absolute_edit(tmp_path, monkeypatch):

--- a/tests/agent/test_verification_stop.py
+++ b/tests/agent/test_verification_stop.py
@@ -187,6 +187,43 @@ def test_ad_hoc_pass_satisfies_no_suite_stop_loop(tmp_path, monkeypatch):
     assert build_verify_on_stop_nudge(session_id="s1", changed_paths=[changed]) is None
 
 
+def test_targeted_ad_hoc_pass_gets_one_canonical_nudge_then_stops(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    changed = str(tmp_path / "src" / "app.ts")
+    mark_workspace_edited(session_id="s1", cwd=tmp_path, paths=[changed])
+    script = Path(tempfile.gettempdir()) / f"hermes-verify-stop-{tmp_path.name}.py"
+    script.write_text("print('targeted ok')\n", encoding="utf-8")
+    try:
+        record_terminal_result(
+            command=f"python {script}",
+            cwd=tmp_path,
+            session_id="s1",
+            exit_code=0,
+            output="targeted ok",
+        )
+    finally:
+        script.unlink(missing_ok=True)
+
+    first_nudge = build_verify_on_stop_nudge(
+        session_id="s1",
+        changed_paths=[changed],
+        attempts=0,
+    )
+    assert first_nudge is not None
+    assert "targeted ad-hoc verification passed" in first_nudge
+    assert "canonical" in first_nudge
+    assert "`pnpm run test`" in first_nudge
+
+    assert build_verify_on_stop_nudge(
+        session_id="s1",
+        changed_paths=[changed],
+        attempts=1,
+    ) is None
+
+
 def test_nudge_attempts_are_bounded(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
     _node_project(tmp_path)


### PR DESCRIPTION
## Problem

The verify-on-stop guard can produce repeated no-progress nudges after a passing targeted ad-hoc verification run in a workspace that also has canonical `verifyCommands`.

The real symptom is not that ad-hoc verification should replace the canonical suite. The problem is that the stop guard needs to distinguish:

- canonical suite passed,
- targeted ad-hoc verification passed,
- no fresh verification evidence.

## Fix

This rework preserves the canonical-suite contract while avoiding the loop:

- Passing ad-hoc verification in a workspace with canonical `verifyCommands` is recorded as targeted evidence.
- `verification_status()` reports this as `targeted_passed`, not full `passed`.
- `verification_stop` emits at most one differentiated nudge that says targeted ad-hoc verification passed but canonical verification has not run yet.
- On subsequent attempts, the stop guard does not repeat the same no-progress nudge.
- When no canonical commands exist, existing ad-hoc behavior remains unchanged.

## Tests

- Added regression coverage that `targeted_passed` is not suite-green.
- Added stop-guard coverage that targeted ad-hoc pass gets one canonical nudge, then stops.
- Kept failing ad-hoc runs from suppressing canonical verification.

## Verification

```text
python -m pytest tests/agent/test_verification_evidence.py::test_passed_ad_hoc_with_verify_commands_is_targeted_not_suite_green tests/agent/test_verification_stop.py::test_targeted_ad_hoc_pass_gets_one_canonical_nudge_then_stops -q
2 passed in 0.28s

python -m pytest tests/agent/test_verification_evidence.py tests/agent/test_verification_stop.py -q
31 passed in 3.76s

python -m pytest tests/agent -q -k verification
32 passed, 4711 deselected, 35 warnings in 18.96s

ruff check / py_compile on changed files
OK
```
