### PR TITLE
fix(acp_adapter): re-apply session MCP servers after model switch

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -789,6 +789,58 @@ class HermesACPAgent(acp.Agent):
         loop = asyncio.get_running_loop()
         loop.call_soon(asyncio.create_task, self._send_usage_update(state))
 
+    def _apply_session_mcp_servers(
+        self,
+        state: SessionState,
+        mcp_servers: list[McpServerStdio | McpServerHttp | McpServerSse],
+    ) -> None:
+        """Synchronously register ACP MCP servers and refresh the agent tool surface."""
+        from tools.mcp_tool import register_mcp_servers
+        from model_tools import get_tool_definitions
+        from agent.memory_manager import inject_memory_provider_tools
+
+        config_map: dict[str, dict] = {}
+        for server in mcp_servers:
+            name = server.name
+            if isinstance(server, McpServerStdio):
+                config = {
+                    "command": server.command,
+                    "args": list(server.args),
+                    "env": {item.name: item.value for item in server.env},
+                }
+            else:
+                config = {
+                    "url": server.url,
+                    "headers": {item.name: item.value for item in server.headers},
+                }
+            config_map[name] = config
+
+        register_mcp_servers(config_map)
+
+        enabled_toolsets = _expand_acp_enabled_toolsets(
+            getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"],
+            mcp_server_names=[server.name for server in mcp_servers],
+        )
+        state.agent.enabled_toolsets = enabled_toolsets
+        disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
+        state.agent.tools = get_tool_definitions(
+            enabled_toolsets=enabled_toolsets,
+            disabled_toolsets=disabled_toolsets,
+            quiet_mode=True,
+        )
+        state.agent.valid_tool_names = {
+            tool["function"]["name"] for tool in state.agent.tools or []
+        }
+        inject_memory_provider_tools(state.agent)
+        invalidate = getattr(state.agent, "_invalidate_system_prompt", None)
+        if callable(invalidate):
+            invalidate()
+        logger.info(
+            "Session %s: refreshed tool surface after ACP MCP registration (%d tools)",
+            state.session_id,
+            len(state.agent.tools or []),
+        )
+
     async def _register_session_mcp_servers(
         self,
         state: SessionState,
@@ -799,25 +851,7 @@ class HermesACPAgent(acp.Agent):
             return
 
         try:
-            from tools.mcp_tool import register_mcp_servers
-
-            config_map: dict[str, dict] = {}
-            for server in mcp_servers:
-                name = server.name
-                if isinstance(server, McpServerStdio):
-                    config = {
-                        "command": server.command,
-                        "args": list(server.args),
-                        "env": {item.name: item.value for item in server.env},
-                    }
-                else:
-                    config = {
-                        "url": server.url,
-                        "headers": {item.name: item.value for item in server.headers},
-                    }
-                config_map[name] = config
-
-            await asyncio.to_thread(register_mcp_servers, config_map)
+            await asyncio.to_thread(self._apply_session_mcp_servers, state, mcp_servers)
         except Exception:
             logger.warning(
                 "Session %s: failed to register ACP MCP servers",
@@ -826,36 +860,19 @@ class HermesACPAgent(acp.Agent):
             )
             return
 
-        try:
-            from model_tools import get_tool_definitions
-            from agent.memory_manager import inject_memory_provider_tools
+        # Remember for re-application after agent rebuilds (e.g. model switch).
+        state.mcp_servers = list(mcp_servers)
 
-            enabled_toolsets = _expand_acp_enabled_toolsets(
-                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"],
-                mcp_server_names=[server.name for server in mcp_servers],
-            )
-            state.agent.enabled_toolsets = enabled_toolsets
-            disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
-            state.agent.tools = get_tool_definitions(
-                enabled_toolsets=enabled_toolsets,
-                disabled_toolsets=disabled_toolsets,
-                quiet_mode=True,
-            )
-            state.agent.valid_tool_names = {
-                tool["function"]["name"] for tool in state.agent.tools or []
-            }
-            inject_memory_provider_tools(state.agent)
-            invalidate = getattr(state.agent, "_invalidate_system_prompt", None)
-            if callable(invalidate):
-                invalidate()
-            logger.info(
-                "Session %s: refreshed tool surface after ACP MCP registration (%d tools)",
-                state.session_id,
-                len(state.agent.tools or []),
-            )
+    def _reapply_session_mcp_servers(self, state: SessionState) -> None:
+        """Re-bind session-scoped ACP MCP servers onto a freshly rebuilt agent."""
+        mcp_servers = getattr(state, "mcp_servers", None) or []
+        if not mcp_servers:
+            return
+        try:
+            self._apply_session_mcp_servers(state, mcp_servers)
         except Exception:
             logger.warning(
-                "Session %s: failed to refresh tool surface after ACP MCP registration",
+                "Session %s: failed to re-apply ACP MCP servers after agent rebuild",
                 state.session_id,
                 exc_info=True,
             )
@@ -1795,6 +1812,7 @@ class HermesACPAgent(acp.Agent):
             model=new_model,
             requested_provider=target_provider,
         )
