### PR TITLE
feat(desktop): add plugin-scoped pet activity

### DIFF
--- a/apps/desktop/src/contrib/plugin.test.ts
+++ b/apps/desktop/src/contrib/plugin.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
+
+import { $petSignals, clearPetSignals } from '@/store/pet-signals'
+import { $activeGatewayProfile } from '@/store/profile'
+
+import {
+  createPluginContext,
+  PLUGIN_PET_ACTIVITY_LIMITS,
+  type PluginContext,
+  type PluginPetActivityInput
+} from './plugin'
+
+let pluginSequence = 0
+let originalProfile = 'default'
+
+interface TestContext {
+  ctx: PluginContext
+  dispose: () => void
+}
+
+function testContext(id = `pet-test-${++pluginSequence}`): TestContext {
+  const disposers: (() => void)[] = []
+  const ctx = createPluginContext(id, dispose => disposers.push(dispose))
+
+  return {
+    ctx,
+    dispose: () => {
+      for (const dispose of disposers) {
+        dispose()
+      }
+    }
+  }
+}
+
+const activity = (overrides: Partial<PluginPetActivityInput> = {}): PluginPetActivityInput => ({
+  id: 'job',
+  state: 'working',
+  ttlMs: PLUGIN_PET_ACTIVITY_LIMITS.minTtlMs,
+  ...overrides
+})
+
+beforeEach(() => {
+  originalProfile = $activeGatewayProfile.get()
+})
+
+afterEach(() => {
+  for (const source of new Set($petSignals.get().map(signal => signal.source))) {
+    clearPetSignals(source)
+  }
+
+  $activeGatewayProfile.set(originalProfile)
+  vi.useRealTimers()
+})
+
+describe('plugin pet activity', () => {
+  it('publishes only through the host-injected plugin source', () => {
+    const { ctx, dispose } = testContext('source-owner')
+
+    try {
+      expectTypeOf<PluginPetActivityInput>().not.toHaveProperty('source')
+      expect(() =>
+        ctx.pet.publishActivity({ ...activity(), source: 'plugin:spoofed' } as PluginPetActivityInput)
+      ).toThrow(/unsupported field/i)
+      expect($petSignals.get()).toEqual([])
+
+      ctx.pet.publishActivity(activity())
+      expect($petSignals.get()).toMatchObject([{ id: 'job', source: 'plugin:source-owner' }])
+    } finally {
+      dispose()
+    }
+  })
+
+  it('clears only the calling plugin source', () => {
+    const first = testContext('first-owner')
+    const second = testContext('second-owner')
+
+    try {
+      first.ctx.pet.publishActivity(activity())
+      second.ctx.pet.publishActivity(activity())
+
+      first.ctx.pet.clearActivity('job')
+
+      expect($petSignals.get()).toMatchObject([{ source: 'plugin:second-owner' }])
+    } finally {
+      first.dispose()
+      second.dispose()
+    }
+  })
+
+  it('clears every visible signal on plugin disposal and rejects late publication', () => {
+    const owned = testContext('dispose-owner')
+
+    owned.ctx.pet.publishActivity(activity({ id: 'one' }))
+    owned.ctx.pet.publishActivity(activity({ id: 'two' }))
+    owned.dispose()
+
+    expect($petSignals.get()).toEqual([])
+    expect(() => owned.ctx.pet.publishActivity(activity({ id: 'late' }))).toThrow(/disposed/i)
+  })
+
+  it('injects strictly increasing source generations within one millisecond', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    const { ctx, dispose } = testContext('same-millisecond')
+
+    try {
+      ctx.pet.publishActivity(activity({ id: 'one' }))
+      const first = $petSignals.get()[0].createdAt
+
+      ctx.pet.publishActivity(activity({ id: 'two' }))
+      const second = $petSignals.get().find(signal => signal.id === 'two')?.createdAt
+
+      ctx.pet.publishActivity(activity({ id: 'one', state: 'thinking' }))
+      const replacement = $petSignals.get().find(signal => signal.id === 'one')?.createdAt
+
+      expect(second).toBeGreaterThan(first)
+      expect(replacement).toBeGreaterThan(second ?? first)
+    } finally {
+      dispose()
+    }
+  })
+
+  it('publishes a newer generation after hot reload and retained tombstones', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(2_000)
+    const first = testContext('hot-reload')
+
+    first.ctx.pet.publishActivity(activity())
+    const firstGeneration = $petSignals.get()[0].createdAt
+    first.dispose()
+
+    const reloaded = testContext('hot-reload')
+
+    try {
+      reloaded.ctx.pet.publishActivity(activity({ state: 'thinking' }))
+      expect($petSignals.get()[0].createdAt).toBeGreaterThan(firstGeneration)
+      expect($petSignals.get()[0].state).toBe('thinking')
+    } finally {
+      reloaded.dispose()
+    }
+  })
+
+  it('bounds distinct identities per source without evicting another plugin', () => {
+    const bounded = testContext('bounded-owner')
+    const other = testContext('other-owner')
+
+    try {
+      other.ctx.pet.publishActivity(activity({ id: 'kept' }))
+
+      for (let index = 0; index < PLUGIN_PET_ACTIVITY_LIMITS.maxIdsPerSource; index += 1) {
+        bounded.ctx.pet.publishActivity(activity({ id: `job-${index}` }))
+      }
+
+      expect(() => bounded.ctx.pet.publishActivity(activity({ id: 'overflow' }))).toThrow(/identity limit/i)
+      expect($petSignals.get()).toHaveLength(PLUGIN_PET_ACTIVITY_LIMITS.maxIdsPerSource + 1)
+      expect($petSignals.get()).toContainEqual(expect.objectContaining({ id: 'kept', source: 'plugin:other-owner' }))
+    } finally {
+      bounded.dispose()
+      other.dispose()
+    }
+  })
+
+  it.each([
+    ['empty id', { id: '' }],
+    ['padded id', { id: ' job ' }],
+    ['oversized id', { id: 'x'.repeat(PLUGIN_PET_ACTIVITY_LIMITS.maxIdLength + 1) }],
+    ['short TTL', { ttlMs: PLUGIN_PET_ACTIVITY_LIMITS.minTtlMs - 1 }],
+    ['long TTL', { ttlMs: PLUGIN_PET_ACTIVITY_LIMITS.maxTtlMs + 1 }],
+    ['fractional TTL', { ttlMs: PLUGIN_PET_ACTIVITY_LIMITS.minTtlMs + 0.5 }],
+    ['non-finite TTL', { ttlMs: Number.POSITIVE_INFINITY }],
+    ['unknown state', { state: 'unknown' }],
+    ['idle state', { state: 'idle' }],
+    ['negative priority', { priority: PLUGIN_PET_ACTIVITY_LIMITS.minPriority - 1 }],
+    ['oversized priority', { priority: PLUGIN_PET_ACTIVITY_LIMITS.maxPriority + 1 }],
+    ['fractional priority', { priority: 0.5 }],
+    ['non-finite priority', { priority: Number.POSITIVE_INFINITY }],
+    ['title metadata', { title: 'not public' }],
+    ['action metadata', { actions: [{ id: 'done', label: 'Done' }] }]
+  ])('fails closed for %s', (_label, overrides) => {
+    const { ctx, dispose } = testContext()
+
+    try {
+      expect(() => ctx.pet.publishActivity({ ...activity(), ...overrides } as PluginPetActivityInput)).toThrow()
+      expect($petSignals.get()).toEqual([])
+    } finally {
+      dispose()
+    }
+  })
+
+  it('clears visible activity on active-profile changes', () => {
+    $activeGatewayProfile.set('profile-a')
+    const { ctx, dispose } = testContext('profile-owner')
+
+    try {
+      ctx.pet.publishActivity(activity())
+      expect($petSignals.get()).toHaveLength(1)
+
+      $activeGatewayProfile.set('profile-b')
+      expect($petSignals.get()).toEqual([])
+
+      ctx.pet.publishActivity(activity({ state: 'thinking' }))
+      expect($petSignals.get()).toMatchObject([{ state: 'thinking' }])
+    } finally {
+      dispose()
+    }
+  })
+
+  it('guards a publication disposer against clearing a newer replacement', () => {
+    const { ctx, dispose } = testContext('guarded-disposer')
+
+    try {
+      const clearFirst = ctx.pet.publishActivity(activity({ state: 'working' }))
+      ctx.pet.publishActivity(activity({ state: 'thinking' }))
+
+      clearFirst()
+      expect($petSignals.get()).toMatchObject([{ state: 'thinking' }])
+    } finally {
+      dispose()
+    }
+  })
+})

