### PR TITLE
fix: preserve configured fallback transport

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1689,10 +1689,24 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # (not substring) — see GHSA-76xc-57q6-vm5m.
         if fb_base_url_hint and base_url_host_matches(fb_base_url_hint, "ollama.com") and not fb_api_key_hint:
             fb_api_key_hint = os.getenv("OLLAMA_API_KEY") or None
+        from hermes_cli.fallback_config import resolve_entry_api_mode
+
+        try:
+            configured_mode = resolve_entry_api_mode(fb)
+        except ValueError as exc:
+            logger.warning(
+                "Fallback skip: %s/%s has invalid transport (%s)",
+                fb_provider,
+                fb_model,
+                exc,
+            )
+            unavailable.add(fb_key)
+            return agent._try_activate_fallback(reason)
         fb_client, _resolved_fb_model = resolve_provider_client(
             fb_provider, model=fb_model, raw_codex=True,
             explicit_base_url=fb_base_url_hint,
-            explicit_api_key=fb_api_key_hint)
+            explicit_api_key=fb_api_key_hint,
+            api_mode=configured_mode)
         if fb_client is None:
             logger.warning(
                 "Fallback to %s failed: provider not configured",
@@ -1709,11 +1723,21 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 fb_model, fb_provider, _norm_err,
             )
 
-        # Determine api_mode from provider / base URL / model
-        fb_api_mode = "chat_completions"
+        # Preserve an explicitly configured transport. Provider/model-name
+        # inference is only a legacy fallback: named relays can expose several
+        # wire protocols at one endpoint, so silently re-deriving the mode here
+        # can pair a valid client with the wrong request shape.
+        fb_api_mode = configured_mode or "chat_completions"
         fb_base_url = str(fb_client.base_url)
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        if fb_provider == "openai-codex":
+        if configured_mode:
+            logger.info(
+                "Fallback %s/%s: preserving configured api_mode=%s",
+                fb_provider,
+                fb_model,
+                configured_mode,
+            )
+        elif fb_provider == "openai-codex":
             fb_api_mode = "codex_responses"
         elif (
             fb_provider == "anthropic"

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1506,11 +1506,18 @@ def rewrite_prompt_model_identity(agent, model: str, provider: str) -> None:
     agent._cached_system_prompt = sp
 
 
-def _fallback_entry_key(fb: dict) -> tuple[str, str, str]:
+def _fallback_entry_key(fb: dict) -> tuple[str, str, str, str]:
+    try:
+        from hermes_cli.fallback_config import resolve_entry_api_mode
+
+        api_mode = resolve_entry_api_mode(fb) or ""
+    except ValueError:
+        api_mode = str(fb.get("api_mode") or fb.get("transport") or "").strip()
     return (
         str(fb.get("provider") or "").strip().lower(),
         str(fb.get("model") or "").strip(),
         str(fb.get("base_url") or "").strip().rstrip("/"),
+        api_mode.lower(),
     )
 
 
@@ -1638,23 +1645,38 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         )
         return agent._try_activate_fallback(reason)
 
-    # Skip entries that resolve to the current (provider, model) — falling
-    # back to the same backend that just failed loops the failure. Compare
+    # Skip entries that resolve to the current (provider, model, transport) —
+    # falling back to the same route that just failed loops the failure. Compare
     # base_url too so two distinct custom_providers entries pointing at the
     # same shim/proxy URL also dedup. See issue #22548. Do NOT treat
     # first-class providers that share a host (xai-oauth vs xai) as the same
     # backend — they use different credentials.
+    from hermes_cli.fallback_config import resolve_entry_api_mode
+
+    try:
+        configured_mode = resolve_entry_api_mode(fb)
+    except ValueError as exc:
+        logger.warning(
+            "Fallback skip: %s/%s has invalid transport (%s)",
+            fb_provider,
+            fb_model,
+            exc,
+        )
+        unavailable.add(fb_key)
+        return agent._try_activate_fallback(reason)
+    current_api_mode = (getattr(agent, "api_mode", "") or "").strip()
+    same_transport = not configured_mode or configured_mode == current_api_mode
     current_provider = (getattr(agent, "provider", "") or "").strip().lower()
     current_model = (getattr(agent, "model", "") or "").strip()
     current_base_url = str(getattr(agent, "base_url", "") or "").rstrip("/").lower()
     fb_base_url_for_dedup = (fb.get("base_url") or "").strip().rstrip("/").lower()
