### PR TITLE
fix(honcho): search target peer self-scope in addition to assistant-target scope

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -964,7 +964,12 @@ class HonchoSessionManager:
         *,
         target: str | None = None,
     ) -> dict[str, Any]:
-        """Fetch representation + peer card directly from a peer object."""
+        """Fetch representation + peer card directly from a peer object.
+
+        When an observer requests context for a different target, merge the
+        observer-owned scope with the target peer's self-scope. Conclusions
+        may be stored in either scope depending on the observation settings.
+        """
         peer = self._get_or_create_peer(peer_id)
         representation = ""
         card: list[str] = []
@@ -998,6 +1003,25 @@ class HonchoSessionManager:
                 card = self._fetch_peer_card(peer_id, target=target)
             except Exception as e:
                 logger.debug("Direct peer card fetch failed for '%s': %s", peer_id, e)
+
+        # Conclusions about a target may also live in its self-scope
+        # (target observing target). Keep the observer-owned result primary,
+        # and treat a failed self-scope lookup as non-fatal.
+        if target is not None and target != peer_id:
+            try:
+                self_ctx = self._fetch_peer_context(
+                    target,
+                    search_query=search_query,
+                    target=target,
+                )
+                self_representation = self_ctx["representation"]
+                if self_representation:
+                    representation = "\n\n".join(
+                        part for part in (representation, self_representation) if part
+                    )
+                card.extend(item for item in self_ctx["card"] if item not in card)
+            except Exception as e:
+                logger.debug("Target peer self-scope fetch failed for '%s': %s", target, e)
 
         return {"representation": representation, "card": card}
 

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -348,18 +348,24 @@ class TestPeerLookupHelpers:
                 else ["Name: Robert"]
             ),
         )
-        mgr._get_or_create_peer = MagicMock(side_effect=[user_peer, ai_peer])
+        mgr._get_or_create_peer = MagicMock(
+            side_effect=lambda peer_id: (
+                ai_peer if peer_id == session.assistant_peer_id else user_peer
+            )
+        )
 
         result = mgr.get_prefetch_context(session.key)
 
         assert result == {
-            "representation": "User representation",
+            "representation": "Mixed representation\n\nUser representation",
             "card": "Name: Robert",
             "ai_representation": "AI representation",
             "ai_card": "Role: Assistant",
         }
         user_peer.context.assert_called_once_with(target=session.user_peer_id)
