### PR TITLE
docs: add community memory provider listing for Memex Zero RAG

### DIFF
--- a/website/docs/user-guide/features/community-memory-providers.md
+++ b/website/docs/user-guide/features/community-memory-providers.md
@@ -1,0 +1,61 @@
+## Community Memory Providers
+
+Beyond the 8 built-in providers, the following **standalone memory provider plugins** are available as community-maintained packages. These integrate with Hermes via the same `MemoryProvider` ABC and plugin discovery system — install them from pip or clone from their repos, and Hermes picks them up automatically.
+
+### Memex Zero RAG
+
+[Memex Zero RAG](https://github.com/JPeetz/MeMex-Zero-RAG) is a **knowledge compilation system** using the Zero-RAG pattern (Karpathy's LLM Wiki). Unlike traditional providers that store individual facts as vector embeddings, Memex compiles sources into a structured, cross-referenced wiki that compounds knowledge over time.
+
+| | |
+|---|---|
+| **Best for** | Deep research, multi-session project knowledge, anti-hallucination-critical workflows, teams that want git-native knowledge management |
+| **Requires** | `pip install memex-hermes` + a running Memex MCP server or local wiki directory |
+| **Data storage** | Local filesystem (git repository) |
+| **Cost** | Free (open-source, Apache 2.0) |
+| **Tools** | `memex_search` (semantic + keyword hybrid search), `memex_ingest` (add sources), `memex_read` (read wiki concepts), `memex_status` (wiki health) |
+
+**Key differentiators:**
+
+- **Anti-hallucination protocol** — every claim in the wiki has a mandatory `[Source: path]` citation. Pages with >20% unsourced content are auto-quarantined.
+- **Knowledge decay** — confidence scoring with time-based decay, revalidation queue, and heat-map prioritization.
+- **Conflict detection** — dedicated contradiction tracking with human-in-the-loop resolution. Immutable nodes with dependency taint propagation.
+- **Local-first, no API key required** — all processing is local. The wiki is a directory of markdown files in a git repo.
+- **Multi-modal ingestion** — PDF with OCR, voice via Whisper, web clipping, markdown.
+- **OKF-compatible** — Memex already implements a superset of Google's Open Knowledge Format (OKF) v0.1 conventions.
+- **Hybrid search** — BM25 keyword + semantic search with configurable weighting.
+- **Knowledge graph** — interactive vis.js force-directed graph visualization.
+- **MCP server** — SSE transport for multi-agent access (Hermes, OpenClaw, Claude Code can share one wiki).
+
+**Setup:**
+
+```bash
+# Install the Memex Hermes plugin
+pip install memex-hermes
+
+# Or clone from source
+git clone https://github.com/JPeetz/memex-hermes-plugin.git
+cd memex-hermes-plugin
+pip install -e .
+
+# Set up Memex Zero RAG (if not already running)
+git clone https://github.com/JPeetz/MeMex-Zero-RAG.git
+cd MeMex-Zero-RAG
+pip install -e .
+python mcp/server.py --transport sse --port 3001
+
+# Configure Hermes
+hermes memory setup  # select "memex"
+```
+
+**Config file:** `$HERMES_HOME/memex.json`
+
+| Key | Default | Description |
+|---|---|---|
+| `endpoint` | `http://localhost:3001` | Memex MCP server URL |
+| `wiki_path` | `~/MeMex-Zero-RAG/wiki/` | Path to the Memex wiki directory |
+| `max_recall` | `10` | Max items injected into context per turn |
+| `search_results` | `10` | Max results for memex_search tool |
+
+**Plugin source:** [github.com/JPeetz/memex-hermes-plugin](https://github.com/JPeetz/memex-hermes-plugin)
+
+To add your own community memory provider, publish a standalone plugin following the [Memory Provider Plugin guide](/developer-guide/memory-provider-plugin) and open a PR to add it to this section.

--- a/website/docs/user-guide/features/community-memory-providers.md
+++ b/website/docs/user-guide/features/community-memory-providers.md
@@ -1,6 +1,14 @@
-## Community Memory Providers
+---
+sidebar_position: 5
+title: "Community Memory Providers"
+description: "External memory provider plugins maintained by the community — Memex Zero RAG"
+---
+
+# Community Memory Providers
 
 Beyond the 8 built-in providers, the following **standalone memory provider plugins** are available as community-maintained packages. They integrate with Hermes via the same `MemoryProvider` ABC and plugin discovery system — install them into `~/.hermes/plugins/`, and Hermes picks them up automatically.
+
+## Available Community Providers
 
 ### Memex Zero RAG
 

--- a/website/docs/user-guide/features/community-memory-providers.md
+++ b/website/docs/user-guide/features/community-memory-providers.md
@@ -1,61 +1,83 @@
 ## Community Memory Providers
 
-Beyond the 8 built-in providers, the following **standalone memory provider plugins** are available as community-maintained packages. These integrate with Hermes via the same `MemoryProvider` ABC and plugin discovery system — install them from pip or clone from their repos, and Hermes picks them up automatically.
+Beyond the 8 built-in providers, the following **standalone memory provider plugins** are available as community-maintained packages. They integrate with Hermes via the same `MemoryProvider` ABC and plugin discovery system — install them into `~/.hermes/plugins/`, and Hermes picks them up automatically.
 
 ### Memex Zero RAG
 
-[Memex Zero RAG](https://github.com/JPeetz/MeMex-Zero-RAG) is a **knowledge compilation system** using the Zero-RAG pattern (Karpathy's LLM Wiki). Unlike traditional providers that store individual facts as vector embeddings, Memex compiles sources into a structured, cross-referenced wiki that compounds knowledge over time.
+[Memex Zero RAG](https://github.com/JPeetz/MeMex-Zero-RAG) is a citation-first knowledge system inspired by Karpathy's LLM Wiki. The [memex-hermes-plugin](https://github.com/JPeetz/memex-hermes-plugin) exposes it to Hermes as a memory provider that stores individual, cited **Facts** rather than free-form vector chunks.
+
+:::warning v0.1.1 status
+This plugin is at **v0.1.1** — file-backed local storage only, no PyPI package yet, install by git clone. HTTP/MCP backends, FTS/BM25 search, and time-based confidence decay are planned for **v0.2**. See the [CHANGELOG](https://github.com/JPeetz/memex-hermes-plugin/blob/main/CHANGELOG.md) for the honest status delta.
+:::
 
 | | |
 |---|---|
-| **Best for** | Deep research, multi-session project knowledge, anti-hallucination-critical workflows, teams that want git-native knowledge management |
-| **Requires** | `pip install memex-hermes` + a running Memex MCP server or local wiki directory |
-| **Data storage** | Local filesystem (git repository) |
-| **Cost** | Free (open-source, Apache 2.0) |
-| **Tools** | `memex_search` (semantic + keyword hybrid search), `memex_ingest` (add sources), `memex_read` (read wiki concepts), `memex_status` (wiki health) |
+| **Best for** | Multi-session project knowledge, citation-critical workflows, teams that want a single-writer store of hand-curated Facts rather than a vector recall soup |
+| **Requires** | `git clone` into `~/.hermes/plugins/memex` + `MEMEX_ENDPOINT=file:///path` (or `hermes memory setup memex`) |
+| **Data storage** | Local filesystem, mode `0o700`, JSON facts under the endpoint path |
+| **Cost** | Free (open-source, see plugin repo for license) |
+| **Tools** | `memex_search`, `memex_read`, `memex_list`, `memex_write`, `memex_flag`, `memex_revalidate` (six total; the last three are write-gated) |
 
 **Key differentiators:**
 
-- **Anti-hallucination protocol** — every claim in the wiki has a mandatory `[Source: path]` citation. Pages with >20% unsourced content are auto-quarantined.
-- **Knowledge decay** — confidence scoring with time-based decay, revalidation queue, and heat-map prioritization.
-- **Conflict detection** — dedicated contradiction tracking with human-in-the-loop resolution. Immutable nodes with dependency taint propagation.
-- **Local-first, no API key required** — all processing is local. The wiki is a directory of markdown files in a git repo.
-- **Multi-modal ingestion** — PDF with OCR, voice via Whisper, web clipping, markdown.
-- **OKF-compatible** — Memex already implements a superset of Google's Open Knowledge Format (OKF) v0.1 conventions.
-- **Hybrid search** — BM25 keyword + semantic search with configurable weighting.
-- **Knowledge graph** — interactive vis.js force-directed graph visualization.
-- **MCP server** — SSE transport for multi-agent access (Hermes, OpenClaw, Claude Code can share one wiki).
+- **Citations required for `source` / `entity` / `concept` facts** — `memex_write` raises `CitationRequiredError` if a citation field is missing on those fact types.
+- **Write-gate on the primary agent** — mutating tools (`memex_write`, `memex_flag`, `memex_revalidate`) are enabled **only** when the plugin is loaded by the primary agent. Subagents and cron jobs get read-only access, preserving a single-writer invariant on the shared store.
+- **Bounded prefetch** — on every turn Hermes calls `prefetch(query)`; the plugin runs a bounded 2-second `memex_search()` on a daemon worker thread and injects the top-5 FactRefs as a `<memex-context>` block into the system prompt. Timeouts, empty results, and client failures all yield an empty block silently — no errors surface to the model.
+- **Immutable + flag/revalidate workflow** — facts can be flagged for revalidation, then confirmed, updated, or retired via `memex_revalidate`. Attempting to mutate an immutable fact raises `ImmutableFactError`.
+- **Local-first, no API key required in v0.1** — `MEMEX_API_KEY` is reserved for the HTTP endpoints landing in v0.2.
+- **Atomic + mode-0600 config writes** — the fallback `~/.hermes/memex.json` writer uses `tempfile.mkstemp` + `fchmod 0o600` + atomic rename; no mode-0644 window.
 
 **Setup:**
 
 ```bash
-# Install the Memex Hermes plugin
-pip install memex-hermes
+# Clone the plugin into the Hermes plugin directory
+git clone https://github.com/JPeetz/memex-hermes-plugin.git ~/.hermes/plugins/memex
 
-# Or clone from source
-git clone https://github.com/JPeetz/memex-hermes-plugin.git
-cd memex-hermes-plugin
-pip install -e .
+# Option A — env var (activates on next Hermes start)
+export MEMEX_ENDPOINT=file:///path/to/your/memex-store
 
-# Set up Memex Zero RAG (if not already running)
-git clone https://github.com/JPeetz/MeMex-Zero-RAG.git
-cd MeMex-Zero-RAG
-pip install -e .
-python mcp/server.py --transport sse --port 3001
+# Option B — interactive setup (writes ~/.hermes/memex.json)
+hermes memory setup memex
 
-# Configure Hermes
-hermes memory setup  # select "memex"
+# Verify
+hermes memory status   # should show: memex — Status: available ✓
 ```
 
-**Config file:** `$HERMES_HOME/memex.json`
+The plugin activates when `MEMEX_ENDPOINT` is set in the environment **or** when `~/.hermes/memex.json` contains an `endpoint` value (whichever is present; env var wins).
 
-| Key | Default | Description |
-|---|---|---|
-| `endpoint` | `http://localhost:3001` | Memex MCP server URL |
-| `wiki_path` | `~/MeMex-Zero-RAG/wiki/` | Path to the Memex wiki directory |
-| `max_recall` | `10` | Max items injected into context per turn |
-| `search_results` | `10` | Max results for memex_search tool |
+**Configuration (env vars):**
 
-**Plugin source:** [github.com/JPeetz/memex-hermes-plugin](https://github.com/JPeetz/memex-hermes-plugin)
+| Env var | Required | Default | Purpose |
+|---|---|---|---|
+| `MEMEX_ENDPOINT` | yes | — | Where the fact store lives. `file://...` in v0.1; HTTP/MCP in v0.2+. |
+| `MEMEX_API_KEY` | no | — | Reserved for HTTP endpoints (v0.2+). |
+| `MEMEX_SESSION_SCOPE` | no | `profile` | `session` / `profile` / `global`. Honored in v0.2+. |
+| `MEMEX_PREFETCH_TIMEOUT` | no | `2.0` | Prefetch deadline in seconds. Must be a positive finite float. |
+
+**Config file:** `~/.hermes/memex.json` (fallback when env vars are unset)
+
+```json
+{
+  "endpoint": "file:///path/to/your/memex-store",
+  "api_key": null
+}
+```
+
+Endpoint resolution precedence (fixed in v0.1.1): `MEMEX_ENDPOINT` env var → `~/.hermes/memex.json` → fallback of `~/.hermes/memex/`.
+
+**Known limitations in v0.1.1:**
+
+- **`file://` endpoints only** — HTTP/MCP backends land in v0.2.
+- **Substring scan, no BM25** — `memex_search` is a substring match over title/body/tags. Full-text search is v0.2.
+- **No in-plugin decay maths** — confidence is stored as provided; time-based decay is a backend concern for v0.2+.
+- **`memex_list` capped at 500 rows** at the tool boundary. Larger stores must paginate via `tags` / `types` / `statuses` filters.
+- **`statuses=["retired"]` returns empty** — the client hides retired facts from `list()` before the tool-boundary post-filter runs.
+- **Single-writer store** — file locking is advisory; concurrent multi-process writes will race.
+
+**One-external-provider invariant:** per Hermes PLUGIN-ABI §Q1, only one external memory provider may be active per Hermes session. If another external provider is already registered, Hermes will refuse to enable this one. Run `hermes memory list` to see which is active.
+
+**Plugin source:** [github.com/JPeetz/memex-hermes-plugin](https://github.com/JPeetz/memex-hermes-plugin) · [DESIGN.md](https://github.com/JPeetz/memex-hermes-plugin/blob/main/DESIGN.md) · [CHANGELOG.md](https://github.com/JPeetz/memex-hermes-plugin/blob/main/CHANGELOG.md)
+
+---
 
 To add your own community memory provider, publish a standalone plugin following the [Memory Provider Plugin guide](/developer-guide/memory-provider-plugin) and open a PR to add it to this section.

--- a/website/docs/user-guide/features/community-memory-providers.md
+++ b/website/docs/user-guide/features/community-memory-providers.md
@@ -14,15 +14,15 @@ Beyond the 8 built-in providers, the following **standalone memory provider plug
 
 [Memex Zero RAG](https://github.com/JPeetz/MeMex-Zero-RAG) is a citation-first knowledge system inspired by Karpathy's LLM Wiki. The [memex-hermes-plugin](https://github.com/JPeetz/memex-hermes-plugin) exposes it to Hermes as a memory provider that stores individual, cited **Facts** rather than free-form vector chunks.
 
-:::warning v0.1.1 status
-This plugin is at **v0.1.1** — file-backed local storage only, no PyPI package yet, install by git clone. HTTP/MCP backends, FTS/BM25 search, and time-based confidence decay are planned for **v0.2**. See the [CHANGELOG](https://github.com/JPeetz/memex-hermes-plugin/blob/main/CHANGELOG.md) for the honest status delta.
+:::info v0.2.0 status
+This plugin is at **v0.2.0** — file-backed local storage, plus remote [MeMex Zero RAG](https://github.com/JPeetz/MeMex-Zero-RAG) backends over MCP (`mcp+stdio://` / `mcp+sse://`). Still no PyPI package — install by git clone. Time-based confidence decay stays backend-side and unshipped. See the [CHANGELOG](https://github.com/JPeetz/memex-hermes-plugin/blob/main/CHANGELOG.md) for the honest status delta.
 :::
 
 | | |
 |---|---|
 | **Best for** | Multi-session project knowledge, citation-critical workflows, teams that want a single-writer store of hand-curated Facts rather than a vector recall soup |
-| **Requires** | `git clone` into `~/.hermes/plugins/memex` + `MEMEX_ENDPOINT=file:///path` (or `hermes memory setup memex`) |
-| **Data storage** | Local filesystem, mode `0o700`, JSON facts under the endpoint path |
+| **Requires** | `git clone` into `~/.hermes/plugins/memex` + `MEMEX_ENDPOINT` set to a `file://`, `mcp+stdio://`, or `mcp+sse://` URL (or `hermes memory setup memex`) |
+| **Data storage** | Local filesystem (`file://`, mode `0o700`, JSON facts) or a remote MeMex Zero RAG backend over MCP (`mcp+stdio://` / `mcp+sse://`) |
 | **Cost** | Free (open-source, see plugin repo for license) |
 | **Tools** | `memex_search`, `memex_read`, `memex_list`, `memex_write`, `memex_flag`, `memex_revalidate` (six total; the last three are write-gated) |
 
@@ -32,7 +32,7 @@ This plugin is at **v0.1.1** — file-backed local storage only, no PyPI package
 - **Write-gate on the primary agent** — mutating tools (`memex_write`, `memex_flag`, `memex_revalidate`) are enabled **only** when the plugin is loaded by the primary agent. Subagents and cron jobs get read-only access, preserving a single-writer invariant on the shared store.
 - **Bounded prefetch** — on every turn Hermes calls `prefetch(query)`; the plugin runs a bounded 2-second `memex_search()` on a daemon worker thread and injects the top-5 FactRefs as a `<memex-context>` block into the system prompt. Timeouts, empty results, and client failures all yield an empty block silently — no errors surface to the model.
 - **Immutable + flag/revalidate workflow** — facts can be flagged for revalidation, then confirmed, updated, or retired via `memex_revalidate`. Attempting to mutate an immutable fact raises `ImmutableFactError`.
-- **Local-first, no API key required in v0.1** — `MEMEX_API_KEY` is reserved for the HTTP endpoints landing in v0.2.
+- **File-first, MCP for shared/remote use** — `file://` needs no API key at all. `mcp+stdio://` and `mcp+sse://` connect to a real MeMex Zero RAG server; `MEMEX_API_KEY` is sent as an env var to the stdio subprocess or as an `Authorization: Bearer` header over SSE.
 - **Atomic + mode-0600 config writes** — the fallback `~/.hermes/memex.json` writer uses `tempfile.mkstemp` + `fchmod 0o600` + atomic rename; no mode-0644 window.
 
 **Setup:**
@@ -43,6 +43,9 @@ git clone https://github.com/JPeetz/memex-hermes-plugin.git ~/.hermes/plugins/me
 
 # Option A — env var (activates on next Hermes start)
 export MEMEX_ENDPOINT=file:///path/to/your/memex-store
+# or, for a remote MeMex Zero RAG backend:
+# export MEMEX_ENDPOINT=mcp+stdio:///path/to/MeMex-Zero-RAG/mcp/server.py
+# export MEMEX_ENDPOINT=mcp+sse://your-memex-host:8000
 
 # Option B — interactive setup (writes ~/.hermes/memex.json)
 hermes memory setup memex
@@ -57,9 +60,9 @@ The plugin activates when `MEMEX_ENDPOINT` is set in the environment **or** when
 
 | Env var | Required | Default | Purpose |
 |---|---|---|---|
-| `MEMEX_ENDPOINT` | yes | — | Where the fact store lives. `file://...` in v0.1; HTTP/MCP in v0.2+. |
-| `MEMEX_API_KEY` | no | — | Reserved for HTTP endpoints (v0.2+). |
-| `MEMEX_SESSION_SCOPE` | no | `profile` | `session` / `profile` / `global`. Honored in v0.2+. |
+| `MEMEX_ENDPOINT` | yes | — | Where the fact store lives: `file://...` for local, `mcp+stdio://...` (spawns a subprocess) or `mcp+sse://host:port` (remote server) for a MeMex Zero RAG backend. |
+| `MEMEX_API_KEY` | no | — | Sent to remote MCP endpoints only: env var for `mcp+stdio://` subprocess env, `Authorization: Bearer` header for `mcp+sse://`. Unused for `file://`. |
+| `MEMEX_SESSION_SCOPE` | no | `profile` | `session` / `profile` / `global` (stored, not yet enforced — reserved for search filtering). |
 | `MEMEX_PREFETCH_TIMEOUT` | no | `2.0` | Prefetch deadline in seconds. Must be a positive finite float. |
 
 **Config file:** `~/.hermes/memex.json` (fallback when env vars are unset)
@@ -71,16 +74,16 @@ The plugin activates when `MEMEX_ENDPOINT` is set in the environment **or** when
 }
 ```
 
-Endpoint resolution precedence (fixed in v0.1.1): `MEMEX_ENDPOINT` env var → `~/.hermes/memex.json` → fallback of `~/.hermes/memex/`.
+Endpoint resolution precedence: `MEMEX_ENDPOINT` env var → `~/.hermes/memex.json` → fallback of `~/.hermes/memex/`.
 
-**Known limitations in v0.1.1:**
+**Known limitations in v0.2.0:**
 
-- **`file://` endpoints only** — HTTP/MCP backends land in v0.2.
-- **Substring scan, no BM25** — `memex_search` is a substring match over title/body/tags. Full-text search is v0.2.
-- **No in-plugin decay maths** — confidence is stored as provided; time-based decay is a backend concern for v0.2+.
+- **No BM25 for `file://`** — local search is a substring match over title/body/tags. Remote backends (`mcp+stdio://` / `mcp+sse://`) get the MeMex Zero RAG server's own hybrid FTS5 search for free.
+- **No in-plugin decay maths** — confidence is stored/returned as provided; time-based decay is a backend concern.
 - **`memex_list` capped at 500 rows** at the tool boundary. Larger stores must paginate via `tags` / `types` / `statuses` filters.
 - **`statuses=["retired"]` returns empty** — the client hides retired facts from `list()` before the tool-boundary post-filter runs.
-- **Single-writer store** — file locking is advisory; concurrent multi-process writes will race.
+- **`file://` is single-writer** — locking is advisory; concurrent multi-process writes will race. Remote backends inherit whatever write coordination the backend itself implements.
+- **Remote `revalidate()` can't restore original confidence** on `confirm`/`update` the way the local `file://` client does — the MeMex Zero RAG backend has no `initial_confidence` field to restore from. A genuine backend schema gap, documented, not a plugin bug.
 
 **One-external-provider invariant:** per Hermes PLUGIN-ABI §Q1, only one external memory provider may be active per Hermes session. If another external provider is already registered, Hermes will refuse to enable this one. Run `hermes memory list` to see which is active.
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -68,6 +68,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/curator',
             'user-guide/features/memory',
             'user-guide/features/memory-providers',
+            'user-guide/features/community-memory-providers',
             'user-guide/features/honcho',
             'user-guide/features/context-files',
             'user-guide/features/context-references',

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -80,6 +80,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/curator',
             'user-guide/features/memory',
             'user-guide/features/memory-providers',
+            'user-guide/features/community-memory-providers',
             'user-guide/features/honcho',
             'user-guide/features/context-files',
             'user-guide/features/context-references',


### PR DESCRIPTION
## Proposal: Add Memex Zero RAG as a Community Memory Provider

This PR adds [Memex Zero RAG](https://github.com/JPeetz/MeMex-Zero-RAG) to a new **Community Memory Providers** page in the Hermes docs.

### Background

I understand, per CONTRIBUTING.md, that the in-tree memory provider set is closed. This PR does **not** add a new directory under `plugins/memory/`. Instead, it:

1. Adds a `community-memory-providers.md` page that documents Memex Zero RAG as a standalone memory provider plugin
2. Links it from the sidebar alongside the built-in providers page

### Why Memex Zero RAG?

Memex Zero RAG is a **knowledge compilation system** that implements the Zero-RAG pattern (Karpathy's LLM Wiki) with capabilities no existing Hermes memory provider offers:

| Capability | Memex | Existing Providers |
|---|---|---|
| **Anti-hallucination protocol** | Mandatory `[Source: path]` citations on every claim. Auto-quarantine for pages >20% unsourced. | No citation enforcement |
| **Knowledge decay** | Confidence scoring with time-based decay, revalidation queue, heat-map prioritization | No decay model |
| **Conflict detection** | Dedicated contradiction tracking with HITL resolution. Immutable nodes with dependency taint propagation | None |
| **Local-first, no API key required** | Zero cloud dependencies. The wiki is local markdown files in git | Most require cloud API keys |
| **Multi-modal ingestion** | PDF with OCR, voice via Whisper, web clipping, markdown | Text/session input only |
| **Hybrid search** | BM25 keyword + semantic search with configurable weighting | Vector-only search |
| **Knowledge graph** | Interactive vis.js force-directed graph | Flat fact lists |
| **OKF-compatible** | Already implements Google's Open Knowledge Format v0.1 spec superset | No standard format |
| **MCP server** | SSE transport for multi-agent access (Hermes, Claude Code, OpenClaw) | REST API or SDK only |

### Plugin Architecture

The standalone plugin (publishable as `pip install memex-hermes`) implements the `MemoryProvider` ABC with:

- **System prompt injection** — wiki available status and tool hints
- **Prefetch** — keyword + semantic hybrid search across compiled wiki pages before each turn
- **4 tools**: `memex_search`, `memex_ingest`, `memex_read`, `memex_status`
- **File-fallback mode** — works with or without the Memex MCP server running
- **Config schema** — endpoint, wiki_path, max_recall, search_results via `hermes memory setup`

The plugin repo will be published at `github.com/JPeetz/memex-hermes-plugin` with the full implementation following the [Memory Provider Plugin guide](https://hermes-agent.nousresearch.com/docs/developer-guide/memory-provider-plugin).

### Plugin Source

https://github.com/JPeetz/memex-hermes-plugin (standalone repo)

### Request

I'd welcome feedback on:
1. The community memory providers format — is this the right way to reference standalone providers?
2. Whether the docs could support a broader "Ecosystem" section listing community plugins
3. Any improvements to the plugin implementation before release
