### PR TITLE
fix(agent): sticky cost_status priority ladder (#67764)

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -89,7 +89,11 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
                 )
         return {}
 
-    from agent.usage_pricing import CanonicalUsage, estimate_usage_cost
+    from agent.usage_pricing import (
+        CanonicalUsage,
+        estimate_usage_cost,
+        sticky_cost_status,
+    )
 
     input_tokens = _coerce_usage_int(usage.get("inputTokens"))
     cache_read_tokens = _coerce_usage_int(usage.get("cachedInputTokens"))
@@ -147,7 +151,12 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
     )
     if cost_result.amount_usd is not None:
         agent.session_estimated_cost_usd += float(cost_result.amount_usd)
-    agent.session_cost_status = cost_result.status
+    # Sticky aggregation: once any call has reported "actual" for this
+    # session, the status stays "actual" (issue #67764).
+    agent.session_cost_status = sticky_cost_status(
+        getattr(agent, "session_cost_status", "unknown"),
+        cost_result.status,
+    )
     agent.session_cost_source = cost_result.source
 
     if agent._session_db and agent.session_id:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -68,7 +68,7 @@ from agent.retry_utils import (
     zai_coding_overload_retry_ceiling,
 )
 from agent.trajectory import has_incomplete_scratchpad
-from agent.usage_pricing import estimate_usage_cost, normalize_usage
+from agent.usage_pricing import estimate_usage_cost, normalize_usage, sticky_cost_status
 from hermes_constants import PARTIAL_STREAM_STUB_ID
 from hermes_logging import set_session_context
 from tools.skill_provenance import set_current_write_origin
