### PR TITLE
feat(skills): add SuperCollider optional skill (supercollider)

### DIFF
--- a/optional-skills/creative/supercollider/SKILL.md
+++ b/optional-skills/creative/supercollider/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: supercollider
+description: Build and control SuperCollider synths over OSC.
+version: 1.0.0
+author: mrev-lab
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [supercollider, scsynth, synthdef, osc, audio, synthesis, dsp, generative-audio, creative-coding, live-coding]
+    related_skills: [pd-patching, songwriting-and-ai-music]
+---
+
+# SuperCollider Skill
+
+Make and control sound in a running SuperCollider audio server (`scsynth`) by
+compiling SynthDefs and sending OSC over UDP, entirely from Python's standard
+library — no `sclang`, no `python-osc`, no compiled bridge. It builds synth
+graphs, plays and live-controls them, exports `.scsyndef` files, and records WAV.
+It does **not** cover the SuperCollider language, patterns, or the IDE.
+
+## When to Use
+
+Use when the user wants to generate or control audio/DSP in SuperCollider: a
+synth, an FM bell, a filter sweep, a drone, or a generative melody — described in
+words, produced as sound. Skip it for tasks that need the `sclang` language
+(patterns, `Pdef`, GUI); this skill drives the bare server directly.
+
+## Prerequisites
+
+- **SuperCollider** installed (provides the `scsynth` server binary):
+  - macOS: `brew install --cask supercollider`
+  - Linux: `sudo apt install supercollider-server`
+- The `terminal` tool, used to boot the server and run the helper scripts below.
+- No Python packages — standard library only.
+
+## How to Run
+
+Run every command through the `terminal` tool. First locate the installed skill
+(helpers import each other by name, so run them from `scripts/`):
+
+```bash
+SKILL="${HERMES_HOME:-$HOME/.hermes}/skills/creative/supercollider"
+cd "$SKILL/scripts"
+```
+
+Boot a bare server once (leave it running), then confirm it answers:
+
+```bash
+"$SKILL/templates/boot_scsynth.sh" &      # listens for OSC on UDP :57110
+python3 sc_client.py --status             # -> ugens=0 synths=0 ... sr=44100
+```
+
+Play a gallery synth, or an arbitrary chord, in one stdin-free command:
+
+```bash
+python3 sc_examples.py wobble_bass --play
+python3 sc_examples.py sines --freqs 120 254 1201 --play
+python3 sc_client.py --free-all           # stop everything
+```
+
+> Pass everything as **arguments**, never via a heredoc — an agent terminal
+> often fails to deliver heredoc stdin and the call hangs. To shape a custom
+> graph, write a real `.py` file in `scripts/` and run it.
+
+## Quick Reference
+
+Helper scripts (all in `scripts/`, standard library only):
+
+| File | Purpose |
+|------|---------|
+| `sc_synthdef.py` | `SynthDef` graph builder → SynthDef v2 bytes (`compile`, `to_scsyndef_file`); UGen palette; `to_out` safety chain; safety linter. |
+| `sc_client.py` | OSC-over-UDP bridge to `scsynth` (`play`/`set`/`free`/`free_all`/`sync`/`status`/`record`) + CLI. |
+| `sc_examples.py` | Gallery of 7 synths + CLI (`--play`, `--export file.scsyndef`, `--freqs`). |
+| `templates/boot_scsynth.sh` | Boots `scsynth` on UDP :57110 (finds the macOS app-bundle binary + plugins). |
+
+Server commands (CLI: an OSC address then args):
+
+| Action | Command |
+|--------|---------|
+| Load a compiled SynthDef | `/d_recv <blob>` (`SCClient.load` / `play`) |
+| Start a synth | `/s_new {name} {id} {addAction} {target} [ctrl val …]` |
+| Set controls live | `/n_set {id} {ctrl} {val} …` |
+| Free all synths (stop) | `--free-all` (`/g_freeAll 0`) |
+| Server status | `--status` |
+
+Gallery: `sine`, `sines --freqs …`, `fm_bell`, `wobble_bass`, `supersaw_drone`,
+`random_blips`, `resonator`. List them with `python3 sc_examples.py --list`.
+
+## Procedure
+
+The agent turns a request into sound like this:
+
+1. **Ensure the server is up.** `python3 sc_client.py --status`; if it does not
+   answer, boot `templates/boot_scsynth.sh`.
+2. **Pick the cheapest path.** Canned sound → a gallery name; a tweak → call a
+   gallery builder with params, or `/n_set` a running node; novel routing →
+   build a `SynthDef`.
+3. **Build and check safety.** End every graph with `to_out(...)` and confirm
+   `is_safe()` before playing.
+4. **Play, then verify it landed.** `--play` calls `/sync` and reports failure
+   if the server does not confirm.
+
+Build a custom synth in a `.py` file under `scripts/`:
+
+```python
+from sc_synthdef import SynthDef
+from sc_client import SCClient
+
+sd = SynthDef("my_synth")
+freq = sd.control("freq", 220)          # live-settable parameter
+sig  = sd.rlpf(sd.saw(freq), 800, 0.2)  # resonant low-pass on a saw
+sd.to_out(sig, 0.15)                    # LeakDC -> *0.15 -> Limiter -> Out.ar(0)
+if not sd.is_safe():
+    raise SystemExit(sd.safety_violations())
+c = SCClient()
+node = c.play(sd, node_id=1000)
+c.sync()                                # confirm it started
+# c.set(1000, freq=110)                 # live control
+# c.free_all()                          # stop
+```
+
+Signal math reads naturally: `a * 0.2`, `a + b` build `BinaryOpUGen` nodes.
+
+**Share an artifact.** Export a standalone `.scsyndef` (loadable by any
+`scsynth`, no Python): `python3 sc_examples.py fm_bell --export bell.scsyndef`.
+Record a WAV of the live output with `SCClient.record(path)` /
+`record_stop()` (needs the server booted with audio).
+
+## [CRITICAL] Audio safety
+
+Every `Out` must be reached through the protective master chain:
+
+```
+source -> LeakDC.ar -> [* <= 0.2] -> Limiter.ar -> Out.ar(0)
+```
+
+`SynthDef.to_out(source, gain)` builds exactly this (dual-mono), and
+`safety_violations()` enforces it: a `Limiter`/`Clip` must feed `Out`, its
+master gain `*` must be a constant `<= 0.2` (`MAX_MASTER_GAIN`), and a `LeakDC`
+must sit upstream. Never wire a raw signal straight to `Out`; always end with
+`to_out(...)`. If a request implies danger ("blast it"), keep the gain `<= 0.2`.
+
+## Pitfalls
+
+- **UGen names must be exact.** The palette (`sinosc`, `saw`, `pulse`, `rlpf`,
+  `lpf`/`hpf`/`bpf`, `resonz`, `combl`, `lfnoise0/1`, `whitenoise`, `dust`,
+  `impulse`, `leakdc`, `limiter`, `clip`, `pan2`) plus `ugen(name, rate, inputs)`
+  cover the rest. A misspelled UGen loads with no Python error, but `scsynth`
+  logs `UGen 'X' not installed` and the def never registers — watch its output.
+- **Calc rates matter.** Audio helpers default to `.ar`, LFOs to `.kr`; mixing an
+  audio and control signal yields audio (the builder picks the higher rate).
+  Scalar-only inputs (`combl` `maxdelay`, `limiter` `dur`) take a number, not a
+  live signal.
+- **Controls need `sd.control(...)`.** A bare constant cannot be changed with
+  `/n_set`; declare a named control to make a parameter live-settable.
+- **The linter checks output *safety*, not signal-flow *correctness*.** It will
+  not catch a wrong input order or a bad rate — watch the `scsynth` console.
+
+## Verification
+
+1. **Before playing:** `SynthDef.is_safe()` / `safety_violations()` catch a
+   missing `Limiter`, a master gain above 0.2, or a missing `LeakDC`;
+   `build_simple_synth()` is a known-safe reference.
+2. **Server handshake:** `python3 sc_client.py --status` returns a
+   `/status.reply` line; no reply means `scsynth` is not running.
+3. **Def loaded & node running:** after `--play`, `--status` shows `synths` and
+   `ugens` climb (the sine reports `ugens=6 synths=1`); after `--free-all` they
+   return to `synths=0`. A def that fails to load leaves `defs` unchanged and
+   logs an error in the `scsynth` output.
+4. **Regression tests:** `scripts/run_tests.sh tests/skills/test_supercollider_skill.py -q`
+   (mocked, no server needed).
+
+## Security
+
+Communication is localhost-only (`127.0.0.1:57110`); `scsynth`'s OSC port has no
+authentication, so keep it on loopback (do not boot with `-B 0.0.0.0`). Server
+commands and UGens can read and write files (`/b_write`, `DiskOut`); only load
+and play defs you trust.

