### PR TITLE
security: prevent credentials from entering memory-backed model context

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -152,6 +152,45 @@ are useful. They are not boundaries.
   reading its Python code and scripts, not just its SKILL.md
   description — skills execute arbitrary Python at import time.
 
+### 2.4.1 Credentials in persistent memory
+
+`MEMORY.md` and `USER.md` are intentionally injected into the system prompt
+every session (see `tools/memory_tool.py`). They are not a credential store.
+Writing a password, API key, token, private key, or connection string into
+memory makes that secret available to the active model and to any model
+provider receiving the system prompt, and it may be reproduced through normal
+responses or prompt-extraction.
+
+Hermes treats this as a **data-leak guard**, not a prompt-injection boundary
+(§2.4). Two independent mechanisms defend against it:
+
+1. **Write-time rejection.** `MemoryStore.add` / `replace` / `apply_batch`
+   scan every entry with `tools/secret_detector` before persisting. A probable
+   credential (prose form `Password for X: VALUE`, direct assignment, API-key
+   prose, `Authorization:` header, private-key block, or credential-bearing
+   connection string) is refused with a message that names where credentials
+   belong (`~/.hermes/.env`) **without echoing the secret**.
+2. **Legacy-load filtering.** At snapshot-build time
+   (`MemoryStore.load_from_disk`), every on-disk entry is re-scanned. A
+   probable credential already present from an older version or a manual edit
+   is withheld from the system prompt and replaced with a value-free
+   `[CREDENTIAL: …]` marker; the original file on disk is left untouched so
+   the operator can see and remove it. This runs independently of the write
+   gate, so it covers entries written before the guard existed.
+
+The shared detector (`tools/secret_detector.py`) is distinct from the
+prompt-injection scanner (`tools/threat_patterns.py`): the former finds
+*confidential values*, the latter finds *instructions*. Detecting probable
+credentials is a heuristic — it requires both credential *semantics* and a
+probable concrete *value*, so harmless sentences ("User rotates passwords
+monthly") are not flagged.
+
+Operators who previously stored credentials in memory must **remove the entry
+and rotate the credential** — removing it from memory does not undo a leak
+that already happened. Use `/memory scan` (or `scan_memory_for_secrets()`) to
+audit existing memory; it reports each match's source, entry index, and
+category without printing the value.
+
 ### 2.5 Plugin Trust Model
 
 Plugins load into the agent process and run with full agent

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1584,7 +1584,7 @@ class CLICommandsMixin:
             print("  /learn needs an active chat session to run.")
 
     def _handle_memory_command(self, cmd: str):
-        """Handle /memory slash command — pending review + approval-gate toggle."""
+        """Handle /memory slash command — pending review + approval-gate toggle + scan."""
         from hermes_cli.write_approval_commands import handle_pending_subcommand
         from tools import write_approval as wa
         parts = cmd.strip().split()
@@ -1601,6 +1601,13 @@ class CLICommandsMixin:
             # an approval here enforces the same caps as the live agent would.
             from tools.memory_tool import load_on_disk_store
             store = load_on_disk_store()
+
+        # /memory scan — audit existing memory for probable credentials without
+        # printing their values.  Reports location + category + remediation.
+        if args and args[0] == "scan":
+            self._handle_memory_scan()
+            return
+
         out = handle_pending_subcommand(
             wa.MEMORY, args,
             memory_store=store,
@@ -1608,8 +1615,29 @@ class CLICommandsMixin:
         )
         if out is None:
             out = ("Unknown /memory subcommand. "
-                   "Use: pending, approve <id>, reject <id>, approval <on|off>.")
+                   "Use: pending, approve <id>, reject <id>, approval <on|off>, scan.")
         print(out)
+
+    def _handle_memory_scan(self):
+        """Audit existing MEMORY.md / USER.md for probable credentials.
+
+        Does not print secret values.  Reports each match's source, entry
+        index, category, and remediation guidance (rotate, don't just remove).
+        """
+        from tools.secret_detector import scan_memory_for_secrets
+
+        findings = scan_memory_for_secrets()
+        if not findings:
+            print("  ✓ No probable credentials found in memory.")
+            return
+        print(f"  ⚠ Found {len(findings)} memory entr"
+              f"{'y' if len(findings) == 1 else 'ies'} with probable credentials:")
+        for source, entries in findings.items():
+            categories = ", ".join(sorted({f.category for f in entries}))
+            print(f"    • {source} — category: {categories}")
+        print("  Remediation: use the memory tool to remove each flagged entry")
+        print("  from MEMORY.md / USER.md, then ROTATE the exposed credential.")
+        print("  Removing it from memory does not undo a prior leak.")
 
     def _save_write_approval(self, subsystem: str, enabled: bool):
         """Persist <subsystem>.write_approval to config (for /memory|/skills approval)."""

--- a/tests/tools/test_memory_credential_guard.py
+++ b/tests/tools/test_memory_credential_guard.py
@@ -163,3 +163,68 @@ class TestNoSecretLeakInLogs:
             store = MemoryStore()
             store.load_from_disk()
         assert "CANARY_PASSWORD_7F39C1_A91D2E" not in caplog.text
