### PR TITLE
fix(cli): Ctrl+B voice hotkey disarms continuous during STT/agent

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13693,6 +13693,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     daemon=True,
                 ).start()
             else:
+                # If continuous is already armed, pressing the hotkey
+                # expresses stop intent — disarm continuous so the loop
+                # won't auto-restart after the current STT/agent turn.
+                # This makes the hotkey a proper toggle even when not
+                # recording (the "dead zone" during STT or agent turns).
+                # Fixes #67545: Ctrl+B ignored during STT/agent.
+                if cli_ref._voice_continuous:
+                    with cli_ref._voice_lock:
+                        cli_ref._voice_continuous = False
+                    event.app.invalidate()
+                    return
+
                 # Guard: don't START recording during agent run or interactive prompts
                 if cli_ref._agent_running:
                     return


### PR DESCRIPTION
## Summary

Fixes #67545: In CLI continuous voice mode, pressing Ctrl+B (the record hotkey) during STT processing or while the agent is running was a silent no-op — it didn't disarm continuous mode, so the loop auto-restarted recording after the turn.

## Root Cause

In `handle_voice_record` in `cli.py`, the non-recording branch (`else`) had three early-return guards (`_agent_running`, interactive prompts, `_voice_processing`) that returned without clearing `_voice_continuous`. The fourth path (default) would arm continuous and start a new recording. There was no path to disarm continuous without being in the recording state.

## Fix

Added a check at the top of the non-recording branch: if `_voice_continuous` is already `True`, disarm it immediately and return. This makes the hotkey a proper toggle:

- **Press while recording** → stop + disarm (existing behavior)
- **Press while continuous armed but not recording** (STT/agent/processing) → disarm (NEW)
- **Press while continuous not armed** → arm + start recording (existing behavior)

## Changes

- `cli.py`: ~12 lines added to `handle_voice_record` — disarm check before the existing guards

## Testing

- All 84 existing voice CLI integration tests pass (`tests/tools/test_voice_cli_integration.py`)
- The fix is purely controlled by the `_voice_continuous` flag — no STT/TTS provider changes