--- a/optional-skills/creative/supercollider/scripts/sc_client.py
+++ b/optional-skills/creative/supercollider/scripts/sc_client.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Lightweight OSC-over-UDP bridge to a running SuperCollider server (scsynth).
+
+scsynth speaks Open Sound Control. This module encodes OSC 1.0 packets in pure
+Python and sends them to ``scsynth`` on UDP :57110 -- no ``sclang``, no
+``python-osc``, no ``supriya``; **standard library only.**
+
+A synth is created, controlled and freed with plain server commands:
+
+    /d_recv  <synthdef-bytes> [completion]   load a compiled SynthDef
+    /s_new   <name> <id> <add> <target> ...  start a synth node
+    /n_set   <id> <ctrl> <val> ...           change a control live
+    /n_free  <id>                            free a node
+    /g_freeAll 0                             free everything (panic / stop)
+    /status                                  query the server
+
+The killer combination is ``/d_recv``'s *completion message*: pack a ``/s_new``
+into the same packet and the synth starts the instant its definition finishes
+loading -- one UDP datagram, no round-trip. That's what :meth:`SCClient.play`
+does.
+
+CLI examples
+------------
+    python3 sc_client.py /status
+    python3 sc_client.py /s_new hermes_sine 1000 0 0 freq 300
+    python3 sc_client.py /n_set 1000 freq 220
+    python3 sc_client.py --free-all          # stop all synths
+    python3 sc_client.py --recv-file foo.scsyndef   # load a compiled def
+    python3 sc_client.py --quit              # shut the server down
+"""
+from __future__ import annotations
+
+import argparse
+import socket
+import struct
+import sys
+import time
+from typing import Any, List, Optional
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 57110          # scsynth's default UDP port
+DEFAULT_TIMEOUT = 1.0
+
+
+# -- OSC 1.0 encoding (big-endian) ------------------------------------------
+def _pad4(b: bytes) -> bytes:
+    """Pad to the next 4-byte boundary with NULs (OSC alignment rule)."""
+    return b + b"\x00" * (-len(b) % 4)
+
+
+def _osc_string(s: str) -> bytes:
+    return _pad4(s.encode("utf-8") + b"\x00")   # NUL-terminated, then padded
+
+
+def _osc_blob(b: bytes) -> bytes:
+    return struct.pack(">i", len(b)) + _pad4(b)
+
+
+def encode_message(address: str, *args: Any) -> bytes:
+    """Encode one OSC message. Types are inferred: int->i, float->f, str->s, bytes->b."""
+    tags = ","
+    payload = bytearray()
+    for a in args:
+        if isinstance(a, bool):
+            raise TypeError("OSC has no bool type; use 0/1")
+        if isinstance(a, int):
+            tags += "i"
+            payload += struct.pack(">i", a)
+        elif isinstance(a, float):
+            tags += "f"
+            payload += struct.pack(">f", a)
+        elif isinstance(a, (bytes, bytearray)):
+            tags += "b"
+            payload += _osc_blob(bytes(a))
+        elif isinstance(a, str):
+            tags += "s"
+            payload += _osc_string(a)
+        else:
+            raise TypeError(f"unsupported OSC arg type: {type(a).__name__}")
+    return _osc_string(address) + _osc_string(tags) + bytes(payload)
+
+
+def _coerce_cli_arg(tok: str) -> Any:
+    """Turn a CLI token into an OSC arg: int if it looks like one, else float, else str."""
+    try:
+        return int(tok)
+    except ValueError:
+        pass
+    try:
+        return float(tok)
+    except ValueError:
+        return tok
+
+
+class SCClient:
+    """Sends server commands to scsynth over UDP; keeps one socket for replies."""
+
+    def __init__(self, host: str = DEFAULT_HOST, port: int = DEFAULT_PORT,
+                 timeout: float = DEFAULT_TIMEOUT):
+        self.host = host
+        self.port = int(port)
+        self.timeout = timeout
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._sock.settimeout(timeout)
+        self._next_node = 1000            # node-id allocator for auto-assigned synths
+
+    # -- transport ----------------------------------------------------------
+    def send(self, address: str, *args: Any) -> None:
+        self._sock.sendto(encode_message(address, *args), (self.host, self.port))
+
+    def send_recv(self, address: str, *args: Any, match: Optional[str] = None,
+                  bufsize: int = 65536) -> Optional[bytes]:
+        """Send, then wait for a reply datagram (or None on timeout).
+
+        If ``match`` is given, skip datagrams whose OSC address does not start
+        with it -- so a stale ``/done`` left over from an earlier ``/d_recv``
+        doesn't get mistaken for the reply we actually want.
+        """
+        self.send(address, *args)
+        while True:
+            try:
+                data, _ = self._sock.recvfrom(bufsize)
+            except socket.timeout:
+                return None
+            if match is None or data.startswith(match.encode("ascii")):
+                return data
+
+    def close(self) -> None:
+        self._sock.close()
+
+    # -- node ids -----------------------------------------------------------
+    def alloc_node(self) -> int:
+        nid = self._next_node
+        self._next_node += 1
+        return nid
+
+    # -- high-level server commands ----------------------------------------
+    def load(self, synthdef: Any) -> None:
+        """Load a compiled SynthDef (a ``SynthDef`` object or raw bytes) via /d_recv."""
+        self.send("/d_recv", _synthdef_bytes(synthdef))
+
+    def play(self, synthdef: Any, node_id: Optional[int] = None,
+             add_action: int = 0, target: int = 0, **controls: float) -> int:
+        """Load ``synthdef`` and start it in one packet; return the node id.
+
+        Uses ``/d_recv``'s completion message so the ``/s_new`` fires only after
+        the definition is registered. ``controls`` become initial ``/s_new``
+        control pairs. ``add_action`` 0=head, 1=tail, 2=before, 3=after; ``target``
+        is the group/node it is added relative to (0 == the root group).
+        """
+        name = _synthdef_name(synthdef)
+        nid = self.alloc_node() if node_id is None else node_id
+        pairs: List[Any] = []
+        for k, v in controls.items():
+            pairs.append(k)
+            pairs.append(float(v))
+        completion = encode_message("/s_new", name, nid, add_action, target, *pairs)
+        self.send("/d_recv", _synthdef_bytes(synthdef), completion)
+        return nid
+
+    def new_synth(self, name: str, node_id: Optional[int] = None,
+                  add_action: int = 0, target: int = 0, **controls: float) -> int:
+        """Start an already-loaded SynthDef by name; return the node id."""
+        nid = self.alloc_node() if node_id is None else node_id
+        pairs: List[Any] = []
+        for k, v in controls.items():
+            pairs.append(k)
+            pairs.append(float(v))
+        self.send("/s_new", name, nid, add_action, target, *pairs)
+        return nid
+
+    def set(self, node_id: int, **controls: float) -> None:
+        """Change controls on a running node live (``/n_set``)."""
+        pairs: List[Any] = []
+        for k, v in controls.items():
+            pairs.append(k)
+            pairs.append(float(v))
+        self.send("/n_set", node_id, *pairs)
+
+    def sync(self, sync_id: int = 1, timeout: float = 2.0) -> bool:
+        """Block until the server has processed all prior async commands.
+
+        Sends ``/sync`` and waits for the matching ``/synced``. Returns ``False``
+        on timeout -- use it to confirm a ``play``/``load`` actually landed
+        instead of assuming a fire-and-forget UDP packet arrived.
+        """
+        old = self._sock.gettimeout()
+        self._sock.settimeout(timeout)
+        try:
+            return self.send_recv("/sync", sync_id, match="/synced") is not None
+        finally:
+            self._sock.settimeout(old)
+
+    def free(self, node_id: int) -> None:
+        self.send("/n_free", node_id)
+
+    def free_all(self, group: int = 0) -> None:
+        """Free every synth in a group (default the root group) -- the stop/panic button."""
+        self.send("/g_freeAll", group)
+
+    def quit(self) -> None:
+        """Ask the server to shut down."""
+        self.send("/quit")
+
+    def status(self) -> Optional[bytes]:
+        """Query the server; returns the raw ``/status.reply`` datagram or None."""
+        return self.send_recv("/status", match="/status.reply")
+
+    # -- recording (needs the server booted with audio) --------------------
+    def record(self, path: str, node_id: int = 1999, bufnum: int = 99,
+               frames: int = 65536, channels: int = 2) -> int:
+        """Start recording the output bus to ``path`` (a WAV). Returns the recorder node.
+
+        Allocates a streaming buffer, opens the soundfile for writing, then plays
+        a DiskOut recorder synth at the **tail** of the node tree so it captures
+        the summed, post-limiter output. Stop with :meth:`record_stop`.
+        """
+        from sc_synthdef import build_recorder
+        self.send("/b_alloc", bufnum, frames, channels)
+        time.sleep(0.05)  # let the buffer allocate before opening the file
+        # /b_write: path, header, sample-format, numFrames(-1=all), start, leaveOpen=1
+        self.send("/b_write", bufnum, path, "wav", "float", -1, 0, 1)
+        time.sleep(0.05)
+        rec = build_recorder(channels=channels)
+        # addAction 1 == addToTail: recorder runs after the sound-producing synths
+        self.play(rec, node_id=node_id, add_action=1, target=0, buf=float(bufnum))
+        return node_id
+
+    def record_stop(self, node_id: int = 1999, bufnum: int = 99) -> None:
+        """Stop recording: free the recorder, close and free the soundfile buffer."""
+        self.free(node_id)
+        time.sleep(0.05)
+        self.send("/b_close", bufnum)
+        self.send("/b_free", bufnum)
+
+
+def _synthdef_bytes(synthdef: Any) -> bytes:
+    if isinstance(synthdef, (bytes, bytearray)):
+        return bytes(synthdef)
+    return synthdef.compile()
+
+
+def _synthdef_name(synthdef: Any) -> str:
+    if isinstance(synthdef, (bytes, bytearray)):
+        # SynthDef v2: "SCgf" + int32 version + int16 count + pstring name
+        length = synthdef[10]
+        return synthdef[11:11 + length].decode("ascii")
+    return synthdef.name
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Send OSC server commands to a running scsynth.",
+    )
+    p.add_argument("message", nargs="*",
+                   help="An OSC address then args, e.g. /s_new hermes_sine 1000 0 0 freq 300")
+    p.add_argument("--host", default=DEFAULT_HOST)
+    p.add_argument("--port", type=int, default=DEFAULT_PORT)
+    p.add_argument("--recv-file", metavar="PATH",
+                   help="Load a compiled .scsyndef file via /d_recv")
+    p.add_argument("--free-all", action="store_true", help="Free all synths (/g_freeAll 0)")
+    p.add_argument("--status", action="store_true", help="Print the server /status reply")
+    p.add_argument("--quit", action="store_true", help="Shut the server down (/quit)")
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    client = SCClient(host=args.host, port=args.port)
+
+    if args.recv_file:
+        with open(args.recv_file, "rb") as fh:
+            client.load(fh.read())
+        return 0
+    if args.free_all:
+        client.free_all()
+        return 0
+    if args.quit:
+        client.quit()
+        return 0
+    if args.status:
+        reply = client.status()
+        if reply is None:
+            print("no reply (is scsynth running on "
+                  f"{args.host}:{args.port}?)", file=sys.stderr)
+            return 1
+        print(_format_status(reply))
+        return 0
+
+    if not args.message:
+        _build_parser().print_usage(sys.stderr)
+        print("error: no OSC message to send", file=sys.stderr)
+        return 2
+
+    address = args.message[0]
+    osc_args = [_coerce_cli_arg(t) for t in args.message[1:]]
+    client.send(address, *osc_args)
+    return 0
+
+
+def _format_status(reply: bytes) -> str:
+    """Decode a /status.reply datagram into a short human summary."""
+    # /status.reply ,iiiiiffdd : cmds, ugens, synths, groups, defs, avgCPU, peakCPU, sr, actualSr
+    try:
+        # skip address + typetag, both OSC strings
+        idx = reply.index(b"\x00")
+        idx = (idx + 4) & ~3            # past address padding
+        tt_end = reply.index(b"\x00", idx)
+        tt_end = (tt_end + 4) & ~3      # past typetag padding
+        body = reply[tt_end:]
+        vals = struct.unpack(">iiiiiffdd", body[:4 * 5 + 4 * 2 + 8 * 2])
+        return (f"ugens={vals[1]} synths={vals[2]} groups={vals[3]} "
+                f"defs={vals[4]} avgCPU={vals[5]:.1f}% peakCPU={vals[6]:.1f}% "
+                f"sr={vals[8]:.0f}")
+    except Exception:
+        return f"<status reply, {len(reply)} bytes>"
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/optional-skills/creative/supercollider/scripts/sc_client.py
+++ b/optional-skills/creative/supercollider/scripts/sc_client.py
@@ -80,6 +80,41 @@ def encode_message(address: str, *args: Any) -> bytes:
     return _osc_string(address) + _osc_string(tags) + bytes(payload)
 
 
+def decode_message(data: bytes):
+    """Minimal OSC message decoder -> (address, [args]). Best-effort.
+
+    Used to read scsynth replies (``/done``, ``/fail``, ``/synced``, ...). Only
+    the common tags (i/f/s/b) are decoded; anything unexpected stops parsing and
+    returns what was read so far.
+    """
+    def read_string(buf: bytes, i: int):
+        end = buf.index(b"\x00", i)
+        s = buf[i:end].decode("utf-8", "replace")
+        return s, (end // 4 + 1) * 4          # advance past NUL, 4-byte aligned
+
+    try:
+        address, i = read_string(data, 0)
+        if i >= len(data) or data[i:i + 1] != b",":
+            return address, []
+        tags, i = read_string(data, i)
+        args: List[Any] = []
+        for t in tags[1:]:
+            if t == "i":
+                args.append(struct.unpack(">i", data[i:i + 4])[0]); i += 4
+            elif t == "f":
+                args.append(struct.unpack(">f", data[i:i + 4])[0]); i += 4
+            elif t == "s":
+                s, i = read_string(data, i); args.append(s)
+            elif t == "b":
+                n = struct.unpack(">i", data[i:i + 4])[0]; i += 4
+                args.append(data[i:i + n]); i += (n + 3) // 4 * 4
+            else:
+                break
+        return address, args
+    except Exception:
+        return "", []
+
+
 def _coerce_cli_arg(tok: str) -> Any:
     """Turn a CLI token into an OSC arg: int if it looks like one, else float, else str."""
     try:
@@ -177,19 +212,40 @@ class SCClient:
             pairs.append(float(v))
         self.send("/n_set", node_id, *pairs)
 
-    def sync(self, sync_id: int = 1, timeout: float = 2.0) -> bool:
-        """Block until the server has processed all prior async commands.
+    def verify(self, sync_id: int = 1, timeout: float = 2.0):
+        """Confirm the preceding commands landed *and* were accepted.
 
-        Sends ``/sync`` and waits for the matching ``/synced``. Returns ``False``
-        on timeout -- use it to confirm a ``play``/``load`` actually landed
-        instead of assuming a fire-and-forget UDP packet arrived.
+        Sends ``/sync`` and drains replies until the matching ``/synced``. A
+        ``/d_recv`` reports success as ``/done`` and rejection as ``/fail``; a
+        bare ``/synced`` only proves the async queue drained, not that the
+        SynthDef loaded. So this watches for ``/fail`` arriving before
+        ``/synced`` and reports it. Returns ``(ok, error)``: ``ok`` is ``False``
+        on a ``/fail`` or on timeout, and ``error`` carries the ``/fail`` text.
         """
