### PR TITLE
fix(tui): pool-route exec quick commands to unblock RPC reader (#67627)

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1496,6 +1496,29 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
             return normalized
 
         _rid, method, _params = normalized
+        # command.dispatch is normally inline, but exec-type quick commands
+        # block the reader for up to 30 s via subprocess.run.  Detect them
+        # early so the pool handles the wait while the reader stays free.
+        if method == "command.dispatch":
+            try:
+                qcmds = _load_cfg().get("quick_commands", {}) or {}
+                qc_name = str((_params or {}).get("name", "")).lstrip("/")
+                resolved = _resolve_name(qc_name) if qc_name else qc_name
+                if resolved in qcmds and qcmds[resolved].get("type") == "exec":
+                    ctx = contextvars.copy_context()
+
+                    def _pool_run():
+                        try:
+                            resp = handle_request(req)
+                        except Exception as exc:
+                            resp = _err(req.get("id"), -32000, f"handler error: {exc}")
+                        if resp is not None:
+                            t.write(resp)
+
+                    _pool.submit(lambda: ctx.run(_pool_run))
+                    return None
+            except Exception:
+                pass  # fall through to normal dispatch
         if method not in _LONG_HANDLERS:
             return handle_request(req)
 


### PR DESCRIPTION
## Fix

Route `command.dispatch` with `type: exec` quick commands to the thread pool so the RPC reader loop stays free while the subprocess runs (up to 30s timeout).

## Problem

`command.dispatch` runs synchronously on the TUI gateway RPC reader thread. When a quick command has `type: exec`, the handler calls `subprocess.run(..., timeout=30)` inline. During this time, fast RPCs like `session.interrupt` or `approval.respond` sit unread in the stdin pipe, making the TUI appear frozen.

## Root cause

`dispatch()` only offloads methods listed in `_LONG_HANDLERS`. `command.dispatch` is not in that set because most quick commands (aliases, slash commands) need inline ordering. But exec-type quick commands block the reader unnecessarily.

## Fix details

In `dispatch()`, before the `_LONG_HANDLERS` check, detect `command.dispatch` calls targeting exec-type quick commands and route them to the pool. Non-exec quick commands remain inline to preserve ordering.

The detection loads `quick_commands` from config and checks the resolved command's `type`. If `type == "exec"`, the handler runs on the pool; otherwise it falls through to normal inline dispatch.

Fixes #67627