### PR TITLE
fix(mcp): serialize stdio spawn window to stop cross-server PID misattribution

### DIFF
--- a/tests/tools/test_mcp_stdio_spawn_attribution.py
+++ b/tests/tools/test_mcp_stdio_spawn_attribution.py
@@ -1,0 +1,213 @@
+"""Regression coverage for concurrent stdio MCP subprocess attribution."""
+
+import asyncio
+import subprocess
+import sys
+from contextlib import asynccontextmanager, contextmanager
+from contextvars import ContextVar
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tools.mcp_tool import (
+    MCPServerTask,
+    _lock,
+    _orphan_stdio_pid_servers,
+    _orphan_stdio_pids,
+    _stdio_pgids,
+    _stdio_pids,
+)
+
+
+_TRACKING_STATE = (
+    _stdio_pids,
+    _orphan_stdio_pids,
+    _orphan_stdio_pid_servers,
+    _stdio_pgids,
+)
+
+_FAKE_SERVER_NAME = ContextVar("fake_mcp_server_name", default=None)
+
+
+def _clear_tracking_state():
+    with _lock:
+        for state in _TRACKING_STATE:
+            state.clear()
+
+
+@pytest.fixture(autouse=True)
+def clean_stdio_pid_tracking():
+    """Keep the module-level subprocess bookkeeping hermetic."""
+    _clear_tracking_state()
+    yield
+    _clear_tracking_state()
+
+
+class _ConcurrentSpawnRig:
+    """Fake stdio transports backed by real, independently owned children."""
+
+    def __init__(self):
+        self._srv_a_entered = asyncio.Event()
+        self._srv_b_entered = asyncio.Event()
+        self.processes = {}
+
+    async def enter(self, server_name):
+        # _run_stdio takes pids_before before invoking this context manager.
+        # Force both coroutines to reach __aenter__ (and therefore take their
+        # snapshots) before either child exists. Then always spawn srv_b first:
+        # srv_b sees only B, while srv_a subsequently sees both A and B and
+        # overwrites B's ownership on the buggy snapshot-delta implementation.
+        if server_name == "srv_a":
+            self._srv_a_entered.set()
+            await asyncio.wait_for(self._srv_b_entered.wait(), timeout=2)
+        elif server_name == "srv_b":
+            await asyncio.wait_for(self._srv_a_entered.wait(), timeout=2)
+            self._srv_b_entered.set()
+        else:  # pragma: no cover - protects the test rig from accidental misuse
+            raise AssertionError(f"unexpected fake server name: {server_name}")
+
+        process = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            start_new_session=True,
+        )
+        self.processes[server_name] = process
+        return MagicMock(name=f"{server_name}_read"), MagicMock(
+            name=f"{server_name}_write"
+        )
+
+    def stop(self, server_name):
+        process = self.processes.get(server_name)
+        if process is None or process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=2)
+
+    def cleanup(self):
+        for server_name in list(self.processes):
+            self.stop(server_name)
+
+
+@contextmanager
+def _patched_stdio_runtime(rig):
+    @asynccontextmanager
+    async def fake_stdio_client(server_params, **_kwargs):
+        server_name = _FAKE_SERVER_NAME.get()
+        streams = await rig.enter(server_name)
+        try:
+            yield streams
+        finally:
+            # Match the real transport's ownership boundary: exiting srv_a's
+            # transport terminates A's child, but must not touch B's live child.
+            rig.stop(server_name)
+
+    @asynccontextmanager
+    async def fake_client_session(*_args, **_kwargs):
+        session = MagicMock()
+        session.initialize = AsyncMock(
+            return_value=MagicMock(capabilities=MagicMock(tools=None))
+        )
+        yield session
+
+    def fake_server_parameters(**kwargs):
+        return SimpleNamespace(**kwargs)
+
+    with (
+        patch("tools.mcp_tool.StdioServerParameters", side_effect=fake_server_parameters),
+        patch("tools.mcp_tool.stdio_client", side_effect=fake_stdio_client),
+        patch("tools.mcp_tool.ClientSession", side_effect=fake_client_session),
+        patch(
+            "tools.mcp_tool._wrap_command_with_watchdog",
+            side_effect=lambda command, args: (command, args),
+        ),
+        patch("tools.osv_check.check_package_for_malware", return_value=None),
+        patch("tools.mcp_tool._write_stderr_log_header"),
+        patch("tools.mcp_tool._get_mcp_stderr_log", return_value=None),
+    ):
+        yield
+
+
+@asynccontextmanager
+async def _running_server_pair():
+    rig = _ConcurrentSpawnRig()
+    srv_a = MCPServerTask("srv_a")
+    srv_b = MCPServerTask("srv_b")
+    config = {"command": "dummy", "args": []}
+
+    async def start(server):
+        # MCPServerTask.start() creates its long-lived run task while this
+        # context is active, so the label is copied into that task without
+        # making the two production configs artificially different.
+        token = _FAKE_SERVER_NAME.set(server.name)
+        try:
+            await server.start(config)
+        finally:
+            _FAKE_SERVER_NAME.reset(token)
+
+    with _patched_stdio_runtime(rig):
+        try:
+            await asyncio.gather(start(srv_a), start(srv_b))
+            yield rig, srv_a, srv_b
+        finally:
+            await asyncio.gather(
+                srv_a.shutdown(), srv_b.shutdown(), return_exceptions=True
+            )
+            rig.cleanup()
+
+
+def test_concurrent_spawns_attribute_exactly_one_pid_per_server():
+    async def run_test():
+        async with _running_server_pair() as (rig, _srv_a, _srv_b):
+            spawned = {
+                server_name: process.pid
+                for server_name, process in rig.processes.items()
+            }
+            with _lock:
+                owners = {
+                    server_name: {
+                        pid
+                        for pid, owner in _stdio_pids.items()
+                        if owner == server_name
+                    }
+                    for server_name in ("srv_a", "srv_b")
+                }
+
+            owner_counts = {name: len(pids) for name, pids in owners.items()}
+            assert owner_counts == {"srv_a": 1, "srv_b": 1}, (
+                f"concurrent stdio PID attribution counts were {owner_counts}; "
+                f"owners={owners}, spawned={spawned}"
+            )
+            assert owners == {
+                "srv_a": {spawned["srv_a"]},
+                "srv_b": {spawned["srv_b"]},
+            }
+
+    asyncio.run(run_test())
+
+
+def test_teardown_of_one_server_does_not_orphan_siblings():
+    async def run_test():
+        async with _running_server_pair() as (rig, srv_a, _srv_b):
+            sibling_pid = rig.processes["srv_b"].pid
+
+            await srv_a.shutdown()
+
+            with _lock:
+                orphan_pids = set(_orphan_stdio_pids)
+                orphan_servers = dict(_orphan_stdio_pid_servers)
+                active_owners = dict(_stdio_pids)
+
+            assert sibling_pid not in orphan_pids, (
+                f"srv_a teardown orphaned live srv_b PID {sibling_pid}; "
+                f"orphan_servers={orphan_servers}"
+            )
+            assert active_owners.get(sibling_pid) == "srv_b", (
+                f"srv_b PID {sibling_pid} lost its active ownership after "
+                f"srv_a teardown; active_owners={active_owners}"
+            )
+
+    asyncio.run(run_test())

--- a/tests/tools/test_mcp_stdio_spawn_attribution.py
+++ b/tests/tools/test_mcp_stdio_spawn_attribution.py
@@ -3,6 +3,7 @@
 import asyncio
 import subprocess
 import sys
