### PR TITLE
feat(desktop): prioritize connected providers in model picker

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -70,6 +70,38 @@ function renderPanel(onSelectModel = vi.fn()) {
   return { onSelectModel, content }
 }
 
+describe('ModelMenuPanel provider order + connection badge', () => {
+  it('pins the current provider first and tags connected / needs-setup headers', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [
+        { name: 'OpenRouter', slug: 'openrouter', models: ['gpt-5.5'], authenticated: true },
+        { name: 'Anthropic', slug: 'anthropic', models: ['claude-sonnet-4'], authenticated: false },
+        { name: 'xAI', slug: 'xai-oauth', models: ['grok-4.5'], authenticated: true },
+        MOA_PROVIDER
+      ]
+    })
+    $currentProvider.set('xai-oauth')
+    $currentModel.set('grok-4.5')
+
+    const { content } = renderPanel()
+    await content.findByText('Grok 4.5')
+
+    // eslint-disable-next-line no-restricted-globals
+    const body = document.body.textContent || ''
+    const xaiAt = body.indexOf('xAI')
+    const openrouterAt = body.indexOf('OpenRouter')
+    const anthropicAt = body.indexOf('Anthropic')
+
+    expect(xaiAt).toBeGreaterThan(-1)
+    expect(openrouterAt).toBeGreaterThan(xaiAt)
+    expect(anthropicAt).toBeGreaterThan(openrouterAt)
+
+    // Connected badge appears for authenticated rows; Needs setup for deauthed.
+    expect(body).toContain('Connected')
+    expect(body).toContain('Needs setup')
+  })
+})
+
 describe('ModelMenuPanel MoA presets', () => {
   it('selecting a MoA preset switches PERSISTENTLY via onSelectModel (not the one-shot dispatch)', async () => {
     const { content, onSelectModel } = renderPanel()

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { createContext, useContext, useMemo, useState } from 'react'
 
 import { useSessionView } from '@/app/chat/session-view'
+import { Badge } from '@/components/ui/badge'
 import { Codicon } from '@/components/ui/codicon'
 import {
   DropdownMenuGroup,
@@ -26,6 +27,7 @@ import {
   modelDisplayParts,
   reasoningEffortLabel
 } from '@/lib/model-status-label'
+import { compareModelProviders, isProviderConnected } from '@/lib/provider-order'
 import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
 import { $modelPresets, applyModelPreset, modelPresetKey } from '@/store/model-presets'
@@ -265,7 +267,8 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
                   ) : (
                     <ChevronDown className="size-2.5 shrink-0" />
                   )}
-                  {group.provider.name}
+                  <span className="min-w-0 truncate">{group.provider.name}</span>
+                  <ProviderConnectionBadge authenticated={group.provider.authenticated} />
                 </DropdownMenuItem>
                 {!collapsed &&
                   group.families.map(family => {
@@ -467,9 +470,21 @@ function groupModels(
     }
   }
 
-  // Stable, logical group order: alphabetical by provider name. (The backend
-  // floats the current provider first, which would reshuffle on every switch.)
-  groups.sort((a, b) => a.provider.name.localeCompare(b.provider.name))
+  // Connected providers first (current pinned), then needs-setup; alpha within
+  // each tier. Shared helper keeps menu / dialog / Edit Models in lockstep.
+  groups.sort((a, b) => compareModelProviders(a.provider, b.provider, current.provider))
 
   return groups
+}
+
+function ProviderConnectionBadge({ authenticated }: { authenticated?: boolean }) {
+  const { t } = useI18n()
+  const copy = t.shell.modelMenu
+  const connected = isProviderConnected({ authenticated })
+
+  return (
+    <Badge className="normal-case tracking-normal" size="xs" variant={connected ? 'default' : 'muted'}>
+      {connected ? copy.connected : copy.needsSetup}
+    </Badge>
+  )
 }

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useI18n } from '@/i18n'
 import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
 import { currentPickerSelection } from '@/lib/model-status-label'
+import { isProviderConnected, sortModelProviders } from '@/lib/provider-order'
 import { normalize } from '@/lib/text'
 import type { ModelOptionProvider, ModelPricing } from '@/types/hermes'
 
@@ -180,7 +181,11 @@ function ModelResults({
   // Only configured providers (those with curated models) are selectable
   // here. Switching to a NOT-yet-configured provider goes through the
   // "Add provider" footer button, which opens the full onboarding selector.
-  const configured = providers.filter(p => (p.models ?? []).length > 0)
+  // Connected / current first — same order as the composer model menu.
+  const configured = sortModelProviders(
+    providers.filter(p => (p.models ?? []).length > 0),
+    currentProvider
+  )
 
   return (
     <>
@@ -320,6 +325,7 @@ function LoadingResults() {
 function ProviderHeading({ provider }: { provider: ModelOptionProvider }) {
   const { t } = useI18n()
   const copy = t.modelPicker
+  const connected = isProviderConnected(provider)
 
   // free_tier is only set for Nous. true → "Free tier", false → "Pro".
   const tierBadge =
@@ -338,6 +344,16 @@ function ProviderHeading({ provider }: { provider: ModelOptionProvider }) {
       <span className="truncate">{provider.name}</span>
       <span className="font-mono text-xs font-normal normal-case tracking-normal text-muted-foreground">
         {provider.slug} · {provider.total_models ?? provider.models?.length ?? 0}
+      </span>
+      <span
+        className={cn(
+          'rounded-sm px-1 py-0.5 text-[0.6rem] font-semibold uppercase tracking-wide',
+          connected
+            ? 'bg-primary/15 text-primary'
+            : 'bg-muted text-muted-foreground'
+        )}
+      >
+        {connected ? copy.connected : copy.needsSetup}
       </span>
       {tierBadge}
     </span>

--- a/apps/desktop/src/components/model-visibility-dialog.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.tsx
@@ -10,6 +10,7 @@ import type { HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
 import { displayModelName, modelDisplayParts } from '@/lib/model-status-label'
+import { isProviderConnected, sortModelProviders } from '@/lib/provider-order'
 import { normalize } from '@/lib/text'
 import {
   $visibleModels,
@@ -50,7 +51,13 @@ export function ModelVisibilityDialog({
   })
 
   const providers = useMemo(
-    () => (modelOptions.data?.providers ?? []).filter(provider => (provider.models ?? []).length > 0),
+    () =>
+      sortModelProviders(
+        (modelOptions.data?.providers ?? []).filter(provider => (provider.models ?? []).length > 0),
+        // Same current-provider pin as the composer menu / switch-model dialog
+        // so Edit Models doesn't A–Z a connected peer above the active route.
+        modelOptions.data?.provider
+      ),
     [modelOptions.data]
   )
 
@@ -98,8 +105,17 @@ export function ModelVisibilityDialog({
 
               return (
                 <div className="py-0.5" key={provider.slug}>
-                  <div className="px-3 pb-0.5 pt-1 text-[0.625rem] font-medium uppercase tracking-wide text-(--ui-text-tertiary)">
-                    {provider.name}
+                  <div className="flex items-center gap-1.5 px-3 pb-0.5 pt-1 text-[0.625rem] font-medium uppercase tracking-wide text-(--ui-text-tertiary)">
+                    <span className="min-w-0 truncate">{provider.name}</span>
+                    <span
+                      className={
+                        isProviderConnected(provider)
+                          ? 'shrink-0 rounded-sm bg-primary/15 px-1 py-px text-[0.55rem] font-semibold normal-case tracking-normal text-primary'
+                          : 'shrink-0 rounded-sm bg-muted px-1 py-px text-[0.55rem] font-semibold normal-case tracking-normal text-muted-foreground'
+                      }
+                    >
+                      {isProviderConnected(provider) ? copy.connected : copy.needsSetup}
+                    </span>
                   </div>
                   {models.map(family => {
                     const { name, tag } = modelDisplayParts(family.id)

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2154,14 +2154,18 @@ export const en: Translations = {
     free: 'Free',
     freeTier: 'Free tier',
     priceTitle: 'Input / Output price per million tokens',
-    wasPrice: 'was'
+    wasPrice: 'was',
+    connected: 'Connected',
+    needsSetup: 'Needs setup'
   },
 
   modelVisibility: {
     title: 'Models',
     search: 'Search models',
     noAuthenticatedProviders: 'No authenticated providers.',
-    addProvider: 'Add provider…'
+    addProvider: 'Add provider…',
+    connected: 'Connected',
+    needsSetup: 'Needs setup'
   },
 
   shell: {
@@ -2174,7 +2178,9 @@ export const en: Translations = {
       editModels: 'Edit Models…',
       refreshModels: 'Refresh Models',
       fast: 'Fast',
-      medium: 'Med'
+      medium: 'Med',
+      connected: 'Connected',
+      needsSetup: 'Needs setup'
     },
     modelOptions: {
       noOptions: 'No options for this model',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2089,14 +2089,18 @@ export const ja = defineLocale({
     free: '無料',
     freeTier: '無料プラン',
     priceTitle: '100 万トークンあたりの入力/出力価格',
-    wasPrice: '旧価格'
+    wasPrice: '旧価格',
+    connected: '接続済み',
+    needsSetup: 'セットアップが必要'
   },
 
   modelVisibility: {
     title: 'モデル',
     search: 'モデルを検索',
     noAuthenticatedProviders: '認証済みプロバイダーがありません。',
-    addProvider: 'プロバイダーを追加…'
+    addProvider: 'プロバイダーを追加…',
+    connected: '接続済み',
+    needsSetup: 'セットアップが必要'
   },
 
   shell: {
@@ -2109,7 +2113,9 @@ export const ja = defineLocale({
       editModels: 'モデルを編集…',
       refreshModels: 'モデルを更新',
       fast: '高速',
-      medium: '中'
+      medium: '中',
+      connected: '接続済み',
+      needsSetup: 'セットアップが必要'
     },
     modelOptions: {
       noOptions: 'このモデルにはオプションがありません',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1773,6 +1773,8 @@ export interface Translations {
     freeTier: string
     priceTitle: string
     wasPrice: string
+    connected: string
+    needsSetup: string
   }
 
   modelVisibility: {
@@ -1780,6 +1782,8 @@ export interface Translations {
     search: string
     noAuthenticatedProviders: string
     addProvider: string
+    connected: string
+    needsSetup: string
   }
 
   shell: {
@@ -1793,6 +1797,8 @@ export interface Translations {
       refreshModels: string
       fast: string
       medium: string
+      connected: string
+      needsSetup: string
     }
     modelOptions: {
       noOptions: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2020,14 +2020,18 @@ export const zhHant = defineLocale({
     free: '免費',
     freeTier: '免費層',
     priceTitle: '每百萬 Token 的輸入/輸出價格',
-    wasPrice: '原價'
+    wasPrice: '原價',
+    connected: '已連線',
+    needsSetup: '需要設定'
   },
 
   modelVisibility: {
     title: '模型',
     search: '搜尋模型',
     noAuthenticatedProviders: '沒有已驗證的提供方。',
-    addProvider: '新增提供方…'
+    addProvider: '新增提供方…',
+    connected: '已連線',
+    needsSetup: '需要設定'
   },
 
   shell: {
@@ -2040,7 +2044,9 @@ export const zhHant = defineLocale({
       editModels: '編輯模型…',
       refreshModels: '重新整理模型',
       fast: '快速',
-      medium: '中'
+      medium: '中',
+      connected: '已連線',
+      needsSetup: '需要設定'
     },
     modelOptions: {
       noOptions: '此模型沒有可用選項',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2332,14 +2332,18 @@ export const zh: Translations = {
     free: '免费',
     freeTier: '免费层',
     priceTitle: '每百万 token 的输入/输出价格',
-    wasPrice: '原价'
+    wasPrice: '原价',
+    connected: '已连接',
+    needsSetup: '需要设置'
   },
 
   modelVisibility: {
     title: '模型',
     search: '搜索模型',
     noAuthenticatedProviders: '没有已认证的提供方。',
-    addProvider: '添加提供方…'
+    addProvider: '添加提供方…',
+    connected: '已连接',
+    needsSetup: '需要设置'
   },
 
   shell: {
@@ -2352,7 +2356,9 @@ export const zh: Translations = {
       editModels: '编辑模型…',
       refreshModels: '刷新模型',
       fast: '快速',
-      medium: '中'
+      medium: '中',
+      connected: '已连接',
+      needsSetup: '需要设置'
     },
     modelOptions: {
       noOptions: '此模型没有可用选项',

--- a/apps/desktop/src/lib/provider-order.test.ts
+++ b/apps/desktop/src/lib/provider-order.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import { compareModelProviders, isProviderConnected, sortModelProviders } from './provider-order'
+
+const openrouter = { name: 'OpenRouter', slug: 'openrouter', authenticated: true }
+const copilot = { name: 'GitHub Copilot', slug: 'copilot', authenticated: true }
+const xai = { name: 'xAI', slug: 'xai-oauth', authenticated: true }
+const nous = { name: 'Nous Portal', slug: 'nous' } // flag omitted → connected
+const broken = { name: 'Anthropic', slug: 'anthropic', authenticated: false }
+
+describe('isProviderConnected', () => {
+  it('treats missing authenticated as connected', () => {
+    expect(isProviderConnected({ authenticated: undefined })).toBe(true)
+  })
+
+  it('treats true as connected and false as not', () => {
+    expect(isProviderConnected({ authenticated: true })).toBe(true)
+    expect(isProviderConnected({ authenticated: false })).toBe(false)
+  })
+})
+
+describe('compareModelProviders / sortModelProviders', () => {
+  it('sorts alphabetically when every provider is connected and none is current', () => {
+    expect(sortModelProviders([xai, openrouter, copilot, nous]).map(p => p.slug)).toEqual([
+      'copilot',
+      'nous',
+      'openrouter',
+      'xai-oauth'
+    ])
+  })
+
+  it('pins the current provider first without reshuffling peers', () => {
+    const ordered = sortModelProviders([xai, openrouter, copilot, nous], 'xai-oauth')
+    expect(ordered.map(p => p.slug)).toEqual(['xai-oauth', 'copilot', 'nous', 'openrouter'])
+  })
+
+  it('accepts the model-options payload provider field as the current slug', () => {
+    // Edit Models / other catalog consumers get current via payload.provider
+    // (inventory.build_models_payload), not a separate session store.
+    const payload = {
+      provider: 'xai-oauth',
+      providers: [openrouter, xai, copilot]
+    }
+    const ordered = sortModelProviders(payload.providers, payload.provider)
+    expect(ordered.map(p => p.slug)).toEqual(['xai-oauth', 'copilot', 'openrouter'])
+  })
+
+  it('keeps connected providers above needs-setup rows', () => {
+    const ordered = sortModelProviders([broken, xai, openrouter], 'openrouter')
+    expect(ordered.map(p => p.slug)).toEqual(['openrouter', 'xai-oauth', 'anthropic'])
+  })
+
+  it('matches current slug case-insensitively and by trim', () => {
+    expect(compareModelProviders(xai, openrouter, ' XAI-OAUTH ')).toBeLessThan(0)
+    expect(compareModelProviders(openrouter, xai, 'xai-oauth')).toBeGreaterThan(0)
+  })
+
+  it('does not move an already-current provider relative to itself', () => {
+    expect(compareModelProviders(xai, xai, 'xai-oauth')).toBe(0)
+  })
+})

--- a/apps/desktop/src/lib/provider-order.ts
+++ b/apps/desktop/src/lib/provider-order.ts
@@ -1,0 +1,60 @@
+import type { ModelOptionProvider } from '@/types/hermes'
+
+type ProviderOrderFields = Pick<ModelOptionProvider, 'name' | 'slug'> &
+  Pick<Partial<ModelOptionProvider>, 'authenticated'>
+
+/**
+ * Whether Hermes has usable credentials for this catalog row.
+ *
+ * Authenticated rows from `list_authenticated_providers` often omit the flag
+ * (treat as connected). Explicit `authenticated: false` is used for
+ * configured-but-deauthed skeletons that still need a setup affordance.
+ */
+export function isProviderConnected(provider: Pick<Partial<ModelOptionProvider>, 'authenticated'>): boolean {
+  return provider.authenticated !== false
+}
+
+/**
+ * Model-picker group order:
+ * 1. Current provider (session / global selection)
+ * 2. Connected providers
+ * 3. Needs-setup / unauthenticated rows
+ * 4. Alphabetical by display name within each tier
+ *
+ * Intentionally stable: switching models only moves the "current" tier, not
+ * the relative order of peers (avoids the list thrashing the old backend
+ * is_current-first ordering caused).
+ */
+export function compareModelProviders(
+  a: ProviderOrderFields,
+  b: ProviderOrderFields,
+  currentSlug?: null | string
+): number {
+  const current = (currentSlug || '').trim().toLowerCase()
+  const aSlug = (a.slug || '').trim().toLowerCase()
+  const bSlug = (b.slug || '').trim().toLowerCase()
+
+  if (current) {
+    if (aSlug === current && bSlug !== current) {
+      return -1
+    }
+
+    if (bSlug === current && aSlug !== current) {
+      return 1
+    }
+  }
+
+  const aConnected = isProviderConnected(a)
+  const bConnected = isProviderConnected(b)
+
+  if (aConnected !== bConnected) {
+    return aConnected ? -1 : 1
+  }
+
+  return a.name.localeCompare(b.name)
+}
+
+/** Sort a provider list with {@link compareModelProviders}. Returns a new array. */
+export function sortModelProviders<T extends ProviderOrderFields>(providers: T[], currentSlug?: null | string): T[] {
+  return [...providers].sort((a, b) => compareModelProviders(a, b, currentSlug))
+}


### PR DESCRIPTION
## Summary

- Sort Desktop model-menu / model-picker / Edit Models provider groups so **connected (authenticated) providers appear first**, with the **current provider pinned** at the top.
- Show a compact **Connected** / **Needs setup** badge on each provider section header (same language as Settings → Providers).
- Share ordering logic in `provider-order.ts` so the three surfaces cannot drift.

## Motivation

When several providers are configured (e.g. xAI OAuth, Nous Portal, OpenRouter, Copilot, Codex), the Desktop model dropdown previously listed groups alphabetically only. Picking a model that exists on multiple routes (e.g. Grok on xAI OAuth + Nous + OpenRouter) forced users to skim past unrelated providers every time.

Settings → Providers already groups **Connected** accounts first with a badge. The chat model menu now matches that mental model.

## Changes

### UX
- **Order**:
  1. Current provider (session/global)
  2. Connected / authenticated providers (`authenticated !== false`)
  3. Needs-setup / unauthenticated rows (`authenticated: false`)
  4. Alphabetical by display name within each tier
- **Badge** on provider headers: `Connected` or `Needs setup`
- **Search**: still matches all providers/models; group tiering is unchanged under filter
- Does **not** change backend catalog construction or `explicit_only` filtering (#56974)

### Code
- `apps/desktop/src/lib/provider-order.ts` (+ unit tests)
- `apps/desktop/src/app/shell/model-menu-panel.tsx` (+ coverage)
- `apps/desktop/src/components/model-picker.tsx`
- `apps/desktop/src/components/model-visibility-dialog.tsx`
- i18n: en / zh / zh-hant / ja + types

## Non-goals
- Collapsible provider groups (see #64690)
- Redesigning headers into full provider cards (see #54965)
- Changing which providers the backend includes in `explicit_only` catalogs
- Auto-picking a provider when the same model id exists on multiple routes

## Test plan
- [x] Unit tests for `compareModelProviders` / `sortModelProviders` (7)
- [x] `ModelMenuPanel` test: current first + Connected / Needs setup badges
- [x] Existing MoA menu tests still pass
- [x] `npm test -- src/lib/provider-order.test.ts src/app/shell/model-menu-panel.test.tsx` green
- [x] `npm run typecheck` (apps/desktop) green
- [ ] Manual: open Desktop model menu with multiple providers; current group is first; badges visible
- [ ] Manual: search a shared model name; connected providers remain ordered first among groups
- [ ] Manual: selecting a model still switches provider+model correctly

## Notes for Reviewers
- Reuses Settings → Providers “Connected” copy; chips stay tiny for dense dropdown density.
- Compatible with #64690 (collapse) and #54965 (cards) if those land first or after.