### PR TITLE
perf(agent): drop per-call base64 re-serialization from request-size estimate

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1073,14 +1073,11 @@ def run_conversation(
         # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
         _sanitize_messages_surrogates(api_messages)
 
-        # Approximate request size for logging + pressure checks, from ONE
-        # message-token estimate. Tool schemas ship as a separate field, so add
-        # them back for compression decisions (50+ tools = 20-30K tokens).
-        # (estimate_messages_tokens_rough already image-strips base64.) This
-        # replaces a `str(msg)` char walk that re-serialized the whole history
-        # incl. base64 every call, plus estimate_request_tokens_rough re-walking
-        # the messages a second time. total_chars stays a rough (~) proxy — it
-        # only feeds a verbose log + the pre-api-request hook metric.
+        # One image-stripped message estimate feeds both figures. Was: a
+        # str(msg) char walk (re-serialized base64 every call) + a second
+        # messages walk inside estimate_request_tokens_rough. Tools added
+        # separately (compression needs them: 50+ tools = 20-30K tokens).
+        # total_chars is a rough (~) proxy — verbose log + hook metric only.
         approx_tokens = estimate_messages_tokens_rough(api_messages)
         request_pressure_tokens = approx_tokens + (
             _estimate_tools_tokens_rough(agent.tools) if agent.tools else 0

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -52,6 +52,7 @@ from agent.message_sanitization import (
 )
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
+    _estimate_tools_tokens_rough,
     estimate_messages_tokens_rough,
     estimate_request_tokens_rough,
     get_context_length_from_provider_error,
@@ -1072,17 +1073,19 @@ def run_conversation(
         # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
         _sanitize_messages_surrogates(api_messages)
 
-        # Calculate approximate request size for logging and pressure checks.
-        # estimate_messages_tokens_rough(api_messages) includes the system
-        # prompt copy but not the tool schema payload, which is sent as a
-        # separate field. Add tools back for compression decisions so long
-        # tool-heavy turns do not creep up to the context ceiling and leave
-        # no room for the model's final answer.
-        total_chars = sum(len(str(msg)) for msg in api_messages)
+        # Approximate request size for logging + pressure checks, from ONE
+        # message-token estimate. Tool schemas ship as a separate field, so add
+        # them back for compression decisions (50+ tools = 20-30K tokens).
+        # (estimate_messages_tokens_rough already image-strips base64.) This
+        # replaces a `str(msg)` char walk that re-serialized the whole history
+        # incl. base64 every call, plus estimate_request_tokens_rough re-walking
+        # the messages a second time. total_chars stays a rough (~) proxy — it
+        # only feeds a verbose log + the pre-api-request hook metric.
         approx_tokens = estimate_messages_tokens_rough(api_messages)
-        request_pressure_tokens = estimate_request_tokens_rough(
-            api_messages, tools=agent.tools or None
+        request_pressure_tokens = approx_tokens + (
+            _estimate_tools_tokens_rough(agent.tools) if agent.tools else 0
         )
+        total_chars = approx_tokens * 4
 
         _runtime_context_error = _ollama_context_limit_error(
             agent, request_pressure_tokens


### PR DESCRIPTION
## Summary

A real TTFT / per-turn win on the critical path for **every** API call.

Each iteration did:
```python
total_chars = sum(len(str(msg)) for msg in api_messages)          # (1)
approx_tokens = estimate_messages_tokens_rough(api_messages)      # (2)
request_pressure_tokens = estimate_request_tokens_rough(          # (3)
    api_messages, tools=agent.tools or None
)
```
- (1) `str(msg)` serializes the **entire history** — including base64 images and large tool results — just to `len()` it. A single ~1MB screenshot allocates a ~1MB+ string every call.
- (3) re-walks the messages a **second** time (it calls `estimate_messages_tokens_rough` internally, already computed at (2)).

Now derived from **one** image-stripped message estimate:
```python
approx_tokens = estimate_messages_tokens_rough(api_messages)
request_pressure_tokens = approx_tokens + (_estimate_tools_tokens_rough(agent.tools) if agent.tools else 0)
total_chars = approx_tokens * 4
```

## Correctness
- `request_pressure_tokens` is **byte-identical** to the old call: `estimate_request_tokens_rough(msgs, tools=agent.tools or None)` with no `system_prompt` = `estimate_messages_tokens_rough(msgs) + _estimate_tools_tokens_rough(tools)`.
- `total_chars` only feeds a verbose log line and the `pre_api_request` hook's `request_char_count` (no decision uses it), so a rough token-derived proxy is fine — and it no longer balloons on image turns.
- `tests/agent/test_model_metadata.py` (122) + `test_compressor_image_tokens.py` (12) green.

## Context
First of the backend TTFT batch from the perf sweep. The bigger sibling — the Anthropic prompt-caching `deepcopy` of the whole transcript per call — is deferred: that `deepcopy` looks **load-bearing** for the downstream `_sanitize_api_messages` / thinking-drop mutators, so it needs provenance tracing + a no-mutation test before it's safe to touch.

## Test plan
- [x] `scripts/run_tests.sh tests/agent/test_model_metadata.py tests/agent/test_compressor_image_tokens.py`
- [ ] Sanity: a real image-heavy turn still reports sane request-size logs