+        self._reapply_session_mcp_servers(state)
         self.session_manager.save_session(state.session_id)
         provider_label = getattr(state.agent, "provider", None) or target_provider or current_provider
         logger.info("Session %s: model switched to %s", state.session_id, new_model)
@@ -2042,6 +2060,7 @@ class HermesACPAgent(acp.Agent):
                 base_url=current_base_url,
                 api_mode=current_api_mode,
             )
+            self._reapply_session_mcp_servers(state)
             self.session_manager.save_session(session_id)
             logger.info(
                 "Session %s: model switched to %s via provider %s",

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -860,22 +860,28 @@ class HermesACPAgent(acp.Agent):
             )
             return
 
-        # Remember for re-application after agent rebuilds (e.g. model switch).
+        # Remember names for toolset preservation across agent rebuilds (model switch).
+        # Live MCP connections stay process-global; we do NOT re-register on rebuild.
         state.mcp_servers = list(mcp_servers)
 
-    def _reapply_session_mcp_servers(self, state: SessionState) -> None:
-        """Re-bind session-scoped ACP MCP servers onto a freshly rebuilt agent."""
-        mcp_servers = getattr(state, "mcp_servers", None) or []
-        if not mcp_servers:
-            return
-        try:
-            self._apply_session_mcp_servers(state, mcp_servers)
-        except Exception:
-            logger.warning(
-                "Session %s: failed to re-apply ACP MCP servers after agent rebuild",
-                state.session_id,
-                exc_info=True,
-            )
+    def _model_switch_agent_kwargs(self, state: SessionState) -> dict[str, Any]:
+        """Carry forward runtime toolset state when rebuilding the agent for a model switch.
+
+        ACP client MCP servers are already registered globally at session start.
+        Reconnecting them on every switch can block for discovery (up to ~120s);
+        preserve the expanded toolsets instead.
+        """
+        enabled = getattr(state.agent, "enabled_toolsets", None)
+        disabled = getattr(state.agent, "disabled_toolsets", None)
+        mcp_names = [
+            getattr(server, "name", None)
+            for server in (getattr(state, "mcp_servers", None) or [])
+        ]
+        return {
+            "enabled_toolsets": list(enabled) if enabled is not None else None,
+            "disabled_toolsets": list(disabled) if disabled is not None else None,
+            "mcp_server_names": [name for name in mcp_names if name],
+        }
 
     # ---- ACP lifecycle ------------------------------------------------------
 
@@ -1811,8 +1817,8 @@ class HermesACPAgent(acp.Agent):
             cwd=state.cwd,
             model=new_model,
             requested_provider=target_provider,
+            **self._model_switch_agent_kwargs(state),
         )
