### PR TITLE
fix(vision): handle windows drive letters in file:// URIs properly

### DIFF
--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -39,6 +39,272 @@ class TestDataUrl:
         assert res.mime == "image/png"
         assert res.origin == "data"
 
+class TestWindowsFileURIParsing:
+    """Helper-level and end-to-end coverage for the file:// URI handler.
+
+    The helper is the chokepoint for Windows drive letters, localhost
+    authority, and remote UNC / device paths. Every assertion below is
+    a direct invariant on what _file_uri_to_path produces — no filesystem
+    is touched (no Path.resolve(), is_file(), stat(), read).
+    """
+
+    # --- happy paths ----------------------------------------------------
+
+    def test_file_uri_to_path_windows(self):
+        from tools.image_source import _file_uri_to_path
+
+        # Standard file URI
+        assert _file_uri_to_path("file:///C:/Users/test/image.png", windows=True) == "C:\\Users\\test\\image.png"
+
+        # Localhost authority (case insensitive)
+        assert _file_uri_to_path("file://localhost/C:/Users/test/image.png", windows=True) == "C:\\Users\\test\\image.png"
+        assert _file_uri_to_path("file://LOCALHOST/C:/Users/test/image.png", windows=True) == "C:\\Users\\test\\image.png"
+
+        # Drive-letter authority (Windows-only)
+        assert _file_uri_to_path("file://C:/image.png", windows=True) == "C:\\image.png"
+
+        # Root-relative path (single leading backslash on the current drive)
+        # — legal, NOT a UNC.
+        assert _file_uri_to_path("file:///images/photo.png", windows=True) == "\\images\\photo.png"
+        assert _file_uri_to_path("file://localhost/images/photo.png", windows=True) == "\\images\\photo.png"
+
+        # Encoded space -> literal space
+        assert _file_uri_to_path("file:///C:/images/a%20b.png", windows=True) == "C:\\images\\a b.png"
+
+        # Double encoded space -> literal %20 (single decode only)
+        assert _file_uri_to_path("file:///C:/images/a%2520b.png", windows=True) == "C:\\images\\a%20b.png"
+
+    def test_file_uri_to_path_posix(self):
+        from tools.image_source import _file_uri_to_path
+
+        # Standard file URI
+        assert _file_uri_to_path("file:///tmp/image.png", windows=False) == "/tmp/image.png"
+
+        # Localhost authority
+        assert _file_uri_to_path("file://localhost/tmp/image.png", windows=False) == "/tmp/image.png"
+
+        # Drive-letter authority is NOT a hostname on POSIX -> rejected
+        with pytest.raises(ValueError, match="Resolving non-local authority 'C:'"):
+            _file_uri_to_path("file://C:/image.png", windows=False)
+
+        # Encoded space
+        assert _file_uri_to_path("file:///tmp/a%20b.png", windows=False) == "/tmp/a b.png"
+
+        # Double encoded space -> literal %20 (single decode only)
+        assert _file_uri_to_path("file:///tmp/a%2520b.png", windows=False) == "/tmp/a%20b.png"
+
+    # --- remote authority rejection (the simple case) -------------------
+
+    def test_remote_authority_rejected_windows(self):
+        from tools.image_source import _file_uri_to_path
+        with pytest.raises(ValueError, match="Resolving non-local authority 'server'"):
+            _file_uri_to_path("file://server/share/image.png", windows=True)
+
+    def test_remote_authority_rejected_posix(self):
+        from tools.image_source import _file_uri_to_path
+        with pytest.raises(ValueError, match="Resolving non-local authority 'server'"):
+            _file_uri_to_path("file://server/share/image.png", windows=False)
+
+    # --- UNC / device-path bypasses that netloc-only checking misses ----
+
+    @pytest.mark.parametrize("uri", [
+        "file:////server/share/image.png",                    # empty netloc + //server
+        "file://localhost//server/share/image.png",           # localhost + //server
+        "file://LOCALHOST//server/share/image.png",           # localhost (case) + //server
+        "file://localhost/%5C%5Cserver/share/image.png",      # localhost + %5C%5C -> \\\\
+        "file:///%2Fserver/share/image.png",                  # empty netloc + %2F -> //
+    ])
+    def test_unc_bypass_blocked_windows(self, uri):
+        """These shapes bypass the netloc check (netloc is empty or
+        localhost), but produce a Windows UNC after url2pathname. They
+        must all be rejected on Windows before any filesystem access."""
+        from tools.image_source import _file_uri_to_path
+        with pytest.raises(ValueError, match="Remote UNC and Windows device paths are not allowed"):
+            _file_uri_to_path(uri, windows=True)
+
+    @pytest.mark.parametrize("uri", [
+        "file:////server/share/image.png",                    # //server decoded as //
+        "file:///%2Fserver/share/image.png",                  # %2F -> //
+        "file://localhost//server/share/image.png",           # //server
+        "file://LOCALHOST//server/share/image.png",
+    ])
+    def test_double_slash_bypass_blocked_posix(self, uri):
+        """POSIX shares the no-leading-// invariant: any URI that resolves
+        to a path starting with ``//`` is rejected as a remote UNC."""
+        from tools.image_source import _file_uri_to_path
+        with pytest.raises(ValueError, match="Remote UNC and Windows device paths are not allowed"):
+            _file_uri_to_path(uri, windows=False)
+
+    # --- drive-relative paths are rejected BEFORE nturl2path ------------
+    #
+    # The check runs on a single-pass decoded copy of the encoded path, so
+    # it does not depend on ``nturl2path.url2pathname`` behavior — which
+    # changed between Python 3.11 and 3.13 (3.11 silently rewrites
+    # ``C:image.png`` to ``C:\\image.png``; 3.13 returns the raw
+    # drive-relative ``C:image.png``). The contract here is stable across
+    # versions: any URI that decodes to ``/X:foo`` (drive + colon + no
+    # separator, or end of path) is rejected.
+    #
+    # Percent-encoded colon forms (``%3A``) are rejected by a separate
+    # check that fires on the raw encoded path *before* percent-decoding
+    # (see ``test_percent_encoded_drive_delimiter_blocked``).
+
+    @pytest.mark.parametrize("uri", [
+        "file:///C:image.png",                # empty netloc, raw colon
+        "file://localhost/C:image.png",       # localhost netloc, raw colon
+        "file:///C:",                         # trailing colon, no body
+    ])
+    def test_drive_relative_blocked_windows(self, uri):
+        """A drive-relative URI resolves against the current directory on
+        the named drive — reject it from a vision input so we never
+        silently depend on the host's cwd."""
+        from tools.image_source import _file_uri_to_path
+        with pytest.raises(ValueError, match="Drive-relative file URI paths are not allowed"):
+            _file_uri_to_path(uri, windows=True)
+
+    # --- percent-encoded drive delimiter rejection --------------------
+
+    @pytest.mark.parametrize("uri", [
+        "file:///C%3Aimage.png",               # encoded colon, no separator
+        "file://localhost/C%3Aimage.png",      # localhost + encoded colon
+        "file:///C%3A/image.png",               # encoded colon + slash
+        "file:///C%3A%2Fimage.png",             # encoded colon + encoded slash
+        "file://localhost/C%3A/image.png",      # localhost + encoded colon + slash
+        "file://localhost/C%3A%2Fimage.png",    # localhost + encoded colon + encoded slash
+    ])
+    def test_percent_encoded_drive_delimiter_blocked(self, uri):
+        """Percent-encoded colon in a drive-letter position produces
+        version-dependent results from nturl2path — reject outright
+        before reaching the stdlib."""
+        from tools.image_source import _file_uri_to_path
+        with pytest.raises(ValueError, match="Percent-encoded Windows drive delimiters"):
+            _file_uri_to_path(uri, windows=True)
+
+    # --- drive-absolute literals are accepted with precise output ----
+
+    @pytest.mark.parametrize("uri, expected", [
+        ("file:///C:/image.png",            "C:\\image.png"),
+        ("file://localhost/C:/image.png",   "C:\\image.png"),
+        ("file://C:/image.png",             "C:\\image.png"),
+        ("file:///C:/image%20one.png",      "C:\\image one.png"),
+    ])
+    def test_drive_absolute_or_root_relative_allowed_windows(self, uri, expected):
+        """Only literal ``:`` + separator forms are stable across Python
+        versions — assert the exact expected path."""
+        from tools.image_source import _file_uri_to_path
+        assert _file_uri_to_path(uri, windows=True) == expected
+
+    # --- "file:logo.png" must NOT enter the helper ----------------------
+
+    @pytest.mark.asyncio
+    async def test_bare_file_colon_name_is_treated_as_path(self, tmp_path, monkeypatch):
+        """A POSIX filename containing a literal colon (e.g. ``file:logo.png``)
+        is a legitimate local path; the URI helper must not be invoked.
+
+        This test passes the literal string ``"file:logo.png"`` so that
+        widening the entry condition back to ``startswith("file:")`` would
+        route it through the URI helper and fail (the helper raises
+        ValueError because ``file:logo.png`` parses with netloc=``file``
+        and path=``logo.png`` — not ``file://`` — and netloc ``file`` is
+        not localhost). The chdir + tmp_path layout mirrors how a real
+        cwd-relative bare filename would resolve."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.chdir(tmp_path)
+
+        img = tmp_path / "file:logo.png"
+        img.write_bytes(PNG)
+
+        res = await isrc.resolve_image_source(
+            "file:logo.png",
+            isrc.ResolveContext(),
+        )
+        assert res.data == PNG
+        assert res.origin == "file"
+
+    # --- end-to-end: UNC bypasses become SourceNotFound -----------------
+
+    @pytest.mark.asyncio
+    async def test_full_resolution_flow_remote_authority_rejected(self, tmp_path, monkeypatch):
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+
+        with pytest.raises(isrc.SourceNotFound) as exc_info:
+            await isrc.resolve_image_source("file://server/share/image.png", isrc.ResolveContext())
+
+        # Verify the underlying ValueError is retained as __cause__
+        assert exc_info.value.__cause__ is not None
+        assert isinstance(exc_info.value.__cause__, ValueError)
+        assert "Resolving non-local authority 'server'" in str(exc_info.value.__cause__)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("uri", [
+        "file:////server/share/image.png",
+        "file://localhost//server/share/image.png",
+        "file://LOCALHOST//server/share/image.png",
+        "file://localhost/%5C%5Cserver/share/image.png",
+        "file:///%2Fserver/share/image.png",
+    ])
+    async def test_full_resolution_flow_unc_bypass_rejected(self, tmp_path, monkeypatch, uri):
+        """UNC bypasses wrapped by resolve_image_source must surface as
+        SourceNotFound with a ValueError __cause__, and the rejection
+        must occur BEFORE any filesystem read."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        with pytest.raises(isrc.SourceNotFound) as exc_info:
+            await isrc.resolve_image_source(uri, isrc.ResolveContext())
+
+        assert exc_info.value.__cause__ is not None
+        assert isinstance(exc_info.value.__cause__, ValueError)
+        assert "Remote UNC" in str(exc_info.value.__cause__)
+
+    @pytest.mark.asyncio
+    async def test_full_resolution_flow_drive_relative_rejected(self, tmp_path, monkeypatch):
+        """A drive-relative URI wrapped by resolve_image_source must
+        surface as SourceNotFound with a ValueError __cause__ carrying
+        the drive-relative message — never as an open file read against
+        the host's cwd.
+
+        The helper defaults to ``windows=platform.system()``, so a
+        pure-POSIX runner would treat ``file:///C:image.png`` as a
+        POSIX path (``/C:image.png``) and never enter the drive-relative
+        rejection branch. Monkey-patch ``_file_uri_to_path`` to force
+        Windows semantics so the rejection is exercised on every OS."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        real_helper = isrc._file_uri_to_path
+
+        monkeypatch.setattr(
+            isrc,
+            "_file_uri_to_path",
+            lambda uri: real_helper(uri, windows=True),
+        )
+
+        with pytest.raises(isrc.SourceNotFound) as exc_info:
+            await isrc.resolve_image_source(
+                "file:///C:image.png",
+                isrc.ResolveContext(),
+            )
+
+        assert isinstance(exc_info.value.__cause__, ValueError)
+        assert "Drive-relative" in str(exc_info.value.__cause__)
+
+    @pytest.mark.asyncio
+    async def test_full_resolution_flow(self, tmp_path, monkeypatch):
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+
+        test_img = tmp_path / "test image.png"
+        test_img.write_bytes(PNG)
+
+        # Windows path representation of tmp_path
+        file_uri = test_img.as_uri()
+
+        # Full end-to-end integration ensures signature is compatible
+        # Returned object is ResolvedImage
+        res = await isrc.resolve_image_source(file_uri, isrc.ResolveContext())
+        assert res.data == PNG
+
     @pytest.mark.asyncio
     async def test_non_image_data_url_rejected(self, tmp_path, monkeypatch):
         isrc = _reload(monkeypatch, tmp_path / "hermes")

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -55,6 +55,272 @@ class TestDataUrl:
         assert res.mime == "image/png"
         assert res.origin == "data"
 
+class TestWindowsFileURIParsing:
+    """Helper-level and end-to-end coverage for the file:// URI handler.
+
+    The helper is the chokepoint for Windows drive letters, localhost
+    authority, and remote UNC / device paths. Every assertion below is
+    a direct invariant on what _file_uri_to_path produces — no filesystem
+    is touched (no Path.resolve(), is_file(), stat(), read).
+    """
+
+    # --- happy paths ----------------------------------------------------
+
+    def test_file_uri_to_path_windows(self):
+        from tools.image_source import _file_uri_to_path
+
+        # Standard file URI
+        assert _file_uri_to_path("file:///C:/Users/test/image.png", windows=True) == "C:\\Users\\test\\image.png"
+
+        # Localhost authority (case insensitive)
+        assert _file_uri_to_path("file://localhost/C:/Users/test/image.png", windows=True) == "C:\\Users\\test\\image.png"
+        assert _file_uri_to_path("file://LOCALHOST/C:/Users/test/image.png", windows=True) == "C:\\Users\\test\\image.png"
+
+        # Drive-letter authority (Windows-only)
+        assert _file_uri_to_path("file://C:/image.png", windows=True) == "C:\\image.png"
+
+        # Root-relative path (single leading backslash on the current drive)
+        # — legal, NOT a UNC.
+        assert _file_uri_to_path("file:///images/photo.png", windows=True) == "\\images\\photo.png"
+        assert _file_uri_to_path("file://localhost/images/photo.png", windows=True) == "\\images\\photo.png"
+
+        # Encoded space -> literal space
+        assert _file_uri_to_path("file:///C:/images/a%20b.png", windows=True) == "C:\\images\\a b.png"
+
+        # Double encoded space -> literal %20 (single decode only)
+        assert _file_uri_to_path("file:///C:/images/a%2520b.png", windows=True) == "C:\\images\\a%20b.png"
+
+    def test_file_uri_to_path_posix(self):
+        from tools.image_source import _file_uri_to_path
+
+        # Standard file URI
+        assert _file_uri_to_path("file:///tmp/image.png", windows=False) == "/tmp/image.png"
+
+        # Localhost authority
+        assert _file_uri_to_path("file://localhost/tmp/image.png", windows=False) == "/tmp/image.png"
+
+        # Drive-letter authority is NOT a hostname on POSIX -> rejected
+        with pytest.raises(ValueError, match="Resolving non-local authority 'C:'"):
+            _file_uri_to_path("file://C:/image.png", windows=False)
+
+        # Encoded space
+        assert _file_uri_to_path("file:///tmp/a%20b.png", windows=False) == "/tmp/a b.png"
+
+        # Double encoded space -> literal %20 (single decode only)
+        assert _file_uri_to_path("file:///tmp/a%2520b.png", windows=False) == "/tmp/a%20b.png"
+
+    # --- remote authority rejection (the simple case) -------------------
+
+    def test_remote_authority_rejected_windows(self):
+        from tools.image_source import _file_uri_to_path
+        with pytest.raises(ValueError, match="Resolving non-local authority 'server'"):
+            _file_uri_to_path("file://server/share/image.png", windows=True)
+
+    def test_remote_authority_rejected_posix(self):
+        from tools.image_source import _file_uri_to_path
+        with pytest.raises(ValueError, match="Resolving non-local authority 'server'"):
+            _file_uri_to_path("file://server/share/image.png", windows=False)
+
+    # --- UNC / device-path bypasses that netloc-only checking misses ----
+
+    @pytest.mark.parametrize("uri", [
+        "file:////server/share/image.png",                    # empty netloc + //server
+        "file://localhost//server/share/image.png",           # localhost + //server
+        "file://LOCALHOST//server/share/image.png",           # localhost (case) + //server
+        "file://localhost/%5C%5Cserver/share/image.png",      # localhost + %5C%5C -> \\\\
+        "file:///%2Fserver/share/image.png",                  # empty netloc + %2F -> //
+    ])
+    def test_unc_bypass_blocked_windows(self, uri):
+        """These shapes bypass the netloc check (netloc is empty or
+        localhost), but produce a Windows UNC after url2pathname. They
+        must all be rejected on Windows before any filesystem access."""
+        from tools.image_source import _file_uri_to_path
+        with pytest.raises(ValueError, match="Remote UNC and Windows device paths are not allowed"):
+            _file_uri_to_path(uri, windows=True)
+
+    @pytest.mark.parametrize("uri", [
+        "file:////server/share/image.png",                    # //server decoded as //
+        "file:///%2Fserver/share/image.png",                  # %2F -> //
+        "file://localhost//server/share/image.png",           # //server
+        "file://LOCALHOST//server/share/image.png",
+    ])
+    def test_double_slash_bypass_blocked_posix(self, uri):
+        """POSIX shares the no-leading-// invariant: any URI that resolves
+        to a path starting with ``//`` is rejected as a remote UNC."""
+        from tools.image_source import _file_uri_to_path
+        with pytest.raises(ValueError, match="Remote UNC and Windows device paths are not allowed"):
+            _file_uri_to_path(uri, windows=False)
+
+    # --- drive-relative paths are rejected BEFORE nturl2path ------------
+    #
+    # The check runs on a single-pass decoded copy of the encoded path, so
+    # it does not depend on ``nturl2path.url2pathname`` behavior — which
+    # changed between Python 3.11 and 3.13 (3.11 silently rewrites
+    # ``C:image.png`` to ``C:\\image.png``; 3.13 returns the raw
+    # drive-relative ``C:image.png``). The contract here is stable across
+    # versions: any URI that decodes to ``/X:foo`` (drive + colon + no
+    # separator, or end of path) is rejected.
+    #
+    # Percent-encoded colon forms (``%3A``) are rejected by a separate
+    # check that fires on the raw encoded path *before* percent-decoding
+    # (see ``test_percent_encoded_drive_delimiter_blocked``).
+
+    @pytest.mark.parametrize("uri", [
+        "file:///C:image.png",                # empty netloc, raw colon
+        "file://localhost/C:image.png",       # localhost netloc, raw colon
+        "file:///C:",                         # trailing colon, no body
+    ])
+    def test_drive_relative_blocked_windows(self, uri):
+        """A drive-relative URI resolves against the current directory on
+        the named drive — reject it from a vision input so we never
+        silently depend on the host's cwd."""
+        from tools.image_source import _file_uri_to_path
+        with pytest.raises(ValueError, match="Drive-relative file URI paths are not allowed"):
+            _file_uri_to_path(uri, windows=True)
+
+    # --- percent-encoded drive delimiter rejection --------------------
+
+    @pytest.mark.parametrize("uri", [
+        "file:///C%3Aimage.png",               # encoded colon, no separator
+        "file://localhost/C%3Aimage.png",      # localhost + encoded colon
+        "file:///C%3A/image.png",               # encoded colon + slash
+        "file:///C%3A%2Fimage.png",             # encoded colon + encoded slash
+        "file://localhost/C%3A/image.png",      # localhost + encoded colon + slash
+        "file://localhost/C%3A%2Fimage.png",    # localhost + encoded colon + encoded slash
+    ])
+    def test_percent_encoded_drive_delimiter_blocked(self, uri):
+        """Percent-encoded colon in a drive-letter position produces
+        version-dependent results from nturl2path — reject outright
+        before reaching the stdlib."""
+        from tools.image_source import _file_uri_to_path
+        with pytest.raises(ValueError, match="Percent-encoded Windows drive delimiters"):
+            _file_uri_to_path(uri, windows=True)
+
+    # --- drive-absolute literals are accepted with precise output ----
+
+    @pytest.mark.parametrize("uri, expected", [
+        ("file:///C:/image.png",            "C:\\image.png"),
+        ("file://localhost/C:/image.png",   "C:\\image.png"),
+        ("file://C:/image.png",             "C:\\image.png"),
+        ("file:///C:/image%20one.png",      "C:\\image one.png"),
+    ])
+    def test_drive_absolute_or_root_relative_allowed_windows(self, uri, expected):
+        """Only literal ``:`` + separator forms are stable across Python
+        versions — assert the exact expected path."""
+        from tools.image_source import _file_uri_to_path
+        assert _file_uri_to_path(uri, windows=True) == expected
+
+    # --- "file:logo.png" must NOT enter the helper ----------------------
+
+    @pytest.mark.asyncio
+    async def test_bare_file_colon_name_is_treated_as_path(self, tmp_path, monkeypatch):
+        """A POSIX filename containing a literal colon (e.g. ``file:logo.png``)
+        is a legitimate local path; the URI helper must not be invoked.
+
+        This test passes the literal string ``"file:logo.png"`` so that
+        widening the entry condition back to ``startswith("file:")`` would
+        route it through the URI helper and fail (the helper raises
+        ValueError because ``file:logo.png`` parses with netloc=``file``
+        and path=``logo.png`` — not ``file://`` — and netloc ``file`` is
+        not localhost). The chdir + tmp_path layout mirrors how a real
+        cwd-relative bare filename would resolve."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.chdir(tmp_path)
+
+        img = tmp_path / "file:logo.png"
+        img.write_bytes(PNG)
+
+        res = await isrc.resolve_image_source(
+            "file:logo.png",
+            isrc.ResolveContext(),
+        )
+        assert res.data == PNG
+        assert res.origin == "file"
+
+    # --- end-to-end: UNC bypasses become SourceNotFound -----------------
+
+    @pytest.mark.asyncio
+    async def test_full_resolution_flow_remote_authority_rejected(self, tmp_path, monkeypatch):
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+
+        with pytest.raises(isrc.SourceNotFound) as exc_info:
+            await isrc.resolve_image_source("file://server/share/image.png", isrc.ResolveContext())
+
+        # Verify the underlying ValueError is retained as __cause__
+        assert exc_info.value.__cause__ is not None
+        assert isinstance(exc_info.value.__cause__, ValueError)
+        assert "Resolving non-local authority 'server'" in str(exc_info.value.__cause__)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("uri", [
+        "file:////server/share/image.png",
+        "file://localhost//server/share/image.png",
+        "file://LOCALHOST//server/share/image.png",
+        "file://localhost/%5C%5Cserver/share/image.png",
+        "file:///%2Fserver/share/image.png",
+    ])
+    async def test_full_resolution_flow_unc_bypass_rejected(self, tmp_path, monkeypatch, uri):
+        """UNC bypasses wrapped by resolve_image_source must surface as
+        SourceNotFound with a ValueError __cause__, and the rejection
+        must occur BEFORE any filesystem read."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        with pytest.raises(isrc.SourceNotFound) as exc_info:
+            await isrc.resolve_image_source(uri, isrc.ResolveContext())
+
+        assert exc_info.value.__cause__ is not None
+        assert isinstance(exc_info.value.__cause__, ValueError)
+        assert "Remote UNC" in str(exc_info.value.__cause__)
+
+    @pytest.mark.asyncio
+    async def test_full_resolution_flow_drive_relative_rejected(self, tmp_path, monkeypatch):
+        """A drive-relative URI wrapped by resolve_image_source must
+        surface as SourceNotFound with a ValueError __cause__ carrying
+        the drive-relative message — never as an open file read against
+        the host's cwd.
+
+        The helper defaults to ``windows=platform.system()``, so a
+        pure-POSIX runner would treat ``file:///C:image.png`` as a
+        POSIX path (``/C:image.png``) and never enter the drive-relative
+        rejection branch. Monkey-patch ``_file_uri_to_path`` to force
+        Windows semantics so the rejection is exercised on every OS."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        real_helper = isrc._file_uri_to_path
+
+        monkeypatch.setattr(
+            isrc,
+            "_file_uri_to_path",
+            lambda uri: real_helper(uri, windows=True),
+        )
+
+        with pytest.raises(isrc.SourceNotFound) as exc_info:
+            await isrc.resolve_image_source(
+                "file:///C:image.png",
+                isrc.ResolveContext(),
+            )
+
+        assert isinstance(exc_info.value.__cause__, ValueError)
+        assert "Drive-relative" in str(exc_info.value.__cause__)
+
+    @pytest.mark.asyncio
+    async def test_full_resolution_flow(self, tmp_path, monkeypatch):
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+
+        test_img = tmp_path / "test image.png"
+        test_img.write_bytes(PNG)
+
+        # Windows path representation of tmp_path
+        file_uri = test_img.as_uri()
+
+        # Full end-to-end integration ensures signature is compatible
+        # Returned object is ResolvedImage
+        res = await isrc.resolve_image_source(file_uri, isrc.ResolveContext())
+        assert res.data == PNG
+
     @pytest.mark.asyncio
     async def test_non_image_data_url_rejected(self, tmp_path, monkeypatch):
         isrc = _reload(monkeypatch, tmp_path / "hermes")

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -888,3 +888,62 @@ class TestVisionCpuBurstCap:
             f"analyses were serialized to the cap (peak={calls_peak}); only the "
             "encode burst should be bounded, not the whole call"
         )
+
+
+# ---------------------------------------------------------------------------
+# video_analyze_tool — file:// URI resolution & regression tests
+# ---------------------------------------------------------------------------
+
+
+class TestVideoAnalyzeFileURI:
+    @pytest.mark.asyncio
+    async def test_video_analyze_uses_shared_file_uri_parser(self, tmp_path):
+        """video_analyze_tool must invoke _file_uri_to_path on file:// URIs."""
+        from tools.image_source import _file_uri_to_path
+        from tools.vision_tools import video_analyze_tool
+
+        video_file = tmp_path / "sample.mp4"
+        video_file.write_bytes(b"\x00\x00\x00\x18ftypmp42" + b"\x00" * 32)
+        uri = f"file://{video_file.as_posix()}"
+
+        mock_resp = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Video analysis result"
+        mock_resp.choices = [mock_choice]
+
+        with (
+            patch("tools.vision_tools._file_uri_to_path", wraps=_file_uri_to_path) as mock_parser,
+            patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock, return_value=mock_resp),
+        ):
+            res_str = await video_analyze_tool(uri, "Describe video")
+            res = json.loads(res_str)
+
+        assert res["success"] is True
+        assert res["analysis"] == "Video analysis result"
+        mock_parser.assert_called_once_with(uri)
+
+    @pytest.mark.asyncio
+    async def test_video_analyze_windows_drive_letter_not_naive_truncated(self):
+        """Windows file:///C:/... URI must resolve via _file_uri_to_path, not manual slicing to /C:/..."""
+        from tools.vision_tools import video_analyze_tool
+
+        with patch("tools.vision_tools._file_uri_to_path", return_value="C:\\videos\\test.mp4") as mock_parser:
+            with patch("pathlib.Path.is_file", return_value=False):
+                res_str = await video_analyze_tool("file:///C:/videos/test.mp4", "prompt")
+                res = json.loads(res_str)
+
+        mock_parser.assert_called_once_with("file:///C:/videos/test.mp4")
+        assert res["success"] is False
+        assert "Invalid video source" in res["error"]
+
+    @pytest.mark.asyncio
+    async def test_video_analyze_invalid_file_uri_security_rejection(self):
+        """Non-local authority file:// URI is rejected without unhandled exception."""
+        from tools.vision_tools import video_analyze_tool
+
+        res_str = await video_analyze_tool("file://remote-server/share/video.mp4", "prompt")
+        res = json.loads(res_str)
+
+        assert res["success"] is False
+        assert "Resolving non-local authority" in res["error"]
+

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -898,29 +898,59 @@ class TestVisionCpuBurstCap:
 class TestVideoAnalyzeFileURI:
     @pytest.mark.asyncio
     async def test_video_analyze_uses_shared_file_uri_parser(self, tmp_path):
