### PR TITLE
feat(telegram): add opt-in polling backlog preservation

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -972,6 +972,7 @@ platform_toolsets:
 #     guest_mode: false
 #     # allowed_chats: ["-1001234567890"]
 #     extra:
+#       preserve_backlog: false      # Preserve messages sent while polling was offline; useful for on-demand gateways
 #       disable_link_previews: false  # Set true to suppress Telegram URL previews in bot messages
 #       rich_messages: false          # Bot API 10.1 rich messages (tables/task lists/details/math); default false for copyable legacy MarkdownV2, set true to opt in
 #       rich_drafts: false            # Experimental rich draft previews during Telegram DM streaming; default false because Telegram Desktop/macOS can visually overlay draft frames

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1332,6 +1332,7 @@ platform_toolsets:
 #     guest_mode: false
 #     # allowed_chats: ["-1001234567890"]
 #     extra:
+#       preserve_backlog: false      # Preserve messages sent while polling was offline; useful for on-demand gateways
 #       disable_link_previews: false  # Set true to suppress Telegram URL previews in bot messages
 #       rich_messages: false          # Bot API 10.1 rich messages (tables/task lists/details/math); default false for copyable legacy MarkdownV2, set true to opt in
 #       rich_drafts: false            # Experimental rich draft previews during Telegram DM streaming; default false because Telegram Desktop/macOS can visually overlay draft frames

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -699,6 +699,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # can leave Bot API 10.1 rich draft frames visually overlaid until the
         # chat is redrawn, while final rich messages remain useful.
         self._rich_drafts_enabled: bool = self._coerce_bool_extra("rich_drafts", False)
+        self._preserve_backlog: bool = self._coerce_bool_extra("preserve_backlog", False)
         # Latched off after a capability failure on sendRichMessage /
         # sendRichMessageDraft (e.g. older python-telegram-bot without the
         # endpoint) so later sends skip the doomed rich attempt entirely.
@@ -3581,11 +3582,11 @@ class TelegramAdapter(BasePlatformAdapter):
         instead.  Webhook mode is useful for cloud deployments (Fly.io,
         Railway) where inbound HTTP can wake a suspended machine.
 
-        ``is_reconnect`` distinguishes a cold first boot (False — drop any
-        stale Bot API queue) from a watcher reconnect after a prolonged
-        outage (True — preserve the updates Telegram queued while the bot
-        was offline, otherwise every message sent during the outage is
-        silently lost). The in-process network-error ladder and the
+        ``is_reconnect`` distinguishes a cold first boot (False, which drops
+        the stale Bot API queue unless ``extra.preserve_backlog`` is enabled)
+        from a watcher reconnect after a prolonged outage (True, which
+        preserves the updates Telegram queued while the bot was offline).
+        The in-process network-error ladder and the
         409-conflict handler already pass ``drop_pending_updates=False``
         for the same reason; bootstrap follows suit on the reconnect path.
 
@@ -4039,10 +4040,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._polling_error_callback_ref = _polling_error_callback
 
                 polling_started = await self._start_polling_resilient(
-                    # On a cold first boot drop the stale Bot API queue; on a
-                    # watcher reconnect after an outage preserve it so messages
-                    # sent while the bot was offline are delivered (#46621).
-                    drop_pending_updates=not is_reconnect,
+                    # Cold boots drop the stale queue unless backlog
+                    # preservation is enabled. Reconnects always preserve it (#46621).
+                    drop_pending_updates=not (
+                        is_reconnect or self._preserve_backlog
+                    ),
                     error_callback=_polling_error_callback,
                     require_progress=not is_reconnect,
                 )

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -365,6 +365,18 @@ class _PollingLifecycleAbort(RuntimeError):
     """Internal control flow for polling startup fenced by teardown."""
 
 
+class _PollingStartupConflict(RuntimeError):
+    """A 409 seen during the cold-start readiness gate, with a backlog to keep.
+
+    Distinct from the conflict the background handler recovers from. That
+    ladder restarts polling with ``drop_pending_updates=True`` to evict the
+    competing getUpdates session, which also discards everything Telegram has
+    queued. When ``extra.preserve_backlog`` is on, that queue is the whole
+    point of the setting, so startup stops and reports instead of recovering
+    into the one action the operator asked us not to take.
+    """
+
+
 class TelegramAdapter(BasePlatformAdapter):
     """Telegram bot adapter: users/groups, MarkdownV2 replies, forum topics, media."""
 
