### PR TITLE
fix(agent): rehydrate session accumulators from SQLite on restart (#67762)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2059,7 +2059,50 @@ def init_agent(
     agent.session_estimated_cost_usd = 0.0
     agent.session_cost_status = "unknown"
     agent.session_cost_source = "none"
-    
+
+    # ── Rehydrate session accumulators from persisted state ──
+    # When the gateway restarts mid-session, the session row already exists
+    # in SQLite with the correct accumulated totals.  Read them back so the
+    # live cost/token counters don't reset to zero on every restart.
+    if agent._session_db and agent.session_id:
+        try:
+            _existing = agent._session_db.get_session(agent.session_id)
+            if _existing:
+                agent.session_estimated_cost_usd = float(
+                    _existing.get("estimated_cost_usd") or 0.0
+                )
+                agent.session_cost_status = str(
+                    _existing.get("cost_status") or "unknown"
+                )
+                agent.session_cost_source = str(
+                    _existing.get("cost_source") or "none"
+                )
+                agent.session_prompt_tokens = int(
+                    _existing.get("input_tokens") or 0
+                )
+                agent.session_completion_tokens = int(
+                    _existing.get("output_tokens") or 0
+                )
+                agent.session_total_tokens = (
+                    agent.session_prompt_tokens + agent.session_completion_tokens
+                )
+                agent.session_input_tokens = agent.session_prompt_tokens
+                agent.session_output_tokens = agent.session_completion_tokens
+                agent.session_cache_read_tokens = int(
+                    _existing.get("cache_read_tokens") or 0
+                )
+                agent.session_cache_write_tokens = int(
+                    _existing.get("cache_write_tokens") or 0
+                )
+                agent.session_reasoning_tokens = int(
+                    _existing.get("reasoning_tokens") or 0
+                )
+                agent.session_api_calls = int(
+                    _existing.get("api_call_count") or 0
+                )
+        except Exception:
+            pass  # fail-open: fresh counters are better than crashing
+
     # ── Ollama num_ctx injection ──
     # Ollama defaults to 2048 context regardless of the model's capabilities.
     # When running against an Ollama server, detect the model's max context


### PR DESCRIPTION
## Problem

When the gateway restarts mid-session, `init_agent()` resets all session accumulators (`session_estimated_cost_usd`, token counts, `session_api_calls`) to zero. The persisted data in SQLite (`sessions.estimated_cost_usd`, `session_model_usage` rows) is correct, but nothing copies it back into the agent's in-memory state.

This means:
- The live cost counter shows only post-restart costs
- Token totals reset to zero
- `/insights` dashboard shows the correct total, but the agent's runtime state lies

Verified against `main` (commit `26480e6c5`).

## Reproduction

1. Start a session, run several turns (cost accumulates to, say, $4.27).
2. Restart the gateway process.
3. Resume the session by sending a new message.
4. Inspect `agent.session_estimated_cost_usd` -- shows $0.0 (or only post-restart cost).
5. Check `sessions.estimated_cost_usd` in `~/.hermes/state.db` -- correctly shows the full total.

## Fix

After the accumulator reset block in `agent/agent_init.py`, read the existing session row from SQLite (if present) and restore the persisted totals:

- `session_estimated_cost_usd`
- `session_cost_status` / `session_cost_source`
- All token counters (input, output, cache, reasoning)
- `session_api_calls`

For new sessions, `get_session()` returns `None` and the block is a no-op. DB errors are caught and swallowed (fail-open).

## Files Changed

- `agent/agent_init.py` -- add rehydration block after accumulator reset

Fixes #67762
