### PR TITLE
fix(model_switch): allow vendor-prefixed model names to route away from custom endpoints

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -620,18 +620,31 @@ def resolve_alias(
             mid for mid in catalog
             if mid.lower().startswith(prefix)
         ]
+        prefix_for_sort = f"{vendor}/{family}"
     else:
         family_lower = family.lower()
         matches = [
             mid for mid in catalog
             if mid.lower().startswith(family_lower)
         ]
+        prefix_for_sort = family
+        # Non-aggregator providers may use vendor/prefix model IDs
+        # (e.g. nvidia/nemotron-3-ultra-550b-a55b).  When the bare
+        # family prefix yields no matches, fall back to the full
+        # vendor/family prefix so aliases still resolve.
+        if not matches:
+            vendor_family_lower = f"{vendor}/{family}".lower()
+            matches = [
+                mid for mid in catalog
+                if mid.lower().startswith(vendor_family_lower)
+            ]
+            if matches:
+                prefix_for_sort = f"{vendor}/{family}"
 
     if not matches:
         return None
 
     # Sort by version descending — prefer the latest/highest version
-    prefix_for_sort = f"{vendor}/{family}" if aggregator else family
     matches.sort(key=lambda m: _model_sort_key(m, prefix_for_sort))
     return (current_provider, matches[0], key)
 
@@ -1135,12 +1148,21 @@ def switch_model(
             or ("localhost" in _base or "127.0.0.1" in _base)
         )
 
+        # Vendor-prefixed model names (e.g. "anthropic/claude-..." on a local
+        # custom endpoint) are a clear signal that the user wants that provider.
+        # Even when the current provider is custom, detect_provider_for_model()
+        # must be allowed to route such names to the correct provider (#59000).
+        _has_vendor_prefix = "/" in new_model
+
         if (
             target_provider == current_provider
-            and not is_custom
             and not resolved_alias
             and not resolved_in_current_catalog
             and not config_routed
+            and (
+                not is_custom  # non-custom: always try detection
+                or (is_custom and _has_vendor_prefix)  # custom: only on vendor-prefixed names
+            )
         ):
             detected = detect_provider_for_model(new_model, current_provider)
             if detected:


### PR DESCRIPTION
When on a custom/local endpoint (e.g., DGX Spark via `custom:qwen3.6-35b`), selecting a vendor-hosted model like `nvidia/nemotron-3-ultra-550b-a55b` from the /model picker would silently stay on the local endpoint instead of routing to the vendor's API. The local endpoint returns 404 since it doesn't host that model.

## Two bugs fixed:

### 1. **resolve_alias(): vendor/prefix fallback for non-aggregator providers**
- Aliases like `nemotron` map to `ModelIdentity("nvidia", "nemotron")`
- On non-aggregator providers, the catalog uses `nvidia/nemotron-*` format
- The bare family prefix (`nemotron`) yielded no matches
- Fix: when bare prefix fails, fall back to `vendor/family` prefix

### 2. **switch_model() Step e: allow detect_provider_for_model() on vendor-prefixed names**
- Custom endpoints previously blocked ALL provider auto-detection
- But a model name containing "/" (e.g., `nvidia/nemotron-...`) is an explicit user intent to use that vendor's API
- Fix: when `is_custom` and model has vendor prefix ("/" in name), allow `detect_provider_for_model()` to route to the correct provider

## Result
`/model nvidia/nemotron-3-ultra-550b-a55b` on a `custom:...` endpoint now correctly switches to the NVIDIA provider (https://integrate.api.nvidia.com/v1) instead of staying on the local DGX endpoint.

Related: #59000 (vendor-prefixed routing for custom endpoints)