-        self._reapply_session_mcp_servers(state)
         self.session_manager.save_session(state.session_id)
         provider_label = getattr(state.agent, "provider", None) or target_provider or current_provider
         logger.info("Session %s: model switched to %s", state.session_id, new_model)
@@ -2059,8 +2065,8 @@ class HermesACPAgent(acp.Agent):
                 requested_provider=requested_provider,
                 base_url=current_base_url,
                 api_mode=current_api_mode,
+                **self._model_switch_agent_kwargs(state),
             )
-            self._reapply_session_mcp_servers(state)
             self.session_manager.save_session(session_id)
             logger.info(
                 "Session %s: model switched to %s via provider %s",

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -170,7 +170,7 @@ class SessionState:
     runtime_lock: Any = field(default_factory=Lock)
     current_prompt_text: str = ""
     interrupted_prompt_text: str = ""
-    # ACP client-provided MCP servers for this session (re-applied after agent rebuilds).
+    # ACP client-provided MCP servers for this session (names preserved across agent rebuilds).
     mcp_servers: List[Any] = field(default_factory=list)
 
 
@@ -598,6 +598,9 @@ class SessionManager:
         requested_provider: str | None = None,
         base_url: str | None = None,
         api_mode: str | None = None,
+        enabled_toolsets: List[str] | None = None,
+        disabled_toolsets: List[str] | None = None,
+        mcp_server_names: List[str] | None = None,
     ):
         if self._agent_factory is not None:
             return self._agent_factory()
@@ -621,18 +624,26 @@ class SessionManager:
             for name, cfg in (config.get("mcp_servers") or {}).items()
             if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
         ]
+        # Union config MCP names with any session-scoped ACP MCP names so model
+        # switches can rebuild the agent without re-registering live servers.
+        merged_mcp_names: List[str] = []
+        for name in list(mcp_server_names or []) + configured_mcp_servers:
+            if name and name not in merged_mcp_names:
+                merged_mcp_names.append(name)
 
         kwargs = {
             "platform": "acp",
             "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
-                mcp_server_names=configured_mcp_servers,
+                list(enabled_toolsets) if enabled_toolsets is not None else ["hermes-acp"],
+                mcp_server_names=merged_mcp_names,
             ),
             "quiet_mode": True,
             "session_id": session_id,
             "session_db": self._get_db(),
             "model": model or default_model,
         }
+        if disabled_toolsets is not None:
+            kwargs["disabled_toolsets"] = list(disabled_toolsets)
 
         try:
             runtime = resolve_runtime_provider(requested=requested_provider or config_provider)

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -170,6 +170,8 @@ class SessionState:
     runtime_lock: Any = field(default_factory=Lock)
     current_prompt_text: str = ""
     interrupted_prompt_text: str = ""
+    # ACP client-provided MCP servers for this session (re-applied after agent rebuilds).
+    mcp_servers: List[Any] = field(default_factory=list)
 
 
 class SessionManager:

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1903,3 +1903,184 @@ class TestRegisterSessionMcpServers:
         with patch("tools.mcp_tool.register_mcp_servers", side_effect=RuntimeError("boom")):
             # Should not raise
             await agent._register_session_mcp_servers(state, [server])