-        """video_analyze_tool must invoke _file_uri_to_path on file:// URIs."""
-        from tools.image_source import _file_uri_to_path
+        """video_analyze_tool must resolve file:// URIs via _file_uri_to_path and read real file bytes."""
         from tools.vision_tools import video_analyze_tool
 
+        raw_bytes = b"\x00\x00\x00\x18ftypmp42" + b"\x00" * 32
         video_file = tmp_path / "sample.mp4"
-        video_file.write_bytes(b"\x00\x00\x00\x18ftypmp42" + b"\x00" * 32)
-        uri = f"file://{video_file.as_posix()}"
+        video_file.write_bytes(raw_bytes)
+        uri = video_file.as_uri()
 
         mock_resp = MagicMock()
         mock_choice = MagicMock()
         mock_choice.message.content = "Video analysis result"
         mock_resp.choices = [mock_choice]
 
-        with (
-            patch("tools.vision_tools._file_uri_to_path", wraps=_file_uri_to_path) as mock_parser,
-            patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock, return_value=mock_resp),
-        ):
+        with patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock, return_value=mock_resp) as mock_llm:
             res_str = await video_analyze_tool(uri, "Describe video")
             res = json.loads(res_str)
 
         assert res["success"] is True
         assert res["analysis"] == "Video analysis result"
