### PR TITLE
feat: add prompt-only agent toolset

### DIFF
--- a/tests/test_prompt_only_toolset.py
+++ b/tests/test_prompt_only_toolset.py
@@ -1,0 +1,9 @@
+from toolsets import get_toolset, resolve_toolset
+
+
+def test_prompt_only_toolset_is_registered_without_model_callable_tools():
+    toolset = get_toolset("prompt_only", include_registry=False)
+
+    assert toolset is not None
+    assert toolset["includes"] == []
+    assert resolve_toolset("prompt_only", include_registry=False) == []

--- a/toolsets.py
+++ b/toolsets.py
@@ -341,6 +341,12 @@ TOOLSETS = {
         "includes": ["web", "vision", "image_gen"]
     },
 
+    "prompt_only": {
+        "description": "No-tools runtime for isolated prompt-only classification and synthesis",
+        "tools": [],
+        "includes": []
+    },
+
     # Coding posture (base Hermes — CLI/TUI/desktop/ACP). Auto-selected in a
     # code workspace; see agent/coding_context.py. Keeps everything you reach
     # for while pairing on code and drops the rest (messaging, tts, image_gen,


### PR DESCRIPTION
## What does this PR do?

Adds an explicit `prompt_only` toolset that resolves to zero model-callable tools. It gives isolated classification and synthesis runtimes a named, deterministic no-tools posture instead of relying on an incidental empty dynamic toolset.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `toolsets.py`: registers `prompt_only` with no tools and no included toolsets.
- `tests/test_prompt_only_toolset.py`: proves registry lookup and resolved model-callable tool surface are both empty.

## How to Test

1. `scripts/run_tests.sh tests/test_prompt_only_toolset.py -q --tb=short`
2. Confirm `resolve_toolset("prompt_only", include_registry=False) == []`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing PRs; no equivalent static no-tools toolset was found
- [x] This PR contains only the prompt-only toolset and its contract test
- [x] The focused test passes
- [x] I've added tests
- [x] Tested on macOS 26.5.1

### Documentation & Housekeeping

- [x] Public documentation update: N/A; the toolset description is self-documenting
- [x] Config-key update: N/A
- [x] Contributor-contract update: N/A
- [x] Cross-platform impact considered; this is data-only toolset resolution
- [x] Tool schema update: N/A

## Screenshots / Logs

```text
1 test passed
resolve_toolset("prompt_only", include_registry=False) == []
```
