### PR TITLE
fix(config): resolve model.key_env in bare custom provider path (#67453)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -948,8 +948,18 @@ def _resolve_named_custom_runtime(
             return pool_result
         _da_is_openai_url   = base_url_host_matches(base_url, "openai.com") or base_url_host_matches(base_url, "openai.azure.com")
         _da_is_openrouter   = base_url_host_matches(base_url, "openrouter.ai")
+        # Read key_env from model config so bare `provider: custom` with
+        # `model.key_env: MY_API_KEY` resolves the key from the env var
+        # on every request — not just the first session after boot (#67453).
+        _model_cfg_key_env = str(
+            (_get_model_config().get("key_env") or "").strip()
+        )
+        _model_cfg_env_key = (
+            _getenv(_model_cfg_key_env, "").strip() if _model_cfg_key_env else ""
+        )
         api_key_candidates = [
             (explicit_api_key or "").strip(),
+            _model_cfg_env_key,
             # Gate env key fallbacks on authoritative hosts (#28660)
             (_getenv("OPENAI_API_KEY", "").strip()     if _da_is_openai_url else ""),
             (_getenv("OPENROUTER_API_KEY", "").strip() if _da_is_openrouter  else ""),


### PR DESCRIPTION
## Summary

When `provider: custom` is configured with `model.key_env` (instead of an inline `api_key`), the API key is correctly resolved for the first session after boot but fails with 403 for every subsequent session.

## Root Cause

The bare `provider: custom` + `model.base_url` path in `resolve_runtime_provider()` (lines 940-972) builds an `api_key_candidates` list but never reads `key_env` from the model config. It only checks:

1. `explicit_api_key` (always None when called from `_resolve_runtime_agent_kwargs`)
2. `OPENAI_API_KEY` (gated on OpenAI host)
3. `OPENROUTER_API_KEY` (gated on OpenRouter host)
4. `_host_derived_api_key` (derived from hostname)

The `model.key_env` field (e.g. `SCW_LLM_API_KEY`) is completely ignored. The first session may succeed through a different resolution path (e.g. `_host_derived_api_key` matching), but subsequent sessions fail because the key is never re-resolved from the configured env var.

## Fix

Read `model.key_env` from config and resolve the env var via `_getenv()`, adding it to the `api_key_candidates` list after `explicit_api_key` and before host-gated fallbacks. This mirrors the named-custom-provider path at line 1013 which already reads `key_env`.

## Testing

- All 151 `tests/hermes_cli/test_runtime_provider*.py` tests pass
- `py_compile` clean

Fixes #67453