### PR TITLE
feat(discord): allowlist bot senders by ID

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -888,6 +888,10 @@ platform_toolsets:
 #
 # discord:
 #   require_mention: true            # Require @mention in server channels (default: true)
+#   thread_require_mention: true     # Require @mention inside threads too
+#   allow_bots: mentions             # none, mentions, or all
+#   bot_allow_from: []               # Discord bot user IDs allowed by allow_bots
+#   bots_require_inline_mention: true # Ignore reply pings from bots; require a typed @mention
 #   auto_thread: true                # Auto-create thread on @mention (default: true)
 #   free_response_channels: ""       # Channel IDs where no mention is needed
 #   reactions: true                  # Show processing reactions (default: true)

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -372,6 +372,15 @@ class GatewayAuthorizationMixin:
         if getattr(source, "is_bot", False):
             allow_bots_var = platform_allow_bots_map.get(source.platform)
             if allow_bots_var and os.getenv(allow_bots_var, "none").lower().strip() in {"mentions", "all"}:
+                if source.platform == Platform.DISCORD:
+                    raw_allowed_bots = os.getenv("DISCORD_ALLOWED_BOTS", "").strip()
+                    if raw_allowed_bots:
+                        allowed_bots = {
+                            bot_id.strip()
+                            for bot_id in raw_allowed_bots.split(",")
+                            if bot_id.strip()
+                        }
+                        return bool(user_id and user_id in allowed_bots)
                 return True
 
         if not user_id:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2533,6 +2533,8 @@ DEFAULT_CONFIG = {
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
         "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
         "bots_require_inline_mention": False,  # Multi-bot rooms: if True, another bot must type @thisbot in its message to trigger a reply; a Discord reply/quote alone won't. Prevents two bots auto-replying to each other forever. Does not affect humans.
+        "allow_bots": "none",          # none, mentions, or all
+        "bot_allow_from": [],           # Optional Discord bot user-ID allowlist
         "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block
         "missed_message_backfill": {

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1269,6 +1269,8 @@ class DiscordAdapter(BasePlatformAdapter):
             allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
             if allow_bots == "none":
                 return False, False
+            if not _discord_bot_id_is_allowed(getattr(message.author, "id", None)):
+                return False, False
             if allow_bots == "mentions" and not self._self_is_explicitly_mentioned(message):
                 return False, False
             if (
@@ -5953,7 +5955,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 if (
                     is_bot_author
                     and msg.author != self._client.user
-                    and not include_other_bots
+                    and (
+                        not include_other_bots
+                        or not _discord_bot_id_is_allowed(getattr(msg.author, "id", None))
+                    )
                 ):
                     return None
                 if not content and msg.attachments:
@@ -9204,6 +9209,15 @@ def _clean_discord_user_ids(raw: str) -> list:
     return cleaned
 
 
+def _discord_bot_id_is_allowed(author_id: Any) -> bool:
+    """Return whether a bot ID passes the optional Discord bot allowlist."""
+    raw = os.getenv("DISCORD_ALLOWED_BOTS", "").strip()
+    if not raw:
+        return True
+    allowed = {value.strip() for value in raw.split(",") if value.strip()}
+    return author_id is not None and str(author_id) in allowed
+
+
 def interactive_setup() -> None:
     """Guide the user through Discord bot setup.
 
@@ -9312,6 +9326,13 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         os.environ["DISCORD_THREAD_REQUIRE_MENTION"] = str(discord_cfg["thread_require_mention"]).lower()
     if "bots_require_inline_mention" in discord_cfg and not os.getenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION"):
         os.environ["DISCORD_BOTS_REQUIRE_INLINE_MENTION"] = str(discord_cfg["bots_require_inline_mention"]).lower()
+    if "allow_bots" in discord_cfg and not os.getenv("DISCORD_ALLOW_BOTS"):
+        os.environ["DISCORD_ALLOW_BOTS"] = str(discord_cfg["allow_bots"]).lower()
+    bot_allow_from_cfg = discord_cfg.get("bot_allow_from")
+    if bot_allow_from_cfg is not None and not os.getenv("DISCORD_ALLOWED_BOTS"):
+        if isinstance(bot_allow_from_cfg, list):
+            bot_allow_from_cfg = ",".join(str(v) for v in bot_allow_from_cfg)
+        os.environ["DISCORD_ALLOWED_BOTS"] = str(bot_allow_from_cfg)
     platforms_cfg = yaml_cfg.get("platforms")
     platform_extra_cfg = {}
     if isinstance(platforms_cfg, dict):

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -810,6 +810,46 @@ class TestLoadGatewayConfig:
 
         assert os.environ.get("DISCORD_BOTS_REQUIRE_INLINE_MENTION") == "true"
 
+    def test_bridges_discord_bot_admission_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "discord:\n"
+            "  allow_bots: mentions\n"
+            "  bot_allow_from:\n"
+            "    - \"123456789012345678\"\n"
+            "    - \"999888777666555444\"\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_ALLOW_BOTS", raising=False)
+        monkeypatch.delenv("DISCORD_ALLOWED_BOTS", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ.get("DISCORD_ALLOW_BOTS") == "mentions"
+        assert os.environ.get("DISCORD_ALLOWED_BOTS") == (
+            "123456789012345678,999888777666555444"
+        )
+
+    def test_discord_bot_admission_env_does_not_overwrite_env(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "discord:\n"
+            "  allow_bots: mentions\n"
+            "  bot_allow_from: [\"123\"]\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+        monkeypatch.setenv("DISCORD_ALLOWED_BOTS", "456")
+
+        load_gateway_config()
+
+        assert os.environ.get("DISCORD_ALLOW_BOTS") == "all"
+        assert os.environ.get("DISCORD_ALLOWED_BOTS") == "456"
+
     def test_bridges_discord_allow_from_from_config_yaml(self, tmp_path, monkeypatch):
         """discord.allow_from should populate DISCORD_ALLOWED_USERS for auth."""
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_discord_bot_auth_bypass.py
+++ b/tests/gateway/test_discord_bot_auth_bypass.py
@@ -28,6 +28,7 @@ def _isolate_discord_env(monkeypatch):
     """
     for var in (
         "DISCORD_ALLOW_BOTS",
+        "DISCORD_ALLOWED_BOTS",
         "DISCORD_ALLOWED_USERS",
         "DISCORD_ALLOWED_ROLES",
         "DISCORD_ALLOW_ALL_USERS",
@@ -107,6 +108,23 @@ def test_discord_bot_authorized_when_allow_bots_all(monkeypatch):
 
     source = _make_discord_bot_source()
     assert runner._is_user_authorized(source) is True
+
+
+def test_discord_bot_authorized_when_id_is_allowlisted(monkeypatch):
+    runner = _make_bare_runner()
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    monkeypatch.setenv("DISCORD_ALLOWED_BOTS", "999888777,111222333")
+
+    assert runner._is_user_authorized(_make_discord_bot_source("999888777")) is True
+
+
+def test_discord_bot_rejected_when_id_is_not_allowlisted(monkeypatch):
+    runner = _make_bare_runner()
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    monkeypatch.setenv("DISCORD_ALLOWED_BOTS", "111222333")
+    monkeypatch.setenv("DISCORD_ALLOWED_USERS", "999888777")
+
+    assert runner._is_user_authorized(_make_discord_bot_source("999888777")) is False
 
 
 def test_discord_bot_NOT_authorized_when_allow_bots_none(monkeypatch):

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -3,7 +3,11 @@
 import os
 import re
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+import plugins.platforms.discord.adapter as discord_platform
+from plugins.platforms.discord.adapter import DiscordAdapter, _discord_bot_id_is_allowed
 
 
 def _make_author(*, bot: bool = False, is_self: bool = False):
@@ -217,6 +221,56 @@ class TestDiscordBotFilter(unittest.TestCase):
         self.assertTrue(self._run_filter(msg, "All"))
         self.assertFalse(self._run_filter(msg, "NONE"))
         self.assertFalse(self._run_filter(msg, "None"))
+
+
+def test_bot_id_allowlist_is_optional(monkeypatch):
+    monkeypatch.delenv("DISCORD_ALLOWED_BOTS", raising=False)
+
+    assert _discord_bot_id_is_allowed("12345") is True
+
+
+def test_bot_id_allowlist_accepts_only_configured_ids(monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOWED_BOTS", "12345, 67890")
+
+    assert _discord_bot_id_is_allowed(12345) is True
+    assert _discord_bot_id_is_allowed("67890") is True
+    assert _discord_bot_id_is_allowed("99999") is False
+    assert _discord_bot_id_is_allowed(None) is False
+
+
+def test_live_admission_rejects_unlisted_bot(monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    monkeypatch.setenv("DISCORD_ALLOWED_BOTS", "67890")
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = SimpleNamespace(user=SimpleNamespace(id=99999, bot=True))
+    adapter._dedup = SimpleNamespace(contains=lambda _message_id: False)
+    adapter._discord_bots_require_inline_mention = lambda: False
+    message = SimpleNamespace(
+        id=1,
+        author=SimpleNamespace(id=12345, bot=True),
+        type=discord_platform.discord.MessageType.default,
+    )
+
+    assert adapter._discord_message_admission(message, claim=False) == (False, False)
+
+
+def test_live_admission_accepts_allowlisted_bot(monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    monkeypatch.setenv("DISCORD_ALLOWED_BOTS", "12345")
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = SimpleNamespace(user=SimpleNamespace(id=99999, bot=True))
+    adapter._dedup = SimpleNamespace(contains=lambda _message_id: False)
+    adapter._discord_bots_require_inline_mention = lambda: False
+    message = SimpleNamespace(
+        id=1,
+        author=SimpleNamespace(id=12345, bot=True),
+        type=discord_platform.discord.MessageType.default,
+        channel=SimpleNamespace(),
+        mentions=[],
+        content="hello",
+    )
+
+    assert adapter._discord_message_admission(message, claim=False) == (True, False)
 
 
 if __name__ == "__main__":

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -1092,6 +1092,28 @@ class TestChannelContextUnverifiedTagging:
         assert "[Gemini [bot]] bot note" in result
 
     @pytest.mark.asyncio
+    async def test_bot_allowlist_filters_history_context(self, adapter, monkeypatch):
+        monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+        monkeypatch.setenv("DISCORD_ALLOWED_BOTS", "58")
+        adapter.config.extra["history_backfill_limit"] = 10
+        allowed_bot = SimpleNamespace(id=58, display_name="Allowed", name="Allowed", bot=True)
+        blocked_bot = SimpleNamespace(id=59, display_name="Blocked", name="Blocked", bot=True)
+        channel = FakeHistoryChannel(
+            [
+                make_history_message(author=allowed_bot, content="trusted", msg_id=1),
+                make_history_message(author=blocked_bot, content="untrusted", msg_id=2),
+            ],
+            channel_id=123,
+        )
+
+        result = await adapter._fetch_channel_context(
+            channel, before=make_message(channel=channel, content="trigger"),
+        )
+
+        assert "[Allowed [bot]] trusted" in result
+        assert "untrusted" not in result
+
+    @pytest.mark.asyncio
     async def test_auth_check_receives_chat_type_group_for_plain_channel(self, adapter, monkeypatch):
         monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
         adapter.config.extra["history_backfill_limit"] = 10
@@ -1485,4 +1507,3 @@ async def test_discord_non_reply_free_channel_skips_backfill(adapter, monkeypatc
     await adapter._handle_message(message)
 
     adapter._fetch_channel_context.assert_not_awaited()
-

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -302,6 +302,7 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_IGNORE_NO_MENTION` | No | `true` | When `true`, the bot stays silent if a message `@mentions` other users but does **not** mention the bot. Prevents the bot from jumping into conversations directed at other people. Only applies in server channels, not DMs. |
 | `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every `@mention` in a text channel, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. |
 | `DISCORD_ALLOW_BOTS` | No | `"none"` | Controls how the bot handles messages from other Discord bots. `"none"` — ignore all other bots. `"mentions"` — only accept bot messages that `@mention` Hermes. `"all"` — accept all bot messages. |
+| `DISCORD_ALLOWED_BOTS` | No | — | Optional comma-separated Discord bot user IDs. When set, `DISCORD_ALLOW_BOTS` accepts only these bots. Prefer `discord.bot_allow_from` in `config.yaml`; this env var remains available as an override. |
 | `DISCORD_REACTIONS` | No | `true` | When `true`, the bot adds emoji reactions to messages during processing (👀 when starting, ✅ on success, ❌ on error). Set to `false` to disable reactions entirely. |
 | `DISCORD_IGNORED_CHANNELS` | No | — | Comma-separated channel IDs where the bot **never** responds, even when `@mentioned`. Takes priority over all other channel settings. |
 | `DISCORD_ALLOWED_CHANNELS` | No | — | Comma-separated channel IDs. When set, the bot **only** responds in these channels (plus DMs if allowed). Overrides `config.yaml` `discord.allowed_channels`. Combine with `DISCORD_IGNORED_CHANNELS` to express allow/deny rules. |
@@ -319,10 +320,8 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS` | No | `0.6` | Grace window the adapter waits before flushing a queued text chunk. Useful for smoothing streamed output. |
 | `HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS` | No | `2.0` | Delay between split chunks when a single message exceeds Discord's length limit. |
 
-:::warning Bot-to-bot conversation is not supported
-`DISCORD_ALLOW_BOTS` exists to accept input from a specific trusted bot (e.g. a relay or webhook bot), not to let two Hermes profiles talk to each other. The default, `"none"`, ignores all other bots and is the safe setting.
-
-Wiring multiple Hermes profiles to reply to one another in a shared channel — by setting `"mentions"` or `"all"` across several profiles — is an unsupported topology. Discord auto-`@mentions` the replied-to author on every reply, so under `"mentions"` two bots will satisfy each other's mention gate indefinitely and ack-loop. There is no circuit breaker for this because the supported configuration is simply to leave `DISCORD_ALLOW_BOTS` at `"none"`. If you must accept a particular bot, scope the acceptance narrowly and never to another auto-replying agent.
+:::warning Avoid bot reply loops
+Discord auto-`@mentions` the replied-to author on replies, so several auto-replying bots can acknowledge each other indefinitely. Keep `allow_bots: none` unless bot input is required. When it is, set `bot_allow_from` to trusted bot IDs and enable `bots_require_inline_mention` so reply pings do not trigger another bot turn.
 :::
 
 ### Config File (`config.yaml`)
@@ -334,6 +333,9 @@ The `discord` section in `~/.hermes/config.yaml` mirrors the env vars above. Con
 discord:
   require_mention: true           # Require @mention in server channels
   thread_require_mention: false   # If true, require @mention in threads too (multi-bot threads)
+  allow_bots: none                # none, mentions, or all
+  bot_allow_from: []              # Optional list of trusted Discord bot user IDs
+  bots_require_inline_mention: false # Require bot authors to type the @mention
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
   reactions: true                 # Add emoji reactions during processing
@@ -377,6 +379,25 @@ discord:
   require_mention: true
   thread_require_mention: true    # multi-bot setup
 ```
+
+#### `discord.allow_bots` and `discord.bot_allow_from`
+
+`allow_bots` controls whether messages from other Discord bots are accepted:
+`none` (default), `mentions`, or `all`. `bot_allow_from` optionally narrows
+that policy to specific Discord bot user IDs.
+
+```yaml
+discord:
+  allow_bots: mentions
+  bot_allow_from:
+    - "123456789012345678"
+    - "999888777666555444"
+  bots_require_inline_mention: true
+```
+
+With this configuration, only the listed bots can trigger Hermes, and each
+must type Hermes' `@mention` in the message body. Human authorization remains
+controlled separately by `discord.allow_from`, roles, or pairing.
 
 #### `discord.free_response_channels`
 
@@ -904,5 +925,4 @@ Leave `everyone` and `roles` at `false` unless you know exactly why you need the
 :::
 
 For more information on securing your Hermes Agent deployment, see the [Security Guide](../security.md).
-
 


### PR DESCRIPTION
## What does this PR do?

Adds an optional Discord bot-user-ID allowlist. Today `DISCORD_ALLOW_BOTS=mentions|all` bypasses the human allowlist for every bot account, so operators cannot trust one relay or peer bot without trusting every bot that can reach the channel.

The new `discord.bot_allow_from` list narrows `discord.allow_bots` to named bot IDs. With no bot allowlist configured, existing behavior is unchanged.

The restriction is enforced in all three relevant paths: live message admission, gateway authorization, and channel-history backfill.

## Related Issue

No exact issue or PR was found after searching open, closed, and merged work.

Related but distinct:

- #56605 prevents reply-ping-only bot loops.
- #25719 covers user-OAuth peer agents, not Discord bot accounts.
- #34654 isolates bot-authored context but retains all-or-nothing bot admission.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `discord.allow_bots` and `discord.bot_allow_from` to structured config.
- Bridge those settings to the existing Discord runtime configuration.
- Reject unlisted bot IDs at live ingress and gateway authorization.
- Exclude unlisted bots from history backfill.
- Document the safe multi-bot configuration with inline mention gating.

## How to Test

1. Set `discord.allow_bots: mentions` and list one bot ID under `discord.bot_allow_from`.
2. Confirm that listed bot can trigger Hermes with an explicit mention.
3. Confirm that an unlisted bot is ignored and excluded from history context.

Automated locally:

```text
scripts/run_tests.sh tests/gateway/test_discord_bot_filter.py tests/gateway/test_discord_bot_auth_bypass.py tests/gateway/test_config.py tests/gateway/test_discord_free_response.py -q
203 passed

scripts/run_tests.sh tests/gateway/test_discord_double_dispatch.py tests/gateway/test_discord_missed_message_backfill.py tests/gateway/test_discord_slash_auth.py tests/gateway/relay/test_relay_policy_send.py -q
109 passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing issues and PRs for duplicates
- [x] My PR contains only related changes
- [x] I've run the repository test wrapper and all selected tests pass
- [x] I've added tests for the change
- [x] Tested on macOS 26.5.2 arm64

### Documentation & Housekeeping

- [x] Updated the Discord documentation
- [x] Updated `cli-config.yaml.example`
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact checked; Windows footgun scan passed
- [x] Tool descriptions/schemas: N/A
