### PR TITLE
refactor(desktop): tidy session-color pass

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/project-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/project-menu.tsx
@@ -112,13 +112,11 @@ export function ProjectMenu({
 
   // Appearance writes route through the adopt-aware helper: an auto project is
   // materialized on its first change (its id then changes), so close the picker
-  // when that happens to avoid a second write double-creating from a stale node.
-  const applyAppearance = (patch: { color?: null | string; icon?: null | string }) => {
-    void setProjectAppearance(project, patch).then(adopted => {
-      if (adopted) {
-        setAppearanceOpen(false)
-      }
-    })
+  // on adopt to stop a second write double-creating from a now-stale node.
+  const applyAppearance = async (patch: { color?: null | string; icon?: null | string }) => {
+    if (await setProjectAppearance(project, patch)) {
+      setAppearanceOpen(false)
+    }
   }
 
   // Set color / pick an icon — shown for explicit projects and for auto ones
@@ -168,12 +166,12 @@ export function ProjectMenu({
             // Inherited (auto) repos can still be themed — the change adopts the
             // repo as a real project. Rename / add-folder / set-active stay out
             // until then (they need the materialized record).
-            project.path ? (
+            project.path && (
               <>
                 {appearanceItem}
                 <DropdownMenuSeparator />
               </>
-            ) : null
+            )
           ) : (
             <>
               <DropdownMenuItem onSelect={() => openProjectRename(target)}>
@@ -224,7 +222,7 @@ export function ProjectMenu({
         <ColorSwatches
           clearIcon="circle-slash"
           clearLabel={p.noColor}
-          onChange={color => applyAppearance({ color })}
+          onChange={color => void applyAppearance({ color })}
           swatches={PROFILE_SWATCHES}
           value={project.color ?? null}
         />
@@ -239,7 +237,7 @@ export function ProjectMenu({
                 project.icon === name && 'bg-(--ui-control-active-background) text-foreground'
               )}
               key={name}
-              onClick={() => applyAppearance({ icon: project.icon === name ? null : name })}
+              onClick={() => void applyAppearance({ icon: project.icon === name ? null : name })}
               style={project.icon === name && project.color ? { color: project.color } : undefined}
               type="button"
             >

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -409,7 +409,7 @@ export function liveSessionProjectId(session: SessionInfo, explicitProjects: Pro
  * unless the user set one, so a session only tints when it belongs to a colored
  * project (inheritance is opt-in by coloring the project). Reuses
  * {@link liveSessionProjectId} so the color follows the SAME membership the
- * sidebar groups by; returns null for cwd-less / kanban / out-of-tree rows and
+ * sidebar groups by; returns null for rootless / kanban / out-of-tree rows and
  * for sessions under an uncolored (or auto) project.
  */
 export function sessionProjectColor(session: SessionInfo, projects: ProjectInfo[]): null | string {

--- a/apps/desktop/src/store/session-color.ts
+++ b/apps/desktop/src/store/session-color.ts
@@ -32,5 +32,5 @@ export const $sessionColorById = computed([$sessions, $projects], (sessions, pro
 // The color for a single session object (the tabs already hold the SessionInfo
 // they render, so they resolve through the same map the sidebar reads).
 export function sessionColorFor(session: null | SessionInfo | undefined): string | undefined {
-  return session ? ($sessionColorById.get()[session.id] ?? undefined) : undefined
+  return session ? $sessionColorById.get()[session.id] : undefined
 }


### PR DESCRIPTION
## Summary
A small `/clean` pass over the just-merged session-color work (#67468, #67469) — real DRY/KISS wins only, no churn.

- `sessionColorFor`: drop the no-op `?? undefined` — the map read is already `string | undefined`.
- `sessionProjectColor`: fix a now-stale doc line. After the repo-root fix, a cwd-less row with a `git_repo_root` resolves, so only a truly *rootless* row returns null.
- `ProjectMenu.applyAppearance`: `await` instead of a `.then` block; flatten the auto-branch nested ternary.

## Test plan
- [x] `tsc` typecheck clean (app + electron)
- [x] eslint clean
- [x] vitest green (51 tests)