--- a/apps/desktop/src/contrib/plugin.ts
+++ b/apps/desktop/src/contrib/plugin.ts
@@ -15,6 +15,8 @@
 import { pluginRest, type PluginRestOptions, pluginSocket } from '@/hermes'
 import { createPluginI18n, type PluginI18n } from '@/i18n'
 import { readKey, writeKey } from '@/lib/storage'
+import { clearPetSignal, clearPetSignals, type PetSignalState, upsertPetSignal } from '@/store/pet-signals'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 
 import { registry } from './registry'
 import type { Contribution } from './types'
@@ -31,6 +33,34 @@ export interface PluginStorage {
   get<T>(key: string, fallback: T): T
   set(key: string, value: unknown): void
   remove(key: string): void
+}
+
+export const PLUGIN_PET_ACTIVITY_LIMITS = {
+  maxIdsPerSource: 64,
+  maxIdLength: 128,
+  maxPriority: 100,
+  maxTtlMs: 300_000,
+  minPriority: 0,
+  minTtlMs: 1_000
+} as const
+
+export type PluginPetActivityState = PetSignalState
+
+/** A deliberately narrow, host-owned animation request. Plugins cannot spoof
+ * another source, create persistent activity, or inject copy/actions into the
+ * mascot surface. Native Hermes activity remains authoritative. */
+export interface PluginPetActivityInput {
+  readonly id: string
+  readonly priority?: number
+  readonly state: PluginPetActivityState
+  readonly ttlMs: number
+}
+
+export interface PluginPetSignals {
+  /** Publish or replace one bounded activity identity. Returns a guarded clear. */
+  publishActivity: (input: PluginPetActivityInput) => () => void
+  /** Clear one identity owned by this plugin. */
+  clearActivity: (id: string) => void
 }
 
 export interface PluginContext {
@@ -55,6 +85,8 @@ export interface PluginContext {
   /** Plugin-scoped i18n: ship + register locale bundles under this plugin,
    *  resolved against the app's active locale — no core `en.ts` edit. */
   i18n: PluginI18n
+  /** Bounded, expiring mascot activity owned by this plugin. */
+  pet: PluginPetSignals
 }
 
 export interface HermesPlugin {
@@ -92,6 +124,144 @@ function createPluginStorage(pluginId: string): PluginStorage {
   }
 }
 
+const PLUGIN_PET_ACTIVITY_FIELDS = new Set(['id', 'priority', 'state', 'ttlMs'])
+const PLUGIN_PET_ACTIVITY_STATES = new Set<PluginPetActivityState>(['blocked', 'done', 'failed', 'thinking', 'working'])
+
+// Process-lifetime source generations and identity sets deliberately survive a
+// plugin hot reload. That keeps new publications ahead of retained tombstones
+// and prevents reloads from bypassing the per-source identity bound.
+const pluginPetGenerations = new Map<string, number>()
+const pluginPetIdentities = new Map<string, Set<string>>()
+
+function validatePluginPetActivityId(id: unknown): string {
+  if (
+    typeof id !== 'string' ||
+    id.length === 0 ||
+    id.length > PLUGIN_PET_ACTIVITY_LIMITS.maxIdLength ||
+    id.trim() !== id
+  ) {
+    throw new Error('Plugin pet activity id must be a non-empty, trimmed, bounded string')
+  }
+
+  return id
+}
+
+function validatePluginPetActivity(input: PluginPetActivityInput): Required<PluginPetActivityInput> {
+  if (!input || typeof input !== 'object') {
+    throw new Error('Plugin pet activity must be an object')
+  }
+
+  const unsupported = Object.keys(input).find(field => !PLUGIN_PET_ACTIVITY_FIELDS.has(field))
+
+  if (unsupported) {
+    throw new Error(`Unsupported field in plugin pet activity: ${unsupported}`)
+  }
+
+  const id = validatePluginPetActivityId(input.id)
+
+  if (!PLUGIN_PET_ACTIVITY_STATES.has(input.state)) {
+    throw new Error('Unsupported plugin pet activity state')
+  }
+
+  if (
+    !Number.isInteger(input.ttlMs) ||
+    input.ttlMs < PLUGIN_PET_ACTIVITY_LIMITS.minTtlMs ||
+    input.ttlMs > PLUGIN_PET_ACTIVITY_LIMITS.maxTtlMs
+  ) {
+    throw new Error('Plugin pet activity TTL is outside the supported range')
+  }
+
+  const priority = input.priority ?? PLUGIN_PET_ACTIVITY_LIMITS.minPriority
+
+  if (
+    !Number.isInteger(priority) ||
+    priority < PLUGIN_PET_ACTIVITY_LIMITS.minPriority ||
+    priority > PLUGIN_PET_ACTIVITY_LIMITS.maxPriority
+  ) {
+    throw new Error('Plugin pet activity priority is outside the supported range')
+  }
+
+  return { id, priority, state: input.state, ttlMs: input.ttlMs }
+}
+
+function createPluginPetSignals(source: string, track: (dispose: () => void) => () => void): PluginPetSignals {
+  let active = true
+  let profile = normalizeProfileKey($activeGatewayProfile.get())
+
+  const stopProfile = $activeGatewayProfile.subscribe(next => {
+    const nextProfile = normalizeProfileKey(next)
+
+    if (nextProfile !== profile) {
+      profile = nextProfile
+      clearPetSignals(source)
+    }
+  })
+
+  track(() => {
+    if (!active) {
+      return
+    }
+
+    active = false
+    stopProfile()
+    clearPetSignals(source)
+  })
+
+  const assertActive = () => {
+    if (!active) {
+      throw new Error('Plugin pet activity publisher is disposed')
+    }
+  }
+
+  return {
+    clearActivity(id) {
+      assertActive()
+      clearPetSignal(source, validatePluginPetActivityId(id))
+    },
+    publishActivity(input) {
+      assertActive()
+      const activity = validatePluginPetActivity(input)
+      let identities = pluginPetIdentities.get(source)
+
+      if (!identities) {
+        identities = new Set()
+        pluginPetIdentities.set(source, identities)
+      }
+
+      if (!identities.has(activity.id)) {
+        if (identities.size >= PLUGIN_PET_ACTIVITY_LIMITS.maxIdsPerSource) {
+          throw new Error('Plugin pet activity identity limit reached')
+        }
+
+        identities.add(activity.id)
+      }
+
+      const now = Date.now()
+      const createdAt = Math.max(now, (pluginPetGenerations.get(source) ?? Number.NEGATIVE_INFINITY) + 1)
+      pluginPetGenerations.set(source, createdAt)
+      upsertPetSignal({
+        createdAt,
+        expiresAt: now + activity.ttlMs,
+        id: activity.id,
+        priority: activity.priority,
+        source,
+        state: activity.state
+      })
+
+      let cleared = false
+
+      return () => {
+        if (cleared) {
+          return
+        }
+
+        cleared = true
+        clearPetSignal(source, activity.id, createdAt)
+      }
+    }
+  }
+}
+
 /** Build the scoped context handed to a plugin's `register`. `onDispose`
  *  receives every registration's disposer (the loader's unload/reload hook). */
 export function createPluginContext(pluginId: string, onDispose?: (dispose: () => void) => void): PluginContext {
@@ -104,6 +274,8 @@ export function createPluginContext(pluginId: string, onDispose?: (dispose: () =
     return dispose
   }
 
+  const pet = createPluginPetSignals(source, track)
+
   return {
     source,
     register: c => track(registry.register(scope(c))),
@@ -111,6 +283,7 @@ export function createPluginContext(pluginId: string, onDispose?: (dispose: () =
     rest: <T>(path: string, opts?: PluginRestOptions) => pluginRest<T>(pluginId, path, opts),
     socket: (path, onMessage) => track(pluginSocket(pluginId, path, onMessage)),
     storage: createPluginStorage(pluginId),
-    i18n: createPluginI18n(pluginId, track)
+    i18n: createPluginI18n(pluginId, track),
+    pet
   }
 }

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -181,6 +181,9 @@ export type {
   HermesPlugin,
   PluginContext,
   PluginContribution,
+  PluginPetActivityInput,
+  PluginPetActivityState,
+  PluginPetSignals,
   PluginRestOptions,
   PluginStorage
 } from '@/contrib/plugin'

--- a/apps/desktop/src/store/pet-signal-state.test.ts
+++ b/apps/desktop/src/store/pet-signal-state.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $petActivity, $petAtRest, $petMotion, $petState, deriveEffectivePetState } from './pet'
+import { $petSignals, clearPetSignals, upsertPetSignal } from './pet-signals'
+
+let signalSourceSequence = 0
+
+const clearTestSignals = () => {
+  for (const source of new Set($petSignals.get().map(signal => signal.source))) {
+    clearPetSignals(source)
+  }
+}
+
+afterEach(() => {
+  clearTestSignals()
+  $petActivity.set({})
+  $petMotion.set(null)
+  vi.useRealTimers()
+})
+
+describe('native and external pet state precedence', () => {
+  it('uses external work and thinking only while native Hermes is idle', () => {
+    expect(deriveEffectivePetState({}, false, 'run')).toBe('run')
+    expect(deriveEffectivePetState({}, false, 'review')).toBe('review')
+  })
+
+  it('keeps native work above an external blocked signal', () => {
+    expect(deriveEffectivePetState({ toolRunning: true }, true, 'waiting')).toBe('run')
+    expect(deriveEffectivePetState({ reasoning: true }, true, 'waiting')).toBe('review')
+  })
+
+  it('keeps native approval, error, celebration, and completion above external work', () => {
+    expect(deriveEffectivePetState({ awaitingInput: true }, true, 'run')).toBe('waiting')
+    expect(deriveEffectivePetState({ error: true }, false, 'run')).toBe('failed')
+    expect(deriveEffectivePetState({ celebrate: true }, false, 'run')).toBe('jump')
+    expect(deriveEffectivePetState({ justCompleted: true }, false, 'run')).toBe('wave')
+  })
+
+  it('lets a live external signal drive the pet and stop idle roaming', () => {
+    const source = `pet-state-${++signalSourceSequence}`
+    $petActivity.set({})
+    $petMotion.set('jump')
+
+    upsertPetSignal({
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 10_000,
+      id: 'job',
+      priority: 0,
+      source,
+      state: 'working'
+    })
+
+    expect($petAtRest.get()).toBe(false)
+    expect($petState.get()).toBe('run')
+
+    clearPetSignals(source)
+    expect($petAtRest.get()).toBe(true)
+    expect($petState.get()).toBe('jump')
+  })
+
+  it('returns both surfaces to the native roam state when a failure expires', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(5_000)
+    const source = `pet-expiry-${++signalSourceSequence}`
+    $petActivity.set({})
+    $petMotion.set('jump')
+
+    upsertPetSignal({
+      createdAt: 5_000,
+      expiresAt: 5_100,
+      id: 'failure',
+      priority: 10,
+      source,
+      state: 'failed'
+    })
+
+    expect($petState.get()).toBe('failed')
+    expect($petAtRest.get()).toBe(false)
+
+    vi.advanceTimersByTime(100)
+    expect($petState.get()).toBe('jump')
+    expect($petAtRest.get()).toBe(true)
+  })
+
+  it('preserves all existing native behavior when no signal exists', () => {
+    expect(deriveEffectivePetState({ reasoning: true }, true, 'idle')).toBe('review')
+    expect(deriveEffectivePetState({}, false, 'idle')).toBe('idle')
+  })
+})

--- a/apps/desktop/src/store/pet-signals.test.ts
+++ b/apps/desktop/src/store/pet-signals.test.ts
@@ -1,0 +1,485 @@
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
+
+import {
+  $petSignals,
+  clearPetSignal,
+  clearPetSignals,
+  derivePetSignalState,
+  type PetSignal,
+  selectPetStateSignal,
+  upsertPetSignal
+} from './pet-signals'
+
+let defaultSignalSource = 'provider-a-0'
+let testSourceSequence = 0
+
+beforeEach(() => {
+  defaultSignalSource = `provider-a-${++testSourceSequence}`
+})
+
+const signal = (overrides: Partial<PetSignal> = {}): PetSignal => ({
+  createdAt: 1_000,
+  id: 'agent-1',
+  priority: 0,
+  source: defaultSignalSource,
+  state: 'working',
+  ...overrides
+})
+
+const malformedOrderingSignals = [
+  ['NaN priority', { priority: Number.NaN }],
+  ['infinite priority', { priority: Number.POSITIVE_INFINITY }],
+  ['NaN creation time', { createdAt: Number.NaN }],
+  ['infinite creation time', { createdAt: Number.POSITIVE_INFINITY }]
+] satisfies readonly (readonly [string, Partial<PetSignal>])[]
+
+const clearAllPetSignals = () => {
+  for (const source of new Set($petSignals.get().map(signal => signal.source))) {
+    clearPetSignals(source)
+  }
+}
+
+afterEach(clearAllPetSignals)
+
+describe('pet signal arbitration', () => {
+  it.each([
+    ['working', 'run'],
+    ['thinking', 'review'],
+    ['blocked', 'waiting'],
+    ['done', 'wave'],
+    ['failed', 'failed']
+  ] as const)('maps %s to the %s animation', (state, expected) => {
+    expect(derivePetSignalState([signal({ state })], 1_000)).toBe(expected)
+  })
+
+  it('ignores a signal at its expiry boundary', () => {
+    expect(derivePetSignalState([signal({ expiresAt: 1_000, state: 'failed' })], 1_000)).toBe('idle')
+  })
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY])('ignores a non-finite expiry timestamp', expiresAt => {
+    expect(derivePetSignalState([signal({ expiresAt, state: 'failed' })], 1_000)).toBe('idle')
+  })
+
+  it('selects the signal with the highest explicit priority', () => {
+    const lower = signal({ createdAt: 900, priority: 1, state: 'failed' })
+    const higher = signal({ createdAt: 800, id: 'agent-2', priority: 2, state: 'working' })
+
+    expect(selectPetStateSignal([lower, higher], 1_000)).toBe(higher)
+  })
+
+  it('selects the newest signal when priorities tie', () => {
+    const older = signal({ createdAt: 900, priority: 1, state: 'failed' })
+    const newer = signal({ createdAt: 950, id: 'agent-2', priority: 1, state: 'done' })
+
+    expect(selectPetStateSignal([older, newer], 1_000)).toBe(newer)
+  })
+
+  it('uses source as a stable tie-breaker', () => {
+    const lexicalLast = signal({ id: 'agent-z', priority: 1, source: 'z-provider', state: 'failed' })
+    const lexicalFirst = signal({ id: 'agent-a', priority: 1, source: 'a-provider', state: 'working' })
+
+    expect(selectPetStateSignal([lexicalLast, lexicalFirst], 1_000)).toBe(lexicalFirst)
+    expect(selectPetStateSignal([lexicalFirst, lexicalLast], 1_000)).toBe(lexicalFirst)
+  })
+
+  it('uses id after source ties', () => {
+    const lexicalLast = signal({ id: 'agent-z', priority: 1, state: 'failed' })
+    const lexicalFirst = signal({ id: 'agent-a', priority: 1, state: 'working' })
+
+    expect(selectPetStateSignal([lexicalLast, lexicalFirst], 1_000)).toBe(lexicalFirst)
+    expect(selectPetStateSignal([lexicalFirst, lexicalLast], 1_000)).toBe(lexicalFirst)
+  })
+
+  it.each(malformedOrderingSignals)('ignores a signal with %s', (_label, overrides) => {
+    const malformed = signal({ priority: 100, state: 'failed', ...overrides })
+    const valid = signal({ id: 'valid', state: 'working' })
+
+    expect(selectPetStateSignal([malformed, valid], 1_000)).toBe(valid)
+  })
+
+  it('ignores an unknown runtime state', () => {
+    const malformed = signal({ priority: 100, state: 'unknown' as PetSignal['state'] })
+    const valid = signal({ id: 'valid', state: 'working' })
+
+    expect(selectPetStateSignal([malformed, valid], 1_000)).toBe(valid)
+  })
+})
+
+describe('pet signal store', () => {
+  it('exposes signal state as read-only', () => {
+    expectTypeOf($petSignals).not.toHaveProperty('set')
+    expectTypeOf($petSignals.get()).toEqualTypeOf<readonly PetSignal[]>()
+  })
+
+  it('inserts a signal', () => {
+    const next = signal()
+
+    upsertPetSignal(next)
+
+    expect($petSignals.get()).toEqual([next])
+  })
+
+  it('replaces a signal with the same source and id', () => {
+    const first = signal()
+    const replacement = signal({ createdAt: 2_000, state: 'thinking' })
+
+    upsertPetSignal(first)
+    upsertPetSignal(replacement)
+
+    expect($petSignals.get()).toEqual([replacement])
+  })
+
+  it('does not replace a newer same-key signal with a stale update', () => {
+    const newer = signal({ createdAt: 2_000, state: 'done' })
+    const stale = signal({ createdAt: 1_000, state: 'failed' })
+
+    upsertPetSignal(newer)
+    upsertPetSignal(stale)
+
+    expect($petSignals.get()).toEqual([newer])
+  })
+
+  it('does not replace a same-key signal with an equal-timestamp retry', () => {
+    const first = signal({ createdAt: 1_000, state: 'working' })
+    const retry = signal({ createdAt: 1_000, state: 'failed' })
+
+    upsertPetSignal(first)
+    upsertPetSignal(retry)
+
+    expect($petSignals.get()).toEqual([first])
+  })
+
+  it('removes a signal at its expiry time', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+
+    try {
+      upsertPetSignal(signal({ expiresAt: 1_100 }))
+
+      vi.advanceTimersByTime(99)
+      expect($petSignals.get()).toHaveLength(1)
+
+      vi.advanceTimersByTime(1)
+      expect($petSignals.get()).toEqual([])
+    } finally {
+      clearAllPetSignals()
+      vi.useRealTimers()
+    }
+  })
+
+  it('snapshots input so caller mutation cannot prevent expiry', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    const input = signal({ expiresAt: 1_100 })
+
+    try {
+      upsertPetSignal(input)
+      ;(input as { expiresAt?: number }).expiresAt = undefined
+
+      vi.advanceTimersByTime(100)
+      expect($petSignals.get()).toEqual([])
+    } finally {
+      clearAllPetSignals()
+      vi.useRealTimers()
+    }
+  })
+
+  it('rearms cleanup for the next signal expiry', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    const later = signal({ expiresAt: 1_200, id: 'agent-2' })
+
+    try {
+      upsertPetSignal(signal({ expiresAt: 1_100 }))
+      upsertPetSignal(later)
+
+      vi.advanceTimersByTime(100)
+      expect($petSignals.get()).toEqual([later])
+
+      vi.advanceTimersByTime(100)
+      expect($petSignals.get()).toEqual([])
+    } finally {
+      clearAllPetSignals()
+      vi.useRealTimers()
+    }
+  })
+
+  it('rearms cleanup when a replacement moves the nearest expiry', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    const replacement = signal({ expiresAt: 1_200 })
+
+    try {
+      upsertPetSignal(signal({ createdAt: 900, expiresAt: 1_100 }))
+      upsertPetSignal(replacement)
+
+      vi.advanceTimersByTime(100)
+      expect($petSignals.get()).toEqual([replacement])
+
+      vi.advanceTimersByTime(100)
+      expect($petSignals.get()).toEqual([])
+    } finally {
+      clearAllPetSignals()
+      vi.useRealTimers()
+    }
+  })
+
+  it('rearms cleanup when the nearest-expiring signal is cleared', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    const later = signal({ expiresAt: 1_200, id: 'agent-2' })
+
+    try {
+      upsertPetSignal(signal({ expiresAt: 1_100 }))
+      upsertPetSignal(later)
+      clearPetSignal(later.source, 'agent-1')
+
+      vi.advanceTimersByTime(100)
+      expect($petSignals.get()).toEqual([later])
+
+      vi.advanceTimersByTime(100)
+      expect($petSignals.get()).toEqual([])
+    } finally {
+      clearAllPetSignals()
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not retain a signal that is already expired', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_100)
+
+    try {
+      upsertPetSignal(signal({ expiresAt: 1_100 }))
+
+      expect($petSignals.get()).toEqual([])
+    } finally {
+      clearAllPetSignals()
+      vi.useRealTimers()
+    }
+  })
+
+  it.each(malformedOrderingSignals)('rejects a signal with %s', (_label, overrides) => {
+    upsertPetSignal(signal(overrides))
+
+    expect($petSignals.get()).toEqual([])
+  })
+
+  it('rejects an unknown runtime state', () => {
+    upsertPetSignal(signal({ state: 'unknown' as PetSignal['state'] }))
+
+    expect($petSignals.get()).toEqual([])
+  })
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY])('rejects a non-finite expiry timestamp', expiresAt => {
+    upsertPetSignal(signal({ expiresAt }))
+
+    expect($petSignals.get()).toEqual([])
+  })
+
+  it('accepts a signal that is owned by explicit clear instead of a timer', () => {
+    const persistent = signal({ expiresAt: undefined })
+
+    upsertPetSignal(persistent)
+
+    expect($petSignals.get()).toEqual([persistent])
+    clearPetSignal(persistent.source, persistent.id)
+  })
+
+  it('clears only signals owned by one source', () => {
+    const remaining = signal({ id: 'build-1', source: `${defaultSignalSource}-b` })
+
+    const owned = signal()
+
+    upsertPetSignal(owned)
+    upsertPetSignal(signal({ id: 'agent-2' }))
+    upsertPetSignal(remaining)
+    clearPetSignals(owned.source)
+
+    expect($petSignals.get()).toEqual([remaining])
+  })
+
+  it('does not let a guarded stale clear erase a newer replacement', () => {
+    const previous = signal({ createdAt: 1_000 })
+    const newer = signal({ createdAt: 2_000 })
+
+    upsertPetSignal(previous)
+    upsertPetSignal(newer)
+    clearPetSignal(newer.source, newer.id, previous.createdAt)
+    expect($petSignals.get()).toEqual([newer])
+
+    clearPetSignal(newer.source, newer.id, newer.createdAt)
+    expect($petSignals.get()).toEqual([])
+  })
+
+  it.each([
+    ['equal-timestamp', 1_000],
+    ['older', 900]
+  ] as const)('does not resurrect an %s retry after guarded clear', (_label, createdAt) => {
+    const first = signal({ createdAt: 1_000 })
+    const retry = signal({ createdAt, state: 'failed' })
+
+    upsertPetSignal(first)
+    clearPetSignal(first.source, first.id, first.createdAt)
+    upsertPetSignal(retry)
+
+    expect($petSignals.get()).toEqual([])
+
+    const newer = signal({ createdAt: 1_100, state: 'done' })
+    upsertPetSignal(newer)
+    expect($petSignals.get()).toEqual([newer])
+  })
+
+  it('does not resurrect a stale retry after source-wide clear', () => {
+    const first = signal({ createdAt: 1_000 })
+
+    upsertPetSignal(first)
+    clearPetSignals(first.source)
+    upsertPetSignal(signal({ createdAt: 1_000, state: 'failed' }))
+
+    expect($petSignals.get()).toEqual([])
+
+    const newer = signal({ createdAt: 1_100, state: 'done' })
+    upsertPetSignal(newer)
+    expect($petSignals.get()).toEqual([newer])
+  })
+
+  it.each([
+    ['equal-timestamp', 1_000],
+    ['older', 900]
+  ] as const)('does not resurrect an %s retry after timer expiry', (_label, createdAt) => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+
+    try {
+      upsertPetSignal(signal({ createdAt: 1_000, expiresAt: 1_100 }))
+      vi.advanceTimersByTime(100)
+      upsertPetSignal(signal({ createdAt, expiresAt: 1_200, state: 'failed' }))
+
+      expect($petSignals.get()).toEqual([])
+
+      const newer = signal({ createdAt: 1_100, expiresAt: 1_200, state: 'done' })
+      upsertPetSignal(newer)
+      expect($petSignals.get()).toEqual([newer])
+    } finally {
+      clearAllPetSignals()
+      vi.useRealTimers()
+    }
+  })
+
+  it.each([
+    ['guarded', 'equal-timestamp', 1_000],
+    ['guarded', 'older', 900],
+    ['unguarded', 'equal-timestamp', 1_000],
+    ['unguarded', 'older', 900],
+    ['source-wide', 'equal-timestamp', 1_000],
+    ['source-wide', 'older', 900]
+  ] as const)('blocks a reentrant %s clear followed by an %s retry', (clearMode, _label, createdAt) => {
+    const first = signal({ createdAt: 1_000 })
+    const retry = signal({ createdAt, state: 'failed' })
+    let reacted = false
+
+    const unlisten = $petSignals.listen(signals => {
+      if (reacted || signals.length !== 1) {
+        return
+      }
+
+      reacted = true
+
+      if (clearMode === 'source-wide') {
+        clearPetSignals(first.source)
+      } else {
+        clearPetSignal(first.source, first.id, clearMode === 'guarded' ? first.createdAt : undefined)
+      }
+
+      upsertPetSignal(retry)
+    })
+
+    try {
+      upsertPetSignal(first)
+      expect($petSignals.get()).toEqual([])
+    } finally {
+      unlisten()
+    }
+  })
+
+  it('blocks intermediate work reentered during replacement publication', () => {
+    const first = signal({ createdAt: 1_000 })
+    const replacement = signal({ createdAt: 2_000, state: 'thinking' })
+    const intermediate = signal({ createdAt: 1_500, state: 'failed' })
+
+    upsertPetSignal(first)
+
+    const unlisten = $petSignals.listen(signals => {
+      if (signals[0]?.createdAt !== replacement.createdAt) {
+        return
+      }
+
+      clearPetSignal(replacement.source, replacement.id, replacement.createdAt)
+      upsertPetSignal(intermediate)
+    })
+
+    try {
+      upsertPetSignal(replacement)
+      expect($petSignals.get()).toEqual([])
+    } finally {
+      unlisten()
+    }
+  })
+
+  it('keeps a strictly newer generation published by a nested listener', () => {
+    const first = signal({ createdAt: 1_000 })
+    const replacement = signal({ createdAt: 2_000, state: 'thinking' })
+    const newest = signal({ createdAt: 3_000, state: 'done' })
+
+    upsertPetSignal(first)
+
+    const unlisten = $petSignals.listen(signals => {
+      if (signals[0]?.createdAt === replacement.createdAt) {
+        upsertPetSignal(newest)
+      }
+    })
+
+    try {
+      upsertPetSignal(replacement)
+      expect($petSignals.get()).toEqual([newest])
+    } finally {
+      unlisten()
+    }
+  })
+
+  it('rejects a queued intermediate generation after a nested newer publication', () => {
+    const first = signal({ createdAt: 1_000 })
+    const replacement = signal({ createdAt: 2_000, state: 'thinking' })
+    const intermediate = signal({ createdAt: 2_500, state: 'failed' })
+    const newest = signal({ createdAt: 3_000, state: 'done' })
+
+    upsertPetSignal(first)
+
+    const unlisten = $petSignals.listen(signals => {
+      if (signals[0]?.createdAt === replacement.createdAt) {
+        upsertPetSignal(newest)
+      }
+    })
+
+    try {
+      upsertPetSignal(replacement)
+      upsertPetSignal(intermediate)
+      expect($petSignals.get()).toEqual([newest])
+    } finally {
+      unlisten()
+    }
+  })
+
+  it('clears one signal without erasing its siblings', () => {
+    const sibling = signal({ id: 'agent-2' })
+    const otherSource = signal({ id: 'build-1', source: `${defaultSignalSource}-b` })
+
+    upsertPetSignal(signal())
+    upsertPetSignal(sibling)
+    upsertPetSignal(otherSource)
+    clearPetSignal(sibling.source, 'agent-1')
+
+    expect($petSignals.get()).toEqual([sibling, otherSource])
+  })
+})