+
+    @pytest.mark.asyncio
+    async def test_register_stores_mcp_servers_on_session(self, agent, mock_manager):
+        """Successful ACP MCP registration remembers servers on SessionState."""
+        from acp.schema import McpServerStdio
+
+        state = mock_manager.create_session(cwd="/tmp")
+        state.agent.enabled_toolsets = ["hermes-acp"]
+        state.agent.disabled_toolsets = None
+        state.agent.tools = []
+        state.agent.valid_tool_names = set()
+
+        server = McpServerStdio(
+            name="session-mcp",
+            command="/usr/bin/mcp",
+            args=[],
+            env=[],
+        )
+
+        with patch("tools.mcp_tool.register_mcp_servers", return_value=[]), \
+             patch("model_tools.get_tool_definitions", return_value=[]):
+            await agent._register_session_mcp_servers(state, [server])
+
+        assert state.mcp_servers == [server]
+
+
+# ---------------------------------------------------------------------------
+# Model switch must preserve session-scoped ACP MCP servers
+# ---------------------------------------------------------------------------
+
+
+class TestModelSwitchPreservesSessionMcp:
+    """BUG-2: rebuilding the agent on model switch must re-apply ACP MCP servers."""
+
+    @pytest.mark.asyncio
+    async def test_set_session_model_reapplies_session_mcp(self, tmp_path, monkeypatch):
+        from acp.schema import McpServerStdio
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            provider = requested or "openrouter"
+            return {
+                "provider": provider,
+                "api_mode": "chat_completions",
+                "base_url": f"https://{provider}.example/v1",
+                "api_key": f"{provider}-key",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("provider"),
+                base_url=kwargs.get("base_url"),
+                api_mode=kwargs.get("api_mode"),
+                enabled_toolsets=list(kwargs.get("enabled_toolsets") or ["hermes-acp"]),
+                disabled_toolsets=None,
+                tools=[],
+                valid_tool_names=set(),
+                _invalidate_system_prompt=MagicMock(),
+            )
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"model": {"provider": "openrouter", "default": "openrouter/gpt-5"}},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.parse_model_input",
+            lambda raw, current: ("openrouter", "openrouter/gpt-4o"),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.detect_provider_for_model",
+            lambda model, current: None,
+        )
+
+        manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
+        server = McpServerStdio(
+            name="zed-fs",
+            command="/usr/bin/mcp-fs",
+            args=["--root", "/tmp"],
+            env=[],
+        )
+        fake_tools = [{"function": {"name": "mcp_zed_fs_read"}}]
+        register_calls = []
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            acp_agent = HermesACPAgent(session_manager=manager)
+            state = manager.create_session(cwd="/tmp")
+
+            with patch(
+                "tools.mcp_tool.register_mcp_servers",
+                side_effect=lambda cfg: register_calls.append(dict(cfg)) or ["mcp_zed_fs_read"],
+            ), patch("model_tools.get_tool_definitions", return_value=fake_tools):
+                await acp_agent._register_session_mcp_servers(state, [server])
+                assert "mcp-zed-fs" in state.agent.enabled_toolsets
+
+                result = await acp_agent.set_session_model(
+                    model_id="openrouter/gpt-4o",
+                    session_id=state.session_id,
+                )
+
+        assert isinstance(result, SetSessionModelResponse)
+        assert len(register_calls) == 2
+        assert "zed-fs" in register_calls[1]
+        assert "mcp-zed-fs" in state.agent.enabled_toolsets
+        assert "mcp_zed_fs_read" in state.agent.valid_tool_names
+
+    def test_cmd_model_reapplies_session_mcp(self, tmp_path, monkeypatch):
+        from acp.schema import McpServerStdio
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            provider = requested or "openrouter"
+            return {
+                "provider": provider,
+                "api_mode": "chat_completions",
+                "base_url": f"https://{provider}.example/v1",
+                "api_key": f"{provider}-key",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("provider"),
+                base_url=kwargs.get("base_url"),
+                api_mode=kwargs.get("api_mode"),
+                enabled_toolsets=list(kwargs.get("enabled_toolsets") or ["hermes-acp"]),
+                disabled_toolsets=None,
+                tools=[],
+                valid_tool_names=set(),
+                _invalidate_system_prompt=MagicMock(),
+            )
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"model": {"provider": "openrouter", "default": "openrouter/gpt-5"}},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.parse_model_input",
+            lambda raw, current: ("openrouter", "openrouter/gpt-4o"),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.detect_provider_for_model",
+            lambda model, current: None,
+        )
+
+        manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
+        server = McpServerStdio(
+            name="zed-fs",
+            command="/usr/bin/mcp-fs",
+            args=[],
+            env=[],
+        )
+        fake_tools = [{"function": {"name": "mcp_zed_fs_read"}}]
+        register_calls = []
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            acp_agent = HermesACPAgent(session_manager=manager)
+            state = manager.create_session(cwd="/tmp")
+            state.mcp_servers = [server]
+
+            with patch(
+                "tools.mcp_tool.register_mcp_servers",
+                side_effect=lambda cfg: register_calls.append(dict(cfg)) or ["mcp_zed_fs_read"],
+            ), patch("model_tools.get_tool_definitions", return_value=fake_tools):
+                result = acp_agent._cmd_model("openrouter/gpt-4o", state)
+
+        assert "Model switched" in result
+        assert len(register_calls) == 1
+        assert "zed-fs" in register_calls[0]
+        assert "mcp-zed-fs" in state.agent.enabled_toolsets
+        assert "mcp_zed_fs_read" in state.agent.valid_tool_names

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1935,10 +1935,10 @@ class TestRegisterSessionMcpServers:
 
 
 class TestModelSwitchPreservesSessionMcp:
