### PR TITLE
fix: initialize PluginManager._cli_ref in query mode (fixes #67597)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15538,6 +15538,13 @@ def main(
         ignore_rules=ignore_rules,
     )
 
+    # Give plugin manager a CLI reference so plugins can resolve the active
+    # agent in both query (`-q`) and interactive mode. Without this,
+    # PluginContext.dispatch_tool() cannot inject parent_agent because
+    # _cli_ref remains None when HermesCLI.run() is never called.
+    from hermes_cli.plugins import get_plugin_manager
+    get_plugin_manager()._cli_ref = cli
+
     if parsed_skills:
         skills_prompt, loaded_skills, missing_skills = build_preloaded_skills_prompt(
             parsed_skills,


### PR DESCRIPTION
## Summary
Fixes #67597: `PluginManager._cli_ref` was not initialized in query mode, preventing `PluginContext.dispatch_tool()` from injecting `parent_agent`.

## Root Cause
`PluginManager._cli_ref` was only set inside `HermesCLI.run()`. Query mode (`hermes chat -q "..."`) bypasses `run()` entirely and calls `cli.agent.run_conversation()` directly, leaving `_cli_ref` as `None`.

## Fix
Move the `_cli_ref` assignment into `main()`, immediately after `HermesCLI` is created — before the query vs. interactive branch. This ensures `_cli_ref` is available in both modes.

## Reproduced At
- Hermes Agent v0.18.2
- Commit `36f2a966c7f9f69987494b867c3dcf96b69a5766`

## Lifecycle Before
```
main()
→ HermesCLI(...)
→ cli.agent.run_conversation(...)   # query mode
→ HermesCLI.run() never called
→ PluginManager._cli_ref == None
```

## Lifecycle After
```
main()
→ HermesCLI(...)
→ get_plugin_manager()._cli_ref = cli   # always set
→ cli.agent.run_conversation(...) or cli.run()
→ PluginManager._cli_ref is available
```

Closes #67597