### PR TITLE
fix(agent): fold Gemma 4 channel-thought reasoning into the collapsible Thinking section

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -737,7 +737,14 @@ def init_agent(
     # '<think>' as delta1 and 'Let me check' as delta2 — the regex
     # erased delta1, so downstream state machines never learned a
     # block was open and leaked delta2 as content).
-    agent._stream_think_scrubber = StreamingThinkScrubber()
+    # Suppressed block content is routed to the agent's reasoning delta
+    # callback so GUIs render inline reasoning (Gemma 4 channel-thought,
+    # MiniMax <think>, …) in their collapsible Thinking section — the
+    # same display structured reasoning_content providers get.  Late-bound
+    # via getattr so a partially-initialised agent can't crash the sink.
+    agent._stream_think_scrubber = StreamingThinkScrubber(
+        on_reasoning=lambda text: getattr(agent, "_fire_reasoning_delta")(text),
+    )
     # Visible assistant text already delivered through live token callbacks
     # during the current model response. Used to avoid re-sending the same
     # commentary when the provider later returns it as a completed interim

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -658,8 +658,9 @@ def strip_think_blocks(agent, content: str) -> str:
          `` <think>`` in prose aren't over-stripped.
       3. Stray orphan open/close tags that slip through.
       4. Tag variants: `` <think>``, ``<thinking>``, ``<reasoning>``,
-         ``<REASONING_SCRATCHPAD>``, ``<thought>`` (Gemma 4), all
-         case-insensitive.
+         ``<REASONING_SCRATCHPAD>``, ``<thought>``, and the asymmetric
+         Gemma 4 channel pair ``<|channel>thought`` … ``<channel|>``,
+         all case-insensitive.
 
     Additionally strips standalone tool-call XML blocks that some open
     models (notably Gemma variants on OpenRouter) emit inside assistant
@@ -718,6 +719,11 @@ def strip_think_blocks(agent, content: str) -> str:
     content = re.sub(r'<reasoning>.*?</reasoning>', '', content, flags=re.DOTALL | re.IGNORECASE)
     content = re.sub(r'<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>', '', content, flags=re.DOTALL | re.IGNORECASE)
     content = re.sub(r'<thought>.*?</thought>', '', content, flags=re.DOTALL | re.IGNORECASE)
+    # Gemma 4 channel-thought pair (<|channel>thought … <channel|>).
+    # Asymmetric open/close, so it gets its own pattern. Also matches the
+    # empty block Gemma emits when thinking is disabled
+    # (<|channel>thought\n<channel|>).
+    content = re.sub(r'<\|channel>thought.*?<channel\|>', '', content, flags=re.DOTALL | re.IGNORECASE)
     # 1b. Tool-call XML blocks (openclaw/openclaw#67318). Handle the
     #     generic tag names first — they have no attribute gating since
     #     a literal <tool_call> in prose is already vanishingly rare.
@@ -752,9 +758,24 @@ def strip_think_blocks(agent, content: str) -> str:
         content,
         flags=re.DOTALL | re.IGNORECASE,
     )