-        mock_parser.assert_called_once_with(uri)
+
+        # Verify call to async_call_llm received real base64-encoded bytes matching raw_bytes
+        mock_llm.assert_awaited_once()
+        call_kwargs = mock_llm.await_args.kwargs
+        messages = call_kwargs["messages"]
+        video_block = messages[0]["content"][1]
+        assert video_block["type"] == "video_url"
+        data_url = video_block["video_url"]["url"]
+        assert data_url.startswith("data:video/mp4;base64,")
+        b64_part = data_url.partition(",")[2]
+        decoded = base64.b64decode(b64_part)
+        assert decoded == raw_bytes
+
+    @pytest.mark.asyncio
+    async def test_video_analyze_plain_local_path(self, tmp_path):
+        """video_analyze_tool must continue to support plain local OS paths."""
+        from tools.vision_tools import video_analyze_tool
+
+        raw_bytes = b"\x00\x00\x00\x18ftypmp42" + b"\x00" * 16
+        video_file = tmp_path / "plain_video.mp4"
+        video_file.write_bytes(raw_bytes)
+
+        mock_resp = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Plain path result"
+        mock_resp.choices = [mock_choice]
+
+        with patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock, return_value=mock_resp) as mock_llm:
+            res_str = await video_analyze_tool(str(video_file), "Describe plain video")
+            res = json.loads(res_str)
+
+        assert res["success"] is True
+        assert res["analysis"] == "Plain path result"
+        mock_llm.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_video_analyze_windows_drive_letter_not_naive_truncated(self):
@@ -946,4 +976,5 @@ class TestVideoAnalyzeFileURI:
 
         assert res["success"] is False
         assert "Resolving non-local authority" in res["error"]
