### PR TITLE
docs: update custom_providers to providers in documentation (#67278)

### DIFF
--- a/website/docs/developer-guide/provider-runtime.md
+++ b/website/docs/developer-guide/provider-runtime.md
@@ -69,7 +69,7 @@ Current provider families include (see `plugins/model-providers/` for the comple
 - LM Studio
 - Tencent TokenHub
 - Custom (`provider: custom`) — first-class provider for any OpenAI-compatible endpoint
-- Named custom providers (`custom_providers` list in config.yaml)
+- Named custom providers (`providers` dict in config.yaml)
 
 ## Output of runtime resolution
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1151,7 +1151,7 @@ Set `model.max_tokens` only when you need to limit how long individual responses
 Hermes uses a multi-source resolution chain to detect the correct context window for your model and provider:
 
 1. **Config override** — `model.context_length` in config.yaml (highest priority)
-2. **Custom provider per-model** — `custom_providers[].models.<id>.context_length`
+2. **Custom provider per-model** — `providers.<name>.models.<id>.context_length`
 3. **Persistent cache** — previously discovered values (survives restarts)
 4. **Endpoint `/models`** — queries your server's API (local/custom endpoints)
 5. **Anthropic `/v1/models`** — queries Anthropic's API for `max_input_tokens` (API-key users only)
@@ -1174,8 +1174,8 @@ model:
 For custom endpoints, you can also set context length per model:
 
 ```yaml
-custom_providers:
-  - name: "My Local LLM"
+providers:
+  my-local-llm:
     base_url: "http://localhost:11434/v1"
     models:
       qwen3.5:27b:
@@ -1199,15 +1199,15 @@ custom_providers:
 If you work with multiple custom endpoints (e.g., a local dev server and a remote GPU server), you can define them as named custom providers in `config.yaml`:
 
 ```yaml
-custom_providers:
-  - name: local
+providers:
+  local:
     base_url: http://localhost:8080/v1
     # api_key omitted — Hermes uses "no-key-required" for keyless local servers
-  - name: work
+  work:
     base_url: https://gpu-server.internal.corp/v1
     key_env: CORP_API_KEY
     api_mode: chat_completions   # set explicitly by `hermes model` → Custom Endpoint wizard; auto-detection still happens as a fallback
-  - name: anthropic-proxy
+  anthropic-proxy:
     base_url: https://proxy.example.com/anthropic
     key_env: ANTHROPIC_PROXY_KEY
     api_mode: anthropic_messages  # for Anthropic-compatible proxies
@@ -1216,8 +1216,8 @@ custom_providers:
 Some OpenAI-compatible endpoints need provider-specific request body fields. Add an `extra_body` map to the matching custom provider and Hermes will merge it into each chat-completions request for that endpoint:
 
 ```yaml
-custom_providers:
-  - name: gemma-local
+providers:
+  gemma-local:
     base_url: http://localhost:8080/v1
     model: google/gemma-4-31b-it
     extra_body:
@@ -1253,7 +1253,7 @@ model:
   supports_vision: true   # send images natively; otherwise vision_analyze pre-describes them
 ```
 
-The same key is honored on per-named-provider models (`custom_providers[*].models[*].supports_vision`) and accepts standard YAML booleans (`true/false/yes/no/on/off/1/0`).
+The same key is honored on per-named-provider models (`providers.<name>.models.<id>.supports_vision`) and accepts standard YAML booleans (`true/false/yes/no/on/off/1/0`).
 
 Switch between them mid-session with the triple syntax:
 
@@ -1269,7 +1269,7 @@ You can also select named custom providers from the interactive `hermes model` m
 
 ### Cookbook: Together AI, Groq, Perplexity
 
-The cloud providers listed in [Other Compatible Providers](#other-compatible-providers) all speak OpenAI's REST dialect, so they wire up the same way under `custom_providers:`. Three worked recipes follow. Each drops into `~/.hermes/config.yaml` and the matching API key goes in `~/.hermes/.env`.
+The cloud providers listed in [Other Compatible Providers](#other-compatible-providers) all speak OpenAI's REST dialect, so they wire up the same way under `providers:`. Three worked recipes follow. Each drops into `~/.hermes/config.yaml` and the matching API key goes in `~/.hermes/.env`.
 
 #### Together AI
 
@@ -1277,8 +1277,8 @@ Hosts open-weight models (Llama, MiniMax, Gemma, DeepSeek, Qwen) at prices signi
 
 ```yaml
 # ~/.hermes/config.yaml
-custom_providers:
-  - name: together
+providers:
+  together:
     base_url: https://api.together.xyz/v1
     key_env: TOGETHER_API_KEY
     # api_mode: chat_completions  # default — no need to set
@@ -1309,8 +1309,8 @@ Ultra-fast inference (~500 tok/s on Llama-3.3-70B). Small catalog but strong for
 
 ```yaml
 # ~/.hermes/config.yaml
-custom_providers:
-  - name: groq
+providers:
+  groq:
     base_url: https://api.groq.com/openai/v1
     key_env: GROQ_API_KEY
 
@@ -1330,8 +1330,8 @@ Useful when you want a model that does live web search and citation automaticall
 
 ```yaml
 # ~/.hermes/config.yaml
-custom_providers:
-  - name: perplexity
+providers:
+  perplexity:
     base_url: https://api.perplexity.ai
     key_env: PERPLEXITY_API_KEY
 
@@ -1350,14 +1350,14 @@ PERPLEXITY_API_KEY=your-perplexity-key
 The three recipes compose — use all of them together and switch per turn with `/model custom:<name>:<model>`:
 
 ```yaml
-custom_providers:
-  - name: together
+providers:
+  together:
     base_url: https://api.together.xyz/v1
     key_env: TOGETHER_API_KEY
-  - name: groq
+  groq:
     base_url: https://api.groq.com/openai/v1
     key_env: GROQ_API_KEY
-  - name: perplexity
+  perplexity:
     base_url: https://api.perplexity.ai
     key_env: PERPLEXITY_API_KEY
 
@@ -1369,7 +1369,7 @@ model:
 :::tip Troubleshooting
 - `hermes doctor` should print no `Unknown provider` warnings for any of these names after the CLI validator fixes in #15083.
 - If a provider's `/v1/models` endpoint is unreachable (Perplexity is the common one), `hermes model` will persist the model with a warning rather than hard-reject — see #15136.
-- To skip `custom_providers:` entirely and use bare `provider: custom` with `CUSTOM_BASE_URL` env var, see #15103.
+- To skip `providers:` entirely and use bare `provider: custom` with `CUSTOM_BASE_URL` env var, see #15103.
 :::
 
 ---

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -316,8 +316,8 @@ model:
 Or for custom endpoints, add it per-model:
 
 ```yaml
-custom_providers:
-  - name: "My Server"
+providers:
+  my-server:
     base_url: "http://localhost:11434/v1"
     models:
       qwen3.5:27b:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1004,7 +1004,7 @@ auxiliary:
 
 When `base_url` is set, Hermes ignores the provider and calls that endpoint directly (using `api_key` or `OPENAI_API_KEY` for auth). When only `provider` is set, Hermes uses that provider's built-in auth and base URL.
 
-Available providers for auxiliary tasks: `auto`, `main`, plus any provider in the [provider registry](/reference/environment-variables) — `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `qwen-oauth`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `alibaba`, `bedrock`, `huggingface`, `arcee`, `xiaomi`, `kilocode`, `opencode-zen`, `opencode-go`, `azure-foundry` — or any named custom provider from your `custom_providers` list (e.g. `provider: "beans"`).
+Available providers for auxiliary tasks: `auto`, `main`, plus any provider in the [provider registry](/reference/environment-variables) — `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `qwen-oauth`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `alibaba`, `bedrock`, `huggingface`, `arcee`, `xiaomi`, `kilocode`, `opencode-zen`, `opencode-go`, `azure-foundry` — or any named custom provider from your `providers` list (e.g. `provider: "beans"`).
 
 :::tip MiniMax OAuth
 `minimax-oauth` logs in via browser OAuth (no API key needed). Run `hermes model` and select **MiniMax (OAuth)** to authenticate. Auxiliary tasks use `MiniMax-M2.7-highspeed` automatically. See the [MiniMax OAuth guide](../guides/minimax-oauth.md).

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -149,7 +149,7 @@ The `has_retried_429` flag resets on every successful API call, so a single tran
 
 ## Custom Endpoint Pools
 
-Custom OpenAI-compatible endpoints (Together.ai, RunPod, local servers) get their own pools, keyed by the endpoint name from `custom_providers` in config.yaml.
+Custom OpenAI-compatible endpoints (Together.ai, RunPod, local servers) get their own pools, keyed by the endpoint name from `providers` in config.yaml.
 
 When you set up a custom endpoint via `hermes model`, it auto-generates a name like "Together.ai" or "Local (localhost:8080)". This name becomes the pool key.
 


### PR DESCRIPTION
## Summary
Updates all documentation references from the deprecated `custom_providers` key to the current `providers` dict format, matching the v11→v12 gated migration.

### Files changed
- `website/docs/integrations/providers.md` — All YAML examples and narrative references updated
- `website/docs/reference/faq.md` — Per-model context_length example updated
- `website/docs/developer-guide/provider-runtime.md` — Description updated
- `website/docs/user-guide/features/credential-pools.md` — Custom endpoint pools reference updated
- `website/docs/user-guide/configuration.md` — Auxiliary tasks provider list updated

Closes #67278