### PR TITLE
fix(gateway): report launchd supervision accurately

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -108,7 +108,7 @@ def snapshot_shutdown_context(received_signal: Any = None) -> Dict[str, Any]:
 
     * The signal number/name (so SIGINT vs SIGTERM is visible)
     * Our own PID/ppid + parent process info from /proc (Linux)
-    * Whether systemd is our parent (``ppid==1`` or ``INVOCATION_ID`` set)
+    * Which supervisor launched us (systemd, launchd, generic PID 1, or none)
     * Whether takeover/planned-stop markers exist (consumed lazily by the caller)
     * /proc/self limits + load average (1-min)
     * Wall-clock and monotonic timestamps for cross-correlating later phases
@@ -131,16 +131,33 @@ def snapshot_shutdown_context(received_signal: Any = None) -> Dict[str, Any]:
         "self": _proc_summary(pid),
     }
 
-    # systemd context.  If we were started by a systemd unit, INVOCATION_ID
-    # is set in our env.  ppid==1 (init) is also a strong signal that
-    # systemd reaped+forwarded the SIGTERM.
+    # Supervisor context. PID 1 is launchd on macOS and may be systemd, s6,
+    # tini, or another init on Linux, so PPID alone must not be labelled
+    # systemd. systemd provides explicit invocation/journal markers; launchd
+    # provides XPC_SERVICE_NAME and reparents daemon jobs to PID 1.
     invocation_id = os.environ.get("INVOCATION_ID")
     if invocation_id:
         ctx["systemd_invocation_id"] = invocation_id
     journal_stream = os.environ.get("JOURNAL_STREAM")
     if journal_stream:
         ctx["systemd_journal_stream"] = journal_stream
-    ctx["under_systemd"] = bool(invocation_id) or ppid == 1
+    xpc_service_name = os.environ.get("XPC_SERVICE_NAME")
+    under_systemd = bool(invocation_id or journal_stream)
+    if under_systemd:
+        supervisor = "systemd"
+    elif sys.platform == "darwin" and (
+        ppid == 1 or xpc_service_name not in (None, "", "0")
+    ):
+        supervisor = "launchd"
+        if xpc_service_name not in (None, "", "0"):
+            ctx["launchd_service_name"] = xpc_service_name
+    elif ppid == 1:
+        supervisor = "pid1"
+    else:
+        supervisor = "none"
+    ctx["supervisor"] = supervisor
+    # Retain the machine-readable compatibility field, but make it truthful.
+    ctx["under_systemd"] = under_systemd
 
     # Load average — high load points the finger at "something else
     # crushing the box" rather than "external killer".
@@ -285,7 +302,9 @@ def format_context_for_log(ctx: Dict[str, Any]) -> str:
     parent_cmd = parent.get("cmdline", "(unknown)")
     parent_name = parent.get("name") or "?"
     parent_pid = parent.get("pid") or "?"
-    under_systemd = "yes" if ctx.get("under_systemd") else "no"
+    supervisor = ctx.get("supervisor") or (
+        "systemd" if ctx.get("under_systemd") else "none"
+    )
     load = ctx.get("loadavg_1m")
     load_str = f"{load:.2f}" if isinstance(load, (int, float)) else "?"
     extras: List[str] = []