+
 

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -1126,3 +1126,62 @@ class TestVisionCpuBurstCap:
             f"analyses were serialized to the cap (peak={calls_peak}); only the "
             "encode burst should be bounded, not the whole call"
         )
+
+
+# ---------------------------------------------------------------------------
+# video_analyze_tool — file:// URI resolution & regression tests
+# ---------------------------------------------------------------------------
+
+
+class TestVideoAnalyzeFileURI:
+    @pytest.mark.asyncio
+    async def test_video_analyze_uses_shared_file_uri_parser(self, tmp_path):
+        """video_analyze_tool must invoke _file_uri_to_path on file:// URIs."""
+        from tools.image_source import _file_uri_to_path
+        from tools.vision_tools import video_analyze_tool
+
+        video_file = tmp_path / "sample.mp4"
+        video_file.write_bytes(b"\x00\x00\x00\x18ftypmp42" + b"\x00" * 32)
+        uri = f"file://{video_file.as_posix()}"
+
+        mock_resp = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Video analysis result"
+        mock_resp.choices = [mock_choice]
+
+        with (
+            patch("tools.vision_tools._file_uri_to_path", wraps=_file_uri_to_path) as mock_parser,
+            patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock, return_value=mock_resp),
+        ):
+            res_str = await video_analyze_tool(uri, "Describe video")
+            res = json.loads(res_str)
+
+        assert res["success"] is True
+        assert res["analysis"] == "Video analysis result"
+        mock_parser.assert_called_once_with(uri)
+
+    @pytest.mark.asyncio
+    async def test_video_analyze_windows_drive_letter_not_naive_truncated(self):
+        """Windows file:///C:/... URI must resolve via _file_uri_to_path, not manual slicing to /C:/..."""
+        from tools.vision_tools import video_analyze_tool
+
+        with patch("tools.vision_tools._file_uri_to_path", return_value="C:\\videos\\test.mp4") as mock_parser:
+            with patch("pathlib.Path.is_file", return_value=False):
+                res_str = await video_analyze_tool("file:///C:/videos/test.mp4", "prompt")
+                res = json.loads(res_str)
+
+        mock_parser.assert_called_once_with("file:///C:/videos/test.mp4")
+        assert res["success"] is False
+        assert "Invalid video source" in res["error"]
+
+    @pytest.mark.asyncio
+    async def test_video_analyze_invalid_file_uri_security_rejection(self):
+        """Non-local authority file:// URI is rejected without unhandled exception."""
+        from tools.vision_tools import video_analyze_tool
+
+        res_str = await video_analyze_tool("file://remote-server/share/video.mp4", "prompt")
+        res = json.loads(res_str)
+
+        assert res["success"] is False
+        assert "Resolving non-local authority" in res["error"]
+

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -1136,29 +1136,59 @@ class TestVisionCpuBurstCap:
 class TestVideoAnalyzeFileURI:
     @pytest.mark.asyncio
     async def test_video_analyze_uses_shared_file_uri_parser(self, tmp_path):
