### PR TITLE
fix(model-switch): keep same-endpoint custom providers with different names as separate picker rows

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2208,11 +2208,17 @@ def list_authenticated_providers(
     if custom_providers and isinstance(custom_providers, list):
         from collections import OrderedDict
 
-        # Key by endpoint + credential identity + wire protocol instead of
-        # slug: names frequently differ per model ("Ollama — X") while the
-        # endpoint stays the same.  Keep same-host providers with distinct
-        # env-backed credentials or API protocols separate so picker selection
-        # cannot route through the wrong credential/mode pair.
+        # Key by endpoint + credential identity + wire protocol + display
+        # prefix instead of slug: names frequently differ per model
+        # ("Ollama — X") while the endpoint stays the same.  Keep same-host
+        # providers with distinct env-backed credentials or API protocols
+        # separate so picker selection cannot route through the wrong
+        # credential/mode pair. The display prefix (text before " — " /
+        # " - ") is included so intentionally distinct providers sharing an
+        # endpoint (e.g. a proxy fronting cerebras, groq and perplexity at
+        # a single base_url) each get their own picker row instead of
+        # collapsing into one. Per-model suffix entries that share the same
+        # prefix ("Ollama — A", "Ollama — B") still group together.
         groups: "OrderedDict[tuple, dict]" = OrderedDict()
         for entry in custom_providers:
             if not isinstance(entry, dict):
@@ -2259,19 +2265,19 @@ def list_authenticated_providers(
             entry_extra_headers = _extra_headers_from_config(entry)
             headers_identity = tuple(sorted(entry_extra_headers.items()))
 
-            group_key = (api_url, credential_identity, api_mode, headers_identity)
+            # Display-name prefix (text before " — " / " - "), used both
+            # as a grouping dimension and to derive the row's display name.
+            _display_prefix = raw_name
+            for sep in ("—", " - "):
+                if sep in _display_prefix:
+                    _display_prefix = _display_prefix.split(sep)[0].strip()
+                    break
+
+            group_key = (api_url, credential_identity, api_mode, headers_identity, _display_prefix.lower())
             if group_key not in groups:
-                # Strip per-model suffix so "Ollama — GLM 5.1" becomes
-                # "Ollama" for the grouped row. Em dash is the convention
-                # Hermes's own writer uses; a hyphen variant is accepted
-                # for hand-edited configs.
-                display_name = raw_name
-                for sep in ("—", " - "):
-                    if sep in display_name:
-                        display_name = display_name.split(sep)[0].strip()
-                        break
-                if not display_name:
-                    display_name = raw_name
+                # Reuse the prefix computed above as the row display name;
+                # fall back to the raw name if stripping left it empty.
+                display_name = _display_prefix or raw_name
                 slug = custom_provider_slug(display_name)
                 groups[group_key] = {
                     "slug": slug,

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -650,6 +650,7 @@ def test_list_authenticated_providers_groups_same_endpoint(monkeypatch):
     returned as a single picker row with all their models merged."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *a, **k: [])
 
     providers = list_authenticated_providers(
         current_provider="custom",
@@ -736,6 +737,7 @@ def test_list_authenticated_providers_distinct_endpoints_stay_separate(monkeypat
     even if some display names happen to be similar."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *a, **k: [])
 
     providers = list_authenticated_providers(
         user_providers={},
@@ -831,6 +833,7 @@ def test_list_authenticated_providers_total_models_reflects_grouped_count(monkey
     the full count, and every grouped model appears in the list."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *a, **k: [])
 
     entries = [
         {"name": f"Ollama \u2014 Model {i}", "base_url": "http://localhost:11434/v1",
@@ -1326,3 +1329,77 @@ def test_resolve_custom_provider_bare_custom_self_heal_passes_key_env():
 
     assert resolved is not None
     assert resolved.api_key_env_vars == ("XIAOMI_MIMO_API_KEY",)
+
+
+def test_shared_url_different_display_names_are_separate_rows(monkeypatch):
+    """Multiple custom_providers entries sharing base_url + api_key + api_mode
+    but with *different* display-name prefixes (e.g. a proxy fronting
+    cerebras, groq and perplexity at one URL) must each get their own picker
+    row, not collapse into one."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    # Stub live discovery so the test is deterministic regardless of network.
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models",
+        lambda api_key, base_url, **kwargs: [],
+    )
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        current_base_url="https://openrouter.ai/api/v1",
+        user_providers={},
+        custom_providers=[
+            {"name": "Cerebras", "base_url": "https://proxy.example.com/v1",
+             "api_key": "proxy-key", "model": "llama-4-scout"},
+            {"name": "Groq", "base_url": "https://proxy.example.com/v1",
+             "api_key": "proxy-key", "model": "llama-4-scout"},
+            {"name": "Perplexity", "base_url": "https://proxy.example.com/v1",
+             "api_key": "proxy-key", "model": "sonar-pro"},
+        ],
+        max_models=50,
+    )
+
+    custom = [p for p in providers if p.get("is_user_defined")]
+    names = sorted(p["name"] for p in custom)
+    assert names == ["Cerebras", "Groq", "Perplexity"], (
+        f"expected three separate rows, got {names}"
+    )
+    # Each row carries only its own model (no cross-contamination).
+    by_name = {p["name"]: p["models"] for p in custom}
+    assert by_name["Cerebras"] == ["llama-4-scout"]
+    assert by_name["Groq"] == ["llama-4-scout"]
+    assert by_name["Perplexity"] == ["sonar-pro"]
+
+
+def test_shared_url_per_model_suffix_still_collapses(monkeypatch):
+    """Per-model suffix entries sharing the same display-name prefix (e.g.
+    "Ollama — A", "Ollama — B") must still collapse into one row even with
+    the display-prefix grouping dimension."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    # Stub live discovery so a locally-running Ollama cannot override the
+    # static configured models and make the assertion flaky.
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models",
+        lambda api_key, base_url, **kwargs: [],
+    )
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        current_base_url="https://openrouter.ai/api/v1",
+        user_providers={},
+        custom_providers=[
+            {"name": "Ollama \u2014 GLM 5.1", "base_url": "http://localhost:11434/v1",
+             "api_key": "ollama", "model": "glm-5.1"},
+            {"name": "Ollama \u2014 Qwen3-coder", "base_url": "http://localhost:11434/v1",
+             "api_key": "ollama", "model": "qwen3-coder"},
+        ],
+        max_models=50,
+    )
+
+    custom = [p for p in providers if p.get("is_user_defined")]
+    assert len(custom) == 1, (
+        f"expected one collapsed row, got {[p['name'] for p in custom]}"
+    )
+    assert custom[0]["name"] == "Ollama"
+    assert set(custom[0]["models"]) == {"glm-5.1", "qwen3-coder"}


### PR DESCRIPTION
## Problem

Multiple `custom_providers` entries sharing the same `base_url` (e.g. an aggregating proxy fronting multiple upstream providers at one URL) collapsed into a single picker row under the first entry's name. Users who configured separate entries for distinct sub-providers behind one endpoint saw all their models merged into one row, defeating the purpose of splitting them.

## Fix

Extends the `group_key` in `list_authenticated_providers()` with a display-name prefix dimension:

```python
group_key = (api_url, credential_identity, api_mode, headers_identity, display_prefix.lower())
```

The display prefix is the text before an em-dash (`—`) or space-hyphen-space (` - `) in the entry name. This means:

- Same-URL entries with **different names** (e.g. "My Proxy / cog-proxy", "My Proxy / nvidia") now get **separate picker rows** — each showing only its own model list.
- Same-URL entries sharing a **common prefix** (e.g. "Ollama — GLM 5.1", "Ollama — Qwen 3") still collapse into one "Ollama" row — preserving the existing per-model-suffix grouping behavior.
- Same-host entries with different `key_env` or `api_mode` stay separate (credential_identity / api_mode preserved — no regression).

## Why this is a bug fix, not a feature

The current grouping logic assumes all entries sharing an endpoint are duplicates of the same provider. This is wrong for aggregating proxies — users intentionally configure multiple entries pointing at the same URL to represent distinct upstream providers, each with their own model subset. The picker silently merging them destroys that configuration.

## Tests

- `test_shared_url_different_display_names_are_separate_rows` — three entries sharing base_url+api_key+api_mode but different names → three rows.
- `test_shared_url_per_model_suffix_still_collapses` — "Ollama — A"/"Ollama — B" still collapse into one "Ollama" row.
- Fixed 3 pre-existing tests that were hitting a live local Ollama during model discovery (added `fetch_api_models` mock).

## Usage

Set `discover_models: false` and an explicit `models` list on each sub-provider entry:

```yaml
custom_providers:
  - name: My Proxy / sub-provider-1
    base_url: http://my-proxy.example.com/v1
    api_key: no-key-needed
    api_mode: chat_completions
    discover_models: false
    models:
      model-1a: {}
      model-1b: {}
  - name: My Proxy / sub-provider-2
    base_url: http://my-proxy.example.com/v1
    api_key: no-key-needed
    api_mode: chat_completions
    discover_models: false
    models:
      model-2a: {}
```

Each entry appears as its own row in the `/model` picker.

Supersedes the grouping fix portion of #28218.