### PR TITLE
fix(cli): recognize group_sessions_per_user and known_plugin_toolsets as known config roots (#67478)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5519,6 +5519,8 @@ _EXTRA_KNOWN_ROOT_KEYS = {
     "require_mention",       # top-level convenience form honored by the gateway (#3979)
     "unauthorized_dm_behavior",  # top-level form read by gateway/config.py
     "signal",            # Signal settings bridged to env vars by gateway/config.py
+    "group_sessions_per_user",  # top-level form bridged into GatewayConfig (gateway/config.py)
+    "known_plugin_toolsets",    # written/read by `hermes tools` (hermes_cli/tools_config.py)
 }
 _KNOWN_ROOT_KEYS = frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -247,6 +247,23 @@ class TestUnknownTopLevelKeys:
         unknown = [i for i in issues if "Unknown top-level config key" in i.message]
         assert unknown == [], f"Unexpected unknown-key warnings: {[i.message for i in unknown]}"
 
+    def test_hermes_written_roots_not_flagged_unknown(self):
+        """Keys Hermes itself reads/writes must not warn as unknown (#67478).
+
+        group_sessions_per_user is a top-level bool bridged into GatewayConfig;
+        known_plugin_toolsets is a dict written by `hermes tools`. Both are absent
+        from DEFAULT_CONFIG, so they must live in _EXTRA_KNOWN_ROOT_KEYS.
+        """
+        for key in ("group_sessions_per_user", "known_plugin_toolsets"):
+            assert key in _KNOWN_ROOT_KEYS
+        issues = validate_config_structure({
+            "model": {"provider": "openrouter"},
+            "group_sessions_per_user": True,
+            "known_plugin_toolsets": {"telegram": ["web_search"]},
+        })
+        unknown = [i for i in issues if "Unknown top-level config key" in i.message]
+        assert unknown == [], f"Unexpected unknown-key warnings: {[i.message for i in unknown]}"
+
     def test_known_root_keys_derived_from_default_config(self):
         """_KNOWN_ROOT_KEYS must be DEFAULT_CONFIG.keys() plus extras — single source of truth."""
         assert set(DEFAULT_CONFIG.keys()).issubset(_KNOWN_ROOT_KEYS)


### PR DESCRIPTION
## What does this PR do?

`hermes doctor` warned `Unknown top-level config key '…' — it will be ignored` for two keys that Hermes itself reads and writes, so the warning fired against valid config that Hermes wrote:

- **`group_sessions_per_user`** — a top-level `bool` bridged into `GatewayConfig` (`gateway/config.py:1206-1207`), accepted alongside the `gateway.*` form.
- **`known_plugin_toolsets`** — a dict written by `hermes tools` (`hermes_cli/tools_config.py:2070-2071`) and read back at `:1917`. Deleting it to silence the warning is self-defeating: `hermes tools` rewrites it, and its absence flips known-but-disabled plugin toolsets back to "new plugin, default enabled".

Both are intentionally absent from `DEFAULT_CONFIG`, so — like the other bridged/written roots already listed — they belong in `_EXTRA_KNOWN_ROOT_KEYS`, which feeds `_KNOWN_ROOT_KEYS` (the set the doctor check consults at `hermes_cli/config.py:5685`).

This completes the partial fix from #67397, which added `_EXTRA_KNOWN_ROOT_KEYS` but did not include these two keys.

## Related Issue

Fixes #67478

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`: add `group_sessions_per_user` and `known_plugin_toolsets` to `_EXTRA_KNOWN_ROOT_KEYS` (each annotated with its read/write site).
- `tests/hermes_cli/test_config_validation.py`: add `test_hermes_written_roots_not_flagged_unknown` — an invariant regression guard asserting both keys are in `_KNOWN_ROOT_KEYS` and that a config using them (bool + dict values) produces no unknown-key warning.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_config_validation.py -q` → passes.
2. Manual: a `config.yaml` containing top-level `group_sessions_per_user: true` and `known_plugin_toolsets: {telegram: [...]}` no longer emits `⚠ Unknown top-level config key …` from `hermes doctor`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (ran the affected `tests/hermes_cli/` files)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (allowlist entries are self-documenting via inline comments)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new keys introduced; these already exist and are read/written)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A (pure allowlist data)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (on `main`):
```
⚠ Unknown top-level config key 'known_plugin_toolsets' — it will be ignored
```
After: no warning.
