### PR TITLE
chore(weixin): remove deprecated default_backend() — backward-compat cleanup (#35432)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -44,12 +44,10 @@ except ImportError:  # pragma: no cover - dependency gate
     AIOHTTP_AVAILABLE = False
 
 try:
-    from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
     CRYPTO_AVAILABLE = True
 except ImportError:  # pragma: no cover - dependency gate
-    default_backend = None  # type: ignore[assignment]
     Cipher = None  # type: ignore[assignment]
     algorithms = None  # type: ignore[assignment]
     modes = None  # type: ignore[assignment]
@@ -178,13 +176,13 @@ def _pkcs7_pad(data: bytes, block_size: int = 16) -> bytes:
 
 
 def _aes128_ecb_encrypt(plaintext: bytes, key: bytes) -> bytes:
-    cipher = Cipher(algorithms.AES(key), modes.ECB(), backend=default_backend())
+    cipher = Cipher(algorithms.AES(key), modes.ECB())
     encryptor = cipher.encryptor()
     return encryptor.update(_pkcs7_pad(plaintext)) + encryptor.finalize()
 
 
 def _aes128_ecb_decrypt(ciphertext: bytes, key: bytes) -> bytes:
-    cipher = Cipher(algorithms.AES(key), modes.ECB(), backend=default_backend())
+    cipher = Cipher(algorithms.AES(key), modes.ECB())
     decryptor = cipher.decryptor()
     padded = decryptor.update(ciphertext) + decryptor.finalize()
     if not padded:


### PR DESCRIPTION
## Summary

Optional deprecated-API cleanup of `gateway/platforms/weixin.py`. Removes the now-redundant `backend=default_backend()` argument from the two `Cipher()` calls in the WeChat AES path.

This is **not** a compatibility fix for `cryptography >= 48.0.0`. Per the review's verification:

- Upstream `cryptography 48.0.0` still defines `default_backend()` in `cryptography.hazmat.backends`.
- `Cipher.__init__` still accepts `backend=None` (and any `default_backend()` instance) on 48.0.0.
- `pyproject.toml:92` currently pins `cryptography==46.0.7`, so the original ">=48.0.0" failure path isn't reachable through the supported dependency set.

## What changed

- Drop the `from cryptography.hazmat.backends import default_backend` import.
- Drop the `default_backend = None` ImportError fallback shim.
- Drop `backend=default_backend()` from both `_aes128_ecb_encrypt` and `_aes128_ecb_decrypt`.

The behavior is unchanged on every supported `cryptography` version: the `backend` argument has been the documented default since `cryptography 2.1` and `default_backend()` was the canonical "pick one for me" call. Passing nothing is equivalent.

## Why this is safe to merge without bumping the pin

- Removing an argument that the upstream API documents as optional and defaults to the same backend (`default_backend()` under the hood) cannot change runtime behavior.
- The ImportError fallback path was guarding a `cryptography < 1.0`-era import that no current Hermes pin can hit. It can also be dropped without losing coverage.
- All existing tests in `tests/gateway/platforms/test_weixin.py` pass locally; the AES encrypt/decrypt round-trip is the relevant coverage.

## Related

- #35483 — competing PR with the same intent. Happy to close in favor of whichever lands first; the diffs are functionally equivalent. If #35483 lands first, I'll close this. If this lands first, #35483 should close and reference it.
- #35432 — original issue. Noting here that the failure described in that issue isn't reproducible through the locked dep set; that's a separate issue with the user's local environment (likely a manually-installed newer `cryptography` via `pip install --upgrade` rather than the project pin).

## Risk

None observable. Pure dead-code removal on a code path that has a 100% round-trip test. No public API surface change.