### PR TITLE
fix(gateway): harden cache invalidation and test dependencies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17209,7 +17209,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         "honcho.runtime_peer_prefix",
         "honcho.user_peer_aliases",
     )
-    _HONCHO_CACHE_BUSTING_MEMO: dict[tuple[str, int | None], dict[str, Any]] = {}
+    _HONCHO_CACHE_BUSTING_MEMO: dict[tuple[str, int | None, int | None], dict[str, Any]] = {}
 
     @classmethod
     def _empty_honcho_cache_busting_config(cls) -> dict[str, Any]:
@@ -17222,11 +17222,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from plugins.memory.honcho.client import HonchoClientConfig, resolve_config_path
 
             path = resolve_config_path()
+            # Key on (mtime_ns, size), not mtime alone: filesystem timestamps
+            # come from the kernel's coarse clock, so an edit landing within
+            # the same tick as the previous one (observed on WSL2) leaves
+            # st_mtime_ns unchanged and a pure-mtime memo would serve the
+            # stale parse. Size catches those same-tick rewrites.
             try:
-                mtime_ns = path.stat().st_mtime_ns
+                _st = path.stat()
+                mtime_ns: int | None = _st.st_mtime_ns
+                size: int | None = _st.st_size
             except OSError:
                 mtime_ns = None
-            memo_key = (str(path), mtime_ns)
+                size = None
+            memo_key = (str(path), mtime_ns, size)
             cached = cls._HONCHO_CACHE_BUSTING_MEMO.get(memo_key)
             if cached is not None:
                 return dict(cached)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,7 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 hindsight = ["hindsight-client==0.6.1"]
-dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0"]  # starlette: CVE-2026-48710; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
+dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0", "hermes-agent[wecom]"]  # starlette: CVE-2026-48710; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.14.1", "brotlicffi==1.2.0.1", "slack-bolt==1.29.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.1: CVE-2026-34513/34518/34519/34520/34525 + 34993(RCE)/47265
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.29.0", "slack-sdk==3.43.0", "aiohttp==3.14.1"]
@@ -165,9 +165,9 @@ matrix = ["mautrix[encryption]==0.21.0", "aiosqlite==0.22.1", "asyncpg==0.31.0",
 # WeCom callback-mode adapter — parses untrusted XML POST bodies from
 # WeCom-controlled callback endpoints, so we use defusedxml (drop-in
 # replacement for stdlib xml.etree.ElementTree) to block billion-laughs
-# and XXE. aiohttp/httpx are already in [messaging]; defusedxml lands
-# here to keep the dependency local to wecom_callback's threat model.
-wecom = ["defusedxml==0.7.1"]
+# and XXE. httpx is core; aiohttp and defusedxml are required by the callback
+# server and stay local to wecom_callback's HTTP/XML threat model.
+wecom = ["aiohttp==3.14.1", "defusedxml==0.7.1"]  # aiohttp: CVE-2026-34513/34518/34519/34520/34525 + 34993(RCE)/47265
 cli = ["simple-term-menu==1.6.6"]
 tts-premium = ["elevenlabs==1.59.0"]
 voice = [

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -70,6 +70,13 @@ def _build_agent_with_db(db: SessionDB, session_id: str):
         ]
 
     compressor.compress.side_effect = _compress_with_overlap
+    # Skip the lazy auxiliary-provider feasibility probe inside
+    # _compress_context - it is not covered by the compressor stub and, left
+    # enabled, makes a real openrouter.ai HTTP call plus a plugin-discovery
+    # pass (~15s+ on WSL2). That delay lands between _compress_context entry
+    # and the stubbed compress() call, so event/barrier waits in these tests
+    # (compression_started.wait(10), etc.) time out spuriously.
+    agent._compression_feasibility_checked = True
     compressor.compression_count = 1
     compressor.last_prompt_tokens = 0
     compressor.last_completion_tokens = 0

--- a/tests/gateway/test_compression_concurrent_sessions.py
+++ b/tests/gateway/test_compression_concurrent_sessions.py
@@ -63,6 +63,14 @@ def _build_agent_with_db(db: SessionDB, session_id: str):
         ]
 
     compressor.compress.side_effect = _compress_with_overlap
+    # Skip the lazy auxiliary-provider feasibility probe inside
+    # _compress_context. It is irrelevant to the lock contract under test and
+    # is NOT covered by the compressor stub: left enabled it makes a real
+    # openrouter.ai HTTP call (with the fake key) plus a full plugin-discovery
+    # pass (~15s+ on WSL2), and its module-global 60s unhealthy-provider cache
+    # leaks across tests so one thread takes the fast path while the other
+    # blows past the 15s barrier/join timeouts (the "got 0" failure).
+    agent._compression_feasibility_checked = True
     compressor.compression_count = 1
     compressor.last_prompt_tokens = 0
     compressor.last_completion_tokens = 0

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -186,6 +186,31 @@ def test_pyproject_pins_match_lazy_deps_pins():
     )
 
 
