### PR TITLE
fix(kanban): scratch children no longer inherit parent workspace path

### DIFF
--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1129,7 +1129,14 @@ def _handle_create(args: dict, **kw) -> str:
                     _self_task = kb.get_task(conn, _self_tid)
                     if _self_task is not None and _self_task.workspace_kind:
                         workspace_kind = _self_task.workspace_kind
-                        workspace_path = _self_task.workspace_path
+                        # Never inherit a scratch parent's materialized path:
+                        # each scratch child must resolve to its own workspace
+                        # directory (<board>/workspaces/<child-id>), not share
+                        # the parent's.  Dir / worktree children keep their
+                        # inherited path so follow-up work lands in the same
+                        # project checkout.
+                        if _self_task.workspace_kind != "scratch":
+                            workspace_path = _self_task.workspace_path
                         # Keep follow-up children inside the same project so the
                         # whole subtree shares one repo + branch convention.
                         if project_id is None and _self_task.project_id:


### PR DESCRIPTION
## Problem

When a dispatcher-spawned Kanban worker creates child tasks via `kanban_create` without explicit workspace arguments, scratch children inherit the parent's literal `workspace_path`. This means the child points at the parent's already-materialized `<board>/workspaces/<parent-id>` directory instead of getting its own isolated workspace.

**Production evidence:** A remediation child editing inside a rejected-review directory invalidated review evidence, and allowed concurrent tasks to share one checkout/index.

## Root cause

In `tools/kanban_tools.py::_handle_create`, lines 1130–1132, when `_inherit_workspace` is true, both `workspace_kind` and `workspace_path` are unconditionally copied from the parent task — without distinguishing the `scratch` case from shared `dir`/`worktree` paths.

## Fix

Only inherit `workspace_path` when the parent's `workspace_kind` is NOT `"scratch"`. Scratch children still inherit `workspace_kind="scratch"` but keep `workspace_path=None`, so the dispatcher materializes a fresh directory at `<board>/workspaces/<child-id>`.

Dir / worktree children continue to inherit the parent's path as before, keeping follow-up work inside the same project checkout.

## Expected behavior after fix

- Worker-created scratch children get `workspace_path=None` → resolved to their own `<board>/workspaces/<child-id>`  
- Dir / worktree children still inherit the parent's shared path  
- Explicit workspace args (`workspace_kind`, `workspace_path`) in `kanban_create` still override inheritance  
- CLI/dashboard callers (no `HERMES_KANBAN_TASK`) unchanged — still default to scratch  
- All 114 existing kanban tests pass

Closes #67567.