### PR TITLE
fix(desktop): route worktree actions by explicit intent

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/coding-row.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/coding-row.test.tsx
@@ -1,8 +1,38 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { atom } from 'nanostores'
+import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { $notifications, clearNotifications } from '@/store/notifications'
+import { $newWorktreeRequest } from '@/store/projects'
+
+const worktreeDialog = vi.fn()
+
+vi.mock('@/app/chat/sidebar/projects/worktree-dialog', () => ({
+  WorktreeDialog: (props: { initialMode: string; open: boolean }) => {
+    worktreeDialog(props)
+
+    return <div data-testid="worktree-dialog" />
+  }
+}))
+
+vi.mock('@/components/ui/actions-menu', () => ({
+  ActionsContextMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  ActionsMenu: ({ children, items }: { children: ReactNode; items: (kit: unknown) => ReactNode }) => (
+    <>
+      {children}
+      {items({
+        Label: ({ children: label }: { children: ReactNode }) => <div>{label}</div>,
+        Separator: () => <div />
+      })}
+    </>
+  ),
+  renderActionItem: (_kit: unknown, item: { key: string; label: ReactNode; onSelect: () => void }) => (
+    <button key={item.key} onClick={item.onSelect} type="button">
+      {item.label}
+    </button>
+  )
+}))
 
 vi.mock('@/store/coding-status', () => ({
   registerRepoStatusCwd: () => undefined,
@@ -89,5 +119,66 @@ describe('CodingStatusRow', () => {
     // Confirmation is the button turning into a checkmark, not a notification.
     await waitFor(() => expect(screen.getByRole('button', { name: 'Copied' })).toBeTruthy())
     expect($notifications.get()).toHaveLength(0)
+  })
+})
+
+function renderWorktreeRow() {
+  worktreeDialog.mockClear()
+
+  render(
+    <CodingStatusRow
+      onBranchOff={() => Promise.resolve()}
+      onConvertBranch={() => Promise.resolve()}
+      onOpen={() => undefined}
+      onOpenWorktree={() => undefined}
+      repoPath="/repo"
+    />
+  )
+}
+
+function latestDialogProps() {
+  const props = worktreeDialog.mock.lastCall?.[0] as undefined | { initialMode: string; open: boolean }
+
+  if (!props) {
+    throw new Error('WorktreeDialog was not rendered')
+  }
+
+  return props
+}
+
+describe('CodingStatusRow worktree dialog mode', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    $newWorktreeRequest.set(0)
+  })
+
+  it('opens Start Work in create mode', async () => {
+    renderWorktreeRow()
+
+    fireEvent.click(screen.getByRole('button', { name: 'New worktree' }))
+
+    await waitFor(() => {
+      expect(latestDialogProps()).toMatchObject({ initialMode: 'create', open: true })
+    })
+  })
+
+  it('opens Convert Branch in convert mode', async () => {
+    renderWorktreeRow()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Convert a branch…' }))
+
+    await waitFor(() => {
+      expect(latestDialogProps()).toMatchObject({ initialMode: 'convert', open: true })
+    })
+  })
+
+  it('opens the global new-worktree request in create mode', async () => {
+    renderWorktreeRow()
+    act(() => $newWorktreeRequest.set(1))
+
+    await waitFor(() => {
+      expect(latestDialogProps()).toMatchObject({ initialMode: 'create', open: true })
+    })
   })
 })

--- a/apps/desktop/src/app/chat/composer/status-stack/coding-row.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/coding-row.test.tsx
@@ -1,10 +1,14 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { atom } from 'nanostores'
+import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { $notifications, clearNotifications } from '@/store/notifications'
 
+const openWorktreeDialog = vi.fn()
+
 vi.mock('@/store/coding-status', () => ({
+  openWorktreeDialog,
   registerRepoStatusCwd: () => undefined,
   repoStatusForCwd: () =>
     atom({
@@ -18,6 +22,24 @@ vi.mock('@/store/coding-status', () => ({
       untracked: 0
     }),
   repoWorktreesForCwd: () => atom([])
+}))
+
+vi.mock('@/components/ui/actions-menu', () => ({
+  ActionsContextMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  ActionsMenu: ({ children, items }: { children: ReactNode; items: (kit: unknown) => ReactNode }) => (
+    <>
+      {children}
+      {items({
+        Label: ({ children: label }: { children: ReactNode }) => <div>{label}</div>,
+        Separator: () => <div />
+      })}
+    </>
+  ),
+  renderActionItem: (_kit: unknown, item: { key: string; label: ReactNode; onSelect: () => void }) => (
+    <button key={item.key} onClick={item.onSelect} type="button">
+      {item.label}
+    </button>
+  )
 }))
 
 const { CodingStatusRow } = await import('./coding-row')
@@ -89,5 +111,58 @@ describe('CodingStatusRow', () => {
     // Confirmation is the button turning into a checkmark, not a notification.
     await waitFor(() => expect(screen.getByRole('button', { name: 'Copied' })).toBeTruthy())
     expect($notifications.get()).toHaveLength(0)
+  })
+})
+
+describe('CodingStatusRow worktree dialog mode routing', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('opens Start Work in create mode', async () => {
+    render(
+      <CodingStatusRow
+        onBranchOff={() => Promise.resolve()}
+        onConvertBranch={() => Promise.resolve()}
+        onOpen={() => undefined}
+        onOpenWorktree={() => undefined}
+        repoPath="/repo"
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'New worktree' }))
+
+    await waitFor(() => {
+      expect(openWorktreeDialog).toHaveBeenCalledWith({ base: undefined, mode: 'create', repoPath: '/repo' })
+    })
+  })
+
+  it('opens Convert Branch in convert mode', async () => {
+    render(
+      <CodingStatusRow
+        onBranchOff={() => Promise.resolve()}
+        onConvertBranch={() => Promise.resolve()}
+        onOpen={() => undefined}
+        onOpenWorktree={() => undefined}
+        repoPath="/repo"
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Convert a branch…' }))
+
+    await waitFor(() => {
+      expect(openWorktreeDialog).toHaveBeenCalledWith({ base: undefined, mode: 'convert', repoPath: '/repo' })
+    })
+  })
+
+  it('opens a branch-off entry in create mode with the base pinned', async () => {
+    render(<CodingStatusRow onBranchOff={() => Promise.resolve()} onOpen={() => undefined} repoPath="/repo" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'New branch from main' }))
+
+    await waitFor(() => {
+      expect(openWorktreeDialog).toHaveBeenCalledWith({ base: 'main', mode: 'create', repoPath: '/repo' })
+    })
   })
 })

--- a/apps/desktop/src/app/chat/composer/status-stack/coding-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/coding-row.tsx
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { memo, useEffect, useRef, useState } from 'react'
 
 import { WorktreeDialog } from '@/app/chat/sidebar/projects/worktree-dialog'
