### PR TITLE
fix(gateway): make turn-lease idle predicate waiter-aware (#67401 audit follow-up)

### DIFF
--- a/gateway/turn_lease.py
+++ b/gateway/turn_lease.py
@@ -40,11 +40,14 @@ Safety properties:
 Known limits (deliberate, flagged on #64934):
 
 - A CLI process sharing the session via CLI-continuity is outside any
-  in-process lock — that pair needs a DB-level lease (separate design).
-- Mid-turn compression rotation leaves a small alias window: the tip-walk can
-  resolve a fresh child id while the parent-holding turn is still in flight.
-  The mid-turn binding-sync sites are the right place to alias the lease in a
-  follow-up.
+  in-process lock — that pair needs a DB-level lease (separate design,
+  tracked in #67442).
+
+Mid-turn compression rotation is handled: :meth:`SessionTurnLeaseRegistry.rebind`
+follows the held lease to the rotated session_id, and the gateway calls it at
+both rotation sites (session-hygiene pre-compression and the agent-result
+session_id swap). The alias window that existed before rebind was wired is
+closed.
 """
 
 import asyncio
@@ -98,18 +101,31 @@ class TurnLeaseToken:
 
 
 class _SessionLease:
-    __slots__ = ("lock", "holder", "acquired_at", "last_used")
+    __slots__ = ("lock", "holder", "acquired_at", "last_used", "waiters")
 
     def __init__(self) -> None:
         self.lock = asyncio.Lock()
         self.holder: Optional[TurnLeaseToken] = None
         self.acquired_at = 0.0
         self.last_used = time.time()
+        # Count of tasks parked in acquire()'s ``await`` for this lease.
+        # ``asyncio.Lock.release()`` clears ``_locked`` and only *schedules*
+        # the queued waiter's wake-up — the waiter sets ``_locked = True`` a
+        # loop iteration later. In that window ``holder is None`` and
+        # ``lock.locked()`` is False, so without this counter ``idle`` would
+        # briefly report an evictable lease that in fact has a turn queued
+        # behind it (audit by @hansai-art on #67401). Evicting it there would
+        # strand the woken waiter on an unregistered lease while the next
+        # acquire() mints a fresh unlocked one — two live holders on one
+        # session, exactly what this registry prevents.
+        self.waiters = 0
 
     @property
     def idle(self) -> bool:
-        """True when this lease can be evicted: nobody holds or awaits it."""
-        return self.holder is None and not self.lock.locked()
+        """True when this lease can be evicted: nobody holds, holds the lock,
+        or is parked waiting to acquire it. The ``waiters`` term is what makes
+        this predicate self-correct rather than dependent on eviction order."""
+        return self.holder is None and not self.lock.locked() and self.waiters == 0
 
 
 class SessionTurnLeaseRegistry:
@@ -187,6 +203,11 @@ class SessionTurnLeaseRegistry:
                 time.time() - lease.acquired_at if lease.acquired_at else -1.0,
             )
 
+        # Mark this task as parked on the lease for the whole await, so a
+        # concurrent eviction pass (fired from another session's acquire on
+        # the same event loop) can never drop a lease with a turn queued
+        # behind it — see ``_SessionLease.waiters``.
+        lease.waiters += 1
         try:
             await asyncio.wait_for(lease.lock.acquire(), timeout=wait)
         except asyncio.TimeoutError:
@@ -206,6 +227,8 @@ class SessionTurnLeaseRegistry:
             )
             token.degraded = True
             return token
+        finally:
+            lease.waiters -= 1
 
         lease.holder = token
         lease.acquired_at = time.time()

--- a/tests/gateway/test_turn_lease.py
+++ b/tests/gateway/test_turn_lease.py
@@ -98,6 +98,47 @@ def test_distinct_sessions_do_not_contend():
 # ---------------------------------------------------------------------------
 
 
+def test_lease_with_queued_waiter_is_not_idle_or_evicted():
+    """A lease reports non-idle while a turn is parked waiting to acquire it,
+    even in the window right after the holder releases (before the waiter's
+    wake-up runs). Guards the waiter-blind eviction hole from @hansai-art's
+    #67401 audit: without the waiters term the woken waiter would be stranded
+    on an unregistered lease while the next acquire mints a fresh one."""
+
+    async def scenario():
+        registry = SessionTurnLeaseRegistry(max_entries=1)  # forces eviction
+
+        a = await registry.acquire("S", owner_key="A", generation=1, timeout=5)
+
+        # B parks waiting for S (A still holds it).
+        b_task = asyncio.ensure_future(
+            registry.acquire("S", owner_key="B", generation=2, timeout=5)
+        )
+        await asyncio.sleep(0)  # let B reach the await
+        assert registry._leases["S"].waiters == 1
+        assert not registry._leases["S"].idle
+
+        # Release A. Now holder is None and lock may read unlocked before B's
+        # wake-up runs — but waiters==1 keeps idle False.
+        registry.release(a)
+        assert not registry._leases["S"].idle
+
+        # An eviction pass fired by a *different* session's acquire (cap=1)
+        # must NOT drop S while B is queued behind it.
+        c = await registry.acquire("OTHER", owner_key="C", generation=1, timeout=5)
+        assert "S" in registry._leases, "contended lease was wrongly evicted"
+
+        # B resumes and takes the lease under the still-registered entry.
+        b = await asyncio.wait_for(b_task, timeout=5)
+        assert b is not None and not b.degraded
+        assert registry._leases["S"].holder is b
+
+        registry.release(b)
+        registry.release(c)
+
+    _run(scenario())
+
+
 # ---------------------------------------------------------------------------
 # Mid-turn rotation rebind
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Hardens the turn-lease from #67401 against a latent invariant gap @hansai-art found auditing it, and corrects a now-stale docstring. Follow-up to #64934 / #67401.

**The gap (safe today, latent):** `_SessionLease.idle` checked only `holder is None and not lock.locked()`, but its own docstring claims "nobody holds *or awaits* it." `asyncio.Lock.release()` clears `_locked` and only *schedules* the queued waiter's wake-up — the waiter sets `_locked = True` a loop iteration later. In that window a lease with a turn parked behind it reports `idle = True`.

Today that's harmless **only** because of eviction ordering, not the predicate: `_evict_idle` drops the oldest idle entry by `last_used`, and `release()` stamps `last_used = now` immediately before unlocking, so a just-released lease is the *newest* entry exactly when it's briefly idle — it sorts last among candidates, and `overflow` is 1 at steady state. @hansai-art built a repro at the production cap (512, 511 primed idle entries) and correctly could **not** reproduce; it only "reproduces" at `max_entries=1`. The problem is that nothing states this dependency: evicting newest-first, evicting >1 per pass, or adding an idle-timeout sweep would open the hole with no test failing — the woken waiter would strand on an unregistered `_SessionLease` while the next `acquire()` for that session mints a fresh unlocked one: **two non-degraded holders on one session**, exactly what the lease exists to prevent.

**Fix:** make the predicate self-correct instead of order-dependent. A `waiters` counter on `_SessionLease` is incremented around `acquire()`'s `await` (decremented in `finally`, covering both the success and timeout paths), and `idle` now also requires `waiters == 0`. No private `asyncio.Lock._waiters` access — the honest version @hansai-art suggested. A regression test reproduces the exact window at the eviction cap: a lease with a queued waiter stays non-idle and survives an eviction pass, and the waiter then acquires the still-registered lease non-degraded.

**Docstring:** the "Known limits" block still described the mid-turn compression-rotation alias window as open with `rebind()` as a possible follow-up. `rebind()` is implemented in this file and wired at both rotation sites — the window is closed. Corrected so the next reader isn't sent after a closed gap.

Credit: the analysis, the `asyncio.Lock` timing probe, and the LRU-ordering-dependency writeup are @hansai-art's ([audit comment](https://github.com/NousResearch/hermes-agent/pull/67401#issuecomment-5016365395)).

## Related Issue

Follow-up to #64934 (closed) / #67401 (merged). Cross-process CLI-continuity lease is the separately-tracked #67442.

## Type of Change

- [x] 🐛 Bug fix (latent invariant hardening — no behavior change on the common path)

## Changes Made

- `gateway/turn_lease.py` — `_SessionLease.waiters` counter; `acquire()` increments around the await (finally-decremented); `idle` requires `waiters == 0`; "Known limits" docstring corrected to reflect `rebind()`.
- `tests/gateway/test_turn_lease.py` — `test_lease_with_queued_waiter_is_not_idle_or_evicted` reproducing the window at the cap.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_turn_lease.py` — 12 passed (11 existing + the new guard). The new test fails against the pre-fix predicate (after `release()`, `holder is None` and the lock reads unlocked, so the old `idle` returns True and the contended lease is evicted).
2. Consumers unaffected: `tests/gateway/test_conversation_scope_funnel.py`, `tests/gateway/test_64934_session_turn_lease.py`, `tests/agent/test_turn_overlap_tripwire.py` all green.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs — this is the follow-up to the #67401 audit; no competing PR
- [x] Single-topic
- [x] Test suite run — see How to Test
- [x] Tests added — the regression guard for the exact window
- [x] Tested on: Windows 11 (native)

### Documentation & Housekeeping

- [x] Documentation — corrected the in-file "Known limits" docstring
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING/AGENTS — N/A
- [x] Cross-platform — pure-Python asyncio; no platform surface
