### PR TITLE
fix(config,doctor): accept known roots and synthetic slugs

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5518,6 +5518,8 @@ _EXTRA_KNOWN_ROOT_KEYS = {
     "platforms",             # top-level per-platform map merged by gateway/config.py
     "require_mention",       # top-level convenience form honored by the gateway (#3979)
     "unauthorized_dm_behavior",  # top-level form read by gateway/config.py
+    "group_sessions_per_user",  # top-level form read by gateway/config.py
+    "known_plugin_toolsets",  # map written/read by hermes_cli/tools_config.py
     "signal",            # Signal settings bridged to env vars by gateway/config.py
 }
 _KNOWN_ROOT_KEYS = frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -845,7 +845,7 @@ def run_doctor(args):
                     PROVIDER_REGISTRY,
                     resolve_provider as _resolve_auth_provider,
                 )
-                known_providers = set(PROVIDER_REGISTRY.keys()) | {"openrouter", "custom", "auto"}
+                known_providers = set(PROVIDER_REGISTRY.keys()) | {"openrouter", "custom", "auto", "synthetic"}
             except Exception:
                 _resolve_auth_provider = None
                 pass
@@ -941,6 +941,9 @@ def run_doctor(args):
                 "lmstudio",
                 "nous",
                 "nvidia",
+                # Synthetic's OpenAI-compatible gateway accepts upstream vendor/model slugs
+                # like hf:zai-org/GLM-5.2 as native model identifiers.
+                "synthetic",
                 # Fireworks' native model IDs are slash-form
                 # (accounts/fireworks/models/... and .../routers/...), so a "/"
                 # is expected, not an aggregator vendor prefix.

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -253,6 +253,16 @@ class TestUnknownTopLevelKeys:
         assert _EXTRA_KNOWN_ROOT_KEYS.issubset(_KNOWN_ROOT_KEYS)
         assert _KNOWN_ROOT_KEYS == frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 
+    def test_gateway_and_toolset_root_keys_are_accepted_without_unknown_warning(self):
+        """Raw gateway/toolset roots read outside DEFAULT_CONFIG must stay accepted."""
+        issues = validate_config_structure({
+            "model": {"provider": "openrouter"},
+            "group_sessions_per_user": True,
+            "known_plugin_toolsets": {"example": True},
+        })
+        unknown = [i for i in issues if "Unknown top-level config key" in i.message]
+        assert unknown == [], f"Unexpected unknown-key warnings: {[i.message for i in unknown]}"
+
     def test_provider_like_unknown_root_keeps_misplaced_message(self):
         """Preserve existing base_url/api_key root-level guidance (not generic unknown)."""
         issues = validate_config_structure({

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -517,6 +517,7 @@ def test_run_doctor_flags_missing_credentials_for_active_openrouter_provider(mon
         ("kilocode", "anthropic/claude-sonnet-4.6"),
         ("kimi-coding", "kimi-k2"),
         ("nvidia", "qwen/qwen3.5-122b-a10b"),
+        ("synthetic", "hf:zai-org/GLM-5.2"),
     ],
 )
 def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(
@@ -557,7 +558,7 @@ def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(
     out = buf.getvalue()
     assert f"model.provider '{provider}' is not a recognised provider" not in out
     assert f"model.provider '{provider}' is unknown" not in out
-    if provider in {"opencode-zen", "kilocode", "nvidia"}:
+    if provider in {"opencode-zen", "kilocode", "nvidia", "synthetic"}:
         assert (
             f"model.default '{default_model}' uses a vendor/model slug but provider is '{provider}'"
             not in out


### PR DESCRIPTION
## Summary

Two targeted fixes for `hermes doctor` false-positives on valid configs:

1. Add `group_sessions_per_user` and `known_plugin_toolsets` to the known top-level config roots. These keys are read outside `DEFAULT_CONFIG`, but doctor currently reports them as unknown. This addresses #67478.
2. Treat `synthetic` as a known provider that accepts vendor-prefixed/native upstream model slugs such as `hf:zai-org/GLM-5.2`, avoiding the incorrect vendor/model slug mismatch warning.

## Changes

- `hermes_cli/config.py`: add the two live root keys to `_EXTRA_KNOWN_ROOT_KEYS`.
- `hermes_cli/doctor.py`: include `synthetic` in the known provider set and in the provider list whose native model IDs may contain vendor/slash-style slugs.
- `tests/hermes_cli/test_config_validation.py`: cover the accepted root keys.
- `tests/hermes_cli/test_doctor.py`: cover `synthetic` with a vendor-prefixed model slug.

## Tests

- `venv/bin/python -m py_compile hermes_cli/config.py hermes_cli/doctor.py`
- `venv/bin/python -m pytest tests/hermes_cli/test_config_validation.py -q`
- `venv/bin/python -m pytest tests/hermes_cli/test_doctor.py -k 'accepts_hermes_provider_ids_that_catalog_aliases or accepts_vendor_slugs_for_named_custom_provider' -q`

## Notes

This intentionally does not include dependency/version changes or local operational remediation changes.

Closes #67478.
