### PR TITLE
feat(models): add Thinking Machines Inkling to curated OpenRouter list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -85,6 +85,8 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("nvidia/nemotron-3-super-120b-a12b",      ""),
     # Sakana
     ("sakana/fugu-ultra",                      ""),
+    # Thinking Machines
+    ("thinkingmachines/inkling",               ""),
     # OpenRouter routers
     ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
     # Free tier
@@ -235,6 +237,8 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "nvidia/nemotron-3-super-120b-a12b",
         # Sakana
         "sakana/fugu-ultra",
+        # Thinking Machines
+        "thinkingmachines/inkling",
     ],
     # Native OpenAI Chat Completions (api.openai.com). Used by /model counts and
     # provider_model_ids fallback when /v1/models is unavailable.

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -142,6 +142,10 @@
           "description": ""
         },
         {
+          "id": "thinkingmachines/inkling",
+          "description": ""
+        },
+        {
           "id": "openrouter/pareto-code",
           "description": "auto-routes to cheapest coder meeting openrouter.min_coding_score"
         },
@@ -270,6 +274,9 @@
         },
         {
           "id": "sakana/fugu-ultra"
+        },
+        {
+          "id": "thinkingmachines/inkling"
         }
       ]
     }


### PR DESCRIPTION
## Problem

`thinkingmachines/inkling` is live on OpenRouter (1M context, tool-calling supported) but does not appear in Hermes' model picker. The picker intersects the live OpenRouter `/api/v1/models` catalog with the in-repo curated `OPENROUTER_MODELS` list in `hermes_cli/models.py` — and Inkling isn't in that curated list, so it gets filtered out and can never surface.

## Fix

One curated-list addition, three synced sites:

- `hermes_cli/models.py` — added `("thinkingmachines/inkling", "")` to `OPENROUTER_MODELS` (new Thinking Machines section)
- `hermes_cli/models.py` — added `"thinkingmachines/inkling"` to the mirrored `_PROVIDER_MODELS["nous"]` list (Nous inference endpoint uses the same OpenRouter IDs)
- `website/static/api/model-catalog.json` — regenerated via `scripts/build_model_catalog.py` (only the Inkling entries + `updated_at` timestamp changed; openrouter count 39 → 40)

Same shape as #67685 (Kimi K3 context entry) — a pure curated-list addition, no logic changes.

## Testing

- `tests/hermes_cli/test_models.py`: **84/84 passed**
- `tests/test_empty_model_fallback.py`: **18/18 passed**
- Live functional check: `fetch_openrouter_models(force_refresh=True)` against the real OpenRouter `/api/v1/models` now returns `('thinkingmachines/inkling', '')` through the actual picker code path (36 models returned; Inkling present in both the hardcoded `OPENROUTER_MODELS` fallback and the live-filtered result)