@@ -437,6 +449,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # but skips rich draft rendering; the final reply still lands via sendRichMessage.
         self._rich_messages_enabled: bool = self._coerce_bool_extra("rich_messages", False)
         self._rich_drafts_enabled: bool = self._coerce_bool_extra("rich_drafts", False)
+        self._preserve_backlog: bool = self._coerce_bool_extra("preserve_backlog", False)
         self._rich_send_disabled = self._rich_draft_disabled = False  # latched after a capability failure
         # Transient sendChatAction failures recur on every keep-typing tick; back off per chat.
         self._telegram_typing_cooldown_until: Dict[str, float] = {}
@@ -1796,7 +1809,12 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _await_cold_start_readiness(self, progress: asyncio.Event, strict_error_event: asyncio.Event, strict_error: list) -> None:
         """Cold start: wait for THIS generation's first getUpdates success or the first polling error;
-        raises OSError so GatewayRunner disposes the partial adapter and retries fresh."""
+        raises OSError so GatewayRunner disposes the partial adapter and retries fresh.
+
+        Progress establishes readiness, not exclusive token ownership. A conflict
+        captured while the gate is open wins even if progress also fired, and is
+        terminal under extra.preserve_backlog so recovery cannot discard the queue.
+        """
         progress_wait = asyncio.ensure_future(progress.wait())
         error_wait = asyncio.ensure_future(strict_error_event.wait())
         try:
@@ -1814,6 +1832,41 @@ class TelegramAdapter(BasePlatformAdapter):
                 if not fut.done():
                     fut.cancel()
             await asyncio.gather(progress_wait, error_wait, return_exceptions=True)
+        # A first successful getUpdates is readiness, not proof that
+        # we own the token: Telegram can answer one getUpdates and
+        # 409 the next (#75017). So a conflict captured while the gate
+        # was open decides the outcome even when progress also fired,
+        # rather than losing the race to it.
+        if (
+            strict_error
+            # getattr: partially constructed adapters reach this gate
+            # in tests and during early teardown.
+            and getattr(self, "_preserve_backlog", False)
+            and self._looks_like_polling_conflict(strict_error[0])
+        ):
+            message = (
+                "Another process is already polling this bot token. "
+                "Startup stopped instead of recovering, because "
+                "conflict recovery restarts polling with "
+                "drop_pending_updates=True and would discard the "
+                "queued updates that extra.preserve_backlog exists to "
+                "keep. Stop the other instance, then start this one."
+            )
+            logger.error(
+                "[%s] %s Original error: %s",
+                self.name,
+                message,
+                _redact_telegram_error_text(strict_error[0]),
+            )
+            # Same code and retryability as the exhausted-retry
+            # escalation, so the conflict reads identically in runtime
+            # status either way. It also fences _handle_polling_conflict,
+            # whose entry guard returns early on this code, in case a
+            # later generation still schedules one.
+            self._set_fatal_error(
+                "telegram_polling_conflict", message, retryable=False
+            )
+            raise _PollingStartupConflict(message) from strict_error[0]
         if strict_error and not progress.is_set():
             raise OSError(
                 "Telegram polling errored before first getUpdates success during initial connect: "
@@ -2901,8 +2954,9 @@ class TelegramAdapter(BasePlatformAdapter):
 
         self._polling_error_callback_ref = _polling_error_callback  # reused by _handle_polling_conflict
         polling_started = await self._start_polling_resilient(
-            # Cold first boot drops the stale Bot API queue; a watcher reconnect preserves it.
-            drop_pending_updates=not is_reconnect, error_callback=_polling_error_callback, require_progress=not is_reconnect)
+            # Opted-in cold boots and all watcher reconnects preserve the queued updates.
+            drop_pending_updates=not (is_reconnect or self._preserve_backlog),
+            error_callback=_polling_error_callback, require_progress=not is_reconnect)
         if not polling_started:
             logger.warning(
                 "[%s] Connected in degraded Telegram mode: gateway is alive, polling will be retried in the background", self.name)
@@ -2910,8 +2964,9 @@ class TelegramAdapter(BasePlatformAdapter):
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect via long polling, or a webhook server if ``TELEGRAM_WEBHOOK_URL`` is set.
 
-        ``is_reconnect``: False = cold boot (drop the stale Bot API queue); True = watcher reconnect (preserve queued
-        updates, else every message sent during the outage is lost). Webhook env: TELEGRAM_WEBHOOK_URL,
+        Cold polling boots drop queued updates unless extra.preserve_backlog is enabled.
+        Watcher reconnects always preserve queued updates. Webhook behavior is unchanged.
+        Webhook env: TELEGRAM_WEBHOOK_URL,
         TELEGRAM_WEBHOOK_PORT (8443), TELEGRAM_WEBHOOK_HOST, TELEGRAM_WEBHOOK_SECRET."""
         # Explicit connect() is the only operation allowed to reopen polling after a completed teardown.
         self._polling_teardown_started = False
