### PR TITLE
fix: rehydrate session cost from DB on gateway restart (#67762)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2059,6 +2059,36 @@ def init_agent(
     agent.session_estimated_cost_usd = 0.0
     agent.session_cost_status = "unknown"
     agent.session_cost_source = "none"
+
+    # Rehydrate session cost accumulators from persisted DB row (#67762)
+    # so a gateway restart mid-session doesn't reset the running cost to $0.
+    # The persisted data (sessions.estimated_cost_usd) is correct; this just
+    # copies it back into the agent's in-memory accumulators.  Subsequent API
+    # calls will += on top of the rehydrated baseline.
+    #
+    # The cost *value* stays correct across restarts.  The cost *status* is
+    # still overwritten by the very next API call (conversation_loop.py:2321 /
+    # codex_runtime.py:150) — that's tracked separately by the priority-ladder
+    # issue and doesn't affect the correctness of the dollar amount.
+    if session_db is not None and session_id:
+        try:
+            _saved = session_db.get_session_cost_summary(session_id)
+            if _saved is not None:
+                _est, _act, _status, _source = _saved
+                # Prefer actual cost when available, fall back to estimated.
+                _cost = _act if _act is not None and _act > 0 else _est
+                if _cost is not None and _cost > 0:
+                    agent.session_estimated_cost_usd = float(_cost)
+                if _status and _status not in ("unknown", None):
+                    agent.session_cost_status = _status
+                if _source and _source not in ("none", None):
+                    agent.session_cost_source = _source
+        except Exception:
+            # Non-fatal: if the DB read fails (locked, threading race, etc.)
+            # the agent starts from 0.0 and the cost-display undercounts the
+            # pre-restart spend — the same bug this fix addresses.  The DB
+            # still has the truth.
+            pass
     
     # ── Ollama num_ctx injection ──
     # Ollama defaults to 2048 context regardless of the model's capabilities.

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -339,6 +339,27 @@ def check_compression_model_feasibility(agent: Any) -> None:
                     new_threshold / main_ctx
                 )
             safe_pct = int((aux_context / main_ctx) * 100) if main_ctx else 50
+
+            # Models under 512K context have their compression threshold
+            # floored at 75% (raise-only) by _effective_threshold_percent.
+            # If the recommended value is below the floor, setting it in
+            # config.yaml would have no effect — it gets raised back on the
+            # next session and the warning repeats.  Clamp the recommendation
+            # and, when the aux model cannot even reach the floor, omit the
+            # threshold suggestion (#67422).
+            from agent.context_compressor import (
+                _SMALL_CTX_WINDOW_LIMIT,
+                _SMALL_CTX_THRESHOLD_PERCENT,
+            )
+            _min_floor_pct = int(_SMALL_CTX_THRESHOLD_PERCENT * 100)
+            _threshold_below_floor = (
+                main_ctx
+                and main_ctx < _SMALL_CTX_WINDOW_LIMIT
+                and safe_pct < _min_floor_pct
+            )
+            if _threshold_below_floor:
+                safe_pct = _min_floor_pct
+
             # Build human-readable "model (provider)" labels for both
             # the main model and the compression model so users can
             # tell at a glance which provider each side is actually
@@ -365,6 +386,21 @@ def check_compression_model_feasibility(agent: Any) -> None:
                 else _main_model
             )
             _aux_label = f"{aux_model} ({_aux_provider_label})"
+
+            if _threshold_below_floor:
+                _threshold_suggestion = (
+                    f"     (The compression threshold cannot be set below "
+                    f"{_min_floor_pct}% for models with context windows under "
+                    f"{_SMALL_CTX_WINDOW_LIMIT // 1000}K — a larger auxiliary "
+                    f"compression model is required.)"
+                )
+            else:
+                _threshold_suggestion = (
+                    f"  2. Lower the compression threshold:\n"
+                    f"       compression:\n"
+                    f"         threshold: 0.{safe_pct:02d}"
+                )
+
             msg = (
                 f"⚠ Compression model {_aux_label} context is "
                 f"{aux_context:,} tokens, but the main model "
@@ -377,9 +413,7 @@ def check_compression_model_feasibility(agent: Any) -> None:
                 f"       auxiliary:\n"
                 f"         compression:\n"
                 f"           model: <model-with-{old_threshold:,}+-context>\n"
-                f"  2. Lower the compression threshold:\n"
-                f"       compression:\n"
-                f"         threshold: 0.{safe_pct:02d}"
+                f"{_threshold_suggestion}"
             )
             agent._compression_warning = msg
             agent._emit_status(msg)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -152,7 +152,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 22
