### PR TITLE
feat(x_search): default model grok-4.20-reasoning -> grok-4.5

### DIFF
--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -111,6 +111,7 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
     # non-reasoning pairs.
     ("grok-4-fast-reasoning", 300),
     ("grok-4.20-reasoning", 300),
+    ("grok-4.5", 300),
     ("grok-4-fast-non-reasoning", 180),
 )
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3299,10 +3299,10 @@ DEFAULT_CONFIG = {
     # OAuth or XAI_API_KEY) AND the x_search toolset is enabled in
     # `hermes tools`. These settings tune the backing Responses API call.
     "x_search": {
-        # xAI model used for the Responses call. grok-4.20-reasoning is
-        # the recommended default; any Grok model with x_search tool
+        # xAI model used for the Responses call. grok-4.5 is the
+        # recommended default; any Grok model with x_search tool
         # access works.
-        "model": "grok-4.20-reasoning",
+        "model": "grok-4.5",
         # Request timeout in seconds (minimum 30). x_search can take
         # 60-120s for complex queries — the default is generous.
         "timeout_seconds": 180,

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -77,6 +77,7 @@ import pytest
     # xAI Grok reasoning variants — explicit, not bare `grok`.
     ("x-ai/grok-4-fast-reasoning", 300.0),
     ("x-ai/grok-4.20-reasoning", 300.0),
+    ("x-ai/grok-4.5", 300.0),
     ("x-ai/grok-4-fast-non-reasoning", 180.0),
 ])
 def test_reasoning_stale_timeout_floor_positive_cases(model, expected):

--- a/tests/tools/test_x_search_tool.py
+++ b/tests/tools/test_x_search_tool.py
@@ -70,7 +70,7 @@ def test_x_search_posts_responses_request(monkeypatch):
     tool_def = captured["json"]["tools"][0]
     assert captured["url"] == "https://api.x.ai/v1/responses"
     assert captured["headers"]["User-Agent"] == f"Hermes-Agent/{__version__}"
-    assert captured["json"]["model"] == "grok-4.20-reasoning"
+    assert captured["json"]["model"] == "grok-4.5"
     assert captured["json"]["store"] is False
     assert tool_def["type"] == "x_search"
     assert tool_def["allowed_x_handles"] == ["xai", "grok"]

--- a/tools/x_search_tool.py
+++ b/tools/x_search_tool.py
@@ -56,7 +56,7 @@ from tools.xai_http import hermes_xai_user_agent, resolve_xai_http_credentials
 logger = logging.getLogger(__name__)
 
 DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
-DEFAULT_X_SEARCH_MODEL = "grok-4.20-reasoning"
+DEFAULT_X_SEARCH_MODEL = "grok-4.5"
 DEFAULT_X_SEARCH_TIMEOUT_SECONDS = 180
 DEFAULT_X_SEARCH_RETRIES = 2
 MAX_HANDLES = 10

--- a/website/docs/user-guide/features/x-search.md
+++ b/website/docs/user-guide/features/x-search.md
@@ -50,9 +50,9 @@ Either choice satisfies the gating. You can pick whichever credentials you alrea
 # ~/.hermes/config.yaml
 x_search:
   # xAI model used for the Responses call.
-  # grok-4.20-reasoning is the recommended default; any Grok model
+  # grok-4.5 is the recommended default; any Grok model
   # with x_search tool access works.
-  model: grok-4.20-reasoning
+  model: grok-4.5
 
   # Request timeout in seconds. x_search can take 60–120s for
   # complex queries — the default is generous. Minimum: 30.
@@ -118,7 +118,7 @@ The tool surfaces this when both auth paths fail. Either set `XAI_API_KEY` in `~
 
 ### "`x_search` is not enabled for this model"
 
-The configured `x_search.model` doesn't have access to the server-side `x_search` tool. Switch to `grok-4.20-reasoning` (the default) or another Grok model that supports it. Check the [xAI documentation](https://docs.x.ai/) for the current list.
+The configured `x_search.model` doesn't have access to the server-side `x_search` tool. Switch to `grok-4.5` (the default) or another Grok model that supports it. Check the [xAI documentation](https://docs.x.ai/) for the current list.
 
 ### Tool doesn't appear in the schema
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/x-search.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/x-search.md
@@ -46,9 +46,9 @@ hermes tools
 # ~/.hermes/config.yaml
 x_search:
   # 用于 Responses 调用的 xAI 模型。
-  # grok-4.20-reasoning 是推荐的默认值；任何支持
+  # grok-4.5 是推荐的默认值；任何支持
   # x_search 工具访问权限的 Grok 模型均可使用。
-  model: grok-4.20-reasoning
+  model: grok-4.5
 
   # 请求超时时间（秒）。复杂查询的 x_search 可能需要 60–120 秒，
   # 默认值较为宽松。最小值：30。
@@ -114,7 +114,7 @@ agent 将：
 
 ### "`x_search` is not enabled for this model"
 
-配置的 `x_search.model` 没有访问服务端 `x_search` 工具的权限。请切换至 `grok-4.20-reasoning`（默认值）或其他支持该工具的 Grok 模型。当前支持列表请查阅 [xAI 文档](https://docs.x.ai/)。
+配置的 `x_search.model` 没有访问服务端 `x_search` 工具的权限。请切换至 `grok-4.5`（默认值）或其他支持该工具的 Grok 模型。当前支持列表请查阅 [xAI 文档](https://docs.x.ai/)。
 
 ### 工具未出现在 schema 中
 


### PR DESCRIPTION
## Summary
The `x_search` tool's default model is now `grok-4.5` (was `grok-4.20-reasoning`) — xAI's newest release (their versioning is non-monotonic: 4.5 succeeds 4.20) and the model xAI's own docs use for the server-side `x_search` tool on the Responses API.

Users who explicitly pinned `x_search.model` in config.yaml keep their choice; everyone else picks up the new default automatically via the config deep-merge. No `_config_version` bump needed.

## Changes
- `tools/x_search_tool.py`: `DEFAULT_X_SEARCH_MODEL` → `grok-4.5`
- `hermes_cli/config.py`: `DEFAULT_CONFIG["x_search"]["model"]` + comment
- `agent/reasoning_timeouts.py`: 300s stale-timeout floor entry for `grok-4.5` (the `grok-4.20-reasoning` entry stays for pinned users)
- `website/docs/user-guide/features/x-search.md` + zh-Hans mirror: config sample + troubleshooting hint name the new default
- Tests: default-model wire assertion (`test_x_search_tool.py`) + timeout-floor positive case (`test_reasoning_stale_timeout_floor.py`)

## Validation
| | Result |
|---|---|
| `scripts/run_tests.sh tests/tools/test_x_search_tool.py tests/agent/test_reasoning_stale_timeout_floor.py` | 83/83 passed |
| `ruff check` on touched files | clean |
| Windows-footgun checker | clean |
| grok-4.5 x_search access | confirmed against docs.x.ai tools overview (quick-start uses grok-4.5 with `x_search`) |

## Infographic

![x-search-grok-4.5-default](https://v3b.fal.media/files/b/0aa2eefb/WfLNC4NHANnMSqd_oGRsu_0nNaSceX.png)
