### PR TITLE
fix(agent): enforce completion reports and normalize content

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -806,7 +806,7 @@ def repair_message_sequence_with_cursor(agent, messages: List[Dict]) -> int:
 
 
 
-def strip_think_blocks(agent, content: str) -> str:
+def strip_think_blocks(agent, content: Any) -> str:
     """Remove reasoning/thinking blocks from content, returning only visible text.
 
     Handles four cases:
@@ -837,6 +837,8 @@ def strip_think_blocks(agent, content: str) -> str:
     after punctuation and carries a ``name="..."`` attribute) so prose
     mentions like "Use <function> in JavaScript" are preserved.
     """
+    from agent.message_content import flatten_message_text
+    content = flatten_message_text(content)
     if not content:
         return ""
     # Coerce non-string content to text before any regex runs.  Providers

--- a/agent/completion_report_gate.py
+++ b/agent/completion_report_gate.py
@@ -1,0 +1,139 @@
+"""Mechanical completion-report gate for consecutive tool batches.
+
+A reportable tool batch arms the gate. If the model attempts another tool batch
+without visible status text, the conversation loop emits a deterministic
+user-facing progress message before dispatching the new tools. The gate never
+mutates model context or injects synthetic user messages, preserving provider
+role alternation and prompt-cache stability.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from agent.message_content import flatten_message_text
+
+
+# Internal bookkeeping/context tools do not represent a user-visible work
+# phase. Everything else defaults to reportable so newly added operational
+# tools cannot silently bypass the gate.
+_NON_REPORTABLE_TOOLS = frozenset(
+    {
+        "clarify",
+        "memory",
+        "session_search",
+        "skill_view",
+        "skills_list",
+        "todo",
+    }
+)
+
+_THINK_BLOCK_RE = re.compile(
+    r"<think\b[^>]*>.*?</think>\s*", re.DOTALL | re.IGNORECASE
+)
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """Decision returned before a consecutive tool batch is dispatched."""
+
+    action: str  # "allow" or "report"
+    message: str = ""
+
+
+class CompletionReportGate:
+    """Require user-visible status between reportable tool batches."""
+
+    def __init__(self, *, enabled: bool) -> None:
+        self.enabled = bool(enabled)
+        self.pending_tools: tuple[str, ...] = ()
+
+    @property
+    def pending(self) -> bool:
+        return bool(self.pending_tools)
+
+    def arm(self, tool_names: Iterable[str]) -> bool:
+        """Require a report before a subsequent tool batch.
+
+        A batch containing only internal bookkeeping tools is ignored. Tool
+        names are deduplicated in call order so deterministic reports remain
+        compact and cannot contain tool outputs or credentials.
+        """
+
+        if not self.enabled:
+            return False
+
+        reportable: list[str] = []
+        seen: set[str] = set()
+        for raw_name in tool_names:
+            name = str(raw_name or "").strip()
+            if not name or name in _NON_REPORTABLE_TOOLS or name in seen:
+                continue
+            seen.add(name)
+            reportable.append(name)
+
+        if not reportable:
+            return False
+
+        self.pending_tools = tuple(reportable)
+        return True
+
+    def before_tool_batch(self, visible_content: Any) -> GateDecision:
+        """Allow the batch or require a deterministic interim report first."""
+
+        if not self.enabled or not self.pending:
+            return GateDecision("allow")
+
+        if _has_visible_report(visible_content):
+            self.pending_tools = ()
+            return GateDecision("allow")
+
+        names = ", ".join(name.replace("_", " ") for name in self.pending_tools[:6])
+        if len(self.pending_tools) > 6:
+            names += f", +{len(self.pending_tools) - 6} more"
+        self.pending_tools = ()
+        return GateDecision(
+            "report",
+            f"Previous tool phase ended ({names}). Continuing with the next step.",
+        )
+
+
+def _has_visible_report(content: Any) -> bool:
+    """Return whether assistant content contains user-visible non-thinking text."""
+
+    visible = flatten_message_text(content)
+    visible = _THINK_BLOCK_RE.sub("", visible).strip()
+    return bool(visible and visible != "(empty)")
+
+
+def completion_report_gate_enabled(config: dict[str, Any] | None = None) -> bool:
+    """Resolve the persisted ``agent.completion_report_gate`` setting."""
+
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        except Exception:
+            config = {}
+
+    agent_cfg = (config or {}).get("agent") if isinstance(config, dict) else None
+    value = (
+        agent_cfg.get("completion_report_gate")
+        if isinstance(agent_cfg, dict)
+        else False
+    )
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return False
+
+
+__all__ = [
+    "CompletionReportGate",
+    "GateDecision",
+    "completion_report_gate_enabled",
+]

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1603,6 +1603,19 @@ def run_conversation(
     # on the next loop iteration. This prevents a second advisor fan-out.
     pending_moa_prepared_request = None
 
+    # Mechanical phase-boundary reporting. When enabled, a reportable tool
+    # batch arms this gate. If the model requests another batch without visible
+    # status, a deterministic interim message is delivered before execution.
+    # No synthetic conversation messages are inserted, preserving role order.
+    from agent.completion_report_gate import (
+        CompletionReportGate,
+        completion_report_gate_enabled,
+    )
+
+    _completion_report_gate = CompletionReportGate(
+        enabled=completion_report_gate_enabled()
+    )
+
     # Per-turn tally of consecutive successful credential-pool token refreshes,
     # keyed by (provider, pool-entry-id). A persistent upstream 401 lets
     # ``try_refresh_current()`` "succeed" forever on a single-entry OAuth pool,
@@ -1907,7 +1920,7 @@ def run_conversation(
             # Remove finish_reason - not accepted by strict APIs (e.g. Mistral)
             if "finish_reason" in api_msg:
                 api_msg.pop("finish_reason")
-            # Strip internal thinking-prefill marker
+            # Strip internal thinking-prefill marker.
             api_msg.pop("_thinking_prefill", None)
             # Strip length-continuation marks; not every transport drops underscore keys.
             api_msg.pop("_length_continuation_fragment", None)
@@ -6751,6 +6764,36 @@ def run_conversation(
                 if not duplicate_previous_interim:
                     agent._emit_interim_assistant_message(assistant_msg)
 
+                # ── Completion Report Gate ───────────────────────────
+                # Post-validation: a prior reportable tool batch ended and
+                # validation has now confirmed at least one executable tool
+                # remains. If the model asks for more tools without visible
+                # commentary, emit a safe deterministic progress message
+                # before dispatching. Routes through interim_assistant_callback
+                # (gateway/TUI) or _vprint (CLI) so every surface sees it.
+                if _completion_report_gate.pending:
+                    _gate_decision = _completion_report_gate.before_tool_batch(
+                        assistant_message.content
+                    )
+                    if _gate_decision.action == "report":
+                        _cb = getattr(agent, "interim_assistant_callback", None)
+                        if _cb is not None:
+                            agent._emit_interim_assistant_message(
+                                {
+                                    "role": "assistant",
+                                    "content": _gate_decision.message,
+                                }
+                            )
+                        else:
+                            agent._vprint(
+                                f"{agent.log_prefix}{_gate_decision.message}",
+                                force=True,
+                            )
+                        logger.info(
+                            "completion report gate emitted status before "
+                            "silent consecutive tool batch"
+                        )
+
                 # Close any open streaming display (response box, reasoning
                 # box) before tool execution begins.  Intermediate turns may
                 # have streamed early content that opened the response box;
@@ -6796,6 +6839,10 @@ def run_conversation(
                             except Exception:
                                 pass
                     break
+
+                _completion_report_gate.arm(
+                    tc.function.name for tc in assistant_message.tool_calls
+                )
 
                 # Reset per-turn retry counters after successful tool
                 # execution so a single truncation doesn't poison the

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -184,6 +184,11 @@ DEFAULT_CONFIG = {
         # a human as chat noise. Doc/markdown/skill-only edits never fire it.
         # Set true to force on everywhere, or false to disable.
         "verify_on_stop": "auto",
+        # Require visible user-facing status between consecutive reportable
+        # tool batches. If the model is silent, emit a deterministic interim
+        # update before executing the next batch without mutating chat history.
+        # Off by default; messaging operators can opt in when visibility matters.
+        "completion_report_gate": False,
         # Staged inactivity warning: send a warning to the user at this
         # threshold before escalating to a full timeout.  The warning fires
         # once per run and does not interrupt the agent.  0 = disable warning.

--- a/run_agent.py
+++ b/run_agent.py
@@ -1674,7 +1674,7 @@ class AIAgent:
         # Check if there's any non-whitespace content remaining
         return bool(cleaned.strip())
 
-    def _strip_think_blocks(self, content: str) -> str:
+    def _strip_think_blocks(self, content: Any) -> str:
         """Forwarder — see ``agent.agent_runtime_helpers.strip_think_blocks``."""
         from agent.agent_runtime_helpers import strip_think_blocks
         return strip_think_blocks(self, content)

--- a/tests/agent/test_completion_report_gate.py
+++ b/tests/agent/test_completion_report_gate.py
@@ -1,0 +1,77 @@
+"""Tests for the post-tool completion-report gate policy."""
+
+from agent.completion_report_gate import (
+    CompletionReportGate,
+    completion_report_gate_enabled,
+)
+
+
+def test_gate_is_disabled_by_default():
+    assert completion_report_gate_enabled({"agent": {}}) is False
+
+
+def test_gate_reads_persisted_config():
+    assert completion_report_gate_enabled(
+        {"agent": {"completion_report_gate": True}}
+    ) is True
+    assert completion_report_gate_enabled(
+        {"agent": {"completion_report_gate": "yes"}}
+    ) is True
+    assert completion_report_gate_enabled(
+        {"agent": {"completion_report_gate": False}}
+    ) is False
+
+
+def test_reportable_batch_arms_gate_but_housekeeping_does_not():
+    gate = CompletionReportGate(enabled=True)
+
+    assert gate.arm(["todo", "skill_view"]) is False
+    assert gate.pending is False
+
+    assert gate.arm(["web_search", "todo"]) is True
+    assert gate.pending is True
+    assert gate.pending_tools == ("web_search",)
+
+
+def test_visible_report_allows_next_tool_batch_and_clears_gate():
+    gate = CompletionReportGate(enabled=True)
+    gate.arm(["terminal"])
+
+    decision = gate.before_tool_batch(
+        "Update finished successfully. Cleanup is the next phase."
+    )
+
+    assert decision.action == "allow"
+    assert gate.pending is False
+
+
+def test_structured_visible_report_allows_next_tool_batch():
+    gate = CompletionReportGate(enabled=True)
+    gate.arm(["terminal"])
+
+    decision = gate.before_tool_batch(
+        [{"type": "output_text", "text": "Update finished successfully."}]
+    )
+
+    assert decision.action == "allow"
+    assert gate.pending is False
+
+
+def test_silent_consecutive_batch_requires_safe_deterministic_report():
+    gate = CompletionReportGate(enabled=True)
+    gate.arm(["terminal", "web_search", "terminal"])
+
+    decision = gate.before_tool_batch("<think>silent</think>")
+
+    assert decision.action == "report"
+    assert decision.message == (
+        "Previous tool phase ended (terminal, web search). "
+        "Continuing with the next step."
+    )
+    assert gate.pending is False
+
+
+def test_disabled_gate_never_reports():
+    gate = CompletionReportGate(enabled=False)
+    assert gate.arm(["terminal"]) is False
+    assert gate.before_tool_batch("").action == "allow"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2711,6 +2711,37 @@ class TestHandleMaxIterations:
         assert tool_ids == ["call_good", "call_bad"]
 
 
+class TestStructuredAssistantContent:
+    """Assistant content blocks must be flattened before regex scrubbing."""
+
+    def test_interim_visible_text_accepts_codex_content_blocks(self, agent):
+        visible = agent._interim_assistant_visible_text(
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "output_text", "text": "Phase complete."},
+                    {"type": "text", "text": "Starting verification."},
+                ],
+            }
+        )
+
+        # flatten_message_text joins parts with \n (v0.20.0+); .strip() removes trailing whitespace
+        assert visible == "Phase complete.\nStarting verification."
+
+    def test_interim_visible_text_ignores_non_text_blocks(self, agent):
+        visible = agent._interim_assistant_visible_text(
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "input_image", "image_url": "data:image/png;base64,abc"},
+                    {"type": "output_text", "text": "Visible status."},
+                ],
+            }
+        )
+
+        assert visible == "Visible status."
+
+
 class TestRunConversation:
     """Tests for the main run_conversation method.
 


