### PR TITLE
Fix tests/hermes_cli/test_gateway_wsl.py on macOS

### DIFF
--- a/tests/hermes_cli/test_gateway_wsl.py
+++ b/tests/hermes_cli/test_gateway_wsl.py
@@ -122,6 +122,10 @@ class TestWslSystemdOperational:
 class TestSupportsSystemdServicesWSL:
     """Test that supports_systemd_services() handles WSL correctly."""
 
+    @pytest.fixture(autouse=True)
+    def systemctl_available(self, monkeypatch):
+        monkeypatch.setattr(gateway.shutil, "which", lambda command: "/usr/bin/systemctl")
+
     def test_wsl_with_systemd(self, monkeypatch):
         """WSL + working systemd → True."""
         monkeypatch.setattr(gateway, "is_linux", lambda: True)


### PR DESCRIPTION
Hermes task: `t_6368c4bf`

Worker report: `ops/bridge-report.md`

Opened as a draft by hermes-orca-bridge. The bridge does not mark PRs ready or merge them.