### PR TITLE
fix(kanban): clear leaked task claim on unblock

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5167,7 +5167,9 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     is a no-op. If a future or external write left the pointer dangling,
     the leaked run is closed as ``reclaimed`` inside the same txn so the
     runs invariant (``current_run_id IS NULL`` ⇔ run row in terminal
-    state) holds for the rest of this function's lifetime.
+    state) holds for the rest of this function's lifetime. Task-level claim
+    metadata is cleared in the same transaction so the ready task can be
+    claimed again after invariant recovery.
     """
     now = int(time.time())
     with write_txn(conn):
@@ -5212,6 +5214,7 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         # start for the dispatcher's retry budget.
         cur = conn.execute(
             "UPDATE tasks SET status = ?, current_run_id = NULL, "
+            "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, "
             "consecutive_failures = 0, last_failure_error = NULL "
             "WHERE id = ? AND status IN ('blocked', 'scheduled')",
             (new_status, task_id),

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2354,7 +2354,8 @@ def test_unblock_invariant_recovery(kanban_home):
         leaked_run_id = kb.latest_run(conn, tid).id
         # Force the bad state.
         conn.execute(
-            "UPDATE tasks SET status = 'blocked' WHERE id = ?", (tid,),
+            "UPDATE tasks SET status = 'blocked', worker_pid = 4242 WHERE id = ?",
+            (tid,),
         )
         conn.commit()
         # current_run_id is still set; run is still open.
@@ -2366,9 +2367,13 @@ def test_unblock_invariant_recovery(kanban_home):
         task = kb.get_task(conn, tid)
         assert task.status == "ready"
         assert task.current_run_id is None
+        assert task.claim_lock is None
+        assert task.claim_expires is None
+        assert task.worker_pid is None
         leaked = kb.get_run(conn, leaked_run_id)
         assert leaked.outcome == "reclaimed"
         assert leaked.ended_at is not None
+        assert kb.claim_task(conn, tid, claimer="replacement-worker") is not None
     finally:
         conn.close()
 


### PR DESCRIPTION
## What does this PR do?

Finishes the existing defensive recovery in `unblock_task` by clearing stale task-level claim metadata (`claim_lock`, `claim_expires`, and `worker_pid`) in the same transaction that closes a leaked run pointer and moves the task back to `ready`/`todo`.

Without this, the function reports success and emits `unblocked`, but a task produced by the documented invariant-recovery scenario remains unclaimable because `claim_task` requires `claim_lock IS NULL`.

This is a focused follow-up to the maintainer guidance on #66349: the existing `hermes kanban unblock --reason "…"` path is sufficient for terminal-task continuation, so no separate `recover` command, endpoint, event, or dashboard action is needed.

## Related Issue

No upstream issue. Follow-up to the maintainer review on #66349 and its existing leaked-run recovery contract.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py`: clear task-level claim metadata atomically during unblock invariant recovery.
- `tests/hermes_cli/test_kanban_core_functionality.py`: prove the leaked task becomes reclaimable, not merely `ready` with a closed run.

## How to Test

1. Claim a task, then engineer the existing invariant-recovery case by changing it to `blocked` while retaining its run pointer and claim metadata.
2. Call `unblock_task`.
3. Verify the leaked run is reclaimed, all task-level claim metadata is cleared, and a replacement worker can claim the task.

Verification on exact head:

```text
uvx ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py
All checks passed!

uv run --with pytest --with pytest-xdist python -m pytest tests/hermes_cli/test_kanban_core_functionality.py -q -n 0
172 passed, 1 skipped
```

The regression failed before the production change with `task.claim_lock` still set, then passed after the one-line SQL correction. A manual exact-head replay also returned `status=ready`, cleared claim metadata, `run_outcome=reclaimed`, and `reclaimable=true`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this is a transactional Kanban DB invariant fix.