@@ -2984,6 +3039,16 @@ class TelegramAdapter(BasePlatformAdapter):
             safe_error = _redact_telegram_error_text(e)
             # Classify by exception TYPE (never message text): auth failures can never self-heal, so
             # marking them retryable put agents into a silent eternal reconnect loop.
+            if isinstance(e, _PollingStartupConflict):
+                # The readiness gate already recorded the terminal conflict
+                # with the operator-facing message. Reclassifying it as a
+                # generic startup failure below would mark it retryable and
+                # put the gateway back into the very reconnect loop this
+                # exception exists to stop.
+                logger.error(
+                    "[%s] Failed to connect to Telegram: %s", self.name, safe_error
+                )
+                return False
             if self._looks_like_auth_error(e):
                 message = (
                     f"Telegram bot token rejected: {safe_error}. "

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -540,10 +540,50 @@ def _build_polling_app(monkeypatch, adapter):
 
 
 @pytest.mark.asyncio
+async def test_cold_connect_preserves_pending_updates_when_enabled(monkeypatch):
+    """An opted-in cold first boot preserves the Bot API queue."""
+    adapter = TelegramAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"preserve_backlog": True},
+        )
+    )
+    captured = _build_polling_app(monkeypatch, adapter)
+
+    ok = await adapter.connect()
+
+    assert ok is True
+    assert captured["drop_pending_updates"] is False
+    await _cancel_heartbeat(adapter)
+
+
+@pytest.mark.asyncio
 async def test_reconnect_preserves_pending_updates(monkeypatch):
     """A watcher reconnect (is_reconnect=True) preserves the queue Telegram
     accumulated during the outage — the core of #46621."""
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    captured = _build_polling_app(monkeypatch, adapter)
+
+    ok = await adapter.connect(is_reconnect=True)
+
+    assert ok is True
+    assert captured["drop_pending_updates"] is False
+    await _cancel_heartbeat(adapter)
+
+
+@pytest.mark.asyncio
+async def test_reconnect_preserves_pending_updates_when_backlog_preservation_enabled(
+    monkeypatch,
+):
+    """An opted-in watcher reconnect keeps its existing queue behavior."""
+    adapter = TelegramAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"preserve_backlog": True},
+        )
+    )
     captured = _build_polling_app(monkeypatch, adapter)
 
     ok = await adapter.connect(is_reconnect=True)
@@ -644,4 +684,274 @@ async def test_conflict_callback_disarms_before_scheduling(monkeypatch):
     # Drain the scheduled recovery task so it doesn't outlive the test.
     for _ in range(10):
         await asyncio.sleep(0)
