### PR TITLE
fix(desktop): new-chat file attachment submit aborted by route-flush drift race

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/new-chat-attach-race.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/new-chat-attach-race.test.tsx
@@ -1,0 +1,172 @@
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import type { MutableRefObject } from 'react'
+import { useEffect, useRef } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { ComposerAttachment } from '@/store/composer'
+
+import { usePromptActions } from '.'
+
+vi.mock('@/hermes', () => ({
+  getProfiles: vi.fn(async () => ({ profiles: [] })),
+  PROMPT_SUBMIT_REQUEST_TIMEOUT_MS: 1_800_000,
+  setApiRequestProfile: vi.fn(),
+  transcribeAudio: vi.fn()
+}))
+
+/**
+ * Regression: new chat + file attachment + text was silently never sent.
+ *
+ * The wiring (contrib/wiring.tsx) derives the routed session id / route token
+ * from useLocation() and only refreshes the backing refs on RE-RENDER. After
+ * createBackendSessionForSend's navigate(), that flush lands asynchronously:
+ * microtask-speed submits (text-only / folder) finish the post-create drift
+ * check BEFORE the flush, but a file attachment awaits the file.attach WS
+ * round-trip, the flush lands mid-await, and a raw-token drift guard reads
+ * our own re-home as a user switch → abortForSessionSwitch → silent false →
+ * the composer restores the draft and prompt.submit never fires.
+ *
+ * This test models that exact timing: the route flush and the file.attach
+ * response are both macrotasks, the flush queued first.
+ */
+
+interface HarnessHandle {
+  submitText: (text: string, options?: { attachments?: ComposerAttachment[] }) => Promise<boolean>
+}
+
+function Harness({
+  activeSessionIdRef,
+  createBackendSessionForSend,
+  getRoutedStoredSessionId,
+  getRouteToken,
+  onReady,
+  requestGateway,
+  selectedStoredSessionIdRef
+}: {
+  activeSessionIdRef: MutableRefObject<null | string>
+  createBackendSessionForSend: () => Promise<null | string>
+  getRoutedStoredSessionId: () => null | string
+  getRouteToken: () => string
+  onReady: (handle: HarnessHandle) => void
+  requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+  selectedStoredSessionIdRef: MutableRefObject<null | string>
+}) {
+  const stateRef = useRef({
+    awaitingResponse: false,
+    busy: false,
+    interrupted: true,
+    messages: []
+  } as never)
+
+  const actions = usePromptActions({
+    activeSessionId: null,
+    activeSessionIdRef,
+    branchCurrentSession: async () => true,
+    busyRef: { current: false },
+    createBackendSessionForSend,
+    getRoutedStoredSessionId,
+    getRuntimeIdForStoredSession: () => null,
+    getRouteToken,
+    handleSkinCommand: () => '',
+    openMemoryGraph: () => undefined,
+    refreshSessions: async () => undefined,
+    requestGateway,
+    resumeStoredSession: () => undefined,
+    selectedStoredSessionIdRef,
+    startFreshSessionDraft: () => undefined,
+    sttEnabled: false,
+    updateSessionState: (_sessionId, updater) => {
+      const next = updater(stateRef.current) as never
+      stateRef.current = next
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    onReady({
+      submitText: (...args: Parameters<typeof actions.submitText>) =>
+        act(async () => actions.submitText(...args)) as Promise<boolean>
+    })
+  }, [actions.submitText, onReady])
+
+  return null
+}
+
+describe('new-chat submit route-flush race', () => {
+  afterEach(() => cleanup())
+
+  function setup() {
+    const calls: { method: string }[] = []
+    // The route ref pair starts on the new-chat route and flushes to the
+    // created session's route one macrotask after create returns — exactly
+    // like React re-rendering after navigate().
+    let routeFlushed = false
+    const activeSessionIdRef: MutableRefObject<null | string> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: null }
+
+    const requestGateway = vi.fn(async (method: string) => {
+      calls.push({ method })
+
+      if (method === 'file.attach') {
+        // WS round-trip: resolves on a macrotask, AFTER the route flush.
+        await new Promise(resolve => setTimeout(resolve, 0))
+
+        return { attached: true, ref_text: '@file:.hermes/desktop-attachments/a.txt', uploaded: false } as never
+      }
+
+      return {} as never
+    })
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      activeSessionIdRef.current = 'rt-new-chat'
+      selectedStoredSessionIdRef.current = 'stored-new-chat'
+      setTimeout(() => {
+        routeFlushed = true
+      }, 0)
+
+      return 'rt-new-chat'
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        getRoutedStoredSessionId={() => (routeFlushed ? 'stored-new-chat' : null)}
+        getRouteToken={() => (routeFlushed ? '/stored-new-chat::' : '/::')}
+        onReady={h => (handle = h)}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+      />
+    )
+
+    return { calls, getHandle: () => handle }
+  }
+
+  it('text-only first send of a new chat survives (flush lands after the drift check)', async () => {
+    const { calls, getHandle } = setup()
+    await waitFor(() => expect(getHandle()).not.toBeNull())
+
+    expect(await getHandle()!.submitText('hello new chat')).toBe(true)
+    expect(calls.some(c => c.method === 'prompt.submit')).toBe(true)
+  })
+
+  it('file attachment first send of a new chat still reaches prompt.submit', async () => {
+    const { calls, getHandle } = setup()
+    await waitFor(() => expect(getHandle()).not.toBeNull())
+
+    const attachments: ComposerAttachment[] = [
+      {
+        id: 'file:a',
+        kind: 'file',
+        label: 'a.txt',
+        path: '/tmp/a.txt',
+        refText: '@file:a.txt'
+      }
+    ]
+
+    expect(await getHandle()!.submitText('describe this file', { attachments })).toBe(true)
+    expect(calls.some(c => c.method === 'prompt.submit')).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -82,7 +82,6 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
     createBackendSessionForSend,
     getRoutedStoredSessionId,
     getRuntimeIdForStoredSession,
-    getRouteToken,
     requestGateway,
     resumeStoredSession,
     selectedStoredSessionIdRef,
@@ -173,11 +172,29 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         ? routedStoredSessionId
         : (selectedStoredSessionId ?? routedStoredSessionId)
 
-      let startingRouteToken = getRouteToken()
+      // The drift guard must compare session IDENTITY, not the raw route
+      // token. The route (and its token) comes from useLocation() and only
+      // refreshes on re-render, so after createBackendSessionForSend's
+      // navigate() the new route flushes asynchronously: a submit with a real
+      // await in this window (file.attach's WS round-trip) sees the flush
+      // land mid-pipeline and misreads our own re-home as a user switch —
+      // aborting silently and restoring the draft (new chat + file
+      // attachment never sent, while text-only/folder submits finished
+      // before the flush). A route that hasn't caught up (no session id) is
+      // not drift; only a route pointing at a DIFFERENT session is.
+      const sessionContextDrifted = (): boolean => {
+        if (!targetStartedInCurrentView) {
+          return false
+        }
 
-      const sessionContextDrifted = (): boolean =>
-        targetStartedInCurrentView &&
-        (selectedStoredSessionIdRef.current !== startingStoredSessionId || getRouteToken() !== startingRouteToken)
+        if (selectedStoredSessionIdRef.current !== startingStoredSessionId) {
+          return true
+        }
+
+        const routed = getRoutedStoredSessionId()
+
+        return routed !== null && routed !== startingStoredSessionId
+      }
 
       const targetIsCurrentView = (): boolean => targetStartedInCurrentView && !sessionContextDrifted()
 
@@ -429,7 +446,6 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // Re-pin the baseline to the created chat for the rest of the
         // pipeline; the closures (seedOptimistic et al) see the new value.
         startingStoredSessionId = selectedStoredSessionIdRef.current
-        startingRouteToken = getRouteToken()
 
         seedOptimistic(sessionId)
       }
@@ -562,7 +578,6 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       createBackendSessionForSend,
       getRoutedStoredSessionId,
       getRuntimeIdForStoredSession,
-      getRouteToken,
       requestGateway,
       resumeStoredSession,
       scope,


### PR DESCRIPTION
## Symptom

On the desktop app, the **first message of a brand-new chat never sends when it carries a file attachment**: the composer briefly shows the optimistic message, then silently restores the draft (file chip + text back in the input), with no error bubble and nothing in the transcript. Text-only and folder-attachment first sends work fine.

## Root cause

A race between React Router's async flush and the submit pipeline's session-drift guard (`sessionContextDrifted` in `use-prompt-actions/submit.ts`):

1. A new-chat submit calls `createBackendSessionForSend`, which synchronously re-homes the session refs and calls `navigate()`. The routed-session id / route token refs (backed by `useLocation()`) only refresh **on the next render**.
2. The guard re-pins its baseline immediately, still holding the **stale** route value.
3. Text-only / folder submits finish the sync-attachments step in microtasks — before the flush lands — and pass the drift check.
4. A **file** attachment awaits the `file.attach` WS round-trip; the route flush lands mid-await, the raw-token comparison `getRouteToken() !== startingRouteToken` reads the submit's own re-home as a user session switch, and the pipeline aborts silently (`abortForSessionSwitch`), restoring the draft.

## Fix

Make the drift guard compare **session identity** instead of the raw route token: a route that hasn't caught up yet (no session id) is not drift — only a route pointing at a *different* session is. Genuine mid-flight session switches still abort exactly as before (the `selectedStoredSessionIdRef` half of the guard is unchanged).

## Verification

- New regression test (`new-chat-attach-race.test.tsx`) models the exact timing — route flush and `file.attach` response as ordered macrotasks. It **fails on the old guard** (file-attach submit aborts, `prompt.submit` never fires) and **passes on the new one**; the text-only control passes on both.
- `vitest run --project ui src/app/chat src/app/session`: **349 tests, all pass**
- `npm run typecheck`: clean