### PR TITLE
fix(windows): suppress console window flashes in env probes, lazy installs, and platform.win32_ver()

### DIFF
--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -34,6 +34,7 @@ from typing import Sequence
 __all__ = [
     "IS_WINDOWS",
     "resolve_node_command",
+    "suppress_platform_ver_console",
     "windows_detach_flags",
     "windows_detach_flags_without_breakaway",
     "windows_hide_flags",
@@ -199,6 +200,43 @@ def windows_hide_flags() -> int:
     if not IS_WINDOWS:
         return 0
     return _CREATE_NO_WINDOW
+
+
+def suppress_platform_ver_console() -> None:
+    """Stub out ``platform._syscmd_ver`` on Windows so it can never flash a
+    console window.  No-op on non-Windows.
+
+    CPython's ``platform.win32_ver()`` — reached by ``platform.uname()``,
+    ``platform.version()``, and ``platform.platform()`` — unconditionally
+    shells out ``cmd /c ver`` via ``subprocess.check_output(..., shell=True)``
+    with no ``CREATE_NO_WINDOW``.  From a windowless parent (the pythonw
+    gateway and every kanban worker it spawns) that allocates a fresh
+    *visible* console: one flashing ``cmd`` window per process, triggered by
+    any dependency that merely touches ``platform.uname()`` at import time.
+
+    With ``_syscmd_ver`` stubbed to return its inputs, ``win32_ver()`` hits
+    the documented ``ValueError`` fallback and reads the version from
+    ``sys.getwindowsversion().platform_version`` — same information, queried
+    in-process, no subprocess, no window.  Verified equivalent on
+    CPython 3.11 (``platform()`` → ``Windows-10-10.0.xxxxx-SP0`` either way).
+
+    Call early, before heavyweight imports — the flash typically happens
+    during a dependency's import, not from Hermes' own code.
+    """
+    if not IS_WINDOWS:
+        return
+    try:
+        import platform
+
+        if hasattr(platform, "_syscmd_ver"):
+            def _quiet_syscmd_ver(system="", release="", version="",
+                                  supported_platforms=("win32", "win16", "dos")):
+                return system, release, version
+
+            platform._syscmd_ver = _quiet_syscmd_ver
+    except Exception:
+        # Purely cosmetic hardening — never let it break startup.
+        pass
 
 
 def windows_detach_popen_kwargs() -> dict:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -61,6 +61,15 @@ try:
 except ModuleNotFoundError:
     pass
 
+# Windows: neutralize CPython's ``platform._syscmd_ver`` before anything else
+# imports — it shells out ``cmd /c ver`` (shell=True, no CREATE_NO_WINDOW), so
+# any dependency touching ``platform.uname()`` at import time flashes a
+# visible console when this process is windowless (pythonw gateway + every
+# kanban worker).  No-op on POSIX; never raises.
+from hermes_cli._subprocess_compat import suppress_platform_ver_console
+
+suppress_platform_ver_console()
+
 import os
 import sys
 

--- a/tools/env_probe.py
+++ b/tools/env_probe.py
@@ -37,6 +37,8 @@ import sys
 import threading
 from typing import Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger(__name__)
 
 # Module-level cache.  The probe result is deterministic for the
@@ -66,6 +68,11 @@ def _run(cmd: list[str], timeout: float = 3.0) -> tuple[int, str, str]:
             timeout=timeout,
             check=False,
             stdin=subprocess.DEVNULL,
+            # CREATE_NO_WINDOW (0 on POSIX): the probe runs in windowless
+            # processes (pythonw gateway / kanban workers) where a console
+            # child would otherwise flash a visible window per probe —
+            # ~5 flashes at every worker startup.
+            creationflags=windows_hide_flags(),
         )
         return result.returncode, (result.stdout or "").strip(), (result.stderr or "").strip()
     except FileNotFoundError:

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -79,6 +79,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger(__name__)
 
 
@@ -668,6 +670,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                     [uv_bin, "pip", "install", *target_args, *constraint_args, *specs],
                     capture_output=True, text=True, timeout=timeout, env=uv_env,
                     stdin=subprocess.DEVNULL,
+                    creationflags=windows_hide_flags(),
                 )
                 if r.returncode == 0:
                     if target is not None:
@@ -684,6 +687,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 pip_cmd + ["--version"],
                 capture_output=True, text=True, timeout=15,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
             if probe.returncode != 0:
                 raise FileNotFoundError("pip not in venv")
@@ -693,6 +697,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                     [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
                     capture_output=True, text=True, timeout=120, check=True,
                     stdin=subprocess.DEVNULL,
+                    creationflags=windows_hide_flags(),
                 )
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
                 return _InstallResult(False, "",
@@ -703,6 +708,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 pip_cmd + ["install", *target_args, *constraint_args, *specs],
                 capture_output=True, text=True, timeout=timeout,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
             if r.returncode == 0 and target is not None:
                 _activate_target_on_syspath(target)


### PR DESCRIPTION
## Summary

Three Windows console-window-flash fixes, all hit from windowless processes (a `pythonw` gateway and every kanban worker it spawns). Each worker start was flashing a burst of visible console windows on the user's desktop.

1. **`tools/env_probe.py`** — `_run()` called `subprocess.run` without `creationflags`. The probe sequence (`python3` / `python` / `pip` / `python3 -m pip` / PEP-668 check) is ~5 spawns per worker start, each flashing a console. Now passes `creationflags=windows_hide_flags()`.

2. **`tools/lazy_deps.py`** — four spawn sites with the same defect (`uv pip install`, the `pip --version` probe, `ensurepip`, and the pip-install fallback). Same fix.

3. **`platform.win32_ver()` / `_syscmd_ver()`** — CPython 3.11's `platform.win32_ver()` unconditionally calls `_syscmd_ver()`, which runs `cmd /c ver` via `subprocess.check_output(shell=True)` with no window suppression. Any dependency that merely touches `platform.uname()`/`version()`/`platform()` at import time flashes one `cmd` window per windowless process. New `_subprocess_compat.suppress_platform_ver_console()` helper (Windows-only, wrapped in try/except, no-op on POSIX) stubs `platform._syscmd_ver` so `win32_ver()` takes its documented fallback to `sys.getwindowsversion().platform_version`. Called at the very top of `hermes_cli/main.py`, right after the `hermes_bootstrap` import guard, before heavyweight imports.

`windows_hide_flags()` returns `CREATE_NO_WINDOW` on Windows and `0` on POSIX, and — unlike the detach flags — keeps stdio inherited, so `capture_output=True` in all touched call sites keeps working.

## Verification

- `platform.platform()` output is byte-identical with the stub active on CPython 3.11 / Windows 11 (`Windows-10-10.0.26100-SP0` either way; the fallback reads the same build number in-process via `sys.getwindowsversion()`).
- Flash detection was done by polling `EnumWindows` at ~15 ms and attributing new visible HWNDs to the suspect process tree — note that a `conhost.exe` child is *not* evidence of a visible window (it appears even with `CREATE_NO_WINDOW`), so control runs with/without the flag were used.
- Tests on Windows 11: `tests/tools/test_windows_native_support.py`, `test_env_probe.py`, `test_lazy_deps.py`, `test_lazy_deps_durable_target.py` — **153 passed, 1 skipped**. The 3 failures (`test_no_op_on_posix`, `test_getattr_fallback_prefers_sigkill_when_present`, `test_readonly_target_reports_error`) reproduce identically on a pristine `upstream/main` checkout in the same environment — pre-existing POSIX-only assertions and NTFS `chmod` semantics, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
