### PR TITLE
fix(tui): keep exec quick commands off the RPC reader

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1181,6 +1181,488 @@ def test_dispatch_runs_short_handlers_inline(server):
     assert resp == {"jsonrpc": "2.0", "id": "r1", "result": {"pong": True}}
 
 
+def test_dispatch_quick_command_exec_does_not_block_fast_handler(capture, monkeypatch):
+    """An exec quick command must not monopolize the RPC reader thread."""
+    server, buf = capture
+    released = threading.Event()
+
+    def slow_run(*_args, **_kwargs):
+        released.wait(timeout=5)
+        return types.SimpleNamespace(returncode=0, stdout="done", stderr="")
+
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"quick_commands": {"slow": {"type": "exec", "command": "slow"}}},
+    )
+    monkeypatch.setattr(server.subprocess, "run", slow_run)
+    monkeypatch.setitem(
+        server._methods,
+        "fast.ping",
+        lambda rid, params: server._ok(rid, {"pong": True}),
+    )
+
+    watchdog = threading.Timer(3, released.set)
+    watchdog.start()
+    try:
+        slow_response = server.dispatch({
+            "id": "slow",
+            "method": "command.dispatch",
+            "params": {"name": "slow"},
+        })
+        fast_response = server.dispatch({
+            "id": "fast",
+            "method": "fast.ping",
+            "params": {},
+        })
+
+        assert slow_response is None
+        assert fast_response["result"] == {"pong": True}
+        assert not released.is_set()
+    finally:
+        watchdog.cancel()
+        released.set()
+
+    for _ in range(50):
+        if buf.getvalue():
+            break
+        time.sleep(0.01)
+
+    assert json.loads(buf.getvalue()) == {
+        "jsonrpc": "2.0",
+        "id": "slow",
+        "result": {"type": "exec", "output": "done"},
+    }
+
+
+def test_dispatch_non_exec_quick_command_stays_inline(server, monkeypatch):
+    """Only subprocess-backed quick commands may bypass command ordering."""
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"quick_commands": {"shortcut": {"type": "alias", "target": "/help"}}},
+    )
+
+    response = server.dispatch({
+        "id": "alias",
+        "method": "command.dispatch",
+        "params": {"name": "shortcut"},
+    })
+
+    assert response["result"] == {"type": "alias", "target": "/help"}
+
+
+def test_dispatch_alias_snapshot_survives_config_flip_to_exec(server, monkeypatch):
+    """Inline dispatch must execute the alias snapshot it classified."""
+    configs = iter([
+        {"quick_commands": {"flip": {"type": "alias", "target": "/help"}}},
+        {"quick_commands": {"flip": {"type": "exec", "command": "must-not-run"}}},
+    ])
+    loads = []
+    owner_thread = threading.get_ident()
+    real_load_cfg = server._load_cfg
+
+    def load_cfg():
+        if threading.get_ident() != owner_thread:
+            return real_load_cfg()
+        config = next(configs)
+        loads.append(config)
+        return config
+
+    real_run = server.subprocess.run
+
+    def reject_flipped_exec(command, *args, **kwargs):
+        if command == "must-not-run":
+            pytest.fail("flipped exec command ran inline")
+        return real_run(command, *args, **kwargs)
+
+    monkeypatch.setattr(server, "_load_cfg", load_cfg)
+    monkeypatch.setattr(server.subprocess, "run", reject_flipped_exec)
+
+    response = server.dispatch({
+        "id": "alias-flip",
+        "method": "command.dispatch",
+        "params": {"name": "flip"},
+    })
+
+    assert response["result"] == {"type": "alias", "target": "/help"}
+    assert len(loads) == 1
+
+
+def test_dispatch_exec_snapshot_survives_config_flip_to_alias(capture, monkeypatch):
+    """Pool dispatch must execute the exact exec snapshot it classified."""
+    server, buf = capture
+    configs = iter([
+        {"quick_commands": {"flip": {"type": "exec", "command": "original"}}},
+        {"quick_commands": {"flip": {"type": "alias", "target": "/help"}}},
+    ])
+    loads = []
+    commands = []
+    owner_thread = threading.get_ident()
+    real_load_cfg = server._load_cfg
+    real_run = server.subprocess.run
+
+    def load_cfg():
+        if threading.get_ident() != owner_thread:
+            return real_load_cfg()
+        config = next(configs)
+        loads.append(config)
+        return config
+
+    def run(command, *args, **kwargs):
+        if command == "original":
+            commands.append(command)
+            return types.SimpleNamespace(returncode=0, stdout="original-output", stderr="")
+        return real_run(command, *args, **kwargs)
+
+    monkeypatch.setattr(server, "_load_cfg", load_cfg)
+    # Execute the submitted context immediately so the exact exec→alias flip
+    # ordering is deterministic; the separate slow-command test covers that
+    # the production executor remains asynchronous.
+    monkeypatch.setattr(
+        server, "_pool", types.SimpleNamespace(submit=lambda callback: callback())
+    )
+    monkeypatch.setattr(server.subprocess, "run", run)
+
+    assert server.dispatch({
+        "id": "exec-flip",
+        "method": "command.dispatch",
+        "params": {"name": "flip"},
+    }) is None
+
+    for _ in range(50):
+        if buf.getvalue():
+            break
+        time.sleep(0.01)
+
+    assert len(loads) == 1
+    assert commands == ["original"]
+    assert json.loads(buf.getvalue()) == {
+        "jsonrpc": "2.0",
+        "id": "exec-flip",
+        "result": {"type": "exec", "output": "original-output"},
+    }
+
+
+def test_dispatch_config_load_failure_is_async_logged_and_redacted(
+    capture, monkeypatch, caplog
+):
+    """Unknown classification fails off-reader without leaking config details."""
+    server, buf = capture
+    secret = "config-parser-secret"
+
+    def load_cfg():
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr(server, "_load_cfg", load_cfg)
+    caplog.set_level("WARNING", logger="tui_gateway.server")
+
+    assert server.dispatch({
+        "id": "config-error",
+        "method": "command.dispatch",
+        "params": {"name": "unknown"},
+    }) is None
+
+    for _ in range(50):
+        if buf.getvalue():
+            break
+        time.sleep(0.01)
+
+    response = buf.getvalue()
+    assert secret not in response
+    assert secret not in caplog.text
+    assert "Failed to load config while resolving command.dispatch" in caplog.text
+    assert json.loads(response) == {
+        "jsonrpc": "2.0",
+        "id": "config-error",
+        "error": {"code": 4018, "message": "quick command config unavailable"},
+    }
+
+
+@pytest.mark.parametrize("failure", ["malformed", "io-error"])
+def test_dispatch_real_config_read_failure_is_async_tolerant_and_redacted(
+    capture, monkeypatch, caplog, tmp_path, failure
+):
+    """The production config reader must fail closed only at dispatch's boundary."""
+    server, buf = capture
+    secret = "config-parser-secret"
+    config_path = tmp_path / "config.yaml"
+    if failure == "malformed":
+        config_path.write_text(
+            f"quick_commands:\n  broken: [{secret}\n", encoding="utf-8"
+        )
+    else:
+        config_path.mkdir()
+
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    monkeypatch.setattr(server, "_cfg_cache", None)
+    monkeypatch.setattr(server, "_cfg_mtime", None)
+    monkeypatch.setattr(server, "_cfg_path", None)
+    caplog.set_level("WARNING", logger="tui_gateway.server")
+
+    # Other behavioral config consumers intentionally remain fail-open.
+    assert server._load_cfg() == {}
+
+    assert server.dispatch({
+        "id": f"real-{failure}",
+        "method": "command.dispatch",
+        "params": {"name": "unknown"},
+    }) is None
+
+    for _ in range(50):
+        if buf.getvalue():
+            break
+        time.sleep(0.01)
+
+    responses = buf.getvalue().splitlines()
+    assert len(responses) == 1
+    assert secret not in responses[0]
+    assert secret not in caplog.text
+    assert json.loads(responses[0]) == {
+        "jsonrpc": "2.0",
+        "id": f"real-{failure}",
+        "error": {"code": 4018, "message": "quick command config unavailable"},
+    }
+    assert server._propagate_quick_command_config_errors.get() is False
+    assert server._load_cfg() == {}
+
+
+def test_dispatch_real_valid_alias_config_stays_inline(capture, monkeypatch, tmp_path):
+    """Strict classification still accepts a real valid config without pool routing."""
+    server, buf = capture
+    (tmp_path / "config.yaml").write_text(
+        "quick_commands:\n  shortcut:\n    type: alias\n    target: /help\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    monkeypatch.setattr(server, "_cfg_cache", None)
+    monkeypatch.setattr(server, "_cfg_mtime", None)
+    monkeypatch.setattr(server, "_cfg_path", None)
+
+    response = server.dispatch({
+        "id": "real-alias",
+        "method": "command.dispatch",
+        "params": {"name": "shortcut"},
+    })
+
+    assert response["result"] == {"type": "alias", "target": "/help"}
+    assert buf.getvalue() == ""
+
+
+def test_dispatch_quick_command_timeout_redacts_command(capture, monkeypatch):
+    """A timed-out exec command must not disclose its configured command text."""
+    server, buf = capture
+    command = "quick-command-secret"
+
+    def timeout(*_args, **kwargs):
+        assert kwargs["timeout"] == 30
+        raise server.subprocess.TimeoutExpired(command, 30)
+
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"quick_commands": {"timeout": {"type": "exec", "command": command}}},
+    )
+    monkeypatch.setattr(server.subprocess, "run", timeout)
+
+    assert server.dispatch({
+        "id": "timeout",
+        "method": "command.dispatch",
+        "params": {"name": "timeout"},
+    }) is None
+
+    for _ in range(50):
+        if buf.getvalue():
+            break
+        time.sleep(0.01)
+
+    response = buf.getvalue()
+    assert command not in response
+    assert json.loads(response) == {
+        "jsonrpc": "2.0",
+        "id": "timeout",
+        "error": {"code": 4018, "message": "quick command timed out"},
+    }
+
+
+@pytest.mark.parametrize("failure_site", ["environment", "execution"])
+def test_dispatch_quick_command_failure_is_stable_and_redacted(
+    capture, monkeypatch, failure_site
+):
+    """Worker-side quick-command setup and execution errors never expose details."""
+    from tools.environments import local as local_environment
+
+    server, buf = capture
+    command = "quick-command-config-secret"
+    secret = f"{failure_site}-exception-secret"
+
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"quick_commands": {"broken": {"type": "exec", "command": command}}},
+    )
+    if failure_site == "environment":
+        monkeypatch.setattr(
+            local_environment,
+            "build_subprocess_env",
+            lambda: (_ for _ in ()).throw(RuntimeError(secret)),
+        )
+        monkeypatch.setattr(
+            server.subprocess,
+            "run",
+            lambda *_args, **_kwargs: pytest.fail("command ran after environment failure"),
+        )
+    else:
+        monkeypatch.setattr(
+            server.subprocess,
+            "run",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError(secret)),
+        )
+
+    assert server.dispatch({
+        "id": f"broken-{failure_site}",
+        "method": "command.dispatch",
+        "params": {"name": "broken"},
+    }) is None
+
+    for _ in range(50):
+        if buf.getvalue():
+            break
+        time.sleep(0.01)
+
+    response = buf.getvalue()
+    assert secret not in response
+    assert command not in response
+    assert json.loads(response) == {
+        "jsonrpc": "2.0",
+        "id": f"broken-{failure_site}",
+        "error": {"code": 4018, "message": "quick command failed"},
+    }
+
+
+@pytest.mark.parametrize("failure_site", ["execution", "result"])
+def test_handle_request_quick_command_failure_is_stable_and_redacted(
+    server, monkeypatch, failure_site
+):
+    """Synchronous direct callers receive the same safe execution error."""
+    command = "direct-quick-command-secret"
+    secret = f"direct-{failure_site}-error-secret"
+
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"quick_commands": {"broken": {"type": "exec", "command": command}}},
+    )
+    if failure_site == "execution":
+        run = lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError(secret))
+    else:
+        class BrokenResult:
+            @property
+            def stdout(self):
+                raise RuntimeError(secret)
+
+        run = lambda *_args, **_kwargs: BrokenResult()
+    monkeypatch.setattr(server.subprocess, "run", run)
+
+    response = server.handle_request({
+        "id": f"direct-broken-{failure_site}",
+        "method": "command.dispatch",
+        "params": {"name": "broken"},
+    })
+
+    serialized = json.dumps(response)
+    assert secret not in serialized
+    assert command not in serialized
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": f"direct-broken-{failure_site}",
+        "error": {"code": 4018, "message": "quick command failed"},
+    }
+
+
+def test_dispatch_quick_command_worker_wrapper_is_stable_and_redacted(
+    capture, monkeypatch
+):
+    """The pool's final exception boundary must never serialize exec details."""
+    server, buf = capture
+    command = "worker-wrapper-command-secret"
+    secret = "worker-wrapper-os-error-secret"
+
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"quick_commands": {"broken": {"type": "exec", "command": command}}},
+    )
+    monkeypatch.setitem(
+        server._methods,
+        "command.dispatch",
+        lambda _rid, _params: (_ for _ in ()).throw(OSError(secret)),
+    )
+
+    assert server.dispatch({
+        "id": "worker-wrapper-broken",
+        "method": "command.dispatch",
+        "params": {"name": "broken"},
+    }) is None
+
+    for _ in range(50):
+        if buf.getvalue():
+            break
+        time.sleep(0.01)
+
+    response = buf.getvalue()
+    assert secret not in response
+    assert command not in response
+    assert json.loads(response) == {
+        "jsonrpc": "2.0",
+        "id": "worker-wrapper-broken",
+        "error": {"code": 4018, "message": "quick command failed"},
+    }
+
+
+def test_dispatch_quick_command_pool_rejection_fails_inline_and_redacted(
+    server, monkeypatch, caplog
+):
+    """Executor shutdown must not run an exec command or orphan its response."""
+    command = "must-not-run"
+    secret = "pool-rejection-secret"
+
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"quick_commands": {"blocked": {"type": "exec", "command": command}}},
+    )
+    monkeypatch.setattr(
+        server,
+        "_pool",
+        types.SimpleNamespace(
+            submit=lambda _callback: (_ for _ in ()).throw(RuntimeError(secret))
+        ),
+    )
+    monkeypatch.setattr(
+        server.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("rejected command was executed"),
+    )
+    caplog.set_level("WARNING", logger="tui_gateway.server")
+
+    response = server.dispatch({
+        "id": "pool-rejected",
+        "method": "command.dispatch",
+        "params": {"name": "blocked"},
+    })
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": "pool-rejected",
+        "error": {"code": -32000, "message": "handler unavailable"},
+    }
+    assert secret not in caplog.text
+    assert command not in caplog.text
+    assert "RPC worker unavailable; rejecting request" in caplog.text
+    assert server._resolved_quick_command.get() is None
+
+
 @pytest.mark.parametrize("completion_method", ["complete.path", "complete.slash"])
 def test_completion_handlers_are_pool_routed(completion_method, server):
     """complete.path/complete.slash must run on the pool, never the reader thread.

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -431,25 +431,30 @@ def _(rid, params: dict) -> dict:
 
 @method("command.dispatch")
 def _(rid, params: dict) -> dict:
-    name, arg = params.get("name", "").lstrip("/"), params.get("arg", "")
-    resolved = _resolve_name(name)
-    if resolved != name:
-        name = resolved
+    arg = params.get("arg", "")
+    quick_command = _resolved_quick_command.get()
+    if quick_command is None:
+        # Direct handle_request() callers do not pass through dispatch(), so
+        # resolve once here. Normal RPCs always consume dispatch's snapshot.
+        quick_command = _resolve_quick_command(params)
+    name = quick_command.name
     session = _sessions.get(params.get("session_id", ""))
 
-    qcmds = _load_cfg().get("quick_commands", {})
-    if name in qcmds:
-        qc = qcmds[name]
-        if qc.get("type") == "exec":
-            # Sanitize env to prevent credential leakage —
-            # quick commands run in the TUI server process which
-            # has all API keys in os.environ.
+    if quick_command.config_error:
+        return _err(rid, 4018, "quick command config unavailable")
+    if quick_command.kind == "exec":
+        try:
+            # Sanitize env to prevent credential leakage — quick commands run
+            # in the TUI server process which has all API keys in os.environ.
+            # Keep the whole setup/execute/result boundary guarded: import,
+            # platform, decoding, and redaction failures may all carry details.
             from tools.environments.local import build_subprocess_env
+
             sanitized_env = build_subprocess_env()
             from hermes_cli._subprocess_compat import windows_hide_flags
 
             r = subprocess.run(
-                qc.get("command", ""),
+                quick_command.command,
                 shell=True,
                 capture_output=True,
                 text=True,
@@ -468,6 +473,7 @@ def _(rid, params: dict) -> dict:
             ).strip()[:4000]
             if output:
                 from agent.redact import redact_sensitive_text
+
                 output = redact_sensitive_text(output)
             if r.returncode != 0:
                 return _err(
@@ -476,8 +482,12 @@ def _(rid, params: dict) -> dict:
                     output or f"quick command failed with exit code {r.returncode}",
                 )
             return _ok(rid, {"type": "exec", "output": output})
-        if qc.get("type") == "alias":
-            return _ok(rid, {"type": "alias", "target": qc.get("target", "")})
+        except subprocess.TimeoutExpired:
+            return _err(rid, 4018, "quick command timed out")
+        except Exception:
+            return _err(rid, 4018, "quick command failed")
+    if quick_command.kind == "alias":
+        return _ok(rid, {"type": "alias", "target": quick_command.target})
 
     try:
         from hermes_cli.plugins import (

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2460,6 +2460,72 @@ def _current_session_steer_authority(
         return transport, session
 
 
+class _ResolvedQuickCommand(NamedTuple):
+    """Immutable command.dispatch classification shared with its handler."""
+
+    name: str
+    kind: str | None
+    command: str = ""
+    target: str = ""
+    config_error: bool = False
+
+
+_resolved_quick_command: contextvars.ContextVar[_ResolvedQuickCommand | None] = (
+    contextvars.ContextVar("resolved_quick_command", default=None)
+)
+_propagate_quick_command_config_errors: contextvars.ContextVar[bool] = (
+    contextvars.ContextVar("propagate_quick_command_config_errors", default=False)
+)
+
+
+def _resolve_quick_command(params: dict) -> _ResolvedQuickCommand:
+    name = _resolve_name(params.get("name", "").lstrip("/"))
+    config_error_token = _propagate_quick_command_config_errors.set(True)
+    try:
+        # Classification is the one config read that must distinguish an
+        # absent config from an unreadable one: treating the latter as an
+        # empty mapping could run a newly configured exec command inline.
+        cfg = _load_cfg()
+    except Exception:
+        # Do not include parser exception text: malformed config may contain
+        # credentials. The client receives a similarly fixed, redacted error.
+        logger.warning(
+            "Failed to load config while resolving command.dispatch; routing request to worker"
+        )
+        return _ResolvedQuickCommand(name=name, kind=None, config_error=True)
+    finally:
+        _propagate_quick_command_config_errors.reset(config_error_token)
+
+    quick_commands = cfg.get("quick_commands", {})
+    quick_command = quick_commands.get(name) if isinstance(quick_commands, dict) else None
+    if not isinstance(quick_command, dict):
+        return _ResolvedQuickCommand(name=name, kind=None)
+
+    kind = quick_command.get("type")
+    command = quick_command.get("command", "")
+    target = quick_command.get("target", "")
+    return _ResolvedQuickCommand(
+        name=name,
+        kind=kind if isinstance(kind, str) else None,
+        command=command if isinstance(command, str) else "",
+        target=target if isinstance(target, str) else "",
+    )
+
+
+def _is_pool_routed_request(
+    method: str, quick_command: _ResolvedQuickCommand | None = None
+) -> bool:
+    if method in _LONG_HANDLERS:
+        return True
+    if method != "command.dispatch":
+        return False
+    # A failed config read cannot prove the request is safe to run inline.
+    # Keep it off the reader and let the worker return the redacted error.
+    return quick_command is not None and (
+        quick_command.kind == "exec" or quick_command.config_error
+    )
+
+
 def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
     """Route inbound RPCs — long handlers to the pool, everything else inline.
 
