### PR TITLE
feat(desktop): `hermes://mcp/<name>?url=…` deep link seeds the MCP editor, review-first

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -9,7 +9,7 @@ import { openUpdatesWindow, startUpdatePoller, stopUpdatePoller } from '@/store/
 import { isSecondaryWindow } from '@/store/windows'
 
 import { requestComposerFocus, requestComposerInsert } from '../../chat/composer/focus'
-import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, sessionRoute } from '../../routes'
+import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, sessionRoute, SKILLS_ROUTE } from '../../routes'
 
 interface DesktopIntegrationsParams {
   chatOpen: boolean
@@ -125,10 +125,35 @@ export function useDesktopIntegrations({
     return () => unsubscribe?.()
   }, [])
 
-  // hermes:// deep links -> a reviewable /blueprint command in the composer.
+  // hermes:// deep links. Two kinds, both review-first:
+  //   blueprint -> a reviewable /blueprint command in the composer.
+  //   mcp       -> the Skills > MCP editor, seeded with the server entry;
+  //                the user reviews and saves through the normal flow. A
+  //                website "Add to Hermes" button can emit
+  //                hermes://mcp/<name>?url=<https-endpoint> and nothing is
+  //                installed until the user presses Save.
   useEffect(() => {
     const unsubscribe = window.hermesDesktop?.onDeepLink?.(payload => {
-      if (!payload || payload.kind !== 'blueprint' || !payload.name) {
+      if (!payload || !payload.name) {
+        return
+      }
+
+      if (payload.kind === 'mcp') {
+        const url = payload.params?.url
+
+        // Only hosted HTTP(S) servers can arrive by link; anything else
+        // (stdio commands, file paths) stays a manual, deliberate edit.
+        if (!url || !/^https?:\/\//i.test(url)) {
+          return
+        }
+
+        const query = new URLSearchParams({ addName: payload.name, addUrl: url })
+        navigate(`${SKILLS_ROUTE}?tab=mcp&${query.toString()}`)
+
+        return
+      }
+
+      if (payload.kind !== 'blueprint') {
         return
       }
 
@@ -148,7 +173,7 @@ export function useDesktopIntegrations({
     void window.hermesDesktop?.signalDeepLinkReady?.()
 
     return () => unsubscribe?.()
-  }, [])
+  }, [navigate])
 
   // ⌘W via the macOS menu accelerator → close the focused tab; if nothing is
   // closeable, fall back to closing the window (so ⌘W still works as the

--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -13,6 +13,7 @@ import {
 import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
 import { type ComponentType, type SVGProps, useEffect, useMemo, useRef, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 
 import { type CodeEditorApi } from '@/components/chat/code-editor'
 import { JsonDocumentEditor } from '@/components/chat/json-document-editor'
@@ -544,6 +545,44 @@ export function McpTab({ gateway }: { gateway: HermesGateway | null }) {
     param: 'server',
     ready: serverName => blocks.some(block => block.name === serverName)
   })
+
+  // hermes://mcp/<name>?url=... -> seed the editor draft with the incoming
+  // server and let the user review + Save through the normal flow (probe,
+  // tool enablement, persistence). Nothing touches config.yaml until Save.
+  // If the name already exists, just focus it — a deep link never overwrites.
+  const [addParams, setAddParams] = useSearchParams()
+  const deepAddConsumed = useRef(false)
+
+  useEffect(() => {
+    if (deepAddConsumed.current || profilePending || !config) {
+      return
+    }
+
+    const addName = addParams.get('addName')
+    const addUrl = addParams.get('addUrl')
+
+    if (!addName || !addUrl || !/^https?:\/\//i.test(addUrl)) {
+      return
+    }
+
+    deepAddConsumed.current = true
+
+    const next = new URLSearchParams(addParams)
+    next.delete('addName')
+    next.delete('addUrl')
+
+    if (servers[addName]) {
+      // Already configured — highlight the existing row instead of seeding.
+      next.set('server', addName)
+      setAddParams(next, { replace: true })
+
+      return
+    }
+
+    patchDraft(doc => (doc[addName] ? doc : { ...doc, [addName]: { url: addUrl } }))
+    setDirty(true)
+    setAddParams(next, { replace: true })
+  }, [addParams, config, profilePending, servers, setAddParams])
 
   const runProbe = async (serverName: string) => {
     const epoch = profileEpoch.current


### PR DESCRIPTION
We build Dexter, the agentic bank: a non-custodial wallet an agent can spend from but never steal from (passkey-secured, the human's tap is the only authority), an x402 facilitator settling USDC across 11 chains, and a marketplace of 21,000+ paid endpoints where every listing is re-verified around the clock by actually paying it and grading what comes back. OpenDexter is the agent-facing runtime of that stack, and this week we ran Hermes Agent 0.18.2 end to end to bring it to your users: `hermes mcp add` connected, discovered the full tool suite, and a live Hermes session searched the paid web through it.

One thing is missing that your architecture already reaches for: a browser-to-app path for MCP servers. The desktop app registers the `hermes://` protocol and your docs catalog ships "Send to App" buttons for blueprints, but the renderer drops every deep-link kind except `blueprint` (`use-desktop-integrations.ts`). Meanwhile the ecosystem's MCP install story is copy-a-config-snippet. Cursor and VS Code both ship one-click install links; Hermes users deserve the same door. This PR opens it with the review-first semantics blueprints already have:

- `hermes://mcp/<name>?url=<https-endpoint>` navigates to Skills → MCP and seeds the JSON editor draft with the incoming server entry.
- Nothing touches `config.yaml` until the user presses Save; the normal probe, tool-enable, and persist flow runs unchanged.
- HTTPS/HTTP URLs only: stdio commands and file paths cannot arrive by link, so a malicious page can never suggest local execution.
- An existing server name is never overwritten; the link just focuses the existing row.
- The blueprint path is untouched.

With this merged, any MCP vendor can put an "Add to Hermes" button next to their "Add to Cursor" button, and a Hermes user is one click and one explicit in-app Save away from new capabilities. Ours will be first: an agent that can hold money, find any paid API in plain English, and settle in USDC, with the human's passkey as the only key that exists.

Two adjacent things we hit as fresh users, happy to file separately: the base PyPI package can't speak HTTP MCP (`mcp.client.streamable_http` is missing until `hermes-agent[mcp]`), and `--auth oauth` on `hermes mcp add` reports "MCP SDK auth module not available" even with the extra installed.

Tested by following the existing blueprint deep-link path; we don't run the Electron app in our CI, so a maintainer smoke-run of `hermes://mcp/demo?url=https://open.dexter.cash/mcp` is the fastest validation.