### PR TITLE
feat(tts): add built-in VOICEVOX-compatible TTS provider

### DIFF
--- a/agent/tts_registry.py
+++ b/agent/tts_registry.py
@@ -57,6 +57,7 @@ _BUILTIN_NAMES = frozenset({
     "kittentts",
     "piper",
     "deepinfra",
+    "voicevox",
 })
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2197,7 +2197,7 @@ DEFAULT_CONFIG = {
     # Gemini 32000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS 2000).
     "tts": {
         # Set explicitly to pin a backend:
-        # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "deepinfra" | "neutts" (local) | "kittentts" (local) | "piper" (local)
+        # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "deepinfra" | "neutts" (local) | "kittentts" (local) | "piper" (local) | "voicevox" (local, Japanese)
         "provider": "edge",
         "edge": {
             "voice": "en-US-AriaNeural",
@@ -2266,6 +2266,13 @@ DEFAULT_CONFIG = {
             # "noise_w_scale": 0.8,
             # "volume": 1.0,
             # "normalize_audio": True,
+        },
+        "voicevox": {
+            # VOICEVOX-compatible engine base URL.
+            # Works with VOICEVOX, AivisSpeech, Sharevox, VOICEPEAK, etc.
+            "base_url": "http://127.0.0.1:50021",
+            # Speaker ID — check available speakers at {base_url}/speakers
+            "speaker": 0,
         },
         "deepinfra": {
             "model": "",  # empty = first tts-tagged model from the live catalog

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -544,6 +544,17 @@ def _print_setup_summary(config: dict, hermes_home):
             tool_status.append(("Text-to-Speech (KittenTTS local)", True, None))
         else:
             tool_status.append(("Text-to-Speech (KittenTTS — not installed)", False, "run 'hermes setup tts'"))
+    elif tts_provider == "voicevox":
+        from tools.tts_tool import _check_voicevox_available
+
+        if _check_voicevox_available(config.get("tts")):
+            tool_status.append(("Text-to-Speech (VOICEVOX local)", True, None))
+        else:
+            tool_status.append((
+                "Text-to-Speech (VOICEVOX — engine offline)",
+                False,
+                "start the configured VOICEVOX-compatible engine",
+            ))
     else:
         tool_status.append(("Text-to-Speech (Edge TTS)", True, None))
 
@@ -932,6 +943,54 @@ def _run_xai_oauth_login_from_setup() -> bool:
         return False
 
 
+def _configure_voicevox_settings(config: dict) -> None:
+    """Configure the engine URL and speaker/style for VOICEVOX setup."""
+    from tools.tts_tool import (
+        DEFAULT_VOICEVOX_BASE_URL,
+        DEFAULT_VOICEVOX_SPEAKER,
+        list_voices,
+    )
+
+    tts_config = config.setdefault("tts", {})
+    voicevox_config = tts_config.setdefault("voicevox", {})
+    current_base_url = str(
+        voicevox_config.get("base_url") or DEFAULT_VOICEVOX_BASE_URL
+    ).rstrip("/")
+    base_url = prompt("VOICEVOX engine URL", current_base_url).strip().rstrip("/")
+    voicevox_config["base_url"] = base_url or DEFAULT_VOICEVOX_BASE_URL
+    voicevox_config.setdefault("speaker", DEFAULT_VOICEVOX_SPEAKER)
+
+    try:
+        voices = list_voices("voicevox", tts_config)
+    except RuntimeError as exc:
+        print_warning(f"Could not load VOICEVOX speakers: {exc}")
+        print_info("Start the engine and rerun 'hermes setup tts' to choose a speaker.")
+        return
+    if not voices:
+        print_warning("VOICEVOX returned no talk-compatible speaker styles.")
+        return
+
+    choices = [str(voice.get("display") or voice.get("id")) for voice in voices]
+    current_speaker = str(voicevox_config.get("speaker", DEFAULT_VOICEVOX_SPEAKER))
+    keep_current_index = len(voices)
+    default_index = next(
+        (
+            index
+            for index, voice in enumerate(voices)
+            if str(voice.get("id")) == current_speaker
+        ),
+        keep_current_index,
+    )
+    choices.append(f"Keep current (ID {current_speaker})")
+    selected_index = prompt_choice(
+        "Select VOICEVOX speaker/style:", choices, default_index
+    )
+    if selected_index == keep_current_index:
+        return
+    voicevox_config["speaker"] = int(voices[selected_index]["id"])
+    print_success(f"VOICEVOX speaker set to: {voices[selected_index]['display']}")
+
+
 def _setup_tts_provider(config: dict):
     """Interactive TTS provider selection with install flow for NeuTTS."""
     tts_config = config.get("tts", {})
@@ -948,6 +1007,7 @@ def _setup_tts_provider(config: dict):
         "gemini": "Google Gemini TTS",
         "neutts": "NeuTTS",
         "kittentts": "KittenTTS",
+        "voicevox": "VOICEVOX",
     }
     current_label = provider_labels.get(current_provider, current_provider)
 
@@ -972,9 +1032,13 @@ def _setup_tts_provider(config: dict):
             "Google Gemini TTS (30 prebuilt voices, prompt-controllable, needs API key)",
             "NeuTTS (local on-device, free, ~300MB model download)",
             "KittenTTS (local on-device, free, lightweight ~25-80MB ONNX)",
+            "VOICEVOX (local Japanese TTS, compatible engine required)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts"])
+    providers.extend([
+        "edge", "elevenlabs", "openai", "xai", "minimax", "mistral",
+        "gemini", "neutts", "kittentts", "voicevox",
+    ])
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -1159,6 +1223,9 @@ def _setup_tts_provider(config: dict):
             else:
                 print_info("Skipping install. Set tts.provider to 'kittentts' after installing manually.")
                 selected = "edge"
+
+    elif selected == "voicevox":
+        _configure_voicevox_settings(config)
 
     # Save the selection
     if "tts" not in config:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -374,6 +374,12 @@ TOOL_CATEGORIES = {
                 "post_setup": "piper",
             },
             {
+                "name": "VOICEVOX (local, Japanese)",
+                "badge": "free",
+                "tag": "Japanese TTS — VOICEVOX-compatible engines",
+                "tts_provider": "voicevox",
+            },
+            {
                 "name": "DeepInfra TTS",
                 "badge": "paid",
                 "tag": "Chatterbox, Qwen3-TTS, … — live catalog from api.deepinfra.com",

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -378,6 +378,7 @@ TOOL_CATEGORIES = {
                 "badge": "free",
                 "tag": "Japanese TTS — VOICEVOX-compatible engines",
                 "tts_provider": "voicevox",
+                "readiness_check": "voicevox",
             },
             {
                 "name": "DeepInfra TTS",
@@ -2793,6 +2794,12 @@ def provider_readiness_status(
             return "ready"
         return "needs_keys"
 
+    if provider.get("readiness_check") == "voicevox":
+        from tools.tts_tool import _check_voicevox_available
+
+        tts_config = config.get("tts") if isinstance(config, dict) else None
+        return "ready" if _check_voicevox_available(tts_config) else "needs_setup"
+
     managed_feature = provider.get("managed_nous_feature")
     if provider.get("requires_nous_auth") or managed_feature:
         if features is None:
@@ -3455,6 +3462,54 @@ def _select_plugin_video_gen_provider(plugin_name: str, config: dict, *, use_gat
         _configure_xai_imagine_storage("video_gen", config)
 
 
+def _configure_voicevox_settings(config: dict) -> None:
+    """Prompt for the VOICEVOX engine URL and a catalog speaker/style."""
+    from tools.tts_tool import (
+        DEFAULT_VOICEVOX_BASE_URL,
+        DEFAULT_VOICEVOX_SPEAKER,
+        list_voices,
+    )
+
+    tts_config = config.setdefault("tts", {})
+    voicevox_config = tts_config.setdefault("voicevox", {})
+    current_base_url = str(
+        voicevox_config.get("base_url") or DEFAULT_VOICEVOX_BASE_URL
+    ).rstrip("/")
+    base_url = _prompt("  VOICEVOX engine URL", current_base_url).strip().rstrip("/")
+    voicevox_config["base_url"] = base_url or DEFAULT_VOICEVOX_BASE_URL
+    voicevox_config.setdefault("speaker", DEFAULT_VOICEVOX_SPEAKER)
+
+    try:
+        voices = list_voices("voicevox", tts_config)
+    except RuntimeError as exc:
+        _print_warning(f"  Could not load VOICEVOX speakers: {exc}")
+        _print_info("  Start the engine and reconfigure VOICEVOX to choose a speaker.")
+        return
+    if not voices:
+        _print_warning("  VOICEVOX returned no talk-compatible speaker styles.")
+        return
+
+    choices = [str(voice.get("display") or voice.get("id")) for voice in voices]
+    current_speaker = str(voicevox_config.get("speaker", DEFAULT_VOICEVOX_SPEAKER))
+    keep_current_index = len(voices)
+    default_index = next(
+        (
+            index
+            for index, voice in enumerate(voices)
+            if str(voice.get("id")) == current_speaker
+        ),
+        keep_current_index,
+    )
+    choices.append(f"Keep current (ID {current_speaker})")
+    selected_index = _prompt_choice(
+        "Select VOICEVOX speaker/style:", choices, default_index
+    )
+    if selected_index == keep_current_index:
+        return
+    voicevox_config["speaker"] = int(voices[selected_index]["id"])
+    _print_success(f"  VOICEVOX speaker set to: {voices[selected_index]['display']}")
+
+
 def _write_provider_config(provider: dict, config: dict, *, managed_feature) -> None:
     """Persist the provider/backend config keys for a selected provider.
 
@@ -3630,7 +3685,11 @@ def _configure_provider(
     if not env_vars:
         if provider.get("post_setup"):
             _run_post_setup(provider["post_setup"])
-        _print_success(f"  {provider['name']} - no configuration needed!")
+        if provider.get("tts_provider") == "voicevox":
+            _configure_voicevox_settings(config)
+            _print_success("  VOICEVOX configuration saved")
+        else:
+            _print_success(f"  {provider['name']} - no configuration needed!")
         if managed_feature:
             _print_info("  Requests for this tool will be billed to your Nous subscription.")
         # Plugin-registered image_gen provider: write image_gen.provider

--- a/tests/hermes_cli/test_tts_voicevox_setup.py
+++ b/tests/hermes_cli/test_tts_voicevox_setup.py
@@ -1,0 +1,148 @@
+"""Setup and status integration for the built-in VOICEVOX provider."""
+
+from types import SimpleNamespace
+
+from hermes_cli import setup, tools_config
+
+
+VOICEVOX_VOICES = [
+    {
+        "id": "2",
+        "display": "四国めたん — ノーマル (ID 2)",
+        "language": "ja-JP",
+    },
+    {
+        "id": "3",
+        "display": "ずんだもん — ノーマル (ID 3)",
+        "language": "ja-JP",
+    },
+]
+
+
+def _subscription_features_without_nous():
+    return SimpleNamespace(nous_auth_present=False)
+
+
+def test_setup_tts_lists_voicevox_and_saves_selected_speaker(monkeypatch):
+    config = {}
+    saved = []
+
+    def choose(question, choices, default=0):
+        if question == "Select TTS provider:":
+            return next(i for i, label in enumerate(choices) if "VOICEVOX" in label)
+        if question == "Select VOICEVOX speaker/style:":
+            return next(i for i, label in enumerate(choices) if "四国めたん" in label)
+        raise AssertionError(f"unexpected picker: {question}")
+
+    monkeypatch.setattr(setup, "managed_nous_tools_enabled", lambda: False)
+    monkeypatch.setattr(
+        setup,
+        "get_nous_subscription_features",
+        lambda _config: _subscription_features_without_nous(),
+    )
+    monkeypatch.setattr(setup, "prompt_choice", choose)
+    monkeypatch.setattr(setup, "prompt", lambda _label, default="", **_kw: default)
+    monkeypatch.setattr(setup, "save_config", lambda value: saved.append(value.copy()))
+    monkeypatch.setattr("tools.tts_tool.list_voices", lambda *_args, **_kwargs: VOICEVOX_VOICES)
+
+    setup._setup_tts_provider(config)
+
+    assert config["tts"]["provider"] == "voicevox"
+    assert config["tts"]["voicevox"]["base_url"] == "http://127.0.0.1:50021"
+    assert config["tts"]["voicevox"]["speaker"] == 2
+    assert saved
+
+
+def test_setup_tts_keeps_current_speaker_when_catalog_does_not_contain_it(
+    monkeypatch,
+):
+    config = {
+        "tts": {
+            "provider": "edge",
+            "voicevox": {
+                "base_url": "http://127.0.0.1:50021",
+                "speaker": 999,
+            },
+        },
+    }
+
+    def choose(question, choices, default=0):
+        if question == "Select TTS provider:":
+            return next(i for i, label in enumerate(choices) if "VOICEVOX" in label)
+        if question == "Select VOICEVOX speaker/style:":
+            assert choices[default] == "Keep current (ID 999)"
+            return default
+        raise AssertionError(f"unexpected picker: {question}")
+
+    monkeypatch.setattr(setup, "managed_nous_tools_enabled", lambda: False)
+    monkeypatch.setattr(
+        setup,
+        "get_nous_subscription_features",
+        lambda _config: _subscription_features_without_nous(),
+    )
+    monkeypatch.setattr(setup, "prompt_choice", choose)
+    monkeypatch.setattr(setup, "prompt", lambda _label, default="", **_kw: default)
+    monkeypatch.setattr(setup, "save_config", lambda _value: None)
+    monkeypatch.setattr(
+        "tools.tts_tool.list_voices",
+        lambda *_args, **_kwargs: VOICEVOX_VOICES,
+    )
+
+    setup._setup_tts_provider(config)
+
+    assert config["tts"]["provider"] == "voicevox"
+    assert config["tts"]["voicevox"]["speaker"] == 999
+
+
+def test_tools_picker_configures_voicevox_speaker(monkeypatch):
+    config = {}
+    provider = next(
+        row
+        for row in tools_config.TOOL_CATEGORIES["tts"]["providers"]
+        if row.get("tts_provider") == "voicevox"
+    )
+
+    monkeypatch.setattr(tools_config, "_prompt", lambda _label, default="", **_kw: default)
+    monkeypatch.setattr(
+        tools_config,
+        "_prompt_choice",
+        lambda question, choices, default=0: next(
+            i for i, label in enumerate(choices) if "ずんだもん" in label
+        ),
+    )
+    monkeypatch.setattr("tools.tts_tool.list_voices", lambda *_args, **_kwargs: VOICEVOX_VOICES)
+
+    tools_config._configure_provider(provider, config)
+
+    assert config["tts"]["provider"] == "voicevox"
+    assert config["tts"]["voicevox"]["base_url"] == "http://127.0.0.1:50021"
+    assert config["tts"]["voicevox"]["speaker"] == 3
+
+
+def test_voicevox_picker_status_reflects_engine_availability(monkeypatch):
+    provider = next(
+        row
+        for row in tools_config.TOOL_CATEGORIES["tts"]["providers"]
+        if row.get("tts_provider") == "voicevox"
+    )
+    config = {"tts": {"provider": "voicevox"}}
+
+    monkeypatch.setattr("tools.tts_tool._check_voicevox_available", lambda _cfg=None: True)
+    assert tools_config.provider_readiness_status(provider, config) == "ready"
+
+    monkeypatch.setattr("tools.tts_tool._check_voicevox_available", lambda _cfg=None: False)
+    assert tools_config.provider_readiness_status(provider, config) == "needs_setup"
+
+
+def test_setup_summary_reports_voicevox_engine_status(
+    tmp_path, monkeypatch, capsys,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "tools.tts_tool._check_voicevox_available",
+        lambda _cfg=None: True,
+    )
+
+    setup._print_setup_summary({"tts": {"provider": "voicevox"}}, tmp_path)
+
+    assert "Text-to-Speech (VOICEVOX local)" in capsys.readouterr().out

--- a/tests/tools/test_tts_voicevox.py
+++ b/tests/tools/test_tts_voicevox.py
@@ -1,0 +1,255 @@
+"""
+Tests for the native VOICEVOX TTS provider.
+
+These tests pin the registration / dispatch / error paths for VOICEVOX
+without requiring a running VOICEVOX engine (HTTP calls are monkey-patched).
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools import tts_tool
+from tools.tts_tool import (
+    BUILTIN_TTS_PROVIDERS,
+    DEFAULT_VOICEVOX_BASE_URL,
+    DEFAULT_VOICEVOX_SPEAKER,
+    PROVIDER_MAX_TEXT_LENGTH,
+    _check_voicevox_available,
+    _generate_voicevox_tts,
+    check_tts_requirements,
+    text_to_speech_tool,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry / constants
+# ---------------------------------------------------------------------------
+
+class TestVoicevoxRegistration:
+    def test_voicevox_is_a_builtin_provider(self):
+        assert "voicevox" in BUILTIN_TTS_PROVIDERS
+
+    def test_voicevox_has_a_text_length_cap(self):
+        assert PROVIDER_MAX_TEXT_LENGTH.get("voicevox", 0) > 0
+
+    def test_voicevox_in_registry_builtin_names(self):
+        from agent.tts_registry import _BUILTIN_NAMES
+
+        assert "voicevox" in _BUILTIN_NAMES
+
+
+# ---------------------------------------------------------------------------
+# _check_voicevox_available
+# ---------------------------------------------------------------------------
+
+class TestCheckVoicevoxAvailable:
+    def test_returns_true_when_engine_responds(self, monkeypatch):
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {
+            "voicevox": {"base_url": "http://localhost:50021"}
+        })
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            assert _check_voicevox_available() is True
+
+    def test_returns_false_when_engine_offline(self, monkeypatch):
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {
+            "voicevox": {"base_url": "http://localhost:59999"}
+        })
+        with patch("urllib.request.urlopen", side_effect=Exception("connection refused")):
+            assert _check_voicevox_available() is False
+
+    def test_returns_bool_without_raising(self):
+        assert isinstance(_check_voicevox_available(), bool)
+
+
+# ---------------------------------------------------------------------------
+# _generate_voicevox_tts
+# ---------------------------------------------------------------------------
+
+class TestGenerateVoicevoxTts:
+    def _mock_urlopen(self, responses):
+        """Create a mock urlopen that returns different responses per call."""
+        call_count = [0]
+
+        def side_effect(req, **kwargs):
+            idx = min(call_count[0], len(responses) - 1)
+            call_count[0] += 1
+            resp = MagicMock()
+            resp.read.return_value = responses[idx]
+            resp.status = 200
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = MagicMock(return_value=False)
+            return resp
+
+        return side_effect
+
+    def test_synthesizes_and_writes_wav(self, tmp_path, monkeypatch):
+        fake_query = b'{"accent_phrases": []}'
+        fake_wav = b"RIFF" + b"\x00" * 100  # minimal WAV-like bytes
+
+        config = {"voicevox": {"base_url": "http://localhost:50021", "speaker": 3}}
+        out_path = str(tmp_path / "out.wav")
+
+        with patch("urllib.request.urlopen", side_effect=self._mock_urlopen([fake_query, fake_wav])):
+            result = _generate_voicevox_tts("こんにちは", out_path, config)
+
+        assert result == out_path
+        assert Path(out_path).exists()
+        assert Path(out_path).stat().st_size > 0
+
+    def test_converts_wav_to_mp3_via_ffmpeg(self, tmp_path, monkeypatch):
+        fake_query = b'{"accent_phrases": []}'
+        fake_wav = b"RIFF" + b"\x00" * 100
+
+        config = {"voicevox": {"base_url": "http://localhost:50021", "speaker": 0}}
+        out_path = str(tmp_path / "out.mp3")
+
+        # Mock ffmpeg conversion
+        def fake_run(cmd, **kwargs):
+            # Simulate ffmpeg writing the output file
+            Path(out_path).write_bytes(b"\xff\xfb" + b"\x00" * 50)
+            return MagicMock(returncode=0)
+
+        with patch("urllib.request.urlopen", side_effect=self._mock_urlopen([fake_query, fake_wav])):
+            with patch("tools.tts_tool.subprocess.run", side_effect=fake_run):
+                with patch("tools.tts_tool.shutil.which", return_value="/usr/bin/ffmpeg"):
+                    result = _generate_voicevox_tts("テスト", out_path, config)
+
+        assert result == out_path
+
+    def test_connection_refused_raises_runtime_error(self, tmp_path):
+        import urllib.error
+
+        config = {"voicevox": {"base_url": "http://localhost:59999", "speaker": 0}}
+        out_path = str(tmp_path / "out.wav")
+
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("Connection refused")):
+            with pytest.raises(RuntimeError, match="Cannot connect to VOICEVOX"):
+                _generate_voicevox_tts("hello", out_path, config)
+
+    def test_invalid_speaker_raises_value_error(self, tmp_path):
+        import urllib.error
+
+        config = {"voicevox": {"base_url": "http://localhost:50021", "speaker": 9999}}
+        out_path = str(tmp_path / "out.wav")
+
+        error_resp = MagicMock()
+        error_resp.read.return_value = b"speaker not found"
+        http_error = urllib.error.HTTPError(
+            "http://localhost:50021/audio_query", 422, "Unprocessable", {}, error_resp
+        )
+
+        with patch("urllib.request.urlopen", side_effect=http_error):
+            with pytest.raises(ValueError, match="speaker ID 9999 not found"):
+                _generate_voicevox_tts("hello", out_path, config)
+
+    def test_default_speaker_used_for_invalid_config(self, tmp_path):
+        """Non-integer speaker values fall back to DEFAULT_VOICEVOX_SPEAKER."""
+        fake_query = b'{"accent_phrases": []}'
+        fake_wav = b"RIFF" + b"\x00" * 50
+
+        config = {"voicevox": {"base_url": "http://localhost:50021", "speaker": "invalid"}}
+        out_path = str(tmp_path / "out.wav")
+
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=self._mock_urlopen([fake_query, fake_wav]),
+        ) as mock_open:
+            _generate_voicevox_tts("hi", out_path, config)
+
+        # Verify the speaker in the URL is the default (0), not "invalid"
+        first_call_url = mock_open.call_args_list[0][0][0].full_url
+        assert f"speaker={DEFAULT_VOICEVOX_SPEAKER}" in first_call_url
+
+    def test_empty_synthesis_raises_runtime_error(self, tmp_path):
+        fake_query = b'{"accent_phrases": []}'
+        fake_wav = b""  # empty
+
+        config = {"voicevox": {"base_url": "http://localhost:50021", "speaker": 0}}
+        out_path = str(tmp_path / "out.wav")
+
+        with patch("urllib.request.urlopen", side_effect=self._mock_urlopen([fake_query, fake_wav])):
+            with pytest.raises(RuntimeError, match="empty audio"):
+                _generate_voicevox_tts("hello", out_path, config)
+
+
+# ---------------------------------------------------------------------------
+# text_to_speech_tool end-to-end (provider == "voicevox")
+# ---------------------------------------------------------------------------
+
+class TestTextToSpeechToolWithVoicevox:
+    def test_dispatches_to_voicevox(self, tmp_path, monkeypatch):
+        fake_query = b'{"accent_phrases": []}'
+        fake_wav = b"RIFF" + b"\x00" * 100
+
+        monkeypatch.setattr(tts_tool, "_check_voicevox_available", lambda: True)
+
+        cfg = {
+            "provider": "voicevox",
+            "voicevox": {"base_url": "http://localhost:50021", "speaker": 3},
+        }
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: cfg)
+
+        with patch("urllib.request.urlopen") as mock_open:
+            call_count = [0]
+
+            def side_effect(req, **kwargs):
+                idx = min(call_count[0], 1)
+                call_count[0] += 1
+                resp = MagicMock()
+                resp.read.return_value = [fake_query, fake_wav][idx]
+                resp.status = 200
+                resp.__enter__ = lambda s: s
+                resp.__exit__ = MagicMock(return_value=False)
+                return resp
+
+            mock_open.side_effect = side_effect
+
+            result = text_to_speech_tool(
+                text="こんにちは", output_path=str(tmp_path / "clip.wav")
+            )
+
+        data = json.loads(result)
+        assert data["success"] is True, data
+        assert data["provider"] == "voicevox"
+        assert Path(data["file_path"]).exists()
+
+    def test_engine_offline_surfaces_error(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tts_tool, "_check_voicevox_available", lambda: False)
+
+        cfg = {
+            "provider": "voicevox",
+            "voicevox": {"base_url": "http://localhost:59999"},
+        }
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: cfg)
+
+        result = text_to_speech_tool(
+            text="hello", output_path=str(tmp_path / "clip.wav")
+        )
+        data = json.loads(result)
+
+        assert data["success"] is False
+        assert "VOICEVOX" in data["error"]
+        assert "running" in data["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# check_tts_requirements
+# ---------------------------------------------------------------------------
+
+class TestCheckTtsRequirementsVoicevox:
+    def test_voicevox_available_satisfies_requirements(self, monkeypatch):
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "voicevox"})
+        monkeypatch.setattr(tts_tool, "_has_any_command_tts_provider", lambda: False)
+
+        monkeypatch.setattr(tts_tool, "_check_voicevox_available", lambda: True)
+        assert check_tts_requirements() is True
+
+        monkeypatch.setattr(tts_tool, "_check_voicevox_available", lambda: False)
+        assert check_tts_requirements() is False

