### PR TITLE
fix(mcp): refresh idle-expired OAuth token on reconnect

### DIFF
--- a/tests/tools/test_mcp_oauth_integration.py
+++ b/tests/tools/test_mcp_oauth_integration.py
@@ -201,3 +201,141 @@ async def test_provider_is_reused_across_reconnects(tmp_path, monkeypatch):
     p2 = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
 
     assert p1 is p2, "manager must cache the provider across reconnects"
+
+
+@pytest.mark.asyncio
+async def test_idle_expired_token_self_heals_on_reconnect_without_disk_write(
+    tmp_path, monkeypatch
+):
+    """An OAuth token that expires while the session sits idle must refresh on
+    reconnect — with NO external disk write and NO tokens-file mtime change.
+
+    Repro of the linear-MCP outage: a live streamable-HTTP OAuth session sits
+    idle, its ~24h access token expires in memory, the connection drops, and
+    the run loop's reconnect/parked-revival path rebuilds the transport reusing
+    the SAME cached provider. Disk-watch (invalidate_if_disk_changed) can NOT
+    save it — the tokens file was never rewritten, so its mtime is unchanged.
+    Unless the reconnect path resets ``_initialized``, ``_initialize`` never
+    re-runs, ``token_expiry_time`` is never re-seeded, ``is_token_valid()``
+    keeps reporting the dead token valid, and the SDK's refresh branch never
+    fires — the server parks forever on 401.
+
+    ``reset_initialized`` is the reconnect-path hook that fixes this: it flips
+    ``_initialized`` so the next ``_initialize`` re-reads the (unchanged-on-disk
+    but now-expired) token, re-seeds expiry, and ``can_refresh_token()`` reports
+    True so the SDK refreshes on the reconnect handshake.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools.mcp_oauth_manager import MCPOAuthManager, reset_manager_for_tests
+    reset_manager_for_tests()
+
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir(parents=True)
+    tokens_file = token_dir / "srv.json"
+    (token_dir / "srv.client.json").write_text(json.dumps({
+        "client_id": "test-client",
+        "redirect_uris": ["http://127.0.0.1:12345/callback"],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+    }))
+
+    # Token that is ALREADY EXPIRED on disk (absolute expires_at in the past),
+    # but with a live refresh_token — exactly the idle-drop state.
+    tokens_file.write_text(json.dumps({
+        "access_token": "EXPIRED_ACCESS",
+        "token_type": "Bearer",
+        "expires_at": time.time() - 60,
+        "refresh_token": "LIVE_REFRESH",
+    }))
+
+    mgr = MCPOAuthManager()
+    provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
+    assert provider is not None
+
+    # Record the baseline mtime first (first call flips zero -> real mtime and
+    # resets _initialized as a side effect), then run _initialize so the
+    # provider ends up in the steady "connected" state: _initialized True with
+    # the (already-expired) token loaded — exactly the idle-past-expiry state.
+    await mgr.invalidate_if_disk_changed("srv")
+    await provider._initialize()
+    assert provider._initialized is True
+
+    # Disk-watch alone cannot help — the tokens file was never rewritten, so
+    # its mtime is unchanged.
+    assert await mgr.invalidate_if_disk_changed("srv") is False
+    assert provider._initialized is True, "disk-watch must NOT have reset it"
+
+    # The reconnect path resets _initialized so the SDK re-reads + refreshes.
+    assert mgr.reset_initialized("srv") is True
+    assert provider._initialized is False
+
+    # Next auth flow re-runs _initialize, re-seeds expiry from the expired
+    # on-disk token, and the SDK now knows it must refresh.
+    await provider._initialize()
+    assert provider.context.can_refresh_token() is True, (
+        "after reconnect reset, the SDK must recognise the token as refreshable"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_http_resets_provider_initialized_on_oauth_path(
+    tmp_path, monkeypatch
+):
+    """_run_http must call reset_initialized after fetching the OAuth provider.
+
+    This is the wiring that makes an idle-expired token self-heal on reconnect:
+    every _run_http entry (each reconnect re-enters it) resets the cached
+    provider's _initialized flag so the SDK re-reads storage, re-seeds expiry,
+    and refreshes on the reconnect handshake. Without this call the cached
+    provider keeps _initialized=True and the dead token is reused forever.
+
+    We drive _run_http far enough to fetch the provider, then let the transport
+    step fail (no real server) — reset_initialized must already have fired.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    # Pre-seed cached tokens so provider construction does not fail-fast in the
+    # non-interactive test env (mcp_oauth_manager guard).
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir(parents=True)
+    (token_dir / "srv.json").write_text(json.dumps({
+        "access_token": "TOK",
+        "token_type": "Bearer",
+        "expires_at": time.time() - 60,
+        "refresh_token": "R",
+    }))
+
+    from tools import mcp_tool
+    from tools.mcp_oauth_manager import get_manager, reset_manager_for_tests
+    reset_manager_for_tests()
+
+    reset_calls = []
+    mgr = get_manager()
+    real_reset = mgr.reset_initialized
+
+    def spy_reset(name, **kwargs):
+        reset_calls.append(name)
+        return real_reset(name, **kwargs)
+
+    monkeypatch.setattr(mgr, "reset_initialized", spy_reset)
+
+    task = mcp_tool.MCPServerTask("srv")
+    task._auth_type = "oauth"
+
+    config = {
+        "url": "https://example.com/mcp",
+        "oauth": None,
+        # a short connect timeout so the transport step fails fast
+        "connect_timeout": 0.1,
+    }
+
+    # The transport connection will fail (no server); we only care that the
+    # provider was fetched and reset_initialized fired before that.
+    with pytest.raises(Exception):
+        await task._run_http(config)
+
+    assert "srv" in reset_calls, (
+        "_run_http must call reset_initialized('srv') on the OAuth path so a "
+        "reconnect forces the SDK to re-read + refresh an idle-expired token"
+    )

