### PR TITLE
fmt(js): `npm run fix` auto-fix

### DIFF
--- a/apps/desktop/electron/bootstrap-runner.test.ts
+++ b/apps/desktop/electron/bootstrap-runner.test.ts
@@ -10,8 +10,8 @@ import {
   buildPosixPinArgs,
   cachedScriptPath,
   hasExistingGitCheckout,
-  installRefForStamp,
   installedAgentInstallScript,
+  installRefForStamp,
   isPinnedCommit,
   resolveInstallScript,
   resolveMarkerPinnedCommit,
@@ -160,6 +160,7 @@ test('resolveInstallScript downloads fallback stamps by branch instead of zero c
   try {
     const logs = []
     const refs = []
+
     const result = await resolveInstallScript({
       installStamp: { commit: ZERO_COMMIT, branch: 'main' },
       sourceRepoRoot: null,

--- a/apps/desktop/electron/bootstrap-runner.ts
+++ b/apps/desktop/electron/bootstrap-runner.ts
@@ -58,10 +58,7 @@ type ResolveHeadFn = (activeRoot: string | null | undefined) => string | null
  * (all-zero) install stamps still produce a marker that
  * isBootstrapComplete() accepts (pinnedCommit length >= 7).
  */
-function resolveCheckoutHead(
-  activeRoot: string | null | undefined,
-  opts: { execGit?: ExecGitFn } = {}
-): string | null {
+function resolveCheckoutHead(activeRoot: string | null | undefined, opts: { execGit?: ExecGitFn } = {}): string | null {
   if (!activeRoot) {
     return null
   }
@@ -1027,8 +1024,8 @@ export {
   buildPosixPinArgs,
   cachedScriptPath,
   hasExistingGitCheckout,
-  installRefForStamp,
   installedAgentInstallScript,
+  installRefForStamp,
   isPinnedCommit,
   // Exposed for testability
   parseStageResult,


### PR DESCRIPTION
Auto-generated by the `auto-fix lint issues & formatting` workflow. Auto-merges (squash) once CI passes. If CI fails or `main` moves, the PR is auto-closed and the branch deleted — the next run re-applies on the current state.