### PR DESCRIPTION
## Problem

When the agent runs consecutive tool batches without emitting user-visible status text between them, the user sees silent tool execution with no progress signal. This violates the completion-report discipline that long multi-phase tasks require — the agent should report what it did before moving to the next step.

A secondary issue: assistant content arriving as structured blocks (e.g. OpenAI Responses `output_text`/`input_text`/`text` parts) was not flattened before regex scrubbing, causing `strip_think_blocks` to miss or misparse content on providers that transport it as a parts list.

## Fix

**1. Completion Report Gate** (`agent/completion_report_gate.py`)

A mechanical gate that arms after any reportable tool batch and requires user-visible status text before the next tool batch dispatches. If the model goes silent, a deterministic progress message is emitted — no model context mutation, no synthetic user messages, strict role alternation preserved.

- Config-gated via `agent.completion_report_gate` in `config.yaml` (default: off)
- Internal bookkeeping tools (`clarify`, `memory`, `session_search`, `skill_view`, `skills_list`, `todo`) are non-reportable
- Tool names in the report are deduplicated and capped (max 6, then "+N more")
- The gate never injects into model context — it only emits a user-visible progress line

**2. Content normalization** (`agent/agent_runtime_helpers.py`)

`message_content_to_text()` flattens string or structured message content to visible text before regex scrubbers run. Handles `text`/`input_text`/`output_text` block types; ignores non-text blocks (images, etc.) rather than stringifying them (prevents data-URL leakage into logs/progress).

## Tests

- `tests/agent/test_completion_report_gate.py` — gate arming, reportable vs housekeeping tools, visible-report detection, structured content, disabled-gate no-op
- `tests/run_agent/test_run_agent.py::TestStructuredAssistantContent` — structured assistant content flattening, non-text block ignoring

## Design notes

- The gate is **off by default** and config-gated — no behaviour change for existing users
- Zero prompt-cache impact: no system prompt change, no mid-conversation context mutation
- Preserves role alternation: the progress message is user-visible output, not a synthetic user message
- Aligns with the existing "Completion Report Gate" guidance in the agent system prompt