+
+
+class TestMemoryScanAudit:
+    """Coverage for the /memory scan audit (scan_memory_for_secrets)."""
+
+    def _seed(self, tmp_path, monkeypatch, entries):
+        mem_dir = tmp_path / "memories"
+        mem_dir.mkdir(parents=True, exist_ok=True)
+        body = "\n§\n" + "\n§\n".join(entries) + "\n"
+        (mem_dir / "MEMORY.md").write_text(body, encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from hermes_constants import get_hermes_home
+
+        # get_hermes_home reads HERMES_HOME from the process env, which
+        # monkeypatch.setenv sets.
+        return get_hermes_home()
+
+    def test_scan_reports_source_and_entry_index(self, tmp_path, monkeypatch):
+        from tools.secret_detector import scan_memory_for_secrets
+
+        self._seed(
+            tmp_path, monkeypatch,
+            [
+                "User prefers terse responses.",                        # clean
+                "Password for Test WebUI: CANARY_PASSWORD_7F39C1_A91D2E",  # entry 2 (cred)
+                "Never store API keys in source control.",              # clean
+                "Authorization: Bearer CANARYeyJabc123def456ghi789",      # entry 4 (cred)
+            ],
+        )
+        results = scan_memory_for_secrets()
+        # Two credential entries found (entry 2 and entry 4).
+        assert len(results) == 2
+        assert "MEMORY.md#entry2" in results
+        assert "MEMORY.md#entry4" in results
+        # Each result is value-free (only category + marker).
+        for findings in results.values():
+            for f in findings:
+                assert "CANARY_PASSWORD_7F39C1_A91D2E" not in f.category
+                assert "CANARY_PASSWORD_7F39C1_A91D2E" not in f.marker
+                assert "CANARYeyJabc123def456ghi789" not in f.category
+                assert "CANARYeyJabc123def456ghi789" not in f.marker
+
+    def test_scan_no_value_leak_in_aggregated_output(self, tmp_path, monkeypatch):
+        from tools.secret_detector import scan_memory_for_secrets
+
+        self._seed(
+            tmp_path, monkeypatch,
+            ["Password for X: CANARY_PASSWORD_7F39C1_A91D2E"],
+        )
+        results = scan_memory_for_secrets()
+        flat = str(results)
+        assert "CANARY_PASSWORD_7F39C1_A91D2E" not in flat
+
+    def test_scan_clean_memory_reports_nothing(self, tmp_path, monkeypatch):
+        from tools.secret_detector import scan_memory_for_secrets
+
+        self._seed(
+            tmp_path, monkeypatch,
+            [
+                "User rotates passwords monthly.",
+                "The project has password authentication enabled.",
+                "Never store API keys in source control.",
+            ],
+        )
+        assert scan_memory_for_secrets() == {}

--- a/tests/tools/test_memory_credential_guard.py
+++ b/tests/tools/test_memory_credential_guard.py
@@ -1,0 +1,165 @@
+"""Tests for credential hardening in tools/memory_tool.py.
+
+These reproduce the issue where prose-form credentials could be saved into
+MEMORY.md / USER.md and injected into the model context, then verify the
+defense-in-depth fix:
+
+  1. Write path (add / replace / batch) rejects probable credentials and
+     never echoes the secret.
+  2. Legacy path: a credential already on disk is withheld from the
+     system-prompt snapshot (replaced by a value-free marker) while the
+     on-disk file is left untouched until the user removes it.
+  3. Ordinary non-secret entries are untouched.
+  4. The canary never appears in error responses, logs, or the snapshot.
+
+All canary values are unmistakably fake.
+"""
+
+import logging
+
+import pytest
+
+from tools.memory_tool import MemoryStore
+
+CANARY_PROSE = "Password for Test WebUI on this machine: CANARY_PASSWORD_7F39C1_A91D2E"
+CANARY_ASSIGN = 'password = "CANARY_PASSWORD_7F39C1_A91D2E"'
+CANARY_API_PROSE = "The api key is CANARY_APIKEY_ABC123DEF456GHI789"
+CANARY_BEARER = "Authorization: Bearer CANARYeyJabc123def456ghi789"
+CANARY_PRIVKEY = (
+    "-----BEGIN RSA PRIVATE KEY-----\n"
+    "CANARYMIIEogIBAAKCAQEAexamplekeyvalue1234567890\n"
+    "-----END RSA PRIVATE KEY-----"
+)
+CANARY_CONNSTR = "postgres://admin:CANARY_Sup3rSecret@db.example.com:5432/app"
+
+
+@pytest.fixture
+def mem_store(tmp_path, monkeypatch):
+    """A MemoryStore backed by an isolated temp HERMES_HOME/memories dir."""
+    mem_dir = tmp_path / "memories"
+    mem_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        "tools.memory_tool.get_memory_dir",
+        lambda: mem_dir,
+    )
+    # MemoryStore._path_for and load_from_disk use get_memory_dir via import;
+    # patch the module-level reference used inside the class too.
+    monkeypatch.setattr(MemoryStore, "_path_for", staticmethod(
+        lambda target: mem_dir / ("USER.md" if target == "user" else "MEMORY.md")
+    ))
+    store = MemoryStore()
+    store.load_from_disk()
+    return store
+
+
+def _write_legacy(mem_dir, fname, text):
+    (mem_dir / fname).write_text(f"\n§\n{text}\n", encoding="utf-8")
+
+
+class TestWritePathRejectsCredentials:
+    def test_add_prose_password_rejected(self, mem_store):
+        res = mem_store.add("memory", CANARY_PROSE)
+        assert res["success"] is False
+        assert "Credential" in res["error"] or "credential" in res["error"]
+        assert "CANARY_PASSWORD_7F39C1_A91D2E" not in res["error"]
+
+    def test_add_direct_assignment_rejected(self, mem_store):
+        res = mem_store.add("memory", CANARY_ASSIGN)
+        assert res["success"] is False
+        assert "CANARY_PASSWORD_7F39C1_A91D2E" not in res["error"]
+
+    def test_add_api_token_prose_rejected(self, mem_store):
+        res = mem_store.add("memory", CANARY_API_PROSE)
+        assert res["success"] is False
+        assert "CANARY_APIKEY_ABC123DEF456GHI789" not in res["error"]
+
+    def test_add_authorization_header_rejected(self, mem_store):
+        res = mem_store.add("memory", CANARY_BEARER)
+        assert res["success"] is False
+        assert "CANARYeyJabc123def456ghi789" not in res["error"]
+
+    def test_add_private_key_rejected(self, mem_store):
+        res = mem_store.add("memory", CANARY_PRIVKEY)
+        assert res["success"] is False
+        assert "CANARYMIIEogIBAAKCAQEA" not in res["error"]
+
+    def test_add_connection_string_rejected(self, mem_store):
+        res = mem_store.add("memory", CANARY_CONNSTR)
+        assert res["success"] is False
+        assert "CANARY_Sup3rSecret" not in res["error"]
+
+    def test_replace_with_credential_rejected(self, mem_store):
+        mem_store.add("memory", "The deployment uses a webui.")
+        res = mem_store.replace("memory", "The deployment uses a webui.", CANARY_PROSE)
+        assert res["success"] is False
+        assert "CANARY_PASSWORD_7F39C1_A91D2E" not in res["error"]
+
+    def test_batch_with_credential_rejected(self, mem_store):
+        res = mem_store.apply_batch("memory", [
+            {"action": "add", "content": "A harmless note about the build."},
+            {"action": "add", "content": CANARY_PROSE},
+        ])
+        # Whole batch must be refused; nothing committed.
+        assert res["success"] is False
+        assert "CANARY_PASSWORD_7F39C1_A91D2E" not in res["error"]
+
+
+class TestLegacySnapshotWithholdsCredentials:
+    def test_legacy_prose_password_absent_from_snapshot(self, mem_store, tmp_path):
+        mem_dir = tmp_path / "memories"
+        _write_legacy(mem_dir, "MEMORY.md", CANARY_PROSE)
+
+        store = MemoryStore()
+        store.load_from_disk()
+        snap = store.format_for_system_prompt("memory") or ""
+
+        # The canary must NOT reach the system prompt.
+        assert "CANARY_PASSWORD_7F39C1_A91D2E" not in snap
+        # A safe marker should be present instead.
+        assert "[CREDENTIAL:" in snap
+        # Original file on disk is preserved (user must remove + rotate).
+        assert "CANARY_PASSWORD_7F39C1_A91D2E" in (
+            mem_dir / "MEMORY.md"
+        ).read_text(encoding="utf-8")
+
+
+class TestNonSecretEntriesUnchanged:
+    def test_ordinary_entry_accepted(self, mem_store):
+        res = mem_store.add("memory", "User prefers concise responses.")
+        assert res["success"] is True
+        assert "User prefers concise responses." in (
+            mem_store._path_for("memory").read_text(encoding="utf-8")
+        )
+
+    def test_security_advice_without_value_accepted(self, mem_store):
+        res = mem_store.add(
+            "memory",
+            "Never store API keys in source control or in memory.",
+        )
+        assert res["success"] is True
+        assert "Never store API keys in source control" in (
+            mem_store._path_for("memory").read_text(encoding="utf-8")
+        )
+
+    def test_password_policy_advice_accepted(self, mem_store):
+        res = mem_store.add(
+            "memory",
+            "User rotates passwords monthly for security hygiene.",
+        )
+        assert res["success"] is True
+
+
+class TestNoSecretLeakInLogs:
+    def test_write_rejection_does_not_log_secret(self, mem_store, tmp_path, caplog):
+        with caplog.at_level(logging.WARNING):
+            mem_store.add("memory", CANARY_PROSE)
+        combined = caplog.text
+        assert "CANARY_PASSWORD_7F39C1_A91D2E" not in combined
+
+    def test_legacy_snapshot_does_not_log_secret(self, mem_store, tmp_path, caplog):
+        mem_dir = tmp_path / "memories"
+        _write_legacy(mem_dir, "MEMORY.md", CANARY_PROSE)
+        with caplog.at_level(logging.WARNING):
+            store = MemoryStore()
+            store.load_from_disk()
+        assert "CANARY_PASSWORD_7F39C1_A91D2E" not in caplog.text

