### PR TITLE
fix(discord): make bot admission config-authoritative

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1384,12 +1384,14 @@ def load_gateway_config() -> GatewayConfig:
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
                 if plat == Platform.DISCORD:
-                    # Only allow_bots and bots_require_inline_mention have a
-                    # runtime env-var reader. group_mention_role_ids /
-                    # group_mention_channel_ids are consumed from
-                    # PlatformConfig.extra (see the discord adapter's
-                    # _discord_group_role_mentioned) and have no env reader, so
-                    # they are bridged into ``extra`` below but NOT to os.environ.
+                    # Force-sync to os.environ only the keys with env-only
+                    # cross-module consumers: allow_bots (authz_mixin bot
+                    # bypass, relay policy, history context) and
+                    # bots_require_inline_mention. thread_require_mention and
+                    # group_mention_role_ids / group_mention_channel_ids are
+                    # read from PlatformConfig.extra by the discord adapter
+                    # alone (config-extra-first), so they are bridged into
+                    # ``extra`` below but NOT forced into os.environ.
                     discord_env_bridge = {
                         "allow_bots": "DISCORD_ALLOW_BOTS",
                         "bots_require_inline_mention": "DISCORD_BOTS_REQUIRE_INLINE_MENTION",

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1383,6 +1383,46 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["allowed_topics"] = platform_cfg["allowed_topics"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
+                if plat == Platform.DISCORD:
+                    # Only allow_bots and bots_require_inline_mention have a
+                    # runtime env-var reader. group_mention_role_ids /
+                    # group_mention_channel_ids are consumed from
+                    # PlatformConfig.extra (see the discord adapter's
+                    # _discord_group_role_mentioned) and have no env reader, so
+                    # they are bridged into ``extra`` below but NOT to os.environ.
+                    discord_env_bridge = {
+                        "allow_bots": "DISCORD_ALLOW_BOTS",
+                        "bots_require_inline_mention": "DISCORD_BOTS_REQUIRE_INLINE_MENTION",
+                    }
+                    for key in (
+                        "allow_bots",
+                        "bots_require_inline_mention",
+                        "thread_require_mention",
+                        "group_mention_role_ids",
+                        "group_mention_channel_ids",
+                    ):
+                        if key in platform_cfg:
+                            bridged[key] = platform_cfg[key]
+                            env_key = discord_env_bridge.get(key)
+                            if env_key:
+                                # config.yaml is authoritative: force-sync the
+                                # value into os.environ, overwriting any stale or
+                                # conflicting shell value, so the env-only
+                                # consumers -- authz_mixin's bot bypass, the relay
+                                # policy builder, and the adapter's history
+                                # context assembler -- resolve the same policy as
+                                # the config-first admission gate. When the key is
+                                # absent from config the env var is left as the
+                                # intended fallback (the guard is on ``key in
+                                # platform_cfg`` above, not on the env presence).
+                                value = platform_cfg[key]
+                                # Match the adapter's str(...).lower() so a YAML
+                                # bool True serializes as "true", not "True".
+                                os.environ[env_key] = (
+                                    str(value).lower()
+                                    if isinstance(value, bool)
+                                    else str(value)
+                                )
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "exclusive_bot_mentions" in platform_cfg:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2531,7 +2531,7 @@ DEFAULT_CONFIG = {
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
-        "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
+        "thread_require_mention": False,  # If True, close the in-thread shortcut for bot-authored (allow_bots: all) follow-ups; humans always follow the parent channel policy
         "bots_require_inline_mention": False,  # Multi-bot rooms: if True, another bot must type @thisbot in its message to trigger a reply; a Discord reply/quote alone won't. Prevents two bots auto-replying to each other forever. Does not affect humans.
         "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2159,13 +2159,21 @@ class DiscordAdapter(BasePlatformAdapter):
             parent_id = self._get_parent_channel_id(message.channel)
             channel_keys = self._discord_channel_keys(message, parent_id)
             free_channels = self._discord_free_response_channels()
+            # Group-role handoffs are an address mechanism for human authors
+            # only. Keep this aligned with the live and final handler gates:
+            # a sibling bot must type a real inline self-mention even when
+            # allow_bots=all and inline mentions are otherwise optional.
+            role_handoff = (
+                not bool(getattr(getattr(message, "author", None), "bot", False))
+                and self._discord_group_role_mentioned(message, parent_id)
+            )
             if (
                 self._discord_require_mention()
                 and "*" not in free_channels
                 and not (channel_keys & free_channels)
                 and not self._discord_is_voice_linked_channel(message)
                 and not self._self_is_explicitly_mentioned(message)
-                and not self._discord_group_role_mentioned(message, parent_id)
+                and not role_handoff
             ):
                 return False
         admitted, role_authorized = self._discord_message_admission(

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1355,7 +1355,13 @@ class DiscordAdapter(BasePlatformAdapter):
         )
         if not admitted:
             if getattr(getattr(message, "author", None), "bot", False):
-                logger.info(
+                # A denied bot message that explicitly addressed us (an
+                # attempted handoff) is worth INFO; ambient bot chatter denied
+                # by the default policy would flood INFO on busy servers.
+                logger.log(
+                    logging.INFO
+                    if self._self_is_explicitly_mentioned(message)
+                    else logging.DEBUG,
                     "[Discord] Bot admission rejected: message_id=%s author_id=%s "
                     "allow_bots=%s explicit_mention=%s raw_inline_mention=%s",
                     getattr(message, "id", "-"),
@@ -5772,10 +5778,13 @@ class DiscordAdapter(BasePlatformAdapter):
         """
         content = getattr(message, "content", "") or ""
         ids = {match.group(1) for match in re.finditer(r"<@!?(\d+)>", content)}
-        # discord.py retains the parsed raw IDs even when an upstream relay
-        # normalizes message.content before this adapter sees it. Prefer the
-        # union so reply-pings still remain absent unless Discord recorded an
-        # actual mention token.
+        # discord.py's Message.raw_mentions is itself regex-parsed from
+        # message.content (and cached on first access), so on live objects the
+        # union is redundant but harmless. It matters for relayed or synthetic
+        # messages that carry raw_mentions as plain data while their content
+        # was normalized. Neither source ever contains a reply-ping (those
+        # only appear in the resolved mentions list), so the union can never
+        # loosen the inline-mention gate.
         raw_mentions = getattr(message, "raw_mentions", None)
         if isinstance(raw_mentions, (list, tuple, set)):
             ids.update(str(mention_id) for mention_id in raw_mentions)
@@ -5916,16 +5925,21 @@ class DiscordAdapter(BasePlatformAdapter):
         return keys
 
     def _discord_thread_require_mention(self) -> bool:
-        """Return whether thread participation requires @mention to follow up.
+        """Return whether the in-thread participation shortcut is disabled.
 
-        When ``False`` (default), once the bot has participated in a thread it
-        keeps responding to every message in that thread without needing to be
-        mentioned again — useful for one-on-one conversations.
+        This knob only governs the ``in_bot_thread`` bypass inside
+        ``_handle_message``. Since the admission hardening, that bypass is
+        live-reachable only by messages ``_discord_message_admission`` admits
+        WITHOUT a mention -- in practice bot-authored messages under
+        ``allow_bots: all`` (no inline-mention requirement). Human thread
+        messages are gated earlier, at admission, purely by the parent
+        channel's policy (free parent -> free thread; non-free parent ->
+        mention required), so this setting has no effect on humans.
 
-        When ``True``, the @mention requirement is enforced inside threads as
-        well.  Set this when multiple bots share a thread and you want each
-        one to only fire on explicit @mention, avoiding bot-to-bot loops or
-        unwanted cross-replies.
+        When ``False`` (default), an admitted mention-free bot message in a
+        thread this bot already participates in still gets a response. Set
+        ``True`` to close that residual shortcut so sibling bots must type an
+        explicit inline mention even inside participated threads.
         """
         configured = self.config.extra.get("thread_require_mention")
         if configured is not None:
@@ -7153,9 +7167,13 @@ class DiscordAdapter(BasePlatformAdapter):
         recovered: bool = False,
     ) -> bool:
         """Handle one Discord message and report whether it reached dispatch."""
-        # In server channels (not DMs), require the bot to be @mentioned
-        # UNLESS the channel is in the free-response list or the message is
-        # in a thread where the bot has already participated.
+        # Secondary, defense-in-depth mention gate. Live and recovered
+        # dispatch both ran _discord_message_admission first, which already
+        # gates human messages purely by the parent channel's policy (a
+        # non-free parent requires a mention even in threads the bot has
+        # participated in). The in_bot_thread shortcut below is therefore
+        # live-reachable without a mention only by bot-authored traffic
+        # admitted under allow_bots: all.
         #
         # Config (all settable via discord.* in config.yaml or DISCORD_* env vars):
         #   discord.require_mention: Require @mention in server channels (default: true)
@@ -7229,11 +7247,12 @@ class DiscordAdapter(BasePlatformAdapter):
                 or is_voice_linked_channel
             )
 
-            # Skip the mention check if the message is in a thread where
-            # the bot has previously participated (auto-created or replied in)
-            # — UNLESS thread_require_mention is enabled, in which case threads
-            # are gated the same as channels.  Useful when multiple bots share
-            # a thread.
+            # In-thread participation shortcut for THIS gate only: admission
+            # has already denied unmentioned human messages under a non-free
+            # parent, so the only live traffic that reaches this bypass
+            # without a mention is bot-authored (allow_bots: all).
+            # thread_require_mention=true closes that residual shortcut so
+            # sibling bots must mention explicitly even in shared threads.
             in_bot_thread = (
                 is_thread
                 and thread_id in self._threads

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1266,8 +1266,19 @@ class DiscordAdapter(BasePlatformAdapter):
 
         role_authorized = False
         if getattr(message.author, "bot", False):
-            allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
-            if allow_bots == "none":
+            # allow_bots resolution is config-authoritative: config.extra
+            # (config.yaml) wins over the DISCORD_ALLOW_BOTS env var; the env var
+            # is only the fallback for deployments that never set it in config
+            # (see _discord_allow_bots). The gateway boot bridge force-syncs
+            # config -> env so the env-only cross-module consumers (authz_mixin
+            # bot bypass, relay policy) resolve the same value and cannot
+            # split-brain from this gate. Do not flip this precedence.
+            allow_bots = self._discord_allow_bots()
+            # Strict fail-closed enum: only "mentions" and "all" admit bots.
+            # Any other value -- "none", "false", empty, or a typo -- denies,
+            # matching the fail-closed checks in relay/__init__.py and
+            # authz_mixin.py. Never fall through to "all" for an unknown value.
+            if allow_bots not in {"mentions", "all"}:
                 return False, False
             if allow_bots == "mentions" and not self._self_is_explicitly_mentioned(message):
                 return False, False
@@ -1280,6 +1291,7 @@ class DiscordAdapter(BasePlatformAdapter):
             msg_guild = getattr(message, "guild", None)
             is_dm = isinstance(message.channel, discord.DMChannel) or msg_guild is None
             msg_channel_ids = None
+            parent_id = None
             if not is_dm:
                 msg_channel_ids = {str(message.channel.id)}
                 parent_id = self._get_parent_channel_id(message.channel)
@@ -1295,6 +1307,17 @@ class DiscordAdapter(BasePlatformAdapter):
                 self._warn_if_fail_closed_default()
                 return False, False
             role_authorized = bool(getattr(self, "_allowed_role_ids", set()))
+            if not is_dm and self._discord_require_mention():
+                free_channels = self._discord_free_response_channels()
+                channel_keys = self._discord_channel_keys(message, parent_id)
+                if (
+                    "*" not in free_channels
+                    and not (channel_keys & free_channels)
+                    and not self._discord_is_voice_linked_channel(message)
+                    and not self._self_is_explicitly_mentioned(message)
+                    and not self._discord_group_role_mentioned(message, parent_id)
+                ):
+                    return False, False
 
         raw_self_mention = self._self_is_explicitly_mentioned(message)
         if not isinstance(message.channel, discord.DMChannel) and (
@@ -1331,6 +1354,16 @@ class DiscordAdapter(BasePlatformAdapter):
             message, claim=True,
         )
         if not admitted:
+            if getattr(getattr(message, "author", None), "bot", False):
+                logger.info(
+                    "[Discord] Bot admission rejected: message_id=%s author_id=%s "
+                    "allow_bots=%s explicit_mention=%s raw_inline_mention=%s",
+                    getattr(message, "id", "-"),
+                    getattr(getattr(message, "author", None), "id", "-"),
+                    self._discord_allow_bots(),
+                    self._self_is_explicitly_mentioned(message),
+                    self._self_is_raw_mentioned(message),
+                )
             return False
         return await self._handle_message(
             message, role_authorized=role_authorized,
@@ -2120,17 +2153,13 @@ class DiscordAdapter(BasePlatformAdapter):
             parent_id = self._get_parent_channel_id(message.channel)
             channel_keys = self._discord_channel_keys(message, parent_id)
             free_channels = self._discord_free_response_channels()
-            in_bot_thread = (
-                isinstance(message.channel, discord.Thread)
-                and str(message.channel.id) in self._threads
-                and not self._discord_thread_require_mention()
-            )
             if (
                 self._discord_require_mention()
                 and "*" not in free_channels
                 and not (channel_keys & free_channels)
-                and not in_bot_thread
+                and not self._discord_is_voice_linked_channel(message)
                 and not self._self_is_explicitly_mentioned(message)
+                and not self._discord_group_role_mentioned(message, parent_id)
             ):
                 return False
         admitted, role_authorized = self._discord_message_admission(
@@ -5720,6 +5749,19 @@ class DiscordAdapter(BasePlatformAdapter):
             return {part.strip() for part in s.split(",") if part.strip()}
         return set()
 
+    def _discord_is_voice_linked_channel(self, message: Any) -> bool:
+        """Return True when the message's exact channel is a bound voice text channel.
+
+        Voice-linked text channels act as free-response while voice is active.
+        Only the exact bound channel gets the exemption, not sibling threads.
+        """
+        channel = getattr(message, "channel", None)
+        channel_id = getattr(channel, "id", None)
+        if channel_id is None:
+            return False
+        voice_linked_ids = {str(ch_id) for ch_id in self._voice_text_channels.values()}
+        return str(channel_id) in voice_linked_ids
+
     def _raw_mentioned_user_ids(self, message: Any) -> set:
         """Extract Discord user-mention IDs directly from raw message content.
 
@@ -5729,7 +5771,15 @@ class DiscordAdapter(BasePlatformAdapter):
         leaving the resolved ``mentions`` list empty).
         """
         content = getattr(message, "content", "") or ""
-        return {match.group(1) for match in re.finditer(r"<@!?(\d+)>", content)}
+        ids = {match.group(1) for match in re.finditer(r"<@!?(\d+)>", content)}
+        # discord.py retains the parsed raw IDs even when an upstream relay
+        # normalizes message.content before this adapter sees it. Prefer the
+        # union so reply-pings still remain absent unless Discord recorded an
+        # actual mention token.
+        raw_mentions = getattr(message, "raw_mentions", None)
+        if isinstance(raw_mentions, (list, tuple, set)):
+            ids.update(str(mention_id) for mention_id in raw_mentions)
+        return ids
 
     def _self_is_explicitly_mentioned(self, message: Any) -> bool:
         """Return True when this bot is explicitly @mentioned in the message.
@@ -5755,6 +5805,45 @@ class DiscordAdapter(BasePlatformAdapter):
         if not self._client or not self._client.user:
             return False
         return str(self._client.user.id) in self._raw_mentioned_user_ids(message)
+
+    def _discord_group_role_mentioned(self, message: Any, parent_id: Optional[str]) -> bool:
+        """Return True for an allowed inline Discord role mention in scope."""
+        configured_roles = self.config.extra.get("group_mention_role_ids", [])
+        if not isinstance(configured_roles, list):
+            configured_roles = str(configured_roles or "").split(",")
+        allowed_roles = {str(role_id).strip() for role_id in configured_roles if str(role_id).strip()}
+        role_mentions = set(re.findall(r"<@&(\d+)>", getattr(message, "content", "") or ""))
+        if not (allowed_roles & role_mentions):
+            return False
+        configured_channels = self.config.extra.get("group_mention_channel_ids", [])
+        if not isinstance(configured_channels, list):
+            configured_channels = str(configured_channels or "").split(",")
+        allowed_channels = {str(channel_id).strip() for channel_id in configured_channels if str(channel_id).strip()}
+        if "*" in allowed_channels:
+            return True
+        return bool(self._discord_channel_keys(message, parent_id) & allowed_channels)
+
+    def _discord_allow_bots(self) -> str:
+        """Resolve the effective ``allow_bots`` policy string, config-first.
+
+        config.yaml (``PlatformConfig.extra``) is the operator's authoritative
+        source of truth and wins over the ``DISCORD_ALLOW_BOTS`` environment
+        variable, which is only the fallback for deployments that never set it
+        in config. Returns the lower-cased, stripped raw value; callers apply
+        the strict fail-closed enum ``{mentions, all}``. The gateway boot bridge
+        force-syncs config -> env so the env-only cross-module consumers
+        (authz_mixin bot bypass, relay policy) resolve this same value.
+        """
+        configured = self.config.extra.get("allow_bots")
+        return (
+            str(
+                configured
+                if configured is not None
+                else os.getenv("DISCORD_ALLOW_BOTS", "none")
+            )
+            .lower()
+            .strip()
+        )
 
     def _discord_bots_require_inline_mention(self) -> bool:
         """Whether another bot must type an inline @mention to trigger us.
@@ -5905,9 +5994,11 @@ class DiscordAdapter(BasePlatformAdapter):
         if limit <= 0:
             return ""
 
-        # Determine which bot messages to include in context
-        allow_bots_raw = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
-        include_other_bots = allow_bots_raw != "none"
+        # Determine which bot messages to include in context. Config-first via
+        # the shared resolver so history matches the admission gate; strict
+        # fail-closed enum means only {mentions, all} include other bots (for
+        # context, "mentions" is treated as "all" -- see the _keep filter).
+        include_other_bots = self._discord_allow_bots() in {"mentions", "all"}
 
         # Use the in-memory cache to narrow the fetch window on hot paths.
         # If we know our last message ID in this channel, pass it as `after`
@@ -7131,9 +7222,7 @@ class DiscordAdapter(BasePlatformAdapter):
             require_mention = self._discord_require_mention()
             # Voice-linked text channels act as free-response while voice is active.
             # Only the exact bound channel gets the exemption, not sibling threads.
-            voice_linked_ids = {str(ch_id) for ch_id in self._voice_text_channels.values()}
-            current_channel_id = str(message.channel.id)
-            is_voice_linked_channel = current_channel_id in voice_linked_ids
+            is_voice_linked_channel = self._discord_is_voice_linked_channel(message)
             is_free_channel = (
                 "*" in free_channels
                 or bool(channel_keys & free_channels)
@@ -7152,7 +7241,21 @@ class DiscordAdapter(BasePlatformAdapter):
             )
 
             if require_mention and not is_free_channel and not in_bot_thread:
-                if not self._self_is_explicitly_mentioned(message) and not mention_prefix:
+                # A configured in-scope group-role mention addresses the bot the
+                # same way an explicit @mention does -- but only for humans. A
+                # sibling bot must still type a real inline self-mention, so a
+                # role mention alone never hands off to a bot.
+                author_is_bot = bool(
+                    getattr(getattr(message, "author", None), "bot", False)
+                )
+                role_handoff = not author_is_bot and self._discord_group_role_mentioned(
+                    message, parent_channel_id
+                )
+                if (
+                    not self._self_is_explicitly_mentioned(message)
+                    and not mention_prefix
+                    and not role_handoff
+                ):
                     return False
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -792,8 +792,13 @@ class TestLoadGatewayConfig:
 
         assert os.environ.get("DISCORD_BOTS_REQUIRE_INLINE_MENTION") == "true"
 
-    def test_bots_require_inline_mention_yaml_does_not_overwrite_env(self, tmp_path, monkeypatch):
-        """Explicit env var should win over config.yaml for inline bot mention gating."""
+    def test_bots_require_inline_mention_yaml_force_syncs_over_env(self, tmp_path, monkeypatch):
+        """config.yaml is authoritative: a stale env var is force-overwritten.
+
+        A YAML ``false`` must win over a stale
+        ``DISCORD_BOTS_REQUIRE_INLINE_MENTION=true`` so the env-only consumers
+        cannot split from the config-first admission path.
+        """
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
         config_path = hermes_home / "config.yaml"
@@ -808,7 +813,7 @@ class TestLoadGatewayConfig:
 
         load_gateway_config()
 
-        assert os.environ.get("DISCORD_BOTS_REQUIRE_INLINE_MENTION") == "true"
+        assert os.environ.get("DISCORD_BOTS_REQUIRE_INLINE_MENTION") == "false"
 
     def test_bridges_discord_allow_from_from_config_yaml(self, tmp_path, monkeypatch):
         """discord.allow_from should populate DISCORD_ALLOWED_USERS for auth."""

--- a/tests/gateway/test_discord_admission_hardening.py
+++ b/tests/gateway/test_discord_admission_hardening.py
@@ -1,0 +1,480 @@
+"""Focused hardening coverage for the three Discord ingress gates.
+
+Pins three policy-safe blockers across the live-admission
+(``_discord_message_admission``), recovered pre-gate
+(``_dispatch_recovered_message``) and final ``_handle_message`` gates:
+
+* P0-1  The final ``_handle_message`` mention gate honors an in-scope
+        configured group-role mention (humans only). A sibling bot must
+        still type a real inline self-mention -- a role mention alone
+        never hands off to a bot.
+* P0-2  A voice-linked text channel keeps its free-response exemption on
+        every gate, not only inside ``_handle_message``. The exemption is
+        exact-channel-only: a thread under a voice-linked parent still
+        requires a mention.
+* P1-3  ``allow_bots`` is a strict fail-closed enum ``{mentions, all}``.
+        Any other value -- ``none``, ``false``, empty, or a typo -- denies.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+import sys
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_discord_mock():
+    """Install a mock discord module when discord.py isn't available."""
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ui = SimpleNamespace(
+        View=object, button=lambda *a, **k: lambda fn: fn, Button=object
+    )
+    discord_mod.ButtonStyle = SimpleNamespace(
+        success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3
+    )
+    discord_mod.Color = SimpleNamespace(
+        orange=lambda: 1,
+        green=lambda: 2,
+        blue=lambda: 3,
+        red=lambda: 4,
+        purple=lambda: 5,
+    )
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock
+    discord_mod.Object = lambda *, id: SimpleNamespace(id=id)
+    discord_mod.Message = type("Message", (), {})
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: lambda fn: fn,
+        choices=lambda **kwargs: lambda fn: fn,
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+import plugins.platforms.discord.adapter as discord_platform  # noqa: E402
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+
+BOT_ID = 999
+AUTHOR_ID = 42
+OPS_ID = 100  # non-free parent (mention required)
+VOICE_CH_ID = 555  # a text channel bound to an active voice session
+ROLE_ID = 777
+GUILD_ID = 1
+
+
+class FakeDMChannel:
+    def __init__(self, channel_id: int = 1, name: str = "dm"):
+        self.id = channel_id
+        self.name = name
+
+
+class FakeTextChannel:
+    def __init__(self, channel_id: int, name: str = "general"):
+        self.id = channel_id
+        self.name = name
+        self.guild = SimpleNamespace(id=GUILD_ID, name="Hermes Server")
+        self.topic = None
+
+
+class FakeThread:
+    def __init__(self, channel_id: int, name: str = "thread", parent=None):
+        self.id = channel_id
+        self.name = name
+        self.parent = parent
+        self.parent_id = getattr(parent, "id", None)
+        self.guild = getattr(parent, "guild", None) or SimpleNamespace(
+            id=GUILD_ID, name="Hermes Server"
+        )
+        self.topic = None
+
+
+def _install_channel_types(monkeypatch):
+    monkeypatch.setattr(
+        discord_platform.discord, "DMChannel", FakeDMChannel, raising=False
+    )
+    monkeypatch.setattr(discord_platform.discord, "Thread", FakeThread, raising=False)
+
+
+def _clear_discord_env(monkeypatch):
+    for _var in (
+        "DISCORD_REQUIRE_MENTION",
+        "DISCORD_THREAD_REQUIRE_MENTION",
+        "DISCORD_FREE_RESPONSE_CHANNELS",
+        "DISCORD_ALLOW_BOTS",
+        "DISCORD_BOTS_REQUIRE_INLINE_MENTION",
+        "DISCORD_ALLOWED_CHANNELS",
+        "DISCORD_IGNORED_CHANNELS",
+        "DISCORD_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+        "DISCORD_IGNORE_NO_MENTION",
+        "DISCORD_AUTO_THREAD",
+        "DISCORD_NO_THREAD_CHANNELS",
+    ):
+        monkeypatch.delenv(_var, raising=False)
+
+
+@pytest.fixture
+def admission_adapter(monkeypatch):
+    """Adapter for the two pre-``_handle_message`` gates.
+
+    ``_handle_message`` is stubbed so an admit is observable as a bool /
+    awaited call without dragging in the downstream handler.
+    """
+    _install_channel_types(monkeypatch)
+    _clear_discord_env(monkeypatch)
+
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = DiscordAdapter(config)
+    adapter._client = SimpleNamespace(user=SimpleNamespace(id=BOT_ID, bot=True))
+    adapter._allowed_user_ids = {str(AUTHOR_ID)}
+    adapter._text_batch_delay_seconds = 0
+    adapter._handle_message = AsyncMock(return_value=True)
+    return adapter
+
+
+@pytest.fixture
+def handle_adapter(monkeypatch):
+    """Adapter that runs the REAL ``_handle_message`` gate end-to-end.
+
+    ``handle_message`` (the downstream dispatch callback) is stubbed, so an
+    admit is observable as ``handle_message`` being awaited.
+    """
+    _install_channel_types(monkeypatch)
+    _clear_discord_env(monkeypatch)
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = DiscordAdapter(config)
+    adapter._client = SimpleNamespace(user=SimpleNamespace(id=BOT_ID, bot=True))
+    adapter._text_batch_delay_seconds = 0
+    adapter.handle_message = AsyncMock()
+    # Keep these gate tests focused on admission, not on the history-backfill
+    # I/O that a mention-gap admit would otherwise trigger.
+    adapter._fetch_channel_context = AsyncMock(return_value=None)
+    return adapter
+
+
+def make_message(
+    *,
+    channel,
+    content: str = "hello",
+    mentions=None,
+    bot: bool = False,
+    msg_id: int = 123,
+):
+    author = SimpleNamespace(
+        id=(BOT_ID + 1 if bot else AUTHOR_ID),
+        display_name="Author",
+        name="Author",
+        bot=bot,
+    )
+    is_dm = isinstance(channel, FakeDMChannel)
+    return SimpleNamespace(
+        id=msg_id,
+        content=content,
+        mentions=list(mentions or []),
+        attachments=[],
+        reference=None,
+        created_at=datetime.now(timezone.utc),
+        channel=channel,
+        author=author,
+        guild=None if is_dm else channel.guild,
+        type=discord_platform.discord.MessageType.default,
+    )
+
+
+def _voice_channel() -> FakeTextChannel:
+    return FakeTextChannel(VOICE_CH_ID, "voice-text")
+
+
+def _ops_channel() -> FakeTextChannel:
+    return FakeTextChannel(OPS_ID, "ops")
+
+
+def _admitted(adapter, message) -> bool:
+    admitted, _role = adapter._discord_message_admission(message, claim=True)
+    return admitted
+
+
+# ---------------------------------------------------------------------------
+# P0-2 voice-linked exemption -- live admission gate
+# ---------------------------------------------------------------------------
+
+
+def test_admission_admits_voice_linked_channel_no_mention(admission_adapter):
+    """A no-mention message in an active voice-linked channel is admitted."""
+    admission_adapter._voice_text_channels = {GUILD_ID: VOICE_CH_ID}
+    message = make_message(
+        channel=_voice_channel(), content="follow-up from voice chat, no mention"
+    )
+
+    assert _admitted(admission_adapter, message) is True
+
+
+def test_admission_denies_voice_linked_parent_thread_no_mention(admission_adapter):
+    """The exemption is exact-channel-only: a thread under a voice-linked
+    parent still requires a mention on the live gate."""
+    admission_adapter._voice_text_channels = {GUILD_ID: VOICE_CH_ID}
+    thread = FakeThread(790, name="topic", parent=_voice_channel())
+    message = make_message(channel=thread, content="thread reply, no mention")
+
+    assert _admitted(admission_adapter, message) is False
+
+
+def test_admission_denies_nonvoice_channel_no_mention(admission_adapter):
+    """Control: with no voice link, a no-mention channel message is denied."""
+    admission_adapter._voice_text_channels = {}
+    message = make_message(channel=_voice_channel(), content="no mention, no voice")
+
+    assert _admitted(admission_adapter, message) is False
+
+
+# ---------------------------------------------------------------------------
+# P0-2 voice-linked exemption -- recovered pre-gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recovered_admits_voice_linked_channel_no_mention(admission_adapter):
+    """A recovered no-mention message in a voice-linked channel is admitted."""
+    admission_adapter._voice_text_channels = {GUILD_ID: VOICE_CH_ID}
+    message = make_message(
+        channel=_voice_channel(), content="recovered voice-chat follow-up"
+    )
+
+    admitted = await admission_adapter._dispatch_recovered_message(message)
+
+    assert admitted is True
+    admission_adapter._handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_recovered_denies_voice_linked_parent_thread_no_mention(
+    admission_adapter,
+):
+    """Recovered exemption is also exact-channel-only."""
+    admission_adapter._voice_text_channels = {GUILD_ID: VOICE_CH_ID}
+    thread = FakeThread(790, name="topic", parent=_voice_channel())
+    message = make_message(channel=thread, content="recovered thread reply, no mention")
+
+    admitted = await admission_adapter._dispatch_recovered_message(message)
+
+    assert admitted is False
+    admission_adapter._handle_message.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# P0-2 voice-linked exemption -- final _handle_message gate (still honored)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_admits_voice_linked_channel_no_mention(handle_adapter):
+    """The final gate keeps the voice-linked free-response exemption."""
+    handle_adapter._voice_text_channels = {GUILD_ID: VOICE_CH_ID}
+    message = make_message(channel=_voice_channel(), content="voice text follow-up")
+
+    await handle_adapter._handle_message(message)
+
+    handle_adapter.handle_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# P0-1 group-role mention -- final _handle_message gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_admits_configured_group_role_mention_in_scope(handle_adapter):
+    """A human in-scope group-role mention passes the final gate.
+
+    The earlier admission gate already honors this; the final gate must
+    agree, otherwise a valid handoff is admitted then silently dropped.
+    """
+    handle_adapter.config.extra["group_mention_role_ids"] = [str(ROLE_ID)]
+    handle_adapter.config.extra["group_mention_channel_ids"] = [str(OPS_ID)]
+    message = make_message(
+        channel=_ops_channel(),
+        content=f"<@&{ROLE_ID}> hermes team, handoff",
+    )
+
+    await handle_adapter._handle_message(message)
+
+    handle_adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_denies_group_role_mention_out_of_scope(handle_adapter):
+    """An out-of-scope group-role mention is denied by the final gate."""
+    handle_adapter.config.extra["group_mention_role_ids"] = [str(ROLE_ID)]
+    handle_adapter.config.extra["group_mention_channel_ids"] = ["999999"]
+    message = make_message(
+        channel=_ops_channel(),
+        content=f"<@&{ROLE_ID}> hermes team, handoff",
+    )
+
+    await handle_adapter._handle_message(message)
+
+    handle_adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_denies_bot_role_only_handoff(handle_adapter, monkeypatch):
+    """A sibling bot must NOT be handed off by a role mention alone.
+
+    Even with ``allow_bots=all`` and the role configured in-scope, a bot that
+    did not type a real inline self-mention is denied at the final gate.
+    """
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    handle_adapter.config.extra["group_mention_role_ids"] = [str(ROLE_ID)]
+    handle_adapter.config.extra["group_mention_channel_ids"] = [str(OPS_ID)]
+    message = make_message(
+        channel=_ops_channel(),
+        content=f"<@&{ROLE_ID}> sibling bot, no self-mention",
+        bot=True,
+    )
+
+    await handle_adapter._handle_message(message)
+
+    handle_adapter.handle_message.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# P1-3 allow_bots strict fail-closed enum {mentions, all}
+# ---------------------------------------------------------------------------
+
+
+def test_admission_admits_bot_allow_bots_all(admission_adapter):
+    """Positive control: allow_bots=all admits a bot."""
+    admission_adapter.config.extra["allow_bots"] = "all"
+    message = make_message(channel=_ops_channel(), content="bot chatter", bot=True)
+
+    assert _admitted(admission_adapter, message) is True
+
+
+def test_admission_admits_bot_allow_bots_mentions_with_self_mention(admission_adapter):
+    """Positive control: allow_bots=mentions admits a bot that self-mentions."""
+    admission_adapter.config.extra["allow_bots"] = "mentions"
+    message = make_message(
+        channel=_ops_channel(),
+        content=f"<@{BOT_ID}> deliberate handoff",
+        mentions=[admission_adapter._client.user],
+        bot=True,
+    )
+
+    assert _admitted(admission_adapter, message) is True
+
+
+def test_admission_denies_bot_allow_bots_mentions_without_mention(admission_adapter):
+    """allow_bots=mentions denies a bot with no self-mention."""
+    admission_adapter.config.extra["allow_bots"] = "mentions"
+    message = make_message(channel=_ops_channel(), content="bot chatter", bot=True)
+
+    assert _admitted(admission_adapter, message) is False
+
+
+def test_admission_denies_bot_allow_bots_mentions_group_role_only(admission_adapter):
+    """allow_bots=mentions denies a bot that only pings the in-scope group role.
+
+    A configured group-role ping is treated as an explicit self-mention for a
+    human author (so co-located bots wake), but a sibling bot must still type a
+    real inline self-mention. A role-only ping must never hand off to a bot.
+    """
+    admission_adapter.config.extra["allow_bots"] = "mentions"
+    admission_adapter.config.extra["group_mention_role_ids"] = [str(ROLE_ID)]
+    admission_adapter.config.extra["group_mention_channel_ids"] = [str(OPS_ID)]
+    message = make_message(
+        channel=_ops_channel(),
+        content=f"<@&{ROLE_ID}> sibling bot, no self-mention",
+        bot=True,
+    )
+
+    assert _admitted(admission_adapter, message) is False
+
+
+def test_admission_denies_bot_allow_bots_false_even_with_self_mention(
+    admission_adapter,
+):
+    """allow_bots="false" is not a valid enum value: fail closed.
+
+    A YAML ``allow_bots: false`` serializes to "false" and must deny, even
+    when the bot types a real self-mention -- not fall through to "all".
+    """
+    admission_adapter.config.extra["allow_bots"] = "false"
+    message = make_message(
+        channel=_ops_channel(),
+        content=f"<@{BOT_ID}> self-mention but disallowed",
+        mentions=[admission_adapter._client.user],
+        bot=True,
+    )
+
+    assert _admitted(admission_adapter, message) is False
+
+
+def test_admission_denies_bot_allow_bots_typo_even_with_self_mention(admission_adapter):
+    """A typo (e.g. "mention") is not a valid enum value: fail closed."""
+    admission_adapter.config.extra["allow_bots"] = "mention"
+    message = make_message(
+        channel=_ops_channel(),
+        content=f"<@{BOT_ID}> self-mention but typo enum",
+        mentions=[admission_adapter._client.user],
+        bot=True,
+    )
+
+    assert _admitted(admission_adapter, message) is False
+
+
+def test_admission_denies_bot_allow_bots_empty_even_with_self_mention(
+    admission_adapter,
+):
+    """An empty value is not a valid enum value: fail closed."""
+    admission_adapter.config.extra["allow_bots"] = ""
+    message = make_message(
+        channel=_ops_channel(),
+        content=f"<@{BOT_ID}> self-mention but empty enum",
+        mentions=[admission_adapter._client.user],
+        bot=True,
+    )
+
+    assert _admitted(admission_adapter, message) is False
+
+
+@pytest.mark.asyncio
+async def test_recovered_denies_bot_allow_bots_false(admission_adapter):
+    """The fail-closed enum also holds on the recovered path."""
+    admission_adapter.config.extra["allow_bots"] = "false"
+    message = make_message(
+        channel=_ops_channel(),
+        content=f"<@{BOT_ID}> recovered self-mention but disallowed",
+        mentions=[admission_adapter._client.user],
+        bot=True,
+    )
+
+    admitted = await admission_adapter._dispatch_recovered_message(message)
+
+    assert admitted is False
+    admission_adapter._handle_message.assert_not_awaited()

--- a/tests/gateway/test_discord_config_authoritative.py
+++ b/tests/gateway/test_discord_config_authoritative.py
@@ -1,0 +1,102 @@
+"""End-to-end config-authoritative precedence for Discord bot admission.
+
+Proves the fix at the FINAL bot authorization route -- the gateway's
+``_is_user_authorized`` (``gateway/authz_mixin.py``), not the adapter admission
+gate alone. That route reads ``DISCORD_ALLOW_BOTS`` from the process env
+directly. After ``load_gateway_config`` runs the boot bridge, a stale /
+conflicting ``DISCORD_ALLOW_BOTS`` shell value can no longer split the
+authorization decision from config.yaml: config wins and the env is
+force-synced to match.
+"""
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import load_gateway_config
+from gateway.session import Platform, SessionSource
+
+
+def _make_bare_runner():
+    """GatewayRunner skeleton with just enough wiring for the auth route.
+
+    Mirrors ``tests/gateway/test_discord_bot_auth_bypass.py``: skip the heavy
+    __init__ and stub the pairing store so the real allowlist / bot-bypass path
+    is exercised.
+    """
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.pairing_store = SimpleNamespace(is_approved=lambda *_a, **_kw: False)
+    return runner
+
+
+def _discord_bot_source(bot_id="999888777"):
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="123",
+        chat_type="channel",
+        user_id=bot_id,
+        user_name="SomeBot",
+        is_bot=True,
+    )
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Isolate the Discord auth env vars the boot bridge writes.
+
+    ``load_gateway_config`` writes directly to ``os.environ``, so pop anything
+    it created after the test (monkeypatch's finalizer would otherwise restore
+    the loader's mid-test write for vars that were absent at setup).
+    """
+    managed = (
+        "DISCORD_ALLOW_BOTS",
+        "DISCORD_ALLOWED_USERS",
+        "DISCORD_ALLOWED_ROLES",
+        "DISCORD_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+    )
+    for var in managed:
+        monkeypatch.delenv(var, raising=False)
+    yield monkeypatch
+    for var in managed:
+        os.environ.pop(var, None)
+
+
+def _write_discord_config(tmp_path, monkeypatch, allow_bots):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        f"discord:\n  allow_bots: {allow_bots}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+
+def test_final_authz_route_config_admits_bot_over_stale_env(clean_env, tmp_path):
+    """config allow_bots=all admits a bot at the gateway authorization route
+    even when a stale DISCORD_ALLOW_BOTS=none shell value disagrees."""
+    clean_env.setenv("DISCORD_ALLOW_BOTS", "none")  # stale / conflicting
+    _write_discord_config(tmp_path, clean_env, "all")
+
+    load_gateway_config()  # boot bridge force-syncs config -> env
+
+    assert os.environ["DISCORD_ALLOW_BOTS"] == "all"
+    runner = _make_bare_runner()
+    assert runner._is_user_authorized(_discord_bot_source()) is True
+
+
+def test_final_authz_route_config_denies_bot_over_stale_env(clean_env, tmp_path):
+    """config allow_bots=none denies a bot at the gateway authorization route
+    even when a stale DISCORD_ALLOW_BOTS=all shell value would otherwise admit."""
+    clean_env.setenv("DISCORD_ALLOW_BOTS", "all")  # stale / conflicting
+    _write_discord_config(tmp_path, clean_env, "none")
+
+    load_gateway_config()
+
+    assert os.environ["DISCORD_ALLOW_BOTS"] == "none"
+    runner = _make_bare_runner()
+    assert runner._is_user_authorized(_discord_bot_source()) is False

--- a/tests/gateway/test_discord_config_bridge.py
+++ b/tests/gateway/test_discord_config_bridge.py
@@ -1,0 +1,168 @@
+"""Unit coverage for the Discord config.yaml -> extra / env bridge.
+
+``load_gateway_config`` bridges a ``discord:`` config block into
+``PlatformConfig.extra`` and, for the two keys that have a runtime env-var
+reader, also into ``os.environ``. These tests pin that contract:
+
+* all bridged Discord keys land in ``extra``;
+* a YAML bool serializes to a *lowercase* env string ("true", not "True"),
+  matching the adapter's ``str(...).lower()`` reader;
+* config.yaml is authoritative for the two env-backed keys (``allow_bots``,
+  ``bots_require_inline_mention``): a present config value force-overwrites a
+  stale/conflicting env var so every env-only consumer (authz_mixin, relay,
+  history) resolves the same value as the config-first admission path; when
+  config omits the key the existing env var stays as the intended fallback;
+* ``group_mention_role_ids`` / ``group_mention_channel_ids`` are bridged to
+  ``extra`` only and are intentionally NOT exported to ``os.environ`` (they
+  have no env reader; the adapter consumes them from ``extra``).
+
+The bridge writes directly to ``os.environ``; the ``clean_discord_env``
+fixture ``delenv``s the affected vars so monkeypatch teardown restores the
+environment even for vars the loader sets mid-test.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, load_gateway_config
+
+DISCORD_ENV_VARS = (
+    "DISCORD_ALLOW_BOTS",
+    "DISCORD_BOTS_REQUIRE_INLINE_MENTION",
+    "DISCORD_THREAD_REQUIRE_MENTION",
+)
+# Group role/channel lists have no env reader and must never be exported.
+NON_EXPORTED_ENV_VARS = (
+    "DISCORD_GROUP_MENTION_ROLE_IDS",
+    "DISCORD_GROUP_MENTION_CHANNEL_IDS",
+)
+
+
+def _load_with_yaml_dict(yaml_dict: dict):
+    """Patch the filesystem so load_gateway_config() sees *yaml_dict*."""
+    fake_home = Path("/tmp/fake_hermes_home_discord_bridge")
+
+    def fake_exists(self):
+        return str(self).endswith("config.yaml")
+
+    with (
+        patch("gateway.config.get_hermes_home", return_value=fake_home),
+        patch.object(Path, "exists", fake_exists),
+        patch("builtins.open", create=True) as mock_file,
+    ):
+        mock_file.return_value.__enter__ = lambda s: s
+        mock_file.return_value.__exit__ = MagicMock(return_value=False)
+        with patch("yaml.safe_load", return_value=yaml_dict):
+            return load_gateway_config()
+
+
+@pytest.fixture
+def clean_discord_env(monkeypatch):
+    """Isolate every Discord env var this file touches.
+
+    ``load_gateway_config`` writes directly to ``os.environ``, so remove any
+    variables it creates before monkeypatch restores the original environment.
+    """
+    vars_to_clear = DISCORD_ENV_VARS + NON_EXPORTED_ENV_VARS
+    for var in vars_to_clear:
+        monkeypatch.delenv(var, raising=False)
+    yield monkeypatch
+    # Do not use monkeypatch here: its finalizer would restore the loader's
+    # direct write after this fixture exits. These keys were intentionally
+    # absent at setup, so remove every value the loader created.
+    import os
+
+    for var in vars_to_clear:
+        os.environ.pop(var, None)
+
+
+def _discord_extra(cfg):
+    return cfg.platforms[Platform.DISCORD].extra
+
+
+def test_all_discord_keys_bridged_to_extra(clean_discord_env):
+    """Every bridged Discord key is surfaced on PlatformConfig.extra."""
+    cfg = _load_with_yaml_dict({
+        "discord": {
+            "allow_bots": "all",
+            "bots_require_inline_mention": True,
+            "thread_require_mention": False,
+            "group_mention_role_ids": ["111", "222"],
+            "group_mention_channel_ids": ["333"],
+        }
+    })
+    extra = _discord_extra(cfg)
+    assert extra["allow_bots"] == "all"
+    assert extra["bots_require_inline_mention"] is True
+    assert extra["thread_require_mention"] is False
+    assert extra["group_mention_role_ids"] == ["111", "222"]
+    assert extra["group_mention_channel_ids"] == ["333"]
+
+
+def test_yaml_bool_serializes_to_lowercase_env(clean_discord_env):
+    """A YAML bool True bridges to the lowercase env string "true"."""
+    import os
+
+    _load_with_yaml_dict({"discord": {"bots_require_inline_mention": True}})
+    assert os.environ["DISCORD_BOTS_REQUIRE_INLINE_MENTION"] == "true"
+
+
+def test_config_force_syncs_allow_bots_over_stale_env(clean_discord_env):
+    """config.yaml is authoritative: a stale/conflicting DISCORD_ALLOW_BOTS is
+    force-overwritten, not preserved.
+
+    The env-only consumers (authz_mixin, relay, history) read the env var
+    directly; force-syncing it to the config value is what keeps them from
+    splitting from the config-first admission path.
+    """
+    import os
+
+    clean_discord_env.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    cfg = _load_with_yaml_dict({"discord": {"allow_bots": "all"}})
+    # Config wins: env force-synced to the config value...
+    assert os.environ["DISCORD_ALLOW_BOTS"] == "all"
+    # ...and extra carries the same value for the config-first reader.
+    assert _discord_extra(cfg)["allow_bots"] == "all"
+
+
+def test_config_force_syncs_inline_mention_over_stale_env(clean_discord_env):
+    """The same force-sync holds for bots_require_inline_mention: a YAML bool
+    overwrites a stale env string and serializes lowercase."""
+    import os
+
+    clean_discord_env.setenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION", "false")
+    _load_with_yaml_dict({"discord": {"bots_require_inline_mention": True}})
+    assert os.environ["DISCORD_BOTS_REQUIRE_INLINE_MENTION"] == "true"
+
+
+def test_config_absent_leaves_env_fallback_intact(clean_discord_env):
+    """When config omits allow_bots, the existing env var is the intended
+    fallback and must be left untouched (no force-sync without a config value)."""
+    import os
+
+    clean_discord_env.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    # discord block present (require_mention) but no allow_bots key -> fallback.
+    _load_with_yaml_dict({"discord": {"require_mention": True}})
+    assert os.environ["DISCORD_ALLOW_BOTS"] == "mentions"
+
+
+def test_group_role_and_channel_lists_not_exported_to_env(clean_discord_env):
+    """group_mention_* lists bridge to extra only, never to os.environ."""
+    import os
+
+    cfg = _load_with_yaml_dict({
+        "discord": {
+            "group_mention_role_ids": ["111"],
+            "group_mention_channel_ids": ["333"],
+            "thread_require_mention": True,
+        }
+    })
+    for var in NON_EXPORTED_ENV_VARS:
+        assert var not in os.environ, f"{var} must not be exported"
+    # Still present where the adapter actually reads them.
+    extra = _discord_extra(cfg)
+    assert extra["group_mention_role_ids"] == ["111"]
+    assert extra["group_mention_channel_ids"] == ["333"]
+    assert extra["thread_require_mention"] is True

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -1486,3 +1486,59 @@ async def test_discord_non_reply_free_channel_skips_backfill(adapter, monkeypatc
 
     adapter._fetch_channel_context.assert_not_awaited()
 
+
+
+@pytest.mark.asyncio
+async def test_fetch_channel_context_allow_bots_config_wins_over_stale_env(adapter, monkeypatch):
+    """History context is config-authoritative: config allow_bots="all" includes
+    other-bot messages even when a stale DISCORD_ALLOW_BOTS=none env disagrees.
+
+    The assembler used to read the env var directly; routing it through the
+    config-first resolver keeps it from splitting from the admission gate.
+    """
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "none")  # stale/conflicting env
+    adapter.config.extra["allow_bots"] = "all"
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    other_bot = SimpleNamespace(id=55, display_name="Gemini", name="Gemini", bot=True)
+    human = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
+    channel = FakeHistoryChannel(
+        [
+            make_history_message(author=human, content="human note", msg_id=3),
+            make_history_message(author=other_bot, content="bot note", msg_id=2),
+        ],
+        channel_id=123,
+    )
+
+    result = await adapter._fetch_channel_context(
+        channel, before=make_message(channel=channel, content="trigger")
+    )
+
+    assert "[Gemini [bot]] bot note" in result
+    assert "[Alice] human note" in result
+
+
+@pytest.mark.asyncio
+async def test_fetch_channel_context_allow_bots_strict_enum_fails_closed(adapter, monkeypatch):
+    """A non-enum allow_bots value ("false") fails closed for history context:
+    other-bot messages are excluded even when a stale env says "all"."""
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")  # stale/conflicting env
+    adapter.config.extra["allow_bots"] = "false"  # invalid enum -> fail closed
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    other_bot = SimpleNamespace(id=55, display_name="Gemini", name="Gemini", bot=True)
+    human = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
+    channel = FakeHistoryChannel(
+        [
+            make_history_message(author=human, content="human note", msg_id=3),
+            make_history_message(author=other_bot, content="bot note", msg_id=2),
+        ],
+        channel_id=123,
+    )
+
+    result = await adapter._fetch_channel_context(
+        channel, before=make_message(channel=channel, content="trigger")
+    )
+
+    assert "[Gemini [bot]] bot note" not in result
+    assert "[Alice] human note" in result

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -704,75 +704,138 @@ async def test_discord_voice_linked_parent_thread_still_requires_mention(adapter
     adapter.handle_message.assert_not_awaited()
 
 
+def _arm_live_dispatch(adapter, monkeypatch):
+    """Arm the adapter for full live-path dispatch (_dispatch_discord_message).
+
+    The thread-gating tests below deliberately run the real ingress chain
+    (_discord_message_admission -> _handle_message) instead of calling
+    _handle_message directly: the direct call skips admission, which is where
+    human thread messages are actually gated, and previously masked the live
+    behavior.
+    """
+    adapter._ready_event.set()
+    adapter._allowed_user_ids = {"42"}
+    adapter._client.user.bot = True
+    for _var in (
+        "DISCORD_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+        "DISCORD_ALLOWED_USERS",
+        "DISCORD_BOTS_REQUIRE_INLINE_MENTION",
+        "DISCORD_IGNORE_NO_MENTION",
+    ):
+        monkeypatch.delenv(_var, raising=False)
+
+
+def make_live_message(*, channel, content, mentions=None, bot=False):
+    """A make_message variant carrying the guild/bot fields admission reads."""
+    message = make_message(channel=channel, content=content, mentions=mentions)
+    message.guild = SimpleNamespace(id=1, name="Hermes Server")
+    message.author.bot = bot
+    if bot:
+        message.author.id = 555  # a sibling bot, not the allowed human
+    return message
+
+
+def _participated_thread(adapter):
+    """A thread under a non-free parent that the bot has already spoken in."""
+    thread = FakeThread(
+        channel_id=456,
+        name="follow-up",
+        parent=FakeTextChannel(channel_id=100, name="ops"),
+    )
+    adapter._threads.mark("456")
+    return thread
+
+
 @pytest.mark.asyncio
-async def test_discord_thread_default_keeps_responding_after_participation(adapter, monkeypatch):
-    """Default behavior: once the bot is in a thread, it auto-responds without @mention."""
+async def test_discord_thread_followup_without_mention_denied_on_live_path(adapter, monkeypatch):
+    """A human no-mention follow-up in a participated thread is denied.
+
+    Threads inherit the parent channel's mention policy at admission; bot
+    participation does not make a non-free parent's thread mention-free, and
+    thread_require_mention plays no part in the human decision.
+    """
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
-    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
-    monkeypatch.delenv("DISCORD_THREAD_REQUIRE_MENTION", raising=False)
+    _arm_live_dispatch(adapter, monkeypatch)
+    thread = _participated_thread(adapter)
 
-    thread = FakeThread(channel_id=456, name="follow-up")
-    adapter._threads.mark("456")  # bot has previously participated
+    message = make_live_message(channel=thread, content="follow-up without mention")
+    admitted = await adapter._dispatch_discord_message(message)
 
-    message = make_message(channel=thread, content="follow-up without mention")
-    await adapter._handle_message(message)
+    assert admitted is False
+    adapter.handle_message.assert_not_awaited()
 
+
+@pytest.mark.asyncio
+async def test_discord_bot_thread_followup_responds_by_default(adapter, monkeypatch):
+    """allow_bots=all: a mention-free bot follow-up in a participated thread responds.
+
+    This is the one live-reachable consumer of _handle_message's in_bot_thread
+    shortcut, and the behavioral contract that keeps thread_require_mention a
+    real config option.
+    """
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    _arm_live_dispatch(adapter, monkeypatch)
+    thread = _participated_thread(adapter)
+
+    message = make_live_message(channel=thread, content="bot follow-up", bot=True)
+    admitted = await adapter._dispatch_discord_message(message)
+
+    assert admitted is True
     adapter.handle_message.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_discord_thread_require_mention_gates_followups(adapter, monkeypatch):
-    """When thread_require_mention=true, even bot-participated threads need @mention."""
+async def test_discord_thread_require_mention_gates_bot_followups(adapter, monkeypatch):
+    """thread_require_mention=true closes the bot in-thread shortcut end-to-end."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
     monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "true")
-    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    _arm_live_dispatch(adapter, monkeypatch)
+    thread = _participated_thread(adapter)
 
-    thread = FakeThread(channel_id=456, name="multi-bot thread")
-    adapter._threads.mark("456")  # bot has previously participated
+    message = make_live_message(channel=thread, content="ambient bot chatter", bot=True)
+    admitted = await adapter._dispatch_discord_message(message)
 
-    message = make_message(channel=thread, content="ambient chatter — not for me")
-    await adapter._handle_message(message)
-
+    assert admitted is False
     adapter.handle_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_discord_thread_require_mention_still_responds_when_mentioned(adapter, monkeypatch):
-    """thread_require_mention=true still lets explicit @mentions through in threads."""
+    """thread_require_mention=true still lets explicit @mentions through, full path."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "true")
-    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
-
-    thread = FakeThread(channel_id=456, name="multi-bot thread")
-    adapter._threads.mark("456")
+    _arm_live_dispatch(adapter, monkeypatch)
+    thread = _participated_thread(adapter)
     bot_user = adapter._client.user
 
-    message = make_message(
+    message = make_live_message(
         channel=thread,
         content=f"<@{bot_user.id}> hey, this one's for you",
         mentions=[bot_user],
     )
-    await adapter._handle_message(message)
+    admitted = await adapter._dispatch_discord_message(message)
 
+    assert admitted is True
     adapter.handle_message.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_discord_thread_require_mention_via_config_extra(adapter, monkeypatch):
-    """thread_require_mention can also be set via config.extra (yaml)."""
+    """thread_require_mention via config.extra (yaml) gates the bot shortcut too."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
-    monkeypatch.delenv("DISCORD_THREAD_REQUIRE_MENTION", raising=False)
-    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    _arm_live_dispatch(adapter, monkeypatch)
+    adapter.config.extra["allow_bots"] = "all"
     adapter.config.extra["thread_require_mention"] = True
+    thread = _participated_thread(adapter)
 
-    thread = FakeThread(channel_id=456, name="multi-bot thread")
-    adapter._threads.mark("456")
+    message = make_live_message(channel=thread, content="ambient, should be ignored", bot=True)
+    admitted = await adapter._dispatch_discord_message(message)
 
-    message = make_message(channel=thread, content="ambient — should be ignored")
-    await adapter._handle_message(message)
-
+    assert admitted is False
     adapter.handle_message.assert_not_awaited()
-
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_thread_admission_policy.py
+++ b/tests/gateway/test_discord_thread_admission_policy.py
@@ -1,0 +1,543 @@
+"""Regression coverage for Discord thread mention-admission policy.
+
+These tests pin the two authoritative ingress gates that the live and
+recovered dispatch paths run *before* ``_handle_message``:
+
+* ``_discord_message_admission`` (live path, ``_dispatch_discord_message``)
+* ``_dispatch_recovered_message`` (missed-message backfill / recovered path)
+
+Shared policy under test (intended config: ``require_mention=true``,
+``thread_require_mention=false``; a non-free parent like ``#ops`` and a
+free-response parent like ``#lounge``):
+
+    A human no-mention message in a thread inherits ONLY its parent's
+    free-response / default-bot policy. Bot *participation* in a thread must
+    NOT bypass a non-free parent's mention requirement.
+
+The historical ``in_bot_thread`` bypass -- which let any thread the bot had
+previously spoken in skip the mention gate -- was removed from these two gates
+on purpose. This file proves the removal holds and that the surrounding
+admission behaviour is preserved, so the bypass is not silently reintroduced.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+import sys
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_discord_mock():
+    """Install a mock discord module when discord.py isn't available."""
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ui = SimpleNamespace(
+        View=object, button=lambda *a, **k: (lambda fn: fn), Button=object
+    )
+    discord_mod.ButtonStyle = SimpleNamespace(
+        success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3
+    )
+    discord_mod.Color = SimpleNamespace(
+        orange=lambda: 1,
+        green=lambda: 2,
+        blue=lambda: 3,
+        red=lambda: 4,
+        purple=lambda: 5,
+    )
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock
+    discord_mod.Object = lambda *, id: SimpleNamespace(id=id)
+    discord_mod.Message = type("Message", (), {})
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+import plugins.platforms.discord.adapter as discord_platform  # noqa: E402
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+
+BOT_ID = 999
+AUTHOR_ID = 42
+OPS_ID = 100  # non-free parent (e.g. #ops)
+LOUNGE_ID = 200  # free-response parent (e.g. #lounge)
+ROLE_ID = 777
+
+
+class FakeDMChannel:
+    def __init__(self, channel_id: int = 1, name: str = "dm"):
+        self.id = channel_id
+        self.name = name
+
+
+class FakeTextChannel:
+    def __init__(self, channel_id: int, name: str = "general"):
+        self.id = channel_id
+        self.name = name
+        self.guild = SimpleNamespace(id=1, name="Hermes Server")
+        self.topic = None
+
+
+class FakeThread:
+    def __init__(self, channel_id: int, name: str = "thread", parent=None):
+        self.id = channel_id
+        self.name = name
+        self.parent = parent
+        self.parent_id = getattr(parent, "id", None)
+        self.guild = getattr(parent, "guild", None) or SimpleNamespace(
+            id=1, name="Hermes Server"
+        )
+        self.topic = None
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    monkeypatch.setattr(
+        discord_platform.discord, "DMChannel", FakeDMChannel, raising=False
+    )
+    monkeypatch.setattr(discord_platform.discord, "Thread", FakeThread, raising=False)
+
+    # Isolate from the contributor's shell: every DISCORD_* knob this file
+    # exercises must come from config.extra / per-test env, not leaked state.
+    for _var in (
+        "DISCORD_REQUIRE_MENTION",
+        "DISCORD_THREAD_REQUIRE_MENTION",
+        "DISCORD_FREE_RESPONSE_CHANNELS",
+        "DISCORD_ALLOW_BOTS",
+        "DISCORD_BOTS_REQUIRE_INLINE_MENTION",
+        "DISCORD_ALLOWED_CHANNELS",
+        "DISCORD_IGNORED_CHANNELS",
+        "DISCORD_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+        "DISCORD_IGNORE_NO_MENTION",
+    ):
+        monkeypatch.delenv(_var, raising=False)
+
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = DiscordAdapter(config)
+    adapter._client = SimpleNamespace(user=SimpleNamespace(id=BOT_ID, bot=True))
+    adapter._allowed_user_ids = {str(AUTHOR_ID)}
+    adapter._text_batch_delay_seconds = 0
+    # The two gates under test run before _handle_message. Stub it so a
+    # recovered admit is observable as a bool / awaited call without dragging
+    # in the full downstream handler (which has its own, separate gate).
+    adapter._handle_message = AsyncMock(return_value=True)
+    return adapter
+
+
+def make_message(
+    *,
+    channel,
+    content: str = "hello",
+    mentions=None,
+    bot: bool = False,
+    msg_id: int = 123,
+):
+    author = SimpleNamespace(
+        id=(BOT_ID + 1 if bot else AUTHOR_ID),
+        display_name="Author",
+        name="Author",
+        bot=bot,
+    )
+    is_dm = isinstance(channel, FakeDMChannel)
+    return SimpleNamespace(
+        id=msg_id,
+        content=content,
+        mentions=list(mentions or []),
+        attachments=[],
+        reference=None,
+        created_at=datetime.now(timezone.utc),
+        channel=channel,
+        author=author,
+        guild=None if is_dm else channel.guild,
+        type=discord_platform.discord.MessageType.default,
+    )
+
+
+def _ops_thread(thread_id: int = 456) -> FakeThread:
+    """A thread whose parent is a non-free channel (mention required)."""
+    return FakeThread(thread_id, name="topic", parent=FakeTextChannel(OPS_ID, "ops"))
+
+
+def _lounge_thread(thread_id: int = 456) -> FakeThread:
+    """A thread whose parent is a free-response channel (no mention required)."""
+    return FakeThread(
+        thread_id, name="topic", parent=FakeTextChannel(LOUNGE_ID, "lounge")
+    )
+
+
+def _free_config(adapter):
+    adapter.config.extra["free_response_channels"] = [str(LOUNGE_ID)]
+
+
+def _admitted(adapter, message) -> bool:
+    admitted, _role_authorized = adapter._discord_message_admission(message, claim=True)
+    return admitted
+
+
+# ---------------------------------------------------------------------------
+# Admission path (_discord_message_admission)
+# ---------------------------------------------------------------------------
+
+
+def test_admission_denies_participated_nonfree_parent_thread_no_mention(adapter):
+    """(1) Participation does NOT bypass a non-free parent on the live gate."""
+    _free_config(adapter)
+    adapter._threads.mark("456")  # bot has previously spoken here
+    message = make_message(
+        channel=_ops_thread(), content="ambient follow-up, no mention"
+    )
+
+    assert _admitted(adapter, message) is False
+
+
+def test_admission_admits_participated_free_parent_thread_no_mention(adapter):
+    """(2) A thread under a free-response parent inherits its free policy."""
+    _free_config(adapter)
+    adapter._threads.mark("456")
+    message = make_message(channel=_lounge_thread(), content="casual chat, no mention")
+
+    assert _admitted(adapter, message) is True
+
+
+def test_admission_denies_unparticipated_nonfree_thread_no_mention(adapter):
+    """(3) An unparticipated thread under a non-free parent still requires @mention."""
+    _free_config(adapter)
+    # thread 789 is NOT marked as participated
+    message = make_message(
+        channel=_ops_thread(789), content="hello from unknown thread"
+    )
+
+    assert _admitted(adapter, message) is False
+
+
+def test_admission_thread_require_mention_denies_participated_nonfree_no_mention(
+    adapter,
+):
+    """(4) thread_require_mention=true keeps a participated non-free thread gated.
+
+    Enabling the stricter knob must not loosen anything: a no-mention
+    follow-up in a participated thread under a non-free parent stays denied.
+    """
+    _free_config(adapter)
+    adapter.config.extra["thread_require_mention"] = True
+    adapter._threads.mark("456")
+    message = make_message(channel=_ops_thread(), content="ambient chatter, not for me")
+
+    assert _admitted(adapter, message) is False
+
+
+def test_admission_free_parent_inheritance_survives_thread_require_mention(adapter):
+    """(4, companion) Free-response inheritance is by-parent and is NOT
+
+    overridden by thread_require_mention on this gate. This pins the current,
+    policy-consistent behaviour ("a thread inherits ONLY its parent
+    free-response policy"): a thread under a free parent is still admitted
+    without a mention even when thread_require_mention=true. If the shared
+    policy ever changes to make thread_require_mention override a free parent,
+    THIS is the test that must be updated deliberately.
+    """
+    _free_config(adapter)
+    adapter.config.extra["thread_require_mention"] = True
+    adapter._threads.mark("456")
+    message = make_message(channel=_lounge_thread(), content="casual chat, no mention")
+
+    assert _admitted(adapter, message) is True
+
+
+def test_admission_admits_direct_self_mention_in_nonfree_thread(adapter):
+    """(5) An explicit @bot mention is admitted even under a non-free parent."""
+    _free_config(adapter)
+    message = make_message(
+        channel=_ops_thread(),
+        content=f"<@{BOT_ID}> please look at this",
+        mentions=[adapter._client.user],
+    )
+
+    assert _admitted(adapter, message) is True
+
+
+def test_admission_admits_configured_group_role_mention_in_scope(adapter):
+    """(5) A configured group-role mention in a configured channel is admitted."""
+    _free_config(adapter)
+    adapter.config.extra["group_mention_role_ids"] = [str(ROLE_ID)]
+    adapter.config.extra["group_mention_channel_ids"] = [str(OPS_ID)]
+    message = make_message(
+        channel=_ops_thread(),
+        content=f"<@&{ROLE_ID}> hermes team, handoff",
+    )
+
+    assert _admitted(adapter, message) is True
+
+
+def test_admission_denies_group_role_mention_out_of_configured_scope(adapter):
+    """(5, negative) A group-role mention outside its configured channels is denied."""
+    _free_config(adapter)
+    adapter.config.extra["group_mention_role_ids"] = [str(ROLE_ID)]
+    adapter.config.extra["group_mention_channel_ids"] = ["999999"]  # not the ops parent
+    message = make_message(
+        channel=_ops_thread(),
+        content=f"<@&{ROLE_ID}> hermes team, handoff",
+    )
+
+    assert _admitted(adapter, message) is False
+
+
+def test_admission_admits_group_role_mention_wildcard_channel_scope(adapter):
+    """(5) A wildcard channel scope honors a human group-role mention anywhere.
+
+    ``group_mention_channel_ids: ["*"]`` means the configured role addresses
+    the bot in any channel, including a thread under a non-free parent.
+    """
+    _free_config(adapter)
+    adapter.config.extra["group_mention_role_ids"] = [str(ROLE_ID)]
+    adapter.config.extra["group_mention_channel_ids"] = ["*"]
+    message = make_message(
+        channel=_ops_thread(),
+        content=f"<@&{ROLE_ID}> hermes team, handoff",
+    )
+
+    assert _admitted(adapter, message) is True
+
+
+def test_admission_denies_bot_no_mention_when_inline_required(adapter):
+    """(6) A bot's ambient (no-mention) message is denied when inline is required."""
+    _free_config(adapter)
+    adapter.config.extra["allow_bots"] = "all"
+    adapter.config.extra["bots_require_inline_mention"] = True
+    message = make_message(channel=_ops_thread(), content="just chatter", bot=True)
+
+    assert _admitted(adapter, message) is False
+
+
+def test_admission_denies_bot_reply_ping_when_inline_required(adapter):
+    """(6) A reply-ping (bot in message.mentions, no literal token) is denied.
+
+    Discord's reply-ping silently adds us to ``message.mentions`` without the
+    author typing our handle; the inline-required gate must reject it so two
+    bots don't ping-pong replies forever.
+    """
+    _free_config(adapter)
+    adapter.config.extra["allow_bots"] = "all"
+    adapter.config.extra["bots_require_inline_mention"] = True
+    message = make_message(
+        channel=_ops_thread(),
+        content="reply body, no literal token",
+        mentions=[adapter._client.user],  # reply-ping populates mentions only
+        bot=True,
+    )
+
+    assert _admitted(adapter, message) is False
+
+
+def test_admission_admits_bot_real_inline_mention(adapter):
+    """(6, positive control) A bot that types a real <@bot> token is admitted."""
+    _free_config(adapter)
+    adapter.config.extra["allow_bots"] = "all"
+    adapter.config.extra["bots_require_inline_mention"] = True
+    message = make_message(
+        channel=_ops_thread(),
+        content=f"<@{BOT_ID}> deliberate handoff",
+        mentions=[adapter._client.user],
+        bot=True,
+    )
+
+    assert _admitted(adapter, message) is True
+
+
+# ---------------------------------------------------------------------------
+# Bot-admission config-vs-env precedence. config.extra["allow_bots"] wins over
+# the DISCORD_ALLOW_BOTS env var when present; the env var is the fallback.
+# Pins the documented precedence at the admission resolution site so it is not
+# silently flipped. ``adapter`` and the test share one monkeypatch instance,
+# and the fixture has already cleared DISCORD_ALLOW_BOTS from the environment.
+# ---------------------------------------------------------------------------
+
+
+def test_admission_allow_bots_config_wins_over_env_permissive(adapter, monkeypatch):
+    """config allow_bots="all" admits even when env says "none"."""
+    _free_config(adapter)
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "none")
+    adapter.config.extra["allow_bots"] = "all"
+    message = make_message(channel=_ops_thread(), content="bot handoff", bot=True)
+
+    assert _admitted(adapter, message) is True
+
+
+def test_admission_allow_bots_config_wins_over_env_restrictive(adapter, monkeypatch):
+    """config allow_bots="none" denies even when env says "all"."""
+    _free_config(adapter)
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    adapter.config.extra["allow_bots"] = "none"
+    message = make_message(channel=_ops_thread(), content="bot chatter", bot=True)
+
+    assert _admitted(adapter, message) is False
+
+
+def test_admission_allow_bots_env_fallback_when_config_absent(adapter, monkeypatch):
+    """With no config allow_bots, the DISCORD_ALLOW_BOTS env var governs."""
+    _free_config(adapter)
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    # config.extra has no "allow_bots" key -> env is the fallback source.
+    message = make_message(channel=_ops_thread(), content="bot handoff", bot=True)
+
+    assert _admitted(adapter, message) is True
+
+
+def test_admission_allow_bots_default_denies_when_neither_set(adapter):
+    """Absent both config and env, bots default to denied ("none")."""
+    _free_config(adapter)
+    # Fixture already cleared DISCORD_ALLOW_BOTS; no config key set.
+    message = make_message(channel=_ops_thread(), content="bot handoff", bot=True)
+
+    assert _admitted(adapter, message) is False
+
+
+# ---------------------------------------------------------------------------
+# Recovered path (_dispatch_recovered_message) -- where the in_bot_thread
+# bypass was removed. These mirror the key admission cases end-to-end.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recovered_denies_participated_nonfree_parent_thread_no_mention(adapter):
+    """(1, recovered) The removed bypass stays removed on the recovered path."""
+    _free_config(adapter)
+    adapter._threads.mark("456")
+    message = make_message(
+        channel=_ops_thread(), content="recovered ambient, no mention"
+    )
+
+    admitted = await adapter._dispatch_recovered_message(message)
+
+    assert admitted is False
+    adapter._handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recovered_admits_participated_free_parent_thread_no_mention(adapter):
+    """(2, recovered) Free-response parent inheritance still admits on recovery."""
+    _free_config(adapter)
+    adapter._threads.mark("456")
+    message = make_message(channel=_lounge_thread(), content="recovered casual chat")
+
+    admitted = await adapter._dispatch_recovered_message(message)
+
+    assert admitted is True
+    adapter._handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_recovered_denies_unparticipated_nonfree_thread_no_mention(adapter):
+    """(3, recovered) Unparticipated non-free thread still requires @mention."""
+    _free_config(adapter)
+    message = make_message(channel=_ops_thread(789), content="recovered unknown thread")
+
+    admitted = await adapter._dispatch_recovered_message(message)
+
+    assert admitted is False
+    adapter._handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recovered_admits_direct_self_mention(adapter):
+    """(5, recovered) An explicit @bot mention is recovered under a non-free parent."""
+    _free_config(adapter)
+    message = make_message(
+        channel=_ops_thread(),
+        content=f"<@{BOT_ID}> recovered mention",
+        mentions=[adapter._client.user],
+    )
+
+    admitted = await adapter._dispatch_recovered_message(message)
+
+    assert admitted is True
+    adapter._handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_recovered_denies_bot_reply_ping_when_inline_required(adapter):
+    """(6, recovered) Bot reply-ping denial also holds on the recovered path."""
+    _free_config(adapter)
+    adapter.config.extra["allow_bots"] = "all"
+    adapter.config.extra["bots_require_inline_mention"] = True
+    message = make_message(
+        channel=_ops_thread(),
+        content="recovered reply body, no token",
+        mentions=[adapter._client.user],
+        bot=True,
+    )
+
+    admitted = await adapter._dispatch_recovered_message(message)
+
+    assert admitted is False
+    adapter._handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recovered_admits_configured_group_role_mention_in_scope(adapter):
+    """(5, recovered) A configured in-scope group-role mention is recovered.
+
+    Mirrors ``test_admission_admits_configured_group_role_mention_in_scope`` on
+    the recovered path: the recovered pre-gate must honor the same group-role
+    exception the live gate does, so a valid handoff missed while offline is
+    not silently dropped on backfill.
+    """
+    _free_config(adapter)
+    adapter.config.extra["group_mention_role_ids"] = [str(ROLE_ID)]
+    adapter.config.extra["group_mention_channel_ids"] = [str(OPS_ID)]
+    message = make_message(
+        channel=_ops_thread(),
+        content=f"<@&{ROLE_ID}> hermes team, recovered handoff",
+    )
+
+    admitted = await adapter._dispatch_recovered_message(message)
+
+    assert admitted is True
+    adapter._handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_recovered_denies_group_role_mention_out_of_configured_scope(adapter):
+    """(5, recovered, negative) An out-of-scope group-role mention stays denied.
+
+    The group-role exception must not become a blanket bypass on recovery: a
+    role mention whose channel is not in ``group_mention_channel_ids`` is
+    denied exactly as on the live gate.
+    """
+    _free_config(adapter)
+    adapter.config.extra["group_mention_role_ids"] = [str(ROLE_ID)]
+    adapter.config.extra["group_mention_channel_ids"] = ["999999"]  # not the ops parent
+    message = make_message(
+        channel=_ops_thread(),
+        content=f"<@&{ROLE_ID}> hermes team, recovered handoff",
+    )
+
+    admitted = await adapter._dispatch_recovered_message(message)
+
+    assert admitted is False
+    adapter._handle_message.assert_not_awaited()

--- a/tests/gateway/test_discord_thread_admission_policy.py
+++ b/tests/gateway/test_discord_thread_admission_policy.py
@@ -539,6 +539,32 @@ async def test_recovered_admits_configured_group_role_mention_in_scope(adapter):
 
 
 @pytest.mark.asyncio
+async def test_recovered_denies_bot_role_only_handoff_in_participated_thread(adapter):
+    """Backfill cannot hand off a configured role ping from a sibling bot.
+
+    This pins the formerly divergent recovered pre-gate. Even with permissive
+    bot policy, inline mentions disabled, an in-scope role, and prior thread
+    participation, only a human author may use a group-role handoff.
+    """
+    _free_config(adapter)
+    adapter.config.extra["allow_bots"] = "all"
+    adapter.config.extra["bots_require_inline_mention"] = False
+    adapter.config.extra["group_mention_role_ids"] = [str(ROLE_ID)]
+    adapter.config.extra["group_mention_channel_ids"] = [str(OPS_ID)]
+    adapter._threads.mark("456")
+    message = make_message(
+        channel=_ops_thread(),
+        content=f"<@&{ROLE_ID}> sibling bot, recovered role-only handoff",
+        bot=True,
+    )
+
+    admitted = await adapter._dispatch_recovered_message(message)
+
+    assert admitted is False
+    adapter._handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_recovered_denies_group_role_mention_out_of_configured_scope(adapter):
     """(5, recovered, negative) An out-of-scope group-role mention stays denied.
 

--- a/tests/gateway/test_discord_thread_admission_policy.py
+++ b/tests/gateway/test_discord_thread_admission_policy.py
@@ -369,6 +369,23 @@ def test_admission_admits_bot_real_inline_mention(adapter):
     assert _admitted(adapter, message) is True
 
 
+
+def test_admission_admits_bot_ambient_followup_allow_bots_all(adapter):
+    """(7) Admission admits ambient allow_bots=all bot traffic in a thread.
+
+    The in-thread shortcut / thread_require_mention decision for this traffic
+    happens later, in _handle_message (pinned end-to-end in
+    test_discord_free_response.py); admission's job here is only the
+    allow_bots policy, so the message passes this gate.
+    """
+    _free_config(adapter)
+    adapter.config.extra["allow_bots"] = "all"
+    adapter._threads.mark("456")
+    message = make_message(channel=_ops_thread(), content="ambient bot chatter", bot=True)
+
+    assert _admitted(adapter, message) is True
+
+
 # ---------------------------------------------------------------------------
 # Bot-admission config-vs-env precedence. config.extra["allow_bots"] wins over
 # the DISCORD_ALLOW_BOTS env var when present; the env var is the fallback.
@@ -535,6 +552,28 @@ async def test_recovered_denies_group_role_mention_out_of_configured_scope(adapt
     message = make_message(
         channel=_ops_thread(),
         content=f"<@&{ROLE_ID}> hermes team, recovered handoff",
+    )
+
+    admitted = await adapter._dispatch_recovered_message(message)
+
+    assert admitted is False
+    adapter._handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recovered_denies_bot_ambient_followup_even_with_allow_bots_all(adapter):
+    """(7, recovered) Backfill never rides the in-thread shortcut.
+
+    The recovered pre-gate is stricter than live dispatch: a mention-free bot
+    follow-up in a participated thread under a non-free parent is not
+    recovered even though allow_bots=all admits it live. As a consequence,
+    thread_require_mention has no effect at all on the recovered path.
+    """
+    _free_config(adapter)
+    adapter.config.extra["allow_bots"] = "all"
+    adapter._threads.mark("456")
+    message = make_message(
+        channel=_ops_thread(), content="recovered bot chatter", bot=True
     )
 
     admitted = await adapter._dispatch_recovered_message(message)

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -297,7 +297,7 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_HOME_CHANNEL_NAME` | No | `"Home"` | Display name for the home channel in logs and status output. |
 | `DISCORD_COMMAND_SYNC_POLICY` | No | `"safe"` | Controls native slash-command startup sync. `"safe"` diffs existing global commands and only updates what changed, recreating commands when Discord metadata changes cannot be applied via patch. `"bulk"` preserves the old `tree.sync()` behavior. `"off"` skips startup sync entirely. |
 | `DISCORD_REQUIRE_MENTION` | No | `true` | When `true`, the bot only responds in server channels when `@mentioned`. Set to `false` to respond to all messages in every channel. |
-| `DISCORD_THREAD_REQUIRE_MENTION` | No | `false` | When `true`, the in-thread mention shortcut is disabled — threads are gated the same as channels, requiring `@mention` even after the bot has already participated. Use this when multiple bots share a thread and you want each to fire only on explicit `@mention`. |
+| `DISCORD_THREAD_REQUIRE_MENTION` | No | `false` | When `true`, closes the in-thread shortcut for **bot-authored** messages admitted via `DISCORD_ALLOW_BOTS="all"`: such bots must type an explicit inline `@mention` even in threads the bot already participates in. Human messages are unaffected by this setting: threads always inherit the parent channel's mention policy (see [`discord.thread_require_mention`](#discordthread_require_mention)). |
 | `DISCORD_FREE_RESPONSE_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds without requiring an `@mention`, even when `DISCORD_REQUIRE_MENTION` is `true`. |
 | `DISCORD_IGNORE_NO_MENTION` | No | `true` | When `true`, the bot stays silent if a message `@mentions` other users but does **not** mention the bot. Prevents the bot from jumping into conversations directed at other people. Only applies in server channels, not DMs. |
 | `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every `@mention` in a text channel, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. |
@@ -327,13 +327,13 @@ Wiring multiple Hermes profiles to reply to one another in a shared channel — 
 
 ### Config File (`config.yaml`)
 
-The `discord` section in `~/.hermes/config.yaml` mirrors the env vars above. Config.yaml settings are applied as defaults — if the equivalent env var is already set, the env var wins.
+The `discord` section in `~/.hermes/config.yaml` mirrors the env vars above. Config.yaml settings are applied as defaults — if the equivalent env var is already set, the env var wins. Exception: `allow_bots`, `bots_require_inline_mention`, and `thread_require_mention` are config-authoritative: when present in config.yaml they override their env vars, which act only as a fallback.
 
 ```yaml
 # Discord-specific settings
 discord:
   require_mention: true           # Require @mention in server channels
-  thread_require_mention: false   # If true, require @mention in threads too (multi-bot threads)
+  thread_require_mention: false   # If true, bots admitted via allow_bots:"all" also need @mention in threads
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
   reactions: true                 # Add emoji reactions during processing
@@ -368,14 +368,15 @@ When enabled, the bot only responds in server channels when directly `@mentioned
 
 **Type:** boolean — **Default:** `false`
 
-By default, once the bot has participated in a thread (auto-created on `@mention` or replied in once), it keeps responding to every subsequent message in that thread without needing to be `@mentioned` again. That's the right default for one-on-one conversations.
+For **human** messages this setting has no effect: threads always inherit their parent channel's mention policy. Under a free-response parent the thread is mention-free; under a mention-gated parent every message needs an `@mention` (or a configured group-role mention), even after the bot has participated in the thread.
 
-In **multi-bot threads** where users address one bot per turn, this default becomes a footgun — every other bot in the thread also fires on every message, burning credits and spamming the channel. Set `thread_require_mention: true` to disable the in-thread shortcut and gate threads the same way channels are gated. Explicit `@mentions` still work as before.
+What it still controls is the **bot-authored** in-thread shortcut. When `allow_bots` (`DISCORD_ALLOW_BOTS`) is `"all"`, an admitted bot message in a thread this bot already participates in gets a response without an explicit mention by default. Set `thread_require_mention: true` to close that shortcut so sibling bots must type a literal inline `@mention` everywhere - useful when multiple bots share threads and each should fire only on explicit address.
 
 ```yaml
 discord:
   require_mention: true
-  thread_require_mention: true    # multi-bot setup
+  allow_bots: "all"               # only then does this setting matter
+  thread_require_mention: true    # bots need explicit @mention even in shared threads
 ```
 
 #### `discord.free_response_channels`
@@ -404,7 +405,7 @@ Free-response channels also **skip auto-threading** — the bot replies inline r
 
 **Type:** boolean — **Default:** `true`
 
-When enabled, every `@mention` in a regular text channel automatically creates a new thread for the conversation. This keeps the main channel clean and gives each conversation its own isolated session history. Once a thread is created, subsequent messages in that thread don't require `@mention` — the bot knows it's already participating. Set [`thread_require_mention`](#discordthread_require_mention) to `true` to disable this in-thread shortcut for multi-bot setups.
+When enabled, every `@mention` in a regular text channel automatically creates a new thread for the conversation. This keeps the main channel clean and gives each conversation its own isolated session history. Follow-up messages inside the created thread are still gated by the parent channel's policy: if the parent requires `@mention`, each follow-up needs an `@mention` too - the bot having participated in the thread does not make it mention-free. For mention-free follow-ups, put the parent channel in [`free_response_channels`](#discordfree_response_channels).
 
 Messages sent in existing threads or DMs are unaffected by this setting. Channels listed in `discord.free_response_channels` or `discord.no_thread_channels` also bypass auto-threading and get inline replies instead.
 

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -302,6 +302,7 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_IGNORE_NO_MENTION` | No | `true` | When `true`, the bot stays silent if a message `@mentions` other users but does **not** mention the bot. Prevents the bot from jumping into conversations directed at other people. Only applies in server channels, not DMs. |
 | `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every `@mention` in a text channel, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. |
 | `DISCORD_ALLOW_BOTS` | No | `"none"` | Controls how the bot handles messages from other Discord bots. `"none"` — ignore all other bots. `"mentions"` — only accept bot messages that `@mention` Hermes. `"all"` — accept all bot messages. |
+| `DISCORD_BOTS_REQUIRE_INLINE_MENTION` | No | `false` | Legacy fallback for `discord.bots_require_inline_mention` when that config key is absent. When `true`, an admitted bot-authored message must contain a literal raw inline personal mention of this bot (`<@BOT_ID>` or `<@!BOT_ID>`). A Discord reply-ping, quote, or role-only mention is insufficient. |
 | `DISCORD_REACTIONS` | No | `true` | When `true`, the bot adds emoji reactions to messages during processing (👀 when starting, ✅ on success, ❌ on error). Set to `false` to disable reactions entirely. |
 | `DISCORD_IGNORED_CHANNELS` | No | — | Comma-separated channel IDs where the bot **never** responds, even when `@mentioned`. Takes priority over all other channel settings. |
 | `DISCORD_ALLOWED_CHANNELS` | No | — | Comma-separated channel IDs. When set, the bot **only** responds in these channels (plus DMs if allowed). Overrides `config.yaml` `discord.allowed_channels`. Combine with `DISCORD_IGNORED_CHANNELS` to express allow/deny rules. |
@@ -319,6 +320,8 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS` | No | `0.6` | Grace window the adapter waits before flushing a queued text chunk. Useful for smoothing streamed output. |
 | `HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS` | No | `2.0` | Delay between split chunks when a single message exceeds Discord's length limit. |
 
+`DISCORD_ALLOW_BOTS` and `DISCORD_BOTS_REQUIRE_INLINE_MENTION` are legacy environment fallbacks: their `config.yaml` counterparts, when present, are authoritative. The group-role settings below are config-only; `DISCORD_GROUP_MENTION_ROLE_IDS` and `DISCORD_GROUP_MENTION_CHANNEL_IDS` are not supported environment variables.
+
 :::warning Bot-to-bot conversation is not supported
 `DISCORD_ALLOW_BOTS` exists to accept input from a specific trusted bot (e.g. a relay or webhook bot), not to let two Hermes profiles talk to each other. The default, `"none"`, ignores all other bots and is the safe setting.
 
@@ -333,6 +336,10 @@ The `discord` section in `~/.hermes/config.yaml` mirrors the env vars above. Con
 # Discord-specific settings
 discord:
   require_mention: true           # Require @mention in server channels
+  allow_bots: "mentions"          # Admit bot-authored messages only when they address this bot
+  bots_require_inline_mention: false  # If true, bot messages need a raw inline personal mention
+  group_mention_role_ids: []      # Human-only role mentions that can trigger the bot
+  group_mention_channel_ids: []   # Where those role mentions apply; ["*"] means every server channel
   thread_require_mention: false   # If true, bots admitted via allow_bots:"all" also need @mention in threads
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
@@ -377,6 +384,37 @@ discord:
   require_mention: true
   allow_bots: "all"               # only then does this setting matter
   thread_require_mention: true    # bots need explicit @mention even in shared threads
+```
+
+#### `discord.bots_require_inline_mention`
+
+**Type:** boolean — **Default:** `false`
+
+This is an additional admission gate for **bot-authored** Discord messages; it does not affect human messages. Set it to `true` in a trusted multi-bot room to require the sending bot to type a literal raw inline personal mention of this bot in its message content (`<@BOT_ID>` or `<@!BOT_ID>`). A Discord reply-ping/quote can add this bot to the resolved mentions list without that raw token, so it is not enough; a role-only mention is not enough either.
+
+The config key is authoritative when present. For legacy deployments that omit it, `DISCORD_BOTS_REQUIRE_INLINE_MENTION` is the fallback. This gate does not itself admit bots: configure `allow_bots` as `"mentions"` or `"all"` as appropriate.
+
+```yaml
+discord:
+  allow_bots: "mentions"
+  bots_require_inline_mention: true
+```
+
+#### `discord.group_mention_role_ids` and `discord.group_mention_channel_ids`
+
+**Type:** string or list — **Default:** `[]` for both
+
+These settings let a configured inline Discord role mention satisfy the normal server-channel mention gate for **human-authored messages only**. `group_mention_role_ids` is the allowlist of role IDs; `group_mention_channel_ids` scopes where those role mentions work. Use `"*"` in the channel scope to allow the configured role mention in every reachable server channel. Bot-authored messages cannot use a group-role mention to pass admission, and these settings have no environment-variable fallback.
+
+```yaml
+discord:
+  require_mention: true
+  group_mention_role_ids:
+    - "ROLE_ID"
+  group_mention_channel_ids:
+    - "CHANNEL_ID"
+  # Or scope the configured role mention to every server channel:
+  # group_mention_channel_ids: ["*"]
 ```
 
 #### `discord.free_response_channels`

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/discord.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/discord.md
@@ -299,6 +299,7 @@ Discord 行为通过两个文件控制：**`~/.hermes/.env`** 用于凭据和环
 | `DISCORD_IGNORE_NO_MENTION` | 否 | `true` | 为 `true` 时，如果消息 `@提及` 了其他用户但**未**提及机器人，机器人保持沉默。防止机器人介入针对其他人的对话。仅适用于服务器频道，不适用于私信。 |
 | `DISCORD_AUTO_THREAD` | 否 | `true` | 为 `true` 时，自动为文本频道中的每次 `@提及` 创建新线程，使每个对话相互隔离（类似 Slack 行为）。已在线程或私信中的消息不受影响。 |
 | `DISCORD_ALLOW_BOTS` | 否 | `"none"` | 控制机器人如何处理来自其他 Discord 机器人的消息。`"none"` — 忽略所有其他机器人。`"mentions"` — 仅接受 `@提及` Hermes 的机器人消息。`"all"` — 接受所有机器人消息。 |
+| `DISCORD_BOTS_REQUIRE_INLINE_MENTION` | 否 | `false` | 当 `discord.bots_require_inline_mention` 未设置时，作为其旧环境变量兜底。为 `true` 时，已放行的机器人消息必须包含对本机器人的字面原始内联个人提及（`<@BOT_ID>` 或 `<@!BOT_ID>`）。Discord 的回复 ping、引用或仅提及角色均不足以满足条件。 |
 | `DISCORD_REACTIONS` | 否 | `true` | 为 `true` 时，机器人在处理过程中为消息添加 emoji 反应（开始时 👀，成功时 ✅，出错时 ❌）。设置为 `false` 可完全禁用反应。 |
 | `DISCORD_IGNORED_CHANNELS` | 否 | — | 机器人**永不**响应的频道 ID，逗号分隔，即使被 `@提及` 也不响应。优先于所有其他频道设置。 |
 | `DISCORD_ALLOWED_CHANNELS` | 否 | — | 频道 ID，逗号分隔。设置后，机器人**仅**在这些频道（以及允许的私信）中响应。覆盖 `config.yaml` 中的 `discord.allowed_channels`。与 `DISCORD_IGNORED_CHANNELS` 结合使用可表达允许/拒绝规则。 |
@@ -316,6 +317,8 @@ Discord 行为通过两个文件控制：**`~/.hermes/.env`** 用于凭据和环
 | `HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS` | 否 | `0.6` | 适配器在刷新排队文本块之前等待的宽限窗口。用于平滑流式输出。 |
 | `HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS` | 否 | `2.0` | 当单条消息超过 Discord 长度限制时，分割块之间的延迟。 |
 
+`DISCORD_ALLOW_BOTS` 与 `DISCORD_BOTS_REQUIRE_INLINE_MENTION` 是旧环境变量兜底：对应的 `config.yaml` 配置存在时，配置文件具有权威性。下面的群组角色设置仅支持配置文件；`DISCORD_GROUP_MENTION_ROLE_IDS` 和 `DISCORD_GROUP_MENTION_CHANNEL_IDS` 不是受支持的环境变量。
+
 ### 配置文件（`config.yaml`）
 
 `~/.hermes/config.yaml` 中的 `discord` 部分与上述环境变量对应。config.yaml 设置作为默认值应用——如果已设置等效的环境变量，则环境变量优先。例外：`allow_bots`、`bots_require_inline_mention` 和 `thread_require_mention` 以 config.yaml 为准：在 config.yaml 中设置时会覆盖对应环境变量，环境变量仅作为兜底。
@@ -324,6 +327,10 @@ Discord 行为通过两个文件控制：**`~/.hermes/.env`** 用于凭据和环
 # Discord 特定设置
 discord:
   require_mention: true           # 在服务器频道中需要 @提及
+  allow_bots: "mentions"          # 仅在机器人消息明确指向本机器人时放行
+  bots_require_inline_mention: false  # 为 true 时，机器人消息需要原始内联个人提及
+  group_mention_role_ids: []      # 可触发机器人的、仅限人类消息的角色提及
+  group_mention_channel_ids: []   # 这些角色提及的生效范围；["*"] 表示所有服务器频道
   thread_require_mention: false   # 为 true 时，经 allow_bots:"all" 放行的机器人在线程中也需要 @提及
   free_response_channels: ""      # 逗号分隔的频道 ID（或 YAML 列表）
   auto_thread: true               # 在 @提及 时自动创建线程
@@ -368,6 +375,37 @@ discord:
   require_mention: true
   allow_bots: "all"               # 只有此时该设置才有意义
   thread_require_mention: true    # 机器人在共享线程中也需要显式 @提及
+```
+
+#### `discord.bots_require_inline_mention`
+
+**类型：** 布尔值 — **默认值：** `false`
+
+这是针对**机器人作者** Discord 消息的额外放行门控；不影响人类消息。在受信任的多机器人频道中，将其设为 `true`，以要求发送机器人在消息内容中键入对本机器人的字面原始内联个人提及（`<@BOT_ID>` 或 `<@!BOT_ID>`）。Discord 的回复 ping/引用可能在没有原始 token 的情况下把本机器人加入解析后的提及列表，因此不满足条件；仅提及角色同样不满足条件。
+
+配置键存在时具有权威性。对于未设置该键的旧部署，`DISCORD_BOTS_REQUIRE_INLINE_MENTION` 是兜底。此门控本身不会放行机器人：请按需要将 `allow_bots` 配置为 `"mentions"` 或 `"all"`。
+
+```yaml
+discord:
+  allow_bots: "mentions"
+  bots_require_inline_mention: true
+```
+
+#### `discord.group_mention_role_ids` 和 `discord.group_mention_channel_ids`
+
+**类型：** 字符串或列表 — **默认值：** 两者均为 `[]`
+
+这些设置允许已配置的内联 Discord 角色提及满足普通服务器频道的提及门控，且**只适用于人类作者的消息**。`group_mention_role_ids` 是角色 ID 允许列表；`group_mention_channel_ids` 限定这些角色提及生效的频道范围。在频道范围中使用 `"*"`，可让已配置的角色提及在每个可访问的服务器频道中生效。机器人作者的消息不能通过群组角色提及放行，并且这些设置没有环境变量兜底。
+
+```yaml
+discord:
+  require_mention: true
+  group_mention_role_ids:
+    - "ROLE_ID"
+  group_mention_channel_ids:
+    - "CHANNEL_ID"
+  # 或将已配置角色提及的范围设为所有服务器频道：
+  # group_mention_channel_ids: ["*"]
 ```
 
 #### `discord.free_response_channels`

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/discord.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/discord.md
@@ -294,7 +294,7 @@ Discord 行为通过两个文件控制：**`~/.hermes/.env`** 用于凭据和环
 | `DISCORD_HOME_CHANNEL_NAME` | 否 | `"Home"` | 主频道在日志和状态输出中的显示名称。 |
 | `DISCORD_COMMAND_SYNC_POLICY` | 否 | `"safe"` | 控制原生斜杠命令启动同步。`"safe"` 对现有全局命令进行差异比较，仅更新已更改的内容，当 Discord 元数据更改无法通过补丁应用时重新创建命令。`"bulk"` 保留旧的 `tree.sync()` 行为。`"off"` 完全跳过启动同步。 |
 | `DISCORD_REQUIRE_MENTION` | 否 | `true` | 为 `true` 时，机器人仅在服务器频道中被 `@提及` 时响应。设置为 `false` 可响应每个频道中的所有消息。 |
-| `DISCORD_THREAD_REQUIRE_MENTION` | 否 | `false` | 为 `true` 时，禁用线程内的提及快捷方式——线程与频道的门控方式相同，即使机器人已经参与其中，也需要 `@提及`。当多个机器人共享一个线程且你希望每个机器人仅在明确 `@提及` 时触发时使用此设置。 |
+| `DISCORD_THREAD_REQUIRE_MENTION` | 否 | `false` | 为 `true` 时，关闭经 `DISCORD_ALLOW_BOTS="all"` 放行的**机器人消息**的线程内快捷方式：这些机器人即使在本机器人已参与的线程中，也必须键入显式的内联 `@提及`。人类消息不受此设置影响：线程始终继承父频道的提及策略（参见 [`discord.thread_require_mention`](#discordthread_require_mention)）。 |
 | `DISCORD_FREE_RESPONSE_CHANNELS` | 否 | — | 机器人无需 `@提及` 即可响应的频道 ID，逗号分隔，即使 `DISCORD_REQUIRE_MENTION` 为 `true` 也适用。 |
 | `DISCORD_IGNORE_NO_MENTION` | 否 | `true` | 为 `true` 时，如果消息 `@提及` 了其他用户但**未**提及机器人，机器人保持沉默。防止机器人介入针对其他人的对话。仅适用于服务器频道，不适用于私信。 |
 | `DISCORD_AUTO_THREAD` | 否 | `true` | 为 `true` 时，自动为文本频道中的每次 `@提及` 创建新线程，使每个对话相互隔离（类似 Slack 行为）。已在线程或私信中的消息不受影响。 |
@@ -318,13 +318,13 @@ Discord 行为通过两个文件控制：**`~/.hermes/.env`** 用于凭据和环
 
 ### 配置文件（`config.yaml`）
 
-`~/.hermes/config.yaml` 中的 `discord` 部分与上述环境变量对应。config.yaml 设置作为默认值应用——如果已设置等效的环境变量，则环境变量优先。
+`~/.hermes/config.yaml` 中的 `discord` 部分与上述环境变量对应。config.yaml 设置作为默认值应用——如果已设置等效的环境变量，则环境变量优先。例外：`allow_bots`、`bots_require_inline_mention` 和 `thread_require_mention` 以 config.yaml 为准：在 config.yaml 中设置时会覆盖对应环境变量，环境变量仅作为兜底。
 
 ```yaml
 # Discord 特定设置
 discord:
   require_mention: true           # 在服务器频道中需要 @提及
-  thread_require_mention: false   # 为 true 时，线程中也需要 @提及（多机器人线程）
+  thread_require_mention: false   # 为 true 时，经 allow_bots:"all" 放行的机器人在线程中也需要 @提及
   free_response_channels: ""      # 逗号分隔的频道 ID（或 YAML 列表）
   auto_thread: true               # 在 @提及 时自动创建线程
   reactions: true                 # 处理过程中添加 emoji 反应
@@ -359,14 +359,15 @@ group_sessions_per_user: true     # 在共享频道中按用户隔离会话
 
 **类型：** 布尔值 — **默认值：** `false`
 
-默认情况下，一旦机器人参与了某个线程（通过 `@提及` 自动创建或回复过一次），它就会继续响应该线程中的每条后续消息，无需再次 `@提及`。这对于一对一对话来说是正确的默认行为。
+对**人类**消息此设置没有任何影响：线程始终继承其父频道的提及策略。父频道是自由响应频道时，线程也无需提及；父频道需要提及时，线程中的每条消息都需要 `@提及`（或已配置的群组角色提及），即使机器人已经参与了该线程。
 
-在**多机器人线程**中，用户每次只与一个机器人交流，这个默认行为会成为隐患——线程中的每个其他机器人也会对每条消息触发，消耗额度并刷屏。将 `thread_require_mention: true` 设置为禁用线程内快捷方式，使线程与频道的门控方式相同。显式 `@提及` 仍然有效。
+它仍然控制的是**机器人消息**的线程内快捷方式。当 `allow_bots`（`DISCORD_ALLOW_BOTS`）为 `"all"` 时，已放行的机器人消息在本机器人已参与的线程中默认无需显式提及即可得到响应。设置 `thread_require_mention: true` 可关闭该快捷方式，让其他机器人在任何位置都必须键入字面的内联 `@提及`。适用于多个机器人共享线程、且每个机器人只应在被明确点名时触发的场景。
 
 ```yaml
 discord:
   require_mention: true
-  thread_require_mention: true    # 多机器人设置
+  allow_bots: "all"               # 只有此时该设置才有意义
+  thread_require_mention: true    # 机器人在共享线程中也需要显式 @提及
 ```
 
 #### `discord.free_response_channels`
@@ -395,7 +396,7 @@ discord:
 
 **类型：** 布尔值 — **默认值：** `true`
 
-启用后，普通文本频道中的每次 `@提及` 都会自动为对话创建新线程。这保持主频道整洁，并为每个对话提供独立的会话历史。一旦创建线程，该线程中的后续消息不需要 `@提及`——机器人知道它已经在参与其中。对于多机器人设置，将 [`thread_require_mention`](#discordthread_require_mention) 设置为 `true` 可禁用此线程内快捷方式。
+启用后，普通文本频道中的每次 `@提及` 都会自动为对话创建新线程。这保持主频道整洁，并为每个对话提供独立的会话历史。创建的线程中的后续消息仍然遵循父频道的策略：如果父频道需要 `@提及`，每条后续消息也需要 `@提及`。机器人参与过该线程并不会使其变为无需提及。若需要无提及的后续对话，请将父频道加入 [`free_response_channels`](#discordfree_response_channels)。
 
 在现有线程或私信中发送的消息不受此设置影响。`discord.free_response_channels` 或 `discord.no_thread_channels` 中列出的频道也会绕过自动创建线程，改为直接回复。
 


### PR DESCRIPTION
## Summary
- make Discord bot admission keys config-authoritative with bounded legacy env fallback
- require raw inline personal bot mentions for bot-origin handoffs
- support human-only scoped group-role mentions and preserve parent thread policy
- document the security-sensitive Discord admission configuration in English and zh-Hans

## Validation
- focused Discord admission/config/thread suites: 728 passed, 3 skipped
- adversarial review: blocking findings fixed (thread docs/options, recovered role-only bot handoff)
- docs site build: pass
- ruff and diff checks: pass

No user-specific IDs, channels, or runtime configuration are included.