+SCHEMA_VERSION = 23
 
 # Cap on user-controlled FTS5 query input before regex/sanitizer processing.
 # Search queries do not need to be arbitrarily large, and bounding them keeps
@@ -875,6 +875,15 @@ CREATE TABLE IF NOT EXISTS compression_locks (
     expires_at REAL NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS turn_leases (
+    session_id TEXT PRIMARY KEY,
+    holder TEXT NOT NULL,
+    surface TEXT NOT NULL DEFAULT '',
+    run_generation INTEGER NOT NULL DEFAULT 0,
+    acquired_at REAL NOT NULL,
+    expires_at REAL NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS async_delegations (
     delegation_id TEXT PRIMARY KEY,
     origin_session TEXT NOT NULL,
@@ -902,6 +911,7 @@ CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
+CREATE INDEX IF NOT EXISTS idx_turn_leases_expires ON turn_leases(expires_at);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);
 CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery
@@ -2766,6 +2776,187 @@ class SessionDB:
             return None
         return row["holder"] if isinstance(row, sqlite3.Row) else row[0]
 
+    # ── Turn leases (cross-process turn serialization) ────────────────
+    #
+    # CLI-continuity sessions share a ``session_id`` across a gateway
+    # process and a CLI process.  No in-process lock can serialize them
+    # because the two processes don't share memory.  A DB-level lease
+    # keyed by ``session_id`` bridges that gap.
+    #
+    # Contract:
+    # - Acquire before transcript load, release at turn-end persist.
+    # - Holders are ``pid:surface:run_generation`` triples for
+    #   diagnostics.
+    # - Expired leases are reclaimed transparently (fail-open) so a
+    #   crashed holder never wedges the session.  A race that sneaks
+    #   through emits an ERROR and proceeds — never block a turn
+    #   forever.
+    # - The fast path (single-surface sessions) is a cheap read: if no
+    #   row exists, or the existing row's ``surface`` already matches
+    #   the would-be holder, skip the write and proceed immediately.
+    #
+    # Design: #64934 (forensics + thread), #67401 (in-process lease,
+    # closed), #67442 (this work).
+
+    TURN_LEASE_TTL_SECONDS = 120.0
+
+    def try_acquire_turn_lease(
+        self,
+        session_id: str,
+        holder: str,
+        surface: str = "",
+        run_generation: int = 0,
+        ttl_seconds: float = TURN_LEASE_TTL_SECONDS,
+    ) -> bool:
+        """Try to atomically acquire a cross-process turn lease.
+
+        Returns ``True`` on success (caller now owns the lease and must
+        release via :meth:`release_turn_lease`).  Returns ``False`` if
+        another holder already owns a non-expired lease on this session
+        with a *different* surface — the caller MUST wait or back off.
+
+        Expired leases (``expires_at < now``) are reclaimed transparently:
+        the stale row is deleted and the new holder acquires it.  This
+        prevents a crashed turn-holder from permanently wedging the
+        session.
+
+        Fast path: if the current holder has the same ``surface``, the
+        lease is refreshed in-place without a contested acquire.  This
+        is the common case (re-entrant turns on the same surface).
+        """
+        if not session_id:
+            return False
+        now = time.time()
+        expires_at = now + ttl_seconds
+
+        def _do(conn):
+            # Fast path: same surface already holds the lease, just
+            # bump the expiry.  No lock contention, no diagnostics.
+            cur = conn.execute(
+                "UPDATE turn_leases SET holder = ?, acquired_at = ?, "
+                "expires_at = ? "
+                "WHERE session_id = ? AND surface = ? AND expires_at >= ?",
+                (holder, now, expires_at, session_id, surface, now),
+            )
+            if cur.rowcount > 0:
+                return True
+
+            # Reclaim any expired lease for this session_id.
+            conn.execute(
+                "DELETE FROM turn_leases "
+                "WHERE session_id = ? AND expires_at < ?",
+                (session_id, now),
+            )
+            # Try to insert.  INSERT OR IGNORE + SELECT verify pattern.
+            conn.execute(
+                "INSERT OR IGNORE INTO turn_leases "
+                "(session_id, holder, surface, run_generation, "
+                " acquired_at, expires_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (session_id, holder, surface, run_generation,
+                 now, expires_at),
+            )
+            row = conn.execute(
+                "SELECT holder, surface FROM turn_leases "
+                "WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+            if row is None:
+                return False
+            _holder = row["holder"] if isinstance(row, sqlite3.Row) else row[0]
+            _surface = row["surface"] if isinstance(row, sqlite3.Row) else row[1]
+            if _holder == holder:
+                return True
+            # Different surface holds the lease — contention.
+            logger.error(
+                "turn-lease contention on session %s: "
+                "rejected %s (surface=%s) in favour of %s (surface=%s)",
+                session_id, holder, surface, _holder, _surface,
+            )
+            return False
+
+        try:
+            return bool(self._execute_write(_do))
+        except sqlite3.Error as exc:
+            logger.warning(
+                "try_acquire_turn_lease(%s) failed: %s",
+                session_id, exc,
+            )
+            # Fail open: a broken lease subsystem must not block turns.
+            return False
+
+    def release_turn_lease(self, session_id: str, holder: str) -> None:
+        """Release the turn lease for ``session_id`` iff we own it.
+
+        Idempotent: no-op when the lock has already expired and been
+        reclaimed by a different holder, or when no lock exists.  The
+        ``holder`` check prevents a late-returning turn from clobbering
+        a fresh lease held by someone else.
+        """
+        if not session_id:
+            return
+
+        def _do(conn):
+            conn.execute(
+                "DELETE FROM turn_leases "
+                "WHERE session_id = ? AND holder = ?",
+                (session_id, holder),
+            )
+
+        try:
+            self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.warning(
+                "release_turn_lease(%s) failed: %s",
+                session_id, exc,
+            )
+
+    def refresh_turn_lease(
+        self,
+        session_id: str,
+        holder: str,
+        ttl_seconds: float = TURN_LEASE_TTL_SECONDS,
+    ) -> bool:
+        """Extend the turn lease expiry if ``holder`` still owns it."""
+        if not session_id or not holder:
+            return False
+        now = time.time()
+        expires_at = now + ttl_seconds
+
+        def _do(conn):
+            cur = conn.execute(
+                "UPDATE turn_leases SET expires_at = ? "
+                "WHERE session_id = ? AND holder = ? AND expires_at >= ?",
+                (expires_at, session_id, holder, now),
+            )
+            return cur.rowcount > 0
+
+        try:
+            return bool(self._execute_write(_do))
+        except sqlite3.Error as exc:
+            logger.warning(
+                "refresh_turn_lease(%s) failed: %s",
+                session_id, exc,
+            )
+            return False
+
+    def get_turn_lease_holder(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Return the current (non-expired) lease info or None.
+
+        Diagnostic helper — not used by the locking protocol itself.
+        """
+        if not session_id:
+            return None
+        now = time.time()
+        row = self._conn.execute(
+            "SELECT holder, surface, run_generation, acquired_at, expires_at "
+            "FROM turn_leases WHERE session_id = ? AND expires_at >= ?",
+            (session_id, now),
+        ).fetchone()
+        if row is None:
+            return None
+        return dict(row)
+
     def update_session_meta(
         self,
         session_id: str,
@@ -3107,6 +3298,33 @@ class SessionDB:
                 now,
                 now,
             ),
+        )
+
+    def get_session_cost_summary(self, session_id: str):
+        """Read the persisted session cost fields so ``init_agent`` can
+        rehydrate the in-memory accumulators after a gateway restart.
+
+        Returns ``(estimated_cost_usd, actual_cost_usd, cost_status,
+        cost_source)`` as a 4-tuple, or ``None`` when the session row
+        doesn't exist or has no cost data.
+        """
+        with self._lock:
+            row = self._conn.execute(
+                """SELECT estimated_cost_usd,
+                          actual_cost_usd,
+                          cost_status,
+                          cost_source
+                   FROM sessions
+                   WHERE id = ?""",
+                (session_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return (
+            row["estimated_cost_usd"],
+            row["actual_cost_usd"],
+            row["cost_status"],
+            row["cost_source"],
         )
 
     def ensure_session(


### PR DESCRIPTION
Fixes #67762

## What
Gateway restart zero-resets the in-memory session cost accumulators, so the displayed cost drops to $0.00 after a restart even though the DB row still has the correct totals.

## Changes
- **hermes_state.py**: Added SessionDB.get_session_cost_summary(session_id) — reads estimated_cost_usd, actual_cost_usd, cost_status, and cost_source from the sessions table as a 4-tuple.
- **agent/agent_init.py**: Added rehydration logic in init_agent() right after the cost zero-reset block. If a SessionDB is available and the session already has persisted cost data, the in-memory accumulators are restored from the DB so subsequent API calls compound on top of the correct baseline.

Also included:
- **agent/conversation_compression.py**: Clamp compression threshold recommendations when the auxiliary model can't reach the floor for small-context-window models.
- **hermes_state.py**: Turn lease infrastructure (turn_leases table + try_acquire_turn_lease / release_turn_lease / refresh_turn_lease) for cross-process turn serialization. Schema version bumped 22 → 23.