+        self.send("/sync", sync_id)
+        error: Optional[str] = None
         old = self._sock.gettimeout()
         self._sock.settimeout(timeout)
         try:
-            return self.send_recv("/sync", sync_id, match="/synced") is not None
+            while True:
+                try:
+                    data, _ = self._sock.recvfrom(65536)
+                except socket.timeout:
+                    return (False, error or "no /synced reply from scsynth")
+                address, args = decode_message(data)
+                if address == "/fail":
+                    error = " ".join(str(a) for a in args) or "/fail"
+                elif address == "/synced":
+                    return (error is None, error)
         finally:
             self._sock.settimeout(old)
+
+    def sync(self, sync_id: int = 1, timeout: float = 2.0) -> bool:
+        """Confirm the preceding commands landed and were accepted (bool form).
+
+        Thin wrapper over :meth:`verify` -- ``False`` on a ``/fail`` or timeout.
+        """
+        return self.verify(sync_id, timeout)[0]
 
     def free(self, node_id: int) -> None:
         self.send("/n_free", node_id)

--- a/optional-skills/creative/supercollider/scripts/sc_examples.py
+++ b/optional-skills/creative/supercollider/scripts/sc_examples.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""A gallery of ready-to-play SuperCollider synths for the dynamic-SynthDef skill.
+
+Every example is a continuous synth that makes sound the moment it starts -- no
+sequencer, gate or trigger needed. Each returns a :class:`sc_synthdef.SynthDef`,
+so it is safety-linted (master gain <= 0.2, no raw signal wired straight to
+``Out``) and ready to hand to :class:`sc_client.SCClient`.
+
+Try one (with scsynth booted -- see templates/boot_scsynth.sh):
+
+    python3 sc_examples.py --list
+    python3 sc_examples.py wobble_bass --play        # load + start it
+    python3 sc_examples.py sines --freqs 120 254 1201 --play
+    python3 sc_examples.py fm_bell --export bell.scsyndef   # shareable file
+
+Standard library only.
+"""
+from __future__ import annotations
+
+from functools import reduce
+
+from sc_synthdef import AR, KR, SynthDef, build_simple_synth
+
+
+# --- the gallery -----------------------------------------------------------
+
+def sines(freqs=(220, 440, 660), name: str = "hermes_sines") -> SynthDef:
+    """Mix any number of sine waves (default a major triad).
+
+    Handles the "play a 120/254/1201 Hz chord" request directly: one SinOsc per
+    tone, summed with ``+``, scaled by a safe master gain.
+    """
+    freqs = list(freqs) or [440]
+    sd = SynthDef(name)
+    oscs = [sd.sinosc(f) for f in freqs]
+    mixed = reduce(lambda a, b: a + b, oscs)   # (((o0 + o1) + o2) + ...)
+    # N summed sines peak near N; scale the master gain down so the mix stays
+    # well under full scale (the Limiter still guards the rest).
+    sd.to_out(mixed, min(0.2, 0.8 / len(freqs)))
+    return sd
+
+
+def fm_bell(carrier: float = 220, ratio: float = 1.414, index: float = 260,
+            name: str = "hermes_fm_bell") -> SynthDef:
+    """Metallic FM tone: a modulator bends the carrier's frequency.
+
+    ``carrier * ratio`` is the modulator pitch; ``index`` is how far the carrier
+    frequency swings. Irrational ratios (~1.414) give clangorous, bell-like
+    timbres; whole-number ratios sound more harmonic.
+    """
+    sd = SynthDef(name)
+    freq = sd.control("freq", carrier)
+    mod = sd.sinosc(freq * ratio) * index          # modulator * depth
+    car = sd.sinosc(freq + mod)                     # carrier, frequency-modulated
+    sd.to_out(car, 0.2)
+    return sd
+
+
+def wobble_bass(freq: float = 55, rate: float = 2, depth: float = 1200,
+                base: float = 700, rq: float = 0.2,
+                name: str = "hermes_wobble") -> SynthDef:
+    """Dubstep 'wob': a buzzy saw bass swept by an LFO-driven resonant low-pass.
+
+    ``rate`` is the wobble speed (Hz); ``base``/``depth`` set where and how far
+    the filter cutoff sweeps. RLPF's cutoff is driven by a control-rate LFO.
+    """
+    sd = SynthDef(name)
+    f = sd.control("freq", freq)
+    wob = sd.control("rate", rate)
+    saw = sd.saw(f)
+    lfo = sd.sinosc(wob, rate=KR)                   # -1..1 wobble
+    cutoff = lfo * depth + base                     # base +/- depth
+    filt = sd.rlpf(saw, cutoff, rq)
+    sd.to_out(filt, 0.2)
+    return sd
+
+
+def supersaw_drone(freq: float = 110, detune: float = 0.6,
+                   name: str = "hermes_supersaw") -> SynthDef:
+    """Fat detuned drone: three saws a few cents apart, mixed and smoothed.
+
+    The slight ``detune`` makes the three Saws drift in and out of phase, giving
+    the thick, shimmering 'supersaw' character. A LPF tames the buzz.
+    """
+    sd = SynthDef(name)
+    f = sd.control("freq", freq)
+    a = sd.saw(f)
+    b = sd.saw(f + detune)
+    c = sd.saw(f - detune)
+    mixed = (a + b + c) * 0.4
+    smooth = sd.lpf(mixed, 2500)
+    sd.to_out(smooth, 0.16)
+    return sd
+
+
+def random_blips(speed: float = 5, low: float = 300, span: float = 500,
+                 name: str = "hermes_blips") -> SynthDef:
+    """Generative blip melody -- a new random pitch ``speed`` times a second.
+
+    LFNoise0 latches a fresh random value ``speed`` times/sec (no sequencer); it
+    is mapped from -1..1 onto ``[low, low+span]`` to pick the pitch. This is the
+    SC idiom that Pd needs a whole samphold/phasor rig for.
+    """
+    sd = SynthDef(name)
+    rate = sd.control("speed", speed)
+    note = sd.lfnoise0(rate) * (span / 2.0) + (low + span / 2.0)
+    tone = sd.sinosc(note)
+    sd.to_out(tone, 0.2)
+    return sd
+
+
+def resonator(pitch: float = 220, decay: float = 3.0,
+              name: str = "hermes_resonator") -> SynthDef:
+    """Plucked/blown string drone: noise poured into a tuned comb resonator.
+
+    A short CombL tuned to ``1/pitch`` seconds with a long ``decay`` acts as a
+    Karplus-Strong-style resonator; a LPF in front rolls off the highs so it
+    sings rather than hisses. Continuous noise keeps it droning.
+    """
+    sd = SynthDef(name)
+    f = sd.control("freq", pitch)
+    delay = 1.0 / pitch
+    exc = sd.lpf(sd.whitenoise() * 0.15, 4000)
+    string = sd.combl(exc, maxdelay=0.05, delay=delay, decay=decay)
+    sd.to_out(string, 0.2)
+    return sd
+
+
+# Registry: name -> (builder, one-line description)
+EXAMPLES = {
+    "sine": (lambda: build_simple_synth(), "Plain 440 Hz sine -- the 'hello world' synth."),
+    "sines": (sines, "Mix N sine waves; set them with --freqs 120 254 1201."),
+    "fm_bell": (fm_bell, "Metallic FM bell tone."),
+    "wobble_bass": (wobble_bass, "Dubstep LFO-swept resonant bass."),
+    "supersaw_drone": (supersaw_drone, "Fat detuned three-saw drone."),
+    "random_blips": (random_blips, "Generative random-pitch blip melody."),
+    "resonator": (resonator, "Karplus-Strong plucked/blown string drone."),
+}
+
+
+def _main(argv=None) -> int:
+    import argparse
+    import os
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description="Build and (optionally) play example SuperCollider synths.",
+    )
+    parser.add_argument("name", nargs="?", help="Example to build (see --list)")
+    parser.add_argument("--list", action="store_true", help="List all examples")
+    parser.add_argument("--freqs", type=float, nargs="+",
+                        help="Frequencies (Hz) for 'sines', e.g. --freqs 120 254 1201")
+    parser.add_argument("--play", action="store_true", help="Load + start it on a running scsynth")
+    parser.add_argument("--node", type=int, default=1000, help="Node id to create (default 1000)")
+    parser.add_argument("--export", metavar="PATH",
+                        help="Write a standalone, loadable .scsyndef file and exit")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=57110)
+    args = parser.parse_args(argv)
+
+    if args.list or not args.name:
+        width = max(len(k) for k in EXAMPLES)
+        for nm, (_, desc) in EXAMPLES.items():
+            print(f"  {nm:<{width}}  {desc}")
+        return 0
+
+    if args.name not in EXAMPLES:
+        print(f"unknown example: {args.name!r} (try --list)", file=sys.stderr)
+        return 2
+
+    if args.name == "sines" and args.freqs:
+        sd = sines(args.freqs)
+    else:
+        sd = EXAMPLES[args.name][0]()
+
+    violations = sd.safety_violations()
+    if violations:
+        print("SAFETY VIOLATIONS (not playing):", file=sys.stderr)
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        return 1
+
+    if args.export:
+        path = os.path.abspath(args.export)
+        sd.to_scsyndef_file(path)
+        print(f"exported {args.name} -> {path}")
+        return 0
+
+    if args.play:
+        from sc_client import SCClient
+        client = SCClient(host=args.host, port=args.port)
+        try:
+            nid = client.play(sd, node_id=args.node)
+        except OSError as e:
+            print(f"failed to reach scsynth at {args.host}:{args.port}: {e}",
+                  file=sys.stderr)
+            return 1
+        if not client.sync():
+            print("sent, but scsynth did not confirm (/sync timed out); is the "
+                  "server booted? see templates/boot_scsynth.sh", file=sys.stderr)
+            return 1
+        print(f"playing {args.name} as node {nid} "
+              f"(stop: python3 sc_client.py --free-all)")
+        return 0
+
+    # default: emit the compiled .scsyndef bytes on stdout
+    sys.stdout.buffer.write(sd.compile())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/optional-skills/creative/supercollider/scripts/sc_examples.py
+++ b/optional-skills/creative/supercollider/scripts/sc_examples.py
@@ -195,9 +195,11 @@ def _main(argv=None) -> int:
             print(f"failed to reach scsynth at {args.host}:{args.port}: {e}",
                   file=sys.stderr)
             return 1
-        if not client.sync():
-            print("sent, but scsynth did not confirm (/sync timed out); is the "
-                  "server booted? see templates/boot_scsynth.sh", file=sys.stderr)
+        ok, err = client.verify()
+        if not ok:
+            print(f"scsynth did not confirm playback ({err}); the SynthDef may "
+                  "have been rejected, or the server is not booted "
+                  "(see templates/boot_scsynth.sh)", file=sys.stderr)
             return 1
         print(f"playing {args.name} as node {nid} "
               f"(stop: python3 sc_client.py --free-all)")

--- a/optional-skills/creative/supercollider/scripts/sc_synthdef.py
+++ b/optional-skills/creative/supercollider/scripts/sc_synthdef.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+"""Pure-Python SuperCollider SynthDef compiler + graph builder + safety linter.
+
+SuperCollider splits into two programs: the language ``sclang`` (which usually
+*compiles* SynthDefs) and the audio server ``scsynth`` (which plays them). The
+usual path routes everything through ``sclang``. This module skips it: it emits
+the **SynthDef v2 binary format** directly from Python, so a compiled synth graph
+can be shipped to a bare ``scsynth`` over OSC (see ``sc_client.py``) with **no
+sclang, no external packages -- standard library only.**
+
+Build a graph the way you would patch modular gear::
+
+    sd = SynthDef("hello")
+    freq = sd.control("freq", 440)       # a live-settable parameter
+    sig  = sd.sinosc(freq)               # SinOsc.ar(freq)
+    sd.to_out(sig, 0.2)                  # LeakDC -> *0.2 -> Limiter -> Out.ar(0)
+    blob = sd.compile()                  # -> bytes of a .scsyndef, ready for /d_recv
+
+``OutRef`` overloads ``+ - * /`` so signal math reads naturally
+(``sig = sd.sinosc(200) * 0.5 + sd.sinosc(300) * 0.5``); each operator emits a
+``BinaryOpUGen`` behind the scenes.
+
+The safety linter (:meth:`SynthDef.safety_violations`) enforces the same class of
+ear/speaker protections the Pure Data skill does: every ``Out`` must be reached
+through ``LeakDC -> [* <= MAX_MASTER_GAIN] -> Limiter``. Call :meth:`is_safe`
+before you play.
+
+Standard library only.
+"""
+from __future__ import annotations
+
+import struct
+from typing import Dict, List, Optional, Tuple, Union
+
+# -- calculation rates (SynthDef byte values) -------------------------------
+IR = 0   # scalar   (a constant, computed once)
+KR = 1   # control  (block rate, ~ every 64 samples)
+AR = 2   # audio    (sample rate)
+DR = 3   # demand
+
+# -- BinaryOpUGen operator -> special index (from the SC operator table) ----
+#   These indices are what scsynth uses to pick +, -, *, / at run time.
+BINOP = {"+": 0, "-": 1, "*": 2, "/": 4}
+
+# -- master-output safety (speaker / headphone / ear protection) ------------
+# Every Out must be reached through this protective chain:
+#   source -> LeakDC.ar -> [* <= MAX_MASTER_GAIN] -> Limiter.ar -> Out.ar
+# LeakDC   removes DC offset / subsonics that waste headroom and over-excurse
+#          woofers (the analog of Pd's [hip~ 5]).
+# Limiter  is a look-ahead brick wall so transient overshoots never reach the
+#          DAC as full-scale bursts (the analog of Pd's [clip~ -1 1]).
+MAX_MASTER_GAIN = 0.2
+DCBLOCK_OBJECT = "LeakDC"
+LIMITER_OBJECTS = ("Limiter", "Clip")
+OUT_OBJECT = "Out"
+GAIN_OBJECT = "BinaryOpUGen"   # a '*' BinaryOpUGen is the master gain
+LIMITER_LOOKAHEAD = 0.01       # seconds, Limiter's fixed (scalar) window
+
+
+Number = Union[int, float]
+
+
+class OutRef:
+    """A reference to one output of one UGen; the currency of graph wiring.
+
+    Returned by every UGen-creating method. Passing it as an input wires the two
+    UGens together. Arithmetic operators build ``BinaryOpUGen`` nodes so signal
+    math reads like ordinary Python: ``sd.sinosc(440) * 0.2``.
+    """
+
+    __slots__ = ("ugen", "out", "rate", "_def")
+
+    def __init__(self, ugen: int, out: int, rate: int, sdef: "SynthDef"):
+        self.ugen = ugen      # index of the source UGen in the graph
+        self.out = out        # which output of that UGen
+        self.rate = rate      # calc rate of this output (IR/KR/AR)
+        self._def = sdef
+
+    def _binop(self, other: "InputLike", op: str, reverse: bool = False) -> "OutRef":
+        rate = max(self.rate, _rate_of(other))
+        inputs = [other, self] if reverse else [self, other]
+        return self._def._add("BinaryOpUGen", rate, inputs, special=BINOP[op])
+
+    def __mul__(self, o: "InputLike") -> "OutRef":
+        return self._binop(o, "*")
+
+    __rmul__ = __mul__          # multiplication is commutative
+
+    def __add__(self, o: "InputLike") -> "OutRef":
+        return self._binop(o, "+")
+
+    __radd__ = __add__          # addition is commutative
+
+    def __sub__(self, o: "InputLike") -> "OutRef":
+        return self._binop(o, "-")
+
+    def __rsub__(self, o: "InputLike") -> "OutRef":
+        return self._binop(o, "-", reverse=True)
+
+    def __truediv__(self, o: "InputLike") -> "OutRef":
+        return self._binop(o, "/")
+
+    def __rtruediv__(self, o: "InputLike") -> "OutRef":
+        return self._binop(o, "/", reverse=True)
+
+    def __neg__(self) -> "OutRef":
+        return self._binop(-1.0, "*")
+
+
+InputLike = Union[OutRef, Number]
+
+
+def _rate_of(x: "InputLike") -> int:
+    return x.rate if isinstance(x, OutRef) else IR
+
+
+class _UGen:
+    __slots__ = ("name", "rate", "inputs", "num_outputs", "special", "output_rates")
+
+    def __init__(self, name: str, rate: int, inputs: List[InputLike],
+                 num_outputs: int, special: int, output_rates: List[int]):
+        self.name = name
+        self.rate = rate
+        self.inputs = inputs
+        self.num_outputs = num_outputs
+        self.special = special
+        self.output_rates = output_rates
+
+
+# -- little-endian? no: SynthDef files are big-endian --------------------------
+def _pstr(s: str) -> bytes:
+    """A Pascal string: one length byte followed by the raw bytes."""
+    data = s.encode("ascii")
+    if len(data) > 255:
+        raise ValueError(f"symbol too long for a SynthDef pstring: {s!r}")
+    return bytes([len(data)]) + data
+
+
+class SynthDef:
+    """Accumulates a UGen graph and compiles it to SynthDef v2 bytes."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.ugens: List[_UGen] = []
+        self.params: List[Tuple[str, float]] = []   # (name, default)
+        self._control_ugen: Optional[int] = None     # index of the lone Control
+
+    # -- low-level construction --------------------------------------------
+    def _add(self, name: str, rate: int, inputs: List[InputLike],
+             num_outputs: int = 1, special: int = 0,
+             output_rates: Optional[List[int]] = None) -> Union[OutRef, List[OutRef]]:
+        """Append a UGen. Returns an OutRef (or a list, for multi-output UGens)."""
+        idx = len(self.ugens)
+        rates = output_rates if output_rates is not None else [rate] * num_outputs
+        self.ugens.append(_UGen(name, rate, list(inputs), num_outputs, special, rates))
+        if num_outputs == 1:
+            return OutRef(idx, 0, rates[0], self)
+        return [OutRef(idx, k, rates[k], self) for k in range(num_outputs)]
+
+    def ugen(self, name: str, rate: int, inputs: List[InputLike],
+             num_outputs: int = 1, special: int = 0) -> Union[OutRef, List[OutRef]]:
+        """Public escape hatch: add any UGen the helpers below don't cover."""
+        return self._add(name, rate, inputs, num_outputs, special)
+
+    def control(self, name: str, default: Number = 0.0) -> OutRef:
+        """Declare a named, live-settable control (a synth parameter).
+
+        Reference the returned OutRef anywhere a signal is expected; at run time
+        send ``/n_set <node> <name> <value>`` (``SCClient.set``) to change it.
+        All controls share one ``Control`` UGen, created on first call.
+        """
+        if self._control_ugen is None:
+            self._control_ugen = len(self.ugens)
+            self.ugens.append(_UGen("Control", KR, [], 0, 0, []))
+        ctl = self.ugens[self._control_ugen]
+        out_index = ctl.num_outputs
+        ctl.num_outputs += 1
+        ctl.output_rates.append(KR)
+        self.params.append((name, float(default)))
+        return OutRef(self._control_ugen, out_index, KR, self)
+
+    # -- curated UGen palette ----------------------------------------------
+    # Oscillators / sources
+    def sinosc(self, freq: InputLike = 440, phase: InputLike = 0, rate: int = AR) -> OutRef:
+        return self._add("SinOsc", rate, [freq, phase])
+
+    def saw(self, freq: InputLike = 440, rate: int = AR) -> OutRef:
+        return self._add("Saw", rate, [freq])
+
+    def pulse(self, freq: InputLike = 440, width: InputLike = 0.5, rate: int = AR) -> OutRef:
+        return self._add("Pulse", rate, [freq, width])
+
+    def lfsaw(self, freq: InputLike = 1, iphase: InputLike = 0, rate: int = KR) -> OutRef:
+        return self._add("LFSaw", rate, [freq, iphase])
+
+    def lftri(self, freq: InputLike = 1, iphase: InputLike = 0, rate: int = KR) -> OutRef:
+        return self._add("LFTri", rate, [freq, iphase])
+
+    def impulse(self, freq: InputLike = 1, phase: InputLike = 0, rate: int = AR) -> OutRef:
+        return self._add("Impulse", rate, [freq, phase])
+
+    def whitenoise(self, rate: int = AR) -> OutRef:
+        return self._add("WhiteNoise", rate, [])
+
+    def pinknoise(self, rate: int = AR) -> OutRef:
+        return self._add("PinkNoise", rate, [])
+
+    def brownnoise(self, rate: int = AR) -> OutRef:
+        return self._add("BrownNoise", rate, [])
+
+    def dust(self, density: InputLike = 100, rate: int = AR) -> OutRef:
+        return self._add("Dust", rate, [density])
+
+    def lfnoise0(self, freq: InputLike = 10, rate: int = KR) -> OutRef:
+        """Stepped random (sample-and-hold noise) -- a new value ``freq`` times/sec."""
+        return self._add("LFNoise0", rate, [freq])
+
+    def lfnoise1(self, freq: InputLike = 10, rate: int = KR) -> OutRef:
+        """Ramped (linearly interpolated) random noise."""
+        return self._add("LFNoise1", rate, [freq])
+
+    # Filters
+    def lpf(self, sig: InputLike, freq: InputLike = 1000, rate: int = AR) -> OutRef:
+        return self._add("LPF", rate, [sig, freq])
+
+    def hpf(self, sig: InputLike, freq: InputLike = 1000, rate: int = AR) -> OutRef:
+        return self._add("HPF", rate, [sig, freq])
+
+    def bpf(self, sig: InputLike, freq: InputLike = 1000, rq: InputLike = 1, rate: int = AR) -> OutRef:
+        return self._add("BPF", rate, [sig, freq, rq])
+
+    def rlpf(self, sig: InputLike, freq: InputLike = 1000, rq: InputLike = 1, rate: int = AR) -> OutRef:
+        return self._add("RLPF", rate, [sig, freq, rq])
+
+    def rhpf(self, sig: InputLike, freq: InputLike = 1000, rq: InputLike = 1, rate: int = AR) -> OutRef:
+        return self._add("RHPF", rate, [sig, freq, rq])
+
+    def resonz(self, sig: InputLike, freq: InputLike = 440, bwr: InputLike = 1, rate: int = AR) -> OutRef:
+        return self._add("Resonz", rate, [sig, freq, bwr])
+
+    # Delay / resonator
+    def combl(self, sig: InputLike, maxdelay: Number = 0.2,
+              delay: InputLike = 0.2, decay: InputLike = 1.0, rate: int = AR) -> OutRef:
+        """CombL: interpolating comb delay with feedback set by ``decay`` (seconds).
+
+        A short delay tuned to ``1/pitch`` seconds with a long decay behaves like a
+        Karplus-Strong resonator. ``maxdelay`` is a scalar (fixed at build time).
+        """
+        return self._add("CombL", rate, [sig, float(maxdelay), delay, decay])
+
+    # Utility / dynamics
+    def leakdc(self, sig: InputLike, coef: InputLike = 0.995, rate: int = AR) -> OutRef:
+        return self._add("LeakDC", rate, [sig, coef])
+
+    def limiter(self, sig: InputLike, level: InputLike = 1.0,
+                dur: Number = LIMITER_LOOKAHEAD, rate: int = AR) -> OutRef:
+        return self._add("Limiter", rate, [sig, level, float(dur)])
+
+    def clip(self, sig: InputLike, lo: InputLike = -1, hi: InputLike = 1, rate: int = AR) -> OutRef:
+        return self._add("Clip", rate, [sig, lo, hi])
+
+    def pan2(self, sig: InputLike, pos: InputLike = 0, level: InputLike = 1) -> List[OutRef]:
+        """Equal-power stereo pan; returns ``[left, right]`` OutRefs."""
+        return self._add("Pan2", AR, [sig, pos, level], num_outputs=2)  # type: ignore[return-value]
+
+    # -- output stage + safety ---------------------------------------------
+    def out(self, bus: InputLike, *channels: InputLike) -> None:
+        """Raw ``Out.ar(bus, *channels)``. Prefer :meth:`to_out` for safety."""
+        self._add(OUT_OBJECT, AR, [bus, *channels], num_outputs=0)
+
+    def to_out(self, source: InputLike, gain: Number = MAX_MASTER_GAIN,
+               bus: InputLike = 0) -> OutRef:
+        """Wire ``source`` to hardware out through the protective master chain.
+
+        Builds ``LeakDC -> [* gain] -> Limiter`` and sends the result to both
+        output channels (dual-mono), so every synth that ends here is DC-blocked,
+        gain-bounded and hard-limited before it reaches the speakers. Returns the
+        Limiter's OutRef. This is exactly what :meth:`safety_violations` checks
+        for -- always end a synth with ``to_out(...)``.
+        """
+        dc = self.leakdc(source)                 # DC / subsonic blocker
+        amp = dc * float(gain)                   # bounded master gain (BinaryOp *)
+        lim = self.limiter(amp, 1.0)             # brick-wall limiter
+        self.out(bus, lim, lim)                  # L and R (dual-mono)
+        return lim
+
+    # -- compilation -------------------------------------------------------
+    def compile(self) -> bytes:
+        """Serialize the graph to SynthDef v2 bytes (a valid ``.scsyndef``)."""
+        # 1. Gather the constant pool (every numeric, non-OutRef input), deduped.
+        consts: List[float] = []
+        cindex: Dict[float, int] = {}
+
+        def register(v: Number) -> int:
+            f = float(v)
+            if f not in cindex:
+                cindex[f] = len(consts)
+                consts.append(f)
+            return cindex[f]
+
+        for u in self.ugens:
+            for inp in u.inputs:
+                if not isinstance(inp, OutRef):
+                    register(inp)
+
+        out = bytearray()
+        out += b"SCgf"                       # file type id
+        out += struct.pack(">i", 2)          # file version 2
+        out += struct.pack(">h", 1)          # number of synthdefs in this file
+
+        out += _pstr(self.name)
+
+        out += struct.pack(">i", len(consts))
+        for c in consts:
+            out += struct.pack(">f", c)
+
+        out += struct.pack(">i", len(self.params))          # initial param values
+        for _, default in self.params:
+            out += struct.pack(">f", default)
+
+        out += struct.pack(">i", len(self.params))          # param name -> index
+        for i, (pname, _) in enumerate(self.params):
+            out += _pstr(pname)
+            out += struct.pack(">i", i)
+
+        out += struct.pack(">i", len(self.ugens))
+        for u in self.ugens:
+            out += _pstr(u.name)
+            out += struct.pack(">b", u.rate)
+            out += struct.pack(">i", len(u.inputs))
+            out += struct.pack(">i", u.num_outputs)
+            out += struct.pack(">h", u.special)
+            for inp in u.inputs:
+                if isinstance(inp, OutRef):
+                    out += struct.pack(">i", inp.ugen)   # source UGen index
+                    out += struct.pack(">i", inp.out)    # source output index
+                else:
+                    out += struct.pack(">i", -1)         # -1 == constant
+                    out += struct.pack(">i", cindex[float(inp)])
+            for r in u.output_rates:
+                out += struct.pack(">b", r)
+
+        out += struct.pack(">h", 0)          # number of variants
+        return bytes(out)
+
+    def to_scsyndef_file(self, path: str) -> str:
+        """Write the compiled graph as a standalone, loadable ``.scsyndef`` file.
+
+        Any scsynth can load it (``/d_load`` / ``/d_loadDir``) with no Python and
+        no sclang -- the natural shareable artifact for a synth built here.
+        """
+        with open(path, "wb") as fh:
+            fh.write(self.compile())
+        return path
+
+    # -- safety linting -----------------------------------------------------
+    def _incoming(self) -> Dict[int, List[int]]:
+        edges: Dict[int, List[int]] = {}
+        for i, u in enumerate(self.ugens):
+            for inp in u.inputs:
+                if isinstance(inp, OutRef):
+                    edges.setdefault(i, []).append(inp.ugen)
+        return edges
+
+    def _ancestors(self, idx: int, incoming: Dict[int, List[int]]) -> set:
+        seen: set = set()
+        stack = list(incoming.get(idx, []))
+        while stack:
+            cur = stack.pop()
+            if cur in seen:
+                continue
+            seen.add(cur)
+            stack.extend(incoming.get(cur, []))
+        return seen
+
+    def safety_violations(self) -> List[str]:
+        """Return human-readable master-output safety violations (empty == safe).
+
+        For every connected ``Out``:
+
+        1. **Limiter at the output.** Each signal input of ``Out`` must be a
+           ``Limiter`` (or ``Clip``); a raw signal wired to ``Out`` lets
+           overshoots reach the DAC as full-scale bursts.
+        2. **Bounded master gain.** That limiter must be fed by a ``*``
+           ``BinaryOpUGen`` whose constant multiplier is <= ``MAX_MASTER_GAIN``.
+        3. **DC / subsonic block.** A ``LeakDC`` must sit somewhere upstream of
+           the ``Out``.
+
+        :meth:`to_out` builds exactly this chain.
+        """
+        violations: List[str] = []
+        incoming = self._incoming()
+        outs = [i for i, u in enumerate(self.ugens) if u.name == OUT_OBJECT]
+
+        for oi in outs:
+            out_u = self.ugens[oi]
+            signal_inputs = out_u.inputs[1:]     # input 0 is the bus number
+            connected = [s for s in signal_inputs if isinstance(s, OutRef)]
+            if not connected:
+                continue  # Out with no signal makes no sound; nothing to check
+
+            for s in connected:
+                feeder = self.ugens[s.ugen]
+                # (1) limiter directly before Out
+                if feeder.name not in LIMITER_OBJECTS:
+                    violations.append(
+                        f"[{feeder.name}] (ugen {s.ugen}) feeds Out (ugen {oi}) "
+                        f"without a Limiter/Clip; overshoots can hit the DAC as "
+                        f"full-scale bursts"
+                    )
+                    continue
+                # (2) bounded master gain feeding that limiter
+                if not feeder.inputs:
+                    continue
+                gain_in = feeder.inputs[0]
+                gain_ok = False
+                if isinstance(gain_in, OutRef):
+                    g = self.ugens[gain_in.ugen]
+                    if g.name == GAIN_OBJECT and g.special == BINOP["*"]:
+                        const_operands = [x for x in g.inputs if not isinstance(x, OutRef)]
+                        for value in const_operands:
+                            if float(value) <= MAX_MASTER_GAIN:
+                                gain_ok = True
+                            else:
+                                violations.append(
+                                    f"master gain [* {value}] (ugen {gain_in.ugen}) "
+                                    f"exceeds {MAX_MASTER_GAIN}; lower it to protect "
+                                    f"ears/gear"
+                                )
+                        if not const_operands:
+                            violations.append(
+                                f"master gain [*] (ugen {gain_in.ugen}) before the "
+                                f"Limiter has no constant multiplier <= "
+                                f"{MAX_MASTER_GAIN}"
+                            )
+                            gain_ok = True  # reported; don't double-report below
+                if not gain_ok:
+                    violations.append(
+                        f"Limiter (ugen {s.ugen}) before Out has no bounded master "
+                        f"gain [* <= {MAX_MASTER_GAIN}] feeding it"
+                    )
+
+            # (3) DC / subsonic blocker somewhere upstream
+            anc_names = {self.ugens[i].name for i in self._ancestors(oi, incoming)}
+            if DCBLOCK_OBJECT not in anc_names:
+                violations.append(
+                    f"Out (ugen {oi}) chain has no DC/subsonic blocker "
+                    f"[{DCBLOCK_OBJECT}]; DC offset can over-excurse speakers"
+                )
+        # Out is fed dual-mono (the same limiter twice), so the same problem can
+        # surface more than once; report each distinct violation only once.
+        deduped: List[str] = []
+        for v in violations:
+            if v not in deduped:
+                deduped.append(v)
+        return deduped
+
+    def is_safe(self) -> bool:
+        return not self.safety_violations()
+
+
+def build_simple_synth(name: str = "hermes_sine", freq: Number = 440,
+                       gain: Number = MAX_MASTER_GAIN) -> SynthDef:
+    """The canonical safe reference synth: a single sine through the master chain.
+
+    ``SinOsc.ar(freq) -> LeakDC -> [* gain] -> Limiter -> Out.ar(0)`` via
+    :meth:`SynthDef.to_out`.
+    """
+    sd = SynthDef(name)
+    f = sd.control("freq", freq)
+    sd.to_out(sd.sinosc(f), gain)
+    return sd
+
+
+def build_recorder(name: str = "hermes_recorder", channels: int = 2) -> SynthDef:
+    """A synth that streams the output bus to disk via ``DiskOut``.
+
+    Reads the hardware output bus (``In.ar(0, channels)``) -- i.e. the exact,
+    post-limiter audio you hear -- and writes it to the buffer named by the
+    ``buf`` control. Play it at the tail of the node tree while your synths run,
+    then free it to finish the file. See ``SCClient.record``.
+    """
+    sd = SynthDef(name)
+    buf = sd.control("buf", 0)
+    sig = sd.ugen("In", AR, [0.0], num_outputs=channels)
+    if channels == 1:
+        sig = [sig]  # type: ignore[list-item]
+    sd.ugen("DiskOut", AR, [buf, *sig], num_outputs=0)
+    return sd
+
+
+if __name__ == "__main__":
+    import sys
+
+    patch = build_simple_synth()
+    blob = patch.compile()
+    sys.stderr.write(f"{patch.name}: {len(blob)} bytes, "
+                     f"{len(patch.ugens)} ugens, {len(patch.params)} params\n")
+    problems = patch.safety_violations()
+    if problems:
+        sys.stderr.write("SAFETY VIOLATIONS:\n")
+        for p in problems:
+            sys.stderr.write(f"  - {p}\n")
+        sys.exit(1)
+    sys.stdout.buffer.write(blob)   # emit raw .scsyndef bytes on stdout

