### PR TITLE
fix(skills): follow symlinks in skill management

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -18,6 +18,8 @@ from tools.skill_manager_tool import (
     _delete_skill,
     _write_file,
     _remove_file,
+    _find_skill,
+    _find_skill_in_other_profiles,
     skill_manage,
     MAX_NAME_LENGTH,
 )
@@ -258,6 +260,57 @@ class TestCreateSkill:
         assert result["success"] is False
         assert f"Invalid category '{outside}'" in result["error"]
         assert not (outside / "my-skill" / "SKILL.md").exists()
+
+
+def _symlink_or_skip(link: Path, target: Path) -> None:
+    """Create a directory symlink or skip where the platform forbids it."""
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("Directory symlinks are unavailable on this platform")
+
+
+class TestFindSkillSymlinks:
+    """Regression tests for #35184 and #54195."""
+
+    def test_find_skill_follows_external_directory_symlink(self, tmp_path):
+        local = tmp_path / "local"
+        external = tmp_path / "external"
+        source = tmp_path / "source" / "repo-backed-skill"
+        local.mkdir()
+        external.mkdir()
+        source.mkdir(parents=True)
+        (source / "SKILL.md").write_text(VALID_SKILL_CONTENT)
+        installed = external / "repo-backed-skill"
+        _symlink_or_skip(installed, source)
+
+        with patch("tools.skill_manager_tool.SKILLS_DIR", local), patch(
+            "agent.skill_utils.get_all_skills_dirs",
+            return_value=[local, external],
+        ):
+            result = _find_skill("repo-backed-skill")
+
+        assert result == {"path": installed}
+
+    def test_other_profile_lookup_follows_directory_symlink(self, tmp_path):
+        root = tmp_path / "hermes"
+        active_skills = root / "skills"
+        profile_skills = root / "profiles" / "researcher" / "skills"
+        source_category = tmp_path / "source" / "category"
+        source_skill = source_category / "profile-skill"
+        active_skills.mkdir(parents=True)
+        profile_skills.mkdir(parents=True)
+        source_skill.mkdir(parents=True)
+        (source_skill / "SKILL.md").write_text(VALID_SKILL_CONTENT)
+        installed_category = profile_skills / "category"
+        _symlink_or_skip(installed_category, source_category)
+
+        with patch("tools.skill_manager_tool.SKILLS_DIR", active_skills), patch(
+            "hermes_constants.get_default_hermes_root", return_value=root
+        ):
+            result = _find_skill_in_other_profiles("profile-skill")
+
+        assert result == [("researcher", installed_category / "profile-skill")]
 
 
 class TestEditSkill:

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -610,11 +610,15 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
     """
-    from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
+    from agent.skill_utils import (
+        get_all_skills_dirs,
+        is_excluded_skill_path,
+        iter_skill_index_files,
+    )
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
-        for skill_md in skills_dir.rglob("SKILL.md"):
+        for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
             if is_excluded_skill_path(skill_md):
                 continue
             if skill_md.parent.name == name:
@@ -634,7 +638,7 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
     matches: List[Tuple[str, Path]] = []
     try:
         from hermes_constants import get_default_hermes_root
-        from agent.skill_utils import is_excluded_skill_path
+        from agent.skill_utils import is_excluded_skill_path, iter_skill_index_files
     except Exception:
         return matches
 
@@ -678,7 +682,7 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
         if not skills_dir.is_dir():
             continue
         try:
-            for skill_md in skills_dir.rglob("SKILL.md"):
+            for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
                 if is_excluded_skill_path(skill_md):
                     continue
                 if skill_md.parent.name == name:


### PR DESCRIPTION
## What does this PR do?

`skill_manage` used `Path.rglob("SKILL.md")` in `_find_skill()` and `_find_skill_in_other_profiles()`. Unlike the shared `iter_skill_index_files()` helper, `Path.rglob()` does not follow directory symlinks. A symlinked skill could therefore appear in `skills_list` and load through `skill_view`, but `skill_manage` reported it as missing.

This PR routes both skill-management lookups through the existing shared iterator. The change is deliberately narrow: it keeps current matching, exclusion, precedence, and mutation behavior, while making traversal consistent with the rest of the skills system.

This supersedes #35244 by preserving its minimal approach and adding the two items requested in maintainer review: platform-safe symlink setup and regression coverage for `_find_skill_in_other_profiles()`. Credit to @Linux2010 for #35244 and @liuhao1024 for the related #54200 implementation.

## Related Issue

Fixes #35184
Closes #54195
Supersedes #35244

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skill_manager_tool.py`
  - replace both skill-discovery `rglob()` calls with `iter_skill_index_files()`
  - preserve existing exclusion and basename matching logic
- `tests/tools/test_skill_manager_tool.py`
  - verify `_find_skill()` discovers a skill installed as a directory symlink in an external skills root
  - verify `_find_skill_in_other_profiles()` discovers a skill below a symlinked category in another profile
  - skip cleanly when the host cannot create directory symlinks

## How to Test

1. Configure an external skills directory containing a directory symlink to a real skill package.
2. Call `skill_manage(action="patch", name="<skill>", old_string="__DOES_NOT_EXIST__", new_string="x")` and confirm lookup reaches content matching instead of returning `Skill '<skill>' not found`.
3. Run:

   ```bash
   scripts/run_tests.sh tests/tools/test_skill_manager_tool.py -q
   python3 scripts/check-windows-footguns.py --diff origin/main
   uv run --extra dev ruff check .
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused canonical suite passes; full-suite green is not claimed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.7

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no public API or configuration change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; existing shared iterator is reused
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-safe symlink helper added; Windows-footgun scan passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no schema or description change

## Screenshots / Logs

```text
scripts/run_tests.sh tests/tools/test_skill_manager_tool.py -q
✓ targeted canonical test run passed

pytest TestFindSkillSymlinks
2 passed in 0.21s

python3 scripts/check-windows-footguns.py --diff origin/main
✓ No Windows footguns found (2 file(s) scanned).

uv run --extra dev ruff check .
All checks passed!
```
