### PR TITLE
fix(web): avoid blocking provider validation

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7169,8 +7169,8 @@ async def validate_custom_endpoint(body: CustomEndpointUpdate):
         headers["Authorization"] = f"Bearer {body.api_key.strip()}"
 
     try:
-        with httpx.Client(timeout=httpx.Timeout(8.0)) as client:
-            resp = client.get(url, headers=headers)
+        async with httpx.AsyncClient(timeout=httpx.Timeout(8.0)) as client:
+            resp = await client.get(url, headers=headers)
     except Exception:
         return {"ok": False, "reachable": False, "message": f"Could not reach {url}.", "models": []}
 
@@ -7211,8 +7211,8 @@ async def validate_provider_credential(body: EnvVarUpdate, request: Request):
         api_key = (body.api_key or "").strip()
         headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
         try:
-            with httpx.Client(timeout=httpx.Timeout(8.0)) as client:
-                resp = client.get(url, headers=headers)
+            async with httpx.AsyncClient(timeout=httpx.Timeout(8.0)) as client:
+                resp = await client.get(url, headers=headers)
             return {"ok": True, "reachable": True, "message": "", "models": _parse_model_ids(resp)}
         except Exception:
             return {"ok": False, "reachable": False, "message": f"Could not reach {url}."}
@@ -7231,8 +7231,8 @@ async def validate_provider_credential(body: EnvVarUpdate, request: Request):
         params["key"] = value
 
     try:
-        with httpx.Client(timeout=httpx.Timeout(10.0)) as client:
-            resp = client.get(url, headers=headers, params=params)
+        async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
+            resp = await client.get(url, headers=headers, params=params)
     except Exception:
         return {"ok": False, "reachable": False, "message": "Could not reach the provider to verify the key."}
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -8755,10 +8755,9 @@ class TestDashboardPluginStaticAssetAllowlist:
         assert resp.status_code in (403, 404)
 
 
-def _fake_httpx_client(*, status: int | None = None, raise_exc: bool = False):
-    """Build a drop-in for httpx.Client whose .get() returns a canned status
-    (or raises a transport error). Patched in for the credential-validate probe
-    so tests never touch the network."""
+def _fake_httpx_async_client(*, status: int | None = None, raise_exc: bool = False):
+    """Build a drop-in for httpx.AsyncClient with a canned GET response."""
+
     class _Resp:
         def __init__(self, code):
             self.status_code = code
@@ -8771,13 +8770,13 @@ def _fake_httpx_client(*, status: int | None = None, raise_exc: bool = False):
         def __init__(self, *a, **k):
             pass
 
-        def __enter__(self):
+        async def __aenter__(self):
             return self
 
-        def __exit__(self, *a):
+        async def __aexit__(self, *a):
             return False
 
-        def get(self, *a, **k):
+        async def get(self, *a, **k):
             if raise_exc:
                 raise RuntimeError("connection refused")
             return _Resp(status)
@@ -8800,26 +8799,38 @@ class TestValidateProviderCredential:
         self.client = TestClient(app)
         self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
 
+        class _BlockingClient:
+            def __init__(self, *args, **kwargs):
+                raise AssertionError(
+                    "async validation route used blocking httpx.Client"
+                )
+
+        monkeypatch.setattr("httpx.Client", _BlockingClient)
+
     def _post(self, key, value):
-        return self.client.post("/api/providers/validate", json={"key": key, "value": value})
+        return self.client.post(
+            "/api/providers/validate", json={"key": key, "value": value}
+        )
 
     def test_rejected_key_blocks(self, monkeypatch):
-        monkeypatch.setattr("httpx.Client", _fake_httpx_client(status=401))
+        monkeypatch.setattr("httpx.AsyncClient", _fake_httpx_async_client(status=401))
         data = self._post("OPENROUTER_API_KEY", "sk-bogus").json()
         assert data["ok"] is False and data["reachable"] is True
 
     def test_valid_key_passes(self, monkeypatch):
-        monkeypatch.setattr("httpx.Client", _fake_httpx_client(status=200))
+        monkeypatch.setattr("httpx.AsyncClient", _fake_httpx_async_client(status=200))
         data = self._post("OPENAI_API_KEY", "sk-real").json()
         assert data["ok"] is True and data["reachable"] is True
 
     def test_rate_limited_counts_as_valid(self, monkeypatch):
-        monkeypatch.setattr("httpx.Client", _fake_httpx_client(status=429))
+        monkeypatch.setattr("httpx.AsyncClient", _fake_httpx_async_client(status=429))
         data = self._post("XAI_API_KEY", "xai-real").json()
         assert data["ok"] is True
 
     def test_network_error_is_unreachable_not_blocking(self, monkeypatch):
