### PR TITLE
fix(api-server): forward Codex commentary in streaming SSE endpoint

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1754,6 +1754,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        interim_assistant_callback=None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -1869,6 +1870,7 @@ class APIServerAdapter(BasePlatformAdapter):
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,
             tool_complete_callback=tool_complete_callback,
+            interim_assistant_callback=interim_assistant_callback,
             session_db=self._ensure_session_db(),
             fallback_model=fallback_model,
             reasoning_config=reasoning_config,
@@ -2568,11 +2570,27 @@ class APIServerAdapter(BasePlatformAdapter):
                 event_name = event_type.replace("tool.", "tool.")
                 _enqueue(event_name, {"message_id": message_id, "tool_name": tool_name, "preview": preview, "args": args})
 
+        def _commentary(text: str, *, already_streamed: bool = False) -> None:
+            if text and text.strip():
+                _enqueue("assistant.commentary", {
+                    "message_id": message_id,
+                    "text": text,
+                    "already_streamed": already_streamed,
+                })
+
         async def _run_and_signal() -> None:
             try:
                 await queue.put(_event_payload("run.started", {"user_message": {"role": "user", "content": user_message}}))
                 await queue.put(_event_payload("message.started", {"message": {"id": message_id, "role": "assistant"}}))
                 history = await self._conversation_history_for_session(session_id)
+
+                # Respect display.show_commentary config gate
+                from gateway.run import _load_gateway_config
+                user_config = _load_gateway_config()
+                display_section = user_config.get("display", {}) if isinstance(user_config, dict) else {}
+                show_commentary = display_section.get("show_commentary", True) if isinstance(display_section, dict) else True
+                commentary_cb = _commentary if show_commentary else None
+
                 result, usage = await self._run_agent(
                     user_message=user_message,
                     conversation_history=history,
@@ -2581,6 +2599,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     stream_delta_callback=_delta,
                     tool_progress_callback=_tool_progress,
                     gateway_session_key=gateway_session_key,
+                    interim_assistant_callback=commentary_cb,
                 )
                 final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
                 effective_session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
@@ -4632,6 +4651,7 @@ class APIServerAdapter(BasePlatformAdapter):
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        interim_assistant_callback=None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -4673,6 +4693,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         tool_complete_callback=tool_complete_callback,
                         gateway_session_key=gateway_session_key,
                         route=route,
+                        interim_assistant_callback=interim_assistant_callback,
                     )
                     if agent_ref is not None:
                         agent_ref[0] = agent


### PR DESCRIPTION
## Summary

Wire `interim_assistant_callback` through `APIServerAdapter._create_agent()` and `_run_agent()` so Codex commentary (`phase=commentary`) is forwarded to API Server streaming clients.

Add `assistant.commentary` SSE event to the Hermes session stream endpoint (`POST /api/sessions/{session_id}/chat/stream`), gated behind `display.show_commentary` (defaults to `true`).

Fixes #67580

## Problem

When Hermes uses the `openai-codex` backend through API Server, Codex can generate user-facing progress messages as assistant output items with `phase="commentary"`. Hermes preserves those items in `codex_message_items`, but API Server streaming clients do not receive them.

Long-running, tool-heavy turns remain silent until the final answer. The user cannot tell whether the agent is making progress, stalled, or has misunderstood the task.

## Root Cause

`APIServerAdapter._create_agent()` forwards `stream_delta_callback`, `tool_progress_callback`, `tool_start_callback`, and `tool_complete_callback` to `AIAgent`, but it does not accept or forward `interim_assistant_callback`. `_run_agent()` has the same omission. The Hermes session SSE handler wires assistant deltas and tool progress without a commentary path.

The core commentary behavior was added in #66115 and defaults to visible, but `gateway/platforms/api_server.py` was not part of that callback wiring.

## Changes

1. **`_create_agent()`**: Added `interim_assistant_callback=None` parameter and passes it to `AIAgent()`
2. **`_run_agent()`**: Added `interim_assistant_callback=None` parameter and forwards it to `_create_agent()`
3. **`_handle_session_chat_stream()`**: Added `_commentary` callback that emits `assistant.commentary` SSE events with `message_id`, `text`, and `already_streamed` fields. Gated behind `display.show_commentary` config.

## Safety

- Commentary only — `phase="analysis"` / raw chain-of-thought / reasoning summaries are NOT exposed through this path
- Final content remains unchanged — commentary is emitted as a separate event type and is never concatenated into `assistant.completed` content
- `display.show_commentary: false` preserves the quiet behavior (no commentary events emitted)
- Non-streaming endpoints continue to return only the final answer (no change)
- `/v1/chat/completions` delta content is unaffected (commentary does not go into `choices[].delta.content`)