### PR TITLE
fix(params): require model family boundaries

### DIFF
--- a/tests/test_model_forces_max_completion_tokens.py
+++ b/tests/test_model_forces_max_completion_tokens.py
@@ -135,3 +135,18 @@ class TestEdgeCases:
     def test_gpt_5_substring_in_middle_not_matched(self):
         # Only a prefix should match — "local-gpt-5-clone" is a different model.
         assert model_forces_max_completion_tokens("local-gpt-5-clone") is False
+
+    def test_family_prefix_requires_a_model_boundary(self):
+        # Custom model names that merely begin with a known family must keep
+        # using max_tokens. Only the bare family, dotted releases, and hyphen
+        # variants are part of the documented OpenAI model families.
+        for model in (
+            "gpt-4ocean",
+            "gpt-4.1custom",
+            "gpt-5clone",
+            "o123",
+            "o3mega",
+            "o4custom",
+            "vendor/o1clone",
+        ):
+            assert model_forces_max_completion_tokens(model) is False

--- a/utils.py
+++ b/utils.py
@@ -515,13 +515,13 @@ def model_forces_max_completion_tokens(model: str) -> bool:
         return False
     if "/" in m:
         m = m.rsplit("/", 1)[-1]
-    return (
-        m.startswith("gpt-4o")
-        or m.startswith("gpt-4.1")
-        or m.startswith("gpt-5")
-        or m.startswith("o1")
-        or m.startswith("o3")
-        or m.startswith("o4")
+
+    def matches_family(family: str) -> bool:
+        return m == family or m.startswith((f"{family}-", f"{family}."))
+
+    return any(
+        matches_family(family)
+        for family in ("gpt-4o", "gpt-4.1", "gpt-5", "o1", "o3", "o4")
     )
 
 


### PR DESCRIPTION
## What does this PR do?

`model_forces_max_completion_tokens()` used plain prefix matching for OpenAI model families. Because Hermes supports custom OpenAI-compatible endpoints, unrelated custom names such as `gpt-4ocean`, `gpt-5clone`, and `o123` were classified as OpenAI family models and received `max_completion_tokens` instead of the compatible `max_tokens` parameter.

The helper now requires the exact family name or a documented hyphen/dot boundary. Valid names such as `gpt-4o-mini`, `gpt-5.4`, and `o3-mini` remain supported.

## Related Issue

N/A — discovered during a source audit; no existing issue or equivalent PR matched.

Related but not equivalent: #43382 adds the missing positive alias `chatgpt-4o-latest`. This PR fixes false-positive family overmatching. The two changes touch the same helper but address opposite cases.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `utils.py`: match model families only at exact, hyphen, or dotted boundaries.
- `tests/test_model_forces_max_completion_tokens.py`: add false-positive regressions for GPT and o-series lookalike names, including a vendor-prefixed custom model.

## How to Test

1. On the pre-fix implementation, run `tests/test_model_forces_max_completion_tokens.py`; the new boundary regression fails for `gpt-4ocean` (`31 passed, 1 failed`).
2. Run `HERMES_PYTHON=/tmp/hermes-agent-contrib-venv/bin/python scripts/run_tests.sh tests/test_model_forces_max_completion_tokens.py -q` (`32 passed`).
3. Run the actual parameter-selection call paths: `tests/run_agent/test_run_agent.py -q -k TestMaxTokensParam` (`13 passed`) and `tests/agent/test_auxiliary_client.py -q -k TestAuxiliaryMaxTokensParam` (`7 passed`).
4. Run Ruff and `scripts/check-windows-footguns.py` on the two changed files (both pass).

The repository-wide suite was attempted, but local collection is polluted by `tests/agent/test_anthropic_output_field_leak.py` inserting the user's separate `~/.hermes/hermes-agent` checkout. I am not marking the full-suite checkbox below.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — pure helper behavior is covered by regression tests.