-    """BUG-2: rebuilding the agent on model switch must re-apply ACP MCP servers."""
+    """BUG-2: rebuilding the agent on model switch must keep ACP MCP toolsets."""
 
     @pytest.mark.asyncio
-    async def test_set_session_model_reapplies_session_mcp(self, tmp_path, monkeypatch):
+    async def test_set_session_model_preserves_session_mcp_toolsets(self, tmp_path, monkeypatch):
         from acp.schema import McpServerStdio
 
         def fake_resolve_runtime_provider(requested=None, **kwargs):
@@ -1959,7 +1959,11 @@ class TestModelSwitchPreservesSessionMcp:
                 base_url=kwargs.get("base_url"),
                 api_mode=kwargs.get("api_mode"),
                 enabled_toolsets=list(kwargs.get("enabled_toolsets") or ["hermes-acp"]),
-                disabled_toolsets=None,
+                disabled_toolsets=(
+                    list(kwargs["disabled_toolsets"])
+                    if kwargs.get("disabled_toolsets") is not None
+                    else None
+                ),
                 tools=[],
                 valid_tool_names=set(),
                 _invalidate_system_prompt=MagicMock(),
@@ -2009,12 +2013,87 @@ class TestModelSwitchPreservesSessionMcp:
                 )
 
         assert isinstance(result, SetSessionModelResponse)
-        assert len(register_calls) == 2
-        assert "zed-fs" in register_calls[1]
+        # Model switch must preserve toolsets without reconnecting MCP servers.
+        assert len(register_calls) == 1
         assert "mcp-zed-fs" in state.agent.enabled_toolsets
-        assert "mcp_zed_fs_read" in state.agent.valid_tool_names
 
