### PR TITLE
fix(providers): clarify Qwen Cloud PAYG billing lane

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -48,7 +48,7 @@ def _resolve_requests_verify() -> bool | str:
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
     "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek", "deepinfra",
-    "opencode-zen", "opencode-go", "kilocode", "alibaba", "novita",
+    "opencode-zen", "opencode-go", "kilocode", "alibaba", "alibaba-cloud", "novita",
     "qwen-oauth",
     "xiaomi",
     "arcee",
@@ -61,6 +61,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "github-models", "kimi", "moonshot", "kimi-cn", "moonshot-cn", "claude", "deep-seek", "deep-infra",
     "ollama",
     "stepfun", "opencode", "zen", "go", "kilo", "dashscope", "aliyun", "qwen",
+    "qwen-dashscope", "qwen-cloud", "qwencloud",
     "mimo", "xiaomi-mimo",
     "tencent", "tokenhub", "tencent-cloud", "tencentmaas",
     "arcee-ai", "arceeai",
@@ -274,7 +275,16 @@ DEFAULT_CONTEXT_LENGTHS = {
     "llama": 131072,
     # Qwen — specific model families before the catch-all.
     # Official docs: https://help.aliyun.com/zh/model-studio/developer-reference/
-    "qwen3.6-plus": 1048576,      # 1M context (DashScope/Alibaba & OpenRouter)
+    # Qwen Cloud's current client guides publish 983,616 for the Token Plan
+    # Qwen3.8 preview and 1,000,000 for Qwen3.7/Qwen3.6. Keep these entries
+    # provider-neutral:
+    # the same IDs can be reached through DashScope, OpenRouter, or another
+    # compatible endpoint. Specific keys must precede the generic qwen key.
+    "qwen3.8-max-preview": 983_616,
+    "qwen3.7-max": 1_000_000,
+    "qwen3.7-plus": 1_000_000,
+    "qwen3.6-plus": 1_000_000,
+    "qwen3.6-flash": 1_000_000,
     "qwen3-coder-plus": 1000000,  # 1M context
     "qwen3-coder": 262144,        # 256K context
     "qwen": 131072,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3751,7 +3751,7 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
     },
     "DASHSCOPE_BASE_URL": {
-        "description": "Custom DashScope base URL (default: coding-intl OpenAI-compat endpoint)",
+        "description": "Qwen Cloud PAYG base URL override (default: international DashScope OpenAI-compat endpoint)",
         "prompt": "DashScope Base URL",
         "url": "",
         "password": False,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1658,7 +1658,7 @@ def list_authenticated_providers(
     # Section 4 uses this to hide ``custom_providers`` entries that point at the
     # same endpoint as a built-in (e.g. a user-defined "my-dashscope" on
     # https://coding-intl.dashscope.aliyuncs.com/v1 collides with the built-in
-    # alibaba-coding-plan row when DASHSCOPE_API_KEY is present). Fixes #16970.
+    # alibaba-coding-plan row when that provider is configured). Fixes #16970.
     _builtin_endpoints: set = set()
 
     def _norm_url(url: str) -> str:
@@ -2436,8 +2436,8 @@ def list_authenticated_providers(
             # Skip if a built-in row (sections 1/2/2b) already represents this
             # endpoint. Fixes #16970: a user-defined "my-dashscope" pointing at
             # https://coding-intl.dashscope.aliyuncs.com/v1 duplicates the
-            # built-in alibaba-coding-plan row whenever DASHSCOPE_API_KEY is
-            # set. The built-in row carries the curated model list, correct
+            # built-in alibaba-coding-plan row when that provider is configured.
+            # The built-in row carries the curated model list, correct
             # auth wiring, and canonical slug — keep it and hide the shadow.
             _grp_url_norm = _pair_key[1]
             if _grp_url_norm and _grp_url_norm in _builtin_endpoints:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -486,25 +486,23 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "google/gemini-3-pro-preview",
         "google/gemini-3-flash-preview",
     ],
-    # Alibaba DashScope Coding platform (coding-intl) — default endpoint.
-    # Supports Qwen models + third-party providers (GLM, Kimi, MiniMax).
-    # Users with classic DashScope keys should override DASHSCOPE_BASE_URL
-    # to https://dashscope-intl.aliyuncs.com/compatible-mode/v1 (OpenAI-compat)
-    # or https://dashscope-intl.aliyuncs.com/apps/anthropic (Anthropic-compat).
+    # Qwen Cloud PAYG / Alibaba DashScope (international) — default endpoint.
+    # Keep this offline catalog limited to current agentic Qwen models.  The
+    # qwen3.8-max-preview Token Plan model deliberately belongs to the
+    # standalone vendor plugin and must not be implied by this PAYG provider.
     "alibaba": [
         "qwen3.7-max",
+        "qwen3.7-plus",
         "qwen3.6-plus",
-        "kimi-k2.5",
+        "qwen3.6-flash",
         "qwen3.5-plus",
+        "qwen3.5-flash",
         "qwen3-coder-plus",
+        "qwen3-coder-flash",
         "qwen3-coder-next",
-        # Third-party models available on coding-intl
-        "glm-5",
-        "glm-4.7",
-        "MiniMax-M2.5",
     ],
-    # Alibaba Coding Plan — same platform as alibaba (DashScope coding-intl),
-    # separate provider ID with its own base_url_env_var.
+    # Alibaba Coding Plan — dedicated subscription endpoint and provider ID;
+    # prefer its named key while preserving the legacy PAYG-key fallback.
     "alibaba-coding-plan": [
         "qwen3.7-max",
         "qwen3.6-plus",
@@ -1265,6 +1263,9 @@ _PROVIDER_ALIASES = {
     "aliyun": "alibaba",
     "qwen": "alibaba",
     "alibaba-cloud": "alibaba",
+    "qwen-dashscope": "alibaba",
+    "qwen-cloud": "alibaba",
+    "qwencloud": "alibaba",
     "qwen-portal": "qwen-oauth",
     "hf": "huggingface",
     "hugging-face": "huggingface",

--- a/plugins/model-providers/alibaba/__init__.py
+++ b/plugins/model-providers/alibaba/__init__.py
@@ -1,13 +1,70 @@
-"""Alibaba Cloud DashScope provider profile."""
+"""Qwen Cloud PAYG provider profile via Alibaba Cloud DashScope."""
 
+from typing import Any
 from providers import register_provider
 from providers.base import ProviderProfile
 
-alibaba = ProviderProfile(
+
+PAYG_FALLBACK_MODELS = (
+    "qwen3.7-max",
+    "qwen3.7-plus",
+    "qwen3.6-plus",
+    "qwen3.6-flash",
+    "qwen3.5-plus",
+    "qwen3.5-flash",
+    "qwen3-coder-plus",
+    "qwen3-coder-flash",
+    "qwen3-coder-next",
+)
+
+
+class QwenCloudPaygProfile(ProviderProfile):
+    """Qwen Cloud PAYG — DashScope hybrid-thinking request controls."""
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        model: str | None = None,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Map explicit Hermes thinking toggles to Qwen's extra_body field.
+
+        Qwen3.7, Qwen3.6, and Qwen3.5 use ``enable_thinking`` as a boolean
+        inside ``extra_body``.  When Hermes has no reasoning configuration,
+        omit the field so DashScope keeps its documented model default. Hermes
+        effort levels intentionally do not become a made-up Qwen depth knob.
+        Other PAYG models, including Qwen Coder, receive no hybrid-thinking
+        field unless Qwen documents support for that exact family.
+        """
+        model_name = str(model or "").strip().lower()
+        if not model_name.startswith(("qwen3.7-", "qwen3.6-", "qwen3.5-")):
+            return {}, {}
+        if not isinstance(reasoning_config, dict):
+            return {}, {}
+
+        enabled = reasoning_config.get("enabled")
+        if isinstance(enabled, bool):
+            return {"enable_thinking": enabled}, {}
+        return {}, {}
+
+
+alibaba = QwenCloudPaygProfile(
     name="alibaba",
-    aliases=("dashscope", "alibaba-cloud", "qwen-dashscope"),
-    env_vars=("DASHSCOPE_API_KEY",),
+    aliases=(
+        "dashscope",
+        "alibaba-cloud",
+        "qwen-dashscope",
+        "qwen-cloud",
+        "qwencloud",
+    ),
+    display_name="Qwen Cloud (PAYG)",
+    description="Qwen Cloud pay-as-you-go API via Alibaba Cloud DashScope",
+    signup_url="https://modelstudio.console.alibabacloud.com/",
+    env_vars=("DASHSCOPE_API_KEY", "DASHSCOPE_BASE_URL"),
     base_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    fallback_models=PAYG_FALLBACK_MODELS,
+    default_aux_model="qwen3.6-flash",
 )
 
 register_provider(alibaba)

--- a/plugins/model-providers/alibaba/plugin.yaml
+++ b/plugins/model-providers/alibaba/plugin.yaml
@@ -1,5 +1,5 @@
 name: alibaba-provider
 kind: model-provider
-version: 1.0.0
-description: Alibaba DashScope (international)
+version: 1.1.0
+description: Qwen Cloud PAYG via Alibaba DashScope
 author: Nous Research

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -174,6 +174,25 @@ class TestEstimateRequestTokensRough:
 # =========================================================================
 
 class TestDefaultContextLengths:
+    def test_qwen_cloud_alias_prefixes_and_current_models_use_published_context(self):
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             patch("agent.model_metadata._query_ollama_api_show", return_value=None), \
+             patch("agent.models_dev.lookup_models_dev_context", return_value=None):
+            cases = (
+                ("qwen3.8-max-preview", 983_616),
+                ("qwen3.7-max", 1_000_000),
+                ("qwen3.7-plus", 1_000_000),
+                ("qwen3.6-plus", 1_000_000),
+                ("qwen3.6-flash", 1_000_000),
+                ("qwen-cloud:qwen3.7-plus", 1_000_000),
+                ("qwencloud:qwen3.6-flash", 1_000_000),
+                ("qwen-dashscope:qwen3.7-max", 1_000_000),
+            )
+            for model, expected in cases:
+                assert get_model_context_length(model) == expected
+
     def test_k3_context_is_scoped_to_confirmed_coding_endpoint(self):
         """K3's 1 Mi context must not leak to unverified Moonshot endpoints."""
         with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
@@ -877,13 +896,13 @@ class TestGetModelContextLength:
 
     @patch("agent.model_metadata.fetch_model_metadata")
     def test_qwen3_6_plus_context_length(self, mock_fetch):
-        """qwen3.6-plus has a 1M context window, not the generic 128K Qwen default."""
+        """qwen3.6-plus uses the current Qwen Cloud-published 1M window."""
         mock_fetch.return_value = {}
-        assert get_model_context_length("qwen3.6-plus") == 1048576
+        assert get_model_context_length("qwen3.6-plus") == 1_000_000
         # Provider-prefixed variants must resolve to the same explicit entry
         # via the longest-substring fallback (no portal/OR cache available).
-        assert get_model_context_length("qwen/qwen3.6-plus") == 1048576
-        assert get_model_context_length("dashscope/qwen3.6-plus") == 1048576
+        assert get_model_context_length("qwen/qwen3.6-plus") == 1_000_000
+        assert get_model_context_length("dashscope/qwen3.6-plus") == 1_000_000
 
     @patch("agent.model_metadata.fetch_model_metadata")
     def test_qwen_generic_context_length(self, mock_fetch):

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -45,6 +45,26 @@ class TestModelIds:
         assert len(ids) == len(set(ids)), "Duplicate model IDs found"
 
 
+class TestAlibabaStaticCatalog:
+    def test_payg_catalog_is_curated_and_excludes_token_plan_preview(self):
+        assert _models_mod._PROVIDER_MODELS["alibaba"] == [
+            "qwen3.7-max",
+            "qwen3.7-plus",
+            "qwen3.6-plus",
+            "qwen3.6-flash",
+            "qwen3.5-plus",
+            "qwen3.5-flash",
+            "qwen3-coder-plus",
+            "qwen3-coder-flash",
+            "qwen3-coder-next",
+        ]
+        assert "qwen3.8-max-preview" not in _models_mod._PROVIDER_MODELS["alibaba"]
+
+    def test_payg_aliases_are_known_to_model_syntax(self):
+        for alias in ("qwen-cloud", "qwencloud", "qwen-dashscope"):
+            assert _models_mod._PROVIDER_ALIASES[alias] == "alibaba"
+
+
 
 
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1637,8 +1637,8 @@ def test_minimax_config_base_url_ignored_for_different_provider(monkeypatch):
     assert resolved["base_url"] == "https://api.minimax.io/anthropic"
 
 
-def test_alibaba_default_coding_intl_endpoint_uses_chat_completions(monkeypatch):
-    """Alibaba default coding-intl /v1 URL should use chat_completions mode."""
+def test_alibaba_default_payg_endpoint_uses_chat_completions(monkeypatch):
+    """Qwen Cloud PAYG's default DashScope URL uses chat_completions mode."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "alibaba")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {})
     monkeypatch.setenv("DASHSCOPE_API_KEY", "test-dashscope-key")
@@ -1649,6 +1649,31 @@ def test_alibaba_default_coding_intl_endpoint_uses_chat_completions(monkeypatch)
     assert resolved["provider"] == "alibaba"
     assert resolved["api_mode"] == "chat_completions"
     assert resolved["base_url"] == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+
+
+@pytest.mark.parametrize(
+    "requested",
+    [
+        "alibaba",
+        "dashscope",
+        "alibaba-cloud",
+        "qwen-dashscope",
+        "qwen-cloud",
+        "qwencloud",
+    ],
+)
+def test_qwen_cloud_payg_aliases_keep_runtime_credentials(monkeypatch, requested):
+    """PAYG aliases canonicalize without changing the endpoint or key lane."""
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "payg-key-canary")
+    monkeypatch.delenv("DASHSCOPE_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested=requested)
+
+    assert resolved["provider"] == "alibaba"
+    assert resolved["base_url"] == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["api_key"] == "payg-key-canary"
 
 
 def test_alibaba_anthropic_endpoint_override_uses_anthropic_messages(monkeypatch):

--- a/tests/plugins/model_providers/test_alibaba_profile.py
+++ b/tests/plugins/model_providers/test_alibaba_profile.py
@@ -1,0 +1,179 @@
+"""Behavior contract for the Alibaba/Qwen Cloud PAYG provider profile.
+
+Qwen Cloud PAYG and Alibaba Cloud Token Plan are separate billing lanes.  The
+profile tests intentionally exercise the registered profile, runtime resolver,
+and API-key resolver rather than a source snapshot so aliases and credentials
+cannot silently drift across lanes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+PAYG_ALIASES = (
+    "dashscope",
+    "alibaba-cloud",
+    "qwen-dashscope",
+    "qwen-cloud",
+    "qwencloud",
+)
+PAYG_BASE_URL = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+PAYG_FALLBACK_MODELS = (
+    "qwen3.7-max",
+    "qwen3.7-plus",
+    "qwen3.6-plus",
+    "qwen3.6-flash",
+    "qwen3.5-plus",
+    "qwen3.5-flash",
+    "qwen3-coder-plus",
+    "qwen3-coder-flash",
+    "qwen3-coder-next",
+)
+
+
+@pytest.fixture
+def alibaba_profile():
+    """Resolve the PAYG profile through the real provider discovery path."""
+    import model_tools  # noqa: F401  -- triggers provider plugin discovery
+    import providers
+
+    profile = providers.get_provider_profile("alibaba")
+    assert profile is not None, "alibaba PAYG provider profile must be registered"
+    return profile
+
+
+class TestAlibabaPaygIdentity:
+    def test_canonical_identity_and_public_naming(self, alibaba_profile):
+        assert alibaba_profile.name == "alibaba"
+        assert alibaba_profile.auth_type == "api_key"
+        assert alibaba_profile.api_mode == "chat_completions"
+
+        # Keep the established public label while making the profile's billing
+        # lane unambiguous in picker/profile metadata.
+        display = alibaba_profile.display_name.lower()
+        assert "qwen" in display and "cloud" in display
+        assert "payg" in display or "pay-as-you-go" in display
+
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        from hermes_cli.models import CANONICAL_PROVIDERS
+
+        assert PROVIDER_REGISTRY["alibaba"].name == "Qwen Cloud"
+        assert next(p for p in CANONICAL_PROVIDERS if p.slug == "alibaba").label == "Qwen Cloud"
+
+    @pytest.mark.parametrize("alias", PAYG_ALIASES)
+    def test_alias_resolves_to_payg_canonical(self, alibaba_profile, alias):
+        import providers
+        from hermes_cli.auth import resolve_provider
+
+        assert providers.get_provider_profile(alias) is alibaba_profile
+        assert resolve_provider(alias) == "alibaba"
+
+    def test_aliases_are_declared_on_profile(self, alibaba_profile):
+        assert set(PAYG_ALIASES).issubset(set(alibaba_profile.aliases))
+
+    def test_endpoint_and_auth_environment_contract(self, alibaba_profile):
+        assert alibaba_profile.base_url == PAYG_BASE_URL
+        assert alibaba_profile.env_vars[0] == "DASHSCOPE_API_KEY"
+        assert "DASHSCOPE_BASE_URL" in alibaba_profile.env_vars
+        assert alibaba_profile.env_vars.index("DASHSCOPE_API_KEY") < alibaba_profile.env_vars.index(
+            "DASHSCOPE_BASE_URL"
+        )
+
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        config = PROVIDER_REGISTRY["alibaba"]
+        assert config.auth_type == "api_key"
+        assert config.api_key_env_vars == ("DASHSCOPE_API_KEY",)
+        assert config.base_url_env_var == "DASHSCOPE_BASE_URL"
+        assert config.inference_base_url == PAYG_BASE_URL
+
+    def test_fallbacks_are_agentic_and_auxiliary_model_is_cheap(self, alibaba_profile):
+        """Offline fallbacks stay in the agent/tool-capable model lane.
+
+        ProviderProfile is the curated fallback boundary; it must not be filled
+        with embedding, reranking, speech, or preview-only models that cannot
+        serve the normal Hermes tool loop.  The auxiliary choice should be a
+        cheap model from that same curated set.
+        """
+        fallback_models = tuple(alibaba_profile.fallback_models)
+        assert fallback_models
+        assert all(isinstance(model, str) and model.strip() for model in fallback_models)
+        assert "qwen3.8-max-preview" not in {model.lower() for model in fallback_models}
+
+        auxiliary = alibaba_profile.default_aux_model
+        assert auxiliary in fallback_models
+        assert any(
+            marker in auxiliary.lower() for marker in ("flash", "mini", "lite")
+        ), f"expected a cheap auxiliary model, got {auxiliary!r}"
+
+        non_agentic_markers = ("embed", "rerank", "whisper", "tts", "image", "video")
+        assert not any(
+            any(marker in model.lower() for marker in non_agentic_markers)
+            for model in fallback_models
+        )
+
+    def test_fallback_catalog_is_the_curated_payg_catalog(self, alibaba_profile):
+        assert tuple(alibaba_profile.fallback_models) == PAYG_FALLBACK_MODELS
+        assert alibaba_profile.default_aux_model == "qwen3.6-flash"
+
+    @pytest.mark.parametrize(
+        ("reasoning_config", "expected"),
+        [
+            (None, {}),
+            ({"enabled": True, "effort": "high"}, {"enable_thinking": True}),
+            ({"enabled": False}, {"enable_thinking": False}),
+        ],
+    )
+    def test_thinking_wire_shape(self, alibaba_profile, reasoning_config, expected):
+        extra_body, top_level = alibaba_profile.build_api_kwargs_extras(
+            reasoning_config=reasoning_config,
+            model="qwen3.7-plus",
+        )
+        assert extra_body == expected
+        assert top_level == {}
+
+    def test_non_hybrid_models_do_not_receive_qwen_thinking_fields(
+        self, alibaba_profile
+    ):
+        assert alibaba_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="qwen3-coder-next",
+        ) == ({}, {})
+
+
+class TestAlibabaPaygCredentials:
+    def test_runtime_uses_payg_credentials_when_both_billing_lanes_exist(
+        self, monkeypatch, alibaba_profile
+    ):
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "payg-key-canary")
+        monkeypatch.setenv("DASHSCOPE_BASE_URL", "https://payg.example.test/v1")
+        monkeypatch.setenv("QWEN_TOKEN_PLAN_API_KEY", "token-plan-key-canary")
+        monkeypatch.setenv("BAILIAN_TOKEN_PLAN_API_KEY", "bailian-key-canary")
+
+        from hermes_cli.auth import resolve_api_key_provider_credentials
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        credentials = resolve_api_key_provider_credentials("alibaba")
+        assert credentials["api_key"] == "payg-key-canary"
+        assert credentials["source"] == "DASHSCOPE_API_KEY"
+        assert credentials["base_url"] == "https://payg.example.test/v1"
+
+        runtime = resolve_runtime_provider(requested="alibaba")
+        assert runtime["provider"] == "alibaba"
+        assert runtime["api_key"] == "payg-key-canary"
+        assert runtime["base_url"] == "https://payg.example.test/v1"
+        assert runtime["api_mode"] == "chat_completions"
+
+    def test_payg_does_not_cross_fallback_to_token_plan_key(self, monkeypatch, alibaba_profile):
+        monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+        monkeypatch.delenv("DASHSCOPE_BASE_URL", raising=False)
+        monkeypatch.setenv("QWEN_TOKEN_PLAN_API_KEY", "token-plan-key-canary")
+        monkeypatch.setenv("BAILIAN_TOKEN_PLAN_API_KEY", "bailian-key-canary")
+
+        from hermes_cli.auth import resolve_api_key_provider_credentials
+
+        credentials = resolve_api_key_provider_credentials("alibaba")
+        assert credentials["api_key"] == ""
+        assert credentials["source"] == "default"
+        assert credentials["base_url"] == PAYG_BASE_URL

--- a/tests/plugins/model_providers/test_alibaba_profile.py
+++ b/tests/plugins/model_providers/test_alibaba_profile.py
@@ -59,7 +59,10 @@ class TestAlibabaPaygIdentity:
         from hermes_cli.models import CANONICAL_PROVIDERS
 
         assert PROVIDER_REGISTRY["alibaba"].name == "Qwen Cloud"
-        assert next(p for p in CANONICAL_PROVIDERS if p.slug == "alibaba").label == "Qwen Cloud"
+        assert (
+            next(p for p in CANONICAL_PROVIDERS if p.slug == "alibaba").label
+            == "Qwen Cloud"
+        )
 
     @pytest.mark.parametrize("alias", PAYG_ALIASES)
     def test_alias_resolves_to_payg_canonical(self, alibaba_profile, alias):
@@ -76,9 +79,9 @@ class TestAlibabaPaygIdentity:
         assert alibaba_profile.base_url == PAYG_BASE_URL
         assert alibaba_profile.env_vars[0] == "DASHSCOPE_API_KEY"
         assert "DASHSCOPE_BASE_URL" in alibaba_profile.env_vars
-        assert alibaba_profile.env_vars.index("DASHSCOPE_API_KEY") < alibaba_profile.env_vars.index(
-            "DASHSCOPE_BASE_URL"
-        )
+        assert alibaba_profile.env_vars.index(
+            "DASHSCOPE_API_KEY"
+        ) < alibaba_profile.env_vars.index("DASHSCOPE_BASE_URL")
 
         from hermes_cli.auth import PROVIDER_REGISTRY
 
@@ -98,7 +101,9 @@ class TestAlibabaPaygIdentity:
         """
         fallback_models = tuple(alibaba_profile.fallback_models)
         assert fallback_models
-        assert all(isinstance(model, str) and model.strip() for model in fallback_models)
+        assert all(
+            isinstance(model, str) and model.strip() for model in fallback_models
+        )
         assert "qwen3.8-max-preview" not in {model.lower() for model in fallback_models}
 
         auxiliary = alibaba_profile.default_aux_model
@@ -165,7 +170,9 @@ class TestAlibabaPaygCredentials:
         assert runtime["base_url"] == "https://payg.example.test/v1"
         assert runtime["api_mode"] == "chat_completions"
 
-    def test_payg_does_not_cross_fallback_to_token_plan_key(self, monkeypatch, alibaba_profile):
+    def test_payg_does_not_cross_fallback_to_token_plan_key(
+        self, monkeypatch, alibaba_profile
+    ):
         monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
         monkeypatch.delenv("DASHSCOPE_BASE_URL", raising=False)
         monkeypatch.setenv("QWEN_TOKEN_PLAN_API_KEY", "token-plan-key-canary")

--- a/tests/providers/test_transport_parity.py
+++ b/tests/providers/test_transport_parity.py
@@ -284,6 +284,37 @@ class TestQwenParity:
         assert "metadata" not in kw.get("extra_body", {})
 
 
+class TestQwenCloudPaygParity:
+    """Qwen Cloud PAYG: native hybrid-thinking toggle only when configured."""
+
+    def test_thinking_defaults_to_provider_behavior(self, transport):
+        kw = transport.build_kwargs(
+            model="qwen3.7-plus",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("alibaba"),
+        )
+        assert "extra_body" not in kw
+
+    @pytest.mark.parametrize(
+        ("reasoning_config", "expected"),
+        [
+            ({"enabled": True, "effort": "high"}, True),
+            ({"enabled": False}, False),
+        ],
+    )
+    def test_thinking_maps_to_enable_thinking(self, transport, reasoning_config, expected):
+        kw = transport.build_kwargs(
+            model="qwen3.7-plus",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("alibaba"),
+            reasoning_config=reasoning_config,
+        )
+        assert kw["extra_body"] == {"enable_thinking": expected}
+        assert "reasoning_effort" not in kw
+
+
 class TestCustomOllamaParity:
     """Custom/Ollama: num_ctx, thinking controls — now tested via profile."""
 

--- a/website/docs/developer-guide/provider-runtime.md
+++ b/website/docs/developer-guide/provider-runtime.md
@@ -48,7 +48,8 @@ Current provider families include (see `plugins/model-providers/` for the comple
 - Copilot / Copilot ACP
 - Anthropic (native)
 - Google / Gemini (`gemini`)
-- Alibaba / DashScope (`alibaba`, `alibaba-coding-plan`)
+- Qwen Cloud PAYG / Alibaba DashScope (`alibaba`)
+- Alibaba Cloud Coding Plan (`alibaba-coding-plan`)
 - DeepSeek
 - Z.AI
 - Kimi / Moonshot (`kimi-coding`, `kimi-coding-cn`)

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -122,7 +122,7 @@ Good defaults:
 | **MiniMax (OAuth)** | MiniMax frontier model via browser OAuth — no API key needed (model name in `hermes_cli/models.py` may change between releases) | `hermes model` → MiniMax (OAuth) |
 | **MiniMax** | International MiniMax endpoint | Set `MINIMAX_API_KEY` |
 | **MiniMax China** | China-region MiniMax endpoint | Set `MINIMAX_CN_API_KEY` |
-| **Alibaba Cloud** | Qwen models via DashScope | Set `DASHSCOPE_API_KEY` (Qwen Coding Plan also accepts `ALIBABA_CODING_PLAN_API_KEY`) |
+| **Qwen Cloud PAYG** | Qwen models via international DashScope | Set `DASHSCOPE_API_KEY`; Token Plan uses a separate plugin/key/URL, while Coding Plan retains its documented compatibility fallback |
 | **Hugging Face** | 20+ open models via unified router (Qwen, DeepSeek, Kimi, etc.) | Set `HF_TOKEN` |
 | **AWS Bedrock** | Claude, Nova, Llama, DeepSeek via native Converse API | IAM role or `aws configure` ([guide](../guides/aws-bedrock.md)) |
 | **Azure Foundry** | Azure AI Foundry-hosted models | Set `AZURE_FOUNDRY_API_KEY` + `AZURE_FOUNDRY_BASE_URL` |

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -31,8 +31,9 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **MiniMax China** | `MINIMAX_CN_API_KEY` in `~/.hermes/.env` (provider: `minimax-cn`) |
 | **xAI (Grok) — Responses API** | `XAI_API_KEY` in `~/.hermes/.env` (provider: `xai`) |
 | **xAI Grok OAuth (SuperGrok)** | `hermes model` → "xAI Grok OAuth (SuperGrok / Premium+)" — browser login, no API key. See [guide](../guides/xai-grok-oauth.md) |
-| **Qwen Cloud (Alibaba DashScope)** | `DASHSCOPE_API_KEY` in `~/.hermes/.env` (provider: `alibaba`) |
-| **Alibaba Cloud (Coding Plan)** | `DASHSCOPE_API_KEY` (provider: `alibaba-coding-plan`, alias: `alibaba_coding`) — separate billing SKU, different endpoint |
+| **Qwen Cloud PAYG (Alibaba DashScope)** | `DASHSCOPE_API_KEY` in `~/.hermes/.env` (provider: `alibaba`; aliases: `qwen-cloud`, `qwencloud`) |
+| **Alibaba Cloud Coding Plan** | Prefer `ALIBABA_CODING_PLAN_API_KEY` in `~/.hermes/.env` (provider: `alibaba-coding-plan`; legacy `DASHSCOPE_API_KEY` fallback retained) |
+| **Qwen Cloud Token Plan** | Standalone third-party provider only. Install a compatible plugin through Hermes' [model-provider plugin mechanism](../developer-guide/model-provider-plugin.md) and use its dedicated key and URL. |
 | **Kilo Code** | `KILOCODE_API_KEY` in `~/.hermes/.env` (provider: `kilocode`) |
 | **Xiaomi MiMo** | `XIAOMI_API_KEY` in `~/.hermes/.env` (provider: `xiaomi`, aliases: `mimo`, `xiaomi-mimo`) |
 | **Tencent TokenHub** | `TOKENHUB_API_KEY` in `~/.hermes/.env` (provider: `tencent-tokenhub`, aliases: `tencent`, `tokenhub`, `tencentmaas`) |
@@ -243,8 +244,8 @@ hermes chat --provider minimax --model MiniMax-M2.7
 hermes chat --provider minimax-cn --model MiniMax-M2.7
 # Requires: MINIMAX_CN_API_KEY in ~/.hermes/.env
 
-# Qwen Cloud / DashScope (Qwen models)
-hermes chat --provider alibaba --model qwen3.5-plus
+# Qwen Cloud PAYG / DashScope (Qwen models)
+hermes chat --provider alibaba --model qwen3.7-plus
 # Requires: DASHSCOPE_API_KEY in ~/.hermes/.env
 
 # Xiaomi MiMo
@@ -274,7 +275,7 @@ model:
   default: "zai-org/GLM-5.1-FP8"
 ```
 
-Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
+Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables. `DASHSCOPE_BASE_URL` is for the Qwen Cloud PAYG lane; do not use a Token Plan or Coding Plan URL with `provider: alibaba`.
 
 :::note Z.AI Endpoint Auto-Detection
 When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoints (global, China, coding variants) to find one that accepts your API key. You don't need to set `GLM_BASE_URL` manually — the working endpoint is detected and cached automatically.
@@ -428,26 +429,93 @@ model:
 Set `HERMES_QWEN_BASE_URL` only if the portal endpoint relocates (default: `https://portal.qwen.ai/v1`).
 
 :::tip Qwen OAuth vs Qwen Cloud (Alibaba DashScope)
-`qwen-oauth` uses the consumer-facing Qwen Portal with OAuth login — ideal for individual users. The `alibaba` provider uses Qwen Cloud (Alibaba DashScope) with a `DASHSCOPE_API_KEY` — ideal for programmatic / production workloads. Both route to Qwen-family models but live at different endpoints.
+`qwen-oauth` uses the consumer-facing Qwen Portal with OAuth login — ideal for individual users. The `alibaba` provider is Qwen Cloud PAYG (Alibaba DashScope) with a `DASHSCOPE_API_KEY` — ideal for programmatic / production workloads. Both route to Qwen-family models but live at different endpoints and billing surfaces.
 :::
 
-### Alibaba Cloud (Coding Plan)
+### Qwen Cloud PAYG (Alibaba DashScope)
 
-If you're subscribed to Alibaba's **Coding Plan** (a pricing SKU separate from standard DashScope API access), Hermes exposes it as its own first-class provider: `alibaba-coding-plan`. Endpoint: `https://coding-intl.dashscope.aliyuncs.com/v1`. It's OpenAI-compatible like the regular `alibaba` provider but with a different base URL and billing surface.
+Qwen Cloud PAYG is Hermes' canonical `alibaba` provider. It uses Alibaba Model Studio / DashScope's OpenAI-compatible Chat Completions endpoint and is independent of Qwen Portal OAuth, Token Plan, and Coding Plan subscriptions.
+
+#### Setup and region pairing
+
+Create or select the Model Studio workspace that owns your Qwen Cloud PAYG access, create a PAYG API key, and save it in the Hermes home `.env` file. The key and endpoint must belong to the same region:
+
+| Region | Key | Base URL |
+|---|---|---|
+| International (default) | `DASHSCOPE_API_KEY` | `https://dashscope-intl.aliyuncs.com/compatible-mode/v1` |
+| Mainland China | `DASHSCOPE_API_KEY` | `https://dashscope.aliyuncs.com/compatible-mode/v1` |
+
+```dotenv
+# ~/.hermes/.env — keep the key local and out of source control
+DASHSCOPE_API_KEY=replace-with-your-payg-key
+# Optional mainland-China override; omit this line for international PAYG.
+DASHSCOPE_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+```
+
+The international endpoint is the default, so an international setup only needs `DASHSCOPE_API_KEY`. `DASHSCOPE_BASE_URL` is an endpoint override, not a second credential. You can also set `model.base_url` in `config.yaml` when you need a per-configuration override.
+
+Select it interactively with `hermes model`, or configure it directly:
+
+```bash
+hermes model
+# → pick "Qwen Cloud (PAYG)"
+# → enter DASHSCOPE_API_KEY when prompted
+
+hermes chat --provider alibaba --model qwen3.7-plus
+```
 
 ```yaml
 model:
-  provider: alibaba_coding     # alias for alibaba-coding-plan
-  model: qwen3-coder-plus
+  provider: alibaba
+  default: qwen3.7-plus
 ```
 
-Or from the CLI:
+The `alibaba` aliases `dashscope`, `alibaba-cloud`, `qwen-dashscope`, `qwen-cloud`, and `qwencloud` stay on this PAYG lane. Hermes' offline agentic fallback catalog is `qwen3.7-max`, `qwen3.7-plus`, `qwen3.6-plus`, `qwen3.6-flash`, `qwen3.5-plus`, `qwen3.5-flash`, `qwen3-coder-plus`, `qwen3-coder-flash`, and `qwen3-coder-next`. `qwen3.8-max-preview` is Token Plan-only and is intentionally not a PAYG fallback.
+
+#### Chat, streaming, tools, and thinking
+
+Qwen Cloud PAYG speaks the OpenAI-compatible Chat Completions protocol. Hermes uses it for normal chat, streamed responses, tool/function calling, and tool continuations. Qwen reasoning traces returned as `reasoning_content` remain reasoning metadata; they do not replace the visible `content` response.
+
+Qwen3.7, Qwen3.6, and Qwen3.5 hybrid-thinking models accept the provider-specific boolean in `extra_body`:
+
+```json
+{"extra_body": {"enable_thinking": true}}
+```
+
+Hermes omits `enable_thinking` when no reasoning setting is configured, preserving Qwen's server-side default. An explicit Hermes reasoning enable/disable setting maps to `true`/`false`. Hermes does not invent a `reasoning_effort` mapping for these Qwen generations. Tools and streaming use the same PAYG endpoint; no alternate Coding Plan or Token Plan URL is required or implied.
+
+#### Workspace scope, errors, and limits
+
+API keys are workspace/account credentials for Qwen Cloud PAYG. Model availability, quota, and rate limits are evaluated by the workspace and region associated with the key. Keep the key, workspace, model access, and endpoint region aligned; a key from another workspace or region can look like an authentication, entitlement, or model-not-found failure.
+
+- **401/403:** missing, invalid, revoked, or wrong-lane key; verify `DASHSCOPE_API_KEY` and the workspace entitlement.
+- **400:** unsupported model or request field; verify the model is available to the workspace and that `extra_body.enable_thinking` is supported by that model.
+- **404:** wrong host/path or a billing-lane mismatch; the PAYG default must end in `/compatible-mode/v1`.
+- **429:** workspace quota or provider rate limit; reduce concurrency, wait for the retry window, or review the Qwen Cloud quota for that workspace. Hermes cannot raise a provider-side limit.
+
+These limits are enforced by Qwen Cloud and may vary by model, workspace, region, and account tier. Check the current Model Studio quota/error response for the authoritative limit rather than assuming a fixed Hermes-side value.
+
+#### Security and billing-lane isolation
+
+Keep `DASHSCOPE_API_KEY` in `~/.hermes/.env` or another secret manager, never commit it to a repository, and do not paste it into tickets or chat logs. Restrict file permissions on the secret file and rotate/revoke the key through Model Studio if it leaks. `DASHSCOPE_BASE_URL` is not a secret, but it still selects a billing lane and region, so review it before use.
+
+PAYG, Token Plan, and Coding Plan are separate products with distinct URLs and billing semantics. Never use a Token Plan key or URL with `provider: alibaba`. Hermes retains the existing `DASHSCOPE_API_KEY` compatibility fallback for the bundled Coding Plan provider, but `ALIBABA_CODING_PLAN_API_KEY` is clearer and preferred. Hermes core intentionally does not bundle a Token Plan provider or token-specific plumbing. If you use Token Plan (or another vendor-only lane), install and review a compatible standalone model-provider plugin via the generic [model-provider plugin mechanism](../developer-guide/model-provider-plugin.md); do not assume a plugin's key, URL, catalog, or quota behavior matches PAYG.
+
+### Alibaba Cloud Coding Plan
+
+Coding Plan remains a bundled provider under `alibaba-coding-plan` (alias `alibaba_coding`). It uses its own credential and OpenAI-compatible endpoint:
+
+```dotenv
+ALIBABA_CODING_PLAN_API_KEY=replace-with-your-coding-plan-key
+# Optional override; normally omit it.
+# ALIBABA_CODING_PLAN_BASE_URL=https://coding-intl.dashscope.aliyuncs.com/v1
+```
 
 ```bash
-hermes chat --provider alibaba_coding --model qwen3-coder-plus
+hermes chat --provider alibaba-coding-plan --model qwen3-coder-plus
 ```
 
-`alibaba_coding` uses the same `DASHSCOPE_API_KEY` your `alibaba` entry already uses — no separate key needed, just a different routing target. Before this provider was registered, users who set `provider: alibaba_coding` in `config.yaml` silently fell through to OpenRouter routing.
+The default endpoint is `https://coding-intl.dashscope.aliyuncs.com/v1`. Configure `ALIBABA_CODING_PLAN_API_KEY` explicitly when possible; the historical `DASHSCOPE_API_KEY` fallback remains for backward compatibility. Token Plan is a different product again and remains a standalone plugin under current Hermes integration policy.
 
 ### MiniMax (OAuth)
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -73,10 +73,10 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `ANTHROPIC_API_KEY` | Anthropic Console API key ([console.anthropic.com](https://console.anthropic.com/)) |
 | `ANTHROPIC_BASE_URL` | Override the Anthropic API base URL |
 | `ANTHROPIC_TOKEN` | Manual or legacy Anthropic OAuth/setup-token override |
-| `DASHSCOPE_API_KEY` | Qwen Cloud (Alibaba DashScope) API key for Qwen models ([modelstudio.console.alibabacloud.com](https://modelstudio.console.alibabacloud.com/)) |
-| `DASHSCOPE_BASE_URL` | Custom DashScope base URL (default: `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`; use `https://dashscope.aliyuncs.com/compatible-mode/v1` for mainland-China region) |
-| `ALIBABA_CODING_PLAN_API_KEY` | Qwen Coding Plan API key (`alibaba-coding-plan` provider) |
-| `ALIBABA_CODING_PLAN_BASE_URL` | Override the Qwen Coding Plan base URL |
+| `DASHSCOPE_API_KEY` | Qwen Cloud PAYG (Alibaba DashScope) API key for the Model Studio workspace ([modelstudio.console.alibabacloud.com](https://modelstudio.console.alibabacloud.com/)); use with `provider: alibaba` |
+| `DASHSCOPE_BASE_URL` | Qwen Cloud PAYG endpoint override (default international: `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`; mainland-China region: `https://dashscope.aliyuncs.com/compatible-mode/v1`) |
+| `ALIBABA_CODING_PLAN_API_KEY` | Preferred dedicated Alibaba Coding Plan API key; legacy `DASHSCOPE_API_KEY` fallback remains supported |
+| `ALIBABA_CODING_PLAN_BASE_URL` | Dedicated Coding Plan endpoint override; do not use it with `provider: alibaba` |
 | `DEEPSEEK_API_KEY` | DeepSeek API key for direct DeepSeek access ([platform.deepseek.com](https://platform.deepseek.com/api_keys)) |
 | `DEEPSEEK_BASE_URL` | Custom DeepSeek API base URL |
 | `NOVITA_API_KEY` | NovitaAI API key — AI-native cloud for Model API, Agent Sandbox, and GPU Cloud ([novita.ai/settings/key-management](https://novita.ai/settings/key-management)) |

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -76,7 +76,7 @@ Each entry requires both `provider` and `model`. Entries missing either field ar
 | Arcee AI | `arcee` | `ARCEEAI_API_KEY` |
 | GMI Cloud | `gmi` | `GMI_API_KEY` |
 | Alibaba / DashScope | `alibaba` | `DASHSCOPE_API_KEY` |
-| Alibaba Coding Plan | `alibaba-coding-plan` | `ALIBABA_CODING_PLAN_API_KEY` (falls back to `DASHSCOPE_API_KEY`) |
+| Alibaba Coding Plan | `alibaba-coding-plan` | `ALIBABA_CODING_PLAN_API_KEY` (preferred; legacy `DASHSCOPE_API_KEY` fallback retained) |
 | Kimi / Moonshot (China) | `kimi-coding-cn` | `KIMI_CN_API_KEY` |
 | StepFun | `stepfun` | `STEPFUN_API_KEY` |
 | Tencent TokenHub | `tencent-tokenhub` | `TOKENHUB_API_KEY` |


### PR DESCRIPTION
## Summary

- clarify the existing canonical `alibaba` provider as Qwen Cloud pay-as-you-go without introducing a duplicate PAYG provider
- add PAYG-local aliases (`qwen-dashscope`, `qwen-cloud`, `qwencloud`) across profile, model parsing, and metadata prefix handling
- replace the stale mixed-provider offline catalog with a current agent-capable Qwen PAYG fallback catalog and `qwen3.6-flash` auxiliary default
- map explicit Hermes reasoning enable/disable controls to Qwen's documented `extra_body.enable_thinking` field only for Qwen3.5/3.6/3.7 hybrid-thinking families
- add exact current Qwen context metadata (`qwen3.8-max-preview`: 983,616; Qwen3.7/Qwen3.6: 1,000,000)
- document PAYG setup, endpoint/region pairing, streaming, tools, thinking, errors, quotas, security, and billing-lane boundaries
- preserve existing Coding Plan key fallback behavior and all Qwen OAuth behavior

## Token Plan architecture

Current Hermes policy requires third-party model providers to ship as standalone plugins. Token Plan Personal and Team are therefore implemented in the existing standalone repository rather than added as another bundled core provider:

- companion PR: https://github.com/oliver-mee/hermes-alibaba-token-plan/pull/1
- canonical standalone provider: `alibaba-token-plan`
- distinct Token Plan credentials, endpoint, catalog, quotas, and subscription semantics

This core PR intentionally keeps `alibaba` PAYG-only and excludes Token Plan-only `qwen3.8-max-preview` from its fallback catalog.

## Compatibility

- `alibaba` remains the canonical PAYG provider
- `DASHSCOPE_API_KEY` and `DASHSCOPE_BASE_URL` remain supported
- international PAYG endpoint remains `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`
- existing `alibaba-coding-plan`, `qwen-oauth`, and `qwen-portal` behavior is preserved
- no alias crosses into the standalone Token Plan billing lane

## Validation

- focused provider/runtime/auth/catalog/metadata/transport/desktop/auxiliary suite: **918 passed**
- standalone Token Plan integration against this exact Hermes worktree: **9 passed**
- Docusaurus production build: **passed** (both locales generated; existing unrelated link warnings remain)
- `git diff --check`: passed
- added-line secret scan: passed
- compile/syntax checks: passed
- exact-head GitHub Actions (`119ed36cb63c757da014be3f75d19e4cf643153c`): **24 success, 8 skipped by affected-area policy, 1 neutral; no failures; PR clean/mergeable**

A whole-repository local run was timeboxed because this checkout's shared development environment lacks the optional ACP test dependency and carries a persistent Z.AI endpoint cache. The relevant API-key test module passes in an isolated `HERMES_HOME` (**183 passed**), and the focused acceptance matrix above passes in an isolated `HERMES_HOME`. Repository CI remains the authoritative full-suite gate.

## Official sources

- Qwen Cloud OpenAI-compatible Chat API: https://docs.qwencloud.com/api-reference/chat/openai-chat
- Qwen Cloud OpenClaw configuration/model metadata: https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/openclaw
- Qwen Code billing-path configurations: https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/qwen-code
- Qwen Cloud Hermes Agent guide: https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/hermes-agent

## Prior art and credit

This keeps the existing in-tree PAYG implementation and contributor history rather than recreating the provider. Token Plan contributor work from @cudasuan and @oliver-mee is preserved and credited in the companion standalone-plugin PR. Relevant prior-art PRs reviewed before implementation include #35347 and #52915.
