### PR TITLE
fix(file_tools): strip duplicated prefix for cwd-shaped relative paths (review fixes)

### DIFF
--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -16,6 +16,7 @@ Core invariant these tests pin:
 """
 
 import os
+import warnings as _warnings
 from pathlib import Path, PurePosixPath
 
 import pytest
@@ -459,3 +460,57 @@ def test_unregistered_session_never_inherits_another_sessions_record(
     assert not str(resolved).startswith(str(wt_a))
     assert not str(resolved).startswith(str(wt_b))
     assert resolved == (main / "target.py").resolve()
+
+
+class TestCwdShapedPathGuard:
+    """Regression: model echoes cwd-shaped relative path missing leading slash."""
+
+    def test_linux_doubled_base_is_detected_and_fixed(self, monkeypatch, tmp_path):
+        """Relative input missing leading '/' doubles the base when joined."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+        monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+
+        cwd_shaped = str(workspace.relative_to("/")) + "/notes/x.md"
+        resolved = ft._resolve_path_for_task(cwd_shaped, task_id="default")
+        assert resolved == (workspace / "notes" / "x.md").resolve()
+
+    def test_linux_doubled_base_emits_warning(self, monkeypatch, tmp_path):
+        """The fix path must emit a _path_resolution_warning before correcting."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+        monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+
+        cwd_shaped = str(workspace.relative_to("/")) + "/notes/x.md"
+        with _warnings.catch_warnings(record=True) as w:
+            _warnings.simplefilter("always")
+            ft._resolve_path_for_task(cwd_shaped, task_id="default")
+        assert any("doubled base" in str(warning.message).lower() for warning in w)
+
+    def test_linux_normal_relative_path_unchanged(self, monkeypatch, tmp_path):
+        """Normal relative paths must still resolve correctly."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+        monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+
+        resolved = ft._resolve_path_for_task("notes/x.md", task_id="default")
+        assert resolved == (workspace / "notes" / "x.md").resolve()
+
+    def test_is_doubled_path_detects_duplication(self):
+        base = Path("/home/user/dev")
+        doubled = Path("/home/user/dev/home/user/dev/notes/x.md")
+        assert ft._is_doubled_path(base, doubled)
+
+    def test_is_doubled_path_passes_clean_path(self):
+        base = Path("/home/user/dev")
+        clean = Path("/home/user/dev/notes/x.md")
+        assert not ft._is_doubled_path(base, clean)
+
+    def test_strip_cwd_shaped_prefix_removes_both_copies(self):
+        base = Path("/home/user/dev")
+        doubled = Path("/home/user/dev/home/user/dev/notes/x.md")
+        stripped = ft._strip_cwd_shaped_prefix(base, doubled)
+        assert stripped == Path("notes/x.md")

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -361,6 +361,69 @@ def _resolve_base_dir(
     return base.resolve()
 
 
+def _is_doubled_path(base: Path | PurePosixPath, resolved: Path | PurePosixPath) -> bool:
+    """Return True when ``resolved`` contains ``base`` more than once.
+
+    This detects the "cwd-shaped relative path" failure mode: a model echoes
+    an absolute-looking string with the leading ``/`` missing (e.g. base is
+    ``/home/user/dev`` and the input is ``home/user/dev/notes/x.md``), which
+    naive join resolves to ``/home/user/dev/home/user/dev/notes/x.md``.
+    """
+    resolved_str = str(resolved)
+    base_str = str(base)
+    return base_str and resolved_str.count(base_str) > 1
+
+
+def _strip_cwd_shaped_prefix(base: Path | PurePosixPath, resolved: Path | PurePosixPath) -> Path | None:
+    """Strip the duplicated base prefix from a doubled path, if present.
+
+    The cwd-shaped failure mode joins base ``/A/B/C`` with relative
+    ``A/B/C/notes/x.md``, producing ``/A/B/C/A/B/C/notes/x.md``. After
+    detecting the doubled prefix, strip BOTH copies so the result is just
+    ``notes/x.md`` (to be re-joined onto the original base).
+    """
+    try:
+        base_rel = base.relative_to("/")
+        base_rel_str = str(base_rel)
+        resolved_str = str(resolved)
+        if not base_rel_str:
+            return None
+        doubled_prefix = "/" + base_rel_str + "/" + base_rel_str + "/"
+        if resolved_str.startswith(doubled_prefix):
+            stripped = resolved_str[len(doubled_prefix):].lstrip("/")
+            return type(resolved)(stripped) if stripped else type(resolved)(".")
+        doubled_prefix_rel = base_rel_str + "/" + base_rel_str + "/"
+        if resolved_str.startswith(doubled_prefix_rel):
+            stripped = resolved_str[len(doubled_prefix_rel):].lstrip("/")
+            return type(resolved)(stripped) if stripped else type(resolved)(".")
+    except ValueError:
+        pass
+    return None
+
+
+def _apply_cwd_shaped_fix(
+    base: Path | PurePosixPath,
+    doubled: Path | PurePosixPath,
+    original_filepath: str,
+    task_id: str,
+) -> Path | PurePosixPath:
+    """Warn and return the corrected path when a doubled base is detected."""
+    stripped = _strip_cwd_shaped_prefix(base, doubled)
+    if stripped is None:
+        return doubled
+    import warnings as _warnings
+    corrected = base / stripped
+    if hasattr(corrected, "resolve"):
+        corrected = corrected.resolve()
+    _warnings.warn(
+        f"Relative path {original_filepath!r} resolved to a doubled base "
+        f"({str(doubled)!r}). Corrected to {str(corrected)!r}. "
+        f"Pass an absolute path to avoid this.",
+        stacklevel=4,
+    )
+    return corrected
+
+
 def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | PurePosixPath:
     """Resolve *filepath* against the task's absolute base directory.
 
@@ -376,8 +439,9 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
         expanded = _expand_tilde(filepath)
         if posixpath.isabs(expanded):
             return _normalize_without_host_deref(expanded)
-        resolved = _resolve_base_dir(task_id, container_paths=True) / expanded
-        return _normalize_without_host_deref(resolved)
+        base = _resolve_base_dir(task_id, container_paths=True)
+        resolved = _normalize_without_host_deref(base / expanded)
+        return _apply_cwd_shaped_fix(base, resolved, filepath, task_id)
 
     # Host paths only — never rewrite Linux paths inside a container/WSL env.
     from tools.environments.local import _msys_to_windows_path
@@ -388,14 +452,17 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
 
         if ntpath.isabs(expanded):
             return Path(ntpath.normpath(expanded))
-        joined = ntpath.join(str(_resolve_base_dir(task_id, container_paths=False)), expanded)
-        return Path(ntpath.normpath(joined))
+        base = _resolve_base_dir(task_id, container_paths=False)
+        joined = ntpath.join(str(base), expanded)
+        resolved = Path(ntpath.normpath(joined))
+        return _apply_cwd_shaped_fix(base, resolved, filepath, task_id)
 
     p = Path(expanded)
     if p.is_absolute():
         return p.resolve()
-    resolved = _resolve_base_dir(task_id, container_paths=False) / p
-    return resolved.resolve()
+    base = _resolve_base_dir(task_id, container_paths=False)
+    resolved = (base / p).resolve()
+    return _apply_cwd_shaped_fix(base, resolved, filepath, task_id)
 
 
 def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "default") -> str | None:


### PR DESCRIPTION
## Summary
Fixes #67185 — a model that emits a relative path mirroring the working directory (an absolute path missing its leading `/`) was silently written to a doubled location.

## Changes
- Add `_is_doubled_path`, `_strip_cwd_shaped_prefix`, `_apply_cwd_shaped_fix` helpers
- Wire the guard into `_resolve_path_for_task` for Linux, Windows (`ntpath`), and container branches
- Emit a `UserWarning` before correcting so the agent sees the rewrite
- Add regression tests in `test_file_tools_cwd_resolution.py`

## Review feedback addressed
- Silent rewriting now emits a warning before correcting
- Windows `ntpath.join` branch also covered by the same guard
- Unused `path_module` parameter removed from `_apply_cwd_shaped_fix`

## Test plan
```bash
python3 -m pytest tests/tools/test_file_tools_cwd_resolution.py -v
```
All 37 tests pass (including 6 new regression tests for the cwd-shaped path guard).