### PR TITLE
fix(tui): prevent non-QWERTY Cmd+V from opening sessions

### DIFF
--- a/ui-tui/src/__tests__/platform.test.ts
+++ b/ui-tui/src/__tests__/platform.test.ts
@@ -31,6 +31,16 @@ describe('platform action modifier', () => {
   })
 })
 
+describe('isLiteralCtrl', () => {
+  it('rejects Cmd/Alt-forwarded Ctrl+X events used by non-QWERTY paste', async () => {
+    const { isLiteralCtrl } = await importPlatform('darwin')
+
+    expect(isLiteralCtrl({ ctrl: true, meta: false, super: false }, 'x', 'x')).toBe(true)
+    expect(isLiteralCtrl({ ctrl: true, meta: true, super: false }, 'x', 'x')).toBe(false)
+    expect(isLiteralCtrl({ ctrl: true, meta: false, super: true }, 'x', 'x')).toBe(false)
+  })
+})
+
 describe('isCopyShortcut', () => {
   it('keeps Ctrl+C as the local non-macOS copy chord', async () => {
     const { isCopyShortcut } = await importPlatform('linux')

--- a/ui-tui/src/__tests__/textInputPassThrough.test.ts
+++ b/ui-tui/src/__tests__/textInputPassThrough.test.ts
@@ -44,6 +44,8 @@ describe('shouldPassThroughToGlobalHandler', () => {
   it('always passes through non-voice global control keys', () => {
     expect(shouldPassThroughToGlobalHandler('c', key({ ctrl: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('x', key({ ctrl: true }))).toBe(true)
+    expect(shouldPassThroughToGlobalHandler('x', key({ ctrl: true, meta: true }))).toBe(false)
+    expect(shouldPassThroughToGlobalHandler('x', key({ ctrl: true, super: true }))).toBe(false)
     expect(shouldPassThroughToGlobalHandler('o', key({ ctrl: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('', key({ escape: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('', key({ tab: true }))).toBe(true)

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -12,7 +12,7 @@ import type {
   SudoRespondResponse,
   VoiceRecordResponse
 } from '../gatewayTypes.js'
-import { isAction, isCopyShortcut, isMac, isVoiceToggleKey } from '../lib/platform.js'
+import { isAction, isCopyShortcut, isLiteralCtrl, isMac, isVoiceToggleKey } from '../lib/platform.js'
 import { computePrecisionWheelStep, initPrecisionWheel } from '../lib/precisionWheel.js'
 import { computeWheelStep, initWheelAccelForHost } from '../lib/wheelAccel.js'
 import { closeWidget, dispatchWidgetInput } from '../sdk/host.js'
@@ -586,17 +586,17 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       }
     }
 
-    if (isCtrl(key, ch, 'x') && handleInputSelectionClipboard(getInputSelection(), 'cut')) {
+    if (isLiteralCtrl(key, ch, 'x') && handleInputSelectionClipboard(getInputSelection(), 'cut')) {
       return
     }
 
-    if (isCtrl(key, ch, 'x') && cState.queueEditIdx !== null) {
+    if (isLiteralCtrl(key, ch, 'x') && cState.queueEditIdx !== null) {
       cActions.removeQueue(cState.queueEditIdx)
 
       return cActions.clearIn()
     }
 
-    if (isCtrl(key, ch, 'x')) {
+    if (isLiteralCtrl(key, ch, 'x')) {
       return patchOverlayState({ sessions: true })
     }
 

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -12,7 +12,7 @@ import type {
   SudoRespondResponse,
   VoiceRecordResponse
 } from '../gatewayTypes.js'
-import { isAction, isCopyShortcut, isMac, isVoiceToggleKey } from '../lib/platform.js'
+import { isAction, isCopyShortcut, isLiteralCtrl, isMac, isVoiceToggleKey } from '../lib/platform.js'
 import { computePrecisionWheelStep, initPrecisionWheel } from '../lib/precisionWheel.js'
 import { computeWheelStep, initWheelAccelForHost } from '../lib/wheelAccel.js'
 import { closeWidget, dispatchWidgetInput } from '../sdk/host.js'
@@ -575,13 +575,13 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       }
     }
 
-    if (isCtrl(key, ch, 'x') && cState.queueEditIdx !== null) {
+    if (isLiteralCtrl(key, ch, 'x') && cState.queueEditIdx !== null) {
       cActions.removeQueue(cState.queueEditIdx)
 
       return cActions.clearIn()
     }
 
-    if (isCtrl(key, ch, 'x')) {
+    if (isLiteralCtrl(key, ch, 'x')) {
       return patchOverlayState({ sessions: true })
     }
 

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -8,6 +8,7 @@ import { cursorLayout, offsetFromPosition } from '../lib/inputMetrics.js'
 import {
   DEFAULT_VOICE_RECORD_KEY,
   isActionMod,
+  isLiteralCtrl,
   isMac,
   isMacActionFallback,
   isVoiceToggleKey,
@@ -1700,7 +1701,7 @@ export const shouldPassThroughToGlobalHandler = (
   voiceRecordKey: ParsedVoiceRecordKey = DEFAULT_VOICE_RECORD_KEY
 ): boolean =>
   (key.ctrl && input === 'c') ||
-  (key.ctrl && input === 'x') ||
+  isLiteralCtrl(key, input, 'x') ||
   (key.ctrl && input === 'o') ||
   key.tab ||
   (key.shift && key.tab) ||

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -8,6 +8,7 @@ import { cursorLayout, offsetFromPosition } from '../lib/inputMetrics.js'
 import {
   DEFAULT_VOICE_RECORD_KEY,
   isActionMod,
+  isLiteralCtrl,
   isMac,
   isMacActionFallback,
   isVoiceToggleKey,
@@ -1539,7 +1540,7 @@ export const shouldPassThroughToGlobalHandler = (
   voiceRecordKey: ParsedVoiceRecordKey = DEFAULT_VOICE_RECORD_KEY
 ): boolean =>
   (key.ctrl && input === 'c') ||
-  (key.ctrl && input === 'x') ||
+  isLiteralCtrl(key, input, 'x') ||
   (key.ctrl && input === 'o') ||
   key.tab ||
   (key.shift && key.tab) ||

--- a/ui-tui/src/lib/platform.ts
+++ b/ui-tui/src/lib/platform.ts
@@ -34,6 +34,13 @@ export const isMacActionFallback = (
 export const isAction = (key: { ctrl: boolean; meta: boolean; super?: boolean }, ch: string, target: string): boolean =>
   isActionMod(key) && ch.toLowerCase() === target
 
+/** Match a literal Ctrl chord, excluding terminal-forwarded Cmd/Alt events. */
+export const isLiteralCtrl = (
+  key: { ctrl: boolean; meta: boolean; super?: boolean },
+  ch: string,
+  target: string
+): boolean => key.ctrl && !key.meta && key.super !== true && ch.toLowerCase() === target
+
 export const isRemoteShell = (env: NodeJS.ProcessEnv = process.env): boolean =>
   Boolean(env.SSH_CONNECTION || env.SSH_CLIENT || env.SSH_TTY)
 


### PR DESCRIPTION
Rebased onto current `main` and consolidated to a single commit (0076db661). The fix is still needed — upstream still matches any Ctrl+X via `isCtrl`/`key.ctrl && input === 'x'`, so terminal-forwarded Cmd/V-paste on non-QWERTY layouts still opens the overlay.

**Validation** — `npx vitest run src/__tests__/platform.test.ts src/__tests__/textInputPassThrough.test.ts` → 53 passed. (The other 7 suite failures are pre-existing on clean `main`: IME Telex recomposition, cursor-drift, execFileNoThrow timing.)
