### PR TITLE
fix(matrix): ignore stale invites from left rooms

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2435,12 +2435,76 @@ class MatrixAdapter(BasePlatformAdapter):
     # Event callbacks
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _without_stale_left_room_invites(
+        sync_data: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Remove historical invite events from rooms the account has left.
+
+        A full Matrix sync can include the complete timeline for ``rooms.leave``.
+        Passing an old ``membership=invite`` event from that timeline through
+        mautrix dispatches ``InternalEventType.INVITE`` and makes Hermes try to
+        rejoin a room that the account subsequently left.  Current invitations
+        live under ``rooms.invite`` and remain untouched.
+        """
+
+        rooms = sync_data.get("rooms")
+        if not isinstance(rooms, dict):
+            return sync_data
+        leave = rooms.get("leave")
+        if not isinstance(leave, dict):
+            return sync_data
+
+        filtered_leave: Optional[Dict[str, Any]] = None
+        for room_id, room_data in leave.items():
+            if not isinstance(room_data, dict):
+                continue
+            updated_room: Optional[Dict[str, Any]] = None
+            for bucket_name in ("state", "timeline"):
+                bucket = room_data.get(bucket_name)
+                if not isinstance(bucket, dict):
+                    continue
+                events = bucket.get("events")
+                if not isinstance(events, list):
+                    continue
+                filtered_events = [
+                    event
+                    for event in events
+                    if not (
+                        isinstance(event, dict)
+                        and event.get("type") == "m.room.member"
+                        and isinstance(event.get("content"), dict)
+                        and event["content"].get("membership") == "invite"
+                    )
+                ]
+                if len(filtered_events) == len(events):
+                    continue
+                if updated_room is None:
+                    updated_room = dict(room_data)
+                updated_bucket = dict(bucket)
+                updated_bucket["events"] = filtered_events
+                updated_room[bucket_name] = updated_bucket
+
+            if updated_room is not None:
+                if filtered_leave is None:
+                    filtered_leave = dict(leave)
+                filtered_leave[room_id] = updated_room
+
+        if filtered_leave is None:
+            return sync_data
+
+        filtered_sync = dict(sync_data)
+        filtered_rooms = dict(rooms)
+        filtered_rooms["leave"] = filtered_leave
+        filtered_sync["rooms"] = filtered_rooms
+        return filtered_sync
+
     async def _dispatch_sync(self, sync_data: Dict[str, Any]) -> None:
         """Dispatch a sync response through the mautrix event machinery."""
         client = self._client
         if not client or not hasattr(client, "handle_sync"):
             return
-        tasks = client.handle_sync(sync_data)
+        tasks = client.handle_sync(self._without_stale_left_room_invites(sync_data))
         if inspect.isawaitable(tasks):
             tasks = await tasks
         if tasks:

--- a/tests/gateway/test_matrix_stale_invite_replay.py
+++ b/tests/gateway/test_matrix_stale_invite_replay.py
@@ -1,0 +1,148 @@
+"""Regression tests for stale Matrix invite replay from rooms.leave.
+
+A full /sync includes historical timelines for rooms the bot has left.  Old
+membership=invite events in those timelines must never trigger a fresh join;
+current rooms.invite entries must continue through normal mautrix dispatch.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.matrix.adapter import MatrixAdapter
+
+
+def _make_adapter() -> MatrixAdapter:
+    config = PlatformConfig(
+        enabled=True,
+        token="syt_test_token",
+        extra={
+            "homeserver": "https://matrix.example.org",
+            "user_id": "@hermes:example.org",
+        },
+    )
+    return MatrixAdapter(config)
+
+
+def test_filters_only_invite_membership_events_from_left_rooms():
+    stale_invite = {
+        "type": "m.room.member",
+        "state_key": "@hermes:example.org",
+        "content": {"membership": "invite", "is_direct": False},
+    }
+    later_leave = {
+        "type": "m.room.member",
+        "state_key": "@hermes:example.org",
+        "content": {"membership": "leave"},
+    }
+    encrypted_message = {
+        "type": "m.room.encrypted",
+        "content": {"ciphertext": "preserve-me"},
+    }
+    current_invite = {
+        "type": "m.room.member",
+        "state_key": "@hermes:example.org",
+        "content": {"membership": "invite", "is_direct": True},
+    }
+    sync_data = {
+        "next_batch": "s123",
+        "rooms": {
+            "leave": {
+                "!old:example.org": {
+                    "state": {"events": [stale_invite]},
+                    "timeline": {
+                        "events": [stale_invite, encrypted_message, later_leave],
+                        "limited": False,
+                    },
+                }
+            },
+            "invite": {
+                "!current:example.org": {
+                    "invite_state": {"events": [current_invite]}
+                }
+            },
+        },
+    }
+
+    filtered = MatrixAdapter._without_stale_left_room_invites(sync_data)
+
+    assert filtered is not sync_data
+    assert filtered["rooms"]["leave"]["!old:example.org"]["state"]["events"] == []
+    assert filtered["rooms"]["leave"]["!old:example.org"]["timeline"][
+        "events"
+    ] == [encrypted_message, later_leave]
+    assert filtered["rooms"]["invite"] is sync_data["rooms"]["invite"]
+    assert sync_data["rooms"]["leave"]["!old:example.org"]["timeline"][
+        "events"
+    ] == [stale_invite, encrypted_message, later_leave]
+
+
+def test_no_match_returns_original_sync_object():
+    sync_data = {
+        "rooms": {
+            "leave": {
+                "!old:example.org": {
+                    "timeline": {
+                        "events": [
+                            {
+                                "type": "m.room.member",
+                                "content": {"membership": "leave"},
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+
+    assert MatrixAdapter._without_stale_left_room_invites(sync_data) is sync_data
+
+
+@pytest.mark.asyncio
+async def test_dispatch_sync_filters_stale_invite_before_mautrix():
+    adapter = _make_adapter()
+    adapter._client = MagicMock()
+    adapter._client.handle_sync.return_value = []
+    sync_data = {
+        "rooms": {
+            "leave": {
+                "!old:example.org": {
+                    "timeline": {
+                        "events": [
+                            {
+                                "type": "m.room.member",
+                                "content": {"membership": "invite"},
+                            },
+                            {
+                                "type": "m.room.member",
+                                "content": {"membership": "leave"},
+                            },
+                        ]
+                    }
+                }
+            },
+            "invite": {
+                "!current:example.org": {
+                    "invite_state": {
+                        "events": [
+                            {
+                                "type": "m.room.member",
+                                "content": {"membership": "invite"},
+                            }
+                        ]
+                    }
+                }
+            },
+        }
+    }
+
+    await adapter._dispatch_sync(sync_data)
+
+    dispatched = adapter._client.handle_sync.call_args.args[0]
+    assert dispatched["rooms"]["leave"]["!old:example.org"]["timeline"][
+        "events"
+    ] == [
+        {"type": "m.room.member", "content": {"membership": "leave"}}
+    ]
+    assert "!current:example.org" in dispatched["rooms"]["invite"]


### PR DESCRIPTION
## Summary

- prevent historical `membership=invite` events under `rooms.leave` from reaching mautrix invite dispatch
- preserve current invitations under `rooms.invite` and all non-invite events from left-room state/timelines
- add regression coverage for filtering, input immutability, no-op behavior, and the actual `_dispatch_sync` path

## Problem

A full Matrix `/sync` can include the historical timeline for rooms the bot has left. If that timeline contains the original invite followed by join/leave events, `client.handle_sync()` dispatches the old invite as `InternalEventType.INVITE`. Hermes then tries to join a room whose current membership is already `leave`.

This reproduced on a live self-hosted Matrix gateway after four consecutive gateway restarts. Each startup retried the abandoned room for 45 seconds even though a current `/sync` reported zero rooms under `rooms.invite` and the target only under `rooms.leave`.

## Fix

Filter only `m.room.member` events with `content.membership == "invite"` from the `state` and `timeline` buckets of `rooms.leave` before passing the sync payload to mautrix. The helper uses copy-on-write so the original sync response and unrelated sections are not mutated.

Current invite handling is preserved because `rooms.invite` is not modified.

## Verification

- Live payload replay: stale left-room invite events `1 -> 0`; current invite section preserved
- Post-restart observation: no stale room join attempt during a window longer than the previous 45-second failure
- `15 passed` — focused stale-invite and DM-invite tests
- `348 passed, 2 deselected` — broader Matrix suite excluding two unrelated auto-thread tests that also fail on an untouched `origin/main` worktree in this local environment
- `ruff check` and `py_compile` passed for the changed files
