### PR TITLE
fix(macos): prevent root-run gateway install that breaks launchd and creates root-owned state (#67732)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4201,6 +4201,19 @@ def refresh_launchd_plist_if_needed() -> bool:
 
 
 def launchd_install(force: bool = False):
+    # Guard against running as root on macOS — launchd service management
+    # requires a GUI user session.  Root's /var/root plist, bootstrap
+    # failure on the GUI-less root domain, and the subsequent
+    # root-owned ~/.hermes state would compound into a broken install
+    # that blocks a correct user-level retry (#67732).
+    if is_macos() and os.geteuid() == 0:
+        print_error(
+            "Running `hermes gateway install` as root on macOS is not supported.\n"
+            "  launchd requires a GUI user session; root has none.\n"
+            "  Run the command without sudo, or use --system on Linux:\n"
+            "    hermes gateway install"
+        )
+        sys.exit(1)
     plist_path = get_launchd_plist_path()
 
     if plist_path.exists() and not force:


### PR DESCRIPTION
## Summary
On macOS, running `sudo hermes gateway install` produces four compounding failures:
1. Writes the plist to `/var/root/Library/LaunchAgents/`
2. `launchctl bootstrap` fails (root has no GUI session → exit 125)
3. Misdiagnoses this as "launchd cannot manage the gateway on this macOS version" and writes a persistent `.gateway-launchd-unsupported` marker
4. Falls back to a root-run gateway that litters `~/.hermes` with root-owned files, breaking any subsequent user-level install

### Fix
Adds a guard at the top of `launchd_install()` that catches the root-on-macOS case and exits with a clear error message before any state is written. The guard is scoped to `is_macos() and os.geteuid() == 0` so it only fires on the affected platform.

Tests: 2 existing launchd_install tests pass, 13 install gateway tests pass.

Closes #67732
