### PR TITLE
fix: prevent empty session resume from reusing durable ids

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1096,6 +1096,50 @@ describe('resumeSession warm-cache mapping integrity', () => {
     expect(runtimeIdByStoredSessionIdRef.current.get('stored-A')).toBe('rt-A')
     expect(sessionStateByRuntimeIdRef.current.get('rt-A')?.messages[0]?.id).toBe('user-optimistic')
   })
+
+  it('drops an empty resumed runtime when the gateway refuses its durable identity', async () => {
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-empty']])
+    }
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-empty', clientState('stored-A')]])
+    }
+
+    const durabilityError = new Error(
+      'refusing to resume a durable session with an empty transcript; start a new session instead'
+    )
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate' || method === 'session.resume') {
+        throw durabilityError
+      }
+
+      return {} as never
+    })
+
+    vi.mocked(getSessionMessages).mockResolvedValue({ messages: [], session_id: 'stored-A' } as never)
+    setSessions([storedSession({ id: 'stored-A', message_count: 0 })])
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(
+      <ResumeHarness
+        onReady={r => (resume = r)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-A', true)
+
+    const methods = requestGateway.mock.calls.map(([method]) => method)
+    expect(methods).toContain('session.activate')
+    expect(methods).toContain('session.resume')
+    expect(runtimeIdByStoredSessionIdRef.current.has('stored-A')).toBe(false)
+    expect(sessionStateByRuntimeIdRef.current.has('rt-empty')).toBe(false)
+    expect($activeSessionId.get()).toBeNull()
+  })
 })
 
 describe('createBackendSessionForSend workspace target', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -39,9 +39,14 @@ describe('applyRuntimeInfo approval mode', () => {
 })
 
 describe('isSessionGoneError', () => {
-  it('is true for 404 / session-not-found, false otherwise', () => {
+  it('is true for missing or unsafe durable session identities, false otherwise', () => {
     expect(isSessionGoneError(new Error('Request failed 404'))).toBe(true)
     expect(isSessionGoneError(new Error('Session not found'))).toBe(true)
+    expect(
+      isSessionGoneError(
+        new Error('refusing to resume a durable session with an empty transcript; start a new session instead')
+      )
+    ).toBe(true)
     expect(isSessionGoneError(new Error('ECONNREFUSED'))).toBe(false)
     expect(isSessionGoneError(null)).toBe(false)
   })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -555,12 +555,16 @@ export function applyStoredSessionPreviewRuntimeInfo(stored: { model?: null | st
   setCurrentPersonality('')
 }
 
-// A "session genuinely doesn't exist" failure (deleted, or an id from a wiped /
-// rotated backend) — the REST transcript 404s with `Session not found`. Distinct
-// from a transient/wedged backend (ECONNREFUSED, timeout), which must still
-// retry rather than discard the id.
+// A session identity that cannot be safely activated: either it no longer
+// exists, or the gateway refused to reuse its durable id with an empty runtime.
+// Both require dropping the warm runtime mapping and falling through to a cold
+// resume. Transient transport failures must retain the mapping for retry.
 export function isSessionGoneError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err ?? '')
 
-  return message.includes('404') || /session not found/i.test(message)
+  return (
+    message.includes('404') ||
+    /session not found/i.test(message) ||
+    /durable session with an empty transcript/i.test(message)
+  )
 }

--- a/tests/tui_gateway/test_restart_resume_durability.py
+++ b/tests/tui_gateway/test_restart_resume_durability.py
@@ -1,0 +1,177 @@
+"""Regression coverage for Desktop restart/reconnect session durability."""
+
+from __future__ import annotations
+
+import threading
+
+from hermes_state import SessionDB
+
+
+def _reset_live_sessions(server) -> None:
+    """Drop process-local sessions to model a backend process restart."""
+    with server._sessions_lock:
+        server._sessions.clear()
+
+
+def _role_content(messages: list[dict]) -> list[dict[str, str]]:
+    """Compare transcript identity without generated SQLite timestamps."""
+    return [
+        {"role": message["role"], "content": message["content"]} for message in messages
+    ]
+
+
+def test_restart_resume_rejects_empty_history_and_preserves_durable_transcript(
+    tmp_path, monkeypatch
+):
+    """A reconnect must not attach an empty agent to an existing durable id."""
+    import tui_gateway.server as server
+
+    db_path = tmp_path / "state.db"
+    session_id = "20260719_142032_0e82bb"
+    expected = [
+        {"role": "user", "content": "FitMass durable prompt"},
+        {"role": "assistant", "content": "FitMass durable answer"},
+    ]
+
+    seed_db = SessionDB(db_path=db_path)
+    seed_db.create_session(session_id, source="desktop")
+    for message in expected:
+        seed_db.append_message(
+            session_id,
+            role=message["role"],
+            content=message["content"],
+        )
+    seed_db.close()
+
+    opened_dbs: list[SessionDB] = []
+
+    def restart_db() -> SessionDB:
+        db = SessionDB(db_path=db_path)
+        opened_dbs.append(db)
+        monkeypatch.setattr(server, "_get_db", lambda: db)
+        return db
+
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        server,
+        "_wait_agent",
+        lambda *_args, **_kwargs: {
+            "error": {"message": "agent build disabled by durability test"}
+        },
+    )
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+    monkeypatch.setattr(server, "_default_session_cwd", lambda: str(tmp_path))
+    monkeypatch.setattr(
+        server,
+        "_claim_active_session_slot",
+        lambda *_args, **_kwargs: (None, None),
+    )
+
+    try:
+        _reset_live_sessions(server)
+        first_db = restart_db()
+        first = server.handle_request({
+            "id": "resume-after-reconnect",
+            "method": "session.resume",
+            "params": {"session_id": session_id, "source": "desktop"},
+        })
+        assert first is not None
+        assert "error" not in first
+        assert first["result"]["session_key"] == session_id
+        assert [
+            {"role": message["role"], "content": message["text"]}
+            for message in first["result"]["messages"]
+        ] == expected
+        assert (
+            _role_content(first_db.get_messages_as_conversation(session_id)) == expected
+        )
+
+        # A second process-local reset models the backend restart that followed
+        # `hermes update`. Reopening the same durable conversation must hydrate
+        # it again rather than manufacturing an empty runtime under the same id.
+        _reset_live_sessions(server)
+        first_db.close()
+        second_db = restart_db()
+        second = server.handle_request({
+            "id": "resume-after-restart",
+            "method": "session.resume",
+            "params": {"session_id": session_id, "source": "desktop"},
+        })
+        assert second is not None
+        assert "error" not in second
+        assert second["result"]["message_count"] == len(expected)
+        assert (
+            _role_content(second_db.get_messages_as_conversation(session_id))
+            == expected
+        )
+
+        # Reproduce the incident's post-restart shape without touching the
+        # durable rows: the loader unexpectedly returns history=0 for the same
+        # id even though its canonical transcript still exists in SQLite.
+        _reset_live_sessions(server)
+        real_get_resume_conversations = second_db.get_resume_conversations
+        monkeypatch.setattr(
+            second_db,
+            "get_resume_conversations",
+            lambda target: (
+                ([], [])
+                if target == session_id
+                else real_get_resume_conversations(target)
+            ),
+        )
+        damaged = server.handle_request({
+            "id": "resume-empty-after-restart",
+            "method": "session.resume",
+            "params": {"session_id": session_id, "source": "desktop"},
+        })
+
+        assert damaged is not None
+        assert damaged["error"]["code"] == 4091
+        assert "empty transcript" in damaged["error"]["message"]
+        assert not any(
+            session.get("session_key") == session_id
+            for session in server._sessions.values()
+        )
+
+        # Reconnect has a distinct fast path: a process-local session can still
+        # exist after its WebSocket detached. It must enforce the same invariant
+        # rather than returning that empty record merely because the id matches.
+        with server._sessions_lock:
+            server._sessions["empty-runtime"] = {
+                "history": [],
+                "history_lock": threading.Lock(),
+                "inflight_turn": None,
+                "queued_prompt": None,
+                "resumed_session": True,
+                "running": False,
+                "session_key": session_id,
+            }
+        reconnected = server.handle_request({
+            "id": "reconnect-empty-live-session",
+            "method": "session.activate",
+            "params": {"session_id": "empty-runtime"},
+        })
+        assert reconnected is not None
+        assert reconnected["error"]["code"] == 4091
+
+        submitted = server.handle_request({
+            "id": "submit-to-empty-live-session",
+            "method": "prompt.submit",
+            "params": {"session_id": "empty-runtime", "text": "new conversation"},
+        })
+        assert submitted is not None
+        assert submitted["error"]["code"] == 4091
+        assert (
+            _role_content(second_db.get_messages_as_conversation(session_id))
+            == expected
+        )
+    finally:
+        _reset_live_sessions(server)
+        for db in opened_dbs:
+            try:
+                db.close()
+            except Exception:
+                pass

--- a/tests/tui_gateway/test_subagent_child_mirror.py
+++ b/tests/tui_gateway/test_subagent_child_mirror.py
@@ -187,6 +187,28 @@ def test_prompt_submit_rejected_while_child_run_active(server, emits):
     assert server._child_run_active("child-1") is False
 
 
+def test_session_activate_allows_empty_lazy_runtime_while_child_run_active(
+    server, emits
+):
+    """A Desktop reconnect must keep an active child watch window attached even
+    before its first mirrored message has entered the runtime history."""
+    server._sessions["live-1"] = server._deferred_session_record(
+        "child-1",
+        cols=80,
+        cwd="/tmp",
+        history=[],
+        lease=None,
+        lazy=True,
+    )
+    _relay(server, "subagent.start", preview="starting", child_session_id="child-1")
+
+    result = server._methods["session.activate"]("rid-1", {"session_id": "live-1"})
+
+    assert "error" not in result
+    assert result["result"]["session_key"] == "child-1"
+    assert result["result"]["running"] is True
+
+
 def test_active_child_runs_registry_tracks_liveness(server, emits):
     """Every relayed event marks the child as in flight (even with no window
     open), and completion clears it — lazy watch resumes read this registry to

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5115,6 +5115,7 @@ def _init_session(
     cwd: str | None = None,
     session_db=None,
     source: str | None = None,
+    resumed_session: bool = False,
 ):
     now = time.time()
     with _sessions_lock:
@@ -5127,6 +5128,7 @@ def _init_session(
             "inflight_turn": None,
             "created_at": now,
             "last_active": now,
+            "resumed_session": resumed_session,
             "running": False,
             "attached_images": [],
             "image_counter": 0,
@@ -5783,6 +5785,7 @@ def _(rid, params: dict) -> dict:
             "created_at": now,
             "edit_snapshots": {},
             "explicit_cwd": explicit_cwd,
+            "fresh_session": True,
             "history": history,
             "history_lock": threading.Lock(),
             "history_version": 0,
@@ -6049,6 +6052,7 @@ def _deferred_session_record(
         "pending_title": None,
         "profile_home": str(profile_home) if profile_home is not None else None,
         "resume_runtime_overrides": resume_runtime_overrides,
+        "resumed_session": True,
         "resume_session_id": session_key,
         "running": False,
         "session_key": session_key,
@@ -6077,6 +6081,55 @@ def _claim_or_reuse_live(
             _sessions[sid] = record
             _register_session_cwd(_sessions[sid])
     return None
+
+
+def _live_session_has_resumable_history(session: dict) -> bool:
+    """Return whether an existing live session is safe to reattach.
+
+    A running turn may still have an empty committed history while its first
+    user message lives in ``inflight_turn``. Otherwise, an empty history on a
+    persisted session id is a fail-closed durability condition: reconnecting it
+    would let the next prompt create a second conversation under that id.
+    """
+    lock = session.get("history_lock")
+    if lock is not None:
+        with lock:
+            history = session.get("history") or []
+            in_flight = session.get("inflight_turn")
+            queued = session.get("queued_prompt")
+            running = session.get("running")
+    else:
+        history = session.get("history") or []
+        in_flight = session.get("inflight_turn")
+        queued = session.get("queued_prompt")
+        running = session.get("running")
+    return bool(
+        history or in_flight or queued or running or session.get("fresh_session")
+    )
+
+
+def _empty_resumed_session_id(session: dict) -> str | None:
+    """Return the durable id when a resumed runtime has no usable history."""
+    if not session.get("resumed_session"):
+        return None
+    if _live_session_has_resumable_history(session):
+        return None
+    session_id = str(session.get("session_key") or "")
+    return session_id or None
+
+
+def _empty_resume_error(rid, session_id: str) -> dict:
+    """Refuse to reuse a durable id when no active transcript can be restored."""
+    logger.error(
+        "Refusing empty session resume to protect durable identity: session=%s",
+        session_id,
+    )
+    return _err(
+        rid,
+        4091,
+        "refusing to resume a durable session with an empty transcript; "
+        "start a new session instead",
+    )
 
 
 def _schedule_agent_build(sid: str, delay: float = 0.05) -> None:
@@ -6180,10 +6233,17 @@ def _(rid, params: dict) -> dict:
             payload["status"] = "streaming"
         return payload
 
-    # Fast path: if the session is already live, reuse it under the lock.
+    # Fast path: if the session is already live, reuse it under the lock. A
+    # non-running empty record is not a valid reconnect target: attaching it
+    # would reuse the durable id for a second, unrelated conversation.
     with _session_resume_lock:
         live = _find_live_session_by_key(target)
         if live is not None:
+            if (
+                not is_truthy_value(params.get("lazy", False))
+                and not _live_session_has_resumable_history(live[1])
+            ):
+                return _empty_resume_error(rid, target)
             return _ok(rid, _reuse_live_payload(*live))
 
     # Lazy/watch resume: register the live session WITHOUT building an agent.
@@ -6273,13 +6333,17 @@ def _(rid, params: dict) -> dict:
         # the deferred build wires the remaining per-session callbacks.
         _enable_gateway_prompts()
         try:
-            db.reopen_session(target)
             # One lineage SELECT feeds both projections (#67142-adjacent perf,
             # from the desktop audit): the model-fed copy is alternation-repaired
             # (raw_history → sanitize_replay_history → the resumed session's
             # working conversation) and the display copy stays verbatim —
             # inspection/export must show what is actually stored.
             raw_history, display_history = db.get_resume_conversations(target)
+            if not raw_history:
+                if lease is not None:
+                    lease.release()
+                return _empty_resume_error(rid, target)
+            db.reopen_session(target)
         except Exception as e:
             if lease is not None:
                 lease.release()
@@ -6351,11 +6415,15 @@ def _(rid, params: dict) -> dict:
         set_hermes_home_override(str(profile_home)) if profile_home is not None else None
     )
     try:
-        db.reopen_session(target)
         # One lineage SELECT feeds both projections (see the interactive resume
         # above): the model-fed copy is alternation-repaired for LIVE REPLAY, the
         # display copy stays verbatim.
         raw_history, display_history = db.get_resume_conversations(target)
+        if not raw_history:
+            if lease is not None:
+                lease.release()
+            return _empty_resume_error(rid, target)
+        db.reopen_session(target)
         # The display transcript keeps every row so the user still sees their
         # full history.  The model-fed history is sanitized: a session whose
         # last turn died mid-tool-loop persists a dangling assistant(tool_calls)
@@ -6433,6 +6501,7 @@ def _(rid, params: dict) -> dict:
                     cwd=profile_resume_cwd,
                     session_db=db,
                     source=source,
+                    resumed_session=True,
                 )
             finally:
                 if init_home_token is not None:
@@ -6689,14 +6758,31 @@ def _(rid, params: dict) -> dict:
         return err
     assert session is not None
 
+    # Desktop reconnects a warm runtime through session.activate rather than
+    # session.resume. Apply the same durable-identity guard to runtimes whose
+    # provenance is an actual resume; a brand-new, never-submitted chat is
+    # legitimately empty.
+    active_lazy_child = bool(
+        session.get("lazy")
+        and _child_run_active(str(session.get("session_key") or ""))
+    )
+    if not active_lazy_child and (
+        empty_resumed_id := _empty_resumed_session_id(session)
+    ):
+        return _empty_resume_error(rid, empty_resumed_id)
+
+    payload = _live_session_payload(
+        sid,
+        session,
+        touch=True,
+        transport=current_transport() or _stdio_transport,
+    )
+    if active_lazy_child:
+        payload["running"] = True
+        payload["status"] = "streaming"
     return _ok(
         rid,
-        _live_session_payload(
-            sid,
-            session,
-            touch=True,
-            transport=current_transport() or _stdio_transport,
-        ),
+        payload,
     )
 
 
@@ -9342,6 +9428,17 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
+    assert session is not None
+    # ``session.activate`` is the normal Desktop reconnect gate, but transport
+    # races or older clients can still submit directly to the cached runtime.
+    # Enforce the durability invariant at the mutation boundary as well. Fresh
+    # session.create records are explicitly exempt until their first real turn.
+    if not (
+        session.get("lazy")
+        and _child_run_active(str(session.get("session_key") or ""))
+    ):
+        if empty_resumed_id := _empty_resumed_session_id(session):
+            return _empty_resume_error(rid, empty_resumed_id)
     isolation_cfg = _load_dashboard_process_isolation_config()
     turn_isolation = _session_uses_compute_host(session, isolation_cfg)
     # Re-bind to the current client transport for this request. This keeps


### PR DESCRIPTION
## Summary

- fail closed when a durable session resume restores an empty model history
- distinguish fresh runtimes from runtimes created by `session.resume`
- enforce the invariant across cold resume, warm `session.activate`, and direct `prompt.submit`
- teach Desktop to discard an unsafe warm-runtime mapping and fall through to cold resume
- preserve active lazy child-watch reconnects while their first mirrored turn is still in flight

## Incident reproduced

Hermes Desktop session `20260719_142032_0e82bb` had `history=186`. After `hermes update` plus gateway restart, the same durable ID resumed with `history=0`; subsequent messages then became the only canonical transcript visible for that ID.

The regression test uses a temporary SQLite database, seeds a durable transcript under that exact ID, closes/reopens the DB to model reconnect and restart, then forces the post-restart loader to return `history=0` while the durable rows still exist. It verifies that `session.resume`, `session.activate`, and `prompt.submit` refuse the unsafe runtime and that the original transcript remains unchanged.

No test reads or writes the live `~/.hermes/state.db`.

## Root cause

`session.resume` previously accepted an existing durable session even when `get_resume_conversations()` returned an empty active history. The gateway could therefore reconstruct an empty runtime under the same durable session key. Desktop's warm reconnect path could reattach it through `session.activate`, allowing a new conversation to continue under the old identity.

The incident logs also contain `database or disk is full` failures. Those likely contributed to the transcript becoming unavailable, but the exact first destructive persistence event is not provable from the remaining canonical rows. This change fixes the independently reproducible invariant violation: an empty resumed runtime can no longer become authoritative for an existing durable ID.

## Verification

- `401` focused gateway/session tests passed
- `768` `tests/tui_gateway` + `tests/test_hermes_state.py` tests passed
- `53` targeted Desktop session-action tests passed
- Desktop TypeScript typecheck passed
- Desktop ESLint: 0 errors (pre-existing warnings only)
- Ruff passed
- Desktop production build passed
- `git diff --check` passed

## Notes

The Desktop full Vitest suite under local Node 26 requires an explicit `--localstorage-file`. With that runtime workaround, 2071 tests passed and one unrelated onboarding persistence test flaked; that test passed immediately when rerun in isolation.
