### PR TITLE
fix(webui): show active fallback model

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -346,6 +346,9 @@ def test_compute_host_turn_end_updates_metadata_mirror(monkeypatch):
                 "session_info": {
                     "model": "host-model",
                     "provider": "host-provider",
+                    "fallback_activated": True,
+                    "primary_model": "primary-model",
+                    "primary_provider": "primary-provider",
                     "system_prompt": "host system prompt",
                     "tools": {"core": ["terminal"]},
                     "usage": {"total": 140, "context_used": 80, "context_max": 1000},
@@ -359,6 +362,9 @@ def test_compute_host_turn_end_updates_metadata_mirror(monkeypatch):
         info = server._session_info(None, session)
         assert info["model"] == "host-model"
         assert info["provider"] == "host-provider"
+        assert info["fallback_activated"] is True
+        assert info["primary_model"] == "primary-model"
+        assert info["primary_provider"] == "primary-provider"
         assert info["system_prompt"] == "host system prompt"
         assert info["tools"] == {"core": ["terminal"]}
         assert info["usage"]["total"] == 140
@@ -6322,6 +6328,57 @@ def test_session_steer_errors_when_agent_has_no_steer_method():
 
     assert "error" in resp, resp
     assert resp["error"]["code"] == 4010
+
+
+def test_restore_primary_runtime_for_turn_emits_live_identity(monkeypatch):
+    emitted = []
+    agent = types.SimpleNamespace(
+        model="gpt-5.5",
+        provider="openai-codex",
+        _fallback_activated=True,
+        _primary_runtime={"model": "kimi-k3", "provider": "opencode-go"},
+    )
+
+    def restore():
+        agent.model = "kimi-k3"
+        agent.provider = "opencode-go"
+        agent._fallback_activated = False
+        return True
+
+    agent._restore_primary_runtime = restore
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+    monkeypatch.setattr(server, "_session_info", lambda actual_agent, session: {
+        "model": actual_agent.model,
+        "provider": actual_agent.provider,
+        "fallback_activated": actual_agent._fallback_activated,
+    })
+
+    assert server._restore_primary_runtime_for_turn("sid", {}, agent) is True
+    assert emitted == [
+        (
+            "session.info",
+            "sid",
+            {"model": "kimi-k3", "provider": "opencode-go", "fallback_activated": False},
+        )
+    ]
+
+
+def test_session_info_reports_active_fallback_runtime(monkeypatch):
+    agent = types.SimpleNamespace(
+        tools=[],
+        model="gpt-5.5",
+        provider="openai-codex",
+        _fallback_activated=True,
+        _primary_runtime={"model": "kimi-k3", "provider": "opencode-go"},
+    )
+
+    info = server._session_info(agent)
+
+    assert info["model"] == "gpt-5.5"
+    assert info["provider"] == "openai-codex"
+    assert info["fallback_activated"] is True
+    assert info["primary_model"] == "kimi-k3"
+    assert info["primary_provider"] == "opencode-go"
 
 
 def test_session_info_includes_mcp_servers(monkeypatch):

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -474,6 +474,110 @@ def test_session_resume_defaults_to_deferred_build(server, monkeypatch):
     assert server._find_live_session_by_key(target) == (sid, session)
 
 
+def test_prompt_submit_final_session_info_reports_fallback_runtime(server, monkeypatch, tmp_path):
+    """A fallback activated inside the live PTY turn path must reach session.info."""
+
+    events: list[tuple[str, str, dict]] = []
+
+    class _Worker:
+        def close(self):
+            pass
+
+    class _FallbackAgent:
+        def __init__(self):
+            self.model = "primary/model"
+            self.provider = "primary-provider"
+            self.base_url = "https://primary.example/v1"
+            self.api_key = "primary-key"
+            self.api_mode = "openai"
+            self.session_id = "stored-fallback-turn"
+            self._fallback_activated = False
+            self._primary_runtime = {
+                "model": "primary/model",
+                "provider": "primary-provider",
+            }
+
+        def clear_interrupt(self):
+            pass
+
+        def run_conversation(self, message, conversation_history=None, stream_callback=None, **_kwargs):
+            self._fallback_activated = True
+            self.model = "fallback/model"
+            self.provider = "fallback-provider"
+            if stream_callback:
+                stream_callback("ok")
+            return {
+                "final_response": "ok",
+                "messages": [
+                    *(conversation_history or []),
+                    {"role": "user", "content": message},
+                    {"role": "assistant", "content": "ok"},
+                ],
+            }
+
+    fake_approval = types.SimpleNamespace(
+        reset_current_session_key=lambda _token: None,
+        set_current_session_key=lambda _key: object(),
+        register_gateway_notify=lambda *_args, **_kwargs: None,
+        load_permanent_allowlist=lambda: None,
+    )
+
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_SlashWorker", lambda _key, _model, **_kwargs: _Worker())
+    monkeypatch.setattr(server, "_start_notification_poller", lambda _sid, _session: threading.Event())
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_schedule_mcp_late_refresh", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_sync_agent_model_with_config", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_voice_tts_enabled", lambda: False)
+    monkeypatch.setattr(server, "_drain_queued_prompt", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: events.append((event, sid, payload or {})),
+    )
+
+    with patch.dict(sys.modules, {"tools.approval": fake_approval}):
+        agent = _FallbackAgent()
+        sid = "live-fallback-turn"
+        server._init_session(
+            sid,
+            "stored-fallback-turn",
+            agent,
+            [],
+            cols=100,
+            cwd=str(tmp_path),
+        )
+        events.clear()
+
+        response = server.handle_request(
+            {
+                "id": "turn-1",
+                "method": "prompt.submit",
+                "params": {"session_id": sid, "text": "trigger fallback"},
+            }
+        )
+
+        assert response["result"] == {"status": "streaming"}
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and server._sessions[sid].get("running"):
+            time.sleep(0.01)
+        run_thread = server._sessions[sid].get("_run_thread")
+        if run_thread is not None:
+            run_thread.join(timeout=1)
+
+    session_infos = [payload for event, _sid, payload in events if event == "session.info"]
+    assert session_infos, events
+    final_info = session_infos[-1]
+    assert final_info["model"] == "fallback/model"
+    assert final_info["provider"] == "fallback-provider"
+    assert final_info["fallback_activated"] is True
+    assert final_info["primary_model"] == "primary/model"
+    assert final_info["primary_provider"] == "primary-provider"
+
+
 def test_enforce_session_cap_evicts_oldest_detached_only(server, monkeypatch):
     """The LRU cap frees the least-recently-active DETACHED sessions when over
     the limit, and never a live-transport / running / mid-build one."""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3771,9 +3771,29 @@ def _session_info(agent, session: dict | None = None) -> dict:
         yolo = bool(_YOLO_MODE_FROZEN) or session_yolo or approval_mode == "off"
     except Exception:
         yolo = False
+    fallback_activated = bool(
+        mirror.get("fallback_activated", getattr(agent, "_fallback_activated", False))
+    )
+    primary_runtime = getattr(agent, "_primary_runtime", {}) or {}
+    primary_model = (
+        mirror.get("primary_model", primary_runtime.get("model", ""))
+        if fallback_activated
+        else ""
+    )
+    primary_provider = (
+        mirror.get("primary_provider", primary_runtime.get("provider", ""))
+        if fallback_activated
+        else ""
+    )
     info: dict = {
         "model": mirror.get("model", getattr(agent, "model", "")),
         "provider": mirror.get("provider", getattr(agent, "provider", "")),
+        # A fallback can replace the configured primary during this turn. The
+        # dashboard needs the live route, not just config.yaml, to avoid
+        # attributing the visible response to a model that failed.
+        "fallback_activated": fallback_activated,
+        "primary_model": str(primary_model or ""),
+        "primary_provider": str(primary_provider or ""),
         "reasoning_effort": reasoning_effort,
         "service_tier": service_tier,
         "fast": service_tier == "priority",
@@ -9855,6 +9875,26 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
     return stop
 
 
+def _restore_primary_runtime_for_turn(sid: str, session: dict, agent) -> bool:
+    """Restore a prior turn's primary runtime and publish the live identity.
+
+    ``AIAgent.run_conversation`` also restores its primary internally, but the
+    dashboard needs this transition before the first request of a new turn so a
+    previous fallback badge cannot remain visible while the primary is running.
+    """
+    restore = getattr(agent, "_restore_primary_runtime", None)
+    if not callable(restore):
+        return False
+    try:
+        restored = bool(restore())
+    except Exception:
+        logger.debug("TUI primary runtime restore before turn failed", exc_info=True)
+        return False
+    if restored:
+        _emit("session.info", sid, _session_info(agent, session))
+    return restored
+
+
 def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
     with session["history_lock"]:
         history = list(session["history"])
@@ -9898,6 +9938,10 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             # the sudo.request overlay. (secret capture is a module global, so
             # re-running is a harmless no-op.)
             _wire_callbacks(sid)
+            # Restore the primary before config synchronization and emit the
+            # transition. This keeps the dashboard model badge aligned with the
+            # request that is about to run, not the prior turn's fallback.
+            _restore_primary_runtime_for_turn(sid, session, agent)
             # Skip the config-model sync while a /model --once override is
             # active: the once-model is intentionally not pinned as a session
             # model_override (it must not persist), so without this guard the

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -33,6 +33,11 @@ import { ReasoningPicker } from "@/components/ReasoningPicker";
 import { GatewayClient, type ConnectionState } from "@/lib/gatewayClient";
 import { api, buildWsUrl } from "@/lib/api";
 import { titleFromSessionInfoPayload } from "@/lib/chat-title";
+import {
+  runtimeModelFromSessionInfo,
+  selectChatModel,
+  type RuntimeModelInfo,
+} from "@/lib/runtime-model";
 
 import { cn } from "@/lib/utils";
 import { AlertCircle, ChevronDown, RefreshCw } from "lucide-react";
@@ -44,6 +49,9 @@ interface SessionInfo {
   provider?: string;
   credential_warning?: string;
   title?: string;
+  fallback_activated?: boolean;
+  primary_model?: string;
+  primary_provider?: string;
 }
 
 interface RpcEnvelope {
@@ -111,6 +119,9 @@ export function ChatSidebar({
 
   const [state, setState] = useState<ConnectionState>("idle");
   const [info, setInfo] = useState<SessionInfo>({});
+  // Runtime identity is published by the PTY-side chat session. Keep it
+  // separate from the throwaway sidecar's session.info snapshot.
+  const [runtimeModel, setRuntimeModel] = useState<RuntimeModelInfo | null>(null);
   const [modelOpen, setModelOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // The badge shows config.yaml's main model (`model.default`) via
@@ -175,6 +186,7 @@ export function ChatSidebar({
     queueMicrotask(() => {
       if (cancelled) return;
       setInfo({});
+      setRuntimeModel(null);
       setError(null);
     });
     const offState = gw.onState(setState);
@@ -281,6 +293,10 @@ export function ChatSidebar({
         const { type, payload } = frame.params;
 
         if (type === "session.info") {
+          const runtime = runtimeModelFromSessionInfo(payload);
+          if (runtime) {
+            setRuntimeModel(runtime);
+          }
           const title = titleFromSessionInfoPayload(payload);
           if (title !== undefined) {
             onSessionTitleChange?.(title);
@@ -312,8 +328,11 @@ export function ChatSidebar({
 
   // The picker writes config.yaml over REST and reloads — it doesn't ride the
   // sidecar gateway session, so it's available whenever the sidebar is mounted.
-  const modelName = effectiveModel || info.model || "—";
+  const modelName = selectChatModel(effectiveModel || info.model || "", runtimeModel);
   const modelLabel = modelName.split("/").slice(-1)[0] ?? "—";
+  const fallbackLabel = runtimeModel?.primaryModel
+    ? `Fallback from ${runtimeModel.primaryModel}`
+    : "Fallback model active";
   const banner = error ?? info.credential_warning ?? null;
 
   return (
@@ -348,9 +367,16 @@ export function ChatSidebar({
           </Button>
         </div>
 
-        <Badge tone={STATE_TONE[state]} className="shrink-0">
-          {STATE_LABEL[state]}
-        </Badge>
+        <div className="flex shrink-0 items-center gap-1">
+          {runtimeModel?.fallbackActivated && (
+            <Badge tone="warning" title={fallbackLabel}>
+              fallback
+            </Badge>
+          )}
+          <Badge tone={STATE_TONE[state]}>
+            {STATE_LABEL[state]}
+          </Badge>
+        </div>
       </Card>
 
       {supportsReasoning && (

--- a/web/src/lib/runtime-model.test.ts
+++ b/web/src/lib/runtime-model.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { runtimeModelFromSessionInfo, selectChatModel } from "./runtime-model";
+
+describe("runtimeModelFromSessionInfo", () => {
+  it("keeps the active fallback and its original primary identity", () => {
+    expect(
+      runtimeModelFromSessionInfo({
+        model: "gpt-5.5",
+        provider: "openai-codex",
+        fallback_activated: true,
+        primary_model: "kimi-k3",
+        primary_provider: "opencode-go",
+      }),
+    ).toEqual({
+      model: "gpt-5.5",
+      provider: "openai-codex",
+      fallbackActivated: true,
+      primaryModel: "kimi-k3",
+      primaryProvider: "opencode-go",
+    });
+  });
+
+  it("rejects malformed event payloads", () => {
+    expect(runtimeModelFromSessionInfo(null)).toBeNull();
+    expect(runtimeModelFromSessionInfo({ model: 42 })).toBeNull();
+  });
+});
+
+describe("selectChatModel", () => {
+  it("prefers the live PTY runtime over the configured model", () => {
+    expect(
+      selectChatModel("kimi-k3", {
+        model: "gpt-5.5",
+        provider: "openai-codex",
+        fallbackActivated: true,
+        primaryModel: "kimi-k3",
+        primaryProvider: "opencode-go",
+      }),
+    ).toBe("gpt-5.5");
+  });
+
+  it("uses the configured model until the PTY emits runtime identity", () => {
+    expect(selectChatModel("kimi-k3", null)).toBe("kimi-k3");
+  });
+});

--- a/web/src/lib/runtime-model.ts
+++ b/web/src/lib/runtime-model.ts
@@ -1,0 +1,40 @@
+export interface RuntimeModelInfo {
+  model: string;
+  provider: string;
+  fallbackActivated: boolean;
+  primaryModel: string;
+  primaryProvider: string;
+}
+
+function nonEmptyString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * Normalizes the session.info payload emitted by the live PTY session.
+ * The configured model is intentionally not consulted here: this data is
+ * runtime-only and takes precedence in the chat sidebar once it exists.
+ */
+export function runtimeModelFromSessionInfo(payload: unknown): RuntimeModelInfo | null {
+  if (!payload || typeof payload !== "object") return null;
+
+  const raw = payload as Record<string, unknown>;
+  const model = nonEmptyString(raw.model);
+  if (!model) return null;
+
+  return {
+    model,
+    provider: nonEmptyString(raw.provider),
+    fallbackActivated: raw.fallback_activated === true,
+    primaryModel: nonEmptyString(raw.primary_model),
+    primaryProvider: nonEmptyString(raw.primary_provider),
+  };
+}
+
+/** Returns the visible model, preferring the model that is actually answering. */
+export function selectChatModel(
+  configuredModel: string,
+  runtime: RuntimeModelInfo | null,
+): string {
+  return runtime?.model || configuredModel || "—";
+}


### PR DESCRIPTION
## Summary

- publish fallback and primary runtime identity in TUI `session.info` events
- make the WebUI chat sidebar prefer the PTY session’s live model over `config.yaml`
- show an amber `fallback` badge with the originating primary model in its tooltip
- clear the fallback badge before the next primary turn starts
- preserve this metadata through compute-host isolation

Closes #54509

## Verification

- `python3 -m pytest tests/ -o 'addopts=' -q` \u2014 377 passed\n- `npm run test` (web) \u2014 101 passed\n- `npm run typecheck` (web)\n- `npm run lint` (web; existing warnings only, exit 0)\n- `NODE_OPTIONS=--max-old-space-size=4096 npm run build` (web)