### PR TITLE
feat(api): allow per-run toolset restriction

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1712,6 +1712,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        enabled_toolsets_override: Optional[List[str]] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -1732,6 +1733,11 @@ class APIServerAdapter(BasePlatformAdapter):
         routing).  When set — and no session ``/model`` override exists for
         this session — its model/provider/api_key/base_url override the
         global defaults for this agent instance only.
+
+        ``enabled_toolsets_override`` is a per-run restriction. It may only
+        remove toolsets from the API server platform configuration; it cannot
+        grant a toolset that the platform did not already expose. An explicit
+        empty list therefore creates a genuinely tool-free agent.
         """
         from run_agent import AIAgent
         from gateway.run import (
@@ -1805,7 +1811,13 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         user_config = _load_gateway_config()
-        enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        platform_toolsets = set(_get_platform_tools(user_config, "api_server"))
+        if enabled_toolsets_override is None:
+            enabled_toolsets = sorted(platform_toolsets)
+        else:
+            enabled_toolsets = sorted(
+                platform_toolsets.intersection(enabled_toolsets_override)
+            )
 
         max_iterations = _current_max_iterations()
 
@@ -1983,6 +1995,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "responses_api": True,
                 "responses_streaming": True,
                 "run_submission": True,
+                "run_toolset_restriction": True,
                 "run_status": True,
                 "run_events_sse": True,
                 "run_stop": True,
@@ -4700,6 +4713,21 @@ class APIServerAdapter(BasePlatformAdapter):
         if not user_message:
             return web.json_response(_openai_error("No user message found in input"), status=400)
 
+        enabled_toolsets_override = None
+        if "enabled_toolsets" in body:
+            raw_enabled_toolsets = body["enabled_toolsets"]
+            if not isinstance(raw_enabled_toolsets, list) or any(
+                not isinstance(item, str) or not item.strip()
+                for item in raw_enabled_toolsets
+            ):
+                return web.json_response(
+                    _openai_error(
+                        "'enabled_toolsets' must be an array of non-empty strings"
+                    ),
+                    status=400,
+                )
+            enabled_toolsets_override = list(dict.fromkeys(raw_enabled_toolsets))
+
         instructions = body.get("instructions")
         previous_response_id = body.get("previous_response_id")
 
@@ -4823,6 +4851,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         tool_progress_callback=event_cb,
                         gateway_session_key=gateway_session_key,
                         route=route,
+                        enabled_toolsets_override=enabled_toolsets_override,
                     )
                 self._active_run_agents[run_id] = agent
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -366,12 +366,17 @@ def _compute_tool_definitions(
 
     if enabled_toolsets is not None:
         effective_enabled_toolsets = list(enabled_toolsets)
-        if os.environ.get("HERMES_KANBAN_TASK") and "kanban" not in effective_enabled_toolsets:
-            # Dispatcher-spawned workers are scoped by HERMES_KANBAN_TASK and
-            # must always receive the lifecycle handoff tools. Assignee
-            # profiles may intentionally restrict their normal chat toolsets
-            # (for token/cost reasons), but that should not strip the kanban
-            # worker's completion/block/heartbeat surface.
+        if (
+            effective_enabled_toolsets
+            and os.environ.get("HERMES_KANBAN_TASK")
+            and "kanban" not in effective_enabled_toolsets
+        ):
+            # Dispatcher-spawned workers with a non-empty restriction retain
+            # lifecycle handoff tools. An explicit empty list is an absolute
+            # deny-all boundary and must not be expanded implicitly.
+            # Assignee profiles may intentionally restrict their normal chat
+            # toolsets (for token/cost reasons), but that should not strip the
+            # kanban worker's completion/block/heartbeat surface.
             effective_enabled_toolsets.append("kanban")
         for toolset_name in effective_enabled_toolsets:
             if validate_toolset(toolset_name):

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -366,6 +366,48 @@ class TestAdapterInit:
         assert isinstance(agent, FakeAgent)
         assert captured["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
 
+    def test_create_agent_honors_empty_per_run_toolset_restriction(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "openai",
+                "base_url": "https://example.test/v1",
+                "api_mode": "chat_completions",
+            },
+        )
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "gpt-5")
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr(
+            "gateway.run.GatewayRunner._load_reasoning_config",
+            staticmethod(lambda: {}),
+        )
+        monkeypatch.setattr(
+            "gateway.run.GatewayRunner._load_fallback_model",
+            staticmethod(lambda: None),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_platform_tools",
+            lambda *_: {"terminal", "web"},
+        )
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        agent = adapter._create_agent(
+            session_id="api-session",
+            enabled_toolsets_override=[],
+        )
+
+        assert isinstance(agent, FakeAgent)
+        assert captured["enabled_toolsets"] == []
+
     def test_create_agent_refreshes_max_iterations_from_runtime_config(self, monkeypatch):
         captured = {}
 
@@ -986,6 +1028,7 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["chat_completions"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
+            assert data["features"]["run_toolset_restriction"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -173,6 +173,48 @@ class TestStartRun:
         assert resp.status == 400
 
     @pytest.mark.asyncio
+    async def test_start_forwards_empty_enabled_toolsets_to_agent(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "enabled_toolsets": []},
+                )
+                assert resp.status == 202
+                for _ in range(20):
+                    if mock_create.called:
+                        break
+                    await asyncio.sleep(0.01)
+
+                assert mock_create.call_args.kwargs["enabled_toolsets_override"] == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "enabled_toolsets",
+        [None, "terminal", ["terminal", 1], [""], {"terminal": True}],
+    )
+    async def test_start_rejects_invalid_enabled_toolsets(
+        self, adapter, enabled_toolsets
+    ):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/runs",
+                json={"input": "hello", "enabled_toolsets": enabled_toolsets},
+            )
+        assert resp.status == 400
+        assert adapter._run_streams == {}
+        assert adapter._run_statuses == {}
+
+    @pytest.mark.asyncio
     async def test_start_invalid_history_does_not_allocate_run(self, adapter):
         app = _create_runs_app(adapter)
         async with TestClient(TestServer(app)) as cli:

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -462,6 +462,18 @@ class TestDisabledToolsetsPlatformBundle:
     """Regression test for #33924: disabling a platform bundle (hermes-*)
     must not remove core tools from other enabled toolsets."""
 
+    def test_explicit_empty_toolsets_remain_empty_in_kanban_worker(
+        self, monkeypatch
+    ):
+        """An explicit deny-all must override implicit kanban lifecycle tools."""
+        from model_tools import get_tool_definitions
+
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "task-security-boundary")
+
+        tools = get_tool_definitions(enabled_toolsets=[], quiet_mode=True)
+
+        assert tools == []
+
     def test_disabling_platform_bundle_preserves_core_tools(self):
         """Disabling hermes-yuanbao should not strip core tools from hermes-telegram."""
         from model_tools import get_tool_definitions

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -252,7 +252,18 @@ Create a new agent run. Returns a `run_id` that can be used to subscribe to prog
 }
 ```
 
-Runs accept a simple `input` string and optional `session_id`, `instructions`, `conversation_history`, or `previous_response_id`. When `session_id` is provided, Hermes surfaces it in the run status so external UIs can correlate runs with their own conversation IDs.
+Runs accept a simple `input` string and optional `session_id`, `instructions`, `conversation_history`, `previous_response_id`, or `enabled_toolsets`. When `session_id` is provided, Hermes surfaces it in the run status so external UIs can correlate runs with their own conversation IDs.
+
+`enabled_toolsets` is a per-run restriction, not a capability grant. Hermes intersects it with the API server platform's configured toolsets, so a client cannot enable tools that the platform does not expose. Send an empty array to create a genuinely tool-free run:
+
+```json
+{
+  "input": "Summarize the supplied document without external actions.",
+  "enabled_toolsets": []
+}
+```
+
+Clients that require this security boundary should first verify `features.run_toolset_restriction` from `GET /v1/capabilities`; older servers may ignore unknown request fields.
 
 ### GET /v1/runs/\{run_id\}
 


### PR DESCRIPTION
## Summary
- add optional `enabled_toolsets` to `POST /v1/runs`
- restrict requested toolsets to the API platform configuration, so requests cannot grant authority
- preserve the three-state contract: omitted = defaults, empty = deny all, non-empty = server-side intersection
- advertise support through `features.run_toolset_restriction`
- keep explicit deny-all authoritative even for Kanban worker environments

## Safety
The API validates the field before run allocation. `enabled_toolsets: []` reaches the agent as an empty tool surface, including memory/context additions and `HERMES_KANBAN_TASK`.

## Verification
- 275 relevant model-tools and API-server tests passed
- Ruff passed
- `git diff --check` passed
- two independent immutable reviews plus two blocker-closure reviews passed

The broad repository suite was attempted but was stopped after unrelated provider-dependent E2E tests hung and emitted temporary logging-path failures; no claim is made that the entire repository suite passed.