### PR TITLE
fix(cli): wire plugin manager _cli_ref in query mode so dispatch_tool injects parent_agent (#67597)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15538,6 +15538,17 @@ def main(
         ignore_rules=ignore_rules,
     )
 
+    # Give the plugin manager a CLI reference as soon as the instance exists,
+    # before we branch into query vs. interactive execution. Interactive mode
+    # re-sets this inside ``HermesCLI.run()``, but single-query (`-q`) mode
+    # calls ``cli.chat()`` directly and never enters ``run()`` — so without
+    # this, ``PluginContext.dispatch_tool()`` cannot resolve ``parent_agent``
+    # (its ``_cli_ref`` stays ``None``) and agent-context tools like
+    # ``delegate_task`` lose the active agent in query mode (#67597).
+    from hermes_cli.plugins import get_plugin_manager as _get_plugin_manager
+
+    _get_plugin_manager()._cli_ref = cli
+
     if parsed_skills:
         skills_prompt, loaded_skills, missing_skills = build_preloaded_skills_prompt(
             parsed_skills,

--- a/cli.py
+++ b/cli.py
@@ -4546,6 +4546,17 @@ def main(
     cli = _build_cli_from_args(model, toolsets, provider, reasoning, api_key, base_url, max_turns, run_budget,
                                verbose, compact, resume, checkpoints, pass_session_id, ignore_rules, skills)
 
+    # Give the plugin manager a CLI reference as soon as the instance exists,
+    # before we branch into query vs. interactive execution. Interactive mode
+    # re-sets this inside ``HermesCLI.run()``, but single-query (`-q`) mode
+    # calls ``cli.chat()`` directly and never enters ``run()`` — so without
+    # this, ``PluginContext.dispatch_tool()`` cannot resolve ``parent_agent``
+    # (its ``_cli_ref`` stays ``None``) and agent-context tools like
+    # ``delegate_task`` lose the active agent in query mode (#67597).
+    from hermes_cli.plugins import get_plugin_manager as _get_plugin_manager
+
+    _get_plugin_manager()._cli_ref = cli
+
     # Join the background worktree creation before anything consumes TERMINAL_CWD.
     # A requested worktree whose setup failed aborts: never silently run without isolation.
     wt_info = _join_worktree() if _join_worktree is not None else None

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -2366,3 +2366,62 @@ class TestDispatchToolWithoutCliRef:
             assert calls[0][1].get("parent_agent") is None
         finally:
             registry.deregister("_test_dispatch_probe")
+
+
+class TestMainSetsCliRefForQueryMode:
+    """Regression for #67597.
+
+    Single-query mode (`hermes chat -q "…"`) invokes ``cli.chat()`` directly
+    and never enters ``HermesCLI.run()``, which is where the interactive path
+    assigns ``get_plugin_manager()._cli_ref = self``. If the assignment lives
+    ONLY inside ``run()``, ``PluginContext.dispatch_tool()`` cannot resolve
+    ``parent_agent`` in query mode and agent-context tools like
+    ``delegate_task`` lose the active agent.
+
+    The fix wires ``_cli_ref`` in ``main()``'s top-level flow, right after the
+    ``HermesCLI`` instance is built and before the query/interactive branch, so
+    BOTH modes get it. These tests pin that structural invariant (driving all
+    of ``main()`` would require mocking credential + agent init).
+    """
+
+    @staticmethod
+    def _main_funcdef():
+        import ast
+        from pathlib import Path
+
+        source = Path(__file__).resolve().parents[2] / "cli.py"
+        tree = ast.parse(source.read_text(encoding="utf-8"))
+        for node in tree.body:
+            if isinstance(node, ast.FunctionDef) and node.name == "main":
+                return node
+        raise AssertionError("could not find top-level main() in cli.py")
+
+    @staticmethod
+    def _assigns_cli_ref(stmt: "object") -> bool:
+        import ast
+
+        for assign in ast.walk(stmt):
+            if not isinstance(assign, ast.Assign):
+                continue
+            for target in assign.targets:
+                if isinstance(target, ast.Attribute) and target.attr == "_cli_ref":
+                    return True
+        return False
+
+    def test_cli_ref_assigned_at_main_top_level(self):
+        """The assignment must sit directly in main()'s body, not nested inside
+        the interactive/query branch — otherwise query mode never runs it."""
+        import ast
+
+        main = self._main_funcdef()
+
+        top_level_assign = any(
+            self._assigns_cli_ref(stmt)
+            for stmt in main.body
+            if not isinstance(stmt, (ast.If, ast.Try, ast.With, ast.For, ast.While))
+        )
+        assert top_level_assign, (
+            "main() must assign `_cli_ref` in its top-level flow (before the "
+            "query vs. interactive branch) so single-query mode wires it too "
+            "(#67597)."
+        )

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -2369,7 +2369,7 @@ class TestDispatchToolWithoutCliRef:
 
 
 class TestMainSetsCliRefForQueryMode:
-    """Regression for #67597.
+    """Regression for #67597 — behavioral, not source-shape.
 
     Single-query mode (`hermes chat -q "…"`) invokes ``cli.chat()`` directly
     and never enters ``HermesCLI.run()``, which is where the interactive path
@@ -2378,50 +2378,78 @@ class TestMainSetsCliRefForQueryMode:
     ``parent_agent`` in query mode and agent-context tools like
     ``delegate_task`` lose the active agent.
 
-    The fix wires ``_cli_ref`` in ``main()``'s top-level flow, right after the
-    ``HermesCLI`` instance is built and before the query/interactive branch, so
-    BOTH modes get it. These tests pin that structural invariant (driving all
-    of ``main()`` would require mocking credential + agent init).
+    This drives the real ``main(query=…)`` control flow with a fake
+    ``HermesCLI`` (so no credentials / agent init are needed) and asserts the
+    observable effect: by the time query mode dispatches to ``cli.chat()``,
+    ``get_plugin_manager()._cli_ref`` points at that CLI instance, and a real
+    ``PluginContext.dispatch_tool()`` therefore injects the instance's agent as
+    ``parent_agent``.
     """
 
-    @staticmethod
-    def _main_funcdef():
-        import ast
-        from pathlib import Path
+    def test_query_mode_wires_cli_ref_so_dispatch_injects_parent_agent(self, monkeypatch):
+        import cli as cli_mod
+        from hermes_cli.plugins import PluginManager
 
-        source = Path(__file__).resolve().parents[2] / "cli.py"
-        tree = ast.parse(source.read_text(encoding="utf-8"))
-        for node in tree.body:
-            if isinstance(node, ast.FunctionDef) and node.name == "main":
-                return node
-        raise AssertionError("could not find top-level main() in cli.py")
+        # A controlled plugin-manager singleton so main()'s
+        # ``get_plugin_manager()._cli_ref = cli`` lands somewhere we can read
+        # and there is no cross-test global state to reset.
+        manager = PluginManager()
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
 
-    @staticmethod
-    def _assigns_cli_ref(stmt: "object") -> bool:
-        import ast
+        sentinel_agent = object()
+        captured: dict = {}
 
-        for assign in ast.walk(stmt):
-            if not isinstance(assign, ast.Assign):
-                continue
-            for target in assign.targets:
-                if isinstance(target, ast.Attribute) and target.attr == "_cli_ref":
-                    return True
-        return False
+        class _StopMain(Exception):
+            """Halt main() at the query dispatch — we only need the wiring."""
 
-    def test_cli_ref_assigned_at_main_top_level(self):
-        """The assignment must sit directly in main()'s body, not nested inside
-        the interactive/query branch — otherwise query mode never runs it."""
-        import ast
+        class _FakeCLI:
+            def __init__(self, **_kwargs):
+                self.agent = sentinel_agent
+                self.session_id = "test_session"
+                self.conversation_history = []
+                self.console = types.SimpleNamespace(print=lambda *a, **k: None)
 
-        main = self._main_funcdef()
+            def _claim_active_session(self, *_a, **_k):
+                return True
 
-        top_level_assign = any(
-            self._assigns_cli_ref(stmt)
-            for stmt in main.body
-            if not isinstance(stmt, (ast.If, ast.Try, ast.With, ast.For, ast.While))
-        )
-        assert top_level_assign, (
-            "main() must assign `_cli_ref` in its top-level flow (before the "
-            "query vs. interactive branch) so single-query mode wires it too "
-            "(#67597)."
-        )
+            def _show_security_advisories(self):
+                pass
+
+            def chat(self, _query, images=None):
+                # main() must have wired _cli_ref to this instance *before*
+                # reaching the query-mode chat dispatch.
+                captured["cli_ref_at_chat"] = manager._cli_ref
+                raise _StopMain
+
+        # Keep main()'s prefix cheap and side-effect free.
+        monkeypatch.setattr(cli_mod, "HermesCLI", _FakeCLI)
+        monkeypatch.setattr(cli_mod, "_collect_query_images", lambda q, img=None: (q, []))
+        monkeypatch.setattr(cli_mod, "_finalize_single_query", lambda cli: None)
+        monkeypatch.setattr("signal.signal", lambda *a, **k: None)
+
+        with pytest.raises(_StopMain):
+            cli_mod.main(query="ping", toolsets="coding", quiet=False)
+
+        # (1) Query mode wired _cli_ref to the built CLI instance.
+        assert isinstance(captured.get("cli_ref_at_chat"), _FakeCLI)
+
+        # (2) dispatch_tool now injects that instance's agent as parent_agent.
+        ctx = PluginContext(PluginManifest(name="probe", source="user"), manager)
+        mock_registry = MagicMock()
+        mock_registry.dispatch.return_value = "{}"
+        with patch("tools.registry.registry", mock_registry):
+            ctx.dispatch_tool("delegate_task", {"goal": "x"})
+        assert mock_registry.dispatch.call_args[1].get("parent_agent") is sentinel_agent
+
+    def test_gateway_mode_leaves_cli_ref_unset_so_no_parent_agent(self):
+        """Guard the other side: with no CLI run (gateway mode), _cli_ref stays
+        None and dispatch_tool omits parent_agent entirely."""
+        manager = PluginManager()
+        manager._cli_ref = None
+
+        ctx = PluginContext(PluginManifest(name="probe", source="user"), manager)
+        mock_registry = MagicMock()
+        mock_registry.dispatch.return_value = "{}"
+        with patch("tools.registry.registry", mock_registry):
+            ctx.dispatch_tool("delegate_task", {"goal": "x"})
+        assert "parent_agent" not in mock_registry.dispatch.call_args[1]

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -2381,7 +2381,7 @@ class TestDispatchToolWithoutCliRef:
 
 
 class TestMainSetsCliRefForQueryMode:
-    """Regression for #67597.
+    """Regression for #67597 — behavioral, not source-shape.
 
     Single-query mode (`hermes chat -q "…"`) invokes ``cli.chat()`` directly
     and never enters ``HermesCLI.run()``, which is where the interactive path
@@ -2390,50 +2390,78 @@ class TestMainSetsCliRefForQueryMode:
     ``parent_agent`` in query mode and agent-context tools like
     ``delegate_task`` lose the active agent.
 
-    The fix wires ``_cli_ref`` in ``main()``'s top-level flow, right after the
-    ``HermesCLI`` instance is built and before the query/interactive branch, so
-    BOTH modes get it. These tests pin that structural invariant (driving all
-    of ``main()`` would require mocking credential + agent init).
+    This drives the real ``main(query=…)`` control flow with a fake
+    ``HermesCLI`` (so no credentials / agent init are needed) and asserts the
+    observable effect: by the time query mode dispatches to ``cli.chat()``,
+    ``get_plugin_manager()._cli_ref`` points at that CLI instance, and a real
+    ``PluginContext.dispatch_tool()`` therefore injects the instance's agent as
+    ``parent_agent``.
     """
 
-    @staticmethod
-    def _main_funcdef():
-        import ast
-        from pathlib import Path
+    def test_query_mode_wires_cli_ref_so_dispatch_injects_parent_agent(self, monkeypatch):
+        import cli as cli_mod
+        from hermes_cli.plugins import PluginManager
 
-        source = Path(__file__).resolve().parents[2] / "cli.py"
-        tree = ast.parse(source.read_text(encoding="utf-8"))
-        for node in tree.body:
-            if isinstance(node, ast.FunctionDef) and node.name == "main":
-                return node
-        raise AssertionError("could not find top-level main() in cli.py")
+        # A controlled plugin-manager singleton so main()'s
+        # ``get_plugin_manager()._cli_ref = cli`` lands somewhere we can read
+        # and there is no cross-test global state to reset.
+        manager = PluginManager()
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
 
-    @staticmethod
-    def _assigns_cli_ref(stmt: "object") -> bool:
-        import ast
+        sentinel_agent = object()
+        captured: dict = {}
 
-        for assign in ast.walk(stmt):
-            if not isinstance(assign, ast.Assign):
-                continue
-            for target in assign.targets:
-                if isinstance(target, ast.Attribute) and target.attr == "_cli_ref":
-                    return True
-        return False
+        class _StopMain(Exception):
+            """Halt main() at the query dispatch — we only need the wiring."""
 
-    def test_cli_ref_assigned_at_main_top_level(self):
-        """The assignment must sit directly in main()'s body, not nested inside
-        the interactive/query branch — otherwise query mode never runs it."""
-        import ast
+        class _FakeCLI:
+            def __init__(self, **_kwargs):
+                self.agent = sentinel_agent
+                self.session_id = "test_session"
+                self.conversation_history = []
+                self.console = types.SimpleNamespace(print=lambda *a, **k: None)
 
-        main = self._main_funcdef()
+            def _claim_active_session(self, *_a, **_k):
+                return True
 
-        top_level_assign = any(
-            self._assigns_cli_ref(stmt)
-            for stmt in main.body
-            if not isinstance(stmt, (ast.If, ast.Try, ast.With, ast.For, ast.While))
-        )
-        assert top_level_assign, (
-            "main() must assign `_cli_ref` in its top-level flow (before the "
-            "query vs. interactive branch) so single-query mode wires it too "
-            "(#67597)."
-        )
+            def _show_security_advisories(self):
+                pass
+
+            def chat(self, _query, images=None):
+                # main() must have wired _cli_ref to this instance *before*
+                # reaching the query-mode chat dispatch.
+                captured["cli_ref_at_chat"] = manager._cli_ref
+                raise _StopMain
+
+        # Keep main()'s prefix cheap and side-effect free.
+        monkeypatch.setattr(cli_mod, "HermesCLI", _FakeCLI)
+        monkeypatch.setattr(cli_mod, "_collect_query_images", lambda q, img=None: (q, []))
+        monkeypatch.setattr(cli_mod, "_finalize_single_query", lambda cli: None)
+        monkeypatch.setattr("signal.signal", lambda *a, **k: None)
+
+        with pytest.raises(_StopMain):
+            cli_mod.main(query="ping", toolsets="coding", quiet=False)
+
+        # (1) Query mode wired _cli_ref to the built CLI instance.
+        assert isinstance(captured.get("cli_ref_at_chat"), _FakeCLI)
+
+        # (2) dispatch_tool now injects that instance's agent as parent_agent.
+        ctx = PluginContext(PluginManifest(name="probe", source="user"), manager)
+        mock_registry = MagicMock()
+        mock_registry.dispatch.return_value = "{}"
+        with patch("tools.registry.registry", mock_registry):
+            ctx.dispatch_tool("delegate_task", {"goal": "x"})
+        assert mock_registry.dispatch.call_args[1].get("parent_agent") is sentinel_agent
+
+    def test_gateway_mode_leaves_cli_ref_unset_so_no_parent_agent(self):
+        """Guard the other side: with no CLI run (gateway mode), _cli_ref stays
+        None and dispatch_tool omits parent_agent entirely."""
+        manager = PluginManager()
+        manager._cli_ref = None
+
+        ctx = PluginContext(PluginManifest(name="probe", source="user"), manager)
+        mock_registry = MagicMock()
+        mock_registry.dispatch.return_value = "{}"
+        with patch("tools.registry.registry", mock_registry):
+            ctx.dispatch_tool("delegate_task", {"goal": "x"})
+        assert "parent_agent" not in mock_registry.dispatch.call_args[1]

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -2378,3 +2378,62 @@ class TestDispatchToolWithoutCliRef:
             assert calls[0][1].get("parent_agent") is None
         finally:
             registry.deregister("_test_dispatch_probe")
+
+
+class TestMainSetsCliRefForQueryMode:
+    """Regression for #67597.
+
+    Single-query mode (`hermes chat -q "…"`) invokes ``cli.chat()`` directly
+    and never enters ``HermesCLI.run()``, which is where the interactive path
+    assigns ``get_plugin_manager()._cli_ref = self``. If the assignment lives
+    ONLY inside ``run()``, ``PluginContext.dispatch_tool()`` cannot resolve
+    ``parent_agent`` in query mode and agent-context tools like
+    ``delegate_task`` lose the active agent.
+
+    The fix wires ``_cli_ref`` in ``main()``'s top-level flow, right after the
+    ``HermesCLI`` instance is built and before the query/interactive branch, so
+    BOTH modes get it. These tests pin that structural invariant (driving all
+    of ``main()`` would require mocking credential + agent init).
+    """
+
+    @staticmethod
+    def _main_funcdef():
+        import ast
+        from pathlib import Path
+
+        source = Path(__file__).resolve().parents[2] / "cli.py"
+        tree = ast.parse(source.read_text(encoding="utf-8"))
+        for node in tree.body:
+            if isinstance(node, ast.FunctionDef) and node.name == "main":
+                return node
+        raise AssertionError("could not find top-level main() in cli.py")
+
+    @staticmethod
+    def _assigns_cli_ref(stmt: "object") -> bool:
+        import ast
+
+        for assign in ast.walk(stmt):
+            if not isinstance(assign, ast.Assign):
+                continue
+            for target in assign.targets:
+                if isinstance(target, ast.Attribute) and target.attr == "_cli_ref":
+                    return True
+        return False
+
+    def test_cli_ref_assigned_at_main_top_level(self):
+        """The assignment must sit directly in main()'s body, not nested inside
+        the interactive/query branch — otherwise query mode never runs it."""
+        import ast
+
+        main = self._main_funcdef()
+
+        top_level_assign = any(
+            self._assigns_cli_ref(stmt)
+            for stmt in main.body
+            if not isinstance(stmt, (ast.If, ast.Try, ast.With, ast.For, ast.While))
+        )
+        assert top_level_assign, (
+            "main() must assign `_cli_ref` in its top-level flow (before the "
+            "query vs. interactive branch) so single-query mode wires it too "
+            "(#67597)."
+        )


### PR DESCRIPTION
## What does this PR do?

Single-query mode (`hermes chat -q "…"`) invokes `cli.chat()` directly and
never enters `HermesCLI.run()` — which was the **only** place that assigned
`get_plugin_manager()._cli_ref = self`. With `_cli_ref` left `None`,
`PluginContext.dispatch_tool()` cannot resolve the active agent, so
agent-context tools such as `delegate_task` lose `parent_agent` in query mode,
violating the documented `dispatch_tool()` contract.

The fix assigns `_cli_ref` in `main()`'s top-level flow, right after the
`HermesCLI` instance is built and **before** the query-vs-interactive branch, so
both modes wire it. Interactive `run()` still re-sets it to the same instance
(idempotent), so the interactive path is unchanged.

## Related Issue

Fixes #67597

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py` — in `main()`, after the `cli = HermesCLI(...)` construction and
  before the skills/query/interactive branch, assign
  `get_plugin_manager()._cli_ref = cli`.
- `tests/hermes_cli/test_plugins.py` — add
  `TestMainSetsCliRefForQueryMode`, an AST regression test asserting the
  `_cli_ref` assignment lives in `main()`'s top-level body (not nested inside
  the query/interactive branch), so single-query mode is guaranteed to wire it.
  Driving all of `main()` would require mocking credential + agent init, so the
  test pins the structural invariant directly.

## How to Test

```
scripts/run_tests.sh tests/hermes_cli/test_plugins.py -q
```

Result: `117 passed` (includes the new `TestMainSetsCliRefForQueryMode`). The
new test fails against unpatched `main()` (no top-level `_cli_ref` assignment)
and passes with the fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
