### PR TITLE
fix(tools): reject boolean output limits

### DIFF
--- a/tests/tools/test_tool_output_limits.py
+++ b/tests/tools/test_tool_output_limits.py
@@ -95,7 +95,7 @@ class TestOverrides:
 
 
 class TestCoercion:
-    @pytest.mark.parametrize("bad", [None, "not a number", -1, 0, [], {}])
+    @pytest.mark.parametrize("bad", [None, "not a number", -1, 0, True, False, [], {}])
     def test_invalid_values_fall_back_to_defaults(self, bad):
         cfg = {"tool_output": {"max_bytes": bad, "max_lines": bad, "max_line_length": bad}}
         with patch("hermes_cli.config.load_config", return_value=cfg):

--- a/tools/tool_output_limits.py
+++ b/tools/tool_output_limits.py
@@ -47,6 +47,11 @@ _cached_limits: dict | None = None
 
 def _coerce_positive_int(value: Any, default: int) -> int:
     """Return ``value`` as a positive int, or ``default`` on any issue."""
+    # bool is an int subclass, but YAML true/false is not a meaningful output
+    # limit. Treat it as a malformed type instead of silently turning true
+    # into a one-byte/one-line cap.
+    if isinstance(value, bool):
+        return default
     try:
         iv = int(value)
     except (TypeError, ValueError):


### PR DESCRIPTION
## What does this PR do?

The tool-output limit parser accepted booleans as positive integers because Python's `bool` is a subclass of `int`. A YAML value such as `tool_output.max_bytes: true` therefore became a one-byte limit instead of falling back to the documented default, causing almost every tool result to be truncated.

This explicitly treats `True` and `False` as malformed limit types while preserving existing integer and numeric-string behavior.

## Related Issue

N/A — discovered during a source audit; no existing issue or equivalent PR matched.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/tool_output_limits.py`: reject booleans before integer coercion and fall back to the configured default.
- `tests/tools/test_tool_output_limits.py`: cover both YAML boolean values for all three output-limit fields.

## How to Test

1. On the pre-fix implementation, run the updated test file; `True` resolves to `1` instead of `50000` (`19 passed, 1 failed`).
2. Run `HERMES_PYTHON=/tmp/hermes-agent-contrib-venv/bin/python scripts/run_tests.sh tests/tools/test_tool_output_limits.py -q` (`20 passed`).
3. Run `/tmp/hermes-agent-contrib-venv/bin/python -m ruff check tools/tool_output_limits.py tests/tools/test_tool_output_limits.py` (passes).
4. Run `/tmp/hermes-agent-contrib-venv/bin/python scripts/check-windows-footguns.py tools/tool_output_limits.py tests/tools/test_tool_output_limits.py` (passes).

The repository-wide suite was attempted, but local collection is polluted by `tests/agent/test_anthropic_output_field_leak.py` inserting the user's separate `~/.hermes/hermes-agent` checkout. I am not marking the full-suite checkbox below.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — configuration parsing behavior is covered by regression tests.
