### PR TITLE
fix(gateway): Phase 1 fast-path hardening — data loss, overbroad detectors, dry-run stubs

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5033,6 +5033,271 @@ class BasePlatformAdapter(ABC):
         try:
             await self._run_processing_hook("on_processing_start", event)
 
+            # ── Pre-agent expense capture fast-path ──────────────────────
+            # Deterministic route for spend messages so they bypass the agent
+            # and recur directly through `log_expense.py`.
+            #
+            # Guards:
+            # * TEXT messages only
+            # * no command prefix
+            # * amount pattern matched
+            if getattr(event, "message_type", None) is MessageType.TEXT and not getattr(event, "text", "").strip().startswith("/"):
+                try:
+                    from tools.expense_detection import classify_expense_intent
+                    expense_decision = classify_expense_intent(event.text or "")
+                except Exception:
+                    expense_decision = None
+
+                if expense_decision and expense_decision.get("is_expense"):
+                    logger.info(
+                        "[%s] Fast-path expense capture for session %s: %s",
+                        self.name,
+                        session_key,
+                        expense_decision,
+                    )
+                    try:
+                        from tools.log_expense_gateway import handle_expense_fast_path
+                        fast_path_text = await handle_expense_fast_path(
+                            event=event,
+                            session_key=session_key,
+                            expense_decision=expense_decision,
+                        )
+                    except Exception as fast_path_err:
+                        logger.exception(
+                            "[%s] Expense fast-path failed for session %s: %s",
+                            self.name,
+                            session_key,
+                            fast_path_err,
+                        )
+                        fast_path_text = f"Expense capture failed: {fast_path_err}"
+
+                    if fast_path_text:
+                        _thread_meta = _thread_metadata_for_source(
+                            event.source, _reply_anchor_for_event(event)
+                        )
+                        _r = await self._send_with_retry(
+                            chat_id=event.source.chat_id,
+                            content=fast_path_text,
+                            reply_to=_reply_anchor_for_event(event),
+                            metadata=_mark_notify_metadata(_thread_meta),
+                        )
+                        await self._run_processing_hook(
+                            "on_processing_complete",
+                            event,
+                            ProcessingOutcome.SUCCESS,
+                        )
+                        return
+                    # Handler returned None — fall through to next lane
+
+                # ── Habit confirmation fast-path ─────────────────────────
+                try:
+                    from tools.habit_detection import classify_habit_intent
+                    habit_decision = classify_habit_intent(event.text or "")
+                except Exception:
+                    habit_decision = None
+
+                if habit_decision and habit_decision.get("is_habit"):
+                    try:
+                        from tools.habit_gateway import handle_habit_fast_path
+                        fast_path_text = await handle_habit_fast_path(
+                            event=event,
+                            session_key=session_key,
+                            habit_decision=habit_decision,
+                        )
+                    except Exception as fast_path_err:
+                        logger.exception(
+                            "[%s] Habit fast-path failed for session %s: %s",
+                            self.name,
+                            session_key,
+                            fast_path_err,
+                        )
+                        fast_path_text = f"Habit capture failed: {fast_path_err}"
+
+                    if fast_path_text:
+                        _thread_meta = _thread_metadata_for_source(
+                            event.source, _reply_anchor_for_event(event)
+                        )
+                        _r = await self._send_with_retry(
+                            chat_id=event.source.chat_id,
+                            content=fast_path_text,
+                            reply_to=_reply_anchor_for_event(event),
+                            metadata=_mark_notify_metadata(_thread_meta),
+                        )
+                        await self._run_processing_hook(
+                            "on_processing_complete",
+                            event,
+                            ProcessingOutcome.SUCCESS,
+                        )
+                        return
+                    # Handler returned None — fall through to next lane
+
+                # ── Punch-in confirmation fast-path ──────────────────────
+                try:
+                    from tools.punch_in_detection import contains_punch_in
+                    is_punch_in = contains_punch_in(event.text or "")
+                except Exception:
+                    is_punch_in = False
+
+                if is_punch_in:
+                    try:
+                        from tools.punch_in_gateway import handle_punch_in_fast_path
+                        fast_path_text = await handle_punch_in_fast_path(
+                            event=event,
+                            session_key=session_key,
+                        )
+                    except Exception as fast_path_err:
+                        logger.exception(
+                            "[%s] Punch-in fast-path failed for session %s: %s",
+                            self.name,
+                            session_key,
+                            fast_path_err,
+                        )
+                        fast_path_text = f"Punch-in capture failed: {fast_path_err}"
+
+                    if fast_path_text:
+                        _thread_meta = _thread_metadata_for_source(
+                            event.source, _reply_anchor_for_event(event)
+                        )
+                        _r = await self._send_with_retry(
+                            chat_id=event.source.chat_id,
+                            content=fast_path_text,
+                            reply_to=_reply_anchor_for_event(event),
+                            metadata=_mark_notify_metadata(_thread_meta),
+                        )
+                        await self._run_processing_hook(
+                            "on_processing_complete",
+                            event,
+                            ProcessingOutcome.SUCCESS,
+                        )
+                        return
+                    # Handler returned None — fall through to next lane
+
+                # ── Entry confirmation fast-path ──────────────────────
+                try:
+                    from tools.entry_detection import classify_entry_intent
+                    entry_decision = classify_entry_intent(event.text or "")
+                except Exception:
+                    entry_decision = None
+
+                if entry_decision and entry_decision.get("is_entry"):
+                    try:
+                        from tools.entry_gateway import handle_entry_fast_path
+                        fast_path_text = await handle_entry_fast_path(
+                            event=event,
+                            session_key=session_key,
+                            decision=entry_decision,
+                        )
+                    except Exception as fast_path_err:
+                        logger.exception(
+                            "[%s] Entry fast-path failed for session %s: %s",
+                            self.name,
+                            session_key,
+                            fast_path_err,
+                        )
+                        fast_path_text = f"Entry capture failed: {fast_path_err}"
+
+                    if fast_path_text:
+                        _thread_meta = _thread_metadata_for_source(
+                            event.source, _reply_anchor_for_event(event)
+                        )
+                        _r = await self._send_with_retry(
+                            chat_id=event.source.chat_id,
+                            content=fast_path_text,
+                            reply_to=_reply_anchor_for_event(event),
+                            metadata=_mark_notify_metadata(_thread_meta),
+                        )
+                        await self._run_processing_hook(
+                            "on_processing_complete",
+                            event,
+                            ProcessingOutcome.SUCCESS,
+                        )
+                        return
+                    # Handler returned None — fall through to next lane
+
+                # ── Health confirmation fast-path ───────────────────────
+                try:
+                    from tools.health_detection import classify_health_intent
+                    health_decision = classify_health_intent(event.text or "")
+                except Exception:
+                    health_decision = None
+
+                if health_decision and health_decision.get("is_health"):
+                    try:
+                        from tools.health_gateway import handle_health_fast_path
+                        fast_path_text = await handle_health_fast_path(
+                            event=event,
+                            session_key=session_key,
+                            decision=health_decision,
+                        )
+                    except Exception as fast_path_err:
+                        logger.exception(
+                            "[%s] Health fast-path failed for session %s: %s",
+                            self.name,
+                            session_key,
+                            fast_path_err,
+                        )
+                        fast_path_text = f"Health capture failed: {fast_path_err}"
+
+                    if fast_path_text:
+                        _thread_meta = _thread_metadata_for_source(
+                            event.source, _reply_anchor_for_event(event)
+                        )
+                        _r = await self._send_with_retry(
+                            chat_id=event.source.chat_id,
+                            content=fast_path_text,
+                            reply_to=_reply_anchor_for_event(event),
+                            metadata=_mark_notify_metadata(_thread_meta),
+                        )
+                        await self._run_processing_hook(
+                            "on_processing_complete",
+                            event,
+                            ProcessingOutcome.SUCCESS,
+                        )
+                        return
+                    # Handler returned None — fall through to next lane
+
+                # ── Work confirmation fast-path ─────────────────────────
+                try:
+                    from tools.work_detection import classify_work_intent
+                    work_decision = classify_work_intent(event.text or "")
+                except Exception:
+                    work_decision = None
+
+                if work_decision and work_decision.get("is_work"):
+                    try:
+                        from tools.work_gateway import handle_work_fast_path
+                        fast_path_text = await handle_work_fast_path(
+                            event=event,
+                            session_key=session_key,
+                            decision=work_decision,
+                        )
+                    except Exception as fast_path_err:
+                        logger.exception(
+                            "[%s] Work fast-path failed for session %s: %s",
+                            self.name,
+                            session_key,
+                            fast_path_err,
+                        )
+                        fast_path_text = f"Work capture failed: {fast_path_err}"
+
+                    if fast_path_text:
+                        _thread_meta = _thread_metadata_for_source(
+                            event.source, _reply_anchor_for_event(event)
+                        )
+                        _r = await self._send_with_retry(
+                            chat_id=event.source.chat_id,
+                            content=fast_path_text,
+                            reply_to=_reply_anchor_for_event(event),
+                            metadata=_mark_notify_metadata(_thread_meta),
+                        )
+                        await self._run_processing_hook(
+                            "on_processing_complete",
+                            event,
+                            ProcessingOutcome.SUCCESS,
+                        )
+                        return
+                    # Handler returned None — fall through to next lane
+
             # Call the handler (this can take a while with tool calls)
             response = await self._message_handler(event)
             is_ephemeral_response = isinstance(response, EphemeralReply)

