### PR TITLE
feat(vision): decode HEIF/HEIC/AVIF images (iPhone photos)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ dependencies = [
   # _normalize_to_supported_image can re-encode HEIF/AVIF to PNG before embed.
   # Ships prebuilt wheels bundling libheif for the common platforms (no system
   # libs needed), so it's safe in the base install alongside Pillow.
-  "pillow-heif==1.4.0",
+  "pillow-heif>=1.4.0,<2",
   # Windows log rotation. Stdlib ``RotatingFileHandler.doRollover()`` uses
   # ``os.rename()`` which fails with ``PermissionError [WinError 32]`` on
   # Windows whenever any other process holds an append-mode handle on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,14 @@ dependencies = [
   # install rather than gating it behind an extra + a mid-session lazy install
   # (which deadlocked the CLI under prompt_toolkit — see #40490).
   "Pillow==12.3.0",
+  # HEIF/HEIC/AVIF decode for the vision tools. iPhone photos and screenshots
+  # are HEIC (frequently mislabeled .jpg by upload pipelines); Pillow has no
+  # built-in HEIF codec, so without this the vision resolver rejects them as
+  # "not a recognized image". pillow-heif registers a Pillow opener so
+  # _normalize_to_supported_image can re-encode HEIF/AVIF to PNG before embed.
+  # Ships prebuilt wheels bundling libheif for the common platforms (no system
+  # libs needed), so it's safe in the base install alongside Pillow.
+  "pillow-heif==1.4.0",
   # Windows log rotation. Stdlib ``RotatingFileHandler.doRollover()`` uses
   # ``os.rename()`` which fails with ``PermissionError [WinError 32]`` on
   # Windows whenever any other process holds an append-mode handle on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ dependencies = [
   # _normalize_to_supported_image can re-encode HEIF/AVIF to PNG before embed.
   # Ships prebuilt wheels bundling libheif for the common platforms (no system
   # libs needed), so it's safe in the base install alongside Pillow.
-  "pillow-heif==1.4.0",
+  "pillow-heif>=1.4.0,<2",
   # Windows log rotation. Stdlib ``RotatingFileHandler.doRollover()`` uses
   # ``os.rename()`` which fails with ``PermissionError [WinError 32]`` on
   # Windows whenever any other process holds an append-mode handle on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,14 @@ dependencies = [
   # install rather than gating it behind an extra + a mid-session lazy install
   # (which deadlocked the CLI under prompt_toolkit — see #40490).
   "Pillow==12.3.0",
+  # HEIF/HEIC/AVIF decode for the vision tools. iPhone photos and screenshots
+  # are HEIC (frequently mislabeled .jpg by upload pipelines); Pillow has no
+  # built-in HEIF codec, so without this the vision resolver rejects them as
+  # "not a recognized image". pillow-heif registers a Pillow opener so
+  # _normalize_to_supported_image can re-encode HEIF/AVIF to PNG before embed.
+  # Ships prebuilt wheels bundling libheif for the common platforms (no system
+  # libs needed), so it's safe in the base install alongside Pillow.
+  "pillow-heif==1.4.0",
   # Windows log rotation. Stdlib ``RotatingFileHandler.doRollover()`` uses
   # ``os.rename()`` which fails with ``PermissionError [WinError 32]`` on
   # Windows whenever any other process holds an append-mode handle on

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -381,3 +381,80 @@ class TestLazySandboxBringUp:
 
         with pytest.raises(isrc.SourceNotFound):
             await isrc.resolve_image_source(str(secret), isrc.ResolveContext(task_id="t1"))
+
+
+# HEIF/HEIC/AVIF ISO-BMFF headers: 'ftyp' box at bytes 4-8, major brand at 8-12.
+# 0x18-byte box length prefix mirrors a real iPhone HEIC (\x00\x00\x00\x18 ftyp...).
+HEIC_HEADER = b"\x00\x00\x00\x18ftypheic\x00\x00\x00\x00mif1heic" + b"\x00" * 32
+AVIF_HEADER = b"\x00\x00\x00\x1cftypavif\x00\x00\x00\x00avifmif1" + b"\x00" * 32
+MIF1_HEADER = b"\x00\x00\x00\x18ftypmif1\x00\x00\x00\x00mif1heic" + b"\x00" * 32
+
+
+class TestHeicDetection:
+    """iPhone HEIC/HEIF (and AVIF) are sniffed from the ISO-BMFF ftyp brand so
+    they reach _normalize_to_supported_image instead of being rejected as
+    'not a recognized image' (the pre-fix behavior for iPhone photos)."""
+
+    def test_heic_brand_detected(self):
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        assert _detect_image_mime_type_from_bytes(HEIC_HEADER) == "image/heic"
+
+    def test_generic_mif1_brand_detected_as_heic(self):
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        assert _detect_image_mime_type_from_bytes(MIF1_HEADER) == "image/heic"
+
+    def test_avif_brand_detected(self):
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        assert _detect_image_mime_type_from_bytes(AVIF_HEADER) == "image/avif"
+
+    def test_ftyp_with_unknown_brand_not_misdetected(self):
+        """An ISO-BMFF ftyp box that isn't an image brand (e.g. mp4) stays
+        unrecognized — we must not claim every ftyp container is an image."""
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        mp4 = b"\x00\x00\x00\x18ftypmp42\x00\x00\x00\x00mp42isom" + b"\x00" * 32
+        assert _detect_image_mime_type_from_bytes(mp4) is None
+
+    @pytest.mark.asyncio
+    async def test_heic_resolves_and_normalizes_to_png(self, tmp_path, monkeypatch):
+        """End-to-end: a real HEIC file resolves (mime image/heic) and
+        _normalize_to_supported_image re-encodes it to PNG via pillow-heif."""
+        pillow_heif = pytest.importorskip("pillow_heif")
+        pillow_heif.register_heif_opener()
+        from PIL import Image
+        from tools import vision_tools as vt
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        heic = tmp_path / "photo.heic"
+        Image.new("RGB", (8, 8), (120, 60, 200)).save(str(heic), format="HEIF")
+
+        res = await isrc.resolve_image_source(str(heic), isrc.ResolveContext())
+        assert res.mime == "image/heic"
+
+        path, mime, err = vt._normalize_to_supported_image(heic, "image/heic")
+        assert err is None
+        assert mime == "image/png"
+        assert path.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+        path.unlink()
+
+    def test_heic_actionable_error_when_decoder_missing(self, tmp_path, monkeypatch):
+        """With pillow-heif unavailable, a HEIC image gets an actionable error
+        (install pillow-heif) rather than a generic conversion failure — the
+        same soft-dependency posture as SVG-without-rasterizer."""
+        from tools import vision_tools as vt
+        _reload(monkeypatch, tmp_path / "hermes")
+        heic = tmp_path / "photo.heic"
+        heic.write_bytes(HEIC_HEADER)
+
+        import builtins
+        real_import = builtins.__import__
+
+        def _no_heif(name, *args, **kwargs):
+            if name == "pillow_heif":
+                raise ImportError("pillow_heif not installed")
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=_no_heif):
+            path, mime, err = vt._normalize_to_supported_image(heic, "image/heic")
+        assert path is None
+        assert "pillow-heif" in err

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -383,11 +383,21 @@ class TestLazySandboxBringUp:
             await isrc.resolve_image_source(str(secret), isrc.ResolveContext(task_id="t1"))
 
 
-# HEIF/HEIC/AVIF ISO-BMFF headers: 'ftyp' box at bytes 4-8, major brand at 8-12.
+# HEIF/HEIC/AVIF ISO-BMFF headers: 'ftyp' box at bytes 4-8, major brand at 8-12,
+# minor version at 12-16, then a list of 4-byte compatible brands.
 # 0x18-byte box length prefix mirrors a real iPhone HEIC (\x00\x00\x00\x18 ftyp...).
 HEIC_HEADER = b"\x00\x00\x00\x18ftypheic\x00\x00\x00\x00mif1heic" + b"\x00" * 32
 AVIF_HEADER = b"\x00\x00\x00\x1cftypavif\x00\x00\x00\x00avifmif1" + b"\x00" * 32
 MIF1_HEADER = b"\x00\x00\x00\x18ftypmif1\x00\x00\x00\x00mif1heic" + b"\x00" * 32