+    await _cancel_heartbeat(adapter)
+
+
+# ---------------------------------------------------------------------------
+# Startup conflict under backlog preservation.
+#
+# Conflict recovery restarts polling with drop_pending_updates=True to evict
+# the competing getUpdates session, which also discards everything Telegram
+# has queued. That is the right trade by default. It is the wrong trade when
+# extra.preserve_backlog is on, because the queue is the whole point of the
+# setting, so a 409 seen during the cold-start readiness gate is terminal
+# instead.
+#
+# A first successful getUpdates is readiness, not proof of exclusive
+# ownership: Telegram can answer one getUpdates and 409 the next (#75017).
+# ---------------------------------------------------------------------------
+
+_CONFLICT_TEXT = "Conflict: terminated by other getUpdates request"
+
+
+def _build_conflicting_polling_app(
+    monkeypatch, adapter, *, also_make_progress: bool
+):
+    """Polling app whose first generation reports a 409 to the error callback.
+
+    ``also_make_progress`` additionally records getUpdates progress for that
+    generation, which is the readiness/conflict race: both signals land before
+    the gate resolves.
+    """
+    captured = {}
+    conflict_cls = type("Conflict", (Exception,), {})
+
+    async def fake_start_polling(**kwargs):
+        captured.update(kwargs)
+        captured.setdefault("start_polling_calls", []).append(
+            kwargs.get("drop_pending_updates")
+        )
+        if also_make_progress:
+            adapter._record_polling_progress(adapter._polling_generation)
+        cb = kwargs.get("error_callback")
+        if cb is not None:
+            cb(conflict_cls(_CONFLICT_TEXT))
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(side_effect=fake_start_polling),
+        stop=AsyncMock(),
+        running=True,
+    )
+    bot = SimpleNamespace(set_my_commands=AsyncMock(), delete_webhook=AsyncMock())
+    app = SimpleNamespace(
+        bot=bot,
+        updater=updater,
+        add_handler=MagicMock(),
+        initialize=AsyncMock(),
+        start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock", lambda scope, identity: None
+    )
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+    captured["app"] = app
+    return captured
+
+
+def _preserving_adapter():
+    return TelegramAdapter(
+        PlatformConfig(
+            enabled=True, token="***", extra={"preserve_backlog": True}
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_pre_progress_conflict_is_terminal_and_not_retryable(monkeypatch):
+    """1. A 409 before readiness fails startup non-retryably."""
+    adapter = _preserving_adapter()
+    adapter.set_fatal_error_handler(AsyncMock())
+    _build_conflicting_polling_app(monkeypatch, adapter, also_make_progress=False)
+
+    ok = await adapter.connect()
+
+    assert ok is False
+    assert adapter.has_fatal_error is True
+    assert adapter.fatal_error_code == "telegram_polling_conflict"
+    assert adapter._fatal_error_retryable is False, (
+        "a startup conflict must not be retried; the competing instance has "
+        "to be stopped first"
+    )
+    await _cancel_heartbeat(adapter)
+
+
+@pytest.mark.asyncio
+async def test_pre_progress_conflict_skips_recovery_and_destructive_restart(
+    monkeypatch,
+):
+    """2. It neither runs conflict recovery nor restarts destructively."""
+    adapter = _preserving_adapter()
+    adapter.set_fatal_error_handler(AsyncMock())
+    recovery = AsyncMock()
+    monkeypatch.setattr(adapter, "_handle_polling_conflict", recovery)
+    captured = _build_conflicting_polling_app(
+        monkeypatch, adapter, also_make_progress=False
+    )
+
+    await adapter.connect()
+
+    recovery.assert_not_awaited()
+    assert adapter._polling_conflict_count == 0, (
+        "the conflict-retry ladder must not have been entered"
+    )
+    assert True not in captured["start_polling_calls"], (
+        "no start_polling may run with drop_pending_updates=True, which is "
+        f"what discards the backlog; saw {captured['start_polling_calls']}"
+    )
+    await _cancel_heartbeat(adapter)
+
+
+@pytest.mark.asyncio
+async def test_stored_conflict_wins_a_simultaneous_progress_race(monkeypatch):
+    """3. Readiness does not out-race a conflict captured in the same gate.
+
+    Progress proves the transport answered once, not that we own the token
+    (#75017). Before the guard this case connected successfully and the 409
+    was discarded.
+    """
+    adapter = _preserving_adapter()
+    adapter.set_fatal_error_handler(AsyncMock())
+    _build_conflicting_polling_app(monkeypatch, adapter, also_make_progress=True)
+
+    ok = await adapter.connect()
+
+    assert ok is False, "a captured conflict must decide the outcome"
+    assert adapter.fatal_error_code == "telegram_polling_conflict"
+    assert adapter._fatal_error_retryable is False
+    await _cancel_heartbeat(adapter)
+
+
+@pytest.mark.asyncio
+async def test_conflict_after_readiness_still_uses_the_recovery_ladder(
+    monkeypatch,
+):
+    """4. Post-readiness conflicts keep recovering, even with the flag on.
+
+    The gate has closed and the backlog has already been collected, so the
+    established retry ladder still applies.
+    """
+    adapter = _preserving_adapter()
+    adapter.set_fatal_error_handler(AsyncMock())
+    captured = _build_polling_app(monkeypatch, adapter)
+
+    ok = await adapter.connect()
+    assert ok is True
+    assert adapter.has_fatal_error is False
+
+    conflict = type("Conflict", (Exception,), {})
+    captured["error_callback"](conflict(_CONFLICT_TEXT))
+    await adapter._polling_error_task
+
+    assert adapter._polling_conflict_count == 1, (
+        "a conflict after readiness must still enter the retry ladder"
+    )
+    assert adapter.has_fatal_error is False
+    await _cancel_heartbeat(adapter)
+
+
+@pytest.mark.asyncio
+async def test_default_config_keeps_the_recovery_ladder_for_startup_conflicts(
+    monkeypatch,
+):
+    """5a. Without the flag, a startup 409 behaves exactly as before."""
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter.set_fatal_error_handler(AsyncMock())
+    _build_conflicting_polling_app(monkeypatch, adapter, also_make_progress=False)
+
+    ok = await adapter.connect()
+
+    assert ok is False
+    assert adapter.fatal_error_code != "telegram_polling_conflict", (
+        "the terminal startup conflict is opt-in via preserve_backlog; the "
+        "default path must keep its previous generic classification"
+    )
+    assert adapter._fatal_error_retryable is True
+    await _cancel_heartbeat(adapter)
+
+
+@pytest.mark.asyncio
+async def test_reconnect_is_unaffected_by_the_startup_conflict_guard(monkeypatch):
+    """5b. Reconnects have no readiness gate, so the guard cannot fire."""
+    adapter = _preserving_adapter()
+    adapter.set_fatal_error_handler(AsyncMock())
+    captured = _build_conflicting_polling_app(
+        monkeypatch, adapter, also_make_progress=False
+    )
+
+    ok = await adapter.connect(is_reconnect=True)
+
+    assert ok is True, "a reconnect must stay alive and recover in background"
+    assert captured["drop_pending_updates"] is False
+    await _cancel_heartbeat(adapter)
+
+
+@pytest.mark.asyncio
+async def test_startup_conflict_message_does_not_leak_the_token(monkeypatch):
+    """5c. Redaction still applies to the terminal conflict message.
+
+    The token uses a realistic shape (35+ chars after the colon) because that
+    is what the shared redactor matches. A short placeholder passes straight
+    through and would prove nothing.
+    """
+    secret = "123456789:AAHrealistic_len_token_35chars_abcdef"
+    adapter = TelegramAdapter(
+        PlatformConfig(
+            enabled=True, token=secret, extra={"preserve_backlog": True}
+        )
+    )
+    adapter.set_fatal_error_handler(AsyncMock())
+
+    captured = {}
+    conflict_cls = type("Conflict", (Exception,), {})
+
+    async def fake_start_polling(**kwargs):
+        captured.update(kwargs)
+        cb = kwargs.get("error_callback")
+        if cb is not None:
+            cb(conflict_cls(f"Conflict on https://api.telegram.org/bot{secret}/getUpdates"))
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(side_effect=fake_start_polling),
+        stop=AsyncMock(),
+        running=True,
+    )
+    bot = SimpleNamespace(set_my_commands=AsyncMock(), delete_webhook=AsyncMock())
+    app = SimpleNamespace(
+        bot=bot, updater=updater, add_handler=MagicMock(),
+        initialize=AsyncMock(), start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock", lambda scope, identity: None
+    )
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+    await adapter.connect()
+
+    assert secret not in (adapter._fatal_error_message or "")
     await _cancel_heartbeat(adapter)

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -495,10 +495,50 @@ def _build_polling_app(monkeypatch, adapter):
 
 
 @pytest.mark.asyncio
+async def test_cold_connect_preserves_pending_updates_when_enabled(monkeypatch):
+    """An opted-in cold first boot preserves the Bot API queue."""
+    adapter = TelegramAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"preserve_backlog": True},
+        )
+    )
+    captured = _build_polling_app(monkeypatch, adapter)
+
+    ok = await adapter.connect()
+
+    assert ok is True
+    assert captured["drop_pending_updates"] is False
+    await _cancel_heartbeat(adapter)
+
+
+@pytest.mark.asyncio
 async def test_reconnect_preserves_pending_updates(monkeypatch):
     """A watcher reconnect (is_reconnect=True) preserves the queue Telegram
     accumulated during the outage — the core of #46621."""
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    captured = _build_polling_app(monkeypatch, adapter)
+
+    ok = await adapter.connect(is_reconnect=True)
+
+    assert ok is True
+    assert captured["drop_pending_updates"] is False
+    await _cancel_heartbeat(adapter)
+
+
+@pytest.mark.asyncio
+async def test_reconnect_preserves_pending_updates_when_backlog_preservation_enabled(
+    monkeypatch,
+):
+    """An opted-in watcher reconnect keeps its existing queue behavior."""
+    adapter = TelegramAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"preserve_backlog": True},
+        )
+    )
     captured = _build_polling_app(monkeypatch, adapter)
 
     ok = await adapter.connect(is_reconnect=True)

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2053,6 +2053,19 @@ timezone: "America/New_York"   # IANA timezone (default: "" = server-local time)
 
 Supported values: any IANA timezone identifier (e.g. `America/New_York`, `Europe/London`, `Asia/Kolkata`, `UTC`). Leave empty or omit for server-local time.
 