--- a/apps/desktop/src/store/pet-signals.ts
+++ b/apps/desktop/src/store/pet-signals.ts
@@ -1,0 +1,217 @@
+import { atom, type ReadableAtom } from 'nanostores'
+
+import type { PetState } from './pet'
+
+export type PetSignalState = 'working' | 'thinking' | 'blocked' | 'done' | 'failed'
+
+/**
+ * A provider-owned pet signal. The `(source, id)` pair is its stable identity.
+ * `expiresAt` is an absolute epoch timestamp; omit it only when the owner will
+ * explicitly clear the signal (for example, during plugin disposal).
+ */
+export interface PetSignal {
+  /** Event timestamp used for arbitration; replacements must strictly increase it. */
+  readonly createdAt: number
+  readonly expiresAt?: number
+  readonly id: string
+  /** Higher values win arbitration. */
+  readonly priority: number
+  readonly source: string
+  readonly state: PetSignalState
+}
+
+const $petSignalsWritable = atom<readonly PetSignal[]>([])
+export const $petSignals: ReadableAtom<readonly PetSignal[]> = $petSignalsWritable
+
+const MAX_TIMER_DELAY_MS = 2_147_483_647
+let expiryTimer: ReturnType<typeof setTimeout> | undefined
+
+// Tombstones live for the renderer process lifetime so delayed provider work
+// cannot resurrect a cleared or expired identity. Provider IDs should be bounded.
+const petSignalCreatedAtHighWatermarks = new Map<string, Map<string, number>>()
+
+const PET_SIGNAL_STATE: Record<PetSignalState, PetState> = {
+  working: 'run',
+  thinking: 'review',
+  blocked: 'waiting',
+  done: 'wave',
+  failed: 'failed'
+}
+
+function isPetSignalCurrent(signal: PetSignal, now: number): boolean {
+  return signal.expiresAt === undefined || (Number.isFinite(signal.expiresAt) && signal.expiresAt > now)
+}
+
+function isPetSignalValid(signal: PetSignal, now: number): boolean {
+  return (
+    Number.isFinite(signal.createdAt) &&
+    Number.isFinite(signal.priority) &&
+    Object.hasOwn(PET_SIGNAL_STATE, signal.state) &&
+    isPetSignalCurrent(signal, now)
+  )
+}
+
+function getPetSignalCreatedAtHighWatermark(source: string, id: string): number | undefined {
+  return petSignalCreatedAtHighWatermarks.get(source)?.get(id)
+}
+
+function recordPetSignalCreatedAt(signal: Pick<PetSignal, 'createdAt' | 'id' | 'source'>) {
+  let sourceHighWatermarks = petSignalCreatedAtHighWatermarks.get(signal.source)
+
+  if (!sourceHighWatermarks) {
+    sourceHighWatermarks = new Map()
+    petSignalCreatedAtHighWatermarks.set(signal.source, sourceHighWatermarks)
+  }
+
+  const currentHighWatermark = sourceHighWatermarks.get(signal.id)
+
+  if (currentHighWatermark === undefined || signal.createdAt > currentHighWatermark) {
+    sourceHighWatermarks.set(signal.id, signal.createdAt)
+  }
+}
+
+function snapshotPetSignal(signal: PetSignal): PetSignal {
+  return { ...signal }
+}
+
+function armPetSignalExpiry() {
+  clearTimeout(expiryTimer)
+  expiryTimer = undefined
+
+  let expiresAt = Number.POSITIVE_INFINITY
+
+  for (const signal of $petSignalsWritable.get()) {
+    if (signal.expiresAt !== undefined && signal.expiresAt < expiresAt) {
+      expiresAt = signal.expiresAt
+    }
+  }
+
+  if (!Number.isFinite(expiresAt)) {
+    return
+  }
+
+  const delay = Math.min(MAX_TIMER_DELAY_MS, Math.max(0, expiresAt - Date.now()))
+  expiryTimer = setTimeout(() => {
+    expiryTimer = undefined
+
+    const now = Date.now()
+    const current = $petSignalsWritable.get()
+    const next = current.filter(signal => isPetSignalCurrent(signal, now))
+
+    if (next.length !== current.length) {
+      $petSignalsWritable.set(next)
+    }
+
+    armPetSignalExpiry()
+  }, delay)
+}
+
+/** Insert one identity or apply a strictly newer valid replacement. */
+export function upsertPetSignal(signal: PetSignal) {
+  if (!isPetSignalValid(signal, Date.now())) {
+    return
+  }
+
+  const highWatermark = getPetSignalCreatedAtHighWatermark(signal.source, signal.id)
+
+  if (highWatermark !== undefined && highWatermark >= signal.createdAt) {
+    return
+  }
+
+  const storedSignal = snapshotPetSignal(signal)
+  const current = $petSignalsWritable.get()
+  const index = current.findIndex(candidate => candidate.source === signal.source && candidate.id === signal.id)
+
+  if (index >= 0 && current[index].createdAt >= storedSignal.createdAt) {
+    return
+  }
+
+  const next = [...current]
+
+  if (index < 0) {
+    next.push(storedSignal)
+  } else {
+    next[index] = storedSignal
+  }
+
+  recordPetSignalCreatedAt(storedSignal)
+  $petSignalsWritable.set(next)
+  armPetSignalExpiry()
+}
+
+/** Remove every signal owned by a provider source. */
+export function clearPetSignals(source: string) {
+  const current = $petSignalsWritable.get()
+  const next = current.filter(signal => signal.source !== source)
+
+  if (next.length === current.length) {
+    return
+  }
+
+  $petSignalsWritable.set(next)
+  armPetSignalExpiry()
+}
+
+/**
+ * Remove one `(source, id)` signal without affecting its siblings. Pass the
+ * expected creation time when a delayed callback must not clear a replacement.
+ */
+export function clearPetSignal(source: string, id: string, expectedCreatedAt?: number) {
+  const current = $petSignalsWritable.get()
+
+  const next = current.filter(
+    signal =>
+      signal.source !== source ||
+      signal.id !== id ||
+      (expectedCreatedAt !== undefined && signal.createdAt !== expectedCreatedAt)
+  )
+
+  if (next.length === current.length) {
+    return
+  }
+
+  $petSignalsWritable.set(next)
+  armPetSignalExpiry()
+}
+
+function petSignalOutranks(candidate: PetSignal, selected: PetSignal): boolean {
+  if (candidate.priority !== selected.priority) {
+    return candidate.priority > selected.priority
+  }
+
+  if (candidate.createdAt !== selected.createdAt) {
+    return candidate.createdAt > selected.createdAt
+  }
+
+  if (candidate.source !== selected.source) {
+    return candidate.source < selected.source
+  }
+
+  return candidate.id < selected.id
+}
+
+/**
+ * Select active state by priority, then recency, then lexical source/id for a
+ * stable final tie-break.
+ */
+export function selectPetStateSignal(signals: readonly PetSignal[], now = Date.now()): PetSignal | undefined {
+  let selected: PetSignal | undefined
+
+  for (const signal of signals) {
+    if (!isPetSignalValid(signal, now)) {
+      continue
+    }
+
+    if (!selected || petSignalOutranks(signal, selected)) {
+      selected = signal
+    }
+  }
+
+  return selected
+}
+
+export function derivePetSignalState(signals: readonly PetSignal[], now = Date.now()): PetState {
+  const signal = selectPetStateSignal(signals, now)
+
+  return signal ? PET_SIGNAL_STATE[signal.state] : 'idle'
+}