+# AVIF encoders routinely stamp the generic still-image brand 'mif1' as the
+# MAJOR brand and declare the AV1 codec only in the compatible-brand list, so a
+# major-brand-only sniff mislabels these as HEVC-coded HEIC.
+MIF1_MAJOR_AVIF_COMPATIBLE = (
+    b"\x00\x00\x00\x1cftypmif1\x00\x00\x00\x00mif1avif" + b"\x00" * 32
+)
+MIF1_MAJOR_AV01_COMPATIBLE = (
+    b"\x00\x00\x00 ftypmif1\x00\x00\x00\x00mif1av01avif" + b"\x00" * 32
+)
 
 
 class TestHeicDetection:
@@ -406,6 +416,47 @@ class TestHeicDetection:
     def test_avif_brand_detected(self):
         from tools.vision_tools import _detect_image_mime_type_from_bytes
         assert _detect_image_mime_type_from_bytes(AVIF_HEADER) == "image/avif"
+
+    def test_mif1_major_with_avif_compatible_brand_is_avif(self):
+        """Regression: a 'mif1'-major file that lists 'avif' among its
+        compatible brands is AV1-coded and must be reported as AVIF. Sniffing
+        only the major brand labeled every mif1 file HEIC, which routes an AVIF
+        to the HEVC error text and mis-reports the format to the caller."""
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        assert _detect_image_mime_type_from_bytes(
+            MIF1_MAJOR_AVIF_COMPATIBLE) == "image/avif"
+
+    def test_mif1_major_with_av01_compatible_brand_is_avif(self):
+        """Same as above for the 'av01' codec brand, deeper in the list."""
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        assert _detect_image_mime_type_from_bytes(
+            MIF1_MAJOR_AV01_COMPATIBLE) == "image/avif"
+
+    def test_mif1_major_with_heic_compatible_stays_heic(self):
+        """The compatible-brand scan must not over-trigger: a genuine HEVC-coded
+        HEIF (mif1 major, heic compatible, no AV1 brand) is still HEIC."""
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        assert _detect_image_mime_type_from_bytes(MIF1_HEADER) == "image/heic"
+
+    def test_brand_scan_does_not_read_past_the_ftyp_box(self):
+        """The scan is bounded by the declared ftyp box size, so an 'avif' token
+        sitting in a FOLLOWING box must not upgrade a HEIC to AVIF."""
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        # ftyp box is exactly 0x18 bytes (major mif1 + one compatible 'heic');
+        # the next box then contains the literal bytes 'avif'.
+        hdr = (
+            b"\x00\x00\x00\x18ftypmif1\x00\x00\x00\x00heic"
+            b"\x00\x00\x00\x10metaavif" + b"\x00" * 32
+        )
+        assert _detect_image_mime_type_from_bytes(hdr) == "image/heic"
+
+    def test_truncated_ftyp_header_does_not_crash(self):
+        """A short/garbage read must return a value, not raise."""
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        assert _detect_image_mime_type_from_bytes(b"\x00\x00\x00\x18ftyp") is None
+        # Bogus (huge) declared box size must fall back to the sniffed window.
+        assert _detect_image_mime_type_from_bytes(
+            b"\xff\xff\xff\xffftypmif1\x00\x00\x00\x00mif1avif") == "image/avif"
 
     def test_ftyp_with_unknown_brand_not_misdetected(self):
         """An ISO-BMFF ftyp box that isn't an image brand (e.g. mp4) stays
@@ -458,3 +509,53 @@ class TestHeicDetection:
             path, mime, err = vt._normalize_to_supported_image(heic, "image/heic")
         assert path is None
         assert "pillow-heif" in err
+
+    def test_avif_converts_without_pillow_heif(self, tmp_path, monkeypatch):
+        """Regression: AVIF must NOT be gated on pillow-heif.
+
+        Pillow >= 11.3 bundles a native AvifImagePlugin, while pillow-heif
+        wheels are commonly built with no AV1 codec at all (libheif_info()
+        reports ``AVIF: ''``). Gating AVIF on a pillow-heif import therefore
+        rejected files Pillow could already decode and told the user to install
+        a library that cannot decode them. With pillow-heif absent, a real AVIF
+        must still normalize to PNG.
+        """
+        pytest.importorskip("PIL")
+        from PIL import Image, features
+        if not features.check("avif"):
+            pytest.skip("this Pillow build has no native AVIF codec")
+        from tools import vision_tools as vt
+        _reload(monkeypatch, tmp_path / "hermes")
+
+        avif = tmp_path / "photo.avif"
+        Image.new("RGB", (8, 8), (10, 180, 90)).save(str(avif), format="AVIF")
+
+        import builtins
+        real_import = builtins.__import__
+
+        def _no_heif(name, *args, **kwargs):
+            if name == "pillow_heif":
+                raise ImportError("pillow_heif not installed")
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=_no_heif):
+            path, mime, err = vt._normalize_to_supported_image(avif, "image/avif")
+
+        assert err is None, f"AVIF was rejected without pillow-heif: {err}"
+        assert mime == "image/png"
+        assert path.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+        path.unlink()
+
+    def test_avif_error_names_av1_not_just_pillow_heif(self, tmp_path, monkeypatch):
+        """When an AVIF genuinely cannot be decoded, the guidance must mention
+        the AV1/Pillow path — not blame pillow-heif alone, which frequently
+        ships without any AV1 codec."""
+        from tools import vision_tools as vt
+        _reload(monkeypatch, tmp_path / "hermes")
+        # Valid AVIF brand, but the payload is not decodable by anything.
+        broken = tmp_path / "broken.avif"
+        broken.write_bytes(AVIF_HEADER)
+
+        path, mime, err = vt._normalize_to_supported_image(broken, "image/avif")
+        assert path is None
+        assert "AV1" in err or "Pillow" in err

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -450,6 +450,56 @@ class TestHeicDetection:
         )
         assert _detect_image_mime_type_from_bytes(hdr) == "image/heic"
 
+    @pytest.mark.parametrize("declared_size", [0, 1, 4, 8, 12, 15])
+    def test_malformed_box_size_fails_closed(self, declared_size):
+        """A malformed declared size must NOT widen the brand scan.
+
+        Regression: the bound previously fell back to the whole 64-byte sniff
+        window whenever the declared size was outside ``16 <= size <= len``. That
+        failed OPEN in precisely the attacker-controlled case — a declared size
+        of 0/4/8/12 on a genuine HEIC let the literal bytes ``avif`` in a LATER
+        box upgrade it to AVIF, defeating the box bound this code exists to
+        enforce. Every malformed size must still report HEIC.
+        """
+        import struct
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        hdr = (
+            struct.pack(">I", declared_size)
+            + b"ftyp" + b"mif1" + b"\x00" * 4 + b"heic"
+            + b"\x00\x00\x00\x10" + b"meta" + b"avif" + b"\x00" * 24
+        )
+        assert _detect_image_mime_type_from_bytes(hdr) == "image/heic", (
+            f"declared size {declared_size} widened the scan and leaked an "
+            f"'avif' token from a following box"
+        )
+
+    def test_honest_oversized_box_still_scans_what_arrived(self):
+        """A size >= 16 that overruns the sniff window is a truncated read, not
+        an attack: clamp to the available bytes rather than failing closed, so a
+        genuine AVIF whose ftyp box is larger than 64 bytes is still detected."""
+        import struct
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        hdr = (
+            struct.pack(">I", 9999)
+            + b"ftyp" + b"mif1" + b"\x00" * 4 + b"mif1avif"
+        )
+        assert _detect_image_mime_type_from_bytes(hdr) == "image/avif"
+
+    def test_misaligned_box_size_does_not_crash_or_misdetect(self):
+        """A size that is not a multiple of 4 must not misalign the brand loop
+        into reading a partial brand."""
+        import struct
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        for size in (17, 18, 19, 21, 22, 23):
+            hdr = (
+                struct.pack(">I", size)
+                + b"ftyp" + b"mif1" + b"\x00" * 4 + b"heic"
+                + b"\x00\x00\x00\x10" + b"meta" + b"avif" + b"\x00" * 24
+            )
+            got = _detect_image_mime_type_from_bytes(hdr)
+            assert got == "image/heic", f"size {size} -> {got}"
+
+
     def test_truncated_ftyp_header_does_not_crash(self):
         """A short/garbage read must return a value, not raise."""
         from tools.vision_tools import _detect_image_mime_type_from_bytes

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -270,3 +270,80 @@ class TestSvgNormalization:
             path, mime, err = vt._normalize_to_supported_image(svg, "image/svg+xml")
         assert path is None
         assert "rasterizer" in err
+
+
+# HEIF/HEIC/AVIF ISO-BMFF headers: 'ftyp' box at bytes 4-8, major brand at 8-12.
+# 0x18-byte box length prefix mirrors a real iPhone HEIC (\x00\x00\x00\x18 ftyp...).
+HEIC_HEADER = b"\x00\x00\x00\x18ftypheic\x00\x00\x00\x00mif1heic" + b"\x00" * 32
+AVIF_HEADER = b"\x00\x00\x00\x1cftypavif\x00\x00\x00\x00avifmif1" + b"\x00" * 32
+MIF1_HEADER = b"\x00\x00\x00\x18ftypmif1\x00\x00\x00\x00mif1heic" + b"\x00" * 32
+
+
+class TestHeicDetection:
+    """iPhone HEIC/HEIF (and AVIF) are sniffed from the ISO-BMFF ftyp brand so
+    they reach _normalize_to_supported_image instead of being rejected as
+    'not a recognized image' (the pre-fix behavior for iPhone photos)."""
+
+    def test_heic_brand_detected(self):
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        assert _detect_image_mime_type_from_bytes(HEIC_HEADER) == "image/heic"
+
+    def test_generic_mif1_brand_detected_as_heic(self):
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        assert _detect_image_mime_type_from_bytes(MIF1_HEADER) == "image/heic"
+
+    def test_avif_brand_detected(self):
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        assert _detect_image_mime_type_from_bytes(AVIF_HEADER) == "image/avif"
+
+    def test_ftyp_with_unknown_brand_not_misdetected(self):
+        """An ISO-BMFF ftyp box that isn't an image brand (e.g. mp4) stays
+        unrecognized — we must not claim every ftyp container is an image."""
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        mp4 = b"\x00\x00\x00\x18ftypmp42\x00\x00\x00\x00mp42isom" + b"\x00" * 32
+        assert _detect_image_mime_type_from_bytes(mp4) is None
+
+    @pytest.mark.asyncio
+    async def test_heic_resolves_and_normalizes_to_png(self, tmp_path, monkeypatch):
+        """End-to-end: a real HEIC file resolves (mime image/heic) and
+        _normalize_to_supported_image re-encodes it to PNG via pillow-heif."""
+        pillow_heif = pytest.importorskip("pillow_heif")
+        pillow_heif.register_heif_opener()
+        from PIL import Image
+        from tools import vision_tools as vt
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        heic = tmp_path / "photo.heic"
+        Image.new("RGB", (8, 8), (120, 60, 200)).save(str(heic), format="HEIF")
+
+        res = await isrc.resolve_image_source(str(heic), isrc.ResolveContext())
+        assert res.mime == "image/heic"
+
+        path, mime, err = vt._normalize_to_supported_image(heic, "image/heic")
+        assert err is None
+        assert mime == "image/png"
+        assert path.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+        path.unlink()
+
+    def test_heic_actionable_error_when_decoder_missing(self, tmp_path, monkeypatch):
+        """With pillow-heif unavailable, a HEIC image gets an actionable error
+        (install pillow-heif) rather than a generic conversion failure — the
+        same soft-dependency posture as SVG-without-rasterizer."""
+        from tools import vision_tools as vt
+        _reload(monkeypatch, tmp_path / "hermes")
+        heic = tmp_path / "photo.heic"
+        heic.write_bytes(HEIC_HEADER)
+
+        import builtins
+        real_import = builtins.__import__
+
+        def _no_heif(name, *args, **kwargs):
+            if name == "pillow_heif":
+                raise ImportError("pillow_heif not installed")
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=_no_heif):
+            path, mime, err = vt._normalize_to_supported_image(heic, "image/heic")
+        assert path is None
+        assert "pillow-heif" in err

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -272,11 +272,21 @@ class TestSvgNormalization:
         assert "rasterizer" in err
 
 
-# HEIF/HEIC/AVIF ISO-BMFF headers: 'ftyp' box at bytes 4-8, major brand at 8-12.
+# HEIF/HEIC/AVIF ISO-BMFF headers: 'ftyp' box at bytes 4-8, major brand at 8-12,
+# minor version at 12-16, then a list of 4-byte compatible brands.
 # 0x18-byte box length prefix mirrors a real iPhone HEIC (\x00\x00\x00\x18 ftyp...).
 HEIC_HEADER = b"\x00\x00\x00\x18ftypheic\x00\x00\x00\x00mif1heic" + b"\x00" * 32
 AVIF_HEADER = b"\x00\x00\x00\x1cftypavif\x00\x00\x00\x00avifmif1" + b"\x00" * 32
 MIF1_HEADER = b"\x00\x00\x00\x18ftypmif1\x00\x00\x00\x00mif1heic" + b"\x00" * 32
+# AVIF encoders routinely stamp the generic still-image brand 'mif1' as the
+# MAJOR brand and declare the AV1 codec only in the compatible-brand list, so a
+# major-brand-only sniff mislabels these as HEVC-coded HEIC.
+MIF1_MAJOR_AVIF_COMPATIBLE = (
+    b"\x00\x00\x00\x1cftypmif1\x00\x00\x00\x00mif1avif" + b"\x00" * 32
+)
+MIF1_MAJOR_AV01_COMPATIBLE = (
+    b"\x00\x00\x00 ftypmif1\x00\x00\x00\x00mif1av01avif" + b"\x00" * 32
+)
 
 
 class TestHeicDetection:
@@ -295,6 +305,47 @@ class TestHeicDetection:
     def test_avif_brand_detected(self):
         from tools.vision_tools import _detect_image_mime_type_from_bytes
         assert _detect_image_mime_type_from_bytes(AVIF_HEADER) == "image/avif"
+
+    def test_mif1_major_with_avif_compatible_brand_is_avif(self):
+        """Regression: a 'mif1'-major file that lists 'avif' among its
+        compatible brands is AV1-coded and must be reported as AVIF. Sniffing
+        only the major brand labeled every mif1 file HEIC, which routes an AVIF
+        to the HEVC error text and mis-reports the format to the caller."""
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        assert _detect_image_mime_type_from_bytes(
+            MIF1_MAJOR_AVIF_COMPATIBLE) == "image/avif"
+
+    def test_mif1_major_with_av01_compatible_brand_is_avif(self):
+        """Same as above for the 'av01' codec brand, deeper in the list."""
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        assert _detect_image_mime_type_from_bytes(
+            MIF1_MAJOR_AV01_COMPATIBLE) == "image/avif"
+
+    def test_mif1_major_with_heic_compatible_stays_heic(self):
+        """The compatible-brand scan must not over-trigger: a genuine HEVC-coded
+        HEIF (mif1 major, heic compatible, no AV1 brand) is still HEIC."""
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        assert _detect_image_mime_type_from_bytes(MIF1_HEADER) == "image/heic"
+
+    def test_brand_scan_does_not_read_past_the_ftyp_box(self):
+        """The scan is bounded by the declared ftyp box size, so an 'avif' token
+        sitting in a FOLLOWING box must not upgrade a HEIC to AVIF."""
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        # ftyp box is exactly 0x18 bytes (major mif1 + one compatible 'heic');
+        # the next box then contains the literal bytes 'avif'.
+        hdr = (
+            b"\x00\x00\x00\x18ftypmif1\x00\x00\x00\x00heic"
+            b"\x00\x00\x00\x10metaavif" + b"\x00" * 32
+        )
+        assert _detect_image_mime_type_from_bytes(hdr) == "image/heic"
+
+    def test_truncated_ftyp_header_does_not_crash(self):
+        """A short/garbage read must return a value, not raise."""
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        assert _detect_image_mime_type_from_bytes(b"\x00\x00\x00\x18ftyp") is None
+        # Bogus (huge) declared box size must fall back to the sniffed window.
+        assert _detect_image_mime_type_from_bytes(
+            b"\xff\xff\xff\xffftypmif1\x00\x00\x00\x00mif1avif") == "image/avif"
 
     def test_ftyp_with_unknown_brand_not_misdetected(self):
         """An ISO-BMFF ftyp box that isn't an image brand (e.g. mp4) stays
