### PR TITLE
fix(model-switch): sort alias matches by release_date from models.dev

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -584,8 +584,24 @@ def _model_sort_key(model_id: str, prefix: str) -> tuple:
     suffix = suffix_buf.lower().strip("-_.")
     suffix = suffix.strip()
 
+    # Split out YYYYMMDD date stamps (e.g. claude-opus-4-20250514): they are
+    # snapshot markers, not version components, and would otherwise dwarf
+    # real point versions (20250514 > 8).  Kept as a trailing tiebreaker so
+    # bare IDs sort before their dated snapshots, and newer snapshots before
+    # older ones.  The 19_000_101 threshold reclassifies only 8-digit stamps,
+    # so shorter numeric components (mistral-large-2411, gpt-4-0613) keep
+    # their current behavior.
+    version_nums: list[float] = []
+    date_stamp = 0.0
+    for n in nums:
+        if n >= 19_000_101:
+            date_stamp = max(date_stamp, n)
+        else:
+            version_nums.append(n)
+
     # Negate versions so higher → sorts first
-    version_key = tuple(-n for n in nums)
+    version_key = tuple(-n for n in version_nums)
+    date_key = (0.0, 0.0) if date_stamp == 0.0 else (1.0, -date_stamp)
 
     # Suffix quality ranking: pro/max > (no suffix) > omni/flash/mini/lite
     # Lower number = preferred
@@ -597,7 +613,7 @@ def _model_sort_key(model_id: str, prefix: str) -> tuple:
     _SUFFIX_RANK = {"pro": 0, "max": 0, "plus": 0, "turbo": 0, "sol": 0}
     suffix_rank = _SUFFIX_RANK.get(suffix, 1)
 
-    return version_key + (suffix_rank, suffix)
+    return version_key + (suffix_rank, suffix) + date_key
 
 
 def resolve_alias(

--- a/tests/hermes_cli/test_ollama_cloud_auth.py
+++ b/tests/hermes_cli/test_ollama_cloud_auth.py
@@ -429,6 +429,43 @@ class TestResolveAliasEdgeCases:
 
 
 # ---------------------------------------------------------------------------
+# resolve_alias: sort-key date-stamp handling
+# ---------------------------------------------------------------------------
+
+class TestResolveAliasSorting:
+    """resolve_alias must pick the highest-version model, correctly
+    ignoring YYYYMMDD snapshot stamps that would otherwise dwarf real
+    version numbers (e.g. claude-opus-4-20250514 vs claude-opus-4-8)."""
+
+    def test_anthropic_opus_picks_latest(self, monkeypatch):
+        """Date-stamped snapshot ID must not outrank a higher point version."""
+        import hermes_cli.model_switch as ms
+
+        monkeypatch.setattr(ms, "_ensure_direct_aliases", lambda: None)
+        monkeypatch.setattr(ms, "DIRECT_ALIASES", {})
+        monkeypatch.setattr(ms, "list_provider_models",
+                            lambda p: ["claude-opus-4-1", "claude-opus-4-7",
+                                       "claude-opus-4-8",
+                                       "claude-opus-4-20250514"])
+        result = ms.resolve_alias("opus", "anthropic")
+        assert result is not None and result[1] == "claude-opus-4-8"
+
+    def test_unsynced_new_model_wins(self, monkeypatch):
+        """A just-released model missing from models.dev still outranks
+        older, dated siblings (static _PROVIDER_MODELS merge scenario)."""
+        import hermes_cli.model_switch as ms
+
+        monkeypatch.setattr(ms, "_ensure_direct_aliases", lambda: None)
+        monkeypatch.setattr(ms, "DIRECT_ALIASES", {})
+        monkeypatch.setattr(ms, "list_provider_models",
+                            lambda p: ["claude-opus-4-7", "claude-opus-4-8",
+                                       "claude-opus-4-20250514",
+                                       "claude-opus-4-9"])
+        result = ms.resolve_alias("opus", "anthropic")
+        assert result is not None and result[1] == "claude-opus-4-9"
+
+
+# ---------------------------------------------------------------------------
 # switch_model: direct alias base_url override
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`_model_sort_key` treats `YYYYMMDD` date stamps (e.g. `claude-opus-4-20250514`) as version components, so `20250514 > 8` and `resolve_alias("opus", "anthropic")` picks `claude-opus-4-20250514` instead of `claude-opus-4-8`.

Fix: split date stamps (≥ `19_000_101`) out of the version tuple and keep them as a trailing tiebreaker. The `date_key` tuple sorts bare IDs before their dated snapshots (`claude-opus-4-1` over `claude-opus-4-1-20250805`) and newer snapshots over older ones. Shorter numeric IDs like `mistral-large-2411` and `gpt-4-0613` are unaffected — only 8-digit stamps cross the threshold.

No models.dev dependency in the sort path, so the static `_PROVIDER_MODELS` merge scenario (newly released models not yet synced to the registry) continues to work correctly.

## Changes

- `hermes_cli/model_switch.py` — split YYYYMMDD stamps from version
  numbers; add `date_key` trailing tiebreaker to return tuple
- `tests/hermes_cli/test_ollama_cloud_auth.py` — regression test for
  date-stamp ordering + sync-gap test (unsynced new model still wins)
- `contributors/emails/<email>` — email mapping