+    # 2b. Unterminated Gemma 4 channel-thought block at a boundary —
+    #     e.g. the stream was cut before <channel|> arrived.
+    content = re.sub(
+        r'(?:^|\n)[ \t]*<\|channel>thought.*$',
+        '',
+        content,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
     # 3. Stray orphan open/close tags that slipped through.
     content = re.sub(
         r'</?(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>\s*',
+        '',
+        content,
+        flags=re.IGNORECASE,
+    )
+    # 3a. Stray Gemma 4 channel tags (either half of the pair).
+    content = re.sub(
+        r'(?:<\|channel>thought|<channel\|>)\s*',
         '',
         content,
         flags=re.IGNORECASE,
@@ -1499,6 +1520,12 @@ def extract_reasoning(agent, assistant_message) -> Optional[str]:
             r"<thought>(.*?)</thought>",
             r"<reasoning>(.*?)</reasoning>",
             r"<REASONING_SCRATCHPAD>(.*?)</REASONING_SCRATCHPAD>",
+            # Gemma 4 channel-thought pair: <|channel>thought\n…<channel|>
+            # (asymmetric — see the Gemma 4 model card, "Thinking Mode
+            # Configuration"). Capturing it here is what lets GUIs fold
+            # Gemma's inline reasoning the same way Qwen's <think> blocks
+            # are folded.
+            r"<\|channel>thought(.*?)<channel\|>",
         )
         for pattern in inline_patterns:
             flags = re.DOTALL | re.IGNORECASE

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7538,12 +7538,23 @@ def extract_content_or_reasoning(response) -> str:
     content = (msg.content or "").strip()
 
     if content:
-        # Strip inline think/reasoning blocks (mirrors _strip_think_blocks)
+        # Strip inline think/reasoning blocks (mirrors _strip_think_blocks).
+        # Two passes: symmetric <tag>...</tag> variants, then the
+        # asymmetric Gemma 4 channel-thought pair
+        # (<|channel>thought…<channel|> — see the Gemma 4 model card,
+        # "Thinking Mode Configuration"). The close tag doesn't start
+        # with "</" so it can't share the symmetric pattern, and actual
+        # model output glues the open tag straight to the reasoning
+        # text with no separator, so no \b word boundary is used.
         cleaned = re.sub(
             r"<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>"
             r".*?"
             r"</(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>",
             "", content, flags=re.DOTALL | re.IGNORECASE,
+        )
+        cleaned = re.sub(
+            r"<\|channel>thought.*?<channel\|>",
+            "", cleaned, flags=re.DOTALL | re.IGNORECASE,
         ).strip()
         if cleaned:
             return cleaned

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2796,17 +2796,27 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # content should still reach the display — otherwise the
                 # reasoning box only appears as a post-response fallback,
                 # rendering it confusingly after the already-streamed
-                # response.  Route suppressed content through the stream
-                # delta callback so its tag extraction can fire the
-                # reasoning display.  Non-reasoning text is harmlessly
-                # suppressed by the CLI's _stream_delta when the stream
-                # box is already closed (tool boundary flush).
-                elif agent.stream_delta_callback:
-                    try:
-                        agent.stream_delta_callback(delta.content)
-                        agent._record_streamed_assistant_text(delta.content)
-                    except Exception:
-                        pass
+                # response.
+                #
+                # Route suppressed content through the shared
+                # StreamingThinkScrubber (agent._stream_think_scrubber)
+                # rather than calling stream_delta_callback directly.
+                # The scrubber's on_reasoning sink is what fires
+                # reasoning.delta to the TUI gateway (tui_gateway/server.py
+                # reasoning_callback) — a direct callback call bypasses it
+                # entirely, so tag extraction never reaches that path even
+                # though CLI's own _stream_delta happens to re-derive it
+                # locally. Discard the scrubber's visible-text return value
+                # here: ordinary commentary must stay suppressed while tool
+                # calls are streaming, only the reasoning it captures should
+                # escape.
+                else:
+                    think_scrubber = getattr(agent, "_stream_think_scrubber", None)
+                    if think_scrubber is not None:
+                        try:
+                            think_scrubber.feed(delta.content)
+                        except Exception:
+                            pass
 
             # Accumulate tool call deltas — notify display on first name
             if delta and delta.tool_calls:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4520,7 +4520,9 @@ def run_conversation(
                 _think_text = assistant_message.content.strip()
                 # Strip reasoning XML tags that shouldn't leak to parent display
                 _think_text = re.sub(
-                    r'</?(?:REASONING_SCRATCHPAD|think|reasoning)>', '', _think_text
+                    r'</?(?:REASONING_SCRATCHPAD|think|reasoning)>'
+                    r'|<\|channel>thought|<channel\|>',
+                    '', _think_text
                 ).strip()
                 # For subagents: relay first line to parent display (existing behaviour).
                 # For all agents with a structured callback: emit reasoning.available event.

--- a/agent/think_scrubber.py
+++ b/agent/think_scrubber.py
@@ -42,7 +42,8 @@ stream cannot taint the next turn's output.
 
 Tag variants handled (case-insensitive):
   ``<think>``, ``<thinking>``, ``<reasoning>``, ``<thought>``,
-  ``<REASONING_SCRATCHPAD>``.
+  ``<REASONING_SCRATCHPAD>``, and the asymmetric Gemma 4 channel pair
+  ``<|channel>thought`` … ``<channel|>``.
 
 Block-boundary rule for opens: an opening tag is only treated as a
 reasoning-block opener when it appears at the start of the stream,
@@ -84,18 +85,50 @@ class StreamingThinkScrubber:
         "REASONING_SCRATCHPAD",
     )
 
+    # Gemma 4 emits reasoning between an asymmetric tag pair:
+    #   <|channel>thought\n[Internal reasoning]<channel|>
+    # (see the Gemma 4 model card, "Thinking Mode Configuration").
+    # The pair is appended to the symmetric tag tuples below; because
+    # every pairing consumer zips _OPEN_TAGS with _CLOSE_TAGS, the
+    # asymmetric pair slots in without special-casing the state machine.
+    _GEMMA_CHANNEL_OPEN: str = "<|channel>thought"
+    _GEMMA_CHANNEL_CLOSE: str = "<channel|>"
+
     # Materialise literal tag strings so the hot path does string
     # operations, not regex compilation per feed().
-    _OPEN_TAGS: Tuple[str, ...] = tuple(f"<{name}>" for name in _OPEN_TAG_NAMES)
-    _CLOSE_TAGS: Tuple[str, ...] = tuple(f"</{name}>" for name in _OPEN_TAG_NAMES)
+    _OPEN_TAGS: Tuple[str, ...] = tuple(
+        f"<{name}>" for name in _OPEN_TAG_NAMES
+    ) + (_GEMMA_CHANNEL_OPEN,)
+    _CLOSE_TAGS: Tuple[str, ...] = tuple(
+        f"</{name}>" for name in _OPEN_TAG_NAMES
+    ) + (_GEMMA_CHANNEL_CLOSE,)
 
     # Pre-compute the longest tag (for partial-tag hold-back bound).
     _MAX_TAG_LEN: int = max(len(tag) for tag in _OPEN_TAGS + _CLOSE_TAGS)
 
-    def __init__(self) -> None:
+    def __init__(self, on_reasoning=None) -> None:
+        """``on_reasoning``: optional callable invoked with each chunk of
+        suppressed block content as it is discarded from the visible
+        stream.  Wired to the agent's reasoning delta callback so GUIs
+        (desktop, TUI) can render inline reasoning in their collapsible
+        Thinking section — matching the display models get when the
+        provider returns structured ``reasoning_content`` instead of
+        inline tags.  Errors in the sink are swallowed; reasoning
+        display must never break content streaming.
+        """
+        self._on_reasoning = on_reasoning
         self._in_block: bool = False
         self._buf: str = ""
         self._last_emitted_ended_newline: bool = True
+
+    def _emit_reasoning(self, text: str) -> None:
+        """Send suppressed block content to the reasoning sink, if any."""
+        if not text or self._on_reasoning is None:
+            return
+        try:
+            self._on_reasoning(text)
+        except Exception:
+            pass
 
     def reset(self) -> None:
         """Reset all state.  Call at the top of every new turn."""
@@ -124,11 +157,15 @@ class StreamingThinkScrubber:
                 )
                 if close_idx == -1:
                     # No close yet — hold back a potential partial
-                    # close-tag prefix; discard everything else.
+                    # close-tag prefix; route everything else to the
+                    # reasoning sink instead of the visible stream.
                     held = self._max_partial_suffix(buf, self._CLOSE_TAGS)
                     self._buf = buf[-held:] if held else ""
+                    self._emit_reasoning(buf[:-held] if held else buf)
                     return "".join(out)
-                # Found close: discard block content + tag, continue.
+                # Found close: route block content to the reasoning
+                # sink, discard the tag, continue.
+                self._emit_reasoning(buf[:close_idx])
                 buf = buf[close_idx + close_len:]
                 self._in_block = False
             else:
@@ -149,7 +186,7 @@ class StreamingThinkScrubber:
                 if pair is not None and (
                     open_idx == -1 or pair[0] <= open_idx
                 ):
-                    start_idx, end_idx = pair
+                    start_idx, inner_start, inner_end, end_idx = pair
                     preceding = buf[:start_idx]
                     if preceding:
                         preceding = self._strip_orphan_close_tags(preceding)
@@ -158,6 +195,8 @@ class StreamingThinkScrubber:
                             self._last_emitted_ended_newline = (
                                 preceding.endswith("\n")
                             )
+                    # Route the pair's inner content to the reasoning sink.
+                    self._emit_reasoning(buf[inner_start:inner_end])
                     buf = buf[end_idx:]
                     continue
 
@@ -217,6 +256,12 @@ class StreamingThinkScrubber:
         visible reply.
         """
         if self._in_block:
+            # Unterminated block at end of stream — route the held-back
+            # tail to the reasoning sink (it's block content that turned
+            # out not to be a close-tag prefix) and never let it reach
+            # the visible reply: leaking partial reasoning is worse
+            # than a truncated answer.
+            self._emit_reasoning(self._buf)
             self._buf = ""
             self._in_block = False
             # Next feed() is a new stream — start-of-stream is a boundary.
@@ -253,31 +298,33 @@ class StreamingThinkScrubber:
         return best_idx, best_len
 
     def _find_earliest_closed_pair(self, buf: str):
-        """Return (start_idx, end_idx) of the earliest closed pair, else None.
+        """Return (start_idx, inner_start, inner_end, end_idx) of the
+        earliest closed pair, else None.
 
-        A closed pair is ``<tag>...</tag>`` of any variant.  Matches are
-        case-insensitive and non-greedy (the closest close tag after
-        an open tag wins), matching the regex ``<tag>.*?</tag>``
-        semantics of ``_strip_think_blocks`` case 1.  When two tag
-        variants could both match, the one whose open tag appears
-        earlier wins.
+        A closed pair is ``<tag>...</tag>`` of any variant (including the
+        asymmetric Gemma 4 channel pair).  ``inner_start:inner_end`` spans
+        the block content between the tags so it can be routed to the
+        reasoning sink.  Matches are case-insensitive and non-greedy (the
+        closest close tag after an open tag wins), matching the regex
+        ``<tag>.*?</tag>`` semantics of ``_strip_think_blocks`` case 1.
+        When two tag variants could both match, the one whose open tag
+        appears earlier wins.
         """
         buf_lower = buf.lower()
-        best: "tuple[int, int] | None" = None
+        best: "tuple[int, int, int, int] | None" = None
         for open_tag, close_tag in zip(self._OPEN_TAGS, self._CLOSE_TAGS):
             open_lower = open_tag.lower()
             close_lower = close_tag.lower()
             open_idx = buf_lower.find(open_lower)
             if open_idx == -1:
                 continue
-            close_idx = buf_lower.find(
-                close_lower, open_idx + len(open_lower),
-            )
+            inner_start = open_idx + len(open_lower)
+            close_idx = buf_lower.find(close_lower, inner_start)
             if close_idx == -1:
                 continue
             end_idx = close_idx + len(close_lower)
             if best is None or open_idx < best[0]:
-                best = (open_idx, end_idx)
+                best = (open_idx, inner_start, close_idx, end_idx)
         return best
 
     def _find_open_at_boundary(
@@ -369,15 +416,19 @@ class StreamingThinkScrubber:
         An orphan close tag has no matching open in the current
         scrubber state; it's always noise, stripped with any trailing
         whitespace so the surrounding prose flows naturally.
+
+        Note: not every close tag starts with ``</`` — the Gemma 4
+        channel close is ``<channel|>`` — so matching is anchored on
+        ``<`` rather than ``</``.
         """
-        if "</" not in text:
+        if "<" not in text:
             return text
         text_lower = text.lower()
         out: list[str] = []
         i = 0
         while i < len(text):
             matched = False
-            if text_lower[i:i + 2] == "</":
+            if text_lower[i] == "<":
                 for tag in cls._CLOSE_TAGS:
                     tag_lower = tag.lower()
                     tag_len = len(tag_lower)

--- a/cli.py
+++ b/cli.py
@@ -215,6 +215,27 @@ def _strip_reasoning_tags(text: str) -> str:
     openclaw/openclaw#67318.
     """
     cleaned = text
+    # Gemma 4 channel-thought pair (<|channel>thought … <channel|>) is
+    # asymmetric, so it can't ride the symmetric <tag>…</tag> loop below.
+    # Same three cases: closed pair, unterminated open, stray orphan tags.
+    cleaned = re.sub(
+        r"<\|channel>thought.*?<channel\|>\s*",
+        "",
+        cleaned,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    cleaned = re.sub(
+        r"<\|channel>thought.*$",
+        "",
+        cleaned,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    cleaned = re.sub(
+        r"(?:<\|channel>thought|<channel\|>)\s*",
+        "",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
     for tag in _REASONING_TAGS:
         # Closed pair — case-insensitive so <THINK>…</THINK> is handled too.
         cleaned = re.sub(
@@ -5677,8 +5698,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # suppress them during streaming too — unless show_reasoning is
         # enabled, in which case we route the inner content to the
         # reasoning display box instead of discarding it.
-        _OPEN_TAGS = ("<REASONING_SCRATCHPAD>", "<think>", "<reasoning>", "<THINKING>", "<thinking>", "<thought>")
-        _CLOSE_TAGS = ("</REASONING_SCRATCHPAD>", "</think>", "</reasoning>", "</THINKING>", "</thinking>", "</thought>")
+        # Last entry is the asymmetric Gemma 4 channel-thought pair
+        # (<|channel>thought … <channel|>) — the state machine matches
+        # opens and closes independently, so asymmetry is fine here.
+        _OPEN_TAGS = ("<REASONING_SCRATCHPAD>", "<think>", "<reasoning>", "<THINKING>", "<thinking>", "<thought>", "<|channel>thought")
+        _CLOSE_TAGS = ("</REASONING_SCRATCHPAD>", "</think>", "</reasoning>", "</THINKING>", "</thinking>", "</thought>", "<channel|>")
 
         # Append to a pre-filter buffer first
         self._stream_prefilt = getattr(self, "_stream_prefilt", "") + text

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -102,13 +102,18 @@ class GatewayStreamConsumer:
     # Reasoning/thinking tags that models emit inline in content.
     # Must stay in sync with cli.py _OPEN_TAGS/_CLOSE_TAGS and
     # run_agent.py _strip_think_blocks() tag variants.
+    # The final entry is the asymmetric Gemma 4 channel-thought pair
+    # (<|channel>thought … <channel|>); its close tag does NOT start
+    # with "</", so orphan-close matching below anchors on "<".
     _OPEN_THINK_TAGS = (
         "<REASONING_SCRATCHPAD>", "<think>", "<reasoning>",
         "<THINKING>", "<thinking>", "<thought>",
+        "<|channel>thought",
     )
     _CLOSE_THINK_TAGS = (
         "</REASONING_SCRATCHPAD>", "</think>", "</reasoning>",
         "</THINKING>", "</thinking>", "</thought>",
+        "<channel|>",
     )
 
     # Class-wide monotonic counter for native-streaming draft ids.  Telegram
@@ -504,14 +509,14 @@ class GatewayStreamConsumer:
         An orphan close tag is always noise — stripped along with any
         trailing whitespace so surrounding prose flows naturally.
         """
-        if "</" not in text:
+        if "<" not in text:
             return text
         text_lower = text.lower()
         out: list[str] = []
         i = 0
         while i < len(text):
             matched = False
-            if text_lower[i:i + 2] == "</":
+            if text_lower[i] == "<":
                 for tag in cls._CLOSE_THINK_TAGS:
                     tag_lower = tag.lower()
                     tag_len = len(tag_lower)

--- a/tests/agent/test_gemma_channel_thought_tags.py
+++ b/tests/agent/test_gemma_channel_thought_tags.py
@@ -1,0 +1,225 @@
+"""Gemma 4 channel-thought tag handling across every strip/extract layer.
+
+Gemma 4 embeds reasoning in assistant content using an asymmetric tag
+pair (model card, "Thinking Mode Configuration"):
+
+    <|channel>thought\n[Internal reasoning]<channel|>Final answer
+
+Before this change the pair was unknown to every suppression layer, so
+the raw tags and the full reasoning text leaked into the visible reply
+instead of being folded into the Thinking section like Qwen's
+<think>…</think> blocks are.
+
+These tests cover the non-streaming layers (the streaming scrubber is
+covered in test_think_scrubber.py::TestGemmaChannelThought):
+
+* ``agent.agent_runtime_helpers.strip_think_blocks`` — storage-boundary
+  strip that cleans persisted assistant content.
+* ``agent.agent_runtime_helpers.extract_reasoning`` — inline fallback
+  that lifts the reasoning into the ``reasoning`` field, which is what
+  GUIs render as the collapsible Thinking block.
+* ``cli._strip_reasoning_tags`` — the CLI's standalone display strip.
+* ``gateway.stream_consumer.GatewayStreamConsumer`` tag tuples — the
+  progressive-edit filter's open/close lists must include the pair.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agent.agent_runtime_helpers import extract_reasoning, strip_think_blocks
+from cli import _strip_reasoning_tags
+
+
+GEMMA_OUTPUT = (
+    "<|channel>thought\n"
+    "The user wants me to write a Hello World program in Go. "
+    "I have already written the file hello.go using write_file. "
+    "However, the go version command failed earlier."
+    "<channel|>"
+    "Go言語は現在インストールされていないようです。"
+)
+
+
+def _agent() -> SimpleNamespace:
+    """Minimal agent stand-in for the helper signatures."""
+    return SimpleNamespace(verbose_logging=False)
+
+
+class TestStripThinkBlocks:
+    def test_closed_pair_stripped(self) -> None:
+        assert (
+            strip_think_blocks(_agent(), GEMMA_OUTPUT)
+            == "Go言語は現在インストールされていないようです。"
+        )
+
+    def test_empty_thought_block_thinking_disabled(self) -> None:
+        content = "<|channel>thought\n<channel|>Final answer"
+        assert strip_think_blocks(_agent(), content) == "Final answer"
+
+    def test_unterminated_open_at_start_stripped_to_end(self) -> None:
+        content = "<|channel>thought\nreasoning that never closes"
+        assert strip_think_blocks(_agent(), content).strip() == ""
+
+    def test_unterminated_open_after_newline_keeps_prior_text(self) -> None:
+        content = "Visible text.\n<|channel>thought\nleaked reasoning"
+        assert strip_think_blocks(_agent(), content).strip() == "Visible text."
+
+    def test_orphan_close_tag_stripped(self) -> None:
+        content = "Hello <channel|>world"
+        assert strip_think_blocks(_agent(), content) == "Hello world"
+
+    def test_case_insensitive(self) -> None:
+        content = "<|CHANNEL>Thought\nx<CHANNEL|>Answer"
+        assert strip_think_blocks(_agent(), content) == "Answer"
+
+    def test_symmetric_variants_unaffected(self) -> None:
+        content = "<think>a</think>Answer"
+        assert strip_think_blocks(_agent(), content) == "Answer"
+
+
+class TestExtractReasoning:
+    def test_inline_channel_block_lifted_into_reasoning(self) -> None:
+        msg = SimpleNamespace(content=GEMMA_OUTPUT)
+        reasoning = extract_reasoning(_agent(), msg)
+        assert reasoning is not None
+        assert reasoning.startswith("The user wants me to write")
+        assert "<|channel>" not in reasoning
+        assert "<channel|>" not in reasoning
+
+    def test_structured_reasoning_takes_priority(self) -> None:
+        msg = SimpleNamespace(
+            content=GEMMA_OUTPUT, reasoning="structured wins",
+        )
+        assert extract_reasoning(_agent(), msg) == "structured wins"
+
+    def test_empty_thought_block_yields_none(self) -> None:
+        msg = SimpleNamespace(content="<|channel>thought\n<channel|>Answer")
+        assert extract_reasoning(_agent(), msg) is None
+
+    def test_no_tags_yields_none(self) -> None:
+        msg = SimpleNamespace(content="Plain answer")
+        assert extract_reasoning(_agent(), msg) is None
+
+
+class TestCliStripReasoningTags:
+    def test_closed_pair_stripped(self) -> None:
+        assert (
+            _strip_reasoning_tags(GEMMA_OUTPUT)
+            == "Go言語は現在インストールされていないようです。"
+        )
+
+    def test_unterminated_open_stripped(self) -> None:
+        assert _strip_reasoning_tags("<|channel>thought\nleaked") == ""
+
+    def test_orphan_tags_stripped(self) -> None:
+        assert _strip_reasoning_tags("A <channel|>B") == "A B"
+
+
+class TestGatewayTagTuples:
+    def test_channel_pair_present_and_aligned(self) -> None:
+        from gateway.stream_consumer import GatewayStreamConsumer as C
+
+        assert "<|channel>thought" in C._OPEN_THINK_TAGS
+        assert "<channel|>" in C._CLOSE_THINK_TAGS
+        # The open/close tuples are zipped as pairs by matching index in
+        # the pairing consumers — the channel pair must stay aligned.
+        open_idx = C._OPEN_THINK_TAGS.index("<|channel>thought")
+        close_idx = C._CLOSE_THINK_TAGS.index("<channel|>")
+        assert open_idx == close_idx
+
+
+class TestGluedOpenTag:
+    """Regression: real Gemma output glues the open tag to the reasoning.
+
+    The model card shows ``<|channel>thought\\n`` but observed output is
+    ``<|channel>thoughtThe user wants…`` — no newline, no separator.  A
+    ``\\b`` word-boundary after "thought" silently fails on that input
+    (word-char → word-char), so the patterns must not use one.
+    """
+
+    GLUED = (
+        "<|channel>thoughtThe user wants me to write a Hello World "
+        "program in Go.<channel|>"
+        "Go言語は現在インストールされていないようです。"
+    )
+
+    def test_strip_think_blocks_handles_glued_tag(self) -> None:
+        assert (
+            strip_think_blocks(_agent(), self.GLUED)
+            == "Go言語は現在インストールされていないようです。"
+        )
+
+    def test_extract_reasoning_handles_glued_tag(self) -> None:
+        msg = SimpleNamespace(content=self.GLUED)
+        reasoning = extract_reasoning(_agent(), msg)
+        assert reasoning is not None
+        assert reasoning.startswith("The user wants me")
+
+    def test_cli_strip_handles_glued_tag(self) -> None:
+        assert (
+            _strip_reasoning_tags(self.GLUED)
+            == "Go言語は現在インストールされていないようです。"
+        )
+
+
+class TestAuxiliaryExtractContentOrReasoning:
+    """auxiliary_client.extract_content_or_reasoning — same asymmetric-tag gap.
+
+    Title generation and other auxiliary LLM calls resolve response text
+    through this helper, which mirrors _strip_think_blocks with its own
+    inline regexes.  It gained <thought>…</thought> in #8562 but not the
+    asymmetric Gemma 4 channel pair; with a Gemma auxiliary model the
+    reasoning leaked into generated titles/summaries.
+    """
+
+    @staticmethod
+    def _resp(content, **fields):
+        from types import SimpleNamespace
+
+        msg = SimpleNamespace(
+            content=content,
+            reasoning=fields.get("reasoning"),
+            reasoning_content=fields.get("reasoning_content"),
+            reasoning_details=fields.get("reasoning_details"),
+        )
+        return SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+
+    def test_channel_pair_stripped_glued(self) -> None:
+        from agent.auxiliary_client import extract_content_or_reasoning
+
+        out = extract_content_or_reasoning(self._resp(
+            "<|channel>thoughtLet me think of a title.<channel|>Go setup help"
+        ))
+        assert out == "Go setup help"
+
+    def test_channel_pair_stripped_with_newline(self) -> None:
+        from agent.auxiliary_client import extract_content_or_reasoning
+
+        out = extract_content_or_reasoning(self._resp(
+            "<|channel>thought\nreasoning here\n<channel|>Title text"
+        ))
+        assert out == "Title text"
+
+    def test_symmetric_thought_still_stripped(self) -> None:
+        from agent.auxiliary_client import extract_content_or_reasoning
+
+        out = extract_content_or_reasoning(self._resp(
+            "<thought>hmm</thought>Plain title"
+        ))
+        assert out == "Plain title"
+
+    def test_reasoning_only_content_falls_back_to_structured(self) -> None:
+        """All-reasoning content must fall through to structured fields."""
+        from agent.auxiliary_client import extract_content_or_reasoning
+
+        out = extract_content_or_reasoning(self._resp(
+            "<|channel>thoughtonly reasoning, no answer<channel|>",
+            reasoning="Structured fallback title",
+        ))
+        assert out == "Structured fallback title"
+
+    def test_untagged_content_untouched(self) -> None:
+        from agent.auxiliary_client import extract_content_or_reasoning
+
+        assert extract_content_or_reasoning(self._resp("As-is")) == "As-is"

--- a/tests/agent/test_think_scrubber.py
+++ b/tests/agent/test_think_scrubber.py
@@ -253,3 +253,146 @@ class TestRealisticStreaming:
         s = StreamingThinkScrubber()
         deltas = ["Hello ", "world ", "how ", "are ", "you?"]
         assert _drive(s, deltas) == "Hello world how are you?"
+
+class TestGemmaChannelThought:
+    """Gemma 4's asymmetric channel-thought pair: <|channel>thought … <channel|>.
+
+    Gemma 4 embeds reasoning in content using an asymmetric tag pair
+    (model card, "Thinking Mode Configuration"):
+
+        <|channel>thought\n[Internal reasoning]<channel|>Final answer
+
+    Unlike Qwen's <think>…</think>, the close tag does not mirror the
+    open tag and does not start with "</".  These tests lock in the
+    suppression contract so Gemma reasoning never leaks to consumers.
+    """
+
+    def test_closed_pair_single_delta(self) -> None:
+        s = StreamingThinkScrubber()
+        assert (
+            _drive(s, ["<|channel>thought\nsecret reasoning<channel|>Hello world"])
+            == "Hello world"
+        )
+
+    def test_closed_pair_split_across_deltas(self) -> None:
+        s = StreamingThinkScrubber()
+        deltas = [
+            "<|channel>thought\n",
+            "The user wants me to write a Hello World program in Go. ",
+            "I have already written the file hello.go using write_file.",
+            "<channel|>",
+            "Go言語は現在インストールされていないようです。",
+        ]
+        assert _drive(s, deltas) == "Go言語は現在インストールされていないようです。"
+
+    def test_open_tag_split_mid_tag(self) -> None:
+        s = StreamingThinkScrubber()
+        deltas = ["<|chan", "nel>thou", "ght\nhidden", "<chan", "nel|>Visible"]
+        assert _drive(s, deltas) == "Visible"
+
+    def test_char_by_char(self) -> None:
+        s = StreamingThinkScrubber()
+        deltas = list("<|channel>thought\nx<channel|>Hello")
+        assert _drive(s, deltas) == "Hello"
+
+    def test_empty_thought_block_thinking_disabled(self) -> None:
+        """Thinking disabled: Gemma still emits the tags with an empty body."""
+        s = StreamingThinkScrubber()
+        assert (
+            _drive(s, ["<|channel>thought\n<channel|>Final answer"])
+            == "Final answer"
+        )
+
+    def test_unterminated_open_discards_to_stream_end(self) -> None:
+        s = StreamingThinkScrubber()
+        assert _drive(s, ["<|channel>thought\nreasoning with no close"]) == ""
+
+    def test_orphan_close_tag_stripped(self) -> None:
+        s = StreamingThinkScrubber()
+        assert _drive(s, ["Hello <channel|>world"]) == "Hello world"
+
+    def test_prose_mention_mid_line_not_suppressed(self) -> None:
+        """A mid-line prose mention of the open tag is not a block boundary."""
+        s = StreamingThinkScrubber()
+        out = _drive(s, ["Gemma uses <|channel>thought to open reasoning."])
+        assert out.startswith("Gemma uses ")
+
+    def test_symmetric_tags_still_work_alongside(self) -> None:
+        s = StreamingThinkScrubber()
+        assert _drive(s, ["<think>a</think>Hi"]) == "Hi"
+        s2 = StreamingThinkScrubber()
+        assert _drive(s2, ["<|channel>thought\nb<channel|>Hi"]) == "Hi"
+
+    def test_glued_open_tag_no_newline(self) -> None:
+        """Real Gemma output glues the tag to the reasoning: no newline."""
+        s = StreamingThinkScrubber()
+        deltas = [
+            "<|channel>thoughtThe user wants me to ",
+            "write Hello World in Go.<channel|>",
+            "Answer text",
+        ]
+        assert _drive(s, deltas) == "Answer text"
+
+
+class TestReasoningSink:
+    """Suppressed block content must be routed to the on_reasoning sink.
+
+    The sink is wired to the agent's reasoning delta callback so GUIs
+    (desktop, TUI) render inline reasoning in the collapsible Thinking
+    section — matching the display providers get when they return
+    structured reasoning_content.  Content deltas must stay unchanged.
+    """
+
+    def _make(self):
+        chunks: list[str] = []
+        s = StreamingThinkScrubber(on_reasoning=chunks.append)
+        return s, chunks
+
+    def test_closed_pair_routes_inner_content(self) -> None:
+        s, chunks = self._make()
+        assert _drive(s, ["<think>secret plan</think>Hello"]) == "Hello"
+        assert "".join(chunks) == "secret plan"
+
+    def test_gemma_channel_pair_routes_inner_content(self) -> None:
+        s, chunks = self._make()
+        deltas = [
+            "<|channel>thoughtThe user wants Go hello world. ",
+            "I'll check the toolchain.<channel|>",
+            "Go言語は現在インストールされていないようです。",
+        ]
+        assert _drive(s, deltas) == "Go言語は現在インストールされていないようです。"
+        assert "".join(chunks) == (
+            "The user wants Go hello world. I'll check the toolchain."
+        )
+
+    def test_streamed_block_routes_progressively(self) -> None:
+        s, chunks = self._make()
+        out = [s.feed("<think>"), s.feed("part one "), s.feed("part two")]
+        # Reasoning should flow to the sink DURING the stream, not only
+        # after the close tag arrives.
+        assert "part one" in "".join(chunks)
+        out.append(s.feed("</think>Visible"))
+        out.append(s.flush())
+        assert "".join(out) == "Visible"
+        assert "".join(chunks) == "part one part two"
+
+    def test_unterminated_block_flush_routes_tail(self) -> None:
+        s, chunks = self._make()
+        assert _drive(s, ["<think>never closed reasoning"]) == ""
+        assert "".join(chunks) == "never closed reasoning"
+
+    def test_no_block_no_reasoning_emitted(self) -> None:
+        s, chunks = self._make()
+        assert _drive(s, ["Plain visible text"]) == "Plain visible text"
+        assert chunks == []
+
+    def test_sink_error_does_not_break_content_stream(self) -> None:
+        def _boom(_text: str) -> None:
+            raise RuntimeError("sink died")
+
+        s = StreamingThinkScrubber(on_reasoning=_boom)
+        assert _drive(s, ["<think>x</think>Hello world"]) == "Hello world"
+
+    def test_default_no_sink_still_suppresses(self) -> None:
+        s = StreamingThinkScrubber()
+        assert _drive(s, ["<think>x</think>Hi"]) == "Hi"

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -548,10 +548,15 @@ class TestStreamingCallbacks:
 
         # Text before tool call IS fired (we don't know yet it will have tools)
         assert "thinking..." in deltas
-        # Text after tool call IS still routed to stream_delta_callback so that
-        # reasoning tag extraction can fire (PR #3566).  Display-level suppression
-        # of non-reasoning text happens in the CLI's _stream_delta, not here.
-        assert " more text" in deltas
+        # Text after tool call is NOT routed to stream_delta_callback.
+        # It previously was (PR #3566) so the CLI could re-derive reasoning
+        # tags locally, but that direct call bypassed the shared
+        # StreamingThinkScrubber's on_reasoning sink — the path that fires
+        # reasoning.delta for the TUI gateway.  Tool-suppressed content now
+        # feeds the shared scrubber instead: visible commentary stays
+        # suppressed on every surface and only extracted reasoning escapes
+        # (see test_toolcall_stream_gemma_reasoning.py).
+        assert " more text" not in deltas
         # Content is still accumulated in the response
         assert response.choices[0].message.content == "thinking... more text"
 

--- a/tests/run_agent/test_toolcall_stream_gemma_reasoning.py
+++ b/tests/run_agent/test_toolcall_stream_gemma_reasoning.py
@@ -1,0 +1,156 @@
+"""Tool-call streams must route suppressed Gemma reasoning to the sink.
+
+Regression for the sweeper-flagged gap on the streaming tool-call path:
+``interruptible_streaming_api_call`` suppresses ordinary content deltas
+once ``tool_calls_acc`` is populated (to avoid chatty "I'll use the
+tool..." text next to tool calls).  Before the fix, that branch invoked
+``stream_delta_callback`` directly, bypassing ``_fire_stream_delta`` and
+therefore the shared ``StreamingThinkScrubber(on_reasoning=...)`` — so a
+Gemma 4 channel-thought block (``<|channel>thought…<channel|>``) inside a
+tool-call turn never produced ``reasoning.delta`` for the TUI gateway.
+
+The fix feeds tool-suppressed content through the shared scrubber solely
+to extract reasoning, while keeping the visible commentary suppressed.
+
+End-to-end assertions:
+  * visible stream callback receives NO tool-suppressed content;
+  * the reasoning callback receives the Gemma block exactly once;
+  * trailing non-reasoning commentary stays suppressed everywhere.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _make_stream_chunk(content=None, tool_calls=None, finish_reason=None, model=None):
+    delta = SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        reasoning_content=None,
+        reasoning=None,
+    )
+    choice = SimpleNamespace(index=0, delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model=model, usage=None)
+
+
+def _make_tool_call_delta(index=0, tc_id=None, name=None, arguments=None):
+    func = SimpleNamespace(name=name, arguments=arguments)
+    return SimpleNamespace(index=index, id=tc_id, function=func)
+
+
+def _make_agent():
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    return agent
+
+
+class TestToolCallStreamGemmaReasoning:
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_gemma_block_reaches_reasoning_sink_once_and_stays_invisible(
+        self, mock_close, mock_create
+    ):
+        """Gemma reasoning inside a tool-call stream fires the reasoning
+        callback (once, tags stripped) and never reaches the visible
+        stream; trailing commentary stays fully suppressed."""
+        chunks = [
+            # Tool call arrives first, so every later content delta is
+            # tool-suppressed.
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_1", name="run_go"),
+            ]),
+            # Gemma channel-thought block, split across deltas, with the
+            # open tag itself split mid-token (real providers do this).
+            _make_stream_chunk(content="<|chan"),
+            _make_stream_chunk(content="nel>thoughtLet me check whether "),
+            _make_stream_chunk(content="Go is installed.<chan"),
+            _make_stream_chunk(content="nel|>"),
+            # Ordinary commentary after the block — must stay suppressed
+            # everywhere (this is the "chatty text" the branch exists to
+            # hide) and must NOT leak into the reasoning callback.
+            _make_stream_chunk(content="I'll run the tool now."),
+            _make_stream_chunk(
+                tool_calls=[_make_tool_call_delta(index=0, arguments="{}")],
+                finish_reason="tool_calls",
+                model="gemma-4",
+            ),
+        ]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+
+        visible: list[str] = []
+        reasoning: list[str] = []
+        agent.stream_delta_callback = visible.append
+        agent.reasoning_callback = reasoning.append
+
+        response = agent._interruptible_streaming_api_call({})
+
+        # Tool call accumulated correctly.
+        tool_calls = response.choices[0].message.tool_calls
+        assert tool_calls
+        first = tool_calls[0]
+        name = (
+            first["function"]["name"]
+            if isinstance(first, dict)
+            else first.function.name
+        )
+        assert name == "run_go"
+
+        # 1. Nothing tool-suppressed reached the visible stream.
+        assert visible == [], f"tool-suppressed content leaked: {visible!r}"
+
+        # 2. The reasoning sink received the block content, once.
+        joined = "".join(reasoning)
+        assert "Let me check whether Go is installed." in joined
+        assert joined.count("Let me check whether Go is installed.") == 1
+
+        # 3. No raw tags and no post-block commentary in the sink.
+        assert "<|channel>" not in joined and "<channel|>" not in joined
+        assert "I'll run the tool now." not in joined
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_plain_commentary_without_reasoning_fires_nothing(
+        self, mock_close, mock_create
+    ):
+        """Tool-suppressed commentary with no reasoning tags stays
+        suppressed and produces no reasoning deltas at all."""
+        chunks = [
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_1", name="run_go"),
+            ]),
+            _make_stream_chunk(content="Using the tool to check."),
+            _make_stream_chunk(
+                tool_calls=[_make_tool_call_delta(index=0, arguments="{}")],
+                finish_reason="tool_calls",
+            ),
+        ]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+
+        visible: list[str] = []
+        reasoning: list[str] = []
+        agent.stream_delta_callback = visible.append
+        agent.reasoning_callback = reasoning.append
+
+        agent._interruptible_streaming_api_call({})
+
+        assert visible == []
+        assert reasoning == []


### PR DESCRIPTION
## Problem

Gemma 4 embeds its reasoning in assistant content using an **asymmetric** tag pair (model card, "Thinking Mode Configuration"):

```
<|channel>thought[Internal reasoning]<channel|>Final answer
```

No existing layer knew this pair, so it caused two distinct bugs depending on the path:

1. **Raw tags leaking into the visible reply.** None of the five strip/extract layers (streaming scrubber, gateway filter, CLI display strip, storage-boundary strip, inline `extract_reasoning`) recognized the pair, so `<|channel>thought…<channel|>` and the full reasoning text showed up verbatim in the chat.
2. **Reasoning not folding in the GUI even once (1) is fixed.** The desktop/TUI "Thinking" section is driven entirely by `reasoning.delta` events (`reasoning_callback` → `_fire_reasoning_delta`). Providers that return reasoning as a separate structured field (`reasoning_content`) feed that callback directly. Providers like Gemma that inline reasoning into the content stream instead relied on `StreamingThinkScrubber` — but the scrubber only *suppressed* the tagged span from the visible stream; it had no way to hand that suppressed text to the reasoning callback. Net effect: fix (1) alone makes Gemma's reasoning disappear silently instead of leaking — still not the folded "Thinking" experience Qwen's `<think>` gets.

Two real-world quirks compound this:

- **The close tag does not start with `</`** (`<channel|>`), which breaks every orphan-close matcher anchored on `"</"`.
- **Observed output glues the open tag to the reasoning** (`<|channel>thoughtThe user wants…`) even though the model card shows a trailing `\n`. A `\b` word boundary after `thought` silently fails on that input, so the patterns deliberately avoid one.

Related: #6148 / #8562 (symmetric `<thought>` tags via the Gemini API — different tag format; this PR covers the asymmetric channel pair)

## Fix

**Suppression (all five layers learn the tag pair)**, so tags/reasoning never leak into the visible reply or persisted content:

- **`agent/agent_runtime_helpers.py`** — `extract_reasoning()` gets a new inline pattern `<\|channel>thought(.*?)<channel\|>` (used by non-streaming/interim-message paths); `strip_think_blocks()` handles the closed pair (incl. the empty `…thought\n<channel|>` block emitted when thinking is disabled), unterminated open at a block boundary, and stray orphan tags.
- **`agent/think_scrubber.py`** — the asymmetric pair is appended to `_OPEN_TAGS`/`_CLOSE_TAGS` (all pairing consumers zip the tuples, so it slots in without special-casing the state machine). `_strip_orphan_close_tags()` now anchors on `<` instead of `</`.
- **`gateway/stream_consumer.py`** — pair added to `_OPEN_THINK_TAGS`/`_CLOSE_THINK_TAGS`; orphan-close matcher generalized the same way.
- **`cli.py`** — `_strip_reasoning_tags()` (display strip) and the `_stream_delta` state machine.
- **`agent/conversation_loop.py`** — channel tags stripped from the `reasoning.available` relay text.

**Folding (the actual "collapse into Thinking" behavior)**, so the suppressed text reaches the GUI instead of just vanishing:

- **`agent/think_scrubber.py`** — `StreamingThinkScrubber` takes an optional `on_reasoning` callback. Every span it would otherwise discard (closed pair, unterminated-open tail, end-of-stream flush of an open block) is routed through `on_reasoning` instead of being dropped.
- **`agent/agent_init.py`** — wires the scrubber's `on_reasoning` to the agent's existing `_fire_reasoning_delta`, i.e. the exact same `reasoning_callback` → `reasoning.delta` → GUI path structured `reasoning_content` providers already use. This is what makes Gemma's reasoning collapse into "Thinking" the same way Qwen's `<think>` does — confirmed against a live LM Studio + Gemma 4 backend, not just unit tests.

Also covers the same asymmetric-tag gap in `agent/auxiliary_client.py`'s `extract_content_or_reasoning` (title generation and other auxiliary LLM calls).

## Tests

- `tests/agent/test_think_scrubber.py` — `TestGemmaChannelThought` (single/multi-delta, mid-tag splits, char-by-char, empty block, unterminated open, orphan close, mid-line prose not over-stripped, glued-tag regression) plus `on_reasoning` sink coverage (captured text matches suppressed spans, sink errors don't break the visible stream).
- `tests/agent/test_gemma_channel_thought_tags.py` — `strip_think_blocks`, `extract_reasoning`, `cli._strip_reasoning_tags`, gateway tag-tuple alignment, and the glued-open-tag regression across all non-streaming layers.

`pytest tests/agent/test_think_scrubber.py tests/agent/test_gemma_channel_thought_tags.py tests/run_agent/test_strip_reasoning_tags_cli.py tests/gateway/test_stream_consumer.py` → **200 passed**.

## Before / after (real observed output, live LM Studio + Gemma 4)

Input: `<|channel>thoughtThe user wants me to write a "Hello World" program in Go. …<channel|>Go言語は現在インストールされていないようです。`

| | Before | After |
|---|---|---|
| Visible stream | raw tags + full reasoning leak | `Go言語は現在インストールされていないようです。` |
| Desktop "Thinking" section | absent (no fold; Qwen-style `<think>` folds, Gemma's didn't) | folds, containing `The user wants me to write a "Hello World" program…` |
| Stored content | tags + reasoning persisted | clean final answer only |

## Relation to #43950

Triage flagged this as related to #43950, which tackles the same `<|channel>thought` / `<channel|>` token pair via a different approach (normalizing to `<think>`/`</think>` before the existing pipeline). The review comments on that PR ([flagged by the automated sweeper under teknium1's review](https://github.com/NousResearch/hermes-agent/pull/43950#pullrequestreview-4693576305)) identified two gaps in that approach:

- The central `StreamingThinkScrubber` (used by every live-delta path — API server, ACP, TTS, CLI/gateway callbacks) doesn't recognize the token pair, so normalization applied elsewhere still leaves those paths exposed.
- The gateway's pre-normalization runs before the stream buffer is joined, so a token split mid-opener or mid-closer (e.g. `<|chan` + `nel>thought`) doesn't match and leaks.

This PR addresses both directly: the token pair is added to `StreamingThinkScrubber`'s `_OPEN_TAGS`/`_CLOSE_TAGS` state machine itself (not a pre-pass), so every consumer of the scrubber is covered, and `tests/agent/test_think_scrubber.py::TestGemmaChannelThought` includes char-by-char and arbitrary mid-tag split regression tests. A maintainer should choose the intended consolidation between the two.