+import threading
 from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from types import SimpleNamespace
@@ -12,11 +13,14 @@ import pytest
 
 from tools.mcp_tool import (
     MCPServerTask,
+    _ensure_mcp_loop,
     _lock,
     _orphan_stdio_pid_servers,
     _orphan_stdio_pids,
     _stdio_pgids,
     _stdio_pids,
+    _stdio_spawn_attribution_guard,
+    _stop_mcp_loop,
 )
 
 
@@ -47,25 +51,40 @@ def clean_stdio_pid_tracking():
 class _ConcurrentSpawnRig:
     """Fake stdio transports backed by real, independently owned children."""
 
-    def __init__(self):
-        self._srv_a_entered = asyncio.Event()
-        self._srv_b_entered = asyncio.Event()
+    def __init__(self, *, force_spawn_overlap=False):
+        self._preflight_barrier = threading.Barrier(2, timeout=10)
+        self._force_spawn_overlap = force_spawn_overlap
+        self._enter_count = 0
+        self._both_entered = None
+        self.enter_attempts = {"srv_a": 0, "srv_b": 0}
         self.processes = {}
 
+    def preflight(self, _command, _args):
+        # The real OSV preflight runs in asyncio.to_thread before the spawn
+        # lock. Rendezvous there so both server coroutines are ready to race
+        # regardless of whether the production lock correctly serializes them.
+        try:
+            self._preflight_barrier.wait()
+        except threading.BrokenBarrierError:
+            pytest.fail("concurrent stdio starts did not rendezvous in OSV preflight")
+
     async def enter(self, server_name):
-        # _run_stdio takes pids_before before invoking this context manager.
-        # Force both coroutines to reach __aenter__ (and therefore take their
-        # snapshots) before either child exists. Then always spawn srv_b first:
-        # srv_b sees only B, while srv_a subsequently sees both A and B and
-        # overwrites B's ownership on the buggy snapshot-delta implementation.
-        if server_name == "srv_a":
-            self._srv_a_entered.set()
-            await asyncio.wait_for(self._srv_b_entered.wait(), timeout=2)
-        elif server_name == "srv_b":
-            await asyncio.wait_for(self._srv_a_entered.wait(), timeout=2)
-            self._srv_b_entered.set()
-        else:  # pragma: no cover - protects the test rig from accidental misuse
+        if server_name not in self.enter_attempts:  # pragma: no cover
             raise AssertionError(f"unexpected fake server name: {server_name}")
+        self.enter_attempts[server_name] += 1
+
+        if self._force_spawn_overlap:
+            # Used only with the production guard patched out. Do not let either
+            # fake transport spawn until both unguarded _run_stdio tasks have
+            # taken their pre-spawn PID snapshots and reached __aenter__.
+            if self._both_entered is None:
+                self._both_entered = asyncio.Event()
+            self._enter_count += 1
+            if self._enter_count == 2:
+                self._both_entered.set()
+            await asyncio.wait_for(self._both_entered.wait(), timeout=2)
+        else:
+            await asyncio.sleep(0.05)
 
         process = subprocess.Popen(
             [sys.executable, "-c", "import time; time.sleep(60)"],
@@ -124,7 +143,10 @@ def _patched_stdio_runtime(rig):
             "tools.mcp_tool._wrap_command_with_watchdog",
             side_effect=lambda command, args: (command, args),
         ),
-        patch("tools.osv_check.check_package_for_malware", return_value=None),
+        patch(
+            "tools.osv_check.check_package_for_malware",
+            side_effect=rig.preflight,
+        ),
         patch("tools.mcp_tool._write_stderr_log_header"),
         patch("tools.mcp_tool._get_mcp_stderr_log", return_value=None),
     ):
@@ -132,8 +154,8 @@ def _patched_stdio_runtime(rig):
 
 
 @asynccontextmanager
-async def _running_server_pair():
-    rig = _ConcurrentSpawnRig()
+async def _running_server_pair(*, force_spawn_overlap=False):
+    rig = _ConcurrentSpawnRig(force_spawn_overlap=force_spawn_overlap)
     srv_a = MCPServerTask("srv_a")
     srv_b = MCPServerTask("srv_b")
     config = {"command": "dummy", "args": []}
@@ -151,6 +173,7 @@ async def _running_server_pair():
     with _patched_stdio_runtime(rig):
         try:
             await asyncio.gather(start(srv_a), start(srv_b))
+            assert rig.enter_attempts == {"srv_a": 1, "srv_b": 1}
             yield rig, srv_a, srv_b
         finally:
             await asyncio.gather(
@@ -209,5 +232,142 @@ def test_teardown_of_one_server_does_not_orphan_siblings():
                 f"srv_b PID {sibling_pid} lost its active ownership after "
                 f"srv_a teardown; active_owners={active_owners}"
             )
+
+    asyncio.run(run_test())
+
+
+def test_fixture_deterministically_reproduces_race_without_guard():
+    @asynccontextmanager
+    async def no_spawn_guard():
+        yield
+
+    async def run_test():
+        with patch(
+            "tools.mcp_tool._stdio_spawn_attribution_guard",
+            side_effect=no_spawn_guard,
+        ):
+            async with _running_server_pair(force_spawn_overlap=True) as (
+                _rig,
+                _srv_a,
+                _srv_b,
+            ):
+                with _lock:
+                    owner_counts = {
+                        name: sum(owner == name for owner in _stdio_pids.values())
+                        for name in ("srv_a", "srv_b")
+                    }
+                assert sorted(owner_counts.values()) == [0, 2]
+
+    asyncio.run(run_test())
+
+
+def test_spawn_guard_serializes_overlapping_event_loops():
+    """Old and replacement MCP loops must share one attribution guard."""
+    rendezvous = threading.Barrier(2, timeout=10)
+    state_lock = threading.Lock()
+    errors = []
+    active = 0
+    max_active = 0
+
+    async def worker():
+        nonlocal active, max_active
+        await asyncio.to_thread(rendezvous.wait)
+        async with _stdio_spawn_attribution_guard():
+            with state_lock:
+                active += 1
+                max_active = max(max_active, active)
+            await asyncio.sleep(0.05)
+            with state_lock:
+                active -= 1
+
+    def run_worker():
+        try:
+            asyncio.run(worker())
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=run_worker) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not any(thread.is_alive() for thread in threads)
+    assert errors == []
+    assert max_active == 1
+
+
+def test_loop_stop_blocks_replacement_loop_until_final_cleanup():
+    """The old loop's final PID sweep must finish before publishing a new loop."""
+    cleanup_started = threading.Event()
+    release_cleanup = threading.Event()
+    ensure_done = threading.Event()
+    stop_result = []
+
+    def fake_finish_stopping(_loop, _thread):
+        cleanup_started.set()
+        assert release_cleanup.wait(timeout=10)
+        return True
+
+    def stop_loop():
+        stop_result.append(_stop_mcp_loop())
+
+    def ensure_replacement_loop():
+        _ensure_mcp_loop()
+        ensure_done.set()
+
+    with patch(
+        "tools.mcp_tool._finish_stopping_mcp_loop",
+        side_effect=fake_finish_stopping,
+    ):
+        stop_thread = threading.Thread(target=stop_loop)
+        stop_thread.start()
+        assert cleanup_started.wait(timeout=10)
+        ensure_thread = threading.Thread(target=ensure_replacement_loop)
+        ensure_thread.start()
+        assert not ensure_done.wait(timeout=0.05)
+        release_cleanup.set()
+        stop_thread.join(timeout=10)
+        ensure_thread.join(timeout=10)
+
+    assert not stop_thread.is_alive()
+    assert not ensure_thread.is_alive()
+    assert stop_result == [True]
+    assert ensure_done.is_set()
+    assert _stop_mcp_loop()
+
+
+def test_cancelled_spawn_guard_waiter_does_not_strand_lock():
+    async def run_test():
+        holder_started = asyncio.Event()
+        release_holder = asyncio.Event()
+
+        async def hold_guard():
+            async with _stdio_spawn_attribution_guard():
+                holder_started.set()
+                await release_holder.wait()
+
+        async def wait_for_guard():
+            async with _stdio_spawn_attribution_guard():
+                pass
+
+        holder = asyncio.create_task(hold_guard())
+        await holder_started.wait()
+        waiter = asyncio.create_task(wait_for_guard())
+        await asyncio.sleep(0.03)
+        assert not waiter.done()
+
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+
+        release_holder.set()
+        await holder
+
+        # Cancellation while queued must not acquire the threading lock later
+        # and strand it after the cancelled coroutine is gone.
+        async with asyncio.timeout(1):
+            async with _stdio_spawn_attribution_guard():
+                pass
 
     asyncio.run(run_test())

