### PR TITLE
fix(desktop): honor gitignore across Windows path casing

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/ipc.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/ipc.test.ts
@@ -82,6 +82,33 @@ describe('readProjectDir', () => {
     expect(readFileDataUrl).toHaveBeenCalledWith('C:/repo/.gitignore')
   })
 
+  it('filters gitignored entries when Windows path casing differs across IPC results', async () => {
+    gitRoot.mockResolvedValue('C:\\Repo')
+    readDir.mockImplementation(async path => {
+      if (path === 'c:\\repo\\src') {
+        return ok([
+          { name: 'debug.log', path: 'c:\\repo\\src\\debug.log', isDirectory: false },
+          { name: 'keep.ts', path: 'c:\\repo\\src\\keep.ts', isDirectory: false }
+        ])
+      }
+
+      if (path === 'C:/Repo') {
+        return ok([{ name: '.gitignore', path: 'C:/Repo/.gitignore', isDirectory: false }])
+      }
+
+      if (path === 'C:/Repo/src') {
+        return ok([])
+      }
+
+      return ok([])
+    })
+    readFileDataUrl.mockResolvedValue(dataUrl('src/*.log\n'))
+
+    const result = await readProjectDir('c:\\repo\\src', 'c:\\repo')
+
+    expect(result.entries.map(entry => entry.name)).toEqual(['keep.ts'])
+  })
+
   it('does not fetch .gitignore contents when listings do not contain .gitignore', async () => {
     gitRoot.mockResolvedValue('/repo')
     readDir.mockImplementation(async path => {

--- a/apps/desktop/src/app/right-sidebar/files/ipc.ts
+++ b/apps/desktop/src/app/right-sidebar/files/ipc.ts
@@ -32,16 +32,25 @@ function clean(path: string) {
   return path.replace(/\\/g, '/').replace(/\/+$/, '') || '/'
 }
 
+// Windows path identity is case-insensitive. Fold only comparison keys so the
+// relative path returned below keeps the filesystem's original spelling;
+// POSIX paths remain case-sensitive.
+function comparisonPath(path: string) {
+  return /^[A-Za-z]:(?:\/|$)/.test(path) || path.startsWith('//') ? path.toLowerCase() : path
+}
+
 /** Strict POSIX-style relative path; null if `child` is not inside `root`. */
 function relativeTo(root: string, child: string) {
   const r = clean(root)
   const c = clean(child)
+  const rKey = comparisonPath(r)
+  const cKey = comparisonPath(c)
 
-  if (c === r) {
+  if (cKey === rKey) {
     return ''
   }
 
-  return c.startsWith(`${r}/`) ? c.slice(r.length + 1) : null
+  return cKey.startsWith(`${rKey}/`) ? c.slice(r.length + 1) : null
 }
 
 /** Repo-root → repo-root/a → repo-root/a/b → … for every dir between root and `dir`. */


### PR DESCRIPTION
## Summary

- compare normalized Windows drive/UNC path keys case-insensitively when deriving project-tree paths
- preserve original path spelling in emitted relative paths and keep POSIX comparisons case-sensitive
- add a regression test for Git/IPC returning the same Windows repository with different casing

Fixes #67672

## Root cause

The Files pane normalizes `\` to `/`, but `relativeTo()` still used case-sensitive equality and prefix checks. When Git returned `C:\Repo` while directory entries used `c:\repo\...`, the helper returned `null`; those entries never reached the `.gitignore` matcher and ignored files remained visible.

## Verification

- Regression test fails on unmodified `main`: `debug.log` remains in the result.
- `npm --prefix apps/desktop run test:ui -- src/app/right-sidebar/files/ipc.test.ts src/app/right-sidebar/files/use-project-tree.test.ts` — 17 passed
- `npm --prefix apps/desktop run typecheck` — passed
- Targeted ESLint — passed
- Full Desktop UI suite — 197 files passed, 1,618 tests passed, 1 skipped
- `git diff --check` — passed