--- a/tools/entry_detection.py
+++ b/tools/entry_detection.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+import re
+
+# Structured entry patterns — require explicit logging intent.
+# Removed broad match on generic words like daily|entry|journal|note|log
+# that caused false positives on conversational messages.
+_ENTRY_PATTERNS = [
+    # Explicit logging prefix: "log:", "entry:", "note:", "daily log:"
+    re.compile(r"^(?:log|entry|note|daily\s*log|journal\s*entry)\s*[:：]\s*.+", re.I),
+    # "I want to log ..." / "let me log ..."
+    re.compile(r"\b(?:i|let\s*me)\s+(?:want\s+to\s+|need\s+to\s+|should|will)\s+(?:log|record|note|journal)\b", re.I),
+    # "log that ..." / "note that ..."
+    re.compile(r"\b(?:log|record|note)\s+that\b", re.I),
+]
+
+_EXCLUDE_LEAD_RE = re.compile(
+    r"^(/|!|\.|\?| remind| schedule| create| delete| list| show| get| help| ping| todo| task| track| start| stop| new)\b",
+    re.I,
+)
+
+# Explicitly excluded patterns — things that look like logging but are questions/chat
+_QUESTION_RE = re.compile(
+    r"\b(what|which|how|who|where|when|why)\b.*\b(have been|has been|is|are|was|were|did|do|does)\b|"
+    r"\b(have been|has been)\b.*\b(logged|done|recorded|saved)\b",
+    re.I,
+)
+
+def classify_entry_intent(text: str):
+    message = (text or "").strip()
+    if not message or _EXCLUDE_LEAD_RE.search(message):
+        return {"is_entry": False, "text": message}
+    if _QUESTION_RE.search(message):
+        return {"is_entry": False, "text": message}
+    for pattern in _ENTRY_PATTERNS:
+        if pattern.search(message):
+            return {"is_entry": True, "text": message}
+    return {"is_entry": False, "text": message}

