### PR TITLE
feat(telegram): make media upload write timeout configurable

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -972,6 +972,9 @@ platform_toolsets:
 #     guest_mode: false
 #     # allowed_chats: ["-1001234567890"]
 #     extra:
+#       # Seconds allowed for media uploads. Omit to use python-telegram-bot's
+#       # 20 second default.
+#       media_write_timeout: 120.0
 #       disable_link_previews: false  # Set true to suppress Telegram URL previews in bot messages
 #       rich_messages: false          # Bot API 10.1 rich messages (tables/task lists/details/math); default false for copyable legacy MarkdownV2, set true to opt in
 #       rich_drafts: false            # Experimental rich draft previews during Telegram DM streaming; default false because Telegram Desktop/macOS can visually overlay draft frames

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3665,6 +3665,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 "read_timeout": _env_float("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", 20.0),
                 "write_timeout": _env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
             }
+            if self.config.extra.get("media_write_timeout") is not None:
+                request_kwargs["media_write_timeout"] = self._coerce_float_extra(
+                    "media_write_timeout",
+                    20.0,
+                )
 
             # CLOSE_WAIT fd leak (#31599, same class as #18451): PTB's
             # HTTPXRequest builds the underlying httpx.AsyncClient with

--- a/tests/gateway/test_telegram_media_write_timeout.py
+++ b/tests/gateway/test_telegram_media_write_timeout.py
@@ -1,0 +1,102 @@
+"""Behavior tests for Telegram's configurable media upload timeout."""
+
+import asyncio
+import sys
+from unittest.mock import MagicMock
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+    telegram_modules = (
+        "telegram",
+        "telegram.ext",
+        "telegram.constants",
+        "telegram.request",
+    )
+    for name in telegram_modules:
+        sys.modules.setdefault(name, telegram_mod)
+
+
+_ensure_telegram_mock()
+
+from plugins.platforms.telegram import adapter as tg_adapter  # noqa: E402
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+class _StopConnect(Exception):
+    """Stop connect after request construction and before network access."""
+
+
+class _RecordingHTTPXRequest:
+    """Record each HTTPXRequest constructor call."""
+
+    instances: list = []
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.__class__.instances.append(self)
+
+
+def _build_requests(monkeypatch, *, telegram_config=None):
+    _RecordingHTTPXRequest.instances = []
+
+    async def _no_fallback_ips():
+        return []
+
+    monkeypatch.setattr(tg_adapter, "discover_fallback_ips", _no_fallback_ips)
+    monkeypatch.setattr(tg_adapter, "resolve_proxy_url", lambda *args, **kwargs: None)
+    monkeypatch.setattr(tg_adapter, "HTTPXRequest", _RecordingHTTPXRequest)
+
+    extra = tg_adapter._apply_yaml_config({}, telegram_config or {}) or {}
+    adapter = TelegramAdapter(
+        PlatformConfig(enabled=True, token="test-token", extra=extra)
+    )
+    monkeypatch.setattr(
+        adapter,
+        "_acquire_platform_lock",
+        lambda *args, **kwargs: True,
+    )
+    monkeypatch.setattr(adapter, "_fallback_ips", lambda: [])
+
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.side_effect = _StopConnect
+    application = MagicMock()
+    application.builder.return_value = builder
+    monkeypatch.setattr(tg_adapter, "Application", application)
+
+    asyncio.run(adapter.connect())
+    return list(_RecordingHTTPXRequest.instances)
+
+
+def test_configured_media_write_timeout_is_passed_to_httpx_request(monkeypatch):
+    requests = _build_requests(
+        monkeypatch,
+        telegram_config={"extra": {"media_write_timeout": 180.0}},
+    )
+
+    assert len(requests) == 2
+    assert all(
+        request.kwargs.get("media_write_timeout") == 180.0
+        for request in requests
+    )
+
+
+def test_unset_media_write_timeout_uses_ptb_default(monkeypatch):
+    requests = _build_requests(monkeypatch)
+
+    assert len(requests) == 2
+    assert all("media_write_timeout" not in request.kwargs for request in requests)