+## Telegram
+
+Configure whether Telegram polling keeps updates queued while the gateway is offline:
+
+```yaml
+platforms:
+  telegram:
+    extra:
+      preserve_backlog: false  # Default false
+```
+
+Set `preserve_backlog: true` for on-demand or wake-on-message gateways so the initial polling connection processes messages that arrived while the gateway was stopped. Reconnects already preserve queued updates regardless of this setting, and webhook mode is unaffected.
+
 ## Discord
 
 Configure Discord-specific behavior for the messaging gateway:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2522,6 +2522,19 @@ timezone: "America/New_York"   # IANA timezone (default: "" = server-local time)
 
 Supported values: any IANA timezone identifier (e.g. `America/New_York`, `Europe/London`, `Asia/Kolkata`, `UTC`). Leave empty or omit for server-local time.
 
+## Telegram
+
+Configure whether Telegram polling keeps updates queued while the gateway is offline:
+
+```yaml
+platforms:
+  telegram:
+    extra:
+      preserve_backlog: false  # Default false
+```
+
+Set `preserve_backlog: true` for on-demand or wake-on-message gateways so the initial polling connection processes messages that arrived while the gateway was stopped. Reconnects already preserve queued updates regardless of this setting, and webhook mode is unaffected.
+
 ## Discord
 
 Configure Discord-specific behavior for the messaging gateway:


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `platforms.telegram.extra.preserve_backlog` config setting for Telegram polling.