--- a/tests/tools/test_mcp_stdio_spawn_attribution.py
+++ b/tests/tools/test_mcp_stdio_spawn_attribution.py
@@ -1,0 +1,232 @@
+"""Regression coverage for concurrent stdio MCP subprocess attribution."""
+
+import asyncio
+import subprocess
+import sys
+import threading
+from contextlib import asynccontextmanager, contextmanager
+from contextvars import ContextVar
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tools.mcp_tool import (
+    MCPServerTask,
+    _lock,
+    _orphan_stdio_pid_servers,
+    _orphan_stdio_pids,
+    _stdio_pgids,
+    _stdio_pids,
+)
+
+
+_TRACKING_STATE = (
+    _stdio_pids,
+    _orphan_stdio_pids,
+    _orphan_stdio_pid_servers,
+    _stdio_pgids,
+)
+
+_FAKE_SERVER_NAME = ContextVar("fake_mcp_server_name", default=None)
+
+
+def _clear_tracking_state():
+    with _lock:
+        for state in _TRACKING_STATE:
+            state.clear()
+
+
+@pytest.fixture(autouse=True)
+def clean_stdio_pid_tracking():
+    """Keep the module-level subprocess bookkeeping hermetic."""
+    _clear_tracking_state()
+    yield
+    _clear_tracking_state()
+
+
+class _ConcurrentSpawnRig:
+    """Fake stdio transports backed by real, independently owned children."""
+
+    def __init__(self, *, force_spawn_overlap=False):
+        self._preflight_barrier = threading.Barrier(2, timeout=10)
+        self._force_spawn_overlap = force_spawn_overlap
+        self._enter_count = 0
+        self._both_entered = None
+        self.enter_attempts = {"srv_a": 0, "srv_b": 0}
+        self.processes = {}
+
+    def preflight(self, _command, _args):
+        # The real OSV preflight runs in asyncio.to_thread before the spawn
+        # lock. Rendezvous there so both server coroutines are ready to race
+        # regardless of whether the production lock correctly serializes them.
+        try:
+            self._preflight_barrier.wait()
+        except threading.BrokenBarrierError:
+            pytest.fail("concurrent stdio starts did not rendezvous in OSV preflight")
+
+    async def enter(self, server_name):
+        if server_name not in self.enter_attempts:  # pragma: no cover
+            raise AssertionError(f"unexpected fake server name: {server_name}")
+        self.enter_attempts[server_name] += 1
+
+        if self._force_spawn_overlap:
+            # Used only with the production guard patched out. Do not let either
+            # fake transport spawn until both unguarded _run_stdio tasks have
+            # taken their pre-spawn PID snapshots and reached __aenter__.
+            if self._both_entered is None:
+                self._both_entered = asyncio.Event()
+            self._enter_count += 1
+            if self._enter_count == 2:
+                self._both_entered.set()
+            await asyncio.wait_for(self._both_entered.wait(), timeout=2)
+        else:
+            await asyncio.sleep(0.05)
+
+        process = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            start_new_session=True,
+        )
+        self.processes[server_name] = process
+        return MagicMock(name=f"{server_name}_read"), MagicMock(
+            name=f"{server_name}_write"
+        )
+
+    def stop(self, server_name):
+        process = self.processes.get(server_name)
+        if process is None or process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=2)
+
+    def cleanup(self):
+        for server_name in list(self.processes):
+            self.stop(server_name)
+
+
+@contextmanager
+def _patched_stdio_runtime(rig):
+    @asynccontextmanager
+    async def fake_stdio_client(server_params, **_kwargs):
+        server_name = _FAKE_SERVER_NAME.get()
+        streams = await rig.enter(server_name)
+        try:
+            yield streams
+        finally:
+            # Match the real transport's ownership boundary: exiting srv_a's
+            # transport terminates A's child, but must not touch B's live child.
+            rig.stop(server_name)
+
+    @asynccontextmanager
+    async def fake_client_session(*_args, **_kwargs):
+        session = MagicMock()
+        session.initialize = AsyncMock(
+            return_value=MagicMock(capabilities=MagicMock(tools=None))
+        )
+        yield session
+
+    def fake_server_parameters(**kwargs):
+        return SimpleNamespace(**kwargs)
+
+    with (
+        patch("tools.mcp_tool.StdioServerParameters", side_effect=fake_server_parameters),
+        patch("tools.mcp_tool.stdio_client", side_effect=fake_stdio_client),
+        patch("tools.mcp_tool.ClientSession", side_effect=fake_client_session),
+        patch(
+            "tools.mcp_tool._wrap_command_with_watchdog",
+            side_effect=lambda command, args: (command, args),
+        ),
+        patch(
+            "tools.osv_check.check_package_for_malware",
+            side_effect=rig.preflight,
+        ),
+        patch("tools.mcp_tool._write_stderr_log_header"),
+        patch("tools.mcp_tool._get_mcp_stderr_log", return_value=None),
+    ):
+        yield
+
+
+@asynccontextmanager
+async def _running_server_pair(*, force_spawn_overlap=False):
+    rig = _ConcurrentSpawnRig(force_spawn_overlap=force_spawn_overlap)
+    srv_a = MCPServerTask("srv_a")
+    srv_b = MCPServerTask("srv_b")
+    config = {"command": "dummy", "args": []}
+
+    async def start(server):
+        token = _FAKE_SERVER_NAME.set(server.name)
+        try:
+            await server.start(config)
+        finally:
+            _FAKE_SERVER_NAME.reset(token)
+
+    with _patched_stdio_runtime(rig):
+        try:
+            await asyncio.gather(start(srv_a), start(srv_b))
+            assert rig.enter_attempts == {"srv_a": 1, "srv_b": 1}
+            yield rig, srv_a, srv_b
+        finally:
+            await asyncio.gather(
+                srv_a.shutdown(), srv_b.shutdown(), return_exceptions=True
+            )
+            rig.cleanup()
+
+
+def test_concurrent_spawns_attribute_exactly_one_pid_per_server():
+    async def run_test():
+        async with _running_server_pair() as (rig, _srv_a, _srv_b):
+            spawned = {
+                server_name: process.pid
+                for server_name, process in rig.processes.items()
+            }
+            with _lock:
+                owners = {
+                    server_name: {
+                        pid
+                        for pid, owner in _stdio_pids.items()
+                        if owner == server_name
+                    }
+                    for server_name in ("srv_a", "srv_b")
+                }
+
+            owner_counts = {name: len(pids) for name, pids in owners.items()}
+            assert owner_counts == {"srv_a": 1, "srv_b": 1}, (
+                f"concurrent stdio PID attribution counts were {owner_counts}; "
+                f"owners={owners}, spawned={spawned}"
+            )
+            assert owners == {
+                "srv_a": {spawned["srv_a"]},
+                "srv_b": {spawned["srv_b"]},
+            }
+
+    asyncio.run(run_test())
+
+
+def test_teardown_of_one_server_does_not_orphan_siblings():
+    async def run_test():
+        async with _running_server_pair() as (rig, srv_a, _srv_b):
+            sibling_pid = rig.processes["srv_b"].pid
+
+            await srv_a.shutdown()
+
+            with _lock:
+                orphan_pids = set(_orphan_stdio_pids)
+                orphan_servers = dict(_orphan_stdio_pid_servers)
+                active_owners = dict(_stdio_pids)
+
+            assert sibling_pid not in orphan_pids, (
+                f"srv_a teardown orphaned live srv_b PID {sibling_pid}; "
+                f"orphan_servers={orphan_servers}"
+            )
+            assert active_owners.get(sibling_pid) == "srv_b", (
+                f"srv_b PID {sibling_pid} lost its active ownership after "
+                f"srv_a teardown; active_owners={active_owners}"
+            )
+
+    asyncio.run(run_test())
+
+