@@ -2474,13 +2540,19 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
     """
     t = transport or _stdio_transport
     token = bind_transport(t)
+    quick_command_token = None
     try:
         normalized = _normalize_request(req)
         if isinstance(normalized, dict):
             return normalized
 
         _rid, method, _params = normalized
-        if method not in _LONG_HANDLERS:
+        quick_command = None
+        if method == "command.dispatch":
+            quick_command = _resolve_quick_command(_params)
+            quick_command_token = _resolved_quick_command.set(quick_command)
+
+        if not _is_pool_routed_request(method, quick_command):
             return handle_request(req)
 
         # Snapshot the context so the pool worker sees the bound transport.
@@ -2490,14 +2562,29 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
             try:
                 resp = handle_request(req)
             except Exception as exc:
-                resp = _err(req.get("id"), -32000, f"handler error: {exc}")
+                if quick_command is not None and quick_command.kind == "exec":
+                    # Defense in depth: the command handler redacts its own
+                    # setup/execution failures, but no later regression may
+                    # expose command, config, or exception details here.
+                    resp = _err(req.get("id"), 4018, "quick command failed")
+                else:
+                    resp = _err(req.get("id"), -32000, f"handler error: {exc}")
             if resp is not None:
                 t.write(resp)
 
-        _pool.submit(lambda: ctx.run(run))
+        try:
+            _pool.submit(lambda: ctx.run(run))
+        except RuntimeError:
+            # ThreadPoolExecutor rejects submissions during interpreter/server
+            # shutdown. Fail this request once, inline, without running a
+            # subprocess on the reader or retaining exception text.
+            logger.warning("RPC worker unavailable; rejecting request")
+            return _err(req.get("id"), -32000, "handler unavailable")
 
         return None
     finally:
+        if quick_command_token is not None:
+            _resolved_quick_command.reset(quick_command_token)
         reset_transport(token)
 
 
@@ -3815,7 +3902,7 @@ def _load_dashboard_process_isolation_config(cfg: dict | None = None) -> dict[st
     }
 
 
-def _load_cfg_raw() -> dict:
+def _load_cfg_raw(*, raise_on_error: bool = False) -> dict:
     """Read the active profile's config.yaml EXACTLY as written (write-back primitive).
 
     ONLY legal for read→mutate→``_save_cfg`` round-trips (and raw-file
@@ -3833,11 +3920,15 @@ def _load_cfg_raw() -> dict:
         override = get_hermes_home_override()
         home = override if isinstance(override, str) and override else _hermes_home
         p = Path(home) / "config.yaml"
-        mtime = p.stat().st_mtime if p.exists() else None
+        try:
+            stat_result = p.stat()
+        except FileNotFoundError:
+            stat_result = None
+        mtime = stat_result.st_mtime if stat_result is not None else None
         with _cfg_lock:
             if _cfg_cache is not None and _cfg_mtime == mtime and _cfg_path == p:
                 return copy.deepcopy(_cfg_cache)
-        if p.exists():
+        if stat_result is not None:
             from hermes_cli.config import read_user_config_raw
             data = read_user_config_raw(p)
         else:
@@ -3852,7 +3943,8 @@ def _load_cfg_raw() -> dict:
             _cfg_path = p
         return data
     except Exception:
-        pass
+        if raise_on_error:
+            raise
     return {}
 
 
@@ -3867,9 +3959,14 @@ def _load_cfg() -> dict:
     would also break ``_load_cfg() == {}`` sentinels). Do NOT pass the
     result to ``_save_cfg``: use ``_load_cfg_raw()`` for write-back
     round-trips or expanded/overlaid values get persisted into the user's