--- a/apps/desktop/src/store/pet.ts
+++ b/apps/desktop/src/store/pet.ts
@@ -4,6 +4,8 @@ import { persistBoolean, storedBoolean } from '@/lib/storage'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { $busy } from '@/store/session'
 
+import { $petSignals, derivePetSignalState } from './pet-signals'
+
 /**
  * Petdex mascot state for the desktop floating pet.
  *
@@ -163,6 +165,18 @@ function deriveLivePetState(activity: PetActivity, busy: boolean): PetState {
 }
 
 /**
+ * Resolve native Hermes activity against an already-arbitrated external signal.
+ * Any non-idle native state wins: a provider's cosmetic/background activity
+ * must never hide local work, an approval wait, an error, or a completion beat.
+ * External activity animates the mascot only while native Hermes is at rest.
+ */
+export function deriveEffectivePetState(activity: PetActivity, busy: boolean, signalState: PetState): PetState {
+  const nativeState = deriveLivePetState(activity, busy)
+
+  return nativeState === 'idle' ? signalState : nativeState
+}
+
+/**
  * Opt-in: let the floating mascot wander around the window on its own while
  * idle. Pure desktop-client behavior (no agent/config dependency), so it lives
  * in localStorage like the pet's drag position — per-device, not per-profile.
@@ -190,23 +204,25 @@ export const $petMotion = atom<PetState | null>(null)
  */
 export const $petRoamDir = atom<-1 | 0 | 1>(0)
 
