### PR TITLE
fix(desktop): support spaced Windows Git paths in review

### DIFF
--- a/apps/desktop/electron/git-review-ops.test.ts
+++ b/apps/desktop/electron/git-review-ops.test.ts
@@ -6,7 +6,7 @@ import path from 'node:path'
 
 import { afterEach, test } from 'vitest'
 
-import { repoStatus, resolveRenamePath } from './git-review-ops'
+import { gitFor, repoStatus, resolveRenamePath } from './git-review-ops'
 
 const tempDirs: string[] = []
 
@@ -32,6 +32,30 @@ function makeRepo() {
 
 test('resolveRenamePath: plain path is unchanged', () => {
   assert.equal(resolveRenamePath('src/a.ts'), 'src/a.ts')
+})
+
+test('gitFor accepts an internally resolved git binary path containing spaces', () => {
+  assert.doesNotThrow(() => gitFor(process.cwd(), 'C:\\Program Files\\Git\\cmd\\git.exe'))
+})
+
+test('gitFor runs git through a spaced binary path', async () => {
+  if (process.platform !== 'win32') {
+    return
+  }
+
+  const gitBin = path.join(process.env.ProgramFiles || String.raw`C:\Program Files`, 'Git', 'cmd', 'git.exe')
+
+  if (!fs.existsSync(gitBin)) {
+    return
+  }
+
+  const repo = makeRepo()
+
+  fs.writeFileSync(path.join(repo, 'changed.txt'), 'review me\n')
+
+  const status = await gitFor(repo, gitBin).status()
+
+  assert.equal(status.not_added.includes('changed.txt'), true)
 })
 
 test('resolveRenamePath: simple rename resolves to the new path', () => {

--- a/apps/desktop/electron/git-review-ops.ts
+++ b/apps/desktop/electron/git-review-ops.ts
@@ -43,7 +43,20 @@ function runGh(args, cwd, ghBin): Promise<{ ok: boolean; stdout: string }> {
 }
 
 function gitFor(cwd, gitBin) {
-  return simpleGit({ baseDir: cwd, binary: gitBin || 'git', maxConcurrentProcesses: 4, trimmed: false })
+  // `gitBin` is resolved inside the Electron main process from known install
+  // locations or PATH — never renderer/user input. simple-git's custom-binary
+  // validation rejects paths containing spaces (the default Windows install is
+  // `C:\Program Files\Git\cmd\git.exe`), which silently broke the Review pane.
+  // For spaced paths, opt into simple-git's trusted-binary escape hatch instead
+  // of falling back to PATH (often absent in GUI-launched apps, and PATH lookup
+  // could resolve a repo-local git.exe).
+  return simpleGit({
+    baseDir: cwd,
+    binary: gitBin || 'git',
+    maxConcurrentProcesses: 4,
+    trimmed: false,
+    ...(gitBin && /\s/.test(gitBin) ? { unsafe: { allowUnsafeCustomBinary: true } } : {})
+  })
 }
 
 // simple-git reports renames as `old => new` (and `dir/{old => new}/f`); resolve
@@ -680,6 +693,7 @@ async function repoStatus(repoPath, gitBin) {
 export {
   branchBase,
   fileDiffVsHead,
+  gitFor,
   repoStatus,
   resolveRenamePath,
   reviewCommit,


### PR DESCRIPTION
## Summary
The Desktop Review pane now works on Windows when Git lives at a path containing spaces (the default `C:\Program Files\Git\cmd\git.exe`). simple-git's custom-binary validation rejects spaced paths, so every review IPC call threw and the pane silently showed "No diffs" (#54888).

Minimal fix: in `gitFor()` — the single simple-git constructor all desktop git ops use — when the internally resolved binary contains whitespace, opt into simple-git's supported `unsafe.allowUnsafeCustomBinary` escape hatch. The binary is resolved in the Electron main process from known install locations or PATH, never renderer/user input, so keeping the trusted absolute path beats falling back to PATH (often absent in GUI-launched apps; PATH lookup could also resolve a repo-local `git.exe`).

Simplified from #64713 by @unsupportedpastels (authorship preserved): drops the `cmd.exe` 8.3 short-path conversion layer — the escape hatch alone covers all volumes, including those with 8.3 names disabled. Supersedes #55337 / #60156.

## Changes
- `apps/desktop/electron/git-review-ops.ts`: `gitFor()` sets `unsafe.allowUnsafeCustomBinary` only when the resolved binary contains whitespace; `gitFor` exported for tests
- `apps/desktop/electron/git-review-ops.test.ts`: constructor accepts a spaced Windows path (all OS); live `status()` through the real spaced Git for Windows binary (win32-only, skips when absent)

## Validation
| | Before | After |
|---|---|---|
| `gitFor(cwd, 'C:\Program Files\Git\cmd\git.exe')` | throws `GitPluginError` | constructs, runs |
| Non-spaced binaries | validated by simple-git | unchanged (no unsafe flag) |
| desktop vitest (`git-review-ops.test.ts`) | — | 7/7 pass |
| `tsc -p tsconfig.electron.json --noEmit` | — | clean |

Fixes #54888

## Infographic

![review-pane-spaced-git-paths](https://v3b.fal.media/files/b/0aa2e787/8i1NBxwjJY528s5cQ7IDV_uXEPWYx5.png)
