### PR TITLE
fix(cli): clean up oneshot resources before exit

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -310,6 +310,87 @@ def _create_session_db_for_oneshot():
         return None
 
 
+def _cleanup_oneshot_resources(agent: object, session_db: object) -> None:
+    """Release the resources owned by a completed ``hermes -z`` run.
+
+    Oneshot intentionally bypasses ``HermesCLI``.  It therefore cannot rely on
+    the interactive CLI's ``atexit`` finalizer to close MCP and auxiliary
+    clients before Python starts unloading their native extensions.
+    """
+    try:
+        from hermes_cli.plugins import invoke_hook
+
+        invoke_hook(
+            "on_session_finalize",
+            session_id=getattr(agent, "session_id", None),
+            platform=getattr(agent, "platform", None) or "cli",
+            reason="shutdown",
+        )
+    except Exception:
+        logging.debug("Oneshot session finalizer failed", exc_info=True)
+
+    try:
+        from tools.terminal_tool import cleanup_all_environments
+
+        cleanup_all_environments()
+    except Exception:
+        logging.debug("Oneshot terminal cleanup failed", exc_info=True)
+    try:
+        from tools.async_delegation import interrupt_all
+
+        interrupt_all(reason="oneshot shutdown")
+    except Exception:
+        logging.debug("Oneshot delegation cleanup failed", exc_info=True)
+    try:
+        from tools.browser_tool import _emergency_cleanup_all_sessions
+
+        _emergency_cleanup_all_sessions()
+    except Exception:
+        logging.debug("Oneshot browser cleanup failed", exc_info=True)
+    try:
+        from tools.mcp_tool import shutdown_mcp_servers
+
+        shutdown_mcp_servers()
+    except Exception:
+        logging.debug("Oneshot MCP cleanup failed", exc_info=True)
+    try:
+        from agent.auxiliary_client import shutdown_cached_clients
+
+        shutdown_cached_clients()
+    except Exception:
+        logging.debug("Oneshot auxiliary client cleanup failed", exc_info=True)
+
+    try:
+        memory_manager = getattr(agent, "_memory_manager", None)
+        flush_pending = getattr(memory_manager, "flush_pending", None)
+        if callable(flush_pending):
+            flush_pending(timeout=10)
+    except Exception:
+        logging.debug("Oneshot memory flush failed", exc_info=True)
+    try:
+        shutdown_memory_provider = getattr(agent, "shutdown_memory_provider", None)
+        if callable(shutdown_memory_provider):
+            messages = getattr(agent, "_session_messages", None)
+            if isinstance(messages, list):
+                shutdown_memory_provider(messages)
+            else:
+                shutdown_memory_provider()
+    except Exception:
+        logging.debug("Oneshot memory cleanup failed", exc_info=True)
+    try:
+        close_agent = getattr(agent, "close", None)
+        if callable(close_agent):
+            close_agent()
+    except Exception:
+        logging.debug("Oneshot agent cleanup failed", exc_info=True)
+    try:
+        close_session_db = getattr(session_db, "close", None)
+        if callable(close_session_db):
+            close_session_db()
+    except Exception:
+        logging.debug("Oneshot session database cleanup failed", exc_info=True)
+
+
 def _run_agent(
     prompt: str,
     model: Optional[str] = None,
@@ -432,8 +513,11 @@ def _run_agent(
     agent.stream_delta_callback = None
     agent.tool_gen_callback = None
 
-    result = agent.run_conversation(prompt)
-    return (result.get("final_response") or "", result)
+    try:
+        result = agent.run_conversation(prompt)
+        return (result.get("final_response") or "", result)
+    finally:
+        _cleanup_oneshot_resources(agent, session_db)
 
 
 def _oneshot_clarify_callback(question: str, choices=None) -> str:

--- a/tests/hermes_cli/test_oneshot_cleanup.py
+++ b/tests/hermes_cli/test_oneshot_cleanup.py
@@ -1,0 +1,98 @@
+"""Lifecycle coverage for ``hermes -z`` resource teardown."""
+
+import sys
+import types
+
+
+def test_oneshot_cleanup_releases_global_and_agent_resources(monkeypatch):
+    import hermes_cli.oneshot as oneshot_mod
+
+    calls = []
+    messages = [{"role": "user", "content": "hello"}]
+    agent = types.SimpleNamespace(
+        session_id="oneshot-session",
+        platform="cli",
+        _session_messages=messages,
+        _memory_manager=types.SimpleNamespace(
+            flush_pending=lambda timeout: calls.append(("memory_flush", timeout))
+        ),
+        shutdown_memory_provider=lambda received: calls.append(("memory", received)),
+        close=lambda: calls.append(("agent", None)),
+    )
+    session_db = types.SimpleNamespace(close=lambda: calls.append(("session_db", None)))
+
+    def module(name, **attrs):
+        fake = types.ModuleType(name)
+        for key, value in attrs.items():
+            setattr(fake, key, value)
+        return fake
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        module(
+            "hermes_cli.plugins",
+            invoke_hook=lambda name, **kwargs: calls.append((name, kwargs)),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.terminal_tool",
+        module(
+            "tools.terminal_tool",
+            cleanup_all_environments=lambda: calls.append(("terminal", None)),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.async_delegation",
+        module(
+            "tools.async_delegation",
+            interrupt_all=lambda **kwargs: calls.append(("delegation", kwargs)),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.browser_tool",
+        module(
+            "tools.browser_tool",
+            _emergency_cleanup_all_sessions=lambda: calls.append(("browser", None)),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        module(
+            "tools.mcp_tool", shutdown_mcp_servers=lambda: calls.append(("mcp", None))
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.auxiliary_client",
+        module(
+            "agent.auxiliary_client",
+            shutdown_cached_clients=lambda: calls.append(("auxiliary", None)),
+        ),
+    )
+
+    oneshot_mod._cleanup_oneshot_resources(agent, session_db)
+
+    assert calls == [
+        (
+            "on_session_finalize",
+            {
+                "session_id": "oneshot-session",
+                "platform": "cli",
+                "reason": "shutdown",
+            },
+        ),
+        ("terminal", None),
+        ("delegation", {"reason": "oneshot shutdown"}),
+        ("browser", None),
+        ("mcp", None),
+        ("auxiliary", None),
+        ("memory_flush", 10),
+        ("memory", messages),
+        ("agent", None),
+        ("session_db", None),
+    ]

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -820,14 +820,16 @@ def test_oneshot_distinguishes_disabled_mcp_from_unknown(monkeypatch, capsys):
 
 def test_oneshot_wires_session_db_for_recall(monkeypatch):
     """hermes -z bypasses HermesCLI, but recall still needs SessionDB."""
-    from hermes_cli.oneshot import _run_agent
+    import hermes_cli.oneshot as oneshot_mod
 
     captured = {}
+    cleanup_calls = []
     sentinel_db = object()
 
     class FakeAgent:
         def __init__(self, **kwargs):
             captured.update(kwargs)
+            captured["agent"] = self
             self.suppress_status_output = False
             self.stream_delta_callback = object()
             self.tool_gen_callback = object()
@@ -877,13 +879,19 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
         "hermes_cli.tools_config",
         mod("hermes_cli.tools_config", _get_platform_tools=lambda *_args, **_kwargs: {"session_search"}),
     )
+    monkeypatch.setattr(
+        oneshot_mod,
+        "_cleanup_oneshot_resources",
+        lambda agent, session_db: cleanup_calls.append((agent, session_db)),
+    )
 
-    text, result = _run_agent("recall this")
+    text, result = oneshot_mod._run_agent("recall this")
     assert text == "ok"
     assert not result.get("failed")
     assert captured["session_db"] is sentinel_db
     assert captured["enabled_toolsets"] == ["session_search"]
     assert captured["prompt"] == "recall this"
+    assert cleanup_calls == [(captured["agent"], sentinel_db)]
 
 
 def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):


### PR DESCRIPTION
## What does this PR do?

Fixes the `hermes -z` shutdown path so a successful one-shot response releases process-global and agent-owned resources before interpreter teardown. This prevents open MCP/aiohttp, auxiliary-client, memory, terminal, browser, and SQLite resources from being left to native-extension finalization, which could abort the process after the response was printed.

## Related Issue

Fixes #30387

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/oneshot.py`: finalize the one-shot session and explicitly clean up global client managers, memory writes, the agent, and its session database in a `finally` block.
- `tests/hermes_cli/test_oneshot_cleanup.py`: cover teardown order and lifecycle ownership with fake global resources.
- `tests/hermes_cli/test_tui_resume_flow.py`: assert the existing one-shot agent-construction path invokes the cleanup finalizer.

## How to Test

1. Run `PATH="$VIRTUAL_ENV/bin:$PATH" /opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`.
2. Run `PATH="$VIRTUAL_ENV/bin:$PATH" /opt/homebrew/bin/timeout -k 30 480 "$VIRTUAL_ENV/bin/pytest" tests/hermes_cli/test_oneshot_cleanup.py tests/hermes_cli/test_tui_resume_flow.py -q --timeout=60 --deselect tests/hermes_cli/test_tui_resume_flow.py::test_launch_tui_worktree_validates_relative_python_against_final_cwd`.
3. With a configured provider, run `PYTHONFAULTHANDLER=1 hermes --safe-mode -z 'Reply with exactly: ok'`; it should print `ok` and exit 0.

## What platforms tested on

- macOS (Darwin 25.5.0, arm64)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.5.0, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

<!-- autocontrib:worker-id=issue-new-c828b107 kind=pr-open -->