-    file.
+    file. Malformed/unreadable config remains intentionally fail-open for the
+    existing behavioral consumers. The command-dispatch classifier binds a
+    short-lived ContextVar so only that security boundary propagates failures
+    and can distinguish an absent file from a failed read.
     """
-    cfg = _apply_managed(_load_cfg_raw())
+    cfg = _apply_managed(
+        _load_cfg_raw(raise_on_error=_propagate_quick_command_config_errors.get())
+    )
     try:
         from hermes_cli.config import _expand_env_vars
 


### PR DESCRIPTION
## What does this PR do?

Fixes #67627.

`command.dispatch` previously ran subprocess-backed quick commands on the TUI gateway RPC reader. A slow command could therefore prevent subsequent fast RPCs from being read. This change routes resolved `exec` quick commands and configuration-classification failures to the existing worker pool, while aliases and safe non-exec commands remain inline to preserve exact command ordering.

## Related Issue

Fixes #67627

## Type of Change

- [x] 🐛 Bug fix
- [x] ✅ Tests

## Changes Made

- Resolves a quick command once into an immutable snapshot, preventing configuration TOCTOU changes between classification and execution.
- Propagates the resolved snapshot through `ContextVar` into worker execution.
- Keeps subprocess-backed commands and config-read failures off the RPC reader.
- Preserves inline execution and ordering for aliases and non-exec quick commands.
- Bounds subprocess execution to 30 seconds.
- Returns stable redacted errors for configuration, execution, result-processing, worker rejection, and shutdown failures.
- Preserves a distinct redacted timeout response.
- Ensures exactly one RPC response and prevents exception, command, or configuration details from leaking.

## Verification

Exact reviewed commit: `d60aaba9016ec00edc7d7be18f12959f05ec97eb`

- `tests/tui_gateway/test_protocol.py`: **81 passed**
- Focused dispatch/config/error cases: **12 passed, 69 deselected**
- Adjacent quick-command/dispatch tests: **5 passed**
- Ruff: **passed**
- `compileall`: **passed**
- `git diff --check`: **passed**
- Exact-SHA Specification review: **PASS**, no findings
- Exact-SHA Standards review: **PASS**, no findings

Deterministic regressions cover blocking commands, immutable resolution, configuration failures, secret-bearing `OSError`/`RuntimeError`, result-processing failures, direct `handle_request`, generic worker failures, timeout behavior, and executor shutdown.

## Checklist

- [x] Focused tests pass
- [x] Tests added for the bug and failure boundaries
- [x] Cross-platform subprocess behavior considered
- [x] No configuration or RPC schema changes
- [x] Change is limited to the TUI quick-command dispatch path
