### PR TITLE
fix(kanban): guard invalid worktree review dispatch

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4881,7 +4881,7 @@ def block_task(
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
 ) -> bool:
-    """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
+    """Transition ``running``/``ready``/``review`` → ``blocked`` (or route elsewhere).
 
     ``kind`` (one of :data:`VALID_BLOCK_KINDS`, or ``None`` for a legacy
     un-typed block) drives routing instead of every block landing in one
@@ -4943,7 +4943,7 @@ def block_task(
                        worker_pid    = NULL,
                        block_kind    = ?
                  WHERE id = ?
-                   AND status IN ('running', 'ready')
+                   AND status IN ('running', 'ready', 'review')
                 """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
                 (kind, task_id) if expected_run_id is None
                 else (kind, task_id, int(expected_run_id)),
@@ -4997,7 +4997,7 @@ def block_task(
                        block_kind    = ?,
                        block_recurrences = ?
                  WHERE id = ?
-                   AND status IN ('running', 'ready')
+                   AND status IN ('running', 'ready', 'review')
                 """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
                 (kind, recurrences, task_id) if expected_run_id is None
                 else (kind, recurrences, task_id, int(expected_run_id)),
@@ -5036,7 +5036,7 @@ def block_task(
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
-                       AND status IN ('running', 'ready')
+                       AND status IN ('running', 'ready', 'review')
                     """,
                     (kind, recurrences, task_id),
                 )
@@ -5051,7 +5051,7 @@ def block_task(
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
-                       AND status IN ('running', 'ready')
+                       AND status IN ('running', 'ready', 'review')
                        AND current_run_id = ?
                     """,
                     (kind, recurrences, task_id, int(expected_run_id)),
@@ -6053,6 +6053,11 @@ class DispatchResult:
     subsequent tick when the assignee has capacity. Separate bucket so
     telemetry / dashboards can show "this profile is busy" vs
     "task is genuinely stuck"."""
+    skipped_policy_guarded: list[tuple[str, str, str]] = field(default_factory=list)
+    """Tasks blocked before claim/spawn by a deterministic dispatcher policy
+    guard, as ``(task_id, policy, reason)`` triples. These are configuration
+    or safety failures, not worker crashes, so they should not consume retry
+    budget or create a running worker attempt."""
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
@@ -7436,6 +7441,67 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     return False
 
 
+def _worktree_workspace_config_error(
+    task: Task,
+    *,
+    board: Optional[str] = None,
+) -> Optional[str]:
+    """Return a deterministic pre-claim workspace-config error, if any.
+
+    A worktree task with neither an explicit ``workspace_path`` nor a board
+    ``default_workdir`` cannot be materialized by a worker. Guard it before
+    claim/spawn so the board records a human-actionable block instead of a
+    crash/retry-budget failure.
+    """
+    if (task.workspace_kind or "scratch") != "worktree" or task.workspace_path:
+        return None
+    board_slug = board if board else get_current_board()
+    board_default = (
+        read_board_metadata(board_slug).get("default_workdir") or ""
+    ).strip()
+    if board_default:
+        return None
+    return (
+        f"workspace config invalid: task {task.id} has workspace_kind=worktree "
+        f"but no workspace_path, and board {board_slug!r} has no default_workdir. "
+        "Set a board default workdir that points to a git repo, or recreate/update "
+        "the task with --workspace worktree:<absolute-repo-path>."
+    )
+
+
+def _guard_worktree_workspace_config(
+    conn: sqlite3.Connection,
+    result: DispatchResult,
+    task_id: str,
+    *,
+    board: Optional[str] = None,
+    dry_run: bool = False,
+) -> bool:
+    """Apply the pre-claim worktree config guard.
+
+    Returns True when dispatch for this task should stop for this tick.
+    """
+    task = get_task(conn, task_id)
+    if task is None:
+        return True
+    reason = _worktree_workspace_config_error(task, board=board)
+    if reason is None:
+        return False
+    result.skipped_policy_guarded.append((task_id, "workspace-config", reason))
+    if dry_run:
+        return True
+    with write_txn(conn):
+        _append_event(
+            conn,
+            task_id,
+            "dispatch_guarded",
+            {"policy": "workspace-config", "reason": reason},
+        )
+    if block_task(conn, task_id, reason=f"config-blocked: {reason}", kind="needs_input"):
+        result.auto_blocked.append(task_id)
+    return True
+
+
 def dispatch_once(
     conn: sqlite3.Connection,
     *,
@@ -7727,6 +7793,10 @@ def _dispatch_once_locked(
                     (row["id"], row_assignee, current)
                 )
                 continue
+        if _guard_worktree_workspace_config(
+            conn, result, row["id"], board=board, dry_run=dry_run
+        ):
+            continue
         # Respawn guard: refuse to re-spawn when useful work is already
         # in-flight/recent, or when the last failure is a deterministic
         # blocker (quota / auth). The guard defers the spawn this tick so
@@ -7847,6 +7917,10 @@ def _dispatch_once_locked(
             profile_exists = None  # type: ignore[assignment]
         if profile_exists is not None and not profile_exists(row["assignee"]):
             result.skipped_nonspawnable.append(row["id"])
+            continue
+        if _guard_worktree_workspace_config(
+            conn, result, row["id"], board=board, dry_run=dry_run
+        ):
             continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -362,6 +362,65 @@ def test_workspace_resolution_failure_also_counts(kanban_home, all_assignees_spa
         conn.close()
 
 
+@pytest.mark.parametrize("initial_status", ["ready", "review"])
+def test_worktree_without_path_or_board_default_blocks_before_claim(
+    kanban_home,
+    all_assignees_spawnable,
+    initial_status,
+):
+    """Unanchored worktree tasks are config-blocked before worker claim/spawn.
+
+    This must cover both normal ready dispatch and the review dispatch lane:
+    review tasks used to stay in ``status='review'`` because block_task()
+    refused that state.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title=f"broken worktree {initial_status}",
+            assignee="worker",
+            workspace_kind="worktree",
+        )
+        if initial_status == "review":
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET status = 'review' WHERE id = ?",
+                    (tid,),
+                )
+
+        def _should_not_spawn(_task, _workspace):
+            raise AssertionError("workspace guard should fire before spawn")
+
+        res = kb.dispatch_once(conn, spawn_fn=_should_not_spawn, failure_limit=3)
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+        assert task.consecutive_failures == 0
+        assert task.last_failure_error is None
+        assert tid in res.auto_blocked
+        assert res.skipped_policy_guarded
+        guarded_id, policy, reason = res.skipped_policy_guarded[-1]
+        assert guarded_id == tid
+        assert policy == "workspace-config"
+        assert "no workspace_path" in reason
+        assert "no default_workdir" in reason
+        assert res.spawned == []
+
+        events = kb.list_events(conn, tid)
+        assert any(e.kind == "dispatch_guarded" for e in events)
+        assert any(e.kind == "blocked" for e in events)
+        assert not any(e.kind == "claimed" for e in events)
+        run = conn.execute(
+            "SELECT outcome, summary FROM task_runs WHERE task_id = ?",
+            (tid,),
+        ).fetchone()
+        assert run["outcome"] == "blocked"
+        assert run["summary"].startswith("config-blocked: workspace config invalid")
+    finally:
+        conn.close()
+
+
 # ---------------------------------------------------------------------------
 # Worker aliveness / crash detection
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Cherry-picks the reviewed worktree dispatch guard from source card `t_9ea343c8` onto fresh `origin/main` for a clean PR branch.

Scope is intentionally limited to two files:
- `hermes_cli/kanban_db.py`
- `tests/hermes_cli/test_kanban_core_functionality.py`

## Provenance

- Source commit: `2c8ecac1fa5ec9b2ca320682d5c8139e54e144c6`
- New clean commit: `fadc1609f` on `kanban/worktree-review-block-t_32d50bc4`
- Athena gate: `t_40d6b9c2`, verdict `pass_with_nits`, blockers_count=0
- Gate artifact: `/home/omar/.hermes/kanban/artifacts/t_40d6b9c2/review_result.json`

## Verification

Run from `/home/omar/31-Agents/worktrees/hermes-agent-t_32d50bc4`:

- `python3 -m py_compile hermes_cli/kanban_db.py` -> pass
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_core_functionality.py -q -k 'test_worktree_without_path_or_board_default_blocks_before_claim or test_workspace_resolution_failure_also_counts'` -> 3 passed
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_core_functionality.py -q` -> 175 passed
- `git diff --check origin/main...HEAD` -> pass

## Notes

Draft PR by design. No merge, no deploy.
