### PR TITLE
fix(computer-use): infer foreground support from tool schema

### DIFF
--- a/tests/tools/test_computer_use_delivery_ladder.py
+++ b/tests/tools/test_computer_use_delivery_ladder.py
@@ -16,8 +16,10 @@ Stdlib + pytest + unittest.mock only. No live cua-driver, no network.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
+from types import SimpleNamespace
 from typing import Any, Dict, Optional
 from unittest.mock import patch
 
@@ -159,6 +161,59 @@ def test_text_response_surfaces_fields_additively():
 # ---------------------------------------------------------------------------
 # Phase B — delivery_mode threading + capability gating
 # ---------------------------------------------------------------------------
+
+def test_foreground_capability_inferred_from_tool_input_schema():
+    """cua-driver 0.8.3 declares foreground in inputSchema but omits the
+    non-standard capabilities extension."""
+    from tools.computer_use.cua_backend import _CuaDriverSession
+
+    tool = SimpleNamespace(
+        name="hotkey",
+        capabilities=None,
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "delivery_mode": {
+                    "type": "string",
+                    "enum": ["background", "foreground"],
+                },
+            },
+        },
+        model_extra=None,
+    )
+
+    class Session:
+        async def list_tools(self):
+            return SimpleNamespace(tools=[tool], capability_version=None, model_extra=None)
+
+    wrapper = _CuaDriverSession.__new__(_CuaDriverSession)
+    wrapper._capabilities = {}
+    wrapper._capability_version = ""
+    asyncio.run(wrapper._populate_capabilities(Session()))
+
+    assert wrapper.supports_capability("input.delivery_mode", tool="hotkey")
+
+
+def test_foreground_capability_not_inferred_without_schema_support():
+    from tools.computer_use.cua_backend import _CuaDriverSession
+
+    tool = SimpleNamespace(
+        name="hotkey",
+        capabilities=None,
+        inputSchema={"type": "object", "properties": {}},
+        model_extra=None,
+    )
+
+    class Session:
+        async def list_tools(self):
+            return SimpleNamespace(tools=[tool], capability_version=None, model_extra=None)
+
+    wrapper = _CuaDriverSession.__new__(_CuaDriverSession)
+    wrapper._capabilities = {}
+    wrapper._capability_version = ""
+    asyncio.run(wrapper._populate_capabilities(Session()))
+
+    assert not wrapper.supports_capability("input.delivery_mode", tool="hotkey")
 
 def test_background_is_default_no_flag_sent():
     out = {"isError": False, "data": {}, "structuredContent": {"effect": "confirmed"}}

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -746,18 +746,34 @@ class _CuaDriverSession:
                 tool_name = getattr(tool, "name", None)
                 if not isinstance(tool_name, str):
                     continue
+                extra = getattr(tool, "model_extra", None) or {}
                 caps = getattr(tool, "capabilities", None)
                 if caps is None:
                     # Some MCP SDKs forward custom fields via
                     # `model_extra` (Pydantic v2) instead of attributes.
-                    extra = getattr(tool, "model_extra", None) or {}
                     caps = extra.get("capabilities")
                 if isinstance(caps, list):
-                    self._capabilities[tool_name] = {
+                    tool_capabilities = {
                         c for c in caps if isinstance(c, str)
                     }
                 else:
-                    self._capabilities[tool_name] = set()
+                    tool_capabilities = set()
+
+                # cua-driver 0.8.3 exposes foreground delivery in the
+                # standard MCP input schema but does not include the custom
+                # `capabilities` extension. Treat the explicit schema enum as
+                # authoritative so Hermes does not reject a supported action.
+                input_schema = getattr(tool, "inputSchema", None)
+                if input_schema is None:
+                    input_schema = extra.get("inputSchema") or extra.get("input_schema")
+                if isinstance(input_schema, dict):
+                    properties = input_schema.get("properties")
+                    delivery = properties.get("delivery_mode") if isinstance(properties, dict) else None
+                    modes = delivery.get("enum") if isinstance(delivery, dict) else None
+                    if isinstance(modes, list) and "foreground" in modes:
+                        tool_capabilities.add("input.delivery_mode")
+
+                self._capabilities[tool_name] = tool_capabilities
             # capability_version is a top-level sibling of `tools` on the
             # tools/list response. cua-driver-core/src/tool.rs:354 emits
             # it; cua-driver-core/src/protocol.rs:150 leaves it OUT of
@@ -2504,4 +2520,3 @@ class CuaDriverBackend(ComputerUseBackend):
             meta.update(structured)
         return _action_result_from(name, ok, message, meta, structured,
                                    requested_delivery=args.get("delivery_mode"))
-


### PR DESCRIPTION
## Summary
- infer the existing input.delivery_mode capability when a cua-driver tool explicitly declares foreground in its standard MCP input schema
- preserve explicit capability extensions when present
- keep foreground fail-closed for schemas that do not advertise support

## Reproduction
cua-driver 0.8.3 implements foreground delivery and exposes delivery_mode=[background, foreground] for hotkey, but omits the non-standard capabilities extension. Hermes therefore returns foreground_unsupported before invoking a supported action.

## Verification
- focused stdlib regression canary for positive and negative schema inference
- Python compilation of changed source and tests
- git diff --check
- structured Auto Review: no actionable findings, patch correct (0.90 confidence)

The live Hermes runtime was not modified by this PR preparation.