### PR TITLE
fix(docs): update providers.md to use keyed schema format (fixes #67278)

### DIFF
--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1151,7 +1151,7 @@ Set `model.max_tokens` only when you need to limit how long individual responses
 Hermes uses a multi-source resolution chain to detect the correct context window for your model and provider:
 
 1. **Config override** — `model.context_length` in config.yaml (highest priority)
-2. **Custom provider per-model** — `custom_providers[].models.<id>.context_length`
+2. **Custom provider per-model** — `providers.<name>.models.<id>.context_length`
 3. **Persistent cache** — previously discovered values (survives restarts)
 4. **Endpoint `/models`** — queries your server's API (local/custom endpoints)
 5. **Anthropic `/v1/models`** — queries Anthropic's API for `max_input_tokens` (API-key users only)
@@ -1174,8 +1174,8 @@ model:
 For custom endpoints, you can also set context length per model:
 
 ```yaml
-custom_providers:
-  - name: "My Local LLM"
+providers:
+  my-local:
     base_url: "http://localhost:11434/v1"
     models:
       qwen3.5:27b:
@@ -1199,15 +1199,15 @@ custom_providers:
 If you work with multiple custom endpoints (e.g., a local dev server and a remote GPU server), you can define them as named custom providers in `config.yaml`:
 
 ```yaml
-custom_providers:
-  - name: local
+providers:
+  local:
     base_url: http://localhost:8080/v1
     # api_key omitted — Hermes uses "no-key-required" for keyless local servers
-  - name: work
+  work:
     base_url: https://gpu-server.internal.corp/v1
     key_env: CORP_API_KEY
     api_mode: chat_completions   # set explicitly by `hermes model` → Custom Endpoint wizard; auto-detection still happens as a fallback
-  - name: anthropic-proxy
+  anthropic-proxy:
     base_url: https://proxy.example.com/anthropic
     key_env: ANTHROPIC_PROXY_KEY
     api_mode: anthropic_messages  # for Anthropic-compatible proxies
@@ -1216,8 +1216,8 @@ custom_providers:
 Some OpenAI-compatible endpoints need provider-specific request body fields. Add an `extra_body` map to the matching custom provider and Hermes will merge it into each chat-completions request for that endpoint:
 
 ```yaml
-custom_providers:
-  - name: gemma-local
+providers:
+  gemma-local:
     base_url: http://localhost:8080/v1
     model: google/gemma-4-31b-it
     extra_body:
@@ -1253,7 +1253,7 @@ model:
   supports_vision: true   # send images natively; otherwise vision_analyze pre-describes them
 ```
 
-The same key is honored on per-named-provider models (`custom_providers[*].models[*].supports_vision`) and accepts standard YAML booleans (`true/false/yes/no/on/off/1/0`).
+The same key is honored on per-named-provider models (`providers.<name>.models[*].supports_vision`) and accepts standard YAML booleans (`true/false/yes/no/on/off/1/0`).
 
 Switch between them mid-session with the triple syntax:
 
@@ -1269,7 +1269,7 @@ You can also select named custom providers from the interactive `hermes model` m
 
 ### Cookbook: Together AI, Groq, Perplexity
 
-The cloud providers listed in [Other Compatible Providers](#other-compatible-providers) all speak OpenAI's REST dialect, so they wire up the same way under `custom_providers:`. Three worked recipes follow. Each drops into `~/.hermes/config.yaml` and the matching API key goes in `~/.hermes/.env`.
+The cloud providers listed in [Other Compatible Providers](#other-compatible-providers) all speak OpenAI's REST dialect, so they wire up the same way under `providers:`. Three worked recipes follow. Each drops into `~/.hermes/config.yaml` and the matching API key goes in `~/.hermes/.env`.
 
 #### Together AI
 
@@ -1277,8 +1277,8 @@ Hosts open-weight models (Llama, MiniMax, Gemma, DeepSeek, Qwen) at prices signi
 
 ```yaml
 # ~/.hermes/config.yaml
-custom_providers:
-  - name: together
+providers:
+  together:
     base_url: https://api.together.xyz/v1
     key_env: TOGETHER_API_KEY
     # api_mode: chat_completions  # default — no need to set
@@ -1309,8 +1309,8 @@ Ultra-fast inference (~500 tok/s on Llama-3.3-70B). Small catalog but strong for
 
 ```yaml
 # ~/.hermes/config.yaml
-custom_providers:
-  - name: groq
+providers:
+  groq:
     base_url: https://api.groq.com/openai/v1
     key_env: GROQ_API_KEY
 
@@ -1330,8 +1330,8 @@ Useful when you want a model that does live web search and citation automaticall
 
 ```yaml
 # ~/.hermes/config.yaml
-custom_providers:
-  - name: perplexity
+providers:
+  perplexity:
     base_url: https://api.perplexity.ai
     key_env: PERPLEXITY_API_KEY
 
@@ -1350,14 +1350,14 @@ PERPLEXITY_API_KEY=your-perplexity-key
 The three recipes compose — use all of them together and switch per turn with `/model custom:<name>:<model>`:
 
 ```yaml
-custom_providers:
-  - name: together
+providers:
+  together:
     base_url: https://api.together.xyz/v1
     key_env: TOGETHER_API_KEY
-  - name: groq
+  groq:
     base_url: https://api.groq.com/openai/v1
     key_env: GROQ_API_KEY
-  - name: perplexity
+  perplexity:
     base_url: https://api.perplexity.ai
     key_env: PERPLEXITY_API_KEY
 
@@ -1369,7 +1369,7 @@ model:
 :::tip Troubleshooting
 - `hermes doctor` should print no `Unknown provider` warnings for any of these names after the CLI validator fixes in #15083.
 - If a provider's `/v1/models` endpoint is unreachable (Perplexity is the common one), `hermes model` will persist the model with a warning rather than hard-reject — see #15136.
-- To skip `custom_providers:` entirely and use bare `provider: custom` with `CUSTOM_BASE_URL` env var, see #15103.
+- To skip `providers:` entirely and use bare `provider: custom` with `CUSTOM_BASE_URL` env var, see #15103.
 :::
 
 ---


### PR DESCRIPTION
## Problem

The online documentation at https://hermes-agent.nousresearch.com/docs/integrations/providers#named-custom-providers still shows the legacy `custom_providers:` list format, while the codebase has migrated to the `providers:` keyed schema since v12. Both formats are supported at runtime, but the docs should guide users to the newer format.

## Changes

- Replace all `custom_providers:` list examples with `providers:` keyed dict format across 9 code blocks (context_length, named custom providers, extra_body, Together AI, Groq, Perplexity, and multi-provider examples)
- Update inline code references from `custom_providers[]` to `providers.<name>`
- Update prose references from `custom_providers:` to `providers:`

## Verification

- All code blocks render correctly as valid YAML
- The `custom_providers` legacy format is still documented as supported (the section header and the runtime code reference remain unchanged)

Fixes #67278