--- a/tests/tools/test_tts_voicevox.py
+++ b/tests/tools/test_tts_voicevox.py
@@ -6,7 +6,11 @@ without requiring a running VOICEVOX engine (HTTP calls are monkey-patched).
 """
 
 import json
+import threading
+import urllib.error
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -20,8 +24,87 @@ from tools.tts_tool import (
     _check_voicevox_available,
     _generate_voicevox_tts,
     check_tts_requirements,
+    list_voices,
     text_to_speech_tool,
 )
+
+
+def test_voicevox_http_contract_end_to_end(tmp_path):
+    """Exercise readiness, catalog, and synthesis over a real HTTP socket."""
+    requests = []
+    fake_query = b'{"accent_phrases": [], "speedScale": 1}'
+    fake_wav = b"RIFF" + b"\x00" * 100
+    catalog = [
+        {
+            "name": "四国めたん",
+            "styles": [{"name": "ノーマル", "id": 2, "type": "talk"}],
+        },
+    ]
+
+    class Handler(BaseHTTPRequestHandler):
+        def _send(self, body, content_type="application/json"):
+            self.send_response(200)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            parsed = urlparse(self.path)
+            requests.append(("GET", parsed.path, parse_qs(parsed.query), b""))
+            if parsed.path == "/version":
+                self._send(b'"0.24.0"')
+            elif parsed.path == "/speakers":
+                self._send(json.dumps(catalog).encode("utf-8"))
+            else:
+                self.send_error(404)
+
+        def do_POST(self):
+            parsed = urlparse(self.path)
+            body = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+            requests.append(("POST", parsed.path, parse_qs(parsed.query), body))
+            if parsed.path == "/audio_query":
+                self._send(fake_query)
+            elif parsed.path == "/synthesis":
+                self._send(fake_wav, "audio/wav")
+            else:
+                self.send_error(404)
+
+        def log_message(self, format, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    config = {
+        "voicevox": {
+            "base_url": f"http://127.0.0.1:{server.server_port}",
+            "speaker": 2,
+        },
+    }
+
+    try:
+        assert _check_voicevox_available(config) is True
+        assert list_voices("voicevox", config) == [
+            {
+                "id": "2",
+                "display": "四国めたん — ノーマル (ID 2)",
+                "language": "ja-JP",
+            },
+        ]
+        output_path = str(tmp_path / "clip.wav")
+        assert _generate_voicevox_tts("こんにちは", output_path, config) == output_path
+        assert Path(output_path).read_bytes() == fake_wav
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    audio_query = next(request for request in requests if request[1] == "/audio_query")
+    assert audio_query[2] == {"text": ["こんにちは"], "speaker": ["2"]}
+    synthesis = next(request for request in requests if request[1] == "/synthesis")
+    assert synthesis[2] == {"speaker": ["2"]}
+    assert synthesis[3] == fake_query
 
 
 # ---------------------------------------------------------------------------
@@ -64,8 +147,92 @@ class TestCheckVoicevoxAvailable:
         with patch("urllib.request.urlopen", side_effect=Exception("connection refused")):
             assert _check_voicevox_available() is False
 
-    def test_returns_bool_without_raising(self):
-        assert isinstance(_check_voicevox_available(), bool)
+# ---------------------------------------------------------------------------
+# list_voices
+# ---------------------------------------------------------------------------
+
+class TestListVoicevoxVoices:
+    def test_flattens_speakers_and_styles_for_picker(self):
+        catalog = [
+            {
+                "name": "四国めたん",
+                "styles": [
+                    {"name": "ノーマル", "id": 2},
+                    {"name": "あまあま", "id": 0},
+                    {"name": "ソング", "id": 200, "type": "sing"},
+                ],
+            },
+            {
+                "name": "ずんだもん",
+                "styles": [{"name": "ノーマル", "id": 3}],
+            },
+        ]
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(catalog).encode("utf-8")
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
+            voices = list_voices(
+                "voicevox",
+                {"voicevox": {"base_url": "http://localhost:50021/"}},
+            )
+
+        assert voices == [
+            {
+                "id": "2",
+                "display": "四国めたん — ノーマル (ID 2)",
+                "language": "ja-JP",
+            },
+            {
+                "id": "0",
+                "display": "四国めたん — あまあま (ID 0)",
+                "language": "ja-JP",
+            },
+            {
+                "id": "3",
+                "display": "ずんだもん — ノーマル (ID 3)",
+                "language": "ja-JP",
+            },
+        ]
+        request = mock_open.call_args.args[0]
+        assert request.full_url == "http://localhost:50021/speakers"
+        assert request.get_method() == "GET"
+
+    def test_rejects_invalid_catalog_shape(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b'{"not": "a list"}'
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            with pytest.raises(RuntimeError, match="invalid speaker catalog"):
+                list_voices("voicevox", {})
+
+    def test_connection_failure_has_actionable_error(self):
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError("connection refused"),
+        ):
+            with pytest.raises(RuntimeError, match="Is the engine running"):
+                list_voices("voicevox", {})
+
+    def test_other_builtin_without_catalog_returns_empty(self):
+        assert list_voices("edge", {}) == []
+
+    def test_plugin_provider_uses_same_listing_surface(self):
+        provider = MagicMock()
+        provider.list_voices.return_value = [
+            {"id": "voice-1", "display": "Plugin voice"},
+        ]
+
+        with (
+            patch("hermes_cli.plugins._ensure_plugins_discovered"),
+            patch("agent.tts_registry.get_provider", return_value=provider),
+        ):
+            assert list_voices("example-plugin", {}) == [
+                {"id": "voice-1", "display": "Plugin voice"},
+            ]
 
 
 # ---------------------------------------------------------------------------
@@ -237,6 +404,37 @@ class TestTextToSpeechToolWithVoicevox:
         assert data["success"] is False
         assert "VOICEVOX" in data["error"]
         assert "running" in data["error"].lower()
+
+    def test_without_ffmpeg_returns_wav_path_instead_of_mislabeled_mp3(
+        self, tmp_path, monkeypatch,
+    ):
+        fake_query = b'{"accent_phrases": []}'
+        fake_wav = b"RIFF" + b"\x00" * 100
+        cfg = {
+            "provider": "voicevox",
+            "voicevox": {"base_url": "http://localhost:50021", "speaker": 3},
+        }
+
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: cfg)
+        monkeypatch.setattr(tts_tool, "_check_voicevox_available", lambda: True)
+        monkeypatch.setattr(tts_tool.shutil, "which", lambda _name: None)
+
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=TestGenerateVoicevoxTts()._mock_urlopen(
+                [fake_query, fake_wav]
+            ),
+        ):
+            result = text_to_speech_tool(
+                text="こんにちは",
+                output_path=str(tmp_path / "clip.mp3"),
+            )
+
+        data = json.loads(result)
+        assert data["success"] is True, data
+        assert data["file_path"] == str(tmp_path / "clip.wav")
+        assert Path(data["file_path"]).read_bytes() == fake_wav
+        assert not (tmp_path / "clip.mp3").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -13,6 +13,7 @@ Built-in TTS providers:
 - NeuTTS (local, free, no API key): On-device TTS via neutts
 - KittenTTS (local, free, no API key): On-device 25MB model
 - Piper (local, free, no API key): OHF-Voice/piper1-gpl neural VITS, 44 languages
+- VOICEVOX (local, free, no API key): Japanese TTS via a compatible HTTP engine
 
 Custom command providers:
 - Users can declare any number of named providers with ``type: command``
@@ -50,7 +51,7 @@ import threading
 import uuid
 from pathlib import Path
 from typing import Callable, Dict, Any, Optional
-from urllib.parse import urljoin, urlparse
+from urllib.parse import quote, urljoin, urlparse
 
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_constants import display_hermes_home
@@ -180,6 +181,8 @@ MANAGED_OPENAI_TTS_MODELS = frozenset({"gpt-4o-mini-tts"})
 DEFAULT_KITTENTTS_MODEL = "KittenML/kitten-tts-nano-0.8-int8"  # 25MB
 DEFAULT_KITTENTTS_VOICE = "Jasper"
 DEFAULT_PIPER_VOICE = "en_US-lessac-medium"  # balanced size/quality
+DEFAULT_VOICEVOX_BASE_URL = "http://127.0.0.1:50021"
+DEFAULT_VOICEVOX_SPEAKER = 0
 DEFAULT_OPENAI_VOICE = "alloy"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_MINIMAX_MODEL = "speech-02-hd"
@@ -236,6 +239,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
     "piper": 5000,        # local VITS model, phoneme-based; practical cap
+    "voicevox": 5000,     # no documented cap; practical limit consistent with Piper/Edge
 }
 
 # ElevenLabs caps vary by model_id. https://elevenlabs.io/docs/overview/models
@@ -405,6 +409,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "kittentts",
     "piper",
     "deepinfra",
+    "voicevox",
 })
 
 DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
@@ -2059,6 +2064,20 @@ def _check_piper_available() -> bool:
         return False
 
 
+def _check_voicevox_available() -> bool:
+    """Return True when a VOICEVOX-compatible engine responds to /version."""
+    tts_config = _load_tts_config()
+    vv_config = tts_config.get("voicevox") or {}
+    base_url = str(vv_config.get("base_url") or DEFAULT_VOICEVOX_BASE_URL).rstrip("/")
+    try:
+        import urllib.request
+        req = urllib.request.Request(f"{base_url}/version", method="GET")
+        with urllib.request.urlopen(req, timeout=3) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
+
+
 def _get_piper_voices_dir() -> Path:
     """Return the directory where Hermes caches Piper voice models.
 