-        """video_analyze_tool must invoke _file_uri_to_path on file:// URIs."""
-        from tools.image_source import _file_uri_to_path
+        """video_analyze_tool must resolve file:// URIs via _file_uri_to_path and read real file bytes."""
         from tools.vision_tools import video_analyze_tool
 
+        raw_bytes = b"\x00\x00\x00\x18ftypmp42" + b"\x00" * 32
         video_file = tmp_path / "sample.mp4"
-        video_file.write_bytes(b"\x00\x00\x00\x18ftypmp42" + b"\x00" * 32)
-        uri = f"file://{video_file.as_posix()}"
+        video_file.write_bytes(raw_bytes)
+        uri = video_file.as_uri()
 
         mock_resp = MagicMock()
         mock_choice = MagicMock()
         mock_choice.message.content = "Video analysis result"
         mock_resp.choices = [mock_choice]
 
-        with (
-            patch("tools.vision_tools._file_uri_to_path", wraps=_file_uri_to_path) as mock_parser,
-            patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock, return_value=mock_resp),
-        ):
+        with patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock, return_value=mock_resp) as mock_llm:
             res_str = await video_analyze_tool(uri, "Describe video")
             res = json.loads(res_str)
 
         assert res["success"] is True
         assert res["analysis"] == "Video analysis result"