--- a/tests/tools/test_secret_detector.py
+++ b/tests/tools/test_secret_detector.py
@@ -1,0 +1,117 @@
+"""Tests for tools/secret_detector.py — credential detection in model context.
+
+These pin the invariant: "Persistent context intended for injection into an
+LLM must not contain probable authentication credentials."
+
+All canary values are unmistakably fake (CANARY_*, hunter2, ghp_..., etc.).
+
+The detector must:
+  * reject prose and direct-assignment credential forms,
+  * keep prompt-injection detection conceptually separate (this module finds
+    *values*, not *instructions*),
+  * never return or echo the matched secret value,
+  * accept harmless sentences that merely mention credentials.
+"""
+
+import pytest
+
+from tools.secret_detector import (
+    SecretFinding,
+    contains_secret,
+    first_secret_message,
+    scan_for_secrets,
+    scan_memory_for_secrets,
+)
+
+# Synthetic, obviously-fake canaries only.
+CANARY_PROSE = "Password for Test WebUI on this machine: CANARY_PASSWORD_7F39C1_A91D2E"
+CANARY_ASSIGN = 'password = "CANARY_PASSWORD_7F39C1_A91D2E"'
+CANARY_API_PROSE = "The api key is CANARY_APIKEY_ABC123DEF456GHI789"
+CANARY_BEARER = "Authorization: Bearer CANARYeyJabc123def456ghi789"
+CANARY_BASIC = "Authorization: Basic CANARYdXNlcjpwYXNzd29yZA=="
+CANARY_PRIVKEY = (
+    "-----BEGIN RSA PRIVATE KEY-----\n"
+    "CANARYMIIEogIBAAKCAQEAexamplekeyvalue1234567890\n"
+    "-----END RSA PRIVATE KEY-----"
+)
+CANARY_CONNSTR = "postgres://admin:CANARY_Sup3rSecret@db.example.com:5432/app"
+CANARY_URL_USERINFO = "https://user:CANARY_FancyPassw0rd@api.example.com/v1"
+CANARY_GH_PAT = "token: ghp_CANARYabcdefghijklmnopqrstuvwxyz0123"
+
+
+class TestDetectsCredentials:
+    def test_prose_password_rejected(self):
+        assert contains_secret(CANARY_PROSE)
+
+    def test_direct_assignment_rejected(self):
+        assert contains_secret(CANARY_ASSIGN)
+
+    def test_api_token_prose_rejected(self):
+        assert contains_secret(CANARY_API_PROSE)
+
+    def test_authorization_header_rejected(self):
+        assert contains_secret(CANARY_BEARER)
+        assert contains_secret(CANARY_BASIC)
+
+    def test_private_key_material_rejected(self):
+        assert contains_secret(CANARY_PRIVKEY)
+
+    def test_connection_string_rejected(self):
+        assert contains_secret(CANARY_CONNSTR)
+
+    def test_url_userinfo_rejected(self):
+        assert contains_secret(CANARY_URL_USERINFO)
+
+    def test_github_pat_rejected(self):
+        assert contains_secret(CANARY_GH_PAT)
+
+    def test_first_secret_message_explains_and_does_not_echo(self):
+        msg = first_secret_message(CANARY_PROSE)
+        assert msg is not None
+        assert "MEMORY.md" in msg or "memory" in msg.lower()
+        # The actual secret value must never appear in the rejection message.
+        assert "CANARY_PASSWORD_7F39C1_A91D2E" not in msg
+
+
+class TestAcceptsHarmless:
+    @pytest.mark.parametrize("text", [
+        "User rotates passwords monthly for security hygiene.",
+        "The project has password authentication enabled.",
+        "Never store API keys in source control or memory.",
+        "The password is required to log in to the VPN.",
+        "The password field is on the left of the form.",
+        "An API key is needed for the service; obtain one from the portal.",
+        "We are organizing a secret santa gift exchange this year.",
+        "The token economy of the platform rewards active users.",
+        "The meeting is at noon and the report is due Friday.",
+        "Set a password.",
+        # 'password' followed by a normal word, not a value
+        "My password manager suggested a long passphrase.",
+    ])
+    def test_no_false_positive_on_credential_mention(self, text):
+        assert not contains_secret(text)
+
+    def test_first_secret_message_clean_is_none(self):
+        assert first_secret_message("User rotates passwords monthly.") is None
+
+
+class TestFindingIsValueFree:
+    def test_finding_has_no_secret_value(self):
+        findings = scan_for_secrets(CANARY_PROSE)
+        assert findings
+        for f in findings:
+            assert isinstance(f, SecretFinding)
+            assert "CANARY_PASSWORD_7F39C1_A91D2E" not in f.category
+            assert "CANARY_PASSWORD_7F39C1_A91D2E" not in f.marker
+
+    def test_finding_repr_is_safe(self):
+        findings = scan_for_secrets(CANARY_PROSE)
+        for f in findings:
+            assert "CANARY_PASSWORD_7F39C1_A91D2E" not in str(f)
+
+
+class TestEmptyInput:
+    def test_empty_returns_empty(self):
+        assert scan_for_secrets("") == []
+        assert not contains_secret("")
+        assert first_secret_message("") is None

--- a/tests/tools/test_secret_detector.py
+++ b/tests/tools/test_secret_detector.py
@@ -115,3 +115,55 @@ class TestEmptyInput:
         assert scan_for_secrets("") == []
         assert not contains_secret("")
         assert first_secret_message("") is None
