### PR TITLE
fix(desktop): respect i18n labels for reasoning effort in model menu and status bar

### DIFF
--- a/apps/desktop/src/app/chat/composer/model-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.tsx
@@ -41,6 +41,7 @@ export function ModelPill({
   model: ChatBarState['model']
 }) {
   const copy = useI18n().t.shell.statusbar
+  const modelLabels = useI18n().t.shell.modelOptions
   const view = useSessionView()
   // Prefer the chat-bar snapshot (already view-scoped by ChatView); fall back
   // to the live SessionView atoms so a mid-flight session.info still paints.
@@ -95,7 +96,7 @@ export function ModelPill({
     <>
       {currentModel.trim() ? (
         <span className="truncate">
-          {formatModelStatusLabel(currentModel, { defaultEffort, fastMode, reasoningEffort })}
+          {formatModelStatusLabel(currentModel, { defaultEffort, fastMode, reasoningEffort, effortLabels: modelLabels })}
         </span>
       ) : (
         <GlyphSpinner className="opacity-50" spinner="braille" />

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -849,7 +849,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                   <SelectContent>
                     {REASONING_EFFORT_VALUES.map(value => (
                       <SelectItem key={value} value={value}>
-                        {value === 'none' ? m.reasoningOff : t.shell.modelOptions[value]}
+                        {t.shell.modelOptions[value]}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -409,7 +409,7 @@ export function ModelCatalogMenu({
 
                     const meta = [
                       fastControl.kind !== 'none' && fastControl.on ? copy.fast : null,
-                      (caps?.reasoning ?? true) ? reasoningEffortLabel(effEffort || defaultEffort) : null
+                      (caps?.reasoning ?? true) ? reasoningEffortLabel(effEffort || defaultEffort, t.shell.modelOptions) : null
                     ]
                       .filter(Boolean)
                       .join(' ')

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2410,6 +2410,7 @@ export const en: Translations = {
       xhigh: 'Extra High',
       max: 'Max',
       ultra: 'Ultra',
+      none: 'Off',
       updateFailed: 'Model option update failed',
       fastFailed: 'Fast mode update failed'
     },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2252,6 +2252,7 @@ export const ja = defineLocale({
       xhigh: '特高',
       max: '最大',
       ultra: 'ウルトラ',
+      none: 'オフ',
       updateFailed: 'モデルオプションの更新に失敗しました',
       fastFailed: '高速モードの更新に失敗しました'
     },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2013,6 +2013,7 @@ export interface Translations {
       xhigh: string
       max: string
       ultra: string
+      none: string
       updateFailed: string
       fastFailed: string
     }

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2175,6 +2175,7 @@ export const zhHant = defineLocale({
       xhigh: '極高',
       max: '最高',
       ultra: '超高',
+      none: '關閉',
       updateFailed: '模型選項更新失敗',
       fastFailed: '快速模式更新失敗'
     },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2591,6 +2591,7 @@ export const zh: Translations = {
       xhigh: '极高',
       max: '最高',
       ultra: '超高',
+      none: '关闭',
       updateFailed: '模型选项更新失败',
       fastFailed: '快速模式更新失败'
     },

--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -42,6 +42,23 @@ describe('model-status-label', () => {
     )
   })
 
+  it('localizes the effort segment via effortLabels', () => {
+    const zhLabels: Record<string, string> = {
+      low: '低',
+      medium: '中',
+      high: '高',
+      none: '关闭'
+    }
+
+    expect(formatModelStatusLabel('openai/gpt-5.5', { reasoningEffort: 'high', effortLabels: zhLabels })).toBe(
+      'GPT-5.5 · 高'
+    )
+    expect(formatModelStatusLabel('openai/gpt-5.5', { reasoningEffort: 'none', effortLabels: zhLabels })).toBe(
+      'GPT-5.5 · 关闭'
+    )
+    expect(formatModelStatusLabel('openai/gpt-5.5', { effortLabels: zhLabels })).toBe('GPT-5.5 · 中')
+  })
+
   it('returns just the placeholder name when there is no model', () => {
     expect(formatModelStatusLabel('')).toBe('No model')
   })

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -97,10 +97,12 @@ export function displayModelName(model: string): string {
 
 /** Status bar trigger label — model name plus the live session state (effort/fast).
  *  `defaultEffort` is the profile's configured level, used when the surface has
- *  no explicit effort so the label never advertises a default the agent won't use. */
+ *  no explicit effort so the label never advertises a default the agent won't use.
+ *  `effortLabels` (e.g. the i18n `t.shell.modelOptions` catalog) localizes the
+ *  effort segment; without it the compact English labels are used. */
 export function formatModelStatusLabel(
   model: string,
-  options?: { defaultEffort?: string; fastMode?: boolean; reasoningEffort?: string }
+  options?: { defaultEffort?: string; fastMode?: boolean; reasoningEffort?: string; effortLabels?: Record<string, string> }
 ): string {
   const name = displayModelName(model)
 
@@ -118,7 +120,9 @@ export function formatModelStatusLabel(
 
   // Always surface the effort so the current reasoning level is visible at a
   // glance, not just when non-default.
-  parts.push(reasoningEffortLabel(options?.reasoningEffort || options?.defaultEffort || DEFAULT_REASONING_EFFORT))
+  parts.push(
+    reasoningEffortLabel(options?.reasoningEffort || options?.defaultEffort || DEFAULT_REASONING_EFFORT, options?.effortLabels)
+  )
 
   return `${name} · ${parts.join(' ')}`
 }

--- a/apps/desktop/src/lib/reasoning-effort.test.ts
+++ b/apps/desktop/src/lib/reasoning-effort.test.ts
@@ -27,6 +27,22 @@ describe('reasoning-effort', () => {
     expect(reasoningEffortLabel('bogus')).toBe('bogus')
   })
 
+  it('uses i18n labels when provided, falling back per-key', () => {
+    const zhLabels: Record<string, string> = {
+      low: '低',
+      medium: '中',
+      high: '高',
+      none: '关闭'
+    }
+
+    expect(reasoningEffortLabel('high', zhLabels)).toBe('高')
+    expect(reasoningEffortLabel('medium', zhLabels)).toBe('中')
+    expect(reasoningEffortLabel('none', zhLabels)).toBe('关闭')
+    // Keys missing from the catalog fall back to the compact English label.
+    expect(reasoningEffortLabel('ultra', zhLabels)).toBe('Ultra')
+    expect(reasoningEffortLabel('')).toBe('')
+  })
+
   it('recognizes only real scale levels', () => {
     expect(isReasoningEffort(DEFAULT_REASONING_EFFORT)).toBe(true)
     expect(isReasoningEffort('HIGH')).toBe(true)

--- a/apps/desktop/src/lib/reasoning-effort.ts
+++ b/apps/desktop/src/lib/reasoning-effort.ts
@@ -27,10 +27,14 @@ const SHORT_LABELS: Record<string, string> = {
   ultra: 'Ultra'
 }
 
-export function reasoningEffortLabel(effort: string): string {
+/** Map a reasoning effort value to a display label. When `labels` is provided
+ *  (e.g. the i18n `t.shell.modelOptions` catalog) it takes precedence over the
+ *  built-in English fallback map, so localized labels (Chinese "中"/"高"/"低")
+ *  are shown instead of the English "Med"/"High"/"Low". */
+export function reasoningEffortLabel(effort: string, labels?: Record<string, string>): string {
   const key = normalize(effort)
 
-  return key ? (SHORT_LABELS[key] ?? effort) : ''
+  return key ? (labels?.[key] ?? SHORT_LABELS[key] ?? effort) : ''
 }
 
 export const isReasoningEffort = (value: string): value is ReasoningEffort =>


### PR DESCRIPTION
Bug: reasoningEffortLabel uses hardcoded English, bypassing i18n. Fix: optional labels param passed from callers. Added none to modelOptions i18n type + all locales. Simplified model-settings.tsx. Complete regression tests included.