### PR TITLE
feat(kanban): allow scheduled initial tasks

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -365,7 +365,9 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           default="running",
                           help="Initial card status. Use 'blocked' for cards "
                                "that require immediate human ops (R3 gate) "
-                               "to skip the brief running-to-blocked transition.")
+                               "to skip the brief running-to-blocked transition, "
+                               "or 'scheduled' to park outside the dispatcher "
+                               "until explicit release.")
     p_create.add_argument("--json", action="store_true", help="Emit JSON output")
 
     # --- swarm ---

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -100,7 +100,7 @@ _log = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
-VALID_INITIAL_STATUSES = {"running", "blocked"}
+VALID_INITIAL_STATUSES = {"running", "blocked", "scheduled"}
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
 # worker (or human) means by "blocked", so each can be routed differently
@@ -2417,6 +2417,9 @@ def create_task(
     parents — a specifier/triager is expected to promote the task to
     ``todo`` once the spec is fleshed out.
 
+    ``initial_status="scheduled"`` atomically parks a task outside the
+    dispatcher queue until a caller explicitly releases it.
+
     If ``idempotency_key`` is provided and a non-archived task with the
     same key already exists, returns the existing task's id instead of
     creating a duplicate. Useful for retried webhooks / automation that
@@ -2580,10 +2583,10 @@ def create_task(
         try:
             with write_txn(conn):
                 # Determine task status from parent status, unless the caller
-                # parks it directly in blocked for human-ops review or in
-                # triage for a specifier.
-                if initial_status == "blocked":
-                    task_status = "blocked"
+                # parks it directly in blocked for human-ops review,
+                # scheduled for deferred release, or triage for a specifier.
+                if initial_status in {"blocked", "scheduled"}:
+                    task_status = initial_status
                     if parents:
                         missing = _find_missing_parents(conn, parents)
                         if missing:

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -565,3 +565,22 @@ def test_run_slash_board_override_does_not_change_boards_show_current(kanban_hom
     out = kc.run_slash("--board beta boards show")
 
     assert "Current board: alpha" in out
+
+
+def test_run_slash_create_scheduled_stays_outside_dispatch_queue(kanban_home):
+    out = kc.run_slash(
+        "create 'route-before-dispatch' --assignee alice "
+        "--initial-status scheduled --json"
+    )
+    task_data = json.loads(out)
+
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_data["id"])
+        promoted = kb.recompute_ready(conn)
+        after_recompute = kb.get_task(conn, task_data["id"])
+
+    assert task is not None
+    assert after_recompute is not None
+    assert task.status == "scheduled"
+    assert promoted == 0
+    assert after_recompute.status == "scheduled"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -222,6 +222,30 @@ def test_create_task_no_parents_is_ready(kanban_home):
     assert t.workspace_kind == "scratch"
 
 
+def test_create_task_can_start_scheduled_until_explicit_release(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="route before dispatch",
+            assignee="alice",
+            initial_status="scheduled",
+        )
+        task = kb.get_task(conn, tid)
+        promoted = kb.recompute_ready(conn)
+        after_recompute = kb.get_task(conn, tid)
+        released = kb.unblock_task(conn, tid)
+        after_release = kb.get_task(conn, tid)
+
+    assert task is not None
+    assert after_recompute is not None
+    assert after_release is not None
+    assert task.status == "scheduled"
+    assert promoted == 0
+    assert after_recompute.status == "scheduled"
+    assert released is True
+    assert after_release.status == "ready"
+
+
 def test_create_task_with_parent_is_todo_until_parent_done(kanban_home):
     with kb.connect() as conn:
         p = kb.create_task(conn, title="parent")

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1031,7 +1031,7 @@ def test_create_schema_exposes_scheduled_initial_status():
     from tools.kanban_tools import KANBAN_CREATE_SCHEMA
 
     initial_status = KANBAN_CREATE_SCHEMA["parameters"]["properties"]["initial_status"]
-    assert initial_status["enum"] == ["running", "blocked", "scheduled"]
+    assert "scheduled" in initial_status["enum"]
 
 
 def test_create_inherits_worker_dir_workspace(monkeypatch, worker_env):

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1006,6 +1006,34 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+def test_create_scheduled_stays_parked(worker_env):
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    out = kt._handle_create({
+        "title": "route before dispatch",
+        "assignee": "peer",
+        "initial_status": "scheduled",
+    })
+    data = json.loads(out)
+    assert data["ok"] is True
+    assert data["status"] == "scheduled"
+
+    with kb.connect_closing() as conn:
+        assert kb.recompute_ready(conn) == 0
+        task = kb.get_task(conn, data["task_id"])
+
+    assert task is not None
+    assert task.status == "scheduled"
+
+
+def test_create_schema_exposes_scheduled_initial_status():
+    from tools.kanban_tools import KANBAN_CREATE_SCHEMA
+
+    initial_status = KANBAN_CREATE_SCHEMA["parameters"]["properties"]["initial_status"]
+    assert initial_status["enum"] == ["running", "blocked", "scheduled"]
+
+
 def test_create_inherits_worker_dir_workspace(monkeypatch, worker_env):
     """A worker scoped to a dir: task that spawns a child without a
     workspace arg inherits the dir, not scratch (so follow-up code-gen

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1822,12 +1822,14 @@ KANBAN_CREATE_SCHEMA = {
             },
             "initial_status": {
                 "type": "string",
-                "enum": ["running", "blocked"],
+                "enum": ["running", "blocked", "scheduled"],
                 "description": (
                     "Initial card status. Use 'blocked' for tasks that "
                     "require immediate human ops (R3 gate) to skip the "
-                    "brief running-to-blocked transition. Defaults to "
-                    "'running', which preserves the usual dispatch path."
+                    "brief running-to-blocked transition, or 'scheduled' "
+                    "to park outside the dispatcher until explicit "
+                    "release. Defaults to 'running', which preserves the "
+                    "usual dispatch path."
                 ),
             },
             "skills": {

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -585,7 +585,7 @@ Multi-profile, multi-project collaboration board. Each install can host many boa
 | `boards show` / `boards current` | Print the currently-active board's name, DB path, and task counts. |
 | `boards rename <slug> "<name>"` | Change a board's display name. Slug is immutable. |
 | `boards rm <slug>` | Archive (default) or hard-delete a board. `--delete` skips the archive step. Archived boards move to `boards/_archived/<slug>-<ts>/`. Refused for `default`. |
-| `create "<title>"` | Create a new task on the active board. Flags: `--body`, `--assignee`, `--parent` (repeatable), `--workspace scratch\|worktree\|dir:<path>`, `--tenant`, `--priority`, `--triage`, `--idempotency-key`, `--max-runtime`, `--max-retries`, `--skill` (repeatable). |
+| `create "<title>"` | Create a new task on the active board. Flags: `--body`, `--assignee`, `--parent` (repeatable), `--workspace scratch\|worktree\|dir:<path>`, `--tenant`, `--priority`, `--triage`, `--initial-status running\|blocked\|scheduled`, `--idempotency-key`, `--max-runtime`, `--max-retries`, `--skill` (repeatable). `scheduled` parks the task outside the dispatcher until an explicit `unblock`. |
 | `list` / `ls` | List tasks on the active board. Filter with `--mine`, `--assignee`, `--status`, `--tenant`, `--archived`, `--json`. |
 | `show <id>` | Show a task with comments and events. `--json` for machine output. |
 | `assign <id> <profile>` | Assign or reassign. Use `none` to unassign. Refused while task is running. |

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -661,6 +661,7 @@ hermes kanban create "<title>" [--body ...] [--assignee <profile>]
                                 [--workspace scratch|worktree|worktree:<path>|dir:<path>]
                                 [--branch <name>]
                                 [--priority N] [--triage] [--idempotency-key KEY]
+                                [--initial-status running|blocked|scheduled]
                                 [--max-runtime 30m|2h|1d|<seconds>]
                                 [--max-retries N]
                                 [--goal] [--goal-max-turns N]
@@ -712,6 +713,10 @@ hermes kanban specify [<id> | --all] [--tenant T]      # flesh out a triage-colu
 hermes kanban gc [--event-retention-days N]            # workspaces + old events + old logs
         [--log-retention-days N]
 ```
+
+`--initial-status scheduled` creates the task outside the dispatcher queue.
+It remains parked until an explicit `hermes kanban unblock <id>` releases it
+to `ready` or `todo`, depending on whether its parents are complete.
 
 All commands are also available as a slash command in the interactive CLI and in the messaging gateway (see [`/kanban` slash command](#kanban-slash-command) below).
 


### PR DESCRIPTION
## Summary

- allow `create_task(..., initial_status="scheduled")` to atomically park a task outside the dispatcher queue
- expose `scheduled` through `hermes kanban create --initial-status` and the `kanban_create` tool schema
- verify parked tasks are not promoted by `recompute_ready()` and are released only through the existing `unblock_task()` path

## Why

Pre-dispatch routers need a stable state while they persist routing and audit metadata. `triage` is not a fail-closed lock when auto-decomposition is enabled, and a raw `blocked` row without a sticky block event may be recovered by `recompute_ready()`.

`scheduled` already has the desired lifecycle semantics in the Kanban core:

- it is outside the dispatcher queue;
- `recompute_ready()` ignores it;
- `unblock_task()` explicitly transitions it to `todo` or `ready` while preserving parent gating.

Allowing it at creation time removes the create-then-park race without adding a new status or dispatcher branch.

This complements #67518, which adds the `model_override` write surface. This PR intentionally does not duplicate those changes.

## Compatibility

- existing defaults remain unchanged (`running`)
- existing `blocked` and `triage` behavior is unchanged
- no database migration or new status is introduced

## Verification

```text
python3 -m pytest -q \
  tests/hermes_cli/test_kanban_db.py \
  tests/hermes_cli/test_kanban_cli.py \
  tests/hermes_cli/test_kanban_core_functionality.py \
  tests/hermes_cli/test_kanban_worker_spawn_toolsets.py \
  tests/tools/test_kanban_tools.py

572 passed in 18.28s
```

```text
python3 -m ruff check \
  hermes_cli/kanban_db.py \
  hermes_cli/kanban.py \
  tools/kanban_tools.py \
  tests/hermes_cli/test_kanban_db.py \
  tests/hermes_cli/test_kanban_cli.py \
  tests/tools/test_kanban_tools.py

All checks passed!
```
