### PR TITLE
fix: make cost_status sticky across API calls (#67764)

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -89,7 +89,7 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
                 )
         return {}
 
-    from agent.usage_pricing import CanonicalUsage, estimate_usage_cost
+    from agent.usage_pricing import CanonicalUsage, estimate_usage_cost, sticky_cost_status
 
     input_tokens = _coerce_usage_int(usage.get("inputTokens"))
     cache_read_tokens = _coerce_usage_int(usage.get("cachedInputTokens"))
@@ -147,7 +147,9 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
     )
     if cost_result.amount_usd is not None:
         agent.session_estimated_cost_usd += float(cost_result.amount_usd)
-    agent.session_cost_status = cost_result.status
+    agent.session_cost_status = sticky_cost_status(
+        agent.session_cost_status, cost_result.status
+    )
     agent.session_cost_source = cost_result.source
 
     if agent._session_db and agent.session_id:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -68,7 +68,7 @@ from agent.retry_utils import (
     zai_coding_overload_retry_ceiling,
 )
 from agent.trajectory import has_incomplete_scratchpad
-from agent.usage_pricing import estimate_usage_cost, normalize_usage
+from agent.usage_pricing import estimate_usage_cost, normalize_usage, sticky_cost_status
 from hermes_constants import PARTIAL_STREAM_STUB_ID
 from hermes_logging import set_session_context
 from tools.skill_provenance import set_current_write_origin
