### PR TITLE
fix(installer): retry Windows baseline import probe

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -269,7 +269,7 @@ function Invoke-PythonProbeProcess {
             (New-Object System.Text.UTF8Encoding $false)
         )
         $escapedScript = $tempScript.Replace('"', '\"')
-        $arguments = "-I `"$escapedScript`""
+        $arguments = "-I -X utf8 `"$escapedScript`""
         $process = Start-Process -FilePath $PythonExe -ArgumentList $arguments `
             -WorkingDirectory (Get-Location).Path -NoNewWindow -Wait -PassThru `
             -RedirectStandardOutput $tempOut -RedirectStandardError $tempErr

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -245,6 +245,134 @@ function Invoke-NativeWithRelaxedErrorAction {
         $ErrorActionPreference = $prevEAP
     }
 }
+
+function Invoke-PythonProbeProcess {
+    param(
+        [Parameter(Mandatory=$true)] [string]$PythonExe,
+        [Parameter(Mandatory=$true)] [string]$Code
+    )
+
+    # Avoid PowerShell's native stderr plumbing entirely. On hosts affected by
+    # #60129, `2>&1` can raise a StandardErrorEncoding error before Python even
+    # starts. Start-Process with file redirects captures both streams without
+    # involving that path (the same strategy being developed in #60143).
+    $tempOut = [System.IO.Path]::GetTempFileName()
+    $tempErr = [System.IO.Path]::GetTempFileName()
+    $tempScript = [System.IO.Path]::Combine(
+        [System.IO.Path]::GetTempPath(),
+        "hermes-import-probe-$([System.Guid]::NewGuid().ToString('N')).py"
+    )
+    try {
+        [System.IO.File]::WriteAllText(
+            $tempScript,
+            $Code,
+            (New-Object System.Text.UTF8Encoding $false)
+        )
+        $escapedScript = $tempScript.Replace('"', '\"')
+        $arguments = "-I `"$escapedScript`""
+        $process = Start-Process -FilePath $PythonExe -ArgumentList $arguments `
+            -WorkingDirectory (Get-Location).Path -NoNewWindow -Wait -PassThru `
+            -RedirectStandardOutput $tempOut -RedirectStandardError $tempErr
+
+        $stdout = [System.IO.File]::ReadAllText($tempOut).TrimEnd()
+        $stderr = [System.IO.File]::ReadAllText($tempErr).TrimEnd()
+        $parts = @()
+        if ($stdout) { $parts += $stdout }
+        if ($stderr) { $parts += $stderr }
+        return [PSCustomObject]@{
+            ExitCode = $process.ExitCode
+            Output = $parts -join [Environment]::NewLine
+        }
+    } finally {
+        Remove-Item $tempOut, $tempErr, $tempScript -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Invoke-BaselineImportProbe {
+    param(
+        [Parameter(Mandatory=$true)] [string]$PythonExe,
+        [int[]]$RetryDelaysSeconds = @(0, 2, 2)
+    )
+
+    $moduleList = "dotenv, openai, rich, prompt_toolkit"
+    # Validate lexical import paths. uv's supported symlink link mode keeps
+    # module.__file__ under the venv while realpath points into uv's cache.
+    $probeCode = @(
+        "import os, sys, dotenv, openai, rich, prompt_toolkit"
+        "modules = {'dotenv': dotenv, 'openai': openai, 'rich': rich, 'prompt_toolkit': prompt_toolkit}"
+        "root = os.path.normcase(os.path.abspath(sys.prefix))"
+        "origins = {name: os.path.normcase(os.path.abspath(module.__file__)) for name, module in modules.items()}"
+        "resolved = {name: os.path.normcase(os.path.realpath(module.__file__)) for name, module in modules.items()}"
+        "outside = {name: path for name, path in origins.items() if os.path.commonpath([root, path]) != root}"
+        "assert not outside, 'baseline modules outside managed prefix: ' + repr(outside)"
+        "print('module_origins=' + ';'.join(name + '=' + path for name, path in origins.items()))"
+        "print('module_resolved_origins=' + ';'.join(name + '=' + path for name, path in resolved.items()))"
+    ) -join [Environment]::NewLine
+    $environmentCode = "import site, sys; print(sys.executable); print(sys.prefix); print(chr(59).join(site.getsitepackages()))"
+
+    $environmentSummary = "unavailable"
+    try {
+        $environmentResult = Invoke-PythonProbeProcess -PythonExe $PythonExe -Code $environmentCode
+        $environmentLines = @($environmentResult.Output -split "`r?`n")
+        $environmentSummary = "unavailable (exit $($environmentResult.ExitCode))"
+        if ($environmentResult.ExitCode -eq 0 -and $environmentLines.Count -ge 2) {
+            $sitePackages = if ($environmentLines.Count -ge 3) { $environmentLines[2] } else { "unknown" }
+            $environmentSummary = "executable=$($environmentLines[0]); prefix=$($environmentLines[1]); site_packages=$sitePackages"
+        }
+    } catch {
+        $environmentSummary = "unavailable ($($_.Exception.Message))"
+    }
+
+    $lastOutput = ""
+    $probeExitCode = 1
+    $exitCodes = @()
+    $attemptCount = $RetryDelaysSeconds.Count
+    for ($i = 0; $i -lt $attemptCount; $i++) {
+        $delay = $RetryDelaysSeconds[$i]
+        if ($delay -gt 0) {
+            Start-Sleep -Seconds $delay
+        }
+
+        try {
+            $probeResult = Invoke-PythonProbeProcess -PythonExe $PythonExe -Code $probeCode
+            $probeExitCode = $probeResult.ExitCode
+            $lastOutput = $probeResult.Output
+        } catch {
+            # A launch failure is retryable too. Use a synthetic exit code so
+            # the final diagnostic distinguishes it from Python's own status.
+            $probeExitCode = -1
+            $lastOutput = $_.Exception.Message
+        }
+        $exitCodes += $probeExitCode
+
+        if ($probeExitCode -eq 0) {
+            return [PSCustomObject]@{
+                Ok = $true
+                Attempts = $i + 1
+                ExitCode = 0
+                ExitCodes = @($exitCodes)
+                Output = $lastOutput
+                Environment = $environmentSummary
+                Modules = $moduleList
+            }
+        }
+
+        Write-Warn "Baseline import probe failed (attempt $($i + 1)/$attemptCount, exit $probeExitCode)."
+        if ($lastOutput) {
+            Write-Info "Probe output: $lastOutput"
+        }
+    }
+
+    return [PSCustomObject]@{
+        Ok = $false
+        Attempts = $attemptCount
+        ExitCode = $probeExitCode
+        ExitCodes = @($exitCodes)
+        Output = $lastOutput
+        Environment = $environmentSummary
+        Modules = $moduleList
+    }
+}
 function Discard-LockfileChurn {
     param([string]$Repo = $InstallDir)
 
@@ -2083,37 +2211,29 @@ except Exception:
         throw "Failed to install hermes-agent package even with no extras. Inspect the uv pip install output above."
     }
 
-    # Baseline-import gate. Even if a tier reported success above, the
-    # actual deps may have landed somewhere other than $InstallDir\venv\
-    # (e.g. uv 0.5+ syncing into a sibling .venv\ when UV_PROJECT_ENVIRONMENT
-    # isn't set, leaving venv\ empty and hermes.exe broken with
-    # `ModuleNotFoundError: No module named 'dotenv'` on first run).
-    # We probe via the venv's own python so a misdirected sync is caught
-    # here, not 30 seconds later when the user runs `hermes`.
+    # Baseline-import gate. A successful install command above does not prove
+    # imports are immediately usable. Probe via the venv's own isolated Python
+    # with bounded retries so transient file contention can clear, then report
+    # the captured evidence on persistent failure.
+
     if (-not $NoVenv) {
         $venvPython = "$InstallDir\venv\Scripts\python.exe"
         if (-not (Test-Path $venvPython)) {
             throw "Install reported success but $venvPython does not exist. The dependency sync likely landed in a sibling .venv\ directory. Re-run the installer; if it persists, manually: cd '$InstallDir'; Remove-Item -Recurse -Force venv,.venv; uv venv venv --python $PythonVersion; `$env:UV_PROJECT_ENVIRONMENT='$InstallDir\venv'; uv sync --extra all --locked"
         }
-        # Relax EAP=Stop while running the import probe.  Python writes
-        # deprecation warnings and import-system info to stderr; under
-        # EAP=Stop the 2>&1 merge wraps those as ErrorRecord objects and
-        # throws even when the imports succeed.  $LASTEXITCODE is the
-        # reliable signal (it's 0 iff the python invocation exited 0,
-        # regardless of what was written to stderr).
-        $prevEAP = $ErrorActionPreference
-        $ErrorActionPreference = "Continue"
-        & $venvPython -c "import dotenv, openai, rich, prompt_toolkit" 2>&1 | Out-Null
-        $importExitCode = $LASTEXITCODE
-        $ErrorActionPreference = $prevEAP
-        if ($importExitCode -ne 0) {
+        $baselineProbe = Invoke-BaselineImportProbe -PythonExe $venvPython
+        if (-not $baselineProbe.Ok) {
+            $capturedOutput = if ($baselineProbe.Output) { $baselineProbe.Output } else { "<no output captured>" }
+            $exitSummary = ($baselineProbe.ExitCodes | ForEach-Object { $_.ToString() }) -join ", "
             $sibling = "$InstallDir\.venv"
-            $hint = if (Test-Path $sibling) {
-                "Detected sibling .venv\ at $sibling -- uv synced there instead of venv\. Recover with: cd '$InstallDir'; Remove-Item -Recurse -Force venv; Move-Item .venv venv"
-            } else {
-                "Recover with: cd '$InstallDir'; `$env:UV_PROJECT_ENVIRONMENT='$InstallDir\venv'; uv sync --extra all --locked"
-            }
-            throw "Baseline imports failed in $InstallDir\venv (dotenv/openai/rich/prompt_toolkit). The install completed but dependencies are not in the venv. $hint"
+            $siblingNote = if (Test-Path $sibling) {
+                " A sibling .venv also exists at '$sibling'; inspect it while troubleshooting."
+            } else { "" }
+            throw "Baseline imports failed after $($baselineProbe.Attempts) attempts. Exact interpreter: '$venvPython'. Modules: $($baselineProbe.Modules). Exit codes: [$exitSummary]. Environment: $($baselineProbe.Environment). Captured probe output: $capturedOutput.$siblingNote"
+        }
+        Write-Info "Python environment probe: $($baselineProbe.Environment)"
+        if ($baselineProbe.Output) {
+            Write-Info "Python baseline probe: $($baselineProbe.Output)"
         }
         Write-Success "Baseline imports verified in venv"
     }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -254,28 +254,45 @@ function Invoke-PythonProbeProcess {
 
     # Avoid PowerShell's native stderr plumbing entirely. On hosts affected by
     # #60129, `2>&1` can raise a StandardErrorEncoding error before Python even
-    # starts. Start-Process with file redirects captures both streams without
-    # involving that path (the same strategy being developed in #60143).
-    $tempOut = [System.IO.Path]::GetTempFileName()
-    $tempErr = [System.IO.Path]::GetTempFileName()
-    $tempScript = [System.IO.Path]::Combine(
-        [System.IO.Path]::GetTempPath(),
-        "hermes-import-probe-$([System.Guid]::NewGuid().ToString('N')).py"
-    )
+    # starts. Do not use Start-Process: it copies inherited variables into a
+    # case-insensitive dictionary and crashes on Git Bash environments that
+    # contain both TMP and tmp. ProcessStartInfo inherits the raw environment
+    # block as long as its EnvironmentVariables property remains untouched.
+    $tempScript = $null
+    $process = $null
     try {
+        $tempScript = [System.IO.Path]::Combine(
+            [System.IO.Path]::GetTempPath(),
+            "hermes-import-probe-$([System.Guid]::NewGuid().ToString('N')).py"
+        )
+        $utf8 = New-Object System.Text.UTF8Encoding $false
         [System.IO.File]::WriteAllText(
             $tempScript,
             $Code,
-            (New-Object System.Text.UTF8Encoding $false)
+            $utf8
         )
         $escapedScript = $tempScript.Replace('"', '\"')
-        $arguments = "-I -X utf8 `"$escapedScript`""
-        $process = Start-Process -FilePath $PythonExe -ArgumentList $arguments `
-            -WorkingDirectory (Get-Location).Path -NoNewWindow -Wait -PassThru `
-            -RedirectStandardOutput $tempOut -RedirectStandardError $tempErr
+        $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+        $startInfo.FileName = $PythonExe
+        $startInfo.Arguments = "-I -X utf8 `"$escapedScript`""
+        $startInfo.WorkingDirectory = (Get-Location).Path
+        $startInfo.UseShellExecute = $false
+        $startInfo.CreateNoWindow = $true
+        $startInfo.RedirectStandardOutput = $true
+        $startInfo.RedirectStandardError = $true
+        $startInfo.StandardOutputEncoding = $utf8
+        $startInfo.StandardErrorEncoding = $utf8
 
-        $stdout = [System.IO.File]::ReadAllText($tempOut).TrimEnd()
-        $stderr = [System.IO.File]::ReadAllText($tempErr).TrimEnd()
+        $process = New-Object System.Diagnostics.Process
+        $process.StartInfo = $startInfo
+        if (-not $process.Start()) {
+            throw "Failed to start Python import probe."
+        }
+        $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+        $stderrTask = $process.StandardError.ReadToEndAsync()
+        $process.WaitForExit()
+        $stdout = $stdoutTask.GetAwaiter().GetResult().TrimEnd()
+        $stderr = $stderrTask.GetAwaiter().GetResult().TrimEnd()
         $parts = @()
         if ($stdout) { $parts += $stdout }
         if ($stderr) { $parts += $stderr }
@@ -284,7 +301,10 @@ function Invoke-PythonProbeProcess {
             Output = $parts -join [Environment]::NewLine
         }
     } finally {
-        Remove-Item $tempOut, $tempErr, $tempScript -Force -ErrorAction SilentlyContinue
+        if ($process) { $process.Dispose() }
+        if ($tempScript) {
+            Remove-Item -LiteralPath $tempScript -Force -ErrorAction SilentlyContinue
+        }
     }
 }
 

--- a/tests/test_install_ps1_baseline_import_retry.py
+++ b/tests/test_install_ps1_baseline_import_retry.py
@@ -126,7 +126,7 @@ def _prepare_minimal_install(
             state.write_text(str(count), encoding="utf-8")
             failures = int(os.environ.get("HERMES_TEST_PROBE_FAILURES", "0"))
             if count <= failures:
-                raise RuntimeError(f"synthetic baseline import failure {count}")
+                raise RuntimeError(f"synthetic baseline import failure {count}: caf{chr(233)}")
             if os.environ.get("HERMES_TEST_PROBE_STDERR") == "1":
                 print("synthetic benign stderr", file=sys.stderr)
             """
@@ -160,6 +160,11 @@ def _run_dependency_stage(
     env["HERMES_TEST_PROBE_STATE"] = str(state)
     env["HERMES_TEST_PROBE_FAILURES"] = str(failures)
     env["HERMES_TEST_PROBE_STDERR"] = "1" if emit_stderr else "0"
+    # The canonical test runner starts from `env -i`. Windows PowerShell needs
+    # PATHEXT even to dispatch an absolute .exe path through its call operator.
+    env.setdefault("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+    env.pop("PYTHONIOENCODING", None)
+    env.pop("PYTHONUTF8", None)
     if not standins_in_managed_site_packages:
         env["PYTHONPATH"] = str(install_dir)
 
@@ -182,7 +187,7 @@ def _run_dependency_stage(
         cwd=tmp_path,
         env=env,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
         timeout=120,
     )
     managed_python = install_dir / "venv" / "Scripts" / "python.exe"
@@ -272,6 +277,6 @@ def test_dependency_stage_reports_persistent_import_failure(tmp_path: Path) -> N
     assert "Exit codes: [1, 1, 1]" in reason
     assert f"Environment: executable={managed_python}" in reason
     assert "Captured probe output: Traceback" in reason
-    assert "synthetic baseline import failure 3" in reason
+    assert "synthetic baseline import failure 3: caf\u00e9" in reason
     assert "\n" in reason
     assert "dependencies are not in the venv" not in reason

--- a/tests/test_install_ps1_baseline_import_retry.py
+++ b/tests/test_install_ps1_baseline_import_retry.py
@@ -80,13 +80,13 @@ def _prepare_minimal_install(
         ],
         check=True,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
     )
     subprocess.run(
         [str(managed_uv), "lock", "--project", str(install_dir)],
         check=True,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
     )
 
     managed_python = install_dir / "venv" / "Scripts" / "python.exe"
@@ -95,12 +95,14 @@ def _prepare_minimal_install(
             [
                 str(managed_python),
                 "-I",
+                "-X",
+                "utf8",
                 "-c",
                 "import site; print(next(p for p in site.getsitepackages() if p.lower().endswith('site-packages')))",
             ],
             check=True,
             capture_output=True,
-            text=True,
+            encoding="utf-8",
         ).stdout.strip()
     )
 
@@ -148,8 +150,10 @@ def _run_dependency_stage(
     failures: int,
     emit_stderr: bool = False,
     standins_in_managed_site_packages: bool = True,
+    git_bash_case_collision: bool = False,
+    workspace_name: str = "installer workspace",
 ) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
-    workspace = tmp_path / "installer workspace"
+    workspace = tmp_path / workspace_name
     workspace.mkdir()
     hermes_home, install_dir, powershell = _prepare_minimal_install(
         workspace,
@@ -168,22 +172,41 @@ def _run_dependency_stage(
     if not standins_in_managed_site_packages:
         env["PYTHONPATH"] = str(install_dir)
 
+    powershell_args = [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        str(INSTALL_PS1),
+        "-Stage",
+        "dependencies",
+        "-NonInteractive",
+        "-HermesHome",
+        str(hermes_home),
+        "-InstallDir",
+        str(install_dir),
+    ]
+    command = [str(powershell), *powershell_args]
+    if git_bash_case_collision:
+        bash = shutil.which("bash.exe")
+        if not bash:
+            pytest.skip("Git Bash is required for case-colliding environment coverage")
+        collision_temp = workspace / "collision temp"
+        collision_temp.mkdir()
+        launcher = workspace / "launch-dependencies.sh"
+        launcher.write_text(
+            "#!/usr/bin/bash\n"
+            'export TMP="$HERMES_TEST_COLLISION_TEMP"\n'
+            'export tmp="$HERMES_TEST_COLLISION_TEMP"\n'
+            'exec powershell.exe "$@"\n',
+            encoding="utf-8",
+        )
+        env["HERMES_TEST_COLLISION_TEMP"] = str(collision_temp)
+        env["MSYS2_ARG_CONV_EXCL"] = "*"
+        command = [bash, str(launcher), *powershell_args]
+
     result = subprocess.run(
-        [
-            str(powershell),
-            "-NoProfile",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-File",
-            str(INSTALL_PS1),
-            "-Stage",
-            "dependencies",
-            "-NonInteractive",
-            "-HermesHome",
-            str(hermes_home),
-            "-InstallDir",
-            str(install_dir),
-        ],
+        command,
         cwd=tmp_path,
         env=env,
         capture_output=True,
@@ -239,6 +262,23 @@ def test_dependency_stage_retries_transient_baseline_import_failure(
     assert "Baseline imports verified in venv" in output
 
 
+def test_dependency_stage_handles_git_bash_case_colliding_environment(
+    tmp_path: Path,
+) -> None:
+    result, state, _ = _run_dependency_stage(
+        tmp_path,
+        failures=0,
+        git_bash_case_collision=True,
+    )
+    output = result.stdout + result.stderr
+    frame = _stage_frame(result)
+
+    assert result.returncode == 0, output
+    assert frame["ok"] is True
+    assert state.read_text(encoding="utf-8") == "1"
+    assert "Baseline imports verified in venv" in output
+
+
 def test_dependency_stage_ignores_checkout_and_inherited_pythonpath(
     tmp_path: Path,
 ) -> None:
@@ -261,7 +301,11 @@ def test_dependency_stage_ignores_checkout_and_inherited_pythonpath(
 
 
 def test_dependency_stage_reports_persistent_import_failure(tmp_path: Path) -> None:
-    result, state, managed_python = _run_dependency_stage(tmp_path, failures=99)
+    result, state, managed_python = _run_dependency_stage(
+        tmp_path,
+        failures=99,
+        workspace_name=f"installer caf{chr(233)} workspace",
+    )
     output = result.stdout + result.stderr
     frame = _stage_frame(result)
     reason = frame["reason"]

--- a/tests/test_install_ps1_baseline_import_retry.py
+++ b/tests/test_install_ps1_baseline_import_retry.py
@@ -1,0 +1,277 @@
+"""Behavioral regression tests for the Windows baseline-import gate.
+
+The test runs the real ``install.ps1 -Stage dependencies`` path against a
+minimal temporary project. Local stand-in modules avoid network dependency
+resolution, while ``dotenv.py`` fails a controlled number of imports across
+separate Python processes. This exercises PowerShell 5.1 process behavior,
+not the installer's source text.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Windows PowerShell 5.1 installer regression",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+
+def _command_path(name: str) -> Path:
+    resolved = shutil.which(name)
+    if not resolved:
+        pytest.skip(f"required command not available: {name}")
+    return Path(resolved).resolve()
+
+
+def _prepare_minimal_install(
+    tmp_path: Path, *, standins_in_managed_site_packages: bool = True
+) -> tuple[Path, Path, Path]:
+    uv = _command_path("uv.exe")
+    powershell = _command_path("powershell.exe")
+
+    hermes_home = tmp_path / "hermes-home"
+    install_dir = tmp_path / "hermes-agent"
+    managed_uv = hermes_home / "bin" / "uv.exe"
+    managed_uv.parent.mkdir(parents=True)
+    shutil.copy2(uv, managed_uv)
+
+    install_dir.mkdir()
+    (install_dir / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """
+            [project]
+            name = "installer-probe-test"
+            version = "0.0.0"
+            requires-python = ">=3.11"
+            dependencies = []
+
+            [project.optional-dependencies]
+            all = []
+            web = []
+
+            [tool.uv]
+            package = false
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    subprocess.run(
+        [
+            str(managed_uv),
+            "venv",
+            str(install_dir / "venv"),
+            "--python",
+            sys.executable,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        [str(managed_uv), "lock", "--project", str(install_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    managed_python = install_dir / "venv" / "Scripts" / "python.exe"
+    site_packages = Path(
+        subprocess.run(
+            [
+                str(managed_python),
+                "-I",
+                "-c",
+                "import site; print(next(p for p in site.getsitepackages() if p.lower().endswith('site-packages')))",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    )
+
+    # Normal fixtures live in the managed venv. One negative test deliberately
+    # puts them in the checkout to prove isolated mode rejects that shadow path.
+    module_root = site_packages if standins_in_managed_site_packages else install_dir
+    for module in ("openai", "rich", "prompt_toolkit", "fastapi", "uvicorn"):
+        (module_root / f"{module}.py").write_text("# test stand-in\n", encoding="utf-8")
+
+    # Fail a configurable number of imports across separate Python processes.
+    # The installer must tolerate a short-lived import failure, then continue
+    # when the exact same interpreter succeeds on a later probe.
+    (module_root / "dotenv.py").write_text(
+        textwrap.dedent(
+            """
+            import os
+            from pathlib import Path
+            import sys
+
+            state = Path(os.environ["HERMES_TEST_PROBE_STATE"])
+            count = int(state.read_text(encoding="utf-8")) if state.exists() else 0
+            count += 1
+            state.write_text(str(count), encoding="utf-8")
+            failures = int(os.environ.get("HERMES_TEST_PROBE_FAILURES", "0"))
+            if count <= failures:
+                raise RuntimeError(f"synthetic baseline import failure {count}")
+            if os.environ.get("HERMES_TEST_PROBE_STDERR") == "1":
+                print("synthetic benign stderr", file=sys.stderr)
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    web_server = install_dir / "hermes_cli" / "web_server.py"
+    web_server.parent.mkdir()
+    web_server.write_text("# syntax probe fixture\n", encoding="utf-8")
+
+    return hermes_home, install_dir, powershell
+
+
+def _run_dependency_stage(
+    tmp_path: Path,
+    *,
+    failures: int,
+    emit_stderr: bool = False,
+    standins_in_managed_site_packages: bool = True,
+) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
+    workspace = tmp_path / "installer workspace"
+    workspace.mkdir()
+    hermes_home, install_dir, powershell = _prepare_minimal_install(
+        workspace,
+        standins_in_managed_site_packages=standins_in_managed_site_packages,
+    )
+    state = workspace / "probe-count.txt"
+    env = os.environ.copy()
+    env["HERMES_TEST_PROBE_STATE"] = str(state)
+    env["HERMES_TEST_PROBE_FAILURES"] = str(failures)
+    env["HERMES_TEST_PROBE_STDERR"] = "1" if emit_stderr else "0"
+    if not standins_in_managed_site_packages:
+        env["PYTHONPATH"] = str(install_dir)
+
+    result = subprocess.run(
+        [
+            str(powershell),
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(INSTALL_PS1),
+            "-Stage",
+            "dependencies",
+            "-NonInteractive",
+            "-HermesHome",
+            str(hermes_home),
+            "-InstallDir",
+            str(install_dir),
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    managed_python = install_dir / "venv" / "Scripts" / "python.exe"
+    return result, state, managed_python
+
+
+def _stage_frame(result: subprocess.CompletedProcess[str]) -> dict[str, object]:
+    for line in reversed(result.stdout.splitlines()):
+        try:
+            frame = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(frame, dict) and "ok" in frame:
+            return frame
+    pytest.fail(
+        f"dependency stage emitted no JSON frame:\n{result.stdout}{result.stderr}"
+    )
+
+
+def test_dependency_stage_accepts_benign_probe_stderr(tmp_path: Path) -> None:
+    result, state, managed_python = _run_dependency_stage(
+        tmp_path, failures=0, emit_stderr=True
+    )
+    output = result.stdout + result.stderr
+    frame = _stage_frame(result)
+    site_packages = managed_python.parent.parent / "Lib" / "site-packages"
+
+    assert result.returncode == 0, output
+    assert frame["ok"] is True
+    assert state.read_text(encoding="utf-8") == "1"
+    assert "Baseline import probe failed" not in output
+    assert "module_origins=" in output
+    assert str(site_packages).lower() in output.lower()
+    assert "Baseline imports verified in venv" in output
+
+
+def test_dependency_stage_retries_transient_baseline_import_failure(
+    tmp_path: Path,
+) -> None:
+    result, state, _ = _run_dependency_stage(tmp_path, failures=2)
+    output = result.stdout + result.stderr
+    frame = _stage_frame(result)
+
+    assert result.returncode == 0, output
+    assert frame["ok"] is True
+    assert state.read_text(encoding="utf-8") == "3"
+    assert "Baseline import probe failed (attempt 1/3," in output
+    assert "Baseline import probe failed (attempt 2/3," in output
+    assert "Baseline imports verified in venv" in output
+
+
+def test_dependency_stage_ignores_checkout_and_inherited_pythonpath(
+    tmp_path: Path,
+) -> None:
+    result, state, managed_python = _run_dependency_stage(
+        tmp_path,
+        failures=0,
+        standins_in_managed_site_packages=False,
+    )
+    output = result.stdout + result.stderr
+    frame = _stage_frame(result)
+    reason = frame["reason"]
+
+    assert result.returncode == 1, output
+    assert frame["ok"] is False
+    assert isinstance(reason, str)
+    assert not state.exists(), "checkout dotenv.py was imported despite isolated mode"
+    assert f"Exact interpreter: '{managed_python}'" in reason
+    assert "Exit codes: [1, 1, 1]" in reason
+    assert "ModuleNotFoundError: No module named 'dotenv'" in reason
+
+
+def test_dependency_stage_reports_persistent_import_failure(tmp_path: Path) -> None:
+    result, state, managed_python = _run_dependency_stage(tmp_path, failures=99)
+    output = result.stdout + result.stderr
+    frame = _stage_frame(result)
+    reason = frame["reason"]
+
+    assert result.returncode == 1, output
+    assert frame["ok"] is False
+    assert isinstance(reason, str)
+    assert state.read_text(encoding="utf-8") == "3"
+    assert "Reinstalling locked dependencies" not in output
+    assert "Baseline imports failed after 3 attempts" in reason
+    assert f"Exact interpreter: '{managed_python}'" in reason
+    assert "Modules: dotenv, openai, rich, prompt_toolkit" in reason
+    assert "Exit codes: [1, 1, 1]" in reason
+    assert f"Environment: executable={managed_python}" in reason
+    assert "Captured probe output: Traceback" in reason
+    assert "synthetic baseline import failure 3" in reason
+    assert "\n" in reason
+    assert "dependencies are not in the venv" not in reason


### PR DESCRIPTION
## Summary

- retry the Windows baseline-import probe through the exact managed interpreter with bounded 0/2/2-second delays
- launch probes through `System.Diagnostics.ProcessStartInfo` with asynchronous stdout/stderr capture, explicit UTF-8 decoding, and an untouched inherited environment block
- avoid both PowerShell's native `2>&1`/`StandardErrorEncoding` path and `Start-Process`'s case-insensitive environment materialization (`TMP` + `tmp` from Git Bash)
- run Python in isolated UTF-8 mode (`-I -X utf8`) and require lexical module origins inside the managed environment
- emit structured persistent-failure diagnostics with interpreter, prefix, site-packages, module origins, traceback, and exit history
- add real Windows dependency-stage regressions for transient recovery, persistent non-ASCII failure, benign stderr, checkout/PYTHONPATH shadowing, paths with spaces, and Git Bash case-colliding environments

## Root cause addressed

After dependency synchronization succeeds, the installer currently performs one baseline import command, discards its output with `Out-Null`, and aborts on any nonzero exit. This turns a transient import failure into a permanent install failure while erasing the evidence needed to diagnose it.

This patch narrows the remedy to that proved defect. It does **not** guess which dependency-install tier to rerun and does not claim the historical transient trigger is known.

## Behavior

1. The installer invokes the exact managed Python with `-I -X utf8` using a temporary probe script.
2. `ProcessStartInfo` redirects and drains stdout/stderr asynchronously without routing native stderr through PowerShell and without touching `EnvironmentVariables`, so a raw Git Bash environment containing both `TMP` and `tmp` remains valid.
3. Stream readers explicitly decode UTF-8, matching Python UTF-8 mode and preserving non-ASCII profile paths and tracebacks.
4. The environment summary records `sys.executable`, `sys.prefix`, and `site.getsitepackages()`.
5. Baseline imports are attempted up to three times with bounded delays.
6. Success requires each module's lexical `__file__` path to remain under the managed prefix. Lexical validation intentionally preserves symlink-backed environments whose resolved targets live in shared uv cache storage.
7. Persistent failure returns a JSON stage frame containing the exact interpreter, environment summary, attempt count, exit-code history, and captured traceback/output.
8. The helper disposes the child process and removes its temporary script with `-LiteralPath` on success or failure.

## Test plan

- [x] transient failure: first two probes fail, third succeeds
- [x] persistent failure: all three probes fail and diagnostics retain exact non-ASCII traceback text
- [x] benign stderr: exit `0` remains success
- [x] managed interpreter identity and lexical module origins are asserted
- [x] checkout-local modules and inherited `PYTHONPATH` cannot satisfy the gate
- [x] paths containing spaces are exercised
- [x] real Git Bash launches the dependency stage with both `TMP` and `tmp` present
- [x] direct stress probe drains simultaneous 200 KB stdout/stderr streams, preserves non-ASCII text and exit status, propagates launch failure, and leaves no temp script
- [x] canonical Windows wrapper: `scripts/run_tests.sh -j 7 tests/test_install_ps1*.py -v --tb=short` — **22 passed, 0 failed**
- [x] stage-protocol smoke suite
- [x] Git Bash compatibility suite
- [x] Windows PowerShell 5.1 AST parser
- [x] Ruff check and format check
- [x] `git diff --check`

A broader Windows repository run was stopped at 17.9% after 7,849 passes and 55 failures, so this PR does not claim a complete Windows-suite pass. The normal upstream Python workflow is Ubuntu-based and may not enforce these Windows-only behavioral tests without a Windows lane.

## Coordination

Issues #60129 and PR #60143 address broader Windows PowerShell native-process behavior. This PR avoids the affected native stderr path only for the baseline import probe; it is not presented as a complete resolution of #60129.

Closes #67637
