### PR TITLE
feat: add kimi-k3 + kimi-k2.7-code to kimi-coding-cn whitelist

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -329,6 +329,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2-0905-preview",
     ],
     "kimi-coding-cn": [
+        "kimi-k3",
+        "kimi-k2.7-code",
+        "kimi-k2.7-code-highspeed",
         "kimi-k2.6",
         "kimi-k2.5",
         "kimi-k2-thinking",


### PR DESCRIPTION
## What

Moonshot China (`api.moonshot.cn`) now serves `kimi-k3` plus the new `kimi-k2.7-code` / `kimi-k2.7-code-highspeed` variants on CN-endpoint keys, but the `kimi-coding-cn` curated picker whitelist in `hermes_cli/models.py` is still on the k2.6/k2.5-era list. Users holding CN keys can't select any of the new models from `hermes model` or the gateway `/model` picker even though the provider + endpoint already serve them.

## Verified against a live CN key

```
GET https://api.moonshot.cn/v1/models
→ [kimi-k3, kimi-k2.7-code, kimi-k2.7-code-highspeed, kimi-k2.6, kimi-k2.5, moonshot-v1-*, ...]
```

End-to-end smoke test after the patch:

```
hermes chat -m kimi-k3 --provider kimi-coding-cn -q "1+1=?" --quiet
# → 2   (provider=kimi-coding-cn, base_url=https://api.moonshot.cn/v1)
```

## Change

Pure whitelist addition — 3 lines in `_PROVIDER_MODELS["kimi-coding-cn"]`, mirroring how `kimi-coding` (global) already tracks k2.7-code. No provider-code changes.

## Tests

`tests/hermes_cli/test_runtime_provider_resolution.py` → 151/151 pass
`tests/hermes_cli/test_model_switch_custom_providers.py` → 41/41 pass