--- a/optional-skills/creative/supercollider/scripts/sc_synthdef.py
+++ b/optional-skills/creative/supercollider/scripts/sc_synthdef.py
@@ -419,13 +419,16 @@ class SynthDef:
                     if g.name == GAIN_OBJECT and g.special == BINOP["*"]:
                         const_operands = [x for x in g.inputs if not isinstance(x, OutRef)]
                         for value in const_operands:
-                            if float(value) <= MAX_MASTER_GAIN:
+                            # Bound by the documented range: a negative gain has
+                            # magnitude too, so `value <= MAX` alone would wrongly
+                            # pass -10.0. Require 0 <= gain <= MAX_MASTER_GAIN.
+                            if 0 <= float(value) <= MAX_MASTER_GAIN:
                                 gain_ok = True
                             else:
                                 violations.append(
                                     f"master gain [* {value}] (ugen {gain_in.ugen}) "
-                                    f"exceeds {MAX_MASTER_GAIN}; lower it to protect "
-                                    f"ears/gear"
+                                    f"is outside 0..{MAX_MASTER_GAIN}; set it within "
+                                    f"that range to protect ears/gear"
                                 )
                         if not const_operands:
                             violations.append(

--- a/optional-skills/creative/supercollider/templates/boot_scsynth.sh
+++ b/optional-skills/creative/supercollider/templates/boot_scsynth.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Boot a bare SuperCollider audio server (scsynth) listening for OSC on UDP.
+#
+# This is the SuperCollider analog of "open the receiver patch first": once
+# scsynth is up, the Python client speaks OSC to it directly -- no sclang, no
+# IDE. Leave it running, then drive it with sc_examples.py / sc_client.py.
+#
+#   ./templates/boot_scsynth.sh            # boot on UDP :57110 (default)
+#   PORT=57110 ./templates/boot_scsynth.sh # explicit port
+#
+# Stop it with Ctrl-C, or from another shell: python3 sc_client.py --quit
+set -euo pipefail
+
+PORT="${PORT:-57110}"
+
+# 1. Locate the scsynth binary and its UGen plugins.
+if command -v scsynth >/dev/null 2>&1; then
+    SCSYNTH="$(command -v scsynth)"
+    PLUGINS=""   # a PATH install usually finds its own plugins
+else
+    APP="/Applications/SuperCollider.app/Contents/Resources"
+    SCSYNTH="$APP/scsynth"
+    PLUGINS="$APP/plugins"
+fi
+
+if [ ! -x "$SCSYNTH" ]; then
+    echo "scsynth not found. Install SuperCollider:" >&2
+    echo "  macOS:  brew install --cask supercollider" >&2
+    echo "  Linux:  sudo apt install supercollider-server" >&2
+    exit 1
+fi
+
+echo "Booting scsynth on UDP :$PORT  ($SCSYNTH)"
+echo "Stop with Ctrl-C, or: python3 sc_client.py --quit"
+
+# -u <port>  : listen for OSC on this UDP port
+# -U <path>  : where to load UGen plugins from (app-bundle build needs this)
+if [ -n "$PLUGINS" ]; then
+    exec "$SCSYNTH" -u "$PORT" -U "$PLUGINS"
+else
+    exec "$SCSYNTH" -u "$PORT"
+fi

--- a/tests/skills/test_supercollider_skill.py
+++ b/tests/skills/test_supercollider_skill.py
@@ -1,0 +1,168 @@
+"""Regression tests for the `supercollider` optional skill.
+
+Standard library + pytest only; no scsynth, no network. Exercises the two pure
+units: the SynthDef v2 compiler / safety linter (`sc_synthdef.py`) and the OSC
+encoder (`sc_client.py`). Socket I/O in `sc_client` is mocked.
+"""
+from __future__ import annotations
+
+import struct
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+SCRIPTS = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "creative"
+    / "supercollider"
+    / "scripts"
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _add_scripts_to_path():
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        yield
+    finally:
+        sys.path.remove(str(SCRIPTS))
+
+
+# --- sc_synthdef: compiler ------------------------------------------------
+
+def test_simple_synth_compiles_to_valid_synthdef_v2():
+    import sc_synthdef as m
+
+    sd = m.build_simple_synth(name="t_sine", freq=440, gain=0.1)
+    blob = sd.compile()
+
+    assert blob[:4] == b"SCgf"                       # file type id
+    assert struct.unpack(">i", blob[4:8])[0] == 2    # file version 2
+    assert struct.unpack(">h", blob[8:10])[0] == 1   # one synthdef
+    # pstring name follows: length byte then that many bytes
+    name_len = blob[10]
+    assert blob[11:11 + name_len] == b"t_sine"
+
+
+def test_control_becomes_a_parameter():
+    import sc_synthdef as m
+
+    sd = m.SynthDef("t_ctl")
+    f = sd.control("freq", 330)
+    sd.to_out(sd.sinosc(f), 0.1)
+
+    assert sd.params == [("freq", 330.0)]
+    # exactly one Control ugen carries the single parameter
+    controls = [u for u in sd.ugens if u.name == "Control"]
+    assert len(controls) == 1 and controls[0].num_outputs == 1
+
+
+def test_constants_are_deduplicated():
+    import sc_synthdef as m
+
+    sd = m.SynthDef("t_const")
+    # two SinOscs share phase 0.0; the constant pool must not duplicate it
+    a = sd.sinosc(200)
+    b = sd.sinosc(300)
+    sd.to_out(a + b, 0.1)
+    blob = sd.compile()
+
+    # walk to the constant count: 4 (SCgf) + 4 (ver) + 2 (ndefs) + pstring name
+    off = 10
+    off += 1 + blob[10]
+    n_consts = struct.unpack(">i", blob[off:off + 4])[0]
+    consts = struct.unpack(f">{n_consts}f", blob[off + 4:off + 4 + n_consts * 4])
+    assert consts.count(0.0) == 1     # phase 0.0 registered once, not twice
+
+
+# --- sc_synthdef: safety linter -------------------------------------------
+
+def test_to_out_chain_is_safe():
+    import sc_synthdef as m
+
+    sd = m.build_simple_synth(gain=0.1)
+    assert sd.is_safe()
+    assert sd.safety_violations() == []
+
+
+def test_raw_signal_into_out_is_flagged():
+    import sc_synthdef as m
+
+    sd = m.SynthDef("t_raw")
+    sd.out(0, sd.sinosc(440))          # no LeakDC / gain / Limiter
+    violations = sd.safety_violations()
+    assert not sd.is_safe()
+    assert any("Limiter" in v for v in violations)
+    assert any("LeakDC" in v for v in violations)
+
+
+def test_master_gain_over_limit_is_flagged():
+    import sc_synthdef as m
+
+    sd = m.SynthDef("t_loud")
+    sd.to_out(sd.sinosc(440), gain=0.9)   # 0.9 > MAX_MASTER_GAIN (0.2)
+    assert not sd.is_safe()
+    assert any("exceeds" in v for v in sd.safety_violations())
+
+
+# --- sc_client: OSC encoding ----------------------------------------------
+
+def test_osc_message_no_args_is_padded():
+    import sc_client as c
+
+    msg = c.encode_message("/status")
+    # "/status\0" -> 8 bytes (already aligned); typetag ",\0\0\0" -> 4 bytes
+    assert msg == b"/status\x00" + b",\x00\x00\x00"
+    assert len(msg) % 4 == 0
+
+
+def test_osc_message_typetags_and_args():
+    import sc_client as c
+
+    msg = c.encode_message("/n_set", 1000, "freq", 220.0)
+    # address "/n_set\0\0" (8 bytes) then typetag ",isf\0\0\0\0" (8 bytes),
+    # so the first arg (int 1000) begins at offset 16.
+    assert msg[8:12] == b",isf"
+    assert struct.unpack(">i", msg[16:20])[0] == 1000
+    assert len(msg) % 4 == 0
+
+
+def test_osc_blob_length_prefixed_and_padded():
+    import sc_client as c
+
+    blob = c.encode_message("/d_recv", b"abc")   # 3-byte blob -> len prefix + pad to 4
+    # find the blob: address "/d_recv\0" (8) + typetag ",b\0\0" (4) = 12
+    length = struct.unpack(">i", blob[12:16])[0]
+    assert length == 3
+    assert blob[16:20] == b"abc\x00"             # padded to 4 bytes
+
+
+def test_synthdef_name_extracted_from_bytes():
+    import sc_client as c
+    import sc_synthdef as m
+
+    blob = m.build_simple_synth(name="named_def").compile()
+    assert c._synthdef_name(blob) == "named_def"
+
+
+def test_play_sends_d_recv_with_completion(monkeypatch):
+    import sc_client as c
+    import sc_synthdef as m
+
+    sent = []
+
+    def fake_sendto(self, payload, addr):
+        sent.append(payload)
+
+    monkeypatch.setattr(c.socket.socket, "sendto", fake_sendto, raising=True)
+    client = c.SCClient()
+    node = client.play(m.build_simple_synth(name="p_sine"), node_id=1234)
+
+    assert node == 1234
+    assert len(sent) == 1                     # one datagram: /d_recv + completion
+    assert sent[0].startswith(b"/d_recv\x00")
+    assert b"/s_new" in sent[0]               # completion message embedded
+    assert b"p_sine" in sent[0]

--- a/tests/skills/test_supercollider_skill.py
+++ b/tests/skills/test_supercollider_skill.py
@@ -105,7 +105,18 @@ def test_master_gain_over_limit_is_flagged():
     sd = m.SynthDef("t_loud")
     sd.to_out(sd.sinosc(440), gain=0.9)   # 0.9 > MAX_MASTER_GAIN (0.2)
     assert not sd.is_safe()
-    assert any("exceeds" in v for v in sd.safety_violations())
+    assert any("outside 0" in v for v in sd.safety_violations())
+
+
+def test_negative_master_gain_is_flagged():
+    import sc_synthdef as m
+
+    # A negative gain has magnitude too: -10.0 must NOT pass just because
+    # -10.0 <= 0.2. The linter requires 0 <= gain <= MAX_MASTER_GAIN.
+    sd = m.SynthDef("t_neg")
+    sd.to_out(sd.sinosc(440), gain=-10.0)
+    assert not sd.is_safe()
+    assert any("outside 0" in v for v in sd.safety_violations())
 
 
 # --- sc_client: OSC encoding ----------------------------------------------
@@ -146,6 +157,71 @@ def test_synthdef_name_extracted_from_bytes():
 
     blob = m.build_simple_synth(name="named_def").compile()
     assert c._synthdef_name(blob) == "named_def"
+
+
+def test_decode_message_roundtrips_args():
+    import sc_client as c
+
+    addr, args = c.decode_message(c.encode_message("/fail", "/d_recv", "boom", 3))
+    assert addr == "/fail"
+    assert args == ["/d_recv", "boom", 3]
+
+
+class _FakeSock:
+    """Stand-in socket that replays a fixed list of reply datagrams."""
+
+    def __init__(self, replies):
+        self._replies = list(replies)
+        self._timeout = None
+
+    def gettimeout(self):
+        return self._timeout
+
+    def settimeout(self, t):
+        self._timeout = t
+
+    def sendto(self, payload, addr):
+        pass
+
+    def recvfrom(self, n):
+        import socket as _s
+        if self._replies:
+            return self._replies.pop(0), ("127.0.0.1", 57110)
+        raise _s.timeout()
+
+
+def test_verify_succeeds_on_done_then_synced():
+    import sc_client as c
+
+    client = c.SCClient()
+    client._sock = _FakeSock([
+        c.encode_message("/done", "/d_recv"),
+        c.encode_message("/synced", 1),
+    ])
+    ok, err = client.verify(timeout=0.5)
+    assert ok is True and err is None
+
+
+def test_verify_fails_when_synthdef_rejected():
+    import sc_client as c
+
+    client = c.SCClient()
+    client._sock = _FakeSock([
+        c.encode_message("/fail", "/d_recv", "SynthDef not found"),
+        c.encode_message("/synced", 1),
+    ])
+    ok, err = client.verify(timeout=0.5)
+    assert ok is False
+    assert "SynthDef not found" in err
+
+
+def test_verify_fails_on_timeout():
+    import sc_client as c
+
+    client = c.SCClient()
+    client._sock = _FakeSock([])          # no replies -> timeout
+    ok, err = client.verify(timeout=0.2)
+    assert ok is False and "synced" in err
 
 
 def test_play_sends_d_recv_with_completion(monkeypatch):


### PR DESCRIPTION
Adds an optional **`supercollider`** creative skill: make and control sound in a bare SuperCollider server (`scsynth`) by compiling SynthDefs and sending OSC over UDP — Python standard library only, no `sclang`, no `python-osc`.

**What it does**
- Pure-Python **SynthDef v2 binary compiler** + **OSC-over-UDP** encoder (stdlib `socket`/`struct`).
- `/d_recv` completion message starts a synth in one packet; `/sync` confirms it landed (no false-success reporting).
- Safety linter enforces a `LeakDC -> [* <= 0.2] -> Limiter -> Out` master chain before any output.
- Gallery of 7 ready-to-play synths, `.scsyndef` export, and WAV recording.

**Standards**
- `description` ≤ 60 chars; `platforms: [linux, macos]`; helpers in `scripts/`; modern SKILL.md section order.
- `tests/skills/test_supercollider_skill.py` (stdlib + `unittest.mock`, no network) → 11 passed.

**Testing**
Validated end-to-end against `scsynth` from the SuperCollider app bundle: SynthDef bytes load, a played synth appears in `/status`, `/n_set` retunes it live, `/g_freeAll` stops it, and `/sync` confirms delivery.

Sibling to the `pd-patching` optional skill (#67456).
