### PR TITLE
feat(desktop): add safe Windows tray and pet startup controls

### DIFF
--- a/apps/desktop/electron/main-window-lifecycle.test.ts
+++ b/apps/desktop/electron/main-window-lifecycle.test.ts
@@ -70,3 +70,10 @@ test('leaves live-window focus to deep-link delivery', () => {
     focusExisting: false
   })
 })
+
+test('deep-link delivery uses the shared show-and-focus path', async () => {
+  const source = await import('node:fs/promises').then(fs => fs.readFile(new URL('./main.ts', import.meta.url), 'utf8'))
+  const body = source.slice(source.indexOf('function handleDeepLink'), source.indexOf('// Renderer calls this'))
+
+  assert.match(body, /focusWindow\(mainWindow\)/)
+})

--- a/apps/desktop/electron/main-window-lifecycle.test.ts
+++ b/apps/desktop/electron/main-window-lifecycle.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { ensureMainWindow } from './main-window-lifecycle'
+import { deliverDeepLink, ensureMainWindow } from './main-window-lifecycle'
 
 test('recreates a destroyed primary window without focusing it', () => {
   const destroyedWindow = {
@@ -71,9 +71,42 @@ test('leaves live-window focus to deep-link delivery', () => {
   })
 })
 
-test('deep-link delivery uses the shared show-and-focus path', async () => {
-  const source = await import('node:fs/promises').then(fs => fs.readFile(new URL('./main.ts', import.meta.url), 'utf8'))
-  const body = source.slice(source.indexOf('function handleDeepLink'), source.indexOf('// Renderer calls this'))
+test('delivers a deep link after restoring and revealing a hidden minimized window', () => {
+  const calls: string[] = []
+  const payload = { kind: 'blueprint', name: 'morning-brief', params: { time: '08:00' } }
 
-  assert.match(body, /focusWindow\(mainWindow\)/)
+  const window = {
+    focus: () => calls.push('focus'),
+    isDestroyed: () => false,
+    isMinimized: () => true,
+    isVisible: () => false,
+    restore: () => calls.push('restore'),
+    show: () => calls.push('show'),
+    webContents: {
+      send: (channel: string, value: unknown) => calls.push(`send:${channel}:${JSON.stringify(value)}`)
+    }
+  }
+
+  const delivered = deliverDeepLink(window, payload)
+
+  assert.equal(delivered, true)
+  assert.deepEqual(calls, ['restore', 'show', 'focus', `send:hermes:deep-link:${JSON.stringify(payload)}`])
+})
+
+test('does not deliver a deep link to a destroyed window', () => {
+  const window = {
+    focus: () => assert.fail('destroyed window must not be focused'),
+    isDestroyed: () => true,
+    isMinimized: () => false,
+    isVisible: () => false,
+    restore: () => assert.fail('destroyed window must not be restored'),
+    show: () => assert.fail('destroyed window must not be shown'),
+    webContents: {
+      send: () => assert.fail('destroyed window must not receive a deep link')
+    }
+  }
+
+  const delivered = deliverDeepLink(window, { kind: 'blueprint', name: 'brief', params: {} })
+
+  assert.equal(delivered, false)
 })

--- a/apps/desktop/electron/main-window-lifecycle.ts
+++ b/apps/desktop/electron/main-window-lifecycle.ts
@@ -2,11 +2,53 @@ type MainWindowLike = {
   isDestroyed: () => boolean
 }
 
+type FocusableWindowLike = MainWindowLike & {
+  focus: () => void
+  isMinimized: () => boolean
+  isVisible: () => boolean
+  restore: () => void
+  show: () => void
+}
+
+type DeepLinkWindowLike = FocusableWindowLike & {
+  webContents: {
+    send: (channel: string, payload: unknown) => void
+  }
+}
+
 type EnsureMainWindowOptions<T extends MainWindowLike> = {
   isReady: boolean
   createWindow: () => unknown
   focusWindow: (window: T) => unknown
   focusExisting?: boolean
+}
+
+export function focusMainWindow(window: FocusableWindowLike | null | undefined) {
+  if (!window || window.isDestroyed()) {
+    return false
+  }
+
+  if (window.isMinimized()) {
+    window.restore()
+  }
+
+  if (!window.isVisible()) {
+    window.show()
+  }
+
+  window.focus()
+
+  return true
+}
+
+export function deliverDeepLink(window: DeepLinkWindowLike | null | undefined, payload: unknown) {
+  if (!focusMainWindow(window)) {
+    return false
+  }
+
+  window.webContents.send('hermes:deep-link', payload)
+
+  return true
 }
 
 export function ensureMainWindow<T extends MainWindowLike>(

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -25,7 +25,8 @@ import {
   screen,
   session,
   shell,
-  systemPreferences
+  systemPreferences,
+  Tray
 } from 'electron'
 import nodePty from 'node-pty'
 
@@ -115,6 +116,14 @@ import {
 } from './session-windows'
 import { ensureSpawnHelperExecutable } from './spawn-helper-perms'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
+import { destroyTray, quitFromTray, restoreMainWindow } from './tray-actions'
+import { petStartupCommand, type TrayPetCommand } from './tray-pet-policy'
+import {
+  DEFAULT_TRAY_PREFERENCES,
+  loadTrayPreferences,
+  saveTrayPreferences,
+  type TrayPreferences
+} from './tray-preferences'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
 import { readLiveUpdateMarker, writeUpdateMarker } from './update-marker'
 import { runRebuildWithRetry } from './update-rebuild'
@@ -130,6 +139,11 @@ import {
 import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
 import { spawnUpdaterProcess } from './updater-process'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
+import {
+  shouldHideMainWindowToTray,
+  shouldQuitAfterAllWindowsClose,
+  shouldShowMainWindowOnStartup
+} from './window-close-policy'
 import {
   computeWindowOptions,
   debounce,
@@ -929,6 +943,13 @@ function registerMediaProtocol() {
 }
 
 let mainWindow = null
+let hermesTray = null
+let isQuitting = false
+let trayPreferences: TrayPreferences = { ...DEFAULT_TRAY_PREFERENCES }
+let trayPreferencesPath = ''
+let trayPetState = { available: false, poppedOut: false }
+let petStartupRequested = false
+let initialMainWindowPending = true
 const backendConnectionState = createBackendConnectionState<ReturnType<typeof spawn>, any>()
 // True while connection-config:apply soft-rehomes the primary — suppresses the
 // backend-exit toast so an intentional kill doesn't look like a crash.
@@ -4693,6 +4714,102 @@ function getAppIconPath() {
   return APP_ICON_PATHS.find(fileExists)
 }
 
+function showMainWindow() {
+  restoreMainWindow({ window: mainWindow, createWindow, focusWindow })
+}
+
+function updateTrayPreferences(next: Partial<TrayPreferences>) {
+  const previous = trayPreferences
+  const candidate = { ...trayPreferences, ...next }
+
+  try {
+    saveTrayPreferences(trayPreferencesPath, candidate)
+    trayPreferences = candidate
+  } catch (error) {
+    trayPreferences = previous
+    rememberLog(`[tray] failed to save preferences: ${error?.message || error}`)
+  }
+
+  rebuildHermesTrayMenu()
+}
+
+function requestPetCommand(command: TrayPetCommand) {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return
+  }
+
+  mainWindow.webContents.send('hermes:tray:pet-command', command)
+}
+
+function rebuildHermesTrayMenu() {
+  if (!hermesTray) {
+    return
+  }
+
+  hermesTray.setContextMenu(
+    Menu.buildFromTemplate([
+      { label: 'Show Hermes', click: showMainWindow },
+      { label: 'Hide Hermes', click: () => mainWindow?.hide() },
+      {
+        label: trayPetState.poppedOut ? 'Return pet to Hermes' : 'Show desktop pet',
+        enabled: trayPetState.available,
+        click: () => requestPetCommand(trayPetState.poppedOut ? 'pop-in' : 'pop-out')
+      },
+      { type: 'separator' },
+      {
+        label: 'Start in tray',
+        type: 'checkbox',
+        checked: trayPreferences.startInTray,
+        click: item => updateTrayPreferences({ startInTray: item.checked })
+      },
+      {
+        label: 'Pop out pet on startup',
+        type: 'checkbox',
+        checked: trayPreferences.popOutPetOnStartup,
+        click: item => updateTrayPreferences({ popOutPetOnStartup: item.checked })
+      },
+      { type: 'separator' },
+      {
+        label: 'Quit Hermes',
+        click: () => {
+          quitFromTray({
+            markQuitting: () => {
+              isQuitting = true
+            },
+            quit: () => app.quit()
+          })
+        }
+      }
+    ])
+  )
+}
+
+function createHermesTray() {
+  if (!IS_WINDOWS || hermesTray) {
+    return
+  }
+
+  const icon = getAppIconPath()
+
+  if (!icon) {
+    rememberLog('[tray] no icon asset found; tray mode disabled')
+
+    return
+  }
+
+  try {
+    hermesTray = new Tray(icon)
+    hermesTray.setToolTip('Hermes')
+    rebuildHermesTrayMenu()
+    hermesTray.on('click', showMainWindow)
+    hermesTray.on('double-click', showMainWindow)
+  } catch (error) {
+    hermesTray?.destroy()
+    hermesTray = null
+    rememberLog(`[tray] setup failed; falling back to normal window lifecycle: ${error?.message || error}`)
+  }
+}
+
 function sendOpenUpdatesRequested() {
   if (!mainWindow || mainWindow.isDestroyed()) {
     return
@@ -7510,7 +7627,19 @@ function createWindow() {
   }
 
   mainWindow.once('ready-to-show', () => {
-    if (mainWindow && !mainWindow.isDestroyed()) {
+    const isInitialWindow = initialMainWindowPending
+    initialMainWindowPending = false
+
+    if (
+      mainWindow &&
+      !mainWindow.isDestroyed() &&
+      shouldShowMainWindowOnStartup({
+        isWindows: IS_WINDOWS,
+        trayAvailable: Boolean(hermesTray),
+        startInTray: trayPreferences.startInTray,
+        isInitialWindow
+      })
+    ) {
       mainWindow.show()
     }
 
@@ -7549,7 +7678,21 @@ function createWindow() {
   mainWindow.on('moved', schedulePersistWindowState)
   mainWindow.on('maximize', schedulePersistWindowState)
   mainWindow.on('unmaximize', schedulePersistWindowState)
-  mainWindow.on('close', () => schedulePersistWindowState.flush())
+  mainWindow.on('close', event => {
+    schedulePersistWindowState.flush()
+
+    if (
+      shouldHideMainWindowToTray({
+        isWindows: IS_WINDOWS,
+        trayAvailable: Boolean(hermesTray),
+        isQuitting,
+        isQuittingForHandoff
+      })
+    ) {
+      event.preventDefault()
+      mainWindow?.hide()
+    }
+  })
 
   // the closed wrapper remains truthy, so clear only the window this callback owns.
   const createdMainWindow = mainWindow
@@ -7791,6 +7934,25 @@ ipcMain.handle('hermes:pet-overlay:close', async () => {
   closePetOverlay()
 
   return { ok: true }
+})
+ipcMain.on('hermes:tray:pet-state', (_event, payload) => {
+  trayPetState = {
+    available: Boolean(payload?.available),
+    poppedOut: Boolean(payload?.poppedOut)
+  }
+  rebuildHermesTrayMenu()
+
+  const command = petStartupCommand({
+    enabled: trayPreferences.popOutPetOnStartup,
+    available: trayPetState.available,
+    poppedOut: trayPetState.poppedOut,
+    alreadyRequested: petStartupRequested
+  })
+
+  if (command) {
+    petStartupRequested = true
+    requestPetCommand(command)
+  }
 })
 // Drag/resize: the overlay reports new absolute screen bounds (it already knows
 // the pointer's screen coords). Drag keeps the size constant; the wheel-to-scale
@@ -9455,11 +9617,7 @@ function handleDeepLink(url) {
   }
 
   try {
-    if (mainWindow.isMinimized()) {
-      mainWindow.restore()
-    }
-
-    mainWindow.focus()
+    focusWindow(mainWindow)
     mainWindow.webContents.send('hermes:deep-link', payload)
     rememberLog(`[deeplink] delivered ${kind}/${name}`)
   } catch (err) {
@@ -9551,9 +9709,12 @@ app.whenReady().then(() => {
   registerMediaProtocol()
   installEmbedReferer()
   registerDeepLinkProtocol()
+  trayPreferencesPath = path.join(app.getPath('userData'), 'tray-preferences.json')
+  trayPreferences = loadTrayPreferences(trayPreferencesPath)
   ensureWslWindowsFonts()
   configureSpellChecker()
   registerPowerResumeListeners()
+  createHermesTray()
   createWindow()
 
   // Win/Linux cold start: the launching hermes:// URL is in our own argv.
@@ -9599,6 +9760,8 @@ function configureSpellChecker() {
 }
 
 app.on('before-quit', () => {
+  isQuitting = true
+
   // Clean quit mid-boot should not trip next-launch --no-sandbox (#38216).
   // FATAL GPU aborts skip before-quit, leaving the `booting` marker in place.
   // Keyed on sticky (not active): a manual --no-sandbox run still records a
@@ -9631,6 +9794,12 @@ app.on('before-quit', () => {
 
   flushDesktopLogBufferSync()
   closePreviewWatchers()
+  destroyTray({
+    tray: hermesTray,
+    clear: () => {
+      hermesTray = null
+    }
+  })
 
   // Kill open PTYs before environment teardown to avoid the node-pty#904
   // ThreadSafeFunction SIGABRT race.
@@ -9649,7 +9818,15 @@ app.on('window-all-closed', () => {
   // the bundle and relaunch — without this the script's PID-wait spins to its
   // full timeout and the user is left with an invisible app (or an uninstall
   // that appears to do nothing).
-  if (process.platform !== 'darwin' || isQuittingForHandoff) {
+  if (
+    shouldQuitAfterAllWindowsClose({
+      isWindows: IS_WINDOWS,
+      isMac: IS_MAC,
+      trayAvailable: Boolean(hermesTray),
+      isQuitting,
+      isQuittingForHandoff
+    })
+  ) {
     app.quit()
   }
 })

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -104,7 +104,7 @@ import {
   TEXT_PREVIEW_SOURCE_MAX_BYTES
 } from './hardening'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
-import { ensureMainWindow } from './main-window-lifecycle'
+import { deliverDeepLink, ensureMainWindow, focusMainWindow } from './main-window-lifecycle'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
 import {
@@ -7348,19 +7348,7 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
 const sessionWindows = createSessionWindowRegistry()
 
 function focusWindow(win) {
-  if (!win || win.isDestroyed()) {
-    return
-  }
-
-  if (win.isMinimized()) {
-    win.restore()
-  }
-
-  if (!win.isVisible()) {
-    win.show()
-  }
-
-  win.focus()
+  focusMainWindow(win)
 }
 
 function spawnSecondaryWindow({
@@ -9617,8 +9605,7 @@ function handleDeepLink(url) {
   }
 
   try {
-    focusWindow(mainWindow)
-    mainWindow.webContents.send('hermes:deep-link', payload)
+    deliverDeepLink(mainWindow, payload)
     rememberLog(`[deeplink] delivered ${kind}/${name}`)
   } catch (err) {
     rememberLog(`[deeplink] delivery failed: ${err.message}`)

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -33,6 +33,13 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
       ipcRenderer.on('hermes:pet-overlay:control', listener)
 
       return () => ipcRenderer.removeListener('hermes:pet-overlay:control', listener)
+    },
+    reportTrayState: state => ipcRenderer.send('hermes:tray:pet-state', state),
+    onTrayCommand: callback => {
+      const listener = (_event, command) => callback(command)
+      ipcRenderer.on('hermes:tray:pet-command', listener)
+
+      return () => ipcRenderer.removeListener('hermes:tray:pet-command', listener)
     }
   },
   getBootProgress: () => ipcRenderer.invoke('hermes:boot-progress:get'),

--- a/apps/desktop/electron/tray-actions.test.ts
+++ b/apps/desktop/electron/tray-actions.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { destroyTray, quitFromTray, restoreMainWindow } from './tray-actions'
+
+describe('tray actions', () => {
+  it('focuses an existing main window', () => {
+    const window = { isDestroyed: () => false }
+    const createWindow = vi.fn()
+    const focusWindow = vi.fn()
+
+    restoreMainWindow({ window, createWindow, focusWindow })
+
+    expect(createWindow).not.toHaveBeenCalled()
+    expect(focusWindow).toHaveBeenCalledWith(window)
+  })
+
+  it('creates a main window when none can be restored', () => {
+    const createWindow = vi.fn()
+    const focusWindow = vi.fn()
+
+    restoreMainWindow({ window: null, createWindow, focusWindow })
+
+    expect(createWindow).toHaveBeenCalledOnce()
+    expect(focusWindow).not.toHaveBeenCalled()
+  })
+
+  it('creates a main window when the previous window was destroyed', () => {
+    const createWindow = vi.fn()
+    const focusWindow = vi.fn()
+
+    restoreMainWindow({ window: { isDestroyed: () => true }, createWindow, focusWindow })
+
+    expect(createWindow).toHaveBeenCalledOnce()
+    expect(focusWindow).not.toHaveBeenCalled()
+  })
+
+  it('marks the app as quitting before requesting quit', () => {
+    const calls: string[] = []
+
+    quitFromTray({
+      markQuitting: () => calls.push('mark'),
+      quit: () => calls.push('quit')
+    })
+
+    expect(calls).toEqual(['mark', 'quit'])
+  })
+
+  it('destroys a live tray and clears its owner reference', () => {
+    const tray = { destroy: vi.fn(), isDestroyed: () => false }
+    const clear = vi.fn()
+
+    destroyTray({ tray, clear })
+
+    expect(tray.destroy).toHaveBeenCalledOnce()
+    expect(clear).toHaveBeenCalledOnce()
+  })
+
+  it('only clears an already destroyed tray', () => {
+    const tray = { destroy: vi.fn(), isDestroyed: () => true }
+    const clear = vi.fn()
+
+    destroyTray({ tray, clear })
+
+    expect(tray.destroy).not.toHaveBeenCalled()
+    expect(clear).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/electron/tray-actions.ts
+++ b/apps/desktop/electron/tray-actions.ts
@@ -1,0 +1,51 @@
+type RestorableWindow = {
+  isDestroyed(): boolean
+}
+
+type RestoreOptions<T extends RestorableWindow> = {
+  window: T | null
+  createWindow(): void
+  focusWindow(window: T): void
+}
+
+type QuitOptions = {
+  markQuitting(): void
+  quit(): void
+}
+
+type DestroyableTray = {
+  destroy(): void
+  isDestroyed(): boolean
+}
+
+type DestroyTrayOptions<T extends DestroyableTray> = {
+  tray: T | null
+  clear(): void
+}
+
+export function restoreMainWindow<T extends RestorableWindow>({
+  window,
+  createWindow,
+  focusWindow
+}: RestoreOptions<T>) {
+  if (!window || window.isDestroyed()) {
+    createWindow()
+
+    return
+  }
+
+  focusWindow(window)
+}
+
+export function quitFromTray({ markQuitting, quit }: QuitOptions) {
+  markQuitting()
+  quit()
+}
+
+export function destroyTray<T extends DestroyableTray>({ tray, clear }: DestroyTrayOptions<T>) {
+  if (tray && !tray.isDestroyed()) {
+    tray.destroy()
+  }
+
+  clear()
+}

--- a/apps/desktop/electron/tray-pet-policy.test.ts
+++ b/apps/desktop/electron/tray-pet-policy.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { petStartupCommand } from './tray-pet-policy'
+
+describe('tray pet startup policy', () => {
+  it('requests one pop-out only for an available inactive pet', () => {
+    expect(petStartupCommand({ enabled: true, available: true, poppedOut: false, alreadyRequested: false })).toBe('pop-out')
+    expect(petStartupCommand({ enabled: false, available: true, poppedOut: false, alreadyRequested: false })).toBeNull()
+    expect(petStartupCommand({ enabled: true, available: false, poppedOut: false, alreadyRequested: false })).toBeNull()
+    expect(petStartupCommand({ enabled: true, available: true, poppedOut: true, alreadyRequested: false })).toBeNull()
+    expect(petStartupCommand({ enabled: true, available: true, poppedOut: false, alreadyRequested: true })).toBeNull()
+  })
+})

--- a/apps/desktop/electron/tray-pet-policy.ts
+++ b/apps/desktop/electron/tray-pet-policy.ts
@@ -1,0 +1,17 @@
+export type TrayPetCommand = 'pop-out' | 'pop-in'
+
+interface PetStartupPolicy {
+  enabled: boolean
+  available: boolean
+  poppedOut: boolean
+  alreadyRequested: boolean
+}
+
+export function petStartupCommand({
+  enabled,
+  available,
+  poppedOut,
+  alreadyRequested
+}: PetStartupPolicy): TrayPetCommand | null {
+  return enabled && available && !poppedOut && !alreadyRequested ? 'pop-out' : null
+}

--- a/apps/desktop/electron/tray-preferences.test.ts
+++ b/apps/desktop/electron/tray-preferences.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { DEFAULT_TRAY_PREFERENCES, loadTrayPreferences, parseTrayPreferences, saveTrayPreferences } from './tray-preferences'
+
+describe('tray preferences', () => {
+  it('uses safe defaults for missing, malformed, and partial values', () => {
+    expect(parseTrayPreferences(null)).toEqual(DEFAULT_TRAY_PREFERENCES)
+    expect(parseTrayPreferences('bad')).toEqual(DEFAULT_TRAY_PREFERENCES)
+    expect(parseTrayPreferences({ startInTray: true })).toEqual({
+      startInTray: true,
+      popOutPetOnStartup: false
+    })
+  })
+
+  it('loads malformed JSON without throwing', () => {
+    expect(loadTrayPreferences('prefs.json', { readFileSync: () => '{' })).toEqual(DEFAULT_TRAY_PREFERENCES)
+  })
+
+  it('writes independent values through a temporary replacement', () => {
+    const writeFileSync = vi.fn()
+    const renameSync = vi.fn()
+
+    saveTrayPreferences(
+      'prefs.json',
+      { startInTray: false, popOutPetOnStartup: true },
+      { writeFileSync, renameSync }
+    )
+
+    expect(writeFileSync).toHaveBeenCalledWith(
+      'prefs.json.tmp',
+      JSON.stringify({ startInTray: false, popOutPetOnStartup: true }, null, 2),
+      'utf8'
+    )
+    expect(renameSync).toHaveBeenCalledWith('prefs.json.tmp', 'prefs.json')
+  })
+})

--- a/apps/desktop/electron/tray-preferences.ts
+++ b/apps/desktop/electron/tray-preferences.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs'
+
+export interface TrayPreferences {
+  startInTray: boolean
+  popOutPetOnStartup: boolean
+}
+
+export const DEFAULT_TRAY_PREFERENCES: TrayPreferences = {
+  startInTray: false,
+  popOutPetOnStartup: false
+}
+
+type ReadFs = {
+  readFileSync(path: string, encoding: 'utf8'): string
+}
+type WriteFs = {
+  writeFileSync(path: string, data: string, encoding: 'utf8'): void
+  renameSync(oldPath: string, newPath: string): void
+}
+
+export function parseTrayPreferences(value: unknown): TrayPreferences {
+  if (!value || typeof value !== 'object') {
+    return { ...DEFAULT_TRAY_PREFERENCES }
+  }
+
+  const record = value as Record<string, unknown>
+
+  return {
+    startInTray: typeof record.startInTray === 'boolean' ? record.startInTray : false,
+    popOutPetOnStartup: typeof record.popOutPetOnStartup === 'boolean' ? record.popOutPetOnStartup : false
+  }
+}
+
+export function loadTrayPreferences(filePath: string, fileSystem: ReadFs = fs): TrayPreferences {
+  try {
+    const raw = fileSystem.readFileSync(filePath, 'utf8')
+
+    return parseTrayPreferences(JSON.parse(String(raw)))
+  } catch {
+    return { ...DEFAULT_TRAY_PREFERENCES }
+  }
+}
+
+export function saveTrayPreferences(filePath: string, preferences: TrayPreferences, fileSystem: WriteFs = fs): void {
+  const temporaryPath = `${filePath}.tmp`
+  const normalized = parseTrayPreferences(preferences)
+
+  fileSystem.writeFileSync(temporaryPath, JSON.stringify(normalized, null, 2), 'utf8')
+  fileSystem.renameSync(temporaryPath, filePath)
+}

--- a/apps/desktop/electron/window-close-policy.test.ts
+++ b/apps/desktop/electron/window-close-policy.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldHideMainWindowToTray, shouldQuitAfterAllWindowsClose, shouldShowMainWindowOnStartup } from './window-close-policy'
+
+describe('Windows close-to-tray policy', () => {
+  it('does not hide when the tray could not be created', () => {
+    expect(
+      shouldHideMainWindowToTray({
+        isWindows: true,
+        trayAvailable: false,
+        isQuitting: false,
+        isQuittingForHandoff: false
+      })
+    ).toBe(false)
+  })
+
+  it('hides the main window for a normal Windows close', () => {
+    expect(
+      shouldHideMainWindowToTray({
+        isWindows: true,
+        trayAvailable: true,
+        isQuitting: false,
+        isQuittingForHandoff: false
+      })
+    ).toBe(true)
+  })
+
+  it('allows a real quit from the tray menu', () => {
+    expect(
+      shouldHideMainWindowToTray({
+        isWindows: true,
+        trayAvailable: true,
+        isQuitting: true,
+        isQuittingForHandoff: false
+      })
+    ).toBe(false)
+  })
+
+  it('allows updater handoff to close the window', () => {
+    expect(
+      shouldHideMainWindowToTray({
+        isWindows: true,
+        trayAvailable: true,
+        isQuitting: false,
+        isQuittingForHandoff: true
+      })
+    ).toBe(false)
+  })
+
+  it('does not change non-Windows close behavior', () => {
+    expect(
+      shouldHideMainWindowToTray({
+        isWindows: false,
+        trayAvailable: false,
+        isQuitting: false,
+        isQuittingForHandoff: false
+      })
+    ).toBe(false)
+  })
+
+  it('quits Windows when no tray is available to restore the app', () => {
+    expect(
+      shouldQuitAfterAllWindowsClose({
+        isWindows: true,
+        isMac: false,
+        trayAvailable: false,
+        isQuitting: false,
+        isQuittingForHandoff: false
+      })
+    ).toBe(true)
+  })
+
+  it('keeps Windows alive while the tray owns the app lifecycle', () => {
+    expect(
+      shouldQuitAfterAllWindowsClose({
+        isWindows: true,
+        isMac: false,
+        trayAvailable: true,
+        isQuitting: false,
+        isQuittingForHandoff: false
+      })
+    ).toBe(false)
+  })
+
+  it('quits Windows after an explicit tray quit or updater handoff', () => {
+    expect(
+      shouldQuitAfterAllWindowsClose({
+        isWindows: true,
+        isMac: false,
+        trayAvailable: true,
+        isQuitting: true,
+        isQuittingForHandoff: false
+      })
+    ).toBe(true)
+    expect(
+      shouldQuitAfterAllWindowsClose({
+        isWindows: true,
+        isMac: false,
+        trayAvailable: true,
+        isQuitting: false,
+        isQuittingForHandoff: true
+      })
+    ).toBe(true)
+  })
+
+  it('starts hidden only when Windows has a usable tray and the preference is enabled', () => {
+    expect(shouldShowMainWindowOnStartup({ isWindows: true, trayAvailable: true, startInTray: true })).toBe(false)
+    expect(shouldShowMainWindowOnStartup({ isWindows: true, trayAvailable: false, startInTray: true })).toBe(true)
+    expect(shouldShowMainWindowOnStartup({ isWindows: true, trayAvailable: true, startInTray: false })).toBe(true)
+    expect(shouldShowMainWindowOnStartup({ isWindows: false, trayAvailable: true, startInTray: true })).toBe(true)
+    expect(
+      shouldShowMainWindowOnStartup({
+        isWindows: true,
+        trayAvailable: true,
+        startInTray: true,
+        isInitialWindow: false
+      })
+    ).toBe(true)
+  })
+})

--- a/apps/desktop/electron/window-close-policy.ts
+++ b/apps/desktop/electron/window-close-policy.ts
@@ -1,0 +1,53 @@
+type ClosePolicy = {
+  isWindows: boolean
+  trayAvailable: boolean
+  isQuitting: boolean
+  isQuittingForHandoff: boolean
+}
+
+type WindowAllClosedPolicy = {
+  isWindows: boolean
+  isMac: boolean
+  trayAvailable: boolean
+  isQuitting: boolean
+  isQuittingForHandoff: boolean
+}
+
+type StartupVisibilityPolicy = {
+  isWindows: boolean
+  trayAvailable: boolean
+  startInTray: boolean
+  isInitialWindow?: boolean
+}
+
+export function shouldHideMainWindowToTray({
+  isWindows,
+  trayAvailable,
+  isQuitting,
+  isQuittingForHandoff
+}: ClosePolicy) {
+  return isWindows && trayAvailable && !isQuitting && !isQuittingForHandoff
+}
+
+export function shouldShowMainWindowOnStartup({
+  isWindows,
+  trayAvailable,
+  startInTray,
+  isInitialWindow = true
+}: StartupVisibilityPolicy) {
+  return !isInitialWindow || !isWindows || !trayAvailable || !startInTray
+}
+
+export function shouldQuitAfterAllWindowsClose({
+  isWindows,
+  isMac,
+  trayAvailable,
+  isQuitting,
+  isQuittingForHandoff
+}: WindowAllClosedPolicy) {
+  if (isWindows) {
+    return !trayAvailable || isQuitting || isQuittingForHandoff
+  }
+
+  return !isMac || isQuittingForHandoff
+}

--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -17,7 +17,7 @@ import {
   setPetInfo
 } from '@/store/pet'
 import { resetPetGallery, setPetScale } from '@/store/pet-gallery'
-import { $petOverlayActive, initPetOverlayBridge, popOutPet, restorePetOverlay } from '@/store/pet-overlay'
+import { $petOverlayActive, initPetOverlayBridge, popInPet, popOutPet, restorePetOverlay } from '@/store/pet-overlay'
 import { $gatewayState } from '@/store/session'
 import { isSecondaryWindow } from '@/store/windows'
 import { useTheme } from '@/themes/context'
@@ -243,6 +243,38 @@ export function FloatingPet() {
 
     return () => window.removeEventListener('focus', onFocus)
   }, [])
+
+  // Report the renderer-owned pet state to the native tray and handle tray
+  // commands through the same pop-in/pop-out path as the in-window gesture.
+  useEffect(() => {
+    if (isSecondaryWindow()) {
+      return
+    }
+
+    const api = window.hermesDesktop?.petOverlay
+
+    if (!api) {
+      return
+    }
+
+    const off = api.onTrayCommand(command => {
+      if (command === 'pop-in') {
+        popInPet()
+
+        return
+      }
+
+      const rect = containerRef.current?.getBoundingClientRect()
+
+      if (command === 'pop-out' && active && rect) {
+        popOutPet({ height: rect.height, width: rect.width, x: rect.x, y: rect.y })
+      }
+    })
+
+    api.reportTrayState({ available: active, poppedOut: overlayActive })
+
+    return off
+  }, [active, overlayActive])
 
   // Restore a popped-out pet on boot, once the pet has loaded (so we never spawn
   // an empty overlay window). Primary window only; runs at most once.

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -46,6 +46,8 @@ declare global {
         control: (payload: PetOverlayControl) => void
         onState: (callback: (payload: PetOverlayStatePayload) => void) => () => void
         onControl: (callback: (payload: PetOverlayControl) => void) => () => void
+        reportTrayState: (state: { available: boolean; poppedOut: boolean }) => void
+        onTrayCommand: (callback: (command: 'pop-out' | 'pop-in') => void) => () => void
       }
       getBootProgress: () => Promise<DesktopBootProgress>
       getConnectionConfig: (profile?: null | string) => Promise<DesktopConnectionConfig>

--- a/docs/superpowers/specs/2026-07-20-windows-tray-pet-startup-design.md
+++ b/docs/superpowers/specs/2026-07-20-windows-tray-pet-startup-design.md
@@ -1,0 +1,209 @@
+# Windows tray and pet startup design
+
+## Goal
+
+Give Hermes Desktop a safe Windows notification-area lifecycle and two independent startup preferences:
+
+1. Start Hermes with the main window hidden in the tray.
+2. Automatically pop the configured pet out to its desktop overlay after startup.
+
+The tray must remain a reliable way to restore or quit Hermes. Hiding the primary window must not stop the desktop-managed backend, active turns, secondary session windows, cron or gateway work, or an already popped-out pet.
+
+## Scope
+
+This design applies only to Windows. It extends the existing first-party Electron pet overlay and does not create a desktop plugin or a second pet implementation.
+
+Included:
+
+- Safe close-to-tray behavior.
+- A tray menu for current window and pet actions.
+- Persistent, independent startup preferences for starting hidden and automatically popping out the pet.
+- Explicit tray cleanup during a real shutdown.
+- Safe fallback when the tray or pet overlay is unavailable.
+- Automated lifecycle and preference tests.
+
+Excluded:
+
+- Launching Hermes automatically when Windows signs in.
+- Linux tray behavior or a macOS menu-bar implementation.
+- Pet speech containing full assistant responses.
+- Fullscreen-aware pet hiding.
+- Tray badges, unread counters, agent-status icons, or plugin-contributed tray commands.
+
+## User experience
+
+The Windows tray context menu contains:
+
+```text
+Show Hermes / Hide Hermes
+Show desktop pet / Return pet to Hermes
+──────────────────────────
+✓ Start in tray
+✓ Pop out pet on startup
+──────────────────────────
+Quit Hermes
+```
+
+The first two labels reflect current state. The startup preferences are checkboxes and affect future launches only. Toggling either preference must not immediately hide the current main window or move the current pet.
+
+- **Start in tray** means Hermes initializes normally but does not show the primary window after startup. The tray is available immediately as the recovery surface.
+- **Pop out pet on startup** means the renderer invokes the existing pet pop-out flow after it is ready and the configured pet is available.
+- The two preferences are independent. A user may show the main window and the desktop pet together, hide only the main window, or disable either startup behavior.
+- Closing the primary window with the title-bar X hides it when a usable tray exists. It is not a real application quit.
+- **Quit Hermes**, updater handoff, uninstaller handoff, and fatal restart paths retain the existing full-shutdown behavior.
+
+## Architecture
+
+### 1. Windows-local desktop preferences
+
+Store the two preferences in a small desktop-owned JSON file under Electron's local `userData` directory rather than `config.yaml`:
+
+```json
+{
+  "startInTray": false,
+  "popOutPetOnStartup": false
+}
+```
+
+Reasons:
+
+- These settings control the Windows desktop shell, not the agent core.
+- They must not sync through the shared Hermes profile to another operating system.
+- Tray checkbox updates need a small synchronous or atomic local write without invoking the general Hermes configuration pipeline.
+
+The preference module must:
+
+- supply `false` defaults;
+- tolerate a missing, malformed, or partially written file;
+- ignore unknown keys;
+- write atomically through a temporary file and replacement;
+- expose small pure functions that can be tested independently.
+
+### 2. Main-process tray lifecycle
+
+The Electron main process owns:
+
+- the `Tray` instance;
+- main-window show/hide behavior;
+- close-to-tray policy;
+- startup visibility;
+- real-quit state;
+- updater/uninstaller handoff exceptions;
+- tray-menu rendering and preference persistence;
+- explicit tray destruction during shutdown.
+
+Tray creation occurs before deciding whether to reveal the primary window. `startInTray` is honored only when tray creation succeeded. If no icon exists or `new Tray(...)` throws, Hermes shows the main window and retains the existing normal close lifecycle. It must never create an unreachable hidden application.
+
+The main process still creates the renderer while starting in the tray. This preserves backend startup, session state, gateway connections, pet state production, and normal initialization.
+
+### 3. Pet command bridge
+
+The renderer remains the source of truth for pet state and invokes the existing pop-out and return flows. The Electron tray must not create an independent pet window with incomplete state.
+
+Add a narrow desktop IPC contract:
+
+- main process requests `show desktop pet` or `return pet to Hermes`;
+- renderer reports whether the pet is enabled and currently popped out;
+- renderer performs the existing pop-out/return action;
+- renderer reports updated state so the tray menu label can refresh.
+
+After renderer readiness:
+
+1. Load normal pet state and configuration.
+2. Report current availability and overlay state to the main process.
+3. If `popOutPetOnStartup` is enabled and the pet is available but not already popped out, invoke the existing pop-out action once.
+4. Report success or failure without blocking desktop startup.
+
+The startup request must be idempotent. Reloading the renderer or receiving duplicate readiness events must not create duplicate overlays.
+
+### 4. Dynamic tray menu
+
+Rebuild or update the tray context menu when any of these values change:
+
+- main window visible/hidden;
+- pet available/unavailable;
+- pet popped in/out;
+- either startup preference changes.
+
+When the pet is unavailable, the current-action pet item is disabled. The preference checkbox may remain configurable for the next launch, allowing it to take effect after a pet is installed or enabled.
+
+## Lifecycle rules
+
+### Normal launch
+
+- Create tray on Windows.
+- Load desktop preferences.
+- Create the main window and initialize the renderer/backend.
+- Show the main window unless `startInTray` is enabled and tray creation succeeded.
+- Once renderer pet state is ready, optionally pop out the pet.
+
+### Closing the primary window
+
+Hide the primary window only when all are true:
+
+- the platform is Windows;
+- a usable tray exists;
+- the app is not performing a real quit;
+- no updater/uninstaller handoff is active.
+
+The popped-out pet, backend, active turns, and secondary windows remain alive.
+
+### Real quit
+
+Before a real quit:
+
+- mark the application as quitting;
+- close the pet overlay through the existing shutdown path;
+- dispose terminal sessions and stop desktop-managed backends as today;
+- explicitly destroy the tray and clear its reference;
+- allow all windows to close.
+
+### Update and uninstall
+
+Updater, swap, and uninstall handoffs bypass close-to-tray. Their PID wait must not be blocked by a hidden desktop process or surviving tray.
+
+### Failure behavior
+
+- Tray setup failure: log it, show the main window, and use normal exit behavior.
+- Preference read failure: use defaults and continue.
+- Preference write failure: leave the in-memory value unchanged, log the failure, and keep the menu usable.
+- Pet unavailable: skip automatic pop-out and disable the immediate pet action.
+- Pet command timeout or renderer reload: keep Hermes running, refresh state after the next renderer-ready report, and do not duplicate the overlay.
+
+## Testing strategy
+
+Use focused Electron Vitest tests for extracted policy, preference, and tray-action modules, plus an integration-oriented seam around renderer/tray commands.
+
+Required behavior tests:
+
+- Normal Windows close hides the main window only when a tray exists.
+- No tray means the main window appears and the last window closes normally.
+- Tray construction failure does not prevent `createWindow()`.
+- Existing main window is restored and focused; a destroyed one is recreated.
+- Quit marks real-quit state before calling `app.quit()`.
+- Updater/uninstaller handoff is never intercepted.
+- Real shutdown destroys the tray exactly once.
+- Non-Windows close semantics remain unchanged.
+- Missing or malformed preference files return safe defaults.
+- Preference writes preserve independent checkbox values and use an atomic replacement.
+- `startInTray` is ignored when no tray exists.
+- Pet startup action runs only after renderer readiness and only once.
+- Pet unavailable or already popped out produces no duplicate action.
+- Tray pet commands reach the renderer and refresh the menu after state changes.
+
+Verification gates:
+
+```text
+npm run lint
+npm run typecheck
+npm run test:desktop:platforms
+npm run build
+```
+
+A Windows manual check must verify launch visible/hidden combinations, X-to-hide, tray restore, pet pop-out/return, real quit, and update handoff.
+
+## Repository and contribution boundary
+
+The working tree also contains unrelated QQ Bot edits. Every stage, test, diff, commit, and future PR operation for this feature must be path-scoped. Never use `git add -A` in this checkout.
+
+The implementation should build on the existing local Windows tray lifecycle files, but it must close the remaining gaps above before being treated as contribution-ready. The feature is broader than another generic tray PR: its contribution boundary is safe startup visibility, first-party pet coordination, backend preservation, and updater-compatible shutdown.


### PR DESCRIPTION
## Summary

Add a Windows-only system tray lifecycle for Hermes Desktop, including:

- close the primary window to the notification area without stopping the backend or desktop pet
- explicit Show, Hide, and Quit actions
- independent `Start in tray` and `Pop out pet on startup` preferences
- immediate desktop-pet pop-out / return actions from the tray menu
- safe fallback to normal window behavior if tray creation fails
- explicit tray cleanup during a real quit, updater handoff, or uninstall
- restoration of tray-hidden windows when a second instance or `hermes://` deep link requests attention

The startup preferences are stored locally in Electron `userData`; they are not added to the shared Hermes profile configuration.

## Why another tray implementation?

There are several overlapping tray PRs, including #38024, #63663, and #64683. This implementation focuses on the lifecycle gaps raised in those discussions:

- Windows-only behavior
- only hiding the window when a tray was actually created
- preserving updater and uninstall exit semantics
- avoiding an unreachable hidden window
- keeping the existing pet overlay as the single owner of desktop-pet state
- covering the close, startup, deep-link, and pet-command policies with focused tests

It also addresses the desktop-pet lifecycle described in #67064.

## Behavior

The tray menu contains:

- Show Hermes
- Hide Hermes
- Show desktop pet / Return pet to Hermes
- Start in tray
- Pop out pet on startup
- Quit Hermes

`Start in tray` only affects the first primary window created during process startup. A later explicit Show action always reveals a recreated window.

`Pop out pet on startup` waits until the renderer reports that a pet is available, then sends one command through the existing pet-overlay path. It does not create a second overlay implementation.

## Verification

- [x] Focused Electron tests: 24 passed
- [x] TypeScript typecheck
- [x] ESLint on all changed TypeScript/TSX files
- [x] Production desktop build
- [x] Manual Windows smoke test: tray Show/Hide/Quit, close-to-tray, both startup preferences, and pet pop-out/return

The repository-wide `npm run check` was also attempted locally. It reached 2062 passing tests but stopped on 10 unrelated existing failures in Windows/POSIX path fixtures and Billing/Skills UI tests. All tray, startup, deep-link, and pet-policy tests passed within that run.

## Notes

- No macOS or Linux lifecycle behavior is changed.
- Preference write failures keep the previous in-memory value and rebuild the menu to reflect the actual state.
- If the tray icon cannot be created, startup hiding and close-to-tray are disabled so the app remains reachable.