+
+
+class TestNoFalsePositivesOnDictionaryWords:
+    """These are the exact strings that previously triggered false positives
+    because the value matcher accepted long alphabetic dictionary words. A
+    probable secret must look structured (digit / mixed case / base64), not be
+    a long English word.
+    """
+
+    @pytest.mark.parametrize("text", [
+        "Password policy: authentication",
+        "Password reset: documentation",
+        "Token expiration: configurable",
+        "API key rotation: recommended",
+        "Database password: stored_in_keychain",
+        'password = os.getenv("DATABASE_PASSWORD")',
+        "api_key = environment_variable",
+        "The password is intentionally omitted",
+        # Additional prose with long non-secret values.
+        "The password is configuration",
+        "Secret management: documentation",
+        "Credential rotation: recommended",
+        "Access token lifetime: configurable",
+    ])
+    def test_benign_sentences_not_flagged(self, text):
+        assert not contains_secret(text)
+
+
+class TestLooksLikeSecretHelper:
+    """Direct unit coverage of the value validator so the rule is pinned."""
+
+    def test_pure_alpha_word_rejected(self):
+        from tools.secret_detector import _looks_like_secret
+
+        assert not _looks_like_secret("authentication")
+        assert not _looks_like_secret("stored_in_keychain")
+        assert not _looks_like_secret("environment_variable")
+
+    def test_structured_value_accepted(self):
+        from tools.secret_detector import _looks_like_secret
+
+        assert _looks_like_secret("CANARY_PASSWORD_7F39C1_A91D2E")
+        assert _looks_like_secret("hunter2hunter2hunter22")  # has digits
+        assert _looks_like_secret("Sup3rSecretPass")          # mixed case + digit
+        assert _looks_like_secret("abc123def456ghi789")       # has digits
+        assert _looks_like_secret("dXNlcjpwYXNzd29yZA==")    # base64-ish
+
+    def test_env_lookup_not_a_value(self):
+        from tools.secret_detector import _looks_like_secret
+
+        assert not _looks_like_secret('os.getenv("DATABASE_PASSWORD")')
+        assert not _looks_like_secret("process.env.API_KEY")

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -13,6 +13,13 @@ Mid-session writes update files on disk immediately (durable) but do NOT change
 the system prompt -- this preserves the prefix cache for the entire session.
 The snapshot refreshes on the next session start.
 
+IMPORTANT (credential safety): MEMORY.md / USER.md are NOT a credential store.
+Entries are scanned for probable authentication credentials (see
+tools/secret_detector.py) both at write time and at snapshot-build time. A
+probable credential is refused on write and withheld from the system prompt on
+load; the original file is left on disk so the operator can remove it. Credentials
+belong in Hermes' supported credential storage (e.g. ~/.hermes/.env), never here.
+
 Entry delimiter: § (section sign). Entries can be multiline.
 Character limits (not tokens) because char counts are model-independent.
 
@@ -73,11 +80,35 @@ ENTRY_DELIMITER = "\n§\n"
 # ---------------------------------------------------------------------------
 
 from tools.threat_patterns import first_threat_message as _first_threat_message
+from tools.secret_detector import first_secret_message as _first_secret_message
 
 
 def _scan_memory_content(content: str) -> Optional[str]:
-    """Scan memory content for injection/exfil patterns. Returns error string if blocked."""
-    return _first_threat_message(content, scope="strict")
+    """Scan memory content for injection/exfil patterns AND probable credentials.
+
+    Returns a user-facing error string (never the secret itself) when the
+    content should be rejected, else ``None``.
+
+    Two independent checks run here:
+
+    - ``threat_patterns`` — prompt-injection / exfiltration *instructions*.
+    - ``secret_detector`` — *probable authentication credentials* (passwords,
+      API keys, tokens, private keys, connection strings).  This is what the
+      old scanner missed: prose forms like ``Password for X: VALUE`` that are
+      not direct quoted assignments.
+
+    The credential check is the data-leak guard: MEMORY.md / USER.md are
+    injected into the system prompt, so a credential written here can reach the
+    model provider and model responses.  Detection returns only a category,
+    never the matched value.
+    """
+    threat = _first_threat_message(content, scope="strict")
+    if threat:
+        return threat
+    secret = _first_secret_message(content)
+    if secret:
+        return secret
+    return None
 
 
 def _drift_error(path: "Path", bak_path: str) -> Dict[str, Any]:
@@ -206,22 +237,31 @@ class MemoryStore:
 
     @staticmethod
     def _sanitize_entries_for_snapshot(entries: List[str], filename: str) -> List[str]:
-        """Return ``entries`` with any threat-matching entry replaced by a placeholder.
+        """Return ``entries`` with any threat- or credential-matching entry replaced.
 