@@ -2217,6 +2236,108 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
                 pass
         else:
             # No ffmpeg — keep WAV and return that path
+            os.rename(wav_path, output_path)
+
+    return output_path
+
+
+# ===========================================================================
+# Provider: VOICEVOX (local, Japanese TTS, zero dependencies)
+# ===========================================================================
+
+def _generate_voicevox_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech using a VOICEVOX-compatible HTTP engine.
+
+    VOICEVOX and compatible engines (AivisSpeech, Sharevox, VOICEPEAK)
+    expose a two-step HTTP API:
+      1. POST /audio_query?text=...&speaker=N → JSON intonation data
+      2. POST /synthesis?speaker=N (body=JSON) → WAV bytes
+
+    Uses only stdlib (urllib.request) — no pip install required.
+    Output is WAV; caller handles MP3/Opus conversion via ffmpeg.
+    """
+    import urllib.error
+    import urllib.request
+
+    vv_config = tts_config.get("voicevox") or {} if isinstance(tts_config, dict) else {}
+    base_url = str(vv_config.get("base_url") or DEFAULT_VOICEVOX_BASE_URL).rstrip("/")
+    speaker = vv_config.get("speaker", DEFAULT_VOICEVOX_SPEAKER)
+
+    # Validate speaker is an integer
+    if isinstance(speaker, bool) or not isinstance(speaker, int):
+        try:
+            speaker = int(speaker)
+        except (TypeError, ValueError):
+            speaker = DEFAULT_VOICEVOX_SPEAKER
+
+    # Step 1: audio_query — get intonation/accent data
+    query_url = f"{base_url}/audio_query?text={quote(text)}&speaker={speaker}"
+    try:
+        req = urllib.request.Request(query_url, method="POST", data=b"")
+        req.add_header("Content-Type", "application/json")
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            audio_query_json = resp.read()
+    except urllib.error.HTTPError as e:
+        if e.code == 422:
+            raise ValueError(
+                f"VOICEVOX speaker ID {speaker} not found. "
+                f"Check available speakers at {base_url}/speakers"
+            ) from e
+        raise RuntimeError(
+            f"VOICEVOX audio_query failed (HTTP {e.code}): "
+            f"{e.read().decode('utf-8', errors='replace')[:200]}"
+        ) from e
+    except urllib.error.URLError as e:
+        raise RuntimeError(
+            f"Cannot connect to VOICEVOX engine at {base_url}. "
+            f"Is the engine running? Start it with: voicevox --port 50021"
+        ) from e
+
+    # Step 2: synthesis — convert intonation data to WAV audio
+    synthesis_url = f"{base_url}/synthesis?speaker={speaker}"
+    try:
+        req = urllib.request.Request(synthesis_url, data=audio_query_json, method="POST")
+        req.add_header("Content-Type", "application/json")
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            wav_bytes = resp.read()
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(
+            f"VOICEVOX synthesis failed (HTTP {e.code}): "
+            f"{e.read().decode('utf-8', errors='replace')[:200]}"
+        ) from e
+    except urllib.error.URLError as e:
+        raise RuntimeError(
+            f"Cannot connect to VOICEVOX engine at {base_url}. "
+            f"Is the engine running?"
+        ) from e
+
+    if not wav_bytes:
+        raise RuntimeError("VOICEVOX synthesis returned empty audio")
+
+    # Write WAV, then convert to requested format if needed (same pattern as Piper)
+    wav_path = output_path
+    if not output_path.endswith(".wav"):
+        wav_path = output_path.rsplit(".", 1)[0] + ".wav"
+
+    with open(wav_path, "wb") as f:
+        f.write(wav_bytes)
+
+    if wav_path != output_path:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
+            subprocess.run(
+                conv_cmd,
+                check=True,
+                timeout=30,
+                stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
+            )
+            try:
+                os.remove(wav_path)
+            except OSError:
+                pass
+        else:
             os.rename(wav_path, output_path)
 
     return output_path
@@ -2503,6 +2624,17 @@ def text_to_speech_tool(
             logger.info("Generating speech with Piper (local)...")
             _generate_piper_tts(text, file_str, tts_config)
 
+        elif provider == "voicevox":
+            if not _check_voicevox_available():
+                return json.dumps({
+                    "success": False,
+                    "error": "VOICEVOX provider selected but no VOICEVOX-compatible engine is running. "
+                             "Start VOICEVOX (or AivisSpeech, Sharevox, etc.) and ensure it is listening "
+                             "on the configured base_url (default: http://127.0.0.1:50021)."
+                }, ensure_ascii=False)
+            logger.info("Generating speech with VOICEVOX (local)...")
+            _generate_voicevox_tts(text, file_str, tts_config)
+
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback
             edge_available = True
@@ -2568,7 +2700,7 @@ def text_to_speech_tool(
                 voice_compatible = file_str.endswith(".ogg")
         elif (
             want_opus
-            and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper"}
+            and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper", "voicevox"}
             and not file_str.endswith(".ogg")
         ):
             opus_path = _convert_to_opus(file_str)
@@ -2674,6 +2806,8 @@ def check_tts_requirements() -> bool:
         return _check_kittentts_available()
     if provider == "piper":
         return _check_piper_available()
+    if provider == "voicevox":
+        return _check_voicevox_available()
 
     try:
         from agent.tts_registry import get_provider

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2064,10 +2064,17 @@ def _check_piper_available() -> bool:
         return False
 
 
-def _check_voicevox_available() -> bool:
+def _check_voicevox_available(
+    tts_config: Optional[Dict[str, Any]] = None,
+) -> bool:
     """Return True when a VOICEVOX-compatible engine responds to /version."""
-    tts_config = _load_tts_config()
+    if tts_config is None:
+        tts_config = _load_tts_config()
+    if not isinstance(tts_config, dict):
+        tts_config = {}
     vv_config = tts_config.get("voicevox") or {}
+    if not isinstance(vv_config, dict):
+        vv_config = {}
     base_url = str(vv_config.get("base_url") or DEFAULT_VOICEVOX_BASE_URL).rstrip("/")
     try:
         import urllib.request
@@ -2076,6 +2083,113 @@ def _check_voicevox_available() -> bool:
             return resp.status == 200
     except Exception:
         return False
+
+
+def _list_voicevox_voices(
+    tts_config: Optional[Dict[str, Any]] = None,
+) -> list[Dict[str, Any]]:
+    """Fetch and flatten the VOICEVOX ``GET /speakers`` catalog.
+
+    VOICEVOX groups synthesis IDs under speaker ``styles``. The shared TTS
+    picker contract expects one flat row per selectable voice, so every style
+    becomes an ``id`` / ``display`` entry.
+    """
+    import urllib.error
+    import urllib.request
+
+    if not isinstance(tts_config, dict):
+        tts_config = {}
+    vv_config = tts_config.get("voicevox") or {}
+    if not isinstance(vv_config, dict):
+        vv_config = {}
+    base_url = str(vv_config.get("base_url") or DEFAULT_VOICEVOX_BASE_URL).rstrip("/")
+    speakers_url = f"{base_url}/speakers"
+
+    try:
+        request = urllib.request.Request(speakers_url, method="GET")
+        with urllib.request.urlopen(request, timeout=5) as response:
+            payload = response.read()
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(
+            f"VOICEVOX speaker catalog failed (HTTP {exc.code}) at {speakers_url}"
+        ) from exc
+    except (urllib.error.URLError, TimeoutError, ValueError) as exc:
+        raise RuntimeError(
+            f"Cannot connect to VOICEVOX engine at {base_url}. Is the engine running?"
+        ) from exc
+
+    try:
+        catalog = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("VOICEVOX returned an invalid speaker catalog") from exc
+    if not isinstance(catalog, list):
+        raise RuntimeError("VOICEVOX returned an invalid speaker catalog")
+
+    voices: list[Dict[str, Any]] = []
+    for speaker in catalog:
+        if not isinstance(speaker, dict):
+            continue
+        speaker_name = str(speaker.get("name") or "VOICEVOX speaker").strip()
+        styles = speaker.get("styles")
+        if not isinstance(styles, list):
+            continue
+        for style in styles:
+            if not isinstance(style, dict):
+                continue
+            # ``POST /synthesis`` accepts talk styles. Newer engines may also
+            # advertise singing-only styles through the same catalog.
+            style_type = style.get("type")
+            if style_type not in (None, "", "talk"):
+                continue
+            style_id = style.get("id")
+            if isinstance(style_id, bool) or not isinstance(style_id, (int, str)):
+                continue
+            try:
+                style_id_text = str(int(style_id))
+            except (TypeError, ValueError):
+                continue
+            style_name = str(style.get("name") or "default").strip()
+            voices.append({
+                "id": style_id_text,
+                "display": f"{speaker_name} — {style_name} (ID {style_id_text})",
+                "language": "ja-JP",
+            })
+    return voices
+
+
+def list_voices(
+    provider: Optional[str] = None,
+    tts_config: Optional[Dict[str, Any]] = None,
+) -> list[Dict[str, Any]]:
+    """Return picker-compatible voices for the selected TTS provider.
+
+    Built-ins opt in here when they expose a catalog API. Plugin providers
+    continue to use :meth:`agent.tts_provider.TTSProvider.list_voices` through
+    the same public listing surface.
+    """
+    if tts_config is None:
+        tts_config = _load_tts_config()
+    if not isinstance(tts_config, dict):
+        tts_config = {}
+    key = str(provider or _get_provider(tts_config)).strip().lower()
+    if key == "voicevox":
+        return _list_voicevox_voices(tts_config)
+    if key in BUILTIN_TTS_PROVIDERS:
+        return []
+
+    try:
+        from agent.tts_registry import get_provider
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+        plugin_provider = get_provider(key)
+        if plugin_provider is None:
+            return []
+        voices = plugin_provider.list_voices()
+        return voices if isinstance(voices, list) else []
+    except Exception:
+        logger.debug("Failed to list voices for TTS provider '%s'", key, exc_info=True)
+        return []
 
 
 def _get_piper_voices_dir() -> Path:
@@ -2317,7 +2431,7 @@ def _generate_voicevox_tts(text: str, output_path: str, tts_config: Dict[str, An
     # Write WAV, then convert to requested format if needed (same pattern as Piper)
     wav_path = output_path
     if not output_path.endswith(".wav"):
-        wav_path = output_path.rsplit(".", 1)[0] + ".wav"
+        wav_path = os.path.splitext(output_path)[0] + ".wav"
 
     with open(wav_path, "wb") as f:
         f.write(wav_bytes)
@@ -2338,7 +2452,9 @@ def _generate_voicevox_tts(text: str, output_path: str, tts_config: Dict[str, An
             except OSError:
                 pass
         else:
-            os.rename(wav_path, output_path)
+            # Keep the real WAV extension. Renaming WAV bytes to ``.mp3``
+            # produces a mislabeled file that players and gateways may reject.
+            output_path = wav_path
 
     return output_path
 
@@ -2633,7 +2749,7 @@ def text_to_speech_tool(
                              "on the configured base_url (default: http://127.0.0.1:50021)."
                 }, ensure_ascii=False)
             logger.info("Generating speech with VOICEVOX (local)...")
-            _generate_voicevox_tts(text, file_str, tts_config)
+            file_str = _generate_voicevox_tts(text, file_str, tts_config)
 
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -14,7 +14,7 @@ If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, 
 
 ## Text-to-Speech
 
-Convert text to speech with ten providers:
+Convert text to speech with eleven providers:
 
 | Provider | Quality | Cost | API Key |
 |----------|---------|------|---------|
@@ -28,6 +28,7 @@ Convert text to speech with ten providers:
 | **NeuTTS** | Good | Free (local) | None needed |
 | **KittenTTS** | Good | Free (local) | None needed |
 | **Piper** | Good | Free (local) | None needed |
+| **VOICEVOX** | Good | Free (local) | None needed |
 
 ### Platform Delivery
 
@@ -43,7 +44,7 @@ Convert text to speech with ten providers:
 ```yaml
 # In ~/.hermes/config.yaml
 tts:
-  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts" | "piper"
+  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts" | "piper" | "voicevox"
   speed: 1.0                    # Global speed multiplier (provider-specific settings override this)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -95,6 +96,9 @@ tts:
     # noise_w_scale: 0.8
     # volume: 1.0                               # 0.5 = half as loud
     # normalize_audio: true
+  voicevox:
+    base_url: http://127.0.0.1:50021  # VOICEVOX, AivisSpeech, Sharevox, etc.
+    speaker: 0                         # speaker ID (GET /speakers to list)
 ```
 
 **Speed control**: The global `tts.speed` value applies to all providers by default. Each provider can override it with its own `speed` setting (e.g., `tts.openai.speed: 1.5`). Provider-specific speed takes precedence over the global value. Default is `1.0` (normal speed).
@@ -144,6 +148,7 @@ Each provider has a documented per-request input-character cap. Hermes truncates
 | NeuTTS | 2000 |
 | KittenTTS | 2000 |
 | Piper | 5000 |
+| VOICEVOX | 5000 |
 
 **ElevenLabs** picks a cap from the configured `model_id`:
 
@@ -177,6 +182,7 @@ Telegram voice bubbles require Opus/OGG audio format:
 - **NeuTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
 - **KittenTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
 - **Piper** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
+- **VOICEVOX** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
 
 ```bash
 # Ubuntu/Debian
@@ -189,7 +195,7 @@ brew install ffmpeg
 sudo dnf install ffmpeg
 ```
 
-Without ffmpeg, Edge TTS, MiniMax TTS, NeuTTS, KittenTTS, and Piper audio are sent as regular audio files (playable, but shown as a rectangular player instead of a voice bubble).
+Without ffmpeg, Edge TTS, MiniMax TTS, NeuTTS, KittenTTS, Piper, and VOICEVOX audio are sent as regular audio files (playable, but shown as a rectangular player instead of a voice bubble).
 
 :::tip
 If you want voice bubbles without installing ffmpeg, switch to the OpenAI, ElevenLabs, or Mistral provider.
@@ -236,6 +242,30 @@ tts:
 ```
 
 **Advanced knobs** (`tts.piper.length_scale` / `noise_scale` / `noise_w_scale` / `volume` / `normalize_audio`, `use_cuda`) correspond 1:1 to Piper's `SynthesisConfig`. They're ignored on older `piper-tts` versions.
+
+### VOICEVOX (local, Japanese)
+
+[VOICEVOX](https://voicevox.hiroshiba.jp/) is a free, local Japanese TTS engine widely used in the Japanese developer community. The same API is shared by compatible engines like [AivisSpeech](https://aivis-project.com/), [Sharevox](https://www.sharevox.app/), and [VOICEPEAK](https://www.ah-soft.com/voice/) — a single integration covers the entire ecosystem.
+
+**No pip install required.** VOICEVOX uses a simple HTTP API and Hermes talks to it with stdlib only.
+
+**Setup:** Install and start a VOICEVOX-compatible engine, then configure:
+
+```yaml
+tts:
+  provider: voicevox
+  voicevox:
+    base_url: http://127.0.0.1:50021   # engine URL
+    speaker: 3                          # speaker ID
+```
+
+**Finding speaker IDs.** Query the engine's speaker list:
+
+```bash
+curl -s http://127.0.0.1:50021/speakers | python3 -m json.tool
+```
+
+Each speaker has a `name`, `speaker_uuid`, and a list of `styles` with `id` values. Use the `id` as `tts.voicevox.speaker`.
 
 ### Custom command providers
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -249,7 +249,7 @@ tts:
 
 **No pip install required.** VOICEVOX uses a simple HTTP API and Hermes talks to it with stdlib only.
 
-**Setup:** Install and start a VOICEVOX-compatible engine, then configure:
+**Setup:** Install and start a VOICEVOX-compatible engine, then run `hermes setup tts` or select VOICEVOX in `hermes tools`. Hermes reads `GET /speakers` and presents the available speaker/styles in the picker. You can also configure it manually:
 
 ```yaml
 tts:
@@ -259,7 +259,7 @@ tts:
     speaker: 3                          # speaker ID
 ```
 
-**Finding speaker IDs.** Query the engine's speaker list:
+**Finding speaker IDs manually.** If the setup picker cannot reach the engine, query its speaker list:
 
 ```bash
 curl -s http://127.0.0.1:50021/speakers | python3 -m json.tool
@@ -370,7 +370,7 @@ For TTS engines that can't be expressed as a single shell command — Python SDK
 | Two or three CLIs chained with shell pipes | **Command provider** |
 | A Python SDK only — no CLI | **Plugin** |
 | Streaming bytes you want to deliver chunked (mid-generation voice bubbles) | **Plugin** (override `stream()`) |
-| A voice-listing API used by `hermes setup` | **Plugin** (override `list_voices()`) |
+| A voice-listing API for a custom backend used by `hermes setup` | **Plugin** (override `list_voices()`) |
 | OAuth refresh flow (not a static bearer token) | **Plugin** |
 
 Built-ins always win, and command providers win over a same-name plugin — so plugins are safe to register against any non-built-in name without worrying about shadowing your existing config.


### PR DESCRIPTION
## Summary

Add `voicevox` as a built-in local TTS provider that talks to any VOICEVOX-compatible HTTP engine — [VOICEVOX](https://voicevox.hiroshiba.jp/), [AivisSpeech](https://aivis-project.com/), [Sharevox](https://www.sharevox.app/), [VOICEPEAK](https://www.ah-soft.com/voice/), etc.

Closes #67803

## What's included

| File | Change |
|------|--------|
| `tools/tts_tool.py` | `_generate_voicevox_tts()`, `_check_voicevox_available()`, dispatch case, Opus conversion, `check_tts_requirements()` |
| `agent/tts_registry.py` | `"voicevox"` in `_BUILTIN_NAMES` |
| `hermes_cli/config.py` | Default config (`base_url`, `speaker`) |
| `hermes_cli/tools_config.py` | `hermes tools` picker entry |
| `website/docs/user-guide/features/tts.md` | Provider table, config example, input limits, Telegram notes, setup guide |
| `tests/tools/test_tts_voicevox.py` | 14 tests (registration, dispatch, synthesis, error paths) |

## Design decisions

- **Zero external dependencies.** Uses only `urllib.request` (stdlib) — no pip install, unlike Piper (`piper-tts`) or NeuTTS (`neutts[all]`).
- **Two-step HTTP API.** `POST /audio_query` → `POST /synthesis`, matching the VOICEVOX engine spec.
- **WAV → ffmpeg conversion.** Same pattern as Piper/NeuTTS/KittenTTS for MP3/Opus output and Telegram voice bubbles.
- **Availability probe.** `GET /version` with 3s timeout; clear error message when the engine is offline.
- **Speaker validation.** Non-integer speaker IDs fall back to default (0); HTTP 422 surfaces a helpful "check /speakers" message.

## Config

```yaml
tts:
  provider: voicevox
  voicevox:
    base_url: http://127.0.0.1:50021   # any VOICEVOX-compatible engine
    speaker: 0                          # speaker ID (GET /speakers to list)
```

## Testing

```
84 passed in 1.59s
```

- `tests/tools/test_tts_voicevox.py` — 14 new tests (all mocked HTTP, no engine required)
- `tests/agent/test_tts_registry.py` — registry sync check passes
- `tests/tools/test_tts_piper.py` — no regressions
