### PR TITLE
fix(discord): add home-channel owner to handoff thread (#67702)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -414,7 +414,8 @@ class HomeChannel:
     chat_id: str
     name: str  # Human-readable name for display
     thread_id: Optional[str] = None
-    
+    owner_user_id: Optional[str] = None  # user who ran /sethome
+
     def to_dict(self) -> Dict[str, Any]:
         result = {
             "platform": self.platform.value,
@@ -423,8 +424,10 @@ class HomeChannel:
         }
         if self.thread_id:
             result["thread_id"] = self.thread_id
+        if self.owner_user_id:
+            result["owner_user_id"] = self.owner_user_id
         return result
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "HomeChannel":
         return cls(
@@ -432,6 +435,7 @@ class HomeChannel:
             chat_id=str(data["chat_id"]),
             name=data.get("name", "Home"),
             thread_id=str(data["thread_id"]) if data.get("thread_id") else None,
+            owner_user_id=str(data["owner_user_id"]) if data.get("owner_user_id") else None,
         )
 
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3039,6 +3039,8 @@ class BasePlatformAdapter(ABC):
         self,
         parent_chat_id: str,
         name: str,
+        *,
+        owner_user_id: Optional[str] = None,
     ) -> Optional[str]:
         """Create a fresh thread under ``parent_chat_id`` for a session handoff.
 
@@ -3046,6 +3048,11 @@ class BasePlatformAdapter(ABC):
         session to a thread-capable platform — the new thread isolates the
         handed-off conversation from any pre-existing chat in the home
         channel and gives users a clean per-handoff scrollback.
+
+        ``owner_user_id`` is the user who ran ``/sethome``.  Adapters for
+        platforms where private threads require explicit membership (Discord)
+        should add this user to the newly created thread so it is visible
+        to them.
 
         Returns the new thread/topic id (as a string) on success, or
         ``None`` if the platform doesn't support threading or the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8169,6 +8169,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         try:
             new_thread_id = await adapter.create_handoff_thread(
                 str(home.chat_id), thread_name,
+                owner_user_id=getattr(home, "owner_user_id", None),
             )
         except Exception as exc:
             logger.debug(

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2563,6 +2563,7 @@ class GatewaySlashCommandsMixin:
                 chat_id=str(chat_id),
                 name=chat_name,
                 thread_id=str(thread_id) if thread_id else None,
+                owner_user_id=str(source.user_id) if source.user_id else None,
             )
 
         return t("gateway.set_home.success", name=chat_name, chat_id=chat_id)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6338,6 +6338,8 @@ class DiscordAdapter(BasePlatformAdapter):
         self,
         parent_chat_id: str,
         name: str,
+        *,
+        owner_user_id: Optional[str] = None,
     ) -> Optional[str]:
         """Create a Discord thread under a text channel for a handoff.
 
