### PR TITLE
test(desktop): widen Testing Library async deadline to de-flake UI panels

### DIFF
--- a/apps/desktop/vitest.setup.ts
+++ b/apps/desktop/vitest.setup.ts
@@ -1,6 +1,12 @@
-import '@testing-library/react'
+import { configure } from '@testing-library/react'
 
 // React 19 + Testing Library 16: opt into the act environment so render(),
 // fireEvent(), and findBy* queries automatically flush state updates without
 // spurious "not wrapped in act(...)" warnings.
 ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+// findBy*/waitFor default to a 1000ms deadline — too tight for async-heavy
+// panels (radix menus, refetch chains) when the full suite runs under xdist
+// CPU contention in CI. Success still resolves the instant the node appears;
+// the wider deadline only absorbs a starved runner, killing timing flakes.
+configure({ asyncUtilTimeout: 5000 })


### PR DESCRIPTION
## Summary

`findBy*` / `waitFor` default to a **1000ms** deadline. That's too tight for async-heavy settings panels (radix menus, refetch chains) once the full desktop suite runs under xdist CPU contention in CI.

`src/app/settings/toolset-config-panel.test.tsx` (25 async-heavy tests) has reddened **unrelated** PRs multiple times with `Unable to find role="button" and name /Actions for ELEVENLABS_API_KEY/` style timeouts that pass on re-run — the textbook contention flake, not a real regression.

Fix: bump `asyncUtilTimeout` to `5000ms` in the shared `ui` setup (`vitest.setup.ts`). Success still resolves the instant the node appears, so the happy path is unchanged; only a genuinely starved runner (or a real failure) waits longer.

## Test plan
- [x] `npx vitest run src/app/settings/toolset-config-panel.test.tsx` green
- [x] no behavior change — timeout only affects async-query deadlines