+def test_wecom_callback_dependencies_are_available_to_default_test_environment():
+    """Keep the WeCom runtime and default callback-test dependencies aligned.
+
+    The callback adapter's public install hint is ``hermes-agent[wecom]`` and
+    its requirements check needs ``aiohttp``, core ``httpx``, and
+    ``defusedxml``.  The default test suite also collects its callback tests,
+    so ``[dev]`` must include the complete WeCom extra rather than manually
+    duplicating one parser pin.
+    """
+    from tools.lazy_deps import LAZY_DEPS
+
+    optional_dependencies = _load_optional_dependencies()
+    wecom_pins = _exact_pins(optional_dependencies["wecom"])
+    lazy_pins = _exact_pins(LAZY_DEPS["platform.wecom_callback"])
+
+    assert wecom_pins == lazy_pins, (
+        "[wecom] and LAZY_DEPS['platform.wecom_callback'] must declare the "
+        "same runtime dependencies"
+    )
+    assert "hermes-agent[wecom]" in optional_dependencies["dev"], (
+        "[dev] must include [wecom] because the default test suite collects "
+        "tests/gateway/test_wecom_callback.py"
+    )
+
+
 def test_dev_extra_excluded_from_all():
     """End-user installs should not pull test/lint/debug tooling."""
     optional_dependencies = _load_optional_dependencies()

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -191,10 +191,12 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "lark-oapi==1.6.8",
         "qrcode==7.4.2",
     ),
-    # WeCom callback-mode adapter — parses untrusted XML POST bodies. Pulls
-    # defusedxml only; aiohttp/httpx are core dependencies of every messaging
-    # adapter and ship via `platform.discord` / `platform.slack` / etc.
-    "platform.wecom_callback": ("defusedxml==0.7.1",),
+    # WeCom callback-mode adapter — parses untrusted XML POST bodies. httpx is
+    # core; the callback HTTP server and secure XML parser are lazy-installed.
+    "platform.wecom_callback": (
+        "aiohttp==3.14.1",  # CVE-2026-34513/34518/34519/34520/34525 + 34993(RCE)/47265
+        "defusedxml==0.7.1",
+    ),
     # Microsoft Teams adapter — microsoft-teams-apps pulls a heavy tree
     # (microsoft-teams-api/cards/common, dependency-injector, msal). Lazy-
     # installed on demand like every other messaging platform; also exposed

--- a/uv.lock
+++ b/uv.lock
@@ -1589,7 +1589,9 @@ daytona = [
     { name = "daytona" },
 ]
 dev = [
+    { name = "aiohttp" },
     { name = "debugpy" },
+    { name = "defusedxml" },
     { name = "mcp" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1724,6 +1726,7 @@ web = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 wecom = [
+    { name = "aiohttp" },
     { name = "defusedxml" },
 ]
 youtube = [
@@ -1739,6 +1742,7 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'slack'", specifier = "==3.14.1" },
     { name = "aiohttp", marker = "extra == 'sms'", specifier = "==3.14.1" },
     { name = "aiohttp", marker = "extra == 'teams'", specifier = "==3.14.1" },
+    { name = "aiohttp", marker = "extra == 'wecom'", specifier = "==3.14.1" },
     { name = "aiohttp-socks", marker = "extra == 'matrix'", specifier = "==0.11.0" },
     { name = "aiosqlite", marker = "extra == 'matrix'", specifier = "==0.22.1" },
     { name = "alibabacloud-dingtalk", marker = "extra == 'dingtalk'", specifier = "==2.2.42" },
@@ -1789,6 +1793,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["termux"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'termux-all'" },
+    { name = "hermes-agent", extras = ["wecom"], marker = "extra == 'dev'" },
     { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'all'" },
     { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.6.1" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.2.0" },


### PR DESCRIPTION
## Summary
- invalidate Honcho memoized parse results when file size changes within a coarse mtime tick
- isolate compression concurrency fixtures from unrelated external feasibility probes
- make the secure WeCom callback parser available through the dev test dependency contract

## Validation
- cache/metadata: 90 passed
- compression concurrency: 30 passed
- WeCom callback + feasibility: 31 passed
- independent adversarial review: blocking 0
- ruff and locked dependency checks: pass

No Discord/replay behavior or runtime configuration changes.