--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -553,3 +553,41 @@ def test_bridge_forwards_requests_and_poisons_on_token_endpoint_400(
     assert not (d / "srv.client.json").exists()
     assert provider._initialized is False
     assert provider.context.client_info is None
+
+@pytest.mark.asyncio
+async def test_reset_initialized_flips_flag_false(tmp_path, monkeypatch):
+    """reset_initialized(name) forces the cached provider to re-run _initialize.
+
+    On a reconnect/transport-rebuild the manager returns the SAME cached
+    provider, whose in-memory token may have expired while the session sat
+    idle. _initialize() (which re-seeds token_expiry_time so is_token_valid()
+    reports expired and the SDK's refresh branch fires) only re-runs when
+    _initialized is False. Nothing on the reconnect path resets it, so an idle
+    expired token cannot self-heal without an external disk write. This method
+    is the reset hook the reconnect path calls; mirrors invalidate_if_disk_changed
+    minus the mtime gate.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    mgr = MCPOAuthManager()
+    provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
+    assert provider is not None
+    provider._initialized = True
+
+    changed = mgr.reset_initialized("srv")
+
+    assert changed is True
+    assert provider._initialized is False
+
+
+@pytest.mark.asyncio
+async def test_reset_initialized_noop_for_unknown_server(tmp_path, monkeypatch):
+    """reset_initialized on a server with no cached provider is a safe no-op."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    mgr = MCPOAuthManager()
+    # never built a provider for "ghost"
+    assert mgr.reset_initialized("ghost") is False

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -672,6 +672,40 @@ class MCPOAuthManager:
                 return True
             return False
 
+    def reset_initialized(
+        self,
+        server_name: str,
+        *,
+        hermes_home: str | Path | None = None,
+    ) -> bool:
+        """Force the cached provider to re-run ``_initialize`` on its next flow.
+
+        Returns True if a cached provider existed and its ``_initialized`` flag
+        was flipped to False, else False.
+
+        This is the reconnect-path counterpart to
+        :meth:`invalidate_if_disk_changed`. Disk-watch only resets
+        ``_initialized`` when the tokens *file* changed; but when an OAuth MCP
+        session sits idle and its access token expires in memory, the run
+        loop's reconnect/parked-revival path rebuilds the transport reusing the
+        SAME cached provider (``get_or_build_provider`` returns the cached
+        instance) whose ``_initialized`` is still True. The SDK then never
+        re-runs ``_initialize`` — the only place that calls
+        ``update_token_expiry`` so ``is_token_valid()`` reports the token
+        expired and ``async_auth_flow`` takes the ``can_refresh_token()``
+        refresh branch. The result is an idle-expired token that can only
+        self-heal via an external disk write. Resetting ``_initialized`` here
+        forces a fresh disk read + expiry re-seed so the SDK refreshes on the
+        reconnect handshake, with no mtime dependency.
+        """
+        entry = self._entries.get(self._key(server_name, hermes_home))
+        if entry is None or entry.provider is None:
+            return False
+        if not hasattr(entry.provider, "_initialized"):
+            return False
+        entry.provider._initialized = False  # noqa: SLF001
+        return True
+
     # -- 401 handler (dedup'd) -----------------------------------------------
 
     async def handle_401(

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2570,6 +2570,15 @@ class MCPServerTask:
                 _oauth_auth = get_manager().get_or_build_provider(
                     self.name, url, config.get("oauth"),
                 )
+                # Every _run_http entry is a (re)connect. Reusing the cached
+                # provider means an access token that expired while the session
+                # sat idle is still in memory with _initialized=True, so the SDK
+                # never re-checks expiry and never refreshes — the server parks
+                # on 401 until an external disk write nudges it. Reset the flag
+                # so _initialize re-runs, re-seeds expiry from storage, and the
+                # SDK refreshes on this handshake. No-op on the very first
+                # connect (freshly built provider is already _initialized=False).
+                get_manager().reset_initialized(self.name)
             except Exception as exc:
                 logger.warning("MCP OAuth setup failed for '%s': %s", self.name, exc)
                 raise


### PR DESCRIPTION
## Problem

An OAuth-based remote MCP server (e.g. Linear — Streamable HTTP, PKCE public client) permanently parks with `unhandled errors in a TaskGroup (1 sub-exception)` after its access token expires while the session sits **idle**. Only an external disk write (e.g. a cron re-refresh) recovers it. Observed in production: the Linear MCP died at token expiry and stayed parked, self-probing every 300s, for days.

## Root cause

Token refresh only fires on two paths:

1. `handle_401` — requires an actual tool call.
2. `invalidate_if_disk_changed` — requires the tokens **file** mtime to change (external refresh).

When an idle session's access token expires in memory, the connection drops and the run loop's reconnect / parked-revival path (`MCPServerTask._run_http`) rebuilds the transport **reusing the cached provider** (`get_or_build_provider` returns the same instance). That provider's `_initialized` stays `True`, so `HermesMCPOAuthProvider._initialize()` — the only caller of `update_token_expiry()` — never re-runs. `is_token_valid()` keeps reporting the dead token valid, `async_auth_flow` never takes the `can_refresh_token()` branch, and the stale Bearer is reshipped on every reconnect. The initialize handshake fails wrapped in an `ExceptionGroup`, retries exhaust, and the server parks. The tokens file was never rewritten, so disk-watch can't help either.

Nothing on the plain reconnect path ever resets `_initialized` — only disk-watch and `invalid_client` poisoning do.

### Evidence

- The on-disk `refresh_token` was valid the whole time (manual `grant_type=refresh_token` → HTTP 200, fresh tokens).
- Direct MCP `initialize` with the on-disk access token → HTTP 200, full tool list. Server and token were fine; only the gateway's stale in-memory provider failed.

## Fix

Add `MCPOAuthManager.reset_initialized(name)` — the reconnect-path counterpart to `invalidate_if_disk_changed`, minus the mtime gate — and call it from `_run_http` right after fetching the cached provider. Every reconnect now forces a fresh disk read + expiry re-seed, so the SDK refreshes on the handshake. No-op on first connect (a freshly built provider is already `_initialized=False`), and a cheap re-`_initialize` round-trip on reconnect (metadata prefetch is guarded by `oauth_metadata is None`).

## Tests

- `test_reset_initialized_*` — unit behaviour of the new method.
- `test_idle_expired_token_self_heals_on_reconnect_without_disk_write` — an already-expired on-disk token (unchanged mtime) is NOT recovered by disk-watch but IS recovered by `reset_initialized`; `can_refresh_token()` flips `True` after the reset.
- `test_run_http_resets_provider_initialized_on_oauth_path` — wiring: `_run_http` calls `reset_initialized` on the OAuth path.

Full MCP OAuth + reconnect suite green, `ruff` clean.

## Live verification

Applied to a running gateway, restarted. The previously-parked Linear server recovered on its next reconnect with no external disk write:

```
MCP OAuth 'linear': tokens file changed (mtime 0 -> ...), forcing reload
MCP server 'linear' (HTTP): registered 47 tool(s)
```

No `TaskGroup` errors post-restart.