-        Each entry is scanned with the shared threat-pattern library at the
-        ``"strict"`` scope (same as memory writes).  On match, the entry is
-        replaced in the returned list with ``"[BLOCKED: <filename> entry
-        contained threat pattern: <ids>. Removed from system prompt.]"`` —
-        the placeholder enters the snapshot, the original entry stays in
-        live state for the user to inspect and delete.
+        Each entry is scanned with two independent libraries at load time:
+
+        - ``tools.threat_patterns`` (prompt-injection / exfiltration
+          *instructions*) at the ``"strict"`` scope — same as memory writes.
+        - ``tools.secret_detector`` (probable *authentication credentials*).
+          This catches prose-form credentials like ``Password for X: VALUE``
+          that the write-time guard may have missed (older Hermes versions, or
+          manual edits made directly to MEMORY.md / USER.md).
+
+        On a match, the entry is replaced in the returned list with a
+        value-free placeholder that enters the system prompt; the original
+        entry stays in live state (memory_entries / user_entries) so the user
+        can still SEE and remove it via the memory tool.  The original secret
+        value is never placed in the snapshot, the placeholder, or a log line.
 
         Empty or already-block-marker entries pass through unchanged.
         """
         from tools.threat_patterns import scan_for_threats
+        from tools.secret_detector import scan_for_secrets
 
         sanitized: List[str] = []
         for entry in entries:
-            if not entry or entry.startswith("[BLOCKED:"):
+            if not entry or entry.startswith("[BLOCKED:") or entry.startswith("[CREDENTIAL:"):
                 sanitized.append(entry)
                 continue
             findings = scan_for_threats(entry, scope="strict")
@@ -235,6 +275,25 @@ class MemoryStore:
                     f"{', '.join(findings)}. Removed from system prompt; "
                     f"use memory(action=remove) "
                     f"to delete the original.]"
+                )
+                continue
+            secret_findings = scan_for_secrets(entry)
+            if secret_findings:
+                categories = ", ".join(sorted({f.category for f in secret_findings}))
+                logger.warning(
+                    "Memory entry from %s withheld from system prompt: probable "
+                    "credential (category: %s). Original file on disk is "
+                    "unchanged; remove the entry with memory(action=remove) and "
+                    "rotate the exposed credential.",
+                    filename, categories,
+                )
+                sanitized.append(
+                    f"[CREDENTIAL: {filename} entry contained a probable "
+                    f"authentication credential ({categories}). It was withheld "
+                    f"from the system prompt and the original value was not "
+                    f"echoed. Use memory(action=remove) to delete the original "
+                    f"entry from disk, then rotate the credential — removing it "
+                    f"from memory does not undo a leak.]"
                 )
             else:
                 sanitized.append(entry)

--- a/tools/secret_detector.py
+++ b/tools/secret_detector.py
@@ -1,0 +1,314 @@
+"""Shared credential/secret detector for persistent model context.
+
+This module is the single source of truth for detecting *probable
+authentication credentials* in text that is about to enter an LLM's context
+(memory files, context files, and optionally tool-result redaction).
+
+It is deliberately SEPARATE from ``tools/threat_patterns.py``:
+
+- ``threat_patterns`` detects *instructions* (prompt injection, exfiltration
+  C2 vocabulary, persistence).  Those are behavioural attacks.
+- ``secret_detector`` detects *confidential values* (passwords, API keys,
+  tokens, private keys, connection strings).  Those are data leaks.
+
+Conflating the two would blur the threat model: a password in memory is not a
+prompt-injection payload, and a prompt-injection string is not a credential.
+Keeping the detectors apart lets each evolve against its own false-positive
+surface.
+
+Design goals
+------------
+
+- **Require both semantics and a concrete value.**  We never flag a sentence
+  that merely mentions credentials without a probable value, e.g.::
+
+      User rotates passwords monthly
+      The project has password authentication
+      Never store API keys in source control
+
+  Each pattern anchors on a credential keyword *and* an adjacent
+  high-entropy / structured value.
+
+- **Cover prose and direct-assignment forms.**  The legacy memory scanner in
+  ``threat_patterns`` (``hardcoded_secret``) only matched quoted direct
+  assignments like ``password = "xyz"``.  This module additionally catches
+  prose such as ``Password for Test WebUI on this machine: CANARY_...``.
+
+- **Never reveal the value.**  Detection returns only a *category* and a
+  safe, value-free marker.  Callers (memory tool, audit CLI) must never print,
+  log, or echo the matched secret.
+
+- **No duplication of regex sets.**  The memory write path, the memory
+  snapshot path, tool-result redaction, and the audit command all call into
+  this one module.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Optional
+
+# Bound scanned text so adversarial/large inputs can't blow up runtime.
+# Detection only needs to find a credential near the start of injected content.
+MAX_SCAN_CHARS = 65_536
+
+# ---------------------------------------------------------------------------
+# Value shapes (shared by every credential pattern below)
+# ---------------------------------------------------------------------------
+
+# A high-entropy bare token: letters/digits/underscore/hyphen, length >= 12,
+# containing at least one non-pure-alpha and one non-pure-digit run so we don't
+# match ordinary words or pure numbers.  Anchored so it can sit after a colon,
+# an equals sign, "is", "for <svc>", etc.
+_TOKEN = r"[A-Za-z0-9_=\-]{12,}"
+
+# A hex / base64-ish blob (20+ chars) — typical of API keys, hashes, tokens.
+_HEX = r"[A-Za-z0-9+/]{20,}"
+
+# A value that is "probably not a sentence": excludes trailing sentence
+# punctuation and common English words so ``Password is required`` does not
+# match.  Used for the "Password is <value>" prose form.
+_PROSE_VALUE = r"(?!=[\s])([A-Za-z0-9_=\-]{10,}|[A-Za-z0-9+/]{12,})"
+
+# Generic credential-keyword vocabulary (case-insensitive).  Excludes bare
+# "auth" so "Authorization:" (handled separately) and "author:" don't collide
+# with legitimate prose, but keeps auth_token/auth-key via the "token" keyword.
+_CRED_KEY = (
+    r"(?:passphrase|passwd|password|pwd|api[ _-]?key|secret(?:[ _-]?key)?|"
+    r"token|access[ _-]?token|refresh[ _-]?token|auth[ _-]?token|"
+    r"credential|private[ _-]?key|bearer|client[ _-]?secret)"
+)
+
+
+@dataclass(frozen=True)
+class SecretFinding:
+    """A value-free description of a detected credential.
+
+    The matched text is intentionally NOT stored — callers must never surface
+    the secret.  Only the ``category`` (for remediation guidance) and a short
+    ``marker`` (safe to log / place in a system-prompt placeholder) are kept.
+    """
+
+    category: str
+    marker: str
+
+    def __str__(self) -> str:  # pragma: no cover - convenience only
+        return self.marker
+
+
+# Each entry: (compiled regex, category, marker).  Order is irrelevant; all
+# are tried.  Every pattern requires BOTH a credential keyword and a concrete
+# structured value.
+_PATTERNS: List[tuple] = []
+
+
+def _add(pattern: str, category: str, marker: str) -> None:
+    _PATTERNS.append((re.compile(pattern, re.IGNORECASE), category, marker))
+
+
+# --- Prose forms ("Password for X: VALUE", "The password is VALUE") -------
+
+# "Password for <service>: <value>" / "password to the db is <value>"
+# Requires a value of >=10 chars that is not a common English stopword-ish
+# short word.  We additionally require the value NOT be a known FP word.
+_add(
+    rf"{_CRED_KEY}\b[^\n]{{0,40}}?[:=]\s*{_PROSE_VALUE}(?![A-Za-z])",
+    "password_prose",
+    "[credential: password (prose form)]",
+)
+# "The password is <value>" / "my api key is <value>"
+_add(
+    rf"\b(?:the|my|our)\s+{_CRED_KEY}\s+(?:is|was|has|equals)\s+{_PROSE_VALUE}(?![A-Za-z])",
+    "credential_prose",
+    "[credential: api key / token (prose form)]",
+)
+# "store the password as <value>" — imperative/instruction prose still has a
+# concrete value, so it is caught; relies on the value shape, not the verb.
+
+# --- Direct assignments (both quoted and unquoted) -------------------------
+# Legacy threat_patterns only handled the quoted form with >=20 chars.  We
+# also catch unquoted ``password = hunter2`` while still requiring a value.
+_add(
+    rf"{_CRED_KEY}\s*[=:]\s*['\"]?{_TOKEN}['\"]?",
+    "credential_assignment",
+    "[credential: direct assignment]",
+)
+# YAML / .env style ``key: value`` handled above via the assignment pattern.
+
+# --- API key / access token prose ------------------------------------------
+# "API key: <value>" is covered by the prose + assignment patterns above.
+# Add an explicit token-with-scheme form for robustness.
+_add(
+    rf"(?:api[ _-]?key|access[ _-]?token|secret)\s*(?:of|for|to)?\s*[:=]?\s*{_TOKEN}",
+    "api_key_prose",
+    "[credential: api key / token]",
+)
+
+# --- Authorization / bearer headers ----------------------------------------
+# "Authorization: Bearer <token>", "Authorization: Basic <b64>", or any scheme.
+# The credential class excludes quotes so masking never corrupts syntax.
+_add(
+    r"(?:proxy-)?authorization\s*:\s*(?:bearer|basic|token|digest|apikey)?\s*\S+",
+    "authorization_header",
+    "[credential: Authorization header]",
+)
+# Bare scheme token without a header name: "Bearer <token>", "Basic <b64>".
+_add(
+    r"\b(?:bearer|basic|token|digest)\s+[A-Za-z0-9._\-+/]{12,}",
+    "auth_scheme_token",
+    "[credential: bearer/basic token]",
+)
+# x-api-key / x-auth-token header style.
+_add(
+    r"\b(?:x-api-key|x-goog-api-key|api-key|apikey|x-api-token|x-auth-token|x-access-token)\s*:\s*\S+",
+    "secret_header",
+    "[credential: secret header]",
+)
+
+# --- Private key blocks -----------------------------------------------------
+_add(
+    r"-----BEGIN[A-Z ]*PRIVATE KEY-----[\s\S]*?-----END[A-Z ]*PRIVATE KEY-----",
+    "private_key",
+    "[credential: private key block]",
+)
+# PKCS#8 / OpenSSH single-line key material references.
+_add(
+    r"PRIVATE KEY(?: BLOCK)?(?:[ ]?\([^)]*\))?[:=]\s*[A-Za-z0-9+/=]{20,}",
+    "private_key_assignment",
+    "[credential: private key assignment]",
+)
+
+# --- Connection strings with embedded credentials --------------------------
+# postgres://user:PASSWORD@host, mysql://..., mongodb+srv://..., redis://...,
+# amqp://...  Forbids whitespace so the match never spans a line break.
+_add(
+    r"(?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis|amqp)://[^:\s/]+:[^@\s]{4,}@",
+    "db_connection_string",
+    "[credential: database connection string]",
+)
+# Generic scheme://user:pass@host (not just DB protocols).
+_add(
+    r"(?:https?|wss?|ftp|ftps|sftp|ssh|git)://[^/\s:@]+:[^/\s@]{4,}@",
+    "url_userinfo",
+    "[credential: URL user:password]",
+)
+
+# --- Known vendor-key prefixes (high precision) ----------------------------
+_VENDOR_PREFIXES = (
+    r"sk-[A-Za-z0-9_\-]{10,}|"           # OpenAI / OpenRouter / Anthropic
+    r"gh[pousr]_[A-Za-z0-9]{10,}|"        # GitHub PATs
+    r"github_pat_[A-Za-z0-9_]{10,}|"     # GitHub fine-grained
+    r"xox[baprs]-[A-Za-z0-9\-]{10,}|"     # Slack
+    r"AIza[A-Za-z0-9_\-]{30,}|"           # Google
+    r"AKIA[A-Z0-9]{16}|"                  # AWS
+    r"eyJ[A-Za-z0-9_\-]{10,}"             # JWT
+)
+_add(
+    rf"\b(?:{_VENDOR_PREFIXES})\b",
+    "vendor_api_key",
+    "[credential: vendor API key prefix]",
+)
+
+
+def scan_for_secrets(content: str) -> List[SecretFinding]:
+    """Scan ``content`` for probable credentials.
+
+    Returns a list of :class:`SecretFinding` (value-free).  An empty list means
+    no probable credential was found.  Deterministic from the input bytes.
+
+    The matched value is NEVER returned, stored, or logged by this function.
+    Callers must not reconstruct or print the secret.
+    """
+    if not content:
+        return []
+    scanned = content[:MAX_SCAN_CHARS]
+    findings: List[SecretFinding] = []
+    seen_markers = set()
+    for compiled, category, marker in _PATTERNS:
+        if compiled.search(scanned):
+            if marker not in seen_markers:
+                findings.append(SecretFinding(category=category, marker=marker))
+                seen_markers.add(marker)
+    return findings
+
+
+def contains_secret(content: str) -> bool:
+    """Convenience: ``True`` if ``content`` contains a probable credential."""
+    return bool(scan_for_secrets(content))
+
+
+def first_secret_message(content: str) -> Optional[str]:
+    """Return a user-facing rejection message, or ``None`` if clean.
+
+    The message explains *why* the write was blocked and where credentials
+    belong, without echoing the secret.  Used by the memory write path.
+    """
+    findings = scan_for_secrets(content)
+    if not findings:
+        return None
+    categories = ", ".join(sorted({f.category for f in findings}))
+    return (
+        "Blocked: this memory entry looks like it contains a probable "
+        f"authentication credential ({categories}). MEMORY.md and USER.md are "
+        "injected into the model's system prompt every session, so credentials "
+        "stored there can leak to the model provider and into responses. Store "
+        "secrets in Hermes' supported credential storage (e.g. ~/.hermes/.env) "
+        "instead, never in memory. If a real credential was written here, remove "
+        "it and rotate it."
+    )
+
+
+__all__ = [
+    "MAX_SCAN_CHARS",
+    "SecretFinding",
+    "scan_for_secrets",
+    "contains_secret",
+    "first_secret_message",
+    "scan_memory_for_secrets",
+]
+
+# ---------------------------------------------------------------------------
+# Audit command — scan existing on-disk memory for probable credentials
+# ---------------------------------------------------------------------------
+
+from pathlib import Path
+from typing import Dict, List as _List
+
+
+def scan_memory_for_secrets(hermes_home: Optional[str] = None) -> Dict[str, _List[SecretFinding]]:
+    """Scan existing MEMORY.md / USER.md for probable credentials.
+
+    Returns a dict keyed by memory source (e.g. ``"MEMORY.md"``) whose values
+    are lists of :class:`SecretFinding` (value-free).  Sources with no findings
+    are omitted.  The original files are NOT modified and the secret values are
+    NEVER returned, printed, or logged — only the category and a safe marker.
+
+    This is the operator-facing audit: it reports *where* a probable credential
+    lives and *what kind*, so the user can remove and rotate it.  It must not
+    surface the credential itself.
+    """
+    from hermes_constants import get_hermes_home
+    from tools.memory_tool import MemoryStore
+
+    home = Path(hermes_home) if hermes_home else get_hermes_home()
+    mem_dir = home / "memories"
+    results: Dict[str, _List[SecretFinding]] = {}
+    for fname in ("MEMORY.md", "USER.md"):
+        path = mem_dir / fname
+        if not path.exists():
+            continue
+        try:
+            entries = MemoryStore._read_file(path)
+        except (OSError, IOError):
+            continue
+        if not entries:
+            continue
+        for idx, entry in enumerate(entries):
+            findings = scan_for_secrets(entry)
+            if findings:
+                # Keyed by source + entry index so the CLI can point the user
+                # at the exact entry to remove.  The value (findings list) is
+                # value-free by construction.
+                results[f"{fname}#entry{idx + 1}"] = findings
+    return results

