### PR TITLE
fix(anthropic): add claude-sonnet-5 to curated provider model list (#67815)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -370,6 +370,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "claude-opus-4-8",
         "claude-opus-4-7",
         "claude-opus-4-6",
+        "claude-sonnet-5",
         "claude-sonnet-4-6",
         "claude-opus-4-5-20251101",
         "claude-sonnet-4-5-20250929",


### PR DESCRIPTION
## Problem
Issue #67815 reports that claude-sonnet-5 is missing from the Anthropic-direct model picker in the desktop app. Although the API key has confirmed access (the model works via the CLI with `--provider anthropic -m anthropic/claude-sonnet-5` and Anthropic's `/v1/models` endpoint lists it), the desktop model picker doesn't show it because the curated fallback list in `_PROVIDER_MODELS["anthropic"]` doesn't include it.

## Fix
Add `claude-sonnet-5` to `_PROVIDER_MODELS["anthropic"]` in `hermes_cli/models.py`.

When the live API fetch succeeds, `provider_model_ids()` merges the curated list first, then appends live-only models — so adding it to the curated list ensures it always appears in the correct position. When the live fetch fails or the cache is stale, the curated list serves as the fallback, so this fix covers both cases.

## Testing
- `python3 -c "import ast; ast.parse(open('hermes_cli/models.py').read())"` — syntax OK
- `pytest tests/hermes_cli/test_model_validation.py` — 89 passed