### PR TITLE
fix(config): stop flagging three live config roots as unknown in doctor

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5519,6 +5519,9 @@ _EXTRA_KNOWN_ROOT_KEYS = {
     "require_mention",       # top-level convenience form honored by the gateway (#3979)
     "unauthorized_dm_behavior",  # top-level form read by gateway/config.py
     "signal",            # Signal settings bridged to env vars by gateway/config.py
+    "group_sessions_per_user",  # per-user sessions in group chats; read by gateway/run.py + platform adapters
+    "known_plugin_toolsets",    # plugin-toolset bookkeeping written/read by hermes_cli/tools_config.py
+    "provider_routing",         # OpenRouter provider routing read by gateway/run.py (_load_provider_routing)
 }
 _KNOWN_ROOT_KEYS = frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 


### PR DESCRIPTION
## Summary

`hermes doctor` warns that `group_sessions_per_user`, `known_plugin_toolsets`, and `provider_routing` are "Unknown top-level config key … it will be ignored" — but all three are read by live code. The warning invites users to delete working configuration (or, worse, conclude a feature is off when it isn't).

- **`group_sessions_per_user`** — read by `gateway/run.py` (5 sites) and the `weixin`/`yuanbao`/`base` platform adapters; documented in `hermes_cli/tips.py`.
- **`known_plugin_toolsets`** — written and read by `hermes_cli/tools_config.py`; internal bookkeeping that `hermes tools` maintains per platform. Deleting it just makes Hermes rewrite it.
- **`provider_routing`** — read by `gateway/run.py` `_load_provider_routing()` and consumed at two OpenRouter routing sites; documented in `hermes_cli/tips.py`.

The doctor check derives from `_EXTRA_KNOWN_ROOT_KEYS`, which already covers sibling roots (`platform_toolsets`, `plugins`, …) but was missing these three.

## Fix

Add the three keys to `_EXTRA_KNOWN_ROOT_KEYS` with provenance comments. One-file, 3-line change; no behavior change beyond silencing the false positives.

## Test plan

- [x] `pytest tests/hermes_cli/test_config_validation.py` — 26 passed (existing tests iterate `_EXTRA_KNOWN_ROOT_KEYS`, so the new entries are covered automatically; no change-detector test added)
- [x] Manual: `validate_config_structure()` with all three keys present → 0 "Unknown top-level" warnings; a real typo (`skillz:`) is still flagged