### PR TITLE
fix(telegram): use basename for send_document filename (#67552)

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1342,7 +1342,10 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                             )
                         else:
                             last_msg = await bot.send_document(
-                                chat_id=int_chat_id, document=f, **media_kwargs
+                                chat_id=int_chat_id,
+                                document=f,
+                                filename=os.path.basename(media_path),
+                                **media_kwargs,
                             )
                     except Exception as media_err:
                         if _is_telegram_thread_not_found(media_err) and media_kwargs.get("message_thread_id"):
@@ -1373,7 +1376,10 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                                 )
                             else:
                                 last_msg = await bot.send_document(
-                                    chat_id=int_chat_id, document=f, **media_kwargs
+                                    chat_id=int_chat_id,
+                                    document=f,
+                                    filename=os.path.basename(media_path),
+                                    **media_kwargs,
                                 )
                         elif media_kwargs.get("parse_mode") and (
                             "parse" in str(media_err).lower()
@@ -1404,7 +1410,10 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                                 )
                             else:
                                 last_msg = await bot.send_document(
-                                    chat_id=int_chat_id, document=f, **media_kwargs
+                                    chat_id=int_chat_id,
+                                    document=f,
+                                    filename=os.path.basename(media_path),
+                                    **media_kwargs,
                                 )
                         else:
                             raise


### PR DESCRIPTION
## Fix

Pass `filename=os.path.basename(media_path)` to all three `bot.send_document()` call sites in the Telegram media delivery path.

## Problem

When delivering files via `MEDIA:<path>` on Telegram, `send_document(document=f)` without an explicit `filename` parameter causes python-telegram-bot to use `f.name` (the full filesystem path) as the multipart `Content-Disposition` filename. Long paths are silently rejected by Telegram's servers — no file is delivered and no error is surfaced to the user or agent.

## Root cause

`tools/send_message_tool.py` opens files with `open(media_path, "rb")` and passes the file object directly. python-telegram-bot uses the file object's `.name` attribute (the full path) instead of just the basename.

## Fix details

Add `filename=os.path.basename(media_path)` to all three `send_document()` call sites (lines ~1344, ~1375, ~1406) so Telegram receives only the basename in the Content-Disposition header.

Fixes #67552