### PR TITLE
fix(docs): fix broken image and video in TUI docs (supersedes #43501)

### DIFF
--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -134,9 +134,9 @@ Open it with any of these:
 - `/sessions new` to create a fresh live session immediately.
 - Click the `N live sessions` count in the status line.
 
-<img alt="Hermes TUI Session Orchestrator with one live session and a +new row" src="/img/docs/tui-session-orchestrator/session-orchestrator.png" />
+<img alt="Hermes TUI Session Orchestrator with one live session and a +new row" src="/docs/img/docs/tui-session-orchestrator/session-orchestrator.png" />
 
-<video controls muted loop playsInline src="/img/docs/tui-session-orchestrator/session-orchestrator-demo.mp4" title="Hermes TUI Session Orchestrator demo"></video>
+<video controls muted loop playsInline src="/docs/img/docs/tui-session-orchestrator/session-orchestrator-demo.mp4" title="Hermes TUI Session Orchestrator demo" style={{maxWidth: '100%'}}></video>
 
 Inside the switcher:
 

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -136,7 +136,7 @@ Open it with any of these:
 
 <img alt="Hermes TUI Session Orchestrator with one live session and a +new row" src="/img/docs/tui-session-orchestrator/session-orchestrator.png" />
 
-<video controls muted loop playsInline src="/img/docs/tui-session-orchestrator/session-orchestrator-demo.mp4" title="Hermes TUI Session Orchestrator demo" />
+<video controls muted loop playsInline src="/img/docs/tui-session-orchestrator/session-orchestrator-demo.mp4" title="Hermes TUI Session Orchestrator demo"></video>
 
 Inside the switcher:
 


### PR DESCRIPTION
## What does this PR do?

Fixes two bugs that prevented the image and video from rendering on the [TUI docs page](https://nousresearch.github.io/hermes-agent/docs/user-guide/tui):

1. **Wrong asset paths** — `<img>` and `<video>` used `/img/...`, but with `baseUrl: '/docs/'` (see `website/docusaurus.config.ts`) the correct path is `/docs/img/...`. Otherwise the assets 404.
2. **Self-closing video tag** — `<video ... />` is invalid HTML5. `<video>` is not a void element and must use a `</video>` closing tag. Also adds `style={{maxWidth: '100%'}}` so the embed stays responsive.

## Supersedes #43501

This is a **rebased/salvaged** version of #43501 by @alelpoan. That PR was correct and conflict-free, but its branch was ~5,000 commits behind `main` and predated the current `ci.yml` orchestrator, so the required `All required checks pass` gate never triggered on its head commit (stuck at *"Expected — Waiting for status to be reported"*). Re-running wouldn't help — the orchestrator workflow simply never ran on that stale commit.

Rather than force a messy 5k-commit fork rebase, this PR **cherry-picks @alelpoan's original commits onto current `main`** so authorship is preserved in git history and CI runs cleanly. Full credit to @alelpoan for the fix. Please close #43501 in favor of this one once merged.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `website/docs/user-guide/tui.md`:
  - `<img>` `src`: `/img/docs/...` → `/docs/img/docs/...`
  - `<video>` `src`: `/img/docs/...` → `/docs/img/docs/...`, self-closing tag → proper `</video>` close, added `style={{maxWidth: '100%'}}`

## How to Test

1. Run the docs site locally (`cd website && npm run start`) or check the deployed preview.
2. Navigate to the TUI docs page → Live session switcher section.
3. Confirm the session-orchestrator screenshot and demo video both render (previously 404'd).