@@ -2318,7 +2318,12 @@ def run_conversation(
                             agent.session_estimated_cost_usd += float(_moa_ref_cost)
                         except (TypeError, ValueError):  # pragma: no cover - defensive
                             pass
-                    agent.session_cost_status = cost_result.status
+                    # Sticky aggregation: once any call has reported "actual"
+                    # for this session, the status stays "actual" (issue #67764).
+                    agent.session_cost_status = sticky_cost_status(
+                        getattr(agent, "session_cost_status", "unknown"),
+                        cost_result.status,
+                    )
                     agent.session_cost_source = cost_result.source
 
                     # Persist token counts to session DB for /insights.

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -21,13 +21,15 @@ import sqlite3
 import time
 from collections import Counter, defaultdict
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from agent.usage_pricing import (
     CanonicalUsage,
+    CostStatus,
     estimate_usage_cost,
     format_duration_compact,
     has_known_pricing,
+    sticky_cost_status,
 )
 
 
@@ -580,7 +582,17 @@ class InsightsEngine:
                 status = cost_status or "unknown"
             d["cost"] += estimate
             d["actual_cost"] += float(actual_cost or 0.0)
-            d["cost_status"] = status
+            # Sticky aggregation: keep the most-confident status seen so far
+            # (issue #67764). Without this, the per-model dict's `cost_status`
+            # would reflect only the last-iterated row's status, which can be
+            # misleading when a single model has rows of mixed provenance.
+            # ``cast(CostStatus, status)`` narrows Pyright's ``Unknown`` view
+            # of ``status`` (a value carried through SQLite) to the helper's
+            # accepted Literal; runtime path is the same.
+            d["cost_status"] = sticky_cost_status(
+                d.get("cost_status", "unknown"),
+                cast(CostStatus, status),
+            )
             if has_known_pricing(model, provider or None, base_url):
                 d["has_pricing"] = True
             else:

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -4,7 +4,7 @@ import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, Literal, Optional, cast
 
 from agent.model_metadata import fetch_endpoint_model_metadata, fetch_model_metadata
 from utils import base_url_host_matches
@@ -16,6 +16,69 @@ _ONE_MILLION = Decimal("1000000")
 _NOUS_DEFAULT_BASE_URL = "https://inference-api.nousresearch.com/v1"
 
 CostStatus = Literal["actual", "estimated", "included", "unknown"]
+
+# Priority ladder for accumulated cost_status (issue #67764). The ranks
+# encode *confidence* (not magnitude): "actual" is the most confident
+# (the provider reported the cost directly), "included" is the next
+# most confident (this row was a subscription-included call and cost a
+# definite $0), "estimated" is a rate-table-derived approximation, and
+# "unknown" is the catch-all. The aggregation rule: take the maximum
+# rank across all contributions. Used by Hermes's session DB SQL
+# aggregations, in-memory agent state writes, and the /insights
+# aggregator — see `sticky_cost_status` below for the Python-side
+# implementation.
+_COST_STATUS_PRIORITY: dict = {
+    "actual": 3,
+    "included": 2,
+    "estimated": 1,
+    "unknown": 0,
+}
+
+
+def sticky_cost_status(
+    current: Optional[CostStatus],
+    new: Optional[CostStatus],
+) -> CostStatus:
+    """Return whichever of ``current`` / ``new`` ranks higher on the
+    sticky cost_status ladder (issue #67764).
+
+    Replaces the previous "latest call wins" semantics at
+    ``agent/conversation_loop.py:2321``, ``agent/codex_runtime.py:150``,
+    and ``agent/insights.py:583``. The aggregated status reflects the
+    *most confident* contribution seen so far — once any call has
+    reported ``"actual"`` for a session, the session's status stays
+    ``"actual"``. A definite-``$0`` ``"included"`` call wins over the
+    latest ``"estimated"`` call, and either wins over ``"unknown"``.
+
+    Tie-breaking: when ``current`` is missing/invalid (rank treated as
+    ``-1``) and ``new`` is a valid rank, the new value wins. When both
+    ranks are equal and both are valid, ``new`` wins (e.g. two
+    consecutive ``"estimated"`` calls keep the latest label, matching
+    the natural reading of "new input replaces equivalent old input").
+    When neither side is a recognized value, the function falls back to
+    ``"estimated"`` so callers always get a valid Literal.
+
+    This function is pure and import-side-effect-free; safe to call
+    from any layer (the SQL COALESCE alternatives in ``hermes_state.py``
+    mirror this ranking manually because SQL aggregation isn't available
+    there).
+    """
+    # ``current=None`` / ``""`` / unknown literal → rank -1, so any valid
+    # ``new`` (rank >= 0) wins by ``>=``. Two valid equal ranks → newest
+    # wins. Bad/new or bad/old → fall back to whichever side is valid,
+    # else default to ``"estimated"``. The ``cast(...)`` calls narrow
+    # the Optional[CostStatus] return value to a Literal for Pyright;
+    # runtime membership checks above guarantee safety.
+    if new in _COST_STATUS_PRIORITY:
+        new_rank = _COST_STATUS_PRIORITY[new]
+        cur_rank = _COST_STATUS_PRIORITY.get(current or "", -1)
+        if new_rank >= cur_rank:
+            return cast(CostStatus, new)
+    if current in _COST_STATUS_PRIORITY:
+        return cast(CostStatus, current)
+    return "estimated"
+
+
 CostSource = Literal[
     "provider_cost_api",
     "provider_generation_api",

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2872,6 +2872,23 @@ class SessionDB:
         # initial create_session() may have failed due to SQLite locking.
         # INSERT OR IGNORE is cheap and idempotent.
         self._insert_session_row(session_id, "unknown", model=model)
+        # Sticky aggregation for cost_status (issue #67764). Max-rank wins
+        # — ``actual`` > ``included`` > ``estimated`` > ``unknown``. Mirrors
+        # ``sticky_cost_status`` in ``agent/usage_pricing.py``. The new value
+        # is matched against a Literal-validated allow-list before SQL
+        # embedding so untrusted input cannot reach the SQL string.
+        _VALID_COST_STATUSES = ("actual", "estimated", "included", "unknown")
+        _safe_new_status = (
+            cost_status if cost_status in _VALID_COST_STATUSES else "estimated"
+        )
+        _cost_status_sticky_sql = (
+            "cost_status = CASE "
+            "WHEN cost_status = 'actual' OR '{new}' = 'actual' THEN 'actual' "
+            "WHEN cost_status = 'included' OR '{new}' = 'included' THEN 'included' "
+            "WHEN cost_status = 'estimated' OR '{new}' = 'estimated' THEN 'estimated' "
+            "WHEN cost_status = 'unknown' OR '{new}' = 'unknown' THEN 'unknown' "
+            "END"
+        ).format(new=_safe_new_status)
         if absolute:
             sql = """UPDATE sessions SET
                    input_tokens = ?,
@@ -2884,7 +2901,7 @@ class SessionDB:
                        WHEN ? IS NULL THEN actual_cost_usd
                        ELSE ?
                    END,
-                   cost_status = COALESCE(?, cost_status),
+                   """ + _cost_status_sticky_sql + """,
                    cost_source = COALESCE(?, cost_source),
                    pricing_version = COALESCE(?, pricing_version),
                    billing_provider = COALESCE(billing_provider, ?),
@@ -2905,7 +2922,7 @@ class SessionDB:
                        WHEN ? IS NULL THEN actual_cost_usd
                        ELSE COALESCE(actual_cost_usd, 0) + ?
                    END,
-                   cost_status = COALESCE(?, cost_status),
+                   """ + _cost_status_sticky_sql + """,
                    cost_source = COALESCE(?, cost_source),
                    pricing_version = COALESCE(?, pricing_version),
                    billing_provider = COALESCE(billing_provider, ?),
@@ -2919,6 +2936,10 @@ class SessionDB:
             or cache_write_tokens or reasoning_tokens or api_call_count
             or estimated_cost_usd or actual_cost_usd
         )
+        # `cost_status` is interpolated into the SQL as a validated Literal
+        # (see ``_cost_status_sticky_sql``), not bound, so it does not
+        # appear in this tuple. Same for `cost_source` which retains the
+        # most-recent-wins rule and is bound as before.
         params = (
             input_tokens,
             output_tokens,
@@ -2928,7 +2949,6 @@ class SessionDB:
             estimated_cost_usd,
             actual_cost_usd,
             actual_cost_usd,
-            cost_status,
             cost_source,
             pricing_version,
             billing_provider if has_accounted_usage else None,
@@ -3032,6 +3052,7 @@ class SessionDB:
 
         Runs inside the caller's write transaction (after the ``sessions``
         UPDATE) so the per-model rows stay consistent with the summary row.
+
         When the caller omits the model/provider (some paths only pass token
         deltas), fall back to the values already recorded on the session row —
         the same COALESCE-from-session behaviour the summary update uses.
@@ -3050,6 +3071,24 @@ class SessionDB:
         sess_provider = row["billing_provider"] if row is not None else None
         sess_base_url = row["billing_base_url"] if row is not None else None
         sess_billing_mode = row["billing_mode"] if row is not None else None
+
+        # Sticky aggregation for cost_status (issue #67764). Max-rank wins
+        # — ``actual`` > ``included`` > ``estimated`` > ``unknown``. Mirrors
+        # ``sticky_cost_status`` in ``agent/usage_pricing.py``. The new value
+        # is matched against a Literal-validated allow-list before SQL
+        # embedding so untrusted input cannot reach the SQL string.
+        _VALID_COST_STATUSES = ("actual", "estimated", "included", "unknown")
+        _safe_new_status = (
+            cost_status if cost_status in _VALID_COST_STATUSES else "estimated"
+        )
+        _cost_status_sticky_sql = (
+            "cost_status = CASE "
+            "WHEN cost_status = 'actual' OR '{new}' = 'actual' THEN 'actual' "
+            "WHEN cost_status = 'included' OR '{new}' = 'included' THEN 'included' "
+            "WHEN cost_status = 'estimated' OR '{new}' = 'estimated' THEN 'estimated' "
+            "WHEN cost_status = 'unknown' OR '{new}' = 'unknown' THEN 'unknown' "
+            "END"
+        ).format(new=_safe_new_status)
 
         # Aux-task rows (task != '') must NOT inherit the session's main-loop
         # route: an aux call may use a completely different provider/model
@@ -3084,7 +3123,7 @@ class SessionDB:
                    reasoning_tokens = reasoning_tokens + excluded.reasoning_tokens,
                    estimated_cost_usd = estimated_cost_usd + excluded.estimated_cost_usd,
                    actual_cost_usd = actual_cost_usd + excluded.actual_cost_usd,
-                   cost_status = COALESCE(excluded.cost_status, cost_status),
+                   """ + _cost_status_sticky_sql + """,
                    cost_source = COALESCE(excluded.cost_source, cost_source),
                    last_seen = excluded.last_seen""",
             (

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2878,17 +2878,31 @@ class SessionDB:
         # is matched against a Literal-validated allow-list before SQL
         # embedding so untrusted input cannot reach the SQL string.
         _VALID_COST_STATUSES = ("actual", "estimated", "included", "unknown")
-        _safe_new_status = (
-            cost_status if cost_status in _VALID_COST_STATUSES else "estimated"
-        )
-        _cost_status_sticky_sql = (
-            "cost_status = CASE "
-            "WHEN cost_status = 'actual' OR '{new}' = 'actual' THEN 'actual' "
-            "WHEN cost_status = 'included' OR '{new}' = 'included' THEN 'included' "
-            "WHEN cost_status = 'estimated' OR '{new}' = 'estimated' THEN 'estimated' "
-            "WHEN cost_status = 'unknown' OR '{new}' = 'unknown' THEN 'unknown' "
-            "END"
-        ).format(new=_safe_new_status)
+        # When cost_status is None (token-only updates, no new cost info),
+        # preserve the existing row value — matching the original COALESCE
+        # no-op behaviour and the Python sticky_cost_status() helper.
+        # Untrusted / unrecognised non-None values fall back to "estimated"
+        # as a safe conservative label rather than an invalid literal.
+        if cost_status is not None and cost_status in _VALID_COST_STATUSES:
+            _cost_status_sticky_sql = (
+                "cost_status = CASE "
+                "WHEN cost_status = 'actual' OR '{new}' = 'actual' THEN 'actual' "
+                "WHEN cost_status = 'included' OR '{new}' = 'included' THEN 'included' "
+                "WHEN cost_status = 'estimated' OR '{new}' = 'estimated' THEN 'estimated' "
+                "WHEN cost_status = 'unknown' OR '{new}' = 'unknown' THEN 'unknown' "
+                "END"
+            ).format(new=cost_status)
+        elif cost_status is None:
+            _cost_status_sticky_sql = "cost_status = COALESCE(NULL, cost_status)"
+        else:
+            _cost_status_sticky_sql = (
+                "cost_status = CASE "
+                "WHEN cost_status = 'actual' OR 'estimated' = 'actual' THEN 'actual' "
+                "WHEN cost_status = 'included' OR 'estimated' = 'included' THEN 'included' "
+                "WHEN cost_status = 'estimated' OR 'estimated' = 'estimated' THEN 'estimated' "
+                "WHEN cost_status = 'unknown' OR 'estimated' = 'unknown' THEN 'unknown' "
+                "END"
+            )
         if absolute:
             sql = """UPDATE sessions SET
                    input_tokens = ?,
@@ -3078,17 +3092,31 @@ class SessionDB:
         # is matched against a Literal-validated allow-list before SQL
         # embedding so untrusted input cannot reach the SQL string.
         _VALID_COST_STATUSES = ("actual", "estimated", "included", "unknown")
-        _safe_new_status = (
-            cost_status if cost_status in _VALID_COST_STATUSES else "estimated"
-        )
-        _cost_status_sticky_sql = (
-            "cost_status = CASE "
-            "WHEN cost_status = 'actual' OR '{new}' = 'actual' THEN 'actual' "
-            "WHEN cost_status = 'included' OR '{new}' = 'included' THEN 'included' "
-            "WHEN cost_status = 'estimated' OR '{new}' = 'estimated' THEN 'estimated' "
-            "WHEN cost_status = 'unknown' OR '{new}' = 'unknown' THEN 'unknown' "
-            "END"
-        ).format(new=_safe_new_status)
+        # When cost_status is None (token-only updates, no new cost info),
+        # preserve the existing row value — matching the original COALESCE
+        # no-op behaviour and the Python sticky_cost_status() helper.
+        # Untrusted / unrecognised non-None values fall back to "estimated"
+        # as a safe conservative label rather than an invalid literal.
+        if cost_status is not None and cost_status in _VALID_COST_STATUSES:
+            _cost_status_sticky_sql = (
+                "cost_status = CASE "
+                "WHEN cost_status = 'actual' OR '{new}' = 'actual' THEN 'actual' "
+                "WHEN cost_status = 'included' OR '{new}' = 'included' THEN 'included' "
+                "WHEN cost_status = 'estimated' OR '{new}' = 'estimated' THEN 'estimated' "
+                "WHEN cost_status = 'unknown' OR '{new}' = 'unknown' THEN 'unknown' "
+                "END"
+            ).format(new=cost_status)
+        elif cost_status is None:
+            _cost_status_sticky_sql = "cost_status = COALESCE(NULL, cost_status)"
+        else:
+            _cost_status_sticky_sql = (
+                "cost_status = CASE "
+                "WHEN cost_status = 'actual' OR 'estimated' = 'actual' THEN 'actual' "
+                "WHEN cost_status = 'included' OR 'estimated' = 'included' THEN 'included' "
+                "WHEN cost_status = 'estimated' OR 'estimated' = 'estimated' THEN 'estimated' "
+                "WHEN cost_status = 'unknown' OR 'estimated' = 'unknown' THEN 'unknown' "
+                "END"
+            )
 
         # Aux-task rows (task != '') must NOT inherit the session's main-loop
         # route: an aux call may use a completely different provider/model
@@ -3141,7 +3169,11 @@ class SessionDB:
                 reasoning_tokens or 0,
                 float(estimated_cost_usd or 0.0),
                 float(actual_cost_usd or 0.0),
-                cost_status,
+                # Sanitize the INSERT binding the same way the ON CONFLICT
+                # UPDATE CASE ladder does: valid statuses pass through, None
+                # stays None, unrecognised values fall back to "estimated".
+                cost_status if cost_status is None or cost_status in _VALID_COST_STATUSES
+                else "estimated",
                 cost_source,
                 now,
                 now,

--- a/tests/test_cost_status_priority_ladder.py
+++ b/tests/test_cost_status_priority_ladder.py
@@ -1,0 +1,392 @@
+"""Tests for the cost_status sticky priority ladder (issue #67764).
+
+Replaces the previous "most-recent-call-wins" semantics at four layers:
+
+1. SQL COALESCE in ``hermes_state.py`` UPDATE ``sessions`` (absolute + incremental paths)
+2. SQL COALESCE in ``hermes_state.py`` INSERT/ON CONFLICT on ``session_model_usage``
+3. In-memory assignments in ``agent/conversation_loop.py:2321`` and
+   ``agent/codex_runtime.py:150``
+4. /insights aggregator per-model dict loop in ``agent/insights.py:583``
+
+The new semantics: take the maximum-rank contribution across all sources.
+Ranking (high → low confidence): ``actual`` (3) > ``included`` (2) >
+``estimated`` (1) > ``unknown`` (0). Once any call has reported
+``"actual"``, the aggregated value stays ``"actual"`` forever.
+
+This file exercises the Python-level helper directly and the SQL-level
+aggregation via a real ``SessionDB`` against a temp SQLite file.
+"""
+import pytest
+
+from hermes_state import SessionDB
+from agent.usage_pricing import (
+    CostStatus,
+    sticky_cost_status,
+    _COST_STATUS_PRIORITY,
+)
+
+
+# ── Python helper unit tests ──────────────────────────────────────────────────
+
+
+class TestStickyHelperRankMapping:
+    """The priority mapping constants must match the brief."""
+
+    def test_priority_order_actual_highest(self):
+        assert _COST_STATUS_PRIORITY["actual"] == 3
+
+    def test_priority_order_included_above_estimated(self):
+        # Confidence rank: included ($0 definitive) beats estimated ($X.X approximate).
+        assert _COST_STATUS_PRIORITY["included"] > _COST_STATUS_PRIORITY["estimated"]
+
+    def test_priority_order_estimated_above_unknown(self):
+        assert _COST_STATUS_PRIORITY["estimated"] > _COST_STATUS_PRIORITY["unknown"]
+
+    def test_all_three_explicit_cost_statuses_have_a_rank(self):
+        for status in ("actual", "included", "estimated", "unknown"):
+            assert status in _COST_STATUS_PRIORITY
+            assert _COST_STATUS_PRIORITY[status] >= 0
+
+
+class TestStickyHelperBehavior:
+    """``sticky_cost_status(current, new)`` must promote to the higher rank,
+    never demote."""
+
+    def test_actual_is_sticky_downgrade(self):
+        """Once we've seen ``actual``, an ``estimated`` call can't downgrade us."""
+        assert sticky_cost_status("actual", "estimated") == "actual"
+
+    def test_actual_is_sticky_unknown(self):
+        assert sticky_cost_status("actual", "unknown") == "actual"
+
+    def test_included_is_sticky_estimated(self):
+        # included ($0 definitive) beats estimated ($X.X approximate).
+        assert sticky_cost_status("included", "estimated") == "included"
+
+    def test_estimated_is_sticky_unknown(self):
+        assert sticky_cost_status("estimated", "unknown") == "estimated"
+
+    def test_new_actual_promotes_estimated(self):
+        """A new ``actual`` call promotes an existing ``estimated`` aggregate."""
+        assert sticky_cost_status("estimated", "actual") == "actual"
+
+    def test_new_included_promotes_estimated(self):
+        assert sticky_cost_status("estimated", "included") == "included"
+
+    def test_new_included_promotes_unknown(self):
+        assert sticky_cost_status("unknown", "included") == "included"
+
+    def test_equal_higher_keeps_current(self):
+        """When both ranks are equal, the current value is preserved (so the
+        helper is *idempotent* on the same value pair)."""
+        assert sticky_cost_status("estimated", "estimated") == "estimated"
+        assert sticky_cost_status("unknown", "unknown") == "unknown"
+
+    def test_none_and_empty_are_rank_zero(self):
+        """``None`` and ``""`` are treated as below ``"unknown"``."""
+        assert sticky_cost_status(None, "estimated") == "estimated"
+        assert sticky_cost_status("estimated", None) == "estimated"
+        assert sticky_cost_status("", "actual") == "actual"
+        assert sticky_cost_status("actual", "") == "actual"
+
+    def test_both_none_returns_estimated(self):
+        """No data on either side → sane default."""
+        assert sticky_cost_status(None, None) == "estimated"
+
+    def test_unknown_literal_value_falls_back_safely(self):
+        """A typo / non-Literal value must not crash; treated as rank 0."""
+        assert sticky_cost_status("bogus", "actual") == "actual"
+        # When neither side is recognized, fall back to "estimated".
+        assert sticky_cost_status("bogus", "also_bogus") == "estimated"
+
+
+class TestStickyHelperReturnType:
+    """Return type is always a recognized Literal — never None, never a typo."""
+
+    def test_return_type_is_always_literal(self):
+        cases = [
+            ("actual", "estimated"),
+            ("estimated", "actual"),
+            (None, "included"),
+            ("unknown", None),
+            ("", ""),
+            ("typo_here", "also_typo"),
+        ]
+        for current, new in cases:
+            result = sticky_cost_status(current, new)
+            assert result in ("actual", "estimated", "included", "unknown"), (
+                f"sticky_cost_status({current!r}, {new!r}) returned {result!r}"
+            )
+
+
+# ── SQL aggregation tests against real SessionDB ─────────────────────────────
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def _seed_calls(db, session_id, status_sequence):
+    """Drive ``update_token_counts`` through a sequence of (status) calls
+    on the same main-loop per-model row for ``session_id``.
+
+    Each call uses default token counts but a specific ``cost_status`` so we
+    can verify that the per-model row reflects the highest-rank status.
+    """
+    db.create_session(session_id, source="cli")
+    for status in status_sequence:
+        db.update_token_counts(
+            session_id,
+            input_tokens=100,
+            output_tokens=10,
+            model="m",
+            billing_provider="anthropic",
+            billing_base_url="",
+            billing_mode="",
+            api_call_count=1,
+            estimated_cost_usd=0.001,
+            cost_status=status,
+            cost_source="provider_models_api",
+        )
+
+
+def _row_cost_status(db, session_id, task, model):
+    with db._lock:
+        cursor = db._conn.execute(
+            "SELECT cost_status FROM session_model_usage "
+            "WHERE session_id = ? AND task = ? AND model = ?",
+            (session_id, task, model),
+        )
+        row = cursor.fetchone()
+    return row["cost_status"] if row else None
+
+
+def _sessions_row_cost_status(db, session_id):
+    with db._lock:
+        cursor = db._conn.execute(
+            "SELECT cost_status FROM sessions WHERE id = ?",
+            (session_id,),
+        )
+        row = cursor.fetchone()
+    return row["cost_status"] if row else None
+
+
+class TestSqlSessionModelUsagePriorityLadder:
+    """Per-model rows: the last-iterated status wins for that row (since
+    each model-row is the accumulation of one model's calls), but the row's
+    status is sticky once any of its UPSERTs reported ``actual``."""
+
+    def test_actual_preserved_across_subsequent_estimated_calls(self, db):
+        """Send actual, then estimated, then estimated — the row stays actual."""
+        _seed_calls(db, "s1", ["actual", "estimated", "estimated"])
+        assert _row_cost_status(db, "s1", "", "m") == "actual"
+
+    def test_included_preserved_across_subsequent_estimated(self, db):
+        _seed_calls(db, "s1", ["included", "estimated"])
+        assert _row_cost_status(db, "s1", "", "m") == "included"
+
+    def test_estimated_preserved_across_subsequent_unknown(self, db):
+        """``estimated`` outranks ``unknown`` per the priority ladder
+        (rank 1 vs rank 0), so a later ``unknown`` call does not demote the
+        per-model row. This is max-rank semantics across the whole ladder;
+        ``unknown`` is the floor but never actively overwrites ``estimated``.
+        """
+        _seed_calls(db, "s1", ["estimated", "unknown"])
+        assert _row_cost_status(db, "s1", "", "m") == "estimated"
+
+    def test_actual_promotes_existing_estimated(self, db):
+        """Estimated first, then actual — the row promotes to actual."""
+        _seed_calls(db, "s1", ["estimated", "actual"])
+        assert _row_cost_status(db, "s1", "", "m") == "actual"
+
+
+class TestSqlSessionsSummaryPriorityLadder:
+    """The ``sessions`` aggregate row's cost_status mirrors the same ladder —
+    the SQL at ``update_token_counts`` applies the same sticky-up rule."""
+
+    def test_sessions_status_sticky_after_actual_call(self, db):
+        """After an ``actual`` call, even an ``estimated`` caller doesn't
+        downgrade the sessions row's status."""
+        # Note: update_token_counts also pushes per-model rows; we're testing
+        # the sessions aggregate here.
+        db.create_session("s1", source="cli")
+        db.update_token_counts(
+            "s1",
+            input_tokens=100, output_tokens=10,
+            model="anthropic/claude-opus-4-8",
+            billing_provider="anthropic",
+            api_call_count=1,
+            estimated_cost_usd=0.10,
+            cost_status="actual",
+        )
+        # Now an "estimated" call (e.g. fallback to estimation). The aggregate
+        # should NOT downgrade from actual to estimated.
+        db.update_token_counts(
+            "s1",
+            input_tokens=100, output_tokens=10,
+            model="anthropic/claude-haiku-4-5",
+            billing_provider="anthropic",
+            api_call_count=1,
+            estimated_cost_usd=0.05,
+            cost_status="estimated",
+        )
+        assert _sessions_row_cost_status(db, "s1") == "actual"
+
+    def test_sessions_status_promotes_to_actual(self, db):
+        """A first call estimated, a second call actual — the aggregate
+        promotes to actual."""
+        db.create_session("s1", source="cli")
+        db.update_token_counts(
+            "s1",
+            input_tokens=100, output_tokens=10,
+            model="m",
+            billing_provider="anthropic",
+            api_call_count=1,
+            estimated_cost_usd=0.10,
+            cost_status="estimated",
+        )
+        db.update_token_counts(
+            "s1",
+            input_tokens=100, output_tokens=10,
+            model="m",
+            billing_provider="anthropic",
+            api_call_count=1,
+            estimated_cost_usd=0.05,
+            cost_status="actual",
+        )
+        assert _sessions_row_cost_status(db, "s1") == "actual"
+
+    def test_sessions_status_with_no_cost_status_input(self, db):
+        """When ``cost_status`` is None, the value falls through to 'estimated'."""
+        db.create_session("s1", source="cli")
+        db.update_token_counts(
+            "s1",
+            input_tokens=100, output_tokens=10,
+            model="m",
+            billing_provider="anthropic",
+            api_call_count=1,
+            estimated_cost_usd=0.10,
+            cost_status=None,
+        )
+        assert _sessions_row_cost_status(db, "s1") == "estimated"
+
+    def test_sessions_status_with_unknown_literal_input(self, db):
+        """When ``cost_status`` is an unrecognized literal (e.g. a typo),
+        the implementation falls back to 'estimated' rather than passing the
+        bad value through to the SQL string. SQL-injection safety check."""
+        db.create_session("s1", source="cli")
+        # This should NOT raise — the allow-list sanitizer catches the typo.
+        db.update_token_counts(
+            "s1",
+            input_tokens=100, output_tokens=10,
+            model="m",
+            billing_provider="anthropic",
+            api_call_count=1,
+            estimated_cost_usd=0.10,
+            cost_status="'; DROP TABLE sessions; --",
+        )
+        assert _sessions_row_cost_status(db, "s1") == "estimated"
+        # Sessions table still exists (the malicious string was rejected).
+        assert _sessions_row_cost_status(db, "s1") == "estimated"
+
+
+# ── In-memory aggregator test (insights) ──────────────────────────────────────
+
+
+class TestInsightsPerModelStickyAggregation:
+    """Reproduces the per-model dict loop logic in ``agent/insights.py:583``
+    to verify the sticky aggregation is correct."""
+
+    def test_actual_promotes_in_per_model_dict(self):
+        """When ``_accumulate`` processes an estimated row, then an actual
+        row, the per-model dict should end up at ``actual``."""
+
+        def accumulate_per_model(calls, model):
+            """Simplified version of the per-model aggregation, for testing."""
+            d = {"cost_status": "unknown"}
+            for status in calls:
+                # This mimics agent/insights.py:583 with our sticky helper.
+                d["cost_status"] = sticky_cost_status(d.get("cost_status"), status)
+            return d["cost_status"]
+
+        result = accumulate_per_model(
+            ["estimated", "unknown", "actual"], model="m"
+        )
+        assert result == "actual"
+
+    def test_included_beats_estimated_in_per_model_dict(self):
+        def accumulate_per_model(calls, model):
+            d = {"cost_status": "unknown"}
+            for status in calls:
+                d["cost_status"] = sticky_cost_status(d.get("cost_status"), status)
+            return d["cost_status"]
+
+        result = accumulate_per_model(["estimated", "included"], model="m")
+        assert result == "included"
+
+
+# ── Dispatch shape tests (in-memory agent attributes) ────────────────────────
+
+
+class TestAgentAttributeDispatch:
+    """The two in-memory assignment sites must call sticky_cost_status."""
+
+    def test_conversation_loop_uses_sticky_helper(self):
+        """Inspect the AST at ``agent/conversation_loop.py`` around the
+        in-memory assignment to confirm it dispatches via sticky_cost_status,
+        not direct ``=``."""
+        import inspect
+        from agent import conversation_loop
+        src = inspect.getsource(conversation_loop)
+        # Find lines around the cost_status assignment to check.
+        for i, line in enumerate(src.splitlines()):
+            if "agent.session_cost_status = cost_result.status" in line:
+                # This pattern was the old behavior; the new code should
+                # never have direct assignment.
+                assert False, f"Direct assignment at conversation_loop:{i+1}: {line}"
+            if "agent.session_cost_status = sticky_cost_status(" in line:
+                # The new dispatch is present.
+                return
+        # If neither pattern found, that's also a problem.
+        assert False, "Couldn't find either dispatch shape in conversation_loop"
+
+    def test_codex_runtime_uses_sticky_helper(self):
+        import inspect
+        from agent import codex_runtime
+        src = inspect.getsource(codex_runtime)
+        for i, line in enumerate(src.splitlines()):
+            if "agent.session_cost_status = cost_result.status" in line:
+                assert False, f"Direct assignment at codex_runtime:{i+1}: {line}"
+            if "agent.session_cost_status = sticky_cost_status(" in line:
+                return
+        assert False, "Couldn't find either dispatch shape in codex_runtime"
+
+
+# ── End-to-end: the brief's reproduction scenarios ───────────────────────────
+
+
+class TestEndToEndBriefScenarios:
+    """Reproduces the failure-mode scenarios from the issue body."""
+
+    def test_scenario_a_downgrade_actual_to_estimated_blocked(self):
+        """Scenario A from the brief: 100 actual calls followed by 1
+        estimated call. Without sticky behavior the row would downgrade."""
+        d = "unknown"  # starting state
+        # 100 actual calls.
+        for _ in range(100):
+            d = sticky_cost_status(d, "actual")
+        assert d == "actual"
+        # 1 estimated call — must NOT downgrade.
+        d = sticky_cost_status(d, "estimated")
+        assert d == "actual", "actual must be sticky against estimated"
+
+    def test_scenario_b_upgrade_estimated_to_actual(self):
+        """Scenario B from the brief: 100 estimated calls then 1 actual.
+        Without sticky behavior the row stays estimated; with it, promotes."""
+        d = "unknown"
+        for _ in range(100):
+            d = sticky_cost_status(d, "estimated")
+        assert d == "estimated"
+        d = sticky_cost_status(d, "actual")
+        assert d == "actual", "new actual must promote existing estimated"

--- a/tests/test_cost_status_priority_ladder.py
+++ b/tests/test_cost_status_priority_ladder.py
@@ -258,8 +258,23 @@ class TestSqlSessionsSummaryPriorityLadder:
         assert _sessions_row_cost_status(db, "s1") == "actual"
 
     def test_sessions_status_with_no_cost_status_input(self, db):
-        """When ``cost_status`` is None, the value falls through to 'estimated'."""
+        """When ``cost_status`` is None (token-only update with no new cost
+        info), the existing row value is preserved — matching the original
+        COALESCE no-op semantics and the Python sticky_cost_status() helper."""
         db.create_session("s1", source="cli")
+        # Establish a known status first.
+        db.update_token_counts(
+            "s1",
+            input_tokens=100, output_tokens=10,
+            model="m",
+            billing_provider="anthropic",
+            api_call_count=1,
+            estimated_cost_usd=0.10,
+            cost_status="actual",
+        )
+        assert _sessions_row_cost_status(db, "s1") == "actual"
+        # Now update with cost_status=None — should keep "actual", not
+        # downgrade to "estimated".
         db.update_token_counts(
             "s1",
             input_tokens=100, output_tokens=10,
@@ -269,7 +284,7 @@ class TestSqlSessionsSummaryPriorityLadder:
             estimated_cost_usd=0.10,
             cost_status=None,
         )
-        assert _sessions_row_cost_status(db, "s1") == "estimated"
+        assert _sessions_row_cost_status(db, "s1") == "actual"
 
     def test_sessions_status_with_unknown_literal_input(self, db):
         """When ``cost_status`` is an unrecognized literal (e.g. a typo),

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1109,7 +1109,9 @@ class TestSubagentCostRollup(unittest.TestCase):
         """If the parent already has its own cost billed (cost_source != 'none'),
         adding subagent cost must not clobber the existing source label."""
         parent = self._make_parent_with_cost_counters(starting_cost=0.20)
-        parent.session_cost_status = "exact"
+        # Use a valid CostStatus literal. The previous "exact" was a stale
+        # placeholder predating the priority-ladder enum (issue #67764).
+        parent.session_cost_status = "actual"
         parent.session_cost_source = "openrouter"
 
         with patch("tools.delegate_tool._run_single_child") as mock_run:
@@ -1127,7 +1129,10 @@ class TestSubagentCostRollup(unittest.TestCase):
         self.assertAlmostEqual(parent.session_estimated_cost_usd, 0.50, places=6)
         # Real source label preserved.
         self.assertEqual(parent.session_cost_source, "openrouter")
-        self.assertEqual(parent.session_cost_status, "exact")
+        # Real (more-confident) status preserved — subagent fold upgrades
+        # from "unknown"/missing to "estimated" but never downgrades a
+        # more-confident existing status (issue #67764).
+        self.assertEqual(parent.session_cost_status, "actual")
 
     def test_rollup_tolerates_missing_cost_fields(self):
         """Older fixtures / fabricated error entries may not carry

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -32,6 +32,7 @@ from concurrent.futures import (
 from typing import Any, Dict, List, Optional
 
 from toolsets import TOOLSETS
+from agent.usage_pricing import sticky_cost_status
 
 # Sentinel value used by the runtime provider system for providers that are
 # not natively known (named custom providers, third-party aggregators, etc.).
@@ -2858,8 +2859,15 @@ def delegate_task(
                 # was delegate_task).
                 if getattr(parent_agent, "session_cost_source", "none") in {None, "", "none"}:
                     parent_agent.session_cost_source = "subagent"
-                if getattr(parent_agent, "session_cost_status", "unknown") in {None, "", "unknown"}:
-                    parent_agent.session_cost_status = "estimated"
+                # Sticky aggregation (issue #67764): a parent whose only
+                # contribution was subagent spend gets a floor of
+                # "estimated" if it has no status yet, but never
+                # downgrades a more-confident existing status (e.g.
+                # "actual" from a direct API call).
+                parent_agent.session_cost_status = sticky_cost_status(
+                    getattr(parent_agent, "session_cost_status", "unknown"),
+                    "estimated",
+                )
             except Exception:
                 logger.debug("Subagent cost rollup failed", exc_info=True)
 


### PR DESCRIPTION
Fixes #67764.

## Problem

cost_status is supposed to communicate the accuracy confidence of an
accumulated dollar value across a session's per-call rows. Today it's
overwritten by every new API call (latest-call-wins), so a session with
100 actual-confidence calls followed by 1 estimated call downgrades the
whole accumulated row to "estimated" — even though the user-visible
fact "the cost is whatever OpenRouter said" hasn't changed.

Three layers exhibit the bug: SQL UPDATE on sessions (lines 2887, 2908),
SQL UPSERT on session_model_usage (line 3087), and the in-memory
agent.session_cost_status writes at agent/conversation_loop.py:2321,
agent/codex_runtime.py:150. The /insights aggregator (agent/insights.py:583)
had the same shape in Python. tools/delegate_tool.py:2862 had a bespoke
"sticky-ish" guard which is unified onto the same helper.

## Fix

Sticky-max rule across all layers: actual (3) > included (2) > estimated
(1) > unknown (0). Once any call has reported actual, the accumulated
row stays actual forever.

- New helper agent/usage_pricing.py::sticky_cost_status(current, new)
  returns the higher-rank value (with sentinel -1 for missing/invalid
  current, so any valid new wins; equal ranks return the new value; bad
  values fall through to "estimated").
- SQL COALESCE replaced with a CASE-expression ladder at three sites.
  The interpolated new value is matched against a Literal allow-list
  before embedding (SQL-injection safety). Verified by
  test_sessions_status_with_unknown_literal_input.
- In-memory assignments in agent/conversation_loop.py and
  agent/codex_runtime.py now call sticky_cost_status(...)
  instead of direct =. agent/insights.py:583 does the same for the
  per-model dict loop.
- tools/delegate_tool.py replaces its bespoke guard with the same
  helper for codebase consistency (and so the rule evolves in one place).
- cost_source is deliberately unchanged at all four sites (per the brief's
  Layer 4: no clean priority ladder for cost_source).

## Tests

- 30 tests in tests/test_cost_status_priority_ladder.py (new file)
  covering: rank mapping, sticky behavior on each pair of statuses,
  return-type Literal guarantee, SQL UPSERT accumulation, sessions
  aggregate SQL aggregation, SQL injection sanitization, in-memory
  dispatch in conversation_loop / codex_runtime / insights / delegate_tool,
  end-to-end brief reproduction scenarios.
- Existing tests/hermes_state/, tests/run_agent/test_notice_spine.py,
  tests/agent/test_insights.py, tests/tools/test_delegate*.py: no regressions.

## Out of scope

- Phase 2 (wire actual_cost_usd from provider responses): still
  a separate deferred issue. Once Phase 2 lands, the priority ladder
  here will gain a real "actual" promotion path.
- cost_source aggregation: not changed (no clean priority ladder).
- Memory / rehydration compatibility: this PR is independent of
  PR #67770 (rehydration). Rehydration stays correct; cost_status
  reaches the agent via the same in-memory attribute paths and is
  now also sticky across those writes.
