### PR TITLE
perf(desktop): rAF-coalesce pane + console sash resizes

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -172,12 +172,26 @@ export function PreviewPane({
       document.body.style.cursor = 'row-resize'
       document.body.style.userSelect = 'none'
 
+      // Coalesce height writes to one per frame — pointermove outpaces 60fps and
+      // each setHeight reflows the webview + console split.
+      let raf: null | number = null
+      let pendingHeight: null | number = null
+
+      const flushHeight = () => {
+        raf = null
+
+        if (pendingHeight !== null) {
+          consoleState.setHeight(pendingHeight)
+        }
+      }
+
       const handleMove = (moveEvent: PointerEvent) => {
         if (!active) {
           return
         }
 
-        consoleState.setHeight(clampConsoleHeight(startHeight + startY - moveEvent.clientY))
+        pendingHeight = clampConsoleHeight(startHeight + startY - moveEvent.clientY)
+        raf ??= requestAnimationFrame(flushHeight)
       }
 
       const cleanup = () => {
@@ -186,6 +200,16 @@ export function PreviewPane({
         }
 
         active = false
+
+        if (raf !== null) {
+          cancelAnimationFrame(raf)
+          raf = null
+        }
+
+        if (pendingHeight !== null) {
+          consoleState.setHeight(pendingHeight) // commit the final height
+        }
+
         document.body.style.cursor = previousCursor
         document.body.style.userSelect = previousUserSelect
         handle.releasePointerCapture?.(pointerId)

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -7,6 +7,7 @@ import { Tip } from '@/components/ui/tooltip'
 import { type Translations, useI18n } from '@/i18n'
 import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
 import { Bug } from '@/lib/icons'
+import { rafCoalesce } from '@/lib/raf-coalesce'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
 import { $previewServerRestart, failPreviewServerRestart, type PreviewTarget } from '@/store/preview'
@@ -172,26 +173,16 @@ export function PreviewPane({
       document.body.style.cursor = 'row-resize'
       document.body.style.userSelect = 'none'
 
-      // Coalesce height writes to one per frame — pointermove outpaces 60fps and
-      // each setHeight reflows the webview + console split.
-      let raf: null | number = null
-      let pendingHeight: null | number = null
-
-      const flushHeight = () => {
-        raf = null
-
-        if (pendingHeight !== null) {
-          consoleState.setHeight(pendingHeight)
-        }
-      }
+      // pointermove outpaces 60fps and each setHeight reflows the webview +
+      // console split, so coalesce to one apply per frame (commits on cleanup).
+      const resize = rafCoalesce((height: number) => consoleState.setHeight(height))
 
       const handleMove = (moveEvent: PointerEvent) => {
         if (!active) {
           return
         }
 
-        pendingHeight = clampConsoleHeight(startHeight + startY - moveEvent.clientY)
-        raf ??= requestAnimationFrame(flushHeight)
+        resize.push(clampConsoleHeight(startHeight + startY - moveEvent.clientY))
       }
 
       const cleanup = () => {
@@ -200,16 +191,7 @@ export function PreviewPane({
         }
 
         active = false
-
-        if (raf !== null) {
-          cancelAnimationFrame(raf)
-          raf = null
-        }
-
-        if (pendingHeight !== null) {
-          consoleState.setHeight(pendingHeight) // commit the final height
-        }
-
+        resize.finish()
         document.body.style.cursor = previousCursor
         document.body.style.userSelect = previousUserSelect
         handle.releasePointerCapture?.(pointerId)

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
@@ -10,6 +10,7 @@ import { useStore } from '@nanostores/react'
 import { type PointerEvent as ReactPointerEvent, useCallback, useMemo, useRef, useSyncExternalStore } from 'react'
 
 import { useContributions } from '@/contrib/react/use-contributions'
+import { rafCoalesce } from '@/lib/raf-coalesce'
 import { cn } from '@/lib/utils'
 import { $paneStates, type PaneStateSnapshot, setPaneHeightOverride, setPaneWidthOverride } from '@/store/panes'
 
@@ -234,12 +235,8 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
       document.body.style.cursor = horizontal ? 'col-resize' : 'row-resize'
       document.body.style.userSelect = 'none'
 
-      // Coalesce store writes to one per frame: pointermove fires far faster than
-      // 60fps and each write relayouts the whole pane tree. Stash the latest
-      // clamped shift, apply it in a rAF (as drag-session / use-popout-drag do).
-      let raf: null | number = null
-      let pendingShift: null | number = null
-
+      // pointermove outpaces 60fps and each write relayouts the whole pane tree,
+      // so coalesce to one apply per frame (rafCoalesce commits on cleanup).
       const applyShift = (shiftPx: number) => {
         if (a.fixed) {
           a.paneIds.forEach(id => setOverride(id, Math.round(a0px + shiftPx)))
@@ -258,29 +255,14 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
         }
       }
 
-      const flush = () => {
-        raf = null
-
-        if (pendingShift !== null) {
-          applyShift(pendingShift)
-        }
-      }
+      const resize = rafCoalesce(applyShift)
 
       const onMove = (ev: PointerEvent) => {
-        pendingShift = Math.max(lo, Math.min(hi, (horizontal ? ev.clientX : ev.clientY) - start))
-        raf ??= requestAnimationFrame(flush)
+        resize.push(Math.max(lo, Math.min(hi, (horizontal ? ev.clientX : ev.clientY) - start)))
       }
 
       const cleanup = () => {
-        if (raf !== null) {
-          cancelAnimationFrame(raf)
-          raf = null
-        }
-
-        if (pendingShift !== null) {
-          applyShift(pendingShift) // commit the final position
-        }
-
+        resize.finish()
         document.body.style.cursor = restoreCursor
         document.body.style.userSelect = restoreSelect
 

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
@@ -234,9 +234,13 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
       document.body.style.cursor = horizontal ? 'col-resize' : 'row-resize'
       document.body.style.userSelect = 'none'
 
-      const onMove = (ev: PointerEvent) => {
-        const shiftPx = Math.max(lo, Math.min(hi, (horizontal ? ev.clientX : ev.clientY) - start))
+      // Coalesce store writes to one per frame: pointermove fires far faster than
+      // 60fps and each write relayouts the whole pane tree. Stash the latest
+      // clamped shift, apply it in a rAF (as drag-session / use-popout-drag do).
+      let raf: null | number = null
+      let pendingShift: null | number = null
 
+      const applyShift = (shiftPx: number) => {
         if (a.fixed) {
           a.paneIds.forEach(id => setOverride(id, Math.round(a0px + shiftPx)))
         }
@@ -247,15 +251,36 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
 
         if (!a.fixed && !b.fixed) {
           const weights = [...node.weights]
-          // Convert the CLAMPED pixel sizes back to weights so the persisted
-          // weights always agree with what's on screen.
+          // Clamped px → weights so persisted weights match what's on screen.
           weights[aIndex] = (a0px + shiftPx) / pxPerWeight
           weights[bIndex] = (b0px - shiftPx) / pxPerWeight
           setTreeSplitWeights(node.id, weights)
         }
       }
 
+      const flush = () => {
+        raf = null
+
+        if (pendingShift !== null) {
+          applyShift(pendingShift)
+        }
+      }
+
+      const onMove = (ev: PointerEvent) => {
+        pendingShift = Math.max(lo, Math.min(hi, (horizontal ? ev.clientX : ev.clientY) - start))
+        raf ??= requestAnimationFrame(flush)
+      }
+
       const cleanup = () => {
+        if (raf !== null) {
+          cancelAnimationFrame(raf)
+          raf = null
+        }
+
+        if (pendingShift !== null) {
+          applyShift(pendingShift) // commit the final position
+        }
+
         document.body.style.cursor = restoreCursor
         document.body.style.userSelect = restoreSelect
 

--- a/apps/desktop/src/lib/raf-coalesce.ts
+++ b/apps/desktop/src/lib/raf-coalesce.ts
@@ -1,0 +1,34 @@
+/** Coalesce a stream of values (pointermove positions, resize deltas) to one
+ *  `apply` per animation frame, so a drag can't drive several layouts per frame.
+ *  `push` records the latest value and schedules a frame; `finish` commits the
+ *  last value and cancels any pending frame (call it on pointerup/cancel).
+ *  `null` is the empty sentinel, so `T` must never legitimately be `null`. */
+export function rafCoalesce<T>(apply: (value: T) => void): { finish: () => void; push: (value: T) => void } {
+  let frame: null | number = null
+  let pending: null | T = null
+
+  const flush = () => {
+    frame = null
+
+    if (pending !== null) {
+      apply(pending)
+    }
+  }
+
+  return {
+    finish() {
+      if (frame !== null) {
+        cancelAnimationFrame(frame)
+        frame = null
+      }
+
+      if (pending !== null) {
+        apply(pending)
+      }
+    },
+    push(value) {
+      pending = value
+      frame ??= requestAnimationFrame(flush)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Dragging a sash relayouts the app several times per frame. Both resize handlers wrote to nanostores on **every** `pointermove`:
- **pane sash** (`tree-split.tsx`) → `setPaneWidth/HeightOverride` / `setTreeSplitWeights`, which relayouts the whole pane tree;
- **preview console sash** (`preview-pane.tsx`) → `consoleState.setHeight`, which reflows the webview + console split.

`pointermove` fires well above 60fps, so a drag drove multiple store-triggered relayouts per frame.

## Fix
Coalesce to **one apply per frame** via a small shared helper, `lib/raf-coalesce.ts` (`push` records the latest value + schedules a frame; `finish` commits the last value and cancels any pending frame on pointerup/cancel). Both sash handlers use it — same coalescing pattern `drag-session.ts` / `use-popout-drag.ts` already had inline, now factored out and reusable. Behavior identical; one relayout per frame instead of per event.

## Test plan
- [x] `tsc` + `eslint` clean
- [x] `preview-pane` tests green
- [ ] In-app: drag the file/review/preview sash and the preview console sash — smooth, lands where released, weights persist

## Context
Render/panel batch (file-tree findings #3/#4). Remaining: review file-row per-row store subscriptions + virtualization, a shared git working-tree snapshot, eager \`prettyJson\` in the tool view.