### PR TITLE
fix(cli): clear plugin state on removal

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -736,6 +736,12 @@ def _remove_plugin_config_state(
                 changed = True
 
     if changed:
+        from hermes_cli.config import is_managed
+
+        if is_managed():
+            raise RuntimeError(
+                "Cannot clear plugin config state while Hermes is in managed mode"
+            )
         save_config(config)
 
 

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -686,8 +686,57 @@ def cmd_remove(name: str) -> None:
         console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
 
+    _remove_plugin_config_state(name, target, plugins_dir)
     shutil.rmtree(target)
     _display_removed(name, plugins_dir)
+
+
+def _remove_plugin_config_state(
+    name: str,
+    target: Path,
+    plugins_dir: Path,
+) -> None:
+    """Remove every config alias for an installed plugin in one atomic save."""
+    from hermes_cli.config import load_config, save_config
+
+    aliases = {name.strip("/"), target.name}
+    try:
+        relative = target.resolve().relative_to(plugins_dir.resolve())
+        prefix = "/".join(relative.parts[:-1])
+        manifest_info = _read_manifest_info(target, prefix)
+    except (OSError, TypeError, ValueError):
+        manifest_info = None
+    if manifest_info is not None:
+        manifest_name, _version, _description, canonical_key = manifest_info
+        if isinstance(manifest_name, str) and manifest_name:
+            aliases.add(manifest_name)
+        if isinstance(canonical_key, str) and canonical_key:
+            aliases.add(canonical_key)
+
+    config = load_config()
+    plugins_cfg = config.get("plugins")
+    if not isinstance(plugins_cfg, dict):
+        return
+
+    changed = False
+    for state_name in ("enabled", "disabled"):
+        state = plugins_cfg.get(state_name)
+        if not isinstance(state, list):
+            continue
+        cleaned = [plugin_id for plugin_id in state if plugin_id not in aliases]
+        if cleaned != state:
+            plugins_cfg[state_name] = cleaned
+            changed = True
+
+    entries = plugins_cfg.get("entries")
+    if isinstance(entries, dict):
+        for alias in aliases:
+            if alias in entries:
+                del entries[alias]
+                changed = True
+
+    if changed:
+        save_config(config)
 
 
 def _get_disabled_set() -> set:
@@ -1985,7 +2034,7 @@ def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
 
 
 def dashboard_remove_user_plugin(name: str) -> dict[str, Any]:
-    """Delete a plugin tree under ``~/.hermes/plugins/`` only."""
+    """Remove a user plugin tree and its persisted activation state."""
     plugins_dir = _plugins_dir()
     for n, _ver, _d, src, _path, _key in _discover_all_plugins():
         if n == name and src == "bundled":
@@ -1997,6 +2046,11 @@ def dashboard_remove_user_plugin(name: str) -> dict[str, Any]:
             "ok": False,
             "error": f"Plugin '{name}' was not found under {plugins_dir}.",
         }
+
+    try:
+        _remove_plugin_config_state(name, target, plugins_dir)
+    except (OSError, RuntimeError) as exc:
+        return {"ok": False, "error": f"Could not update plugin config: {exc}"}
 
     shutil.rmtree(target)
     return {"ok": True, "name": name}

