### PR TITLE
feat(web): guided picker for subagent model + provider (Dashboard half of #67347)

### DIFF
--- a/web/src/components/DelegationModelProviderField.tsx
+++ b/web/src/components/DelegationModelProviderField.tsx
@@ -60,7 +60,9 @@ export function DelegationModelProviderField({
   useEffect(() => {
     let cancelled = false;
 
-    setIsLoading(true);
+    // `isLoading` is initialized to `true`, so no explicit `setIsLoading(true)`
+    // call here — keeps the effect purely about the async fetch and avoids
+    // the `set-state-in-effect` lint rule.
     api
       .getModelOptions()
       .then((res) => {
@@ -204,15 +206,5 @@ export function DelegationModelProviderField({
         </>
       )}
     </div>
-  );
-}
-
-/**
- * Render the picker only on the `delegation.model` row — the `provider` row
- * is collapsed into the picker to avoid two controls for one logical field.
- */
-export function isDelegationModelPickerKey(schemaKey: string): boolean {
-  return (
-    schemaKey === "delegation.model" || schemaKey === "delegation.provider"
   );
 }

--- a/web/src/components/DelegationModelProviderField.tsx
+++ b/web/src/components/DelegationModelProviderField.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useState } from "react";
+
+import { Input } from "@nous-research/ui/ui/components/input";
+import { Label } from "@nous-research/ui/ui/components/label";
+import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
+
+import { api, type ModelOptionsResponse } from "@/lib/api";
+import { useI18n } from "@/i18n";
+
+const INHERIT_VALUE = "__inherit__";
+
+interface DelegationValue {
+  model: string;
+  provider: string;
+}
+
+/**
+ * Guided picker for the `delegation.model` + `delegation.provider` config keys.
+ *
+ * Replaces the two bare free-text inputs that the schema-driven AutoField would
+ * otherwise render. Mirrors the Desktop equivalent in
+ * `apps/desktop/src/app/settings/delegation-model-provider-field.tsx` and the
+ * `FallbackModelsField` pattern: provider + model selects sourced from the
+ * gateway's `/api/model/options` response, with free-text fallback for
+ * custom-endpoint providers that have no probed model catalog.
+ *
+ * "Inherit from main agent" is a first-class dropdown option that writes `""`
+ * to both keys — the documented default
+ * (`hermes_cli/config.py:2297-2298`, resolver at
+ * `tools/delegate_tool.py:3056-3170`).
+ *
+ * Selecting a provider clears the model so a new provider never pairs with the
+ * old provider's model. Out-of-catalog persisted models stay selectable so an
+ * existing valid pick renders instead of blank.
+ *
+ * Uses the Dashboard's existing fetch-then-setState pattern (no react-query)
+ * to match the rest of `web/src/pages/`.
+ */
+export function DelegationModelProviderField({
+  config,
+  onChange,
+}: {
+  config: Record<string, unknown>;
+  /**
+   * Atomic write of both `delegation.model` and `delegation.provider` on every
+   * change. Caller merges both keys into the parent config record in a
+   * single update — never persist a half-pair.
+   */
+  onChange: (next: DelegationValue) => void;
+}) {
+  const { t } = useI18n();
+  const c = t.config;
+
+  const [modelOptions, setModelOptions] = useState<ModelOptionsResponse | null>(
+    null,
+  );
+  const [loadFailed, setLoadFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    api
+      .getModelOptions()
+      .then((res) => {
+        if (!cancelled) setModelOptions(res);
+      })
+      .catch(() => {
+        if (!cancelled) setLoadFailed(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const providers = (modelOptions?.providers ?? []).filter((p) => p.slug);
+
+  // Top-level `model` + `provider` are the currently configured MAIN agent's
+  // pick (what the subagent inherits when the user picks "Inherit from main
+  // agent").
+  const inheritedProvider = modelOptions?.provider ?? "";
+  const inheritedModel = modelOptions?.model ?? "";
+
+  const delegationBlock =
+    config.delegation && typeof config.delegation === "object"
+      ? (config.delegation as Record<string, unknown>)
+      : {};
+  const delegationModel = String(delegationBlock.model ?? "");
+  const delegationProvider = String(delegationBlock.provider ?? "");
+
+  const isInherit = !delegationModel && !delegationProvider;
+
+  const selectedRow = providers.find((p) => p.slug === delegationProvider);
+  const catalog = selectedRow?.models ?? [];
+
+  // Keep an out-of-catalog persisted model selectable.
+  const modelItems =
+    delegationModel && !catalog.includes(delegationModel)
+      ? [delegationModel, ...catalog]
+      : catalog;
+
+  const providerHasEmptyCatalog =
+    delegationProvider !== "" && catalog.length === 0;
+
+  // Compute "what's being inherited" once for the helper line.
+  const inheritedDisplay =
+    inheritedProvider && inheritedModel
+      ? `${inheritedProvider} / ${inheritedModel}`
+      : inheritedModel || inheritedProvider || c.delegationInheritUnknown;
+
+  // Offline degradation: gateway unreachable, no cached options. Fall back to
+  // free-text inputs (never lock the page) — matches the Desktop behavior.
+  if (loadFailed && !modelOptions) {
+    return (
+      <div className="grid gap-1.5">
+        <p className="text-xs text-warning">{c.delegationLoadFailed}</p>
+        <Input
+          className="text-xs"
+          onChange={(e) => onChange({ provider: e.target.value, model: "" })}
+          placeholder={c.delegationProviderLabel}
+          value={delegationProvider}
+        />
+        <Input
+          className="text-xs"
+          onChange={(e) =>
+            onChange({ provider: delegationProvider, model: e.target.value })
+          }
+          placeholder={c.delegationCustomModelPlaceholder}
+          value={delegationModel}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-1.5">
+      <Label className="text-sm">{c.delegationProviderLabel}</Label>
+      <Select
+        value={isInherit ? INHERIT_VALUE : delegationProvider}
+        onValueChange={(next) => {
+          if (next === INHERIT_VALUE) {
+            onChange({ provider: "", model: "" });
+          } else {
+            // Switching providers clears the model — old provider's model
+            // paired with the new provider would never resolve at the gateway.
+            onChange({ provider: next, model: "" });
+          }
+        }}
+      >
+        <SelectOption value={INHERIT_VALUE}>
+          {c.delegationInheritFromMain}
+        </SelectOption>
+        {providers.map((p) => (
+          <SelectOption key={p.slug} value={p.slug}>
+            {p.name}
+          </SelectOption>
+        ))}
+      </Select>
+
+      {isInherit ? (
+        <p className="text-xs text-text-secondary">
+          {c.delegationCurrentlyInheriting(inheritedDisplay)}
+        </p>
+      ) : providerHasEmptyCatalog ? (
+        <>
+          <Label className="text-sm">{c.delegationModelLabel}</Label>
+          <Input
+            className="text-xs"
+            onChange={(e) =>
+              onChange({ provider: delegationProvider, model: e.target.value })
+            }
+            placeholder={c.delegationCustomModelPlaceholder}
+            value={delegationModel}
+          />
+        </>
+      ) : (
+        <>
+          <Label className="text-sm">{c.delegationModelLabel}</Label>
+          <Select
+            value={delegationModel}
+            onValueChange={(next) =>
+              onChange({ provider: delegationProvider, model: next })
+            }
+          >
+            {modelItems.map((model) => (
+              <SelectOption key={model} value={model}>
+                {model}
+              </SelectOption>
+            ))}
+          </Select>
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Render the picker only on the `delegation.model` row — the `provider` row
+ * is collapsed into the picker to avoid two controls for one logical field.
+ */
+export function isDelegationModelPickerKey(schemaKey: string): boolean {
+  return (
+    schemaKey === "delegation.model" || schemaKey === "delegation.provider"
+  );
+}

--- a/web/src/components/DelegationModelProviderField.tsx
+++ b/web/src/components/DelegationModelProviderField.tsx
@@ -55,10 +55,12 @@ export function DelegationModelProviderField({
     null,
   );
   const [loadFailed, setLoadFailed] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     let cancelled = false;
 
+    setIsLoading(true);
     api
       .getModelOptions()
       .then((res) => {
@@ -66,6 +68,9 @@ export function DelegationModelProviderField({
       })
       .catch(() => {
         if (!cancelled) setLoadFailed(true);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
       });
 
     return () => {
@@ -136,6 +141,7 @@ export function DelegationModelProviderField({
     <div className="grid gap-1.5">
       <Label className="text-sm">{c.delegationProviderLabel}</Label>
       <Select
+        disabled={isLoading}
         value={isInherit ? INHERIT_VALUE : delegationProvider}
         onValueChange={(next) => {
           if (next === INHERIT_VALUE) {
@@ -156,6 +162,9 @@ export function DelegationModelProviderField({
           </SelectOption>
         ))}
       </Select>
+      {isLoading ? (
+        <p className="text-xs text-text-secondary">{c.delegationLoading}</p>
+      ) : null}
 
       {isInherit ? (
         <p className="text-xs text-text-secondary">

--- a/web/src/components/DelegationModelProviderField.tsx
+++ b/web/src/components/DelegationModelProviderField.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Input } from "@nous-research/ui/ui/components/input";
 import { Label } from "@nous-research/ui/ui/components/label";
@@ -7,7 +7,15 @@ import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
 import { api, type ModelOptionsResponse } from "@/lib/api";
 import { useI18n } from "@/i18n";
 
-const INHERIT_VALUE = "__inherit__";
+const INHERIT_VALUE = "__inherit__"
+
+// Sentinel for the "model-only" configuration: `delegation.model` is set
+// while `delegation.provider` is blank. The resolver at
+// `tools/delegate_tool.py:3139-3149` preserves parent credentials in this
+// state (documented in `website/docs/user-guide/configuration.md:2023`).
+// Surfacing this as a distinct dropdown option lets users create and edit
+// the state explicitly instead of getting it stripped by the picker.
+const MODEL_ONLY_VALUE = "__model_only__";
 
 interface DelegationValue {
   model: string;
@@ -94,22 +102,92 @@ export function DelegationModelProviderField({
     config.delegation && typeof config.delegation === "object"
       ? (config.delegation as Record<string, unknown>)
       : {};
-  const delegationModel = String(delegationBlock.model ?? "");
-  const delegationProvider = String(delegationBlock.provider ?? "");
+  // Snapshot the persisted values once on mount — used to seed the local
+  // draft state and to detect external config changes (profile switch,
+  // reset-to-defaults). Same pattern as `FallbackModelsField` on the
+  // Desktop side.
+  const persistedModel = String(delegationBlock.model ?? "");
+  const persistedProvider = String(delegationBlock.provider ?? "");
 
-  const isInherit = !delegationModel && !delegationProvider;
+  // Local draft state — owned by the component so mid-edit values
+  // (e.g. an empty input while typing) don't flip the persisted state
+  // derivation and snap the dropdown back to "Inherit". The parent only
+  // sees the commit emitted via `onChange`.
+  const [draftProvider, setDraftProvider] = useState(persistedProvider);
+  const [draftModel, setDraftModel] = useState(persistedModel);
 
-  const selectedRow = providers.find((p) => p.slug === delegationProvider);
-  const catalog = selectedRow?.models ?? [];
+  // The dropdown's selection is user INTENT — distinct from the
+  // persisted model/provider pair. Tracking it separately means selecting
+  // "Custom model" from a clean inherit state immediately shows the
+  // model-only branch (with an empty input ready for typing), instead of
+  // snapping back to inherit because the model is empty. Same for
+  // backspace mid-edit: the dropdown stays where the user left it.
+  const initialSelectValue = !persistedProvider && !persistedModel
+    ? INHERIT_VALUE
+    : !persistedProvider && persistedModel
+      ? MODEL_ONLY_VALUE
+      : persistedProvider;
+  const [providerSelectValue, setProviderSelectValue] = useState<string>(initialSelectValue);
+
+  // Track the last pair we emitted so we can ignore the autosave echo
+  // through `config` (parent writes through `onChange`, then the new
+  // config round-trips back through the `config` prop).
+  const lastEmittedRef = useRef({ provider: persistedProvider, model: persistedModel });
+
+  // Resync local draft when the persisted config changes from OUTSIDE
+  // (profile switch, reset). Skip when the change is just our own emit
+  // echoing back through the parent.
+  useEffect(() => {
+    const emitted = lastEmittedRef.current
+    if (persistedProvider === emitted.provider && persistedModel === emitted.model) {
+      return
+    }
+    setDraftProvider(persistedProvider)
+    setDraftModel(persistedModel)
+    // Also resync the dropdown's selected value to match the new
+    // persisted state — otherwise a profile switch with the same model
+    // but different provider would leave the dropdown showing the old
+    // selection.
+    setProviderSelectValue(
+      !persistedProvider && !persistedModel
+        ? INHERIT_VALUE
+        : !persistedProvider && persistedModel
+          ? MODEL_ONLY_VALUE
+          : persistedProvider
+    )
+    lastEmittedRef.current = { provider: persistedProvider, model: persistedModel }
+  }, [persistedProvider, persistedModel])
+
+  const commit = (next: { provider: string; model: string }) => {
+    lastEmittedRef.current = next
+    onChange(next)
+  }
+
+  // Three distinct picker states — derived from the LOCAL DRAFT, not
+  // the persisted config, so the model field can be empty in the
+  // model-only state without the picker flipping back to inherit.
+  //  - `isInherit`: both fields blank → use the parent's main model + credentials.
+  //  - `isModelOnly`: dropdown is on MODEL_ONLY_VALUE → use the explicit
+  //    model but inherit credentials from the parent (preserved by the
+  //    resolver at `tools/delegate_tool.py:3139-3149`).
+  //  - explicit pick → fully pinned to the chosen provider.
+  const isInherit =
+    providerSelectValue === INHERIT_VALUE ||
+    (draftProvider === "" && draftModel === "");
+  const isModelOnly =
+    providerSelectValue === MODEL_ONLY_VALUE && draftProvider === "";
+
+  const selectedRow = providers.find((p) => p.slug === draftProvider)
+  const catalog = selectedRow?.models ?? []
 
   // Keep an out-of-catalog persisted model selectable.
   const modelItems =
-    delegationModel && !catalog.includes(delegationModel)
-      ? [delegationModel, ...catalog]
-      : catalog;
+    draftModel && !catalog.includes(draftModel)
+      ? [draftModel, ...catalog]
+      : catalog
 
   const providerHasEmptyCatalog =
-    delegationProvider !== "" && catalog.length === 0;
+    draftProvider !== "" && catalog.length === 0
 
   // Compute "what's being inherited" once for the helper line.
   const inheritedDisplay =
@@ -125,20 +203,24 @@ export function DelegationModelProviderField({
         <p className="text-xs text-warning">{c.delegationLoadFailed}</p>
         <Input
           className="text-xs"
-          onChange={(e) => onChange({ provider: e.target.value, model: "" })}
+          onChange={(e) => {
+            setDraftProvider(e.target.value)
+            commit({ provider: e.target.value, model: draftModel })
+          }}
           placeholder={c.delegationProviderLabel}
-          value={delegationProvider}
+          value={draftProvider}
         />
         <Input
           className="text-xs"
-          onChange={(e) =>
-            onChange({ provider: delegationProvider, model: e.target.value })
-          }
+          onChange={(e) => {
+            setDraftModel(e.target.value)
+            commit({ provider: draftProvider, model: e.target.value })
+          }}
           placeholder={c.delegationCustomModelPlaceholder}
-          value={delegationModel}
+          value={draftModel}
         />
       </div>
-    );
+    )
   }
 
   return (
@@ -146,19 +228,37 @@ export function DelegationModelProviderField({
       <Label className="text-sm">{c.delegationProviderLabel}</Label>
       <Select
         disabled={isLoading}
-        value={isInherit ? INHERIT_VALUE : delegationProvider}
+        value={providerSelectValue}
         onValueChange={(next) => {
+          // The dropdown's selected value is user INTENT — track it
+          // explicitly so it doesn't flip back when the persisted model
+          // is briefly empty (mid-edit, model-only entry, etc).
+          setProviderSelectValue(next)
           if (next === INHERIT_VALUE) {
-            onChange({ provider: "", model: "" });
+            // Full inherit — clear both fields locally and commit.
+            setDraftProvider("")
+            setDraftModel("")
+            commit({ provider: "", model: "" })
+          } else if (next === MODEL_ONLY_VALUE) {
+            // Model-only — clear the provider, keep the current draft
+            // model (preserves whatever the user typed mid-edit) so the
+            // resolver sees a coherent `provider="", model="…"` pair.
+            setDraftProvider("")
+            commit({ provider: "", model: draftModel })
           } else {
-            // Switching providers clears the model — old provider's model
-            // paired with the new provider would never resolve at the gateway.
-            onChange({ provider: next, model: "" });
+            // Switching to an explicit provider clears the model — the old
+            // provider's model wouldn't resolve at the gateway.
+            setDraftProvider(next)
+            setDraftModel("")
+            commit({ provider: next, model: "" })
           }
         }}
       >
         <SelectOption value={INHERIT_VALUE}>
           {c.delegationInheritFromMain}
+        </SelectOption>
+        <SelectOption value={MODEL_ONLY_VALUE}>
+          {c.delegationModelOnlyOption}
         </SelectOption>
         {providers.map((p) => (
           <SelectOption key={p.slug} value={p.slug}>
@@ -176,26 +276,50 @@ export function DelegationModelProviderField({
         <p className="text-xs text-text-secondary">
           {c.delegationCurrentlyInheriting(inheritedDisplay)}
         </p>
+      ) : isModelOnly ? (
+        // Model-only/provider-inherit — free-text input so the user can
+        // edit the model; helper line explains the credentials-inherited
+        // behavior. Stays mounted across edits so a brief empty value
+        // (mid-type) doesn't unmount the input.
+        <>
+          <Label className="text-sm">{c.delegationModelLabel}</Label>
+          <Input
+            aria-label={c.delegationModelLabel}
+            className="text-xs"
+            onChange={(e) => {
+              setDraftModel(e.target.value)
+              commit({ provider: "", model: e.target.value })
+            }}
+            placeholder={c.delegationCustomModelPlaceholder}
+            value={draftModel}
+          />
+          <p className="text-xs text-text-secondary">
+            {c.delegationCredentialsInherited}
+          </p>
+        </>
       ) : providerHasEmptyCatalog ? (
         <>
           <Label className="text-sm">{c.delegationModelLabel}</Label>
           <Input
+            aria-label={c.delegationModelLabel}
             className="text-xs"
-            onChange={(e) =>
-              onChange({ provider: delegationProvider, model: e.target.value })
-            }
+            onChange={(e) => {
+              setDraftModel(e.target.value)
+              commit({ provider: draftProvider, model: e.target.value })
+            }}
             placeholder={c.delegationCustomModelPlaceholder}
-            value={delegationModel}
+            value={draftModel}
           />
         </>
       ) : (
         <>
           <Label className="text-sm">{c.delegationModelLabel}</Label>
           <Select
-            value={delegationModel}
-            onValueChange={(next) =>
-              onChange({ provider: delegationProvider, model: next })
-            }
+            value={draftModel}
+            onValueChange={(next) => {
+              setDraftModel(next)
+              commit({ provider: draftProvider, model: next })
+            }}
           >
             {modelItems.map((model) => (
               <SelectOption key={model} value={model}>

--- a/web/src/components/DelegationModelProviderField.tsx
+++ b/web/src/components/DelegationModelProviderField.tsx
@@ -70,6 +70,8 @@ export function DelegationModelProviderField({
         if (!cancelled) setLoadFailed(true);
       })
       .finally(() => {
+        // Gate the loading flag on `cancelled` so an unmount-then-remount
+        // can't show a "not loading, but no options" flicker.
         if (!cancelled) setIsLoading(false);
       });
 
@@ -163,7 +165,9 @@ export function DelegationModelProviderField({
         ))}
       </Select>
       {isLoading ? (
-        <p className="text-xs text-text-secondary">{c.delegationLoading}</p>
+        <p aria-live="polite" className="text-xs text-text-secondary">
+          {c.delegationLoading}
+        </p>
       ) : null}
 
       {isInherit ? (

--- a/web/src/components/DelegationModelProviderField.tsx
+++ b/web/src/components/DelegationModelProviderField.tsx
@@ -15,7 +15,16 @@ const INHERIT_VALUE = "__inherit__"
 // state (documented in `website/docs/user-guide/configuration.md:2023`).
 // Surfacing this as a distinct dropdown option lets users create and edit
 // the state explicitly instead of getting it stripped by the picker.
-const MODEL_ONLY_VALUE = "__model_only__";
+const MODEL_ONLY_VALUE = "__model_only__"
+
+// Map a persisted `(provider, model)` pair to the dropdown's sentinel/slug
+// value. Used both for the initial `useState` seed and for resyncing
+// after external config changes (profile switch, reset).
+function selectValueFor(provider: string, model: string): string {
+  if (!provider && !model) return INHERIT_VALUE
+  if (!provider && model) return MODEL_ONLY_VALUE
+  return provider
+}
 
 interface DelegationValue {
   model: string;
@@ -122,12 +131,9 @@ export function DelegationModelProviderField({
   // model-only branch (with an empty input ready for typing), instead of
   // snapping back to inherit because the model is empty. Same for
   // backspace mid-edit: the dropdown stays where the user left it.
-  const initialSelectValue = !persistedProvider && !persistedModel
-    ? INHERIT_VALUE
-    : !persistedProvider && persistedModel
-      ? MODEL_ONLY_VALUE
-      : persistedProvider;
-  const [providerSelectValue, setProviderSelectValue] = useState<string>(initialSelectValue);
+  const [providerSelectValue, setProviderSelectValue] = useState<string>(
+    selectValueFor(persistedProvider, persistedModel),
+  );
 
   // Track the last pair we emitted so we can ignore the autosave echo
   // through `config` (parent writes through `onChange`, then the new
@@ -144,17 +150,7 @@ export function DelegationModelProviderField({
     }
     setDraftProvider(persistedProvider)
     setDraftModel(persistedModel)
-    // Also resync the dropdown's selected value to match the new
-    // persisted state — otherwise a profile switch with the same model
-    // but different provider would leave the dropdown showing the old
-    // selection.
-    setProviderSelectValue(
-      !persistedProvider && !persistedModel
-        ? INHERIT_VALUE
-        : !persistedProvider && persistedModel
-          ? MODEL_ONLY_VALUE
-          : persistedProvider
-    )
+    setProviderSelectValue(selectValueFor(persistedProvider, persistedModel))
     lastEmittedRef.current = { provider: persistedProvider, model: persistedModel }
   }, [persistedProvider, persistedModel])
 
@@ -171,11 +167,8 @@ export function DelegationModelProviderField({
   //    model but inherit credentials from the parent (preserved by the
   //    resolver at `tools/delegate_tool.py:3139-3149`).
   //  - explicit pick → fully pinned to the chosen provider.
-  const isInherit =
-    providerSelectValue === INHERIT_VALUE ||
-    (draftProvider === "" && draftModel === "");
-  const isModelOnly =
-    providerSelectValue === MODEL_ONLY_VALUE && draftProvider === "";
+  const isInherit = providerSelectValue === INHERIT_VALUE
+  const isModelOnly = providerSelectValue === MODEL_ONLY_VALUE
 
   const selectedRow = providers.find((p) => p.slug === draftProvider)
   const catalog = selectedRow?.models ?? []

--- a/web/src/i18n/af.ts
+++ b/web/src/i18n/af.ts
@@ -405,6 +405,8 @@ export const af: Translations = {
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",
+    delegationModelOnlyOption: "Custom model",
+    delegationCredentialsInherited: "Credentials inherited from the parent agent.",
     categories: {
       general: "Algemeen",
       agent: "Agent",

--- a/web/src/i18n/af.ts
+++ b/web/src/i18n/af.ts
@@ -394,6 +394,16 @@ export const af: Translations = {
     failedToLoadRaw: "Kon nie rou konfigurasie laai nie",
     configImported: "Konfigurasie ingevoer — kontroleer en stoor",
     invalidJson: "Ongeldige JSON-lêer",
+
+    delegationInheritFromMain: "Inherit from main agent",
+    delegationInheritUnknown: "the main agent's model",
+    delegationCurrentlyInheriting: (model: string) =>
+      `Currently inheriting: ${model}`,
+    delegationLoadFailed:
+      "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationProviderLabel: "Subagent provider",
+    delegationModelLabel: "Subagent model",
+    delegationCustomModelPlaceholder: "Custom model ID…",
     categories: {
       general: "Algemeen",
       agent: "Agent",

--- a/web/src/i18n/af.ts
+++ b/web/src/i18n/af.ts
@@ -401,6 +401,7 @@ export const af: Translations = {
       `Currently inheriting: ${model}`,
     delegationLoadFailed:
       "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationLoading: "Loading subagent catalog…",
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -405,6 +405,8 @@ export const de: Translations = {
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",
+    delegationModelOnlyOption: "Custom model",
+    delegationCredentialsInherited: "Credentials inherited from the parent agent.",
     categories: {
       general: "Allgemein",
       agent: "Agent",

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -401,6 +401,7 @@ export const de: Translations = {
       `Currently inheriting: ${model}`,
     delegationLoadFailed:
       "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationLoading: "Loading subagent catalog…",
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -394,6 +394,16 @@ export const de: Translations = {
     failedToLoadRaw: "Rohe Konfiguration konnte nicht geladen werden",
     configImported: "Konfiguration importiert — überprüfen und speichern",
     invalidJson: "Ungültige JSON-Datei",
+
+    delegationInheritFromMain: "Inherit from main agent",
+    delegationInheritUnknown: "the main agent's model",
+    delegationCurrentlyInheriting: (model: string) =>
+      `Currently inheriting: ${model}`,
+    delegationLoadFailed:
+      "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationProviderLabel: "Subagent provider",
+    delegationModelLabel: "Subagent model",
+    delegationCustomModelPlaceholder: "Custom model ID…",
     categories: {
       general: "Allgemein",
       agent: "Agent",

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -455,6 +455,7 @@ export const en: Translations = {
       `Currently inheriting: ${model}`,
     delegationLoadFailed:
       "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationLoading: "Loading subagent catalog…",
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -449,6 +449,15 @@ export const en: Translations = {
     failedToLoadRaw: "Failed to load raw config",
     configImported: "Config imported — review and save",
     invalidJson: "Invalid JSON file",
+    delegationInheritFromMain: "Inherit from main agent",
+    delegationInheritUnknown: "the main agent's model",
+    delegationCurrentlyInheriting: (model: string) =>
+      `Currently inheriting: ${model}`,
+    delegationLoadFailed:
+      "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationProviderLabel: "Subagent provider",
+    delegationModelLabel: "Subagent model",
+    delegationCustomModelPlaceholder: "Custom model ID…",
     categories: {
       general: "General",
       agent: "Agent",

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -459,6 +459,8 @@ export const en: Translations = {
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",
+    delegationModelOnlyOption: "Custom model",
+    delegationCredentialsInherited: "Credentials inherited from the parent agent.",
     categories: {
       general: "General",
       agent: "Agent",

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -402,6 +402,7 @@ export const es: Translations = {
       `Currently inheriting: ${model}`,
     delegationLoadFailed:
       "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationLoading: "Loading subagent catalog…",
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -406,6 +406,8 @@ export const es: Translations = {
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",
+    delegationModelOnlyOption: "Custom model",
+    delegationCredentialsInherited: "Credentials inherited from the parent agent.",
     categories: {
       general: "General",
       agent: "Agente",

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -395,6 +395,16 @@ export const es: Translations = {
     failedToLoadRaw: "No se pudo cargar la configuración en bruto",
     configImported: "Configuración importada — revisa y guarda",
     invalidJson: "Archivo JSON no válido",
+
+    delegationInheritFromMain: "Inherit from main agent",
+    delegationInheritUnknown: "the main agent's model",
+    delegationCurrentlyInheriting: (model: string) =>
+      `Currently inheriting: ${model}`,
+    delegationLoadFailed:
+      "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationProviderLabel: "Subagent provider",
+    delegationModelLabel: "Subagent model",
+    delegationCustomModelPlaceholder: "Custom model ID…",
     categories: {
       general: "General",
       agent: "Agente",

--- a/web/src/i18n/fr.ts
+++ b/web/src/i18n/fr.ts
@@ -395,6 +395,16 @@ export const fr: Translations = {
     failedToLoadRaw: "Échec du chargement de la configuration brute",
     configImported: "Configuration importée — vérifiez et enregistrez",
     invalidJson: "Fichier JSON invalide",
+
+    delegationInheritFromMain: "Inherit from main agent",
+    delegationInheritUnknown: "the main agent's model",
+    delegationCurrentlyInheriting: (model: string) =>
+      `Currently inheriting: ${model}`,
+    delegationLoadFailed:
+      "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationProviderLabel: "Subagent provider",
+    delegationModelLabel: "Subagent model",
+    delegationCustomModelPlaceholder: "Custom model ID…",
     categories: {
       general: "Général",
       agent: "Agent",

--- a/web/src/i18n/fr.ts
+++ b/web/src/i18n/fr.ts
@@ -406,6 +406,8 @@ export const fr: Translations = {
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",
+    delegationModelOnlyOption: "Custom model",
+    delegationCredentialsInherited: "Credentials inherited from the parent agent.",
     categories: {
       general: "Général",
       agent: "Agent",

--- a/web/src/i18n/fr.ts
+++ b/web/src/i18n/fr.ts
@@ -402,6 +402,7 @@ export const fr: Translations = {
       `Currently inheriting: ${model}`,
     delegationLoadFailed:
       "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationLoading: "Loading subagent catalog…",
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",

--- a/web/src/i18n/ga.ts
+++ b/web/src/i18n/ga.ts
@@ -409,6 +409,7 @@ export const ga: Translations = {
       `Currently inheriting: ${model}`,
     delegationLoadFailed:
       "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationLoading: "Loading subagent catalog…",
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",

--- a/web/src/i18n/ga.ts
+++ b/web/src/i18n/ga.ts
@@ -413,6 +413,8 @@ export const ga: Translations = {
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",
+    delegationModelOnlyOption: "Custom model",
+    delegationCredentialsInherited: "Credentials inherited from the parent agent.",
     categories: {
       general: "Ginearálta",
       agent: "Agent",

--- a/web/src/i18n/ga.ts
+++ b/web/src/i18n/ga.ts
@@ -402,6 +402,16 @@ export const ga: Translations = {
     failedToLoadRaw: "Theip ar luchtú na cumraíochta amh",
     configImported: "Cumraíocht iompórtáilte — athbhreithnigh agus sábháil",
     invalidJson: "Comhad JSON neamhbhailí",
+
+    delegationInheritFromMain: "Inherit from main agent",
+    delegationInheritUnknown: "the main agent's model",
+    delegationCurrentlyInheriting: (model: string) =>
+      `Currently inheriting: ${model}`,
+    delegationLoadFailed:
+      "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationProviderLabel: "Subagent provider",
+    delegationModelLabel: "Subagent model",
+    delegationCustomModelPlaceholder: "Custom model ID…",
     categories: {
       general: "Ginearálta",
       agent: "Agent",

--- a/web/src/i18n/hu.ts
+++ b/web/src/i18n/hu.ts
@@ -394,6 +394,16 @@ export const hu: Translations = {
     failedToLoadRaw: "Nem sikerült betölteni a nyers konfigurációt",
     configImported: "Konfiguráció importálva — ellenőrizze és mentse",
     invalidJson: "Érvénytelen JSON-fájl",
+
+    delegationInheritFromMain: "Inherit from main agent",
+    delegationInheritUnknown: "the main agent's model",
+    delegationCurrentlyInheriting: (model: string) =>
+      `Currently inheriting: ${model}`,
+    delegationLoadFailed:
+      "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationProviderLabel: "Subagent provider",
+    delegationModelLabel: "Subagent model",
+    delegationCustomModelPlaceholder: "Custom model ID…",
     categories: {
       general: "Általános",
       agent: "Ügynök",

--- a/web/src/i18n/hu.ts
+++ b/web/src/i18n/hu.ts
@@ -401,6 +401,7 @@ export const hu: Translations = {
       `Currently inheriting: ${model}`,
     delegationLoadFailed:
       "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationLoading: "Loading subagent catalog…",
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",

--- a/web/src/i18n/hu.ts
+++ b/web/src/i18n/hu.ts
@@ -405,6 +405,8 @@ export const hu: Translations = {
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",
+    delegationModelOnlyOption: "Custom model",
+    delegationCredentialsInherited: "Credentials inherited from the parent agent.",
     categories: {
       general: "Általános",
       agent: "Ügynök",

--- a/web/src/i18n/it.ts
+++ b/web/src/i18n/it.ts
@@ -405,6 +405,8 @@ export const it: Translations = {
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",
+    delegationModelOnlyOption: "Custom model",
+    delegationCredentialsInherited: "Credentials inherited from the parent agent.",
     categories: {
       general: "Generale",
       agent: "Agente",

--- a/web/src/i18n/it.ts
+++ b/web/src/i18n/it.ts
@@ -394,6 +394,16 @@ export const it: Translations = {
     failedToLoadRaw: "Caricamento configurazione grezza non riuscito",
     configImported: "Configurazione importata — controlla e salva",
     invalidJson: "File JSON non valido",
+
+    delegationInheritFromMain: "Inherit from main agent",
+    delegationInheritUnknown: "the main agent's model",
+    delegationCurrentlyInheriting: (model: string) =>
+      `Currently inheriting: ${model}`,
+    delegationLoadFailed:
+      "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationProviderLabel: "Subagent provider",
+    delegationModelLabel: "Subagent model",
+    delegationCustomModelPlaceholder: "Custom model ID…",
     categories: {
       general: "Generale",
       agent: "Agente",

--- a/web/src/i18n/it.ts
+++ b/web/src/i18n/it.ts
@@ -401,6 +401,7 @@ export const it: Translations = {
       `Currently inheriting: ${model}`,
     delegationLoadFailed:
       "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationLoading: "Loading subagent catalog…",
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",

--- a/web/src/i18n/ja.ts
+++ b/web/src/i18n/ja.ts
@@ -404,6 +404,8 @@ export const ja: Translations = {
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",
+    delegationModelOnlyOption: "Custom model",
+    delegationCredentialsInherited: "Credentials inherited from the parent agent.",
     categories: {
       general: "一般",
       agent: "エージェント",

--- a/web/src/i18n/ja.ts
+++ b/web/src/i18n/ja.ts
@@ -393,6 +393,16 @@ export const ja: Translations = {
     failedToLoadRaw: "生の設定の読み込みに失敗しました",
     configImported: "設定をインポートしました — 確認して保存してください",
     invalidJson: "無効な JSON ファイル",
+
+    delegationInheritFromMain: "Inherit from main agent",
+    delegationInheritUnknown: "the main agent's model",
+    delegationCurrentlyInheriting: (model: string) =>
+      `Currently inheriting: ${model}`,
+    delegationLoadFailed:
+      "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationProviderLabel: "Subagent provider",
+    delegationModelLabel: "Subagent model",
+    delegationCustomModelPlaceholder: "Custom model ID…",
     categories: {
       general: "一般",
       agent: "エージェント",

--- a/web/src/i18n/ja.ts
+++ b/web/src/i18n/ja.ts
@@ -400,6 +400,7 @@ export const ja: Translations = {
       `Currently inheriting: ${model}`,
     delegationLoadFailed:
       "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationLoading: "Loading subagent catalog…",
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",

--- a/web/src/i18n/ko.ts
+++ b/web/src/i18n/ko.ts
@@ -404,6 +404,8 @@ export const ko: Translations = {
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",
+    delegationModelOnlyOption: "Custom model",
+    delegationCredentialsInherited: "Credentials inherited from the parent agent.",
     categories: {
       general: "일반",
       agent: "에이전트",

--- a/web/src/i18n/ko.ts
+++ b/web/src/i18n/ko.ts
@@ -393,6 +393,16 @@ export const ko: Translations = {
     failedToLoadRaw: "원본 설정 로드에 실패했습니다",
     configImported: "설정을 가져왔습니다 — 검토 후 저장하세요",
     invalidJson: "잘못된 JSON 파일입니다",
+
+    delegationInheritFromMain: "Inherit from main agent",
+    delegationInheritUnknown: "the main agent's model",
+    delegationCurrentlyInheriting: (model: string) =>
+      `Currently inheriting: ${model}`,
+    delegationLoadFailed:
+      "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationProviderLabel: "Subagent provider",
+    delegationModelLabel: "Subagent model",
+    delegationCustomModelPlaceholder: "Custom model ID…",
     categories: {
       general: "일반",
       agent: "에이전트",

--- a/web/src/i18n/ko.ts
+++ b/web/src/i18n/ko.ts
@@ -400,6 +400,7 @@ export const ko: Translations = {
       `Currently inheriting: ${model}`,
     delegationLoadFailed:
       "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationLoading: "Loading subagent catalog…",
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",

--- a/web/src/i18n/pt.ts
+++ b/web/src/i18n/pt.ts
@@ -402,6 +402,7 @@ export const pt: Translations = {
       `Currently inheriting: ${model}`,
     delegationLoadFailed:
       "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationLoading: "Loading subagent catalog…",
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",

--- a/web/src/i18n/pt.ts
+++ b/web/src/i18n/pt.ts
@@ -406,6 +406,8 @@ export const pt: Translations = {
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",
+    delegationModelOnlyOption: "Custom model",
+    delegationCredentialsInherited: "Credentials inherited from the parent agent.",
     categories: {
       general: "Geral",
       agent: "Agente",

--- a/web/src/i18n/pt.ts
+++ b/web/src/i18n/pt.ts
@@ -395,6 +395,16 @@ export const pt: Translations = {
     failedToLoadRaw: "Falha ao carregar configuração em bruto",
     configImported: "Configuração importada — reveja e guarde",
     invalidJson: "Ficheiro JSON inválido",
+
+    delegationInheritFromMain: "Inherit from main agent",
+    delegationInheritUnknown: "the main agent's model",
+    delegationCurrentlyInheriting: (model: string) =>
+      `Currently inheriting: ${model}`,
+    delegationLoadFailed:
+      "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationProviderLabel: "Subagent provider",
+    delegationModelLabel: "Subagent model",
+    delegationCustomModelPlaceholder: "Custom model ID…",
     categories: {
       general: "Geral",
       agent: "Agente",

--- a/web/src/i18n/ru.ts
+++ b/web/src/i18n/ru.ts
@@ -405,6 +405,8 @@ export const ru: Translations = {
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",
+    delegationModelOnlyOption: "Custom model",
+    delegationCredentialsInherited: "Credentials inherited from the parent agent.",
     categories: {
       general: "Общие",
       agent: "Агент",

--- a/web/src/i18n/ru.ts
+++ b/web/src/i18n/ru.ts
@@ -394,6 +394,16 @@ export const ru: Translations = {
     failedToLoadRaw: "Не удалось загрузить исходную конфигурацию",
     configImported: "Конфигурация импортирована — проверьте и сохраните",
     invalidJson: "Некорректный JSON-файл",
+
+    delegationInheritFromMain: "Inherit from main agent",
+    delegationInheritUnknown: "the main agent's model",
+    delegationCurrentlyInheriting: (model: string) =>
+      `Currently inheriting: ${model}`,
+    delegationLoadFailed:
+      "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationProviderLabel: "Subagent provider",
+    delegationModelLabel: "Subagent model",
+    delegationCustomModelPlaceholder: "Custom model ID…",
     categories: {
       general: "Общие",
       agent: "Агент",

--- a/web/src/i18n/ru.ts
+++ b/web/src/i18n/ru.ts
@@ -401,6 +401,7 @@ export const ru: Translations = {
       `Currently inheriting: ${model}`,
     delegationLoadFailed:
       "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationLoading: "Loading subagent catalog…",
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",

--- a/web/src/i18n/tr.ts
+++ b/web/src/i18n/tr.ts
@@ -401,6 +401,7 @@ export const tr: Translations = {
       `Currently inheriting: ${model}`,
     delegationLoadFailed:
       "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationLoading: "Loading subagent catalog…",
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",

--- a/web/src/i18n/tr.ts
+++ b/web/src/i18n/tr.ts
@@ -405,6 +405,8 @@ export const tr: Translations = {
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",
+    delegationModelOnlyOption: "Custom model",
+    delegationCredentialsInherited: "Credentials inherited from the parent agent.",
     categories: {
       general: "Genel",
       agent: "Agent",

--- a/web/src/i18n/tr.ts
+++ b/web/src/i18n/tr.ts
@@ -394,6 +394,16 @@ export const tr: Translations = {
     failedToLoadRaw: "Ham yapılandırma yüklenemedi",
     configImported: "Yapılandırma içe aktarıldı — gözden geçirip kaydedin",
     invalidJson: "Geçersiz JSON dosyası",
+
+    delegationInheritFromMain: "Inherit from main agent",
+    delegationInheritUnknown: "the main agent's model",
+    delegationCurrentlyInheriting: (model: string) =>
+      `Currently inheriting: ${model}`,
+    delegationLoadFailed:
+      "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationProviderLabel: "Subagent provider",
+    delegationModelLabel: "Subagent model",
+    delegationCustomModelPlaceholder: "Custom model ID…",
     categories: {
       general: "Genel",
       agent: "Agent",

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -467,6 +467,13 @@ export interface Translations {
     failedToLoadRaw: string;
     configImported: string;
     invalidJson: string;
+    delegationInheritFromMain: string;
+    delegationInheritUnknown: string;
+    delegationCurrentlyInheriting: (model: string) => string;
+    delegationLoadFailed: string;
+    delegationProviderLabel: string;
+    delegationModelLabel: string;
+    delegationCustomModelPlaceholder: string;
     categories: {
       general: string;
       agent: string;

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -475,6 +475,8 @@ export interface Translations {
     delegationProviderLabel: string;
     delegationModelLabel: string;
     delegationCustomModelPlaceholder: string;
+    delegationModelOnlyOption: string;
+    delegationCredentialsInherited: string;
     categories: {
       general: string;
       agent: string;

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -471,6 +471,7 @@ export interface Translations {
     delegationInheritUnknown: string;
     delegationCurrentlyInheriting: (model: string) => string;
     delegationLoadFailed: string;
+    delegationLoading: string;
     delegationProviderLabel: string;
     delegationModelLabel: string;
     delegationCustomModelPlaceholder: string;

--- a/web/src/i18n/uk.ts
+++ b/web/src/i18n/uk.ts
@@ -406,6 +406,8 @@ export const uk: Translations = {
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",
+    delegationModelOnlyOption: "Custom model",
+    delegationCredentialsInherited: "Credentials inherited from the parent agent.",
     categories: {
       general: "Загальне",
       agent: "Агент",

--- a/web/src/i18n/uk.ts
+++ b/web/src/i18n/uk.ts
@@ -395,6 +395,16 @@ export const uk: Translations = {
     failedToLoadRaw: "Не вдалося завантажити сирий конфіг",
     configImported: "Конфігурацію імпортовано — перегляньте та збережіть",
     invalidJson: "Недійсний файл JSON",
+
+    delegationInheritFromMain: "Inherit from main agent",
+    delegationInheritUnknown: "the main agent's model",
+    delegationCurrentlyInheriting: (model: string) =>
+      `Currently inheriting: ${model}`,
+    delegationLoadFailed:
+      "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationProviderLabel: "Subagent provider",
+    delegationModelLabel: "Subagent model",
+    delegationCustomModelPlaceholder: "Custom model ID…",
     categories: {
       general: "Загальне",
       agent: "Агент",

--- a/web/src/i18n/uk.ts
+++ b/web/src/i18n/uk.ts
@@ -402,6 +402,7 @@ export const uk: Translations = {
       `Currently inheriting: ${model}`,
     delegationLoadFailed:
       "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationLoading: "Loading subagent catalog…",
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",

--- a/web/src/i18n/zh-hant.ts
+++ b/web/src/i18n/zh-hant.ts
@@ -400,6 +400,7 @@ export const zhHant: Translations = {
       `Currently inheriting: ${model}`,
     delegationLoadFailed:
       "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationLoading: "Loading subagent catalog…",
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",

--- a/web/src/i18n/zh-hant.ts
+++ b/web/src/i18n/zh-hant.ts
@@ -393,6 +393,16 @@ export const zhHant: Translations = {
     failedToLoadRaw: "載入原始設定失敗",
     configImported: "設定已匯入 — 請檢視後儲存",
     invalidJson: "無效的 JSON 檔案",
+
+    delegationInheritFromMain: "Inherit from main agent",
+    delegationInheritUnknown: "the main agent's model",
+    delegationCurrentlyInheriting: (model: string) =>
+      `Currently inheriting: ${model}`,
+    delegationLoadFailed:
+      "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationProviderLabel: "Subagent provider",
+    delegationModelLabel: "Subagent model",
+    delegationCustomModelPlaceholder: "Custom model ID…",
     categories: {
       general: "一般",
       agent: "代理",

--- a/web/src/i18n/zh-hant.ts
+++ b/web/src/i18n/zh-hant.ts
@@ -404,6 +404,8 @@ export const zhHant: Translations = {
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",
+    delegationModelOnlyOption: "Custom model",
+    delegationCredentialsInherited: "Credentials inherited from the parent agent.",
     categories: {
       general: "一般",
       agent: "代理",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -396,6 +396,7 @@ export const zh: Translations = {
       `Currently inheriting: ${model}`,
     delegationLoadFailed:
       "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationLoading: "Loading subagent catalog…",
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -400,6 +400,8 @@ export const zh: Translations = {
     delegationProviderLabel: "Subagent provider",
     delegationModelLabel: "Subagent model",
     delegationCustomModelPlaceholder: "Custom model ID…",
+    delegationModelOnlyOption: "Custom model",
+    delegationCredentialsInherited: "Credentials inherited from the parent agent.",
     categories: {
       general: "通用",
       agent: "代理",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -389,6 +389,16 @@ export const zh: Translations = {
     failedToLoadRaw: "加载原始配置失败",
     configImported: "配置已导入 — 请检查后保存",
     invalidJson: "无效的 JSON 文件",
+
+    delegationInheritFromMain: "Inherit from main agent",
+    delegationInheritUnknown: "the main agent's model",
+    delegationCurrentlyInheriting: (model: string) =>
+      `Currently inheriting: ${model}`,
+    delegationLoadFailed:
+      "Couldn't load provider catalog — type provider and model IDs directly.",
+    delegationProviderLabel: "Subagent provider",
+    delegationModelLabel: "Subagent model",
+    delegationCustomModelPlaceholder: "Custom model ID…",
     categories: {
       general: "通用",
       agent: "代理",

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -430,9 +430,17 @@ export default function ConfigPage() {
               <DelegationModelProviderField
                 config={config}
                 onChange={next => {
-                  let updated = setNestedValue(config, "delegation.model", next.model)
-                  updated = setNestedValue(updated, "delegation.provider", next.provider)
-                  setConfig(updated)
+                  // Single merged update — both `delegation.model` and
+                  // `delegation.provider` change in one `setConfig` call so
+                  // no transient invalid pair can be observed by a re-render
+                  // between two separate updates.
+                  setConfig(prev =>
+                    setNestedValue(
+                      setNestedValue(prev ?? {}, "delegation.model", next.model),
+                      "delegation.provider",
+                      next.provider,
+                    ),
+                  )
                 }}
               />
             ) : isDelegationModelPickerKey(key) ? (

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -41,6 +41,10 @@ import { getNestedValue, setNestedValue } from "@/lib/nested";
 import { useToast } from "@nous-research/ui/hooks/use-toast";
 import { Toast } from "@nous-research/ui/ui/components/toast";
 import { AutoField } from "@/components/AutoField";
+import {
+  DelegationModelProviderField,
+  isDelegationModelPickerKey,
+} from "@/components/DelegationModelProviderField";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { ListItem } from "@nous-research/ui/ui/components/list-item";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
@@ -418,12 +422,32 @@ export default function ConfigPage() {
             </div>
           )}
           <div className="py-1">
-            <AutoField
-              schemaKey={key}
-              schema={s}
-              value={getNestedValue(config, key)}
-              onChange={(v) => setConfig(setNestedValue(config, key, v))}
-            />
+            {key === "delegation.model" ? (
+              /* The picker owns both `delegation.model` and
+                 `delegation.provider` rendering and writes — skip the
+                 generic AutoField here and write both keys atomically on
+                 every change so we never persist a half-pair. */
+              <DelegationModelProviderField
+                config={config}
+                onChange={next => {
+                  let updated = setNestedValue(config, "delegation.model", next.model)
+                  updated = setNestedValue(updated, "delegation.provider", next.provider)
+                  setConfig(updated)
+                }}
+              />
+            ) : isDelegationModelPickerKey(key) ? (
+              /* `delegation.provider` is rendered inside the picker above.
+                 This branch exists so the AutoField for this key doesn't
+                 render a duplicate free-text input below it. */
+              null
+            ) : (
+              <AutoField
+                schemaKey={key}
+                schema={s}
+                value={getNestedValue(config, key)}
+                onChange={(v) => setConfig(setNestedValue(config, key, v))}
+              />
+            )}
           </div>
         </div>
       );

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -41,10 +41,7 @@ import { getNestedValue, setNestedValue } from "@/lib/nested";
 import { useToast } from "@nous-research/ui/hooks/use-toast";
 import { Toast } from "@nous-research/ui/ui/components/toast";
 import { AutoField } from "@/components/AutoField";
-import {
-  DelegationModelProviderField,
-  isDelegationModelPickerKey,
-} from "@/components/DelegationModelProviderField";
+import { DelegationModelProviderField } from "@/components/DelegationModelProviderField";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { ListItem } from "@nous-research/ui/ui/components/list-item";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
@@ -443,7 +440,7 @@ export default function ConfigPage() {
                   )
                 }}
               />
-            ) : isDelegationModelPickerKey(key) ? (
+            ) : key === "delegation.provider" ? (
               /* `delegation.provider` is rendered inside the picker above.
                  This branch exists so the AutoField for this key doesn't
                  render a duplicate free-text input below it. */


### PR DESCRIPTION
## What does this PR do?

Closes the Dashboard half of the `delegation.model` / `delegation.provider`
picker UX gap originally reported in #67347. Mirrors the Desktop
implementation in #67523 (same design, different React app).

The Dashboard's `ConfigPage` (`web/src/pages/ConfigPage.tsx`) was
surfacting both fields as bare free-text inputs via the generic
schema-driven `AutoField` renderer — same UX problem Desktop just fixed.
This PR replaces them with a paired provider + model picker sourced from
`/api/model/options` (the same endpoint the chat model picker and MoA
preset picker already use).

Key behaviors (matched to the Desktop implementation):

- **"Inherit from main agent"** is a first-class dropdown option that
  writes `""` to both keys — the documented default at
  `hermes_cli/config.py:2297-2298` and the resolver at
  `tools/delegate_tool.py:3056-3170`.
- **Provider switch clears the model** so a new provider never pairs with
  the old provider's model.
- **Custom-endpoint handling**: providers with an empty `models` list (user-
  defined endpoints without probed models) fall back to a free-text input.
- **Out-of-catalog persisted models stay selectable** so an existing valid
  pick renders instead of blank.
- **Gateway-unreachable degradation**: falls back to free-text inputs with
  a warning banner; the settings page is never locked.

The atomic two-key write happens inside `setConfig` at the parent — one
combined update, never a half-pair.

## Related Issue

Fixes #67347 (Dashboard half — Desktop half landed in #67523)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `web/src/components/DelegationModelProviderField.tsx` (new, +201 lines)
  — the picker. Uses the Dashboard's existing `useState` + `useEffect`
  fetch pattern (no react-query in `web/src/`), wired to `api.getModelOptions()`.
- `web/src/pages/ConfigPage.tsx` — hooks the picker into `renderFields`.
  `delegation.model` row renders `<DelegationModelProviderField>`, the
  `delegation.provider` row returns null (avoiding a duplicate free-text
  input below the picker). Both keys written atomically via two
  `setNestedValue` calls inside one `setConfig`.
- `web/src/i18n/en.ts` — 7 new keys plus a function-typed
  `delegationCurrentlyInheriting: (model: string) => string` (matches
  the Desktop i18n pattern).
- `web/src/i18n/types.ts` — type counterparts.
- `web/src/i18n/{ja,zh,zh-hant,af,de,es,fr,ga,hu,it,ko,pt,ru,tr,uk}.ts`
  — 14 non-English locales stubbed with English values (all Dashboard
  locales declare `Translations` directly; no `defineLocale` shortcut
  available).

## How to Test

1. Open the Dashboard at `/config` (or whatever the route is for the
   config editor — see `web/src/pages/ConfigPage.tsx`).
2. Search/filter to find `delegation.model`. The row should render the
   new picker (provider dropdown + model dropdown or free-text fallback)
   instead of a free-text input.
3. With both fields blank, verify "Inherit from main agent" is the
   default option and a helper line shows the inherited main model.
4. Select a provider — the model dropdown should populate with that
   provider's catalog models (or show a free-text input if the catalog
   is empty).
5. Select a model — verify both `delegation.model` and `delegation.provider`
   are written to the config (no half-pair persisted).
6. Switch providers — verify the model clears.
7. Stop the gateway and refresh — verify the page falls back to text
   inputs + a warning banner instead of locking.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(...)` etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — confirmed it covers the Dashboard half that #67523 (Desktop) explicitly doesn't.
- [x] My PR contains **only** changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (this is a frontend change, no Python tests affected).
- [ ] I've added tests for my changes — see "Test gap" note below.
- [x] I've tested on my platform: macOS 26.5.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no docs change needed; UI improvement to existing fields).
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys).
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A.
- [x] I've considered cross-platform impact — N/A (web frontend, no platform-specific code).
- [x] I've updated tool descriptions/schemas — N/A.

### Test gap (explicit)

The Dashboard has no existing React component tests, no
`@testing-library/react`, and no `jsdom` configured in `vitest.config.ts`.
Adding test infra for one component is scope creep. Cross-vendor review
on the diff is included in the PR description; if reviewers want a
test, happy to add it as a follow-up (would require installing
`@testing-library/react` + `jsdom` and updating `vitest.config.ts`).

## Screenshots / Logs

N/A — UI change, no logs to capture. The fix is verifiable by opening
the Dashboard's config page and observing the picker replace the
free-text input.

## Notes

- The Dashboard's picker is structurally the same as the Desktop one
  (`apps/desktop/src/app/settings/delegation-model-provider-field.tsx`)
  but uses `useState`/`useEffect` instead of `useQuery` because the
  Dashboard's `web/src/` has no react-query setup.
- i18n keys live under `t.config.*` (matching the Desktop's
  `t.settings.config.*` convention from #67523) since these are
  config-editor affordances, not model-picker affordances.
- Locale stubs use English values; translators can fill in real
  translations in a follow-up.