-    if fb_provider == current_provider and fb_model == current_model:
+    if same_transport and fb_provider == current_provider and fb_model == current_model:
         logger.warning(
-            "Fallback skip: chain entry %s/%s matches current provider/model",
+            "Fallback skip: chain entry %s/%s matches current provider/model/transport",
             fb_provider, fb_model,
         )
         return agent._try_activate_fallback(reason)
-    if _fallback_entry_is_same_backend_by_base_url(
+    if same_transport and _fallback_entry_is_same_backend_by_base_url(
         current_provider=current_provider,
         fb_provider=fb_provider,
         current_base_url=current_base_url,
@@ -1689,19 +1711,6 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # (not substring) — see GHSA-76xc-57q6-vm5m.
         if fb_base_url_hint and base_url_host_matches(fb_base_url_hint, "ollama.com") and not fb_api_key_hint:
             fb_api_key_hint = os.getenv("OLLAMA_API_KEY") or None
-        from hermes_cli.fallback_config import resolve_entry_api_mode
-
-        try:
-            configured_mode = resolve_entry_api_mode(fb)
-        except ValueError as exc:
-            logger.warning(
-                "Fallback skip: %s/%s has invalid transport (%s)",
-                fb_provider,
-                fb_model,
-                exc,
-            )
-            unavailable.add(fb_key)
-            return agent._try_activate_fallback(reason)
         fb_client, _resolved_fb_model = resolve_provider_client(
             fb_provider, model=fb_model, raw_codex=True,
             explicit_base_url=fb_base_url_hint,

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -57,15 +57,25 @@ class CLIAgentSetupMixin:
                     if not _fb_provider or not _fb_model:
                         continue
                     try:
-                        from hermes_cli.fallback_config import resolve_entry_api_key
+                        from hermes_cli.fallback_config import (
+                            resolve_entry_api_key,
+                            resolve_entry_api_mode,
+                        )
 
-                        _fb_kwargs = {"requested": _fb_provider}
+                        _fb_kwargs = {
+                            "requested": _fb_provider,
+                            "target_model": _fb_model,
+                        }
                         if _fb.get("base_url"):
                             _fb_kwargs["explicit_base_url"] = _fb["base_url"]
                         _fb_api_key = resolve_entry_api_key(_fb)
                         if _fb_api_key:
                             _fb_kwargs["explicit_api_key"] = _fb_api_key
                         runtime = resolve_runtime_provider(**_fb_kwargs)
+                        _fb_api_mode = resolve_entry_api_mode(_fb)
+                        if _fb_api_mode:
+                            runtime = dict(runtime)
+                            runtime["api_mode"] = _fb_api_mode
                         logger.warning(
                             "Primary provider auth failed (%s). Falling through to fallback: %s/%s",
                             _primary_exc, _fb_provider, _fb_model,

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import os
 from typing import Any
 
+from hermes_cli.providers import TRANSPORT_TO_API_MODE
+
+_SUPPORTED_API_MODES = frozenset(TRANSPORT_TO_API_MODE.values())
+
 
 def _normalized_base_url(value: Any) -> str:
     if not isinstance(value, str):
@@ -29,6 +33,26 @@ def resolve_entry_api_key(entry: dict[str, Any] | None) -> str | None:
     if key_env:
         return os.getenv(key_env, "").strip() or None
     return None
+
+
+def resolve_entry_api_mode(entry: dict[str, Any] | None) -> str | None:
+    """Return one fallback entry's explicit wire protocol.
+
+    ``api_mode`` is the canonical stored form. ``transport`` accepts the
+    provider-profile spelling (for example ``openai_chat``) and is normalized
+    through the same mapping used by provider resolution. Unknown explicit
+    values raise instead of silently falling back to model-name heuristics.
+    """
+    if not isinstance(entry, dict):
+        return None
+    raw_mode = str(entry.get("api_mode") or "").strip()
+    raw_transport = str(entry.get("transport") or "").strip()
+    mode = raw_mode or TRANSPORT_TO_API_MODE.get(raw_transport, raw_transport)
+    if not mode:
+        return None
+    if mode not in _SUPPORTED_API_MODES:
+        raise ValueError(f"unsupported fallback api_mode: {mode!r}")
+    return mode
 
 
 def _iter_fallback_entries(raw: Any) -> list[dict[str, Any]]:
@@ -60,11 +84,16 @@ def _iter_fallback_entries(raw: Any) -> list[dict[str, Any]]:
     return entries
 
 
-def _entry_identity(entry: dict[str, Any]) -> tuple[str, str, str]:
+def _entry_identity(entry: dict[str, Any]) -> tuple[str, str, str, str]:
+    try:
+        api_mode = resolve_entry_api_mode(entry) or ""
+    except ValueError:
+        api_mode = str(entry.get("api_mode") or entry.get("transport") or "").strip()
     return (
         str(entry.get("provider") or "").strip().lower(),
         str(entry.get("model") or "").strip().lower(),
         _normalized_base_url(entry.get("base_url")).lower(),
+        api_mode.lower(),
     )
 
 
@@ -79,7 +108,7 @@ def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
 
     config = config or {}
     chain: list[dict[str, Any]] = []
-    seen: set[tuple[str, str, str]] = set()
+    seen: set[tuple[str, str, str, str]] = set()
 
     for key in ("fallback_providers", "fallback_model"):
         for entry in _iter_fallback_entries(config.get(key)):

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -172,6 +172,41 @@ def test_runtime_resolution_failure_is_not_sticky(monkeypatch):
     assert shell.agent is not None
 
 
+def test_primary_auth_fallback_preserves_explicit_transport(monkeypatch):
+    cli = _import_cli()
+    calls = []
+
+    def _runtime_resolve(**kwargs):
+        calls.append(kwargs)
+        if kwargs.get("requested") == "broken-primary":
+            raise AuthError("primary unavailable", code="auth_required")
+        return {
+            "provider": "custom-relay",
+            "api_mode": "chat_completions",
+            "base_url": "https://relay.example/v1",
+            "api_key": "fallback-key",
+            "source": "explicit",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+
+    shell = cli.HermesCLI(model="primary-model", compact=True, max_turns=1)
+    shell.requested_provider = "broken-primary"
+    shell._fallback_model = [{
+        "provider": "custom-relay",
+        "model": "relay-model",
+        "base_url": "https://relay.example/v1",
+        "api_mode": "codex_responses",
+    }]
+
+    assert shell._ensure_runtime_credentials() is True
+    assert calls[1]["target_model"] == "relay-model"
+    assert shell.provider == "custom-relay"
+    assert shell.model == "relay-model"
+    assert shell.api_mode == "codex_responses"
+
+
 def test_runtime_resolution_rebuilds_agent_on_routing_change(monkeypatch):
     cli = _import_cli()
 

--- a/tests/hermes_cli/test_fallback_config.py
+++ b/tests/hermes_cli/test_fallback_config.py
@@ -1,6 +1,12 @@
 """Tests for hermes_cli/fallback_config.py — fallback entry API-key resolution."""
 
-from hermes_cli.fallback_config import resolve_entry_api_key
+import pytest
+
+from hermes_cli.fallback_config import (
+    get_fallback_chain,
+    resolve_entry_api_key,
+    resolve_entry_api_mode,
+)
 
 
 class TestResolveEntryApiKey:
@@ -38,3 +44,40 @@ class TestResolveEntryApiKey:
         monkeypatch.setenv("FB_KEY", "env-key")
         entry = {"api_key": "   ", "key_env": "FB_KEY"}
         assert resolve_entry_api_key(entry) == "env-key"
+
+
+class TestResolveEntryApiMode:
+    def test_explicit_api_mode_is_preserved(self):
+        assert resolve_entry_api_mode({"api_mode": "codex_responses"}) == "codex_responses"
+
+    def test_provider_transport_name_is_normalized(self):
+        assert resolve_entry_api_mode({"transport": "openai_chat"}) == "chat_completions"
+
+    def test_unknown_explicit_mode_fails_closed(self):
+        with pytest.raises(ValueError, match="unsupported fallback api_mode"):
+            resolve_entry_api_mode({"api_mode": "made_up_transport"})
+
+    def test_missing_mode_allows_legacy_inference(self):
+        assert resolve_entry_api_mode({"provider": "openrouter"}) is None
+
+    def test_chain_dedup_keeps_same_endpoint_with_distinct_transports(self):
+        config = {
+            "fallback_providers": [
+                {
+                    "provider": "relay",
+                    "model": "shared-model",
+                    "base_url": "https://relay.example/v1",
+                    "api_mode": "chat_completions",
+                }
+            ],
+            "fallback_model": {
+                "provider": "relay",
+                "model": "shared-model",
+                "base_url": "https://relay.example/v1",
+                "api_mode": "codex_responses",
+            },
+        }
+        assert [entry["api_mode"] for entry in get_fallback_chain(config)] == [
+            "chat_completions",
+            "codex_responses",
+        ]

--- a/tests/run_agent/test_nous_fallback_unavailable.py
+++ b/tests/run_agent/test_nous_fallback_unavailable.py
@@ -74,12 +74,11 @@ class TestNousFallbackLocalAvailability:
             return_value={},
         ):
             agent._try_activate_fallback(None)
-        key = (
-            "nous",
-            "anthropic/claude-sonnet-4.6",
-            "",
-        )
-        assert key in getattr(agent, "_unavailable_fallback_keys", set())
+        keys = getattr(agent, "_unavailable_fallback_keys", set())
+        # Key is a 4-tuple: (provider, model, base_url, api_mode)
+        assert any(
+            k[:2] == ("nous", "anthropic/claude-sonnet-4.6") for k in keys
+        ), f"Expected nous entry in unavailable keys, got {keys}"
 
     def test_present_nous_token_allows_activation(self):
         """Nous is considered when token material exists."""

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -439,6 +439,45 @@ class TestExplicitFallbackTransport:
         assert resolve_client.call_args.kwargs["api_mode"] == "chat_completions"
         assert agent.api_mode == "chat_completions"
 
+    def test_sequential_distinct_transports_with_same_backend_are_activated(self):
+        """A later transport for the same endpoint remains a distinct fallback."""
+        fbs = [
+            {
+                "provider": "custom-relay",
+                "model": "relay-model",
+                "base_url": "https://relay.example/v1",
+                "api_mode": "codex_responses",
+            },
+            {
+                "provider": "custom-relay",
+                "model": "relay-model",
+                "base_url": "https://relay.example/v1",
+                "api_mode": "chat_completions",
+            },
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        agent.provider = "custom-relay"
+        agent.model = "relay-model"
+        agent.base_url = "https://relay.example/v1"
+        agent.api_mode = "chat_completions"
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(base_url="https://relay.example/v1"), "relay-model"),
+        ) as resolve_client, patch(
+            "hermes_cli.model_normalize.normalize_model_for_provider",
+            side_effect=lambda model, provider: model,
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent.api_mode == "codex_responses"
+            assert agent._try_activate_fallback() is True
+
+        assert agent.api_mode == "chat_completions"
+        assert [call.kwargs["api_mode"] for call in resolve_client.call_args_list] == [
+            "codex_responses",
+            "chat_completions",
+        ]
+
     def test_invalid_explicit_transport_is_skipped(self):
         fbs = [{
             "provider": "custom-relay",

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -414,6 +414,31 @@ class TestExplicitFallbackTransport:
             assert resolve_client.call_args.kwargs["api_mode"] == "chat_completions"
             agent._provider_model_requires_responses_api.assert_not_called()
 
+    def test_distinct_transport_is_not_skipped_as_current_route(self):
+        """Same endpoint/model can expose a second transport fallback route."""
+        fbs = [{
+            "provider": "custom-relay",
+            "model": "relay-model",
+            "base_url": "https://relay.example/v1",
+            "api_mode": "chat_completions",
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        agent.provider = "custom-relay"
+        agent.model = "relay-model"
+        agent.base_url = "https://relay.example/v1"
+        agent.api_mode = "codex_responses"
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(base_url="https://relay.example/v1"), "relay-model"),
+        ) as resolve_client, patch(
+            "hermes_cli.model_normalize.normalize_model_for_provider",
+            side_effect=lambda model, provider: model,
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert resolve_client.call_args.kwargs["api_mode"] == "chat_completions"
+        assert agent.api_mode == "chat_completions"
+
     def test_invalid_explicit_transport_is_skipped(self):
         fbs = [{
             "provider": "custom-relay",

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -340,7 +340,7 @@ class TestFallbackChainDedup:
 
         A spending-limit 403 on OAuth must still be able to fall over to the
         API-key provider even when both entries use the same model slug and
-        base URL.  Blind base_url+model dedup incorrectly skipped that path.
+        base URL. Blind base_url+model dedup incorrectly skipped that path.
         """
         fbs = [
             {
@@ -371,3 +371,59 @@ class TestFallbackChainDedup:
         assert called == [("xai", "grok-4.5")]
         assert agent.provider == "xai"
         assert agent.model == "grok-4.5"
+
+
+class TestExplicitFallbackTransport:
+    def test_explicit_codex_transport_wins_over_model_inference(self):
+        fbs = [{
+            "provider": "custom-relay",
+            "model": "relay-model",
+            "base_url": "https://relay.example/v1",
+            "api_mode": "codex_responses",
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(base_url="https://relay.example/v1"), "relay-model"),
+        ) as resolve_client, patch(
+            "hermes_cli.model_normalize.normalize_model_for_provider",
+            side_effect=lambda model, provider: model,
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent.api_mode == "codex_responses"
+            assert resolve_client.call_args.kwargs["api_mode"] == "codex_responses"
+
+    def test_explicit_chat_transport_overrides_gpt_responses_heuristic(self):
+        fbs = [{
+            "provider": "custom-relay",
+            "model": "gpt-5.6-sol",
+            "base_url": "https://relay.example/v1",
+            "api_mode": "chat_completions",
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        agent._provider_model_requires_responses_api = MagicMock(return_value=True)
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(base_url="https://relay.example/v1"), "gpt-5.6-sol"),
+        ) as resolve_client, patch(
+            "hermes_cli.model_normalize.normalize_model_for_provider",
+            side_effect=lambda model, provider: model,
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent.api_mode == "chat_completions"
+            assert resolve_client.call_args.kwargs["api_mode"] == "chat_completions"
+            agent._provider_model_requires_responses_api.assert_not_called()
+
+    def test_invalid_explicit_transport_is_skipped(self):
+        fbs = [{
+            "provider": "custom-relay",
+            "model": "relay-model",
+            "api_mode": "made_up_transport",
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "relay-model"),
+        ):
+            assert agent._try_activate_fallback() is False
+            assert agent._fallback_activated is False


### PR DESCRIPTION
## Summary

- preserve `fallback_providers[].api_mode` through normal runtime failover instead of re-inferring transport from provider/model names
- pass the explicit mode into fallback client construction, so wrappers and active runtime use the same wire contract
- preserve the same mode during startup auth fallback and resolve transport-dependent providers against the fallback model
- accept provider-profile `transport` spellings, reject unknown explicit modes, and keep distinct transport routes during chain deduplication

## Why

A fallback entry can target a relay whose provider/model names do not uniquely identify its wire protocol. The fallback picker already persists `api_mode`, but activation discarded it and guessed again. This could pair a valid fallback client with the wrong API surface (for example, a Responses-only relay dispatched as chat completions, or a chat-compatible GPT route forced onto Responses).

## Validation

- `uv run --extra dev pytest -q tests/run_agent/test_provider_fallback.py tests/hermes_cli/test_fallback_config.py tests/cli/test_cli_provider_resolution.py` — 63 passed
- `uv run --extra dev ruff check agent/chat_completion_helpers.py hermes_cli/fallback_config.py hermes_cli/cli_agent_setup_mixin.py tests/run_agent/test_provider_fallback.py tests/hermes_cli/test_fallback_config.py tests/cli/test_cli_provider_resolution.py`
- `git diff --check`