--- a/tools/entry_gateway.py
+++ b/tools/entry_gateway.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+HOME = Path.home()
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CANDIDATE_ROOTS = [HOME / ".hermes" / "scripts", _REPO_ROOT / "scripts", _REPO_ROOT / "obsidian-repo" / "scripts"]
+
+def _resolve_script():
+    for root in _CANDIDATE_ROOTS:
+        if (root / "log_entry.py").exists():
+            return root / "log_entry.py"
+    return None
+
+async def handle_entry_fast_path(*, event, session_key: str, decision: Dict[str, Any]) -> Optional[str]:
+    message = (decision.get("text") or getattr(event, "text", "") or "").strip()
+    if not message:
+        return None
+
+    def _run(dry_run: bool = True) -> Dict[str, Any]:
+        script = _resolve_script()
+        if not script:
+            return {"ok": False, "error": "log_entry.py not found"}
+        cmd = [sys.executable, str(script), message]
+        if dry_run:
+            cmd.append("--dry-run")
+        try:
+            p = __import__("subprocess").run(cmd, capture_output=True, text=True, timeout=30)
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
+        stdout = (p.stdout or "").strip()
+        if p.returncode != 0 or not stdout:
+            err = (p.stderr or "").strip() or "no output"
+            return {"ok": False, "error": err}
+        try:
+            payload = json.loads(stdout)
+            return payload if isinstance(payload, dict) else {"ok": True, "raw": stdout[:160]}
+        except Exception:
+            return {"ok": True, "raw": stdout[:160]}
+
+    # Phase 1: dry-run — classify and validate via log_entry.py router
+    dry_result = await asyncio.get_running_loop().run_in_executor(None, _run, True)
+    if not dry_result.get("ok") and dry_result.get("needs_agent"):
+        return None  # Router said it needs agent → fall through
+
+    if not dry_result.get("ok"):
+        return None  # Can't handle → fall through to agent
+
+    # Phase 2: real persist via log_entry.py
+    persist_result = await asyncio.get_running_loop().run_in_executor(None, _run, False)
+    if persist_result.get("ok"):
+        domain = persist_result.get("domain") or dry_result.get("domain") or "entry"
+        return f"Logged ✅ {domain}"
+
+    return None