-        mock_parser.assert_called_once_with(uri)
+
+        # Verify call to async_call_llm received real base64-encoded bytes matching raw_bytes
+        mock_llm.assert_awaited_once()
+        call_kwargs = mock_llm.await_args.kwargs
+        messages = call_kwargs["messages"]
+        video_block = messages[0]["content"][1]
+        assert video_block["type"] == "video_url"
+        data_url = video_block["video_url"]["url"]
+        assert data_url.startswith("data:video/mp4;base64,")
+        b64_part = data_url.partition(",")[2]
+        decoded = base64.b64decode(b64_part)
+        assert decoded == raw_bytes
+
+    @pytest.mark.asyncio
+    async def test_video_analyze_plain_local_path(self, tmp_path):
+        """video_analyze_tool must continue to support plain local OS paths."""
+        from tools.vision_tools import video_analyze_tool
+
+        raw_bytes = b"\x00\x00\x00\x18ftypmp42" + b"\x00" * 16
+        video_file = tmp_path / "plain_video.mp4"
+        video_file.write_bytes(raw_bytes)
+
+        mock_resp = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Plain path result"
+        mock_resp.choices = [mock_choice]
+
+        with patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock, return_value=mock_resp) as mock_llm:
+            res_str = await video_analyze_tool(str(video_file), "Describe plain video")
+            res = json.loads(res_str)
+
+        assert res["success"] is True
+        assert res["analysis"] == "Plain path result"
+        mock_llm.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_video_analyze_windows_drive_letter_not_naive_truncated(self):
@@ -1184,4 +1214,3 @@ class TestVideoAnalyzeFileURI:
 
         assert res["success"] is False
         assert "Resolving non-local authority" in res["error"]
-

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -92,6 +92,112 @@ class ResolvedImage:
 _SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.\-]*://")
 
 
