### PR TITLE
fix(desktop): recover first-submit draft when session.resume 404s (#67502)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -468,16 +468,26 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             // backend loop (#55578 symptom d) rejects the submit even though
             // the stored session is fine — resume + retry instead of erroring
             // out and losing the session binding.
-            const resumed = await requestGateway<{ session_id: string }>('session.resume', {
-              session_id: recoverStoredSessionId,
-              source: 'desktop'
-            })
+            let recoveredId: string | null | undefined
+            try {
+              const resumed = await requestGateway<{ session_id: string }>('session.resume', {
+                session_id: recoverStoredSessionId,
+                source: 'desktop'
+              })
+              recoveredId = resumed?.session_id
+            } catch (resumeErr) {
+              // The stored session row doesn't exist (never-persisted draft:
+              // session.create was called but the first prompt.submit never
+              // landed, so _ensure_session_db_row never ran). Mint a fresh
+              // backend session instead of surfacing the error (#67502).
+              if (isSessionNotFoundError(resumeErr)) {
+                recoveredId = await createBackendSessionForSend(visibleText)
+              }
+            }
 
             if (sessionContextDrifted()) {
               return abortForSessionSwitch(sessionId)
             }
-
-            const recoveredId = resumed?.session_id
 
             if (recoveredId) {
               if (targetIsCurrentView()) {


### PR DESCRIPTION
## Summary

Submitting the first message of a new chat fails with "Prompt failed / session not found" when the gateway's in-memory session is cleared between `session.create` and the first `prompt.submit` (sleep/wake, network blip, gateway restart).

The sleep/wake recovery path calls `session.resume` without try/catch. For a never-persisted draft (no DB row because `_ensure_session_db_row` only runs on the first successful submit), the resume itself throws 4007 "session not found" — the error escapes to the outer catch and surfaces as the dead-end toast. Every retry hits the same loop.

## Fix

Wrap the recovery `session.resume` in try/catch. When resume fails with session-not-found (the never-persisted-draft signature), mint a fresh backend session via `createBackendSessionForSend` so the message lands instead of being dropped.

## Testing

- Existing chats still use resume+retry recovery (the try/catch only activates when resume itself 404s)
- New drafts that were never persisted now get a fresh session instead of the dead-end toast
- Non-session-not-found resume errors still surface normally

Fixes #67502