--- a/tools/expense_detection.py
+++ b/tools/expense_detection.py
@@ -1,0 +1,56 @@
+"""
+Expense detection helper for deterministic gateway pre-agent routing.
+
+Returns a simple intent dict so the gateway can decide whether a message
+should bypass the agent and recur directly through log_expense.py.
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict
+
+_EXCLUDE_LEAD_RE = re.compile(
+    r"^(/|!|\.|\?| remind| schedule| create| delete| list| show| get| help| ping| todo| task| habit| punch| track| start| stop| new)\b",
+    re.IGNORECASE,
+)
+
+_MERCHANTISH_RE = re.compile(
+    r"""
+    (?:
+      (?:from|at|to|on)\s+[A-Za-z][\w\s&.'’-]{2,}
+     |(?:bought|ordered|got|purchased)\s+(?:\w+\s+)?(?:from|at|on)\s+[A-Za-z][\w\s&.'’-]{2,}
+     |\b(?:Blinkit|Swiggy|Zomato|Amazon\.in|Amazon\b|Flipkart|Zepto|BigBasket|Uber|Ola|Netflix|Spotify|Hostinger|OpenRouter|DMart|HP\b|Shell|BookMyShow|PVR|INOX)\b
+     |\b(?:petrol|diesel|fuel|dinner|lunch|breakfast|coffee|tea|groceries|grocery|ride|trip|bill|rent|ticket|cab|auto|medicine|meds|subscription|fee|water|electricity|internet|mobile|recharge)\b
+     |\b(?:Netflix|Spotify|Prime|Hotstar|Disney|YouTube\s*Premium|Swiggy|Zomato|Amazon|Flipkart|Uber|Ola)\s*(?:sub|annual|monthly|renewal|plan|\d{3,})\b
+    )
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+_AMOUNT_RE = re.compile(
+    r"""
+    (?:
+      (?:₹|Rs\.?|INR|rs\.?|inr)\s*\d[\d,]*\.?\d*
+     |\b\d[\d,]*\.?\d*\s*(?:Rs\.?|INR|/-)\b
+     |\b(?:cost|costs|charged|paid|spent)\s+\d[\d,]*\.?\d*\b
+     |\b(\d[\d,]*\.?\d*)\s*(?:petrol|diesel|fuel|dinner|lunch|breakfast|coffee|tea|groceries|grocery|ride|trip|bill|rent|ticket|cab|auto|medicine|meds|subscription|fee|water|electricity|internet|mobile|recharge)\b
+     |\b(\d[\d,]*\.?\d*)\b(?=[^\n]{0,60}\b(?:from|at|on|via)\b)
+     |\b(?:Netflix|Spotify|Prime|Hotstar|Disney|YouTube\s*Premium|subscription|service)\s+(\d[\d,]*\.?\d*)\b
+     |\b(?:dinner|lunch|breakfast|petrol|fuel|ride|trip|bill)\s+(\d[\d,]*\.?\d*)\b
+    )
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def classify_expense_intent(text: str) -> Dict[str, Any]:
+    message = (text or "").strip()
+    if not message or _EXCLUDE_LEAD_RE.search(message):
+        return {"is_expense": False, "has_amount": False, "merchantish": False, "text": message}
+
+    has_amount = bool(_AMOUNT_RE.search(message))
+    merchantish = bool(_MERCHANTISH_RE.search(message))
+    return {"is_expense": bool(has_amount and merchantish), "has_amount": has_amount, "merchantish": merchantish, "text": message}
+

--- a/tools/habit_detection.py
+++ b/tools/habit_detection.py
@@ -1,0 +1,42 @@
+
+from __future__ import annotations
+
+import re
+
+PHRASES = [
+    r"\byoga\b",
+    r"\byog\b",
+    r"\bcssbattle\b",
+    r"\bcss battle\b",
+    r"\bduolingo\b|\bduo\s*lingo\b",
+    r"\bbrushed\b|\bbrushing\b|\bbrush\b",
+    r"\boil(?:ing|ed)?(?:\s*hair)?\b|\boil_hair\b",
+]
+
+_KEYWORDS = {
+    "yoga": re.compile(r"\byoga\b|\byog\b"),
+    "cssbattle": re.compile(r"\bcssbattle\b|\bcss battle\b"),
+    "duolingo": re.compile(r"\bduolingo\b|\bduo\s*lingo\b"),
+    "night_brushing": re.compile(r"\bbrushed\b|\bbrushing\b|\bbrush\b"),
+    "oil_hair": re.compile(r"\boil(?:ing|ed)?(?:\s*hair)?\b|\boil_hair\b"),
+}
+
+_EXCLUDE_LEAD_RE = re.compile(
+    r"^(/|!|\.|\?| remind| schedule| create| delete| list| show| get| help| ping| todo| task| track| start| stop| new)\b",
+    re.IGNORECASE,
+)
+
+
+def classify_habit_intent(text: str) -> dict:
+    message = (text or "").strip()
+    if not message or _EXCLUDE_LEAD_RE.search(message):
+        return {"is_habit": False, "habit": None, "has_done": False, "text": message}
+
+    message_lower = message.lower()
+    matched_habit = None
+    for key, rx in _KEYWORDS.items():
+        if rx.search(message_lower):
+            matched_habit = key
+            break
+
+    return {"is_habit": bool(matched_habit), "habit": matched_habit, "has_done": bool(matched_habit), "text": message}

--- a/tools/habit_gateway.py
+++ b/tools/habit_gateway.py
@@ -1,0 +1,60 @@
+"""Gateway fast-path handler for habit confirmations."""
+from __future__ import annotations
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+HOME = Path.home()
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CANDIDATE_ROOTS = [HOME / ".hermes" / "scripts", _REPO_ROOT / "scripts", _REPO_ROOT / "obsidian-repo" / "scripts"]
+_KILLER_PHRASES = ["Could not detect habit", "does not look like a completion confirmation", "Unknown habit:"]
+
+def _resolve_script():
+    for root in _CANDIDATE_ROOTS:
+        if (root / "log_habit.py").exists():
+            return root / "log_habit.py"
+    return None
+
+async def handle_habit_fast_path(*, event, session_key: str, habit_decision: dict) -> Optional[str]:
+    message = (habit_decision.get("text") or getattr(event, "text", "") or "").strip()
+    if not message:
+        return None
+    def _run(dry_run: bool = True) -> Dict[str, Any]:
+        script = _resolve_script()
+        if not script:
+            return {"ok": False, "error": "log_habit.py not found"}
+        cmd = [sys.executable, str(script), message]
+        if dry_run:
+            cmd.append("--dry-run")
+        try:
+            p = __import__("subprocess").run(cmd, capture_output=True, text=True, timeout=30)
+        except Exception as exc:
+            return {"ok": False, "error": f"exec: {exc}"}
+        stdout = (p.stdout or "").strip()
+        stderr = (p.stderr or "").strip()
+        if p.returncode != 0 or not stdout:
+            return {"ok": False, "error": stderr or "dry-run returned empty"}
+        try:
+            payload = json.loads(stdout)
+        except Exception:
+            return {"ok": False, "error": "json parse failed"}
+        return payload if isinstance(payload, dict) else {"ok": True}
+
+    # Phase 1: dry-run validation
+    dry_result = await asyncio.get_running_loop().run_in_executor(None, _run, True)
+    if not dry_result.get("ok"):
+        reason = dry_result.get("error") or "unknown"
+        if any(k.lower() in reason.lower() for k in _KILLER_PHRASES):
+            return None  # Not a habit message → fall through
+        return None  # Can't handle → fall through to agent
+
+    # Phase 2: real persist
+    persist_result = await asyncio.get_running_loop().run_in_executor(None, _run, False)
+    if persist_result.get("ok"):
+        row = persist_result.get("row") if isinstance(persist_result.get("row"), dict) else {}
+        habit = row.get("habit") or persist_result.get("habit") or habit_decision.get("habit") or "habit"
+        date = row.get("date") or ""
+        return f"Logged ✅ {habit} · {date}" if date else f"Logged ✅ {habit}"
+
+    return None  # Persist failed → fall through to agent

--- a/tools/health_gateway.py
+++ b/tools/health_gateway.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+HOME = Path.home()
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CANDIDATE_ROOTS = [HOME / ".hermes" / "scripts", _REPO_ROOT / "scripts", _REPO_ROOT / "obsidian-repo" / "scripts"]
+
+def _resolve_script():
+    for root in _CANDIDATE_ROOTS:
+        if (root / "log_health.py").exists():
+            return root / "log_health.py"
+    return None
+
+async def handle_health_fast_path(*, event, session_key: str, decision: Dict[str, Any]) -> Optional[str]:
+    message = (decision.get("text") or getattr(event, "text", "") or "").strip()
+    if not message:
+        return None
+    health_type = decision.get("type") or "yoga"
+
+    def _run(dry_run: bool = True) -> Dict[str, Any]:
+        script = _resolve_script()
+        if not script:
+            return {"ok": False, "error": "log_health.py not found"}
+        args = [sys.executable, str(script), health_type]
+        if dry_run:
+            args.append("--dry-run")
+        try:
+            p = __import__("subprocess").run(args, capture_output=True, text=True, timeout=30)
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
+        stdout = (p.stdout or "").strip()
+        if p.returncode != 0 or not stdout:
+            return {"ok": False, "error": (p.stderr or "").strip() or "log_health.py returned no output"}
+        try:
+            payload = json.loads(stdout)
+        except Exception:
+            return {"ok": True, "raw": stdout[:160]}
+        return payload if isinstance(payload, dict) else {"ok": True, "raw": stdout[:160]}
+
+    # Phase 1: dry-run validation
+    dry_result = await asyncio.get_running_loop().run_in_executor(None, _run, True)
+    if not dry_result.get("ok"):
+        return None  # Can't handle → fall through to agent
+
+    # Phase 2: real persist
+    persist_result = await asyncio.get_running_loop().run_in_executor(None, _run, False)
+    if persist_result.get("ok"):
+        return f"Health ✅ {health_type} logged"
+
+    return None  # Persist failed → fall through to agent

--- a/tools/log_expense_gateway.py
+++ b/tools/log_expense_gateway.py
@@ -1,0 +1,118 @@
+"""Gateway fast-path handler for expense logging."""
+from __future__ import annotations
+import asyncio
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+HOME = Path.home()
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CANDIDATE_ROOTS = [HOME / ".hermes" / "scripts", _REPO_ROOT / "scripts", _REPO_ROOT / "obsidian-repo" / "scripts"]
+
+_CURRENCY_AMOUNT_RE = re.compile(r'(?:₹|Rs\.?|INR|rs\.?|inr)?\s*(\d[\d,]*\.?\d*)')
+_AMOUNT_RE = re.compile(r'(?:\b|^)(\d[\d,]*\.?\d*)(?:\b|$)')
+_NOT_MERCHANT = {'via','paid','using','with','through','on','at','from','today','yesterday','rs','inr'}
+
+def _clean(s: str) -> str:
+    s = re.sub(r"[^A-Za-z0-9&.'’\-]", " ", s or "")
+    s = re.sub(r"\s+", " ", s).strip().rstrip(".,;")
+    return s
+
+def _guess_amount_merchant(text: str):
+    msg = (text or "").strip()
+    amount = None
+    m = _CURRENCY_AMOUNT_RE.search(msg.replace(",", ""))
+    if m:
+        amount = m.group(1)
+    else:
+        m = _AMOUNT_RE.search(msg.replace(",", ""))
+        if m:
+            amount = m.group(1)
+    stop_words = _NOT_MERCHANT | {str(amount), amount, "for", "and", "the", "a", "an", "of", "in", "kg", "kgs"}
+    words = [w for w in re.split(r"\s+", msg) if w.lower() not in stop_words and w]
+    if amount:
+        words = [w for w in words if w.replace(".", "").replace(",", "") != amount]
+    merchant = _clean(" ".join(words[:3])) if words else None
+    if merchant and amount and merchant.startswith(amount):
+        merchant = merchant[len(amount):].strip()
+    if merchant:
+        merchant = merchant.title()
+    return amount, merchant
+
+def _resolve_script():
+    for root in _CANDIDATE_ROOTS:
+        if (root / "log_expense.py").exists():
+            return root / "log_expense.py"
+    return None
+
+async def handle_expense_fast_path(*, event, session_key: str, expense_decision: Dict[str, Any]) -> Optional[str]:
+    message = (expense_decision.get("text") or getattr(event, "text", "") or "").strip()
+    if not message:
+        return None
+    amount_hint, merchant_hint = _guess_amount_merchant(message)
+
+    def _run(retry: bool = False, dry_run: bool = True) -> Dict[str, Any]:
+        script = _resolve_script()
+        if not script:
+            return {"ok": False, "error": "log_expense.py not found"}
+        if retry and amount_hint:
+            cmd = [sys.executable, str(script), "--amount", amount_hint or "0", "--merchant", merchant_hint or "Expense"]
+            if not merchant_hint:
+                cmd += ["--note", message[:40]]
+        else:
+            cmd = [sys.executable, str(script), message]
+        if dry_run:
+            cmd.append("--dry-run")
+        try:
+            p = __import__("subprocess").run(cmd, capture_output=True, text=True, timeout=30)
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
+        stdout = (p.stdout or "").strip()
+        stderr = (p.stderr or "").strip()
+        if p.returncode != 0 or not stdout:
+            err_text = stdout or stderr or "log_expense.py returned no output"
+            try:
+                err_payload = json.loads(err_text)
+                if isinstance(err_payload, dict):
+                    return err_payload
+            except Exception:
+                pass
+            return {"ok": False, "error": err_text[:400]}
+        try:
+            payload = json.loads(stdout)
+            return payload if isinstance(payload, dict) else {"ok": True}
+        except Exception:
+            return {"ok": True}
+
+    # Phase 1: dry-run with natural language
+    dry_result = await asyncio.get_running_loop().run_in_executor(None, _run, False, True)
+    if dry_result.get("ok"):
+        # Phase 2: real persist
+        persist_result = await asyncio.get_running_loop().run_in_executor(None, _run, False, False)
+        if persist_result.get("ok"):
+            parsed = persist_result.get("parsed") if isinstance(persist_result.get("parsed"), dict) else {}
+            amount_out = parsed.get("amount") or persist_result.get("amount") or amount_hint
+            merchant_out = parsed.get("merchant") or persist_result.get("merchant") or merchant_hint or "expense"
+            category = parsed.get("category") or persist_result.get("category") or ""
+            date = parsed.get("date") or persist_result.get("date") or ""
+            parts = [f"Logged ✅ {merchant_out!s} ₹{amount_out!s}"]
+            if category and category != "other":
+                parts.append(f"· {category}")
+            if date:
+                parts.append(f"· {date}")
+            return " ".join(parts)
+        return None  # Persist failed → fall through to agent
+
+    # NLP dry-run failed — try structured retry
+    reason = dry_result.get("error") or ""
+    if any(k.lower() in reason.lower() for k in ["amount is required", "merchant is required", "could not detect"]):
+        retry_dry = await asyncio.get_running_loop().run_in_executor(None, _run, True, True)
+        if retry_dry.get("ok"):
+            retry_persist = await asyncio.get_running_loop().run_in_executor(None, _run, True, False)
+            if retry_persist.get("ok"):
+                amount_out = retry_persist.get("amount") or amount_hint
+                merchant_out = retry_persist.get("merchant") or merchant_hint or "expense"
+                return f"Logged ✅ {merchant_out!s} ₹{amount_out!s}"
+
+    return None  # Can't handle → fall through to agent

--- a/tools/punch_in_detection.py
+++ b/tools/punch_in_detection.py
@@ -1,0 +1,10 @@
+
+import re
+
+PUNCH_IN_RE = re.compile(
+    r"\b(?:punch(?:ed|ing)?|clock(?:ed|ing)?)(?:[-\s]+)in\b",
+    re.IGNORECASE,
+)
+
+def contains_punch_in(text: str) -> bool:
+    return bool(PUNCH_IN_RE.search(text or ""))

--- a/tools/work_detection.py
+++ b/tools/work_detection.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+import re
+
+# Work-log patterns — require structured format, not conversational words.
+# Removed broad match on generic words like work|task|meeting|sync|deploy|review
+# that caused false positives on everyday chat.
+_WORK_PATTERNS = [
+    # Project identifier + action: "PROJ-123 note ...", "PROJ-123 time 60 ..."
+    re.compile(r"^[A-Za-z]+-\d+\s+(note|time|status)\b", re.I),
+    # "spent 60m on PROJ-123 ..." / "spent 1h on ..."
+    re.compile(r"\bspent\s+\d+\s*(?:m|min|mins|minutes|h|hr|hrs|hours)?\s+on\b", re.I),
+    # Explicit work-log prefix: "work log:", "standup:", "task:"
+    re.compile(r"^(?:work\s*log|standup|task|time\s*log)\s*[:：]\s*.+", re.I),
+    # "I worked on ... for X hours"
+    re.compile(r"\b(?:worked|spent)\s+on\s+.+\s+for\s+\d+\s*(?:min|hour|hr)", re.I),
+]
+
+_EXCLUDE_LEAD_RE = re.compile(
+    r"^(/|!|\.|\?| remind| schedule| create| delete| list| show| get| help| ping| todo| task| track| start| stop| new)\b",
+    re.I,
+)
+
+def classify_work_intent(text: str):
+    message = (text or "").strip()
+    if not message or _EXCLUDE_LEAD_RE.search(message):
+        return {"is_work": False, "text": message}
+    for pattern in _WORK_PATTERNS:
+        if pattern.search(message):
+            return {"is_work": True, "text": message}
+    return {"is_work": False, "text": message}

--- a/tools/work_gateway.py
+++ b/tools/work_gateway.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+HOME = Path.home()
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CANDIDATE_ROOTS = [HOME / ".hermes" / "scripts", _REPO_ROOT / "scripts", _REPO_ROOT / "obsidian-repo" / "scripts"]
+
+def _resolve_script():
+    for root in _CANDIDATE_ROOTS:
+        if (root / "log_work.py").exists():
+            return root / "log_work.py"
+    return None
+
+async def handle_work_fast_path(*, event, session_key: str, decision: Dict[str, Any]) -> Optional[str]:
+    message = (decision.get("text") or getattr(event, "text", "") or "").strip()
+    if not message:
+        return None
+
+    def _run(dry_run: bool = True) -> Dict[str, Any]:
+        script = _resolve_script()
+        if not script:
+            return {"ok": False, "error": "log_work.py not found"}
+        cmd = [sys.executable, str(script), "message", message]
+        if dry_run:
+            cmd.append("--dry-run")
+        try:
+            p = __import__("subprocess").run(cmd, capture_output=True, text=True, timeout=30)
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
+        stdout = (p.stdout or "").strip()
+        if p.returncode != 0 or not stdout:
+            err = (p.stderr or "").strip() or "no output"
+            # If it returned needs_agent, don't force it
+            if any(k.lower() in err.lower() for k in ["required", "could not", "unknown", "needs_agent"]):
+                return {"ok": False, "error": err, "needs_agent": True}
+            return {"ok": False, "error": err}
+        try:
+            payload = json.loads(stdout)
+            return payload if isinstance(payload, dict) else {"ok": True, "raw": stdout[:160]}
+        except Exception:
+            return {"ok": True, "raw": stdout[:160]}
+
+    # Phase 1: dry-run validation
+    dry_result = await asyncio.get_running_loop().run_in_executor(None, _run, True)
+    if dry_result.get("needs_agent") or not dry_result.get("ok"):
+        return None  # Can't handle → fall through to agent
+
+    # Phase 2: real persist
+    persist_result = await asyncio.get_running_loop().run_in_executor(None, _run, False)
+    if persist_result.get("ok"):
+        return "Work ✅ logged"
+
+    return None  # Persist failed → fall through to agent


### PR DESCRIPTION
## Summary

Phase 1 of the gateway fast-path audit ([spec](https://github.com/RitikPatni/obsidian/pull/322)). Fixes 5 bugs identified in the 6-lane offline logger system in `gateway/platforms/base.py`.

## Changes

### 1.1 Data-loss fix (`base.py`)
All 6 fast-path lanes (expense, habit, punch-in, entry, health, work) now fall through to the agent when the handler returns `None`. Previously each lane unconditionally `return`ed after detection, silently dropping messages when the handler could not parse them.

### 1.2 Narrow `entry_detection`  
Replaced broad regex (matching any message with `daily|entry|journal|note|log` + `done|logged|recorded`) with structured patterns requiring explicit logging intent (prefixes, "I want to log", "log that").

### 1.3 Narrow `work_detection`
Replaced conversational words (`work|task|meeting|sync|deploy|review|shipped`) with work-log patterns (`PROJ-123 note/time`, `spent X on...`, explicit prefixes).

### 1.4 Enable health/work persist
`health_gateway` and `work_gateway` now follow the same dry-run→persist pattern as habit/expense. Both were previously dry-run-only stubs that replied "✅ logged" without actually writing to canonical ledgers.

### 1.5 Replace `entry_gateway`
Now routes through `log_entry.py` router instead of writing to orphan `entries.jsonl`. Entry fast-path delegates to the unified router for domain classification and ledger-safe persistence.

### Handler hardening  
`habit_gateway` and `log_expense_gateway` now return `None` on failure/ambiguity, letting messages fall through to the agent instead of showing backend errors to the user.

## Files changed (11)

| File | Change |
|------|--------|
| `gateway/platforms/base.py` | Data-loss fix: move `return` inside `if fast_path_text:` for all 6 lanes |
| `tools/entry_detection.py` | Narrow: structured patterns replacing broad regex |
| `tools/work_detection.py` | Narrow: work-log patterns replacing conversational words |
| `tools/entry_gateway.py` | Replace: route through `log_entry.py` instead of orphan JSONL |
| `tools/health_gateway.py` | Enable persist: dry-run + real write |
| `tools/work_gateway.py` | Enable persist: dry-run + real write |
| `tools/habit_gateway.py` | Harden: return None on failure, two-phase persist |
| `tools/log_expense_gateway.py` | Harden: return None on failure, simplified flow |
| `tools/expense_detection.py` | New: previously only existed as .pyc |
| `tools/habit_detection.py` | New: previously only existed as .pyc |
| `tools/punch_in_detection.py` | New: previously only existed as .pyc |

## Related

- Audit spec: https://github.com/RitikPatni/obsidian/pull/322
- Next: Phase 2 (FastPathLane abstraction to collapse boilerplate)
- Next: Phase 3 (gateway-level tests + instrumentation)