@@ -6346,6 +6348,9 @@ class DiscordAdapter(BasePlatformAdapter):
         permission setups). Returns the new thread id as a string, or
         ``None`` on failure or when the parent isn't a text channel
         (DMs, voice channels, threads themselves can't host threads).
+
+        When ``owner_user_id`` is provided, the user is added as a thread
+        member after creation so that private threads are visible to them.
         """
         if not self._client or not DISCORD_AVAILABLE:
             return None
@@ -6378,6 +6383,7 @@ class DiscordAdapter(BasePlatformAdapter):
         reason = "Hermes session handoff"
 
         # First try: create a thread directly on the channel.
+        thread = None
         try:
             create = getattr(parent, "create_thread", None)
             if create is not None:
@@ -6386,7 +6392,6 @@ class DiscordAdapter(BasePlatformAdapter):
                     auto_archive_duration=1440,
                     reason=reason,
                 )
-                return str(thread.id)
         except Exception as direct_error:
             logger.debug(
                 "[%s] Handoff thread: direct create failed (%s); trying seed-message fallback",
@@ -6394,23 +6399,42 @@ class DiscordAdapter(BasePlatformAdapter):
             )
 
         # Fallback: post a seed message and create the thread from it.
-        try:
-            send = getattr(parent, "send", None)
-            if send is None:
+        if thread is None:
+            try:
+                send = getattr(parent, "send", None)
+                if send is None:
+                    return None
+                seed_msg = await send(f"\U0001f9f5 Hermes handoff: **{thread_name}**")
+                thread = await seed_msg.create_thread(
+                    name=thread_name,
+                    auto_archive_duration=1440,
+                    reason=reason,
+                )
+            except Exception as fallback_error:
+                logger.warning(
+                    "[%s] Handoff thread: both create paths failed for parent %s: %s",
+                    self.name, parent_chat_id, fallback_error,
+                )
                 return None
-            seed_msg = await send(f"\U0001f9f5 Hermes handoff: **{thread_name}**")
-            thread = await seed_msg.create_thread(
-                name=thread_name,
-                auto_archive_duration=1440,
-                reason=reason,
-            )
-            return str(thread.id)
-        except Exception as fallback_error:
-            logger.warning(
-                "[%s] Handoff thread: both create paths failed for parent %s: %s",
-                self.name, parent_chat_id, fallback_error,
-            )
-            return None
+
+        # Add the home-channel owner to the thread so private threads
+        # are visible to them in the Discord client.
+        if owner_user_id and thread is not None:
+            try:
+                guild = getattr(parent, "guild", None)
+                if guild is not None:
+                    member = guild.get_member(int(owner_user_id))
+                    if member is None:
+                        member = await guild.fetch_member(int(owner_user_id))
+                    if member is not None:
+                        await thread.add_user(member)
+            except Exception as add_exc:
+                logger.warning(
+                    "[%s] Handoff thread: could not add user %s to thread %s: %s",
+                    self.name, owner_user_id, thread.id, add_exc,
+                )
+
+        return str(thread.id)
 
     def _self_contained_prompt_content(
         self, header: str, body: str, *, code_block: bool = False, tail: str = ""

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1310,6 +1310,8 @@ class SlackAdapter(BasePlatformAdapter):
         self,
         parent_chat_id: str,
         name: str,
+        *,
+        owner_user_id: Optional[str] = None,
     ) -> Optional[str]:
         """Create a Slack thread anchor for a session handoff.
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3039,6 +3039,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self,
         parent_chat_id: str,
         name: str,
+        *,
+        owner_user_id: Optional[str] = None,
     ) -> Optional[str]:
         """Create a forum topic for a session handoff.
 


### PR DESCRIPTION
## Problem

`/handoff discord` creates a Discord thread but never adds the destination user as a member. For private threads (channel type 12), this makes the thread completely invisible to the user in the Discord client. The handoff reports `completed` but the user has no way to see or enter the continuation thread.

Two cooperating gaps:
1. `create_handoff_thread()` has no `user_id` parameter -- the adapter can't add a member even if it wanted to
2. `_process_handoff()` never passes the user who ran `/sethome` to the adapter

## Fix

1. **Store owner identity**: Add `owner_user_id` field to `HomeChannel`. Populate it in the `/sethome` handler from `source.user_id`.
2. **Plumb through handoff**: `gateway/run.py` passes `home.owner_user_id` to `create_handoff_thread()`.
3. **Add member in Discord**: After creating the thread, Discord adapter calls `thread.add_user(member)` for the owner.
4. **Forward-compat**: Update base adapter, Telegram adapter, and Slack adapter signatures to accept `owner_user_id` (keyword-only, default None).

## Files Changed

- `gateway/config.py` -- `HomeChannel`: add `owner_user_id` field + serialization
- `gateway/slash_commands.py` -- `/sethome`: store `source.user_id`
- `gateway/platforms/base.py` -- base `create_handoff_thread` signature
- `plugins/platforms/discord/adapter.py` -- add user to thread after creation
- `plugins/platforms/telegram/adapter.py` -- accept `owner_user_id` (unused)
- `plugins/platforms/slack/adapter.py` -- accept `owner_user_id` (unused)
- `gateway/run.py` -- pass `owner_user_id` to `create_handoff_thread`

Fixes #67702