@@ -347,3 +398,53 @@ class TestHeicDetection:
             path, mime, err = vt._normalize_to_supported_image(heic, "image/heic")
         assert path is None
         assert "pillow-heif" in err
+
+    def test_avif_converts_without_pillow_heif(self, tmp_path, monkeypatch):
+        """Regression: AVIF must NOT be gated on pillow-heif.
+
+        Pillow >= 11.3 bundles a native AvifImagePlugin, while pillow-heif
+        wheels are commonly built with no AV1 codec at all (libheif_info()
+        reports ``AVIF: ''``). Gating AVIF on a pillow-heif import therefore
+        rejected files Pillow could already decode and told the user to install
+        a library that cannot decode them. With pillow-heif absent, a real AVIF
+        must still normalize to PNG.
+        """
+        pytest.importorskip("PIL")
+        from PIL import Image, features
+        if not features.check("avif"):
+            pytest.skip("this Pillow build has no native AVIF codec")
+        from tools import vision_tools as vt
+        _reload(monkeypatch, tmp_path / "hermes")
+
+        avif = tmp_path / "photo.avif"
+        Image.new("RGB", (8, 8), (10, 180, 90)).save(str(avif), format="AVIF")
+
+        import builtins
+        real_import = builtins.__import__
+
+        def _no_heif(name, *args, **kwargs):
+            if name == "pillow_heif":
+                raise ImportError("pillow_heif not installed")
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=_no_heif):
+            path, mime, err = vt._normalize_to_supported_image(avif, "image/avif")
+
+        assert err is None, f"AVIF was rejected without pillow-heif: {err}"
+        assert mime == "image/png"
+        assert path.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+        path.unlink()
+
+    def test_avif_error_names_av1_not_just_pillow_heif(self, tmp_path, monkeypatch):
+        """When an AVIF genuinely cannot be decoded, the guidance must mention
+        the AV1/Pillow path — not blame pillow-heif alone, which frequently
+        ships without any AV1 codec."""
+        from tools import vision_tools as vt
+        _reload(monkeypatch, tmp_path / "hermes")
+        # Valid AVIF brand, but the payload is not decodable by anything.
+        broken = tmp_path / "broken.avif"
+        broken.write_bytes(AVIF_HEADER)
+
+        path, mime, err = vt._normalize_to_supported_image(broken, "image/avif")
+        assert path is None
+        assert "AV1" in err or "Pillow" in err

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -339,6 +339,56 @@ class TestHeicDetection:
         )
         assert _detect_image_mime_type_from_bytes(hdr) == "image/heic"
 