--- a/tools/secret_detector.py
+++ b/tools/secret_detector.py
@@ -57,19 +57,61 @@ MAX_SCAN_CHARS = 65_536
 # Value shapes (shared by every credential pattern below)
 # ---------------------------------------------------------------------------
 
-# A high-entropy bare token: letters/digits/underscore/hyphen, length >= 12,
-# containing at least one non-pure-alpha and one non-pure-digit run so we don't
-# match ordinary words or pure numbers.  Anchored so it can sit after a colon,
-# an equals sign, "is", "for <svc>", etc.
+# A candidate "value" token: letters/digits/underscore/hyphen, length >= 12.
+# This is intentionally broad — the real filter is ``_looks_like_secret()``
+# below, which rejects pure-lowercase dictionary words (e.g. "authentication",
+# "documentation") so a benign sentence like "Password policy: authentication"
+# is NOT flagged.  The regex only finds *candidates*; the validator decides.
 _TOKEN = r"[A-Za-z0-9_=\-]{12,}"
 
 # A hex / base64-ish blob (20+ chars) — typical of API keys, hashes, tokens.
 _HEX = r"[A-Za-z0-9+/]{20,}"
 
-# A value that is "probably not a sentence": excludes trailing sentence
-# punctuation and common English words so ``Password is required`` does not
-# match.  Used for the "Password is <value>" prose form.
-_PROSE_VALUE = r"(?!=[\s])([A-Za-z0-9_=\-]{10,}|[A-Za-z0-9+/]{12,})"
+# A candidate value for the "Password is <value>" prose form.  Same breadth as
+# ``_TOKEN``; validated by ``_looks_like_secret()`` after the match.
+_PROSE_VALUE = r"[A-Za-z0-9_=\-]{10,}|[A-Za-z0-9+/]{12,}"
+
+
+def _looks_like_secret(value: str) -> bool:
+    """Decide whether a matched value is a *probable* credential, not a word.
+
+    A benign dictionary word (even a long one) must NOT look like a secret.
+    We require at least one of:
+
+    * a digit (``hunter23``, ``CANARY_7F39``),
+    * a mix of upper- and lower-case letters (``CANARYabc``, ``Sup3r``),
+    * an underscore/hyphen joining multiple segments (``stored_in_keychain``
+      is a *variable name*, not a secret, so we additionally require one of the
+      above — but ``my_api_key_abc123`` wins because it has a digit),
+    * a base64/hex structure (``+/`` present, or 20+ chars of [A-Za-z0-9]).
+
+    Pure-lowercase-alpha runs like ``authentication`` / ``configurable`` /
+    ``recommended`` / ``documentation`` fail every check and are rejected.
+    """
+    if not value:
+        return False
+    v = value.strip().strip("\"'")
+    # A bare variable lookup / env reference is not a literal secret value.
+    if v.startswith(("os.getenv", "os.environ", "process.env", "$ENV", "environ[")):
+        return False
+    has_digit = any(ch.isdigit() for ch in v)
+    has_lower = any(ch.islower() for ch in v)
+    has_upper = any(ch.isupper() for ch in v)
+    has_mixed_case = has_lower and has_upper
+    # underscore/hyphen only counts when joined to something structured
+    has_segment_sep = ("_" in v or "-" in v) and any(ch.isalnum() for ch in v)
+    base64ish = ("/" in v) or len(re.sub(r"[^A-Za-z0-9]", "", v)) >= 20
+    # Require a digit OR mixed case OR (a segment separator AND at least 8
+    # alnum chars — catches things like "stored_in_keychain" only if also
+    # structured; here stored_in_keychain has no digit/case so it fails, which
+    # is the desired behaviour for pure variable-name values).
+    if has_digit or has_mixed_case or base64ish:
+        return True
+    if has_segment_sep and len(re.sub(r"[^A-Za-z0-9]", "", v)) >= 16:
+        # e.g. "my_long_apikey_abc123" — but that has a digit, caught above.
+        # A pure "stored_in_keychain" (no digit/case) must NOT pass.
+        return has_digit or has_mixed_case
+    return False
 
 # Generic credential-keyword vocabulary (case-insensitive).  Excludes bare
 # "auth" so "Authorization:" (handled separately) and "author:" don't collide
