### PR TITLE
test(gateway): stabilize cross-platform gateway tests

### DIFF
--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -338,13 +338,24 @@ class TestRunBackgroundTask:
             await runner._run_background_task("make stuff", source, "bg_test")
 
             mock_adapter.send_voice.assert_called_once()
-            assert mock_adapter.send_voice.call_args.kwargs["audio_path"] == _ogg
+            # The media validator resolves the supplied path before delivery.
+            # On macOS, tempfile exposes /var as a symlink to /private/var,
+            # so compare file identity instead of two equivalent spellings.
+            assert _os.path.samefile(
+                mock_adapter.send_voice.call_args.kwargs["audio_path"], _ogg
+            )
             mock_adapter.send_video.assert_called_once()
-            assert mock_adapter.send_video.call_args.kwargs["video_path"] == _mp4
+            assert _os.path.samefile(
+                mock_adapter.send_video.call_args.kwargs["video_path"], _mp4
+            )
             mock_adapter.send_image_file.assert_called_once()
-            assert mock_adapter.send_image_file.call_args.kwargs["image_path"] == _png
+            assert _os.path.samefile(
+                mock_adapter.send_image_file.call_args.kwargs["image_path"], _png
+            )
             mock_adapter.send_document.assert_called_once()
-            assert mock_adapter.send_document.call_args.kwargs["file_path"] == _pdf
+            assert _os.path.samefile(
+                mock_adapter.send_document.call_args.kwargs["file_path"], _pdf
+            )
         finally:
             import shutil as _shutil
             _shutil.rmtree(_tmpdir, ignore_errors=True)

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -613,8 +613,11 @@ class TestBusySessionAck:
         assert "10 min" in content  # elapsed
 
     @pytest.mark.asyncio
