### PR TITLE
fix(honcho): honor saveMessages=false across all automatic write paths

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1330,8 +1330,13 @@ class HonchoMemoryProvider(MemoryProvider):
 
         Messages exceeding the Honcho API limit (default 25k chars) are
         split into multiple messages with continuation markers.
+
+        Honors saveMessages: false — the provider then never persists raw
+        turns to Honcho (read/tools paths stay fully functional).
         """
         if self._cron_skipped:
+            return
+        if not getattr(self._config, "save_messages", True):
             return
         if self._recall_mode == "tools" and not self._session_ready():
             return
@@ -1379,6 +1384,8 @@ class HonchoMemoryProvider(MemoryProvider):
             return
         if self._cron_skipped:
             return
+        if not getattr(self._config, "save_messages", True):
+            return
         if self._recall_mode == "tools" and not self._session_ready():
             return
         if not self._session_ready():
@@ -1397,6 +1404,8 @@ class HonchoMemoryProvider(MemoryProvider):
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Flush all pending messages to Honcho on session end."""
         if self._cron_skipped:
+            return
+        if not getattr(self._config, "save_messages", True):
             return
         if not self._manager:
             return

--- a/tests/honcho_plugin/test_save_messages.py
+++ b/tests/honcho_plugin/test_save_messages.py
@@ -1,0 +1,65 @@
+"""Tests for the saveMessages knob: when false, the provider never writes to Honcho.
+
+The knob has always been parsed by HonchoClientConfig but was not consumed by
+the write paths (sync_turn / on_memory_write / on_session_end). These tests pin
+the contract: saveMessages=false disables all automatic persistence while read
+and tools paths remain untouched.
+"""
+
+from unittest.mock import MagicMock
+
+from plugins.memory.honcho import HonchoMemoryProvider
+from plugins.memory.honcho.client import HonchoClientConfig
+
+
+def _provider(save_messages: bool) -> HonchoMemoryProvider:
+    p = HonchoMemoryProvider()
+    p._config = HonchoClientConfig(save_messages=save_messages)
+    p._manager = MagicMock()
+    p._session_key = 'test-session'
+    p._session_initialized = True
+    return p
+
+
+class TestSyncTurn:
+    def test_disabled_writes_nothing(self):
+        p = _provider(save_messages=False)
+        p.sync_turn('user says', 'assistant says')
+        p._manager.get_or_create.assert_not_called()
+        p._manager._flush_session.assert_not_called()
+
+    def test_enabled_writes(self):
+        p = _provider(save_messages=True)
+        p.sync_turn('user says', 'assistant says')
+        if p._sync_thread is not None:
+            p._sync_thread.join(timeout=5)
+        p._manager.get_or_create.assert_called_once()
+
+
+class TestOnMemoryWrite:
+    def test_disabled_skips_conclusion_mirror(self):
+        p = _provider(save_messages=False)
+        p.on_memory_write('add', 'user', 'user likes coffee')
+        p._manager.create_conclusion.assert_not_called()
+
+    def test_enabled_mirrors(self):
+        import time
+
+        p = _provider(save_messages=True)
+        p.on_memory_write('add', 'user', 'user likes coffee')
+        deadline = time.time() + 5
+        while time.time() < deadline and not p._manager.create_conclusion.called:
+            time.sleep(0.05)
+        p._manager.create_conclusion.assert_called_once()
+
+
+class TestOnSessionEnd:
+    def test_disabled_skips_flush(self):
+        p = _provider(save_messages=False)
+        p.on_session_end([])
+        p._manager.flush_all.assert_not_called()
+
+    def test_enabled_flushes(self):
+        p = _provider(save_messages=True)
+        p.on_session_end([])
+        p._manager.flush_all.assert_called_once()


### PR DESCRIPTION
## Problem

The `saveMessages` knob is parsed by `HonchoClientConfig` (client.py) but is never consumed by the write paths. With `saveMessages: false` in `honcho.json`, the provider still persists everything:

- `sync_turn` records every raw turn;
- `on_memory_write` mirrors built-in profile writes as Honcho conclusions;
- `on_session_end` flushes pending messages.

So the documented config key is effectively dead: there is no way to run Honcho in read/tools-only mode (e.g. a curated workspace fed by an explicit pipeline) without the provider polluting it with raw chat.

## Fix

Gate all three automatic write paths on `save_messages`. The guard uses `getattr(self._config, "save_messages", True)` so legacy/injected configs (including test doubles that build `_config` from a SimpleNamespace) keep the previous behavior. Read and tools paths are untouched.

## Tests

`tests/honcho_plugin/test_save_messages.py`: six cases pinning the contract - each write path is inert with `save_messages=False` and still works with `True`. Full `tests/honcho_plugin/` suite passes (429 tests) on top of current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018giroL5zeMPnPxERxAxXHY