### PR TITLE
fix(relay): wire edit streaming capabilities 🩷

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -157,7 +157,12 @@ class GatewayAuthorizationMixin:
             # Only the transport-stamped, wire-invisible trust marker may
             # redirect this lookup; ordinary direct-platform events retain
             # their original adapter.
-            platform = Platform.RELAY
+            # Relay is one process-level ingress connection in multiplex mode;
+            # secondary profile registries intentionally omit it. Resolve it
+            # directly from the shared adapter map rather than applying the
+            # profile-specific fail-closed lookup used by ordinary adapters.
+            adapters = getattr(self, "adapters", None) or {}
+            return adapters.get(Platform.RELAY)
         return self._authorization_adapter(
             platform,
             getattr(source, "profile", None),

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -149,22 +149,8 @@ class GatewayAuthorizationMixin:
             return adapters.get(Platform.RELAY)
         # ``getattr`` guards test fixtures that build a bare source via
         # SimpleNamespace and omit ``profile`` (see AGENTS.md pitfall #17).
-        platform = getattr(source, "platform", None)
-        if getattr(source, "delivered_via_upstream_relay", False) is True:
-            # Relay preserves the underlying platform on SessionSource for
-            # stable session identity and connector egress routing. The live
-            # response adapter, however, is registered under Platform.RELAY.
-            # Only the transport-stamped, wire-invisible trust marker may
-            # redirect this lookup; ordinary direct-platform events retain
-            # their original adapter.
-            # Relay is one process-level ingress connection in multiplex mode;
-            # secondary profile registries intentionally omit it. Resolve it
-            # directly from the shared adapter map rather than applying the
-            # profile-specific fail-closed lookup used by ordinary adapters.
-            adapters = getattr(self, "adapters", None) or {}
-            return adapters.get(Platform.RELAY)
         return self._authorization_adapter(
-            platform,
+            getattr(source, "platform", None),
             getattr(source, "profile", None),
         )
 

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -149,8 +149,17 @@ class GatewayAuthorizationMixin:
             return adapters.get(Platform.RELAY)
         # ``getattr`` guards test fixtures that build a bare source via
         # SimpleNamespace and omit ``profile`` (see AGENTS.md pitfall #17).
+        platform = getattr(source, "platform", None)
+        if getattr(source, "delivered_via_upstream_relay", False) is True:
+            # Relay preserves the underlying platform on SessionSource for
+            # stable session identity and connector egress routing. The live
+            # response adapter, however, is registered under Platform.RELAY.
+            # Only the transport-stamped, wire-invisible trust marker may
+            # redirect this lookup; ordinary direct-platform events retain
+            # their original adapter.
+            platform = Platform.RELAY
         return self._authorization_adapter(
-            getattr(source, "platform", None),
+            platform,
             getattr(source, "profile", None),
         )
 

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -249,6 +249,12 @@ class RelayAdapter(BasePlatformAdapter):
         set_passthrough = getattr(self._transport, "set_passthrough_handler", None)
         if callable(set_passthrough):
             set_passthrough(self._on_passthrough)
+        set_descriptor = getattr(self._transport, "set_descriptor_handler", None)
+        if callable(set_descriptor):
+            # The production transport re-handshakes inside its own reconnect
+            # supervisor. Observe every descriptor so negotiated limits and edit
+            # support cannot remain stale after a reconnect.
+            set_descriptor(self._apply_descriptor)
         ok = await self._transport.connect()
         if not ok:
             return False

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -68,6 +68,10 @@ class RelayAdapter(BasePlatformAdapter):
         self._transport = transport
         # Capability surface read by stream_consumer (getattr(..., 4096)).
         self.MAX_MESSAGE_LENGTH = descriptor.max_message_length
+        self.SUPPORTS_MESSAGE_EDITING = descriptor.supports_edit
+        # Edit availability does not imply an explicit lifecycle-closing edit.
+        # Relay has no separately negotiated finalize capability or wire field.
+        self.REQUIRES_EDIT_FINALIZE = False
         # chat_id -> scope_id (server/workspace scope), learned from inbound
         # events. The connector's egress guard resolves the owning tenant from
         # the OUTBOUND action's metadata.scope_id; the gateway's generic delivery
@@ -328,6 +332,7 @@ class RelayAdapter(BasePlatformAdapter):
         """Adopt a (re)negotiated descriptor into the live capability surface."""
         self.descriptor = descriptor
         self.MAX_MESSAGE_LENGTH = descriptor.max_message_length
+        self.SUPPORTS_MESSAGE_EDITING = descriptor.supports_edit
         self.supports_code_blocks = descriptor.markdown_dialect not in ("", "plain")
 
     async def _on_inbound(self, event) -> None:
@@ -1161,6 +1166,8 @@ class RelayAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Edit a relayed message through the connector-owned platform API."""
+        if not self._descriptor_for_chat(chat_id).supports_edit:
+            return SendResult(success=False, error="Not supported")
         if self._transport is None:
             return SendResult(success=False, error="no transport")
         result = await self._transport.send_outbound(

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -419,7 +419,7 @@ class WebSocketRelayTransport:
         # (primary-identity) descriptor for back-compat; this map is the
         # per-platform capability surface read via `descriptor_for_platform`.
         self._descriptors_by_platform: Dict[str, CapabilityDescriptor] = {}
-        self._descriptor_handler: Optional[Callable[[CapabilityDescriptor], Any]] = None
+        self._descriptor_handler: Optional[Callable[[CapabilityDescriptor], None]] = None
         self._descriptor_ready: asyncio.Future[CapabilityDescriptor] | None = None
         # requestId -> future awaiting the matching outbound_result.
         self._pending: Dict[str, asyncio.Future[Dict[str, Any]]] = {}
@@ -445,9 +445,9 @@ class WebSocketRelayTransport:
 
     def set_descriptor_handler(
         self,
-        handler: Callable[[CapabilityDescriptor], Any],
+        handler: Callable[[CapabilityDescriptor], None],
     ) -> None:
-        """Observe every negotiated descriptor, including reconnects."""
+        """Observe every negotiated descriptor via a synchronous callback."""
         self._descriptor_handler = handler
 
     async def _dial_and_start(self) -> None:
@@ -856,10 +856,6 @@ class WebSocketRelayTransport:
             # applying them here would make multi-platform capability state
             # depend on arrival order. A reconnect resets _descriptor, so its
             # first descriptor still refreshes the live adapter.
-            if is_primary and self._descriptor_handler is not None:
-                result = self._descriptor_handler(descriptor)
-                if asyncio.iscoroutine(result):
-                    await result
             # Phase 7 Unit 7d-B: a received descriptor means the WS upgrade auth
             # passed and the connector accepted us — record that we've handshaked
             # at least once, so a LATER 4401 close is read as a revocation
@@ -867,6 +863,21 @@ class WebSocketRelayTransport:
             self._handshake_succeeded = True
             if self._descriptor_ready is not None and not self._descriptor_ready.done():
                 self._descriptor_ready.set_result(descriptor)
+            if is_primary and self._descriptor_handler is not None:
+                try:
+                    result = self._descriptor_handler(descriptor)
+                    if asyncio.iscoroutine(result):
+                        # The callback is deliberately synchronous: awaiting it
+                        # in the sole reader could deadlock on a future frame.
+                        result.close()
+                        logger.warning(
+                            "relay descriptor handler must be synchronous; result ignored"
+                        )
+                except Exception:
+                    # Descriptor adoption is advisory to the adapter surface.
+                    # Never sacrifice the authenticated handshake/read loop if a
+                    # callback regresses; the transport's descriptor stays valid.
+                    logger.warning("relay descriptor handler failed", exc_info=True)
         elif ftype == "inbound":
             if self._inbound is not None:
                 event = _event_from_wire(frame.get("event", {}))

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -34,7 +34,7 @@ import json
 import logging
 import uuid
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from gateway.platforms.base import MessageEvent, MessageType
 from gateway.session import SessionSource
@@ -419,6 +419,7 @@ class WebSocketRelayTransport:
         # (primary-identity) descriptor for back-compat; this map is the
         # per-platform capability surface read via `descriptor_for_platform`.
         self._descriptors_by_platform: Dict[str, CapabilityDescriptor] = {}
+        self._descriptor_handler: Optional[Callable[[CapabilityDescriptor], Any]] = None
         self._descriptor_ready: asyncio.Future[CapabilityDescriptor] | None = None
         # requestId -> future awaiting the matching outbound_result.
         self._pending: Dict[str, asyncio.Future[Dict[str, Any]]] = {}
@@ -441,6 +442,13 @@ class WebSocketRelayTransport:
     async def connect(self) -> bool:
         await self._dial_and_start()
         return True
+
+    def set_descriptor_handler(
+        self,
+        handler: Callable[[CapabilityDescriptor], Any],
+    ) -> None:
+        """Observe every negotiated descriptor, including reconnects."""
+        self._descriptor_handler = handler
 
     async def _dial_and_start(self) -> None:
         """Open the socket, start the reader, send hello. Used by connect() and
@@ -840,8 +848,18 @@ class WebSocketRelayTransport:
             # default (the primary identity's) — later arrivals must NOT
             # overwrite it, or the scalar capability surface silently becomes
             # last-writer-wins across platforms.
-            if self._descriptor is None:
+            is_primary = self._descriptor is None
+            if is_primary:
                 self._descriptor = descriptor
+            # Only the first descriptor is the adapter's scalar/default profile.
+            # Later descriptors remain available through descriptor_for_platform;
+            # applying them here would make multi-platform capability state
+            # depend on arrival order. A reconnect resets _descriptor, so its
+            # first descriptor still refreshes the live adapter.
+            if is_primary and self._descriptor_handler is not None:
+                result = self._descriptor_handler(descriptor)
+                if asyncio.iscoroutine(result):
+                    await result
             # Phase 7 Unit 7d-B: a received descriptor means the WS upgrade auth
             # passed and the connector accepted us — record that we've handshaked
             # at least once, so a LATER 4401 close is read as a revocation

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -844,24 +844,29 @@ class WebSocketRelayTransport:
             # platforms onto whichever descriptor arrived last.
             if descriptor.platform:
                 self._descriptors_by_platform[descriptor.platform] = descriptor
-            # The FIRST descriptor of this connection generation is the session
-            # default (the primary identity's) — later arrivals must NOT
-            # overwrite it, or the scalar capability surface silently becomes
-            # last-writer-wins across platforms.
-            is_primary = self._descriptor is None
+            # The configured first identity is the session default. Descriptor
+            # frames may arrive out of order, so arrival order is not enough to
+            # choose the scalar capability surface in a multiplexed connection.
+            primary_platform = self._identities[0][0] if self._identities else self._platform
+            is_primary = descriptor.platform == primary_platform or (
+                len(self._identities) == 1 and not descriptor.platform
+            )
             if is_primary:
                 self._descriptor = descriptor
-            # Only the first descriptor is the adapter's scalar/default profile.
-            # Later descriptors remain available through descriptor_for_platform;
-            # applying them here would make multi-platform capability state
-            # depend on arrival order. A reconnect resets _descriptor, so its
-            # first descriptor still refreshes the live adapter.
+            # Secondary descriptors remain available through
+            # descriptor_for_platform; applying them to the scalar surface would
+            # make capability state depend on arrival order. A reconnect resets
+            # _descriptor, so the configured primary descriptor refreshes it.
             # Phase 7 Unit 7d-B: a received descriptor means the WS upgrade auth
             # passed and the connector accepted us — record that we've handshaked
             # at least once, so a LATER 4401 close is read as a revocation
             # (opt-out), not a cold-start race.
             self._handshake_succeeded = True
-            if self._descriptor_ready is not None and not self._descriptor_ready.done():
+            if (
+                self._descriptor_ready is not None
+                and is_primary
+                and not self._descriptor_ready.done()
+            ):
                 self._descriptor_ready.set_result(descriptor)
             if is_primary and self._descriptor_handler is not None:
                 try:

--- a/tests/gateway/relay/test_relay_adapter.py
+++ b/tests/gateway/relay/test_relay_adapter.py
@@ -51,6 +51,28 @@ def test_message_editing_capability_follows_descriptor():
     assert _adapter(supports_edit=True).SUPPORTS_MESSAGE_EDITING is True
 
 
+def test_edit_support_does_not_imply_explicit_finalize_contract():
+    """supports_edit is availability, not a negotiated finalize requirement."""
+    assert _adapter(supports_edit=True).REQUIRES_EDIT_FINALIZE is False
+
+
+def test_reconnect_descriptor_refresh_updates_live_edit_capability():
+    """A fresh descriptor updates the live scalar capability surface."""
+    a = _adapter(supports_edit=True)
+    refreshed = make_desc(
+        supports_edit=False,
+        max_message_length=2000,
+        markdown_dialect="plain",
+    )
+
+    a._apply_descriptor(refreshed)
+
+    assert a.descriptor is refreshed
+    assert a.SUPPORTS_MESSAGE_EDITING is False
+    assert a.MAX_MESSAGE_LENGTH == 2000
+    assert a.supports_code_blocks is False
+
+
 def test_len_fn_utf16_counts_code_units():
     a = _adapter(len_unit="utf16")
     # An astral-plane emoji is two UTF-16 code units.
@@ -99,6 +121,15 @@ class _CaptureTransport:
         self.sent = action
         self.sent_platform = platform
         return {"success": True, "message_id": "m1"}
+
+
+class _PerPlatformCaptureTransport(_CaptureTransport):
+    def __init__(self, descriptors):
+        super().__init__()
+        self._descriptors = descriptors
+
+    def descriptor_for_platform(self, platform):
+        return self._descriptors.get(platform)
 
 
 def _make_event(chat_id="chan-1", scope_id="scope-9"):
@@ -184,7 +215,7 @@ async def test_send_preserves_explicit_scope_id():
 
 
 @pytest.mark.asyncio
-async def test_edit_forwards_scope_platform_without_undocumented_finalize():
+async def test_edit_forwards_scope_and_platform_without_undocumented_finalize():
     t = _CaptureTransport()
     a = RelayAdapter(PlatformConfig(), make_desc(platform="discord"), transport=t)
     event = _make_event(chat_id="chan-1", scope_id="scope-9")
@@ -225,6 +256,26 @@ async def test_edit_is_rejected_when_descriptor_disables_it():
     assert result.success is False
     assert result.error == "Not supported"
     assert t.sent is None
+
+
+@pytest.mark.asyncio
+async def test_edit_uses_per_platform_descriptor_for_multiplexed_chats():
+    primary = make_desc(platform="telegram", supports_edit=False)
+    secondary = make_desc(platform="discord", supports_edit=True)
+    t = _PerPlatformCaptureTransport(
+        {"telegram": primary, "discord": secondary}
+    )
+    a = RelayAdapter(PlatformConfig(), primary, transport=t)
+    a._platform_by_chat["discord-chat"] = "discord"
+    a._platform_by_chat["telegram-chat"] = "telegram"
+
+    allowed = await a.edit_message("discord-chat", "message-1", "reply")
+    rejected = await a.edit_message("telegram-chat", "message-2", "reply")
+
+    assert allowed.success is True
+    assert rejected.success is False
+    assert rejected.error == "Not supported"
+    assert t.sent["chat_id"] == "discord-chat"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/relay/test_relay_adapter.py
+++ b/tests/gateway/relay/test_relay_adapter.py
@@ -46,6 +46,11 @@ def test_supports_draft_streaming_follows_descriptor():
     assert _adapter(supports_draft_streaming=True).supports_draft_streaming() is True
 
 
+def test_message_editing_capability_follows_descriptor():
+    assert _adapter(supports_edit=False).SUPPORTS_MESSAGE_EDITING is False
+    assert _adapter(supports_edit=True).SUPPORTS_MESSAGE_EDITING is True
+
+
 def test_len_fn_utf16_counts_code_units():
     a = _adapter(len_unit="utf16")
     # An astral-plane emoji is two UTF-16 code units.
@@ -143,6 +148,114 @@ def _make_scoped_event_with_author(
         user_id=user_id,
     )
     return MessageEvent(text="hi", source=src, message_type=MessageType.TEXT)
+
+
+@pytest.mark.asyncio
+async def test_send_reattaches_scope_id_from_inbound_scope():
+    """The connector's egress guard resolves the owning tenant from
+    metadata.scope_id; the gateway's generic delivery path drops it, so the
+    relay adapter must re-attach the scope learned from the inbound event.
+    Regression for live 'egress declined: target not routed to an
+    onboarded tenant'."""
+    t = _CaptureTransport()
+    a = RelayAdapter(PlatformConfig(), make_desc(platform="discord"), transport=t)
+    a._capture_scope(_make_event(chat_id="chan-1", scope_id="scope-9"))
+    await a.send("chan-1", "the reply")
+    assert t.sent["metadata"].get("scope_id") == "scope-9"
+
+
+@pytest.mark.asyncio
+async def test_send_without_known_scope_omits_scope_id():
+    """A chat we never saw inbound gets no invented scope_id."""
+    t = _CaptureTransport()
+    a = RelayAdapter(PlatformConfig(), make_desc(platform="discord"), transport=t)
+    await a.send("unknown-chat", "hi")
+    assert "scope_id" not in t.sent["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_send_preserves_explicit_scope_id():
+    """An explicitly-provided metadata.scope_id is never overwritten."""
+    t = _CaptureTransport()
+    a = RelayAdapter(PlatformConfig(), make_desc(platform="discord"), transport=t)
+    a._capture_scope(_make_event(chat_id="chan-1", scope_id="scope-9"))
+    await a.send("chan-1", "hi", metadata={"scope_id": "explicit-1"})
+    assert t.sent["metadata"]["scope_id"] == "explicit-1"
+
+
+@pytest.mark.asyncio
+async def test_edit_forwards_scope_platform_without_undocumented_finalize():
+    t = _CaptureTransport()
+    a = RelayAdapter(PlatformConfig(), make_desc(platform="discord"), transport=t)
+    event = _make_event(chat_id="chan-1", scope_id="scope-9")
+    event.source.platform = Platform.DISCORD
+    a._capture_scope(event)
+
+    result = await a.edit_message(
+        "chan-1",
+        "message-7",
+        "complete reply",
+        finalize=True,
+        metadata={"thread_id": "thread-2"},
+    )
+
+    assert result.success is True
+    assert result.message_id == "m1"
+    assert t.sent == {
+        "op": "edit",
+        "chat_id": "chan-1",
+        "message_id": "message-7",
+        "content": "complete reply",
+        "metadata": {"thread_id": "thread-2", "scope_id": "scope-9"},
+    }
+    assert t.sent_platform == "discord"
+
+
+@pytest.mark.asyncio
+async def test_edit_is_rejected_when_descriptor_disables_it():
+    t = _CaptureTransport()
+    a = RelayAdapter(
+        PlatformConfig(),
+        make_desc(platform="discord", supports_edit=False),
+        transport=t,
+    )
+
+    result = await a.edit_message("chan-1", "message-7", "reply")
+
+    assert result.success is False
+    assert result.error == "Not supported"
+    assert t.sent is None
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_does_not_force_terminal_relay_edit():
+    """Unchanged final content needs no unnegotiated lifecycle-closing edit."""
+    from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+    class _HistoryTransport(_CaptureTransport):
+        def __init__(self):
+            super().__init__()
+            self.actions = []
+
+        async def send_outbound(self, action, *, platform=None):
+            self.actions.append(action)
+            return await super().send_outbound(action, platform=platform)
+
+    t = _HistoryTransport()
+    a = RelayAdapter(PlatformConfig(), make_desc(platform="discord"), transport=t)
+    consumer = GatewayStreamConsumer(
+        a,
+        "chan-1",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5, cursor=""),
+    )
+    consumer.on_delta("Hello")
+    consumer.finish()
+
+    await consumer.run()
+
+    assert [action["op"] for action in t.actions] == ["send"]
+    assert t.actions[-1]["content"] == "Hello"
+    assert "finalize" not in t.actions[-1]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/relay/test_relay_going_idle.py
+++ b/tests/gateway/relay/test_relay_going_idle.py
@@ -112,18 +112,21 @@ async def test_go_idle_awaits_ack(server):
 
 
 @pytest.mark.asyncio
-async def test_descriptor_handler_failure_does_not_block_handshake():
-    t = WebSocketRelayTransport("ws://127.0.0.1:1", "discord", "appShared")
-    t._descriptor_ready = asyncio.get_running_loop().create_future()
+async def test_descriptor_handler_failure_does_not_block_handshake(server):
+    """Drive the callback through the production socket reader."""
+    t = WebSocketRelayTransport(server.url, "discord", "appShared")
 
     def broken_handler(_descriptor):
         raise RuntimeError("boom")
 
     t.set_descriptor_handler(broken_handler)
-    await t._handle_frame(json.dumps({"type": "descriptor", "descriptor": DESCRIPTOR}))
-
-    descriptor = await asyncio.wait_for(t.handshake(), timeout=0.1)
-    assert descriptor.supports_edit is True
+    await t.connect()
+    try:
+        descriptor = await asyncio.wait_for(t.handshake(), timeout=1)
+        assert descriptor.supports_edit is True
+        assert t._reader is not None and not t._reader.done()
+    finally:
+        await t.disconnect()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/relay/test_relay_going_idle.py
+++ b/tests/gateway/relay/test_relay_going_idle.py
@@ -15,6 +15,9 @@ import json
 import pytest
 import pytest_asyncio
 
+from gateway.config import PlatformConfig
+from gateway.relay.adapter import RelayAdapter
+from gateway.relay.descriptor import CONTRACT_VERSION, CapabilityDescriptor
 from gateway.relay.ws_transport import WebSocketRelayTransport, WEBSOCKETS_AVAILABLE
 
 pytestmark = pytest.mark.skipif(not WEBSOCKETS_AVAILABLE, reason="websockets not installed")
@@ -170,6 +173,97 @@ async def test_reconnect_redials_after_unexpected_close():
         await t.disconnect()
         srv._server.close()
         await srv._server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_descriptor_refreshes_adapter_capabilities():
+    """A reconnect negotiation must update the live adapter capability surface."""
+    drops = {"n": 0}
+    srv = _IdleAwareServer()
+
+    async def handle(ws):
+        srv.connections += 1
+        async for raw in ws:
+            for line in str(raw).split("\n"):
+                if not line.strip():
+                    continue
+                frame = json.loads(line)
+                if frame.get("type") != "hello":
+                    continue
+                descriptor = dict(DESCRIPTOR)
+                descriptor["supports_edit"] = drops["n"] == 0
+                await ws.send(json.dumps({"type": "descriptor", "descriptor": descriptor}) + "\n")
+                if drops["n"] == 0:
+                    drops["n"] += 1
+                    await ws.close()
+                    return
+
+    srv._server = await websockets.serve(handle, "127.0.0.1", 0)
+    sock = next(iter(srv._server.sockets))
+    srv.url = f"ws://127.0.0.1:{sock.getsockname()[1]}"
+    placeholder = CapabilityDescriptor(
+        contract_version=CONTRACT_VERSION,
+        platform="discord",
+        label="Relay",
+        max_message_length=4096,
+        supports_draft_streaming=False,
+        supports_edit=True,
+        supports_threads=False,
+        markdown_dialect="plain",
+        len_unit="chars",
+    )
+    transport = WebSocketRelayTransport(
+        srv.url, "discord", "appShared", reconnect=True, reconnect_backoff_s=0.05
+    )
+    adapter = RelayAdapter(PlatformConfig(), placeholder, transport=transport)
+    try:
+        await adapter.connect()
+        await asyncio.sleep(0.5)
+        assert srv.connections >= 2
+        assert adapter.SUPPORTS_MESSAGE_EDITING is False
+        assert adapter.REQUIRES_EDIT_FINALIZE is False
+    finally:
+        await adapter.disconnect()
+        srv._server.close()
+        await srv._server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_no_reconnect_after_deliberate_disconnect(server):
+    t = WebSocketRelayTransport(server.url, "discord", "appShared", reconnect=True, reconnect_backoff_s=0.05)
+    await t.connect()
+    await t.handshake()
+    before = server.connections
+    await t.disconnect()
+    await asyncio.sleep(0.3)
+    # A deliberate disconnect must NOT trigger the reconnect loop.
+    assert server.connections == before
+
+
+@pytest.mark.asyncio
+async def test_adapter_emits_going_idle_on_disconnect(server):
+    # The RelayAdapter emits going_idle as part of its existing disconnect (drain)
+    # transition, then tears down the transport.
+    from gateway.config import PlatformConfig
+    from gateway.relay.adapter import RelayAdapter
+    from gateway.relay.descriptor import CONTRACT_VERSION, CapabilityDescriptor
+
+    placeholder = CapabilityDescriptor(
+        contract_version=CONTRACT_VERSION,
+        platform="discord",
+        label="Relay",
+        max_message_length=4096,
+        supports_draft_streaming=False,
+        supports_edit=True,
+        supports_threads=False,
+        markdown_dialect="plain",
+        len_unit="chars",
+    )
+    transport = WebSocketRelayTransport(server.url, "discord", "appShared")
+    adapter = RelayAdapter(PlatformConfig(), placeholder, transport=transport)
+    await adapter.connect()
+    await adapter.disconnect()
+    assert server.going_idle_count == 1
 
 
 # ── scale-to-zero go_dormant() (D12 / F14) ───────────────────────────────────

--- a/tests/gateway/relay/test_relay_going_idle.py
+++ b/tests/gateway/relay/test_relay_going_idle.py
@@ -98,6 +98,54 @@ async def server():
 
 
 @pytest.mark.asyncio
+async def test_go_idle_awaits_ack(server):
+    t = WebSocketRelayTransport(server.url, "discord", "appShared")
+    await t.connect()
+    try:
+        await t.handshake()
+        acked = await t.go_idle(timeout_s=2)
+        assert acked is True
+        assert server.going_idle_count == 1
+        assert any(f["type"] == "going_idle" for f in server.received)
+    finally:
+        await t.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_descriptor_handler_failure_does_not_block_handshake():
+    t = WebSocketRelayTransport("ws://127.0.0.1:1", "discord", "appShared")
+    t._descriptor_ready = asyncio.get_running_loop().create_future()
+
+    def broken_handler(_descriptor):
+        raise RuntimeError("boom")
+
+    t.set_descriptor_handler(broken_handler)
+    await t._handle_frame(json.dumps({"type": "descriptor", "descriptor": DESCRIPTOR}))
+
+    descriptor = await asyncio.wait_for(t.handshake(), timeout=0.1)
+    assert descriptor.supports_edit is True
+
+
+@pytest.mark.asyncio
+async def test_go_idle_returns_false_on_timeout(server):
+    # A server that never acks going_idle -> go_idle returns False (caller closes anyway).
+    async def no_ack(ws, frame):
+        if frame.get("type") == "hello":
+            await ws.send(json.dumps({"type": "descriptor", "descriptor": DESCRIPTOR}) + "\n")
+        # deliberately ignore going_idle
+
+    server._on_frame = no_ack  # type: ignore[assignment]
+    t = WebSocketRelayTransport(server.url, "discord", "appShared")
+    await t.connect()
+    try:
+        await t.handshake()
+        acked = await t.go_idle(timeout_s=0.3)
+        assert acked is False
+    finally:
+        await t.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_buffered_inbound_is_acked_after_handler(server):
     # A buffered delivery (bufferId present) is acked AFTER the handler runs; a
     # live delivery (no bufferId) is not acked.

--- a/tests/gateway/relay/test_ws_transport.py
+++ b/tests/gateway/relay/test_ws_transport.py
@@ -151,6 +151,31 @@ async def test_outbound_round_trips_with_correlation(server):
 
 
 @pytest.mark.asyncio
+async def test_multi_platform_descriptor_callback_only_adopts_primary():
+    """Secondary descriptors stay per-platform and cannot overwrite scalar caps."""
+    t = WebSocketRelayTransport(
+        "ws://127.0.0.1:1",
+        "discord",
+        "appShared",
+        identities=[("discord", "appShared"), ("telegram", "botShared")],
+    )
+    seen = []
+    t.set_descriptor_handler(seen.append)
+
+    primary = dict(DESCRIPTOR, platform="discord", max_message_length=2000)
+    secondary = dict(DESCRIPTOR, platform="telegram", max_message_length=4096)
+    await t._handle_frame(json.dumps({"type": "descriptor", "descriptor": secondary}))
+    await t._handle_frame(json.dumps({"type": "descriptor", "descriptor": primary}))
+
+    assert [descriptor.platform for descriptor in seen] == ["discord"]
+    assert t._descriptor is not None and t._descriptor.platform == "discord"
+    discord = t.descriptor_for_platform("discord")
+    telegram = t.descriptor_for_platform("telegram")
+    assert discord is not None and discord.max_message_length == 2000
+    assert telegram is not None and telegram.max_message_length == 4096
+
+
+@pytest.mark.asyncio
 async def test_edit_outbound_round_trips_with_full_wire_action(server):
     """Prove the edit operation crosses the production WebSocket transport."""
     t = WebSocketRelayTransport(server.url, "discord", "appShared")
@@ -162,7 +187,6 @@ async def test_edit_outbound_round_trips_with_full_wire_action(server):
             "chat_id": "chan1",
             "message_id": "msg1",
             "content": "final text",
-            "finalize": True,
             "metadata": {"scope_id": "guildA"},
         }
         result = await t.send_outbound(action, platform="discord")

