### PR TITLE
feat(config): atomically activate model profiles

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8504,17 +8504,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if result.warning_message:
             _cprint(f"    ⚠ {result.warning_message}")
         if persist_global:
-            HermesCLI._clear_persisted_context_for_model_switch(self, result)
-            save_config_value("model.default", result.new_model)
-            save_config_value("model.provider", result.target_provider)
-            # base_url/api_mode were previously never persisted here, so a
-            # global switch left the OLD provider's endpoint/wire-protocol in
-            # config.yaml. result.base_url/api_mode are always freshly
-            # resolved for the target provider (see model_switch.py), so sync
-            # them every time; None clears a value the new provider doesn't
-            # need (#25106).
-            save_config_value("model.base_url", result.base_url or None)
-            save_config_value("model.api_mode", result.api_mode or None)
+            from hermes_cli.model_activation import model_activation_lock
+
+            with model_activation_lock():
+                HermesCLI._clear_persisted_context_for_model_switch(self, result)
+                save_config_value("model.default", result.new_model)
+                save_config_value("model.provider", result.target_provider)
+                # base_url/api_mode were previously never persisted here, so a
+                # global switch left the OLD provider's endpoint/wire-protocol in
+                # config.yaml. result.base_url/api_mode are always freshly
+                # resolved for the target provider (see model_switch.py), so sync
+                # them every time; None clears a value the new provider doesn't
+                # need (#25106).
+                save_config_value("model.base_url", result.base_url or None)
+                save_config_value("model.api_mode", result.api_mode or None)
             _cprint("    Saved to config.yaml (--global)")
         else:
             _cprint("    (session only — add --global to persist)")
@@ -8858,13 +8861,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         # Persistence
         if persist_global:
-            HermesCLI._clear_persisted_context_for_model_switch(self, result)
-            save_config_value("model.default", result.new_model)
-            save_config_value("model.provider", result.target_provider)
-            # See _apply_model_switch_result above for why base_url/api_mode
-            # must be synced on every global switch (#25106).
-            save_config_value("model.base_url", result.base_url or None)
-            save_config_value("model.api_mode", result.api_mode or None)
+            from hermes_cli.model_activation import model_activation_lock
+
+            with model_activation_lock():
+                HermesCLI._clear_persisted_context_for_model_switch(self, result)
+                save_config_value("model.default", result.new_model)
+                save_config_value("model.provider", result.target_provider)
+                # See _apply_model_switch_result above for why base_url/api_mode
+                # must be synced on every global switch (#25106).
+                save_config_value("model.base_url", result.base_url or None)
+                save_config_value("model.api_mode", result.api_mode or None)
             _cprint("    Saved to config.yaml")
         elif one_turn:
             _cprint("    (next turn only — restores after one response)")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18442,6 +18442,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # Each entry is a tuple of (section, key) read from the raw config dict.
     # Add more here as new baked-at-construction config settings are added.
     _CACHE_BUSTING_CONFIG_KEYS: tuple = (
+        # Atomic profile activation increments this only after the complete
+        # model/provider/api_mode tuple lands. Existing sessions therefore
+        # rebuild on the next safe turn; in-flight calls retain their agent.
+        ("model", "routing_generation"),
         ("model", "context_length"),
         ("model", "max_tokens"),
         ("compression", "enabled"),

--- a/hermes_cli/model_activation.py
+++ b/hermes_cli/model_activation.py
@@ -1,0 +1,257 @@
+"""Atomic, compare-and-swap activation of Hermes' complete main-model route."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from hermes_constants import get_hermes_home
+
+_ROUTE_FIELDS = ("default", "provider", "api_mode")
+_STALE_ENDPOINT_FIELDS = ("api_key", "api", "base_url", "context_length")
+
+
+class ModelActivationError(RuntimeError):
+    """Base error for a rejected model activation."""
+
+
+class ModelActivationCASMismatch(ModelActivationError):
+    """The active route changed after the caller observed it."""
+
+
+@dataclass(frozen=True)
+class ModelRoute:
+    model: str
+    provider: str
+    api_mode: str
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any]) -> "ModelRoute":
+        model = str(raw.get("model") or raw.get("default") or "").strip()
+        provider = str(raw.get("provider") or "").strip()
+        api_mode = str(raw.get("api_mode") or raw.get("transport") or "").strip()
+        if not model or not provider or not api_mode:
+            raise ValueError("model, provider, and api_mode are required")
+        return cls(model=model, provider=provider, api_mode=api_mode)
+
+    def as_config(self) -> dict[str, str]:
+        return {"default": self.model, "provider": self.provider, "api_mode": self.api_mode}
+
+
+@dataclass(frozen=True)
+class ActivationResult:
+    old_route: ModelRoute
+    new_route: ModelRoute
+    old_fingerprint: str
+    new_fingerprint: str
+    generation: int
+    runtime_rollover_required: bool
+
+
+def route_fingerprint(route: ModelRoute | Mapping[str, Any]) -> str:
+    value = route if isinstance(route, ModelRoute) else ModelRoute.from_mapping(route)
+    payload = json.dumps(value.as_config(), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _current_route(config: Mapping[str, Any]) -> ModelRoute:
+    model_cfg = config.get("model")
+    if not isinstance(model_cfg, Mapping):
+        raise ModelActivationError("current model config is missing")
+    try:
+        return ModelRoute.from_mapping(model_cfg)
+    except ValueError as exc:
+        raise ModelActivationError("current model route is incomplete") from exc
+
+
+def _validate_target(route: ModelRoute, config: Mapping[str, Any]) -> None:
+    from hermes_cli.providers import (
+        TRANSPORT_TO_API_MODE,
+        host_mandated_api_mode,
+        resolve_provider_full,
+    )
+
+    providers = config.get("providers")
+    custom_providers = config.get("custom_providers")
+    provider = resolve_provider_full(
+        route.provider,
+        user_providers=providers if isinstance(providers, dict) else None,
+        custom_providers=custom_providers if isinstance(custom_providers, list) else None,
+    )
+    if provider is None:
+        raise ModelActivationError(f"unknown provider: {route.provider}")
+
+    supported_modes = set(TRANSPORT_TO_API_MODE.values())
+    if route.api_mode not in supported_modes:
+        raise ModelActivationError(f"unsupported api_mode: {route.api_mode}")
+
+    mandated = host_mandated_api_mode(provider.base_url)
+    declared = TRANSPORT_TO_API_MODE.get(provider.transport)
+    required = mandated or declared
+    if required and route.api_mode != required:
+        raise ModelActivationError(
+            f"provider {route.provider} requires api_mode {required}, not {route.api_mode}"
+        )
+
+
+def _lock_path() -> Path:
+    return Path(get_hermes_home()) / "runtime" / "model-activation.lock"
+
+
+class _ActivationLock:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._handle = None
+
+    def __enter__(self) -> "_ActivationLock":
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._handle = self.path.open("a+b")
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                self._handle.seek(0)
+                self._handle.write(b"0")
+                self._handle.flush()
+                self._handle.seek(0)
+                msvcrt.locking(self._handle.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(self._handle.fileno(), fcntl.LOCK_EX)
+        except Exception as exc:
+            self._handle.close()
+            self._handle = None
+            raise ModelActivationError("model activation lock unavailable") from exc
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._handle is None:
+            return
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                self._handle.seek(0)
+                msvcrt.locking(self._handle.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(self._handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            self._handle.close()
+            self._handle = None
+
+
+def activate_model_profile(
+    profile: ModelRoute | Mapping[str, Any],
+    *,
+    expected_current: ModelRoute | Mapping[str, Any] | None = None,
+    expected_fingerprint: str | None = None,
+    expected_generation: int | None = None,
+    mirror_legacy_main: bool = True,
+) -> ActivationResult:
+    """CAS-update model/default/provider/api_mode in one durable YAML write.
+
+    The raw user YAML is read and mutated under both the in-process config lock
+    and an inter-process file lock, preserving environment-reference templates.
+    Existing endpoint-specific fields are removed when the provider changes.
+    """
+    from hermes_cli import managed_scope
+    from hermes_cli.config import (
+        _CONFIG_LOCK,
+        _LOAD_CONFIG_CACHE,
+        _RAW_CONFIG_CACHE,
+        atomic_config_write,
+        get_config_path,
+        is_managed,
+    )
+    from utils import fast_safe_load
+
+    if is_managed():
+        raise ModelActivationError("configuration is managed and cannot be activated")
+    managed = managed_scope.managed_config_keys()
+    blocked = sorted({key for key in managed if key in {
+        "model.default", "model.provider", "model.api_mode", "model.main",
+        "model.routing_generation",
+    }})
+    if blocked:
+        raise ModelActivationError("model route is managed: " + ", ".join(blocked))
+
+    target = profile if isinstance(profile, ModelRoute) else ModelRoute.from_mapping(profile)
+    expected = None
+    if expected_current is not None:
+        expected = (
+            expected_current
+            if isinstance(expected_current, ModelRoute)
+            else ModelRoute.from_mapping(expected_current)
+        )
+
+    config_path = get_config_path()
+    with _CONFIG_LOCK, _ActivationLock(_lock_path()):
+        if not config_path.exists():
+            raise ModelActivationError("current config.yaml is missing")
+        try:
+            loaded = fast_safe_load(config_path.read_text(encoding="utf-8")) or {}
+        except Exception as exc:
+            raise ModelActivationError("current config.yaml is unreadable") from exc
+        if not isinstance(loaded, dict):
+            raise ModelActivationError("current config root must be a mapping")
+        raw = copy.deepcopy(loaded)
+        current = _current_route(raw)
+        current_fingerprint = route_fingerprint(current)
+        generation_raw = raw.get("model", {}).get("routing_generation", 0)
+        generation = generation_raw if isinstance(generation_raw, int) and not isinstance(generation_raw, bool) else 0
+
+        if expected is not None and current != expected:
+            raise ModelActivationCASMismatch("current model route does not match expected_current")
+        if expected_fingerprint is not None and current_fingerprint != expected_fingerprint:
+            raise ModelActivationCASMismatch("current model route fingerprint changed")
+        if expected_generation is not None and generation != expected_generation:
+            raise ModelActivationCASMismatch(
+                f"expected generation {expected_generation}, found {generation}"
+            )
+
+        _validate_target(target, raw)
+        model_cfg = raw.setdefault("model", {})
+        if not isinstance(model_cfg, dict):
+            raise ModelActivationError("model config must be a mapping")
+        if current.provider != target.provider:
+            for field in _STALE_ENDPOINT_FIELDS:
+                model_cfg.pop(field, None)
+        model_cfg.update(target.as_config())
+        if mirror_legacy_main:
+            model_cfg["main"] = target.model
+        else:
+            model_cfg.pop("main", None)
+        new_generation = generation + 1
+        model_cfg["routing_generation"] = new_generation
+
+        atomic_config_write(config_path, raw, sort_keys=False)
+        path_key = str(config_path)
+        _RAW_CONFIG_CACHE.pop(path_key, None)
+        _LOAD_CONFIG_CACHE.pop(path_key, None)
+
+    return ActivationResult(
+        old_route=current,
+        new_route=target,
+        old_fingerprint=current_fingerprint,
+        new_fingerprint=route_fingerprint(target),
+        generation=new_generation,
+        runtime_rollover_required=current != target,
+    )
+
+
+__all__ = [
+    "ActivationResult",
+    "ModelActivationCASMismatch",
+    "ModelActivationError",
+    "ModelRoute",
+    "activate_model_profile",
+    "route_fingerprint",
+]

--- a/hermes_cli/model_activation.py
+++ b/hermes_cli/model_activation.py
@@ -12,7 +12,7 @@ from typing import Any, Mapping
 
 from hermes_constants import get_hermes_home
 
-_ROUTE_FIELDS = ("default", "provider", "api_mode")
+_ROUTE_FIELDS = ("default", "provider", "api_mode", "base_url")
 _STALE_ENDPOINT_FIELDS = ("api_key", "api", "base_url", "context_length")
 
 
@@ -29,18 +29,25 @@ class ModelRoute:
     model: str
     provider: str
     api_mode: str
+    base_url: str = ""
 
     @classmethod
     def from_mapping(cls, raw: Mapping[str, Any]) -> "ModelRoute":
         model = str(raw.get("model") or raw.get("default") or "").strip()
         provider = str(raw.get("provider") or "").strip()
         api_mode = str(raw.get("api_mode") or raw.get("transport") or "").strip()
+        base_url = str(raw.get("base_url") or "").strip()
         if not model or not provider or not api_mode:
             raise ValueError("model, provider, and api_mode are required")
-        return cls(model=model, provider=provider, api_mode=api_mode)
+        return cls(model=model, provider=provider, api_mode=api_mode, base_url=base_url)
 
     def as_config(self) -> dict[str, str]:
-        return {"default": self.model, "provider": self.provider, "api_mode": self.api_mode}
+        return {
+            "default": self.model,
+            "provider": self.provider,
+            "api_mode": self.api_mode,
+            "base_url": self.base_url,
+        }
 
 
 @dataclass(frozen=True)
@@ -90,7 +97,7 @@ def _validate_target(route: ModelRoute, config: Mapping[str, Any]) -> None:
     if route.api_mode not in supported_modes:
         raise ModelActivationError(f"unsupported api_mode: {route.api_mode}")
 
-    mandated = host_mandated_api_mode(provider.base_url)
+    mandated = host_mandated_api_mode(route.base_url or provider.base_url)
     declared = TRANSPORT_TO_API_MODE.get(provider.transport)
     required = mandated or declared
     if required and route.api_mode != required:
@@ -148,6 +155,15 @@ class _ActivationLock:
             self._handle = None
 
 
+def model_activation_lock() -> _ActivationLock:
+    """Serialize complete main-model route transactions across processes.
+
+    Existing model writers must hold this lock from their config read through
+    their write so an activation CAS cannot race a stale route snapshot.
+    """
+    return _ActivationLock(_lock_path())
+
+
 def activate_model_profile(
     profile: ModelRoute | Mapping[str, Any],
     *,
@@ -193,7 +209,7 @@ def activate_model_profile(
         )
 
     config_path = get_config_path()
-    with _CONFIG_LOCK, _ActivationLock(_lock_path()):
+    with _CONFIG_LOCK, model_activation_lock():
         if not config_path.exists():
             raise ModelActivationError("current config.yaml is missing")
         try:
@@ -229,8 +245,10 @@ def activate_model_profile(
             model_cfg["main"] = target.model
         else:
             model_cfg.pop("main", None)
-        new_generation = generation + 1
-        model_cfg["routing_generation"] = new_generation
+        route_changed = current != target
+        new_generation = generation + 1 if route_changed else generation
+        if route_changed:
+            model_cfg["routing_generation"] = new_generation
 
         atomic_config_write(config_path, raw, sort_keys=False)
         path_key = str(config_path)
@@ -253,5 +271,6 @@ __all__ = [
     "ModelActivationError",
     "ModelRoute",
     "activate_model_profile",
+    "model_activation_lock",
     "route_fingerprint",
 ]

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7017,6 +7017,18 @@ async def set_model_assignment(body: ModelAssignment, profile: Optional[str] = N
 def _apply_model_assignment_sync(
     scope: str, provider: str, model: str, task: str, base_url: str, api_key: str = ""
 ):
+    """Apply a model assignment under the shared route transaction lock."""
+    from hermes_cli.model_activation import model_activation_lock
+
+    with model_activation_lock():
+        return _apply_model_assignment_sync_unlocked(
+            scope, provider, model, task, base_url, api_key
+        )
+
+
+def _apply_model_assignment_sync_unlocked(
+    scope: str, provider: str, model: str, task: str, base_url: str, api_key: str = ""
+):
     """Synchronous body of POST /api/model/set.
 
     Runs inside ``_profile_scope`` (in a worker thread) so every

--- a/tests/hermes_cli/test_model_activation.py
+++ b/tests/hermes_cli/test_model_activation.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermes_cli.model_activation import (
+    ModelActivationCASMismatch,
+    ModelActivationError,
+    ModelRoute,
+    activate_model_profile,
+    route_fingerprint,
+)
+
+
+def _write_config(home: Path) -> None:
+    (home / "config.yaml").write_text(
+        """
+model:
+  default: anthropic/claude-fable-5
+  main: anthropic/claude-fable-5
+  provider: anthropic
+  api_mode: anthropic_messages
+  routing_generation: 7
+  base_url: ${CLAUDE_PROXY_URL}
+  api_key: ${CLAUDE_PROXY_KEY}
+  context_length: 200000
+providers:
+  codex:
+    name: Codex Pool
+    base_url: https://api.openai.com/v1
+    transport: openai_responses
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
+def test_activation_writes_whole_route_and_preserves_templates(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(tmp_path)
+    expected = ModelRoute(
+        model="anthropic/claude-fable-5",
+        provider="anthropic",
+        api_mode="anthropic_messages",
+    )
+
+    result = activate_model_profile(
+        {
+            "model": "codex/gpt-5.6-sol",
+            "provider": "codex",
+            "api_mode": "codex_responses",
+        },
+        expected_current=expected,
+        expected_fingerprint=route_fingerprint(expected),
+        expected_generation=7,
+    )
+
+    raw_text = (tmp_path / "config.yaml").read_text(encoding="utf-8")
+    raw = yaml.safe_load(raw_text)
+    assert raw["model"] == {
+        "default": "codex/gpt-5.6-sol",
+        "main": "codex/gpt-5.6-sol",
+        "provider": "codex",
+        "api_mode": "codex_responses",
+        "routing_generation": 8,
+    }
+    assert "${CLAUDE_PROXY" not in raw_text
+    assert raw["providers"]["codex"]["base_url"] == "https://api.openai.com/v1"
+    assert result.old_route == expected
+    assert result.generation == 8
+    assert result.runtime_rollover_required is True
+
+
+def test_activation_rejects_stale_cas_without_writing(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(tmp_path)
+    before = (tmp_path / "config.yaml").read_bytes()
+
+    with pytest.raises(ModelActivationCASMismatch):
+        activate_model_profile(
+            ModelRoute("codex/gpt-5.6-sol", "codex", "codex_responses"),
+            expected_generation=6,
+        )
+
+    assert (tmp_path / "config.yaml").read_bytes() == before
+
+
+def test_activation_rejects_provider_transport_mismatch(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(tmp_path)
+
+    with pytest.raises(ModelActivationError, match="requires api_mode codex_responses"):
+        activate_model_profile(
+            ModelRoute("codex/gpt-5.6-sol", "codex", "chat_completions"),
+            expected_generation=7,
+        )
+
+
+def test_gateway_cache_watches_atomic_routing_generation():
+    source = (Path(__file__).parents[2] / "gateway" / "run.py").read_text(
+        encoding="utf-8"
+    )
+    assert '("model", "routing_generation")' in source

--- a/tests/hermes_cli/test_model_activation.py
+++ b/tests/hermes_cli/test_model_activation.py
@@ -43,6 +43,7 @@ def test_activation_writes_whole_route_and_preserves_templates(tmp_path, monkeyp
         model="anthropic/claude-fable-5",
         provider="anthropic",
         api_mode="anthropic_messages",
+        base_url="${CLAUDE_PROXY_URL}",
     )
 
     result = activate_model_profile(
@@ -50,6 +51,7 @@ def test_activation_writes_whole_route_and_preserves_templates(tmp_path, monkeyp
             "model": "codex/gpt-5.6-sol",
             "provider": "codex",
             "api_mode": "codex_responses",
+            "base_url": "https://api.openai.com/v1",
         },
         expected_current=expected,
         expected_fingerprint=route_fingerprint(expected),
@@ -63,6 +65,7 @@ def test_activation_writes_whole_route_and_preserves_templates(tmp_path, monkeyp
         "main": "codex/gpt-5.6-sol",
         "provider": "codex",
         "api_mode": "codex_responses",
+        "base_url": "https://api.openai.com/v1",
         "routing_generation": 8,
     }
     assert "${CLAUDE_PROXY" not in raw_text
@@ -70,6 +73,25 @@ def test_activation_writes_whole_route_and_preserves_templates(tmp_path, monkeyp
     assert result.old_route == expected
     assert result.generation == 8
     assert result.runtime_rollover_required is True
+
+
+def test_activation_preserves_target_base_url_and_skips_noop_generation(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(tmp_path)
+    target = ModelRoute(
+        "anthropic/claude-fable-5",
+        "anthropic",
+        "anthropic_messages",
+        "${CLAUDE_PROXY_URL}",
+    )
+
+    result = activate_model_profile(target, expected_generation=7)
+
+    raw = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+    assert raw["model"]["base_url"] == "${CLAUDE_PROXY_URL}"
+    assert raw["model"]["routing_generation"] == 7
+    assert result.generation == 7
+    assert result.runtime_rollover_required is False
 
 
 def test_activation_rejects_stale_cas_without_writing(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add a public `activate_model_profile` API that compare-and-swap updates the complete `model.default` / `model.provider` / `model.api_mode` tuple in one atomic YAML write
- preserve raw `${ENV_REF}` templates and unrelated config while clearing stale endpoint-specific model fields on provider changes
- increment `model.routing_generation` so the gateway rebuilds cached persistent-session agents on the next safe turn while in-flight turns continue on their existing agent

## Safety
- serializes activation with process and inter-process locks
- validates provider and transport compatibility before writing
- supports expected route fingerprint and generation CAS guards so manual config changes win
- returns old/new fingerprints and whether runtime rollover is required

## Tests
- `pytest -q tests/hermes_cli/test_model_activation.py`
- `ruff check hermes_cli/model_activation.py tests/hermes_cli/test_model_activation.py`
