### PR TITLE
fix: activate the fallback pool credential before its first request

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1797,6 +1797,21 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 # not only after a later credential-rotation rebuild.
                 agent._replace_primary_openai_client(reason="fallback_timeout_apply")
 
+        # ``resolve_provider_client`` runs before the fallback pool is loaded
+        # above, so its client can still carry a provider environment key.  If
+        # a pool is available, activate its current credential now so the
+        # first fallback request uses the same credential source as retries.
+        _fallback_pool = getattr(agent, "_credential_pool", None)
+        _fallback_entry = _fallback_pool.current() if _fallback_pool is not None else None
+        if _fallback_entry is not None:
+            try:
+                agent._swap_credential(_fallback_entry)
+            except Exception as exc:
+                logger.warning(
+                    "Fallback to %s/%s: could not activate pooled credential: %s",
+                    fb_provider, fb_model, exc,
+                )
+
         # Re-evaluate prompt caching for the new provider/model
         agent._use_prompt_caching, agent._use_native_cache_layout = (
             agent._anthropic_prompt_cache_policy(

--- a/tests/run_agent/test_fallback_credential_isolation.py
+++ b/tests/run_agent/test_fallback_credential_isolation.py
@@ -167,6 +167,51 @@ class TestFallbackCredentialIsolation:
         assert agent._credential_pool.provider == "openai-codex"
         assert agent._transport_cache == {}
 
+    def test_fallback_activates_attached_pool_credential_immediately(self):
+        """The first fallback request must use the fallback pool's key.
+
+        ``resolve_provider_client`` resolves its client before the fallback pool
+        is attached.  Without an immediate credential swap, that first client
+        can retain a stale environment key instead of the pool's current key.
+        """
+        from agent.chat_completion_helpers import try_activate_fallback
+
+        agent = _make_agent(
+            provider="ollama-cloud",
+            model="glm-5.2",
+            base_url="https://ollama.com/v1",
+            api_mode="chat_completions",
+        )
+        agent._fallback_chain = [{"provider": "openai-codex", "model": "gpt-5.5"}]
+        agent._credential_pool = _make_pool("ollama-cloud")
+        agent._buffer_status = MagicMock()
+        agent._is_azure_openai_url.return_value = False
+        agent._is_direct_openai_url.return_value = False
+        agent._provider_model_requires_responses_api.return_value = False
+        agent._anthropic_prompt_cache_policy.return_value = (False, False)
+        agent._ensure_lmstudio_runtime_loaded = MagicMock()
+        agent._replace_primary_openai_client = MagicMock()
+        agent.context_compressor = None
+
+        fallback_client = SimpleNamespace(
+            api_key="stale-environment-key",
+            base_url="https://chatgpt.com/backend-api/codex",
+            _custom_headers={},
+        )
+        fallback_pool = _make_pool("openai-codex")
+        fallback_entry = fallback_pool.current()
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fallback_client, "gpt-5.5"),
+        ), patch(
+            "agent.credential_pool.load_pool",
+            return_value=fallback_pool,
+        ):
+            assert try_activate_fallback(agent) is True
+
+        agent._swap_credential.assert_called_once_with(fallback_entry)
+
 
 # ── Test: _recover_with_credential_pool rejects mismatched pool ──────
 


### PR DESCRIPTION
## Summary\n- activate the current fallback credential-pool entry immediately after fallback client setup\n- prevent the first fallback request from retaining a stale provider environment key\n- add a regression test for the immediate credential activation\n\n## Validation\n- exercised the fallback credential isolation test module against current main source\n- performed a real MiniMax fallback canary with an isolated production profile\n\nFixes the remaining first-request gap after #33233, which correctly attaches the fallback pool but does not activate its current credential for the already-resolved client.