--- a/tests/gateway/relay/test_ws_transport.py
+++ b/tests/gateway/relay/test_ws_transport.py
@@ -137,6 +137,95 @@ async def test_inbound_frame_reaches_handler(server):
         await t.disconnect()
 
 
+@pytest.mark.asyncio
+async def test_outbound_round_trips_with_correlation(server):
+    t = WebSocketRelayTransport(server.url, "discord", "appShared")
+    await t.connect()
+    try:
+        await t.handshake()
+        result = await t.send_outbound({"op": "send", "chat_id": "chan1", "content": "hi"})
+        assert result["success"] is True
+        assert result["message_id"] == "srv-send"
+    finally:
+        await t.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_edit_outbound_round_trips_with_full_wire_action(server):
+    """Prove the edit operation crosses the production WebSocket transport."""
+    t = WebSocketRelayTransport(server.url, "discord", "appShared")
+    await t.connect()
+    try:
+        await t.handshake()
+        action = {
+            "op": "edit",
+            "chat_id": "chan1",
+            "message_id": "msg1",
+            "content": "final text",
+            "finalize": True,
+            "metadata": {"scope_id": "guildA"},
+        }
+        result = await t.send_outbound(action, platform="discord")
+
+        assert result == {"success": True, "message_id": "srv-edit"}
+        outbound = next(f for f in server.received if f["type"] == "outbound")
+        assert outbound["action"] == action
+        assert outbound["platform"] == "discord"
+    finally:
+        await t.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_follow_up_round_trips(server):
+    t = WebSocketRelayTransport(server.url, "discord", "appShared")
+    await t.connect()
+    try:
+        await t.handshake()
+        result = await t.send_follow_up(
+            {"op": "follow_up", "session_key": "s1", "kind": "discord.interaction_token", "content": "fu"}
+        )
+        assert result["success"] is True
+        assert result["message_id"] == "srv-follow_up"
+        # The follow_up rode an outbound frame the connector saw.
+        outbound = [f for f in server.received if f["type"] == "outbound"]
+        assert any(f["action"]["op"] == "follow_up" for f in outbound)
+    finally:
+        await t.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_fails_pending_waiters_cleanly(server):
+    t = WebSocketRelayTransport(server.url, "discord", "appShared", outbound_timeout_s=5)
+    await t.connect()
+    await t.handshake()
+    await t.disconnect()
+    # After disconnect, an outbound returns a structured failure rather than hanging.
+    result = await t.send_outbound({"op": "send", "chat_id": "c", "content": "x"})
+    assert result["success"] is False
+
+
+def test_https_url_normalized_to_wss():
+    """The relay URL is configured once as the http(s):// BASE (for the provision
+    POST), but websockets.connect needs ws(s):// and the connector mounts its WS
+    server at /relay. The transport must convert scheme AND ensure the /relay
+    path. Regression for the live staging failures 'scheme isn't ws or wss' then
+    'server rejected WebSocket connection: HTTP 400' (wrong path)."""
+    t = WebSocketRelayTransport("https://connector.example", "discord", "b")
+    assert t._url == "wss://connector.example/relay"
+    t2 = WebSocketRelayTransport("http://connector.local:8080", "discord", "b")
+    assert t2._url == "ws://connector.local:8080/relay"
+
+
+def test_ws_dial_url_idempotent_with_scheme_and_path():
+    # Already ws(s):// and/or already ending in /relay -> unchanged (no double append).
+    t = WebSocketRelayTransport("wss://connector.example/relay", "discord", "b")
+    assert t._url == "wss://connector.example/relay"
+    t2 = WebSocketRelayTransport("https://connector.example/relay/", "discord", "b")
+    assert t2._url == "wss://connector.example/relay"
+    t3 = WebSocketRelayTransport("ws://127.0.0.1:9", "discord", "b")
+    assert t3._url == "ws://127.0.0.1:9/relay"
+
+
 # ── Phase 7 Unit 7d-B: terminal 4401 (opt-out revocation) ────────────────────
 
 

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -74,6 +74,133 @@ def test_active_profile_stamp_resolves_primary_adapter(monkeypatch):
     assert runner._authorization_adapter(Platform.WECOM, profile="dev") is default_adapter
 
 