--- a/tests/gateway/test_telegram_media_write_timeout.py
+++ b/tests/gateway/test_telegram_media_write_timeout.py
@@ -100,3 +100,167 @@ def test_unset_media_write_timeout_uses_ptb_default(monkeypatch):
 
     assert len(requests) == 2
     assert all("media_write_timeout" not in request.kwargs for request in requests)
+
+
+# --------------------------------------------------------------------------
+# End-to-end config resolution.
+#
+# The constructor assertions above build ``extra`` by calling
+# ``_apply_yaml_config`` directly, which skips the real YAML resolution. This
+# drives ``load_gateway_config()`` so a regression in the loader itself cannot
+# pass unnoticed.
+# --------------------------------------------------------------------------
+
+
+def _load_with_yaml_dict(yaml_dict: dict):
+    """Drive the real ``load_gateway_config()`` with *yaml_dict* as config.yaml."""
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from gateway.config import load_gateway_config
+
+    fake_home = Path("/tmp/fake_hermes_home_67655")
+
+    def fake_exists(self):
+        return str(self).endswith("config.yaml")
+
+    with patch("gateway.config.get_hermes_home", return_value=fake_home), \
+         patch.object(Path, "exists", fake_exists), \
+         patch("builtins.open", create=True) as mock_file:
+        mock_file.return_value.__enter__ = lambda s: s
+        mock_file.return_value.__exit__ = MagicMock(return_value=False)
+        with patch("yaml.safe_load", return_value=yaml_dict):
+            return load_gateway_config()
+
+
+def _telegram_extra(yaml_dict: dict) -> dict:
+    from gateway.config import Platform
+
+    cfg = _load_with_yaml_dict(yaml_dict)
+    return cfg.platforms[Platform.TELEGRAM].extra or {}
+
+
+def test_media_write_timeout_survives_the_real_config_loader():
+    extra = _telegram_extra({
+        "platforms": {
+            "telegram": {
+                "enabled": True,
+                "token": "test-token",
+                "extra": {"media_write_timeout": 180.0},
+            }
+        }
+    })
+
+    assert extra.get("media_write_timeout") == 180.0
+
+
+def test_config_loader_leaves_media_write_timeout_unset_when_absent():
+    extra = _telegram_extra({
+        "platforms": {
+            "telegram": {"enabled": True, "token": "test-token"},
+        }
+    })
+
+    assert "media_write_timeout" not in extra
+
+
+# --------------------------------------------------------------------------
+# Standalone sender.
+#
+# tools/send_message_tool.py::_send_telegram builds its own Bot rather than
+# reusing the gateway adapter's, so the configured timeout has to be threaded
+# through separately or media uploads there keep PTB's 20 second default.
+# --------------------------------------------------------------------------
+
+
+class _StopAfterBot(Exception):
+    """Abort _send_telegram once the Bot has been constructed."""
+
+
+_built_bots: list = []
+
+
+class _StubBot:
+    def __init__(self, *args, **kwargs):
+        object.__setattr__(self, "init_kwargs", kwargs)
+        _built_bots.append(self)
+
+    def __getattr__(self, name):
+        raise _StopAfterBot(name)
+
+
+def _capture_standalone_requests(monkeypatch, *, media_write_timeout, proxy=None):
+    """Call ``_send_telegram`` far enough to build its Bot, returning the
+    HTTPXRequest kwargs it used and the Bot constructor kwargs.
+
+    ``_send_telegram`` resolves ``telegram`` and ``telegram.request`` lazily
+    through ``sys.modules``, and the module-level mock above may already own
+    those entries, so patch the objects sys.modules actually holds rather than
+    whatever ``import telegram.request`` binds.
+    """
+    import tools.send_message_tool as smt
+    from gateway.platforms import base as gateway_base
+
+    recorded: list = []
+    _built_bots.clear()
+
+    class _RecordingRequest:
+        def __init__(self, *args, **kwargs):
+            recorded.append(kwargs)
+
+    tg_mod = sys.modules["telegram"]
+    tg_request_mod = sys.modules.get("telegram.request", tg_mod)
+
+    monkeypatch.setattr(tg_mod, "Bot", _StubBot, raising=False)
+    monkeypatch.setattr(tg_request_mod, "HTTPXRequest", _RecordingRequest, raising=False)
+    monkeypatch.setattr(
+        gateway_base, "resolve_proxy_url", lambda *a, **k: proxy, raising=False
+    )
+
+    asyncio.run(
+        smt._send_telegram(
+            "test-token",
+            "12345",
+            "hello",
+            media_write_timeout=media_write_timeout,
+        )
+    )
+    return recorded, list(_built_bots)
+
+
+def test_standalone_direct_path_applies_configured_media_write_timeout(monkeypatch):
+    recorded, bots = _capture_standalone_requests(monkeypatch, media_write_timeout=180.0)
+
+    assert recorded, "the direct path should build a configured HTTPXRequest"
+    assert all(kw.get("media_write_timeout") == 180.0 for kw in recorded)
+    assert bots and "request" in bots[0].init_kwargs
+
+
+def test_standalone_proxy_path_applies_configured_media_write_timeout(monkeypatch):
+    recorded, bots = _capture_standalone_requests(
+        monkeypatch, media_write_timeout=180.0, proxy="http://proxy.example:8080"
+    )
+
+    assert len(recorded) == 2, "proxy path builds request and get_updates_request"
+    assert all(kw.get("media_write_timeout") == 180.0 for kw in recorded)
+    assert all(kw.get("proxy") == "http://proxy.example:8080" for kw in recorded)
+    assert bots and "get_updates_request" in bots[0].init_kwargs
+
+
+def test_standalone_unset_media_write_timeout_keeps_ptb_defaults(monkeypatch):
+    recorded, bots = _capture_standalone_requests(monkeypatch, media_write_timeout=None)
+
+    # With nothing configured the direct path builds a bare Bot, so PTB's own
+    # request defaults apply untouched.
+    assert all("media_write_timeout" not in kw for kw in recorded)
+    assert bots, "a Bot should still be constructed"
+    assert "request" not in bots[0].init_kwargs
+
+
+def test_standalone_non_numeric_media_write_timeout_is_ignored(monkeypatch):
+    recorded, bots = _capture_standalone_requests(
+        monkeypatch, media_write_timeout="not-a-number"
+    )
+
+    assert all("media_write_timeout" not in kw for kw in recorded)
+    assert bots and "request" not in bots[0].init_kwargs

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -851,7 +851,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     # limit (issue #28557). Pass the whole message in one call; media attaches
     # after all text chunks.
     if platform == Platform.TELEGRAM:
-        disable_link_previews = bool(getattr(pconfig, "extra", {}) and pconfig.extra.get("disable_link_previews"))
+        _tg_extra = getattr(pconfig, "extra", None) or {}
+        disable_link_previews = bool(_tg_extra.get("disable_link_previews"))
         return await _send_telegram(
             pconfig.token,
             chat_id,
@@ -860,6 +861,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             thread_id=thread_id,
             disable_link_previews=disable_link_previews,
             force_document=force_document,
+            media_write_timeout=_tg_extra.get("media_write_timeout"),
         )
 
     # --- Discord: chunked delivery via the registry's standalone_sender_fn.
@@ -1173,7 +1175,7 @@ def _is_telegram_thread_not_found(error: Exception) -> bool:
     return "thread not found" in str(error).lower()
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False, media_write_timeout=None):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
     Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
@@ -1213,20 +1215,43 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             _tg_proxy = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=["api.telegram.org"])
         except Exception:
             _tg_proxy = None
+        # platforms.telegram.extra.media_write_timeout reaches the gateway
+        # adapter's request construction, but this standalone path built an
+        # unconfigured Bot, so its uploads kept PTB's 20 second write default.
+        # A multi-MB voice or video that the gateway uploads fine still timed
+        # out when sent from here. Apply the same value to both the proxy and
+        # the direct path, and leave PTB's defaults untouched when it is unset.
+        _request_kwargs = {}
+        if media_write_timeout is not None:
+            try:
+                _request_kwargs["media_write_timeout"] = float(media_write_timeout)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "send_message: ignoring non-numeric media_write_timeout %r",
+                    media_write_timeout,
+                )
+                _request_kwargs = {}
+
+        def _direct_bot():
+            if not _request_kwargs:
+                return Bot(token=token)
+            from telegram.request import HTTPXRequest
+            return Bot(token=token, request=HTTPXRequest(**_request_kwargs))
+
         if _tg_proxy:
             try:
                 from telegram.request import HTTPXRequest
                 logger.info("send_message: standalone Telegram send routed through proxy %s", _tg_proxy)
                 bot = Bot(
                     token=token,
-                    request=HTTPXRequest(proxy=_tg_proxy),
-                    get_updates_request=HTTPXRequest(proxy=_tg_proxy),
+                    request=HTTPXRequest(proxy=_tg_proxy, **_request_kwargs),
+                    get_updates_request=HTTPXRequest(proxy=_tg_proxy, **_request_kwargs),
                 )
             except Exception as _proxy_err:
                 logger.warning("send_message: failed to attach Telegram proxy (%s), falling back to direct connection", _proxy_err)
