### PR TITLE
fix(mcp): recover from OAuth cleanup lock errors

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1973,6 +1973,71 @@ class TestHTTPConfig:
         assert captured["legacy_headers"]["MCP-Protocol-Version"] == "custom-version"
         assert "mcp-protocol-version" not in captured["legacy_headers"]
 
+    def test_http_cleanup_lock_error_reconnects_after_ready(self):
+        """An OAuth teardown error must not consume the reconnect budget."""
+        from tools.mcp_tool import MCPServerTask
+
+        class DummyAsyncClient:
+            def __init__(self, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class CleanupErrorTransportCtx:
+            async def __aenter__(self):
+                return MagicMock(), MagicMock(), (lambda: None)
+
+            async def __aexit__(self, exc_type, exc, tb):
+                raise ExceptionGroup("unhandled errors in a TaskGroup", [
+                    RuntimeError("The current task is not holding this lock"),
+                ])
+
+        class DummySession:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def initialize(self):
+                return None
+
+        async def _test():
+            server = MCPServerTask("oauth_http")
+            with patch("tools.mcp_tool._MCP_HTTP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._MCP_NEW_HTTP", True), \
+                 patch("httpx.AsyncClient", DummyAsyncClient), \
+                 patch("tools.mcp_tool.streamable_http_client", return_value=CleanupErrorTransportCtx()), \
+                 patch("tools.mcp_tool.ClientSession", DummySession), \
+                 patch.object(MCPServerTask, "_discover_tools", AsyncMock()), \
+                 patch.object(MCPServerTask, "_wait_for_lifecycle_event", AsyncMock(return_value="reconnect")):
+                assert await server._run_http({"url": "https://example.com/mcp"}) == "reconnect"
+
+        asyncio.run(_test())
+
+    def test_http_cleanup_only_ignores_the_known_lock_error(self):
+        """Other Streamable HTTP teardown failures still reach normal retry handling."""
+        from tools.mcp_tool import _is_streamable_http_cleanup_lock_error
+
+        assert _is_streamable_http_cleanup_lock_error(
+            ExceptionGroup("cleanup", [
+                RuntimeError("The current task is not holding this lock"),
+            ])
+        )
+        assert not _is_streamable_http_cleanup_lock_error(
+            ExceptionGroup("cleanup", [
+                RuntimeError("The current task is not holding this lock"),
+                OSError("socket closed"),
+            ])
+        )
+
 
 # ---------------------------------------------------------------------------
 # Reconnection logic

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -121,6 +121,24 @@ logger = logging.getLogger(__name__)
 _OSV_MALWARE_CHECK_TIMEOUT_S = 12.0
 
 
+def _is_streamable_http_cleanup_lock_error(exc: BaseException) -> bool:
+    """Return whether ``exc`` is the MCP SDK's task-ownership cleanup error.
+
+    MCP 1.26's OAuth auth-flow generator holds an anyio lock across ``yield``.
+    If httpx tears that generator down from another task, its transport context
+    can raise this error after a session was already connected.  Nested task
+    groups preserve the error inside ``BaseExceptionGroup`` on Python 3.11+.
+    """
+    if isinstance(exc, RuntimeError):
+        return "the current task is not holding this lock" in str(exc).lower()
+    if isinstance(exc, BaseExceptionGroup):
+        return bool(exc.exceptions) and all(
+            _is_streamable_http_cleanup_lock_error(child)
+            for child in exc.exceptions
+        )
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Stdio subprocess stderr redirection
 # ---------------------------------------------------------------------------
@@ -2701,30 +2719,43 @@ class MCPServerTask:
 
             # Caller owns the client lifecycle — the SDK skips cleanup when
             # http_client is provided, so we wrap in async-with.
-            async with httpx.AsyncClient(**client_kwargs) as http_client:
-                async with streamable_http_client(url, http_client=http_client) as (
-                    read_stream, write_stream, _get_session_id,
-                ):
-                    async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
-                        # Bound the handshake (#59349) — see stdio path.
-                        self.initialize_result = await asyncio.wait_for(
-                            session.initialize(), timeout=float(connect_timeout)
-                        )
-                        self.session = session
-                        await self._discover_tools()
-                        self._ready.set()
-                        # Session is live again: clear any breaker state from
-                        # a prior outage so the first call after recovery
-                        # isn't gated on a stale failure count (#16788).
-                        _reset_server_error(self.name)
-                        self._reconnect_retries = 0
-                        reason = await self._wait_for_lifecycle_event()
-                        if reason == "reconnect":
-                            logger.info(
-                                "MCP server '%s': reconnect requested — "
-                                "tearing down HTTP session", self.name,
+            try:
+                async with httpx.AsyncClient(**client_kwargs) as http_client:
+                    async with streamable_http_client(url, http_client=http_client) as (
+                        read_stream, write_stream, _get_session_id,
+                    ):
+                        async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
+                            # Bound the handshake (#59349) — see stdio path.
+                            self.initialize_result = await asyncio.wait_for(
+                                session.initialize(), timeout=float(connect_timeout)
                             )
-            return reason
+                            self.session = session
+                            await self._discover_tools()
+                            self._ready.set()
+                            # Session is live again: clear any breaker state from
+                            # a prior outage so the first call after recovery
+                            # isn't gated on a stale failure count (#16788).
+                            _reset_server_error(self.name)
+                            self._reconnect_retries = 0
+                            reason = await self._wait_for_lifecycle_event()
+                            if reason == "reconnect":
+                                logger.info(
+                                    "MCP server '%s': reconnect requested — "
+                                    "tearing down HTTP session", self.name,
+                                )
+                return reason
+            except BaseException as exc:
+                if (
+                    self._ready.is_set()
+                    and _is_streamable_http_cleanup_lock_error(exc)
+                ):
+                    logger.warning(
+                        "MCP server '%s': ignoring known Streamable HTTP "
+                        "OAuth cleanup lock error and reconnecting: %s",
+                        self.name, exc,
+                    )
+                    return "reconnect"
+                raise
         else:
             # Deprecated API (mcp < 1.24.0): manages httpx client internally.
             _http_kwargs: dict = {


### PR DESCRIPTION
## What does this PR do?

Treat the MCP SDK's known OAuth Streamable HTTP cleanup lock error as a clean reconnect only after the MCP session has become ready. This prevents a teardown race from consuming Hermes' reconnect budget and parking an otherwise recoverable server.

## Related Issue

Refs #49543
Refs #31987

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/mcp_tool.py`: recognize the specific AnyIO task-ownership cleanup error, including an all-known-error task-group wrapper, and return the existing reconnect lifecycle result after a ready Streamable HTTP session.
- `tests/tools/test_mcp_tool.py`: cover the task-group cleanup error and ensure mixed teardown failures are not suppressed.

## What changed and why

- A ready OAuth Streamable HTTP connection can fail while its context manager is closing because MCP 1.26 yields while holding an AnyIO lock. The fix contains that exact teardown failure at the HTTP boundary and lets the established reconnect path rebuild the session without incrementing its failure counter.
- Other cleanup failures, and the same error before initial readiness, still propagate to normal error handling.

## How to Test

1. Run `$VIRTUAL_ENV/bin/python -m pytest tests/tools/test_mcp_tool.py -q --timeout=60`.
2. Confirm `TestHTTPConfig.test_http_cleanup_lock_error_reconnects_after_ready` returns `reconnect` for the task-group-wrapped cleanup error.
3. Confirm the mixed-error regression test keeps unrelated transport errors on the normal retry path.

## What platforms tested on

- macOS (darwin-arm64), Python 3.11.15.
- `scripts/check-windows-footguns.py tools/mcp_tool.py tests/tools/test_mcp_tool.py` passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable.

## Test notes

- Focused changed-module suite: `216 passed` (`tests/tools/test_mcp_tool.py`).
- The bounded broad suite could not complete locally: after selecting the provided virtual environment, it stopped on two unrelated ACP approval assertions before reaching the MCP area. The broader MCP subset also hits this sandbox's loopback-socket restriction (`PermissionError: [Errno 1] Operation not permitted` in existing OAuth callback-port tests). CI should run the complete suite in its network-capable test environment.

<!-- autocontrib:worker-id=issue-new-94d9557b kind=pr-open -->