+def test_adapter_for_source_resolves_secondary_profile_adapter(monkeypatch):
+    """Ingress adapter lookup must use the stamped profile's adapter map."""
+    runner, default_adapter, secondary_adapter = _make_multiplex_runner(monkeypatch)
+
+    source = SessionSource(
+        platform=Platform.WECOM,
+        user_id="attacker",
+        chat_id="dm-chat",
+        user_name="attacker",
+        chat_type="dm",
+        profile="coder",
+    )
+
+    assert runner._adapter_for_source(source) is secondary_adapter
+    assert runner._adapter_for_source(
+        SessionSource(
+            platform=Platform.WECOM,
+            user_id="allowed-user",
+            chat_id="dm-chat",
+            user_name="allowed-user",
+            chat_type="dm",
+            profile=None,
+        )
+    ) is default_adapter
+
+
+def test_chat_routed_source_keeps_receiving_shared_adapter(monkeypatch):
+    """A runtime-only profile route must not discard the shared transport.
+
+    ``source.profile`` selects the routed runtime/session namespace, but the
+    adapter that built the source still owns outbound delivery and intake
+    policy when that profile has no credential of its own.
+    """
+    runner, default_adapter, _secondary_adapter = _make_multiplex_runner(
+        monkeypatch
+    )
+    runner._profile_adapters["routed"] = {}
+
+    source = SessionSource(
+        platform=Platform.WECOM,
+        user_id="allowed-user",
+        chat_id="dm-chat",
+        user_name="allowed-user",
+        chat_type="dm",
+        profile="routed",
+    )
+    assert runner._adapter_for_source(source) is None
+    source._transport_adapter_ref = lambda: default_adapter
+    assert runner._adapter_for_source(source) is default_adapter
+    assert runner._is_user_authorized(source) is True
+
+
+def test_adapter_for_relay_delivered_source_uses_relay_transport(monkeypatch):
+    """A relayed Slack event keeps Slack session semantics but replies over relay."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    slack_adapter = SimpleNamespace(send=AsyncMock())
+    relay_adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters = {
+        Platform.SLACK: slack_adapter,
+        Platform.RELAY: relay_adapter,
+    }
+    runner._profile_adapters = {}
+
+    source = SessionSource(
+        platform=Platform.SLACK,
+        user_id="U123",
+        chat_id="C123",
+        chat_type="channel",
+        profile="coder",
+        delivered_via_upstream_relay=True,
+    )
+
+    assert runner._adapter_for_source(source) is relay_adapter
+
+
+def test_adapter_for_direct_source_keeps_native_platform_adapter(monkeypatch):
+    """The relay routing rule must not affect direct Slack connector delivery."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    slack_adapter = SimpleNamespace(send=AsyncMock())
+    relay_adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters = {
+        Platform.SLACK: slack_adapter,
+        Platform.RELAY: relay_adapter,
+    }
+    runner._profile_adapters = {}
+
+    source = SessionSource(
+        platform=Platform.SLACK,
+        user_id="U123",
+        chat_id="C123",
+        chat_type="channel",
+    )
+
+    assert runner._adapter_for_source(source) is slack_adapter
+
+
+def test_explicit_active_profile_stamp_uses_default_adapter_map(monkeypatch):
+    """A named active profile is not misclassified as multiplex secondary."""
+    runner, default_adapter, _secondary_adapter = _make_multiplex_runner(monkeypatch)
+    runner._active_profile_name = lambda: "main"
+
+    assert runner._authorization_adapter(Platform.WECOM, profile="main") is default_adapter
+
+
+
+def test_adapter_for_relay_delivered_secondary_profile_uses_shared_relay(monkeypatch):
+    """Relay is process-level ingress, not duplicated in secondary registries."""
+    runner, _default_adapter, _secondary_adapter = _make_multiplex_runner(monkeypatch)
+    relay_adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters[Platform.RELAY] = relay_adapter
+
+    relayed = SessionSource(
+        platform=Platform.WECOM,
+        user_id="allowed-user",
+        chat_id="dm-chat",
+        chat_type="dm",
+        profile="coder",
+        delivered_via_upstream_relay=True,
+    )
+
+    assert runner._adapter_for_source(relayed) is relay_adapter
+
+
 def test_secondary_allowlist_dm_behavior_ignores_unauthorized(monkeypatch):
     """Unauthorized-DM behavior must read the secondary adapter's dm_policy."""
     runner, _default_adapter, secondary_adapter = _make_multiplex_runner(monkeypatch)


