### PR TITLE
fix: add Kimi K3 1M context window to DEFAULT_CONTEXT_LENGTHS

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -316,7 +316,10 @@ DEFAULT_CONTEXT_LENGTHS = {
     "grok-3": 131072,           # grok-3, grok-3-mini, grok-3-fast, grok-3-mini-fast
     "grok-2": 131072,           # grok-2, grok-2-1212, grok-2-latest
     "grok": 131072,             # catch-all (grok-beta, unknown grok-*)
-    # Kimi
+    # Kimi — K3 ships with a 1M context window (verified: platform.kimi.ai/docs/overview).
+    # Longest-key-first substring matching ensures "kimi-k3" resolves to 1M
+    # while older/unknown Kimi models still hit the generic 256K fallback.
+    "kimi-k3": 1_000_000,
     "kimi": 262144,
     # Tencent — Hy3 Preview (Hunyuan) with 256K context window.
     # OpenRouter live metadata reports 262144 (256 × 1024); align the

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -296,6 +296,31 @@ class TestDefaultContextLengths:
             assert get_model_context_length("glm-5") == 202752
             assert get_model_context_length("glm-5.1") == 202752
 
+    def test_kimi_k3_context_1m(self):
+        """Kimi K3 must resolve to 1M, not the generic Kimi fallback of 256K.
+
+        Context window verified against platform.kimi.ai/docs/overview
+        (2026-07). Kimi K3 is the current flagship model with a 1M-token
+        context window.
+        """
+        from agent.model_metadata import get_model_context_length
+        from unittest.mock import patch as mock_patch
+
+        assert DEFAULT_CONTEXT_LENGTHS["kimi-k3"] == 1_000_000
+        assert DEFAULT_CONTEXT_LENGTHS["kimi"] == 262144
+
+        with mock_patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.get_cached_context_length", return_value=None):
+            # Kimi K3 (1M) must NOT fall through to the generic 256K entry
+            assert get_model_context_length("kimi-k3") == 1_000_000
+            # Vendor-prefixed forms (kimi provider, openrouter)
+            assert get_model_context_length("kimi/kimi-k3") == 1_000_000
+            assert get_model_context_length("moonshotai/kimi-k3") == 1_000_000
+            # Older/unknown Kimi models still resolve to 256K fallback
+            assert get_model_context_length("kimi-k2.6") == 262144
+            assert get_model_context_length("kimi-k2") == 262144
+
     def test_openrouter_live_metadata_beats_hardcoded_catchall(self):
         """OpenRouter-routed slugs resolve via the live OR catalog before the
         hardcoded family catch-all.


### PR DESCRIPTION
## Summary

Kimi K3 ships with a **1M-token context window** (verified: [platform.kimi.ai/docs/overview](https://platform.kimi.ai/docs/overview)) but was falling through to the generic `"kimi": 262144` catch-all in `DEFAULT_CONTEXT_LENGTHS`.

## Change

- Added `"kimi-k3": 1_000_000` before the `"kimi": 262144` catch-all in `agent/model_metadata.py`
- Longest-key-first substring matching ensures K3 resolves to 1M while older/unknown Kimi models still hit the 256K default
- Added `test_kimi_k3_context_1m` covering native, vendor-prefixed (`kimi/`, `moonshotai/`), and older model (kimi-k2.6, kimi-k2) fallback verification

## Verification

```
tests/agent/test_model_metadata.py::TestDefaultContextLengths::test_kimi_k3_context_1m PASSED
tests/agent/test_model_metadata.py - 122/122 passed, 0 failed
```

## Pattern

Same longest-key-first approach used by DeepSeek V4 (#...), GLM-5.2 (#...), and others.