--- a/tests/hermes_cli/test_plugins_cmd_remove.py
+++ b/tests/hermes_cli/test_plugins_cmd_remove.py
@@ -1,0 +1,129 @@
+"""Removal lifecycle tests for ``hermes plugins``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from hermes_cli.plugins_cmd import cmd_remove, dashboard_remove_user_plugin
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch) -> Path:
+    home = tmp_path / "hermes"
+    (home / "plugins").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def _install_plugin(
+    hermes_home: Path,
+    directory_name: str,
+    *,
+    manifest_name: str | None = None,
+) -> Path:
+    plugin_dir = hermes_home / "plugins" / directory_name
+    plugin_dir.mkdir()
+    if manifest_name is not None:
+        (plugin_dir / "plugin.yaml").write_text(
+            f"name: {manifest_name}\nversion: 1.0.0\n",
+            encoding="utf-8",
+        )
+    return plugin_dir
+
+
+def _write_config(hermes_home: Path, plugins: dict) -> Path:
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump({"plugins": plugins}, sort_keys=False),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def test_remove_clears_all_config_aliases(hermes_home):
+    plugin_dir = _install_plugin(
+        hermes_home,
+        "directory-name",
+        manifest_name="manifest-name",
+    )
+    config_path = _write_config(
+        hermes_home,
+        {
+            "enabled": ["directory-name", "manifest-name", "other"],
+            "disabled": ["directory-name", "manifest-name", "other-disabled"],
+            "entries": {
+                "directory-name": {"allow_tool_override": True},
+                "manifest-name": {"allow_tool_override": False},
+                "other": {"allow_tool_override": True},
+            },
+        },
+    )
+
+    cmd_remove("directory-name")
+
+    assert not plugin_dir.exists()
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert config["plugins"]["enabled"] == ["other"]
+    assert config["plugins"]["disabled"] == ["other-disabled"]
+    assert config["plugins"]["entries"] == {"other": {"allow_tool_override": True}}
+
+
+def test_remove_absent_plugin_does_not_mutate_config(hermes_home):
+    config_path = hermes_home / "config.yaml"
+    original = yaml.safe_dump(
+        {
+            "plugins": {
+                "enabled": ["absent-plugin", "other"],
+                "disabled": ["absent-plugin"],
+                "entries": {"absent-plugin": {"allow_tool_override": True}},
+            }
+        },
+        sort_keys=False,
+    )
+    config_path.write_text(original, encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc_info:
+        cmd_remove("absent-plugin")
+
+    assert exc_info.value.code == 1
+    assert config_path.read_text(encoding="utf-8") == original
+
+
+def test_remove_keeps_plugin_when_config_save_fails(hermes_home):
+    plugin_dir = _install_plugin(hermes_home, "test-plugin")
+    _write_config(hermes_home, {"enabled": ["test-plugin"]})
+
+    with patch(
+        "hermes_cli.config.save_config",
+        side_effect=RuntimeError("config unavailable"),
+    ):
+        with pytest.raises(RuntimeError, match="config unavailable"):
+            cmd_remove("test-plugin")
+
+    assert plugin_dir.is_dir()
+
+
+def test_dashboard_remove_clears_plugin_config_state(hermes_home):
+    plugin_dir = _install_plugin(hermes_home, "test-plugin")
+    config_path = _write_config(
+        hermes_home,
+        {
+            "enabled": ["test-plugin", "other"],
+            "disabled": ["test-plugin"],
+            "entries": {"test-plugin": {"allow_tool_override": True}},
+        },
+    )
+
+    with patch("hermes_cli.plugins_cmd._discover_all_plugins", return_value=[]):
+        result = dashboard_remove_user_plugin("test-plugin")
+
+    assert result["ok"] is True
+    assert not plugin_dir.exists()
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert config["plugins"]["enabled"] == ["other"]
+    assert config["plugins"]["disabled"] == []
+    assert config["plugins"]["entries"] == {}

--- a/tests/hermes_cli/test_plugins_cmd_remove.py
+++ b/tests/hermes_cli/test_plugins_cmd_remove.py
@@ -44,6 +44,11 @@ def _write_config(hermes_home: Path, plugins: dict) -> Path:
     return config_path
 
 
+def _managed_home_dirs(hermes_home: Path) -> None:
+    for subdir in ("cron", "sessions", "logs", "memories"):
+        (hermes_home / subdir).mkdir(parents=True, exist_ok=True)
+
+
 def test_remove_clears_all_config_aliases(hermes_home):
     plugin_dir = _install_plugin(
         hermes_home,
@@ -105,6 +110,44 @@ def test_remove_keeps_plugin_when_config_save_fails(hermes_home):
             cmd_remove("test-plugin")
 
     assert plugin_dir.is_dir()
+
+
+def test_remove_keeps_plugin_when_managed(hermes_home):
+    plugin_dir = _install_plugin(hermes_home, "test-plugin")
+    _managed_home_dirs(hermes_home)
+    config_path = _write_config(hermes_home, {"enabled": ["test-plugin"]})
+    original = config_path.read_text(encoding="utf-8")
+
+    with patch("hermes_cli.config.is_managed", return_value=True):
+        with pytest.raises(RuntimeError, match="managed mode"):
+            cmd_remove("test-plugin")
+
+    assert plugin_dir.is_dir()
+    assert config_path.read_text(encoding="utf-8") == original
+
+
+def test_dashboard_remove_keeps_plugin_when_managed(hermes_home):
+    plugin_dir = _install_plugin(hermes_home, "test-plugin")
+    _managed_home_dirs(hermes_home)
+    config_path = _write_config(
+        hermes_home,
+        {
+            "enabled": ["test-plugin", "other"],
+            "entries": {"test-plugin": {"allow_tool_override": True}},
+        },
+    )
+    original = config_path.read_text(encoding="utf-8")
+
+    with (
+        patch("hermes_cli.plugins_cmd._discover_all_plugins", return_value=[]),
+        patch("hermes_cli.config.is_managed", return_value=True),
+    ):
+        result = dashboard_remove_user_plugin("test-plugin")
+
+    assert result["ok"] is False
+    assert "managed mode" in result["error"]
+    assert plugin_dir.is_dir()
+    assert config_path.read_text(encoding="utf-8") == original
 
 
 def test_dashboard_remove_clears_plugin_config_state(hermes_home):


### PR DESCRIPTION
## Summary

`hermes plugins remove` currently deletes the plugin directory but leaves stale activation state in `config.yaml`.

This PR makes successful removal a complete one-command cleanup for **any** installed plugin:

- clear the plugin (and aliases) from `plugins.enabled`, `plugins.disabled`, and `plugins.entries` before deleting the plugin tree
- use the same cleanup path for CLI and dashboard removal
- if the atomic config save fails, preserve the plugin tree (do not delete files after a failed state cleanup)
- managed installs: abort before tree delete when config cannot be persisted (`is_managed()`)

## Why

Incomplete remove means:

1. the plugin looks uninstalled on disk
2. config still lists it as enabled / retains per-plugin grants

Reinstalling the same plugin can then reactivate it without a fresh enable step, and can retain privileges such as `allow_tool_override`.

## Reproduction (current Hermes)

```bash
hermes plugins install <plugin>
hermes plugins enable <plugin>
hermes plugins remove <plugin>
```

Observed today:
- plugin directory is gone
- `config.yaml` still contains the plugin under `plugins.enabled`

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_plugins*.py -q` — 271 passed
- `ruff check hermes_cli/plugins_cmd.py tests/hermes_cli/test_plugins_cmd_remove.py`
- `scripts/check-windows-footguns.py` on the staged files
- managed-mode CLI + dashboard regressions (`is_managed()` true): plugin tree preserved, config unchanged

Tested on macOS with Python 3.11. Also reproduced the incomplete-remove behavior on stock Hermes (Ubuntu CI + macOS) and verified this PR head clears activation state on the install → enable → remove path.