@@ -302,7 +321,7 @@ def format_context_for_log(ctx: Dict[str, Any]) -> str:
     # Parent cmdline is the most useful single signal — log it prominently.
     return (
         f"signal={sig} "
-        f"under_systemd={under_systemd} "
+        f"supervisor={supervisor} "
         f"parent_pid={parent_pid} "
         f"parent_name={parent_name} "
         f"loadavg_1m={load_str}"

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -77,6 +77,7 @@ class GatewayRuntimeSnapshot:
     service_running: bool = False
     gateway_pids: tuple[int, ...] = ()
     service_scope: str | None = None
+    service_name: str | None = None
 
     @property
     def running(self) -> bool:
@@ -1274,6 +1275,52 @@ def _parse_launchd_pid_from_list_output(output: str) -> int | None:
     return None
 
 
+def _parse_launchd_job_for_gateway_pids(
+    output: str, gateway_pids: tuple[int, ...]
+) -> tuple[int, str] | None:
+    """Find a launchd job whose live PID is one of *gateway_pids*.
+
+    ``launchctl list`` without a label emits a tabular ``PID Status Label``
+    view.  Operator-managed LaunchDaemons are allowed to use labels other than
+    Hermes' generated ``ai.hermes.gateway`` label, so PID ownership is the
+    reliable bridge between the process scan and launchd's registry.
+    """
+    wanted = set(gateway_pids)
+    if not wanted:
+        return None
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        try:
+            pid = int(parts[0])
+        except ValueError:
+            continue
+        if pid in wanted:
+            return pid, parts[2]
+    return None
+
+
+def _probe_launchd_gateway_supervisor(
+    gateway_pids: tuple[int, ...],
+) -> tuple[int, str] | None:
+    """Return ``(pid, label)`` when launchd owns a discovered gateway PID."""
+    if not gateway_pids:
+        return None
+    try:
+        result = subprocess.run(
+            ["launchctl", "list"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    return _parse_launchd_job_for_gateway_pids(result.stdout, gateway_pids)
+
+
 def _probe_launchd_service_running() -> bool:
     """Return True when launchd is actively supervising the gateway process.
 
@@ -1358,10 +1405,35 @@ def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot
         )
 
     if is_macos():
+        plist_exists = get_launchd_plist_path().exists()
+        generated_service_running = (
+            _probe_launchd_service_running() if plist_exists else False
+        )
+        if generated_service_running:
+            return GatewayRuntimeSnapshot(
+                manager="launchd",
+                service_installed=True,
+                service_running=True,
+                gateway_pids=gateway_pids,
+                service_scope="launchd",
+            )
+
+        external_job = _probe_launchd_gateway_supervisor(gateway_pids)
+        if external_job is not None:
+            _pid, label = external_job
+            return GatewayRuntimeSnapshot(
+                manager="launchd (external service)",
+                service_installed=True,
+                service_running=True,
+                gateway_pids=gateway_pids,
+                service_scope="launchd",
+                service_name=label,
+            )
+
         return GatewayRuntimeSnapshot(
             manager="launchd",
-            service_installed=get_launchd_plist_path().exists(),
-            service_running=_probe_launchd_service_running(),
+            service_installed=plist_exists,
+            service_running=False,
             gateway_pids=gateway_pids,
             service_scope="launchd",
         )
@@ -7178,6 +7250,17 @@ def _gateway_command_inner(args):
         ):
             systemd_status(deep, system=system, full=full)
             _print_gateway_process_mismatch(snapshot)
+        elif is_macos() and snapshot.service_running and snapshot.service_name:
+            pids = ", ".join(map(str, snapshot.gateway_pids))
+            print(f"✓ Gateway is running, supervised by launchd (PID: {pids})")
+            print(f"  Service: {snapshot.service_name}")
+            print("  (Externally managed launchd service; no duplicate install needed)")
+            runtime_lines = _runtime_health_lines()
+            if runtime_lines:
+                print()
+                print("Recent gateway health:")
+                for line in runtime_lines:
+                    print(f"  {line}")
         elif is_macos() and get_launchd_plist_path().exists():
             launchd_status(deep)
             _print_gateway_process_mismatch(snapshot)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1312,6 +1312,8 @@ def _probe_launchd_gateway_supervisor(
             ["launchctl", "list"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=10,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -67,7 +67,31 @@ class TestSnapshotShutdownContext:
         monkeypatch.setenv("INVOCATION_ID", "abc123")
         ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
         assert ctx["under_systemd"] is True
+        assert ctx["supervisor"] == "systemd"
         assert ctx["systemd_invocation_id"] == "abc123"
+
+    def test_ppid_one_on_macos_is_launchd_not_systemd(self, monkeypatch):
+        monkeypatch.setattr(sf.sys, "platform", "darwin")
+        monkeypatch.setattr(sf.os, "getppid", lambda: 1)
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        monkeypatch.setenv("XPC_SERVICE_NAME", "com.example.hermes-gateway")
+
+        ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
+
+        assert ctx["supervisor"] == "launchd"
+        assert ctx["launchd_service_name"] == "com.example.hermes-gateway"
+        assert ctx["under_systemd"] is False
+
+    def test_ppid_one_without_platform_marker_is_generic_pid1(self, monkeypatch):
+        monkeypatch.setattr(sf.sys, "platform", "linux")
+        monkeypatch.setattr(sf.os, "getppid", lambda: 1)
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
+
+        ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
+
+        assert ctx["supervisor"] == "pid1"
+        assert ctx["under_systemd"] is False
 
     def test_under_systemd_false_without_invocation_id_and_normal_ppid(
         self, monkeypatch
@@ -127,6 +151,8 @@ class TestFormatters:
         ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
         line = sf.format_context_for_log(ctx)
         assert "signal=SIGTERM" in line
+        assert "supervisor=" in line
+        assert "under_systemd=" not in line
         assert "parent_pid=" in line
         assert "parent_cmdline=" in line
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1226,6 +1226,42 @@ class TestLaunchdServiceRecovery:
         output = '{\n    "PID" = -1;\n    "Label" = "ai.hermes.gateway";\n}'
         assert gateway_cli._parse_launchd_pid_from_list_output(output) is None
 
+    def test_parse_launchd_job_for_gateway_pid_accepts_custom_label(self):
+        """A system LaunchDaemon may supervise Hermes under an operator label."""
+        output = (
+            "PID\tStatus\tLabel\n"
+            "-\t0\tcom.apple.unrelated\n"
+            "4242\t0\tcom.example.hermes-gateway\n"
+        )
+
+        assert gateway_cli._parse_launchd_job_for_gateway_pids(
+            output, (4242,)
+        ) == (4242, "com.example.hermes-gateway")
+
+    def test_runtime_snapshot_detects_external_launchd_supervisor(
+        self, tmp_path, monkeypatch
+    ):
+        """Do not report a launchd-owned gateway as a manual process."""
+        missing_plist = tmp_path / "ai.hermes.gateway.plist"
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: missing_plist)
+        monkeypatch.setattr(gateway_cli, "find_gateway_pids", lambda: [4242])
+        monkeypatch.setattr(
+            gateway_cli,
+            "_probe_launchd_gateway_supervisor",
+            lambda pids: (4242, "com.example.hermes-gateway"),
+        )
+
+        snapshot = gateway_cli.get_gateway_runtime_snapshot()
+
+        assert snapshot.manager == "launchd (external service)"
+        assert snapshot.service_installed is True
+        assert snapshot.service_running is True
+        assert snapshot.service_name == "com.example.hermes-gateway"
+        assert snapshot.gateway_pids == (4242,)
+
     # ── Probe requires PID ───────────────────────────────────────────────
 
     def test_probe_launchd_service_running_false_without_pid_in_output(self, tmp_path, monkeypatch):
@@ -1800,6 +1836,44 @@ class TestGatewaySystemServiceRouting:
         )
 
         assert calls == [(False, False, True)]
+
+    def test_gateway_status_reports_external_launchd_supervisor(
+        self, monkeypatch, capsys
+    ):
+        missing_plist = SimpleNamespace(exists=lambda: False)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: missing_plist)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_runtime_snapshot",
+            lambda system=False: gateway_cli.GatewayRuntimeSnapshot(
+                manager="launchd (external service)",
+                service_installed=True,
+                service_running=True,
+                gateway_pids=(4242,),
+                service_scope="launchd",
+                service_name="com.example.hermes-gateway",
+            ),
+        )
+        monkeypatch.setattr(gateway_cli, "_runtime_health_lines", lambda: [])
+        monkeypatch.setattr(
+            gateway_cli, "_print_other_profiles_gateway_status", lambda: None
+        )
+
+        gateway_cli.gateway_command(
+            SimpleNamespace(
+                gateway_command="status", deep=False, system=False, full=False
+            )
+        )
+
+        out = capsys.readouterr().out
+        assert "supervised by launchd" in out
+        assert "com.example.hermes-gateway" in out
+        assert "Running manually" not in out
+        assert "gateway install" not in out
 
     def test_gateway_install_reports_termux_manual_mode(self, monkeypatch, capsys):
         monkeypatch.setattr(gateway_cli, "is_termux", lambda: True)


### PR DESCRIPTION
## What does this PR do?

Fixes two misleading macOS gateway diagnostics:

1. `hermes gateway status` reported a live gateway as “Running manually” when it was actually owned by a system LaunchDaemon using an operator-defined label such as `com.example.hermes-gateway`.
2. Shutdown forensics labelled any PID-1 parent as `under_systemd=yes`, even though PID 1 is launchd on macOS and may be another init/supervisor on Linux.

The status path now correlates discovered gateway PIDs with `launchctl list`, so externally managed launchd jobs are reported truthfully without suggesting a duplicate service install. Shutdown logs now emit `supervisor=systemd|launchd|pid1|none`; the legacy structured `under_systemd` field remains but is true only when explicit systemd markers are present.

## Related Issue

No issue filed. I searched open issues and PRs for `launchd status manual system service`, `under_systemd launchd`, and the exact `"Running manually" launchd` symptom; no duplicate was found.

Related but non-duplicative: #65177 changes restart lifecycle ownership. It does not address external launchd labels or shutdown supervisor labelling.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py`
  - add optional service-name metadata to the runtime snapshot
  - correlate gateway PIDs with all launchd jobs, not only Hermes' generated label
  - report operator-managed launchd services as supervised and suppress duplicate-install guidance
- `gateway/shutdown_forensics.py`
  - distinguish systemd, launchd, generic PID 1, and unsupervised processes
  - emit `supervisor=...` instead of the misleading `under_systemd=yes|no` log token
- Add regression coverage for custom launchd labels, status rendering, and macOS PID-1 classification.

## How to Test

1. Run the focused regression set:
   ```bash
   pytest tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery \
     tests/hermes_cli/test_gateway_service.py::TestGatewaySystemServiceRouting::test_gateway_status_reports_external_launchd_supervisor \
     tests/gateway/test_shutdown_forensics.py -o 'addopts=' -q
   ```
2. On macOS, run a gateway from a system LaunchDaemon with a non-generated label, then run `hermes gateway status` from a shell.
3. Confirm status names the launchd service and does not say “Running manually” or suggest `hermes gateway install`.
4. Trigger/format a shutdown context and confirm the log contains `supervisor=launchd`, not `under_systemd=yes`.

Verification performed after rebasing onto current upstream `main`:

- Focused regression set: **68 passed**
- Broader affected files: **220 passed, 4 deselected** (four systemd restart tests invoke Linux user-D-Bus preflight and are incompatible with the macOS host)
- Ruff focused check: **passed**
- Python compile check: **passed**
- `git diff --check`: **passed**
- Direct behavior contract probe: **passed**

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused and affected-file suites were run; full repository suite was not run locally
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings updated; no user-facing docs change required
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture/workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool schema changes

## Screenshots / Logs

Observed before:

```text
✓ Gateway is running (PID: 4242)
  (Running manually, not as a system service)
```

Observed after:

```text
✓ Gateway is running, supervised by launchd (PID: 4242)
  Service: com.example.hermes-gateway
  (Externally managed launchd service; no duplicate install needed)
```

Shutdown formatter after:

```text
signal=SIGTERM supervisor=launchd parent_pid=1 ...
```