-    def test_cmd_model_reapplies_session_mcp(self, tmp_path, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_set_session_model_does_not_block_on_mcp_reregister(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression: model switch must not invoke register_mcp_servers on the event loop."""
+        from acp.schema import McpServerStdio
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            provider = requested or "openrouter"
+            return {
+                "provider": provider,
+                "api_mode": "chat_completions",
+                "base_url": f"https://{provider}.example/v1",
+                "api_key": f"{provider}-key",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("provider"),
+                base_url=kwargs.get("base_url"),
+                api_mode=kwargs.get("api_mode"),
+                enabled_toolsets=list(kwargs.get("enabled_toolsets") or ["hermes-acp"]),
+                disabled_toolsets=None,
+                tools=[],
+                valid_tool_names=set(),
+                _invalidate_system_prompt=MagicMock(),
+            )
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"model": {"provider": "openrouter", "default": "openrouter/gpt-5"}},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.parse_model_input",
+            lambda raw, current: ("openrouter", "openrouter/gpt-4o"),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.detect_provider_for_model",
+            lambda model, current: None,
+        )
+
+        manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
+        server = McpServerStdio(
+            name="slow-mcp",
+            command="/usr/bin/mcp-slow",
+            args=[],
+            env=[],
+        )
+
+        def _hang_register(_cfg):
+            raise AssertionError(
+                "set_session_model must not re-register MCP servers synchronously"
+            )
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            acp_agent = HermesACPAgent(session_manager=manager)
+            state = manager.create_session(cwd="/tmp")
+            state.mcp_servers = [server]
+            state.agent.enabled_toolsets = ["hermes-acp", "mcp-slow-mcp"]
+
+            with patch("tools.mcp_tool.register_mcp_servers", side_effect=_hang_register):
+                result = await acp_agent.set_session_model(
+                    model_id="openrouter/gpt-4o",
+                    session_id=state.session_id,
+                )
+
+        assert isinstance(result, SetSessionModelResponse)
+        assert "mcp-slow-mcp" in state.agent.enabled_toolsets
+
+    def test_cmd_model_preserves_session_mcp_toolsets(self, tmp_path, monkeypatch):
         from acp.schema import McpServerStdio
 
         def fake_resolve_runtime_provider(requested=None, **kwargs):
@@ -2065,22 +2144,20 @@ class TestModelSwitchPreservesSessionMcp:
             args=[],
             env=[],
         )
-        fake_tools = [{"function": {"name": "mcp_zed_fs_read"}}]
         register_calls = []
 
         with patch("run_agent.AIAgent", side_effect=fake_agent):
             acp_agent = HermesACPAgent(session_manager=manager)
             state = manager.create_session(cwd="/tmp")
             state.mcp_servers = [server]
+            state.agent.enabled_toolsets = ["hermes-acp", "mcp-zed-fs"]
 
             with patch(
                 "tools.mcp_tool.register_mcp_servers",
-                side_effect=lambda cfg: register_calls.append(dict(cfg)) or ["mcp_zed_fs_read"],
-            ), patch("model_tools.get_tool_definitions", return_value=fake_tools):
+                side_effect=lambda cfg: register_calls.append(dict(cfg)) or [],
+            ):
                 result = acp_agent._cmd_model("openrouter/gpt-4o", state)
 
         assert "Model switched" in result
-        assert len(register_calls) == 1
-        assert "zed-fs" in register_calls[0]
+        assert register_calls == []
         assert "mcp-zed-fs" in state.agent.enabled_toolsets
-        assert "mcp_zed_fs_read" in state.agent.valid_tool_names


### PR DESCRIPTION
## What does this PR do?

ACP session-scoped MCP servers were registered once at session start, but model switches rebuild the `AIAgent` and dropped those tools. This PR remembers the client-provided MCP servers on `SessionState` and re-applies them (register + refresh tool surface) after every agent rebuild on model switch.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Extract `_apply_session_mcp_servers` and add `_reapply_session_mcp_servers` in `acp_adapter/server.py`
- Persist `mcp_servers` on `SessionState` in `acp_adapter/session.py`
- Re-apply after `set_session_model` and `/model` (`_cmd_model`)
- Add regression tests in `tests/acp/test_server.py`

## How to Test

1. `scripts/run_tests.sh tests/acp/test_server.py -k 'ModelSwitchPreservesSessionMcp or test_register_stores_mcp_servers_on_session' -q`
2. Manually: open an ACP session with client MCP servers (e.g. Zed), confirm MCP tools work, switch model via UI or `/model`, confirm MCP tools remain available on the next turn

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run the relevant ACP tests via `scripts/run_tests.sh`
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md / AGENTS.md — N/A
- [x] Cross-platform impact considered — N/A (ACP session logic only)
- [x] Tool descriptions/schemas — N/A