--- a/tests/tools/test_mcp_stdio_spawn_attribution.py
+++ b/tests/tools/test_mcp_stdio_spawn_attribution.py
@@ -13,11 +13,14 @@ import pytest
 
 from tools.mcp_tool import (
     MCPServerTask,
+    _ensure_mcp_loop,
     _lock,
     _orphan_stdio_pid_servers,
     _orphan_stdio_pids,
     _stdio_pgids,
     _stdio_pids,
+    _stdio_spawn_attribution_guard,
+    _stop_mcp_loop,
 )
 
 
@@ -230,3 +233,136 @@ def test_teardown_of_one_server_does_not_orphan_siblings():
     asyncio.run(run_test())
 
 
+def test_fixture_deterministically_reproduces_race_without_guard():
+    @asynccontextmanager
+    async def no_spawn_guard():
+        yield
+
+    async def run_test():
+        with patch(
+            "tools.mcp_tool._stdio_spawn_attribution_guard",
+            side_effect=no_spawn_guard,
+        ):
+            async with _running_server_pair(force_spawn_overlap=True) as (
+                _rig,
+                _srv_a,
+                _srv_b,
+            ):
+                with _lock:
+                    owner_counts = {
+                        name: sum(owner == name for owner in _stdio_pids.values())
+                        for name in ("srv_a", "srv_b")
+                    }
+                assert sorted(owner_counts.values()) == [0, 2]
+
+    asyncio.run(run_test())
+
+
+def test_spawn_guard_serializes_overlapping_event_loops():
+    """Old and replacement MCP loops must share one attribution guard."""
+    rendezvous = threading.Barrier(2, timeout=10)
+    state_lock = threading.Lock()
+    errors = []
+    active = 0
+    max_active = 0
+
+    async def worker():
+        nonlocal active, max_active
+        await asyncio.to_thread(rendezvous.wait)
+        async with _stdio_spawn_attribution_guard():
+            with state_lock:
+                active += 1
+                max_active = max(max_active, active)
+            await asyncio.sleep(0.05)
+            with state_lock:
+                active -= 1
+
+    def run_worker():
+        try:
+            asyncio.run(worker())
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=run_worker) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not any(thread.is_alive() for thread in threads)
+    assert errors == []
+    assert max_active == 1
+
+
+def test_loop_stop_blocks_replacement_loop_until_final_cleanup():
+    """The old loop's final PID sweep must finish before publishing a new loop."""
+    cleanup_started = threading.Event()
+    release_cleanup = threading.Event()
+    ensure_done = threading.Event()
+    stop_result = []
+
+    def fake_finish_stopping(_loop, _thread):
+        cleanup_started.set()
+        assert release_cleanup.wait(timeout=10)
+        return True
+
+    def stop_loop():
+        stop_result.append(_stop_mcp_loop())
+
+    def ensure_replacement_loop():
+        _ensure_mcp_loop()
+        ensure_done.set()
+
+    with patch(
+        "tools.mcp_tool._finish_stopping_mcp_loop",
+        side_effect=fake_finish_stopping,
+    ):
+        stop_thread = threading.Thread(target=stop_loop)
+        stop_thread.start()
+        assert cleanup_started.wait(timeout=10)
+        ensure_thread = threading.Thread(target=ensure_replacement_loop)
+        ensure_thread.start()
+        assert not ensure_done.wait(timeout=0.05)
+        release_cleanup.set()
+        stop_thread.join(timeout=10)
+        ensure_thread.join(timeout=10)
+
+    assert not stop_thread.is_alive()
+    assert not ensure_thread.is_alive()
+    assert stop_result == [True]
+    assert ensure_done.is_set()
+    assert _stop_mcp_loop()
+
+
+def test_cancelled_spawn_guard_waiter_does_not_strand_lock():
+    async def run_test():
+        holder_started = asyncio.Event()
+        release_holder = asyncio.Event()
+
+        async def hold_guard():
+            async with _stdio_spawn_attribution_guard():
+                holder_started.set()
+                await release_holder.wait()
+
+        async def wait_for_guard():
+            async with _stdio_spawn_attribution_guard():
+                pass
+
+        holder = asyncio.create_task(hold_guard())
+        await holder_started.wait()
+        waiter = asyncio.create_task(wait_for_guard())
+        await asyncio.sleep(0.03)
+        assert not waiter.done()
+
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+
+        release_holder.set()
+        await holder
+
+        async with asyncio.timeout(1):
+            async with _stdio_spawn_attribution_guard():
+                pass
+
+    asyncio.run(run_test())

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -90,6 +90,7 @@ Thread safety:
 """
 
 import asyncio
+import contextlib
 import contextvars
 import concurrent.futures
 import errno
@@ -2463,85 +2464,86 @@ class MCPServerTask:
         # exist, which would otherwise stall the shared MCP event loop.
         await asyncio.to_thread(_kill_orphaned_mcp_children)
 
-        # Snapshot child PIDs before spawning so we can track the new one.
-        pids_before = _snapshot_child_pids()
         new_pids: set = set()
-        # Redirect subprocess stderr into a shared log file so MCP servers
-        # (FastMCP banners, slack-mcp startup JSON, etc.) don't dump onto
-        # the user's TTY and corrupt the TUI.  Preserves debuggability via
-        # ~/.hermes/logs/mcp-stderr.log.
-        _write_stderr_log_header(self.name)
-        _errlog = _get_mcp_stderr_log()
         try:
-            async with stdio_client(server_params, errlog=_errlog) as (
-                read_stream,
-                write_stream,
-            ):
-                # Capture the newly spawned subprocess PID for force-kill cleanup.
-                # Filter out non-MCP children that race into the snapshot window:
-                # slash_worker and LSP servers (jdtls/pyright/yaml-ls) are spawned
-                # directly by the gateway without start_new_session, so their pgid
-                # equals the TUI parent PID. If they leak into _stdio_pgids, the
-                # shutdown sweep's killpg() kills the TUI parent itself.
-                # See agent/lsp/client.py for the complementary start_new_session fix.
-                new_pids = _filter_mcp_children(
-                    _snapshot_child_pids() - pids_before
-                )
-                if new_pids:
-                    # Capture pgid while the child is alive — once it exits we
-                    # can no longer call ``os.getpgid`` on it, and the cleanup
-                    # sweep needs the pgid to reach any reparented descendants
-                    # (e.g. ``claude mcp serve`` spawned by a stdio wrapper).
-                    new_pgids: Dict[int, int] = {}
-                    for _pid in new_pids:
-                        try:
-                            new_pgids[_pid] = os.getpgid(_pid)
-                        except (AttributeError, ProcessLookupError, OSError):
-                            # AttributeError: Windows (os.getpgid is POSIX-only)
-                            # ProcessLookupError: child raced and already exited
-                            pass
-                    with _lock:
+            async with contextlib.AsyncExitStack() as stack:
+                async with _stdio_spawn_lock:
+                    # Snapshot child PIDs before spawning so we can track the new one.
+                    pids_before = _snapshot_child_pids()
+                    # Redirect subprocess stderr into a shared log file so MCP servers
+                    # (FastMCP banners, slack-mcp startup JSON, etc.) don't dump onto
+                    # the user's TTY and corrupt the TUI. Preserves debuggability via
+                    # ~/.hermes/logs/mcp-stderr.log.
+                    _write_stderr_log_header(self.name)
+                    _errlog = _get_mcp_stderr_log()
+                    read_stream, write_stream = await stack.enter_async_context(
+                        stdio_client(server_params, errlog=_errlog)
+                    )
+                    # Capture the newly spawned subprocess PID for force-kill cleanup.
+                    # Filter out non-MCP children that race into the snapshot window:
+                    # slash_worker and LSP servers (jdtls/pyright/yaml-ls) are spawned
+                    # directly by the gateway without start_new_session, so their pgid
+                    # equals the TUI parent PID. If they leak into _stdio_pgids, the
+                    # shutdown sweep's killpg() kills the TUI parent itself.
+                    # See agent/lsp/client.py for the complementary start_new_session fix.
+                    new_pids = _filter_mcp_children(
+                        _snapshot_child_pids() - pids_before
+                    )
+                    if new_pids:
+                        # Capture pgid while the child is alive — once it exits we
+                        # can no longer call ``os.getpgid`` on it, and the cleanup
+                        # sweep needs the pgid to reach any reparented descendants
+                        # (e.g. ``claude mcp serve`` spawned by a stdio wrapper).
+                        new_pgids: Dict[int, int] = {}
                         for _pid in new_pids:
-                            _stdio_pids[_pid] = self.name
-                        _stdio_pgids.update(new_pgids)
-                async with ClientSession(
-                    read_stream, write_stream, **sampling_kwargs
-                ) as session:
-                    # Bound the MCP handshake. A stdio server that never
-                    # completes ``initialize`` (e.g. emits a non-JSON-RPC frame
-                    # and then blocks on stdin) otherwise hangs this coroutine
-                    # forever on the background loop: ``connect_timeout`` only
-                    # bounds the caller's ``.result()`` wait, not the coroutine
-                    # itself. Because the connect never unwinds, the cleanup
-                    # ``finally`` below never runs, so the spawned child and its
-                    # stdio pipes/pidfd leak on every discovery retry — unbounded
-                    # until the gateway hits EMFILE. Timing out here converts the
-                    # hang into a normal failure, letting the ``finally`` reap the
-                    # child. See #59349.
-                    connect_timeout = float(
-                        config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
-                    )
-                    self.initialize_result = await asyncio.wait_for(
-                        session.initialize(), timeout=connect_timeout
-                    )
-                    self.session = session
-                    self._mark_lifecycle_started()
-                    await self._discover_tools()
-                    self._ready.set()
-                    # Session is live again: clear any breaker state from a
-                    # prior outage so the first call after recovery isn't
-                    # gated on a stale consecutive-failure count (#16788).
-                    _reset_server_error(self.name)
-                    # A completed handshake alone is NOT proof of health: a
-                    # flapping transport can handshake fine and drop moments
-                    # later, forever (#62212). The session must prove itself
-                    # (keepalive success or a successful tool call) before the
-                    # reconnect budget is cleared — see _mark_session_proven.
-                    self._session_proven = False
-                    # stdio transport does not use OAuth, but we still honor
-                    # _reconnect_event (e.g. future manual /mcp refresh) for
-                    # consistency with _run_http.
-                    return await self._wait_for_lifecycle_event()
+                            try:
+                                new_pgids[_pid] = os.getpgid(_pid)
+                            except (AttributeError, ProcessLookupError, OSError):
+                                # AttributeError: Windows (os.getpgid is POSIX-only)
+                                # ProcessLookupError: child raced and already exited
+                                pass
+                        with _lock:
+                            for _pid in new_pids:
+                                _stdio_pids[_pid] = self.name
+                            _stdio_pgids.update(new_pgids)
+                session = await stack.enter_async_context(
+                    ClientSession(read_stream, write_stream, **sampling_kwargs)
+                )
+                # Bound the MCP handshake. A stdio server that never
+                # completes ``initialize`` (e.g. emits a non-JSON-RPC frame
+                # and then blocks on stdin) otherwise hangs this coroutine
+                # forever on the background loop: ``connect_timeout`` only
+                # bounds the caller's ``.result()`` wait, not the coroutine
+                # itself. Because the connect never unwinds, the cleanup
+                # ``finally`` below never runs, so the spawned child and its
+                # stdio pipes/pidfd leak on every discovery retry — unbounded
+                # until the gateway hits EMFILE. Timing out here converts the
+                # hang into a normal failure, letting the ``finally`` reap the
+                # child. See #59349.
+                connect_timeout = float(
+                    config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+                )
+                self.initialize_result = await asyncio.wait_for(
+                    session.initialize(), timeout=connect_timeout
+                )
+                self.session = session
+                self._mark_lifecycle_started()
+                await self._discover_tools()
+                self._ready.set()
+                # Session is live again: clear any breaker state from a
+                # prior outage so the first call after recovery isn't
+                # gated on a stale consecutive-failure count (#16788).
+                _reset_server_error(self.name)
+                # A completed handshake alone is NOT proof of health: a
+                # flapping transport can handshake fine and drop moments
+                # later, forever (#62212). The session must prove itself
+                # (keepalive success or a successful tool call) before the
+                # reconnect budget is cleared — see _mark_session_proven.
+                self._session_proven = False
+                # stdio transport does not use OAuth, but we still honor
+                # _reconnect_event (e.g. future manual /mcp refresh) for
+                # consistency with _run_http.
+                return await self._wait_for_lifecycle_event()
         finally:
             # Runs on clean exit, exceptions, AND asyncio cancellation.
             # If any of the spawned PIDs are still alive, the SDK's
@@ -4140,6 +4142,14 @@ _mcp_thread: Optional[threading.Thread] = None
 # Protects _mcp_loop, _mcp_thread, _servers, MCP connection status maps,
 # _parallel_safe_servers, _mcp_tool_server_names, and _stdio_pids.
 _lock = threading.Lock()
+
+# Serialize only the stdio spawn-attribution window (snapshot → spawn → delta
+# → registration) so concurrent _run_stdio() coroutines on the shared MCP loop
+# cannot claim each other's child PIDs. Spawns are rare, so the serialization
+# cost is negligible; _filter_mcp_children remains defense-in-depth for
+# unrelated children. On Python 3.10+ asyncio.Lock() is loop-agnostic at
+# construction and this lock is only awaited on the MCP loop.
+_stdio_spawn_lock = asyncio.Lock()
 
 # ---------------------------------------------------------------------------
 # Cross-process MCP discovery guard

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2467,15 +2467,16 @@ class MCPServerTask:
         new_pids: set = set()
         try:
             async with contextlib.AsyncExitStack() as stack:
-                async with _stdio_spawn_lock:
+                # Redirect subprocess stderr into a shared log file so MCP servers
+                # (FastMCP banners, slack-mcp startup JSON, etc.) don't dump onto
+                # the user's TTY and corrupt the TUI. Preserves debuggability via
+                # ~/.hermes/logs/mcp-stderr.log. Keep this setup outside the spawn
+                # attribution critical section.
+                _write_stderr_log_header(self.name)
+                _errlog = _get_mcp_stderr_log()
+                async with _stdio_spawn_attribution_guard():
                     # Snapshot child PIDs before spawning so we can track the new one.
                     pids_before = _snapshot_child_pids()
-                    # Redirect subprocess stderr into a shared log file so MCP servers
-                    # (FastMCP banners, slack-mcp startup JSON, etc.) don't dump onto
-                    # the user's TTY and corrupt the TUI. Preserves debuggability via
-                    # ~/.hermes/logs/mcp-stderr.log.
-                    _write_stderr_log_header(self.name)
-                    _errlog = _get_mcp_stderr_log()
                     read_stream, write_stream = await stack.enter_async_context(
                         stdio_client(server_params, errlog=_errlog)
                     )
@@ -4143,13 +4144,37 @@ _mcp_thread: Optional[threading.Thread] = None
 # _parallel_safe_servers, _mcp_tool_server_names, and _stdio_pids.
 _lock = threading.Lock()
 
+# Prevent a replacement MCP loop from being published while the old loop is
+# draining and performing its final active-PID sweep. The condition shares
+# _lock so loop publication and the stopping flag change atomically.
+_mcp_loop_state_condition = threading.Condition(_lock)
+_mcp_loop_stopping = False
+
 # Serialize only the stdio spawn-attribution window (snapshot → spawn → delta
-# → registration) so concurrent _run_stdio() coroutines on the shared MCP loop
-# cannot claim each other's child PIDs. Spawns are rare, so the serialization
-# cost is negligible; _filter_mcp_children remains defense-in-depth for
-# unrelated children. On Python 3.10+ asyncio.Lock() is loop-agnostic at
-# construction and this lock is only awaited on the MCP loop.
-_stdio_spawn_lock = asyncio.Lock()
+# → registration) so concurrent _run_stdio() coroutines cannot claim each
+# other's child PIDs. Unexpected loop failure can leave an old thread unwinding
+# while _ensure_mcp_loop() publishes a replacement, so this guard must work
+# across event loops and threads.
+# A dedicated threading.Lock provides that process-wide exclusion. Polling its
+# non-blocking acquire keeps every event loop responsive and, unlike
+# asyncio.to_thread(lock.acquire), cannot strand the lock if a queued coroutine
+# is cancelled while a worker thread is still waiting.
+_stdio_spawn_lock = threading.Lock()
+_STDIO_SPAWN_LOCK_POLL_INTERVAL_S = 0.01
+
+
+@contextlib.asynccontextmanager
+async def _stdio_spawn_attribution_guard():
+    """Cancellation-safe, cross-loop guard for stdio PID attribution."""
+    acquired = False
+    try:
+        while not _stdio_spawn_lock.acquire(blocking=False):
+            await asyncio.sleep(_STDIO_SPAWN_LOCK_POLL_INTERVAL_S)
+        acquired = True
+        yield
+    finally:
+        if acquired:
+            _stdio_spawn_lock.release()
 
 # ---------------------------------------------------------------------------
 # Cross-process MCP discovery guard
@@ -4394,7 +4419,9 @@ def _mcp_loop_exception_handler(loop, context):
 def _ensure_mcp_loop():
     """Start the background event loop thread if not already running."""
     global _mcp_loop, _mcp_thread
-    with _lock:
+    with _mcp_loop_state_condition:
+        while _mcp_loop_stopping:
+            _mcp_loop_state_condition.wait()
         if _mcp_loop is not None and _mcp_loop.is_running():
             return
         _mcp_loop = asyncio.new_event_loop()
@@ -7178,9 +7205,11 @@ async def _drain_and_stop_mcp_loop() -> None:
 
 
 def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
-    """Stop the background event loop and join its thread."""
-    global _mcp_loop, _mcp_thread
-    with _lock:
+    """Stop the old loop before allowing a replacement loop to be published."""
+    global _mcp_loop, _mcp_thread, _mcp_loop_stopping
+    with _mcp_loop_state_condition:
+        while _mcp_loop_stopping:
+            _mcp_loop_state_condition.wait()
         if only_if_idle and (_servers or _server_connecting):
             logger.debug("Leaving MCP event loop running; active servers are registered or connecting")
             return False
@@ -7188,6 +7217,20 @@ def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
         thread = _mcp_thread
         _mcp_loop = None
         _mcp_thread = None
+        _mcp_loop_stopping = True
+    try:
+        return _finish_stopping_mcp_loop(loop, thread)
+    finally:
+        with _mcp_loop_state_condition:
+            _mcp_loop_stopping = False
+            _mcp_loop_state_condition.notify_all()
+
+
+def _finish_stopping_mcp_loop(
+    loop: Optional[asyncio.AbstractEventLoop],
+    thread: Optional[threading.Thread],
+) -> bool:
+    """Drain/close one detached MCP loop and reap only before replacement."""
     if loop is not None:
         # Drain before stopping: closing the loop with tasks still suspended
         # leaves their coroutines for the GC, whose finalizer then resumes them

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5217,6 +5217,12 @@ _mcp_thread: Optional[threading.Thread] = None
 # _parallel_safe_servers, _mcp_tool_server_names, and _stdio_pids.
 _lock = threading.Lock()
 
+# Prevent a replacement MCP loop from being published while the old loop is
+# draining and performing its final active-PID sweep. The condition shares
+# _lock so loop publication and the stopping flag change atomically.
+_mcp_loop_state_condition = threading.Condition(_lock)
+_mcp_loop_stopping = False
+
 # Serialize only the stdio spawn-attribution window (snapshot → spawn → delta
 # → registration) so concurrent _run_stdio() coroutines cannot claim each
 # other's child PIDs. Unexpected loop failure can leave an old thread unwinding
@@ -5486,7 +5492,9 @@ def _mcp_loop_exception_handler(loop, context):
 def _ensure_mcp_loop():
     """Start the background event loop thread if not already running."""
     global _mcp_loop, _mcp_thread
-    with _lock:
+    with _mcp_loop_state_condition:
+        while _mcp_loop_stopping:
+            _mcp_loop_state_condition.wait()
         if _mcp_loop is not None and _mcp_loop.is_running():
             return
         _mcp_loop = asyncio.new_event_loop()
@@ -8550,9 +8558,11 @@ async def _drain_and_stop_mcp_loop() -> None:
 
 
 def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
-    """Stop the background event loop and join its thread."""
-    global _mcp_loop, _mcp_thread
-    with _lock:
+    """Stop the old loop before allowing a replacement loop to be published."""
+    global _mcp_loop, _mcp_thread, _mcp_loop_stopping
+    with _mcp_loop_state_condition:
+        while _mcp_loop_stopping:
+            _mcp_loop_state_condition.wait()
         if only_if_idle and (_servers or _server_connecting):
             logger.debug("Leaving MCP event loop running; active servers are registered or connecting")
             return False
@@ -8560,6 +8570,20 @@ def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
         thread = _mcp_thread
         _mcp_loop = None
         _mcp_thread = None
+        _mcp_loop_stopping = True
+    try:
+        return _finish_stopping_mcp_loop(loop, thread)
+    finally:
+        with _mcp_loop_state_condition:
+            _mcp_loop_stopping = False
+            _mcp_loop_state_condition.notify_all()
+
+
+def _finish_stopping_mcp_loop(
+    loop: Optional[asyncio.AbstractEventLoop],
+    thread: Optional[threading.Thread],
+) -> bool:
+    """Drain/close one detached MCP loop and reap only before replacement."""
     if loop is not None:
         # Drain before stopping: closing the loop with tasks still suspended
         # leaves their coroutines for the GC, whose finalizer then resumes them

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -110,7 +110,7 @@ import shutil
 import sys
 import threading
 import time
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, AsyncExitStack
 from types import SimpleNamespace
 from typing import Callable
 from datetime import datetime
@@ -3266,89 +3266,91 @@ class MCPServerTask:
         # exist, which would otherwise stall the shared MCP event loop.
         await asyncio.to_thread(_kill_orphaned_mcp_children)
 
-        # Snapshot child PIDs before spawning so we can track the new one.
-        pids_before = _snapshot_child_pids()
         new_pids: set = set()
-        # Redirect subprocess stderr into a shared log file so MCP servers
-        # (FastMCP banners, slack-mcp startup JSON, etc.) don't dump onto
-        # the user's TTY and corrupt the TUI.  Preserves debuggability via
-        # ~/.hermes/logs/mcp-stderr.log.
-        _write_stderr_log_header(self.name)
-        _errlog = _get_mcp_stderr_log()
         try:
-            async with stdio_client(server_params, errlog=_errlog) as (
-                read_stream,
-                write_stream,
-            ):
-                # Capture the newly spawned subprocess PID for force-kill cleanup.
-                # Filter out non-MCP children that race into the snapshot window:
-                # slash_worker and LSP servers (jdtls/pyright/yaml-ls) are spawned
-                # directly by the gateway without start_new_session, so their pgid
-                # equals the TUI parent PID. If they leak into _stdio_pgids, the
-                # shutdown sweep's killpg() kills the TUI parent itself.
-                # See agent/lsp/client.py for the complementary start_new_session fix.
-                new_pids = _filter_mcp_children(
-                    _snapshot_child_pids() - pids_before
-                )
-                if new_pids:
-                    # Capture pgid while the child is alive — once it exits we
-                    # can no longer call ``os.getpgid`` on it, and the cleanup
-                    # sweep needs the pgid to reach any reparented descendants
-                    # (e.g. ``claude mcp serve`` spawned by a stdio wrapper).
-                    new_pgids: Dict[int, int] = {}
-                    for _pid in new_pids:
-                        try:
-                            new_pgids[_pid] = os.getpgid(_pid)
-                        except (AttributeError, ProcessLookupError, OSError):
-                            # AttributeError: Windows (os.getpgid is POSIX-only)
-                            # ProcessLookupError: child raced and already exited
-                            pass
-                    with _lock:
+            async with AsyncExitStack() as stack:
+                # Redirect subprocess stderr into a shared log file so MCP servers
+                # (FastMCP banners, slack-mcp startup JSON, etc.) don't dump onto
+                # the user's TTY and corrupt the TUI. Preserves debuggability via
+                # ~/.hermes/logs/mcp-stderr.log. Keep this setup outside the spawn
+                # attribution critical section.
+                _write_stderr_log_header(self.name)
+                _errlog = _get_mcp_stderr_log()
+                async with _stdio_spawn_attribution_guard():
+                    # Snapshot child PIDs before spawning so we can track the new one.
+                    pids_before = _snapshot_child_pids()
+                    read_stream, write_stream = await stack.enter_async_context(
+                        stdio_client(server_params, errlog=_errlog)
+                    )
+                    # Capture the newly spawned subprocess PID for force-kill cleanup.
+                    # Filter out non-MCP children that race into the snapshot window:
+                    # slash_worker and LSP servers (jdtls/pyright/yaml-ls) are spawned
+                    # directly by the gateway without start_new_session, so their pgid
+                    # equals the TUI parent PID. If they leak into _stdio_pgids, the
+                    # shutdown sweep's killpg() kills the TUI parent itself.
+                    # See agent/lsp/client.py for the complementary start_new_session fix.
+                    new_pids = _filter_mcp_children(
+                        _snapshot_child_pids() - pids_before
+                    )
+                    if new_pids:
+                        # Capture pgid while the child is alive — once it exits we
+                        # can no longer call ``os.getpgid`` on it, and the cleanup
+                        # sweep needs the pgid to reach any reparented descendants
+                        # (e.g. ``claude mcp serve`` spawned by a stdio wrapper).
+                        new_pgids: Dict[int, int] = {}
                         for _pid in new_pids:
-                            _stdio_pids[_pid] = self.name
-                        _stdio_pgids.update(new_pgids)
+                            try:
+                                new_pgids[_pid] = os.getpgid(_pid)
+                            except (AttributeError, ProcessLookupError, OSError):
+                                # AttributeError: Windows (os.getpgid is POSIX-only)
+                                # ProcessLookupError: child raced and already exited
+                                pass
+                        with _lock:
+                            for _pid in new_pids:
+                                _stdio_pids[_pid] = self.name
+                            _stdio_pgids.update(new_pgids)
                 # Track the spawned children on the connection object for
                 # fast-fail of in-flight calls when the subprocess dies
-                # (#81995).
+                # (#81995). Keep this outside the attribution critical section.
                 self._stdio_child_pids = set(new_pids)
-                async with ClientSession(
-                    read_stream, write_stream, **sampling_kwargs
-                ) as session:
-                    # Bound the MCP handshake. A stdio server that never
-                    # completes ``initialize`` (e.g. emits a non-JSON-RPC frame
-                    # and then blocks on stdin) otherwise hangs this coroutine
-                    # forever on the background loop: ``connect_timeout`` only
-                    # bounds the caller's ``.result()`` wait, not the coroutine
-                    # itself. Because the connect never unwinds, the cleanup
-                    # ``finally`` below never runs, so the spawned child and its
-                    # stdio pipes/pidfd leak on every discovery retry — unbounded
-                    # until the gateway hits EMFILE. Timing out here converts the
-                    # hang into a normal failure, letting the ``finally`` reap the
-                    # child. See #59349.
-                    connect_timeout = float(
-                        config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
-                    )
-                    self.initialize_result = await self._negotiate_session(
-                        session, connect_timeout
-                    )
-                    self.session = session
-                    self._mark_lifecycle_started()
-                    await self._discover_tools()
-                    self._ready.set()
-                    # Session is live again: clear any breaker state from a
-                    # prior outage so the first call after recovery isn't
-                    # gated on a stale consecutive-failure count (#16788).
-                    _reset_server_error(self.name)
-                    # A completed handshake alone is NOT proof of health: a
-                    # flapping transport can handshake fine and drop moments
-                    # later, forever (#62212). The session must prove itself
-                    # (keepalive success or a successful tool call) before the
-                    # reconnect budget is cleared — see _mark_session_proven.
-                    self._session_proven = False
-                    # stdio transport does not use OAuth, but we still honor
-                    # _reconnect_event (e.g. future manual /mcp refresh) for
-                    # consistency with _run_http.
-                    return await self._wait_for_lifecycle_event()
+                session = await stack.enter_async_context(
+                    ClientSession(read_stream, write_stream, **sampling_kwargs)
+                )
+                # Bound the MCP handshake. A stdio server that never
+                # completes ``initialize`` (e.g. emits a non-JSON-RPC frame
+                # and then blocks on stdin) otherwise hangs this coroutine
+                # forever on the background loop: ``connect_timeout`` only
+                # bounds the caller's ``.result()`` wait, not the coroutine
+                # itself. Because the connect never unwinds, the cleanup
+                # ``finally`` below never runs, so the spawned child and its
+                # stdio pipes/pidfd leak on every discovery retry — unbounded
+                # until the gateway hits EMFILE. Timing out here converts the
+                # hang into a normal failure, letting the ``finally`` reap the
+                # child. See #59349.
+                connect_timeout = float(
+                    config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+                )
+                self.initialize_result = await self._negotiate_session(
+                    session, connect_timeout
+                )
+                self.session = session
+                self._mark_lifecycle_started()
+                await self._discover_tools()
+                self._ready.set()
+                # Session is live again: clear any breaker state from a
+                # prior outage so the first call after recovery isn't
+                # gated on a stale consecutive-failure count (#16788).
+                _reset_server_error(self.name)
+                # A completed handshake alone is NOT proof of health: a
+                # flapping transport can handshake fine and drop moments
+                # later, forever (#62212). The session must prove itself
+                # (keepalive success or a successful tool call) before the
+                # reconnect budget is cleared — see _mark_session_proven.
+                self._session_proven = False
+                # stdio transport does not use OAuth, but we still honor
+                # _reconnect_event (e.g. future manual /mcp refresh) for
+                # consistency with _run_http.
+                return await self._wait_for_lifecycle_event()
         finally:
             # Runs on clean exit, exceptions, AND asyncio cancellation.
             # If any of the spawned PIDs are still alive, the SDK's
@@ -5214,6 +5216,32 @@ _mcp_thread: Optional[threading.Thread] = None
 # Protects _mcp_loop, _mcp_thread, _servers, MCP connection status maps,
 # _parallel_safe_servers, _mcp_tool_server_names, and _stdio_pids.
 _lock = threading.Lock()
+
+# Serialize only the stdio spawn-attribution window (snapshot → spawn → delta
+# → registration) so concurrent _run_stdio() coroutines cannot claim each
+# other's child PIDs. Unexpected loop failure can leave an old thread unwinding
+# while _ensure_mcp_loop() publishes a replacement, so this guard must work
+# across event loops and threads.
+# A dedicated threading.Lock provides that process-wide exclusion. Polling its
+# non-blocking acquire keeps every event loop responsive and, unlike
+# asyncio.to_thread(lock.acquire), cannot strand the lock if a queued coroutine
+# is cancelled while a worker thread is still waiting.
+_stdio_spawn_lock = threading.Lock()
+_STDIO_SPAWN_LOCK_POLL_INTERVAL_S = 0.01
+
+
+@asynccontextmanager
+async def _stdio_spawn_attribution_guard():
+    """Cancellation-safe, cross-loop guard for stdio PID attribution."""
+    acquired = False
+    try:
+        while not _stdio_spawn_lock.acquire(blocking=False):
+            await asyncio.sleep(_STDIO_SPAWN_LOCK_POLL_INTERVAL_S)
+        acquired = True
+        yield
+    finally:
+        if acquired:
+            _stdio_spawn_lock.release()
 
 # ---------------------------------------------------------------------------
 # Cross-process MCP discovery guard


### PR DESCRIPTION
## Problem

When one Hermes process starts multiple MCP stdio servers concurrently (for example `gbrain`, `context7`, and `hermes-atlas`), their `_run_stdio()` tasks can overlap this sequence:

1. snapshot child PIDs;
2. enter `stdio_client()` and spawn a child;
3. snapshot again and attribute the delta.

Overlapping windows can make one server claim a sibling server's subprocess PID. When the misattributing task tears down, its orphan cleanup can kill that still-live sibling process, surfacing as `ClosedResourceError`, keepalive failures, and reconnect flapping across stdio servers.

This remains present on current `main` (reconfirmed 2026-08-21 / `41447a6d70`). Upstream lazy startup (`mcp_servers.<name>.lazy`, default OFF) can reduce how often several servers spawn at once, but does not close the race for eager multi-stdio setups or concurrent first-use connects. `_filter_mcp_children` only drops slash_worker/LSP PIDs — it does **not** serialize sibling MCP spawns.

## Fix

- Serialize only the PID-attribution-critical window: **snapshot → stdio spawn → delta/filter → PID/PGID registration**.
- Use one `AsyncExitStack` so `ClientSession` and stdio transport teardown remain LIFO and in the owning `_run_stdio()` task.
- Release the spawn lock before `ClientSession`, `_negotiate_session`, tool discovery, lifecycle waiting, cleanup, and `self._stdio_child_pids` assignment (#81995).
- Use one process-wide `threading.Lock` so any concurrently unwinding event loops cannot overlap attribution windows. Acquire it through cancellation-safe nonblocking async polling.
- Coordinate `_stop_mcp_loop()` and `_ensure_mcp_loop()` with a condition: the old loop drains and releases any held spawn guard before shutdown, while replacement-loop publication remains blocked until the old loop's final active-PID sweep completes.

This branch is rebased onto current `main` at `41447a6d70` and preserves:

- `self._session_proven = False` after handshake;
- current `_negotiate_session` (not a restore of raw `session.initialize()`);
- current `_stdio_child_pids` tracking (#81995);
- OSV preflight, watchdog wrap, encoding_error_handler, cancellation, parked-startup, drain-based `_stop_mcp_loop`.

## Regression coverage

`tests/tools/test_mcp_stdio_spawn_attribution.py` verifies:

1. the fixture deterministically reproduces a `2/0` ownership split when the guard is disabled;
2. two guarded concurrent stdio starts attribute exactly one PID to each server;
3. tearing down one server does not orphan or steal the sibling's live PID;
4. two overlapping event loops/threads never enter the attribution window together;
5. loop shutdown blocks replacement-loop publication through its final active-PID sweep;
6. cancelling a waiter does not acquire or strand the process-wide guard later.

## Verification (candidate `5bd82c5cab` on base `41447a6d70`)

- Semantic rebase of previously published head `f80a017447` onto current `_run_stdio` (now includes `#81995` `_stdio_child_pids`).
- `scripts/run_tests.sh tests/tools/test_mcp*.py`: **589 passed** / 0 failed / 58 files
- Focused attribution file: **6 passed**, repeated **5/5** times
- Protocol-negotiation tests: **12 passed**
- `ruff check` on the two changed files: **passed**
- `py_compile`, `git diff --check`, added-line security scan: passed
- Independent security/logic review: **pass**
- Concurrency/lifecycle review: stated guard-scope invariants hold. Residual note (pre-existing on `main`, not introduced here): if the old MCP thread survives the 5s join timeout, `_finish_stopping_mcp_loop` still returns and a replacement loop can be published. Fixing that would be a follow-up (generation-scoped PID maps), not this refresh.
- Scope remains exactly two paths: `tools/mcp_tool.py`, `tests/tools/test_mcp_stdio_spawn_attribution.py`

## Scope

This complements the stdio watchdog's parent/PID-reuse protections. It does not modify watchdog behavior.

This change was prepared with AI assistance and reviewed before submitting.
