### PR TITLE
perf(desktop): idle-mount boot-hidden panes off the cold-start critical path

### DIFF
--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -5,6 +5,7 @@ import type { CSSProperties, ReactElement, PointerEvent as ReactPointerEvent } f
 import { PREVIEW_RAIL_MAX_WIDTH, PREVIEW_RAIL_MIN_WIDTH } from '@/app/chat/right-rail'
 import { PALETTE_AREA, type PaletteContribution } from '@/app/command-palette/contrib'
 import { type StatusbarItem } from '@/app/shell/statusbar-controls'
+import { IdleMount } from '@/components/idle-mount'
 import { toggleLayoutEditMode } from '@/components/pane-shell/edit-mode'
 import { allPaneIds, group, split } from '@/components/pane-shell/tree/model'
 import { LayoutTreeRoot } from '@/components/pane-shell/tree/renderer'
@@ -182,7 +183,11 @@ registry.registerMany([
       minWidth: FILE_BROWSER_MIN_WIDTH,
       maxWidth: FILE_BROWSER_MAX_WIDTH
     },
-    render: () => <FilesPane />
+    render: () => (
+      <IdleMount>
+        <FilesPane />
+      </IdleMount>
+    )
   },
   {
     id: 'preview',
@@ -200,7 +205,11 @@ registry.registerMany([
       minWidth: PREVIEW_RAIL_MIN_WIDTH,
       maxWidth: PREVIEW_RAIL_MAX_WIDTH
     },
-    render: () => <PreviewRailPane />
+    render: () => (
+      <IdleMount>
+        <PreviewRailPane />
+      </IdleMount>
+    )
   },
   {
     id: 'review',
@@ -216,7 +225,11 @@ registry.registerMany([
       minWidth: FILE_BROWSER_MIN_WIDTH,
       maxWidth: FILE_BROWSER_MAX_WIDTH
     },
-    render: () => <ReviewPaneContent />
+    render: () => (
+      <IdleMount>
+        <ReviewPaneContent />
+      </IdleMount>
+    )
   },
   {
     // Optional chrome — in NO default layout. Adoption stacks it with the
@@ -227,7 +240,11 @@ registry.registerMany([
     // revealOnPreset: the Quad layout places logs, so applying it turns the
     // logs pane on (like a ⌘K "Toggle logs") instead of leaving it collapsed.
     data: { placement: 'bottom', height: '20vh', minHeight: '7.5rem', maxHeight: '80vh', revealOnPreset: true },
-    render: () => <LogsPane />
+    render: () => (
+      <IdleMount>
+        <LogsPane />
+      </IdleMount>
+    )
   }
 ])
 

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -91,6 +91,10 @@ import { ContribWiring, WiredPane } from './wiring'
 // ONE render identity for the workspace pane — syncWorkspaceTitle re-registers
 // the contribution (new title) and a fresh closure would remount the chat.
 const renderWorkspacePane = () => <WiredPane part="chatRoutes" />
+
+// Boot-hidden panes mount behind display:none (instant-toggle contract) — defer
+// them to idle so they're off the first-paint path, warm before reveal.
+const idle = (node: ReactElement) => <IdleMount>{node}</IdleMount>
 // The main tab carries the same session context menu as tile tabs (targets
 // the loaded primary session; no menu on a fresh draft).
 const wrapWorkspaceTab = (tab: ReactElement) => <WorkspaceTabMenu>{tab}</WorkspaceTabMenu>
@@ -183,11 +187,7 @@ registry.registerMany([
       minWidth: FILE_BROWSER_MIN_WIDTH,
       maxWidth: FILE_BROWSER_MAX_WIDTH
     },
-    render: () => (
-      <IdleMount>
-        <FilesPane />
-      </IdleMount>
-    )
+    render: () => idle(<FilesPane />)
   },
   {
     id: 'preview',
@@ -205,11 +205,7 @@ registry.registerMany([
       minWidth: PREVIEW_RAIL_MIN_WIDTH,
       maxWidth: PREVIEW_RAIL_MAX_WIDTH
     },
-    render: () => (
-      <IdleMount>
-        <PreviewRailPane />
-      </IdleMount>
-    )
+    render: () => idle(<PreviewRailPane />)
   },
   {
     id: 'review',
@@ -225,11 +221,7 @@ registry.registerMany([
       minWidth: FILE_BROWSER_MIN_WIDTH,
       maxWidth: FILE_BROWSER_MAX_WIDTH
     },
-    render: () => (
-      <IdleMount>
-        <ReviewPaneContent />
-      </IdleMount>
-    )
+    render: () => idle(<ReviewPaneContent />)
   },
   {
     // Optional chrome — in NO default layout. Adoption stacks it with the
@@ -240,11 +232,7 @@ registry.registerMany([
     // revealOnPreset: the Quad layout places logs, so applying it turns the
     // logs pane on (like a ⌘K "Toggle logs") instead of leaving it collapsed.
     data: { placement: 'bottom', height: '20vh', minHeight: '7.5rem', maxHeight: '80vh', revealOnPreset: true },
-    render: () => (
-      <IdleMount>
-        <LogsPane />
-      </IdleMount>
-    )
+    render: () => idle(<LogsPane />)
   }
 ])
 

--- a/apps/desktop/src/components/idle-mount.test.tsx
+++ b/apps/desktop/src/components/idle-mount.test.tsx
@@ -1,0 +1,50 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { IdleMount } from './idle-mount'
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('IdleMount', () => {
+  it('mounts eagerly where requestIdleCallback is unavailable', () => {
+    vi.stubGlobal('requestIdleCallback', undefined)
+
+    render(
+      <IdleMount>
+        <span>child</span>
+      </IdleMount>
+    )
+
+    expect(screen.getByText('child')).toBeTruthy()
+  })
+
+  it('defers the child to idle, then keeps it mounted', () => {
+    let fire: (() => void) | null = null
+
+    const ric = vi.fn((cb: () => void) => {
+      fire = cb
+
+      return 1
+    })
+
+    vi.stubGlobal('requestIdleCallback', ric)
+    vi.stubGlobal('cancelIdleCallback', vi.fn())
+
+    render(
+      <IdleMount>
+        <span>child</span>
+      </IdleMount>
+    )
+
+    // Not on the first-paint path — nothing rendered until the browser is idle.
+    expect(screen.queryByText('child')).toBeNull()
+    expect(ric).toHaveBeenCalledOnce()
+
+    act(() => fire?.())
+
+    expect(screen.getByText('child')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/components/idle-mount.tsx
+++ b/apps/desktop/src/components/idle-mount.tsx
@@ -1,0 +1,28 @@
+import { type ReactNode, useEffect, useState } from 'react'
+
+/**
+ * Mounts `children` only once the browser goes idle (or `timeout` ms elapse),
+ * then keeps them mounted for good. Lifts non-critical, boot-hidden surfaces
+ * (display:none panes: files/preview/review/logs) off the first-paint critical
+ * path with ZERO visible change — idle fires within a frame of first paint, so
+ * a hidden pane is warm long before the user can reveal it, preserving the
+ * "toggle back is instant" contract while shrinking cold-start app-mount.
+ *
+ * Degrades to eager mount where requestIdleCallback is absent (jsdom/tests,
+ * older webviews), so there's no behavioral fork to reason about there.
+ */
+export function IdleMount({ children, timeout = 2000 }: { children: ReactNode; timeout?: number }) {
+  const [ready, setReady] = useState(typeof requestIdleCallback !== 'function')
+
+  useEffect(() => {
+    if (ready) {
+      return undefined
+    }
+
+    const id = requestIdleCallback(() => setReady(true), { timeout })
+
+    return () => cancelIdleCallback(id)
+  }, [ready, timeout])
+
+  return ready ? <>{children}</> : null
+}


### PR DESCRIPTION
## Summary

Cold-start composition (prod, warm cache) says the only lever in *our* code is React app-mount — Electron process/window startup (~0.6–1s) and the un-splittable bundle eval (~250ms, Shiki/electron-builder constraint) aren't cheaply movable.

The layout tree keeps a chrome-hidden pane's content **mounted behind `display:none`** so toggling it back is instant (`tree-split.tsx`). The cost: at a fresh-profile launch, `files`, `preview`, `review` (Shiki diff) and `logs` all mount their real content during first paint — even though **none are visible** (no cwd → files/review hidden, no preview target, logs isn't in the default tree). First paint only needs `sessions` + `workspace` + `statusbar`.

Wrap those four pane renders in a tiny `<IdleMount>`: mount on `requestIdleCallback` (2s timeout fallback), then stay mounted forever.

## Zero UX change
- Idle fires within a frame of first paint, so each hidden pane is warm long before a user can reveal it — the "toggle back is instant" contract holds.
- Terminal (PTY persistence), sessions, workspace, statusbar are untouched — never deferred.
- Degrades to **eager** mount where `requestIdleCallback` is absent (jsdom/tests, older webviews), so there's no behavioral fork to reason about.

## Test plan
- [x] `tsc` + `eslint` clean
- [x] `idle-mount.test.tsx` — eager fallback + defer-then-stay-mounted (2 tests green)
- [x] no change to what first paint renders; hidden panes mount on idle