@@ -97,42 +139,64 @@ class SecretFinding:
         return self.marker
 
 
-# Each entry: (compiled regex, category, marker).  Order is irrelevant; all
-# are tried.  Every pattern requires BOTH a credential keyword and a concrete
-# structured value.
+# Each entry: (compiled regex, category, marker, validate_value).  When
+# ``validate_value`` is True the matched value must also pass
+# ``_looks_like_secret()`` — this is what keeps prose/assignment forms from
+# firing on pure dictionary words.  Patterns that are *themselves* proof (a
+# PEM block, a vendor-key prefix, a Bearer/Basic token) skip value validation.
 _PATTERNS: List[tuple] = []
 
 
-def _add(pattern: str, category: str, marker: str) -> None:
-    _PATTERNS.append((re.compile(pattern, re.IGNORECASE), category, marker))
+def _add(pattern: str, category: str, marker: str, validate_value: bool = False) -> None:
+    _PATTERNS.append(
+        (re.compile(pattern, re.IGNORECASE), category, marker, validate_value)
+    )
+
+
+# Pull the most likely credential value out of a matched span: the trailing
+# run of token characters.  Used only to validate prose/assignment matches.
+_VALUE_EXTRACT_RE = re.compile(r"[A-Za-z0-9_=\-+/]{8,}")
+
+
+def _extract_candidate_value(match: "re.Match") -> str:
+    span = match.group(0)
+    # Prefer the token after a colon/equals if present.
+    candidates = _VALUE_EXTRACT_RE.findall(span)
+    if not candidates:
+        return ""
+    # The credential value is usually the last sizeable token in the span
+    # (after the keyword), e.g. "Password for X: <VALUE>".
+    return candidates[-1]
 
 
 # --- Prose forms ("Password for X: VALUE", "The password is VALUE") -------
-
-# "Password for <service>: <value>" / "password to the db is <value>"
-# Requires a value of >=10 chars that is not a common English stopword-ish
-# short word.  We additionally require the value NOT be a known FP word.
+# Requires the extracted value to look like a secret (digit / mixed case /
+# base64), so "Password policy: authentication" is NOT flagged.
 _add(
     rf"{_CRED_KEY}\b[^\n]{{0,40}}?[:=]\s*{_PROSE_VALUE}(?![A-Za-z])",
     "password_prose",
     "[credential: password (prose form)]",
+    validate_value=True,
 )
 # "The password is <value>" / "my api key is <value>"
 _add(
     rf"\b(?:the|my|our)\s+{_CRED_KEY}\s+(?:is|was|has|equals)\s+{_PROSE_VALUE}(?![A-Za-z])",
     "credential_prose",
     "[credential: api key / token (prose form)]",
+    validate_value=True,
 )
 # "store the password as <value>" — imperative/instruction prose still has a
 # concrete value, so it is caught; relies on the value shape, not the verb.
 
 # --- Direct assignments (both quoted and unquoted) -------------------------
 # Legacy threat_patterns only handled the quoted form with >=20 chars.  We
-# also catch unquoted ``password = hunter2`` while still requiring a value.
+# also catch unquoted ``password = hunter2`` while still requiring a value
+# that looks like a secret.
 _add(
     rf"{_CRED_KEY}\s*[=:]\s*['\"]?{_TOKEN}['\"]?",
     "credential_assignment",
     "[credential: direct assignment]",
+    validate_value=True,
 )
 # YAML / .env style ``key: value`` handled above via the assignment pattern.
 
@@ -143,27 +207,33 @@ _add(
     rf"(?:api[ _-]?key|access[ _-]?token|secret)\s*(?:of|for|to)?\s*[:=]?\s*{_TOKEN}",
     "api_key_prose",
     "[credential: api key / token]",
+    validate_value=True,
 )
 
 # --- Authorization / bearer headers ----------------------------------------
 # "Authorization: Bearer <token>", "Authorization: Basic <b64>", or any scheme.
-# The credential class excludes quotes so masking never corrupts syntax.
+# A real scheme word + token is itself the proof; still require the trailing
+# token to look structured (a bare "Authorization: Bearer" with no token is
+# not a leak).
 _add(
-    r"(?:proxy-)?authorization\s*:\s*(?:bearer|basic|token|digest|apikey)?\s*\S+",
+    r"(?:proxy-)?authorization\s*:\s*(?:bearer|basic|token|digest|apikey)?\s*(\S+)",
     "authorization_header",
     "[credential: Authorization header]",
+    validate_value=True,
 )
 # Bare scheme token without a header name: "Bearer <token>", "Basic <b64>".
 _add(
-    r"\b(?:bearer|basic|token|digest)\s+[A-Za-z0-9._\-+/]{12,}",
+    r"\b(?:bearer|basic|token|digest)\s+([A-Za-z0-9._\-+/]{12,})",
     "auth_scheme_token",
     "[credential: bearer/basic token]",
+    validate_value=True,
 )
 # x-api-key / x-auth-token header style.
 _add(
-    r"\b(?:x-api-key|x-goog-api-key|api-key|apikey|x-api-token|x-auth-token|x-access-token)\s*:\s*\S+",
+    r"\b(?:x-api-key|x-goog-api-key|api-key|apikey|x-api-token|x-auth-token|x-access-token)\s*:\s*(\S+)",
     "secret_header",
     "[credential: secret header]",
+    validate_value=True,
 )
 
 # --- Private key blocks -----------------------------------------------------