+    @pytest.mark.parametrize("declared_size", [0, 1, 4, 8, 12, 15])
+    def test_malformed_box_size_fails_closed(self, declared_size):
+        """A malformed declared size must NOT widen the brand scan.
+
+        Regression: the bound previously fell back to the whole 64-byte sniff
+        window whenever the declared size was outside ``16 <= size <= len``. That
+        failed OPEN in precisely the attacker-controlled case — a declared size
+        of 0/4/8/12 on a genuine HEIC let the literal bytes ``avif`` in a LATER
+        box upgrade it to AVIF, defeating the box bound this code exists to
+        enforce. Every malformed size must still report HEIC.
+        """
+        import struct
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        hdr = (
+            struct.pack(">I", declared_size)
+            + b"ftyp" + b"mif1" + b"\x00" * 4 + b"heic"
+            + b"\x00\x00\x00\x10" + b"meta" + b"avif" + b"\x00" * 24
+        )
+        assert _detect_image_mime_type_from_bytes(hdr) == "image/heic", (
+            f"declared size {declared_size} widened the scan and leaked an "
+            f"'avif' token from a following box"
+        )
+
+    def test_honest_oversized_box_still_scans_what_arrived(self):
+        """A size >= 16 that overruns the sniff window is a truncated read, not
+        an attack: clamp to the available bytes rather than failing closed, so a
+        genuine AVIF whose ftyp box is larger than 64 bytes is still detected."""
+        import struct
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        hdr = (
+            struct.pack(">I", 9999)
+            + b"ftyp" + b"mif1" + b"\x00" * 4 + b"mif1avif"
+        )
+        assert _detect_image_mime_type_from_bytes(hdr) == "image/avif"
+
+    def test_misaligned_box_size_does_not_crash_or_misdetect(self):
+        """A size that is not a multiple of 4 must not misalign the brand loop
+        into reading a partial brand."""
+        import struct
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+        for size in (17, 18, 19, 21, 22, 23):
+            hdr = (
+                struct.pack(">I", size)
+                + b"ftyp" + b"mif1" + b"\x00" * 4 + b"heic"
+                + b"\x00\x00\x00\x10" + b"meta" + b"avif" + b"\x00" * 24
+            )
+            got = _detect_image_mime_type_from_bytes(hdr)
+            assert got == "image/heic", f"size {size} -> {got}"
+
+
     def test_truncated_ftyp_header_does_not_crash(self):
         """A short/garbage read must return a value, not raise."""
         from tools.vision_tools import _detect_image_mime_type_from_bytes

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -260,6 +260,21 @@ def _detect_image_mime_type_from_bytes(data: bytes) -> Optional[str]:
         return "image/bmp"
     if len(header) >= 12 and header[:4] == b"RIFF" and header[8:12] == b"WEBP":
         return "image/webp"
+    # HEIF/HEIC/AVIF — ISO-BMFF container: bytes 4-8 are the box type 'ftyp',
+    # bytes 8-12 the major brand. iPhone photos/screenshots are HEIC (often
+    # mislabeled .jpg by upload pipelines). None of the vision providers ingest
+    # HEIF, but _normalize_to_supported_image re-encodes it to PNG via
+    # pillow-heif (same soft-dependency pattern as SVG). Sniffed here so it
+    # reaches that step instead of being rejected as "not a recognized image".
+    if len(header) >= 12 and header[4:8] == b"ftyp":
+        brand = header[8:12]
+        if brand in (
+            b"heic", b"heix", b"heim", b"heis",  # HEVC-coded HEIF still/sequence
+            b"hevc", b"hevx",
+            b"mif1", b"msf1",                     # generic HEIF image / sequence
+            b"avif", b"avis",                     # AV1-coded (AVIF)
+        ):
+            return "image/avif" if brand.startswith(b"avi") else "image/heic"
     return None
 
 
@@ -358,7 +373,25 @@ def _normalize_to_supported_image(
             "(`pip install cairosvg`) — then re-run vision_analyze on the PNG.",
         )
 