+import type { WorktreeDialogMode } from '@/app/chat/sidebar/projects/worktree-dialog'
 import { StatusRow } from '@/components/chat/status-row'
 import {
   type ActionItemSpec,
@@ -83,6 +84,7 @@ export const CodingStatusRow = memo(function CodingStatusRow({
   // dropdown menu's "branch off" items and the global ⌘⇧B hotkey.
   const [worktreeOpen, setWorktreeOpen] = useState(false)
   const [worktreeBase, setWorktreeBase] = useState<string | undefined>(undefined)
+  const [worktreeMode, setWorktreeMode] = useState<WorktreeDialogMode>('create')
 
   const switchToBranch = async (branch: string) => {
     if (!onSwitchBranch) {
@@ -116,13 +118,15 @@ export const CodingStatusRow = memo(function CodingStatusRow({
     }
 
     setWorktreeBase(undefined)
+    setWorktreeMode('create')
     setWorktreeOpen(true)
   }, [onOpenWorktree, resolvedRepoPath, worktreeReq])
 
   // Open the worktree dialog from the dropdown menu with a pre-selected base.
-  const startBranch = (base: string | undefined) => {
+  const startBranch = (base: string | undefined, mode: WorktreeDialogMode) => {
+    setWorktreeMode(mode)
     setWorktreeBase(base)
-    setTimeout(() => setWorktreeOpen(true), 0)
+    setWorktreeOpen(true)
   }
 
   if (!status) {
@@ -172,7 +176,7 @@ export const CodingStatusRow = memo(function CodingStatusRow({
     const branchItems: ActionItemSpec[] = branchTargets.map(target => ({
       key: target.base ?? '__head__',
       label: <span className="truncate">{target.label}</span>,
-      onSelect: () => startBranch(target.base)
+      onSelect: () => startBranch(target.base, 'create')
     }))
 
     const worktreeItems: ActionItemSpec[] = otherWorktrees.map(worktree => ({
@@ -199,13 +203,13 @@ export const CodingStatusRow = memo(function CodingStatusRow({
         {renderActionItem(kit, {
           key: '__start__',
           label: <span className="truncate">{p.startWork}</span>,
-          onSelect: () => startBranch(undefined)
+          onSelect: () => startBranch(undefined, 'create')
         })}
         {onConvertBranch &&
           renderActionItem(kit, {
             key: '__convert__',
             label: <span className="truncate">{p.convertBranch}</span>,
-            onSelect: () => startBranch(undefined)
+            onSelect: () => startBranch(undefined, 'convert')
           })}
       </>
     )
@@ -337,6 +341,7 @@ export const CodingStatusRow = memo(function CodingStatusRow({
       {resolvedRepoPath && onOpenWorktree && (
         <WorktreeDialog
           initialBase={worktreeBase}
+          initialMode={worktreeMode}
           onOpenChange={setWorktreeOpen}
           onStarted={onOpenWorktree}
           open={worktreeOpen}

--- a/apps/desktop/src/app/chat/composer/status-stack/coding-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/coding-row.tsx
@@ -19,6 +19,7 @@ import { useI18n } from '@/i18n'
 import { displayPath } from '@/lib/display-path'
 import { openWorktreeDialog, registerRepoStatusCwd, repoStatusForCwd, repoWorktreesForCwd } from '@/store/coding-status'
 import { notifyError } from '@/store/notifications'
+import { type WorktreeDialogMode } from '@/store/projects'
 import { $pullRequestsByBranch, branchPrKey, refreshPullRequests } from '@/store/pull-requests'
 
 // Tiny uppercase section header, matching the composer "+" menu's labels.
@@ -110,8 +111,11 @@ export const CodingStatusRow = memo(function CodingStatusRow({
   // rails can no longer each open their own copy. The menu items below only
   // publish the intent. They pin the repo of THIS rail, so the kebab of a tile
   // targets the worktree of that tile.
-  const startBranch = (base: string | undefined) => {
-    void openWorktreeDialog({ base, repoPath: resolvedRepoPath })
+  // Start Work opens the dialog in create mode; Convert Branch opens it in
+  // convert mode, so the first committed content and autofocus target already
+  // match the caller's intent.
+  const startBranch = (base: string | undefined, mode: WorktreeDialogMode) => {
+    void openWorktreeDialog({ base, mode, repoPath: resolvedRepoPath })
   }
 
   if (!status) {
@@ -132,7 +136,7 @@ export const CodingStatusRow = memo(function CodingStatusRow({
     branchTargets.push({ base: current, label: s.branchOffFrom(current) })
   }
 
-  if (status.defaultBranch && status.defaultBranch !== current) {
+  if (status.defaultBranch && current && status.defaultBranch !== current) {
     branchTargets.push({ base: status.defaultBranch, label: s.branchOffFrom(status.defaultBranch) })
   }
 
@@ -161,7 +165,7 @@ export const CodingStatusRow = memo(function CodingStatusRow({
     const branchItems: ActionItemSpec[] = branchTargets.map(target => ({
       key: target.base ?? '__head__',
       label: <span className="truncate">{target.label}</span>,
-      onSelect: () => startBranch(target.base)
+      onSelect: () => startBranch(target.base, 'create')
     }))
 
     const worktreeItems: ActionItemSpec[] = otherWorktrees.map(worktree => ({
@@ -188,13 +192,13 @@ export const CodingStatusRow = memo(function CodingStatusRow({
         {renderActionItem(kit, {
           key: '__start__',
           label: <span className="truncate">{p.startWork}</span>,
-          onSelect: () => startBranch(undefined)
+          onSelect: () => startBranch(undefined, 'create')
         })}
         {onConvertBranch &&
           renderActionItem(kit, {
             key: '__convert__',
             label: <span className="truncate">{p.convertBranch}</span>,
-            onSelect: () => startBranch(undefined)
+            onSelect: () => startBranch(undefined, 'convert')
           })}
       </>
     )

--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.test.tsx
@@ -1,0 +1,112 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+
+import { EnteredProjectContent } from './entered-content'
+import type { SidebarProjectTree } from './workspace-groups'
+
+const { startWorkInRepo } = vi.hoisted(() => ({
+  startWorkInRepo: vi.fn()
+}))
+
+vi.mock('./worktree-dialog', async () => {
+  const React = await import('react')
+
+  return {
+    WorktreeDialog: ({
+      open,
+      onOpenChange,
+      onStarted,
+      repoPath
+    }: {
+      open: boolean
+      onOpenChange: (next: boolean) => void
+      onStarted: (path: string) => void
+      repoPath: string
+    }) => {
+      React.useEffect(() => {
+        if (!open) {
+          return
+        }
+        void (async () => {
+          const result = await startWorkInRepo(repoPath, { branch: 'feature-start', name: 'feature-start' })
+
+          if (result && typeof result === 'object' && 'path' in result) {
+            onStarted(result.path as string)
+          }
+
+          onOpenChange(false)
+        })()
+      }, [open, onOpenChange, onStarted, repoPath])
+
+      return null
+    }
+  }
+})
+
+vi.mock('@/store/projects', () => ({
+  $worktreeRefreshToken: {
+    subscribe: vi.fn(() => vi.fn())
+  },
+  startWorkInRepo: (...args: unknown[]) => startWorkInRepo(...args)
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+beforeEach(() => {
+  startWorkInRepo.mockReset()
+})
+
+describe('EnteredProjectContent', () => {
+  it('starts work from the selected repo and opens the returned worktree path', async () => {
+    const createdWorktreePath = '/work/repo-two/.worktrees/feature-start'
+    const repoOnePath = '/work/repo-one'
+    const repoTwoPath = '/work/repo-two'
+
+    const project: SidebarProjectTree = {
+      id: 'p_multi_repo',
+      label: 'Multi Repo Project',
+      path: '/project/root',
+      repos: [
+        {
+          id: 'r_one',
+          label: 'Repo One',
+          path: repoOnePath,
+          groups: [],
+          sessionCount: 0
+        },
+        {
+          id: 'r_two',
+          label: 'Repo Two',
+          path: repoTwoPath,
+          groups: [],
+          sessionCount: 0
+        }
+      ],
+      sessionCount: 0
+    }
+
+    const onNewSession = vi.fn()
+
+    startWorkInRepo.mockResolvedValue({ branch: 'feature-start', path: createdWorktreePath })
+
+    render(
+      <I18nProvider configClient={null}>
+        <EnteredProjectContent onNewSession={onNewSession} project={project} renderRows={() => null} />
+      </I18nProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'New worktree: Repo Two' }))
+
+    await waitFor(() => expect(startWorkInRepo).toHaveBeenCalledTimes(1))
+    expect(startWorkInRepo).toHaveBeenCalledWith(
+      repoTwoPath,
+      expect.objectContaining({ branch: 'feature-start', name: 'feature-start' })
+    )
+    expect(onNewSession).toHaveBeenCalledWith(createdWorktreePath)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.test.tsx
@@ -1,0 +1,97 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+
+import { EnteredProjectContent } from './entered-content'
+import type { SidebarProjectTree } from './workspace-groups'
+
+const startWorkInRepo = vi.fn()
+const openWorktreeDialog = vi.fn()
+const requestStartWorkSession = vi.fn()
+
+vi.mock('@/store/projects', () => ({
+  $worktreeRefreshToken: {
+    subscribe: vi.fn(() => vi.fn())
+  },
+  startWorkInRepo: (...args: unknown[]) => startWorkInRepo(...args),
+  requestStartWorkSession: (...args: unknown[]) => requestStartWorkSession(...args)
+}))
+
+vi.mock('@/store/coding-status', () => ({
+  openWorktreeDialog: (...args: unknown[]) => openWorktreeDialog(...args),
+  registerRepoStatusCwd: () => undefined,
+  repoStatusForCwd: () => vi.fn(),
+  repoWorktreesForCwd: () => vi.fn()
+}))
+
+vi.mock('./workspace-header', () => ({
+  StartWorkButton: ({ repoPath }: { repoPath: string }) => (
+    <button onClick={() => openWorktreeDialog({ mode: 'create', repoPath })} type="button">
+      Start work for {repoPath}
+    </button>
+  ),
+  WorkspaceAddButton: ({ label, onClick }: { label: string; onClick: () => void }) => (
+    <button onClick={onClick} type="button">
+      {label}
+    </button>
+  ),
+  WorkspaceHeader: ({ action, children }: { action?: React.ReactNode; children: React.ReactNode }) => (
+    <div>
+      {action}
+      {children}
+    </div>
+  )
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+beforeEach(() => {
+  startWorkInRepo.mockReset()
+  openWorktreeDialog.mockReset()
+  requestStartWorkSession.mockReset()
+})
+
+describe('EnteredProjectContent', () => {
+  it('starts work from the selected repo via the shared worktree dialog', async () => {
+    const repoTwoPath = '/work/repo-two'
+
+    const project: SidebarProjectTree = {
+      id: 'p_multi_repo',
+      label: 'Multi Repo Project',
+      path: '/project/root',
+      repos: [
+        {
+          id: 'r_one',
+          label: 'Repo One',
+          path: '/work/repo-one',
+          groups: [],
+          sessionCount: 0
+        },
+        {
+          id: 'r_two',
+          label: 'Repo Two',
+          path: repoTwoPath,
+          groups: [],
+          sessionCount: 0
+        }
+      ],
+      sessionCount: 0
+    }
+
+    render(
+      <I18nProvider configClient={null}>
+        <EnteredProjectContent onNewSession={vi.fn()} project={project} renderRows={() => null} />
+      </I18nProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start work for /work/repo-two' }))
+
+    await waitFor(() => {
+      expect(openWorktreeDialog).toHaveBeenCalledWith({ mode: 'create', repoPath: repoTwoPath })
+    })
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
@@ -31,7 +31,7 @@ import {
   type SidebarSessionGroup,
   type SidebarWorkspaceTree
 } from './workspace-groups'
-import { WorkspaceAddButton, WorkspaceHeader } from './workspace-header'
+import { StartWorkButton, WorkspaceAddButton, WorkspaceHeader } from './workspace-header'
 
 // The entered project's body. Main-checkout sessions render directly — no
 // redundant repo/branch header (the breadcrumb already names the project). Only
@@ -262,15 +262,24 @@ function RepoFlatSection({
       <WorkspaceHeader
         action={
           onNewSession && (
-            <WorkspaceAddButton
-              label={s.newSessionIn(repo.label)}
-              onClick={() => {
-                // Reveal the repo the new session targets if the user had it
-                // collapsed — the session lands in one of its lanes.
-                setWorkspaceNodeOpen(repo.id, true)
-                onNewSession(repo.path)
-              }}
-            />
+            <div className="flex items-center">
+              <WorkspaceAddButton
+                label={s.newSessionIn(repo.label)}
+                onClick={() => {
+                  // Reveal the repo the new session targets if the user had it
+                  // collapsed — the session lands in one of its lanes.
+                  setWorkspaceNodeOpen(repo.id, true)
+                  onNewSession(repo.path)
+                }}
+              />
+              {repo.path && (
+                <StartWorkButton
+                  label={`${s.projects.startWork}: ${repo.label}`}
+                  onStarted={onNewSession}
+                  repoPath={repo.path}
+                />
+              )}
+            </div>
           )
         }
         emphasis

--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
@@ -31,7 +31,7 @@ import {
   type SidebarSessionGroup,
   type SidebarWorkspaceTree
 } from './workspace-groups'
-import { WorkspaceAddButton, WorkspaceHeader } from './workspace-header'
+import { StartWorkButton, WorkspaceAddButton, WorkspaceHeader } from './workspace-header'
 
 // The entered project's body. Main-checkout sessions render directly — no
 // redundant repo/branch header (the breadcrumb already names the project). Only
@@ -262,15 +262,18 @@ function RepoFlatSection({
       <WorkspaceHeader
         action={
           onNewSession && (
-            <WorkspaceAddButton
-              label={s.newSessionIn(repo.label)}
-              onClick={() => {
-                // Reveal the repo the new session targets if the user had it
-                // collapsed — the session lands in one of its lanes.
-                setWorkspaceNodeOpen(repo.id, true)
-                onNewSession(repo.path)
-              }}
-            />
+            <div className="flex items-center">
+              <WorkspaceAddButton
+                label={s.newSessionIn(repo.label)}
+                onClick={() => {
+                  // Reveal the repo the new session targets if the user had it
+                  // collapsed — the session lands in one of its lanes.
+                  setWorkspaceNodeOpen(repo.id, true)
+                  onNewSession(repo.path)
+                }}
+              />
+              {repo.path && <StartWorkButton label={`${s.projects.startWork}: ${repo.label}`} repoPath={repo.path} />}
+            </div>
           )
         }
         emphasis

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx
@@ -158,16 +158,24 @@ export function WorkspaceContextMenu({
 // inside it. Naming is explicit — no auto-generated `hermes/work-<ts>` trees.
 // The base branch defaults to the remote default (origin/HEAD); the user can
 // pick any local or remote-tracking branch via a filterable combobox.
-export function StartWorkButton({ repoPath, onStarted }: { repoPath: string; onStarted: (path: string) => void }) {
+export function StartWorkButton({
+  label,
+  repoPath,
+  onStarted
+}: {
+  label?: string
+  repoPath: string
+  onStarted: (path: string) => void
+}) {
   const { t } = useI18n()
   const p = t.sidebar.projects
   const [open, setOpen] = useState(false)
 
   return (
     <>
-      <Tip label={p.startWork}>
+      <Tip label={label ?? p.startWork}>
         <button
-          aria-label={p.startWork}
+          aria-label={label ?? p.startWork}
           className="grid size-4 shrink-0 place-items-center rounded-sm bg-transparent text-(--ui-text-quaternary) opacity-0 transition-opacity hover:bg-(--ui-control-hover-background) hover:text-foreground group-hover/section:opacity-100 focus-visible:opacity-100"
           onClick={() => setOpen(true)}
           type="button"

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx
@@ -176,7 +176,7 @@ export function StartWorkButton({
       <Tip label={label ?? p.startWork}>
         <button
           aria-label={label ?? p.startWork}
-          className="grid size-4 shrink-0 place-items-center rounded-sm bg-transparent text-(--ui-text-quaternary) opacity-0 transition-opacity hover:bg-(--ui-control-hover-background) hover:text-foreground group-hover/section:opacity-100 focus-visible:opacity-100"
+          className="grid size-4 shrink-0 place-items-center rounded-sm bg-transparent text-(--ui-text-quaternary) opacity-0 transition-opacity hover:bg-(--ui-control-hover-background) hover:text-foreground group-hover/section:opacity-100 group-hover/workspace:opacity-100 focus-visible:opacity-100"
           onClick={() => setOpen(true)}
           type="button"
         >

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx
@@ -156,15 +156,15 @@ export function WorkspaceContextMenu({
 // inside it. Naming is explicit — no auto-generated `hermes/work-<ts>` trees.
 // The base branch defaults to the remote default (origin/HEAD); the user can
 // pick any local or remote-tracking branch via a filterable combobox.
-export function StartWorkButton({ repoPath }: { repoPath: string }) {
+export function StartWorkButton({ label, repoPath }: { label?: string; repoPath: string }) {
   const { t } = useI18n()
   const p = t.sidebar.projects
 
   return (
-    <Tip label={p.startWork}>
+    <Tip label={label ?? p.startWork}>
       <button
-        aria-label={p.startWork}
-        className="grid size-4 shrink-0 place-items-center rounded-sm bg-transparent text-(--ui-text-quaternary) opacity-0 transition-opacity hover:bg-(--ui-control-hover-background) hover:text-foreground group-hover/section:opacity-100 focus-visible:opacity-100"
+        aria-label={label ?? p.startWork}
+        className="grid size-4 shrink-0 place-items-center rounded-sm bg-transparent text-(--ui-text-quaternary) opacity-0 transition-opacity hover:bg-(--ui-control-hover-background) hover:text-foreground group-hover/workspace:opacity-100 focus-visible:opacity-100"
         // Publish the intent. The one WorktreeDialog in the sidebar renders it.
         // This button pins its own repo, so it targets this section.
         onClick={() => void openWorktreeDialog({ repoPath })}

--- a/apps/desktop/src/app/chat/sidebar/projects/worktree-dialog.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/worktree-dialog.test.tsx
@@ -1,10 +1,20 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesGitBaseBranch, HermesGitBranch } from '@/global'
 import { I18nProvider } from '@/i18n'
 
 import { WorktreeDialog } from './worktree-dialog'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(next => {
+    resolve = next
+  })
+
+  return { promise, resolve }
+}
 
 vi.mock('./base-branch-picker', () => ({
   BaseBranchPicker: () => <div data-testid="base-branch-picker" />
@@ -97,5 +107,99 @@ describe('WorktreeDialog mode initialization', () => {
     await waitFor(() => expect(screen.getByText('feature/quick-fix')).toBeTruthy())
     expect(screen.queryByPlaceholderText('e.g. my-feature')).toBeNull()
     expect(listRepoBranches).toHaveBeenCalledWith('/repo')
+  })
+
+  it('remounts each opening with the requested mode and focus target', async () => {
+    const props = {
+      onOpenChange: () => undefined,
+      onStarted: () => undefined,
+      repoPath: '/repo'
+    }
+
+    const view = render(
+      <I18nProvider configClient={null}>
+        <WorktreeDialog {...props} initialMode="create" open />
+      </I18nProvider>
+    )
+
+    const branchName = screen.getByPlaceholderText('e.g. my-feature')
+    await waitFor(() => expect(globalThis.document.activeElement).toBe(branchName))
+
+    view.rerender(
+      <I18nProvider configClient={null}>
+        <WorktreeDialog {...props} initialMode="create" open={false} />
+      </I18nProvider>
+    )
+    expect(screen.queryByRole('heading', { name: 'New worktree' })).toBeNull()
+
+    view.rerender(
+      <I18nProvider configClient={null}>
+        <WorktreeDialog {...props} initialMode="convert" open />
+      </I18nProvider>
+    )
+
+    expect(screen.getByRole('heading', { name: 'Convert a branch' })).toBeTruthy()
+    const branchSearch = screen.getByPlaceholderText('Search branches…')
+    await waitFor(() => expect(globalThis.document.activeElement).toBe(branchSearch))
+
+    view.rerender(
+      <I18nProvider configClient={null}>
+        <WorktreeDialog {...props} initialMode="convert" open={false} />
+      </I18nProvider>
+    )
+    view.rerender(
+      <I18nProvider configClient={null}>
+        <WorktreeDialog {...props} initialMode="create" open />
+      </I18nProvider>
+    )
+
+    expect(screen.getByRole('heading', { name: 'New worktree' })).toBeTruthy()
+    const reopenedBranchName = screen.getByPlaceholderText('e.g. my-feature')
+    await waitFor(() => expect(globalThis.document.activeElement).toBe(reopenedBranchName))
+  })
+
+  it('ignores a stale branch response after reopening for another repository', async () => {
+    const repoA = deferred<HermesGitBranch[]>()
+    const repoB = deferred<HermesGitBranch[]>()
+    listRepoBranches.mockImplementationOnce(() => repoA.promise).mockImplementationOnce(() => repoB.promise)
+
+    const props = {
+      initialMode: 'convert' as const,
+      onOpenChange: () => undefined,
+      onStarted: () => undefined
+    }
+
+    const view = render(
+      <I18nProvider configClient={null}>
+        <WorktreeDialog {...props} open repoPath="/repo-a" />
+      </I18nProvider>
+    )
+
+    await waitFor(() => expect(listRepoBranches).toHaveBeenCalledWith('/repo-a'))
+    view.rerender(
+      <I18nProvider configClient={null}>
+        <WorktreeDialog {...props} open={false} repoPath="/repo-a" />
+      </I18nProvider>
+    )
+    view.rerender(
+      <I18nProvider configClient={null}>
+        <WorktreeDialog {...props} open repoPath="/repo-b" />
+      </I18nProvider>
+    )
+    await waitFor(() => expect(listRepoBranches).toHaveBeenCalledWith('/repo-b'))
+
+    await act(async () => {
+      repoB.resolve([{ checkedOut: false, isDefault: false, name: 'repo-b-branch', worktreePath: null }])
+      await repoB.promise
+    })
+    await waitFor(() => expect(screen.getByText('repo-b-branch')).toBeTruthy())
+
+    await act(async () => {
+      repoA.resolve([{ checkedOut: false, isDefault: false, name: 'repo-a-branch', worktreePath: null }])
+      await repoA.promise
+    })
+
+    expect(screen.queryByText('repo-a-branch')).toBeNull()
+    expect(screen.getByText('repo-b-branch')).toBeTruthy()
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/worktree-dialog.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/worktree-dialog.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesGitBaseBranch, HermesGitBranch } from '@/global'
+import { I18nProvider } from '@/i18n'
+
+import { WorktreeDialog } from './worktree-dialog'
+
+vi.mock('./base-branch-picker', () => ({
+  BaseBranchPicker: () => <div data-testid="base-branch-picker" />
+}))
+
+const { listBaseBranches, listRepoBranches, startWorkInRepo, switchBranchInRepo, $worktreeRefreshToken } = vi.hoisted(
+  () => ({
+    listBaseBranches: vi.fn<(repoPath: string) => Promise<HermesGitBaseBranch[]>>(),
+    listRepoBranches: vi.fn<(repoPath: string) => Promise<HermesGitBranch[]>>(),
+    startWorkInRepo: vi.fn(),
+    switchBranchInRepo: vi.fn(),
+    $worktreeRefreshToken: {
+      subscribe: vi.fn(() => vi.fn())
+    }
+  })
+)
+
+vi.mock('@/store/projects', () => ({
+  $worktreeRefreshToken,
+  listBaseBranches: (repoPath: string) => listBaseBranches(repoPath),
+  listRepoBranches: (repoPath: string) => listRepoBranches(repoPath),
+  startWorkInRepo: (...args: unknown[]) => startWorkInRepo(...args),
+  switchBranchInRepo: (...args: unknown[]) => switchBranchInRepo(...args)
+}))
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe = vi.fn()
+    unobserve = vi.fn()
+    disconnect = vi.fn()
+    constructor() {}
+  } as any
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+beforeEach(() => {
+  listBaseBranches.mockResolvedValue([] as HermesGitBaseBranch[])
+  listRepoBranches.mockResolvedValue([] as HermesGitBranch[])
+  startWorkInRepo.mockReset()
+  switchBranchInRepo.mockReset()
+})
+
+describe('WorktreeDialog mode initialization', () => {
+  it('shows create content when opened in create mode', () => {
+    render(
+      <I18nProvider configClient={null}>
+        <WorktreeDialog
+          initialBase="main"
+          initialMode="create"
+          onOpenChange={() => undefined}
+          onStarted={() => undefined}
+          open
+          repoPath="/repo"
+        />
+      </I18nProvider>
+    )
+
+    expect(screen.getByRole('heading', { name: 'New worktree' })).toBeTruthy()
+    expect(screen.getByPlaceholderText('e.g. my-feature')).toBeTruthy()
+    expect(screen.queryByRole('heading', { name: 'Convert a branch' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Convert an existing branch' })).toBeTruthy()
+    expect(screen.queryByPlaceholderText('Search branches…')).toBeNull()
+    expect(listRepoBranches).not.toHaveBeenCalled()
+  })
+
+  it('loads and shows branch conversion content when opened in convert mode', async () => {
+    listRepoBranches.mockResolvedValue([
+      { checkedOut: false, isDefault: true, name: 'main', worktreePath: null },
+      { checkedOut: false, isDefault: false, name: 'feature/quick-fix', worktreePath: null }
+    ])
+
+    render(
+      <I18nProvider configClient={null}>
+        <WorktreeDialog
+          initialMode="convert"
+          onOpenChange={() => undefined}
+          onStarted={() => undefined}
+          open
+          repoPath="/repo"
+        />
+      </I18nProvider>
+    )
+
+    expect(screen.getByRole('heading', { name: 'Convert a branch' })).toBeTruthy()
+    expect(screen.getByPlaceholderText('Search branches…')).toBeTruthy()
+    await waitFor(() => expect(screen.getByText('feature/quick-fix')).toBeTruthy())
+    expect(screen.queryByPlaceholderText('e.g. my-feature')).toBeNull()
+    expect(listRepoBranches).toHaveBeenCalledWith('/repo')
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/projects/worktree-dialog.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/worktree-dialog.test.tsx
@@ -1,0 +1,283 @@
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesGitBaseBranch, HermesGitBranch } from '@/global'
+import { I18nProvider } from '@/i18n'
+
+import { WorktreeDialog } from './worktree-dialog'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(next => {
+    resolve = next
+  })
+
+  return { promise, resolve }
+}
+
+// Minimal nanostores-compatible store mock that supports useStore from @nanostores/react.
+// Defined inside vi.hoisted so the class is available where the store instances are created.
+const { $worktreeDialog, $projectTree, listBaseBranches, listRepoBranches, startWorkInRepo, switchBranchInRepo } =
+  vi.hoisted(() => {
+    class MockStore<T> {
+      private value: T
+      private listeners: Set<(value: T) => void> = new Set()
+
+      constructor(initial: T) {
+        this.value = initial
+      }
+
+      get() {
+        return this.value
+      }
+
+      set(next: T) {
+        this.value = next
+
+        for (const cb of this.listeners) {
+          cb(this.value)
+        }
+      }
+
+      subscribe(cb: (value: T) => void) {
+        this.listeners.add(cb)
+        cb(this.value)
+
+        return () => {
+          this.listeners.delete(cb)
+        }
+      }
+
+      listen(cb: (value: T) => void) {
+        this.listeners.add(cb)
+        cb(this.value)
+
+        return () => {
+          this.listeners.delete(cb)
+        }
+      }
+
+      notify() {}
+    }
+
+    return {
+      $worktreeDialog: new MockStore<null | { base?: string; mode?: 'create' | 'convert'; repoPath: string }>(null),
+      $projectTree: new MockStore([]),
+      listBaseBranches: vi.fn<(repoPath: string) => Promise<HermesGitBaseBranch[]>>(),
+      listRepoBranches: vi.fn<(repoPath: string) => Promise<HermesGitBranch[]>>(),
+      startWorkInRepo: vi.fn(),
+      switchBranchInRepo: vi.fn()
+    }
+  })
+
+vi.mock('@/store/projects', () => ({
+  $projectTree,
+  $worktreeDialog,
+  closeWorktreeDialog: vi.fn(),
+  listBaseBranches: (repoPath: string) => listBaseBranches(repoPath),
+  listRepoBranches: (repoPath: string) => listRepoBranches(repoPath),
+  projectIdForCwd: vi.fn(() => null),
+  projectRootCwd: vi.fn(() => null),
+  requestStartWorkSession: vi.fn(),
+  startWorkInRepo: (...args: unknown[]) => startWorkInRepo(...args),
+  switchBranchInRepo: (...args: unknown[]) => switchBranchInRepo(...args)
+}))
+
+vi.mock('@/store/coding-status', () => ({
+  registerRepoStatusCwd: () => undefined,
+  repoStatusForCwd: () => vi.fn(),
+  repoWorktreesForCwd: () => vi.fn(),
+  resolveWorktreeRepoPath: vi.fn().mockResolvedValue('/repo')
+}))
+
+vi.mock('@/lib/sanitize', () => ({
+  gitRef: (s: string) => s
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notifyError: vi.fn()
+}))
+
+vi.mock('./base-branch-picker', () => ({
+  BaseBranchPicker: () => <div data-testid="base-branch-picker" />
+}))
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe = vi.fn()
+    unobserve = vi.fn()
+    disconnect = vi.fn()
+    constructor() {}
+  } as any
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  $worktreeDialog.set(null)
+})
+
+beforeEach(() => {
+  listBaseBranches.mockResolvedValue([] as HermesGitBaseBranch[])
+  listRepoBranches.mockResolvedValue([] as HermesGitBranch[])
+  startWorkInRepo.mockReset()
+  switchBranchInRepo.mockReset()
+})
+
+describe('WorktreeDialog mode initialization', () => {
+  it('shows create content when opened in create mode', () => {
+    $worktreeDialog.set({ repoPath: '/repo', mode: 'create' })
+
+    render(
+      <I18nProvider configClient={null}>
+        <WorktreeDialog />
+      </I18nProvider>
+    )
+
+    expect(screen.getByRole('heading', { name: 'New worktree' })).toBeTruthy()
+    expect(screen.getByPlaceholderText('e.g. my-feature')).toBeTruthy()
+    expect(screen.queryByRole('heading', { name: 'Convert a branch' })).toBeNull()
+    expect(listRepoBranches).not.toHaveBeenCalled()
+  })
+
+  it('shows create content by default when mode is omitted', () => {
+    $worktreeDialog.set({ repoPath: '/repo' })
+
+    render(
+      <I18nProvider configClient={null}>
+        <WorktreeDialog />
+      </I18nProvider>
+    )
+
+    expect(screen.getByRole('heading', { name: 'New worktree' })).toBeTruthy()
+  })
+
+  it('loads and shows branch conversion content when opened in convert mode', async () => {
+    listRepoBranches.mockResolvedValue([
+      { checkedOut: false, isDefault: true, isRemote: false, name: 'main', worktreePath: null },
+      { checkedOut: false, isDefault: false, isRemote: false, name: 'feature/quick-fix', worktreePath: null }
+    ])
+
+    $worktreeDialog.set({ repoPath: '/repo', mode: 'convert' })
+
+    render(
+      <I18nProvider configClient={null}>
+        <WorktreeDialog />
+      </I18nProvider>
+    )
+
+    expect(screen.getByRole('heading', { name: 'Convert a branch' })).toBeTruthy()
+    expect(screen.getByPlaceholderText('Search branches…')).toBeTruthy()
+    await waitFor(() => expect(screen.getByText('feature/quick-fix')).toBeTruthy())
+    expect(screen.queryByPlaceholderText('e.g. my-feature')).toBeNull()
+    expect(listRepoBranches).toHaveBeenCalledWith('/repo')
+  })
+
+  it('remounts with the requested mode when the dialog reopens after close', async () => {
+    $worktreeDialog.set({ repoPath: '/repo', mode: 'create' })
+
+    const { rerender } = render(
+      <I18nProvider configClient={null}>
+        <WorktreeDialog />
+      </I18nProvider>
+    )
+
+    expect(screen.getByRole('heading', { name: 'New worktree' })).toBeTruthy()
+
+    act(() => {
+      $worktreeDialog.set(null)
+    })
+    rerender(
+      <I18nProvider configClient={null}>
+        <WorktreeDialog />
+      </I18nProvider>
+    )
+    expect(screen.queryByRole('heading', { name: 'New worktree' })).toBeNull()
+
+    act(() => {
+      $worktreeDialog.set({ repoPath: '/repo', mode: 'convert' })
+    })
+    rerender(
+      <I18nProvider configClient={null}>
+        <WorktreeDialog />
+      </I18nProvider>
+    )
+
+    expect(screen.getByRole('heading', { name: 'Convert a branch' })).toBeTruthy()
+
+    act(() => {
+      $worktreeDialog.set(null)
+    })
+    rerender(
+      <I18nProvider configClient={null}>
+        <WorktreeDialog />
+      </I18nProvider>
+    )
+    act(() => {
+      $worktreeDialog.set({ repoPath: '/repo', mode: 'create' })
+    })
+    rerender(
+      <I18nProvider configClient={null}>
+        <WorktreeDialog />
+      </I18nProvider>
+    )
+
+    expect(screen.getByRole('heading', { name: 'New worktree' })).toBeTruthy()
+  })
+
+  it('ignores a stale branch response after reopening for another repository', async () => {
+    const repoA = deferred<HermesGitBranch[]>()
+    const repoB = deferred<HermesGitBranch[]>()
+    listRepoBranches.mockImplementation(repoPath => {
+      if (repoPath === '/repo-a') {
+        return repoA.promise
+      }
+
+      if (repoPath === '/repo-b') {
+        return repoB.promise
+      }
+
+      return Promise.resolve([])
+    })
+
+    $worktreeDialog.set({ repoPath: '/repo-a', mode: 'convert' })
+
+    render(
+      <I18nProvider configClient={null}>
+        <WorktreeDialog />
+      </I18nProvider>
+    )
+
+    await waitFor(() => expect(listRepoBranches).toHaveBeenCalledWith('/repo-a'))
+
+    // Reopen for a different repo — invalidates the first load
+    act(() => {
+      $worktreeDialog.set(null)
+    })
+    act(() => {
+      $worktreeDialog.set({ repoPath: '/repo-b', mode: 'convert' })
+    })
+
+    await waitFor(() => expect(listRepoBranches).toHaveBeenCalledWith('/repo-b'))
+
+    await act(async () => {
+      repoB.resolve([
+        { checkedOut: false, isDefault: false, isRemote: false, name: 'repo-b-branch', worktreePath: null }
+      ])
+      await repoB.promise
+    })
+    await waitFor(() => expect(screen.getByText('repo-b-branch')).toBeTruthy())
+
+    // The stale repoA response must not appear
+    await act(async () => {
+      repoA.resolve([
+        { checkedOut: false, isDefault: false, isRemote: false, name: 'repo-a-branch', worktreePath: null }
+      ])
+      await repoA.promise
+    })
+
+    expect(screen.queryByText('repo-a-branch')).toBeNull()
+    expect(screen.getByText('repo-b-branch')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/projects/worktree-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/worktree-dialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
@@ -69,47 +69,79 @@ export function WorktreeDialog({
   open,
   repoPath
 }: WorktreeDialogProps) {
+  if (!open) {
+    return null
+  }
+
+  return (
+    <OpenWorktreeDialog
+      initialBase={initialBase}
+      initialMode={initialMode}
+      key={`${repoPath}\0${initialMode}\0${initialBase ?? ''}`}
+      onOpenChange={onOpenChange}
+      onStarted={onStarted}
+      repoPath={repoPath}
+    />
+  )
+}
+
+function OpenWorktreeDialog({
+  initialBase,
+  initialMode,
+  onOpenChange,
+  onStarted,
+  repoPath
+}: Omit<WorktreeDialogProps, 'open'> & { initialMode: WorktreeDialogMode }) {
   const { t } = useI18n()
   const p = t.sidebar.projects
   const [name, setName] = useState('')
   const [pending, setPending] = useState(false)
-  const [convertMode, setConvertMode] = useState<WorktreeDialogMode>('create')
+  const [convertMode, setConvertMode] = useState<WorktreeDialogMode>(initialMode)
   const [branches, setBranches] = useState<HermesGitBranch[]>([])
   const [branchesLoading, setBranchesLoading] = useState(false)
-  const [selectedBase, setSelectedBase] = useState('')
+  const [selectedBase, setSelectedBase] = useState(initialMode === 'convert' ? '' : (initialBase ?? ''))
+  const branchLoadGenerationRef = useRef(0)
 
   const loadBranches = useCallback(async () => {
     if (!repoPath) {
       return
     }
 
+    const generation = ++branchLoadGenerationRef.current
     setBranchesLoading(true)
 
     try {
-      setBranches(await listRepoBranches(repoPath))
+      const nextBranches = await listRepoBranches(repoPath)
+
+      if (generation === branchLoadGenerationRef.current) {
+        setBranches(nextBranches)
+      }
     } catch {
-      setBranches([])
+      if (generation === branchLoadGenerationRef.current) {
+        setBranches([])
+      }
     } finally {
-      setBranchesLoading(false)
+      if (generation === branchLoadGenerationRef.current) {
+        setBranchesLoading(false)
+      }
     }
   }, [repoPath])
 
-  // Reset to a fresh state each time the dialog opens, applying any pre-selected
-  // base branch from the caller (e.g. "branch off from main" in the coding row's
-  // dropdown menu). When `initialBase` changes while open (shouldn't happen in
-  // practice), the effect re-syncs.
+  // The open session mounts with the requested mode, so its first committed
+  // content and autofocus target already match the caller's intent. Invalidate
+  // any outstanding branch request when this session closes or is replaced.
   useEffect(() => {
-    if (open) {
-      setName('')
-      setConvertMode(initialMode)
-      setSelectedBase(initialMode === 'convert' ? '' : (initialBase ?? ''))
-
-      if (initialMode === 'convert') {
-        setBranches([])
-        void loadBranches()
-      }
+    if (initialMode === 'convert') {
+      void loadBranches()
     }
-  }, [initialMode, loadBranches, open, initialBase])
+  }, [initialMode, loadBranches])
+
+  useEffect(
+    () => () => {
+      branchLoadGenerationRef.current += 1
+    },
+    []
+  )
 
   const submit = async () => {
     const branch = name.trim()
@@ -171,7 +203,7 @@ export function WorktreeDialog({
   }
 
   return (
-    <Dialog onOpenChange={next => !pending && onOpenChange(next)} open={open}>
+    <Dialog onOpenChange={next => !pending && onOpenChange(next)} open>
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>{convertMode === 'convert' ? p.convertBranchTitle : p.newWorktreeTitle}</DialogTitle>

--- a/apps/desktop/src/app/chat/sidebar/projects/worktree-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/worktree-dialog.tsx
@@ -26,6 +26,8 @@ interface BranchActionCopy {
   branchSwitchHome: string
 }
 
+export type WorktreeDialogMode = 'create' | 'convert'
+
 const branchActionLabel = (branch: HermesGitBranch, copy: BranchActionCopy) => {
   if (branch.checkedOut) {
     return copy.branchOpenExisting
@@ -43,6 +45,8 @@ export interface WorktreeDialogProps {
   open: boolean
   /** Called when the user requests the dialog to close (cancel, Esc, backdrop). */
   onOpenChange: (open: boolean) => void
+  /** Open the dialog in create or convert mode. */
+  initialMode?: WorktreeDialogMode
   /** Pre-select a base branch when opening (from "branch off from X" menus). */
   initialBase?: string
 }
@@ -57,27 +61,22 @@ export interface WorktreeDialogProps {
  * The caller owns the open state so both the sidebar button and the global
  * hotkey can trigger the same dialog instance.
  */
-export function WorktreeDialog({ repoPath, onStarted, open, onOpenChange, initialBase }: WorktreeDialogProps) {
+export function WorktreeDialog({
+  initialBase,
+  initialMode = 'create',
+  onOpenChange,
+  onStarted,
+  open,
+  repoPath
+}: WorktreeDialogProps) {
   const { t } = useI18n()
   const p = t.sidebar.projects
   const [name, setName] = useState('')
   const [pending, setPending] = useState(false)
-  const [convertMode, setConvertMode] = useState(false)
+  const [convertMode, setConvertMode] = useState<WorktreeDialogMode>('create')
   const [branches, setBranches] = useState<HermesGitBranch[]>([])
   const [branchesLoading, setBranchesLoading] = useState(false)
   const [selectedBase, setSelectedBase] = useState('')
-
-  // Reset to a fresh state each time the dialog opens, applying any pre-selected
-  // base branch from the caller (e.g. "branch off from main" in the coding row's
-  // dropdown menu). When `initialBase` changes while open (shouldn't happen in
-  // practice), the effect re-syncs.
-  useEffect(() => {
-    if (open) {
-      setName('')
-      setConvertMode(false)
-      setSelectedBase(initialBase ?? '')
-    }
-  }, [open, initialBase])
 
   const loadBranches = useCallback(async () => {
     if (!repoPath) {
@@ -94,6 +93,23 @@ export function WorktreeDialog({ repoPath, onStarted, open, onOpenChange, initia
       setBranchesLoading(false)
     }
   }, [repoPath])
+
+  // Reset to a fresh state each time the dialog opens, applying any pre-selected
+  // base branch from the caller (e.g. "branch off from main" in the coding row's
+  // dropdown menu). When `initialBase` changes while open (shouldn't happen in
+  // practice), the effect re-syncs.
+  useEffect(() => {
+    if (open) {
+      setName('')
+      setConvertMode(initialMode)
+      setSelectedBase(initialMode === 'convert' ? '' : (initialBase ?? ''))
+
+      if (initialMode === 'convert') {
+        setBranches([])
+        void loadBranches()
+      }
+    }
+  }, [initialMode, loadBranches, open, initialBase])
 
   const submit = async () => {
     const branch = name.trim()
@@ -150,7 +166,7 @@ export function WorktreeDialog({ repoPath, onStarted, open, onOpenChange, initia
   }
 
   const enterConvert = () => {
-    setConvertMode(true)
+    setConvertMode('convert')
     void loadBranches()
   }
 
@@ -158,11 +174,11 @@ export function WorktreeDialog({ repoPath, onStarted, open, onOpenChange, initia
     <Dialog onOpenChange={next => !pending && onOpenChange(next)} open={open}>
       <DialogContent className="max-w-md">
         <DialogHeader>
-          <DialogTitle>{convertMode ? p.convertBranchTitle : p.newWorktreeTitle}</DialogTitle>
-          <DialogDescription>{convertMode ? p.convertBranchDesc : p.newWorktreeDesc}</DialogDescription>
+          <DialogTitle>{convertMode === 'convert' ? p.convertBranchTitle : p.newWorktreeTitle}</DialogTitle>
+          <DialogDescription>{convertMode === 'convert' ? p.convertBranchDesc : p.newWorktreeDesc}</DialogDescription>
         </DialogHeader>
 
-        {convertMode ? (
+        {convertMode === 'convert' ? (
           <Command
             className="rounded-md border border-(--ui-stroke-tertiary)"
             filter={(value, search) => (value.toLowerCase().includes(search.toLowerCase()) ? 1 : 0)}
@@ -215,12 +231,12 @@ export function WorktreeDialog({ repoPath, onStarted, open, onOpenChange, initia
           </>
         )}
 
-        {convertMode ? (
+        {convertMode === 'convert' ? (
           <DialogFooter className="sm:justify-start">
             <Button
               className="px-0 text-(--ui-text-secondary) hover:text-foreground"
               disabled={pending}
-              onClick={() => setConvertMode(false)}
+              onClick={() => setConvertMode('create')}
               type="button"
               variant="link"
             >

--- a/apps/desktop/src/app/chat/sidebar/projects/worktree-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/worktree-dialog.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
@@ -27,7 +27,8 @@ import {
   projectRootCwd,
   requestStartWorkSession,
   startWorkInRepo,
-  switchBranchInRepo
+  switchBranchInRepo,
+  type WorktreeDialogMode
 } from '@/store/projects'
 
 import { BaseBranchPicker } from './base-branch-picker'
@@ -73,7 +74,7 @@ export function WorktreeDialog() {
 
   const [name, setName] = useState('')
   const [pending, setPending] = useState(false)
-  const [convertMode, setConvertMode] = useState(false)
+  const [convertMode, setConvertMode] = useState<WorktreeDialogMode>('create')
   const [branches, setBranches] = useState<HermesGitBranch[]>([])
   const [branchesLoading, setBranchesLoading] = useState(false)
   const [selectedBase, setSelectedBase] = useState('')
@@ -82,6 +83,7 @@ export function WorktreeDialog() {
   // and the user does not reopen the dialog.
   const [repoPath, setRepoPath] = useState('')
   const [projectOpen, setProjectOpen] = useState(false)
+  const branchLoadGenerationRef = useRef(0)
 
   // Every project with a working root is a valid target. The list is deduped by
   // path, because an auto project and a user project can share one folder.
@@ -116,13 +118,15 @@ export function WorktreeDialog() {
 
   const activeProjectLabel = activeOption?.label ?? repoPath.split('/').pop() ?? repoPath
 
-  // Reset to a fresh state each time the dialog opens. Apply the resolved repo
-  // and the base branch that the caller selected, for example "branch off from
-  // main" in the dropdown menu of the coding row.
+  // Reset to a fresh state each time the dialog opens. Apply the resolved repo,
+  // the mode, and the base branch that the caller selected, for example "branch
+  // off from main" in the dropdown menu of the coding row. The mode is initialized
+  // synchronously from the caller's intent, so the dialog's first committed
+  // content and autofocus target already match.
   useEffect(() => {
     if (state) {
       setName('')
-      setConvertMode(false)
+      setConvertMode(state.mode ?? 'create')
       setSelectedBase(state.base ?? '')
       setRepoPath(state.repoPath)
       setBranches([])
@@ -140,14 +144,27 @@ export function WorktreeDialog() {
       return
     }
 
+    // Generation guard: async branch loading across close/reopen and repository
+    // replacement can resolve out of order. Stale success, error, or finally
+    // updates must not repaint newer state.
+    const generation = ++branchLoadGenerationRef.current
+
     setBranchesLoading(true)
 
     try {
-      setBranches(await listRepoBranches(repoPath))
+      const nextBranches = await listRepoBranches(repoPath)
+
+      if (generation === branchLoadGenerationRef.current) {
+        setBranches(nextBranches)
+      }
     } catch {
-      setBranches([])
+      if (generation === branchLoadGenerationRef.current) {
+        setBranches([])
+      }
     } finally {
-      setBranchesLoading(false)
+      if (generation === branchLoadGenerationRef.current) {
+        setBranchesLoading(false)
+      }
     }
   }, [repoPath])
 
@@ -156,6 +173,23 @@ export function WorktreeDialog() {
     requestStartWorkSession(path)
     closeWorktreeDialog()
   }
+
+  // When the dialog opens in convert mode, load the branch list immediately so
+  // the user does not have to click "convert" again. Invalidates any outstanding
+  // branch request when this session closes or is replaced, so stale updates
+  // cannot repaint newer state.
+  useEffect(() => {
+    if (state && state.mode === 'convert') {
+      void loadBranches()
+    }
+  }, [state, loadBranches])
+
+  useEffect(
+    () => () => {
+      branchLoadGenerationRef.current += 1
+    },
+    []
+  )
 
   const submit = async () => {
     const branch = name.trim()
@@ -210,7 +244,7 @@ export function WorktreeDialog() {
   }
 
   const enterConvert = () => {
-    setConvertMode(true)
+    setConvertMode('convert')
     void loadBranches()
   }
 
@@ -218,8 +252,8 @@ export function WorktreeDialog() {
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent className="max-w-md">
         <DialogHeader>
-          <DialogTitle>{convertMode ? p.convertBranchTitle : p.newWorktreeTitle}</DialogTitle>
-          <DialogDescription>{convertMode ? p.convertBranchDesc : p.newWorktreeDesc}</DialogDescription>
+          <DialogTitle>{convertMode === 'convert' ? p.convertBranchTitle : p.newWorktreeTitle}</DialogTitle>
+          <DialogDescription>{convertMode === 'convert' ? p.convertBranchDesc : p.newWorktreeDesc}</DialogDescription>
         </DialogHeader>
 
         {/* Project picker: change the repo that the worktree is cut from. Show
@@ -274,7 +308,7 @@ export function WorktreeDialog() {
           </Popover>
         )}
 
-        {convertMode ? (
+        {convertMode === 'convert' ? (
           <Command
             className="rounded-md border border-(--ui-stroke-tertiary)"
             filter={(value, search) => (value.toLowerCase().includes(search.toLowerCase()) ? 1 : 0)}
@@ -334,12 +368,12 @@ export function WorktreeDialog() {
           </>
         )}
 
-        {convertMode ? (
+        {convertMode === 'convert' ? (
           <DialogFooter className="sm:justify-start">
             <Button
               className="px-0 text-(--ui-text-secondary) hover:text-foreground"
               disabled={pending}
-              onClick={() => setConvertMode(false)}
+              onClick={() => setConvertMode('create')}
               type="button"
               variant="link"
             >

--- a/apps/desktop/src/store/coding-status.ts
+++ b/apps/desktop/src/store/coding-status.ts
@@ -9,7 +9,8 @@ import {
   $worktreeDialog,
   $worktreeRefreshToken,
   ALL_PROJECTS,
-  projectRootCwd
+  projectRootCwd,
+  type WorktreeDialogMode
 } from './projects'
 import {
   $busy,
@@ -517,10 +518,14 @@ export async function resolveWorktreeRepoPath(): Promise<string> {
   return ''
 }
 
-export async function openWorktreeDialog(options?: { base?: string; repoPath?: string }): Promise<void> {
+export async function openWorktreeDialog(options?: {
+  base?: string
+  mode?: WorktreeDialogMode
+  repoPath?: string
+}): Promise<void> {
   const repoPath = options?.repoPath?.trim() || (await resolveWorktreeRepoPath())
 
   if (repoPath) {
-    $worktreeDialog.set({ base: options?.base, repoPath })
+    $worktreeDialog.set({ base: options?.base, mode: options?.mode, repoPath })
   }
 }

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -1162,10 +1162,14 @@ export const $startWorkSessionRequest = atom<StartWorkSessionRequest | null>(nul
 // `repoPath` is resolved when the dialog opens (see resolveWorktreeRepoPath).
 // It is not read from the rail that received the key, so the dialog always
 // targets the surface the user looks at.
+export type WorktreeDialogMode = 'create' | 'convert'
+
 export interface WorktreeDialogState {
   repoPath: string
   /** The base branch selected in a "branch off from X" menu. */
   base?: string
+  /** Open the dialog in create or convert mode. */
+  mode?: WorktreeDialogMode
 }
 
 export const $worktreeDialog = atom<null | WorktreeDialogState>(null)


### PR DESCRIPTION
## What changed and why

Hermes Desktop already distinguishes creating a new worktree from converting or opening an existing branch, but the composer routed both actions through the same implicit dialog state. Multi-repository Projects also lacked a repository-specific Start Work action.

This PR makes those worktree actions explicit and deterministic:

- routes Start Work directly to create mode and Convert Branch directly to convert mode;
- initializes each dialog opening synchronously from the caller's repository, mode, and base, avoiding a wrong first title/content/focus commit;
- generation-guards asynchronous branch loading across close/reopen and repository replacement so stale success, error, or `finally` updates cannot repaint newer state;
- adds Start Work to each repository row in multi-repository Projects;
- uses the selected repository path as the authoritative Git root and passes the returned worktree path to the existing new-session lifecycle;
- uses the standard themed tooltip and matching accessible name for the icon-only Start Work control.

The change preserves the existing remote-aware Git facade, global Ctrl/Cmd+N behavior, and session lifecycle.

## How to test

From `apps/desktop`:

```bash
npm exec vitest run -- \
  src/app/chat/composer/status-stack/coding-row.test.tsx \
  src/app/chat/sidebar/projects/entered-content.test.tsx \
  src/app/chat/sidebar/projects/worktree-dialog.test.tsx \
  electron/git-worktree-ops.test.ts \
  src/store/projects.test.ts \
  src/components/ui/__tests__/no-native-title.test.ts
npm run typecheck
npm run lint
npm run build
```

Also run changed-file Prettier and `git diff --check`.

Local results on Linux:

- focused Vitest: 6 files / 42 tests passed;
- renderer and Electron TypeScript checks passed;
- full Desktop ESLint: 0 errors / 9 existing warnings;
- changed-file Prettier passed;
- production Desktop build passed;
- `git diff --check` passed;
- independent exact-head review approved with no P0–P3 findings.

## Regression coverage

Tests cover:

- Start Work versus Convert Branch opening intent;
- create → close → convert → close → create mode and focus transitions;
- out-of-order branch-list responses across repository replacement;
- exact selected-repository targeting and returned-path session handoff;
- existing worktree Git operations and project-store behavior;
- the native-title design-system guard.

## Platforms and known gaps

Validated on Linux through focused tests, renderer/Electron typechecking, lint, and production build. This clean publication replay did not include a separate manual packaged-Desktop UI run. No placement/configuration, Command Palette, documentation, CLI, or global New Session behavior is changed here.