@@ -2318,7 +2318,9 @@ def run_conversation(
                             agent.session_estimated_cost_usd += float(_moa_ref_cost)
                         except (TypeError, ValueError):  # pragma: no cover - defensive
                             pass
-                    agent.session_cost_status = cost_result.status
+                    agent.session_cost_status = sticky_cost_status(
+                        agent.session_cost_status, cost_result.status
+                    )
                     agent.session_cost_source = cost_result.source
 
                     # Persist token counts to session DB for /insights.

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -28,6 +28,7 @@ from agent.usage_pricing import (
     estimate_usage_cost,
     format_duration_compact,
     has_known_pricing,
+    sticky_cost_status,
 )
 
 
@@ -580,7 +581,9 @@ class InsightsEngine:
                 status = cost_status or "unknown"
             d["cost"] += estimate
             d["actual_cost"] += float(actual_cost or 0.0)
-            d["cost_status"] = status
+            d["cost_status"] = sticky_cost_status(
+                d.get("cost_status", "unknown"), status
+            )
             if has_known_pricing(model, provider or None, base_url):
                 d["has_pricing"] = True
             else:

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -26,6 +26,25 @@ CostSource = Literal[
     "none",
 ]
 
+_COST_STATUS_PRIORITY: dict[str, int] = {
+    "actual": 3,
+    "included": 2,
+    "estimated": 1,
+    "unknown": 0,
+}
+
+
+def sticky_cost_status(current: str | None, incoming: str | None) -> str:
+    """Return the most-confident status, favoring accuracy over recency.
+
+    Priority ladder: actual > included > estimated > unknown.
+    Once any call reports ``"actual"`` the row stays ``"actual"`` forever;
+    once ``"included"`` it stays ``"included"`` unless an ``"actual"`` arrives.
+    """
+    cur_rank = _COST_STATUS_PRIORITY.get(current or "", 0)
+    inc_rank = _COST_STATUS_PRIORITY.get(incoming or "", 0)
+    return incoming if inc_rank > cur_rank else (current or "unknown")
+
 
 @dataclass(frozen=True)
 class CanonicalUsage:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2884,7 +2884,13 @@ class SessionDB:
                        WHEN ? IS NULL THEN actual_cost_usd
                        ELSE ?
                    END,
-                   cost_status = COALESCE(?, cost_status),
+                   cost_status = CASE
+                       WHEN cost_status = 'actual' THEN 'actual'
+                       WHEN ? = 'actual' THEN 'actual'
+                       WHEN cost_status = 'included' THEN 'included'
+                       WHEN ? = 'included' THEN 'included'
+                       ELSE COALESCE(?, cost_status)
+                   END,
                    cost_source = COALESCE(?, cost_source),
                    pricing_version = COALESCE(?, pricing_version),
                    billing_provider = COALESCE(billing_provider, ?),
@@ -2905,7 +2911,13 @@ class SessionDB:
                        WHEN ? IS NULL THEN actual_cost_usd
                        ELSE COALESCE(actual_cost_usd, 0) + ?
                    END,
-                   cost_status = COALESCE(?, cost_status),
+                   cost_status = CASE
+                       WHEN cost_status = 'actual' THEN 'actual'
+                       WHEN ? = 'actual' THEN 'actual'
+                       WHEN cost_status = 'included' THEN 'included'
+                       WHEN ? = 'included' THEN 'included'
+                       ELSE COALESCE(?, cost_status)
+                   END,
                    cost_source = COALESCE(?, cost_source),
                    pricing_version = COALESCE(?, pricing_version),
                    billing_provider = COALESCE(billing_provider, ?),
@@ -2928,6 +2940,8 @@ class SessionDB:
             estimated_cost_usd,
             actual_cost_usd,
             actual_cost_usd,
+            cost_status,
+            cost_status,
             cost_status,
             cost_source,
             pricing_version,
@@ -3084,7 +3098,13 @@ class SessionDB:
                    reasoning_tokens = reasoning_tokens + excluded.reasoning_tokens,
                    estimated_cost_usd = estimated_cost_usd + excluded.estimated_cost_usd,
                    actual_cost_usd = actual_cost_usd + excluded.actual_cost_usd,
-                   cost_status = COALESCE(excluded.cost_status, cost_status),
+                   cost_status = CASE
+                       WHEN cost_status = 'actual' THEN 'actual'
+                       WHEN excluded.cost_status = 'actual' THEN 'actual'
+                       WHEN cost_status = 'included' THEN 'included'
+                       WHEN excluded.cost_status = 'included' THEN 'included'
+                       ELSE COALESCE(excluded.cost_status, cost_status)
+                   END,
                    cost_source = COALESCE(excluded.cost_source, cost_source),
                    last_seen = excluded.last_seen""",
             (
@@ -3107,6 +3127,33 @@ class SessionDB:
                 now,
                 now,
             ),
+        )
+
+    def get_session_cost_summary(self, session_id: str):
+        """Read the persisted session cost fields so ``init_agent`` can
+        rehydrate the in-memory accumulators after a gateway restart.
+
+        Returns ``(estimated_cost_usd, actual_cost_usd, cost_status,
+        cost_source)`` as a 4-tuple, or ``None`` when the session row
+        doesn't exist or has no cost data.
+        """
+        with self._lock:
+            row = self._conn.execute(
+                """SELECT estimated_cost_usd,
+                          actual_cost_usd,
+                          cost_status,
+                          cost_source
+                   FROM sessions
+                   WHERE id = ?""",
+                (session_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return (
+            row["estimated_cost_usd"],
+            row["actual_cost_usd"],
+            row["cost_status"],
+            row["cost_source"],
         )
 
     def ensure_session(


### PR DESCRIPTION
## Summary

`cost_status` was being overwritten on every API call instead of accumulating the highest-confidence value. Once a call reports `"actual"`, the session/model row should stay `"actual"` forever.

**Priority ladder:** `actual` > `included` > `estimated` > `unknown`

## Changes

### Layer 0 — Helper
- **`agent/usage_pricing.py`**: Added `sticky_cost_status(current, incoming)` that returns the highest-confidence status.

### Layer 1 — SQL persistence (3 sites)
- **`hermes_state.py`**: Replaced `COALESCE(?, cost_status)` with a `CASE` expression in:
  - `sessions` absolute UPDATE
  - `sessions` incremental UPDATE
  - `session_model_usage` ON CONFLICT DO UPDATE

### Layer 2 — In-memory agent attribute
- **`agent/conversation_loop.py:2321`**: Sticky assignment via `sticky_cost_status()`
- **`agent/codex_runtime.py:150`**: Sticky assignment via `sticky_cost_status()`

### Layer 3 — Insights aggregator
- **`agent/insights.py:583`**: Per-model sticky aggregation via `sticky_cost_status()`

Fixes: #67764