@@ -225,11 +295,17 @@ def scan_for_secrets(content: str) -> List[SecretFinding]:
     scanned = content[:MAX_SCAN_CHARS]
     findings: List[SecretFinding] = []
     seen_markers = set()
-    for compiled, category, marker in _PATTERNS:
-        if compiled.search(scanned):
-            if marker not in seen_markers:
-                findings.append(SecretFinding(category=category, marker=marker))
-                seen_markers.add(marker)
+    for compiled, category, marker, validate_value in _PATTERNS:
+        match = compiled.search(scanned)
+        if not match:
+            continue
+        if validate_value:
+            candidate = _extract_candidate_value(match)
+            if not _looks_like_secret(candidate):
+                continue
+        if marker not in seen_markers:
+            findings.append(SecretFinding(category=category, marker=marker))
+            seen_markers.add(marker)
     return findings
 
 


### PR DESCRIPTION
## Problem

`MEMORY.md` and `USER.md` are intentionally included in the model's system
context every session (see `tools/memory_tool.py`). However, the existing memory
scanner can miss credentials written in **prose form**, such as:

```
Password for Test WebUI on this machine: CANARY_PASSWORD_7F39C1_A91D2E
```

A missed credential can therefore become available to the active model and may
be reproduced through normal responses or prompt-extraction attempts.

## Deterministic reproduction

Reproduced against current `main` (commit `1b17015`) using:

- an isolated temporary `HERMES_HOME` (never the operator's real `~/.hermes`);
- the real `MemoryStore.add` code path;
- a synthetic canary credential (`CANARY_PASSWORD_7F39C1_A91D2E`);
- direct inspection of the frozen memory snapshot and the assembled model
  context (no LLM response was used as proof).

The prose canary was accepted by `MemoryStore.add`, written to `MEMORY.md`, and
appeared verbatim in the frozen system-prompt snapshot.

## Root cause

The previous `hardcoded_secret` pattern in `tools/threat_patterns.py` primarily
detected **quoted direct assignments** (`password = "value"`) and did **not**
detect prose-form credentials (`Password for X: VALUE`). It was also scoped
`"strict"` (writes + snapshot only) and required a quoted value, so prose
credentials passed both the write-time scan and the load-time snapshot scan.

Credential detection had been mixed into the prompt-injection pattern module
rather than implemented as a separate, value-oriented detector. This conflated
two different concerns: prompt injection finds *instructions*; credential
detection finds *confidential values*.

## Security impact

Credentials stored in persistent memory may be:

- sent to the configured model provider (the snapshot is part of the system
  prompt);
- exposed to the active model;
- reproduced in normal model output or through prompt-extraction attempts.

This patch does **not** claim to make system prompts non-extractable. Per
`SECURITY.md` §2.4, regex scanning and output redaction are in-process
heuristics, not security boundaries. Generic prompt injection remains
out of scope; this change is a hardening contribution under §3.2.

## Fix

- **New shared credential detector** (`tools/secret_detector.py`) — the single
  source of truth for credential detection, conceptually separate from
  `tools/threat_patterns.py`. Covers prose passwords, direct assignments
  (quoted and unquoted), API-key prose, `Authorization:`/bearer/basic headers,
  private-key blocks, and credential-bearing connection strings. Requires both
  credential *semantics* and a probable concrete *value*. Never returns or
  echoes the matched secret.
- **Write-time rejection** for memory `add`, `replace`, and `apply_batch`
  operations — a probable credential is refused with a message that names where
  credentials belong (`~/.hermes/.env`) without echoing the value.
- **Independent legacy-memory filtering** during frozen snapshot construction
  (`MemoryStore._sanitize_entries_for_snapshot`) — every on-disk entry is
  re-scanned; a probable credential already present from an older version or a
  manual edit is withheld from the system prompt and replaced with a value-free
  `[CREDENTIAL: …]` marker. The original file on disk is left untouched so the
  operator can see and remove it. This runs independently of the write gate.
- **Value-free warning markers** — the snapshot placeholder and the log line
  carry only the credential category, never the value.
- **`/memory scan` audit command** — scans existing `MEMORY.md`/`USER.md` for
  probable credentials and reports source, entry index, and category with
  remediation guidance, without printing any secret value.
- **Documentation updates** — added §2.4.1 "Credentials in persistent memory" to
  `SECURITY.md` and a credential-safety note to the `memory_tool.py` module
  docstring.
- **Regression tests** — new suites covering detection, write rejection, legacy
  snapshot filtering, non-secret acceptance, false positives, and
  no-value-leak in logs/errors.

### False-positive hardening (follow-up commit)

A focused review found the value matcher accepted any 12+ char alphabetic run,
so benign prose such as `Password policy: authentication`,
`Database password: stored_in_keychain`, or `The password is intentionally
omitted` was wrongly flagged. A value validator (`_looks_like_secret`) now
requires a probable credential value to contain a digit, mixed case, or a
base64/hex structure (and treats env lookups like `os.getenv(...)` as
non-values). PEM blocks and vendor-key prefixes remain self-evident proof.
Detection of all synthetic credential cases is preserved.

## Tests

Commands run from the repo root with an isolated `HERMES_HOME`:

```
python -m pytest tests/tools/test_secret_detector.py tests/tools/test_memory_credential_guard.py -v
# 56 passed
python -m pytest tests/agent/test_redact.py tests/agent/test_tool_dispatch_helpers.py \
    tests/tools/test_secret_detector.py tests/tools/test_memory_credential_guard.py \
    tests/tools/test_threat_patterns.py -q
# 499 passed
python -m pytest tests/tools/test_threat_patterns.py tests/agent/test_memory_write_bridge.py \
    tests/agent/test_prompt_builder.py tests/agent/test_redact.py tests/tools/test_write_approval.py -q
# 404 passed, 1 skipped (pre-existing skip)
```

- **56 new credential-guard tests passing** (38 detection + write/snapshot
  coverage, plus 18 false-positive and `/memory scan` audit tests).
- **499 tests passing** in the combined relevant suites.
- **404 tests passing and 1 pre-existing skip** in the broader run.
- **Ruff**: clean on all changed files.
- **Type check** (`ty`): `tools/secret_detector.py` clean; the diagnostics
  reported for `tools/memory_tool.py` (5) and `hermes_cli/cli_commands_mixin.py`
  (86) were confirmed to be **pre-existing** on unmodified `main` via
  `git stash`.

No real credentials, usernames, home paths, IP addresses, or conversation
excerpts appear in the branch — only synthetic canaries (`CANARY_*`, `hunter2`).

## User action

Users who previously stored credentials in persistent memory should:

1. remove or redact those memory entries (e.g. via the memory tool or
   `/memory scan` to locate them);
2. **rotate the affected credentials** — removing them from memory does not
   undo a leak that already happened;
3. use the supported Hermes credential or environment configuration
   (`~/.hermes/.env`) instead of memory.

## Limitations

- This patch **reduces accidental credential exposure** to model providers and
  model responses.
- It does **not** make system prompts impossible to extract, and does not turn
  regex redaction into a security boundary (per `SECURITY.md` §2.4).
- Secret detection is defense in depth and may not detect every possible secret
  format; it is a heuristic, not a guarantee.
- Secrets should never intentionally be stored in LLM-visible persistent
  context.
