### PR TITLE
feat(agent): assistant-turn repetition guard — nudge identical no-progress turns, opt-in clean abort

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -579,6 +579,8 @@ def init_agent(
     agent._executing_tools = False
     agent._tool_guardrails = ToolCallGuardrailController()
     agent._tool_guardrail_halt_decision: ToolGuardrailDecision | None = None
+    from agent.repetition_guard import AssistantRepetitionGuard
+    agent._repetition_guard = AssistantRepetitionGuard()
 
     # Interrupt mechanism for breaking out of tool loops
     agent._interrupt_requested = False
@@ -1415,6 +1417,18 @@ def init_agent(
         )
     except Exception as _tlg_err:
         _ra().logger.warning("Tool loop guardrail config ignored: %s", _tlg_err)
+    try:
+        from agent.repetition_guard import (
+            AssistantRepetitionGuard,
+            RepetitionGuardConfig,
+        )
+        agent._repetition_guard = AssistantRepetitionGuard(
+            RepetitionGuardConfig.from_mapping(
+                _agent_cfg.get("repetition_guard", {})
+            )
+        )
+    except Exception as _rg_err:
+        _ra().logger.warning("Repetition guard config ignored: %s", _rg_err)
     # Cache only the derived auxiliary compression context override that is
     # needed later by the startup feasibility check.  Avoid exposing a
     # broad pseudo-public config object on the agent instance.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5077,6 +5077,62 @@ def run_conversation(
                                 pass
                     break
 
+                # ── Assistant-turn repetition guard ────────────────────
+                # The tool guardrails above key on tool results, so they
+                # cannot see the loop where every tool call SUCCEEDS but
+                # the model keeps emitting the identical message + tool
+                # calls without progress (e.g. re-screenshotting a page
+                # that changes by a few pixels while narrating the same
+                # "verifying the scene" line indefinitely).  Detect the
+                # repeated assistant turn itself and inject a corrective
+                # user message after this round's tool results; with
+                # ``repetition_guard.abort_enabled`` set, continued
+                # repetition after the nudge ends the turn cleanly.
+                _rep_action = "ok"
+                try:
+                    _rep_guard = getattr(agent, "_repetition_guard", None)
+                    if _rep_guard is not None:
+                        _rep_action = _rep_guard.observe(assistant_msg)
+                except Exception:
+                    logger.debug("repetition guard check failed", exc_info=True)
+                    _rep_action = "ok"
+
+                if _rep_action == "abort":
+                    _turn_exit_reason = "repetition_guard_abort"
+                    final_response = (
+                        "I stopped this run: the last several steps repeated "
+                        "the same action without making progress, even after "
+                        "a corrective notice. The session history is "
+                        "preserved — you can resume with new instructions or "
+                        "narrow the task."
+                    )
+                    agent._emit_status(
+                        "⚠️ Repetition guard ended the turn: identical steps kept repeating"
+                    )
+                    messages.append({"role": "assistant", "content": final_response})
+                    agent._safe_print(f"\n{final_response}\n")
+                    if agent.stream_delta_callback:
+                        try:
+                            agent.stream_delta_callback(final_response)
+                            agent.stream_delta_callback(None)
+                        except Exception:
+                            pass
+                    break
+                if _rep_action == "nudge":
+                    from agent.repetition_guard import REPETITION_NUDGE_MESSAGE
+                    messages.append({
+                        "role": "user",
+                        "content": REPETITION_NUDGE_MESSAGE,
+                        "_repetition_guard_synthetic": True,
+                    })
+                    agent._session_messages = messages
+                    logger.info(
+                        "repetition guard nudge issued (identical assistant turn repeated)"
+                    )
+                    agent._emit_status(
+                        "⚠️ Repeated identical steps detected — nudging the model to change approach"
+                    )
+
                 # Reset per-turn retry counters after successful tool
                 # execution so a single truncation doesn't poison the
                 # entire conversation.

--- a/agent/repetition_guard.py
+++ b/agent/repetition_guard.py
@@ -1,0 +1,162 @@
+"""Assistant-turn repetition guard.
+
+Complements ``agent.tool_guardrails``, which keys on tool *results* (repeated
+failures, identical read-only results). That guardrail cannot see the loop
+where every tool call *succeeds* but the assistant keeps emitting the same
+message with the same tool calls — e.g. re-screenshotting a page that changes
+by a few pixels each frame while narrating the identical "verifying the
+scene" line, indefinitely.
+
+This guard keys on the assistant turn itself: a signature over the visible
+content plus the tool-call names/arguments. When the same signature keeps
+recurring, the runtime injects a corrective user message (nudge); if the
+model still repeats after being told and hard aborts are enabled, the runtime
+ends the turn cleanly instead of burning the iteration budget.
+
+Like ``tool_guardrails``, this module is side-effect free: it tracks
+observations and returns decisions; the conversation loop owns what those
+decisions become (a synthetic user message, a controlled turn halt).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from agent.message_content import flatten_message_text
+
+
+REPETITION_NUDGE_MESSAGE = (
+    "[Repetition guard] Your recent turns repeated the same message and the "
+    "same tool calls without making progress. Do not repeat this step again. "
+    "Take a materially different action — a different tool, different "
+    "arguments, or a different approach — or state clearly why you are "
+    "blocked and stop."
+)
+
+
+@dataclass(frozen=True)
+class RepetitionGuardConfig:
+    """Thresholds for assistant-turn repetition detection.
+
+    Nudges are enabled by default and never prevent tool execution — they only
+    append a corrective user message after the repeated turn's tool results.
+    Hard aborts are explicit opt-in (mirroring ``tool_loop_guardrails``'s
+    ``hard_stop_enabled``) because legitimate workflows can repeat identical
+    turns for a while (e.g. polling a build), and a nudged model that keeps
+    polling on purpose should be allowed to.
+    """
+
+    enabled: bool = True
+    window: int = 5           # how many recent turns the nudge check looks at
+    nudge_after: int = 3      # identical turns within the window → nudge
+    abort_enabled: bool = False
+    abort_after: int = 2      # identical turns AFTER the nudge → abort
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | None) -> "RepetitionGuardConfig":
+        """Build config from the ``repetition_guard`` config.yaml section."""
+        if not isinstance(data, Mapping):
+            return cls()
+        defaults = cls()
+        return cls(
+            enabled=_as_bool(data.get("enabled"), defaults.enabled),
+            window=_positive_int(data.get("window"), defaults.window),
+            nudge_after=_positive_int(data.get("nudge_after"), defaults.nudge_after),
+            abort_enabled=_as_bool(data.get("abort_enabled"), defaults.abort_enabled),
+            abort_after=_positive_int(data.get("abort_after"), defaults.abort_after),
+        )
+
+
+def assistant_turn_signature(assistant_msg: Mapping[str, Any]) -> str:
+    """Stable identity for an assistant turn: visible text + tool calls.
+
+    Tool-call ids are excluded — they are freshly generated per API call, so
+    including them would make every turn unique. Reasoning is also excluded:
+    two turns that produce the same visible action are the same step from the
+    outside, regardless of how the model talked itself into it.
+    """
+    content_text = flatten_message_text(assistant_msg.get("content")).strip()
+    calls = []
+    for tc in assistant_msg.get("tool_calls") or []:
+        if not isinstance(tc, Mapping):
+            continue
+        fn = tc.get("function") or {}
+        if not isinstance(fn, Mapping):
+            fn = {}
+        calls.append((str(fn.get("name") or ""), str(fn.get("arguments") or "")))
+    canonical = json.dumps(
+        {"content": content_text, "tool_calls": calls},
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+class AssistantRepetitionGuard:
+    """Tracks recent assistant-turn signatures and decides nudge/abort."""
+
+    def __init__(self, config: RepetitionGuardConfig | None = None):
+        self.config = config or RepetitionGuardConfig()
+        self.reset_for_turn()
+
+    def reset_for_turn(self) -> None:
+        self._recent: deque[str] = deque(maxlen=max(1, self.config.window))
+        self._nudged_sig: str | None = None
+        self._post_nudge_repeats = 0
+
+    def observe(self, assistant_msg: Mapping[str, Any]) -> str:
+        """Record one assistant turn; return ``"ok"``, ``"nudge"``, or ``"abort"``.
+
+        ``"nudge"`` may be returned repeatedly for the same signature — every
+        post-nudge repeat re-injects the corrective message so the pressure
+        does not decay as the transcript grows.
+        """
+        if not self.config.enabled:
+            return "ok"
+
+        sig = assistant_turn_signature(assistant_msg)
+        self._recent.append(sig)
+
+        if self._nudged_sig == sig:
+            self._post_nudge_repeats += 1
+            if self.config.abort_enabled and self._post_nudge_repeats >= self.config.abort_after:
+                return "abort"
+            return "nudge"
+
+        if list(self._recent).count(sig) >= self.config.nudge_after:
+            self._nudged_sig = sig
+            self._post_nudge_repeats = 0
+            return "nudge"
+
+        return "ok"
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on", "enabled"}:
+            return True
+        if lowered in {"0", "false", "no", "off", "disabled"}:
+            return False
+    return default
+
+
+def _positive_int(value: Any, default: int) -> int:
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 1 else default

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -390,6 +390,9 @@ def build_turn_context(
     agent._unicode_sanitization_passes = 0
     agent._tool_guardrails.reset_for_turn()
     agent._tool_guardrail_halt_decision = None
+    _rep_guard = getattr(agent, "_repetition_guard", None)
+    if _rep_guard is not None:
+        _rep_guard.reset_for_turn()
     _reset_consol = getattr(agent._memory_store, "reset_consolidation_failures", None)
     if callable(_reset_consol):
         _reset_consol()

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -386,6 +386,26 @@ tool_loop_guardrails:
     idempotent_no_progress: 5
 
 # =============================================================================
+# Assistant-Turn Repetition Guard
+# =============================================================================
+# Catches the model repeating the same message + tool calls turn after turn
+# even though every tool call succeeds — invisible to tool_loop_guardrails,
+# which keys on tool results (a live-page screenshot differs slightly on every
+# capture, so its result hash never repeats). After `nudge_after` identical
+# turns within the last `window` turns, a corrective user message is injected
+# telling the model to change approach or report the blocker. With
+# `abort_enabled`, `abort_after` further identical turns after the nudge end
+# the turn cleanly with a resumable session. Abort is opt-in: legitimate
+# workflows (e.g. polling a build until it finishes) repeat identical turns
+# on purpose.
+repetition_guard:
+  enabled: true
+  window: 5
+  nudge_after: 3
+  abort_enabled: false
+  abort_after: 2
+
+# =============================================================================
 # Context Compression (Auto-shrinks long conversations)
 # =============================================================================
 # When conversation approaches model's context limit, middle turns are

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1447,6 +1447,21 @@ DEFAULT_CONFIG = {
         },
     },
 
+    # Assistant-turn repetition guard: detects the model emitting the same
+    # message + tool calls over and over even though every tool call succeeds
+    # (which tool_loop_guardrails cannot see). A corrective user message is
+    # injected after `nudge_after` identical turns within `window`; with
+    # abort_enabled, `abort_after` further identical turns end the turn
+    # cleanly. Abort is opt-in because legitimate workflows (e.g. polling a
+    # build) may repeat identical turns on purpose.
+    "repetition_guard": {
+        "enabled": True,
+        "window": 5,
+        "nudge_after": 3,
+        "abort_enabled": False,
+        "abort_after": 2,
+    },
+
     "compression": {
         "enabled": True,
         "threshold": 0.50,            # compress when context usage exceeds this ratio.

--- a/tests/agent/test_repetition_guard.py
+++ b/tests/agent/test_repetition_guard.py
@@ -1,0 +1,146 @@
+"""Assistant-turn repetition guard primitive tests."""
+
+from agent.repetition_guard import (
+    AssistantRepetitionGuard,
+    RepetitionGuardConfig,
+    assistant_turn_signature,
+)
+
+
+def _turn(content="Verifying the scene:", args='{"action": "screenshot"}'):
+    return {
+        "role": "assistant",
+        "content": content,
+        "tool_calls": [
+            {
+                "id": "call_abc123",
+                "type": "function",
+                "function": {"name": "browser", "arguments": args},
+            }
+        ],
+    }
+
+
+def test_signature_ignores_tool_call_ids_and_reasoning():
+    a = _turn()
+    a["reasoning"] = "first attempt"
+    b = _turn()
+    b["reasoning"] = "second attempt, different thoughts"
+    b["tool_calls"][0]["id"] = "call_zzz999"
+
+    assert assistant_turn_signature(a) == assistant_turn_signature(b)
+
+
+def test_signature_distinguishes_different_arguments():
+    a = _turn(args='{"action": "screenshot"}')
+    b = _turn(args='{"action": "click", "x": 10}')
+
+    assert assistant_turn_signature(a) != assistant_turn_signature(b)
+
+
+def test_signature_flattens_list_content():
+    a = _turn(content=[{"type": "text", "text": "hello"}])
+    b = _turn(content="hello")
+
+    assert assistant_turn_signature(a) == assistant_turn_signature(b)
+
+
+def test_default_config_nudges_but_never_aborts():
+    guard = AssistantRepetitionGuard()
+
+    assert guard.observe(_turn()) == "ok"
+    assert guard.observe(_turn()) == "ok"
+    assert guard.observe(_turn()) == "nudge"
+    # Post-nudge repeats keep nudging; abort stays off by default.
+    for _ in range(10):
+        assert guard.observe(_turn()) == "nudge"
+
+
+def test_varied_turns_never_trigger():
+    guard = AssistantRepetitionGuard()
+
+    for i in range(20):
+        assert guard.observe(_turn(args=f'{{"step": {i}}}')) == "ok"
+
+
+def test_abort_fires_after_post_nudge_repeats_when_enabled():
+    guard = AssistantRepetitionGuard(
+        RepetitionGuardConfig(abort_enabled=True)
+    )
+
+    assert guard.observe(_turn()) == "ok"
+    assert guard.observe(_turn()) == "ok"
+    assert guard.observe(_turn()) == "nudge"
+    assert guard.observe(_turn()) == "nudge"
+    assert guard.observe(_turn()) == "abort"
+
+
+def test_progress_between_repeats_defers_the_nudge():
+    guard = AssistantRepetitionGuard()
+
+    assert guard.observe(_turn()) == "ok"
+    assert guard.observe(_turn(args='{"action": "click"}')) == "ok"
+    assert guard.observe(_turn()) == "ok"
+    assert guard.observe(_turn(args='{"action": "type"}')) == "ok"
+    # Third identical within the 5-turn window → nudge.
+    assert guard.observe(_turn()) == "nudge"
+
+
+def test_old_repeats_age_out_of_the_window():
+    guard = AssistantRepetitionGuard()
+
+    assert guard.observe(_turn()) == "ok"
+    assert guard.observe(_turn()) == "ok"
+    for i in range(5):
+        assert guard.observe(_turn(args=f'{{"step": {i}}}')) == "ok"
+    # The two early repeats have aged out — this is 1 of 5, not 3 of 5.
+    assert guard.observe(_turn()) == "ok"
+
+
+def test_reset_for_turn_clears_state():
+    guard = AssistantRepetitionGuard()
+
+    guard.observe(_turn())
+    guard.observe(_turn())
+    guard.observe(_turn())
+    guard.reset_for_turn()
+    assert guard.observe(_turn()) == "ok"
+    assert guard.observe(_turn()) == "ok"
+
+
+def test_disabled_guard_returns_ok():
+    guard = AssistantRepetitionGuard(RepetitionGuardConfig(enabled=False))
+
+    for _ in range(10):
+        assert guard.observe(_turn()) == "ok"
+
+
+def test_config_from_mapping_parses_and_falls_back():
+    cfg = RepetitionGuardConfig.from_mapping(
+        {
+            "enabled": "yes",
+            "window": 7,
+            "nudge_after": 2,
+            "abort_enabled": True,
+            "abort_after": "3",
+        }
+    )
+    assert cfg.enabled is True
+    assert cfg.window == 7
+    assert cfg.nudge_after == 2
+    assert cfg.abort_enabled is True
+    assert cfg.abort_after == 3
+
+    defaults = RepetitionGuardConfig.from_mapping(None)
+    assert defaults.enabled is True
+    assert defaults.abort_enabled is False
+    assert defaults.window == 5
+    assert defaults.nudge_after == 3
+    assert defaults.abort_after == 2
+
+    garbage = RepetitionGuardConfig.from_mapping(
+        {"window": -3, "nudge_after": "lots", "abort_after": 0}
+    )
+    assert garbage.window == 5
+    assert garbage.nudge_after == 3
+    assert garbage.abort_after == 2


### PR DESCRIPTION
## What does this PR do?

Adds an **assistant-turn repetition guard** that catches the loop `tool_loop_guardrails` cannot see: the model emitting the identical assistant message + identical tool calls turn after turn while **every tool call succeeds**.

Observed on a long unattended browser-testing run (moonshotai/kimi-k3 via OpenRouter, Windows 11): the model repeated the same narration ("… Starting gameplay to verify the actual scene:") with the same screenshot call every iteration until `max_iterations`. The existing guardrails never fired because:

- the failure counters only see *failing* tool calls — these all succeeded
- the idempotent no-progress detector hashes tool *results* — a live-page screenshot differs by a few pixels per capture, so the hash never repeats

The guard keys on the assistant turn itself: sha256 over the flattened visible content plus tool-call names/arguments (tool-call ids and reasoning excluded — ids are per-call unique, and two turns with the same outward action are the same step regardless of how the model talked itself into it). Behavior:

- **3 identical turns within the last 5** → inject a corrective user message after that round's tool results (default **on**; the message tells the model to take a materially different action or report the blocker)
- **continued repetition after the nudge** → end the turn cleanly with a resumable session (**opt-in** via `repetition_guard.abort_enabled`, default off — polling workflows legitimately repeat identical turns on purpose)

Design mirrors `agent/tool_guardrails.py`: a pure, side-effect-free controller; config parsed from a `config.yaml` section with the same conventions; per-turn reset in the turn prologue; the runtime owns what decisions become (synthetic user message / controlled halt).

## Related Issue

No open issue for this. Complementary to the outer-loop deterministic-error handling from #66267: that change stops retrying local processing *bugs*; this one stops semantic no-progress loops where nothing errors at all.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/repetition_guard.py` — new pure controller (`AssistantRepetitionGuard`, `RepetitionGuardConfig`, `assistant_turn_signature`)
- `agent/conversation_loop.py` — observe the built assistant message right after the tool-guardrail halt check; append the nudge after tool results, or perform a controlled clean abort
- `agent/turn_context.py` — per-turn guard reset alongside `_tool_guardrails.reset_for_turn()`
- `agent/agent_init.py` — default + config-driven construction (mirrors the tool-guardrail wiring)
- `hermes_cli/config.py` — `repetition_guard` defaults
- `cli-config.yaml.example` — documented section
- `tests/agent/test_repetition_guard.py` — 11 unit tests (signature stability, window aging, nudge/abort thresholds, config parsing, disabled mode)

## How to Test

1. `pytest tests/agent/test_repetition_guard.py -q` — unit coverage
2. `pytest tests/agent/test_tool_guardrails.py tests/run_agent/test_tool_call_guardrail_runtime.py -q` — neighboring guardrail suites unaffected
3. Manual: run a long browser/vision session with a loop-prone model; after 3 identical turns the corrective `[Repetition guard]` user message appears in the transcript. With `repetition_guard: {abort_enabled: true}` in config.yaml, 2 further identical turns end the turn with a clean, resumable message instead of spending the whole iteration budget.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the relevant suites (`tests/agent`, plus the guardrail runtime suite) — the full `tests/` run on this machine carries pre-existing environment-dependent failures that are identical with and without this change (verified by an A/B sweep of `tests/agent`, ~5.7k tests each way)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`cli-config.yaml.example`, module docstrings)
- [x] I've updated `cli-config.yaml.example` for the new config keys
- [x] I've considered cross-platform impact (pure Python, no platform-specific code)
- [x] Tool descriptions/schemas — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
