### PR TITLE
fix(cron): reapply terminal config after .env reload in standalone runs (#67323)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3038,6 +3038,16 @@ def run_job(
         reset_secret_source_cache()
         load_hermes_dotenv(hermes_home=_get_hermes_home())
 
+        # Reapply terminal config after .env reload — dotenv uses override
+        # semantics, so stale .env values can replace the terminal backend
+        # and related settings that were bridged at startup (see #67323).
+        try:
+            from hermes_cli.config import apply_terminal_config_to_env
+            apply_terminal_config_to_env()
+        except Exception:
+            logger.debug("terminal config reapply failed after .env reload",
+                         exc_info=True)
+
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:
             _VAR_MAP["HERMES_CRON_AUTO_DELIVER_PLATFORM"].set(delivery_target["platform"])


### PR DESCRIPTION
## Summary

The standalone cron run path loads `.env` with override semantics after terminal config was already bridged into environment variables at startup. Stale `.env` values (e.g. `TERMINAL_BACKEND=docker`) overwrite the selected terminal backend and related settings, causing cron jobs to run with wrong terminal configuration.

## Fix

Reapply `apply_terminal_config_to_env()` after each `load_hermes_dotenv()` call in the per-job run path (`cron/scheduler.py`). This mirrors the existing pattern in the dashboard/serve startup path (`hermes_cli/main.py:12511-12513`).

The reapply is wrapped in try/except since terminal config bridging is best-effort — a failure here should not prevent the job from running.

## Testing

- All 49 cron-related tests pass
- `py_compile` clean

Fixes #67323