### PR TITLE
fix: reap idle LSP clients and raise macOS gateway file limits

### DIFF
--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -485,6 +485,13 @@ class LSPService:
         return list(client.diagnostics_for(file_path))
 
     async def _get_or_spawn(self, file_path: str) -> Optional[LSPClient]:
+        # Reap clients that have outlived the configured idle window before
+        # allocating another process and three more stdio pipes.  The timeout
+        # existed from the original service design but was previously never
+        # enforced, allowing a long-running gateway to retain one LSP tree per
+        # historical workspace until it exhausted launchd's file limit.
+        await self._reap_idle_clients()
+
         srv = find_server_for_file(file_path)
         if srv is None:
             return None
@@ -565,6 +572,31 @@ class LSPService:
         finally:
             with self._state_lock:
                 self._spawning.pop(key, None)
+
+    async def _reap_idle_clients(self) -> None:
+        """Shut down clients unused for longer than ``_idle_timeout``.
+
+        Client selection and removal are atomic under ``_state_lock`` so a
+        concurrent request cannot acquire a client after it has been chosen
+        for shutdown.  Process shutdown runs outside the lock because language
+        servers may take up to their grace timeout to exit.
+        """
+        cutoff = time.time() - self._idle_timeout
+        stale: List[LSPClient] = []
+        with self._state_lock:
+            for key, client in list(self._clients.items()):
+                if key in self._spawning:
+                    continue
+                if self._last_used.get(key, 0.0) > cutoff:
+                    continue
+                self._clients.pop(key, None)
+                self._last_used.pop(key, None)
+                stale.append(client)
+        if stale:
+            await asyncio.gather(
+                *(client.shutdown() for client in stale),
+                return_exceptions=True,
+            )
 
     async def _shutdown_async(self) -> None:
         with self._state_lock:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -65,6 +65,13 @@ from hermes_cli.colors import Colors, color
 
 logger = logging.getLogger(__name__)
 
+# The macOS launchd default soft limit is commonly only 256 file descriptors.
+# A long-running gateway owns messaging sockets, cron subprocess pipes, and
+# optional language-server children, so that default can cause unrelated cron
+# launches to fail with EMFILE even while the system-wide limit is healthy.
+LAUNCHD_GATEWAY_SOFT_NOFILE_LIMIT = 4096
+LAUNCHD_GATEWAY_HARD_NOFILE_LIMIT = 8192
+
 # =============================================================================
 # Process Management (for manual gateway runs)
 # =============================================================================
@@ -4020,6 +4027,18 @@ def generate_launchd_plist() -> str:
         <string>{venv_dir}</string>
         <key>HERMES_HOME</key>
         <string>{hermes_home}</string>
+    </dict>
+
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>{LAUNCHD_GATEWAY_SOFT_NOFILE_LIMIT}</integer>
+    </dict>
+
+    <key>HardResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>{LAUNCHD_GATEWAY_HARD_NOFILE_LIMIT}</integer>
     </dict>
 
     <key>LimitLoadToSessionType</key>

--- a/tests/agent/lsp/test_service.py
+++ b/tests/agent/lsp/test_service.py
@@ -7,11 +7,15 @@ on.
 """
 from __future__ import annotations
 
+import asyncio
 import sys
+import time
 from pathlib import Path
+from typing import cast
 
 import pytest
 
+from agent.lsp.client import LSPClient
 from agent.lsp.manager import LSPService
 from agent.lsp.servers import (
     SERVERS,
@@ -88,6 +92,54 @@ def test_service_returns_empty_when_disabled(tmp_path):
     f.write_text("")
     assert svc.get_diagnostics_sync(str(f)) == []
     svc.shutdown()
+
+
+def test_reap_idle_clients_shuts_down_only_stale_nonspawning_clients():
+    class FakeClient:
+        def __init__(self):
+            self.shutdown_called = False
+
+        async def shutdown(self):
+            self.shutdown_called = True
+
+    svc = LSPService(
+        enabled=False,
+        wait_mode="document",
+        wait_timeout=2.0,
+        install_strategy="manual",
+        idle_timeout=600,
+    )
+    stale_key = ("pyright", "/repo/stale")
+    active_key = ("pyright", "/repo/active")
+    spawning_key = ("pyright", "/repo/spawning")
+    stale = FakeClient()
+    active = FakeClient()
+    spawning = FakeClient()
+    now = time.time()
+    svc._clients = {
+        stale_key: cast(LSPClient, stale),
+        active_key: cast(LSPClient, active),
+        spawning_key: cast(LSPClient, spawning),
+    }
+    svc._last_used = {
+        stale_key: now - 601,
+        active_key: now,
+        spawning_key: now - 601,
+    }
+
+    async def exercise_reaper():
+        svc._spawning[spawning_key] = asyncio.get_running_loop().create_future()
+        await svc._reap_idle_clients()
+
+    asyncio.run(exercise_reaper())
+
+    assert stale.shutdown_called is True
+    assert stale_key not in svc._clients
+    assert stale_key not in svc._last_used
+    assert active.shutdown_called is False
+    assert active_key in svc._clients
+    assert spawning.shutdown_called is False
+    assert spawning_key in svc._clients
 
 
 def test_service_skips_files_outside_workspace(tmp_path):

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -505,6 +505,14 @@ class TestGeneratedSystemdUnits:
         assert str(local_bin) in plist
         assert str(profile_node_bin) not in plist
 
+    def test_launchd_plist_raises_file_limit_for_long_running_gateway(self):
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert "<key>SoftResourceLimits</key>" in plist
+        assert "<key>HardResourceLimits</key>" in plist
+        assert "<key>NumberOfFiles</key>\n        <integer>4096</integer>" in plist
+        assert "<key>NumberOfFiles</key>\n        <integer>8192</integer>" in plist
+
     def test_user_unit_includes_wsl_windows_interop_paths(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_wsl", lambda: True)
         monkeypatch.setenv(


### PR DESCRIPTION
## Summary

- enforce the existing 10-minute LSP idle timeout by shutting down stale workspace clients before spawning another
- preserve clients that are active or currently spawning
- raise the macOS launchd gateway file-descriptor limit from the default 256 to 4096 soft / 8192 hard
- add regression coverage for both lifecycle and generated launchd plist behavior

## Production symptom

A long-running macOS gateway accumulated one LSP process tree per historical workspace. The gateway reached 238/256 descriptors, and an unrelated script-only cron failed with `OSError: [Errno 24] Too many open files`. The existing `DEFAULT_IDLE_TIMEOUT = 600` was configured but never enforced.

## Verification

- `tests/agent/lsp`: 160 passed
- `TestGeneratedSystemdUnits`: 10 passed
- focused live watchdog rerun: success
- live launchd resource limits confirmed at 4096 soft / 8192 hard
- production gateway descriptor use after stale-client cleanup: 40/4096

The reaper never restarts the gateway. It shuts down only LSP clients past the configured idle timeout and outside the spawning set.