### PR TITLE
fix(state): use contentless-safe FTS5 delete in trigram triggers

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -955,11 +955,11 @@ CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_insert AFTER INSERT ON message
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_delete AFTER DELETE ON messages BEGIN
-    DELETE FROM messages_fts_trigram WHERE rowid = old.id;
+    INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content) VALUES('delete', old.id, NULL);
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_update AFTER UPDATE ON messages BEGIN
-    DELETE FROM messages_fts_trigram WHERE rowid = old.id;
+    INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content) VALUES('delete', old.id, NULL);
     INSERT INTO messages_fts_trigram(rowid, content) VALUES (
         new.id,
         COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, '')
@@ -1200,7 +1200,7 @@ class SessionDB:
         )
         if not include_trigram:
             return
-        cursor.execute("DELETE FROM messages_fts_trigram")
+        cursor.execute("INSERT INTO messages_fts_trigram(messages_fts_trigram) VALUES('rebuild')")
         cursor.execute(
             "INSERT INTO messages_fts_trigram(rowid, content) "
             "SELECT id, "


### PR DESCRIPTION
## Problem

`hermes sessions prune` fails with:

```
sqlite3.OperationalError: cannot DELETE from contentless fts5 table: messages_fts_trigram
```

The `messages_fts_trigram` virtual table is created with `content=''` (contentless FTS5). SQLite does not support `DELETE` statements on contentless FTS5 tables — only the special `'delete'` command via `INSERT INTO <table>(<table>, rowid, content) VALUES('delete', ...)`.

The old delete and update triggers used `DELETE FROM messages_fts_trigram WHERE rowid = old.id`, which fails on any `DELETE` from the `messages` table. The main `messages_fts` table is **not** contentless, so the same trigger pattern worked there — masking the bug on databases where trigram search was not enabled.

## Repro

```
$ hermes sessions prune --source cron --older-than 30
Traceback (most recent call last):
  File ".../hermes_cli/main.py", line 14857, in cmd_sessions
    count = db.prune_sessions(sessions_dir=sessions_dir, **filters)
  File ".../hermes_state.py", line 6774, in prune_sessions
    count = self._execute_write(_do)
  ...
  File ".../hermes_state.py", line 6769, in _do
    conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))
sqlite3.OperationalError: cannot DELETE from contentless fts5 table: messages_fts_trigram
```

Confirmed schema:
```
$ sqlite3 state.db ".schema messages_fts_trigram"
CREATE VIRTUAL TABLE messages_fts_trigram USING fts5(content, tokenize='trigram', content='')
```

## Fix

Replace `DELETE FROM messages_fts_trigram WHERE rowid = old.id` in the delete and update triggers with the contentless-safe command:

```sql
INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content) VALUES('delete', old.id, NULL);
```

Same fix applied to `_rebuild_fts_trigram`, which cleared the table with `DELETE FROM messages_fts_trigram` before reinserting — replaced with the `'rebuild'` command:

```sql
INSERT INTO messages_fts_trigram(messages_fts_trigram) VALUES('rebuild')
```

## Verification

Tested on a live `state.db` (Hermes v0.18.2, SQLite 3.51.0):

- Recreated the two triggers with the new syntax on the live DB.
- `hermes sessions prune --source cron --older-than 30 --yes` → **Pruned 369 session(s)** (previously failed with the OperationalError).

## Migrations for existing databases

Existing databases already have the broken triggers created (via `CREATE TRIGGER IF NOT EXISTS`). The `IF NOT EXISTS` clause means the new trigger SQL in `FTS_TRIGRAM_SQL` will **not** replace them. Users with existing databases need to either:

1. Drop and recreate the two triggers manually, or
2. Run `hermes sessions rebuild-fts` (if that recreates triggers), or
3. The PR could add a one-time migration that drops and recreates the trigram triggers on startup if the old form is detected.

Option 3 is the safest for users who just upgrade. Happy to add that if maintainers want it.