### PR TITLE
fix(compression): retain prompt cache when memory is unchanged

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -15,7 +15,7 @@ Three concerns live here:
 * :func:`compress_context` — the actual compression call.  Runs the
   configured compressor, splits the SQLite session, rotates the
   session_id, notifies plugin context engines / memory providers, and
-  returns the compressed message list and freshly-built system prompt.
+  returns the compressed message list and active system prompt.
 
 * :func:`try_shrink_image_parts_in_messages` — image-too-large recovery
   helper that re-encodes ``data:image/...;base64,...`` parts at a smaller
@@ -51,6 +51,34 @@ COMPACTION_STATUS_MARKER = "Compacting context"
 COMPACTION_STATUS = (
     f"🗜️ {COMPACTION_STATUS_MARKER} — summarizing earlier conversation so I can continue..."
 )
+
+
+def _builtin_memory_prompt_snapshot(agent: Any) -> Optional[Tuple[str, str]]:
+    """Return the built-in memory text that can affect a system prompt.
+
+    ``MemoryStore`` freezes this text until ``load_from_disk()``.  Comparing
+    the frozen blocks before and after that reload lets compression retain the
+    exact cached system prompt when no built-in memory actually changed.  An
+    unreadable snapshot returns ``None`` so callers take the conservative
+    rebuild path.
+    """
+    store = getattr(agent, "_memory_store", None)
+    if store is None:
+        return "", ""
+    try:
+        memory = (
+            store.format_for_system_prompt("memory") or ""
+            if getattr(agent, "_memory_enabled", False)
+            else ""
+        )
+        user = (
+            store.format_for_system_prompt("user") or ""
+            if getattr(agent, "_user_profile_enabled", False)
+            else ""
+        )
+    except Exception:
+        return None
+    return memory, user
 
 
 def _lock_api_is_absent_on_session_db(lock_db: Any) -> bool:
@@ -604,7 +632,8 @@ def compress_context(
     Args:
         agent: The owning :class:`AIAgent`.
         messages: Current message history (will be summarised).
-        system_message: Current system prompt; rebuilt after compression.
+        system_message: Current system prompt; used when compression needs a
+            rebuilt cached prompt.
         approx_tokens: Pre-compression token estimate, logged for ops.
         task_id: Tool task scope (used for clearing file-read dedup state).
         focus_topic: Optional focus string for guided compression — the
@@ -671,8 +700,9 @@ def compress_context(
 
     _pre_msg_count = len(messages)
     # In-place compaction (config: compression.in_place, see #38763). When True,
-    # this compaction rewrites the message list + rebuilds the system prompt but
-    # keeps the SAME session_id — no end_session, no parent_session_id child, no
+    # this compaction rewrites the message list and refreshes the system prompt
+    # when necessary, but keeps the SAME session_id — no end_session, no
+    # parent_session_id child, no
     # `name #N` renumber, no contextvar/env/logging re-sync, no memory/context-
     # engine session-switch. The conversation keeps one durable id for life,
     # eliminating the session-rotation bug cluster. Default False during rollout.
@@ -1021,9 +1051,27 @@ def compress_context(
             })
         _ensure_compressed_has_user_turn(messages, compressed)
 
+        cached_system_prompt = agent._cached_system_prompt
+        old_memory_snapshot = _builtin_memory_prompt_snapshot(agent)
         agent._invalidate_system_prompt()
-        new_system_prompt = agent._build_system_prompt(system_message)
-        agent._cached_system_prompt = new_system_prompt
+        new_memory_snapshot = _builtin_memory_prompt_snapshot(agent)
+
+        # Built-in memory snapshots are the only system-prompt input that a
+        # normal compaction reloads. When their rendered text is unchanged,
+        # keep the exact cached prompt so local backends retain their KV-cache
+        # prefix. External providers can change their own prompt block during
+        # on_pre_compress(), so they deliberately retain the rebuild path.
+        if (
+            cached_system_prompt is not None
+            and getattr(agent, "_memory_manager", None) is None
+            and old_memory_snapshot is not None
+            and old_memory_snapshot == new_memory_snapshot
+        ):
+            new_system_prompt = cached_system_prompt
+            agent._cached_system_prompt = cached_system_prompt
+        else:
+            new_system_prompt = agent._build_system_prompt(system_message)
+            agent._cached_system_prompt = new_system_prompt
 
         if agent._session_db:
             try:

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -574,7 +574,7 @@ class TestPreflightCompression:
 
         with (
             patch.object(agent.context_compressor, "compress", side_effect=_fake_compress),
-            patch.object(agent, "_build_system_prompt", return_value="new system prompt"),
+            patch.object(agent, "_build_system_prompt", return_value="new system prompt") as build_prompt,
             patch("run_agent.estimate_request_tokens_rough", return_value=42),
         ):
             compressed, new_system_prompt = agent._compress_context(
@@ -591,10 +591,73 @@ class TestPreflightCompression:
             {"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"},
             {"role": "user", "content": "hello"},
         ]
-        assert new_system_prompt == "new system prompt"
+        assert new_system_prompt == "You are helpful."
+        build_prompt.assert_not_called()
         assert events[0][0] == "lifecycle"
         assert "Compacting context" in events[0][1]
         assert events[1] == ("compress", "started")
+
+    def test_compression_reuses_cached_prompt_when_memory_snapshot_is_unchanged(self, agent):
+        """A memory reload without new injected text must keep the cache prefix."""
+        agent.compression_enabled = False
+        agent._memory_enabled = True
+        agent._user_profile_enabled = False
+        agent._memory_manager = None
+        agent._cached_system_prompt = "cached system prompt"
+        memory_store = MagicMock()
+        memory_store.format_for_system_prompt.return_value = "<memory>same facts</memory>"
+        agent._memory_store = memory_store
+
+        with (
+            patch.object(
+                agent.context_compressor,
+                "compress",
+                return_value=[{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}],
+            ),
+            patch.object(agent, "_build_system_prompt") as build_prompt,
+        ):
+            _, new_system_prompt = agent._compress_context(
+                [{"role": "user", "content": "hello"}],
+                "system prompt",
+                approx_tokens=1234,
+            )
+
+        assert new_system_prompt is agent._cached_system_prompt
+        assert new_system_prompt == "cached system prompt"
+        build_prompt.assert_not_called()
+        memory_store.load_from_disk.assert_called_once()
+
+    def test_compression_rebuilds_prompt_when_memory_snapshot_changes(self, agent):
+        """A changed memory block must be reflected in the next model request."""
+        agent.compression_enabled = False
+        agent._memory_enabled = True
+        agent._user_profile_enabled = False
+        agent._memory_manager = None
+        agent._cached_system_prompt = "cached system prompt"
+        memory_store = MagicMock()
+        memory_store.format_for_system_prompt.side_effect = [
+            "<memory>old facts</memory>",
+            "<memory>new facts</memory>",
+        ]
+        agent._memory_store = memory_store
+
+        with (
+            patch.object(
+                agent.context_compressor,
+                "compress",
+                return_value=[{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}],
+            ),
+            patch.object(agent, "_build_system_prompt", return_value="rebuilt system prompt") as build_prompt,
+        ):
+            _, new_system_prompt = agent._compress_context(
+                [{"role": "user", "content": "hello"}],
+                "system prompt",
+                approx_tokens=1234,
+            )
+
+        assert new_system_prompt == "rebuilt system prompt"
+        build_prompt.assert_called_once_with("system prompt")
+        memory_store.load_from_disk.assert_called_once()
 
     def test_preflight_compresses_oversized_history(self, agent):
         """When loaded history exceeds the model's context threshold, compress before API call."""


### PR DESCRIPTION
## What changed and why

Per the collaborator's clarification on 2026-07-19, timestamp stabilization did not address the remaining cache miss when compression reloads unchanged built-in memory. Compression now compares the rendered built-in memory snapshot before and after its required disk reload, retaining the exact cached system prompt when the injected content is unchanged. A changed snapshot still rebuilds the prompt; external memory providers also retain the conservative rebuild path because their prompt block can change during pre-compression hooks.

## Addressing maintainer feedback

- #27675 addressed timestamp churn; this change preserves the existing timestamp work and covers the separate unchanged-memory path.
- #8689 addressed timestamp churn; this change preserves the existing timestamp work and covers the separate unchanged-memory path.

## How to test

- `HERMES_HOME=/private/tmp/hermes-followup-test-home pytest tests/run_agent/test_413_compression.py tests/run_agent/test_compress_focus_plugin_fallback.py tests/run_agent/test_run_agent.py::TestInvalidateSystemPrompt -q --timeout=60`
- `ruff check agent/conversation_compression.py tests/run_agent/test_413_compression.py`

## What platforms tested on

- macOS (local test sandbox)

Refs #4319

<!-- autocontrib:worker-id=issue-followup-e39e35b0 kind=pr-open -->