-    async def test_telegram_omits_status_detail_by_default(self):
+    async def test_telegram_omits_status_detail_by_default(self, monkeypatch):
         """Telegram busy acks stay concise unless busy_ack_detail is enabled."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
         runner, sentinel = _make_runner()
         runner._busy_input_mode = "interrupt"
         adapter = _make_adapter()

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -37,10 +37,16 @@ from gateway.platforms.base import (
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_event(text="hello", chat_id="123", platform_val="telegram"):
+def _make_event(
+    text="hello", chat_id="123", platform_val: str | Platform = "telegram"
+):
     """Build a minimal MessageEvent."""
     source = SessionSource(
-        platform=MagicMock(value=platform_val),
+        platform=(
+            platform_val
+            if isinstance(platform_val, Platform)
+            else MagicMock(value=platform_val)
+        ),
         chat_id=chat_id,
         chat_type="private",
         user_id="user1",
@@ -582,7 +588,7 @@ class TestBusySessionAck:
         runner._busy_input_mode = "interrupt"
         adapter = _make_adapter()
 
-        event = _make_event(text="yo")
+        event = _make_event(text="yo", platform_val=Platform.TELEGRAM)
         sk = build_session_key(event.source)
 
         agent = MagicMock()
@@ -613,7 +619,7 @@ class TestBusySessionAck:
         runner._busy_input_mode = "interrupt"
         adapter = _make_adapter()
 
-        event = _make_event(text="yo")
+        event = _make_event(text="yo", platform_val=Platform.TELEGRAM)
         sk = build_session_key(event.source)
 
         agent = MagicMock()

--- a/tests/gateway/test_memory_monitor.py
+++ b/tests/gateway/test_memory_monitor.py
@@ -91,17 +91,25 @@ def test_periodic_timer_fires(caplog):
     caplog.set_level(logging.INFO, logger="gateway.memory_monitor")
     # Short interval so we can observe multiple ticks inside the test budget.
     mm.start_memory_monitoring(interval_seconds=0.1)
-    time.sleep(0.45)
+
+    def periodic_records():
+        # Bare "[MEMORY] rss=..." lines only: baseline and shutdown snapshots
+        # carry a prefix tag so they don't match this strict prefix.
+        return [
+            r for r in caplog.records
+            if r.getMessage().startswith("[MEMORY] rss=")
+        ]
+
+    # Wait on the observable condition instead of a fixed sleep: macOS timer
+    # coalescing stretches Event.wait(0.1) to ~0.25s, so a fixed wall-clock
+    # budget makes the tick count nondeterministic.  The contract is
+    # unchanged: the background timer must keep firing on its own.
+    deadline = time.monotonic() + 5.0
+    while len(periodic_records()) < 3 and time.monotonic() < deadline:
+        time.sleep(0.02)
     mm.stop_memory_monitoring(timeout=1.0)
 
-    periodic = [
-        r for r in caplog.records
-        if r.getMessage().startswith("[MEMORY] rss=") or r.getMessage().startswith("[MEMORY] rss=unavailable")
-    ]
-    # baseline + at least 2 periodic + shutdown — but shutdown has the
-    # "shutdown " prefix so it won't match the strict "[MEMORY] rss=" start.
-    # We expect >= 3 bare "[MEMORY] rss=..." lines.
-    assert len(periodic) >= 3, [r.getMessage() for r in caplog.records]
+    assert len(periodic_records()) >= 3, [r.getMessage() for r in caplog.records]
 
 
 def test_thread_is_daemon():

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -88,7 +88,12 @@ def make_startup_runner(tmp_path):
     runner.hooks.discover_and_load = MagicMock()
     runner.hooks.emit = AsyncMock()
     runner.session_store = MagicMock()
-    runner.session_store.suspend_recently_active.return_value = 0
+    # Startup-race tests only exercise adapter lifecycle.  Bypass the real
+    # AsyncSessionStore thread-pool facade so unrelated executor contention
+    # cannot delay the race past its platform-connect boundary.
+    runner._async_session_store = MagicMock()
+    runner._async_session_store._store = runner.session_store
+    runner._async_session_store.suspend_recently_active = AsyncMock(return_value=0)
     runner.delivery_router = MagicMock()
     runner.delivery_router.adapters = {}
 
@@ -167,7 +172,10 @@ async def test_startup_aborts_when_restart_begins_during_platform_connect(tmp_pa
     telegram.disconnect = disconnect_and_release
     runner._create_adapter = MagicMock(side_effect=[telegram, slack])
 
-    result = await asyncio.wait_for(runner.start(), timeout=2)
+    # Startup imports and shutdown cleanup can legitimately take longer under
+    # the full-suite scheduler; this test asserts lifecycle ordering, not a
+    # two-second performance budget.
+    result = await asyncio.wait_for(runner.start(), timeout=10)
 
     assert result is True
     assert telegram.disconnected is True

--- a/tests/gateway/test_systemd_notify.py
+++ b/tests/gateway/test_systemd_notify.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import socket
+import sys
 
 import pytest
 
@@ -31,7 +32,8 @@ def test_notify_sends_real_unix_datagram(tmp_path, monkeypatch):
 
 
 @pytest.mark.skipif(
-    not hasattr(socket, "AF_UNIX"), reason="Unix datagram sockets are unavailable"
+    sys.platform != "linux" or not hasattr(socket, "AF_UNIX"),
+    reason="systemd abstract Unix sockets are Linux-only",
 )
 def test_notify_supports_systemd_abstract_socket(monkeypatch):
     name = "\0hermes-test-notify"

--- a/tests/gateway/test_systemd_notify.py
+++ b/tests/gateway/test_systemd_notify.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 import socket
 import sys
+import tempfile
 
 import pytest
 
@@ -17,18 +19,20 @@ def test_notify_without_notify_socket_is_a_noop(monkeypatch):
     assert notify("READY=1") is False
 
 
-def test_notify_sends_real_unix_datagram(tmp_path, monkeypatch):
-    address = str(tmp_path / "notify.sock")
-    receiver = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-    receiver.bind(address)
-    receiver.settimeout(1.0)
-    monkeypatch.setenv("NOTIFY_SOCKET", address)
+def test_notify_sends_real_unix_datagram(monkeypatch):
+    # macOS has a short AF_UNIX pathname limit; pytest's tmp_path can exceed it.
+    # The nested context managers close the receiver before removing its socket.
+    with tempfile.TemporaryDirectory(dir="/tmp", prefix="h-") as socket_dir:
+        address = str(Path(socket_dir) / "n")
+        with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as receiver:
+            receiver.bind(address)
+            receiver.settimeout(1.0)
+            monkeypatch.setenv("NOTIFY_SOCKET", address)
 
-    from gateway.systemd_notify import notify
+            from gateway.systemd_notify import notify
 
-    assert notify("READY=1") is True
-    assert receiver.recv(4096) == b"READY=1"
-    receiver.close()
+            assert notify("READY=1") is True
+            assert receiver.recv(4096) == b"READY=1"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary
- make filesystem and Unix-socket assertions portable across macOS/Linux
- isolate restart fixture and busy-ACK defaults from ambient configuration
- replace timer-dependent memory monitor sleep with observable condition waiting

## Validation
- `scripts/run_tests.sh -q tests/gateway/test_background_command.py tests/gateway/test_memory_monitor.py tests/gateway/test_systemd_notify.py tests/gateway/test_startup_restart_race.py tests/gateway/test_busy_session_ack.py`
  - 74 passed, 1 skipped
- repeated memory/startup race runs: pass
- `ruff check` and `git diff --check`: pass

No runtime behavior changes.