### PR TITLE
fix(gateway): declare splits_long_messages on SmsAdapter

### DIFF
--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -63,6 +63,7 @@ class SmsAdapter(BasePlatformAdapter):
     """
 
     MAX_MESSAGE_LENGTH = MAX_SMS_LENGTH
+    splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.SMS)
@@ -164,7 +165,7 @@ class SmsAdapter(BasePlatformAdapter):
         import aiohttp
 
         formatted = self.format_message(content)
-        chunks = self.truncate_message(formatted)
+        chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
         last_result = SendResult(success=True)
 
         url = f"{TWILIO_API_BASE}/{self._account_sid}/Messages.json"

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -352,6 +352,28 @@ async def test_long_output_preserved_for_chunking_adapter(tmp_path, monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_long_output_preserved_for_sms_adapter(tmp_path, monkeypatch):
+    from plugins.platforms.sms.adapter import SmsAdapter
+
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    adapter = object.__new__(SmsAdapter)
+    delivered = []
+
+    async def capture_send(chat_id, content, metadata=None):
+        delivered.append(content)
+        return SendResult(success=True)
+
+    adapter.send = capture_send
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.SMS: adapter})
+    target = DeliveryTarget.parse("sms:+15551234567")
+    long_content = "x" * 5000
+
+    await router._deliver_to_platform(target, long_content, metadata={"job_id": "sms-long"})
+
+    assert delivered == [long_content]
+
+
+@pytest.mark.asyncio
 async def test_short_output_never_truncated(tmp_path, monkeypatch):
     """Output under the limit passes through untouched for any adapter."""
     monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)

--- a/tests/gateway/test_sms.py
+++ b/tests/gateway/test_sms.py
@@ -76,6 +76,29 @@ class TestSmsFormatAndTruncate:
             adapter._from_number = "+15550001111"
         return adapter
 
+    def test_declares_native_long_message_splitting(self):
+        from plugins.platforms.sms.adapter import SmsAdapter
+
+        content = "x" * 5000
+        chunks = SmsAdapter.truncate_message(content, SmsAdapter.MAX_MESSAGE_LENGTH)
+
+        assert SmsAdapter.splits_long_messages is True
+        assert len(chunks) > 1
+        assert all(len(chunk) <= SmsAdapter.MAX_MESSAGE_LENGTH for chunk in chunks)
+
+    @pytest.mark.asyncio
+    async def test_send_chunks_at_sms_max_message_length(self):
+        adapter = self._make_adapter()
+        adapter._http_session = MagicMock()
+        adapter.truncate_message = MagicMock(return_value=[])
+        content = "x" * 5000
+
+        await adapter.send("+15551234567", content)
+
+        adapter.truncate_message.assert_called_once_with(
+            content, adapter.MAX_MESSAGE_LENGTH
+        )
+
     def test_strips_bold(self):
         adapter = self._make_adapter()
         assert adapter.format_message("**hello**") == "hello"


### PR DESCRIPTION
## What does this PR do?

Prevents `DeliveryRouter` from truncating long SMS output at 4,000 characters before the SMS adapter can split it. `SmsAdapter` already owns outbound chunking, but it did not advertise that capability; its send path also relied on the helper's 4,096-character default instead of the adapter's 1,600-character limit.

## Related Issue

Fixes #62751

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Declare `SmsAdapter.splits_long_messages = True`.
- Pass `SmsAdapter.MAX_MESSAGE_LENGTH` to the actual send-path chunker.
- Add regressions for adapter chunk bounds, send-path wiring, and preservation of a 5,000-character payload through `DeliveryRouter`.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_sms.py tests/gateway/test_delivery.py -q`.
2. Confirm all 72 tests pass.
3. The router regression verifies a 5,000-character SMS reaches the adapter intact; adapter tests verify chunks are at most 1,600 characters.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the entire repository test suite (targeted suites: 72 passed)
- [x] I've added tests for my changes
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] Config example update: N/A
- [x] Architecture/workflow docs update: N/A
- [x] Cross-platform impact considered; adapter/router behavior is platform-independent
- [x] Tool descriptions/schemas update: N/A
