### PR TITLE
fix(kanban): allow complete/block from parked triage lanes

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -102,6 +102,22 @@ _log = logging.getLogger(__name__)
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
 
+# Operator/worker may close a card to ``done`` from any non-terminal lane.
+# Parked columns (triage/todo/scheduled/review) must be completable so stale
+# cards can leave the board without first being promoted into the work pool —
+# the board API and CLI both route through :func:`complete_task`.
+COMPLETABLE_STATUSES = frozenset({
+    "triage", "todo", "scheduled", "ready", "running", "blocked", "review",
+})
+
+# Operator/worker may block a card from any non-terminal, non-blocked lane.
+# Includes triage so block-loop escalations and abandoned drafts can still be
+# parked as human blockers (or dependency-waited into ``todo``) without a
+# forced promote-then-block dance.
+BLOCKABLE_STATUSES = frozenset({
+    "triage", "todo", "scheduled", "ready", "running", "review",
+})
+
 # Typed block reasons. Distinguishes the two fundamentally different things a
 # worker (or human) means by "blocked", so each can be routed differently
 # instead of all landing in one undifferentiated ``blocked`` bucket that a cron
@@ -4091,6 +4107,11 @@ class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
 
 
+def _sql_status_in(statuses: frozenset) -> str:
+    """Render an ``IN (...)`` list from internal status constants only."""
+    return ", ".join(f"'{s}'" for s in sorted(statuses))
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4101,11 +4122,12 @@ def complete_task(
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
 ) -> bool:
-    """Transition ``running|ready -> done`` and record ``result``.
+    """Transition a non-terminal task → ``done`` and record ``result``.
 
-    Accepts a task that is merely ``ready`` too, so a manual CLI
-    completion (``hermes kanban complete <id>``) works without requiring
-    a claim/start/complete sequence.
+    Accepts any status in :data:`COMPLETABLE_STATUSES` (work-pool lanes plus
+    parked ``triage``/``todo``/``scheduled``/``review`` and ``blocked``) so a
+    manual CLI/dashboard completion works without requiring a
+    claim/start/complete sequence or a promote-out-of-triage first.
 
     ``summary`` and ``metadata`` are stored on the closing run (if any)
     and surfaced to downstream children via :func:`build_worker_context`.
@@ -4161,10 +4183,11 @@ def complete_task(
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,
     )