+/** Native + external state, deliberately independent of roam motion. */
+const $effectivePetState = computed(
+  [$petActivity, $busy, $petSignals],
+  (activity, busy, signals): PetState => deriveEffectivePetState(activity, busy, derivePetSignalState(signals))
+)
+
 /**
  * Whether the agent-driven state is at rest (plain `idle`). The roam loop gates
  * on this — never on `$petState` itself, which would feed back on its own
  * `$petMotion`-driven pose and stall the wander.
  */
-export const $petAtRest = computed(
-  [$petActivity, $busy],
-  (activity, busy): boolean => deriveLivePetState(activity, busy) === 'idle'
-)
+export const $petAtRest = computed($effectivePetState, (state): boolean => state === 'idle')
 
 /**
  * The live pet state. Activity always wins; only when the agent is at rest does
  * a roam pose (walking → `run`, hopping → `jump`) show through, so the wander
  * reads as deliberate movement.
  */
-export const $petState = computed([$petActivity, $busy, $petMotion], (activity, busy, motion): PetState => {
-  const base = deriveLivePetState(activity, busy)
-
-  return base === 'idle' && motion ? motion : base
-})
+export const $petState = computed(
+  [$effectivePetState, $petMotion],
+  (base, motion): PetState => (base === 'idle' && motion ? motion : base)
+)

