### PR TITLE
docs(links): update moved Cloudflare Tunnel docs URL

### DIFF
--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -116,7 +116,7 @@ cloudflared tunnel --url http://localhost:8090
 Note the printed URL — that's what you'll give Meta.
 
 :::warning Quick tunnels rotate
-The free quick-tunnel URL changes every time you restart `cloudflared`.  For a stable URL, log in with `cloudflared tunnel login` and create a named tunnel.  Free Cloudflare accounts get unlimited named tunnels — see [Cloudflare's docs](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) for the named-tunnel workflow.
+The free quick-tunnel URL changes every time you restart `cloudflared`.  For a stable URL, log in with `cloudflared tunnel login` and create a named tunnel.  Free Cloudflare accounts get unlimited named tunnels — see [Cloudflare's docs](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/) for the named-tunnel workflow.
 :::
 
 ### ngrok


### PR DESCRIPTION
### Problem

The WhatsApp Cloud guide points readers at Cloudflare's named-tunnel docs using a path Cloudflare has since reorganized:

```
$ curl -sI https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/
HTTP/1.1 301 Moved Permanently
Location: /cloudflare-one/networks/connectors/cloudflare-tunnel/
```

Cloudflare restructured the Cloudflare One docs, moving `connections/connect-networks` to `networks/connectors/cloudflare-tunnel`. The new location is a direct 200:

```
$ curl -sI https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/
HTTP/1.1 200 OK
```

### Fix

Point the link at the canonical URL Cloudflare redirects to. The destination page is the Cloudflare Tunnel / named-tunnel workflow that this paragraph is sending readers to, so the reference stays semantically correct.

```diff
-...unlimited named tunnels — see [Cloudflare's docs](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) for the named-tunnel workflow.
+...unlimited named tunnels — see [Cloudflare's docs](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/) for the named-tunnel workflow.
```

Docs-only, no runtime or behavior change. The replacement is exactly the `Location` header returned by the old URL, so there is no ambiguity about the destination. This URL appears only in this one file — no other occurrence anywhere in the repo, so the fix is complete.



## Infographic

![docs-cloudflare-tunnel-link](https://v3b.fal.media/files/b/0aa2fbb2/0AWwyQWK9BzoqKlcpLWMU_nKkfoAUX.png)
