### PR TITLE
feat(kanban): add transactional external worker lifecycle

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1147,7 +1147,7 @@ def _cmd_boards_rm(args: argparse.Namespace) -> int:
     force_delete = getattr(args, "delete", False) or getattr(args, "boards_action", "") == "delete"
     try:
         res = kb.remove_board(args.slug, archive=not force_delete)
-    except ValueError as exc:
+    except (ValueError, kb.ExternalTaskConflict) as exc:
         print(f"kanban boards rm: {exc}", file=sys.stderr)
         return 1
     if res["action"] == "archived":

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -101,6 +101,8 @@ _log = logging.getLogger(__name__)
 
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
+WORKER_KIND_EXTERNAL_MAS = "external-mas"
+EXTERNAL_SPEC_ATTACHMENT_NAME = "mas-task-spec.v1.json"
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
 # worker (or human) means by "blocked", so each can be routed differently
@@ -122,7 +124,10 @@ VALID_INITIAL_STATUSES = {"running", "blocked"}
 # ``BLOCK_RECURRENCE_LIMIT``) escalates them to ``triage`` if a cron keeps
 # unblocking them only to have the worker re-block for the same reason.
 # ``None`` = legacy/un-typed block (treated as a generic human blocker).
-VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
+VALID_BLOCK_KINDS = {
+    "dependency", "needs_input", "capability", "transient",
+    "review-required", "environment-error",
+}
 
 # After a task has been blocked, unblocked, and re-blocked this many times for
 # the same (truly-blocked) reason, the unblock-loop breaker stops trusting the
@@ -136,6 +141,31 @@ VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
 KANBAN_ATTACHMENT_MAX_BYTES = 25 * 1024 * 1024
+
+
+class ExternalTaskConflict(RuntimeError):
+    """A native mutation conflicts with external-worker ownership."""
+
+    def __init__(
+        self,
+        code: str,
+        task_id: str,
+        operation: str,
+        *,
+        run_id: Optional[int] = None,
+    ) -> None:
+        self.code = code
+        self.task_id = task_id
+        self.operation = operation
+        self.run_id = run_id
+        detail = f"{operation} refused for external task {task_id}: {code}"
+        if run_id is not None:
+            detail += f" (run_id={run_id})"
+        super().__init__(detail)
+
+
+class StaleBoardConnection(RuntimeError):
+    """A connection outlived archive/replacement of its board database."""
 
 
 def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None:
@@ -590,6 +620,37 @@ def attachments_root(board: Optional[str] = None) -> Path:
     return board_dir(slug) / "attachments"
 
 
+def _connection_db_path(conn: sqlite3.Connection) -> Optional[Path]:
+    """Return the resolved path backing ``conn``'s main database.
+
+    ``None`` is returned for in-memory/unnamed databases.  Callers that need
+    board-scoped filesystem state must derive it from the connected database,
+    not from the mutable current-board pointer.
+    """
+    rows = conn.execute("PRAGMA database_list").fetchall()
+    for row in rows:
+        name = row[1]
+        if name != "main":
+            continue
+        raw = row[2]
+        return Path(raw).resolve() if raw else None
+    return None
+
+
+def attachments_root_for_connection(conn: sqlite3.Connection) -> Path:
+    """Return the attachment root for the board backing ``conn``."""
+    override = os.environ.get("HERMES_KANBAN_ATTACHMENTS_ROOT", "").strip()
+    if override:
+        return Path(override).expanduser()
+    db_path = _connection_db_path(conn)
+    if db_path is None:
+        raise RuntimeError("filesystem attachments require a file-backed kanban DB")
+    default_db = (kanban_home() / "kanban.db").resolve()
+    if db_path == default_db:
+        return kanban_home() / "kanban" / "attachments"
+    return db_path.parent / "attachments"
+
+
 def task_attachments_dir(task_id: str, board: Optional[str] = None) -> Path:
     """Return the per-task attachment directory ``<root>/<task_id>/``."""
     return attachments_root(board=board) / task_id
@@ -802,32 +863,52 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
     if normed == DEFAULT_BOARD:
         raise ValueError("the 'default' board cannot be removed")
     d = board_dir(normed)
-    if not d.exists():
-        raise ValueError(f"board {normed!r} does not exist")
+    db_path = d / "kanban.db"
+    with _board_lifecycle_lock(db_path):
+        if not d.exists():
+            raise ValueError(f"board {normed!r} does not exist")
 
-    # If the user removed the currently-active board, revert to default.
-    if get_current_board() == normed:
-        clear_current_board()
+        if db_path.exists():
+            conn = connect(db_path=db_path)
+            try:
+                active = conn.execute(
+                    "SELECT id, task_id FROM task_runs "
+                    "WHERE worker_kind = ? AND ended_at IS NULL "
+                    "ORDER BY id LIMIT 1",
+                    (WORKER_KIND_EXTERNAL_MAS,),
+                ).fetchone()
+            finally:
+                conn.close()
+            if active is not None:
+                raise ExternalTaskConflict(
+                    "external_run_active",
+                    active["task_id"],
+                    "remove_board",
+                    run_id=int(active["id"]),
+                )
 
-    # A concurrent connect(board=normed) after the rename/delete recreates
-    # an empty sqlite file via mkdir(exist_ok=True); the cache entry must be
-    # dropped first so the schema init pass re-runs on that fresh file.
-    _INITIALIZED_PATHS.discard(str((d / "kanban.db").resolve()))
+        # If the user removed the currently-active board, revert to default.
+        if get_current_board() == normed:
+            clear_current_board()
 
-    if archive:
-        archive_root = boards_root() / "_archived"
-        archive_root.mkdir(parents=True, exist_ok=True)
-        ts = int(time.time())
-        target = archive_root / f"{normed}-{ts}"
-        # Avoid collision on rapid double-archives.
-        suffix = 1
-        while target.exists():
-            target = archive_root / f"{normed}-{ts}-{suffix}"
-            suffix += 1
-        d.rename(target)
-        return {"slug": normed, "action": "archived", "new_path": str(target)}
-    else:
-        import shutil
+        # A concurrent connect(board=normed) after the rename/delete recreates
+        # an empty sqlite file via mkdir(exist_ok=True); the cache entry must be
+        # dropped first so the schema init pass re-runs on that fresh file.
+        _INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+        if archive:
+            archive_root = boards_root() / "_archived"
+            archive_root.mkdir(parents=True, exist_ok=True)
+            ts = int(time.time())
+            target = archive_root / f"{normed}-{ts}"
+            # Avoid collision on rapid double-archives.
+            suffix = 1
+            while target.exists():
+                target = archive_root / f"{normed}-{ts}-{suffix}"
+                suffix += 1
+            d.rename(target)
+            return {"slug": normed, "action": "archived", "new_path": str(target)}
+
         shutil.rmtree(d)
         return {"slug": normed, "action": "deleted", "new_path": ""}
 
@@ -915,6 +996,10 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    external_spec_attachment_id: Optional[int] = None
+    external_spec_hash: Optional[str] = None
+    external_spec_schema: Optional[str] = None
+    external_spec_locked_at: Optional[int] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -999,6 +1084,26 @@ class Task:
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
             ),
+            external_spec_attachment_id=(
+                int(row["external_spec_attachment_id"])
+                if "external_spec_attachment_id" in keys
+                and row["external_spec_attachment_id"] is not None
+                else None
+            ),
+            external_spec_hash=(
+                row["external_spec_hash"]
+                if "external_spec_hash" in keys else None
+            ),
+            external_spec_schema=(
+                row["external_spec_schema"]
+                if "external_spec_schema" in keys else None
+            ),
+            external_spec_locked_at=(
+                int(row["external_spec_locked_at"])
+                if "external_spec_locked_at" in keys
+                and row["external_spec_locked_at"] is not None
+                else None
+            ),
         )
 
 
@@ -1077,6 +1182,7 @@ class Attachment:
     size: int
     uploaded_by: Optional[str]
     created_at: int
+    spec_hash: Optional[str] = None
 
 
 @dataclass
@@ -1176,7 +1282,12 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Immutable identity accepted by kanban_external_worker.submit().
+    external_spec_attachment_id INTEGER,
+    external_spec_hash     TEXT,
+    external_spec_schema   TEXT,
+    external_spec_locked_at INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1228,7 +1339,24 @@ CREATE TABLE IF NOT EXISTS task_runs (
     --          gave_up | reclaimed | (null while still running)
     summary             TEXT,
     metadata            TEXT,
-    error               TEXT
+    error               TEXT,
+    -- External-worker lease, process, spec, and terminal-result identity.
+    worker_kind                TEXT,
+    external_host              TEXT,
+    external_pid               INTEGER,
+    external_pgid              INTEGER,
+    external_start_token       TEXT,
+    external_spec_attachment_id INTEGER,
+    external_spec_hash         TEXT,
+    external_spec_schema       TEXT,
+    external_attempt           INTEGER NOT NULL DEFAULT 1,
+    external_substate          TEXT,
+    external_lease_state       TEXT,
+    external_recovery_count    INTEGER NOT NULL DEFAULT 0,
+    external_terminal_disposition TEXT,
+    external_block_kind        TEXT,
+    external_result_hash       TEXT,
+    external_result_json       TEXT
 );
 
 -- Files attached to a task (PDFs, images, source documents). The blob
@@ -1245,8 +1373,31 @@ CREATE TABLE IF NOT EXISTS task_attachments (
     content_type TEXT,
     size         INTEGER NOT NULL DEFAULT 0,
     uploaded_by  TEXT,
-    created_at   INTEGER NOT NULL
+    created_at   INTEGER NOT NULL,
+    spec_hash    TEXT
 );
+
+CREATE TABLE IF NOT EXISTS task_external_artifacts (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id       INTEGER NOT NULL,
+    task_id      TEXT NOT NULL,
+    name         TEXT NOT NULL,
+    stored_path  TEXT NOT NULL,
+    content_type TEXT,
+    size         INTEGER NOT NULL DEFAULT 0,
+    sha256       TEXT NOT NULL,
+    created_at   INTEGER NOT NULL,
+    UNIQUE (run_id, name)
+);
+
+-- Stable database generation used to invalidate connections that outlive a
+-- named board archive/delete and would otherwise keep writing the moved inode.
+CREATE TABLE IF NOT EXISTS kanban_board_identity (
+    singleton  INTEGER PRIMARY KEY CHECK (singleton = 1),
+    generation TEXT NOT NULL
+);
+INSERT OR IGNORE INTO kanban_board_identity (singleton, generation)
+VALUES (1, lower(hex(randomblob(16))));
 
 -- Subscription from a gateway source (platform + chat + thread) to a
 -- task. The gateway's kanban-notifier watcher tails task_events and
@@ -1274,6 +1425,7 @@ CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, start
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_attachments_task      ON task_attachments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
+CREATE INDEX IF NOT EXISTS idx_external_artifacts_run ON task_external_artifacts(run_id, name);
 """
 
 
@@ -1283,6 +1435,7 @@ CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_
 
 _INITIALIZED_PATHS: set[str] = set()
 _INIT_LOCK = threading.RLock()
+_BOARD_LIFECYCLE_THREAD_LOCK = threading.RLock()
 _SQLITE_HEADER = b"SQLite format 3\x00"
 DEFAULT_BUSY_TIMEOUT_MS = 120_000
 
@@ -1293,6 +1446,130 @@ DEFAULT_BUSY_TIMEOUT_MS = 120_000
 # lock (the in-process _INIT_LOCK + idempotent init remain the backstop).
 _INIT_LOCK_TIMEOUT_SECONDS = 10.0
 _INIT_LOCK_POLL_SECONDS = 0.05
+
+
+@contextlib.contextmanager
+def _board_lifecycle_lock(db_path: Optional[Path]):
+    """Serialize external claims with archive/delete of the same board.
+
+    The lock lives outside named board directories so it remains stable while
+    a board directory is renamed or removed.  Unlike the schema-init lock this
+    lock fails closed on timeout: proceeding would permit a live external run
+    to become detached from the visible board.
+    """
+    if db_path is None:
+        yield
+        return
+    resolved = db_path.resolve()
+    digest = hashlib.sha256(str(resolved).encode("utf-8")).hexdigest()
+    lock_path = kanban_home() / "kanban" / ".board-locks" / f"{digest}.lock"
+    with _BOARD_LIFECYCLE_THREAD_LOCK:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = lock_path.open("a+b")
+        acquired = False
+        try:
+            if _IS_WINDOWS and handle.seek(0, os.SEEK_END) == 0:
+                handle.write(b"\0")
+                handle.flush()
+            deadline = time.monotonic() + _INIT_LOCK_TIMEOUT_SECONDS
+            if _IS_WINDOWS:
+                import msvcrt
+
+                locking = getattr(msvcrt, "locking")
+                nb_lock = getattr(msvcrt, "LK_NBLCK")
+                while True:
+                    try:
+                        handle.seek(0)
+                        locking(handle.fileno(), nb_lock, 1)
+                        acquired = True
+                        break
+                    except OSError:
+                        if time.monotonic() >= deadline:
+                            break
+                        time.sleep(_INIT_LOCK_POLL_SECONDS)
+            else:
+                import fcntl
+
+                while True:
+                    try:
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                        acquired = True
+                        break
+                    except (BlockingIOError, OSError):
+                        if time.monotonic() >= deadline:
+                            break
+                        time.sleep(_INIT_LOCK_POLL_SECONDS)
+            if not acquired:
+                raise RuntimeError(
+                    f"kanban board lifecycle lock timed out for {resolved}"
+                )
+            yield
+        finally:
+            try:
+                if acquired:
+                    if _IS_WINDOWS:
+                        import msvcrt
+
+                        handle.seek(0)
+                        getattr(msvcrt, "locking")(
+                            handle.fileno(), getattr(msvcrt, "LK_UNLCK"), 1
+                        )
+                    else:
+                        import fcntl
+
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            finally:
+                handle.close()
+
+
+def _assert_connection_matches_live_board(conn: sqlite3.Connection) -> None:
+    """Fail closed when ``conn`` no longer backs the live DB at its path."""
+    db_path = _connection_db_path(conn)
+    if db_path is None:
+        return
+    try:
+        connection_row = conn.execute(
+            "SELECT generation FROM kanban_board_identity WHERE singleton = 1"
+        ).fetchone()
+    except sqlite3.DatabaseError as exc:
+        raise StaleBoardConnection(
+            "kanban connection has no board generation"
+        ) from exc
+    if connection_row is None or not db_path.is_file():
+        raise StaleBoardConnection(
+            f"kanban connection points to a removed board: {db_path}"
+        )
+
+    probe = None
+    try:
+        probe = sqlite3.connect(
+            f"{db_path.as_uri()}?mode=ro",
+            uri=True,
+            timeout=_resolve_busy_timeout_ms() / 1000.0,
+        )
+        disk_row = probe.execute(
+            "SELECT generation FROM kanban_board_identity WHERE singleton = 1"
+        ).fetchone()
+    except (OSError, sqlite3.DatabaseError) as exc:
+        raise StaleBoardConnection(
+            f"kanban board is no longer live at {db_path}"
+        ) from exc
+    finally:
+        if probe is not None:
+            probe.close()
+    if disk_row is None or disk_row[0] != connection_row[0]:
+        raise StaleBoardConnection(
+            f"kanban connection generation is stale for {db_path}"
+        )
+
+
+@contextlib.contextmanager
+def _board_lifecycle_write_txn(conn: sqlite3.Connection):
+    """Write transaction that cannot target an archived/replaced board."""
+    with _board_lifecycle_lock(_connection_db_path(conn)):
+        _assert_connection_matches_live_board(conn)
+        with write_txn(conn):
+            yield
 
 
 def _resolve_busy_timeout_ms() -> int:
@@ -2028,6 +2305,72 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
                 conn, "kanban_notify_subs", "notifier_profile", "notifier_profile TEXT"
             )
 
+    # External-worker columns are additive so existing boards retain their
+    # native behavior until an external spec is explicitly submitted.
+    task_external_columns = {
+        "external_spec_attachment_id": "external_spec_attachment_id INTEGER",
+        "external_spec_hash": "external_spec_hash TEXT",
+        "external_spec_schema": "external_spec_schema TEXT",
+        "external_spec_locked_at": "external_spec_locked_at INTEGER",
+    }
+    cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
+    for name, definition in task_external_columns.items():
+        if name not in cols:
+            _add_column_if_missing(conn, "tasks", name, definition)
+
+    run_external_columns = {
+        "worker_kind": "worker_kind TEXT",
+        "external_host": "external_host TEXT",
+        "external_pid": "external_pid INTEGER",
+        "external_pgid": "external_pgid INTEGER",
+        "external_start_token": "external_start_token TEXT",
+        "external_spec_attachment_id": "external_spec_attachment_id INTEGER",
+        "external_spec_hash": "external_spec_hash TEXT",
+        "external_spec_schema": "external_spec_schema TEXT",
+        "external_attempt": "external_attempt INTEGER NOT NULL DEFAULT 1",
+        "external_substate": "external_substate TEXT",
+        "external_lease_state": "external_lease_state TEXT",
+        "external_recovery_count": (
+            "external_recovery_count INTEGER NOT NULL DEFAULT 0"
+        ),
+        "external_terminal_disposition": "external_terminal_disposition TEXT",
+        "external_block_kind": "external_block_kind TEXT",
+        "external_result_hash": "external_result_hash TEXT",
+        "external_result_json": "external_result_json TEXT",
+    }
+    run_table_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='task_runs'"
+    ).fetchone() is not None
+    if run_table_exists:
+        run_cols = {
+            row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")
+        }
+        for name, definition in run_external_columns.items():
+            if name not in run_cols:
+                _add_column_if_missing(conn, "task_runs", name, definition)
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_runs_worker_kind "
+            "ON task_runs(worker_kind, task_id)"
+        )
+
+    attachment_table_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master "
+        "WHERE type='table' AND name='task_attachments'"
+    ).fetchone() is not None
+    if attachment_table_exists:
+        attachment_cols = {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info(task_attachments)")
+        }
+        if "spec_hash" not in attachment_cols:
+            _add_column_if_missing(
+                conn, "task_attachments", "spec_hash", "spec_hash TEXT"
+            )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_external_spec "
+        "ON tasks(external_spec_hash)"
+    )
+
     # One-shot backfill: any task that is 'running' before runs existed
     # had its claim_lock / claim_expires / worker_pid on the task row.
     # Synthesize a matching task_runs row so subsequent end-run / heartbeat
@@ -2140,10 +2483,20 @@ _REBUILD_SPECS = {
         " worker_pid INTEGER, max_runtime_seconds INTEGER,"
         " last_heartbeat_at INTEGER, started_at INTEGER NOT NULL,"
         " ended_at INTEGER, outcome TEXT, summary TEXT, metadata TEXT,"
-        " error TEXT)",
+        " error TEXT, worker_kind TEXT, external_host TEXT,"
+        " external_pid INTEGER, external_pgid INTEGER,"
+        " external_start_token TEXT, external_spec_attachment_id INTEGER,"
+        " external_spec_hash TEXT, external_spec_schema TEXT,"
+        " external_attempt INTEGER NOT NULL DEFAULT 1,"
+        " external_substate TEXT, external_lease_state TEXT,"
+        " external_recovery_count INTEGER NOT NULL DEFAULT 0,"
+        " external_terminal_disposition TEXT, external_block_kind TEXT,"
+        " external_result_hash TEXT, external_result_json TEXT)",
         (
             "CREATE INDEX idx_runs_task ON task_runs(task_id, started_at)",
             "CREATE INDEX idx_runs_status ON task_runs(status)",
+            "CREATE INDEX idx_runs_worker_kind "
+            "ON task_runs(worker_kind, task_id)",
         ),
     ),
     "kanban_notify_subs": (
@@ -2782,6 +3135,7 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
     """
     profile = _canonical_assignee(profile)
     with write_txn(conn):
+        _assert_no_open_external_run(conn, task_id, "assign_task")
         row = conn.execute(
             "SELECT status, claim_lock, assignee FROM tasks WHERE id = ?", (task_id,)
         ).fetchone()
@@ -2818,6 +3172,7 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
         missing = _find_missing_parents(conn, [parent_id, child_id])
         if missing:
             raise ValueError(f"unknown task(s): {', '.join(missing)}")