--- a/contributors/emails/konurud@gmail.com
+++ b/contributors/emails/konurud@gmail.com
@@ -1,0 +1,2 @@
+chaosmaximus
+# Pet activity signals desktop contribution

--- a/skills/hermes-desktop-plugins/SKILL.md
+++ b/skills/hermes-desktop-plugins/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hermes-desktop-plugins
-description: Write desktop app plugins that add UI panes and commands.
-version: 1.0.0
+description: Write desktop app plugins that add UI panes, commands, and bounded pet activity.
+version: 1.1.0
 platforms: [linux, macos, windows]
 metadata:
   hermes:
@@ -83,6 +83,12 @@ The ONLY import surface is `@hermes/plugin-sdk` (plus `react` /
   (renders below Artifacts, lights up at the route) — and/or a
   `PALETTE_AREA` command calling `host.navigate('/my-page')`.
 - `ctx.storage.get/set/remove` — persistence namespaced to your plugin.
+- `ctx.pet.publishActivity({ id, state, ttlMs, priority? })` — animate the
+  selected in-window pet for bounded plugin-owned background activity. `state` is
+  `working`, `thinking`, `blocked`, `done`, or `failed`; native Hermes activity
+  always wins. The returned disposer clears only that published generation.
+  `ctx.pet.clearActivity(id)` clears the current generation explicitly, and all
+  plugin activity is removed on unload or profile change.
 - `ctx.i18n.register({ en, ja, ... })` — ship your OWN locale bundles, scoped
   to your plugin (never edit core `en.ts`). Values are literal strings or
   interpolator functions; nested trees are addressed by dot-path. Read them

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -170,6 +170,8 @@ interface PluginContext {
   socket: (path: string, onMessage: (data: unknown) => void) => () => void
   /** Plugin-scoped JSON persistence (keys live under `hermes.plugin.<id>.`). */
   storage: PluginStorage
+  /** Bounded, expiring mascot activity owned by this plugin. */
+  pet: PluginPetSignals
 }
 ```
 
@@ -537,6 +539,37 @@ const tab = ctx.storage.get('lastTab', 'summary')
 ctx.storage.remove('lastTab')
 ```
 
+## Pet activity
+
+Use `ctx.pet` when a desktop plugin has useful background activity that should
+animate the user's selected in-window pet. The API is deliberately cosmetic:
+plugins can request a bounded activity state, but cannot inject pet copy or
+actions, spoof another plugin's source, or override active Hermes work.
+
+```javascript
+const clearSync = ctx.pet.publishActivity({
+  id: 'sync',
+  state: 'working',
+  ttlMs: 30_000
+})
+
+// Clear early when the work finishes. The signal also expires at its TTL.
+clearSync()
+```
+
+`state` is one of `working`, `thinking`, `blocked`, `done`, or `failed`.
+`ttlMs` must be between 1 second and 5 minutes. `priority` is optional and must
+be an integer from 0 to 100. IDs are plugin-local, trimmed, at most 128
+characters, and capped at 64 distinct identities per plugin process.
+
+Publishing the same ID replaces its older generation. The disposer returned by
+`publishActivity` is generation-guarded, so delayed cleanup cannot erase a
+newer replacement. You can also call `ctx.pet.clearActivity(id)`. All activity
+owned by a plugin is cleared when that plugin unloads, when its active profile
+changes, or when its TTL expires. Native Hermes activity always takes
+precedence; plugin activity drives the pet only while Hermes itself is idle.
+The detached desktop overlay is intentionally unchanged by this API.
+
 ## Bundled plugins
 
 A plugin can ship in-tree at `apps/desktop/src/plugins/<id>/plugin.tsx` (default
@@ -597,7 +630,7 @@ not treat this pipeline as a trust boundary.
 | Category | Exports |
 |----------|---------|
 | Host | `host` (`.state.*`, `.notify`, `.notifyError`, `.navigate`, `.onEvent`, `.logs`, `.status`, `.restartGateway`, `.request`) |
-| Plugin contract | `HermesPlugin`, `PluginContext`, `PluginContribution`, `PluginStorage`, `PluginRestOptions`, `Contribution` |
+| Plugin contract | `HermesPlugin`, `PluginContext`, `PluginContribution`, `PluginStorage`, `PluginRestOptions`, `PluginPetSignals`, `PluginPetActivityInput`, `PluginPetActivityState`, `Contribution` |
 | Area constants | `PANES_AREA`, `ROUTES_AREA`, `SIDEBAR_NAV_AREA`, `STATUSBAR_AREAS`, `TITLEBAR_AREAS`, `PALETTE_AREA`, `KEYBINDS_AREA`, `THEMES_AREA`, `COMPOSER_AREAS` |
 | Area payloads | `RouteContribution`, `SidebarNavContribution`, `StatusbarItem`, `TitlebarTool`, `PaletteContribution`, `KeybindContribution`, `ComposerMiddleware`, `ComposerAttachmentProvider` |
 | React / state | `useValue`, `atom`, `computed`, `useQuery`, `useMutation`, `useQueryClient`, `queryClient`, `Contribute` |


### PR DESCRIPTION
### What does this PR do?

This adds a small, provider-neutral desktop plugin API for reflecting bounded
background activity through the user's selected in-window pet.

Plugins can publish one of five cosmetic states (`working`, `thinking`,
`blocked`, `done`, or `failed`) with a required expiry. Native Hermes activity
always takes precedence, and plugin activity is removed automatically when its
TTL expires, the plugin unloads, or the active gateway profile changes.

The API is intentionally narrow: plugins cannot inject pet text, actions, or
persistent state, and cannot clear activity owned by another plugin. This gives
optional integrations a safe generic boundary without coupling desktop core to
any external service.

### Related Issue

N/A — this is a provider-neutral plugin-surface addition. It does not implement
the dashboard-specific behavior discussed in #61559.

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

### Changes Made

- Add a deterministic pet-signal store with TTL expiry, priority arbitration,
  stable tie-breaking, and bounded per-source identities.
- Expose `ctx.pet.publishActivity(...)` and `ctx.pet.clearActivity(...)` through
  the desktop plugin context and public SDK types.
- Keep ownership scoped to the publishing plugin and clear its signals during
  disposal or profile changes.
- Let plugin activity animate the in-window pet only while native Hermes is
  idle; native work, approvals, failures, and completion beats remain
  authoritative.
- Document the API in the desktop plugin SDK guide and update the existing
  desktop-plugin skill reference.
- Add focused coverage for validation, ownership isolation, replacement safety,
  expiry scheduling, arbitration, lifecycle cleanup, profile isolation, and
  native-state precedence.

### Security and lifecycle model

- Activity IDs are trimmed, length-bounded, and scoped to a generated plugin
  source; caller-provided source IDs are rejected.
- Inputs are allow-listed. Copy, actions, and unknown fields are rejected.
- TTL, priority, and per-plugin identity counts are bounded.
- A disposer returned by an older publish call cannot clear a newer generation
  of the same activity ID.
- Plugin unload and gateway-profile changes clear owned signals.
- No provider credentials, network transport, filesystem access, notifications,
  or user content are introduced by this API.

### How to Test

1. Run the focused desktop tests:
   `vitest run src/store/pet-signals.test.ts src/store/pet-signal-state.test.ts src/contrib/plugin.test.ts src/store/pet.test.ts`
2. Run the desktop typecheck and lint.
3. Run the complete desktop Vitest suite.
4. Build and package the macOS arm64 desktop application.

### Verification performed

- Focused desktop tests: 4 files, 90 tests passed.
- Desktop typecheck: passed.
- Desktop lint: 0 errors; 9 pre-existing warnings in unrelated files.
- Changed-file formatting and `git diff --check`: passed.
- Full desktop suite: 245 files passed; 2,155 tests passed and 2 skipped.
- Real macOS arm64 application and DMG build: passed for commit
  `2ee15a131d4595f944aa175e8af69ad1f0a82514`.
- Packaged application: arm64; ad-hoc `codesign --verify --deep --strict` passed.

### Scope and coordination

This PR does **not** include:

- Herdr or any other provider-specific adapter;
- reminders, native notifications, pet copy, or pet actions;
- detached overlay/window behavior or pet controls/settings;
- SSH, socket, or network code; or
- the local-source desktop startup compatibility fix.

Open PR #61267 changes detached pet-overlay presentation. The only shared
implementation file is `apps/desktop/src/store/pet.ts`, and the two changes
merge automatically in a merge simulation. PR #61267 currently has a separate
conflict with newer upstream work in `floating-pet.tsx`; this branch does not
touch that file.

### Checklist

#### Code

- [x] I've read the Contributing Guide.
- [x] The commit follows Conventional Commits.
- [x] I searched existing issues and pull requests, including #61267 and
  #61559.
- [x] This PR contains one focused commit and no unrelated changes.
- [x] Test requirement addressed: no Python product files changed, so the
  Python suite is not applicable; desktop tests, typecheck, lint, and packaging
  were run instead.
- [x] Tests were added for the new behavior.
- [x] Tested on macOS arm64.

#### Documentation & Housekeeping

- [x] Relevant desktop SDK and skill documentation is updated.
- [x] `cli-config.yaml.example`: N/A; no configuration keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no repository workflow changed.
- [x] Cross-platform impact considered: the feature is renderer/store logic and
  introduces no platform-specific path, process, or transport behavior.
- [x] Tool descriptions/schemas: N/A; no agent tool behavior changed.

### Commit

`2ee15a131d4595f944aa175e8af69ad1f0a82514`