### PR TITLE
feat(picker): fold Qwen providers into one group row in provider pickers

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1141,6 +1141,7 @@ PROVIDER_GROUPS: dict[str, tuple[str, str, list[str]]] = {
     "xai":      ("xAI Grok",        "Direct API or SuperGrok / Premium+ OAuth",        ["xai", "xai-oauth"]),
     "google":   ("Google Gemini",   "Google AI Studio (API key)",                     ["gemini"]),
     "openai":   ("OpenAI",          "Codex CLI or direct OpenAI API",                  ["openai-codex", "openai-api"]),
+    "qwen":     ("Qwen",            "Qwen Cloud / DashScope, Coding Plan & Qwen CLI OAuth", ["alibaba", "alibaba-coding-plan", "qwen-oauth"]),
     "opencode": ("OpenCode",        "Zen pay-as-you-go or Go subscription",            ["opencode-zen", "opencode-go"]),
     "copilot":  ("GitHub Copilot",  "GitHub token API or copilot --acp process",       ["copilot", "copilot-acp"]),
 }


### PR DESCRIPTION
## Summary
The three Qwen provider slugs now fold into a single "Qwen" group row in the interactive provider pickers, matching the existing OpenAI / Kimi / MiniMax / xAI / OpenCode / Copilot groups.

## Changes
- `hermes_cli/models.py`: added a `qwen` entry to `PROVIDER_GROUPS` with members `alibaba` (Qwen Cloud / DashScope), `alibaba-coding-plan` (Alibaba Cloud Coding Plan), and `qwen-oauth` (Qwen CLI OAuth).

Display-only — `group_providers()` is the single shared fold, so the CLI `hermes model` picker, the setup wizard, and the Telegram `/model` keyboard all pick up the grouping with no per-surface changes. Slug identity, `--provider`, and `/model <provider:model>` typed paths are unchanged; every member slug remains individually addressable.

## Validation
| Check | Result |
|---|---|
| `tests/hermes_cli/test_provider_groups.py` (invariants: members are canonical slugs, unique across groups, lossless fold) | 11/11 pass |
| `test_list_picker_providers.py`, `test_telegram_model_picker.py`, `test_model_catalog.py` | 62/62 pass |
| E2E: replicated the `hermes model` row build from `main.py` — "Qwen ▸ (Qwen Cloud / DashScope, Coding Plan & Qwen CLI OAuth)" renders as one row, submenu shows Qwen Cloud / Alibaba Cloud (Coding Plan) / Qwen OAuth (Portal), active `alibaba` provider pre-selects the group, no member slug leaks at top level | pass |
| E2E: Telegram-style `group_providers` fold places the group at the first member position with declaration order | pass |

Top-level canonical picker rows: 34 → 32.

## Infographic
![qwen-provider-group](https://v3b.fal.media/files/b/0aa2f01b/nMXPEOXWvf8nQWN9dz3cL_y1jRjkrO.png)
