### PR TITLE
fix(desktop): preserve OAuth sessions in sidebar

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -142,6 +142,7 @@ import { createKeepAwake } from './power-save'
 import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
+import { fetchPrimaryProfileSessions } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import * as remoteLifecycle from './remote-lifecycle'
 import { RemoteLivenessTracker, RemoteRevalidationCoordinator, revalidateRemoteConnection } from './remote-liveness'
@@ -9775,12 +9776,7 @@ async function fetchProfilesSessionSlice(searchParams, remoteProfiles) {
       return remoteSessionList(requested, searchParams)
     }
 
-    const primary = await ensureBackend(null)
-
-    return fetchJson(`${primary.baseUrl}/api/profiles/sessions?${searchParams}`, primary.token, {
-      method: 'GET',
-      timeoutMs: DEFAULT_FETCH_TIMEOUT_MS
-    }).catch(() => ({ sessions: [], total: 0, profile_totals: {} }))
+    return fetchPrimaryProfileSessions(searchParams, fetchJsonForProfile)
   }
 
   return mergeRemoteProfileSessions(searchParams, remoteProfiles)
@@ -9795,12 +9791,7 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
   const offset = Math.max(0, Number(searchParams.get('offset')) || 0)
   const order = searchParams.get('order') === 'created' ? 'started_at' : 'last_active'
 
-  const primary = await ensureBackend(null)
-
-  const base = (await fetchJson(`${primary.baseUrl}/api/profiles/sessions?${searchParams}`, primary.token, {
-    method: 'GET',
-    timeoutMs: DEFAULT_FETCH_TIMEOUT_MS
-  }).catch(() => ({ sessions: [], total: 0, profile_totals: {} }))) as any
+  const base = (await fetchPrimaryProfileSessions(searchParams, fetchJsonForProfile)) as any
 
   // Over-fetch each remote from offset 0 (limit+offset rows) so the merged window
   // is correct for this page — mirrors the primary's per-profile over-fetch.

--- a/apps/desktop/electron/profile-session-routing.test.ts
+++ b/apps/desktop/electron/profile-session-routing.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { fetchPrimaryProfileSessions } from './profile-session-routing'
+
+test('primary session reads use the profile-aware request path', async () => {
+  const calls: Array<{ profile: string | null; path: string }> = []
+  const expected = { sessions: [{ id: 'session-1' }], total: 1, profile_totals: { default: 1 } }
+
+  const result = await fetchPrimaryProfileSessions(
+    new URLSearchParams({ profile: 'default', limit: '20' }),
+    async (profile, path) => {
+      calls.push({ profile, path })
+
+      return expected
+    }
+  )
+
+  assert.deepEqual(calls, [{ profile: null, path: '/api/profiles/sessions?profile=default&limit=20' }])
+  assert.equal(result, expected)
+})
+
+test('primary session reads preserve the empty-list fallback', async () => {
+  const result = await fetchPrimaryProfileSessions(new URLSearchParams({ profile: 'all' }), async () => {
+    throw new Error('remote unavailable')
+  })
+
+  assert.deepEqual(result, { sessions: [], total: 0, profile_totals: {} })
+})

--- a/apps/desktop/electron/profile-session-routing.ts
+++ b/apps/desktop/electron/profile-session-routing.ts
@@ -1,0 +1,19 @@
+export interface ProfileSessionsResponse {
+  sessions: unknown[]
+  total: number
+  profile_totals: Record<string, number>
+  [key: string]: unknown
+}
+
+type FetchJsonForProfile = (profile: string | null, path: string) => Promise<unknown>
+
+export async function fetchPrimaryProfileSessions(
+  searchParams: URLSearchParams,
+  fetchJsonForProfile: FetchJsonForProfile
+): Promise<ProfileSessionsResponse> {
+  try {
+    return (await fetchJsonForProfile(null, `/api/profiles/sessions?${searchParams}`)) as ProfileSessionsResponse
+  } catch {
+    return { sessions: [], total: 0, profile_totals: {} }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #41529 and supersedes the stale implementation in #41530.

Hermes Desktop's primary/global session list bypassed its existing auth-aware request helper in two places:

- the legacy cross-profile merge path; and
- the batched sidebar path added in #67245.

Both paths called the token transport directly. For an OAuth-backed primary gateway, the token is `null`, so the request failed and the existing fallback silently returned an empty list. Sessions remained in the backend and could still be opened by ID, but disappeared from the sidebar.

## Change

- Route primary session reads through the existing `fetchJsonForProfile(null, ...)` path, which already selects OAuth-session or token transport from the resolved connection.
- Share that behavior between the legacy merged list and the batched sidebar list.
- Preserve the existing empty-list fallback when a remote is unavailable.
- Add focused regression coverage for the profile-aware primary request path and fallback.

## Proof

- `vitest run --project electron`: 460 passed, 1 skipped.
- `tsc -p tsconfig.electron.json --noEmit`: passed.
- ESLint on the three changed files: passed.
- Prettier check on the three changed files: passed.
- `git diff --check`: passed.

## Runtime reproduction

On current `main`, with a global OAuth backend plus named remote profile overrides:

- `/api/profiles/sessions/sidebar` returned zero recent sessions;
- the direct authenticated `/api/profiles/sessions?profile=default` path returned the persisted sessions.

The difference is the primary fetch transport selected by Electron's remote-profile interception path.
