### PR TITLE
fix: prevent false positives in file-mutation verifier

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2958,9 +2958,12 @@ class AIAgent:
 
         On failure, store ``{path: {error_preview, tool}}`` entries.  On
         success, remove any prior failure entries for the same paths (the
-        model recovered within the turn).  Silently no-ops if the per-turn
-        state dict hasn't been initialised yet (e.g. a tool dispatched
-        outside ``run_conversation``).
+        model recovered within the turn).  Also skips recording failures
+        for files that were already successfully written by a prior tool
+        call in the same turn (prevents false positives when write_file
+        succeeds but a subsequent patch on the same file fails).
+        Silently no-ops if the per-turn state dict hasn't been initialised
+        yet (e.g. a tool dispatched outside ``run_conversation``).
         """
         if tool_name not in _FILE_MUTATING_TOOLS:
             return
@@ -2977,11 +2980,18 @@ class AIAgent:
                 changed.update(_extract_landed_file_mutation_paths(tool_name, args, result))
         if is_error and not landed:
             preview = _extract_error_preview(result)
+            changed = getattr(self, "_turn_file_mutation_paths", None)
             for path in targets:
                 # Keep the FIRST error we saw for a given path unless we
                 # later see success.  A repeated failure with a different
                 # message shouldn't silently overwrite the original.
                 if path not in state:
+                    # Skip recording failure if this file was already
+                    # successfully written by a prior tool call this turn.
+                    # Prevents false positives when write_file succeeds
+                    # but a subsequent patch on the same file fails.
+                    if changed is not None and path in changed:
+                        continue
                     state[path] = {
                         "tool": tool_name,
                         "error_preview": preview,

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -243,6 +243,36 @@ class TestRecordFileMutationResult:
 
         assert agent._turn_failed_file_mutations == {}
 
+    def test_write_file_success_prevents_false_positive_from_later_patch_failure(self):
+        """Regression: write_file succeeds then patch on same file fails.
+
+        The verifier should NOT warn because the file was already correctly
+        written by write_file. The later patch failure is a no-op — the
+        file content is already correct from the write_file call.
+        """
+        agent = _bare_agent()
+        # Step 1: write_file succeeds
+        agent._record_file_mutation_result(
+            "write_file",
+            {"path": "/tmp/chapter-14.md", "content": "new content"},
+            json.dumps({"bytes_written": 1024}),
+            is_error=False,
+        )
+        assert agent._turn_failed_file_mutations == {}
+        assert "/tmp/chapter-14.md" in agent._turn_file_mutation_paths
+
+        # Step 2: patch on same file fails (old_string identical to new_string)
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "replace", "path": "/tmp/chapter-14.md",
+             "old_string": "same", "new_string": "same"},
+            json.dumps({"error": "old_string and new_string are identical"}),
+            is_error=True,
+        )
+        # Should NOT be recorded as a failure — write_file already landed
+        assert "/tmp/chapter-14.md" not in agent._turn_failed_file_mutations
+        assert agent._turn_failed_file_mutations == {}
+
     def test_repeated_failure_keeps_first_error(self):
         agent = _bare_agent()
         agent._record_file_mutation_result(


### PR DESCRIPTION
When write_file succeeds for a file, then a subsequent patch on the same file fails (e.g. old_string identical to new_string), the verifier incorrectly warns that the file was not modified. The file WAS already correctly written by the earlier write_file call.

Check _turn_file_mutation_paths before recording a failure. If the path is already in the successful-mutations set, skip recording the failure.

Adds regression test covering the exact scenario from subagent delegation batches.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

