### PR TITLE
fix(agent): propagate _user_id to session DB + return text summary for non-vision computer_use (#35407 #35817)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -616,7 +616,7 @@ class AIAgent:
                 model=self.model,
                 model_config=self._session_init_model_config,
                 system_prompt=self._cached_system_prompt,
-                user_id=None,
+                user_id=getattr(self, "_user_id", None),
                 parent_session_id=self._parent_session_id,
                 cwd=_launch_cwd_for_session(source),
                 profile_name=_profile_for_session,
@@ -5572,16 +5572,6 @@ class AIAgent:
             return content
 
         summary = _multimodal_text_summary(result)
-        if tool_name == "computer_use":
-            return json.dumps({
-                "error": (
-                    "computer_use returned screenshot/image content, but the active "
-                    "model/provider does not support image input. Switch to a "
-                    "vision-capable model for desktop computer use, or use browser "
-                    "tools for browser tasks."
-                ),
-                "text_summary": summary,
-            })
 
         logger.warning(
             "Tool %s returned image content for non-vision model %s/%s; "

--- a/tests/run_agent/test_ensure_db_session_user_id.py
+++ b/tests/run_agent/test_ensure_db_session_user_id.py
@@ -1,0 +1,86 @@
+"""Regression test: ``_ensure_db_session()`` propagates ``agent._user_id``.
+
+Before the fix in #35407, ``_ensure_db_session()`` hardcoded
+``user_id=None`` when calling ``SessionDB.create_session``, so direct
+AIAgent callers (CLI, tests, programmatic use) never had the user's
+identity stored in the ``sessions`` table. The fix routes the agent's
+``_user_id`` attribute into the row.
+
+The gateway path (``gateway/session.py``) writes ``user_id`` separately
+via ``record_gateway_session_peer`` and is unaffected by this fix.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+USER_ID = "test-user-123"
+SESSION_ID = "test-ensure-db-session"
+
+
+def _make_agent(session_db, session_id=SESSION_ID, user_id: str | None = None):
+    """Build a minimal AIAgent pointing at the supplied SessionDB.
+
+    Mirrors the ``_make_agent`` helper used in ``test_identity_flush.py``
+    (avoids the heavyweight ``init_agent`` pathway — we only need the
+    attributes ``_ensure_db_session`` reads).
+    """
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    if user_id is not None:
+        agent._user_id = user_id
+    return agent
+
+
+class TestEnsureDbSessionUserId:
+    def test_user_id_is_persisted_to_session_row(self, tmp_path):
+        """``agent._user_id`` must reach the ``sessions`` table column."""
+        from hermes_state import SessionDB
+
+        db_path = Path(tmp_path) / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            agent = _make_agent(db, user_id=USER_ID)
+
+            # The first call creates the row; the second is a no-op thanks
+            # to ``_session_db_created``.
+            agent._ensure_db_session()
+
+            row = db.get_session(SESSION_ID)
+            assert row is not None, "expected a session row to be created"
+            assert row["user_id"] == USER_ID, (
+                f"user_id was not propagated; row={row!r}"
+            )
+        finally:
+            db.close()
+
+    def test_user_id_defaults_to_none_when_unset(self, tmp_path):
+        """Without ``_user_id`` (CLI default), the row keeps ``user_id=NULL``
+        so the pre-fix behavior on that path is preserved."""
+        from hermes_state import SessionDB
+
+        db_path = Path(tmp_path) / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            agent = _make_agent(db)  # no _user_id
+
+            agent._ensure_db_session()
+
+            row = db.get_session(SESSION_ID)
+            assert row is not None
+            assert row["user_id"] is None
+        finally:
+            db.close()

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1012,8 +1012,8 @@ class TestRunAgentMultimodalHelpers:
             for p in cleaned["content"]
         )
 
-    def test_computer_use_image_result_becomes_error_for_text_only_model(self):
-        from run_agent import AIAgent
+    def test_computer_use_image_result_uses_text_summary_for_text_only_model(self):
+        from run_agent import AIAgent, _multimodal_text_summary
 
         agent = object.__new__(AIAgent)
         agent.provider = "deepseek"
@@ -1030,9 +1030,10 @@ class TestRunAgentMultimodalHelpers:
         with patch.object(agent, "_model_supports_vision", return_value=False):
             content = agent._tool_result_content_for_active_model("computer_use", result)
 
-        parsed = json.loads(content)
-        assert "computer_use returned screenshot/image content" in parsed["error"]
-        assert parsed["text_summary"] == "screen captured"
+        # Non-vision computer_use now falls through to the plain text summary,
+        # matching every other image-returning tool (no JSON error block).
+        assert content == _multimodal_text_summary(result)
+        assert content == "screen captured"
         assert "image_url" not in content
 
     def test_computer_use_image_result_preserved_for_vision_model(self):


### PR DESCRIPTION
Fixes #35407, fixes #35817.

Two run_agent.py fixes:

**#35407** — `_ensure_db_session()` hardcoded `user_id=None`, so direct AIAgent callers (CLI, tests, programmatic use) never stored the user's identity in the sessions table. Changes to `getattr(self, "_user_id", None)`. The gateway path (`gateway/session.py:2085`) already passes `user_id` via `db_create_kwargs`, so gateway sessions were unaffected and remain unchanged.

**#35817** — Non-vision models calling `computer_use(action='capture')` got a JSON error block instead of the text summary. Removes the `computer_use` special case so non-vision models fall through to the plain text summary, like every other image-returning tool.