### PR TITLE
fix(plugins): expose inbound event metadata to hooks

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -769,6 +769,7 @@ def init_agent(
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = None
     agent._persist_user_message_timestamp = None
+    agent._persist_user_message_id = None
 
     # Cache anthropic image-to-text fallbacks per image payload/URL so a
     # single tool loop does not repeatedly re-run auxiliary vision on the

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -594,6 +594,7 @@ def run_conversation(
     persist_user_message: Optional[Any] = None,
     persist_user_timestamp: Optional[float] = None,
     moa_config: Optional[dict[str, Any]] = None,
+    persist_user_message_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Run a complete conversation with tool calling until completion.
@@ -611,7 +612,9 @@ def run_conversation(
             synthetic prefixes.
         persist_user_timestamp: Optional platform event timestamp to store
             as metadata on that persisted user message.
-                or queuing follow-up prefetch work.
+        moa_config: Optional mixture-of-agents configuration for this turn.
+        persist_user_message_id: Optional immutable platform event identifier
+            to expose to hooks and store on that persisted user message.
 
     Returns:
         Dict: Complete conversation result with final response and message history
@@ -646,6 +649,7 @@ def run_conversation(
         stream_callback,
         persist_user_message,
         persist_user_timestamp,
+        persist_user_message_id,
         restore_or_build_system_prompt=_restore_or_build_system_prompt,
         install_safe_stdio=_install_safe_stdio,
         sanitize_surrogates=_sanitize_surrogates,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -274,6 +274,7 @@ def build_turn_context(
     stream_callback,
     persist_user_message: Optional[Any],
     persist_user_timestamp: Optional[float] = None,
+    persist_user_message_id: Optional[str] = None,
     *,
     restore_or_build_system_prompt,
     install_safe_stdio,
@@ -364,6 +365,7 @@ def build_turn_context(
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = persist_user_message
     agent._persist_user_message_timestamp = persist_user_timestamp
+    agent._persist_user_message_id = persist_user_message_id
     # Generate unique task_id if not provided to isolate VMs between tasks.
     effective_task_id = task_id or str(uuid.uuid4())
     agent._current_task_id = effective_task_id
@@ -704,6 +706,8 @@ def build_turn_context(
             model=agent.model,
             platform=getattr(agent, "platform", None) or "",
             sender_id=getattr(agent, "_user_id", None) or "",
+            user_message_id=persist_user_message_id or "",
+            user_message_timestamp=persist_user_timestamp,
         )
         _ctx_parts: list[str] = []
         # Spill oversized per-hook context to disk so a runaway plugin

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12071,6 +12071,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _redact_pii = False
         persist_user_message = None
         persist_user_timestamp = None
+        persist_user_message_id = (
+            str(getattr(event, "message_id", "") or "").strip() or None
+        )
         try:
             _pcfg = _load_gateway_config()
             _redact_pii = bool((_pcfg.get("privacy") or {}).get("redact_pii", False))
@@ -12864,6 +12867,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 moa_config=getattr(event, "_moa_config", None),
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                persist_user_message_id=persist_user_message_id,
             )
 
             # Stop persistent typing indicator now that the agent is done.
@@ -18672,6 +18676,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        persist_user_message_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
 
@@ -18690,6 +18695,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                persist_user_message_id=persist_user_message_id,
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
@@ -18701,6 +18707,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                persist_user_message_id=persist_user_message_id,
             )
 
     def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
@@ -18822,6 +18829,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        persist_user_message_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -20645,6 +20653,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # message so stale guidance never replays as user-authored text.
             _persist_user_message_override: Optional[Any] = persist_user_message
             _persist_user_timestamp_override: Optional[float] = persist_user_timestamp
+            _persist_user_message_id_override: Optional[str] = persist_user_message_id
 
             # Prepend pending model switch note so the model knows about the switch
             _pending_notes = getattr(self, '_pending_model_notes', {})
@@ -20834,6 +20843,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _conversation_kwargs["moa_config"] = moa_config
                 if _persist_user_timestamp_override is not None:
                     _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
+                if _persist_user_message_id_override is not None:
+                    _conversation_kwargs["persist_user_message_id"] = _persist_user_message_id_override
                 result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
             finally:
                 unregister_gateway_notify(_approval_session_key)
@@ -21802,6 +21813,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 next_source = source
                 next_message = pending
                 next_message_id = None
+                next_user_message_id = None
+                next_user_message_timestamp = None
                 next_channel_prompt = None
                 next_session_key = session_key
                 if pending_event is not None:
@@ -21834,6 +21847,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if next_message is None:
                         return result
                     next_message_id = self._reply_anchor_for_event(pending_event)
+                    next_user_message_id = (
+                        str(getattr(pending_event, "message_id", "") or "").strip()
+                        or None
+                    )
+                    try:
+                        from hermes_time import get_timezone as _get_followup_tz
+                        from gateway.message_timestamps import (
+                            coerce_message_timestamp as _coerce_followup_ts,
+                        )
+
+                        next_user_message_timestamp = _coerce_followup_ts(
+                            getattr(pending_event, "timestamp", None),
+                            tz=_get_followup_tz(),
+                        )
+                    except Exception:
+                        logger.debug(
+                            "Queued follow-up timestamp coercion failed",
+                            exc_info=True,
+                        )
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
 
                 # Restart typing indicator so the user sees activity while
@@ -21876,6 +21908,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,
                     channel_prompt=next_channel_prompt,
+                    persist_user_message_id=next_user_message_id,
+                    persist_user_timestamp=next_user_message_timestamp,
                 )
                 return _preserve_queued_followup_history_offset(result, followup_result)
         finally:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1693,13 +1693,14 @@ class AIAgent:
         that synthetic text leak into persisted transcripts or resumed session
         history. When an override is configured for the active turn, mutate the
         in-memory messages list in place so both persistence and returned
-        history stay clean.  A paired timestamp override preserves the platform
-        event time as message metadata, rather than embedding it in content.
+        history stay clean. Paired timestamp and message-ID overrides preserve
+        immutable platform event metadata rather than embedding it in content.
         """
         idx = getattr(self, "_persist_user_message_idx", None)
         override = getattr(self, "_persist_user_message_override", None)
         timestamp = getattr(self, "_persist_user_message_timestamp", None)
-        if idx is None or (override is None and timestamp is None):
+        message_id = getattr(self, "_persist_user_message_id", None)
+        if idx is None or (override is None and timestamp is None and message_id is None):
             return
         if 0 <= idx < len(messages):
             msg = messages[idx]
@@ -1716,6 +1717,8 @@ class AIAgent:
                     msg["content"] = override
                 if timestamp is not None:
                     msg["timestamp"] = timestamp
+                if message_id is not None:
+                    msg["platform_message_id"] = message_id
 
     def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):
         """Save session state to both JSON log and SQLite on any exit path.
@@ -1866,6 +1869,7 @@ class AIAgent:
         _ov_idx = getattr(self, "_persist_user_message_idx", None)
         _ov_content = getattr(self, "_persist_user_message_override", None)
         _ov_timestamp = getattr(self, "_persist_user_message_timestamp", None)
+        _ov_message_id = getattr(self, "_persist_user_message_id", None)
         try:
             # Retry row creation if the earlier attempt failed transiently.
             if not self._session_db_created:
@@ -1939,6 +1943,9 @@ class AIAgent:
                 if not isinstance(_row_api_content, str):
                     _row_api_content = None
                 _row_timestamp = msg.get("timestamp")
+                _row_platform_message_id = (
+                    msg.get("platform_message_id") or msg.get("message_id")
+                )
                 # Apply the persist override to THIS row's written values only
                 # (never to the live dict). A multimodal override is a complete
                 # clean replacement for an API-local noted payload. Preserve the
@@ -1980,6 +1987,8 @@ class AIAgent:
                         content = _ov_content
                     if _ov_timestamp is not None:
                         _row_timestamp = _ov_timestamp
+                    if _ov_message_id is not None:
+                        _row_platform_message_id = _ov_message_id
                 # Store the sidecar only when it actually differs.
                 if _row_api_content == content:
                     _row_api_content = None
@@ -2037,6 +2046,7 @@ class AIAgent:
                     reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                     codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
+                    platform_message_id=_row_platform_message_id,
                     timestamp=_row_timestamp,
                     api_content=_row_api_content,
                 )
@@ -6336,6 +6346,7 @@ class AIAgent:
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
         moa_config: Optional[dict[str, Any]] = None,
+        persist_user_message_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         from agent.aux_accounting import (
@@ -6377,6 +6388,7 @@ class AIAgent:
                     stream_callback,
                     persist_user_message,
                     persist_user_timestamp=persist_user_timestamp,
+                    persist_user_message_id=persist_user_message_id,
                     moa_config=moa_config,
                 )
             finally:

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -179,6 +179,21 @@ def test_returns_turn_context_with_user_message_appended():
     assert ctx.active_system_prompt == "SYSTEM"
 
 
+def test_pre_llm_hook_receives_inbound_event_identity_and_timestamp():
+    agent = _FakeAgent()
+
+    with patch("hermes_cli.plugins.invoke_hook", return_value=[]) as invoke_hook:
+        _build(
+            agent,
+            persist_user_message_id="telegram-message-123",
+            persist_user_timestamp=1_752_464_800.0,
+        )
+
+    hook_kwargs = invoke_hook.call_args.kwargs
+    assert hook_kwargs["user_message_id"] == "telegram-message-123"
+    assert hook_kwargs["user_message_timestamp"] == 1_752_464_800.0
+
+
 def test_applies_agent_side_effects():
     agent = _FakeAgent()
     _build(agent)
@@ -450,4 +465,3 @@ def test_expired_cooldown_allows_preflight(tmp_path):
     assert isinstance(ctx, TurnContext)
     agent._emit_status.assert_called_once()
     agent._compress_context.assert_called()
-

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -151,6 +151,9 @@ async def test_agent_failed_early_skip_db_when_agent_has_session_db(
     _assert_user_call_has_skip_db(
         runner.session_store.append_to_transcript.call_args_list, True
     )
+    run_kwargs = runner._run_agent.call_args.kwargs
+    assert run_kwargs["event_message_id"] is None
+    assert run_kwargs["persist_user_message_id"] == "msg-42"
 
 
 # ── Test 2: agent_failed_early with no _session_db → skip_db not True ─

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -30,6 +30,7 @@ class _CapturingAgent:
         task_id=None,
         persist_user_message=None,
         persist_user_timestamp=None,
+        persist_user_message_id=None,
     ):
         type(self).last_run = {
             "user_message": user_message,
@@ -37,6 +38,7 @@ class _CapturingAgent:
             "task_id": task_id,
             "persist_user_message": persist_user_message,
             "persist_user_timestamp": persist_user_timestamp,
+            "persist_user_message_id": persist_user_message_id,
         }
         return {
             "final_response": "ok",
@@ -201,11 +203,13 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
         source=_make_source(),
         session_id="session-1",
         session_key="agent:main:telegram:dm:12345",
+        persist_user_message_id="m1",
     )
 
     assert result["final_response"] == "ok"
     assert _CapturingAgent.last_init["service_tier"] == "priority"
     assert _CapturingAgent.last_init["request_overrides"] == {"service_tier": "priority"}
+    assert _CapturingAgent.last_run["persist_user_message_id"] == "m1"
 
 
 @pytest.mark.asyncio

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -96,6 +96,18 @@ def test_run_conversation_dict_returns_include_final_response():
     )
 
 
+def test_inbound_message_id_is_additive_to_run_conversation_signature():
+    """Keep the pre-existing positional moa_config argument stable."""
+    from agent import conversation_loop
+
+    expected_tail = ["persist_user_timestamp", "moa_config", "persist_user_message_id"]
+    loop_parameters = list(inspect.signature(conversation_loop.run_conversation).parameters)
+    agent_parameters = list(inspect.signature(AIAgent.run_conversation).parameters)
+
+    assert loop_parameters[-3:] == expected_tail
+    assert agent_parameters[-3:] == expected_tail
+
+
 @pytest.fixture()
 def agent():
     """Minimal AIAgent with mocked OpenAI client and tool loading."""
@@ -7814,6 +7826,7 @@ class TestPersistUserMessageOverride:
         agent._last_flushed_db_idx = 0
         agent._persist_user_message_idx = 0
         agent._persist_user_message_override = "Hello there"
+        agent._persist_user_message_id = "telegram-message-123"
         messages = [
             {
                 "role": "user",
@@ -7839,6 +7852,28 @@ class TestPersistUserMessageOverride:
         # But the DB write must get the override.
         first_db_write = agent._session_db.append_message.call_args_list[0].kwargs
         assert first_db_write["content"] == "Hello there"
+        assert first_db_write["platform_message_id"] == "telegram-message-123"
+
+    def test_persist_session_preserves_existing_platform_message_id(self, agent):
+        agent._session_db = MagicMock()
+        agent.session_id = "session-123"
+        agent._last_flushed_db_idx = 0
+        agent._persist_user_message_idx = None
+        agent._persist_user_message_override = None
+        agent._persist_user_message_timestamp = None
+        agent._persist_user_message_id = None
+        messages = [
+            {
+                "role": "user",
+                "content": "Compacted but still attributable",
+                "platform_message_id": "discord-message-456",
+            }
+        ]
+
+        agent._persist_session(messages, [])
+
+        db_write = agent._session_db.append_message.call_args.kwargs
+        assert db_write["platform_message_id"] == "discord-message-456"
 
 
 class TestReasoningReplayForStrictProviders:


### PR DESCRIPTION
## What does this PR do?

Plugin hooks can now distinguish the inbound event being processed from earlier user messages. Before this change, hooks received the sender and platform but not the immutable platform message ID or event timestamp, so state-backed plugins could accidentally treat the current row as prior history or measure delivery delay instead of the user-to-user gap.

The gateway now carries the raw inbound ID and normalized event time through the agent turn, exposes both to `pre_llm_call`, and persists the ID with the clean user row. Queued follow-ups preserve the same contract. The new argument remains additive after the existing positional `moa_config` parameter.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Preserve immutable inbound message IDs separately from reply-routing anchors.
- Make inbound ID and timestamp available to plugin prompt-context hooks.
- Persist platform IDs through normal turns, failures, queued follow-ups, and compacted history.
- Keep the pre-existing positional conversation API compatible.

## How to Test

1. Run `python -m pytest -q tests/agent/test_turn_context.py tests/gateway/test_42039_duplicate_user_message.py tests/gateway/test_fast_command.py tests/run_agent/test_run_agent.py`.
2. Run `ruff check` over the changed Python and test files.
3. Send an inbound gateway message and verify the user row in `state.db` carries the platform message ID and original event timestamp.

Focused result: 467 tests passed and Ruff passed. A full-suite run was attempted in a clean dev environment, but unrelated tests repeatedly removed the shared temporary logging path and caused cascading logging failures; CI remains the trustworthy broad-suite gate.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A; this is internal gateway and persistence plumbing.

## Post-Deploy Monitoring & Validation

- Inspect recent inbound user rows with `select s.source, s.user_id, m.platform_message_id, m.timestamp from messages m join sessions s on s.id=m.session_id where m.role='user' order by m.id desc limit 20;`.
- Expected: newly processed gateway messages have a non-empty platform ID and their original event timestamp; `pre_llm_call` consumers receive the same values.
- Watch for missing IDs on queued follow-ups, duplicate user rows, or plugins remaining in approximate mode after multiple inbound messages.
- Roll back by reverting this commit or returning to the prior Hermes image; every new parameter defaults to `None`, so older callers remain compatible.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