-        ai_peer.context.assert_called_once_with(target=session.assistant_peer_id)
+        assert ai_peer.context.call_count == 2
+        ai_peer.context.assert_any_call(target=session.user_peer_id)
+        ai_peer.context.assert_any_call(target=session.assistant_peer_id)
 
     def test_get_prefetch_context_uses_assistant_observer_for_user_when_ai_observe_others(self):
         """With ai_observe_others enabled, get_prefetch_context must query
@@ -383,21 +389,115 @@ class TestPeerLookupHelpers:
             return SimpleNamespace(representation="Unknown", peer_card=[])
 
         assistant_peer.context.side_effect = _assistant_context
+        user_peer = MagicMock()
+        user_peer.context.return_value = SimpleNamespace(
+            representation="User self",
+            peer_card=["Prefers: concise answers"],
+        )
         mgr._get_or_create_peer = MagicMock(
-            side_effect=[assistant_peer, assistant_peer],
+            side_effect=lambda peer_id: (
+                assistant_peer if peer_id == session.assistant_peer_id else user_peer
+            ),
         )
 
         result = mgr.get_prefetch_context(session.key)
 
         assert result == {
-            "representation": "User via assistant",
-            "card": "Name: Robert",
+            "representation": "User via assistant\n\nUser self",
+            "card": "Name: Robert\nPrefers: concise answers",
             "ai_representation": "AI self",
             "ai_card": "Role: Assistant",
         }
         assert assistant_peer.context.call_count == 2
         assistant_peer.context.assert_any_call(target=session.user_peer_id)
         assistant_peer.context.assert_any_call(target=session.assistant_peer_id)
+
+    def test_fetch_peer_context_merges_directional_and_target_self_scopes(self):
+        mgr, session = self._make_cached_manager()
+        assistant_peer = MagicMock()
+        assistant_peer.context.return_value = SimpleNamespace(
+            representation="Assistant-observed context",
+            peer_card=["Location: Melbourne"],
+        )
+        user_peer = MagicMock()
+        user_peer.context.return_value = SimpleNamespace(
+            representation="User self-scope context",
+            peer_card=["Prefers: concise answers"],
+        )
+        mgr._get_or_create_peer = MagicMock(
+            side_effect=lambda peer_id: (
+                assistant_peer if peer_id == session.assistant_peer_id else user_peer
+            )
+        )
+
+        result = mgr._fetch_peer_context(
+            session.assistant_peer_id,
+            search_query="preferences",
+            target=session.user_peer_id,
+        )
+
+        assert result == {
+            "representation": "Assistant-observed context\n\nUser self-scope context",
+            "card": ["Location: Melbourne", "Prefers: concise answers"],
+        }
+        assistant_peer.context.assert_called_once_with(
+            target=session.user_peer_id,
+            search_query="preferences",
+        )
+        user_peer.context.assert_called_once_with(
+            target=session.user_peer_id,
+            search_query="preferences",
+        )
+
+    def test_fetch_peer_context_preserves_primary_result_when_self_scope_fails(self):
+        mgr, session = self._make_cached_manager()
+        assistant_peer = MagicMock()
+        assistant_peer.context.return_value = SimpleNamespace(
+            representation="Primary representation",
+            peer_card=["Primary card"],
+        )
+
+        def _peer(peer_id):
+            if peer_id == session.assistant_peer_id:
+                return assistant_peer
+            raise RuntimeError("self-scope unavailable")
+
+        mgr._get_or_create_peer = MagicMock(side_effect=_peer)
+
+        result = mgr._fetch_peer_context(
+            session.assistant_peer_id,
+            target=session.user_peer_id,
+        )
+
+        assert result == {
+            "representation": "Primary representation",
+            "card": ["Primary card"],
+        }
+
+    def test_fetch_peer_context_assistant_self_uses_one_scope_call(self):
+        mgr, session = self._make_cached_manager()
+        assistant_peer = MagicMock()
+        assistant_peer.context.return_value = SimpleNamespace(
+            representation="Assistant self context",
+            peer_card=["Role: Assistant"],
+        )
+        mgr._get_or_create_peer = MagicMock(return_value=assistant_peer)
+
+        result = mgr._fetch_peer_context(
+            session.assistant_peer_id,
+            search_query="identity",
+            target=session.assistant_peer_id,
+        )
+
+        assert result == {
+            "representation": "Assistant self context",
+            "card": ["Role: Assistant"],
+        }
+        mgr._get_or_create_peer.assert_called_once_with(session.assistant_peer_id)
+        assistant_peer.context.assert_called_once_with(
+            target=session.assistant_peer_id,
+            search_query="identity",
+        )
 
     def test_get_ai_representation_uses_peer_api(self):
         mgr, session = self._make_cached_manager()


### PR DESCRIPTION
Rebased #61685 onto current main after #62290 rewrote honcho_search.

The original patch's self-scope gap moved with the rewrite. search_context() now uses workspace message search via peer_perspective and no longer calls _fetch_peer_context(search_query=...). The gap that #61685 fixes still exists in _fetch_peer_context (used by get_prefetch_context and get_reason_context), where assistant->target context can omit conclusions stored under target->target.

This branch is the same patch as #61685 rebased onto origin/main. The original commit ed0a77e14 was authored by Hermes Pi (pi@hermes.local); the rebased commit 06ed2ffe1 keeps the same message and AUTHOR_MAP attribution path.

Verification:
- git rebase against origin/main (9c3ffcaae): clean, no conflicts
- pytest tests/honcho_plugin/test_session.py -k 'search_context or fetch_peer_context or self_scope' -> 8 passed (including the three regression tests added in 4d39acead)
- pytest tests/honcho_plugin/ (excluding test_oauth_flow.py which needs httpx): 387 passed, 20 skipped, 6 failed with ImportError on agent.auxiliary_client (httpx missing in this env, unrelated to this PR)

Supersedes #61685.