### PR TITLE
fix(dashboard): stop /api/config/schema leaking config.yaml to anonymous callers

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -83,6 +83,48 @@ def _path_is_public(path: str) -> bool:
     )
 
 
+# Public routes that reveal MORE to a logged-in caller than to an anonymous
+# one. They stay public — reachable with no cookies, always 200 — but the gate
+# short-circuits before any cookie verification, so without this a logged-in
+# browser is indistinguishable from a stranger and the handler silently serves
+# everyone the anonymous view.
+#
+# Keep this minimal, and keep the anonymous response the SAFE one: a route
+# belongs here only when the extra detail is an enrichment, never when the
+# anonymous response would be wrong.
+_OPTIONAL_SESSION_PUBLIC_PATHS: frozenset[str] = frozenset({
+    # Serves the plain CONFIG_SCHEMA anonymously; folds the operator's
+    # config.yaml voice providers in for an authenticated caller.
+    "/api/config/schema",
+})
+
+
+def _attach_optional_session(request: Request) -> None:
+    """Best-effort ``request.state.session`` for an optional-session route.
+
+    Deliberately a thin subset of the main gate: verify the access token if one
+    was supplied, attach the Session, and stop. No refresh, no cookie rotation,
+    no clearing, no 401/redirect — an absent, expired, or unrecognised cookie
+    just leaves the request anonymous, because the route is public and must
+    keep answering 200. Never raises: a provider outage degrades the caller to
+    the anonymous view rather than breaking a public endpoint.
+    """
+    try:
+        access_token, _refresh_token = read_session_cookies(request)
+        if not access_token:
+            return
+        for provider in _ordered_session_providers(read_session_provider(request)):
+            try:
+                session = provider.verify_session(access_token=access_token)
+            except Exception:
+                continue
+            if session is not None:
+                request.state.session = session
+                return
+    except Exception:
+        return
+
+
 def _client_ip(request: Request) -> str:
     fwd = request.headers.get("x-forwarded-for", "")
     if fwd:
@@ -296,6 +338,8 @@ async def gated_auth_middleware(
 
     path = request.url.path
     if _path_is_public(path):
+        if path in _OPTIONAL_SESSION_PUBLIC_PATHS:
+            _attach_optional_session(request)
         return await call_next(request)
 
     at, _rt = read_session_cookies(request)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -386,6 +386,24 @@ def _require_token(request: Request) -> None:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
 
+def _request_is_authenticated(request: Request) -> bool:
+    """Non-raising sibling of :func:`_require_token`.
+
+    For endpoints on the public allowlist that expose EXTRA detail to a
+    logged-in caller while staying reachable anonymously. Resolves the active
+    auth scheme exactly like ``_require_token`` so the two can't drift.
+
+    Under the OAuth gate this depends on the route being listed in
+    ``dashboard_auth.middleware._OPTIONAL_SESSION_PUBLIC_PATHS``: public routes
+    short-circuit before cookie verification, so without that opt-in
+    ``request.state.session`` is never attached and a logged-in browser would
+    read as anonymous here.
+    """
+    if getattr(request.app.state, "auth_required", False):
+        return getattr(request.state, "session", None) is not None
+    return _has_valid_session_token(request)
+
+
 # Accepted Host header values for loopback binds. DNS rebinding attacks
 # point a victim browser at an attacker-controlled hostname (evil.test)
 # which resolves to 127.0.0.1 after a TTL flip — bypassing same-origin
@@ -5937,10 +5955,22 @@ async def get_defaults():
 
 
 @app.get("/api/config/schema")
-async def get_schema(profile: Optional[str] = None):
-    # Voice provider options are merged per-request so user-declared
-    # command providers (tts.providers.* / stt.providers.*) added after
-    # server start still show up, scoped to the requested profile's config.
+async def get_schema(request: Request, profile: Optional[str] = None):
+    # This route is on the PUBLIC_API_PATHS allowlist so the SPA can render
+    # the Config page shell before login — the static CONFIG_SCHEMA is
+    # non-sensitive by construction.
+    #
+    # The per-request voice-provider merge is NOT: it reads
+    # ``tts.providers.*`` / ``stt.providers.*`` out of the operator's
+    # config.yaml, and those keys are user data (internal vendor and host
+    # identifiers), not schema defaults. On a wildcard-subdomain deployment
+    # — the same public reachability that makes /api/status the portal's
+    # liveness probe — anyone who curls the hostname would otherwise
+    # enumerate them. Enrich only for an authenticated caller; anonymous
+    # callers get the plain schema, which is what they got before the
+    # options became config-derived.
+    if not _request_is_authenticated(request):
+        return {"fields": CONFIG_SCHEMA, "category_order": _CATEGORY_ORDER}
     with _config_profile_scope(profile):
         fields = _schema_with_voice_provider_options()
     return {"fields": fields, "category_order": _CATEGORY_ORDER}

--- a/tests/hermes_cli/test_config_schema_public_exposure.py
+++ b/tests/hermes_cli/test_config_schema_public_exposure.py
@@ -1,0 +1,226 @@
+"""``/api/config/schema`` is public — it must not leak config.yaml contents.
+
+The route sits on ``PUBLIC_API_PATHS`` so the SPA can render the Config page
+shell before login. That allowlist's contract is explicit: every entry has to
+be safe to hand to "anyone who happens to curl the hostname", because a
+wildcard-subdomain deployment is publicly reachable (the same reachability
+that makes ``/api/status`` the portal's liveness probe).
+
+The static ``CONFIG_SCHEMA`` satisfies that. The per-request voice-provider
+merge does not: it reads ``tts.providers.*`` / ``stt.providers.*`` out of the
+operator's config.yaml, and those keys are user data — internal vendor and
+host identifiers — not schema defaults. Once the options became config-derived
+an anonymous caller could enumerate them.
+
+Pinned here: anonymous callers get the plain schema, authenticated callers
+still get the enriched options, and the anonymous response stays usable so the
+pre-login SPA is unaffected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    starlette = pytest.importorskip("starlette.testclient")
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "tts:\n"
+        "  providers:\n"
+        "    mycompany-voice:\n"
+        "      type: command\n"
+        "      command: '/opt/acme/bin/tts'\n"
+        "stt:\n"
+        "  providers:\n"
+        "    internal-stt:\n"
+        "      type: command\n"
+        "      command: '/opt/acme/bin/stt'\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from hermes_cli.config import invalidate_env_cache
+
+    invalidate_env_cache()
+    from hermes_cli.web_server import app
+
+    return starlette.TestClient(app)
+
+
+def _token():
+    from hermes_cli.web_server import _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    return {_SESSION_HEADER_NAME: _SESSION_TOKEN}
+
+
+CUSTOM_NAMES = ("mycompany-voice", "internal-stt")
+
+
+def test_anonymous_caller_gets_no_config_derived_options(client):
+    resp = client.get("/api/config/schema")
+    assert resp.status_code == 200
+    leaked = [n for n in CUSTOM_NAMES if n in resp.text]
+    assert not leaked, f"config.yaml provider names exposed anonymously: {leaked}"
+
+
+def test_authenticated_caller_still_sees_custom_providers(client):
+    resp = client.get("/api/config/schema", headers=_token())
+    assert resp.status_code == 200
+    options = resp.json()["fields"]["tts.provider"]["options"]
+    assert "mycompany-voice" in options
+    stt_options = resp.json()["fields"]["stt.provider"]["options"]
+    assert "internal-stt" in stt_options
+
+
+def test_legacy_bearer_header_also_counts_as_authenticated(client):
+    from hermes_cli.web_server import _SESSION_TOKEN
+
+    resp = client.get(
+        "/api/config/schema",
+        headers={"Authorization": f"Bearer {_SESSION_TOKEN}"},
+    )
+    assert resp.status_code == 200
+    assert "mycompany-voice" in resp.json()["fields"]["tts.provider"]["options"]
+
+
+def test_anonymous_schema_is_still_usable(client):
+    """The pre-login SPA must keep rendering — this is not a 401."""
+    resp = client.get("/api/config/schema")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["fields"]) > 100
+    assert "model" in data["fields"]
+    assert "general" in data["category_order"]
+    # The builtin voice options survive; only the config-derived ones are held back.
+    assert data["fields"]["tts.provider"]["options"]
+
+
+class TestRequestIsAuthenticated:
+    """The helper must resolve the active scheme the same way _require_token does."""
+
+    @staticmethod
+    def _req(*, auth_required, session=None, token=None):
+        from types import SimpleNamespace
+
+        from hermes_cli.web_server import _SESSION_HEADER_NAME
+
+        headers = {_SESSION_HEADER_NAME: token} if token else {}
+        return SimpleNamespace(
+            app=SimpleNamespace(state=SimpleNamespace(auth_required=auth_required)),
+            state=SimpleNamespace(session=session),
+            headers=headers,
+        )
+
+    def test_gated_mode_requires_a_verified_session(self):
+        from hermes_cli.web_server import _request_is_authenticated
+
+        assert not _request_is_authenticated(self._req(auth_required=True))
+        assert _request_is_authenticated(
+            self._req(auth_required=True, session=object())
+        )
+
+    def test_token_mode_requires_the_session_token(self):
+        from hermes_cli.web_server import _SESSION_TOKEN, _request_is_authenticated
+
+        assert not _request_is_authenticated(self._req(auth_required=False))
+        assert not _request_is_authenticated(
+            self._req(auth_required=False, token="wrong")
+        )
+        assert _request_is_authenticated(
+            self._req(auth_required=False, token=_SESSION_TOKEN)
+        )
+
+
+# ---------------------------------------------------------------------------
+# OAuth-gated deployment
+# ---------------------------------------------------------------------------
+#
+# Public routes short-circuit in ``gated_auth_middleware`` BEFORE cookie
+# verification, so ``request.state.session`` is never attached for them. Without
+# the ``_OPTIONAL_SESSION_PUBLIC_PATHS`` opt-in a logged-in browser reads as
+# anonymous and silently loses its own provider options — the enrichment would
+# be dead code on exactly the deployment shape that needs the guard.
+
+
+@pytest.fixture()
+def gated_client(monkeypatch, tmp_path):
+    starlette = pytest.importorskip("starlette.testclient")
+    from hermes_cli import web_server
+    from hermes_cli.dashboard_auth import clear_providers, register_provider
+    from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "tts:\n"
+        "  providers:\n"
+        "    mycompany-voice:\n"
+        "      type: command\n"
+        "      command: '/opt/acme/bin/tts'\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from hermes_cli.config import invalidate_env_cache
+
+    invalidate_env_cache()
+
+    clear_providers()
+    register_provider(StubAuthProvider())
+    prev = (
+        getattr(web_server.app.state, "bound_host", None),
+        getattr(web_server.app.state, "bound_port", None),
+        getattr(web_server.app.state, "auth_required", None),
+    )
+    web_server.app.state.bound_host = "fly-app.fly.dev"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+    client = starlette.TestClient(web_server.app, base_url="https://fly-app.fly.dev")
+    yield client
+    clear_providers()
+    (
+        web_server.app.state.bound_host,
+        web_server.app.state.bound_port,
+        web_server.app.state.auth_required,
+    ) = prev
+
+
+def _stub_login(client):
+    """Walk the stub IdP round trip so the client holds session cookies."""
+    r1 = client.get("/auth/login?provider=stub", follow_redirects=False)
+    assert r1.status_code == 302
+    state = r1.headers["location"].split("state=")[1]
+    r2 = client.get(
+        f"/auth/callback?code=stub_code&state={state}", follow_redirects=False
+    )
+    assert r2.status_code == 302
+    assert any("hermes_session_at" in c for c in r2.headers.get_list("set-cookie"))
+
+
+def test_gated_anonymous_caller_gets_no_config_derived_options(gated_client):
+    resp = gated_client.get("/api/config/schema")
+    assert resp.status_code == 200, "the route must stay public under the gate"
+    assert "mycompany-voice" not in resp.text
+
+
+def test_gated_caller_sees_custom_providers_after_login(gated_client):
+    """The whole point of the guard: logged-in users keep their own options."""
+    _stub_login(gated_client)
+    resp = gated_client.get("/api/config/schema")
+    assert resp.status_code == 200
+    options = resp.json()["fields"]["tts.provider"]["options"]
+    assert "mycompany-voice" in options, (
+        "a logged-in browser was treated as anonymous — the public-route "
+        "short-circuit skipped session attachment"
+    )
+
+
+def test_gated_invalid_cookie_still_answers_200_anonymously(gated_client):
+    """A dead cookie must not turn a public route into a 401."""
+    from hermes_cli.dashboard_auth.cookies import SESSION_AT_COOKIE
+
+    gated_client.cookies.set(SESSION_AT_COOKIE, "garbage-not-a-real-token")
+    resp = gated_client.get("/api/config/schema")
+    assert resp.status_code == 200
+    assert "mycompany-voice" not in resp.text


### PR DESCRIPTION
## What

`/api/config/schema` sits on the `PUBLIC_API_PATHS` allowlist so the SPA can render
the Config page shell before login. That allowlist states its own bar — every entry
must be safe to hand to **"anyone who happens to `curl` the hostname."**

The static `CONFIG_SCHEMA` meets that bar. The per-request voice-provider merge does
not — it reads `tts.providers.*` / `stt.providers.*` out of the operator's
`config.yaml` and folds those names into the response. They're user data, internal
vendor and host identifiers, not schema defaults.

A **regression**, not a long-standing gap. Verified against the commit before the
options became config-derived, with no credentials presented:

```
BEFORE -> 200, leaks: none
AFTER  -> 200, leaks: ['mycompany-voice', 'internal-stt']
```

## Fix

Gate the enrichment on an authenticated caller. Anonymous requests get the plain
schema — builtin voice options intact — so the pre-login SPA is unaffected and this
is **not** a 401.

Under the OAuth gate that needs a second half. `gated_auth_middleware()`
short-circuits every `PUBLIC_API_PATHS` entry **before** reading or verifying
cookies, so `request.state.session` is never attached on a public route — a
logged-in browser would read as anonymous and silently lose its own provider
options. So this adds a narrowly scoped optional-session step for such routes:
verify a supplied access token and attach the `Session`, with **no** refresh, **no**
cookie rotation, **no** clearing and **no** 401/redirect. An absent, expired or
unrecognised cookie simply leaves the request anonymous and the route stays public.

`_request_is_authenticated()` is a non-raising sibling of `_require_token()` and
resolves the active scheme the same way, so the two can't drift.

## Tests

`tests/hermes_cli/test_config_schema_public_exposure.py` covers both binds:

- **token mode** — anonymous leaks nothing; header and legacy Bearer both enrich
- **gated mode** — driven through the stub-IdP login round trip: anonymous leaks
  nothing, post-login sees the custom providers, and an invalid cookie still answers
  **200 anonymously** rather than 401
- unit coverage of `_request_is_authenticated` in both schemes

`test_anonymous_caller_gets_no_config_derived_options` fails on `main` with the leak;
`test_gated_caller_sees_custom_providers_after_login` fails without the middleware
half.

Auth + dashboard suites baseline-compared against a clean `origin/main` worktree:
identical single pre-existing failure
(`test_put_honcho_first_save_merges_into_resolved_config`), `543 → 552` passed.

## Out of scope

`/api/model/info` is also public and returns the operator's configured model id. That
predates this change and is arguably covered by the allowlist's "provider catalogs
are already public" rationale, so I left it alone.