### PR TITLE
fix(kanban): complete reviewed PR revision lifecycle

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -580,6 +580,41 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                             help='JSON dict of structured facts (e.g. \'{"changed_files": [...], '
                                  '"tests_run": 12}\'). Stored on the closing run.')
 
+    p_review = sub.add_parser(
+        "review",
+        help="Submit a running task for review or return review changes",
+    )
+    p_review.add_argument("task_id")
+    p_review.add_argument(
+        "action",
+        choices=("submit", "request-changes"),
+        help=(
+            "'submit' routes the card to an independent reviewer; "
+            "'request-changes' returns it to the recorded implementation owner"
+        ),
+    )
+    p_review.add_argument(
+        "--reviewer",
+        default=None,
+        help="Independent reviewer profile (required for submit)",
+    )
+    p_review.add_argument(
+        "--pr-url",
+        default=None,
+        help="Canonical GitHub pull request URL (required for submit)",
+    )
+    p_review.add_argument(
+        "--head",
+        dest="reviewed_head",
+        required=True,
+        help="Exact 40-character Git commit SHA submitted or reviewed",
+    )
+    p_review.add_argument(
+        "--summary",
+        default=None,
+        help="Implementation handoff or concrete requested changes",
+    )
+
     p_edit = sub.add_parser(
         "edit",
         help="Edit recovery fields on an already-completed task",
@@ -1040,6 +1075,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "attachments": _cmd_attachments,
             "attach-rm": _cmd_attach_rm,
             "complete": _cmd_complete,
+            "review":   _cmd_review,
             "edit":     _cmd_edit,
             "block":    _cmd_block,
             "schedule": _cmd_schedule,
@@ -2203,6 +2239,62 @@ def _cmd_complete(args: argparse.Namespace) -> int:
             else:
                 print(f"Completed {tid}")
     return 0 if not failed else 1
+
+
+def _cmd_review(args: argparse.Namespace) -> int:
+    action = str(args.action).replace("-", "_")
+    reviewer = (getattr(args, "reviewer", None) or "").strip()
+    pr_url = (getattr(args, "pr_url", None) or "").strip()
+    summary = (getattr(args, "summary", None) or "").strip()
+    if action == "submit" and (not reviewer or not pr_url):
+        print(
+            "kanban: review submit requires --reviewer and --pr-url",
+            file=sys.stderr,
+        )
+        return 2
+    if action == "request_changes" and not summary:
+        print(
+            "kanban: review request-changes requires --summary",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        with kb.connect_closing() as conn:
+            if action == "submit":
+                ok = kb.submit_task_for_review(
+                    conn,
+                    args.task_id,
+                    reviewer=reviewer,
+                    pr_url=pr_url,
+                    reviewed_head=args.reviewed_head,
+                    summary=summary or None,
+                    expected_run_id=_worker_run_id_for(args.task_id),
+                )
+            else:
+                ok = kb.request_review_changes(
+                    conn,
+                    args.task_id,
+                    reviewed_head=args.reviewed_head,
+                    summary=summary,
+                    expected_run_id=_worker_run_id_for(args.task_id),
+                )
+            task = kb.get_task(conn, args.task_id) if ok else None
+    except ValueError as exc:
+        print(f"kanban: review: {exc}", file=sys.stderr)
+        return 2
+    if not ok:
+        print(
+            f"cannot apply review action {args.action!r} to {args.task_id} "
+            "(wrong task state or stale run)",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        f"{args.task_id} → {task.status} "
+        f"(assignee: {task.assignee or '-'})"
+    )
+    return 0
 
 
 def _cmd_edit(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3721,7 +3721,7 @@ def _append_event(
     payload: Optional[dict] = None,
     *,
     run_id: Optional[int] = None,
-) -> None:
+) -> int:
     """Record an event row.  Called from within an already-open txn.
 
     ``run_id`` is optional: pass the current run id so UIs can group
@@ -3731,11 +3731,12 @@ def _append_event(
     """
     now = int(time.time())
     pl = json.dumps(payload, ensure_ascii=False) if payload else None
-    conn.execute(
+    cur = conn.execute(
         "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
         "VALUES (?, ?, ?, ?, ?)",
         (task_id, run_id, kind, pl, now),
     )
+    return int(cur.lastrowid or 0)
 
 
 def _end_run(
@@ -3992,6 +3993,7 @@ def claim_task(
     *,
     ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
+    review_revision_event_id: Optional[int] = None,
 ) -> Optional[Task]:
     """Atomically transition ``ready -> running``.
 
@@ -4027,6 +4029,26 @@ def claim_task(
                 {"reason": "parents_not_done"},
             )
             return None
+        review_revision = None
+        if review_revision_event_id is not None:
+            review_revision = _review_revision_authorization(
+                conn,
+                task_id,
+                required_event_id=review_revision_event_id,
+            )
+            if review_revision is None:
+                _append_event(
+                    conn,
+                    task_id,
+                    "claim_rejected",
+                    {
+                        "reason": "review_revision_authorization_revoked",
+                        "review_revision_event_id": int(
+                            review_revision_event_id
+                        ),
+                    },
+                )
+                return None
         # Defensive: if a prior run somehow leaked (invariant violation from
         # an unknown code path), close it as 'reclaimed' so we don't strand
         # it when the CAS resets the pointer below. No-op when the invariant
@@ -4097,6 +4119,21 @@ def claim_task(
             {"lock": lock, "expires": expires, "run_id": run_id},
             run_id=run_id,
         )
+        if review_revision is not None:
+            _append_event(
+                conn,
+                task_id,
+                "review_revision_claimed",
+                {
+                    "review_changes_event_id": review_revision["event_id"],
+                    "review_requested_event_id": (
+                        review_revision["review_requested_event_id"]
+                    ),
+                    "pr_url": review_revision["pr_url"],
+                    "reviewed_head": review_revision["reviewed_head"],
+                },
+                run_id=run_id,
+            )
         claimed = get_task(conn, task_id)
     _fire_kanban_lifecycle_hook(
         "kanban_task_claimed",
@@ -4181,6 +4218,257 @@ def claim_review_task(
             run_id=run_id,
         )
         return get_task(conn, task_id)
+
+
+def _canonical_review_pr_url(value: str) -> str:
+    raw = (value or "").strip()
+    match = _RESPAWN_GUARD_PR_URL_RE.fullmatch(raw)
+    if match is None:
+        raise ValueError("review pr_url must be a canonical GitHub pull request URL")
+    return match.group(0)
+
+
+def _canonical_review_head(value: str) -> str:
+    head = (value or "").strip().lower()
+    if _REVIEW_HEAD_RE.fullmatch(head) is None:
+        raise ValueError("reviewed_head must be a full 40-character Git commit SHA")
+    return head
+
+
+def _review_request_event(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    event_id: Optional[int] = None,
+) -> tuple[int, dict[str, Any]]:
+    sql = (
+        "SELECT id, payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'review_requested'"
+    )
+    params: list[Any] = [task_id]
+    if event_id is not None:
+        sql += " AND id = ?"
+        params.append(int(event_id))
+    sql += " ORDER BY id DESC LIMIT 1"
+    row = conn.execute(sql, params).fetchone()
+    if row is None:
+        raise ValueError("review lifecycle has no review_requested event")
+    try:
+        payload = json.loads(row["payload"]) if row["payload"] else None
+    except (TypeError, ValueError) as exc:
+        raise ValueError("review_requested event payload is malformed") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("review_requested event payload is malformed")
+    required = {
+        "version",
+        "implementation_assignee",
+        "reviewer",
+        "pr_url",
+        "reviewed_head",
+    }
+    if not required.issubset(payload):
+        raise ValueError("review_requested event payload is incomplete")
+    if payload.get("version") != _REVIEW_HANDOFF_VERSION:
+        raise ValueError("review_requested event version is unsupported")
+    payload["pr_url"] = _canonical_review_pr_url(str(payload["pr_url"]))
+    payload["reviewed_head"] = _canonical_review_head(str(payload["reviewed_head"]))
+    for field_name in ("implementation_assignee", "reviewer"):
+        value = str(payload[field_name]).strip()
+        if not value:
+            raise ValueError(f"review_requested {field_name} is empty")
+        payload[field_name] = value
+    if payload["implementation_assignee"] == payload["reviewer"]:
+        raise ValueError("reviewer must be independent of the implementation assignee")
+    return int(row["id"]), payload
+
+
+def submit_task_for_review(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reviewer: str,
+    pr_url: str,
+    reviewed_head: str,
+    summary: Optional[str] = None,
+    expected_run_id: Optional[int] = None,
+) -> bool:
+    """Finish an implementation run and route the same card through review.
+
+    The task's current assignee is persisted as the implementation owner in
+    the ordered ``review_requested`` event, then the task is assigned to the
+    independent reviewer and moved to the existing ``review`` column. This is
+    the canonical entry into :func:`claim_review_task`; it does not use the
+    generic blocked/unblock lifecycle.
+    """
+    reviewer = (_canonical_assignee(reviewer) or "").strip()
+    if not reviewer:
+        raise ValueError("reviewer is required")
+    canonical_pr_url = _canonical_review_pr_url(pr_url)
+    canonical_head = _canonical_review_head(reviewed_head)
+    handoff_summary = (summary or "").strip() or None
+
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status, assignee, current_run_id FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if row is None or row["status"] != "running":
+            return False
+        implementation_assignee = (row["assignee"] or "").strip()
+        if not implementation_assignee:
+            raise ValueError("review handoff requires an implementation assignee")
+        if reviewer == implementation_assignee:
+            raise ValueError("reviewer must be independent of the implementation assignee")
+        if (
+            expected_run_id is not None
+            and row["current_run_id"] != int(expected_run_id)
+        ):
+            return False
+
+        params: list[Any] = [reviewer, task_id]
+        run_predicate = ""
+        if expected_run_id is not None:
+            run_predicate = " AND current_run_id = ?"
+            params.append(int(expected_run_id))
+        cur = conn.execute(
+            "UPDATE tasks "
+            "SET status = 'review', assignee = ?, claim_lock = NULL, "
+            "claim_expires = NULL, worker_pid = NULL, block_kind = NULL "
+            "WHERE id = ? AND status = 'running'" + run_predicate,
+            params,
+        )
+        if cur.rowcount != 1:
+            return False
+
+        run_id = _end_run(
+            conn,
+            task_id,
+            outcome="review_requested",
+            status="review",
+            summary=handoff_summary,
+            metadata={
+                "pr_url": canonical_pr_url,
+                "reviewed_head": canonical_head,
+                "reviewer": reviewer,
+            },
+        )
+        now = int(time.time())
+        comment = (
+            f"Review requested for {canonical_pr_url} at {canonical_head}"
+        )
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            (task_id, implementation_assignee, comment, now),
+        )
+        _append_event(
+            conn,
+            task_id,
+            "commented",
+            {"author": implementation_assignee, "len": len(comment)},
+            run_id=run_id,
+        )
+        _append_event(
+            conn,
+            task_id,
+            "review_requested",
+            {
+                "version": _REVIEW_HANDOFF_VERSION,
+                "implementation_assignee": implementation_assignee,
+                "reviewer": reviewer,
+                "pr_url": canonical_pr_url,
+                "reviewed_head": canonical_head,
+                "summary": handoff_summary,
+            },
+            run_id=run_id,
+        )
+    return True
+
+
+def request_review_changes(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reviewed_head: str,
+    summary: str,
+    expected_run_id: Optional[int] = None,
+) -> bool:
+    """Finish a review run and return the same card to its implementation owner.
+
+    The ordered review event is the durable authority. The reviewer cannot
+    redirect the task to an arbitrary profile or a different PR/head, and the
+    resulting one-shot revision authorization is consumed atomically by the
+    next :func:`claim_task`.
+    """
+    canonical_head = _canonical_review_head(reviewed_head)
+    reason = (summary or "").strip()
+    if not reason:
+        raise ValueError("review changes summary is required")
+
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status, assignee, current_run_id FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if row is None or row["status"] != "running":
+            return False
+        request_event_id, request = _review_request_event(conn, task_id)
+        if row["assignee"] != request["reviewer"]:
+            raise ValueError("current assignee is not the requested reviewer")
+        if canonical_head != request["reviewed_head"]:
+            raise ValueError("reviewed_head does not match the review request")
+        if (
+            expected_run_id is not None
+            and row["current_run_id"] != int(expected_run_id)
+        ):
+            return False
+
+        params: list[Any] = [request["implementation_assignee"], task_id]
+        run_predicate = ""
+        if expected_run_id is not None:
+            run_predicate = " AND current_run_id = ?"
+            params.append(int(expected_run_id))
+        cur = conn.execute(
+            "UPDATE tasks "
+            "SET status = 'ready', assignee = ?, claim_lock = NULL, "
+            "claim_expires = NULL, worker_pid = NULL, "
+            "last_failure_error = NULL "
+            "WHERE id = ? AND status = 'running'" + run_predicate,
+            params,
+        )
+        if cur.rowcount != 1:
+            return False
+
+        run_id = _end_run(
+            conn,
+            task_id,
+            outcome="review_changes_requested",
+            status="ready",
+            summary=reason,
+            metadata={
+                "review_requested_event_id": request_event_id,
+                "pr_url": request["pr_url"],
+                "reviewed_head": canonical_head,
+                "implementation_assignee": request["implementation_assignee"],
+                "reviewer": request["reviewer"],
+            },
+        )
+        _append_event(
+            conn,
+            task_id,
+            "review_changes_requested",
+            {
+                "version": _REVIEW_HANDOFF_VERSION,
+                "review_requested_event_id": request_event_id,
+                "implementation_assignee": request["implementation_assignee"],
+                "reviewer": request["reviewer"],
+                "pr_url": request["pr_url"],
+                "reviewed_head": canonical_head,
+                "summary": reason,
+            },
+            run_id=run_id,
+        )
+    return True
 
 
 def heartbeat_claim(
@@ -6552,6 +6840,23 @@ _RESPAWN_GUARD_PR_URL_RE = re.compile(
     re.IGNORECASE,
 )
 
+_REVIEW_HANDOFF_VERSION = 1
+_REVIEW_HEAD_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
+_REVIEW_REVOCATION_EVENT_KINDS = frozenset(
+    {
+        "archived",
+        "blocked",
+        "claimed",
+        "completed",
+        "promoted",
+        "reclaimed",
+        "review_changes_requested",
+        "review_requested",
+        "status",
+        "unblocked",
+    }
+)
+
 
 @dataclass
 class DispatchResult:
@@ -7776,6 +8081,125 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
 _clear_spawn_failures = _clear_failure_counter
 
 
+def _recent_active_pr_urls(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    now: Optional[int] = None,
+) -> set[str]:
+    cutoff = int(time.time() if now is None else now) - _RESPAWN_GUARD_PR_WINDOW
+    urls: set[str] = set()
+    rows = conn.execute(
+        "SELECT body FROM task_comments "
+        "WHERE task_id = ? AND created_at >= ? ORDER BY id DESC",
+        (task_id, cutoff),
+    ).fetchall()
+    for row in rows:
+        body = row["body"] or ""
+        for match in _RESPAWN_GUARD_PR_URL_RE.finditer(body):
+            urls.add(match.group(0))
+    return urls
+
+
+def _review_revision_authorization(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    required_event_id: Optional[int] = None,
+) -> Optional[dict[str, Any]]:
+    """Return the current one-shot review revision receipt, or ``None``.
+
+    This only trusts ordered kernel events emitted by
+    :func:`request_review_changes`. Free-form comments remain evidence that a
+    PR exists, never authority to bypass the duplicate-PR guard.
+    """
+    row = conn.execute(
+        "SELECT id, payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'review_changes_requested' "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    event_id = int(row["id"])
+    if required_event_id is not None and event_id != int(required_event_id):
+        return None
+    try:
+        payload = json.loads(row["payload"]) if row["payload"] else None
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    required = {
+        "version",
+        "review_requested_event_id",
+        "implementation_assignee",
+        "reviewer",
+        "pr_url",
+        "reviewed_head",
+    }
+    if not required.issubset(payload):
+        return None
+    if payload.get("version") != _REVIEW_HANDOFF_VERSION:
+        return None
+    try:
+        request_event_id = int(payload["review_requested_event_id"])
+        pr_url = _canonical_review_pr_url(str(payload["pr_url"]))
+        reviewed_head = _canonical_review_head(str(payload["reviewed_head"]))
+        stored_request_event_id, request = _review_request_event(
+            conn,
+            task_id,
+            event_id=request_event_id,
+        )
+    except (TypeError, ValueError):
+        return None
+    implementation_assignee = str(payload["implementation_assignee"]).strip()
+    reviewer = str(payload["reviewer"]).strip()
+    if (
+        not implementation_assignee
+        or not reviewer
+        or implementation_assignee == reviewer
+        or stored_request_event_id != request_event_id
+        or request["implementation_assignee"] != implementation_assignee
+        or request["reviewer"] != reviewer
+        or request["pr_url"] != pr_url
+        or request["reviewed_head"] != reviewed_head
+    ):
+        return None
+
+    task = conn.execute(
+        "SELECT status, assignee, current_run_id FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if (
+        task is None
+        or task["status"] != "ready"
+        or task["assignee"] != implementation_assignee
+        or task["current_run_id"] is not None
+    ):
+        return None
+
+    newer = conn.execute(
+        "SELECT kind FROM task_events "
+        "WHERE task_id = ? AND id > ? ORDER BY id ASC",
+        (task_id, event_id),
+    ).fetchall()
+    if any(row["kind"] in _REVIEW_REVOCATION_EVENT_KINDS for row in newer):
+        return None
+
+    active_pr_urls = _recent_active_pr_urls(conn, task_id)
+    if active_pr_urls != {pr_url}:
+        return None
+    return {
+        "event_id": event_id,
+        "review_requested_event_id": request_event_id,
+        "implementation_assignee": implementation_assignee,
+        "reviewer": reviewer,
+        "pr_url": pr_url,
+        "reviewed_head": reviewed_head,
+    }
+
+
 def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
     """Return a guard reason if ``task_id`` should NOT be re-spawned, else None.
 
@@ -7900,13 +8324,9 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
-    pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
-    for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
-        (task_id, pr_cutoff),
-    ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+    active_pr_urls = _recent_active_pr_urls(conn, task_id, now=now)
+    if active_pr_urls and _review_revision_authorization(conn, task_id) is None:
+        return "active_pr"
 
     return None
 
@@ -8284,6 +8704,12 @@ def _dispatch_once_locked(
                         {"reason": guard_reason},
                     )
             continue
+        review_revision = _review_revision_authorization(conn, row["id"])
+        review_revision_event_id = (
+            int(review_revision["event_id"])
+            if review_revision is not None
+            else None
+        )
         if dry_run:
             result.spawned.append((row["id"], row_assignee, ""))
             # Increment per-profile counter even in dry_run so the cap
@@ -8295,7 +8721,12 @@ def _dispatch_once_locked(
                     _per_profile_running.get(row_assignee, 0) + 1
                 )
             continue
-        claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
+        claimed = claim_task(
+            conn,
+            row["id"],
+            ttl_seconds=ttl_seconds,
+            review_revision_event_id=review_revision_event_id,
+        )
         if claimed is None:
             continue
         try:
@@ -8359,9 +8790,9 @@ def _dispatch_once_locked(
 
     # ---- review column dispatch ----
     # Review tasks are tasks that a worker moved to 'review' after
-    # creating a PR.  The dispatcher spawns a review agent (loading
-    # sdlc-review skill) that verifies the PR and either merges (→ done)
-    # or rejects (→ back to running for the worker to fix).
+    # creating a PR.  The dispatcher spawns a review agent (loading the
+    # bundled github-code-review skill) that verifies the PR and either
+    # merges (→ done) or requests changes (→ ready for the implementer).
     #
     # Same concurrency model as ready dispatch: review spawns count
     # against max_spawn alongside ready tasks, so the total number of
@@ -8409,12 +8840,11 @@ def _dispatch_once_locked(
         if claimed.workspace_kind == "worktree":
             set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
-        # Force-load the sdlc-review skill for review agents — it carries
-        # the review logic (AC verification, merge, etc.). The mandatory
-        # kanban lifecycle is already injected into every worker's system
-        # prompt via KANBAN_GUIDANCE, so this is the only extra skill the
-        # review agent needs.
-        claimed.skills = ["sdlc-review"]
+        # Force-load the bundled GitHub review skill for review agents. The
+        # mandatory kanban lifecycle is already injected into every worker's
+        # system prompt via KANBAN_GUIDANCE, so this is the only extra skill
+        # the review agent needs.
+        claimed.skills = ["github-code-review"]
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
             import inspect

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -159,6 +159,33 @@ def test_run_slash_block_unblock_cycle(kanban_home):
     assert "Unblocked" in kc.run_slash(f"unblock {tid}")
 
 
+def test_run_slash_review_lifecycle(kanban_home):
+    out = kc.run_slash("create 'reviewed work' --assignee implementer")
+    import re
+    tid = re.search(r"(t_[a-f0-9]+)", out).group(1)
+    kc.run_slash(f"claim {tid}")
+    head = "a" * 40
+    pr_url = "https://github.com/NousResearch/hermes-agent/pull/42"
+
+    submitted = kc.run_slash(
+        f"review {tid} submit --reviewer reviewer "
+        f"--pr-url {pr_url} --head {head} --summary 'ready'"
+    )
+    assert "→ review" in submitted
+    assert "assignee: reviewer" in submitted
+
+    with kb.connect() as conn:
+        review = kb.claim_review_task(conn, tid)
+        assert review is not None
+
+    returned = kc.run_slash(
+        f"review {tid} request-changes --head {head} "
+        "--summary 'cover retry edge'"
+    )
+    assert "→ ready" in returned
+    assert "assignee: implementer" in returned
+
+
 def test_run_slash_json_output(kanban_home):
     out = kc.run_slash("create 'jsontask' --assignee alice --json")
     payload = json.loads(out)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3895,6 +3895,202 @@ def test_claim_review_task_fails_when_already_claimed(kanban_home):
     assert second is None
 
 
+_REVIEW_PR_URL = "https://github.com/NousResearch/hermes-agent/pull/42"
+_REVIEW_HEAD = "a" * 40
+
+
+def _review_changes_ready_task(conn: sqlite3.Connection) -> str:
+    task_id = kb.create_task(
+        conn,
+        title="implementation with review",
+        assignee="implementer",
+        workspace_kind="scratch",
+    )
+    implementation = kb.claim_task(conn, task_id, claimer="host:implementer")
+    assert implementation is not None
+    assert kb.submit_task_for_review(
+        conn,
+        task_id,
+        reviewer="reviewer",
+        pr_url=_REVIEW_PR_URL,
+        reviewed_head=_REVIEW_HEAD,
+        summary="implementation ready for independent review",
+        expected_run_id=implementation.current_run_id,
+    )
+    review = kb.claim_review_task(conn, task_id, claimer="host:reviewer")
+    assert review is not None
+    assert kb.request_review_changes(
+        conn,
+        task_id,
+        reviewed_head=_REVIEW_HEAD,
+        summary="please cover the retry edge case",
+        expected_run_id=review.current_run_id,
+    )
+    return task_id
+
+
+def test_submit_task_for_review_enters_existing_review_lifecycle(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="review me",
+            assignee="implementer",
+            workspace_kind="worktree",
+        )
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        assert kb.submit_task_for_review(
+            conn,
+            task_id,
+            reviewer="reviewer",
+            pr_url=_REVIEW_PR_URL,
+            reviewed_head=_REVIEW_HEAD,
+            summary="ready",
+            expected_run_id=claimed.current_run_id,
+        )
+        task = kb.get_task(conn, task_id)
+        run = kb.latest_run(conn, task_id)
+        events = kb.list_events(conn, task_id)
+        comments = kb.list_comments(conn, task_id)
+
+    assert task is not None
+    assert task.status == "review"
+    assert task.assignee == "reviewer"
+    assert task.current_run_id is None
+    assert run is not None
+    assert run.outcome == "review_requested"
+    request = next(event for event in events if event.kind == "review_requested")
+    assert request.payload["implementation_assignee"] == "implementer"
+    assert request.payload["reviewer"] == "reviewer"
+    assert request.payload["pr_url"] == _REVIEW_PR_URL
+    assert comments[-1].body.endswith(f"{_REVIEW_PR_URL} at {_REVIEW_HEAD}")
+
+
+def test_review_changes_restore_implementation_assignee(kanban_home):
+    with kb.connect() as conn:
+        task_id = _review_changes_ready_task(conn)
+        task = kb.get_task(conn, task_id)
+        run = kb.latest_run(conn, task_id)
+
+    assert task is not None
+    assert task.status == "ready"
+    assert task.assignee == "implementer"
+    assert task.current_run_id is None
+    assert run is not None
+    assert run.profile == "reviewer"
+    assert run.outcome == "review_changes_requested"
+
+
+def test_review_changes_authorize_exactly_one_revision_claim(kanban_home):
+    with kb.connect() as conn:
+        task_id = _review_changes_ready_task(conn)
+        assert kb.check_respawn_guard(conn, task_id) is None
+        authorization = kb._review_revision_authorization(conn, task_id)
+        assert authorization is not None
+        claimed = kb.claim_task(
+            conn,
+            task_id,
+            claimer="host:revision",
+            review_revision_event_id=authorization["event_id"],
+        )
+        assert claimed is not None
+        assert claimed.assignee == "implementer"
+
+        conn.execute(
+            "UPDATE tasks SET status = 'ready', current_run_id = NULL, "
+            "claim_lock = NULL, claim_expires = NULL WHERE id = ?",
+            (task_id,),
+        )
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
+
+
+def test_dispatch_claims_authorized_review_revision(
+    kanban_home, all_assignees_spawnable,
+):
+    spawned_tasks = []
+
+    def capture_spawn(task, workspace, board=None):
+        spawned_tasks.append(task)
+        return 42
+
+    with kb.connect() as conn:
+        task_id = _review_changes_ready_task(conn)
+        result = kb.dispatch_once(conn, spawn_fn=capture_spawn)
+        task = kb.get_task(conn, task_id)
+        events = kb.list_events(conn, task_id)
+
+    assert [item[0] for item in result.spawned] == [task_id]
+    assert len(spawned_tasks) == 1
+    assert spawned_tasks[0].assignee == "implementer"
+    assert task is not None
+    assert task.status == "running"
+    assert any(event.kind == "review_revision_claimed" for event in events)
+
+
+def test_review_revision_claim_fails_closed_after_newer_lifecycle_event(
+    kanban_home,
+):
+    with kb.connect() as conn:
+        task_id = _review_changes_ready_task(conn)
+        authorization = kb._review_revision_authorization(conn, task_id)
+        assert authorization is not None
+        with kb.write_txn(conn):
+            kb._append_event(
+                conn,
+                task_id,
+                "status",
+                {"reason": "operator changed routing"},
+            )
+        claimed = kb.claim_task(
+            conn,
+            task_id,
+            review_revision_event_id=authorization["event_id"],
+        )
+
+    assert claimed is None
+
+
+def test_review_revision_does_not_bypass_a_second_active_pr(kanban_home):
+    with kb.connect() as conn:
+        task_id = _review_changes_ready_task(conn)
+        kb.add_comment(
+            conn,
+            task_id,
+            "operator",
+            "Unrelated https://github.com/NousResearch/hermes-agent/pull/43",
+        )
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
+
+
+def test_review_changes_reject_mismatched_head(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="review me",
+            assignee="implementer",
+        )
+        implementation = kb.claim_task(conn, task_id)
+        assert implementation is not None
+        assert kb.submit_task_for_review(
+            conn,
+            task_id,
+            reviewer="reviewer",
+            pr_url=_REVIEW_PR_URL,
+            reviewed_head=_REVIEW_HEAD,
+            expected_run_id=implementation.current_run_id,
+        )
+        review = kb.claim_review_task(conn, task_id)
+        assert review is not None
+        with pytest.raises(ValueError, match="does not match"):
+            kb.request_review_changes(
+                conn,
+                task_id,
+                reviewed_head="b" * 40,
+                summary="changes requested",
+                expected_run_id=review.current_run_id,
+            )
+
+
 def test_dispatch_review_dry_run(kanban_home, all_assignees_spawnable):
     """dispatch_once dry-run sees review tasks and reports them as spawned."""
     with kb.connect() as conn:
@@ -3911,7 +4107,7 @@ def test_dispatch_review_dry_run(kanban_home, all_assignees_spawnable):
 def test_dispatch_review_spawns_with_correct_skills(
     kanban_home, all_assignees_spawnable,
 ):
-    """Review tasks get sdlc-review skill set before spawning."""
+    """Review tasks get the bundled GitHub review skill before spawning."""
     spawned_tasks = []
 
     def capture_spawn(task, workspace, board=None):
@@ -3924,7 +4120,15 @@ def test_dispatch_review_spawns_with_correct_skills(
         res = kb.dispatch_once(conn, spawn_fn=capture_spawn)
     assert len(res.spawned) == 1
     assert len(spawned_tasks) == 1
-    assert spawned_tasks[0].skills == ["sdlc-review"]
+    assert spawned_tasks[0].skills == ["github-code-review"]
+    skill_path = (
+        Path(__file__).parents[2]
+        / "skills"
+        / "github"
+        / "github-code-review"
+        / "SKILL.md"
+    )
+    assert skill_path.is_file()
 
 
 def test_dispatch_review_skips_unassigned(kanban_home):

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -56,7 +56,8 @@ def test_kanban_tools_visible_with_env_var(monkeypatch, tmp_path):
     names = {s["function"].get("name") for s in schema if "function" in s}
     kanban = {n for n in names if n and n.startswith("kanban_")}
     expected = {
-        "kanban_show", "kanban_complete", "kanban_block", "kanban_heartbeat",
+        "kanban_show", "kanban_complete", "kanban_block", "kanban_review",
+        "kanban_heartbeat",
         "kanban_comment", "kanban_create", "kanban_link",
         "kanban_attach", "kanban_attach_url", "kanban_attachments",
     }
@@ -86,6 +87,7 @@ def test_kanban_worker_env_overrides_profile_toolset_filter(monkeypatch, tmp_pat
     assert "kanban_show" in names
     assert "kanban_complete" in names
     assert "kanban_block" in names
+    assert "kanban_review" in names
     assert "kanban_list" not in names
 
 
@@ -137,7 +139,8 @@ def test_kanban_tools_visible_with_toolset_config(monkeypatch, tmp_path):
     kanban = {n for n in names if n and n.startswith("kanban_")}
     expected = {
         "kanban_list",
-        "kanban_show", "kanban_complete", "kanban_block", "kanban_heartbeat",
+        "kanban_show", "kanban_complete", "kanban_block", "kanban_review",
+        "kanban_heartbeat",
         "kanban_comment", "kanban_create", "kanban_link",
         "kanban_unblock",
         "kanban_attach", "kanban_attach_url", "kanban_attachments",
@@ -855,6 +858,57 @@ def test_block_non_goal_mode_task_unaffected_by_new_gate(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_block({"reason": "need clarification"})
     assert json.loads(out).get("ok") is True
+
+
+def test_review_tool_routes_submit_and_request_changes(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    pr_url = "https://github.com/NousResearch/hermes-agent/pull/42"
+    head = "a" * 40
+    submitted = json.loads(
+        kt._handle_review(
+            {
+                "action": "submit",
+                "reviewer": "reviewer",
+                "pr_url": pr_url,
+                "reviewed_head": head,
+                "summary": "implementation ready",
+            }
+        )
+    )
+    assert submitted["status"] == "review"
+    assert submitted["assignee"] == "reviewer"
+
+    with kb.connect() as conn:
+        review = kb.claim_review_task(conn, worker_env)
+        assert review is not None
+
+    returned = json.loads(
+        kt._handle_review(
+            {
+                "action": "request_changes",
+                "reviewed_head": head,
+                "summary": "cover the retry edge case",
+            }
+        )
+    )
+    assert returned["status"] == "ready"
+    assert returned["assignee"] == "test-worker"
+
+
+def test_review_tool_rejects_incomplete_submit(worker_env):
+    from tools import kanban_tools as kt
+
+    out = json.loads(
+        kt._handle_review(
+            {
+                "action": "submit",
+                "reviewed_head": "a" * 40,
+            }
+        )
+    )
+    assert "submit requires reviewer and pr_url" in out["error"]
 
 
 def test_heartbeat_happy_path(worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -796,6 +796,80 @@ def _handle_block(args: dict, **kw) -> str:
         return tool_error(f"kanban_block: {e}")
 
 
+def _handle_review(args: dict, **kw) -> str:
+    """Enter review or return an independently reviewed task for revision."""
+    delegated_err = _reject_delegated_child_mutation("kanban_review")
+    if delegated_err:
+        return delegated_err
+    tid = _default_task_id(args.get("task_id"))
+    if not tid:
+        return tool_error(
+            "task_id is required (or set HERMES_KANBAN_TASK)"
+        )
+    ownership_err = _enforce_worker_task_ownership(tid)
+    if ownership_err:
+        return ownership_err
+    action = (args.get("action") or "").strip()
+    if action not in {"submit", "request_changes"}:
+        return tool_error("action must be 'submit' or 'request_changes'")
+    reviewed_head = (args.get("reviewed_head") or "").strip()
+    if not reviewed_head:
+        return tool_error("reviewed_head is required")
+    summary = (args.get("summary") or "").strip()
+    board = args.get("board")
+
+    try:
+        kb, conn = _connect(board=board)
+        try:
+            if action == "submit":
+                reviewer = (args.get("reviewer") or "").strip()
+                pr_url = (args.get("pr_url") or "").strip()
+                if not reviewer or not pr_url:
+                    return tool_error(
+                        "submit requires reviewer and pr_url"
+                    )
+                ok = kb.submit_task_for_review(
+                    conn,
+                    tid,
+                    reviewer=reviewer,
+                    pr_url=pr_url,
+                    reviewed_head=reviewed_head,
+                    summary=summary or None,
+                    expected_run_id=_worker_run_id(tid),
+                )
+            else:
+                if not summary:
+                    return tool_error(
+                        "request_changes requires a non-empty summary"
+                    )
+                ok = kb.request_review_changes(
+                    conn,
+                    tid,
+                    reviewed_head=reviewed_head,
+                    summary=summary,
+                    expected_run_id=_worker_run_id(tid),
+                )
+            if not ok:
+                return tool_error(
+                    f"could not apply review action {action!r} to {tid} "
+                    "(wrong task state or stale run)"
+                )
+            task = kb.get_task(conn, tid)
+            return _ok(
+                task_id=tid,
+                action=action,
+                status=task.status if task else None,
+                assignee=task.assignee if task else None,
+            )
+        finally:
+            conn.close()
+    except ValueError as e:
+        return tool_error(f"kanban_review: {e}")
+    except Exception as e:
+        logger.exception("kanban_review failed")
+        return tool_error(f"kanban_review: {e}")
+
+
 def _handle_heartbeat(args: dict, **kw) -> str:
     """Signal that the worker is still alive during a long operation.
 
@@ -1646,6 +1720,68 @@ KANBAN_BLOCK_SCHEMA = {
     },
 }
 
+KANBAN_REVIEW_SCHEMA = {
+    "name": "kanban_review",
+    "description": (
+        "Advance the current card through the canonical review lifecycle. "
+        "Use action='submit' after opening a PR: this closes the "
+        "implementation run, records the exact PR/head and implementation "
+        "owner, assigns an independent reviewer, and moves the card to "
+        "'review'. A dispatched reviewer uses action='request_changes' to "
+        "return that same card to the recorded implementation owner for one "
+        "audited revision run. Approval/merge closes the card with "
+        "kanban_complete. Do not use kanban_block/unblock for review handoffs."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": _DESC_TASK_ID_DEFAULT,
+            },
+            "action": {
+                "type": "string",
+                "enum": ["submit", "request_changes"],
+                "description": (
+                    "'submit' routes implementation to an independent "
+                    "reviewer. 'request_changes' returns an active review to "
+                    "the implementation owner."
+                ),
+            },
+            "reviewer": {
+                "type": "string",
+                "description": (
+                    "Independent Hermes profile that should review the PR. "
+                    "Required only for action='submit'."
+                ),
+            },
+            "pr_url": {
+                "type": "string",
+                "description": (
+                    "Canonical GitHub pull request URL. Required only for "
+                    "action='submit'."
+                ),
+            },
+            "reviewed_head": {
+                "type": "string",
+                "description": (
+                    "Exact 40-character Git commit SHA submitted or reviewed."
+                ),
+            },
+            "summary": {
+                "type": "string",
+                "description": (
+                    "Implementation handoff for 'submit', or concrete review "
+                    "findings for 'request_changes'. Required for "
+                    "'request_changes'."
+                ),
+            },
+            "board": _board_schema_prop(),
+        },
+        "required": ["action", "reviewed_head"],
+    },
+}
+
 KANBAN_HEARTBEAT_SCHEMA = {
     "name": "kanban_heartbeat",
     "description": (
@@ -2056,6 +2192,15 @@ registry.register(
     handler=_handle_block,
     check_fn=_check_kanban_mode,
     emoji="⏸",
+)
+
+registry.register(
+    name="kanban_review",
+    toolset="kanban",
+    schema=KANBAN_REVIEW_SCHEMA,
+    handler=_handle_review,
+    check_fn=_check_kanban_mode,
+    emoji="🔎",
 )
 
 registry.register(

--- a/toolsets.py
+++ b/toolsets.py
@@ -72,7 +72,7 @@ _HERMES_CORE_TOOLS = [
     # profile explicitly enables the kanban toolset. Gated via check_fn in
     # tools/kanban_tools.py.
     "kanban_show", "kanban_list",
-    "kanban_complete", "kanban_block", "kanban_heartbeat",
+    "kanban_complete", "kanban_block", "kanban_review", "kanban_heartbeat",
     "kanban_comment", "kanban_create", "kanban_link",
     "kanban_unblock",
     "kanban_attach", "kanban_attach_url", "kanban_attachments",
@@ -266,12 +266,14 @@ TOOLSETS = {
             "is spawned by the kanban dispatcher (HERMES_KANBAN_TASK env "
             "set). The dispatcher runs inside the gateway by default; see "
             "`kanban.dispatch_in_gateway` in config.yaml. Lets workers mark "
-            "tasks done with structured handoffs, block for human input, "
+            "tasks done with structured handoffs, route independent review, "
+            "block for human input, "
             "heartbeat during long ops, comment on threads, attach files, and "
             "(for orchestrators) list, unblock, and fan out tasks."
         ),
         "tools": [
             "kanban_show", "kanban_list", "kanban_complete", "kanban_block",
+            "kanban_review",
             "kanban_heartbeat", "kanban_comment",
             "kanban_create", "kanban_link",
             "kanban_unblock",

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -14,7 +14,7 @@ Hermes Kanban is a durable task board, shared across all your Hermes profiles, t
 
 The board has two front doors, both backed by the same `~/.hermes/kanban.db`:
 
-- **Agents drive the board through a dedicated `kanban_*` toolset** — `kanban_show`, `kanban_list`, `kanban_complete`, `kanban_block`, `kanban_heartbeat`, `kanban_comment`, `kanban_create`, `kanban_link`, `kanban_unblock`. The dispatcher spawns each worker with these tools already in its schema; orchestrator profiles can also enable the `kanban` toolset explicitly. The model reads and routes tasks by calling tools directly, *not* by shelling out to `hermes kanban`. See [How workers interact with the board](#how-workers-interact-with-the-board) below.
+- **Agents drive the board through a dedicated `kanban_*` toolset** — `kanban_show`, `kanban_list`, `kanban_complete`, `kanban_block`, `kanban_review`, `kanban_heartbeat`, `kanban_comment`, `kanban_create`, `kanban_link`, `kanban_unblock`. The dispatcher spawns each worker with these tools already in its schema; orchestrator profiles can also enable the `kanban` toolset explicitly. The model reads and routes tasks by calling tools directly, *not* by shelling out to `hermes kanban`. See [How workers interact with the board](#how-workers-interact-with-the-board) below.
 - **You (and scripts, and cron) drive the board through `hermes kanban …`** on the CLI, `/kanban …` as a slash command, or the dashboard. These are for humans and automation — the places without a tool-calling model behind them.
 
 Both surfaces route through the same `kanban_db` layer, so reads see a consistent view and writes can't drift. The rest of this page shows CLI examples because they're easy to copy-paste, but every CLI verb has a tool-call equivalent the model uses.
@@ -59,7 +59,7 @@ They coexist: a kanban worker may call `delegate_task` internally during its run
   (e.g. one per project, repo, or domain); see [Boards (multi-project)](#boards-multi-project)
   below. Single-project users stay on the `default` board and never see the
   word "board" outside this docs section.
-- **Task** — a row with title, optional body, one assignee (a profile name), status (`triage | todo | ready | running | blocked | done | archived`), optional tenant namespace, optional idempotency key (dedup for retried automation).
+- **Task** — a row with title, optional body, one assignee (a profile name), status (`triage | todo | ready | running | review | blocked | done | archived`), optional tenant namespace, optional idempotency key (dedup for retried automation).
 - **Link** — `task_links` row recording a parent → child dependency. The dispatcher promotes `todo → ready` when all parents are `done`.
 - **Comment** — the inter-agent protocol. Agents and humans append comments; when a worker is (re-)spawned it reads the full comment thread as part of its context.
 - **Workspace** — the directory a worker operates in. Three kinds:
@@ -294,6 +294,7 @@ parent, missing input, unmet capability) before unblocking, or raise
 | `kanban_list` | List task summaries with filters for `assignee`, `status`, `tenant`, archived visibility, and limit. Intended for orchestrators discovering board work. | — |
 | `kanban_complete` | Finish with `summary` + `metadata` structured handoff. | at least one of `summary` / `result` |
 | `kanban_block` | Stop work and route by why: `kind=dependency` (waits in `todo`, auto-resumes), `needs_input`/`capability`/`transient` (surface to a human). Repeated same-kind re-blocks auto-escalate to `triage`. | `reason` |
+| `kanban_review` | Enter the canonical review route (`submit`) or return an independently reviewed card to its recorded implementation owner (`request_changes`). | `action`, `reviewed_head` |
 | `kanban_heartbeat` | Signal liveness during long operations. Pure side-effect. | — |
 | `kanban_comment` | Append a durable note to the task thread. | `task_id`, `body` |
 | `kanban_create` | (Orchestrators) fan out into child tasks with an `assignee`, optional `parents`, `skills`, etc. | `title`, `assignee` |
@@ -391,6 +392,17 @@ Every profile that works kanban tasks automatically gets the worker lifecycle �
 2. `cd $HERMES_KANBAN_WORKSPACE` (via the terminal tool) and do the work there.
 3. Call `kanban_heartbeat(note="...")` every few minutes during long operations. **If your work may run longer than 1 hour, call `kanban_heartbeat` at least once an hour** — the dispatcher reclaims tasks that have been running past `kanban.dispatch_stale_timeout_seconds` (default 4 h) with no heartbeat in the last hour, on the assumption the worker crashed without cleanup. A reclaim is benign (the task goes back to `ready` for re-dispatch without a failure-counter tick) but you lose your current run's progress.
 4. Complete with `kanban_complete(summary="...", metadata={...})`, or `kanban_block(reason="...")` if stuck.
+
+For a PR review, the implementation worker ends its run with
+`kanban_review(action="submit", reviewer="...", pr_url="...", reviewed_head="...")`
+instead of completing or blocking. The same card moves to `review`, is assigned
+to the independent reviewer, and the dispatcher claims it through
+`claim_review_task()`. The reviewer then either merges and calls
+`kanban_complete`, or calls
+`kanban_review(action="request_changes", reviewed_head="...", summary="...")`.
+Requested changes restore the recorded implementation assignee and authorize
+exactly one revision claim for that same PR/head. `kanban_unblock` is not a
+review mechanism and cannot create this authorization.
 
 That final `kanban_complete` / `kanban_block` call is part of the worker
 protocol. If the worker process exits with status 0 while the task is still
@@ -508,7 +520,7 @@ hermes dashboard        # "Kanban" tab appears in the nav, after "Skills"
 
 ### What the plugin gives you
 
-- A **Kanban** tab showing one column per status: `triage`, `todo`, `ready`, `running`, `blocked`, `done` (plus `archived` when the toggle is on).
+- A **Kanban** tab showing one column per status: `triage`, `todo`, `ready`, `running`, `review`, `blocked`, `done` (plus `archived` when the toggle is on).
   - `triage` is the parking column for rough ideas. By default (`kanban.auto_decompose: true`), the dispatcher auto-runs the **decomposer** on tasks that land here. The built-in decomposer uses the `auxiliary.kanban_decomposer` model path, reads your profile roster (with descriptions), and fans the task out into a small graph of child tasks routed to the best-fit specialists. The original task stays alive as the parent of every child so its assignee (`kanban.orchestrator_profile`, or the active default profile when unset) wakes back up to judge completion when everything finishes. Flip the **Orchestration: Auto/Manual** pill at the top of the page (emerald = Auto, muted gray = Manual), or by editing `config.yaml` directly. Both modes coexist with `hermes kanban specify` - that's still available as a single-task spec rewrite when you don't want fan-out.
 - Cards show the task id, title, priority badge, tenant tag, assigned profile, comment/link counts, a **progress pill** (`N/M` children done when the task has dependents), and "created N ago". A per-card checkbox enables multi-select.
 - **Per-profile lanes inside Running** — toolbar checkbox toggles sub-grouping of the Running column by assignee.
@@ -682,6 +694,8 @@ hermes kanban link <parent_id> <child_id>
 hermes kanban unlink <parent_id> <child_id>
 hermes kanban claim <id> [--ttl SECONDS]
 hermes kanban comment <id> "<text>" [--author NAME]
+hermes kanban review <id> submit --reviewer PROFILE --pr-url URL --head SHA [--summary "..."]
+hermes kanban review <id> request-changes --head SHA --summary "..."
 
 # Bulk verbs — accept multiple ids:
 hermes kanban complete <id>... [--result "..."]
@@ -939,6 +953,9 @@ Every transition appends a row to `task_events`. Each row carries an optional `r
 | `created` | `{assignee, status, parents, tenant}` | Task inserted. `run_id` is `NULL`. |
 | `promoted` | — | `todo → ready` because all parents hit `done`. `run_id` is `NULL`. |
 | `claimed` | `{lock, expires, run_id}` | Dispatcher atomically claimed a `ready` task for spawn. |
+| `review_requested` | `{implementation_assignee, reviewer, pr_url, reviewed_head}` | Implementation ended and the same card entered `review` under an independent reviewer. |
+| `review_changes_requested` | `{review_requested_event_id, implementation_assignee, reviewer, pr_url, reviewed_head, summary}` | Review ended with concrete changes and restored the card to the implementation owner in `ready`. |
+| `review_revision_claimed` | `{review_changes_event_id, review_requested_event_id, pr_url, reviewed_head}` | The one-shot revision authorization was atomically consumed by the implementation claim. |
 | `completed` | `{result_len, summary?}` | Worker wrote `--result` / `--summary` and task hit `done`. `summary` is the first-line handoff (400-char cap); full version lives on the run row. If `complete_task` is called on a never-claimed task with handoff fields, a zero-duration run is synthesized so `run_id` still points at something. |
 | `blocked` | `{reason, kind, recurrences}` | Worker or human flipped the task to `blocked`. `kind` is the typed block reason (`needs_input`, `capability`, `transient`, or `null` for a generic block); `recurrences` is the unblock-loop counter. Synthesizes a zero-duration run when called on a never-claimed task with `--reason`. |
 | `dependency_wait` | `{reason, kind}` | Worker blocked with `kind=dependency` — the task is only waiting on another task, so it routes to `todo` (parent-gated, auto-promoted) instead of `blocked`. No human needed. |
@@ -965,7 +982,7 @@ Every transition appends a row to `task_events`. Each row carries an optional `r
 | `crashed` | `{pid, claimer}` | Worker PID no longer alive but TTL hadn't expired yet. |
 | `timed_out` | `{pid, elapsed_seconds, limit_seconds, sigkill}` | `max_runtime_seconds` exceeded; dispatcher SIGTERM'd (then SIGKILL'd after 5 s grace) and re-queued. |
 | `stale` | `{elapsed_seconds, last_heartbeat_at, heartbeat_age_seconds, timeout_seconds, pid, terminated}` | Task ran longer than `kanban.dispatch_stale_timeout_seconds` (default 4 h) AND no `kanban_heartbeat` arrived in the last hour. Dispatcher SIGTERM'd the host-local worker (if any), reset the task to `ready` for re-dispatch. Does NOT tick the failure counter (stale is dispatcher-side absence detection, not a worker fault). Workers running long operations should call `kanban_heartbeat` at least once an hour to avoid this. |
-| `respawn_guarded` | `{reason}` | Dispatcher refused to re-spawn this ready task this tick. Reasons: `blocker_auth` (last failure was a quota/auth/429 error — wait for the rate window to reset), `recent_success` (a completed run happened in the last hour — wait for review before re-running), `active_pr` (a GitHub PR URL appears in a recent comment — a prior worker already opened a PR). The task stays in `ready`; the next tick gets another chance to spawn. If the underlying condition persists, the normal `consecutive_failures` circuit breaker will auto-block via `gave_up` after `failure_limit` failures. |
+| `respawn_guarded` | `{reason}` | Dispatcher refused to re-spawn this ready task this tick. Reasons: `blocker_auth` (last failure was a quota/auth/429 error — wait for the rate window to reset), `recent_success` (a completed run happened in the last hour — wait for review before re-running), `active_pr` (a GitHub PR URL appears in a recent comment — a prior worker already opened a PR). `active_pr` is bypassed only by the current ordered `review_requested → review_changes_requested` lifecycle for the exact same PR/head; free-form comments and generic unblock actions are never authority. |
 | `spawn_failed` | `{error, failures}` | One spawn attempt failed (missing PATH, workspace unmountable, …). Counter increments; task returns to `ready` for retry. |
 | `protocol_violation` | `{pid, claimer, exit_code, protocol_violation}` | Worker exited successfully while the task was still `running`, usually because it answered without calling `kanban_complete` or `kanban_block`. Emitted on every violation (the payload's `protocol_violation: true` marker is copied into the run metadata and feeds the violation-only retry budget). Below the budget — up to `_PROTOCOL_VIOLATION_FAILURE_LIMIT` (default 3) *consecutive* violations, per-task `max_retries` overriding — the task simply returns to `ready` for another attempt; when the streak reaches the bound the dispatcher also emits `gave_up` and auto-blocks. |
 | `gave_up` | `{failures, effective_limit, limit_source, error}` | Circuit breaker fired after N consecutive non-successful attempts. Task auto-blocks with the last error. The effective limit resolves as task `max_retries`, then dispatcher `failure_limit` / `kanban.failure_limit`, then the built-in default. |


### PR DESCRIPTION
## Summary

This rework removes the competing `blocked → ready` active-PR bypass and completes Hermes' existing review lifecycle instead:

1. An implementation worker submits the same card through `kanban_review(action="submit")`, recording the exact PR URL and full head SHA.
2. The card enters the existing `review` status under an independent reviewer and is claimed by the existing review dispatcher.
3. `request_changes` closes the review run, restores the original implementation assignee, and creates one ordered revision authorization for the same PR/head.
4. The dispatcher revalidates and consumes that authorization atomically when it claims the revision run.

Free-form comments, generic unblock actions, a second PR, stale/superseded events, a mismatched head, or reassignment cannot authorize recovery.

The review dispatcher now force-loads the bundled `github-code-review` skill. The previous `sdlc-review` name does not exist in the repository.

## Why this addresses the review

- `review` plus `claim_review_task()` remains the single authoritative review route.
- No parallel receipt protocol is exposed through `kanban_unblock`.
- Implementation, review, and requested changes remain on one durable card and ordered event stream.
- Approval still closes through `kanban_complete`; requested changes return to the implementation owner.

## Verification

- `405 passed`: full affected DB, CLI, and tool suites, excluding one confirmed upstream order-dependent logging failure.
- The excluded `test_connect_falls_back_to_delete_on_locking_protocol` fails in the full file on clean `upstream/main` and passes in isolation.
- Review-focused DB suite: `21 passed`.
- Ruff, Python byte compilation, `git diff --check`, and Windows-footgun scan of changed production files passed.
- No GitHub Actions workflow was manually triggered.

## Rework provenance

- Reworked by Codex (`gpt-5.6-sol`) in a fresh worktree from current `upstream/main`.
- No subagents were used for this rework.
- The original agency provenance remains available in the PR/commit history at `a123150d`.