+        _assert_no_open_external_run(conn, child_id, "link_tasks")
         if _would_cycle(conn, parent_id, child_id):
             raise ValueError(
                 f"linking {parent_id} -> {child_id} would create a cycle"
@@ -2866,6 +3221,7 @@ def _would_cycle(conn: sqlite3.Connection, parent_id: str, child_id: str) -> boo
 
 def unlink_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> bool:
     with write_txn(conn):
+        _assert_no_open_external_run(conn, child_id, "unlink_tasks")
         cur = conn.execute(
             "DELETE FROM task_links WHERE parent_id = ? AND child_id = ?",
             (parent_id, child_id),
@@ -3100,6 +3456,13 @@ def add_attachment(
             "SELECT 1 FROM tasks WHERE id = ?", (task_id,)
         ).fetchone():
             raise ValueError(f"unknown task {task_id}")
+        if (
+            filename.strip() == EXTERNAL_SPEC_ATTACHMENT_NAME
+            and task_is_external(conn, task_id)
+        ):
+            raise ExternalTaskConflict(
+                "external_spec_locked", task_id, "add_attachment"
+            )
         cur = conn.execute(
             "INSERT INTO task_attachments "
             "(task_id, filename, stored_path, content_type, size, uploaded_by, created_at) "
@@ -3138,6 +3501,7 @@ def list_attachments(conn: sqlite3.Connection, task_id: str) -> list[Attachment]
             size=r["size"] or 0,
             uploaded_by=r["uploaded_by"],
             created_at=r["created_at"],
+            spec_hash=(r["spec_hash"] if "spec_hash" in r.keys() else None),
         )
         for r in rows
     ]
@@ -3158,6 +3522,7 @@ def get_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[Att
         size=r["size"] or 0,
         uploaded_by=r["uploaded_by"],
         created_at=r["created_at"],
+        spec_hash=(r["spec_hash"] if "spec_hash" in r.keys() else None),
     )
 
 
@@ -3172,6 +3537,10 @@ def delete_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[
         att = get_attachment(conn, attachment_id)
         if att is None:
             return None
+        if att.spec_hash is not None:
+            raise ExternalTaskConflict(
+                "external_spec_locked", att.task_id, "delete_attachment"
+            )
         conn.execute("DELETE FROM task_attachments WHERE id = ?", (attachment_id,))
         _append_event(
             conn, att.task_id, "attachment_removed", {"filename": att.filename}
@@ -3252,6 +3621,7 @@ def _end_run(
     existed (e.g. a CLI user calling ``hermes kanban complete`` on a
     task that was never claimed).
     """
+    _assert_no_open_external_run(conn, task_id, "_end_run")
     now = int(time.time())
     row = conn.execute(
         "SELECT current_run_id FROM tasks WHERE id = ?", (task_id,),
@@ -3371,10 +3741,10 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
       finish, transient infra error clears).
 
     The cheapest signal that distinguishes the two is the most recent
-    ``"blocked"`` / ``"unblocked"`` event for the task.  If the most
-    recent one is ``"blocked"`` (or there is a ``"blocked"`` event and
-    no ``"unblocked"`` event has fired since), the task is sticky and
-    ``recompute_ready`` must *not* auto-promote it.
+    ``"blocked"`` / external-finalize / ``"unblocked"`` event for the task.
+    If the most recent one is a block (or no ``"unblocked"`` event has fired
+    since), the task is sticky and ``recompute_ready`` must *not* auto-promote
+    it.
 
     Returns ``False`` when there is no such event at all (e.g. the task
     was set to ``status='blocked'`` by the circuit breaker or by direct
@@ -3383,11 +3753,66 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     """
     row = conn.execute(
         "SELECT kind FROM task_events "
-        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
+        "WHERE task_id = ? "
+        "AND kind IN ('blocked', 'external_finalized_block', 'unblocked') "
         "ORDER BY id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
-    return bool(row) and row["kind"] == "blocked"
+    return bool(row) and row["kind"] in {"blocked", "external_finalized_block"}
+
+
+def _recompute_ready_in_txn(
+    conn: sqlite3.Connection, failure_limit: int = None,
+) -> int:
+    """Transaction-internal implementation of :func:`recompute_ready`."""
+    if failure_limit is None:
+        failure_limit = DEFAULT_FAILURE_LIMIT
+    promoted = 0
+    todo_rows = conn.execute(
+        "SELECT id, status, consecutive_failures, max_retries "
+        "FROM tasks WHERE status IN ('todo', 'blocked') "
+        "AND NOT EXISTS ("
+        "    SELECT 1 FROM task_runs r WHERE r.task_id = tasks.id "
+        "    AND r.worker_kind = ? AND r.ended_at IS NULL"
+        ")",
+        (WORKER_KIND_EXTERNAL_MAS,),
+    ).fetchall()
+    for row in todo_rows:
+        task_id = row["id"]
+        cur_status = row["status"]
+        if cur_status == "blocked" and _has_sticky_block(conn, task_id):
+            continue
+        parents = conn.execute(
+            "SELECT t.status FROM tasks t "
+            "JOIN task_links l ON l.parent_id = t.id "
+            "WHERE l.child_id = ?",
+            (task_id,),
+        ).fetchall()
+        if all(p["status"] in ("done", "archived") for p in parents):
+            if cur_status == "blocked":
+                failures = int(row["consecutive_failures"] or 0)
+                task_limit = row["max_retries"]
+                effective_limit = (
+                    int(task_limit) if task_limit is not None
+                    else int(failure_limit)
+                )
+                if failures >= effective_limit:
+                    continue
+                cur = conn.execute(
+                    "UPDATE tasks SET status = 'ready' "
+                    "WHERE id = ? AND status = 'blocked'",
+                    (task_id,),
+                )
+            else:
+                cur = conn.execute(
+                    "UPDATE tasks SET status = 'ready' "
+                    "WHERE id = ? AND status = 'todo'",
+                    (task_id,),
+                )
+            if cur.rowcount == 1:
+                _append_event(conn, task_id, "promoted", None)
+                promoted += 1
+    return promoted
 
 
 def recompute_ready(
@@ -3421,60 +3846,55 @@ def recompute_ready(
          ``kanban.failure_limit`` config value through ``dispatch_once``)
       3. ``DEFAULT_FAILURE_LIMIT``
     """
-    if failure_limit is None:
-        failure_limit = DEFAULT_FAILURE_LIMIT
-    promoted = 0
     with write_txn(conn):
-        todo_rows = conn.execute(
-            "SELECT id, status, consecutive_failures, max_retries "
-            "FROM tasks WHERE status IN ('todo', 'blocked')"
-        ).fetchall()
-        for row in todo_rows:
-            task_id = row["id"]
-            cur_status = row["status"]
-            if cur_status == "blocked" and _has_sticky_block(conn, task_id):
-                # Worker / operator asked for human review — do not
-                # silently auto-recover.  ``unblock_task`` is the only
-                # legitimate exit (it emits ``"unblocked"`` which flips
-                # this predicate back).
-                continue
-            parents = conn.execute(
-                "SELECT t.status FROM tasks t "
-                "JOIN task_links l ON l.parent_id = t.id "
-                "WHERE l.child_id = ?",
-                (task_id,),
-            ).fetchall()
-            if all(p["status"] in ("done", "archived") for p in parents):
-                if cur_status == "blocked":
-                    # Don't auto-recover tasks that have hit the
-                    # circuit-breaker failure limit.  Without this
-                    # guard, a task that repeatedly exhausts its
-                    # iteration budget would cycle forever:
-                    # block → auto-recover → respawn → budget
-                    # exhausted → block → …  The counter must also
-                    # be preserved so the breaker can accumulate
-                    # across recovery cycles.
-                    failures = int(row["consecutive_failures"] or 0)
-                    task_limit = row["max_retries"]
-                    effective_limit = (
-                        int(task_limit) if task_limit is not None
-                        else int(failure_limit)
-                    )
-                    if failures >= effective_limit:
-                        continue
-                    conn.execute(
-                        "UPDATE tasks SET status = 'ready' "
-                        "WHERE id = ? AND status = 'blocked'",
-                        (task_id,),
-                    )
-                else:
-                    conn.execute(
-                        "UPDATE tasks SET status = 'ready' WHERE id = ? AND status = 'todo'",
-                        (task_id,),
-                    )
-                _append_event(conn, task_id, "promoted", None)
-                promoted += 1
-    return promoted
+        return _recompute_ready_in_txn(conn, failure_limit)
+
+
+# ---------------------------------------------------------------------------
+# External-worker ownership guards
+# ---------------------------------------------------------------------------
+
+def _open_external_run_id(
+    conn: sqlite3.Connection, task_id: str
+) -> Optional[int]:
+    """Return an open external run without trusting mutable task state."""
+    row = conn.execute(
+        "SELECT id FROM task_runs "
+        "WHERE task_id = ? AND worker_kind = ? AND ended_at IS NULL "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id, WORKER_KIND_EXTERNAL_MAS),
+    ).fetchone()
+    return int(row["id"]) if row is not None else None
+
+
+def _assert_no_open_external_run(
+    conn: sqlite3.Connection, task_id: str, operation: str
+) -> None:
+    run_id = _open_external_run_id(conn, task_id)
+    if run_id is not None:
+        raise ExternalTaskConflict(
+            "external_run_active", task_id, operation, run_id=run_id
+        )
+
+
+def task_is_external(conn: sqlite3.Connection, task_id: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM tasks "
+        "WHERE id = ? AND external_spec_hash IS NOT NULL",
+        (task_id,),
+    ).fetchone()
+    return row is not None
+
+
+def _assert_native_claimable(conn: sqlite3.Connection, task_id: str) -> None:
+    if not task_is_external(conn, task_id):
+        return
+    run_id = _open_external_run_id(conn, task_id)
+    if run_id is not None:
+        raise ExternalTaskConflict(
+            "external_run_active", task_id, "claim_task", run_id=run_id
+        )
+    raise ExternalTaskConflict("external_spec_locked", task_id, "claim_task")
 
 
 # ---------------------------------------------------------------------------
@@ -3497,6 +3917,7 @@ def claim_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        _assert_native_claimable(conn, task_id)
         # Structural invariant: never transition ready -> running while any
         # parent is not yet 'done'. This is the single enforcement point
         # regardless of which writer (create_task, link_tasks, unblock_task,
@@ -3626,6 +4047,7 @@ def claim_review_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        _assert_native_claimable(conn, task_id)
         cur = conn.execute(
             """
             UPDATE tasks
@@ -3693,6 +4115,7 @@ def heartbeat_claim(
     expires = int(time.time()) + _resolve_claim_ttl_seconds(ttl_seconds)
     lock = claimer or _claimer_id()
     with write_txn(conn):
+        _assert_no_open_external_run(conn, task_id, "heartbeat_claim")
         cur = conn.execute(
             "UPDATE tasks SET claim_expires = ? "
             "WHERE id = ? AND status = 'running' AND claim_lock = ?",
@@ -3746,8 +4169,12 @@ def release_stale_claims(
         "SELECT id, claim_lock, worker_pid, claim_expires, last_heartbeat_at "
         "FROM tasks "
         "WHERE status = 'running' AND claim_expires IS NOT NULL "
-        "  AND claim_expires < ?",
-        (now,),
+        "  AND claim_expires < ? "
+        "  AND NOT EXISTS ("
+        "      SELECT 1 FROM task_runs r WHERE r.task_id = tasks.id "
+        "      AND r.worker_kind = ? AND r.ended_at IS NULL"
+        "  )",
+        (now, WORKER_KIND_EXTERNAL_MAS),
     ).fetchall()
     for row in stale:
         lock = row["claim_lock"] or ""
@@ -3769,6 +4196,8 @@ def release_stale_claims(
         ):
             new_expires = now + _resolve_claim_ttl_seconds()
             with write_txn(conn):
+                if _open_external_run_id(conn, row["id"]) is not None:
+                    continue
                 cur = conn.execute(
                     "UPDATE tasks SET claim_expires = ? "
                     "WHERE id = ? AND status = 'running' "
@@ -3815,6 +4244,8 @@ def release_stale_claims(
             )
             continue
         with write_txn(conn):
+            if _open_external_run_id(conn, row["id"]) is not None:
+                continue
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL "
@@ -3873,10 +4304,12 @@ def reclaim_task(
     Returns True if a reclaim happened, False if the task isn't in a
     reclaimable state (not running, or doesn't exist).
     """
-    row = conn.execute(
-        "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?",
-        (task_id,),
-    ).fetchone()
+    with write_txn(conn):
+        _assert_no_open_external_run(conn, task_id, "reclaim_task")
+        row = conn.execute(
+            "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
     if not row:
         return False
     if row["status"] != "running" and row["claim_lock"] is None:
@@ -3887,6 +4320,7 @@ def reclaim_task(
         row["worker_pid"], prev_lock, signal_fn=signal_fn,
     )
     with write_txn(conn):
+        _assert_no_open_external_run(conn, task_id, "reclaim_task")
         cur = conn.execute(
             "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
             "claim_expires = NULL, worker_pid = NULL "
@@ -3943,12 +4377,16 @@ def reassign_task(
     Returns True if the reassign landed. ``profile`` may be ``None`` to
     unassign entirely.
     """
+    with write_txn(conn):
+        _assert_no_open_external_run(conn, task_id, "reassign_task")
     if reclaim_first:
         # Safe to call even if nothing to reclaim.
         reclaim_task(conn, task_id, reason=reason or "reassign")
     # assign_task handles its own txn + the still-running guard.
     try:
         return assign_task(conn, task_id, profile)
+    except ExternalTaskConflict:
+        raise
     except RuntimeError:
         # Task is still running and reclaim_first was False; caller
         # needs to decide whether to retry with reclaim.
@@ -4162,6 +4600,7 @@ def complete_task(
         conn, task_id, metadata, summary=summary, result=result,
     )
     with write_txn(conn):
+        _assert_no_open_external_run(conn, task_id, "complete_task")
         if expected_run_id is None:
             cur = conn.execute(
                 """
@@ -4817,6 +5256,18 @@ def edit_completed_task_result(
     """Backfill the user-visible result for an already completed task."""
     handoff_summary = summary if summary is not None else result
     with write_txn(conn):
+        external_result = conn.execute(
+            "SELECT id FROM task_runs WHERE task_id = ? AND worker_kind = ? "
+            "AND external_result_hash IS NOT NULL ORDER BY id DESC LIMIT 1",
+            (task_id, WORKER_KIND_EXTERNAL_MAS),
+        ).fetchone()
+        if external_result is not None:
+            raise ExternalTaskConflict(
+                "external_result_immutable",
+                task_id,
+                "edit_completed_task_result",
+                run_id=int(external_result["id"]),
+            )
         row = conn.execute(
             "SELECT status FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
@@ -4915,6 +5366,7 @@ def block_task(
     routed_to = "blocked"
     recurrences = 0
     with write_txn(conn):
+        _assert_no_open_external_run(conn, task_id, "block_task")
         cur_row = conn.execute(
             "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
             (task_id,),
@@ -5108,6 +5560,7 @@ def promote_task(
     ``(False, reason)`` if refused. ``dry_run=True`` validates the
     promotion would succeed without mutating state.
     """
+    _assert_no_open_external_run(conn, task_id, "promote_task")
     row = conn.execute(
         "SELECT status FROM tasks WHERE id = ?", (task_id,)
     ).fetchone()
@@ -5142,6 +5595,7 @@ def promote_task(
         return True, None
 
     with write_txn(conn):
+        _assert_no_open_external_run(conn, task_id, "promote_task")
         upd = conn.execute(
             "UPDATE tasks SET status = 'ready' "
             "WHERE id = ? AND status IN ('todo', 'blocked')",
@@ -5171,6 +5625,7 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     """
     now = int(time.time())
     with write_txn(conn):
+        _assert_no_open_external_run(conn, task_id, "unblock_task")
         stale = conn.execute(
             "SELECT current_run_id FROM tasks WHERE id = ? AND status IN ('blocked', 'scheduled')",
             (task_id,),
@@ -5254,6 +5709,7 @@ def specify_triage_task(
         raise ValueError("title cannot be blank")
     assignee = _canonical_assignee(assignee)
     with write_txn(conn):
+        _assert_no_open_external_run(conn, task_id, "specify_triage_task")
         existing = conn.execute(
             "SELECT title, body, assignee FROM tasks WHERE id = ? AND status = 'triage'",
             (task_id,),
@@ -5408,6 +5864,7 @@ def decompose_triage_task(
     now = int(time.time())
     child_ids: list[str] = []
     with write_txn(conn):
+        _assert_no_open_external_run(conn, task_id, "decompose_triage_task")
         root_row = conn.execute(
             "SELECT id, status, tenant, workspace_kind, workspace_path "
             "FROM tasks WHERE id = ?",
@@ -5541,6 +5998,7 @@ def decompose_triage_task(
 
 def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
     with write_txn(conn):
+        _assert_no_open_external_run(conn, task_id, "archive_task")
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
             "    claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
@@ -5573,6 +6031,7 @@ def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
     second deliberate action.
     """
     with write_txn(conn):
+        _assert_no_open_external_run(conn, task_id, "delete_archived_task")
         row = conn.execute(
             "SELECT status FROM tasks WHERE id = ?",
             (task_id,),
@@ -5585,6 +6044,9 @@ def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
         )
         conn.execute("DELETE FROM task_comments WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_events WHERE task_id = ?", (task_id,))
+        conn.execute(
+            "DELETE FROM task_external_artifacts WHERE task_id = ?", (task_id,)
+        )
         conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
         cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
@@ -5602,12 +6064,16 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
     if the task was not found.
     """
     with write_txn(conn):
+        _assert_no_open_external_run(conn, task_id, "delete_task")
         cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
         if cur.rowcount != 1:
             return False
         conn.execute("DELETE FROM task_links WHERE parent_id = ? OR child_id = ?", (task_id, task_id))
         conn.execute("DELETE FROM task_comments WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_events WHERE task_id = ?", (task_id,))
+        conn.execute(
+            "DELETE FROM task_external_artifacts WHERE task_id = ?", (task_id,)
+        )
         conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
     recompute_ready(conn)
@@ -5934,6 +6400,7 @@ def schedule_task(
     to ``ready`` (or ``todo`` if parents are still incomplete).
     """
     with write_txn(conn):
+        _assert_no_open_external_run(conn, task_id, "schedule_task")
         params: list[Any] = [task_id]
         sql = """
             UPDATE tasks
@@ -6385,6 +6852,7 @@ def heartbeat_worker(
     """
     now = int(time.time())
     with write_txn(conn):
+        _assert_no_open_external_run(conn, task_id, "heartbeat_worker")
         if expected_run_id is None:
             cur = conn.execute(
                 "UPDATE tasks SET last_heartbeat_at = ? "
@@ -6447,7 +6915,12 @@ def enforce_max_runtime(
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
         "WHERE t.status = 'running' AND t.max_runtime_seconds IS NOT NULL "
         "  AND COALESCE(r.started_at, t.started_at) IS NOT NULL "
-        "  AND t.worker_pid IS NOT NULL"
+        "  AND t.worker_pid IS NOT NULL "
+        "  AND NOT EXISTS ("
+        "      SELECT 1 FROM task_runs xr WHERE xr.task_id = t.id "
+        "      AND xr.worker_kind = ? AND xr.ended_at IS NULL"
+        "  )",
+        (WORKER_KIND_EXTERNAL_MAS,),
     ).fetchall()
     for row in rows:
         lock = row["claim_lock"] or ""
@@ -6489,6 +6962,8 @@ def enforce_max_runtime(
                     pass
 
         with write_txn(conn):
+            if _open_external_run_id(conn, tid) is not None:
+                continue
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL, "
@@ -6579,7 +7054,12 @@ def detect_stale_running(
         "       COALESCE(r.started_at, t.started_at) AS active_started_at "
         "FROM tasks t "
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
-        "WHERE t.status = 'running'"
+        "WHERE t.status = 'running' "
+        "  AND NOT EXISTS ("
+        "      SELECT 1 FROM task_runs xr WHERE xr.task_id = t.id "
+        "      AND xr.worker_kind = ? AND xr.ended_at IS NULL"
+        "  )",
+        (WORKER_KIND_EXTERNAL_MAS,),
     ).fetchall()
 
     for row in rows:
@@ -6615,6 +7095,8 @@ def detect_stale_running(
             continue
 
         with write_txn(conn):
+            if _open_external_run_id(conn, tid) is not None:
+                continue
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL, "
@@ -6790,7 +7272,12 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     with write_txn(conn):
         rows = conn.execute(
             "SELECT id, worker_pid, claim_lock, started_at FROM tasks "
-            "WHERE status = 'running' AND worker_pid IS NOT NULL"
+            "WHERE status = 'running' AND worker_pid IS NOT NULL "
+            "AND NOT EXISTS ("
+            "    SELECT 1 FROM task_runs r WHERE r.task_id = tasks.id "
+            "    AND r.worker_kind = ? AND r.ended_at IS NULL"
+            ")",
+            (WORKER_KIND_EXTERNAL_MAS,),
         ).fetchall()
         host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
         for row in rows:
@@ -7396,7 +7883,7 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     rows = conn.execute(
         "SELECT DISTINCT assignee FROM tasks "
         "WHERE status = 'ready' AND assignee IS NOT NULL "
-        "    AND claim_lock IS NULL"
+        "    AND claim_lock IS NULL AND external_spec_hash IS NULL"
     ).fetchall()
     if not rows:
         return False
@@ -7591,6 +8078,7 @@ def _dispatch_once_locked(
     ready_rows = conn.execute(
         "SELECT id, assignee FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
+        "AND external_spec_hash IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
     # Honour kanban.max_in_progress: if the board already has enough running

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4569,6 +4569,10 @@ def complete_task(
     """
     now = int(time.time())
 
+    # Reject an external run before generic completion can emit any event. The
+    # checks inside write transactions below remain necessary to close races.
+    _assert_no_open_external_run(conn, task_id, "complete_task")
+
     # Gate: verify created_cards BEFORE the main write txn. A rejected
     # completion still needs an auditable event, so we emit it in a
     # tiny dedicated txn, then raise. The caller is responsible for
@@ -4580,6 +4584,7 @@ def complete_task(
         )
         if phantom_cards:
             with write_txn(conn):
+                _assert_no_open_external_run(conn, task_id, "complete_task")
                 _append_event(
                     conn, task_id, "completion_blocked_hallucination",
                     {

--- a/hermes_cli/kanban_external_worker.py
+++ b/hermes_cli/kanban_external_worker.py
@@ -87,8 +87,10 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import os
 import re
 import sqlite3
+import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -361,6 +363,7 @@ class Lease:
     result_hash: Optional[str] = None
     disposition: Optional[str] = None
     block_kind: Optional[str] = None
+    previous_failure_signatures: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -707,7 +710,9 @@ def _validate_taskspec(obj: Any) -> str:
         keys=_TASKSPEC_NESTED_KEYS["execution"],
     )
     for field_name in ("timeout_seconds", "max_attempts", "max_tokens"):
-        _ensure_int(execution[field_name], label=f"execution.{field_name}")
+        value = _ensure_int(execution[field_name], label=f"execution.{field_name}")
+        if value <= 0:
+            raise SpecParseError(f"execution.{field_name} must be positive")
     cost = execution["max_cost_usd"]
     if cost is not None and (
         isinstance(cost, bool)
@@ -947,13 +952,34 @@ def _validate_execution_result(
         isinstance(cost, bool)
         or not isinstance(cost, (int, float))
         or not math.isfinite(float(cost))
+        or float(cost) < 0
     ):
-        raise SpecParseError("mas.usage.cost_usd must be finite numeric or null")
-    _ensure_str(usage["cost_status"], label="mas.usage.cost_status")
-    _ensure_str(usage["source"], label="mas.usage.source")
+        raise SpecParseError(
+            "mas.usage.cost_usd must be non-negative finite numeric or null"
+        )
+    cost_status = _ensure_str(
+        usage["cost_status"], label="mas.usage.cost_status"
+    )
+    if cost_status not in {"known", "unknown"}:
+        raise SpecParseError(f"unsupported cost status: {cost_status!r}")
+    source = _ensure_str(usage["source"], label="mas.usage.source")
+    if source not in {"provider-reported", "cli-reported", "estimated", "unknown"}:
+        raise SpecParseError(f"unsupported usage source: {source!r}")
+    if cost_status == "unknown" and cost is not None:
+        raise SpecParseError("unknown cost must remain null")
+    if cost_status == "known" and (cost is None or source == "unknown"):
+        raise SpecParseError("known cost requires numeric value and provenance")
 
-    _ensure_nullable_str(mas["failure_signature"], label="mas.failure_signature")
+    failure_signature = _ensure_nullable_str(
+        mas["failure_signature"], label="mas.failure_signature"
+    )
+    if failure_signature is not None and (
+        not failure_signature or len(failure_signature) > 128
+    ):
+        raise SpecParseError("mas.failure_signature must be 1..128 characters")
     summary = _ensure_str(mas["summary"], label="mas.summary")
+    if not summary or len(summary) > 2_000:
+        raise SpecParseError("mas.summary must be 1..2000 characters")
     artifacts = mas["artifacts"]
     if not isinstance(artifacts, list):
         raise SpecParseError("mas.artifacts must be an array")
@@ -1021,7 +1047,46 @@ def _read_attachment_bytes(row: sqlite3.Row) -> bytes:
     return raw
 
 
-def _lease_from_run_row(row: sqlite3.Row) -> Lease:
+def _previous_failure_signatures(
+    conn: sqlite3.Connection,
+    row: sqlite3.Row,
+) -> tuple[str, ...]:
+    """Return validated signatures from closed earlier runs of the same spec."""
+
+    prior_rows = conn.execute(
+        "SELECT id, external_spec_attachment_id, external_spec_hash, "
+        "       external_spec_schema, external_result_json, external_result_hash "
+        "FROM task_runs "
+        "WHERE task_id = ? AND worker_kind = ? AND external_spec_hash = ? "
+        "  AND ended_at IS NOT NULL AND id < ? "
+        "ORDER BY id ASC",
+        (row["task_id"], WORKER_KIND, row["external_spec_hash"], int(row["id"])),
+    ).fetchall()
+    signatures: list[str] = []
+    for prior in prior_rows:
+        raw_json = prior["external_result_json"]
+        stored_hash = prior["external_result_hash"]
+        if not isinstance(raw_json, str) or not isinstance(stored_hash, str):
+            raise ResultRejected("prior external run has incomplete result evidence")
+        prior_spec = SpecIdentity(
+            attachment_id=int(prior["external_spec_attachment_id"]),
+            spec_hash=prior["external_spec_hash"],
+            schema_version=prior["external_spec_schema"],
+        )
+        actual_hash, facts = _validate_and_hash_result(
+            raw_json.encode("utf-8"),
+            expected_run_id=int(prior["id"]),
+            expected_spec=prior_spec,
+        )
+        if actual_hash != stored_hash:
+            raise ResultRejected("prior external result hash drift")
+        signature = facts["parsed"]["mas"]["failure_signature"]
+        if signature is not None:
+            signatures.append(signature)
+    return tuple(signatures)
+
+
+def _lease_from_run_row(conn: sqlite3.Connection, row: sqlite3.Row) -> Lease:
     """Build a :class:`Lease` from a ``task_runs`` row using its CURRENT
     lease state. Used by read paths (:func:`list_active`, :func:`get_run`)."""
     spec = SpecIdentity(
@@ -1050,6 +1115,7 @@ def _lease_from_run_row(row: sqlite3.Row) -> Lease:
         result_hash=row["external_result_hash"],
         disposition=row["external_terminal_disposition"],
         block_kind=row["external_block_kind"],
+        previous_failure_signatures=_previous_failure_signatures(conn, row),
     )
 
 
@@ -1739,6 +1805,23 @@ def claim_external(
             raise ClaimRejected(
                 f"attachment {expected_spec.attachment_id} lock hash drift"
             )
+        spec_payload = _decode_strict_json(raw)
+        _validate_taskspec(spec_payload)
+        max_attempts = int(spec_payload["execution"]["max_attempts"])
+        # Attempts are scoped to closed external runs of this exact spec. Check
+        # the ceiling before the task-state CAS so rejection is mutation-free.
+        prior = conn.execute(
+            "SELECT COUNT(*) AS n FROM task_runs "
+            "WHERE task_id = ? AND worker_kind = ? "
+            "AND external_spec_hash = ? AND ended_at IS NOT NULL",
+            (task_id, WORKER_KIND, expected_spec.spec_hash),
+        ).fetchone()
+        attempt = int(prior["n"]) + 1
+        if attempt > max_attempts:
+            raise ClaimRejected(
+                f"task {task_id} exhausted max_attempts={max_attempts} "
+                f"for spec {expected_spec.spec_hash}"
+            )
         # CAS: only transition ready → running if the task is still
         # ready and unclaimed. A concurrent writer (dashboard, native
         # claim, another external worker) flips status and we refuse.
@@ -1754,14 +1837,6 @@ def claim_external(
             raise ClaimRejected(
                 f"task {task_id} not claimable (racing writer changed state)"
             )
-        # Attempts are scoped to closed external runs of this exact spec.
-        prior = conn.execute(
-            "SELECT COUNT(*) AS n FROM task_runs "
-            "WHERE task_id = ? AND worker_kind = ? "
-            "AND external_spec_hash = ? AND ended_at IS NOT NULL",
-            (task_id, WORKER_KIND, expected_spec.spec_hash),
-        ).fetchone()
-        attempt = int(prior["n"]) + 1
         run_cur = conn.execute(
             "INSERT INTO task_runs ("
             "    task_id, status, claim_lock, claim_expires, started_at, "
@@ -1802,15 +1877,10 @@ def claim_external(
             },
             run_id=run_id,
         )
-        return Lease(
-            run_id=run_id,
-            task_id=task_id,
-            spec=expected_spec,
-            lease_token=lease_token,
-            lease_state=LEASE_ACTIVE,
-            lease_expires_at=int(lease_expires_at),
-            attempt=attempt,
-        )
+        claimed = conn.execute(
+            "SELECT * FROM task_runs WHERE id = ?", (run_id,)
+        ).fetchone()
+        return _lease_from_run_row(conn, claimed)
 
 
 def bind_process(
@@ -1857,7 +1927,7 @@ def bind_process(
                 LEASE_BOUND,
             }:
                 raise LeaseStateError(f"run {run_id} is not in bound state")
-            return _lease_from_run_row(row)
+            return _lease_from_run_row(conn, row)
         if (
             lease.lease_state != LEASE_ACTIVE
             or (row["external_lease_state"] or LEASE_ACTIVE) != LEASE_ACTIVE
@@ -1904,7 +1974,7 @@ def bind_process(
         updated = conn.execute(
             "SELECT * FROM task_runs WHERE id = ?", (run_id,)
         ).fetchone()
-        return _lease_from_run_row(updated)
+        return _lease_from_run_row(conn, updated)
 
 
 def heartbeat(
@@ -1965,7 +2035,7 @@ def heartbeat(
         updated = conn.execute(
             "SELECT * FROM task_runs WHERE id = ?", (run_id,)
         ).fetchone()
-        return _lease_from_run_row(updated)
+        return _lease_from_run_row(conn, updated)
 
 
 def still_owns(
@@ -2120,7 +2190,7 @@ def hold_for_recovery(
         updated = conn.execute(
             "SELECT * FROM task_runs WHERE id = ?", (run_id,)
         ).fetchone()
-        return _lease_from_run_row(updated)
+        return _lease_from_run_row(conn, updated)
 
 
 # ---------------------------------------------------------------------------
@@ -2712,7 +2782,7 @@ def list_active(
         params.append(host)
     q += " ORDER BY r.started_at ASC, r.id ASC"
     rows = conn.execute(q, params).fetchall()
-    return [_lease_from_run_row(r) for r in rows]
+    return [_lease_from_run_row(conn, r) for r in rows]
 
 
 def get_run(
@@ -2727,7 +2797,7 @@ def get_run(
     ).fetchone()
     if row is None:
         raise ExternalWorkerError(f"unknown external run {run_id}")
-    return _lease_from_run_row(row)
+    return _lease_from_run_row(conn, row)
 
 
 def read_result(
@@ -2841,7 +2911,7 @@ def put_artifact(
         # (impossible because AUTOINCREMENT, but be safe).
         if dest_path.exists():
             dest_path = dest_dir / f"{run_id}-{safe}-{sha[:8]}"
-        dest_path.write_bytes(data)
+        _durably_write_new_file(dest_path, data)
         try:
             conn.execute(
                 "INSERT INTO task_external_artifacts "
@@ -2860,7 +2930,7 @@ def put_artifact(
                 ),
             )
         except Exception:
-            dest_path.unlink(missing_ok=True)
+            _durably_unlink(dest_path)
             raise
         return ArtifactRef(
             run_id=run_id,
@@ -2868,6 +2938,50 @@ def put_artifact(
             sha256=sha,
             size=len(data),
         )
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    directory_fd = os.open(path, flags)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def _durably_unlink(path: Path) -> None:
+    path.unlink(missing_ok=True)
+    _fsync_directory(path.parent)
+
+
+def _durably_write_new_file(path: Path, data: bytes) -> None:
+    """Publish new bytes without replacement, then make the name durable."""
+
+    fd, raw_temp = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temp_path = Path(raw_temp)
+    published = False
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        # Hard-link publication is atomic and refuses to replace an existing
+        # destination. Both names are in the same directory/filesystem.
+        os.link(temp_path, path)
+        published = True
+        temp_path.unlink()
+        _fsync_directory(path.parent)
+    except Exception:
+        temp_path.unlink(missing_ok=True)
+        if published:
+            path.unlink(missing_ok=True)
+        try:
+            _fsync_directory(path.parent)
+        except OSError:
+            pass
+        raise
 
 
 def read_artifact(

--- a/hermes_cli/kanban_external_worker.py
+++ b/hermes_cli/kanban_external_worker.py
@@ -3,6 +3,8 @@
 This module is the public lifecycle surface for an out-of-process worker or
 supervisor driving a Kanban task:
 
+* :func:`read_candidate_attachment` — read an unlocked candidate spec without
+  mutating task state;
 * :func:`submit` — validate and lock an existing task attachment named
   ``mas-task-spec.v1.json`` as the immutable spec for a task;
 * :func:`connect` — open an initialized board connection without requiring
@@ -133,86 +135,77 @@ DEFAULT_LEASE_TTL_SECONDS = kb.DEFAULT_CLAIM_TTL_SECONDS
 MAX_RESULT_BYTES = 1024 * 1024
 MAX_ARTIFACT_BYTES = kb.KANBAN_ATTACHMENT_MAX_BYTES
 
-_TASKSPEC_KEYS = frozenset(
-    {
-        "schema_version",
-        "board",
-        "repo_key",
-        "objective",
-        "acceptance_criteria",
-        "scope",
-        "base_sha",
-        "risk",
-        "workflow",
-        "execution",
-        "verification",
-        "delivery",
-    }
-)
+_TASKSPEC_KEYS = frozenset({
+    "schema_version",
+    "board",
+    "repo_key",
+    "objective",
+    "acceptance_criteria",
+    "scope",
+    "base_sha",
+    "risk",
+    "workflow",
+    "execution",
+    "verification",
+    "delivery",
+})
 _TASKSPEC_NESTED_KEYS = {
     "scope": frozenset({"include", "exclude"}),
-    "execution": frozenset(
-        {"timeout_seconds", "max_attempts", "max_tokens", "max_cost_usd"}
-    ),
-    "verification": frozenset(
-        {"check_ids", "fresh_reviewer", "security_review"}
-    ),
+    "execution": frozenset({
+        "timeout_seconds",
+        "max_attempts",
+        "max_tokens",
+        "max_cost_usd",
+    }),
+    "verification": frozenset({"check_ids", "fresh_reviewer", "security_review"}),
     "delivery": frozenset({"mode", "push", "deploy"}),
 }
 
 _RESULT_TOP_KEYS = frozenset({"mas"})
-_RESULT_MAS_KEYS = frozenset(
-    {
-        "schema_version",
-        "spec_sha256",
-        "submitted_attachment_id",
-        "run_id",
-        "attempt",
-        "outcome",
-        "disposition",
-        "block_kind",
-        "writer",
-        "reviewer",
-        "process",
-        "git",
-        "deliverable",
-        "checks",
-        "usage",
-        "failure_signature",
-        "summary",
-        "artifacts",
-    }
-)
+_RESULT_MAS_KEYS = frozenset({
+    "schema_version",
+    "spec_sha256",
+    "submitted_attachment_id",
+    "run_id",
+    "attempt",
+    "outcome",
+    "disposition",
+    "block_kind",
+    "writer",
+    "reviewer",
+    "process",
+    "git",
+    "deliverable",
+    "checks",
+    "usage",
+    "failure_signature",
+    "summary",
+    "artifacts",
+})
 _RESULT_NESTED_KEYS = {
     "writer": frozenset({"backend", "model"}),
     "reviewer": frozenset({"backend", "model", "verdict"}),
     "process": frozenset({"identity", "termination_status", "absence_proven"}),
-    "git": frozenset(
-        {
-            "base_sha",
-            "head_sha",
-            "branch",
-            "diff_sha256",
-            "changed_files",
-            "primary_unchanged",
-        }
-    ),
+    "git": frozenset({
+        "base_sha",
+        "head_sha",
+        "branch",
+        "diff_sha256",
+        "changed_files",
+        "primary_unchanged",
+    }),
     "deliverable": frozenset({"kind", "attachment", "sha256"}),
-    "usage": frozenset(
-        {
-            "input_tokens",
-            "output_tokens",
-            "reasoning_tokens",
-            "cost_usd",
-            "cost_status",
-            "source",
-        }
-    ),
+    "usage": frozenset({
+        "input_tokens",
+        "output_tokens",
+        "reasoning_tokens",
+        "cost_usd",
+        "cost_status",
+        "source",
+    }),
 }
 _RESULT_IDENTITY_KEYS = frozenset({"host", "pid", "pgid", "start_token"})
-_RESULT_CHECK_KEYS = frozenset(
-    {"id", "status", "argv", "exit_code", "duration_ms"}
-)
+_RESULT_CHECK_KEYS = frozenset({"id", "status", "argv", "exit_code", "duration_ms"})
 _RESULT_ARTIFACT_KEYS = frozenset({"name", "sha256"})
 _RESULT_DISPOSITIONS = {
     "COMPLETE": "complete",
@@ -658,9 +651,7 @@ def _ensure_bool(value: Any, *, label: str) -> bool:
     return value
 
 
-def _ensure_object(
-    value: Any, *, label: str, keys: frozenset[str]
-) -> dict[str, Any]:
+def _ensure_object(value: Any, *, label: str, keys: frozenset[str]) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise SpecParseError(f"{label} must be an object")
     actual = set(value)
@@ -687,7 +678,14 @@ def _validate_taskspec(obj: Any) -> str:
             f"TaskSpec schema_version must be {SPEC_SCHEMA_VERSION!r}, "
             f"got {schema_version!r}"
         )
-    for field_name in ("board", "repo_key", "objective", "base_sha", "risk", "workflow"):
+    for field_name in (
+        "board",
+        "repo_key",
+        "objective",
+        "base_sha",
+        "risk",
+        "workflow",
+    ):
         if not _ensure_str(spec[field_name], label=field_name):
             raise SpecParseError(f"TaskSpec.{field_name} must not be empty")
     _ensure_str_list(spec["acceptance_criteria"], label="acceptance_criteria")
@@ -852,7 +850,9 @@ def _validate_execution_result(
         keys=_RESULT_NESTED_KEYS["deliverable"],
     )
     for field_name in ("kind", "attachment", "sha256"):
-        _ensure_nullable_str(deliverable[field_name], label=f"mas.deliverable.{field_name}")
+        _ensure_nullable_str(
+            deliverable[field_name], label=f"mas.deliverable.{field_name}"
+        )
 
     checks = mas["checks"]
     if not isinstance(checks, list):
@@ -868,7 +868,10 @@ def _validate_execution_result(
         _ensure_str_list(check["argv"], label=f"mas.checks[{index}].argv")
         if check["exit_code"] is not None:
             _ensure_int(check["exit_code"], label=f"mas.checks[{index}].exit_code")
-        if _ensure_int(check["duration_ms"], label=f"mas.checks[{index}].duration_ms") < 0:
+        if (
+            _ensure_int(check["duration_ms"], label=f"mas.checks[{index}].duration_ms")
+            < 0
+        ):
             raise SpecParseError("check duration_ms must be non-negative")
 
     usage = _ensure_object(
@@ -876,7 +879,10 @@ def _validate_execution_result(
     )
     for field_name in ("input_tokens", "output_tokens", "reasoning_tokens"):
         value = usage[field_name]
-        if value is not None and _ensure_int(value, label=f"mas.usage.{field_name}") < 0:
+        if (
+            value is not None
+            and _ensure_int(value, label=f"mas.usage.{field_name}") < 0
+        ):
             raise SpecParseError(f"mas.usage.{field_name} must be non-negative")
     cost = usage["cost_usd"]
     if cost is not None and (
@@ -1118,9 +1124,7 @@ def _validate_result_artifacts(
             raise ResultRejected(f"invalid declared artifact name: {exc}") from exc
         sha = artifact["sha256"]
         if not re.fullmatch(r"[0-9a-f]{64}", sha):
-            raise ResultRejected(
-                f"declared artifact {name!r} has an invalid SHA-256"
-            )
+            raise ResultRejected(f"declared artifact {name!r} has an invalid SHA-256")
         if name in declared:
             raise ResultRejected(f"artifact {name!r} is declared more than once")
         declared[name] = sha
@@ -1246,7 +1250,7 @@ def _transition_task_for_terminal(
 
 
 # ---------------------------------------------------------------------------
-# Public API — submit / read_submitted_attachment / list_ready
+# Public API — candidate read / submit / submitted read / list_ready
 # ---------------------------------------------------------------------------
 
 
@@ -1264,11 +1268,69 @@ def connect(
     return kb.connect(db_path, board=board)
 
 
+def read_candidate_attachment(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    attachment_id: int,
+) -> bytes:
+    """Read an unlocked canonical TaskSpec candidate without changing state.
+
+    The caller may apply deployment-specific policy before :func:`submit`.
+    ``submit(expected_spec_hash=...)`` re-reads the bytes in its write
+    transaction, so a mutation between this read and submit fails closed.
+    """
+    if not isinstance(task_id, str) or not task_id.strip():
+        raise ValueError("task_id is required")
+    if not isinstance(attachment_id, int) or attachment_id <= 0:
+        raise ValueError("attachment_id must be a positive int")
+    task_row = conn.execute(
+        "SELECT id, status, claim_lock, current_run_id, external_spec_hash "
+        "FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if task_row is None:
+        raise ExternalWorkerError(f"task {task_id} does not exist")
+    if task_row["external_spec_hash"] is not None:
+        raise SpecMutationError(
+            f"task {task_id} already has an immutable external spec"
+        )
+    if task_row["status"] not in {"triage", "todo"}:
+        raise ExternalWorkerError(
+            f"task {task_id} must be in triage or todo before submit "
+            f"(status={task_row['status']!r})"
+        )
+    if task_row["claim_lock"] is not None or task_row["current_run_id"] is not None:
+        raise ExternalWorkerError(f"task {task_id} already has execution state")
+    att = _read_attachment_row(conn, attachment_id)
+    if att["task_id"] != task_id:
+        raise AttachmentNotOwnedError(
+            f"attachment {attachment_id} belongs to task {att['task_id']}, "
+            f"not {task_id}"
+        )
+    canonical = conn.execute(
+        "SELECT id FROM task_attachments "
+        "WHERE task_id = ? AND filename = ? ORDER BY id",
+        (task_id, SPEC_ATTACHMENT_NAME),
+    ).fetchall()
+    if len(canonical) != 1 or int(canonical[0]["id"]) != attachment_id:
+        raise AttachmentMismatchError(
+            f"task {task_id} must have exactly one canonical spec attachment"
+        )
+    if att["filename"] != SPEC_ATTACHMENT_NAME:
+        raise AttachmentMismatchError(
+            f"attachment {attachment_id}: filename must be "
+            f"{SPEC_ATTACHMENT_NAME!r}, got {att['filename']!r}"
+        )
+    return _read_attachment_bytes(att)
+
+
 def submit(
     conn: sqlite3.Connection,
     *,
     task_id: str,
     spec_attachment_id: int,
+    expected_spec_hash: Optional[str] = None,
 ) -> SpecIdentity:
     """Validate and lock the spec attachment onto ``task_id``.
 
@@ -1287,12 +1349,20 @@ def submit(
     with :class:`SpecMutationError`. Does NOT touch task title/body — the
     spec attachment is the sole authoritative input from this point on.
 
+    When ``expected_spec_hash`` is supplied, submit compares it with the exact
+    bytes re-read inside the transaction before any task mutation. This closes
+    the candidate-read/policy-validation race for external policy engines.
+
     Returns the immutable :class:`SpecIdentity`.
     """
     if not isinstance(task_id, str) or not task_id.strip():
         raise ValueError("task_id is required")
     if not isinstance(spec_attachment_id, int) or spec_attachment_id <= 0:
         raise ValueError("spec_attachment_id must be a positive int")
+    if expected_spec_hash is not None and not re.fullmatch(
+        r"[0-9a-f]{64}", expected_spec_hash
+    ):
+        raise ValueError("expected_spec_hash must be a lowercase SHA-256 hex digest")
 
     with kb._board_lifecycle_write_txn(conn):
         task_row = conn.execute(
@@ -1347,6 +1417,10 @@ def submit(
         schema_version = _validate_taskspec(obj)
         # Compute the spec hash from the exact raw bytes.
         spec_hash = _sha256_hex(raw)
+        if expected_spec_hash is not None and spec_hash != expected_spec_hash:
+            raise SpecMutationError(
+                f"attachment {spec_attachment_id}: candidate hash changed before submit"
+            )
         unfinished_parent = conn.execute(
             "SELECT 1 FROM task_links l "
             "JOIN tasks p ON p.id = l.parent_id "
@@ -1928,9 +2002,7 @@ def hold_for_recovery(
             )
         prior_holds = int(row["external_recovery_count"])
         if prior_holds >= RECOVERY_REQUEUE_LIMIT:
-            raise RecoveryRejected(
-                f"run {run_id} already requires manual recovery"
-            )
+            raise RecoveryRejected(f"run {run_id} already requires manual recovery")
         new_holds = prior_holds + 1
         cur = conn.execute(
             "UPDATE task_runs "
@@ -2009,9 +2081,7 @@ def _validate_and_hash_result(
     caller. Raises :class:`ResultRejected` on any contract violation.
     """
     if len(raw) > MAX_RESULT_BYTES:
-        raise ResultRejected(
-            f"ExecutionResult exceeds {MAX_RESULT_BYTES} byte limit"
-        )
+        raise ResultRejected(f"ExecutionResult exceeds {MAX_RESULT_BYTES} byte limit")
     try:
         obj = _decode_strict_json(raw)
     except SpecParseError as exc:
@@ -2429,8 +2499,7 @@ def recover_expired(
             raise RecoveryRejected(f"run {run_id} already ended")
         db_lease_state = row["external_lease_state"] or LEASE_ACTIVE
         if (
-            lease.lease_state
-            not in {LEASE_ACTIVE, LEASE_BOUND, LEASE_HOLDING}
+            lease.lease_state not in {LEASE_ACTIVE, LEASE_BOUND, LEASE_HOLDING}
             or db_lease_state != lease.lease_state
         ):
             raise RecoveryRejected(
@@ -2576,10 +2645,7 @@ def list_active(
     ``host`` filters by the bound process host. Without ``host``, returns
     every active external run on the board.
     """
-    q = (
-        "SELECT r.* FROM task_runs r "
-        "WHERE r.worker_kind = ? AND r.ended_at IS NULL"
-    )
+    q = "SELECT r.* FROM task_runs r WHERE r.worker_kind = ? AND r.ended_at IS NULL"
     params: list[Any] = [WORKER_KIND]
     if host is not None:
         q += " AND r.external_host = ?"
@@ -2636,10 +2702,9 @@ def read_result(
         raise ResultRejected(f"run {lease.run_id} durable result hash drift")
     if facts["attempt"] != lease.attempt:
         raise ResultRejected(f"run {lease.run_id} durable result attempt mismatch")
-    if (
-        facts["disposition"] != row["external_terminal_disposition"]
-        or (facts["block_kind"] or None) != (row["external_block_kind"] or None)
-    ):
+    if facts["disposition"] != row["external_terminal_disposition"] or (
+        facts["block_kind"] or None
+    ) != (row["external_block_kind"] or None):
         raise ResultRejected(f"run {lease.run_id} durable result tuple drift")
     _validate_result_artifacts(conn, run_id=lease.run_id, facts=facts)
     return PersistedResult(
@@ -2843,6 +2908,7 @@ __all__ = [
     "StaleBoardConnection",
     # Public API
     "connect",
+    "read_candidate_attachment",
     "submit",
     "read_submitted_attachment",
     "list_ready",

--- a/hermes_cli/kanban_external_worker.py
+++ b/hermes_cli/kanban_external_worker.py
@@ -185,7 +185,12 @@ _RESULT_MAS_KEYS = frozenset({
 _RESULT_NESTED_KEYS = {
     "writer": frozenset({"backend", "model"}),
     "reviewer": frozenset({"backend", "model", "verdict"}),
-    "process": frozenset({"identity", "termination_status", "absence_proven"}),
+    "process": frozenset({
+        "identity",
+        "termination_status",
+        "absence_proven",
+        "absence_proof",
+    }),
     "git": frozenset({
         "base_sha",
         "head_sha",
@@ -836,6 +841,59 @@ def _validate_execution_result(
     absence_proven = _ensure_bool(
         process["absence_proven"], label="mas.process.absence_proven"
     )
+    raw_absence_proof = process["absence_proof"]
+    absence_proof: dict[str, Any] | None
+    if raw_absence_proof is None:
+        absence_proof = None
+    elif identity is None:
+        absence_proof = _ensure_object(
+            raw_absence_proof,
+            label="mas.process.absence_proof",
+            keys=frozenset({"run_id", "task_id", "evidence"}),
+        )
+        proof_run_id = _ensure_int(
+            absence_proof["run_id"], label="mas.process.absence_proof.run_id"
+        )
+        if proof_run_id != expected_run_id:
+            raise SpecParseError(
+                "mas.process.absence_proof.run_id does not match the run"
+            )
+        _ensure_str(absence_proof["task_id"], label="mas.process.absence_proof.task_id")
+        _ensure_str(
+            absence_proof["evidence"], label="mas.process.absence_proof.evidence"
+        )
+    else:
+        absence_proof = _ensure_object(
+            raw_absence_proof,
+            label="mas.process.absence_proof",
+            keys=_RESULT_IDENTITY_KEYS | frozenset({"evidence"}),
+        )
+        _ensure_str(absence_proof["host"], label="mas.process.absence_proof.host")
+        if (
+            _ensure_int(absence_proof["pid"], label="mas.process.absence_proof.pid")
+            <= 0
+        ):
+            raise SpecParseError("mas.process.absence_proof.pid must be positive")
+        if (
+            _ensure_int(absence_proof["pgid"], label="mas.process.absence_proof.pgid")
+            <= 0
+        ):
+            raise SpecParseError("mas.process.absence_proof.pgid must be positive")
+        _ensure_str(
+            absence_proof["start_token"],
+            label="mas.process.absence_proof.start_token",
+        )
+        _ensure_str(
+            absence_proof["evidence"], label="mas.process.absence_proof.evidence"
+        )
+        if any(absence_proof[key] != identity[key] for key in _RESULT_IDENTITY_KEYS):
+            raise SpecParseError(
+                "mas.process.absence_proof identity does not match process.identity"
+            )
+    if absence_proven != (absence_proof is not None):
+        raise SpecParseError(
+            "mas.process.absence_proven must match the presence of absence_proof"
+        )
 
     git = _ensure_object(mas["git"], label="mas.git", keys=_RESULT_NESTED_KEYS["git"])
     _ensure_str(git["base_sha"], label="mas.git.base_sha")
@@ -914,6 +972,7 @@ def _validate_execution_result(
         "process_identity": identity,
         "termination_status": termination_status,
         "absence_proven": absence_proven,
+        "absence_proof": absence_proof,
         "parsed": top,
     }
 
@@ -2106,6 +2165,7 @@ def _require_result_absence_proof(row: sqlite3.Row, facts: dict[str, Any]) -> No
             identity is not None
             or facts["outcome"] != "aborted_before_start"
             or facts["termination_status"] != "not_started"
+            or facts["absence_proof"]["task_id"] != row["task_id"]
         ):
             raise ResultRejected(
                 "unbound run requires aborted_before_start, not_started, "

--- a/hermes_cli/kanban_external_worker.py
+++ b/hermes_cli/kanban_external_worker.py
@@ -1,0 +1,2862 @@
+"""Public transactional seam for external workers driving the Kanban board.
+
+This module is the public lifecycle surface for an out-of-process worker or
+supervisor driving a Kanban task:
+
+* :func:`submit` — validate and lock an existing task attachment named
+  ``mas-task-spec.v1.json`` as the immutable spec for a task;
+* :func:`connect` — open an initialized board connection without requiring
+  consumers to import Kanban's implementation module;
+* :func:`read_submitted_attachment` — reload the accepted spec attachment's
+  exact bytes;
+* :func:`list_ready` — enumerate ready tasks waiting for an external
+  claim;
+* :func:`claim_external` — atomically claim a ready task for an
+  external worker, returning a typed :class:`Lease`;
+* :func:`bind_process` — bind a host/pid/pgid/start-token quad before any
+  child is started;
+* :func:`heartbeat` / :func:`still_owns` — refresh / check the lease;
+* :func:`hold_for_recovery` — atomically extend the lease and bump the
+  inconclusive-hold counter (uncertainty is NOT absence);
+* :func:`put_result` — validate and persist a typed ExecutionResult on the
+  run BEFORE finalize;
+* :func:`finalize` — close the run with COMPLETE / REQUEUE / BLOCK,
+  returning a typed COMMITTED / ALREADY_COMMITTED_SAME_HASH / REJECTED
+  outcome;
+* :func:`recover_expired` — recover one explicitly-expected run whose
+  lease has lapsed, with affirmative process-absence or no-start proof;
+* :func:`list_active`, :func:`get_run` — typed lease inspection;
+* :func:`read_result` — reload exact result bytes staged before a restart;
+* :func:`put_artifact` / :func:`read_artifact` — idempotent named-output
+  persistence bound to the active lease.
+
+Design invariants:
+
+* **Immutable spec identity.** The canonical input is exactly one task
+  attachment named ``mas-task-spec.v1.json``. Its identity is the triple
+  ``(attachment_id, SHA-256 of the exact raw bytes, schema_version =
+  "mas-task-spec.v1")``. We never hash normalized title/body or attachment
+  lists — the raw bytes ARE the spec.
+
+* **Strict JSON.** Spec and result bytes are decoded with a strict parser
+  that rejects invalid UTF-8, BOM, trailing data, duplicate keys,
+  NaN/Infinity, a missing or wrong ``schema_version``, extra or missing
+  top-level keys, and wrong container types. Callers can NEVER supply a
+  hash; the module always computes SHA-256 itself.
+
+* **Per-run typed identity.** Every mutating call carries a :class:`Lease`
+  that bundles the expected run id, task id, copied spec identity, opaque
+  lease token, and expected lease state. Inside ONE ``BEGIN IMMEDIATE``
+  transaction the call validates ALL of them against the run row before
+  touching anything. Authorization is never by run id alone.
+
+* **Durable substates.** Bind records a durable ``bound`` substate BEFORE
+  any child start ACK. Hold records durable ``recovery_required`` and
+  increments the recovery counter. Finalize / recover record ``committed``
+  plus the typed result metadata (exact bytes, hash, disposition, block
+  kind).
+
+* **Affirmative recovery.** :func:`recover_expired` operates on ONE
+  explicitly expected run, requires the lease to be expired, and accepts
+  EITHER a typed ``ProcessAbsenceProof`` whose identity matches the bound
+  process OR a typed ``NoStartAckProof`` for an unbound run. It NEVER
+  performs ``os.kill``-based absence inference, NEVER releases/requeues
+  without an affirmative proof, and MAY NOT create a new requeue decision once
+  two inconclusive holds are durable. Exact result bytes already staged before
+  a crash remain replayable. Uncertainty leaves the run active.
+
+* **Uniform result persistence.** :func:`finalize` stores the SAME result
+  metadata (exact bytes, hash, disposition, block kind) for COMPLETE,
+  REQUEUE, and BLOCK. :func:`put_result` allows the complete terminal result to
+  be persisted AFTER process absence is proven but BEFORE the task transition.
+  A same-hash replay also requires an exact disposition + block_kind match;
+  anything else is REJECTED.
+
+* **Bridge has no private surface.** The bridge uses only this module.
+  It never opens Hermes SQL or touches the filesystem directly; named
+  artifacts flow through :func:`put_artifact` / :func:`read_artifact`.
+
+The module has no dependency on a specific external supervisor. It talks to
+``kanban_db`` through the same SQLite connection the rest of Hermes uses.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_cli import kanban_db as kb
+
+
+# ---------------------------------------------------------------------------
+# Module constants
+# ---------------------------------------------------------------------------
+
+#: Public API version. Bumped only if the public surface of this module
+#: changes shape (new required argument, removed function, new typed return
+#: field). Additive optional changes do NOT bump this.
+EXTERNAL_WORKER_API_VERSION = 1
+
+#: The worker kind stamped on every run this module creates. Native
+#: dispatcher runs leave ``worker_kind`` NULL (treated as ``native``); the
+#: distinction lets native reclaim/crash/runtime iteration filter external
+#: runs out and lets the public module find its own runs cheaply.
+WORKER_KIND = kb.WORKER_KIND_EXTERNAL_MAS
+StaleBoardConnection = kb.StaleBoardConnection
+
+#: Canonical schema_version strings. Folded into the spec identity triple
+#: and validated by the strict parser.
+SPEC_SCHEMA_VERSION = "mas-task-spec.v1"
+RESULT_SCHEMA_VERSION = "mas-execution-result.v1"
+
+#: The exact filename of the canonical spec attachment. ``submit`` refuses
+#: any other name; ``read_submitted_attachment`` reloads by this name.
+SPEC_ATTACHMENT_NAME = kb.EXTERNAL_SPEC_ATTACHMENT_NAME
+
+#: Ceiling on inconclusive holds. Once ``external_recovery_count`` reaches
+#: this value, :func:`recover_expired` refuses a newly supplied REQUEUE — the
+#: supervisor has lost contact too many times without progress. Exact result
+#: bytes durably staged before a crash remain replayable.
+RECOVERY_REQUEUE_LIMIT = 2
+
+#: Default lease TTL when callers don't pass an explicit expiry. Mirrors
+#: the native dispatcher default so external workers inherit the same
+#: lease window.
+DEFAULT_LEASE_TTL_SECONDS = kb.DEFAULT_CLAIM_TTL_SECONDS
+MAX_RESULT_BYTES = 1024 * 1024
+MAX_ARTIFACT_BYTES = kb.KANBAN_ATTACHMENT_MAX_BYTES
+
+_TASKSPEC_KEYS = frozenset(
+    {
+        "schema_version",
+        "board",
+        "repo_key",
+        "objective",
+        "acceptance_criteria",
+        "scope",
+        "base_sha",
+        "risk",
+        "workflow",
+        "execution",
+        "verification",
+        "delivery",
+    }
+)
+_TASKSPEC_NESTED_KEYS = {
+    "scope": frozenset({"include", "exclude"}),
+    "execution": frozenset(
+        {"timeout_seconds", "max_attempts", "max_tokens", "max_cost_usd"}
+    ),
+    "verification": frozenset(
+        {"check_ids", "fresh_reviewer", "security_review"}
+    ),
+    "delivery": frozenset({"mode", "push", "deploy"}),
+}
+
+_RESULT_TOP_KEYS = frozenset({"mas"})
+_RESULT_MAS_KEYS = frozenset(
+    {
+        "schema_version",
+        "spec_sha256",
+        "submitted_attachment_id",
+        "run_id",
+        "attempt",
+        "outcome",
+        "disposition",
+        "block_kind",
+        "writer",
+        "reviewer",
+        "process",
+        "git",
+        "deliverable",
+        "checks",
+        "usage",
+        "failure_signature",
+        "summary",
+        "artifacts",
+    }
+)
+_RESULT_NESTED_KEYS = {
+    "writer": frozenset({"backend", "model"}),
+    "reviewer": frozenset({"backend", "model", "verdict"}),
+    "process": frozenset({"identity", "termination_status", "absence_proven"}),
+    "git": frozenset(
+        {
+            "base_sha",
+            "head_sha",
+            "branch",
+            "diff_sha256",
+            "changed_files",
+            "primary_unchanged",
+        }
+    ),
+    "deliverable": frozenset({"kind", "attachment", "sha256"}),
+    "usage": frozenset(
+        {
+            "input_tokens",
+            "output_tokens",
+            "reasoning_tokens",
+            "cost_usd",
+            "cost_status",
+            "source",
+        }
+    ),
+}
+_RESULT_IDENTITY_KEYS = frozenset({"host", "pid", "pgid", "start_token"})
+_RESULT_CHECK_KEYS = frozenset(
+    {"id", "status", "argv", "exit_code", "duration_ms"}
+)
+_RESULT_ARTIFACT_KEYS = frozenset({"name", "sha256"})
+_RESULT_DISPOSITIONS = {
+    "COMPLETE": "complete",
+    "REQUEUE": "requeue",
+    "BLOCK": "block",
+}
+
+
+# ---------------------------------------------------------------------------
+# Lease states (durable external state-machine positions on the run)
+# ---------------------------------------------------------------------------
+
+#: Just claimed — no process bound yet. ``bind_process`` requires this.
+LEASE_ACTIVE = "active"
+#: Process identity bound; ``bind_process`` transitioned the run here.
+LEASE_BOUND = "bound"
+#: Held for recovery; ``hold_for_recovery`` transitioned the run here.
+LEASE_HOLDING = "holding"
+#: Terminal — ``finalize`` or ``recover_expired`` closed the run.
+LEASE_COMMITTED = "committed"
+
+#: Internal durable substate labels (recorded on ``external_substate``).
+#: These mirror the lease states plus a typed ``claimed`` value for the
+#: post-claim, pre-bind window.
+SUBSTATE_CLAIMED = "claimed"
+SUBSTATE_BOUND = "bound"
+SUBSTATE_HOLDING = "recovery_required"
+SUBSTATE_COMMITTED = "committed"
+
+#: Dispositions accepted by finalize / recover.
+DISPOSITION_COMPLETE = "COMPLETE"
+DISPOSITION_REQUEUE = "REQUEUE"
+DISPOSITION_BLOCK = "BLOCK"
+VALID_DISPOSITIONS = frozenset({
+    DISPOSITION_COMPLETE,
+    DISPOSITION_REQUEUE,
+    DISPOSITION_BLOCK,
+})
+
+#: Finalize outcomes.
+FINALIZE_COMMITTED = "COMMITTED"
+FINALIZE_ALREADY_COMMITTED_SAME_HASH = "ALREADY_COMMITTED_SAME_HASH"
+FINALIZE_REJECTED = "REJECTED"
+
+
+# ---------------------------------------------------------------------------
+# Typed errors
+# ---------------------------------------------------------------------------
+
+
+class ExternalWorkerError(RuntimeError):
+    """Base class for all external-worker seam errors."""
+
+
+class SpecParseError(ExternalWorkerError):
+    """Raised when strict JSON parsing or TaskSpec/Result schema validation fails."""
+
+
+class SpecMutationError(ExternalWorkerError):
+    """Raised when ``submit`` is called on a task that is already locked."""
+
+
+class AttachmentMismatchError(ExternalWorkerError):
+    """Raised when an attachment's on-disk bytes drift from the locked hash,
+    when its filename is not the canonical spec name, or when its recorded
+    size disagrees with the bytes on disk."""
+
+
+class AttachmentNotOwnedError(ExternalWorkerError):
+    """Raised when an attachment id belongs to a different task."""
+
+
+class ClaimRejected(ExternalWorkerError):
+    """Raised when ``claim_external`` cannot transition the task to running."""
+
+
+class BindMismatch(ExternalWorkerError):
+    """Raised when ``bind_process`` is called with a divergent identity quad."""
+
+
+class NotOwner(ExternalWorkerError):
+    """Raised when a mutating caller's lease does not match the run row."""
+
+
+class LeaseStateError(ExternalWorkerError):
+    """Raised when the run's durable lease state disagrees with the caller's
+    expected state, or the operation does not accept the caller's state."""
+
+
+class RecoveryRejected(ExternalWorkerError):
+    """Raised when ``recover_expired`` refuses to recover (uncertainty,
+    threshold reached, proof mismatch)."""
+
+
+class ResultRejected(ExternalWorkerError):
+    """Raised when a result fails strict JSON / schema / identity validation."""
+
+
+class ArtifactCollision(ExternalWorkerError):
+    """Raised when ``put_artifact`` is called with a name already used for
+    different bytes on the same run."""
+
+
+class ArtifactNotFound(ExternalWorkerError):
+    """Raised when ``read_artifact`` is called for a name that doesn't exist."""
+
+
+# ---------------------------------------------------------------------------
+# Typed dataclasses — public API surface
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SpecIdentity:
+    """Immutable identity triple of a locked spec.
+
+    ``attachment_id`` is the row id of the accepted spec attachment;
+    ``spec_hash`` is the SHA-256 of its exact raw bytes at lock time;
+    ``schema_version`` is the ``schema_version`` field from inside the
+    spec (``mas-task-spec.v1``). All three are recorded on the task row
+    by :func:`submit` and copied into ``task_runs`` by :func:`claim_external`.
+    """
+
+    attachment_id: int
+    spec_hash: str
+    schema_version: str
+
+
+@dataclass(frozen=True)
+class Lease:
+    """Typed lease / run handle.
+
+    Carries everything a mutating call must validate inside its
+    ``BEGIN IMMEDIATE`` transaction: the run id, task id, copied spec
+    identity, opaque lease token, the caller's expected lease state,
+    the lease expiry, and the 1-based attempt index.
+    """
+
+    run_id: int
+    task_id: str
+    spec: SpecIdentity
+    lease_token: str
+    lease_state: str
+    lease_expires_at: int
+    attempt: int
+    recovery_count: int = 0
+    process: Optional[BoundProcess] = None
+    result_hash: Optional[str] = None
+    disposition: Optional[str] = None
+    block_kind: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class BoundProcess:
+    """Per-run external process identity. Bound before any child starts.
+
+    The quad (host, pid, pgid, start_token) is the identity recovery
+    matches against. ``start_token`` is an opaque caller-chosen nonce
+    (UUID / random hex) that lets the caller prove the bind corresponds
+    to *this* launch attempt and not a racing sibling.
+    """
+
+    host: str
+    pid: int
+    pgid: int
+    start_token: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.host, str) or not self.host.strip():
+            raise ValueError("BoundProcess.host is required")
+        if not isinstance(self.pid, int) or self.pid <= 0:
+            raise ValueError("BoundProcess.pid must be a positive int")
+        if not isinstance(self.pgid, int) or self.pgid <= 0:
+            raise ValueError("BoundProcess.pgid must be a positive int")
+        if not isinstance(self.start_token, str) or not self.start_token.strip():
+            raise ValueError("BoundProcess.start_token is required")
+
+
+@dataclass(frozen=True)
+class ProcessAbsenceProof:
+    """Affirmative, caller-supplied proof that the bound process is gone.
+
+    The identity quad MUST match the run's bound :class:`BoundProcess`.
+    ``evidence`` is a free-form short string (e.g. ``"waitpid:9"``,
+    ``"container:exited"``) the caller uses to justify the claim. This
+    module NEVER performs ``os.kill``-based absence inference — the
+    caller must supply this proof affirmatively.
+    """
+
+    host: str
+    pid: int
+    pgid: int
+    start_token: str
+    evidence: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.host, str) or not self.host.strip():
+            raise ValueError("ProcessAbsenceProof.host is required")
+        if not isinstance(self.pid, int) or self.pid <= 0:
+            raise ValueError("ProcessAbsenceProof.pid must be a positive int")
+        if not isinstance(self.pgid, int) or self.pgid <= 0:
+            raise ValueError("ProcessAbsenceProof.pgid must be a positive int")
+        if not isinstance(self.start_token, str) or not self.start_token.strip():
+            raise ValueError("ProcessAbsenceProof.start_token is required")
+        if not isinstance(self.evidence, str) or not self.evidence.strip():
+            raise ValueError("ProcessAbsenceProof.evidence is required")
+
+
+@dataclass(frozen=True)
+class NoStartAckProof:
+    """Affirmative proof that no child was ever started for this run.
+
+    Used by :func:`recover_expired` for a run that was claimed but never
+    had :func:`bind_process` called (so there is no process to prove
+    absent). The supervisor asserts it never ACK'd a child start.
+    """
+
+    run_id: int
+    task_id: str
+    evidence: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.run_id, int) or self.run_id <= 0:
+            raise ValueError("NoStartAckProof.run_id must be a positive int")
+        if not isinstance(self.task_id, str) or not self.task_id.strip():
+            raise ValueError("NoStartAckProof.task_id is required")
+        if not isinstance(self.evidence, str) or not self.evidence.strip():
+            raise ValueError("NoStartAckProof.evidence is required")
+
+
+@dataclass(frozen=True)
+class RecoveryHoldProof:
+    """Typed bounded proof accepted by :func:`hold_for_recovery`.
+
+    The supervisor has lost contact with the worker but is NOT yet
+    declaring it dead — it just needs a bounded window to investigate.
+    Carries the run/task identity and a short evidence string. If a
+    process was bound, ``bound`` must match the run's bound identity.
+    """
+
+    run_id: int
+    task_id: str
+    bound: Optional[BoundProcess]
+    evidence: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.run_id, int) or self.run_id <= 0:
+            raise ValueError("RecoveryHoldProof.run_id must be a positive int")
+        if not isinstance(self.task_id, str) or not self.task_id.strip():
+            raise ValueError("RecoveryHoldProof.task_id is required")
+        if self.bound is not None and not isinstance(self.bound, BoundProcess):
+            raise TypeError("RecoveryHoldProof.bound must be BoundProcess or None")
+        if not isinstance(self.evidence, str) or not self.evidence.strip():
+            raise ValueError("RecoveryHoldProof.evidence is required")
+
+
+@dataclass(frozen=True)
+class ExecutionResult:
+    """Typed ExecutionResult. ``result_bytes`` are canonical strict JSON
+    (schema ``mas-execution-result.v1``). The module computes the SHA-256
+    itself; callers must never supply a hash.
+
+    ``disposition`` / ``block_kind`` duplicate the JSON fields so the
+    public API has them as first-class typed values. They MUST match the
+    JSON exactly on :func:`finalize` / :func:`put_result`.
+    """
+
+    disposition: str
+    block_kind: Optional[str]
+    result_bytes: bytes
+    run_id: int
+    task_id: str
+    spec: SpecIdentity
+
+    def __post_init__(self) -> None:
+        if self.disposition not in VALID_DISPOSITIONS:
+            raise ValueError(
+                f"disposition must be one of {sorted(VALID_DISPOSITIONS)}, "
+                f"got {self.disposition!r}"
+            )
+        if self.disposition == DISPOSITION_BLOCK:
+            if self.block_kind not in kb.VALID_BLOCK_KINDS:
+                raise ValueError(
+                    f"block_kind must be one of {sorted(kb.VALID_BLOCK_KINDS)} "
+                    f"for BLOCK, got {self.block_kind!r}"
+                )
+        else:
+            if self.block_kind is not None:
+                raise ValueError(
+                    f"block_kind must be None for disposition={self.disposition!r}"
+                )
+        if not isinstance(self.result_bytes, (bytes, bytearray)):
+            raise TypeError("result_bytes must be bytes")
+        if not isinstance(self.run_id, int) or self.run_id <= 0:
+            raise ValueError("run_id must be a positive int")
+        if not isinstance(self.task_id, str) or not self.task_id.strip():
+            raise ValueError("task_id is required")
+        if not isinstance(self.spec, SpecIdentity):
+            raise TypeError("spec must be SpecIdentity")
+
+
+@dataclass(frozen=True)
+class PersistedResult:
+    """Exact durable result bytes and their terminal identity tuple."""
+
+    run_id: int
+    task_id: str
+    result_bytes: bytes
+    result_hash: str
+    disposition: str
+    block_kind: Optional[str]
+
+
+@dataclass(frozen=True)
+class FinalizeOutcome:
+    """Typed return value of :func:`finalize`."""
+
+    status: str
+    run_id: int
+    task_id: str
+    result_hash: str
+    prior_hash: Optional[str] = None
+    disposition: Optional[str] = None
+    block_kind: Optional[str] = None
+
+    @property
+    def committed(self) -> bool:
+        return self.status == FINALIZE_COMMITTED
+
+    @property
+    def already_committed(self) -> bool:
+        return self.status == FINALIZE_ALREADY_COMMITTED_SAME_HASH
+
+
+@dataclass(frozen=True)
+class RecoveredRun:
+    """Typed return value of :func:`recover_expired` for one reclaimed run."""
+
+    run_id: int
+    task_id: str
+    spec: SpecIdentity
+    disposition: str
+    block_kind: Optional[str]
+    recovery_count: int
+    requeued: bool
+    blocked: bool
+
+
+@dataclass(frozen=True)
+class ArtifactRef:
+    """Reference to a named external artifact persisted on a run."""
+
+    run_id: int
+    name: str
+    sha256: str
+    size: int
+
+
+# ---------------------------------------------------------------------------
+# Strict JSON parsing + schema validation
+# ---------------------------------------------------------------------------
+
+
+def _reject_constant(value: str) -> None:
+    """``parse_constant`` hook: refuse NaN / Infinity / -Infinity."""
+    raise SpecParseError(f"numeric constant not allowed: {value!r}")
+
+
+def _pairs_no_duplicates(pairs: list[tuple[str, Any]]) -> dict:
+    """``object_pairs_hook``: build a dict but reject duplicate keys."""
+    seen: set[str] = set()
+    out: dict = {}
+    for k, v in pairs:
+        if not isinstance(k, str):
+            raise SpecParseError(f"non-string JSON key: {k!r}")
+        if k in seen:
+            raise SpecParseError(f"duplicate key: {k!r}")
+        seen.add(k)
+        out[k] = v
+    return out
+
+
+def _decode_strict_json(raw: bytes) -> Any:
+    """Decode bytes as strict JSON.
+
+    Rejects: non-bytes input, empty input, UTF-8 BOM (both byte-mark and
+    decoded codepoint), invalid UTF-8, trailing non-whitespace data,
+    duplicate keys, NaN / Infinity / -Infinity, and any ``JSONDecodeError``.
+    Returns the parsed top-level value (caller validates container type).
+    """
+    if isinstance(raw, bytearray):
+        raw = bytes(raw)
+    if not isinstance(raw, bytes):
+        raise SpecParseError("input must be bytes")
+    if not raw:
+        raise SpecParseError("empty input")
+    # Reject UTF-8 / UTF-16 BOMs at the byte level.
+    if raw.startswith(b"\xef\xbb\xbf"):
+        raise SpecParseError("UTF-8 BOM not allowed")
+    if raw.startswith(b"\xff\xfe") or raw.startswith(b"\xfe\xff"):
+        raise SpecParseError("UTF-16 BOM not allowed")
+    # Strict UTF-8 decode (rejects invalid UTF-8 sequences).
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise SpecParseError(f"invalid UTF-8: {exc}") from exc
+    # Reject a BOM that slipped through as the U+FEFF codepoint.
+    if text and text[0] == "\ufeff":
+        raise SpecParseError("UTF-8 BOM not allowed")
+    try:
+        return json.loads(
+            text,
+            object_pairs_hook=_pairs_no_duplicates,
+            parse_constant=_reject_constant,
+        )
+    except json.JSONDecodeError as exc:
+        raise SpecParseError(f"invalid JSON: {exc}") from exc
+
+
+def _ensure_str(value: Any, *, label: str) -> str:
+    if not isinstance(value, str):
+        raise SpecParseError(f"{label} must be a string, got {type(value).__name__}")
+    return value
+
+
+def _ensure_nullable_str(value: Any, *, label: str) -> Optional[str]:
+    if value is None:
+        return None
+    return _ensure_str(value, label=label)
+
+
+def _ensure_int(value: Any, *, label: str) -> int:
+    # JSON floats that happen to be integer-valued are NOT accepted —
+    # an integer field means an integer token in the source.
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise SpecParseError(f"{label} must be an integer, got {type(value).__name__}")
+    return value
+
+
+def _ensure_bool(value: Any, *, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise SpecParseError(f"{label} must be a boolean")
+    return value
+
+
+def _ensure_object(
+    value: Any, *, label: str, keys: frozenset[str]
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise SpecParseError(f"{label} must be an object")
+    actual = set(value)
+    if actual != keys:
+        missing = sorted(keys - actual)
+        extra = sorted(actual - keys)
+        raise SpecParseError(f"{label} keys mismatch: missing={missing}, extra={extra}")
+    return value
+
+
+def _ensure_str_list(value: Any, *, label: str) -> list[str]:
+    if not isinstance(value, list):
+        raise SpecParseError(f"{label} must be an array")
+    if any(not isinstance(item, str) for item in value):
+        raise SpecParseError(f"{label} must contain only strings")
+    return value
+
+
+def _validate_taskspec(obj: Any) -> str:
+    spec = _ensure_object(obj, label="TaskSpec", keys=_TASKSPEC_KEYS)
+    schema_version = _ensure_str(spec["schema_version"], label="schema_version")
+    if schema_version != SPEC_SCHEMA_VERSION:
+        raise SpecParseError(
+            f"TaskSpec schema_version must be {SPEC_SCHEMA_VERSION!r}, "
+            f"got {schema_version!r}"
+        )
+    for field_name in ("board", "repo_key", "objective", "base_sha", "risk", "workflow"):
+        if not _ensure_str(spec[field_name], label=field_name):
+            raise SpecParseError(f"TaskSpec.{field_name} must not be empty")
+    _ensure_str_list(spec["acceptance_criteria"], label="acceptance_criteria")
+
+    scope = _ensure_object(
+        spec["scope"], label="scope", keys=_TASKSPEC_NESTED_KEYS["scope"]
+    )
+    _ensure_str_list(scope["include"], label="scope.include")
+    _ensure_str_list(scope["exclude"], label="scope.exclude")
+
+    execution = _ensure_object(
+        spec["execution"],
+        label="execution",
+        keys=_TASKSPEC_NESTED_KEYS["execution"],
+    )
+    for field_name in ("timeout_seconds", "max_attempts", "max_tokens"):
+        _ensure_int(execution[field_name], label=f"execution.{field_name}")
+    cost = execution["max_cost_usd"]
+    if cost is not None and (
+        isinstance(cost, bool)
+        or not isinstance(cost, (int, float))
+        or not math.isfinite(float(cost))
+    ):
+        raise SpecParseError("execution.max_cost_usd must be finite numeric or null")
+
+    verification = _ensure_object(
+        spec["verification"],
+        label="verification",
+        keys=_TASKSPEC_NESTED_KEYS["verification"],
+    )
+    _ensure_str_list(verification["check_ids"], label="verification.check_ids")
+    _ensure_bool(verification["fresh_reviewer"], label="verification.fresh_reviewer")
+    _ensure_bool(verification["security_review"], label="verification.security_review")
+
+    delivery = _ensure_object(
+        spec["delivery"], label="delivery", keys=_TASKSPEC_NESTED_KEYS["delivery"]
+    )
+    _ensure_str(delivery["mode"], label="delivery.mode")
+    _ensure_bool(delivery["push"], label="delivery.push")
+    _ensure_bool(delivery["deploy"], label="delivery.deploy")
+    return schema_version
+
+
+def _validate_execution_result(
+    obj: Any,
+    *,
+    expected_run_id: int,
+    expected_spec: SpecIdentity,
+) -> dict[str, Any]:
+    """Validate a parsed mas-execution-result.v1 object.
+
+    Returns ``(disposition, block_kind)``. Raises on any contract violation.
+    """
+    top = _ensure_object(obj, label="ExecutionResult", keys=_RESULT_TOP_KEYS)
+    mas = _ensure_object(top["mas"], label="ExecutionResult.mas", keys=_RESULT_MAS_KEYS)
+    schema_version = _ensure_str(mas["schema_version"], label="mas.schema_version")
+    if schema_version != RESULT_SCHEMA_VERSION:
+        raise SpecParseError(
+            f"ExecutionResult schema_version must be {RESULT_SCHEMA_VERSION!r}, "
+            f"got {schema_version!r}"
+        )
+    run_id = _ensure_int(mas["run_id"], label="mas.run_id")
+    if run_id != expected_run_id:
+        raise SpecParseError(
+            f"ExecutionResult.run_id {run_id} != expected {expected_run_id}"
+        )
+    spec_attachment_id = _ensure_int(
+        mas["submitted_attachment_id"], label="mas.submitted_attachment_id"
+    )
+    if spec_attachment_id != expected_spec.attachment_id:
+        raise SpecParseError(
+            f"ExecutionResult.spec_attachment_id {spec_attachment_id} != "
+            f"expected {expected_spec.attachment_id}"
+        )
+    spec_hash = _ensure_str(mas["spec_sha256"], label="mas.spec_sha256")
+    if spec_hash != expected_spec.spec_hash:
+        raise SpecParseError(f"ExecutionResult.spec_hash {spec_hash!r} != expected")
+    attempt = _ensure_int(mas["attempt"], label="mas.attempt")
+    if attempt <= 0:
+        raise SpecParseError("mas.attempt must be positive")
+    outcome = _ensure_str(mas["outcome"], label="mas.outcome")
+    if outcome not in {
+        "completed",
+        "failed",
+        "aborted_before_start",
+        "recovered_after_crash",
+    }:
+        raise SpecParseError(f"unsupported mas.outcome: {outcome!r}")
+    raw_disposition = _ensure_str(mas["disposition"], label="mas.disposition")
+    reverse_dispositions = {value: key for key, value in _RESULT_DISPOSITIONS.items()}
+    disposition = reverse_dispositions.get(raw_disposition)
+    if disposition is None:
+        raise SpecParseError(
+            f"ExecutionResult.mas.disposition must be one of "
+            f"{sorted(reverse_dispositions)}, got {raw_disposition!r}"
+        )
+    raw_block_kind = mas["block_kind"]
+    if raw_block_kind is None:
+        block_kind: Optional[str] = None
+    elif isinstance(raw_block_kind, str):
+        block_kind = raw_block_kind
+    else:
+        raise SpecParseError(
+            f"ExecutionResult.block_kind must be a string or null, "
+            f"got {type(raw_block_kind).__name__}"
+        )
+    if disposition == DISPOSITION_BLOCK:
+        if block_kind not in kb.VALID_BLOCK_KINDS:
+            raise SpecParseError(
+                f"ExecutionResult.block_kind must be one of "
+                f"{sorted(kb.VALID_BLOCK_KINDS)} for BLOCK, got {block_kind!r}"
+            )
+    else:
+        if block_kind is not None:
+            raise SpecParseError(
+                f"ExecutionResult.block_kind must be null for "
+                f"disposition={disposition!r}"
+            )
+    writer = _ensure_object(
+        mas["writer"], label="mas.writer", keys=_RESULT_NESTED_KEYS["writer"]
+    )
+    _ensure_nullable_str(writer["backend"], label="mas.writer.backend")
+    _ensure_nullable_str(writer["model"], label="mas.writer.model")
+    reviewer = _ensure_object(
+        mas["reviewer"], label="mas.reviewer", keys=_RESULT_NESTED_KEYS["reviewer"]
+    )
+    _ensure_nullable_str(reviewer["backend"], label="mas.reviewer.backend")
+    _ensure_nullable_str(reviewer["model"], label="mas.reviewer.model")
+    _ensure_nullable_str(reviewer["verdict"], label="mas.reviewer.verdict")
+
+    process = _ensure_object(
+        mas["process"], label="mas.process", keys=_RESULT_NESTED_KEYS["process"]
+    )
+    identity = process["identity"]
+    if identity is not None:
+        identity = _ensure_object(
+            identity, label="mas.process.identity", keys=_RESULT_IDENTITY_KEYS
+        )
+        _ensure_str(identity["host"], label="mas.process.identity.host")
+        if _ensure_int(identity["pid"], label="mas.process.identity.pid") <= 0:
+            raise SpecParseError("mas.process.identity.pid must be positive")
+        if _ensure_int(identity["pgid"], label="mas.process.identity.pgid") <= 0:
+            raise SpecParseError("mas.process.identity.pgid must be positive")
+        _ensure_str(identity["start_token"], label="mas.process.identity.start_token")
+    termination_status = _ensure_str(
+        process["termination_status"], label="mas.process.termination_status"
+    )
+    absence_proven = _ensure_bool(
+        process["absence_proven"], label="mas.process.absence_proven"
+    )
+
+    git = _ensure_object(mas["git"], label="mas.git", keys=_RESULT_NESTED_KEYS["git"])
+    _ensure_str(git["base_sha"], label="mas.git.base_sha")
+    for field_name in ("head_sha", "branch", "diff_sha256"):
+        _ensure_nullable_str(git[field_name], label=f"mas.git.{field_name}")
+    _ensure_str_list(git["changed_files"], label="mas.git.changed_files")
+    _ensure_bool(git["primary_unchanged"], label="mas.git.primary_unchanged")
+
+    deliverable = _ensure_object(
+        mas["deliverable"],
+        label="mas.deliverable",
+        keys=_RESULT_NESTED_KEYS["deliverable"],
+    )
+    for field_name in ("kind", "attachment", "sha256"):
+        _ensure_nullable_str(deliverable[field_name], label=f"mas.deliverable.{field_name}")
+
+    checks = mas["checks"]
+    if not isinstance(checks, list):
+        raise SpecParseError("mas.checks must be an array")
+    for index, check in enumerate(checks):
+        check = _ensure_object(
+            check, label=f"mas.checks[{index}]", keys=_RESULT_CHECK_KEYS
+        )
+        _ensure_str(check["id"], label=f"mas.checks[{index}].id")
+        status = _ensure_str(check["status"], label=f"mas.checks[{index}].status")
+        if status not in {"passed", "failed", "infra_error"}:
+            raise SpecParseError(f"unsupported check status: {status!r}")
+        _ensure_str_list(check["argv"], label=f"mas.checks[{index}].argv")
+        if check["exit_code"] is not None:
+            _ensure_int(check["exit_code"], label=f"mas.checks[{index}].exit_code")
+        if _ensure_int(check["duration_ms"], label=f"mas.checks[{index}].duration_ms") < 0:
+            raise SpecParseError("check duration_ms must be non-negative")
+
+    usage = _ensure_object(
+        mas["usage"], label="mas.usage", keys=_RESULT_NESTED_KEYS["usage"]
+    )
+    for field_name in ("input_tokens", "output_tokens", "reasoning_tokens"):
+        value = usage[field_name]
+        if value is not None and _ensure_int(value, label=f"mas.usage.{field_name}") < 0:
+            raise SpecParseError(f"mas.usage.{field_name} must be non-negative")
+    cost = usage["cost_usd"]
+    if cost is not None and (
+        isinstance(cost, bool)
+        or not isinstance(cost, (int, float))
+        or not math.isfinite(float(cost))
+    ):
+        raise SpecParseError("mas.usage.cost_usd must be finite numeric or null")
+    _ensure_str(usage["cost_status"], label="mas.usage.cost_status")
+    _ensure_str(usage["source"], label="mas.usage.source")
+
+    _ensure_nullable_str(mas["failure_signature"], label="mas.failure_signature")
+    summary = _ensure_str(mas["summary"], label="mas.summary")
+    artifacts = mas["artifacts"]
+    if not isinstance(artifacts, list):
+        raise SpecParseError("mas.artifacts must be an array")
+    for index, artifact in enumerate(artifacts):
+        artifact = _ensure_object(
+            artifact, label=f"mas.artifacts[{index}]", keys=_RESULT_ARTIFACT_KEYS
+        )
+        _ensure_str(artifact["name"], label=f"mas.artifacts[{index}].name")
+        _ensure_str(artifact["sha256"], label=f"mas.artifacts[{index}].sha256")
+    return {
+        "disposition": disposition,
+        "block_kind": block_kind,
+        "summary": summary,
+        "attempt": attempt,
+        "outcome": outcome,
+        "process_identity": identity,
+        "termination_status": termination_status,
+        "absence_proven": absence_proven,
+        "parsed": top,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _read_attachment_row(conn: sqlite3.Connection, attachment_id: int) -> sqlite3.Row:
+    row = conn.execute(
+        "SELECT id, task_id, filename, stored_path, size, spec_hash "
+        "FROM task_attachments WHERE id = ?",
+        (int(attachment_id),),
+    ).fetchone()
+    if row is None:
+        raise AttachmentMismatchError(f"attachment {attachment_id} does not exist")
+    return row
+
+
+def _read_attachment_bytes(row: sqlite3.Row) -> bytes:
+    p = Path(row["stored_path"])
+    if not p.is_file():
+        raise AttachmentMismatchError(
+            f"attachment {row['id']}: blob missing at {row['stored_path']!r}"
+        )
+    file_size = p.stat().st_size
+    if file_size > kb.KANBAN_ATTACHMENT_MAX_BYTES:
+        raise AttachmentMismatchError(
+            f"attachment {row['id']}: exceeds the attachment size limit"
+        )
+    if int(row["size"] or 0) != file_size:
+        raise AttachmentMismatchError(
+            f"attachment {row['id']}: size drifted "
+            f"(row={row['size']}, disk={file_size})"
+        )
+    raw = p.read_bytes()
+    if file_size != len(raw):
+        raise AttachmentMismatchError(
+            f"attachment {row['id']}: size changed while reading"
+        )
+    return raw
+
+
+def _lease_from_run_row(row: sqlite3.Row) -> Lease:
+    """Build a :class:`Lease` from a ``task_runs`` row using its CURRENT
+    lease state. Used by read paths (:func:`list_active`, :func:`get_run`)."""
+    spec = SpecIdentity(
+        attachment_id=int(row["external_spec_attachment_id"]),
+        spec_hash=row["external_spec_hash"],
+        schema_version=row["external_spec_schema"],
+    )
+    process = None
+    if row["external_host"] is not None:
+        process = BoundProcess(
+            host=row["external_host"],
+            pid=int(row["external_pid"]),
+            pgid=int(row["external_pgid"]),
+            start_token=row["external_start_token"],
+        )
+    return Lease(
+        run_id=int(row["id"]),
+        task_id=row["task_id"],
+        spec=spec,
+        lease_token=row["claim_lock"] or "",
+        lease_state=row["external_lease_state"] or LEASE_ACTIVE,
+        lease_expires_at=int(row["claim_expires"]) if row["claim_expires"] else 0,
+        attempt=int(row["external_attempt"]),
+        recovery_count=int(row["external_recovery_count"] or 0),
+        process=process,
+        result_hash=row["external_result_hash"],
+        disposition=row["external_terminal_disposition"],
+        block_kind=row["external_block_kind"],
+    )
+
+
+def _check_lease_identity(
+    conn: sqlite3.Connection,
+    lease: Lease,
+    *,
+    check_active_task: bool = True,
+) -> sqlite3.Row:
+    """Validate the identity parts of a lease (run id, task id, worker_kind,
+    copied spec identity, lease token). Does NOT check lease_state or
+    ended_at — callers that need an idempotency path on already-terminal
+    runs use this then route on ``external_substate`` themselves.
+    """
+    row = conn.execute(
+        "SELECT * FROM task_runs WHERE id = ?",
+        (int(lease.run_id),),
+    ).fetchone()
+    if row is None:
+        raise NotOwner(f"unknown run {lease.run_id}")
+    if row["task_id"] != lease.task_id:
+        raise NotOwner(
+            f"run {lease.run_id} task_id mismatch: caller={lease.task_id!r} "
+            f"db={row['task_id']!r}"
+        )
+    if row["worker_kind"] != WORKER_KIND:
+        raise NotOwner(
+            f"run {lease.run_id} is not an external-mas run "
+            f"(worker_kind={row['worker_kind']!r})"
+        )
+    if int(row["external_spec_attachment_id"] or 0) != lease.spec.attachment_id:
+        raise NotOwner(f"run {lease.run_id} spec attachment_id mismatch")
+    if row["external_spec_hash"] != lease.spec.spec_hash:
+        raise NotOwner(f"run {lease.run_id} spec_hash mismatch")
+    if row["external_spec_schema"] != lease.spec.schema_version:
+        raise NotOwner(f"run {lease.run_id} spec_schema mismatch")
+    if int(row["external_attempt"] or 0) != lease.attempt:
+        raise NotOwner(f"run {lease.run_id} attempt mismatch")
+    if row["claim_lock"] != lease.lease_token:
+        raise NotOwner(f"run {lease.run_id} lease_token mismatch")
+    if check_active_task:
+        if row["claim_expires"] is None or int(row["claim_expires"]) != int(
+            lease.lease_expires_at
+        ):
+            raise NotOwner(f"run {lease.run_id} lease expiry mismatch")
+        task = conn.execute(
+            "SELECT status, current_run_id, claim_lock, claim_expires "
+            "FROM tasks WHERE id = ?",
+            (lease.task_id,),
+        ).fetchone()
+        if (
+            task is None
+            or task["status"] != "running"
+            or int(task["current_run_id"] or 0) != lease.run_id
+            or task["claim_lock"] != lease.lease_token
+            or int(task["claim_expires"] or 0) != lease.lease_expires_at
+        ):
+            raise NotOwner(f"task {lease.task_id} no longer matches run lease")
+    return row
+
+
+def _validate_lease(
+    conn: sqlite3.Connection,
+    lease: Lease,
+    *,
+    allowed_states: frozenset[str],
+    require_unexpired: bool = True,
+) -> sqlite3.Row:
+    """Validate every lease field against the DB inside the caller's txn.
+
+    Single source of truth for "does this lease authorise this op?":
+    run id, task id, worker_kind, ended_at IS NULL, copied spec identity
+    (attachment id + hash + schema), opaque lease token (== ``claim_lock``),
+    and the caller's expected lease state (must match the durable
+    ``external_lease_state`` AND be in this op's allowed set).
+
+    Returns the run row for the caller to use.
+    """
+    row = _check_lease_identity(conn, lease)
+    if row["ended_at"] is not None:
+        raise NotOwner(f"run {lease.run_id} already ended")
+    if require_unexpired and lease.lease_expires_at <= int(time.time()):
+        raise NotOwner(f"run {lease.run_id} lease expired")
+    if lease.lease_state not in allowed_states:
+        raise LeaseStateError(
+            f"operation requires lease state in {sorted(allowed_states)}, "
+            f"caller expected {lease.lease_state!r}"
+        )
+    db_state = row["external_lease_state"] or LEASE_ACTIVE
+    if db_state != lease.lease_state:
+        raise LeaseStateError(
+            f"run {lease.run_id} lease state mismatch: "
+            f"caller expected {lease.lease_state!r} db={db_state!r}"
+        )
+    return row
+
+
+def _safe_artifact_name(raw: str) -> str:
+    """Validate a single safe basename without silently rewriting it."""
+    if not isinstance(raw, str) or raw != raw.strip():
+        raise ValueError("artifact name must be a non-empty basename")
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,199}", raw):
+        raise ValueError("artifact name contains an unsafe character")
+    return raw
+
+
+def _external_artifacts_dir(conn: sqlite3.Connection, run_id: int) -> Path:
+    """Directory for named artifacts, using only an integer run id."""
+    base = (
+        kb.attachments_root_for_connection(conn)
+        / "external_artifacts"
+        / f"run-{int(run_id)}"
+    )
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _validate_result_artifacts(
+    conn: sqlite3.Connection,
+    *,
+    run_id: int,
+    facts: dict[str, Any],
+) -> None:
+    """Verify every result-declared artifact is durable and byte-identical."""
+    mas = facts["parsed"]["mas"]
+    declared: dict[str, str] = {}
+    for artifact in mas["artifacts"]:
+        try:
+            name = _safe_artifact_name(artifact["name"])
+        except ValueError as exc:
+            raise ResultRejected(f"invalid declared artifact name: {exc}") from exc
+        sha = artifact["sha256"]
+        if not re.fullmatch(r"[0-9a-f]{64}", sha):
+            raise ResultRejected(
+                f"declared artifact {name!r} has an invalid SHA-256"
+            )
+        if name in declared:
+            raise ResultRejected(f"artifact {name!r} is declared more than once")
+        declared[name] = sha
+
+    deliverable = mas["deliverable"]
+    attachment = deliverable["attachment"]
+    deliverable_sha = deliverable["sha256"]
+    if (attachment is None) != (deliverable_sha is None):
+        raise ResultRejected(
+            "deliverable attachment and sha256 must both be set or both be null"
+        )
+    if attachment is not None:
+        try:
+            attachment = _safe_artifact_name(attachment)
+        except ValueError as exc:
+            raise ResultRejected(f"invalid deliverable artifact name: {exc}") from exc
+        if not re.fullmatch(r"[0-9a-f]{64}", deliverable_sha):
+            raise ResultRejected("deliverable has an invalid SHA-256")
+        prior = declared.get(attachment)
+        if prior is not None and prior != deliverable_sha:
+            raise ResultRejected(
+                f"deliverable {attachment!r} conflicts with its artifact declaration"
+            )
+        declared[attachment] = deliverable_sha
+
+    artifact_root = (
+        kb.attachments_root_for_connection(conn) / "external_artifacts"
+    ).resolve()
+    for name, expected_sha in declared.items():
+        row = conn.execute(
+            "SELECT stored_path, sha256, size FROM task_external_artifacts "
+            "WHERE run_id = ? AND name = ?",
+            (int(run_id), name),
+        ).fetchone()
+        if row is None:
+            raise ResultRejected(
+                f"declared artifact {name!r} is not persisted on run {run_id}"
+            )
+        if row["sha256"] != expected_sha:
+            raise ResultRejected(
+                f"declared artifact {name!r} hash does not match its durable row"
+            )
+        path = Path(row["stored_path"])
+        try:
+            path.resolve().relative_to(artifact_root)
+        except (ValueError, OSError) as exc:
+            raise ResultRejected(
+                f"declared artifact {name!r} escaped the artifact root"
+            ) from exc
+        if not path.is_file():
+            raise ResultRejected(f"declared artifact {name!r} blob is missing")
+        raw = path.read_bytes()
+        if len(raw) != int(row["size"]) or _sha256_hex(raw) != expected_sha:
+            raise ResultRejected(
+                f"declared artifact {name!r} bytes do not match its SHA-256"
+            )
+
+
+def _outcome_for_disposition(disposition: str) -> str:
+    return {
+        DISPOSITION_COMPLETE: "completed",
+        DISPOSITION_REQUEUE: "requeued",
+        DISPOSITION_BLOCK: "blocked",
+    }[disposition]
+
+
+def _transition_task_for_terminal(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    disposition: str,
+    block_kind: Optional[str],
+    summary: str,
+    now: int,
+) -> None:
+    """Transition the task row to match the run's terminal disposition.
+
+    Called inside the enclosing write_txn so the run-row update, task-row
+    transition, and event append are one atomic unit. COMPLETE -> done,
+    REQUEUE -> ready, BLOCK -> blocked / triage with typed block kind.
+    """
+    if disposition == DISPOSITION_COMPLETE:
+        conn.execute(
+            "UPDATE tasks "
+            "SET status = 'done', result = ?, completed_at = ?, "
+            "    claim_lock = NULL, claim_expires = NULL, "
+            "    worker_pid = NULL, current_run_id = NULL, "
+            "    block_kind = NULL, block_recurrences = 0 "
+            "WHERE id = ?",
+            (summary, now, task_id),
+        )
+    elif disposition == DISPOSITION_REQUEUE:
+        conn.execute(
+            "UPDATE tasks "
+            "SET status = 'ready', claim_lock = NULL, "
+            "    claim_expires = NULL, worker_pid = NULL, "
+            "    current_run_id = NULL "
+            "WHERE id = ?",
+            (task_id,),
+        )
+    else:  # DISPOSITION_BLOCK
+        prev = conn.execute(
+            "SELECT block_kind, block_recurrences FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        prev_kind = prev["block_kind"] if prev and prev["block_kind"] else None
+        prev_rec = (
+            int(prev["block_recurrences"])
+            if prev and prev["block_recurrences"] is not None
+            else 0
+        )
+        same_cause = prev_kind == block_kind
+        new_rec = prev_rec + 1 if same_cause else 1
+        routed = "triage" if new_rec >= kb.BLOCK_RECURRENCE_LIMIT else "blocked"
+        conn.execute(
+            "UPDATE tasks "
+            "SET status = ?, claim_lock = NULL, claim_expires = NULL, "
+            "    worker_pid = NULL, current_run_id = NULL, "
+            "    block_kind = ?, block_recurrences = ? "
+            "WHERE id = ?",
+            (routed, block_kind, new_rec, task_id),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API — submit / read_submitted_attachment / list_ready
+# ---------------------------------------------------------------------------
+
+
+def connect(
+    db_path: Optional[Path] = None,
+    *,
+    board: Optional[str] = None,
+) -> sqlite3.Connection:
+    """Open an initialized Kanban board through the public worker seam.
+
+    External-worker integrations should import this module only. The optional
+    ``db_path`` is useful for isolated tests; production callers normally pass
+    an allowlisted ``board`` or rely on Hermes' standard board resolution.
+    """
+    return kb.connect(db_path, board=board)
+
+
+def submit(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    spec_attachment_id: int,
+) -> SpecIdentity:
+    """Validate and lock the spec attachment onto ``task_id``.
+
+    The canonical input is exactly one existing task attachment named
+    :data:`SPEC_ATTACHMENT_NAME` (``mas-task-spec.v1.json``). ``submit``
+    validates the bytes as strict JSON, parses them as a TaskSpec, computes
+    the SHA-256 of the EXACT raw bytes (never a normalized form), and
+    atomically records on the task row: the accepted attachment id, the
+    spec hash, the schema version, and the lock time, then routes the task
+    to Hermes-native ``ready`` or dependency-gated ``todo``. The task /
+    attachment may already exist (the caller is
+    expected to have created them via :func:`kanban_db.create_task` +
+    :func:`kanban_db.store_attachment_bytes`).
+
+    Refuses an already-locked task (``external_spec_hash`` IS NOT NULL)
+    with :class:`SpecMutationError`. Does NOT touch task title/body — the
+    spec attachment is the sole authoritative input from this point on.
+
+    Returns the immutable :class:`SpecIdentity`.
+    """
+    if not isinstance(task_id, str) or not task_id.strip():
+        raise ValueError("task_id is required")
+    if not isinstance(spec_attachment_id, int) or spec_attachment_id <= 0:
+        raise ValueError("spec_attachment_id must be a positive int")
+
+    with kb._board_lifecycle_write_txn(conn):
+        task_row = conn.execute(
+            "SELECT id, status, claim_lock, current_run_id, "
+            "       external_spec_hash, external_spec_attachment_id, "
+            "       external_spec_schema "
+            "FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if task_row is None:
+            raise ExternalWorkerError(f"task {task_id} does not exist")
+        if task_row["external_spec_hash"] is not None:
+            raise SpecMutationError(
+                f"task {task_id} already has an immutable external spec "
+                f"(hash={task_row['external_spec_hash'][:12]}…); "
+                "re-submit is refused"
+            )
+        if task_row["status"] not in {"triage", "todo"}:
+            raise ExternalWorkerError(
+                f"task {task_id} must be in triage or todo before submit "
+                f"(status={task_row['status']!r})"
+            )
+        if task_row["claim_lock"] is not None or task_row["current_run_id"] is not None:
+            raise ExternalWorkerError(f"task {task_id} already has execution state")
+        # Resolve the requested row before checking the canonical-count
+        # invariant so cross-task ids retain their precise ownership error.
+        att = _read_attachment_row(conn, spec_attachment_id)
+        if att["task_id"] != task_id:
+            raise AttachmentNotOwnedError(
+                f"attachment {spec_attachment_id} belongs to task "
+                f"{att['task_id']}, not {task_id}"
+            )
+        canonical = conn.execute(
+            "SELECT id FROM task_attachments "
+            "WHERE task_id = ? AND filename = ? ORDER BY id",
+            (task_id, SPEC_ATTACHMENT_NAME),
+        ).fetchall()
+        if len(canonical) != 1 or int(canonical[0]["id"]) != spec_attachment_id:
+            raise AttachmentMismatchError(
+                f"task {task_id} must have exactly one canonical spec attachment"
+            )
+        if att["filename"] != SPEC_ATTACHMENT_NAME:
+            raise AttachmentMismatchError(
+                f"attachment {spec_attachment_id}: filename must be "
+                f"{SPEC_ATTACHMENT_NAME!r}, got {att['filename']!r}"
+            )
+        raw = _read_attachment_bytes(att)
+        # Strict JSON + TaskSpec schema validation. Any violation raises
+        # and the enclosing write_txn rolls back, leaving the task row
+        # untouched (atomic submit rollback).
+        obj = _decode_strict_json(raw)
+        schema_version = _validate_taskspec(obj)
+        # Compute the spec hash from the exact raw bytes.
+        spec_hash = _sha256_hex(raw)
+        unfinished_parent = conn.execute(
+            "SELECT 1 FROM task_links l "
+            "JOIN tasks p ON p.id = l.parent_id "
+            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') "
+            "LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        next_status = "todo" if unfinished_parent is not None else "ready"
+        # Atomically record identity and route through Hermes-native lanes.
+        now = int(time.time())
+        cur = conn.execute(
+            "UPDATE tasks "
+            "SET external_spec_attachment_id = ?, "
+            "    external_spec_hash = ?, "
+            "    external_spec_schema = ?, "
+            "    external_spec_locked_at = ?, status = ? "
+            "WHERE id = ? AND status IN ('triage', 'todo') "
+            "  AND claim_lock IS NULL AND current_run_id IS NULL "
+            "  AND external_spec_hash IS NULL",
+            (
+                int(spec_attachment_id),
+                spec_hash,
+                schema_version,
+                now,
+                next_status,
+                task_id,
+            ),
+        )
+        if cur.rowcount != 1:
+            raise ExternalWorkerError(f"task {task_id} changed during submit")
+        # Stamp the attachment's spec_hash column for immutability —
+        # delete_attachment refuses to remove it once locked.
+        conn.execute(
+            "UPDATE task_attachments SET spec_hash = ? WHERE id = ?",
+            (spec_hash, int(spec_attachment_id)),
+        )
+        kb._append_event(
+            conn,
+            task_id,
+            "mas_spec_submitted",
+            {
+                "attachment_id": int(spec_attachment_id),
+                "spec_hash": spec_hash,
+                "schema": schema_version,
+                "size": len(raw),
+                "status": next_status,
+            },
+        )
+        return SpecIdentity(
+            attachment_id=int(spec_attachment_id),
+            spec_hash=spec_hash,
+            schema_version=schema_version,
+        )
+
+
+def read_submitted_attachment(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    attachment_id: int,
+) -> bytes:
+    """Reload the accepted spec attachment and return its exact bytes.
+
+    Verifies ownership (attachment belongs to ``task_id``), filename
+    (== ``mas-task-spec.v1.json``), on-disk size (== recorded size), and
+    SHA-256 (== locked ``external_spec_hash`` AND == attachment row's
+    ``spec_hash``). Returns the exact raw bytes.
+
+    Raises :class:`AttachmentMismatchError` on any drift.
+    """
+    if not isinstance(task_id, str) or not task_id.strip():
+        raise ValueError("task_id is required")
+    if not isinstance(attachment_id, int) or attachment_id <= 0:
+        raise ValueError("attachment_id must be a positive int")
+
+    att = _read_attachment_row(conn, attachment_id)
+    if att["task_id"] != task_id:
+        raise AttachmentNotOwnedError(
+            f"attachment {attachment_id} belongs to task {att['task_id']}, "
+            f"not {task_id}"
+        )
+    if att["filename"] != SPEC_ATTACHMENT_NAME:
+        raise AttachmentMismatchError(
+            f"attachment {attachment_id}: filename must be "
+            f"{SPEC_ATTACHMENT_NAME!r}, got {att['filename']!r}"
+        )
+    task_row = conn.execute(
+        "SELECT external_spec_attachment_id, external_spec_hash, "
+        "       external_spec_schema "
+        "FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if task_row is None:
+        raise ExternalWorkerError(f"task {task_id} does not exist")
+    if (
+        task_row["external_spec_attachment_id"] is None
+        or int(task_row["external_spec_attachment_id"]) != attachment_id
+    ):
+        raise AttachmentMismatchError(
+            f"attachment {attachment_id} is not the accepted spec for task {task_id}"
+        )
+    raw = _read_attachment_bytes(att)
+    actual = _sha256_hex(raw)
+    locked_hash = task_row["external_spec_hash"]
+    if locked_hash is None or actual != locked_hash:
+        raise AttachmentMismatchError(
+            f"attachment {attachment_id}: sha256 drift "
+            f"(locked={locked_hash!r}, disk={actual!r})"
+        )
+    if att["spec_hash"] is None or att["spec_hash"] != actual:
+        raise AttachmentMismatchError(
+            f"attachment {attachment_id}: attachment spec_hash drift "
+            f"(row={att['spec_hash']!r}, disk={actual!r})"
+        )
+    return raw
+
+
+def list_ready(
+    conn: sqlite3.Connection,
+    *,
+    assignee: Optional[str] = None,
+    tenant: Optional[str] = None,
+    limit: Optional[int] = None,
+) -> list[kb.Task]:
+    """Return external tasks waiting for a claim.
+
+    Returns tasks in ``ready`` status whose spec is fully locked
+    (``external_spec_hash`` + ``external_spec_attachment_id`` +
+    ``external_spec_schema`` all set), in created-at ascending order.
+    Native ``claim_task`` excludes these.
+    """
+    q = (
+        "SELECT * FROM tasks "
+        "WHERE status = 'ready' "
+        "  AND external_spec_hash IS NOT NULL "
+        "  AND external_spec_attachment_id IS NOT NULL "
+        "  AND external_spec_schema IS NOT NULL "
+        "  AND NOT EXISTS ("
+        "      SELECT 1 FROM task_runs r WHERE r.task_id = tasks.id "
+        "      AND r.worker_kind = ? AND r.ended_at IS NULL"
+        "  )"
+    )
+    params: list[Any] = [WORKER_KIND]
+    if assignee is not None:
+        q += " AND assignee = ?"
+        params.append(kb._canonical_assignee(assignee))
+    if tenant is not None:
+        q += " AND tenant = ?"
+        params.append(tenant)
+    q += " ORDER BY created_at ASC, id ASC"
+    if limit is not None and int(limit) > 0:
+        q += " LIMIT ?"
+        params.append(int(limit))
+    rows = conn.execute(q, params).fetchall()
+    return [kb.Task.from_row(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Public API — claim / bind / heartbeat / still_owns / hold
+# ---------------------------------------------------------------------------
+
+
+def claim_external(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    expected_spec: SpecIdentity,
+    lease_token: str,
+    lease_expires_at: int,
+) -> Lease:
+    """Atomically transition ``ready → running`` for an external worker.
+
+    The caller passes the expected :class:`SpecIdentity`, an opaque
+    ``lease_token`` (any string the caller wants to use as the auth
+    secret for subsequent calls), and the ``lease_expires_at`` epoch
+    second. Inside ONE ``BEGIN IMMEDIATE`` transaction the call re-reads
+    the accepted attachment, recomputes its SHA-256, verifies it matches
+    the locked hash AND the caller's ``expected_spec``, then CAS-transitions
+    the task to running. A new ``task_runs`` row is inserted with the
+    copied spec identity, attempt index, durable ``claimed`` substate,
+    and ``active`` lease state.
+
+    Returns the typed :class:`Lease`.
+    """
+    if not isinstance(expected_spec, SpecIdentity):
+        raise TypeError(
+            f"expected_spec must be SpecIdentity, got {type(expected_spec)!r}"
+        )
+    if not isinstance(lease_token, str) or not lease_token.strip():
+        raise ValueError("lease_token is required")
+    if not isinstance(lease_expires_at, int) or isinstance(lease_expires_at, bool):
+        raise ValueError("lease_expires_at must be an int epoch second")
+    now = int(time.time())
+    if lease_expires_at <= now:
+        raise ExternalWorkerError("lease_expires_at must be a future epoch second")
+
+    with kb._board_lifecycle_write_txn(conn):
+        task_row = conn.execute(
+            "SELECT id, status, external_spec_attachment_id, "
+            "       external_spec_hash, external_spec_schema, "
+            "       current_run_id, claim_lock "
+            "FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if task_row is None:
+            raise ClaimRejected(f"unknown task {task_id}")
+        open_run_id = kb._open_external_run_id(conn, task_id)
+        if open_run_id is not None:
+            raise ClaimRejected(
+                f"task {task_id} already has open external run {open_run_id}"
+            )
+        if task_row["status"] != "ready":
+            raise ClaimRejected(
+                f"task {task_id} not in 'ready' (status={task_row['status']!r})"
+            )
+        if task_row["external_spec_hash"] is None:
+            raise ClaimRejected(f"task {task_id} has no locked external spec")
+        # Spec identity cross-check.
+        if (
+            int(task_row["external_spec_attachment_id"] or 0)
+            != expected_spec.attachment_id
+        ):
+            raise ClaimRejected(f"task {task_id} spec attachment_id mismatch")
+        if task_row["external_spec_hash"] != expected_spec.spec_hash:
+            raise ClaimRejected(f"task {task_id} spec_hash mismatch")
+        if task_row["external_spec_schema"] != expected_spec.schema_version:
+            raise ClaimRejected(f"task {task_id} spec_schema mismatch")
+        unfinished_parent = conn.execute(
+            "SELECT p.id, p.status FROM tasks p "
+            "JOIN task_links l ON l.parent_id = p.id "
+            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') "
+            "ORDER BY p.id LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        if unfinished_parent is not None:
+            raise ClaimRejected(
+                f"task {task_id} has unfinished parent "
+                f"{unfinished_parent['id']} ({unfinished_parent['status']})"
+            )
+        # Re-read & rehash the accepted attachment inside the same txn.
+        att = _read_attachment_row(conn, expected_spec.attachment_id)
+        if att["task_id"] != task_id:
+            raise ClaimRejected(
+                f"attachment {expected_spec.attachment_id} not owned by task {task_id}"
+            )
+        if att["filename"] != SPEC_ATTACHMENT_NAME:
+            raise ClaimRejected(
+                f"attachment {expected_spec.attachment_id} filename mismatch"
+            )
+        raw = _read_attachment_bytes(att)
+        actual_hash = _sha256_hex(raw)
+        if actual_hash != expected_spec.spec_hash:
+            raise ClaimRejected(
+                f"attachment {expected_spec.attachment_id} hash drift on re-read"
+            )
+        if att["spec_hash"] != expected_spec.spec_hash:
+            raise ClaimRejected(
+                f"attachment {expected_spec.attachment_id} lock hash drift"
+            )
+        # CAS: only transition ready → running if the task is still
+        # ready and unclaimed. A concurrent writer (dashboard, native
+        # claim, another external worker) flips status and we refuse.
+        cur = conn.execute(
+            "UPDATE tasks "
+            "SET status = 'running', claim_lock = ?, claim_expires = ?, "
+            "    started_at = COALESCE(started_at, ?) "
+            "WHERE id = ? AND status = 'ready' AND claim_lock IS NULL "
+            "  AND current_run_id IS NULL",
+            (lease_token, int(lease_expires_at), now, task_id),
+        )
+        if cur.rowcount != 1:
+            raise ClaimRejected(
+                f"task {task_id} not claimable (racing writer changed state)"
+            )
+        # Attempts are scoped to closed external runs of this exact spec.
+        prior = conn.execute(
+            "SELECT COUNT(*) AS n FROM task_runs "
+            "WHERE task_id = ? AND worker_kind = ? "
+            "AND external_spec_hash = ? AND ended_at IS NOT NULL",
+            (task_id, WORKER_KIND, expected_spec.spec_hash),
+        ).fetchone()
+        attempt = int(prior["n"]) + 1
+        run_cur = conn.execute(
+            "INSERT INTO task_runs ("
+            "    task_id, status, claim_lock, claim_expires, started_at, "
+            "    worker_kind, external_spec_attachment_id, "
+            "    external_spec_hash, external_spec_schema, "
+            "    external_attempt, external_substate, "
+            "    external_lease_state, external_recovery_count"
+            ") VALUES (?, 'running', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)",
+            (
+                task_id,
+                lease_token,
+                int(lease_expires_at),
+                now,
+                WORKER_KIND,
+                expected_spec.attachment_id,
+                expected_spec.spec_hash,
+                expected_spec.schema_version,
+                attempt,
+                SUBSTATE_CLAIMED,
+                LEASE_ACTIVE,
+            ),
+        )
+        run_id = int(run_cur.lastrowid or 0)
+        conn.execute(
+            "UPDATE tasks SET current_run_id = ? WHERE id = ?",
+            (run_id, task_id),
+        )
+        kb._append_event(
+            conn,
+            task_id,
+            "external_claimed",
+            {
+                "run_id": run_id,
+                "claim_expires": int(lease_expires_at),
+                "attempt": attempt,
+                "spec_attachment_id": expected_spec.attachment_id,
+                "spec_hash": expected_spec.spec_hash,
+            },
+            run_id=run_id,
+        )
+        return Lease(
+            run_id=run_id,
+            task_id=task_id,
+            spec=expected_spec,
+            lease_token=lease_token,
+            lease_state=LEASE_ACTIVE,
+            lease_expires_at=int(lease_expires_at),
+            attempt=attempt,
+        )
+
+
+def bind_process(
+    conn: sqlite3.Connection,
+    *,
+    lease: Lease,
+    process: BoundProcess,
+) -> Lease:
+    """Bind the host/pid/pgid/start_token quad to an external run.
+
+    Must be called BEFORE any external child is started, so a later
+    :func:`recover_expired` can prove the bound process is absent. Records
+    a durable ``bound`` substate BEFORE any child start ACK.
+
+    Idempotent: a second call with the SAME identity quad returns the
+    current lease (state == ``bound``). A second call with a DIVERGENT
+    quad raises :class:`BindMismatch`.
+    """
+    if not isinstance(process, BoundProcess):
+        raise TypeError(f"process must be BoundProcess, got {type(process)!r}")
+
+    with kb.write_txn(conn):
+        row = _check_lease_identity(conn, lease)
+        if row["ended_at"] is not None or lease.lease_expires_at <= int(time.time()):
+            raise NotOwner(f"run {lease.run_id} is not an active lease")
+        run_id = int(row["id"])
+        if row["external_host"] is not None:
+            # Already bound — idempotent iff every field matches exactly.
+            same = (
+                row["external_host"] == process.host
+                and int(row["external_pid"]) == process.pid
+                and int(row["external_pgid"]) == process.pgid
+                and row["external_start_token"] == process.start_token
+            )
+            if not same:
+                raise BindMismatch(
+                    f"run {run_id} already bound to a different process "
+                    f"(host={row['external_host']!r}, "
+                    f"pid={row['external_pid']!r}, "
+                    f"pgid={row['external_pgid']!r})"
+                )
+            if row["external_lease_state"] != LEASE_BOUND or lease.lease_state not in {
+                LEASE_ACTIVE,
+                LEASE_BOUND,
+            }:
+                raise LeaseStateError(f"run {run_id} is not in bound state")
+            return _lease_from_run_row(row)
+        if (
+            lease.lease_state != LEASE_ACTIVE
+            or (row["external_lease_state"] or LEASE_ACTIVE) != LEASE_ACTIVE
+        ):
+            raise LeaseStateError(f"run {run_id} is not claim-active")
+        # Not yet bound — record durable BOUND substate. The CAS clauses
+        # (claim_lock, external_lease_state) close the race with a
+        # concurrent bind / hold / finalize.
+        cur = conn.execute(
+            "UPDATE task_runs "
+            "SET external_host = ?, external_pid = ?, "
+            "    external_pgid = ?, external_start_token = ?, "
+            "    external_substate = ?, external_lease_state = ? "
+            "WHERE id = ? AND ended_at IS NULL "
+            "  AND claim_lock = ? AND external_lease_state = ?",
+            (
+                process.host,
+                int(process.pid),
+                int(process.pgid),
+                process.start_token,
+                SUBSTATE_BOUND,
+                LEASE_BOUND,
+                run_id,
+                lease.lease_token,
+                LEASE_ACTIVE,
+            ),
+        )
+        if cur.rowcount != 1:
+            raise LeaseStateError(
+                f"run {run_id} racing writer changed state during bind"
+            )
+        kb._append_event(
+            conn,
+            lease.task_id,
+            "external_process_bound",
+            {
+                "run_id": run_id,
+                "host": process.host,
+                "pid": int(process.pid),
+                "pgid": int(process.pgid),
+            },
+            run_id=run_id,
+        )
+        updated = conn.execute(
+            "SELECT * FROM task_runs WHERE id = ?", (run_id,)
+        ).fetchone()
+        return _lease_from_run_row(updated)
+
+
+def heartbeat(
+    conn: sqlite3.Connection,
+    *,
+    lease: Lease,
+    lease_expires_at: int,
+) -> Lease:
+    """Extend the lease. Returns the updated :class:`Lease` (same state).
+
+    Accepts ACTIVE, BOUND, and HOLDING lease states. The caller's expected
+    state must match the DB exactly. Raises :class:`NotOwner` /
+    :class:`LeaseStateError` on any mismatch.
+    """
+    if not isinstance(lease_expires_at, int) or isinstance(lease_expires_at, bool):
+        raise ValueError("lease_expires_at must be an int epoch second")
+    if lease_expires_at <= int(time.time()):
+        raise ExternalWorkerError("lease_expires_at must be a future epoch second")
+
+    with kb.write_txn(conn):
+        row = _validate_lease(
+            conn,
+            lease,
+            allowed_states=frozenset({LEASE_ACTIVE, LEASE_BOUND, LEASE_HOLDING}),
+        )
+        run_id = int(row["id"])
+        cur = conn.execute(
+            "UPDATE task_runs "
+            "SET claim_expires = ?, last_heartbeat_at = ? "
+            "WHERE id = ? AND ended_at IS NULL AND claim_lock = ? "
+            "  AND claim_expires = ? AND external_lease_state = ?",
+            (
+                int(lease_expires_at),
+                int(time.time()),
+                run_id,
+                lease.lease_token,
+                lease.lease_expires_at,
+                lease.lease_state,
+            ),
+        )
+        if cur.rowcount != 1:
+            raise NotOwner(f"run {run_id} no longer owned by this lease")
+        task_cur = conn.execute(
+            "UPDATE tasks "
+            "SET claim_expires = ? "
+            "WHERE id = ? AND status = 'running' AND claim_lock = ? "
+            "  AND claim_expires = ? AND current_run_id = ?",
+            (
+                int(lease_expires_at),
+                lease.task_id,
+                lease.lease_token,
+                lease.lease_expires_at,
+                run_id,
+            ),
+        )
+        if task_cur.rowcount != 1:
+            raise NotOwner(f"task {lease.task_id} no longer matches run lease")
+        updated = conn.execute(
+            "SELECT * FROM task_runs WHERE id = ?", (run_id,)
+        ).fetchone()
+        return _lease_from_run_row(updated)
+
+
+def still_owns(
+    conn: sqlite3.Connection,
+    *,
+    lease: Lease,
+) -> bool:
+    """Return True iff the complete expected lease is current and unexpired.
+
+    Read-only; safe to poll. Checks EXACT ownership (run id + task id +
+    copied spec identity + lease token), expiry, and ended_at.
+    """
+    if not isinstance(lease, Lease):
+        raise TypeError("lease must be Lease")
+    try:
+        row = _check_lease_identity(conn, lease)
+    except ExternalWorkerError:
+        return False
+    return (
+        row["ended_at"] is None
+        and (row["external_lease_state"] or LEASE_ACTIVE) == lease.lease_state
+        and lease.lease_expires_at > int(time.time())
+    )
+
+
+def hold_for_recovery(
+    conn: sqlite3.Connection,
+    *,
+    lease: Lease,
+    proof: RecoveryHoldProof,
+    extension_seconds: Optional[int] = None,
+) -> Lease:
+    """Atomically extend the lease, append a bounded event, and bump the
+    inconclusive-hold counter.
+
+    Used by a supervisor that has lost contact with the worker but is not
+    yet ready to declare it dead: it holds the run for a bounded recovery
+    window while it investigates. Each hold increments
+    ``external_recovery_count``; when that counter reaches
+    :data:`RECOVERY_REQUEUE_LIMIT`, :func:`recover_expired` will refuse a new
+    REQUEUE decision. An exact result staged before a crash is still replayed.
+
+    Never treats uncertainty as absence: this call only extends the lease
+    and record the hold. The actual recovery decision is in
+    :func:`recover_expired`, which requires an affirmative proof.
+    """
+    if not isinstance(proof, RecoveryHoldProof):
+        raise TypeError(f"proof must be RecoveryHoldProof, got {type(proof)!r}")
+    if proof.run_id != lease.run_id or proof.task_id != lease.task_id:
+        raise RecoveryRejected("hold proof identity does not match lease")
+
+    ttl = (
+        int(extension_seconds)
+        if extension_seconds is not None
+        else kb._resolve_claim_ttl_seconds(None)
+    )
+    if ttl <= 0:
+        raise ValueError("extension_seconds must be positive")
+    new_expires = int(time.time()) + ttl
+
+    with kb.write_txn(conn):
+        row = _validate_lease(
+            conn,
+            lease,
+            allowed_states=frozenset({LEASE_ACTIVE, LEASE_BOUND, LEASE_HOLDING}),
+            require_unexpired=False,
+        )
+        run_id = int(row["id"])
+        if row["external_result_hash"] is not None:
+            raise RecoveryRejected(
+                f"run {run_id} already has a persisted result; finalize or "
+                "recover those exact bytes instead of adding a recovery hold"
+            )
+        # If a process is bound, the proof's bound identity must match.
+        if row["external_host"] is not None:
+            if proof.bound is None:
+                raise RecoveryRejected(
+                    f"run {run_id} is bound but hold proof carries no bound identity"
+                )
+            if not (
+                proof.bound.host == row["external_host"]
+                and int(proof.bound.pid) == int(row["external_pid"])
+                and int(proof.bound.pgid) == int(row["external_pgid"])
+                and proof.bound.start_token == row["external_start_token"]
+            ):
+                raise RecoveryRejected(
+                    f"run {run_id} hold proof bound identity mismatch"
+                )
+        elif proof.bound is not None:
+            # Proof asserts a bound identity for an unbound run — refuse.
+            raise RecoveryRejected(
+                f"run {run_id} is unbound but hold proof carries a bound identity"
+            )
+        prior_holds = int(row["external_recovery_count"])
+        if prior_holds >= RECOVERY_REQUEUE_LIMIT:
+            raise RecoveryRejected(
+                f"run {run_id} already requires manual recovery"
+            )
+        new_holds = prior_holds + 1
+        cur = conn.execute(
+            "UPDATE task_runs "
+            "SET claim_expires = ?, external_recovery_count = ?, "
+            "    external_substate = ?, external_lease_state = ? "
+            "WHERE id = ? AND ended_at IS NULL AND claim_lock = ? "
+            "  AND claim_expires = ? AND external_lease_state = ?",
+            (
+                new_expires,
+                new_holds,
+                SUBSTATE_HOLDING,
+                LEASE_HOLDING,
+                run_id,
+                lease.lease_token,
+                lease.lease_expires_at,
+                lease.lease_state,
+            ),
+        )
+        if cur.rowcount != 1:
+            raise NotOwner(f"run {run_id} no longer owned by this lease")
+        task_cur = conn.execute(
+            "UPDATE tasks "
+            "SET claim_expires = ? "
+            "WHERE id = ? AND status = 'running' AND claim_lock = ? "
+            "  AND claim_expires = ? AND current_run_id = ?",
+            (
+                new_expires,
+                lease.task_id,
+                lease.lease_token,
+                lease.lease_expires_at,
+                run_id,
+            ),
+        )
+        if task_cur.rowcount != 1:
+            raise NotOwner(f"task {lease.task_id} no longer matches run lease")
+        kb._append_event(
+            conn,
+            lease.task_id,
+            "external_hold_for_recovery",
+            {
+                "run_id": run_id,
+                "reason": (proof.evidence or "").strip()[:200] or None,
+                "inconclusive_holds": new_holds,
+                "claim_expires": new_expires,
+            },
+            run_id=run_id,
+        )
+        if new_holds == RECOVERY_REQUEUE_LIMIT:
+            kb._append_event(
+                conn,
+                lease.task_id,
+                "external_manual_recovery_required",
+                {"run_id": run_id, "inconclusive_holds": new_holds},
+                run_id=run_id,
+            )
+        updated = conn.execute(
+            "SELECT * FROM task_runs WHERE id = ?", (run_id,)
+        ).fetchone()
+        return _lease_from_run_row(updated)
+
+
+# ---------------------------------------------------------------------------
+# Public API — put_result / finalize
+# ---------------------------------------------------------------------------
+
+
+def _validate_and_hash_result(
+    raw: bytes,
+    *,
+    expected_run_id: int,
+    expected_spec: SpecIdentity,
+) -> tuple[str, dict[str, Any]]:
+    """Decode and validate result bytes; return their hash and typed facts.
+
+    The hash is ALWAYS computed by this module, never trusted from the
+    caller. Raises :class:`ResultRejected` on any contract violation.
+    """
+    if len(raw) > MAX_RESULT_BYTES:
+        raise ResultRejected(
+            f"ExecutionResult exceeds {MAX_RESULT_BYTES} byte limit"
+        )
+    try:
+        obj = _decode_strict_json(raw)
+    except SpecParseError as exc:
+        raise ResultRejected(f"invalid ExecutionResult JSON: {exc}") from exc
+    try:
+        facts = _validate_execution_result(
+            obj,
+            expected_run_id=expected_run_id,
+            expected_spec=expected_spec,
+        )
+    except SpecParseError as exc:
+        raise ResultRejected(f"invalid ExecutionResult schema: {exc}") from exc
+    return _sha256_hex(bytes(raw)), facts
+
+
+def _require_result_absence_proof(row: sqlite3.Row, facts: dict[str, Any]) -> None:
+    if not facts["absence_proven"]:
+        raise ResultRejected("ExecutionResult does not prove process-group absence")
+    identity = facts["process_identity"]
+    if row["external_host"] is None:
+        if (
+            identity is not None
+            or facts["outcome"] != "aborted_before_start"
+            or facts["termination_status"] != "not_started"
+        ):
+            raise ResultRejected(
+                "unbound run requires aborted_before_start, not_started, "
+                "and null process identity"
+            )
+        return
+    if identity is None:
+        raise ResultRejected("bound run result is missing process identity")
+    if not (
+        identity["host"] == row["external_host"]
+        and int(identity["pid"]) == int(row["external_pid"])
+        and int(identity["pgid"]) == int(row["external_pgid"])
+        and identity["start_token"] == row["external_start_token"]
+    ):
+        raise ResultRejected("ExecutionResult process identity does not match the run")
+
+
+def put_result(
+    conn: sqlite3.Connection,
+    *,
+    lease: Lease,
+    disposition: str,
+    result_bytes: bytes,
+    block_kind: Optional[str] = None,
+) -> str:
+    """Validate and persist a result on the run WITHOUT finalizing.
+
+    The result is validated (strict JSON, schema, identity) and its hash,
+    disposition, block_kind, and exact bytes are stored on the run row.
+    The run remains active — a subsequent :func:`finalize` with the same
+    bytes is the commit step. Returns the computed SHA-256.
+
+    This lets a supervisor durably stage the complete terminal result after it
+    has proved process absence; :func:`finalize` then commits those same bytes.
+    """
+    if disposition not in VALID_DISPOSITIONS:
+        raise ValueError(f"disposition must be one of {sorted(VALID_DISPOSITIONS)}")
+    if disposition == DISPOSITION_BLOCK:
+        if block_kind not in kb.VALID_BLOCK_KINDS:
+            raise ValueError(
+                f"block_kind must be one of {sorted(kb.VALID_BLOCK_KINDS)}"
+            )
+    else:
+        block_kind = None
+    if not isinstance(result_bytes, (bytes, bytearray)):
+        raise TypeError("result_bytes must be bytes")
+
+    with kb.write_txn(conn):
+        row = _validate_lease(
+            conn,
+            lease,
+            allowed_states=frozenset({LEASE_ACTIVE, LEASE_BOUND, LEASE_HOLDING}),
+        )
+        run_id = int(row["id"])
+        h, facts = _validate_and_hash_result(
+            bytes(result_bytes),
+            expected_run_id=run_id,
+            expected_spec=lease.spec,
+        )
+        json_disposition = facts["disposition"]
+        json_block_kind = facts["block_kind"]
+        if facts["attempt"] != lease.attempt:
+            raise ResultRejected("result attempt does not match the run lease")
+        if json_disposition != disposition:
+            raise ResultRejected(
+                f"result JSON disposition {json_disposition!r} != "
+                f"argument {disposition!r}"
+            )
+        if (json_block_kind or None) != (block_kind or None):
+            raise ResultRejected(
+                f"result JSON block_kind {json_block_kind!r} != argument {block_kind!r}"
+            )
+        _require_result_absence_proof(row, facts)
+        _validate_result_artifacts(conn, run_id=run_id, facts=facts)
+        if row["external_result_hash"] is not None:
+            if (
+                row["external_result_hash"] == h
+                and row["external_terminal_disposition"] == disposition
+                and (row["external_block_kind"] or None) == (block_kind or None)
+                and row["external_result_json"] == bytes(result_bytes).decode("utf-8")
+            ):
+                return h
+            raise ResultRejected(f"run {run_id} already has a divergent staged result")
+        cur = conn.execute(
+            "UPDATE task_runs "
+            "SET external_terminal_disposition = ?, "
+            "    external_block_kind = ?, "
+            "    external_result_hash = ?, "
+            "    external_result_json = ?, metadata = ?, summary = ? "
+            "WHERE id = ? AND ended_at IS NULL AND claim_lock = ? "
+            "  AND claim_expires = ? AND external_lease_state = ? "
+            "  AND external_result_hash IS NULL",
+            (
+                disposition,
+                block_kind,
+                h,
+                bytes(result_bytes).decode("utf-8"),
+                bytes(result_bytes).decode("utf-8"),
+                facts["summary"],
+                run_id,
+                lease.lease_token,
+                lease.lease_expires_at,
+                lease.lease_state,
+            ),
+        )
+        if cur.rowcount != 1:
+            raise ResultRejected(f"run {run_id} changed while staging result")
+        kb._append_event(
+            conn,
+            lease.task_id,
+            "external_result_persisted",
+            {
+                "run_id": run_id,
+                "disposition": disposition,
+                "block_kind": block_kind,
+                "result_hash": h,
+            },
+            run_id=run_id,
+        )
+        return h
+
+
+def finalize(
+    conn: sqlite3.Connection,
+    *,
+    lease: Lease,
+    disposition: str,
+    result_bytes: bytes,
+    block_kind: Optional[str] = None,
+) -> FinalizeOutcome:
+    """Finalize an external run with COMPLETE / REQUEUE / BLOCK.
+
+    Atomically stores the same result metadata (exact bytes, hash,
+    disposition, block_kind) for all three dispositions, transitions the
+    run to ``committed`` and the task to ``done`` / ``ready`` /
+    ``blocked``, and returns a typed outcome:
+
+    * :data:`FINALIZE_COMMITTED` — first finalize for this run+hash+tuple;
+      the run is closed.
+    * :data:`FINALIZE_ALREADY_COMMITTED_SAME_HASH` — idempotent re-finalize
+      with the same hash AND exact disposition AND exact block_kind.
+    * :data:`FINALIZE_REJECTED` — the run was already finalized with a
+      divergent hash or terminal tuple.
+
+    The strict result must contain an affirmative absence proof whose process
+    identity matches the bound run. An unbound run requires a null identity
+    and ``aborted_before_start`` outcome. No task transition can release the
+    claim based on an absent or mismatched proof.
+    """
+    if disposition not in VALID_DISPOSITIONS:
+        raise ValueError(f"disposition must be one of {sorted(VALID_DISPOSITIONS)}")
+    if disposition == DISPOSITION_BLOCK:
+        if block_kind not in kb.VALID_BLOCK_KINDS:
+            raise ValueError(
+                f"block_kind must be one of {sorted(kb.VALID_BLOCK_KINDS)}"
+            )
+    else:
+        block_kind = None
+    if not isinstance(result_bytes, (bytes, bytearray)):
+        raise TypeError("result_bytes must be bytes")
+    with kb.write_txn(conn):
+        row = _check_lease_identity(conn, lease, check_active_task=False)
+        run_id = int(row["id"])
+        new_hash, facts = _validate_and_hash_result(
+            bytes(result_bytes),
+            expected_run_id=run_id,
+            expected_spec=lease.spec,
+        )
+        json_disposition = facts["disposition"]
+        json_block_kind = facts["block_kind"]
+        if facts["attempt"] != lease.attempt:
+            raise ResultRejected("result attempt does not match the run lease")
+        if json_disposition != disposition:
+            raise ResultRejected(
+                f"result JSON disposition {json_disposition!r} != "
+                f"argument {disposition!r}"
+            )
+        if (json_block_kind or None) != (block_kind or None):
+            raise ResultRejected(
+                f"result JSON block_kind {json_block_kind!r} != argument {block_kind!r}"
+            )
+        _validate_result_artifacts(conn, run_id=run_id, facts=facts)
+        # Idempotency: if this run already reached COMMITTED, the replay
+        # must match hash + disposition + block_kind exactly. The caller's
+        # prior lease is still accepted for identity; the lease_state field
+        # is whatever it was at first finalize time.
+        if row["external_substate"] == SUBSTATE_COMMITTED:
+            prior_hash = row["external_result_hash"]
+            prior_disp = row["external_terminal_disposition"]
+            prior_kind = row["external_block_kind"]
+            if (
+                prior_hash == new_hash
+                and prior_disp == disposition
+                and (prior_kind or None) == (block_kind or None)
+            ):
+                return FinalizeOutcome(
+                    status=FINALIZE_ALREADY_COMMITTED_SAME_HASH,
+                    run_id=run_id,
+                    task_id=lease.task_id,
+                    result_hash=new_hash,
+                    disposition=disposition,
+                    block_kind=block_kind,
+                )
+            return FinalizeOutcome(
+                status=FINALIZE_REJECTED,
+                run_id=run_id,
+                task_id=lease.task_id,
+                result_hash=new_hash,
+                prior_hash=prior_hash,
+            )
+        row = _validate_lease(
+            conn,
+            lease,
+            allowed_states=frozenset({LEASE_ACTIVE, LEASE_BOUND, LEASE_HOLDING}),
+        )
+        _require_result_absence_proof(row, facts)
+        if row["external_result_hash"] is not None and not (
+            row["external_result_hash"] == new_hash
+            and row["external_terminal_disposition"] == disposition
+            and (row["external_block_kind"] or None) == (block_kind or None)
+            and row["external_result_json"] == bytes(result_bytes).decode("utf-8")
+        ):
+            return FinalizeOutcome(
+                status=FINALIZE_REJECTED,
+                run_id=run_id,
+                task_id=lease.task_id,
+                result_hash=new_hash,
+                prior_hash=row["external_result_hash"],
+            )
+        # Persist + transition atomically. The CAS clauses close the race
+        # with a concurrent finalize / hold. We do NOT null ``claim_lock``
+        # on the run row: the lease token remains the auth secret for the
+        # idempotent replay path (the row's ``external_lease_state`` /
+        # ``ended_at`` flag prevents any further mutation).
+        now = int(time.time())
+        cur = conn.execute(
+            "UPDATE task_runs "
+            "SET status = ?, outcome = ?, ended_at = ?, "
+            "    external_terminal_disposition = ?, "
+            "    external_block_kind = ?, "
+            "    external_result_hash = ?, "
+            "    external_result_json = ?, "
+            "    metadata = ?, summary = ?, "
+            "    external_substate = ?, external_lease_state = ?, "
+            "    claim_expires = NULL, worker_pid = NULL "
+            "WHERE id = ? AND ended_at IS NULL "
+            "  AND claim_lock = ? AND claim_expires = ? "
+            "  AND external_lease_state = ?",
+            (
+                _outcome_for_disposition(disposition),
+                _outcome_for_disposition(disposition),
+                now,
+                disposition,
+                block_kind,
+                new_hash,
+                bytes(result_bytes).decode("utf-8"),
+                bytes(result_bytes).decode("utf-8"),
+                facts["summary"],
+                SUBSTATE_COMMITTED,
+                LEASE_COMMITTED,
+                run_id,
+                lease.lease_token,
+                lease.lease_expires_at,
+                lease.lease_state,
+            ),
+        )
+        if cur.rowcount != 1:
+            raise NotOwner(f"run {run_id} racing writer changed state")
+        _transition_task_for_terminal(
+            conn,
+            task_id=lease.task_id,
+            disposition=disposition,
+            block_kind=block_kind,
+            summary=facts["summary"],
+            now=now,
+        )
+        kb._append_event(
+            conn,
+            lease.task_id,
+            f"external_finalized_{disposition.lower()}",
+            {
+                "run_id": run_id,
+                "disposition": disposition,
+                "block_kind": block_kind,
+                "hash": new_hash,
+                "termination_status": facts["termination_status"],
+                "absence_proven": facts["absence_proven"],
+            },
+            run_id=run_id,
+        )
+        if disposition == DISPOSITION_COMPLETE:
+            kb._recompute_ready_in_txn(conn)
+        return FinalizeOutcome(
+            status=FINALIZE_COMMITTED,
+            run_id=run_id,
+            task_id=lease.task_id,
+            result_hash=new_hash,
+            disposition=disposition,
+            block_kind=block_kind,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API — recover_expired
+# ---------------------------------------------------------------------------
+
+
+def recover_expired(
+    conn: sqlite3.Connection,
+    *,
+    lease: Lease,
+    proof: ProcessAbsenceProof | NoStartAckProof,
+    result: ExecutionResult,
+) -> RecoveredRun:
+    """Recover ONE explicitly-expected expired run.
+
+    Requires EITHER:
+
+    * a typed :class:`ProcessAbsenceProof` whose identity matches the
+      bound process, AND the lease has expired; OR
+    * a typed :class:`NoStartAckProof` for an unbound run (the supervisor
+      asserts it never ACK'd a child start), AND the lease has expired.
+
+    Accepts a complete :class:`ExecutionResult` and disposition, which
+    is validated, hashed, and persisted exactly as :func:`finalize` does.
+
+    NEVER performs ``os.kill``-based absence inference. NEVER releases or
+    requeues without an affirmative proof. MAY NOT introduce a new REQUEUE
+    once two inconclusive holds are durable (``external_recovery_count >=
+    RECOVERY_REQUEUE_LIMIT``). Exact bytes already staged by :func:`put_result`
+    remain authoritative and replayable after a crash; otherwise a REQUEUE
+    raises :class:`RecoveryRejected` and leaves the run active.
+
+    Uncertainty (any failed identity / proof / state check) raises
+    :class:`RecoveryRejected` and leaves the run active.
+    """
+    if not isinstance(lease, Lease):
+        raise TypeError("lease must be Lease")
+    if not isinstance(proof, (ProcessAbsenceProof, NoStartAckProof)):
+        raise TypeError("proof must be ProcessAbsenceProof or NoStartAckProof")
+    if not isinstance(result, ExecutionResult):
+        raise TypeError("result must be ExecutionResult")
+    now_ts = int(time.time())
+
+    with kb.write_txn(conn):
+        try:
+            row = _check_lease_identity(conn, lease, check_active_task=False)
+        except ExternalWorkerError as exc:
+            raise RecoveryRejected(str(exc)) from exc
+        run_id = lease.run_id
+        task_id = lease.task_id
+        spec = lease.spec
+        result_hash, facts = _validate_and_hash_result(
+            result.result_bytes,
+            expected_run_id=run_id,
+            expected_spec=spec,
+        )
+        if (
+            result.run_id != run_id
+            or result.task_id != task_id
+            or result.spec != spec
+            or result.disposition != facts["disposition"]
+            or (result.block_kind or None) != (facts["block_kind"] or None)
+            or facts["attempt"] != lease.attempt
+        ):
+            raise ResultRejected("ExecutionResult identity does not match the lease")
+        _validate_result_artifacts(conn, run_id=run_id, facts=facts)
+        if row["external_substate"] == SUBSTATE_COMMITTED:
+            if (
+                row["external_result_hash"] == result_hash
+                and row["external_terminal_disposition"] == result.disposition
+                and (row["external_block_kind"] or None) == (result.block_kind or None)
+            ):
+                holds = int(row["external_recovery_count"])
+                return RecoveredRun(
+                    run_id=run_id,
+                    task_id=task_id,
+                    spec=spec,
+                    disposition=result.disposition,
+                    block_kind=result.block_kind,
+                    recovery_count=holds,
+                    requeued=(result.disposition == DISPOSITION_REQUEUE),
+                    blocked=(result.disposition == DISPOSITION_BLOCK),
+                )
+            raise RecoveryRejected(f"run {run_id} already has a divergent result")
+        try:
+            row = _check_lease_identity(conn, lease)
+        except ExternalWorkerError as exc:
+            raise RecoveryRejected(str(exc)) from exc
+        if row["ended_at"] is not None:
+            raise RecoveryRejected(f"run {run_id} already ended")
+        db_lease_state = row["external_lease_state"] or LEASE_ACTIVE
+        if (
+            lease.lease_state
+            not in {LEASE_ACTIVE, LEASE_BOUND, LEASE_HOLDING}
+            or db_lease_state != lease.lease_state
+        ):
+            raise RecoveryRejected(
+                f"run {run_id} lease state mismatch: "
+                f"caller={lease.lease_state!r} db={db_lease_state!r}"
+            )
+        # Lease must be expired.
+        if row["claim_expires"] is None or int(row["claim_expires"]) > now_ts:
+            raise RecoveryRejected(f"run {run_id} lease not expired")
+        # Proof shape vs bound state.
+        if isinstance(proof, NoStartAckProof):
+            if proof.run_id != run_id or proof.task_id != task_id:
+                raise RecoveryRejected(f"run {run_id} no-start proof identity mismatch")
+            if row["external_host"] is not None:
+                raise RecoveryRejected(
+                    f"run {run_id} no-start proof supplied for a bound run"
+                )
+        else:  # ProcessAbsenceProof
+            if row["external_host"] is None:
+                raise RecoveryRejected(
+                    f"run {run_id} absence proof supplied for an unbound run"
+                )
+            if not (
+                proof.host == row["external_host"]
+                and int(proof.pid) == int(row["external_pid"])
+                and int(proof.pgid) == int(row["external_pgid"])
+                and proof.start_token == row["external_start_token"]
+            ):
+                raise RecoveryRejected(f"run {run_id} absence proof identity mismatch")
+        _require_result_absence_proof(row, facts)
+        holds = int(row["external_recovery_count"])
+        staged_same = (
+            row["external_result_hash"] == result_hash
+            and row["external_terminal_disposition"] == result.disposition
+            and (row["external_block_kind"] or None) == (result.block_kind or None)
+            and row["external_result_json"]
+            == bytes(result.result_bytes).decode("utf-8")
+        )
+        # Requeue suppression at the recovery limit. Uncertainty leaves
+        # the run ACTIVE. Exact bytes already staged before a crash are
+        # replayed, however: recovery may not replace that durable decision.
+        if (
+            result.disposition == DISPOSITION_REQUEUE
+            and holds >= RECOVERY_REQUEUE_LIMIT
+            and not staged_same
+        ):
+            raise RecoveryRejected(
+                f"run {run_id} requeue suppressed at "
+                f"{RECOVERY_REQUEUE_LIMIT} inconclusive holds"
+            )
+        if row["external_result_hash"] is not None and not staged_same:
+            raise RecoveryRejected(
+                f"run {run_id} already has a divergent staged result"
+            )
+        # Persist + transition atomically. See ``finalize`` for why
+        # ``claim_lock`` is NOT nulled (idempotent replay auth).
+        ts_now = int(time.time())
+        outcome = _outcome_for_disposition(result.disposition)
+        cur = conn.execute(
+            "UPDATE task_runs "
+            "SET status = ?, outcome = ?, ended_at = ?, "
+            "    external_terminal_disposition = ?, "
+            "    external_block_kind = ?, "
+            "    external_result_hash = ?, "
+            "    external_result_json = ?, "
+            "    metadata = ?, summary = ?, "
+            "    external_substate = ?, external_lease_state = ?, "
+            "    claim_expires = NULL, worker_pid = NULL "
+            "WHERE id = ? AND ended_at IS NULL "
+            "  AND claim_lock = ? AND claim_expires = ? "
+            "  AND external_lease_state = ?",
+            (
+                outcome,
+                outcome,
+                ts_now,
+                result.disposition,
+                result.block_kind,
+                result_hash,
+                bytes(result.result_bytes).decode("utf-8"),
+                bytes(result.result_bytes).decode("utf-8"),
+                facts["summary"],
+                SUBSTATE_COMMITTED,
+                LEASE_COMMITTED,
+                int(run_id),
+                lease.lease_token,
+                lease.lease_expires_at,
+                lease.lease_state,
+            ),
+        )
+        if cur.rowcount != 1:
+            raise RecoveryRejected(
+                f"run {run_id} racing writer changed state during recovery"
+            )
+        _transition_task_for_terminal(
+            conn,
+            task_id=task_id,
+            disposition=result.disposition,
+            block_kind=result.block_kind,
+            summary=facts["summary"],
+            now=ts_now,
+        )
+        kb._append_event(
+            conn,
+            task_id,
+            "external_recovered",
+            {
+                "run_id": int(run_id),
+                "disposition": result.disposition,
+                "block_kind": result.block_kind,
+                "hash": result_hash,
+                "inconclusive_holds": holds,
+                "proof_kind": type(proof).__name__,
+                "proof_evidence": getattr(proof, "evidence", "")[:200],
+            },
+            run_id=int(run_id),
+        )
+        if result.disposition == DISPOSITION_COMPLETE:
+            kb._recompute_ready_in_txn(conn)
+        return RecoveredRun(
+            run_id=int(run_id),
+            task_id=task_id,
+            spec=spec,
+            disposition=result.disposition,
+            block_kind=result.block_kind,
+            recovery_count=holds,
+            requeued=(result.disposition == DISPOSITION_REQUEUE),
+            blocked=(result.disposition == DISPOSITION_BLOCK),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API — list_active / get_run / put_artifact / read_artifact
+# ---------------------------------------------------------------------------
+
+
+def list_active(
+    conn: sqlite3.Connection,
+    *,
+    host: Optional[str] = None,
+) -> list[Lease]:
+    """Return all currently-active external-mas runs as typed leases.
+
+    ``host`` filters by the bound process host. Without ``host``, returns
+    every active external run on the board.
+    """
+    q = (
+        "SELECT r.* FROM task_runs r "
+        "WHERE r.worker_kind = ? AND r.ended_at IS NULL"
+    )
+    params: list[Any] = [WORKER_KIND]
+    if host is not None:
+        q += " AND r.external_host = ?"
+        params.append(host)
+    q += " ORDER BY r.started_at ASC, r.id ASC"
+    rows = conn.execute(q, params).fetchall()
+    return [_lease_from_run_row(r) for r in rows]
+
+
+def get_run(
+    conn: sqlite3.Connection,
+    *,
+    run_id: int,
+) -> Lease:
+    """Fetch one external run, including terminal result identity."""
+    row = conn.execute(
+        "SELECT * FROM task_runs WHERE id = ? AND worker_kind = ?",
+        (int(run_id), WORKER_KIND),
+    ).fetchone()
+    if row is None:
+        raise ExternalWorkerError(f"unknown external run {run_id}")
+    return _lease_from_run_row(row)
+
+
+def read_result(
+    conn: sqlite3.Connection,
+    *,
+    lease: Lease,
+) -> Optional[PersistedResult]:
+    """Return exact staged/terminal result bytes for crash-safe replay.
+
+    The complete run/task/spec/token/attempt identity must match. ``None``
+    means no result has been persisted for this run yet.
+    """
+    if not isinstance(lease, Lease):
+        raise TypeError("lease must be Lease")
+    row = _check_lease_identity(conn, lease, check_active_task=False)
+    values = (
+        row["external_result_json"],
+        row["external_result_hash"],
+        row["external_terminal_disposition"],
+    )
+    if all(value is None for value in values):
+        return None
+    if any(value is None for value in values):
+        raise ResultRejected(f"run {lease.run_id} has an incomplete durable result")
+    raw = row["external_result_json"].encode("utf-8")
+    actual_hash, facts = _validate_and_hash_result(
+        raw,
+        expected_run_id=lease.run_id,
+        expected_spec=lease.spec,
+    )
+    if actual_hash != row["external_result_hash"]:
+        raise ResultRejected(f"run {lease.run_id} durable result hash drift")
+    if facts["attempt"] != lease.attempt:
+        raise ResultRejected(f"run {lease.run_id} durable result attempt mismatch")
+    if (
+        facts["disposition"] != row["external_terminal_disposition"]
+        or (facts["block_kind"] or None) != (row["external_block_kind"] or None)
+    ):
+        raise ResultRejected(f"run {lease.run_id} durable result tuple drift")
+    _validate_result_artifacts(conn, run_id=lease.run_id, facts=facts)
+    return PersistedResult(
+        run_id=lease.run_id,
+        task_id=lease.task_id,
+        result_bytes=raw,
+        result_hash=actual_hash,
+        disposition=facts["disposition"],
+        block_kind=facts["block_kind"],
+    )
+
+
+def put_artifact(
+    conn: sqlite3.Connection,
+    *,
+    lease: Lease,
+    name: str,
+    data: bytes,
+    content_type: Optional[str] = None,
+) -> ArtifactRef:
+    """Persist a named artifact bound to the active lease.
+
+    Keyed by ``(run_id, name)`` with a safe name. Same name + same bytes
+    is idempotent (returns the existing :class:`ArtifactRef`). Same name
+    + divergent bytes raises :class:`ArtifactCollision`. The write is
+    authorized by the lease inside the same ``write_txn`` that inserts
+    the row.
+    """
+    safe = _safe_artifact_name(name)
+    if isinstance(data, bytearray):
+        data = bytes(data)
+    if not isinstance(data, bytes):
+        raise TypeError("data must be bytes")
+    if len(data) > MAX_ARTIFACT_BYTES:
+        raise ValueError(f"artifact exceeds {MAX_ARTIFACT_BYTES} byte limit")
+
+    with kb.write_txn(conn):
+        row = _validate_lease(
+            conn,
+            lease,
+            allowed_states=frozenset({LEASE_ACTIVE, LEASE_BOUND, LEASE_HOLDING}),
+        )
+        run_id = int(row["id"])
+        sha = _sha256_hex(data)
+        existing = conn.execute(
+            "SELECT sha256, size, stored_path FROM task_external_artifacts "
+            "WHERE run_id = ? AND name = ?",
+            (run_id, safe),
+        ).fetchone()
+        if existing is not None:
+            existing_path = Path(existing["stored_path"])
+            existing_bytes = (
+                existing_path.read_bytes() if existing_path.is_file() else None
+            )
+            if (
+                existing["sha256"] != sha
+                or existing_bytes is None
+                or len(existing_bytes) != int(existing["size"])
+                or _sha256_hex(existing_bytes) != sha
+            ):
+                raise ArtifactCollision(
+                    f"artifact {safe!r} already exists on run {run_id} "
+                    "with divergent bytes"
+                )
+            return ArtifactRef(
+                run_id=run_id,
+                name=safe,
+                sha256=sha,
+                size=int(existing["size"]),
+            )
+        dest_dir = _external_artifacts_dir(conn, run_id)
+        dest_path = dest_dir / f"{run_id}-{safe}"
+        # Don't clobber an existing blob from a prior run with the same id
+        # (impossible because AUTOINCREMENT, but be safe).
+        if dest_path.exists():
+            dest_path = dest_dir / f"{run_id}-{safe}-{sha[:8]}"
+        dest_path.write_bytes(data)
+        try:
+            conn.execute(
+                "INSERT INTO task_external_artifacts "
+                "(run_id, task_id, name, stored_path, content_type, size, "
+                " sha256, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    run_id,
+                    lease.task_id,
+                    safe,
+                    str(dest_path.resolve()),
+                    content_type,
+                    len(data),
+                    sha,
+                    int(time.time()),
+                ),
+            )
+        except Exception:
+            dest_path.unlink(missing_ok=True)
+            raise
+        return ArtifactRef(
+            run_id=run_id,
+            name=safe,
+            sha256=sha,
+            size=len(data),
+        )
+
+
+def read_artifact(
+    conn: sqlite3.Connection,
+    *,
+    run_id: int,
+    name: str,
+) -> bytes:
+    """Read and rehash an artifact from an active or terminal external run."""
+    safe = _safe_artifact_name(name)
+    run = conn.execute(
+        "SELECT 1 FROM task_runs WHERE id = ? AND worker_kind = ?",
+        (int(run_id), WORKER_KIND),
+    ).fetchone()
+    if run is None:
+        raise ArtifactNotFound(f"unknown external run {run_id}")
+    art = conn.execute(
+        "SELECT stored_path, sha256, size FROM task_external_artifacts "
+        "WHERE run_id = ? AND name = ?",
+        (int(run_id), safe),
+    ).fetchone()
+    if art is None:
+        raise ArtifactNotFound(f"artifact {safe!r} not found on run {run_id}")
+    p = Path(art["stored_path"])
+    artifact_root = (
+        kb.attachments_root_for_connection(conn) / "external_artifacts"
+    ).resolve()
+    try:
+        p.resolve().relative_to(artifact_root)
+    except (ValueError, OSError) as exc:
+        raise ExternalWorkerError(
+            f"artifact {safe!r} path escaped the artifact root"
+        ) from exc
+    if not p.is_file():
+        raise ExternalWorkerError(f"artifact {safe!r} blob missing on run {run_id}")
+    raw = p.read_bytes()
+    if len(raw) != int(art["size"]) or _sha256_hex(raw) != art["sha256"]:
+        raise ExternalWorkerError(f"artifact {safe!r} content drift on read")
+    return raw
+
+
+__all__ = [
+    # Constants
+    "EXTERNAL_WORKER_API_VERSION",
+    "WORKER_KIND",
+    "SPEC_SCHEMA_VERSION",
+    "RESULT_SCHEMA_VERSION",
+    "SPEC_ATTACHMENT_NAME",
+    "RECOVERY_REQUEUE_LIMIT",
+    "DEFAULT_LEASE_TTL_SECONDS",
+    "MAX_RESULT_BYTES",
+    "MAX_ARTIFACT_BYTES",
+    # Lease states
+    "LEASE_ACTIVE",
+    "LEASE_BOUND",
+    "LEASE_HOLDING",
+    "LEASE_COMMITTED",
+    # Substates
+    "SUBSTATE_CLAIMED",
+    "SUBSTATE_BOUND",
+    "SUBSTATE_HOLDING",
+    "SUBSTATE_COMMITTED",
+    # Dispositions
+    "DISPOSITION_COMPLETE",
+    "DISPOSITION_REQUEUE",
+    "DISPOSITION_BLOCK",
+    "VALID_DISPOSITIONS",
+    # Finalize outcomes
+    "FINALIZE_COMMITTED",
+    "FINALIZE_ALREADY_COMMITTED_SAME_HASH",
+    "FINALIZE_REJECTED",
+    # Dataclasses
+    "SpecIdentity",
+    "Lease",
+    "BoundProcess",
+    "ProcessAbsenceProof",
+    "NoStartAckProof",
+    "RecoveryHoldProof",
+    "ExecutionResult",
+    "PersistedResult",
+    "FinalizeOutcome",
+    "RecoveredRun",
+    "ArtifactRef",
+    # Errors
+    "ExternalWorkerError",
+    "SpecParseError",
+    "SpecMutationError",
+    "AttachmentMismatchError",
+    "AttachmentNotOwnedError",
+    "ClaimRejected",
+    "BindMismatch",
+    "NotOwner",
+    "LeaseStateError",
+    "RecoveryRejected",
+    "ResultRejected",
+    "ArtifactCollision",
+    "ArtifactNotFound",
+    "StaleBoardConnection",
+    # Public API
+    "connect",
+    "submit",
+    "read_submitted_attachment",
+    "list_ready",
+    "claim_external",
+    "bind_process",
+    "heartbeat",
+    "still_owns",
+    "hold_for_recovery",
+    "put_result",
+    "finalize",
+    "recover_expired",
+    "list_active",
+    "get_run",
+    "read_result",
+    "put_artifact",
+    "read_artifact",
+]

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -135,6 +135,20 @@ def _conn(board: Optional[str] = None):
     return kanban_db.connect(board=board)
 
 
+def _external_conflict_http(
+    exc: kanban_db.ExternalTaskConflict,
+) -> HTTPException:
+    return HTTPException(
+        status_code=409,
+        detail={
+            "code": exc.code,
+            "task_id": exc.task_id,
+            "operation": exc.operation,
+            "run_id": exc.run_id,
+        },
+    )
+
+
 # ---------------------------------------------------------------------------
 # Serialization helpers
 # ---------------------------------------------------------------------------
@@ -752,6 +766,12 @@ async def upload_task_attachment(
         )
         att = kanban_db.get_attachment(conn, att_id)
         return {"attachment": _attachment_dict(att) if att else None}
+    except kanban_db.ExternalTaskConflict as exc:
+        try:
+            dest_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise _external_conflict_http(exc)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     finally:
@@ -794,6 +814,8 @@ def remove_attachment(attachment_id: int, board: Optional[str] = Query(None)):
         if att is None:
             raise HTTPException(status_code=404, detail="attachment not found")
         return {"ok": True, "id": attachment_id}
+    except kanban_db.ExternalTaskConflict as exc:
+        raise _external_conflict_http(exc)
     finally:
         conn.close()
 
@@ -832,6 +854,8 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 ok = kanban_db.assign_task(
                     conn, task_id, payload.assignee or None,
                 )
+            except kanban_db.ExternalTaskConflict as exc:
+                raise _external_conflict_http(exc)
             except RuntimeError as e:
                 raise HTTPException(status_code=409, detail=str(e))
             if not ok:
@@ -932,6 +956,8 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
 
         updated = kanban_db.get_task(conn, task_id)
         return {"task": _task_dict(updated) if updated else None}
+    except kanban_db.ExternalTaskConflict as exc:
+        raise _external_conflict_http(exc)
     finally:
         conn.close()
 
@@ -949,6 +975,8 @@ def delete_task(task_id: str, board: Optional[str] = Query(None)):
         if not ok:
             raise HTTPException(status_code=404, detail=f"task {task_id} not found")
         return {"deleted": True, "task_id": task_id}
+    except kanban_db.ExternalTaskConflict as exc:
+        raise _external_conflict_http(exc)
     finally:
         conn.close()
 
@@ -990,6 +1018,9 @@ def _set_status_direct(
     (user yanking a stuck worker back to the queue).
     """
     with kanban_db.write_txn(conn):
+        kanban_db._assert_no_open_external_run(
+            conn, task_id, "dashboard_set_status_direct"
+        )
         # Snapshot current state so we know whether to close a run.
         prev = conn.execute(
             "SELECT status, current_run_id FROM tasks WHERE id = ?",
@@ -1051,6 +1082,9 @@ def _set_status_direct(
                 (task_id,),
             ).fetchall():
                 child_id = row["child_id"]
+                kanban_db._assert_no_open_external_run(
+                    conn, child_id, "dashboard_parent_reopened"
+                )
                 demoted = conn.execute(
                     "UPDATE tasks SET status = 'todo' "
                     "WHERE id = ? AND status = 'ready'",
@@ -1120,6 +1154,8 @@ def add_link(payload: LinkBody, board: Optional[str] = Query(None)):
     try:
         kanban_db.link_tasks(conn, payload.parent_id, payload.child_id)
         return {"ok": True}
+    except kanban_db.ExternalTaskConflict as exc:
+        raise _external_conflict_http(exc)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     finally:
@@ -1137,6 +1173,8 @@ def delete_link(
     try:
         ok = kanban_db.unlink_tasks(conn, parent_id, child_id)
         return {"ok": bool(ok)}
+    except kanban_db.ExternalTaskConflict as exc:
+        raise _external_conflict_http(exc)
     finally:
         conn.close()
 
@@ -1232,6 +1270,13 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                             )
                         if not ok:
                             entry.update(ok=False, error="assign refused")
+                    except kanban_db.ExternalTaskConflict as exc:
+                        entry.update(
+                            ok=False,
+                            error=str(exc),
+                            code=exc.code,
+                            run_id=exc.run_id,
+                        )
                     except RuntimeError as e:
                         entry.update(ok=False, error=str(e))
                 if payload.priority is not None:
@@ -1246,6 +1291,13 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                             (tid, json.dumps({"priority": int(payload.priority)}),
                              int(time.time())),
                         )
+            except kanban_db.ExternalTaskConflict as exc:
+                entry.update(
+                    ok=False,
+                    error=str(exc),
+                    code=exc.code,
+                    run_id=exc.run_id,
+                )
             except Exception as e:  # defensive — one bad id shouldn't kill the batch
                 entry.update(ok=False, error=str(e))
             results.append(entry)
@@ -1547,6 +1599,8 @@ def terminate_run_endpoint(
                 ),
             )
         return {"ok": True, "run_id": run_id, "task_id": r.task_id}
+    except kanban_db.ExternalTaskConflict as exc:
+        raise _external_conflict_http(exc)
     finally:
         conn.close()
 
@@ -1585,6 +1639,8 @@ def reclaim_task_endpoint(
                 ),
             )
         return {"ok": True, "task_id": task_id}
+    except kanban_db.ExternalTaskConflict as exc:
+        raise _external_conflict_http(exc)
     finally:
         conn.close()
 
@@ -1678,6 +1734,8 @@ def reassign_task_endpoint(
                 ),
             )
         return {"ok": True, "task_id": task_id, "assignee": payload.profile or None}
+    except kanban_db.ExternalTaskConflict as exc:
+        raise _external_conflict_http(exc)
     finally:
         conn.close()
 
@@ -2115,6 +2173,8 @@ def delete_board(slug: str, delete: bool = Query(False, description="Hard-delete
     """Archive (default) or hard-delete a board."""
     try:
         res = kanban_db.remove_board(slug, archive=not delete)
+    except kanban_db.ExternalTaskConflict as exc:
+        raise _external_conflict_http(exc)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     return {"result": res, "current": kanban_db.get_current_board()}

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -175,3 +175,59 @@ def test_unseen_events_for_sub_survives_migrated_db(tmp_path, monkeypatch):
         )
         assert isinstance(cursor, int)
         assert isinstance(events, list)
+
+
+def test_external_worker_schema_is_present_on_fresh_and_legacy_boards(
+    tmp_path, monkeypatch
+):
+    legacy_path = _setup_home(tmp_path, monkeypatch)
+    _make_legacy_db(legacy_path)
+    fresh_path = kb.kanban_db_path(board="fresh")
+    fresh_path.parent.mkdir(parents=True, exist_ok=True)
+    kb._INITIALIZED_PATHS.discard(str(fresh_path.resolve()))
+
+    expected_task = {
+        "external_spec_attachment_id",
+        "external_spec_hash",
+        "external_spec_schema",
+        "external_spec_locked_at",
+    }
+    expected_run = {
+        "worker_kind",
+        "external_host",
+        "external_pid",
+        "external_pgid",
+        "external_start_token",
+        "external_spec_attachment_id",
+        "external_spec_hash",
+        "external_spec_schema",
+        "external_attempt",
+        "external_substate",
+        "external_lease_state",
+        "external_recovery_count",
+        "external_terminal_disposition",
+        "external_block_kind",
+        "external_result_hash",
+        "external_result_json",
+    }
+    for path in (legacy_path, fresh_path):
+        with kb.connect(path) as conn:
+            task_cols = {
+                row["name"] for row in conn.execute("PRAGMA table_info(tasks)")
+            }
+            run_cols = {
+                row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")
+            }
+            attachment_cols = {
+                row["name"]
+                for row in conn.execute("PRAGMA table_info(task_attachments)")
+            }
+            assert expected_task <= task_cols
+            assert expected_run <= run_cols
+            assert "spec_hash" in attachment_cols
+            table = conn.execute(
+                "SELECT sql FROM sqlite_master "
+                "WHERE type='table' AND name='task_external_artifacts'"
+            ).fetchone()
+            assert table is not None
+            assert "UNIQUE (run_id, name)" in table["sql"]

--- a/tests/hermes_cli/test_kanban_external_worker.py
+++ b/tests/hermes_cli/test_kanban_external_worker.py
@@ -1,0 +1,2118 @@
+"""Kernel-level tests for the external-worker transaction seam.
+
+These tests assert the *frozen* public contract of
+``hermes_cli.kanban_external_worker``: raw-byte spec identity, strict JSON
+parser negatives, atomic submit rollback, attachment swap/mutation detection,
+copied claim identity, expected-spec/lease CAS, bind mismatch + required
+pgid, heartbeat ownership/expiry, typed uncertain hold, affirmative
+no-start / process-absence recovery, no requeue at two holds, uniform
+COMPLETE/REQUEUE/BLOCK exact result bytes, same-hash same-tuple idempotency,
+divergent hash or tuple rejection, public list/get/read APIs, and
+artifact same-name collision behavior.
+
+All tests run against a temp ``HERMES_HOME`` board. They never assert broad
+status alternatives — every assertion pins an exact outcome or exception
+class.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_external_worker as xw
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = kb.kanban_db_path(board="default")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def conn(kanban_home):
+    c = kb.connect()
+    yield c
+    c.close()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _spec_json(*, objective: str = "implement the requested change") -> bytes:
+    return json.dumps(
+        {
+            "schema_version": xw.SPEC_SCHEMA_VERSION,
+            "board": "default",
+            "repo_key": "fixture",
+            "objective": objective,
+            "acceptance_criteria": ["focused tests pass"],
+            "scope": {"include": ["src/**"], "exclude": [".env"]},
+            "base_sha": "a" * 40,
+            "risk": "small",
+            "workflow": "implement-verify",
+            "execution": {
+                "timeout_seconds": 60,
+                "max_attempts": 2,
+                "max_tokens": 1000,
+                "max_cost_usd": None,
+            },
+            "verification": {
+                "check_ids": ["focused"],
+                "fresh_reviewer": True,
+                "security_review": False,
+            },
+            "delivery": {"mode": "review-only", "push": False, "deploy": False},
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def _result_json(
+    *,
+    run_id: int,
+    task_id: str,
+    spec: xw.SpecIdentity,
+    disposition: str,
+    block_kind: str | None = None,
+    attempt: int = 1,
+    process: xw.BoundProcess | None = None,
+    outcome: str | None = None,
+    absence_proven: bool = True,
+    summary: str = "fixture result",
+    deliverable: dict | None = None,
+    artifacts: list[dict] | None = None,
+) -> bytes:
+    if outcome is None:
+        outcome = "completed" if process is not None else "aborted_before_start"
+    identity = None
+    if process is not None:
+        identity = {
+            "host": process.host,
+            "pid": process.pid,
+            "pgid": process.pgid,
+            "start_token": process.start_token,
+        }
+    return json.dumps(
+        {
+            "mas": {
+                "schema_version": xw.RESULT_SCHEMA_VERSION,
+                "spec_sha256": spec.spec_hash,
+                "submitted_attachment_id": spec.attachment_id,
+                "run_id": run_id,
+                "attempt": attempt,
+                "outcome": outcome,
+                "disposition": disposition.lower(),
+                "block_kind": block_kind,
+                "writer": {"backend": None, "model": None},
+                "reviewer": {"backend": None, "model": None, "verdict": None},
+                "process": {
+                    "identity": identity,
+                    "termination_status": "exited" if process else "not_started",
+                    "absence_proven": absence_proven,
+                },
+                "git": {
+                    "base_sha": "a" * 40,
+                    "head_sha": None,
+                    "branch": None,
+                    "diff_sha256": None,
+                    "changed_files": [],
+                    "primary_unchanged": True,
+                },
+                "deliverable": deliverable
+                or {"kind": None, "attachment": None, "sha256": None},
+                "checks": [],
+                "usage": {
+                    "input_tokens": None,
+                    "output_tokens": None,
+                    "reasoning_tokens": None,
+                    "cost_usd": None,
+                    "cost_status": "unknown",
+                    "source": "unknown",
+                },
+                "failure_signature": None,
+                "summary": summary,
+                "artifacts": artifacts or [],
+            }
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def _make_task_with_spec(
+    conn, *, title: str = "t", body: str = "b"
+) -> tuple[str, int, bytes]:
+    """Create a task, upload a spec attachment, return (task_id, att_id, raw)."""
+    tid = kb.create_task(conn, title=title, body=body, triage=True)
+    raw = _spec_json(objective=title)
+    aid = kb.store_attachment_bytes(
+        conn, tid, filename=xw.SPEC_ATTACHMENT_NAME, data=raw
+    )
+    return tid, aid, raw
+
+
+def _submit_and_claim(
+    conn, *, lease_token: str = "lease-1", ttl: int = 600
+) -> tuple[str, int, bytes, xw.SpecIdentity, xw.Lease]:
+    tid, aid, raw = _make_task_with_spec(conn)
+    spec = xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+    lease = xw.claim_external(
+        conn,
+        task_id=tid,
+        expected_spec=spec,
+        lease_token=lease_token,
+        lease_expires_at=int(time.time()) + ttl,
+    )
+    return tid, aid, raw, spec, lease
+
+
+def _expire_lease(conn, lease: xw.Lease) -> xw.Lease:
+    expired_at = int(time.time()) - 1
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE task_runs SET claim_expires = ? WHERE id = ?",
+            (expired_at, lease.run_id),
+        )
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (expired_at, lease.task_id),
+        )
+    return replace(lease, lease_expires_at=expired_at)
+
+
+# ---------------------------------------------------------------------------
+# Module constants
+# ---------------------------------------------------------------------------
+
+
+def test_module_exposes_api_version():
+    assert xw.EXTERNAL_WORKER_API_VERSION == 1
+    assert xw.SPEC_SCHEMA_VERSION == "mas-task-spec.v1"
+    assert xw.RESULT_SCHEMA_VERSION == "mas-execution-result.v1"
+    assert xw.SPEC_ATTACHMENT_NAME == "mas-task-spec.v1.json"
+
+
+def test_public_seam_opens_named_board_without_kanban_db_import(kanban_home):
+    with xw.connect(board="external-fixture") as public_conn:
+        task_id = kb.create_task(public_conn, title="public connection")
+        assert kb.get_task(public_conn, task_id) is not None
+
+
+# ---------------------------------------------------------------------------
+# submit — raw-byte hash, exact attachment id, atomic lock
+# ---------------------------------------------------------------------------
+
+
+def test_submit_records_raw_byte_hash_and_attachment_id(kanban_home, conn):
+    tid, aid, raw = _make_task_with_spec(conn)
+    spec = xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+    # Identity is the exact raw-byte SHA-256 — never normalized.
+    assert spec.spec_hash == hashlib.sha256(raw).hexdigest()
+    assert spec.attachment_id == aid
+    assert spec.schema_version == xw.SPEC_SCHEMA_VERSION
+
+    t = kb.get_task(conn, tid)
+    assert t is not None
+    assert t.status == "ready"
+    assert t.external_spec_hash == spec.spec_hash
+    assert t.external_spec_attachment_id == aid
+    assert t.external_spec_schema == xw.SPEC_SCHEMA_VERSION
+    assert t.external_spec_locked_at is not None
+
+
+def test_submit_does_not_touch_title_body(kanban_home, conn):
+    """The spec attachment is the sole authoritative input after submit;
+    submit must not rewrite title/body in a separate transaction."""
+    tid = kb.create_task(conn, title="orig-title", body="orig-body", triage=True)
+    raw = _spec_json(objective="DIFFERENT")
+    aid = kb.store_attachment_bytes(
+        conn, tid, filename=xw.SPEC_ATTACHMENT_NAME, data=raw
+    )
+    xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+    t = kb.get_task(conn, tid)
+    assert t is not None
+    # Task row's title/body are exactly what create_task set.
+    assert t.title == "orig-title"
+    assert t.body == "orig-body"
+
+
+def test_submit_rejects_already_locked_task(kanban_home, conn):
+    tid, aid, _ = _make_task_with_spec(conn)
+    xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+    with pytest.raises(xw.SpecMutationError):
+        xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+
+
+def test_submit_rejects_attachment_on_other_task(kanban_home, conn):
+    tid1, aid1, _ = _make_task_with_spec(conn)
+    tid2 = kb.create_task(conn, title="other", triage=True)
+    with pytest.raises(xw.AttachmentNotOwnedError):
+        xw.submit(conn, task_id=tid2, spec_attachment_id=aid1)
+
+
+def test_submit_rejects_wrong_filename(kanban_home, conn):
+    tid = kb.create_task(conn, title="t", body="b", triage=True)
+    aid = kb.store_attachment_bytes(conn, tid, filename="not-the-spec.json", data=b"{}")
+    with pytest.raises(xw.AttachmentMismatchError):
+        xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+
+
+def test_submit_rejects_more_than_one_canonical_attachment(kanban_home, conn):
+    tid, aid, _raw = _make_task_with_spec(conn)
+    att = kb.get_attachment(conn, aid)
+    kb.add_attachment(
+        conn,
+        tid,
+        filename=xw.SPEC_ATTACHMENT_NAME,
+        stored_path=att.stored_path,
+        size=att.size,
+    )
+    with pytest.raises(xw.AttachmentMismatchError):
+        xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+
+
+def test_submit_routes_unfinished_dependency_to_todo(kanban_home, conn):
+    parent = kb.create_task(conn, title="parent", body="b")
+    tid = kb.create_task(
+        conn, title="child", body="b", triage=True, parents=[parent]
+    )
+    raw = _spec_json()
+    aid = kb.store_attachment_bytes(
+        conn, tid, filename=xw.SPEC_ATTACHMENT_NAME, data=raw
+    )
+    xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+    assert kb.get_task(conn, tid).status == "todo"
+
+
+def test_submitted_canonical_attachment_cannot_be_added_or_deleted(
+    kanban_home, conn
+):
+    tid, aid, _raw = _make_task_with_spec(conn)
+    xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+    att = kb.get_attachment(conn, aid)
+    with pytest.raises(kb.ExternalTaskConflict) as added:
+        kb.add_attachment(
+            conn,
+            tid,
+            filename=xw.SPEC_ATTACHMENT_NAME,
+            stored_path=att.stored_path,
+            size=att.size,
+        )
+    assert added.value.code == "external_spec_locked"
+    with pytest.raises(kb.ExternalTaskConflict) as deleted:
+        kb.delete_attachment(conn, aid)
+    assert deleted.value.code == "external_spec_locked"
+
+
+def test_submit_atomic_rollback_on_bad_json(kanban_home, conn):
+    """A failed submit must leave the task row untouched — no partial lock."""
+    tid = kb.create_task(conn, title="t", body="b", triage=True)
+    bad = b"{not valid json"
+    aid = kb.store_attachment_bytes(
+        conn, tid, filename=xw.SPEC_ATTACHMENT_NAME, data=bad
+    )
+    with pytest.raises(xw.SpecParseError):
+        xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+    t = kb.get_task(conn, tid)
+    assert t is not None
+    # Atomic rollback: no spec lock, task status unchanged.
+    assert t.external_spec_hash is None
+    assert t.external_spec_attachment_id is None
+    assert t.external_spec_locked_at is None
+
+
+def test_submit_is_atomic_under_concurrent_lock(kanban_home, conn):
+    """If the task row is locked by a concurrent writer mid-submit, the
+    spec validation must still roll back (the WHERE clause external_spec_hash
+    IS NULL matches 0 rows → no partial state)."""
+    tid, aid, _ = _make_task_with_spec(conn)
+    # Simulate a concurrent writer locking the spec manually.
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET external_spec_hash = 'existing', "
+            "external_spec_schema = 'mas-task-spec.v1', "
+            "external_spec_attachment_id = 999, "
+            "external_spec_locked_at = 1 WHERE id = ?",
+            (tid,),
+        )
+    with pytest.raises(xw.SpecMutationError):
+        xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+    t = kb.get_task(conn, tid)
+    assert t is not None
+    # The concurrent lock is intact; submit did not overwrite.
+    assert t.external_spec_hash == "existing"
+    assert t.external_spec_attachment_id == 999
+
+
+# ---------------------------------------------------------------------------
+# read_submitted_attachment
+# ---------------------------------------------------------------------------
+
+
+def test_read_submitted_attachment_returns_exact_bytes(kanban_home, conn):
+    tid, aid, raw = _make_task_with_spec(conn)
+    xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+    out = xw.read_submitted_attachment(conn, task_id=tid, attachment_id=aid)
+    assert out == raw
+
+
+def test_read_submitted_attachment_rejects_other_task(kanban_home, conn):
+    tid, aid, _ = _make_task_with_spec(conn)
+    xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+    tid2 = kb.create_task(conn, title="other")
+    with pytest.raises(xw.AttachmentNotOwnedError):
+        xw.read_submitted_attachment(conn, task_id=tid2, attachment_id=aid)
+
+
+def test_read_submitted_attachment_detects_byte_mutation(kanban_home, conn):
+    tid, aid, _ = _make_task_with_spec(conn)
+    spec = xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+    # Mutate the on-disk bytes.
+    att = kb.get_attachment(conn, aid)
+    Path(att.stored_path).write_bytes(b"TAMPERED")
+    with pytest.raises(xw.AttachmentMismatchError):
+        xw.read_submitted_attachment(conn, task_id=tid, attachment_id=aid)
+
+
+def test_read_submitted_attachment_detects_attachment_swap(kanban_home, conn):
+    """If someone swaps the spec attachment row to point at different bytes
+    (same task, same name), the hash check fires."""
+    tid, aid, raw = _make_task_with_spec(conn)
+    xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+    # Upload a second attachment with the same name (collision-resolved)
+    # and repoint the original row's stored_path at it.
+    raw2 = _spec_json(objective="DIFFERENT")
+    aid2 = kb.store_attachment_bytes(
+        conn, tid, filename=xw.SPEC_ATTACHMENT_NAME, data=raw2
+    )
+    att2 = kb.get_attachment(conn, aid2)
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE task_attachments SET stored_path = ?, size = ? WHERE id = ?",
+            (att2.stored_path, len(raw2), aid),
+        )
+    with pytest.raises(xw.AttachmentMismatchError):
+        xw.read_submitted_attachment(conn, task_id=tid, attachment_id=aid)
+
+
+# ---------------------------------------------------------------------------
+# Strict JSON parser negatives
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_bytes",
+    [
+        b"\xff\xfe" + b'"x"',
+        b"\xef\xbb\xbf" + _spec_json(),
+        _spec_json() + b"\x00extra",
+        b'{"a": "\xff"}',
+        b'{"schema_version":"mas-task-spec.v1","schema_version":"duplicate"}',
+        b"NaN",
+    ],
+)
+def test_strict_json_parser_negatives(kanban_home, conn, bad_bytes):
+    tid = kb.create_task(conn, title="t", body="b", triage=True)
+    aid = kb.store_attachment_bytes(
+        conn, tid, filename=xw.SPEC_ATTACHMENT_NAME, data=bad_bytes
+    )
+    with pytest.raises(xw.SpecParseError):
+        xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+
+
+@pytest.mark.parametrize("mutation", ["extra", "missing", "wrong_nested", "infinity"])
+def test_strict_taskspec_shape_rejected(kanban_home, conn, mutation):
+    tid = kb.create_task(conn, title="t", body="b", triage=True)
+    payload = json.loads(_spec_json())
+    if mutation == "extra":
+        payload["extra"] = True
+    elif mutation == "missing":
+        del payload["workflow"]
+    elif mutation == "wrong_nested":
+        payload["scope"] = []
+    else:
+        payload["execution"]["max_cost_usd"] = float("inf")
+    bad = json.dumps(payload, allow_nan=True).encode()
+    aid = kb.store_attachment_bytes(
+        conn, tid, filename=xw.SPEC_ATTACHMENT_NAME, data=bad
+    )
+    with pytest.raises(xw.SpecParseError):
+        xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+
+
+def test_strict_json_allows_trailing_whitespace(kanban_home, conn):
+    tid = kb.create_task(conn, title="t", body="b", triage=True)
+    raw = _spec_json() + b"\n  "
+    aid = kb.store_attachment_bytes(
+        conn, tid, filename=xw.SPEC_ATTACHMENT_NAME, data=raw
+    )
+    spec = xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+    assert spec.spec_hash == hashlib.sha256(raw).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# claim_external — copied spec identity, expected-spec CAS
+# ---------------------------------------------------------------------------
+
+
+def test_claim_copies_spec_identity_into_task_runs(kanban_home, conn):
+    tid, aid, _, spec, lease = _submit_and_claim(conn)
+    assert lease.lease_state == xw.LEASE_ACTIVE
+    assert lease.attempt == 1
+    row = conn.execute(
+        "SELECT * FROM task_runs WHERE id = ?", (lease.run_id,)
+    ).fetchone()
+    assert row["worker_kind"] == xw.WORKER_KIND
+    assert int(row["external_spec_attachment_id"]) == aid
+    assert row["external_spec_hash"] == spec.spec_hash
+    assert row["external_spec_schema"] == spec.schema_version
+    assert int(row["external_attempt"]) == 1
+    assert row["external_substate"] == xw.SUBSTATE_CLAIMED
+    assert row["external_lease_state"] == xw.LEASE_ACTIVE
+    assert int(row["external_recovery_count"]) == 0
+    assert row["claim_lock"] == lease.lease_token
+    events = kb.list_events(conn, tid)
+    claimed = next(event for event in events if event.kind == "external_claimed")
+    assert lease.lease_token not in json.dumps(claimed.payload)
+
+
+def test_claim_refuses_second_open_run_after_task_state_drift(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status='ready', claim_lock=NULL, "
+            "claim_expires=NULL, current_run_id=NULL WHERE id=?",
+            (tid,),
+        )
+    with pytest.raises(xw.ClaimRejected):
+        xw.claim_external(
+            conn,
+            task_id=tid,
+            expected_spec=spec,
+            lease_token="second",
+            lease_expires_at=int(time.time()) + 60,
+        )
+    active = xw.list_active(conn)
+    assert [item.run_id for item in active] == [lease.run_id]
+
+
+def test_claim_rejects_wrong_expected_spec_hash(kanban_home, conn):
+    tid, aid, _, spec, _ = _submit_and_claim(conn)
+    # Requeue back to ready by direct SQL so we can re-claim.
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status='ready', claim_lock=NULL, "
+            "claim_expires=NULL, current_run_id=NULL WHERE id=?",
+            (tid,),
+        )
+    bad_spec = xw.SpecIdentity(
+        attachment_id=aid,
+        spec_hash="0" * 64,
+        schema_version=spec.schema_version,
+    )
+    with pytest.raises(xw.ClaimRejected):
+        xw.claim_external(
+            conn,
+            task_id=tid,
+            expected_spec=bad_spec,
+            lease_token="other",
+            lease_expires_at=int(time.time()) + 60,
+        )
+
+
+def test_claim_rejects_already_claimed(kanban_home, conn):
+    tid, aid, _, spec, _ = _submit_and_claim(conn)
+    with pytest.raises(xw.ClaimRejected):
+        xw.claim_external(
+            conn,
+            task_id=tid,
+            expected_spec=spec,
+            lease_token="other",
+            lease_expires_at=int(time.time()) + 60,
+        )
+
+
+def test_claim_rejects_when_spec_attachment_swapped_after_submit(kanban_home, conn):
+    """Re-reads and rehashes the accepted attachment in the same txn. If
+    the on-disk bytes have drifted between submit and claim, the recomputed
+    hash disagrees and CAS refuses."""
+    tid, aid, raw, spec, _ = _submit_and_claim(conn)
+    # Requeue back to ready for re-claim.
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status='ready', claim_lock=NULL, "
+            "claim_expires=NULL, current_run_id=NULL WHERE id=?",
+            (tid,),
+        )
+    # Tamper with the spec attachment bytes — submit-time hash no longer matches.
+    att = kb.get_attachment(conn, aid)
+    Path(att.stored_path).write_bytes(b"TAMPERED")
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE task_attachments SET size = ? WHERE id = ?",
+            (len(b"TAMPERED"), aid),
+        )
+    with pytest.raises(xw.ClaimRejected):
+        xw.claim_external(
+            conn,
+            task_id=tid,
+            expected_spec=spec,
+            lease_token="other",
+            lease_expires_at=int(time.time()) + 60,
+        )
+
+
+def test_claim_rejects_past_expiry(kanban_home, conn):
+    tid, aid, _, spec, _ = _submit_and_claim(conn)
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status='ready', claim_lock=NULL, "
+            "claim_expires=NULL, current_run_id=NULL WHERE id=?",
+            (tid,),
+        )
+    with pytest.raises(xw.ExternalWorkerError):
+        xw.claim_external(
+            conn,
+            task_id=tid,
+            expected_spec=spec,
+            lease_token="x",
+            lease_expires_at=int(time.time()) - 1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# bind_process — required pgid, mismatch, idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_bind_process_requires_pgid(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    with pytest.raises(ValueError):
+        xw.BoundProcess(host="h", pid=1, pgid=0, start_token="t")
+
+
+def test_bind_process_requires_positive_pid(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    with pytest.raises(ValueError):
+        xw.BoundProcess(host="h", pid=0, pgid=1, start_token="t")
+
+
+def test_bind_process_records_durable_bound_substate(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    proc = xw.BoundProcess(host="h", pid=123, pgid=123, start_token="tok")
+    bound = xw.bind_process(conn, lease=lease, process=proc)
+    assert bound.lease_state == xw.LEASE_BOUND
+    row = conn.execute(
+        "SELECT * FROM task_runs WHERE id = ?", (lease.run_id,)
+    ).fetchone()
+    assert row["external_substate"] == xw.SUBSTATE_BOUND
+    assert row["external_lease_state"] == xw.LEASE_BOUND
+    assert row["external_host"] == "h"
+    assert int(row["external_pid"]) == 123
+    assert int(row["external_pgid"]) == 123
+    assert row["external_start_token"] == "tok"
+
+
+def test_bind_process_idempotent_for_same_identity(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    proc = xw.BoundProcess(host="h", pid=123, pgid=123, start_token="tok")
+    bound1 = xw.bind_process(conn, lease=lease, process=proc)
+    # Same identity quad → idempotent.
+    bound2 = xw.bind_process(conn, lease=bound1, process=proc)
+    assert bound2.lease_state == xw.LEASE_BOUND
+
+
+def test_bind_process_lost_response_replays_with_original_lease(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    proc = xw.BoundProcess(host="h", pid=123, pgid=123, start_token="tok")
+    first = xw.bind_process(conn, lease=lease, process=proc)
+    replay = xw.bind_process(conn, lease=lease, process=proc)
+    assert replay == first
+
+
+def test_bind_process_rejects_divergent_identity(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    proc1 = xw.BoundProcess(host="h", pid=123, pgid=123, start_token="tok1")
+    bound = xw.bind_process(conn, lease=lease, process=proc1)
+    proc2 = xw.BoundProcess(host="h", pid=456, pgid=456, start_token="tok2")
+    # Second call must carry the BOUND-state lease returned by the first
+    # bind — the lease_state field is the caller's assertion about the
+    # run's current state.
+    with pytest.raises(xw.BindMismatch):
+        xw.bind_process(conn, lease=bound, process=proc2)
+
+
+def test_bind_process_rejects_wrong_lease_state(kanban_home, conn):
+    """Bind requires LEASE_ACTIVE; calling it with a BOUND-state lease
+    (i.e. the lease returned by a prior bind) on a divergent identity
+    must raise BindMismatch, not silently accept."""
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    proc1 = xw.BoundProcess(host="h", pid=1, pgid=1, start_token="a")
+    bound = xw.bind_process(conn, lease=lease, process=proc1)
+    # Pass lease with lease_state=BOUND and a divergent process — should
+    # hit the BindMismatch path (identity quad differs).
+    proc2 = xw.BoundProcess(host="h", pid=2, pgid=2, start_token="b")
+    with pytest.raises(xw.BindMismatch):
+        xw.bind_process(conn, lease=bound, process=proc2)
+
+
+# ---------------------------------------------------------------------------
+# heartbeat / still_owns — exact ownership and expiry
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_returns_updated_lease(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    new_expiry = int(time.time()) + 900
+    hb = xw.heartbeat(conn, lease=lease, lease_expires_at=new_expiry)
+    assert hb.lease_expires_at == new_expiry
+    assert hb.lease_state == lease.lease_state
+    row = conn.execute(
+        "SELECT claim_expires FROM task_runs WHERE id = ?", (lease.run_id,)
+    ).fetchone()
+    assert int(row["claim_expires"]) == new_expiry
+
+
+def test_heartbeat_rejects_stale_expected_expiry(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    new_expiry = int(time.time()) + 900
+    xw.heartbeat(conn, lease=lease, lease_expires_at=new_expiry)
+    with pytest.raises(xw.NotOwner):
+        xw.heartbeat(conn, lease=lease, lease_expires_at=new_expiry + 60)
+
+
+def test_heartbeat_cannot_resurrect_expired_lease(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    lease = _expire_lease(conn, lease)
+    with pytest.raises(xw.NotOwner):
+        xw.heartbeat(
+            conn, lease=lease, lease_expires_at=int(time.time()) + 60
+        )
+
+
+def test_heartbeat_rejects_wrong_lease_token(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    bad_lease = xw.Lease(
+        run_id=lease.run_id,
+        task_id=lease.task_id,
+        spec=lease.spec,
+        lease_token="wrong-token",
+        lease_state=xw.LEASE_ACTIVE,
+        lease_expires_at=lease.lease_expires_at,
+        attempt=lease.attempt,
+    )
+    with pytest.raises(xw.NotOwner):
+        xw.heartbeat(conn, lease=bad_lease, lease_expires_at=int(time.time()) + 60)
+
+
+def test_heartbeat_rejects_wrong_expected_state(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    # Caller asserts state=BOUND but the DB is ACTIVE.
+    bad = xw.Lease(
+        run_id=lease.run_id,
+        task_id=lease.task_id,
+        spec=lease.spec,
+        lease_token=lease.lease_token,
+        lease_state=xw.LEASE_BOUND,
+        lease_expires_at=lease.lease_expires_at,
+        attempt=lease.attempt,
+    )
+    with pytest.raises(xw.LeaseStateError):
+        xw.heartbeat(conn, lease=bad, lease_expires_at=int(time.time()) + 60)
+
+
+def test_still_owns_checks_exact_ownership_and_expiry(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    assert not xw.still_owns(conn, lease=replace(lease, lease_token="nope"))
+    expired = _expire_lease(conn, lease)
+    assert not xw.still_owns(conn, lease=expired)
+    # Refresh and verify True.
+    refreshed_at = int(time.time()) + 60
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE task_runs SET claim_expires = ? WHERE id = ?",
+            (refreshed_at, lease.run_id),
+        )
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (refreshed_at, lease.task_id),
+        )
+    assert xw.still_owns(conn, lease=replace(lease, lease_expires_at=refreshed_at))
+
+
+# ---------------------------------------------------------------------------
+# hold_for_recovery — typed bounded proof, durable counter, uncertainty
+# ---------------------------------------------------------------------------
+
+
+def test_hold_for_recovery_increments_counter_and_extends_lease(kanban_home, conn):
+    # Short initial TTL so the recovery extension is observably longer.
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn, ttl=60)
+    proof = xw.RecoveryHoldProof(
+        run_id=lease.run_id, task_id=lease.task_id, bound=None, evidence="lost"
+    )
+    held = xw.hold_for_recovery(conn, lease=lease, proof=proof, extension_seconds=300)
+    assert held.lease_state == xw.LEASE_HOLDING
+    assert held.lease_expires_at > lease.lease_expires_at
+    row = conn.execute(
+        "SELECT * FROM task_runs WHERE id = ?", (lease.run_id,)
+    ).fetchone()
+    assert int(row["external_recovery_count"]) == 1
+    assert row["external_substate"] == xw.SUBSTATE_HOLDING
+    assert row["external_lease_state"] == xw.LEASE_HOLDING
+
+
+def test_hold_for_recovery_can_quarantine_an_expired_lease(kanban_home, conn):
+    tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    lease = _expire_lease(conn, lease)
+    proof = xw.RecoveryHoldProof(
+        run_id=lease.run_id, task_id=tid, bound=None, evidence="uncertain"
+    )
+    held = xw.hold_for_recovery(
+        conn, lease=lease, proof=proof, extension_seconds=60
+    )
+    assert held.lease_state == xw.LEASE_HOLDING
+    assert held.lease_expires_at > int(time.time())
+
+
+def test_second_hold_requires_manual_recovery_and_third_is_rejected(
+    kanban_home, conn
+):
+    tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    proof = xw.RecoveryHoldProof(
+        run_id=lease.run_id, task_id=tid, bound=None, evidence="uncertain"
+    )
+    held = xw.hold_for_recovery(
+        conn, lease=lease, proof=proof, extension_seconds=60
+    )
+    held = xw.hold_for_recovery(
+        conn, lease=held, proof=proof, extension_seconds=60
+    )
+    assert held.recovery_count == 2
+    events = kb.list_events(conn, tid)
+    assert [e.kind for e in events].count("external_manual_recovery_required") == 1
+    with pytest.raises(xw.RecoveryRejected):
+        xw.hold_for_recovery(
+            conn, lease=held, proof=proof, extension_seconds=60
+        )
+
+
+def test_hold_for_recovery_rejects_proof_with_wrong_identity(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    bad = xw.RecoveryHoldProof(
+        run_id=lease.run_id + 999,
+        task_id=lease.task_id,
+        bound=None,
+        evidence="x",
+    )
+    with pytest.raises(xw.RecoveryRejected):
+        xw.hold_for_recovery(conn, lease=lease, proof=bad)
+
+
+def test_hold_for_recovery_rejects_bound_proof_for_unbound_run(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    # Run is unbound (no bind_process called), but proof claims a bound proc.
+    proof = xw.RecoveryHoldProof(
+        run_id=lease.run_id,
+        task_id=lease.task_id,
+        bound=xw.BoundProcess(host="h", pid=1, pgid=1, start_token="x"),
+        evidence="x",
+    )
+    with pytest.raises(xw.RecoveryRejected):
+        xw.hold_for_recovery(conn, lease=lease, proof=proof)
+
+
+def test_hold_for_recovery_uncertainty_does_not_release(kanban_home, conn):
+    """A failed hold (wrong lease state) leaves the run fully active."""
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    bad = xw.Lease(
+        run_id=lease.run_id,
+        task_id=lease.task_id,
+        spec=lease.spec,
+        lease_token=lease.lease_token,
+        lease_state=xw.LEASE_BOUND,  # DB is ACTIVE — mismatch
+        lease_expires_at=lease.lease_expires_at,
+        attempt=lease.attempt,
+    )
+    proof = xw.RecoveryHoldProof(
+        run_id=lease.run_id, task_id=lease.task_id, bound=None, evidence="x"
+    )
+    with pytest.raises(xw.LeaseStateError):
+        xw.hold_for_recovery(conn, lease=bad, proof=proof)
+    # Run is still active and owned.
+    row = conn.execute(
+        "SELECT ended_at, external_lease_state, claim_lock FROM task_runs WHERE id = ?",
+        (lease.run_id,),
+    ).fetchone()
+    assert row["ended_at"] is None
+    assert row["external_lease_state"] == xw.LEASE_ACTIVE
+    assert row["claim_lock"] == lease.lease_token
+
+
+# ---------------------------------------------------------------------------
+# recover_expired — affirmative proof, no os.kill inference, no requeue @ 2 holds
+# ---------------------------------------------------------------------------
+
+
+def test_recover_expired_with_no_start_proof_for_unbound_run(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    lease = _expire_lease(conn, lease)
+    proof = xw.NoStartAckProof(
+        run_id=lease.run_id, task_id=tid, evidence="never-started"
+    )
+    result_bytes = _result_json(
+        run_id=lease.run_id, task_id=tid, spec=spec, disposition="COMPLETE"
+    )
+    result = xw.ExecutionResult(
+        disposition="COMPLETE",
+        block_kind=None,
+        result_bytes=result_bytes,
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+    )
+    out = xw.recover_expired(
+        conn,
+        lease=lease,
+        proof=proof,
+        result=result,
+    )
+    assert out.disposition == "COMPLETE"
+    assert not out.requeued
+    assert not out.blocked
+    t = kb.get_task(conn, tid)
+    assert t is not None and t.status == "done"
+
+
+def test_recover_expired_with_absence_proof_for_bound_run(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    proc = xw.BoundProcess(host="h", pid=12345, pgid=12345, start_token="tok")
+    lease = xw.bind_process(conn, lease=lease, process=proc)
+    lease = _expire_lease(conn, lease)
+    proof = xw.ProcessAbsenceProof(
+        host="h", pid=12345, pgid=12345, start_token="tok", evidence="waitpid:9"
+    )
+    result = xw.ExecutionResult(
+        disposition="COMPLETE",
+        block_kind=None,
+        result_bytes=_result_json(
+            run_id=lease.run_id,
+            task_id=tid,
+            spec=spec,
+            disposition="COMPLETE",
+            process=proc,
+            outcome="recovered_after_crash",
+        ),
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+    )
+    out = xw.recover_expired(
+        conn,
+        lease=lease,
+        proof=proof,
+        result=result,
+    )
+    assert out.disposition == "COMPLETE"
+
+
+def test_recover_expired_rejects_unexpired_lease(kanban_home, conn):
+    """Uncertainty (lease not expired) leaves the run active."""
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    proof = xw.NoStartAckProof(run_id=lease.run_id, task_id=tid, evidence="x")
+    result = xw.ExecutionResult(
+        disposition="COMPLETE",
+        block_kind=None,
+        result_bytes=_result_json(
+            run_id=lease.run_id, task_id=tid, spec=spec, disposition="COMPLETE"
+        ),
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+    )
+    with pytest.raises(xw.RecoveryRejected):
+        xw.recover_expired(
+            conn,
+            lease=lease,
+            proof=proof,
+            result=result,
+        )
+    row = conn.execute(
+        "SELECT ended_at FROM task_runs WHERE id = ?", (lease.run_id,)
+    ).fetchone()
+    assert row["ended_at"] is None
+
+
+def test_recover_expired_rejects_wrong_expected_lease_state(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    lease = _expire_lease(conn, lease)
+    wrong = replace(lease, lease_state=xw.LEASE_BOUND)
+    proof = xw.NoStartAckProof(
+        run_id=lease.run_id, task_id=tid, evidence="never-started"
+    )
+    result = xw.ExecutionResult(
+        disposition="COMPLETE",
+        block_kind=None,
+        result_bytes=_result_json(
+            run_id=lease.run_id, task_id=tid, spec=spec, disposition="COMPLETE"
+        ),
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+    )
+    with pytest.raises(xw.RecoveryRejected):
+        xw.recover_expired(conn, lease=wrong, proof=proof, result=result)
+
+
+def test_recover_expired_rejects_absence_proof_for_unbound_run(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    lease = _expire_lease(conn, lease)
+    proof = xw.ProcessAbsenceProof(
+        host="h", pid=1, pgid=1, start_token="x", evidence="x"
+    )
+    result = xw.ExecutionResult(
+        disposition="COMPLETE",
+        block_kind=None,
+        result_bytes=_result_json(
+            run_id=lease.run_id, task_id=tid, spec=spec, disposition="COMPLETE"
+        ),
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+    )
+    with pytest.raises(xw.RecoveryRejected):
+        xw.recover_expired(
+            conn,
+            lease=lease,
+            proof=proof,
+            result=result,
+        )
+
+
+def test_recover_expired_rejects_no_start_proof_for_bound_run(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    proc = xw.BoundProcess(host="h", pid=12345, pgid=12345, start_token="t")
+    lease = xw.bind_process(
+        conn,
+        lease=lease,
+        process=proc,
+    )
+    lease = _expire_lease(conn, lease)
+    proof = xw.NoStartAckProof(run_id=lease.run_id, task_id=tid, evidence="x")
+    result = xw.ExecutionResult(
+        disposition="COMPLETE",
+        block_kind=None,
+        result_bytes=_result_json(
+            run_id=lease.run_id,
+            task_id=tid,
+            spec=spec,
+            disposition="COMPLETE",
+            process=proc,
+            outcome="recovered_after_crash",
+        ),
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+    )
+    with pytest.raises(xw.RecoveryRejected):
+        xw.recover_expired(
+            conn,
+            lease=lease,
+            proof=proof,
+            result=result,
+        )
+
+
+def test_recover_expired_rejects_requeue_at_two_holds(kanban_home, conn):
+    """After two inconclusive holds, REQUEUE is refused. The run stays
+    active; the caller must supply a non-REQUEUE result orBLOCK disposition."""
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    proof_hold = xw.RecoveryHoldProof(
+        run_id=lease.run_id, task_id=tid, bound=None, evidence="h1"
+    )
+    held_lease = xw.hold_for_recovery(
+        conn, lease=lease, proof=proof_hold, extension_seconds=60
+    )
+    proof_hold2 = xw.RecoveryHoldProof(
+        run_id=lease.run_id, task_id=tid, bound=None, evidence="h2"
+    )
+    held_lease = xw.hold_for_recovery(
+        conn, lease=held_lease, proof=proof_hold2, extension_seconds=60
+    )
+    held_lease = _expire_lease(conn, held_lease)
+    result = xw.ExecutionResult(
+        disposition="REQUEUE",
+        block_kind=None,
+        result_bytes=_result_json(
+            run_id=lease.run_id, task_id=tid, spec=spec, disposition="REQUEUE"
+        ),
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+    )
+    proof = xw.NoStartAckProof(run_id=lease.run_id, task_id=tid, evidence="x")
+    with pytest.raises(xw.RecoveryRejected):
+        xw.recover_expired(
+            conn,
+            lease=held_lease,
+            proof=proof,
+            result=result,
+        )
+    # Run still active (uncertainty leaves it active).
+    row = conn.execute(
+        "SELECT ended_at FROM task_runs WHERE id = ?", (lease.run_id,)
+    ).fetchone()
+    assert row["ended_at"] is None
+
+
+def test_recover_expired_at_two_holds_accepts_block(kanban_home, conn):
+    """At the requeue limit, a BLOCK recovery is accepted."""
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    proof_hold = xw.RecoveryHoldProof(
+        run_id=lease.run_id, task_id=tid, bound=None, evidence="h1"
+    )
+    held = xw.hold_for_recovery(
+        conn, lease=lease, proof=proof_hold, extension_seconds=60
+    )
+    proof_hold2 = xw.RecoveryHoldProof(
+        run_id=lease.run_id, task_id=tid, bound=None, evidence="h2"
+    )
+    held = xw.hold_for_recovery(
+        conn, lease=held, proof=proof_hold2, extension_seconds=60
+    )
+    held = _expire_lease(conn, held)
+    result = xw.ExecutionResult(
+        disposition="BLOCK",
+        block_kind="environment-error",
+        result_bytes=_result_json(
+            run_id=lease.run_id,
+            task_id=tid,
+            spec=spec,
+            disposition="BLOCK",
+            block_kind="environment-error",
+        ),
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+    )
+    proof = xw.NoStartAckProof(run_id=lease.run_id, task_id=tid, evidence="x")
+    out = xw.recover_expired(
+        conn,
+        lease=held,
+        proof=proof,
+        result=result,
+    )
+    assert out.disposition == "BLOCK"
+    assert out.blocked
+    assert out.block_kind == "environment-error"
+
+
+# ---------------------------------------------------------------------------
+# finalize — uniform COMPLETE/REQUEUE/BLOCK, same-hash same-tuple, divergent
+# ---------------------------------------------------------------------------
+
+
+def _bind(_lease):
+    """Helper: no-op placeholder for tests that don't bind."""
+
+
+def test_finalize_complete_persists_exact_result_bytes(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    rb = _result_json(
+        run_id=lease.run_id, task_id=tid, spec=spec, disposition="COMPLETE"
+    )
+    out = xw.finalize(conn, lease=lease, disposition="COMPLETE", result_bytes=rb)
+    assert out.status == xw.FINALIZE_COMMITTED
+    assert out.result_hash == hashlib.sha256(rb).hexdigest()
+    row = conn.execute(
+        "SELECT * FROM task_runs WHERE id = ?", (lease.run_id,)
+    ).fetchone()
+    assert row["external_result_hash"] == out.result_hash
+    assert row["external_result_json"] == rb.decode("utf-8")
+    assert row["metadata"] == rb.decode("utf-8")
+    assert row["summary"] == "fixture result"
+    assert row["external_terminal_disposition"] == "COMPLETE"
+    assert row["external_block_kind"] is None
+    assert row["external_substate"] == xw.SUBSTATE_COMMITTED
+    assert row["external_lease_state"] == xw.LEASE_COMMITTED
+    t = kb.get_task(conn, tid)
+    assert t is not None and t.status == "done"
+    assert t.result == "fixture result"
+
+
+def test_finalize_rejects_result_without_absence_proof(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    rb = _result_json(
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+        disposition="COMPLETE",
+        absence_proven=False,
+    )
+    with pytest.raises(xw.ResultRejected):
+        xw.finalize(conn, lease=lease, disposition="COMPLETE", result_bytes=rb)
+    assert xw.get_run(conn, run_id=lease.run_id).lease_state == xw.LEASE_ACTIVE
+
+
+def test_finalize_rejects_mismatched_bound_process_identity(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    bound = xw.BoundProcess(host="h", pid=10, pgid=10, start_token="bound")
+    lease = xw.bind_process(conn, lease=lease, process=bound)
+    other = xw.BoundProcess(host="h", pid=11, pgid=11, start_token="other")
+    rb = _result_json(
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+        disposition="COMPLETE",
+        process=other,
+    )
+    with pytest.raises(xw.ResultRejected):
+        xw.finalize(conn, lease=lease, disposition="COMPLETE", result_bytes=rb)
+
+
+def test_finalize_requeue_persists_exact_result_bytes(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    rb = _result_json(
+        run_id=lease.run_id, task_id=tid, spec=spec, disposition="REQUEUE"
+    )
+    out = xw.finalize(conn, lease=lease, disposition="REQUEUE", result_bytes=rb)
+    assert out.status == xw.FINALIZE_COMMITTED
+    row = conn.execute(
+        "SELECT * FROM task_runs WHERE id = ?", (lease.run_id,)
+    ).fetchone()
+    assert row["external_result_json"] == rb.decode("utf-8")
+    assert row["external_terminal_disposition"] == "REQUEUE"
+    t = kb.get_task(conn, tid)
+    assert t is not None and t.status == "ready"
+
+
+def test_finalize_block_persists_exact_result_bytes(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    rb = _result_json(
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+        disposition="BLOCK",
+        block_kind="needs_input",
+    )
+    out = xw.finalize(
+        conn,
+        lease=lease,
+        disposition="BLOCK",
+        result_bytes=rb,
+        block_kind="needs_input",
+    )
+    assert out.status == xw.FINALIZE_COMMITTED
+    row = conn.execute(
+        "SELECT * FROM task_runs WHERE id = ?", (lease.run_id,)
+    ).fetchone()
+    assert row["external_terminal_disposition"] == "BLOCK"
+    assert row["external_block_kind"] == "needs_input"
+    t = kb.get_task(conn, tid)
+    assert t is not None and t.status == "blocked"
+    assert kb.recompute_ready(conn) == 0
+    assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_finalize_same_hash_same_tuple_is_idempotent(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    rb = _result_json(
+        run_id=lease.run_id, task_id=tid, spec=spec, disposition="COMPLETE"
+    )
+    xw.finalize(conn, lease=lease, disposition="COMPLETE", result_bytes=rb)
+    out = xw.finalize(conn, lease=lease, disposition="COMPLETE", result_bytes=rb)
+    assert out.status == xw.FINALIZE_ALREADY_COMMITTED_SAME_HASH
+
+
+def test_finalize_same_hash_different_disposition_is_rejected(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    rb = _result_json(
+        run_id=lease.run_id, task_id=tid, spec=spec, disposition="COMPLETE"
+    )
+    xw.finalize(conn, lease=lease, disposition="COMPLETE", result_bytes=rb)
+    # Same bytes but caller passes REQUEUE — the bytes encode COMPLETE so
+    # this fails at result JSON validation, but if we encode a REQUEUE
+    # version with otherwise-identical contents the hash differs. The
+    # divergent-tuple check fires when we craft a REQUEUE result that
+    # still produces a *different* hash.
+    rb2 = _result_json(
+        run_id=lease.run_id, task_id=tid, spec=spec, disposition="REQUEUE"
+    )
+    out = xw.finalize(conn, lease=lease, disposition="REQUEUE", result_bytes=rb2)
+    assert out.status == xw.FINALIZE_REJECTED
+    assert out.prior_hash is not None
+
+
+def test_finalize_divergent_hash_is_rejected(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    rb1 = _result_json(
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+        disposition="COMPLETE",
+    )
+    xw.finalize(conn, lease=lease, disposition="COMPLETE", result_bytes=rb1)
+    # Build a different valid result that hashes differently.
+    rb2 = _result_json(
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+        disposition="BLOCK",
+        block_kind="capability",
+    )
+    out = xw.finalize(
+        conn,
+        lease=lease,
+        disposition="BLOCK",
+        result_bytes=rb2,
+        block_kind="capability",
+    )
+    assert out.status == xw.FINALIZE_REJECTED
+    assert out.prior_hash == hashlib.sha256(rb1).hexdigest()
+
+
+def test_finalize_rejects_wrong_lease_token(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    rb = _result_json(
+        run_id=lease.run_id, task_id=tid, spec=spec, disposition="COMPLETE"
+    )
+    bad = xw.Lease(
+        run_id=lease.run_id,
+        task_id=lease.task_id,
+        spec=spec,
+        lease_token="wrong",
+        lease_state=xw.LEASE_ACTIVE,
+        lease_expires_at=lease.lease_expires_at,
+        attempt=1,
+    )
+    with pytest.raises(xw.NotOwner):
+        xw.finalize(conn, lease=bad, disposition="COMPLETE", result_bytes=rb)
+
+
+def test_finalize_rejects_wrong_run_id(kanban_home, conn):
+    """Authorization is never by run id alone — wrong run id + right token
+    must still reject (the run row's identity doesn't match)."""
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    rb = _result_json(
+        run_id=lease.run_id, task_id=tid, spec=spec, disposition="COMPLETE"
+    )
+    bad = xw.Lease(
+        run_id=lease.run_id + 999,
+        task_id=lease.task_id,
+        spec=spec,
+        lease_token=lease.lease_token,
+        lease_state=xw.LEASE_ACTIVE,
+        lease_expires_at=lease.lease_expires_at,
+        attempt=1,
+    )
+    with pytest.raises(xw.NotOwner):
+        xw.finalize(conn, lease=bad, disposition="COMPLETE", result_bytes=rb)
+
+
+# ---------------------------------------------------------------------------
+# put_result — persist before finalize
+# ---------------------------------------------------------------------------
+
+
+def test_put_result_persists_without_finalizing(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    rb = _result_json(
+        run_id=lease.run_id, task_id=tid, spec=spec, disposition="COMPLETE"
+    )
+    h = xw.put_result(conn, lease=lease, disposition="COMPLETE", result_bytes=rb)
+    assert h == hashlib.sha256(rb).hexdigest()
+    row = conn.execute(
+        "SELECT external_result_hash, external_terminal_disposition, "
+        "external_substate, external_lease_state, ended_at "
+        "FROM task_runs WHERE id = ?",
+        (lease.run_id,),
+    ).fetchone()
+    assert row["external_result_hash"] == h
+    assert row["external_terminal_disposition"] == "COMPLETE"
+    # Run still active.
+    assert row["external_substate"] == xw.SUBSTATE_CLAIMED
+    assert row["external_lease_state"] == xw.LEASE_ACTIVE
+    assert row["ended_at"] is None
+
+
+def test_put_result_then_finalize_commits_same_bytes(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    rb = _result_json(
+        run_id=lease.run_id, task_id=tid, spec=spec, disposition="COMPLETE"
+    )
+    xw.put_result(conn, lease=lease, disposition="COMPLETE", result_bytes=rb)
+    out = xw.finalize(conn, lease=lease, disposition="COMPLETE", result_bytes=rb)
+    assert out.status == xw.FINALIZE_COMMITTED
+
+
+def test_put_result_rejects_divergent_staged_result(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    first = _result_json(
+        run_id=lease.run_id, task_id=tid, spec=spec, disposition="COMPLETE"
+    )
+    second = _result_json(
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+        disposition="BLOCK",
+        block_kind="capability",
+    )
+    xw.put_result(conn, lease=lease, disposition="COMPLETE", result_bytes=first)
+    with pytest.raises(xw.ResultRejected):
+        xw.put_result(
+            conn,
+            lease=lease,
+            disposition="BLOCK",
+            block_kind="capability",
+            result_bytes=second,
+        )
+
+
+def test_recovery_cannot_overwrite_divergent_staged_result(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    first = _result_json(
+        run_id=lease.run_id, task_id=tid, spec=spec, disposition="COMPLETE"
+    )
+    xw.put_result(conn, lease=lease, disposition="COMPLETE", result_bytes=first)
+    lease = _expire_lease(conn, lease)
+    second = _result_json(
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+        disposition="BLOCK",
+        block_kind="environment-error",
+    )
+    result = xw.ExecutionResult(
+        disposition="BLOCK",
+        block_kind="environment-error",
+        result_bytes=second,
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+    )
+    proof = xw.NoStartAckProof(
+        run_id=lease.run_id, task_id=tid, evidence="never-started"
+    )
+    with pytest.raises(xw.RecoveryRejected):
+        xw.recover_expired(conn, lease=lease, proof=proof, result=result)
+    row = conn.execute(
+        "SELECT external_result_json, ended_at FROM task_runs WHERE id=?",
+        (lease.run_id,),
+    ).fetchone()
+    assert row["external_result_json"] == first.decode()
+    assert row["ended_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# Public list/get/read APIs
+# ---------------------------------------------------------------------------
+
+
+def test_list_ready_returns_only_locked_external_tasks(kanban_home, conn):
+    # A task with no spec lock must not appear even if status is ready.
+    tid_no_spec = kb.create_task(conn, title="no-spec", body="b")
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status='ready' WHERE id = ?",
+            (tid_no_spec,),
+        )
+    # A properly locked task with no open run SHOULD appear.
+    tid, aid, _raw = _make_task_with_spec(conn)
+    xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+    ready = xw.list_ready(conn)
+    ids = {t.id for t in ready}
+    assert tid in ids
+    assert tid_no_spec not in ids
+
+
+def test_list_ready_excludes_task_with_open_run_despite_task_state_drift(
+    kanban_home, conn
+):
+    tid, _aid, _raw, _spec, _lease = _submit_and_claim(conn)
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status='ready', claim_lock=NULL, "
+            "claim_expires=NULL, current_run_id=NULL WHERE id=?",
+            (tid,),
+        )
+    assert tid not in {task.id for task in xw.list_ready(conn)}
+
+
+def test_list_active_returns_active_external_runs(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    active = xw.list_active(conn)
+    assert len(active) == 1
+    assert active[0].run_id == lease.run_id
+
+
+def test_list_active_ignores_corrupted_task_status_and_run_pointer(
+    kanban_home, conn
+):
+    tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status='ready', current_run_id=NULL, "
+            "claim_lock=NULL, claim_expires=NULL WHERE id = ?",
+            (tid,),
+        )
+    active = xw.list_active(conn)
+    assert [item.run_id for item in active] == [lease.run_id]
+
+
+def test_get_run_returns_typed_lease(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    got = xw.get_run(conn, run_id=lease.run_id)
+    assert got.run_id == lease.run_id
+    assert got.task_id == tid
+    assert got.spec == spec
+
+
+def test_get_run_rejects_unknown_run(kanban_home, conn):
+    with pytest.raises(xw.ExternalWorkerError):
+        xw.get_run(conn, run_id=999999)
+
+
+# ---------------------------------------------------------------------------
+# Native claim_task excludes external tasks
+# ---------------------------------------------------------------------------
+
+
+def test_native_claim_excludes_ready_external_task(kanban_home, conn):
+    tid, _aid, _raw, _spec, _lease = _submit_and_claim(conn)
+    # Requeue to ready.
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status='ready', claim_lock=NULL, "
+            "claim_expires=NULL, current_run_id=NULL WHERE id = ?",
+            (tid,),
+        )
+    # Native claim_task must surface the still-open run even when mutable task
+    # state no longer points at it.
+    with pytest.raises(kb.ExternalTaskConflict) as caught:
+        kb.claim_task(conn, tid)
+    assert caught.value.code == "external_run_active"
+    assert caught.value.run_id == _lease.run_id
+
+
+def test_native_claim_rejects_submitted_external_task_without_run(
+    kanban_home, conn
+):
+    tid, aid, _raw = _make_task_with_spec(conn)
+    xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+    with pytest.raises(kb.ExternalTaskConflict) as caught:
+        kb.claim_task(conn, tid)
+    assert caught.value.code == "external_spec_locked"
+    assert caught.value.run_id is None
+
+
+def test_end_run_defense_refuses_open_external_run(kanban_home, conn):
+    tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    with pytest.raises(kb.ExternalTaskConflict) as caught:
+        kb._end_run(conn, tid, outcome="reclaimed")
+    assert caught.value.operation == "_end_run"
+    assert caught.value.run_id == lease.run_id
+    assert xw.get_run(conn, run_id=lease.run_id).lease_state == xw.LEASE_ACTIVE
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "assign_task",
+        "reassign_task",
+        "complete_task",
+        "block_task",
+        "schedule_task",
+        "archive_task",
+        "delete_task",
+        "reclaim_task",
+    ],
+)
+def test_native_lifecycle_refuses_open_external_run_despite_task_drift(
+    kanban_home, conn, operation
+):
+    tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status='ready', current_run_id=NULL, "
+            "claim_lock=NULL, claim_expires=NULL WHERE id = ?",
+            (tid,),
+        )
+
+    calls = {
+        "assign_task": lambda: kb.assign_task(conn, tid, "other"),
+        "reassign_task": lambda: kb.reassign_task(conn, tid, "other"),
+        "complete_task": lambda: kb.complete_task(conn, tid, result="native"),
+        "block_task": lambda: kb.block_task(conn, tid, reason="native"),
+        "schedule_task": lambda: kb.schedule_task(conn, tid, reason="native"),
+        "archive_task": lambda: kb.archive_task(conn, tid),
+        "delete_task": lambda: kb.delete_task(conn, tid),
+        "reclaim_task": lambda: kb.reclaim_task(conn, tid, reason="native"),
+    }
+    with pytest.raises(kb.ExternalTaskConflict) as caught:
+        calls[operation]()
+    assert caught.value.code == "external_run_active"
+    assert caught.value.operation == operation
+    assert caught.value.run_id == lease.run_id
+    assert kb.get_task(conn, tid).status == "ready"
+    run = conn.execute(
+        "SELECT ended_at FROM task_runs WHERE id = ?", (lease.run_id,)
+    ).fetchone()
+    assert run["ended_at"] is None
+
+
+def test_native_recovery_scans_ignore_open_external_run(kanban_home, conn, monkeypatch):
+    tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    lease = _expire_lease(conn, lease)
+    host_lock = f"{kb._claimer_id().split(':', 1)[0]}:fixture"
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET started_at=1, last_heartbeat_at=NULL, "
+            "worker_pid=999999, max_runtime_seconds=1, claim_lock=?, "
+            "current_run_id=NULL WHERE id=?",
+            (host_lock, tid),
+        )
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    signals = []
+
+    assert kb.release_stale_claims(conn, signal_fn=lambda *args: signals.append(args)) == 0
+    assert kb.detect_stale_running(
+        conn, stale_timeout_seconds=1, signal_fn=lambda *args: signals.append(args)
+    ) == []
+    assert kb.detect_crashed_workers(conn) == []
+    assert kb.enforce_max_runtime(
+        conn, signal_fn=lambda *args: signals.append(args)
+    ) == []
+    assert signals == []
+    assert xw.get_run(conn, run_id=lease.run_id).lease_state == xw.LEASE_ACTIVE
+
+
+def test_native_heartbeat_refuses_open_external_run(kanban_home, conn):
+    tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    with pytest.raises(kb.ExternalTaskConflict) as caught:
+        kb.heartbeat_worker(conn, tid, expected_run_id=lease.run_id)
+    assert caught.value.code == "external_run_active"
+    assert caught.value.operation == "heartbeat_worker"
+
+
+def test_dispatcher_does_not_spawn_external_ready_task(
+    kanban_home, conn, monkeypatch
+):
+    tid, aid, _raw = _make_task_with_spec(conn)
+    xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET assignee='worker' WHERE id=?", (tid,))
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: True)
+    spawned = []
+    kb.dispatch_once(conn, spawn_fn=lambda *args: spawned.append(args))
+    assert spawned == []
+    assert kb.get_task(conn, tid).status == "ready"
+    assert kb.has_spawnable_ready(conn) is False
+
+
+def test_cli_surfaces_external_lifecycle_conflict(kanban_home, conn):
+    tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    from hermes_cli.kanban import run_slash
+
+    output = run_slash(f"complete {tid}")
+    assert "external_run_active" in output
+    assert f"run_id={lease.run_id}" in output
+    assert kb.get_task(conn, tid).status == "running"
+
+
+# ---------------------------------------------------------------------------
+# put_artifact / read_artifact — idempotency + collision
+# ---------------------------------------------------------------------------
+
+
+def test_put_artifact_idempotent_for_same_name_same_bytes(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    ref1 = xw.put_artifact(conn, lease=lease, name="out.txt", data=b"hello")
+    ref2 = xw.put_artifact(conn, lease=lease, name="out.txt", data=b"hello")
+    assert ref1 == ref2
+    rows = conn.execute(
+        "SELECT COUNT(*) AS n FROM task_external_artifacts WHERE run_id = ?",
+        (lease.run_id,),
+    ).fetchone()
+    assert int(rows["n"]) == 1
+
+
+def test_put_artifact_rejects_divergent_bytes_same_name(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    xw.put_artifact(conn, lease=lease, name="out.txt", data=b"hello")
+    with pytest.raises(xw.ArtifactCollision):
+        xw.put_artifact(conn, lease=lease, name="out.txt", data=b"DIFFERENT")
+
+
+def test_put_artifact_rejects_bad_name(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    with pytest.raises(ValueError):
+        # Shell-meta characters are not in the allowed alphabet.
+        xw.put_artifact(conn, lease=lease, name="out;rm.txt", data=b"x")
+
+
+def test_read_artifact_returns_exact_bytes(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    xw.put_artifact(conn, lease=lease, name="out.txt", data=b"payload")
+    out = xw.read_artifact(
+        conn,
+        run_id=lease.run_id,
+        name="out.txt",
+    )
+    assert out == b"payload"
+
+
+def test_read_artifact_remains_available_after_finalize(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    xw.put_artifact(conn, lease=lease, name="out.txt", data=b"payload")
+    rb = _result_json(
+        run_id=lease.run_id, task_id=tid, spec=spec, disposition="COMPLETE"
+    )
+    xw.finalize(conn, lease=lease, disposition="COMPLETE", result_bytes=rb)
+    assert xw.read_artifact(
+        conn, run_id=lease.run_id, name="out.txt"
+    ) == b"payload"
+
+
+def test_read_artifact_rejects_unknown_name(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    with pytest.raises(xw.ArtifactNotFound):
+        xw.read_artifact(
+            conn,
+            run_id=lease.run_id,
+            name="missing.txt",
+        )
+
+
+def test_put_artifact_rejects_wrong_lease(kanban_home, conn):
+    _tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    bad = xw.Lease(
+        run_id=lease.run_id,
+        task_id=lease.task_id,
+        spec=spec,
+        lease_token="wrong",
+        lease_state=xw.LEASE_ACTIVE,
+        lease_expires_at=lease.lease_expires_at,
+        attempt=1,
+    )
+    with pytest.raises(xw.NotOwner):
+        xw.put_artifact(conn, lease=bad, name="x", data=b"y")
+
+
+# ---------------------------------------------------------------------------
+# Module never trusts caller-provided hash
+# ---------------------------------------------------------------------------
+
+
+def test_execution_result_dataclass_rejects_bad_block_kind(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    rb = _result_json(
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+        disposition="BLOCK",
+        block_kind="not-a-real-kind",
+    )
+    with pytest.raises(ValueError):
+        xw.ExecutionResult(
+            disposition="BLOCK",
+            block_kind="not-a-real-kind",
+            result_bytes=rb,
+            run_id=lease.run_id,
+            task_id=tid,
+            spec=spec,
+        )
+
+
+def test_external_block_kinds_include_review_and_environment():
+    """The two block kinds added by the external result contract are valid."""
+    assert "review-required" in kb.VALID_BLOCK_KINDS
+    assert "environment-error" in kb.VALID_BLOCK_KINDS
+
+
+def test_finalize_block_with_new_block_kinds(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    rb = _result_json(
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+        disposition="BLOCK",
+        block_kind="environment-error",
+    )
+    out = xw.finalize(
+        conn,
+        lease=lease,
+        disposition="BLOCK",
+        result_bytes=rb,
+        block_kind="environment-error",
+    )
+    assert out.status == xw.FINALIZE_COMMITTED
+    t = kb.get_task(conn, tid)
+    assert t is not None and t.status == "blocked"
+# Cross-surface lifecycle and restart regressions
+# ---------------------------------------------------------------------------
+
+
+def test_claim_rejects_caller_supplied_attempt_drift(kanban_home, conn):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    with pytest.raises(xw.NotOwner, match="attempt mismatch"):
+        xw.heartbeat(
+            conn,
+            lease=replace(lease, attempt=lease.attempt + 1),
+            lease_expires_at=int(time.time()) + 700,
+        )
+
+
+def test_attempt_ignores_native_task_run_history(kanban_home, conn):
+    tid, aid, _raw = _make_task_with_spec(conn)
+    now = int(time.time())
+    with kb.write_txn(conn):
+        conn.execute(
+            "INSERT INTO task_runs "
+            "(task_id, status, worker_kind, started_at, ended_at) "
+            "VALUES (?, 'completed', 'native', ?, ?)",
+            (tid, now - 1, now),
+        )
+    spec = xw.submit(conn, task_id=tid, spec_attachment_id=aid)
+    lease = xw.claim_external(
+        conn,
+        task_id=tid,
+        expected_spec=spec,
+        lease_token="external-first",
+        lease_expires_at=now + 600,
+    )
+    assert lease.attempt == 1
+
+
+def test_claim_rechecks_unfinished_parents_after_force_promote(kanban_home, conn):
+    parent_id = kb.create_task(conn, title="parent", body="p", triage=True)
+    child_id, child_aid, _raw = _make_task_with_spec(conn, title="child")
+    kb.link_tasks(conn, parent_id, child_id)
+    child_spec = xw.submit(conn, task_id=child_id, spec_attachment_id=child_aid)
+    assert kb.promote_task(
+        conn, child_id, actor="test", reason="force", force=True
+    ) == (True, None)
+    with pytest.raises(xw.ClaimRejected, match="unfinished parent"):
+        xw.claim_external(
+            conn,
+            task_id=child_id,
+            expected_spec=child_spec,
+            lease_token="must-not-win",
+            lease_expires_at=int(time.time()) + 600,
+        )
+    assert kb.get_task(conn, child_id).status == "ready"
+
+
+def test_complete_atomically_promotes_external_dependents(kanban_home, conn):
+    parent_id, parent_aid, _ = _make_task_with_spec(conn, title="parent")
+    child_id, child_aid, _ = _make_task_with_spec(conn, title="child")
+    kb.link_tasks(conn, parent_id, child_id)
+    parent_spec = xw.submit(conn, task_id=parent_id, spec_attachment_id=parent_aid)
+    xw.submit(conn, task_id=child_id, spec_attachment_id=child_aid)
+    assert kb.get_task(conn, child_id).status == "todo"
+    lease = xw.claim_external(
+        conn,
+        task_id=parent_id,
+        expected_spec=parent_spec,
+        lease_token="parent",
+        lease_expires_at=int(time.time()) + 600,
+    )
+    result = _result_json(
+        run_id=lease.run_id,
+        task_id=parent_id,
+        spec=parent_spec,
+        disposition="COMPLETE",
+    )
+    xw.finalize(conn, lease=lease, disposition="COMPLETE", result_bytes=result)
+    assert kb.get_task(conn, child_id).status == "ready"
+    assert [task.id for task in xw.list_ready(conn)] == [child_id]
+
+
+def test_named_board_artifacts_follow_connected_database(kanban_home):
+    kb.create_board("named")
+    named = xw.connect(board="named")
+    try:
+        _tid, _aid, _raw, _spec, lease = _submit_and_claim(named)
+        xw.put_artifact(named, lease=lease, name="out.txt", data=b"named")
+        row = named.execute(
+            "SELECT stored_path FROM task_external_artifacts WHERE run_id = ?",
+            (lease.run_id,),
+        ).fetchone()
+        stored = Path(row["stored_path"]).resolve()
+        assert stored.is_relative_to(kb.attachments_root(board="named").resolve())
+        assert not stored.is_relative_to(kb.attachments_root(board="default").resolve())
+        kb.set_current_board("default")
+        assert xw.read_artifact(named, run_id=lease.run_id, name="out.txt") == b"named"
+    finally:
+        named.close()
+
+
+def test_board_removal_rejects_active_external_run(kanban_home):
+    kb.create_board("named")
+    named = xw.connect(board="named")
+    try:
+        _tid, _aid, _raw, _spec, lease = _submit_and_claim(named)
+        with pytest.raises(kb.ExternalTaskConflict) as exc_info:
+            kb.remove_board("named")
+        assert exc_info.value.code == "external_run_active"
+        assert exc_info.value.run_id == lease.run_id
+        assert kb.board_exists("named")
+        assert xw.get_run(named, run_id=lease.run_id).lease_state == xw.LEASE_ACTIVE
+    finally:
+        named.close()
+
+
+def test_stale_connection_cannot_claim_after_board_archive(
+    kanban_home, monkeypatch
+):
+    external_attachments = kanban_home / "external-attachments"
+    monkeypatch.setenv(
+        "HERMES_KANBAN_ATTACHMENTS_ROOT", str(external_attachments)
+    )
+    kb.create_board("named")
+    named = xw.connect(board="named")
+    try:
+        tid, aid, _raw = _make_task_with_spec(named)
+        spec = xw.submit(named, task_id=tid, spec_attachment_id=aid)
+        kb.remove_board("named")
+        assert not kb.kanban_db_path(board="named").exists()
+        with pytest.raises(xw.StaleBoardConnection, match="removed board"):
+            xw.claim_external(
+                named,
+                task_id=tid,
+                expected_spec=spec,
+                lease_token="stale",
+                lease_expires_at=int(time.time()) + 600,
+            )
+        assert xw.list_active(named) == []
+    finally:
+        named.close()
+
+
+def test_native_heartbeat_cannot_extend_external_lease(kanban_home, conn):
+    tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    with pytest.raises(kb.ExternalTaskConflict):
+        kb.heartbeat_claim(conn, tid, claimer=lease.lease_token)
+    assert (
+        xw.get_run(conn, run_id=lease.run_id).lease_expires_at == lease.lease_expires_at
+    )
+
+
+def test_status_independent_native_helpers_reject_external_run(kanban_home, conn):
+    tid, _aid, _raw, _spec, _lease = _submit_and_claim(conn)
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status = 'triage' WHERE id = ?", (tid,))
+    with pytest.raises(kb.ExternalTaskConflict):
+        kb.specify_triage_task(conn, tid, title="changed")
+    with pytest.raises(kb.ExternalTaskConflict):
+        kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="owner",
+            children=[{"title": "child"}],
+        )
+    parent = kb.create_task(conn, title="parent", body="p", triage=True)
+    with pytest.raises(kb.ExternalTaskConflict):
+        kb.link_tasks(conn, parent, tid)
+    with kb.write_txn(conn):
+        conn.execute(
+            "INSERT INTO task_links (parent_id, child_id) VALUES (?, ?)",
+            (parent, tid),
+        )
+    with pytest.raises(kb.ExternalTaskConflict):
+        kb.unlink_tasks(conn, parent, tid)
+
+
+def test_persisted_result_can_be_read_and_recovered_after_reopen(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    result_bytes = _result_json(
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+        disposition="COMPLETE",
+    )
+    expected_hash = xw.put_result(
+        conn,
+        lease=lease,
+        disposition="COMPLETE",
+        result_bytes=result_bytes,
+    )
+
+    reopened = xw.connect(board="default")
+    try:
+        recovered_lease = xw.list_active(reopened)[0]
+        persisted = xw.read_result(reopened, lease=recovered_lease)
+        assert persisted is not None
+        assert persisted.result_bytes == result_bytes
+        assert persisted.result_hash == expected_hash
+        recovered_lease = _expire_lease(reopened, recovered_lease)
+        outcome = xw.recover_expired(
+            reopened,
+            lease=recovered_lease,
+            proof=xw.NoStartAckProof(
+                run_id=lease.run_id,
+                task_id=tid,
+                evidence="restart found no start ACK",
+            ),
+            result=xw.ExecutionResult(
+                disposition=persisted.disposition,
+                block_kind=persisted.block_kind,
+                result_bytes=persisted.result_bytes,
+                run_id=lease.run_id,
+                task_id=tid,
+                spec=spec,
+            ),
+        )
+        assert outcome.disposition == "COMPLETE"
+        assert kb.get_task(reopened, tid).status == "done"
+    finally:
+        reopened.close()
+
+
+def test_recovery_hold_rejects_already_persisted_result(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    result_bytes = _result_json(
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+        disposition="REQUEUE",
+    )
+    xw.put_result(
+        conn,
+        lease=lease,
+        disposition="REQUEUE",
+        result_bytes=result_bytes,
+    )
+    with pytest.raises(xw.RecoveryRejected, match="persisted result"):
+        xw.hold_for_recovery(
+            conn,
+            lease=lease,
+            proof=xw.RecoveryHoldProof(
+                run_id=lease.run_id,
+                task_id=tid,
+                bound=None,
+                evidence="must replay staged result",
+            ),
+        )
+    assert xw.get_run(conn, run_id=lease.run_id).recovery_count == 0
+
+
+def test_recovery_replays_staged_requeue_after_two_prior_holds(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    for index in range(2):
+        lease = xw.hold_for_recovery(
+            conn,
+            lease=lease,
+            proof=xw.RecoveryHoldProof(
+                run_id=lease.run_id,
+                task_id=tid,
+                bound=None,
+                evidence=f"inconclusive inspection {index + 1}",
+            ),
+            extension_seconds=60,
+        )
+    result_bytes = _result_json(
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+        disposition="REQUEUE",
+    )
+    xw.put_result(
+        conn,
+        lease=lease,
+        disposition="REQUEUE",
+        result_bytes=result_bytes,
+    )
+    lease = _expire_lease(conn, lease)
+    persisted = xw.read_result(conn, lease=lease)
+    assert persisted is not None
+    outcome = xw.recover_expired(
+        conn,
+        lease=lease,
+        proof=xw.NoStartAckProof(
+            run_id=lease.run_id,
+            task_id=tid,
+            evidence="restart proved no child start",
+        ),
+        result=xw.ExecutionResult(
+            disposition=persisted.disposition,
+            block_kind=persisted.block_kind,
+            result_bytes=persisted.result_bytes,
+            run_id=lease.run_id,
+            task_id=tid,
+            spec=spec,
+        ),
+    )
+    assert outcome.requeued is True
+    assert kb.get_task(conn, tid).status == "ready"
+
+
+def test_finalize_rejects_declared_artifact_that_is_not_durable(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    result_bytes = _result_json(
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+        disposition="COMPLETE",
+        deliverable={
+            "kind": "patch",
+            "attachment": "missing.patch",
+            "sha256": "1" * 64,
+        },
+        artifacts=[{"name": "also-missing.json", "sha256": "2" * 64}],
+    )
+    with pytest.raises(xw.ResultRejected, match="not persisted"):
+        xw.finalize(
+            conn,
+            lease=lease,
+            disposition="COMPLETE",
+            result_bytes=result_bytes,
+        )
+    assert xw.get_run(conn, run_id=lease.run_id).lease_state == xw.LEASE_ACTIVE
+
+
+def test_finalize_accepts_declared_durable_artifact(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    payload = b"patch bytes"
+    ref = xw.put_artifact(conn, lease=lease, name="change.patch", data=payload)
+    result_bytes = _result_json(
+        run_id=lease.run_id,
+        task_id=tid,
+        spec=spec,
+        disposition="COMPLETE",
+        deliverable={
+            "kind": "patch",
+            "attachment": ref.name,
+            "sha256": ref.sha256,
+        },
+        artifacts=[{"name": ref.name, "sha256": ref.sha256}],
+    )
+    outcome = xw.finalize(
+        conn,
+        lease=lease,
+        disposition="COMPLETE",
+        result_bytes=result_bytes,
+    )
+    assert outcome.status == xw.FINALIZE_COMMITTED

--- a/tests/hermes_cli/test_kanban_external_worker.py
+++ b/tests/hermes_cli/test_kanban_external_worker.py
@@ -102,6 +102,7 @@ def _result_json(
     summary: str = "fixture result",
     deliverable: dict | None = None,
     artifacts: list[dict] | None = None,
+    failure_signature: str | None = None,
 ) -> bytes:
     if outcome is None:
         outcome = "completed" if process is not None else "aborted_before_start"
@@ -164,7 +165,7 @@ def _result_json(
                     "cost_status": "unknown",
                     "source": "unknown",
                 },
-                "failure_signature": None,
+                "failure_signature": failure_signature,
                 "summary": summary,
                 "artifacts": artifacts or [],
             }
@@ -550,6 +551,82 @@ def test_claim_copies_spec_identity_into_task_runs(kanban_home, conn):
     events = kb.list_events(conn, tid)
     claimed = next(event for event in events if event.kind == "external_claimed")
     assert lease.lease_token not in json.dumps(claimed.payload)
+
+
+def test_second_claim_carries_validated_prior_failure_signature(kanban_home, conn):
+    tid, _aid, _raw, spec, first = _submit_and_claim(conn)
+    first_result = _result_json(
+        run_id=first.run_id,
+        task_id=tid,
+        spec=spec,
+        disposition="REQUEUE",
+        failure_signature="same-check-failure",
+    )
+    xw.finalize(
+        conn,
+        lease=first,
+        disposition="REQUEUE",
+        result_bytes=first_result,
+    )
+
+    second = xw.claim_external(
+        conn,
+        task_id=tid,
+        expected_spec=spec,
+        lease_token="lease-2",
+        lease_expires_at=int(time.time()) + 600,
+    )
+
+    assert second.attempt == 2
+    assert second.previous_failure_signatures == ("same-check-failure",)
+
+
+def test_claim_refuses_attempt_beyond_taskspec_ceiling(kanban_home, conn):
+    tid, _aid, _raw, spec, first = _submit_and_claim(conn)
+    xw.finalize(
+        conn,
+        lease=first,
+        disposition="REQUEUE",
+        result_bytes=_result_json(
+            run_id=first.run_id,
+            task_id=tid,
+            spec=spec,
+            disposition="REQUEUE",
+        ),
+    )
+    second = xw.claim_external(
+        conn,
+        task_id=tid,
+        expected_spec=spec,
+        lease_token="lease-2",
+        lease_expires_at=int(time.time()) + 600,
+    )
+    xw.finalize(
+        conn,
+        lease=second,
+        disposition="REQUEUE",
+        result_bytes=_result_json(
+            run_id=second.run_id,
+            task_id=tid,
+            spec=spec,
+            disposition="REQUEUE",
+            attempt=2,
+        ),
+    )
+
+    with pytest.raises(xw.ClaimRejected, match="exhausted max_attempts=2"):
+        xw.claim_external(
+            conn,
+            task_id=tid,
+            expected_spec=spec,
+            lease_token="lease-3",
+            lease_expires_at=int(time.time()) + 600,
+        )
+
+    assert kb.get_task(conn, tid).status == "ready"
+    assert conn.execute(
+        "SELECT COUNT(*) FROM task_runs WHERE task_id = ?", (tid,)
+    ).fetchone()[0] == 2
 
 
 def test_claim_refuses_second_open_run_after_task_state_drift(kanban_home, conn):
@@ -1637,6 +1714,26 @@ def test_native_lifecycle_refuses_open_external_run_despite_task_drift(
     assert run["ended_at"] is None
 
 
+def test_complete_with_phantom_cards_refuses_external_run_without_event(
+    kanban_home, conn
+):
+    tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+
+    with pytest.raises(kb.ExternalTaskConflict) as caught:
+        kb.complete_task(
+            conn,
+            tid,
+            result="native",
+            created_cards=["t_does_not_exist"],
+        )
+
+    assert caught.value.operation == "complete_task"
+    assert caught.value.run_id == lease.run_id
+    assert "completion_blocked_hallucination" not in {
+        event.kind for event in kb.list_events(conn, tid)
+    }
+
+
 def test_native_recovery_scans_ignore_open_external_run(kanban_home, conn, monkeypatch):
     tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
     lease = _expire_lease(conn, lease)
@@ -1716,6 +1813,42 @@ def test_put_artifact_idempotent_for_same_name_same_bytes(kanban_home, conn):
         (lease.run_id,),
     ).fetchone()
     assert int(rows["n"]) == 1
+
+
+def test_put_artifact_fsyncs_blob_and_directory_before_return(
+    kanban_home, conn, monkeypatch
+):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+    calls: list[int] = []
+    real_fsync = xw.os.fsync
+
+    def recording_fsync(fd: int) -> None:
+        calls.append(fd)
+        real_fsync(fd)
+
+    monkeypatch.setattr(xw.os, "fsync", recording_fsync)
+    xw.put_artifact(conn, lease=lease, name="durable.txt", data=b"payload")
+
+    assert len(calls) >= 2
+
+
+def test_put_artifact_fsync_failure_leaves_no_row_or_blob(
+    kanban_home, conn, monkeypatch
+):
+    _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
+
+    def failing_fsync(_fd: int) -> None:
+        raise OSError("injected fsync failure")
+
+    monkeypatch.setattr(xw.os, "fsync", failing_fsync)
+    with pytest.raises(OSError, match="injected fsync failure"):
+        xw.put_artifact(conn, lease=lease, name="lost.txt", data=b"payload")
+
+    assert conn.execute(
+        "SELECT COUNT(*) FROM task_external_artifacts WHERE run_id = ?",
+        (lease.run_id,),
+    ).fetchone()[0] == 0
+    assert not list(Path(kanban_home).rglob("*lost.txt*"))
 
 
 def test_put_artifact_rejects_divergent_bytes_same_name(kanban_home, conn):
@@ -2072,6 +2205,62 @@ def test_recovery_hold_rejects_already_persisted_result(kanban_home, conn):
             ),
         )
     assert xw.get_run(conn, run_id=lease.run_id).recovery_count == 0
+
+
+@pytest.mark.parametrize(
+    "variant",
+    [
+        "unknown-zero-cost",
+        "negative-cost",
+        "bad-cost-status",
+        "bad-cost-source",
+        "oversized-failure-signature",
+        "oversized-summary",
+    ],
+)
+def test_put_result_rejects_invalid_cost_and_bounded_text(
+    kanban_home, conn, variant
+):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    document = json.loads(
+        _result_json(
+            run_id=lease.run_id,
+            task_id=tid,
+            spec=spec,
+            disposition="BLOCK",
+            block_kind="capability",
+        )
+    )
+    mas = document["mas"]
+    usage = mas["usage"]
+    if variant == "unknown-zero-cost":
+        usage["cost_usd"] = 0
+    elif variant == "negative-cost":
+        usage.update(
+            cost_usd=-1,
+            cost_status="known",
+            source="provider-reported",
+        )
+    elif variant == "bad-cost-status":
+        usage["cost_status"] = "maybe"
+    elif variant == "bad-cost-source":
+        usage.update(cost_usd=1, cost_status="known", source="invented")
+    elif variant == "oversized-failure-signature":
+        mas["failure_signature"] = "x" * 129
+    else:
+        mas["summary"] = "x" * 2_001
+    raw = json.dumps(document, sort_keys=True, separators=(",", ":")).encode()
+
+    with pytest.raises(xw.ResultRejected, match="invalid ExecutionResult schema"):
+        xw.put_result(
+            conn,
+            lease=lease,
+            disposition="BLOCK",
+            block_kind="capability",
+            result_bytes=raw,
+        )
+
+    assert xw.read_result(conn, lease=lease) is None
 
 
 def test_recovery_replays_staged_requeue_after_two_prior_holds(kanban_home, conn):

--- a/tests/hermes_cli/test_kanban_external_worker.py
+++ b/tests/hermes_cli/test_kanban_external_worker.py
@@ -113,6 +113,19 @@ def _result_json(
             "pgid": process.pgid,
             "start_token": process.start_token,
         }
+    if not absence_proven:
+        absence_proof = None
+    elif identity is None:
+        absence_proof = {
+            "run_id": run_id,
+            "task_id": task_id,
+            "evidence": "no start acknowledgement was sent",
+        }
+    else:
+        absence_proof = {
+            **identity,
+            "evidence": "process identity and group are absent",
+        }
     return json.dumps(
         {
             "mas": {
@@ -130,6 +143,7 @@ def _result_json(
                     "identity": identity,
                     "termination_status": "exited" if process else "not_started",
                     "absence_proven": absence_proven,
+                    "absence_proof": absence_proof,
                 },
                 "git": {
                     "base_sha": "a" * 40,
@@ -1202,6 +1216,23 @@ def test_finalize_rejects_result_without_absence_proof(kanban_home, conn):
     with pytest.raises(xw.ResultRejected):
         xw.finalize(conn, lease=lease, disposition="COMPLETE", result_bytes=rb)
     assert xw.get_run(conn, run_id=lease.run_id).lease_state == xw.LEASE_ACTIVE
+
+
+def test_finalize_rejects_absence_proof_for_another_task(kanban_home, conn):
+    tid, _aid, _raw, spec, lease = _submit_and_claim(conn)
+    payload = json.loads(
+        _result_json(
+            run_id=lease.run_id,
+            task_id=tid,
+            spec=spec,
+            disposition="COMPLETE",
+        )
+    )
+    payload["mas"]["process"]["absence_proof"]["task_id"] = "another-task"
+    rb = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+
+    with pytest.raises(xw.ResultRejected, match="unbound run requires"):
+        xw.finalize(conn, lease=lease, disposition="COMPLETE", result_bytes=rb)
 
 
 def test_finalize_rejects_mismatched_bound_process_identity(kanban_home, conn):

--- a/tests/hermes_cli/test_kanban_external_worker.py
+++ b/tests/hermes_cli/test_kanban_external_worker.py
@@ -224,6 +224,51 @@ def test_public_seam_opens_named_board_without_kanban_db_import(kanban_home):
 # ---------------------------------------------------------------------------
 
 
+def test_candidate_read_is_non_mutating(kanban_home, conn):
+    tid, aid, raw = _make_task_with_spec(conn)
+
+    observed = xw.read_candidate_attachment(
+        conn,
+        task_id=tid,
+        attachment_id=aid,
+    )
+
+    assert observed == raw
+    task = kb.get_task(conn, tid)
+    assert task is not None
+    assert task.status == "triage"
+    assert task.external_spec_hash is None
+    assert task.external_spec_attachment_id is None
+
+
+def test_submit_expected_hash_rejects_candidate_mutation_atomically(kanban_home, conn):
+    tid, aid, raw = _make_task_with_spec(conn)
+    observed = xw.read_candidate_attachment(
+        conn,
+        task_id=tid,
+        attachment_id=aid,
+    )
+    assert observed == raw
+    replacement = _spec_json(objective="x")
+    assert len(replacement) == len(raw)
+    attachment = kb.get_attachment(conn, aid)
+    Path(attachment.stored_path).write_bytes(replacement)
+
+    with pytest.raises(xw.SpecMutationError, match="candidate hash changed"):
+        xw.submit(
+            conn,
+            task_id=tid,
+            spec_attachment_id=aid,
+            expected_spec_hash=hashlib.sha256(raw).hexdigest(),
+        )
+
+    task = kb.get_task(conn, tid)
+    assert task is not None
+    assert task.status == "triage"
+    assert task.external_spec_hash is None
+    assert task.external_spec_attachment_id is None
+
+
 def test_submit_records_raw_byte_hash_and_attachment_id(kanban_home, conn):
     tid, aid, raw = _make_task_with_spec(conn)
     spec = xw.submit(conn, task_id=tid, spec_attachment_id=aid)
@@ -294,9 +339,7 @@ def test_submit_rejects_more_than_one_canonical_attachment(kanban_home, conn):
 
 def test_submit_routes_unfinished_dependency_to_todo(kanban_home, conn):
     parent = kb.create_task(conn, title="parent", body="b")
-    tid = kb.create_task(
-        conn, title="child", body="b", triage=True, parents=[parent]
-    )
+    tid = kb.create_task(conn, title="child", body="b", triage=True, parents=[parent])
     raw = _spec_json()
     aid = kb.store_attachment_bytes(
         conn, tid, filename=xw.SPEC_ATTACHMENT_NAME, data=raw
@@ -305,9 +348,7 @@ def test_submit_routes_unfinished_dependency_to_todo(kanban_home, conn):
     assert kb.get_task(conn, tid).status == "todo"
 
 
-def test_submitted_canonical_attachment_cannot_be_added_or_deleted(
-    kanban_home, conn
-):
+def test_submitted_canonical_attachment_cannot_be_added_or_deleted(kanban_home, conn):
     tid, aid, _raw = _make_task_with_spec(conn)
     xw.submit(conn, task_id=tid, spec_attachment_id=aid)
     att = kb.get_attachment(conn, aid)
@@ -706,9 +747,7 @@ def test_heartbeat_cannot_resurrect_expired_lease(kanban_home, conn):
     _tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
     lease = _expire_lease(conn, lease)
     with pytest.raises(xw.NotOwner):
-        xw.heartbeat(
-            conn, lease=lease, lease_expires_at=int(time.time()) + 60
-        )
+        xw.heartbeat(conn, lease=lease, lease_expires_at=int(time.time()) + 60)
 
 
 def test_heartbeat_rejects_wrong_lease_token(kanban_home, conn):
@@ -789,33 +828,23 @@ def test_hold_for_recovery_can_quarantine_an_expired_lease(kanban_home, conn):
     proof = xw.RecoveryHoldProof(
         run_id=lease.run_id, task_id=tid, bound=None, evidence="uncertain"
     )
-    held = xw.hold_for_recovery(
-        conn, lease=lease, proof=proof, extension_seconds=60
-    )
+    held = xw.hold_for_recovery(conn, lease=lease, proof=proof, extension_seconds=60)
     assert held.lease_state == xw.LEASE_HOLDING
     assert held.lease_expires_at > int(time.time())
 
 
-def test_second_hold_requires_manual_recovery_and_third_is_rejected(
-    kanban_home, conn
-):
+def test_second_hold_requires_manual_recovery_and_third_is_rejected(kanban_home, conn):
     tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
     proof = xw.RecoveryHoldProof(
         run_id=lease.run_id, task_id=tid, bound=None, evidence="uncertain"
     )
-    held = xw.hold_for_recovery(
-        conn, lease=lease, proof=proof, extension_seconds=60
-    )
-    held = xw.hold_for_recovery(
-        conn, lease=held, proof=proof, extension_seconds=60
-    )
+    held = xw.hold_for_recovery(conn, lease=lease, proof=proof, extension_seconds=60)
+    held = xw.hold_for_recovery(conn, lease=held, proof=proof, extension_seconds=60)
     assert held.recovery_count == 2
     events = kb.list_events(conn, tid)
     assert [e.kind for e in events].count("external_manual_recovery_required") == 1
     with pytest.raises(xw.RecoveryRejected):
-        xw.hold_for_recovery(
-            conn, lease=held, proof=proof, extension_seconds=60
-        )
+        xw.hold_for_recovery(conn, lease=held, proof=proof, extension_seconds=60)
 
 
 def test_hold_for_recovery_rejects_proof_with_wrong_identity(kanban_home, conn):
@@ -1466,9 +1495,7 @@ def test_list_active_returns_active_external_runs(kanban_home, conn):
     assert active[0].run_id == lease.run_id
 
 
-def test_list_active_ignores_corrupted_task_status_and_run_pointer(
-    kanban_home, conn
-):
+def test_list_active_ignores_corrupted_task_status_and_run_pointer(kanban_home, conn):
     tid, _aid, _raw, _spec, lease = _submit_and_claim(conn)
     with kb.write_txn(conn):
         conn.execute(
@@ -1515,9 +1542,7 @@ def test_native_claim_excludes_ready_external_task(kanban_home, conn):
     assert caught.value.run_id == _lease.run_id
 
 
-def test_native_claim_rejects_submitted_external_task_without_run(
-    kanban_home, conn
-):
+def test_native_claim_rejects_submitted_external_task_without_run(kanban_home, conn):
     tid, aid, _raw = _make_task_with_spec(conn)
     xw.submit(conn, task_id=tid, spec_attachment_id=aid)
     with pytest.raises(kb.ExternalTaskConflict) as caught:
@@ -1595,14 +1620,19 @@ def test_native_recovery_scans_ignore_open_external_run(kanban_home, conn, monke
     monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
     signals = []
 
-    assert kb.release_stale_claims(conn, signal_fn=lambda *args: signals.append(args)) == 0
-    assert kb.detect_stale_running(
-        conn, stale_timeout_seconds=1, signal_fn=lambda *args: signals.append(args)
-    ) == []
+    assert (
+        kb.release_stale_claims(conn, signal_fn=lambda *args: signals.append(args)) == 0
+    )
+    assert (
+        kb.detect_stale_running(
+            conn, stale_timeout_seconds=1, signal_fn=lambda *args: signals.append(args)
+        )
+        == []
+    )
     assert kb.detect_crashed_workers(conn) == []
-    assert kb.enforce_max_runtime(
-        conn, signal_fn=lambda *args: signals.append(args)
-    ) == []
+    assert (
+        kb.enforce_max_runtime(conn, signal_fn=lambda *args: signals.append(args)) == []
+    )
     assert signals == []
     assert xw.get_run(conn, run_id=lease.run_id).lease_state == xw.LEASE_ACTIVE
 
@@ -1615,9 +1645,7 @@ def test_native_heartbeat_refuses_open_external_run(kanban_home, conn):
     assert caught.value.operation == "heartbeat_worker"
 
 
-def test_dispatcher_does_not_spawn_external_ready_task(
-    kanban_home, conn, monkeypatch
-):
+def test_dispatcher_does_not_spawn_external_ready_task(kanban_home, conn, monkeypatch):
     tid, aid, _raw = _make_task_with_spec(conn)
     xw.submit(conn, task_id=tid, spec_attachment_id=aid)
     with kb.write_txn(conn):
@@ -1691,9 +1719,7 @@ def test_read_artifact_remains_available_after_finalize(kanban_home, conn):
         run_id=lease.run_id, task_id=tid, spec=spec, disposition="COMPLETE"
     )
     xw.finalize(conn, lease=lease, disposition="COMPLETE", result_bytes=rb)
-    assert xw.read_artifact(
-        conn, run_id=lease.run_id, name="out.txt"
-    ) == b"payload"
+    assert xw.read_artifact(conn, run_id=lease.run_id, name="out.txt") == b"payload"
 
 
 def test_read_artifact_rejects_unknown_name(kanban_home, conn):
@@ -1771,6 +1797,8 @@ def test_finalize_block_with_new_block_kinds(kanban_home, conn):
     assert out.status == xw.FINALIZE_COMMITTED
     t = kb.get_task(conn, tid)
     assert t is not None and t.status == "blocked"
+
+
 # Cross-surface lifecycle and restart regressions
 # ---------------------------------------------------------------------------
 
@@ -1884,13 +1912,9 @@ def test_board_removal_rejects_active_external_run(kanban_home):
         named.close()
 
 
-def test_stale_connection_cannot_claim_after_board_archive(
-    kanban_home, monkeypatch
-):
+def test_stale_connection_cannot_claim_after_board_archive(kanban_home, monkeypatch):
     external_attachments = kanban_home / "external-attachments"
-    monkeypatch.setenv(
-        "HERMES_KANBAN_ATTACHMENTS_ROOT", str(external_attachments)
-    )
+    monkeypatch.setenv("HERMES_KANBAN_ATTACHMENTS_ROOT", str(external_attachments))
     kb.create_board("named")
     named = xw.connect(board="named")
     try:

--- a/tests/plugins/test_kanban_external_worker.py
+++ b/tests/plugins/test_kanban_external_worker.py
@@ -1,0 +1,259 @@
+"""Dashboard lifecycle guards for externally owned Kanban runs."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_external_worker as xw
+
+
+def _load_plugin_router():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    spec = importlib.util.spec_from_file_location(
+        "hermes_dashboard_plugin_external_worker_test", plugin_file
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.router
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    app = FastAPI()
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
+    return TestClient(app)
+
+
+def _create_external_run(*, board: str = "default") -> tuple[str, int, xw.Lease]:
+    with xw.connect(board=board) as conn:
+        task_id = kb.create_task(
+            conn, title="external", assignee="mas-runner", triage=True
+        )
+        raw = json.dumps(
+            {
+                "schema_version": xw.SPEC_SCHEMA_VERSION,
+                "board": board,
+                "repo_key": "fixture",
+                "objective": "test dashboard conflicts",
+                "acceptance_criteria": ["conflict is HTTP 409"],
+                "scope": {"include": ["src/**"], "exclude": [".env"]},
+                "base_sha": "a" * 40,
+                "risk": "small",
+                "workflow": "implement-verify",
+                "execution": {
+                    "timeout_seconds": 60,
+                    "max_attempts": 1,
+                    "max_tokens": 1000,
+                    "max_cost_usd": None,
+                },
+                "verification": {
+                    "check_ids": ["focused"],
+                    "fresh_reviewer": True,
+                    "security_review": False,
+                },
+                "delivery": {
+                    "mode": "review-only",
+                    "push": False,
+                    "deploy": False,
+                },
+            },
+            sort_keys=True,
+        ).encode()
+        attachment_id = kb.store_attachment_bytes(
+            conn,
+            task_id,
+            filename=xw.SPEC_ATTACHMENT_NAME,
+            data=raw,
+        )
+        spec = xw.submit(
+            conn, task_id=task_id, spec_attachment_id=attachment_id
+        )
+        lease = xw.claim_external(
+            conn,
+            task_id=task_id,
+            expected_spec=spec,
+            lease_token="dashboard-test",
+            lease_expires_at=int(time.time()) + 600,
+        )
+        return task_id, attachment_id, lease
+
+
+@pytest.mark.parametrize(
+    "status",
+    ["ready", "todo", "triage", "scheduled", "blocked", "done", "archived"],
+)
+def test_status_mutations_return_typed_409(client, status):
+    task_id, _attachment_id, lease = _create_external_run()
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task_id}",
+        json={"status": status, "block_reason": "manual"},
+    )
+    assert response.status_code == 409, response.text
+    detail = response.json()["detail"]
+    assert detail["code"] == "external_run_active"
+    assert detail["task_id"] == task_id
+    assert detail["run_id"] == lease.run_id
+    with xw.connect() as conn:
+        assert kb.get_task(conn, task_id).status == "running"
+        assert kb.get_run(conn, lease.run_id).ended_at is None
+
+
+def test_dashboard_actions_return_typed_409(client):
+    task_id, _attachment_id, lease = _create_external_run()
+    responses = [
+        client.patch(
+            f"/api/plugins/kanban/tasks/{task_id}", json={"assignee": "other"}
+        ),
+        client.post(f"/api/plugins/kanban/tasks/{task_id}/reclaim", json={}),
+        client.post(
+            f"/api/plugins/kanban/tasks/{task_id}/reassign",
+            json={"profile": "other", "reclaim_first": True},
+        ),
+        client.post(
+            f"/api/plugins/kanban/runs/{lease.run_id}/terminate", json={}
+        ),
+        client.delete(f"/api/plugins/kanban/tasks/{task_id}"),
+    ]
+    for response in responses:
+        assert response.status_code == 409, response.text
+        detail = response.json()["detail"]
+        assert detail["code"] == "external_run_active"
+        assert detail["run_id"] == lease.run_id
+
+
+def test_spec_attachment_delete_returns_typed_409(client):
+    task_id, attachment_id, _lease = _create_external_run()
+    response = client.delete(f"/api/plugins/kanban/attachments/{attachment_id}")
+    assert response.status_code == 409, response.text
+    assert response.json()["detail"] == {
+        "code": "external_spec_locked",
+        "task_id": task_id,
+        "operation": "delete_attachment",
+        "run_id": None,
+    }
+
+
+def test_bulk_mutation_reports_typed_conflict(client):
+    task_id, _attachment_id, lease = _create_external_run()
+    response = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={"ids": [task_id], "status": "done"},
+    )
+    assert response.status_code == 200
+    assert response.json()["results"] == [
+        {
+            "id": task_id,
+            "ok": False,
+            "error": (
+                f"complete_task refused for external task {task_id}: "
+                f"external_run_active (run_id={lease.run_id})"
+            ),
+            "code": "external_run_active",
+            "run_id": lease.run_id,
+        }
+    ]
+
+
+def test_board_delete_returns_typed_409_for_active_external_run(client):
+    kb.create_board("named")
+    task_id, _attachment_id, lease = _create_external_run(board="named")
+    response = client.delete("/api/plugins/kanban/boards/named")
+    assert response.status_code == 409, response.text
+    assert response.json()["detail"] == {
+        "code": "external_run_active",
+        "task_id": task_id,
+        "operation": "remove_board",
+        "run_id": lease.run_id,
+    }
+    assert kb.board_exists("named")
+
+
+def test_reopening_parent_cannot_collateral_demote_external_child(client):
+    with xw.connect() as conn:
+        parent_id = kb.create_task(conn, title="parent", body="p", triage=True)
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'done', completed_at = ? WHERE id = ?",
+                (int(time.time()), parent_id),
+            )
+        child_id = kb.create_task(conn, title="child", body="c", triage=True)
+        raw = json.dumps(
+            {
+                "schema_version": xw.SPEC_SCHEMA_VERSION,
+                "board": "default",
+                "repo_key": "fixture",
+                "objective": "stay externally owned",
+                "acceptance_criteria": ["parent reopen conflicts"],
+                "scope": {"include": ["src/**"], "exclude": [".env"]},
+                "base_sha": "a" * 40,
+                "risk": "small",
+                "workflow": "implement-verify",
+                "execution": {
+                    "timeout_seconds": 60,
+                    "max_attempts": 1,
+                    "max_tokens": 1000,
+                    "max_cost_usd": None,
+                },
+                "verification": {
+                    "check_ids": ["focused"],
+                    "fresh_reviewer": True,
+                    "security_review": False,
+                },
+                "delivery": {
+                    "mode": "review-only",
+                    "push": False,
+                    "deploy": False,
+                },
+            },
+            sort_keys=True,
+        ).encode()
+        attachment_id = kb.store_attachment_bytes(
+            conn,
+            child_id,
+            filename=xw.SPEC_ATTACHMENT_NAME,
+            data=raw,
+        )
+        kb.link_tasks(conn, parent_id, child_id)
+        spec = xw.submit(
+            conn, task_id=child_id, spec_attachment_id=attachment_id
+        )
+        lease = xw.claim_external(
+            conn,
+            task_id=child_id,
+            expected_spec=spec,
+            lease_token="child",
+            lease_expires_at=int(time.time()) + 600,
+        )
+
+    unlink_response = client.delete(
+        "/api/plugins/kanban/links",
+        params={"parent_id": parent_id, "child_id": child_id},
+    )
+    assert unlink_response.status_code == 409, unlink_response.text
+    assert unlink_response.json()["detail"]["run_id"] == lease.run_id
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{parent_id}", json={"status": "todo"}
+    )
+    assert response.status_code == 409, response.text
+    assert response.json()["detail"]["run_id"] == lease.run_id
+    with xw.connect() as conn:
+        assert kb.get_task(conn, parent_id).status == "done"
+        assert kb.get_task(conn, child_id).status == "running"

--- a/website/docs/user-guide/features/kanban-worker-lanes.md
+++ b/website/docs/user-guide/features/kanban-worker-lanes.md
@@ -90,7 +90,40 @@ A specialisation of the profile lane: an orchestrator is a Hermes profile whose 
 
 ## Adding an external CLI worker lane
 
-Wiring a non-Hermes CLI tool (Codex CLI, Claude Code CLI, OpenCode CLI, a local coding-model runner, etc.) as a kanban worker lane is *not yet a paved path*. The dispatcher's spawn function is pluggable (`spawn_fn` is a parameter on `dispatch_once`), and a plugin could register its own `spawn_fn` for a non-Hermes assignee, but the surrounding integration work — wrapping the CLI's exit code into `kanban_complete` / `kanban_block` calls, mapping the CLI's workspace/sandbox conventions onto the dispatcher's `HERMES_KANBAN_WORKSPACE` env, handling auth and per-CLI policy — is still per-integration design work.
+Hermes exposes a pull-based, transactional lifecycle API for supervisors that
+run non-Hermes workers. Import `hermes_cli.kanban_external_worker` and use only
+that module for board access. The protocol is:
+
+1. Create a triage task and attach exactly one `mas-task-spec.v1.json` through
+   the existing Kanban attachment surface, then call `submit`. Hermes validates
+   the strict JSON and locks the attachment id, raw-byte SHA-256, and schema.
+2. Poll `list_ready`, re-read the accepted bytes with
+   `read_submitted_attachment`, and call `claim_external` with that exact spec
+   identity and an opaque lease token.
+3. Create an inert process-group leader, persist its host/PID/PGID/start-token
+   identity with `bind_process`, and only then allow it to start child work.
+4. Refresh ownership with `heartbeat` and persist named outputs through
+   `put_artifact`. Before releasing a claim, prove the process group is absent,
+   persist a strict `mas-execution-result.v1` with `put_result`, and call
+   `finalize` with `COMPLETE`, `REQUEUE`, or `BLOCK`. Every artifact named by
+   the result must already exist with the declared SHA-256.
+5. On restart, inspect `list_active` before claiming new work. An expired run is
+   released only through `recover_expired` with affirmative process-absence or
+   no-start proof; uncertainty is recorded with `hold_for_recovery`. If
+   `read_result` returns bytes staged before the restart, replay those exact
+   bytes instead of reconstructing a new result.
+
+The native dispatcher ignores tasks with a locked external spec. Generic CLI
+and dashboard lifecycle actions fail with a typed conflict while an external
+run remains open, so a manual drag or stale-claim sweep cannot create a second
+writer. Finalize is idempotent only for the same result hash and terminal
+disposition.
+
+This API owns lifecycle state, not launcher policy. Integrations still decide
+which CLI to run, how to isolate it, how to scrub credentials, and which
+commands or repositories are allowed. A plugin-managed push lane can continue
+to supply a `spawn_fn`; a standalone supervisor should use the pull protocol
+above instead of writing `kanban.db` directly.
 
 If you're considering adding a CLI lane, open an issue describing the specific CLI and the workflow you're trying to enable. The contract above is the constraints any such lane must satisfy; the implementation shape (one plugin per CLI vs a generic CLI-runner plugin parameterised by config) is open.
 


### PR DESCRIPTION
## What does this PR do?

Adds a public, transactional external-worker lifecycle for Hermes Kanban. External supervisors can submit an immutable task spec, claim it under a lease, durably bind a process identity, heartbeat or hold it for recovery, stage hashed results/artifacts, and finalize or recover the run without writing Hermes SQLite directly or using private helpers.

The native dispatcher remains the default. Tasks accepted by the external-worker port are excluded from native execution, and generic CLI/dashboard lifecycle mutations fail with a typed conflict while an external run owns the task.

## Related Issue

Related to #36079 and #64906.

This complements #63297: that PR provides an atomic terminal handoff, while this PR covers the full claim/bind/heartbeat/recovery/finalize lifecycle and immutable spec/result identity needed by long-lived external supervisors.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Security fix
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Add `hermes_cli.kanban_external_worker`, a public versioned API with strict values and typed outcomes.
- Atomically preserve task id, accepted attachment id, spec hash, run id, attempt, and lease identity across submit and claim.
- Add process bind, heartbeat/ownership, bounded recovery holds, expired-run recovery, and same-hash idempotent finalization.
- Persist exact result bytes and content-addressed artifacts before terminal transitions; reject missing or divergent artifacts/results.
- Prevent native dispatch, recovery, archive/delete, status changes, dependency changes, and result edits from mutating spec-locked or actively owned external tasks.
- Return structured HTTP 409 conflicts for dashboard lifecycle collisions and protect board removal against claim/remove races.
- Document the worker lifecycle and add transaction, crash/replay, conflict, artifact, and stale-board regressions.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_kanban_external_worker.py tests/plugins/test_kanban_external_worker.py -q` (131 passed)
2. `scripts/run_tests.sh tests/hermes_cli/test_kanban_external_worker.py tests/plugins/test_kanban_external_worker.py tests/hermes_cli/test_kanban_db_init.py tests/hermes_cli/test_kanban_boards.py -q` (193 passed)
3. Run all Kanban tests except the known baseline macOS signal-handler case (1,168 passed).
4. `uv run ruff check` on all changed Python files; `uv run ty check hermes_cli/kanban_external_worker.py`; `git diff --check`; and staged `gitleaks` (all passed).

The canonical full runner also completed locally. The macOS/Python 3.13 environment reported 52 failures in 22 unchanged files plus 10 optional-dependency collection failures. They were platform/environment baseline cases (`acp`/WeCom extras, Linux `systemctl`, `/tmp` canonicalization, network catalog access, and timing/concurrency); no changed or new test failed. The same base commit has a green upstream Python CI run: https://github.com/NousResearch/hermes-agent/actions/runs/29700460352

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing issues and PRs; related work is linked above
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass (full local runner completed with the unrelated platform/environment failures documented above)
- [x] I've added tests for my changes
- [x] I've tested on macOS (Darwin), Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation and docstrings
- [x] `cli-config.yaml.example` update is N/A; no config keys were added
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A
- [x] I've considered cross-platform impact; filesystem locking has a fail-closed portable path, with POSIX race coverage
- [x] Tool descriptions/schemas update is N/A; this adds a Python lifecycle API

## Screenshots / Logs

N/A; this is a transaction and lifecycle API with automated regression coverage.