-        monkeypatch.setattr("httpx.Client", _fake_httpx_client(raise_exc=True))
+        monkeypatch.setattr(
+            "httpx.AsyncClient", _fake_httpx_async_client(raise_exc=True)
+        )
         data = self._post("OPENROUTER_API_KEY", "sk-real").json()
         assert data["ok"] is False and data["reachable"] is False
 
@@ -8849,18 +8860,18 @@ class TestValidateProviderCredential:
             def __init__(self, *a, **k):
                 pass
 
-            def __enter__(self):
+            async def __aenter__(self):
                 return self
 
-            def __exit__(self, *a):
+            async def __aexit__(self, *a):
                 return False
 
-            def get(self, url, *a, headers=None, **k):
+            async def get(self, url, *a, headers=None, **k):
                 captured["url"] = url
                 captured["headers"] = headers
                 return _Resp()
 
-        monkeypatch.setattr("httpx.Client", _Client)
+        monkeypatch.setattr("httpx.AsyncClient", _Client)
 
         resp = self.client.post(
             "/api/providers/validate",
@@ -8891,23 +8902,75 @@ class TestValidateProviderCredential:
             def __init__(self, *a, **k):
                 pass
 
-            def __enter__(self):
+            async def __aenter__(self):
                 return self
 
-            def __exit__(self, *a):
+            async def __aexit__(self, *a):
                 return False
 
-            def get(self, url, *a, headers=None, **k):
+            async def get(self, url, *a, headers=None, **k):
                 captured["headers"] = headers
                 return _Resp()
 
-        monkeypatch.setattr("httpx.Client", _Client)
+        monkeypatch.setattr("httpx.AsyncClient", _Client)
 
         self.client.post(
             "/api/providers/validate",
             json={"key": "OPENAI_BASE_URL", "value": "http://127.0.0.1:8000/v1"},
         )
         assert captured["headers"] is None
+
+    def test_named_custom_endpoint_probe_is_async(self, monkeypatch):
+        """Custom endpoint validation must not block the dashboard event loop."""
+        captured = {}
+
+        class _Resp:
+            status_code = 200
+            is_success = True
+
+            def json(self):
+                return {"data": [{"id": "local-model"}]}
+
+        class _Client:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def get(self, url, *args, headers=None, **kwargs):
+                captured["url"] = url
+                captured["headers"] = headers
+                return _Resp()
+
+        monkeypatch.setattr("httpx.AsyncClient", _Client)
+
+        response = self.client.post(
+            "/api/providers/custom-endpoints/validate",
+            json={
+                "name": "Local",
+                "base_url": "http://localhost:8000/v1",
+                "model": "local-model",
+                "api_key": "local-secret",
+            },
+        )
+
+        assert response.json() == {
+            "ok": True,
+            "reachable": True,
+            "message": "",
+            "models": ["local-model"],
+        }
+        assert captured == {
+            "url": "http://localhost:8000/v1/models",
+            "headers": {
+                "Accept": "application/json",
+                "Authorization": "Bearer local-secret",
+            },
+        }
 
 
 class TestDesktopCronTicker:


### PR DESCRIPTION
## What does this PR do?

The dashboard's async provider-validation routes performed blocking network I/O with `httpx.Client`. A slow or unreachable provider could therefore block the FastAPI event loop for the full 8-10 second probe timeout and stall unrelated dashboard requests.

This changes all three probe paths to `httpx.AsyncClient` and awaits the requests. Response semantics and timeout values stay unchanged.

## Related Issue

N/A — discovered during a source audit; no existing issue or equivalent PR matched.

Related but not equivalent: #59962 hardens custom-provider probe URLs and touches one of the same routes, but its current implementation still uses the blocking client. This PR is limited to the async-I/O issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py`: use an awaited `httpx.AsyncClient` in provider and custom-endpoint validation routes.
- `tests/hermes_cli/test_web_server.py`: convert probe doubles to async context managers, fail if the routes instantiate `httpx.Client`, and cover the named custom-endpoint path.

## How to Test

1. On the pre-fix implementation, run the focused regression selection. The async-only doubles reject the blocking client (`6 failed, 3 passed`).
2. Run `HERMES_PYTHON=/tmp/hermes-agent-contrib-venv/bin/python scripts/run_tests.sh tests/hermes_cli/test_web_server.py -q -k TestValidateProviderCredential` (`9 passed`).
3. Run the full affected test file with `HERMES_PYTHON=/tmp/hermes-agent-contrib-venv/bin/python scripts/run_tests.sh tests/hermes_cli/test_web_server.py -q` (`457 passed`; one unrelated PTY/dyld-path flake passed on the runner's automatic retry).
4. Run `/tmp/hermes-agent-contrib-venv/bin/python -m ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py` and the Windows-footgun scanner (both pass).

The repository-wide suite was attempted, but local collection is polluted by `tests/agent/test_anthropic_output_field_leak.py` inserting the user's separate `~/.hermes/hermes-agent` checkout. I am not marking the full-suite checkbox below.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — backend behavior is covered by regression tests.