By default, the first connection after gateway startup continues to discard pending Telegram updates. When `preserve_backlog: true` is configured, the first polling connection processes messages queued while the gateway was stopped. This supports on-demand and wake-on-message deployments (for example resource-constrained hosts that stop the gateway between uses and wake it when a message arrives), without changing existing defaults.

Reconnects continue preserving queued updates regardless of this setting. Webhook startup and the 409 conflict recovery path are unchanged.

PR #46461 was approved earlier but orphaned by the Telegram platform refactor; this reimplements the behavior against the current plugin architecture and config policy.

## Related Issue

No open issue tracks the cold-start case. Reconnects already preserve the queue for the same reason (#46621); this extends the same protection to deliberately stopped gateways as an opt-in.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `plugins/platforms/telegram/adapter.py` to read `extra.preserve_backlog` and preserve pending updates on the initial polling connection when enabled.
- Extended `tests/gateway/test_telegram_conflict.py` with behavior tests covering default and enabled first connections plus both reconnect cases.
- Documented the new setting in `website/docs/user-guide/configuration.md`.
- Added the setting to `cli-config.yaml.example`.

## How to Test

1. Run `python -m pytest tests/gateway/test_telegram_conflict.py -q -o addopts=`.
2. Leave `preserve_backlog` omitted or set it to `false`, queue a Telegram message while the gateway is stopped, then start the gateway and confirm the initial polling connection drops that message.
3. Set `platforms.telegram.extra.preserve_backlog: true`, repeat the stopped-gateway test, and confirm the queued message is processed after startup.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (full suite not run; the platform test file passes on Ubuntu 22.04: `tests/gateway/test_telegram_conflict.py`, 16 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 22.04 (targeted pytest for the changed behavior)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - config and polling logic are platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A. This change affects Telegram polling startup behavior and has no visual interface changes.