-    # Other non-supported raster formats (BMP, TIFF, ...): re-encode via Pillow.
+    # Other non-supported raster formats (BMP, TIFF, HEIF/HEIC/AVIF, ...):
+    # re-encode via Pillow. HEIF/AVIF need the pillow-heif plugin registered
+    # first (Pillow has no built-in HEIF codec); it's a soft dependency, so a
+    # HEIF image with the plugin missing gets an actionable error rather than a
+    # generic failure — same posture as the SVG-without-rasterizer branch.
+    if detected_mime in ("image/heic", "image/avif"):
+        try:
+            import pillow_heif  # type: ignore
+            pillow_heif.register_heif_opener()
+        except Exception:
+            return (
+                None,
+                None,
+                f"This is a {'HEIC/HEIF' if detected_mime == 'image/heic' else 'AVIF'} "
+                "image (common for iPhone photos), which vision models cannot read "
+                "directly, and the pillow-heif decoder is not installed. Install it "
+                "(`pip install pillow-heif`) and re-run vision_analyze, or convert the "
+                "image to PNG/JPEG first.",
+            )
     try:
         from PIL import Image as _PILImage
         with _PILImage.open(image_path) as _img:

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -260,21 +260,38 @@ def _detect_image_mime_type_from_bytes(data: bytes) -> Optional[str]:
         return "image/bmp"
     if len(header) >= 12 and header[:4] == b"RIFF" and header[8:12] == b"WEBP":
         return "image/webp"
-    # HEIF/HEIC/AVIF — ISO-BMFF container: bytes 4-8 are the box type 'ftyp',
-    # bytes 8-12 the major brand. iPhone photos/screenshots are HEIC (often
-    # mislabeled .jpg by upload pipelines). None of the vision providers ingest
-    # HEIF, but _normalize_to_supported_image re-encodes it to PNG via
+    # HEIF/HEIC/AVIF — ISO-BMFF container: bytes 0-4 are the box size, 4-8 the
+    # box type 'ftyp', 8-12 the major brand, 12-16 the minor version, and every
+    # 4 bytes after that a compatible brand. iPhone photos/screenshots are HEIC
+    # (often mislabeled .jpg by upload pipelines). None of the vision providers
+    # ingest HEIF, but _normalize_to_supported_image re-encodes it to PNG via
     # pillow-heif (same soft-dependency pattern as SVG). Sniffed here so it
     # reaches that step instead of being rejected as "not a recognized image".
+    #
+    # The major brand alone is not sufficient to tell AVIF from HEIC: AVIF files
+    # are routinely stamped with the generic still-image brand 'mif1' as major
+    # and identify their codec only in the compatible-brand list. Scanning that
+    # list keeps us from handing an AV1-coded file to the HEVC branch.
     if len(header) >= 12 and header[4:8] == b"ftyp":
-        brand = header[8:12]
-        if brand in (
+        major = header[8:12]
+        # Bound the brand scan by the declared box size when it's sane, so we
+        # never read brands out of a following box; fall back to the sniffed
+        # header window otherwise (truncated reads, bogus size fields).
+        box_size = int.from_bytes(header[:4], "big")
+        limit = box_size if 16 <= box_size <= len(header) else len(header)
+        compatibles = {
+            header[i:i + 4] for i in range(16, limit - 3, 4)
+        }
+        brands = {major} | compatibles
+        # AV1-coded brands win over the generic HEIF ones when both appear.
+        if brands & {b"avif", b"avis", b"av01"}:
+            return "image/avif"
+        if brands & {
             b"heic", b"heix", b"heim", b"heis",  # HEVC-coded HEIF still/sequence
             b"hevc", b"hevx",
-            b"mif1", b"msf1",                     # generic HEIF image / sequence
-            b"avif", b"avis",                     # AV1-coded (AVIF)
-        ):
-            return "image/avif" if brand.startswith(b"avi") else "image/heic"
+            b"mif1", b"msf1",                    # generic HEIF image / sequence
+        }:
+            return "image/heic"
     return None
 
 
@@ -374,24 +391,29 @@ def _normalize_to_supported_image(
         )
 
     # Other non-supported raster formats (BMP, TIFF, HEIF/HEIC/AVIF, ...):
-    # re-encode via Pillow. HEIF/AVIF need the pillow-heif plugin registered
-    # first (Pillow has no built-in HEIF codec); it's a soft dependency, so a
-    # HEIF image with the plugin missing gets an actionable error rather than a
-    # generic failure — same posture as the SVG-without-rasterizer branch.
+    # re-encode via Pillow.
+    #
+    # HEIF/AVIF need a codec Pillow's core doesn't always carry, but the two
+    # formats are served by DIFFERENT optional backends and must not be gated on
+    # one another:
+    #   * HEIC/HEIF (HEVC-coded) — needs the pillow-heif plugin registered.
+    #   * AVIF (AV1-coded) — Pillow >= 11.3 ships a native AvifImagePlugin, and
+    #     pillow-heif wheels are frequently built with NO AV1 codec at all
+    #     (``libheif_info()['AVIF'] == ''``). Demanding pillow-heif for AVIF
+    #     would reject files Pillow can already decode and point the user at a
+    #     library that cannot help.
+    # So: register whatever backend is available, then let the decode attempt
+    # below be the actual arbiter, and only emit a codec-specific error if the
+    # decode really fails. Same soft-dependency posture as the SVG branch.
     if detected_mime in ("image/heic", "image/avif"):
         try:
             import pillow_heif  # type: ignore
             pillow_heif.register_heif_opener()
         except Exception:
-            return (
-                None,
-                None,
-                f"This is a {'HEIC/HEIF' if detected_mime == 'image/heic' else 'AVIF'} "
-                "image (common for iPhone photos), which vision models cannot read "
-                "directly, and the pillow-heif decoder is not installed. Install it "
-                "(`pip install pillow-heif`) and re-run vision_analyze, or convert the "
-                "image to PNG/JPEG first.",
-            )
+            # Not fatal on its own — Pillow may still decode this file (always
+            # true for AVIF on Pillow >= 11.3). Fall through to the decode.
+            logger.debug("pillow-heif unavailable; relying on Pillow for %s",
+                         detected_mime)
     try:
         from PIL import Image as _PILImage
         with _PILImage.open(image_path) as _img:
@@ -403,6 +425,27 @@ def _normalize_to_supported_image(
     except Exception as _exc:
         logger.warning("Failed to normalize %s image to PNG: %s",
                        detected_mime, _exc)
+        # Codec-specific guidance: name the backend that actually serves this
+        # format, rather than blaming a single library for both.
+        if detected_mime == "image/heic":
+            return (
+                None,
+                None,
+                "This is a HEIC/HEIF image (common for iPhone photos), which "
+                "vision models cannot read directly, and no HEIF decoder is "
+                "available. Install one (`pip install pillow-heif`) and re-run "
+                "vision_analyze, or convert the image to PNG/JPEG first.",
+            )
+        if detected_mime == "image/avif":
+            return (
+                None,
+                None,
+                "This is an AVIF image, which vision models cannot read "
+                "directly, and no AV1 decoder is available. Upgrade Pillow "
+                "(>= 11.3 bundles AVIF support) or install a pillow-heif build "
+                "with an AV1 codec, then re-run vision_analyze — or convert the "
+                "image to PNG/JPEG first.",
+            )
     return (
         None,
         None,

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -274,11 +274,21 @@ def _detect_image_mime_type_from_bytes(data: bytes) -> Optional[str]:
     # list keeps us from handing an AV1-coded file to the HEVC branch.
     if len(header) >= 12 and header[4:8] == b"ftyp":
         major = header[8:12]
-        # Bound the brand scan by the declared box size when it's sane, so we
-        # never read brands out of a following box; fall back to the sniffed
-        # header window otherwise (truncated reads, bogus size fields).
+        # Bound the brand scan by the declared box size so we never read brands
+        # out of a FOLLOWING box.
+        #
+        # A malformed size must fail CLOSED (scan no compatible brands) rather
+        # than fall back to the whole sniff window. Falling back widened the scan
+        # in exactly the case an attacker controls: a declared size of 0/4/8/12
+        # on a genuine HEIC let the literal bytes "avif" in a later box upgrade it
+        # to AVIF, defeating the bound this code exists to enforce. A size >= 16
+        # that overruns the sniffed window is merely a truncated read, so clamp
+        # that one to what we actually have.
         box_size = int.from_bytes(header[:4], "big")
-        limit = box_size if 16 <= box_size <= len(header) else len(header)
+        if box_size < 16:
+            limit = 16          # header too small to hold any compatible brand
+        else:
+            limit = min(box_size, len(header))
         compatibles = {
             header[i:i + 4] for i in range(16, limit - 3, 4)
         }

--- a/uv.lock
+++ b/uv.lock
@@ -1586,6 +1586,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pathspec" },
     { name = "pillow" },
+    { name = "pillow-heif" },
     { name = "prompt-toolkit" },
     { name = "psutil" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'" },
@@ -1899,6 +1900,7 @@ requires-dist = [
     { name = "parallel-web", marker = "extra == 'parallel-web'", specifier = "==0.4.2" },
     { name = "pathspec", specifier = "==1.1.1" },
     { name = "pillow", specifier = "==12.3.0" },
+    { name = "pillow-heif", specifier = ">=1.4.0,<2" },
     { name = "prompt-toolkit", specifier = "==3.0.52" },
     { name = "psutil", specifier = "==7.2.2" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'", specifier = ">=0.7.0,<1" },
@@ -3158,6 +3160,43 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow-heif"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/5f/4753689400e657ca5d984f5e897657dab12d91b62f1bb6a1e73487b59a97/pillow_heif-1.4.0.tar.gz", hash = "sha256:55a7c0cb5321538d1ca74037be54b48d147017735a766eb29bcca4761253a1f1", size = 17127538, upload-time = "2026-06-10T16:02:40.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/f3/9fdc040e4b6ae7706ceae366e2791842e0dbde9edb260a41548a2e4e5139/pillow_heif-1.4.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:e93b6f06b521f17c09a42b7ad21949e1e6af5382a5ac886f633a1dcea6646f6a", size = 4729933, upload-time = "2026-06-10T16:01:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/98/73/f928bd4e2ff637d8cd3a7505effbbcef6e23ece336858d00fe274cfcd0be/pillow_heif-1.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c3bba281b64861e15bc43eac384841e0ed4f33347eecfd2e80cd9b7ae1afc72f", size = 3955590, upload-time = "2026-06-10T16:01:09.814Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/00/539f145c3a413f539f72e84160e477140ea96e42887377e2eb225677c129/pillow_heif-1.4.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54faae0df573f5e4a81d6fc07a68025547246d499ac27b2cdf90a21e92d2d0d5", size = 6250797, upload-time = "2026-06-10T16:01:11.709Z" },
+    { url = "https://files.pythonhosted.org/packages/60/b6/12bc3818fb2ef27f1a7821bcc2869c3a91ee9229aa542ce9ab3bf892fef0/pillow_heif-1.4.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27f030e442de916cf44bdca740a3ffe61a5156cb92aaf9aba4b584992e2c33b8", size = 5664872, upload-time = "2026-06-10T16:01:13.645Z" },
+    { url = "https://files.pythonhosted.org/packages/76/6c/14a319ea60291c5fe8d6c6d0d9ef3a3d2a4bed4b91ed855abc8b2a8fea5f/pillow_heif-1.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:45bfbf0124ef0be4349ba64922538292f038772cbbfd153ebf2a00683705ca82", size = 7337402, upload-time = "2026-06-10T16:01:15.598Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/bc/8f67f1bfb4ff8e3736a35775174ea288124d272cfc90bfbabd00f2547942/pillow_heif-1.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:25ae941e34456173c66a6b279ae38c1306e789c9342ae500ecbca864aeaa912e", size = 6598592, upload-time = "2026-06-10T16:01:17.629Z" },
+    { url = "https://files.pythonhosted.org/packages/25/bb/25045177835f21f145835d54148718e8346f430738ab7166708ea359a669/pillow_heif-1.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:786ca8345fa1669c35984d03370aa3bab83d5fae12fe9e725a3857d4566251a0", size = 6514437, upload-time = "2026-06-10T16:01:19.574Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ba/1a8f5a42c14cf8ad7c7a6b459de33e2bbd693a15690802463b370ee578cd/pillow_heif-1.4.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:5c6181fb25c7d28f98702160b98967d1d7d432d71decac9351f5a47ee33554e0", size = 4730173, upload-time = "2026-06-10T16:01:23.282Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/64/e659dd4a9b54ad148b8e753df6c9b84e0140065bebb69665b583b53804a8/pillow_heif-1.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ade286eeadb361773604e294f98c4a1b64b577aca271faa6971e2fbd018918c7", size = 3955563, upload-time = "2026-06-10T16:01:24.75Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/48/73336f6b4c6532ca98025a8c1a0254882d52c93ce7cc377440234fa20317/pillow_heif-1.4.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:972c68fae8379c158aad222defa8b8f10c858a5f7f9cc99942f34b9667a516cd", size = 6249338, upload-time = "2026-06-10T16:01:27.247Z" },
+    { url = "https://files.pythonhosted.org/packages/06/7a/e8053fa5e31f5f330ad1e9eec77625ba7ce97a1e765e5e05c85bf65d574a/pillow_heif-1.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cfcd611a09dbb949715d5f25063bd3668e0daa06b53a3ed5bbd92d36b4f6b2a9", size = 5664216, upload-time = "2026-06-10T16:01:29.074Z" },
+    { url = "https://files.pythonhosted.org/packages/23/e8/76f6ab993238c9d7da53fb64e588fd37ef7b603895b2383f1cbccc209233/pillow_heif-1.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:08026afd5f90628e029fe88aaa222280428ba7cc485a7cae553e78f7bb289b74", size = 7336120, upload-time = "2026-06-10T16:01:30.796Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/45/d77ad6de495dfcc55be00a48434183abd7cf8e3416916236e29d0ecd95b6/pillow_heif-1.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c8d001996e3a4687551385c2fe4d3fb84293727052fca1c0f50528c78b8327c7", size = 6597816, upload-time = "2026-06-10T16:01:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ef/f240ce0e84a6d0cf8dfee1834b4aec29f209c08e3d2047196cee65527fb7/pillow_heif-1.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:107d598a1b1694ba6f371927ffd6d72d6f9af2ca4082577d9edbfdeed465f940", size = 6514536, upload-time = "2026-06-10T16:01:34.571Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d4/d15e568b61f6020b1a772174b5c9c60341a1f0130951c518d33461b36bf8/pillow_heif-1.4.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:c699f8a3e845839bba590d3459ce59dba16c82c38e799955bef7042c54443eba", size = 4730166, upload-time = "2026-06-10T16:01:36.594Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c0/e4d9b5570ee70f12c817722df398cdcba7fb25f4ddc691a79008a31c653d/pillow_heif-1.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8f90b500ec1ae3a59d6613fd96123de35457f69fb9b3cd314d4b5a6799ba9843", size = 3955577, upload-time = "2026-06-10T16:01:38.13Z" },
+    { url = "https://files.pythonhosted.org/packages/17/75/717a3ac5edf3b5c027659c59bbd09f731708e76eab03a7bcd89d68edefd7/pillow_heif-1.4.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d6d907f454afa1958a688902e53f50ed7a98c8cbd6261d20f84b15e25f068020", size = 6249393, upload-time = "2026-06-10T16:01:40.398Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ba/9d1336b1c5a6d2b7098cc851fcd3dbb5f25e37f942f327a404b2c8e0205d/pillow_heif-1.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be955358e501ab03cd83331a49d331c16b8ea1a4f5751d46c24e6b28d8aa6a56", size = 5664268, upload-time = "2026-06-10T16:01:42.018Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/8382df95a9b20d295742f19a54fc8f66c438362b841c416786b4f9a5c3e1/pillow_heif-1.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1207b6b0819654262811a0cb74730cca1ced1ab7786a0fcd92f55b84ca07a05c", size = 7336108, upload-time = "2026-06-10T16:01:44.682Z" },
+    { url = "https://files.pythonhosted.org/packages/da/72/fbcbfac3ee43f8da79b1c6a8cbd62c2b9ee49ae069548029715c5a3fdc55/pillow_heif-1.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cdd3ebd552b50d0221bf525e033fbe3e83130b05c81bfd53d50ed4eafbb77a7c", size = 6597858, upload-time = "2026-06-10T16:01:46.501Z" },
+    { url = "https://files.pythonhosted.org/packages/df/4b/3250c23b53f3ae0b39000da6bc517f2762600516f1d44549c9eb65657587/pillow_heif-1.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:19a2d9bd52b1f6dabed5305b8b5c4962b2bf7c21e8195c909e9425e4ca8ebf72", size = 6514532, upload-time = "2026-06-10T16:01:48.646Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ee/9799038c9e8790ff51976910b41cbf5359ad714d2c4ead688d419e86a65a/pillow_heif-1.4.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7be55e50250a79c2723e2a75aa6da90774fb42cce45d93062f91896c8b569ab3", size = 4718296, upload-time = "2026-06-10T16:02:29.945Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/98/b5e5aa1e2324b4d441d140b802183c33c8f6744d0f01a728be4bcc9d5bda/pillow_heif-1.4.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:6eef7ac1594dafa592435336e7e6954ccfc549e767bff9ed814cdfa92e1278f7", size = 3952059, upload-time = "2026-06-10T16:02:31.465Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d9/79a82fd1802c529777977ac4cbe1210e470ed4ae29f3dbb6d2a0bf08757f/pillow_heif-1.4.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf6b287205bf47aa7423ca3caa795fd381e1e74422d10ba65c3f78e3a4a3c974", size = 6208633, upload-time = "2026-06-10T16:02:33.154Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/35/19d7bbe415657d74fd06e2aa661e5e379f8c6b5f8df0727cf5b0accf6e37/pillow_heif-1.4.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8d6ce8db65311a7f56029bedc46034adb59f51a8f7ad6503edac1b26f50d49e4", size = 5619701, upload-time = "2026-06-10T16:02:34.987Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e9/6a23b01ad080175fb495e37f32c124602ec750e79518dff09e1e51febcc8/pillow_heif-1.4.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:4e34c549dce5f6808b6cee2ebfe81d6a80ef8ba3827007d57ca43c58540107f9", size = 6514779, upload-time = "2026-06-10T16:02:36.65Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4052,7 +4091,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4107,7 +4146,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -4755,11 +4794,11 @@ name = "vercel-workers"
 version = "0.0.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.12'" },
-    { name = "httpx", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
-    { name = "vercel", marker = "python_full_version >= '3.12'" },
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "vercel" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/df/04d37021ad7ca53b7599c313e411d91623c7a005c741f491d1eefb7a9f0c/vercel_workers-0.0.25.tar.gz", hash = "sha256:212ded01400b524be51d251df49f801caf115ad7d48cca7eb168cbeceda3def3", size = 64149, upload-time = "2026-06-20T19:26:27.177Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-20T16:38:42.729819205Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -1576,6 +1576,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pathspec" },
     { name = "pillow" },
+    { name = "pillow-heif" },
     { name = "prompt-toolkit" },
     { name = "psutil" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'" },
@@ -1887,6 +1888,7 @@ requires-dist = [
     { name = "parallel-web", marker = "extra == 'parallel-web'", specifier = "==0.4.2" },
     { name = "pathspec", specifier = "==1.1.1" },
     { name = "pillow", specifier = "==12.3.0" },
+    { name = "pillow-heif", specifier = ">=1.4.0,<2" },
     { name = "prompt-toolkit", specifier = "==3.0.52" },
     { name = "psutil", specifier = "==7.2.2" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'", specifier = ">=0.7.0,<1" },
@@ -3104,6 +3106,43 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow-heif"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/5f/4753689400e657ca5d984f5e897657dab12d91b62f1bb6a1e73487b59a97/pillow_heif-1.4.0.tar.gz", hash = "sha256:55a7c0cb5321538d1ca74037be54b48d147017735a766eb29bcca4761253a1f1", size = 17127538, upload-time = "2026-06-10T16:02:40.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/f3/9fdc040e4b6ae7706ceae366e2791842e0dbde9edb260a41548a2e4e5139/pillow_heif-1.4.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:e93b6f06b521f17c09a42b7ad21949e1e6af5382a5ac886f633a1dcea6646f6a", size = 4729933, upload-time = "2026-06-10T16:01:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/98/73/f928bd4e2ff637d8cd3a7505effbbcef6e23ece336858d00fe274cfcd0be/pillow_heif-1.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c3bba281b64861e15bc43eac384841e0ed4f33347eecfd2e80cd9b7ae1afc72f", size = 3955590, upload-time = "2026-06-10T16:01:09.814Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/00/539f145c3a413f539f72e84160e477140ea96e42887377e2eb225677c129/pillow_heif-1.4.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54faae0df573f5e4a81d6fc07a68025547246d499ac27b2cdf90a21e92d2d0d5", size = 6250797, upload-time = "2026-06-10T16:01:11.709Z" },
+    { url = "https://files.pythonhosted.org/packages/60/b6/12bc3818fb2ef27f1a7821bcc2869c3a91ee9229aa542ce9ab3bf892fef0/pillow_heif-1.4.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27f030e442de916cf44bdca740a3ffe61a5156cb92aaf9aba4b584992e2c33b8", size = 5664872, upload-time = "2026-06-10T16:01:13.645Z" },
+    { url = "https://files.pythonhosted.org/packages/76/6c/14a319ea60291c5fe8d6c6d0d9ef3a3d2a4bed4b91ed855abc8b2a8fea5f/pillow_heif-1.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:45bfbf0124ef0be4349ba64922538292f038772cbbfd153ebf2a00683705ca82", size = 7337402, upload-time = "2026-06-10T16:01:15.598Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/bc/8f67f1bfb4ff8e3736a35775174ea288124d272cfc90bfbabd00f2547942/pillow_heif-1.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:25ae941e34456173c66a6b279ae38c1306e789c9342ae500ecbca864aeaa912e", size = 6598592, upload-time = "2026-06-10T16:01:17.629Z" },
+    { url = "https://files.pythonhosted.org/packages/25/bb/25045177835f21f145835d54148718e8346f430738ab7166708ea359a669/pillow_heif-1.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:786ca8345fa1669c35984d03370aa3bab83d5fae12fe9e725a3857d4566251a0", size = 6514437, upload-time = "2026-06-10T16:01:19.574Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ba/1a8f5a42c14cf8ad7c7a6b459de33e2bbd693a15690802463b370ee578cd/pillow_heif-1.4.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:5c6181fb25c7d28f98702160b98967d1d7d432d71decac9351f5a47ee33554e0", size = 4730173, upload-time = "2026-06-10T16:01:23.282Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/64/e659dd4a9b54ad148b8e753df6c9b84e0140065bebb69665b583b53804a8/pillow_heif-1.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ade286eeadb361773604e294f98c4a1b64b577aca271faa6971e2fbd018918c7", size = 3955563, upload-time = "2026-06-10T16:01:24.75Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/48/73336f6b4c6532ca98025a8c1a0254882d52c93ce7cc377440234fa20317/pillow_heif-1.4.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:972c68fae8379c158aad222defa8b8f10c858a5f7f9cc99942f34b9667a516cd", size = 6249338, upload-time = "2026-06-10T16:01:27.247Z" },
+    { url = "https://files.pythonhosted.org/packages/06/7a/e8053fa5e31f5f330ad1e9eec77625ba7ce97a1e765e5e05c85bf65d574a/pillow_heif-1.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cfcd611a09dbb949715d5f25063bd3668e0daa06b53a3ed5bbd92d36b4f6b2a9", size = 5664216, upload-time = "2026-06-10T16:01:29.074Z" },
+    { url = "https://files.pythonhosted.org/packages/23/e8/76f6ab993238c9d7da53fb64e588fd37ef7b603895b2383f1cbccc209233/pillow_heif-1.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:08026afd5f90628e029fe88aaa222280428ba7cc485a7cae553e78f7bb289b74", size = 7336120, upload-time = "2026-06-10T16:01:30.796Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/45/d77ad6de495dfcc55be00a48434183abd7cf8e3416916236e29d0ecd95b6/pillow_heif-1.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c8d001996e3a4687551385c2fe4d3fb84293727052fca1c0f50528c78b8327c7", size = 6597816, upload-time = "2026-06-10T16:01:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ef/f240ce0e84a6d0cf8dfee1834b4aec29f209c08e3d2047196cee65527fb7/pillow_heif-1.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:107d598a1b1694ba6f371927ffd6d72d6f9af2ca4082577d9edbfdeed465f940", size = 6514536, upload-time = "2026-06-10T16:01:34.571Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d4/d15e568b61f6020b1a772174b5c9c60341a1f0130951c518d33461b36bf8/pillow_heif-1.4.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:c699f8a3e845839bba590d3459ce59dba16c82c38e799955bef7042c54443eba", size = 4730166, upload-time = "2026-06-10T16:01:36.594Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c0/e4d9b5570ee70f12c817722df398cdcba7fb25f4ddc691a79008a31c653d/pillow_heif-1.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8f90b500ec1ae3a59d6613fd96123de35457f69fb9b3cd314d4b5a6799ba9843", size = 3955577, upload-time = "2026-06-10T16:01:38.13Z" },
+    { url = "https://files.pythonhosted.org/packages/17/75/717a3ac5edf3b5c027659c59bbd09f731708e76eab03a7bcd89d68edefd7/pillow_heif-1.4.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d6d907f454afa1958a688902e53f50ed7a98c8cbd6261d20f84b15e25f068020", size = 6249393, upload-time = "2026-06-10T16:01:40.398Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ba/9d1336b1c5a6d2b7098cc851fcd3dbb5f25e37f942f327a404b2c8e0205d/pillow_heif-1.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be955358e501ab03cd83331a49d331c16b8ea1a4f5751d46c24e6b28d8aa6a56", size = 5664268, upload-time = "2026-06-10T16:01:42.018Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/8382df95a9b20d295742f19a54fc8f66c438362b841c416786b4f9a5c3e1/pillow_heif-1.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1207b6b0819654262811a0cb74730cca1ced1ab7786a0fcd92f55b84ca07a05c", size = 7336108, upload-time = "2026-06-10T16:01:44.682Z" },
+    { url = "https://files.pythonhosted.org/packages/da/72/fbcbfac3ee43f8da79b1c6a8cbd62c2b9ee49ae069548029715c5a3fdc55/pillow_heif-1.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cdd3ebd552b50d0221bf525e033fbe3e83130b05c81bfd53d50ed4eafbb77a7c", size = 6597858, upload-time = "2026-06-10T16:01:46.501Z" },
+    { url = "https://files.pythonhosted.org/packages/df/4b/3250c23b53f3ae0b39000da6bc517f2762600516f1d44549c9eb65657587/pillow_heif-1.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:19a2d9bd52b1f6dabed5305b8b5c4962b2bf7c21e8195c909e9425e4ca8ebf72", size = 6514532, upload-time = "2026-06-10T16:01:48.646Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ee/9799038c9e8790ff51976910b41cbf5359ad714d2c4ead688d419e86a65a/pillow_heif-1.4.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7be55e50250a79c2723e2a75aa6da90774fb42cce45d93062f91896c8b569ab3", size = 4718296, upload-time = "2026-06-10T16:02:29.945Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/98/b5e5aa1e2324b4d441d140b802183c33c8f6744d0f01a728be4bcc9d5bda/pillow_heif-1.4.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:6eef7ac1594dafa592435336e7e6954ccfc549e767bff9ed814cdfa92e1278f7", size = 3952059, upload-time = "2026-06-10T16:02:31.465Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d9/79a82fd1802c529777977ac4cbe1210e470ed4ae29f3dbb6d2a0bf08757f/pillow_heif-1.4.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf6b287205bf47aa7423ca3caa795fd381e1e74422d10ba65c3f78e3a4a3c974", size = 6208633, upload-time = "2026-06-10T16:02:33.154Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/35/19d7bbe415657d74fd06e2aa661e5e379f8c6b5f8df0727cf5b0accf6e37/pillow_heif-1.4.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8d6ce8db65311a7f56029bedc46034adb59f51a8f7ad6503edac1b26f50d49e4", size = 5619701, upload-time = "2026-06-10T16:02:34.987Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e9/6a23b01ad080175fb495e37f32c124602ec750e79518dff09e1e51febcc8/pillow_heif-1.4.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:4e34c549dce5f6808b6cee2ebfe81d6a80ef8ba3827007d57ca43c58540107f9", size = 6514779, upload-time = "2026-06-10T16:02:36.65Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3998,7 +4037,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4053,7 +4092,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -4692,11 +4731,11 @@ name = "vercel-workers"
 version = "0.0.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.12'" },
-    { name = "httpx", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
-    { name = "vercel", marker = "python_full_version >= '3.12'" },
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "vercel" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/df/04d37021ad7ca53b7599c313e411d91623c7a005c741f491d1eefb7a9f0c/vercel_workers-0.0.25.tar.gz", hash = "sha256:212ded01400b524be51d251df49f801caf115ad7d48cca7eb168cbeceda3def3", size = 64149, upload-time = "2026-06-20T19:26:27.177Z" }
 wheels = [


### PR DESCRIPTION
## Problem

`vision_analyze` rejects iPhone photos and screenshots with `source is not a recognized image`.

iPhones capture stills as **HEIF/HEIC** (HEVC-coded, ISO-BMFF container), and upload/attachment pipelines frequently hand them to the agent named `.jpg`. The magic-byte sniff in `_detect_image_mime_type_from_bytes` had no HEIF branch, so it returned `None` and `image_source._finalize` raised `NotAnImage` — the bytes never reached the format-normalization step that already exists for other unsupported rasters (SVG, BMP, TIFF).

The extension is a red herring; the resolver correctly trusts magic bytes over the name. It just didn't know the HEIF magic.

Reproduced on two real iPhone files (brands `heic` and `heix`), both `.jpg` on disk:
```
$ file IMG_9527.jpg
IMG_9527.jpg: ISO Media, HEIF Image HEVC Main 10 Profile
```

## Fix

Two touch-points, mirroring the existing SVG soft-dependency pattern:

1. **`_detect_image_mime_type_from_bytes`** — sniff the ISO-BMFF `ftyp` box (bytes 4–8) and recognize the HEIF/HEIC brands (`heic`/`heix`/`heim`/`heis`/`hevc`/`hevx`/`mif1`/`msf1`) and AVIF (`avif`/`avis`), returning `image/heic` or `image/avif`. Non-image `ftyp` brands (e.g. `mp42`) stay unrecognized, so we don't claim every ISO-BMFF container is an image.

2. **`_normalize_to_supported_image`** — register the `pillow-heif` Pillow opener, then re-encode HEIF/AVIF → PNG before embed (providers only ingest jpeg/png/gif/webp). Missing decoder yields an actionable `pip install pillow-heif` error instead of a generic failure — same posture as SVG-without-rasterizer.

3. **`pyproject.toml`** — add `pillow-heif==1.4.0` as a core dep alongside `Pillow`. It ships prebuilt wheels bundling libheif on the common platforms (no system libs required), so it's safe in the base install rather than gated behind an extra + mid-session lazy install.

The resolver's magic-byte sniff stays authoritative (no extension trust); HEIF now reaches the normalize step already used for SVG/BMP/TIFF instead of 400ing.

## Tests

`tests/tools/test_image_source.py::TestHeicDetection`:
- HEIC + generic `mif1` brands detected as `image/heic`; AVIF as `image/avif`
- `mp42` ftyp box **not** misdetected as an image
- end-to-end: a real HEIC file resolves (`image/heic`) and normalizes to a valid PNG via pillow-heif
- decoder-missing path returns the actionable `pip install pillow-heif` error

All **111** tests in `test_image_source.py` + `test_vision_tools.py` pass. Also verified live against two real iPhone HEIC files end-to-end (resolve → normalize → valid PNG, 4896×3672 and 1290×2796).