+    completable_in = _sql_status_in(COMPLETABLE_STATUSES)
     with write_txn(conn):
         if expected_run_id is None:
             cur = conn.execute(
-                """
+                f"""
                 UPDATE tasks
                    SET status       = 'done',
                        result       = ?,
@@ -4175,13 +4198,13 @@ def complete_task(
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
+                   AND status IN ({completable_in})
                 """,
                 (result, now, task_id),
             )
         else:
             cur = conn.execute(
-                """
+                f"""
                 UPDATE tasks
                    SET status       = 'done',
                        result       = ?,
@@ -4192,7 +4215,7 @@ def complete_task(
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
+                   AND status IN ({completable_in})
                    AND current_run_id = ?
                 """,
                 (result, now, task_id, int(expected_run_id)),
@@ -4881,7 +4904,10 @@ def block_task(
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
 ) -> bool:
-    """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
+    """Transition a blockable task → ``blocked`` (or route elsewhere).
+
+    Source statuses are :data:`BLOCKABLE_STATUSES` (work-pool ``running``/
+    ``ready`` plus parked ``triage``/``todo``/``scheduled``/``review``).
 
     ``kind`` (one of :data:`VALID_BLOCK_KINDS`, or ``None`` for a legacy
     un-typed block) drives routing instead of every block landing in one
@@ -4895,11 +4921,14 @@ def block_task(
 
     * ``needs_input`` / ``capability`` / ``None`` — "truly blocked" (Dale's
       "Type 1"). Lands in ``blocked`` for a human. BUT: each time such a task
-      is re-blocked for the SAME kind after having been unblocked, the
-      unblock-loop counter (``block_recurrences``) increments. When it reaches
+      is re-blocked for the SAME kind after having been unblocked *from the
+      work pool* (``running``/``ready``), the unblock-loop counter
+      (``block_recurrences``) increments. When it reaches
       :data:`BLOCK_RECURRENCE_LIMIT`, the task is routed to ``triage`` instead
       of ``blocked`` — breaking the cron-unblock ↔ worker-re-block loop and
-      forcing a human-in-the-loop triage decision.
+      forcing a human-in-the-loop triage decision. Blocks that start from a
+      parked lane (already-triaged stale cards, todo drafts, etc.) do not
+      tick the loop counter — they land in ``blocked`` with a fresh count.
 
     * ``transient`` — treated like a generic block for routing, but a worker
       can use it to signal "this might clear on its own"; it still participates
@@ -4914,6 +4943,7 @@ def block_task(
         )
     routed_to = "blocked"
     recurrences = 0
+    blockable_in = _sql_status_in(BLOCKABLE_STATUSES)
     with write_txn(conn):
         cur_row = conn.execute(
             "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
@@ -4921,6 +4951,7 @@ def block_task(
         ).fetchone()
         if cur_row is None:
             return False
+        prev_status = cur_row["status"]
         prev_kind = cur_row["block_kind"] if "block_kind" in cur_row.keys() else None
         prev_recurrences = (
             int(cur_row["block_recurrences"])
@@ -4935,7 +4966,7 @@ def block_task(
         # a dependency-wait as something to "unblock".
         if kind == "dependency":
             cur = conn.execute(
-                """
+                f"""
                 UPDATE tasks
                    SET status        = 'todo',
                        claim_lock    = NULL,
@@ -4943,7 +4974,7 @@ def block_task(
                        worker_pid    = NULL,
                        block_kind    = ?
                  WHERE id = ?
-                   AND status IN ('running', 'ready')
+                   AND status IN ({blockable_in})
                 """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
                 (kind, task_id) if expected_run_id is None
                 else (kind, task_id, int(expected_run_id)),
@@ -4975,20 +5006,26 @@ def block_task(
             )
             return True
 
-        # Truly-blocked kinds. Increment the unblock-loop counter when this is a
-        # re-block for the SAME reason after a prior unblock. block_task only
-        # fires from running/ready (i.e. AFTER an unblock returned the task to
-        # the work pool), so a stored block_kind that matches the incoming kind
-        # means: blocked → unblocked → about-to-re-block for the same cause.
-        # An un-typed (None) block compares as "same" to a prior un-typed block.
-        same_cause = prev_kind == kind
-        recurrences = prev_recurrences + 1 if same_cause else 1
+        # Truly-blocked kinds. Unblock-loop counting only applies when the
+        # task is re-entering block from the work pool (running/ready) —
+        # i.e. AFTER an unblock returned it to dispatch. Operator blocks
+        # from parked lanes (triage/todo/scheduled/review) start a fresh
+        # human block without ticking the loop breaker.
+        if prev_status in ("running", "ready"):
+            same_cause = prev_kind == kind
+            recurrences = prev_recurrences + 1 if same_cause else 1
+        else:
+            same_cause = False
+            recurrences = 1
 
-        if recurrences >= BLOCK_RECURRENCE_LIMIT:
+        if (
+            prev_status in ("running", "ready")
+            and recurrences >= BLOCK_RECURRENCE_LIMIT
+        ):
             # Loop detected — stop letting the unblocker spin this task. Route
             # to triage for a human-in-the-loop decision instead of blocked.
             cur = conn.execute(
-                """
+                f"""
                 UPDATE tasks
                    SET status        = 'triage',
                        claim_lock    = NULL,
@@ -4997,7 +5034,7 @@ def block_task(
                        block_kind    = ?,
                        block_recurrences = ?
                  WHERE id = ?
-                   AND status IN ('running', 'ready')
+                   AND status IN ({blockable_in})
                 """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
                 (kind, recurrences, task_id) if expected_run_id is None
                 else (kind, recurrences, task_id, int(expected_run_id)),
@@ -5027,7 +5064,7 @@ def block_task(
         else:
             if expected_run_id is None:
                 cur = conn.execute(
-                    """
+                    f"""
                     UPDATE tasks
                        SET status        = 'blocked',
                            claim_lock    = NULL,
@@ -5036,13 +5073,13 @@ def block_task(
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
-                       AND status IN ('running', 'ready')
+                       AND status IN ({blockable_in})
                     """,
                     (kind, recurrences, task_id),
                 )
             else:
                 cur = conn.execute(
-                    """
+                    f"""
                     UPDATE tasks
                        SET status        = 'blocked',
                            claim_lock    = NULL,
@@ -5051,7 +5088,7 @@ def block_task(
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
-                       AND status IN ('running', 'ready')
+                       AND status IN ({blockable_in})
                        AND current_run_id = ?
                     """,
                     (kind, recurrences, task_id, int(expected_run_id)),

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1170,6 +1170,125 @@ def test_complete_records_result(kanban_home):
     assert task.completed_at is not None
 
 
+def test_complete_from_triage_preserves_history_and_links(kanban_home):
+    """Stale triage cards must be completable without promote-first.
+
+    Operator/board recovery path: a card escalated or parked in triage
+    still has attempt history + dependency edges that must survive the
+    terminal transition.
+    """
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        child = kb.create_task(
+            conn, title="stale triage child", assignee="worker", parents=[parent],
+        )
+        # Prior attempt history on the parent before it is parked in triage.
+        assert kb.claim_task(conn, parent)
+        run_before = kb.latest_run(conn, parent)
+        assert run_before is not None and run_before.ended_at is None
+        assert kb.block_task(conn, parent, reason="loop-1", kind="needs_input")
+        assert kb.unblock_task(conn, parent)
+        assert kb.claim_task(conn, parent)
+        assert kb.block_task(conn, parent, reason="loop-2", kind="needs_input")
+        assert kb.get_task(conn, parent).status == "triage"
+
+        prior_runs = list(kb.list_runs(conn, parent))
+        prior_events = list(kb.list_events(conn, parent))
+        assert len(prior_runs) >= 2
+        assert any(e.kind == "block_loop_detected" for e in prior_events)
+
+        ok = kb.complete_task(
+            conn, parent,
+            summary="superseded duplicate — close stale triage card",
+            result="closed-as-duplicate",
+        )
+        assert ok is True
+        task = kb.get_task(conn, parent)
+        assert task.status == "done"
+        assert task.result == "closed-as-duplicate"
+        assert task.completed_at is not None
+        assert task.claim_lock is None
+
+        # History retained.
+        runs_after = list(kb.list_runs(conn, parent))
+        events_after = list(kb.list_events(conn, parent))
+        assert len(runs_after) >= len(prior_runs)
+        assert any(e.kind == "completed" for e in events_after)
+        assert any(e.kind == "block_loop_detected" for e in events_after)
+
+        # Dependency edge preserved; child may promote once parent is done.
+        links = conn.execute(
+            "SELECT parent_id, child_id FROM task_links WHERE parent_id = ?",
+            (parent,),
+        ).fetchall()
+        assert [(r["parent_id"], r["child_id"]) for r in links] == [(parent, child)]
+        child_task = kb.get_task(conn, child)
+        assert child_task.status in ("todo", "ready")
+
+
+def test_archive_from_triage_preserves_history_and_links(kanban_home):
+    """Archive is the soft-terminal path for abandoned triage cards."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="triage-parent", triage=True)
+        child = kb.create_task(
+            conn, title="dep-child", assignee="worker", parents=[parent],
+        )
+        assert kb.get_task(conn, parent).status == "triage"
+        kb.add_comment(conn, parent, "ops", "stale — archive me")
+        assert kb.archive_task(conn, parent) is True
+        task = kb.get_task(conn, parent)
+        assert task.status == "archived"
+        assert task.claim_lock is None
+        events = list(kb.list_events(conn, parent))
+        assert any(e.kind == "archived" for e in events)
+        comments = list(kb.list_comments(conn, parent))
+        assert any("stale" in c.body for c in comments)
+        links = conn.execute(
+            "SELECT child_id FROM task_links WHERE parent_id = ?",
+            (parent,),
+        ).fetchall()
+        assert [r["child_id"] for r in links] == [child]
+        # Archived parents satisfy dependents the same way done does.
+        child_task = kb.get_task(conn, child)
+        assert child_task.status in ("todo", "ready")
+
+
+def test_block_from_triage_lands_in_blocked_without_loop_tick(kanban_home):
+    """Operator can re-park a triage card as blocked; loop counter resets."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="escalated", assignee="worker")
+        assert kb.claim_task(conn, tid)
+        assert kb.block_task(conn, tid, reason="r1", kind="capability")
+        assert kb.unblock_task(conn, tid)
+        assert kb.claim_task(conn, tid)
+        assert kb.block_task(conn, tid, reason="r2", kind="capability")
+        task = kb.get_task(conn, tid)
+        assert task.status == "triage"
+        assert task.block_recurrences >= kb.BLOCK_RECURRENCE_LIMIT
+
+        assert kb.block_task(
+            conn, tid, reason="operator hold after triage", kind="needs_input",
+        ) is True
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.block_kind == "needs_input"
+        # Fresh count — must not immediately re-escalate to triage.
+        assert task.block_recurrences == 1
+        events = list(kb.list_events(conn, tid))
+        assert any(e.kind == "blocked" for e in events)
+        assert any(e.kind == "block_loop_detected" for e in events)
+
+
+def test_complete_rejects_already_terminal(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="once")
+        assert kb.complete_task(conn, tid, summary="first")
+        assert kb.complete_task(conn, tid, summary="second") is False
+        assert kb.archive_task(conn, tid)
+        assert kb.complete_task(conn, tid, summary="third") is False
+        assert kb.get_task(conn, tid).status == "archived"
+
+
 def test_block_then_unblock(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="a")

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -819,6 +819,77 @@ def test_patch_status_triage_works(client):
     assert r.json()["task"]["status"] == "todo"
 
 
+def test_patch_terminal_transitions_from_triage(client):
+    """Board API must complete / block / archive stale triage cards.
+
+    Regression for operator recovery of superseded triage rows that
+    previously 409'd because complete/block only accepted work-pool
+    statuses.
+    """
+    # --- complete ---
+    t = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "stale-complete", "triage": True},
+    ).json()["task"]
+    assert t["status"] == "triage"
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{t['id']}",
+        json={"status": "done", "summary": "closed as duplicate", "result": "dup"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["task"]["status"] == "done"
+
+    # History + handoff preserved via detail endpoint.
+    detail = client.get(f"/api/plugins/kanban/tasks/{t['id']}").json()
+    assert detail["task"]["status"] == "done"
+    assert any(e.get("kind") == "completed" for e in detail.get("events", []))
+
+    # --- archive ---
+    t2 = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "stale-archive", "triage": True},
+    ).json()["task"]
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{t2['id']}",
+        json={"status": "archived"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["task"]["status"] == "archived"
+
+    # --- block ---
+    t3 = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "stale-block", "triage": True},
+    ).json()["task"]
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{t3['id']}",
+        json={"status": "blocked", "block_reason": "needs human disposition"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["task"]["status"] == "blocked"
+
+    # Dependencies survive archive of a triage parent.
+    parent = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "triage-parent", "triage": True},
+    ).json()["task"]
+    child = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "child", "parents": [parent["id"]]},
+    ).json()["task"]
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{parent['id']}",
+        json={"status": "archived"},
+    )
+    assert r.status_code == 200, r.text
+    detail = client.get(f"/api/plugins/kanban/tasks/{parent['id']}").json()
+    child_ids = detail.get("links", {}).get("children", [])
+    assert child["id"] in child_ids
+    child_detail = client.get(f"/api/plugins/kanban/tasks/{child['id']}").json()
+    assert child_detail["task"]["status"] in ("todo", "ready")
+    assert parent["id"] in child_detail.get("links", {}).get("parents", [])
+
+
 # ---------------------------------------------------------------------------
 # Progress rollup (done children / total children)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Stale `triage`/`todo`/`scheduled`/`review` cards could not be completed or blocked via board API/CLI because `complete_task` / `block_task` only accepted work-pool statuses.

- Add `COMPLETABLE_STATUSES` / `BLOCKABLE_STATUSES` including parked lanes
- Reset block recurrence when blocking from a parked lane (avoid immediate re-escalation)
- Tests for complete/archive/block from triage + dashboard PATCH paths

Kanban card: `t_257bacd4` (fork issues disabled — tracking on card + this PR).

## Test plan
- [ ] `pytest tests/hermes_cli/test_kanban_db.py -q -k triage`
- [ ] `pytest tests/plugins/test_kanban_dashboard_plugin.py -q -k triage`

`execution_head`: cal (merge upstream) · cursor optional
`repo`: NousResearch/hermes-agent (via m4r13y fork)