+def _file_uri_to_path(uri: str, *, windows: bool | None = None) -> str:
+    """
+    Parse a ``file://`` URI into a local OS path with strict authority handling.
+
+    Rules:
+        * Empty authority or ``localhost`` (case-insensitive) is local.
+        * Windows only: an authority matching ``[A-Za-z]:`` is treated as a
+          drive-letter part of the path (not as a remote host).
+        * Every other non-empty authority is rejected as a non-local
+          authority (would map to ``\\\\host\\share`` on Windows or to a
+          remote path on POSIX).
+        * Windows only: a drive-relative URI — one whose path begins with
+          a drive letter and no separator (e.g. ``C:image.png`` or the
+          percent-encoded ``C%3Aimage.png``) — is rejected *before* the
+          path is handed to ``nturl2path.url2pathname``. ``stdlib``
+          behavior for that helper changed across Python 3.11 → 3.13
+          (3.11 silently rewrites it to ``C:\\image.png``, 3.13 returns
+          the raw drive-relative ``C:image.png``); we reject in both
+          cases for a stable, version-independent contract.
+        * After platform-specific percent-decoding and path conversion,
+          the result is checked again: on Windows, anything starting
+          with two or more backslashes is a UNC or device-path shape
+          and is rejected; on POSIX, anything starting with ``//`` or
+          ``\\\\`` is rejected. A single leading backslash on Windows
+          is a root-relative path on the current drive and is legal.
+
+    No filesystem access (no ``Path.resolve()``, ``is_file()``, ``stat()``,
+    or read) happens here — the check fires before the path is handed to
+    :func:`resolve_image_source`'s downstream readers.
+    """
+    from urllib.parse import urlparse, unquote
+    import platform
+    import re as _re
+
+    if windows is None:
+        windows = platform.system() == "Windows"
+
+    # Pre-normalize backslashes so ``file://C:\\foo`` parses cleanly.
+    parsed = urlparse(uri.replace("\\", "/"))
+
+    # Drive-letter authority is only meaningful on Windows. POSIX must
+    # reject ``file://C:/...`` outright — ``C:`` is not a hostname there.
+    is_drive_authority = bool(
+        windows and _re.fullmatch(r"[A-Za-z]:", parsed.netloc or "")
+    )
+
+    if parsed.netloc and parsed.netloc.lower() != "localhost" and not is_drive_authority:
+        raise ValueError(
+            f"Resolving non-local authority '{parsed.netloc}' in file:// URI "
+            "is not allowed for security."
+        )
+
+    # Re-stitch the path if ``urlparse`` ate the drive letter into the netloc.
+    path_part = ("/" + parsed.netloc + parsed.path) if is_drive_authority else parsed.path
+
+    if windows:
+        # Reject percent-encoded drive delimiters (``%3A`` / ``%3a``)
+        # because ``nturl2path.url2pathname`` identifies the literal
+        # colon BEFORE percent-decoding — the result of e.g.
+        # ``file:///C%3A%2Fimage.png`` differs across Python 3.11 →
+        # 3.13. The check fires on the raw encoded ``path_part`` so it
+        # does not depend on stdlib behavior.
+        if _re.match(r"^/[A-Za-z]%3[Aa]", path_part):
+            raise ValueError(
+                "Percent-encoded Windows drive delimiters are not supported"
+            )
+        # Validate drive-relative shape on a single-pass decoded copy.
+        # Pattern: leading ``/`` + ASCII drive letter + ``:`` + EITHER
+        # nothing OR a non-separator character. This catches
+        # ``/C:foo`` (raw) and rejects it before any stdlib version-
+        # dependent conversion.
+        validation_path = unquote(path_part).replace("\\", "/")
+        if _re.match(r"^/[A-Za-z]:(?:$|[^/])", validation_path):
+            raise ValueError(
+                "Drive-relative file URI paths are not allowed"
+            )
+        import nturl2path
+        converted = nturl2path.url2pathname(path_part)
+        # ``url2pathname`` does a single percent-decode. The Windows
+        # output is a backslash path. Compute a normalized form for
+        # the security check so mixed ``\\`` / ``/`` (e.g. from an
+        # encoded ``%2F`` slipping through) doesn't mask a leading
+        # double-backslash. UNC (``\\\\server\\share``), device paths
+        # (``\\\\?\\C:\\...``, ``\\\\.\\COM1``), and any 3+ backslash
+        # variant all start with ``\\\\``. A single leading backslash
+        # is a root-relative path on the current drive and is legal.
+        security_path = converted.replace("/", "\\")
+        if security_path.startswith("\\\\"):
+            raise ValueError(
+                "Remote UNC and Windows device paths are not allowed"
+            )
+        return converted
+
+    # POSIX: emulate ``urllib.request.url2pathname`` so the helper is
+    # deterministic on Linux CI (where ``url2pathname`` would dispatch to
+    # ``nturl2path`` on a Windows host). Reject any leading ``//`` or
+    # ``\\\\`` — both shapes can be smuggled through empty / localhost
+    # authority + encoded slashes.
+    converted = unquote(path_part)
+    if converted.startswith("//") or converted.startswith("\\\\"):
+        raise ValueError(
+            "Remote UNC and Windows device paths are not allowed"
+        )
+    return converted
+
+
 async def resolve_image_source(
     src: str,
     ctx: ResolveContext,
@@ -119,7 +225,18 @@ async def resolve_image_source(
 
     # Everything else is a filesystem path — including bare relative names
     # like "pic.png" (accepted on main; a path-shape gate here regressed them).
-    candidate = s[len("file://"):] if s.lower().startswith("file://") else s
+    # Only treat the input as a file:// URI when it actually starts with the
+    # authority-bearing ``file://`` prefix; bare ``file:foo`` is a legitimate
+    # POSIX filename ("file:logo.png") and must NOT enter the URI helper.
+    candidate = s
+    if s.lower().startswith("file://"):
+        try:
+            candidate = _file_uri_to_path(s)
+        except ValueError as exc:
+            raise SourceNotFound(f"Invalid file URI: {s}", src=s) from exc
+        except OSError as exc:
+            raise SourceNotFound(f"Invalid file URI: {s}", src=s) from exc
+
     p = Path(os.path.expanduser(candidate))
     # Confinement decision (see module docstring). Under a non-local backend
     # a path is host-readable ONLY if it lands in a media cache (after

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -50,6 +50,112 @@ class ResolvedImage:
 _SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.\-]*://")
 
 
+def _file_uri_to_path(uri: str, *, windows: bool | None = None) -> str:
+    """
+    Parse a ``file://`` URI into a local OS path with strict authority handling.
+
+    Rules:
+        * Empty authority or ``localhost`` (case-insensitive) is local.
+        * Windows only: an authority matching ``[A-Za-z]:`` is treated as a
+          drive-letter part of the path (not as a remote host).
+        * Every other non-empty authority is rejected as a non-local
+          authority (would map to ``\\\\host\\share`` on Windows or to a
+          remote path on POSIX).
+        * Windows only: a drive-relative URI — one whose path begins with
+          a drive letter and no separator (e.g. ``C:image.png`` or the
+          percent-encoded ``C%3Aimage.png``) — is rejected *before* the
+          path is handed to ``nturl2path.url2pathname``. ``stdlib``
+          behavior for that helper changed across Python 3.11 → 3.13
+          (3.11 silently rewrites it to ``C:\\image.png``, 3.13 returns
+          the raw drive-relative ``C:image.png``); we reject in both
+          cases for a stable, version-independent contract.
+        * After platform-specific percent-decoding and path conversion,
+          the result is checked again: on Windows, anything starting
+          with two or more backslashes is a UNC or device-path shape
+          and is rejected; on POSIX, anything starting with ``//`` or
+          ``\\\\`` is rejected. A single leading backslash on Windows
+          is a root-relative path on the current drive and is legal.
+
+    No filesystem access (no ``Path.resolve()``, ``is_file()``, ``stat()``,
+    or read) happens here — the check fires before the path is handed to
+    :func:`resolve_image_source`'s downstream readers.
+    """
+    from urllib.parse import urlparse, unquote
+    import platform
+    import re as _re
+
+    if windows is None:
+        windows = platform.system() == "Windows"
+
+    # Pre-normalize backslashes so ``file://C:\\foo`` parses cleanly.
+    parsed = urlparse(uri.replace("\\", "/"))
+
+    # Drive-letter authority is only meaningful on Windows. POSIX must
+    # reject ``file://C:/...`` outright — ``C:`` is not a hostname there.
+    is_drive_authority = bool(
+        windows and _re.fullmatch(r"[A-Za-z]:", parsed.netloc or "")
+    )
+
+    if parsed.netloc and parsed.netloc.lower() != "localhost" and not is_drive_authority:
+        raise ValueError(
+            f"Resolving non-local authority '{parsed.netloc}' in file:// URI "
+            "is not allowed for security."
+        )
+
+    # Re-stitch the path if ``urlparse`` ate the drive letter into the netloc.
+    path_part = ("/" + parsed.netloc + parsed.path) if is_drive_authority else parsed.path
+
+    if windows:
+        # Reject percent-encoded drive delimiters (``%3A`` / ``%3a``)
+        # because ``nturl2path.url2pathname`` identifies the literal
+        # colon BEFORE percent-decoding — the result of e.g.
+        # ``file:///C%3A%2Fimage.png`` differs across Python 3.11 →
+        # 3.13. The check fires on the raw encoded ``path_part`` so it
+        # does not depend on stdlib behavior.
+        if _re.match(r"^/[A-Za-z]%3[Aa]", path_part):
+            raise ValueError(
+                "Percent-encoded Windows drive delimiters are not supported"
+            )
+        # Validate drive-relative shape on a single-pass decoded copy.
+        # Pattern: leading ``/`` + ASCII drive letter + ``:`` + EITHER
+        # nothing OR a non-separator character. This catches
+        # ``/C:foo`` (raw) and rejects it before any stdlib version-
+        # dependent conversion.
+        validation_path = unquote(path_part).replace("\\", "/")
+        if _re.match(r"^/[A-Za-z]:(?:$|[^/])", validation_path):
+            raise ValueError(
+                "Drive-relative file URI paths are not allowed"
+            )
+        import nturl2path
+        converted = nturl2path.url2pathname(path_part)
+        # ``url2pathname`` does a single percent-decode. The Windows
+        # output is a backslash path. Compute a normalized form for
+        # the security check so mixed ``\\`` / ``/`` (e.g. from an
+        # encoded ``%2F`` slipping through) doesn't mask a leading
+        # double-backslash. UNC (``\\\\server\\share``), device paths
+        # (``\\\\?\\C:\\...``, ``\\\\.\\COM1``), and any 3+ backslash
+        # variant all start with ``\\\\``. A single leading backslash
+        # is a root-relative path on the current drive and is legal.
+        security_path = converted.replace("/", "\\")
+        if security_path.startswith("\\\\"):
+            raise ValueError(
+                "Remote UNC and Windows device paths are not allowed"
+            )
+        return converted
+
+    # POSIX: emulate ``urllib.request.url2pathname`` so the helper is
+    # deterministic on Linux CI (where ``url2pathname`` would dispatch to
+    # ``nturl2path`` on a Windows host). Reject any leading ``//`` or
+    # ``\\\\`` — both shapes can be smuggled through empty / localhost
+    # authority + encoded slashes.
+    converted = unquote(path_part)
+    if converted.startswith("//") or converted.startswith("\\\\"):
+        raise ValueError(
+            "Remote UNC and Windows device paths are not allowed"
+        )
+    return converted
+
+
 async def resolve_image_source(
     src: str, ctx: ResolveContext, *, permitted: tuple = ("image",)) -> ResolvedImage:
     if not isinstance(src, str) or not src.strip():
@@ -67,10 +173,19 @@ async def resolve_image_source(
         raise UnsupportedScheme(
             "Unrecognized image source scheme. Use an http(s) URL, a local "
             "file path, a file:// URI, or a data: URL.",
-            src=s)
+            src=s,
+        )
     # Everything else is a filesystem path — including bare relative names like "pic.png"
-    # (a path-shape gate here regressed them once).
-    candidate = s[len("file://"):] if s.lower().startswith("file://") else s
+    # (a path-shape gate here regressed them once). Only treat the input as a file:// URI
+    # when it starts with the authority-bearing ``file://`` prefix; bare ``file:foo`` is a
+    # legitimate POSIX filename and must NOT enter the URI helper.
+    candidate = s
+    if s.lower().startswith("file://"):
+        try:
+            candidate = _file_uri_to_path(s)
+        except (ValueError, OSError) as exc:
+            raise SourceNotFound(f"Invalid file URI: {s}", src=s) from exc
+
     p = Path(os.path.expanduser(candidate))
     host_target = _permitted_host_read_target(p, ctx)
     if host_target is not None and host_target.is_file():

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -64,6 +64,7 @@ def _load_auxiliary_client() -> None:
 
 from hermes_constants import get_hermes_dir
 from tools.debug_helpers import DebugSession
+from tools.image_source import _file_uri_to_path
 from tools.website_policy import check_website_access
 import sys
 
@@ -1687,10 +1688,10 @@ async def video_analyze_tool(
         logger.info("User prompt: %s", user_prompt[:100])
 
         # Resolve local path vs remote URL
-        resolved_url = video_url
-        if resolved_url.startswith("file://"):
-            resolved_url = resolved_url[len("file://"):]
-        local_path = Path(os.path.expanduser(resolved_url))
+        if video_url.lower().startswith("file://"):
+            local_path = Path(_file_uri_to_path(video_url))
+        else:
+            local_path = Path(os.path.expanduser(video_url))
 
         if local_path.is_file():
             from agent.file_safety import raise_if_read_blocked

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -35,6 +35,7 @@ def _load_auxiliary_client() -> None:
 
 from hermes_constants import get_hermes_dir
 from tools.debug_helpers import DebugSession
+from tools.image_source import _file_uri_to_path
 from tools.website_policy import check_website_access
 from tools.vision_tools_image_prep import (
     _VISION_MAX_VALIDATED_AGGREGATE_PIXELS,
@@ -938,7 +939,15 @@ async def _materialize_video(video_url: str, task_id: Optional[str], temp_paths:
     from tools.image_source import (
         ImageResolutionError, ResolveContext, _is_local_terminal_backend, resolve_image_source,
     )
-    source = video_url.removeprefix("file://")
+    # ``file://`` URIs go through the shared parser (authority + drive-letter
+    # handling); naive prefix-slicing leaves ``/C:/...`` on Windows.
+    if video_url.lower().startswith("file://"):
+        try:
+            source = _file_uri_to_path(video_url)
+        except (ValueError, OSError) as exc:
+            raise ValueError(f"Invalid video source URI: {exc}") from exc
+    else:
+        source = video_url
     local_path = Path(os.path.expanduser(source))
     lowered = (video_url or "").strip().lower()
     path_like = bool(lowered) and not lowered.startswith(("http://", "https://", "data:"))


### PR DESCRIPTION
## Summary

Fixes `vision_analyze` failing to read local images on Windows when supplied as `file://` URIs containing drive letters (e.g. `file:///C:/path/to/image.png`), and applies the same parser to `video_analyze`.

Root cause: the old code used naive string slicing (`s[len("file://"):]`) to strip the URI prefix. On Windows this produced `/C:/path/...` instead of the OS-native `C:\path\...`. Python `Path.is_file()` returned `False` for the malformed path, and the resolver fell through to `SourceNotFound`. `video_analyze_tool` carried the same bug via `video_url.removeprefix("file://")`.

This PR adds a new helper `_file_uri_to_path` that uses `urllib.parse.urlparse` + `nturl2path.url2pathname` (Windows) / `urllib.parse.unquote` (POSIX) to parse `file://` URIs correctly, with layered security checks that fire **before** any filesystem access, and routes both the image resolver and the video resolver through it.

---

## Design

### Allowed authorities

| Authority | Platforms | Example |
|-----------|-----------|---------|
| empty (three slashes) | all | `file:///C:/path` |
| `localhost` (case-insensitive) | all | `file://localhost/C:/path` |
| Drive letter `[A-Za-z]:` | Windows only | `file://C:/path` |

Everything else — `file://server/...`, `file://192.168.1.1/...` — is rejected as a non-local authority.

### Explicitly rejected shapes

* **Non-local authority** — `file://server/share/image.png` → `ValueError`

* **UNC / device-path bypasses** — the five forms that smuggle a remote target through empty or `localhost` authority + encoded slashes are all caught **after** path conversion by checking for leading `\` (Windows) or `//` / `\` (POSIX):

  ```
  file:////server/share/image.png
  file://localhost//server/share/image.png
  file://LOCALHOST//server/share/image.png
  file://localhost/%5C%5Cserver/share/image.png
  file:///%2Fserver/share/image.png
  ```

* **Drive-relative paths** — `file:///C:image.png` (no separator after `C:`) is rejected **before** `nturl2path` gets it, because `stdlib` behaviour for this shape changed between Python 3.11 → 3.13

* **Percent-encoded drive delimiters** — `file:///C%3A/image.png` and variants are rejected with a dedicated message, because `nturl2path` identifies the literal `:` before percent-decoding, making the result version-dependent

### Other invariants

* Percent-encoding is decoded exactly once (we never double-decode; `%2520` stays as literal `%20`)
* A single leading backslash on Windows (`\images\photo.png`) is a legal root-relative path — only **two or more** backslashes trigger UNC rejection
* Bare `file:logo.png` (no `//`) is a legitimate POSIX filename and does **not** enter the URI helper

---

## Files changed

* `tools/image_source.py` (+118/−3) — adds the `_file_uri_to_path` helper + routes `resolve_image_source` through it when the input starts with `file://`
* `tools/vision_tools.py` (+10/−1) — `_materialize_video` parses `file://` video sources with the same helper instead of `removeprefix("file://")`
* `tests/tools/test_image_source.py` (+266) — authority / UNC / drive-relative / percent-encode matrix
* `tests/tools/test_vision_tools.py` (+88) — `TestVideoAnalyzeFileURI`: shared-parser use, plain local path, Windows drive letter, non-local authority rejection, plus an unmocked end-to-end run over `Path.as_uri()`

---

## Rebase / conflict resolution (2026-09-11)

`main` moved ~6.7k commits past this branch's base and refactored the vision/video path (44 commits touching these files). The 3 commits were rebased onto current `main` (`6c3d4a4af7`) — PR is now mergeable, no merge commit added, authorship preserved.

* `tools/image_source.py` — kept this PR's helper + call site; absorbed main's reformatting of the neighbouring `UnsupportedScheme` raise.
* `tools/vision_tools.py` — main extracted `video_analyze_tool`'s inline body into `_materialize_video()`, which still did the naive `removeprefix("file://")`. Took main's structure and wired the shared parser into `_materialize_video` (failures surface as `Invalid video source URI: ...`), rather than re-adding the old inline block.

---

## Test results (Windows 10, Python 3.11.15, HEAD `0d1df29`)

| Suite | Result |
|-------|--------|
| `tests/tools/test_image_source.py` | 54 passed |
| `tests/tools/test_vision_tools.py` | 41 passed |
| `tests/tools -k "vision or image or media"` | 23 failed / 433 passed — **identical failure set** to the `origin/main` baseline (23 failed / 394 passed), i.e. all failures pre-exist on main, none introduced |
| `ruff check` (`[tool.ruff.lint.select]`) | clean |

RED check: reverting both call sites to the naive prefix strip makes **11 of the new tests fail** on Windows, so the new tests genuinely pin the bug.

Linux CI results are pending — fork PRs need a maintainer to approve the workflow run.