-                bot = Bot(token=token)
+                bot = _direct_bot()
         else:
-            bot = Bot(token=token)
+            bot = _direct_bot()
         from plugins.platforms.telegram.telegram_ids import (
             normalize_telegram_chat_id,
         )

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2053,6 +2053,22 @@ timezone: "America/New_York"   # IANA timezone (default: "" = server-local time)
 
 Supported values: any IANA timezone identifier (e.g. `America/New_York`, `Europe/London`, `Asia/Kolkata`, `UTC`). Leave empty or omit for server-local time.
 
+## Telegram
+
+Configure the timeout for uploading media through the Telegram gateway:
+
+```yaml
+platforms:
+  telegram:
+    extra:
+      media_write_timeout: 120.0  # seconds
+```
+
+`media_write_timeout` applies to media uploads such as voice notes and audio
+files. Increase it on hosts with slow uplinks. When omitted,
+python-telegram-bot keeps its 20 second default. This setting is separate from
+the generic Telegram HTTP write timeout.
+
 ## Discord
 
 Configure Discord-specific behavior for the messaging gateway:


### PR DESCRIPTION
## What does this PR do?

Adds a config.yaml setting for Telegram's media-specific HTTP write timeout.

python-telegram-bot uses a separate 20 second `media_write_timeout` for media uploads. The Telegram adapter previously configured only the generic connection, read, write, pool, and pool-size settings, so large voice notes and audio files could time out on slow uplinks.

Users can now set `platforms.telegram.extra.media_write_timeout` without introducing another user-facing environment variable. When the key is omitted, the adapter leaves the kwarg unset and python-telegram-bot retains its existing 20 second default.

## Related Issue

#21757 tracked this problem and was closed as not planned because the requested mechanism was a new environment variable. This PR implements the underlying need through `config.yaml` instead, per the AGENTS.md contribution rubric.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/telegram/adapter.py`: pass the configured `platforms.telegram.extra.media_write_timeout` value to both HTTPXRequest instances while omitting it when unset.
- `tests/gateway/test_telegram_media_write_timeout.py`: verify configured and unset behavior at the HTTPXRequest construction boundary.
- `website/docs/user-guide/configuration.md`: document the Telegram media upload timeout setting and its default behavior.
- `cli-config.yaml.example`: add the new key to the Telegram platform example.

## How to Test

1. Run `python -m pytest tests/gateway/test_telegram_media_write_timeout.py -q -o addopts=`.
2. Add `platforms.telegram.extra.media_write_timeout: 120.0` to `config.yaml`.
3. Send a multi-MB voice note or audio file through the Telegram gateway on a slow uplink and confirm the upload can continue beyond 20 seconds.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (full suite not run; the feature's test file passes on Ubuntu 22.04: `tests/gateway/test_telegram_media_write_timeout.py`, 2 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 22.04 (targeted pytest for the changed behavior)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - configuration-only numeric setting with no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A. Configuration setting with no visual interface changes.