### PR DESCRIPTION
## Summary

- resolve relay-delivered sources to the live `Platform.RELAY` response adapter while preserving the underlying platform on `SessionSource`
- project negotiated `supports_edit` onto the stream-consumer capability surface and forward relay `edit` actions with routing metadata and explicit finalization
- cover direct-vs-relay lookup, disabled editing, wire payloads, and the real send → forced-finalize stream lifecycle

Closes #67669

## Failing-first proof

Before the implementation, the new focused regression set produced **3 failures / 1 pass**:

- relay-stamped source still resolved the underlying direct adapter
- `RelayAdapter` exposed no `SUPPORTS_MESSAGE_EDITING`
- inherited `edit_message()` rejected routing metadata and never emitted an edit action
- descriptor-disabled editing already returned the base unsupported result

## Verification

- `pytest -q tests/gateway/relay tests/gateway/test_relay_upstream_authz.py tests/gateway/test_relay_capability_surface.py tests/gateway/test_multiplex_profile_authz.py` — **206 passed**
- `ruff check` on all four changed files — passed
- `git diff --check` — passed
- cached-diff secret scan — clean

The canonical full-suite wrapper could not provide a clean repository-wide signal in this checkout: `.venv` exists without pytest, so `scripts/run_tests.sh` selected it and collected zero tests. Re-running the hermetic parallel runner explicitly with the working `venv` executed the repository suite but reported 55 failures across 20 unrelated files (platform/host/network-sensitive areas); the focused relay/authz suite above remains green.