### PR TITLE
feat(plugins): support Telegram Mini App URL delivery

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -37,6 +37,7 @@ import asyncio
 import importlib.metadata
 import importlib.util
 import inspect
+import json
 import logging
 import os
 import sys
@@ -629,6 +630,49 @@ class PluginContext:
                 kwargs["parent_agent"] = agent
 
         return registry.dispatch(tool_name, args, **kwargs)
+
+    def send_message(
+        self,
+        target: str,
+        message: str,
+        /,
+        **delivery_options: Any,
+    ) -> dict[str, Any]:
+        """Deliver a message through Hermes's host-owned platform transport.
+
+        This is the plugin-facing outbound interface for concrete integrations
+        that need richer platform delivery than a plugin tool result can
+        express. It reuses the same target resolution, authorization-adjacent
+        configuration, media handling, retries, and mirroring as ``hermes
+        send`` without registering ``send_message`` as a model-callable tool.
+
+        ``delivery_options`` is intentionally passed through to the existing
+        send engine so platform transports can add optional structured
+        capabilities without growing the plugin facade for each one. Reserved
+        routing fields remain host-owned.
+        """
+        reserved = {"action", "target", "message"}.intersection(delivery_options)
+        if reserved:
+            names = ", ".join(sorted(reserved))
+            raise ValueError(f"Plugin delivery options cannot override: {names}")
+
+        from tools.send_message_tool import send_message_tool
+
+        raw = send_message_tool({
+            "action": "send",
+            "target": target,
+            "message": message,
+            **delivery_options,
+        })
+        if isinstance(raw, dict):
+            return raw
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise RuntimeError("Host send engine returned an invalid result") from exc
+        if not isinstance(parsed, dict):
+            raise RuntimeError("Host send engine returned an invalid result")
+        return parsed
 
     # -- context engine registration -----------------------------------------
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -77,6 +77,14 @@ class PluginToolOverrideError(PermissionError):
     """
 
 
+class PluginOutboundMessagingError(PermissionError):
+    """Raised when a plugin sends outbound messages without operator opt-in.
+
+    Non-bundled plugins must be granted
+    ``plugins.entries.<plugin_id>.allow_outbound_messaging`` explicitly.
+    """
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -645,12 +653,24 @@ class PluginContext:
         express. It reuses the same target resolution, authorization-adjacent
         configuration, media handling, retries, and mirroring as ``hermes
         send`` without registering ``send_message`` as a model-callable tool.
+        Non-bundled plugins need an explicit operator grant under
+        ``plugins.entries.<plugin_id>.allow_outbound_messaging``. This keeps a
+        model-callable plugin tool from acquiring cross-platform send authority
+        merely because its plugin was enabled.
 
         ``delivery_options`` is intentionally passed through to the existing
         send engine so platform transports can add optional structured
         capabilities without growing the plugin facade for each one. Reserved
         routing fields remain host-owned.
         """
+        if not self._outbound_messaging_allowed():
+            plugin_id = self.manifest.key or self.manifest.name
+            raise PluginOutboundMessagingError(
+                f"Plugin {self.manifest.name!r} cannot send outbound messages. "
+                f"Run 'hermes plugins enable {plugin_id} "
+                "--allow-outbound-messaging' to grant this capability."
+            )
+
         reserved = {"action", "target", "message"}.intersection(delivery_options)
         if reserved:
             names = ", ".join(sorted(reserved))
@@ -673,6 +693,35 @@ class PluginContext:
         if not isinstance(parsed, dict):
             raise RuntimeError("Host send engine returned an invalid result")
         return parsed
+
+    def _outbound_messaging_allowed(self) -> bool:
+        """Return whether this plugin may use the host outbound transport.
+
+        Bundled plugins are trusted code shipped with Hermes. Every other
+        plugin source fails closed unless the operator grants the capability
+        for that plugin's canonical id.
+        """
+        source = getattr(self.manifest, "source", "") or ""
+        if source == "bundled":
+            return True
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config() or {}
+        except Exception:
+            return False
+        plugin_id = self.manifest.key or self.manifest.name
+        if not isinstance(cfg, dict):
+            return False
+        plugins_cfg = cfg.get("plugins") or {}
+        if not isinstance(plugins_cfg, dict):
+            return False
+        entries = plugins_cfg.get("entries") or {}
+        if not isinstance(entries, dict):
+            return False
+        entry = entries.get(plugin_id) or {}
+        if not isinstance(entry, dict):
+            return False
+        return entry.get("allow_outbound_messaging") is True
 
     # -- context engine registration -----------------------------------------
 

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -846,7 +846,11 @@ def _set_plugin_entry_flag(plugin_id: str, key: str, value: bool) -> None:
     save_config(config)
 
 
-def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
+def cmd_enable(
+    name: str,
+    allow_tool_override: Optional[bool] = None,
+    allow_outbound_messaging: Optional[bool] = None,
+) -> None:
     """Add a plugin to the enabled allow-list (and remove it from disabled).
 
     For non-bundled plugins, prompt the operator about granting the
@@ -855,6 +859,10 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
     tri-state: ``True`` grants without prompting, ``False`` declines without
     prompting, ``None`` (default) asks interactively. Bundled plugins are
     trusted and never prompted.
+
+    ``allow_outbound_messaging`` changes the separate outbound transport grant
+    only when explicitly set. It is not prompted for every plugin because most
+    plugins do not need this capability.
     """
     from rich.console import Console
 
@@ -905,6 +913,19 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
         return
 
     _resolve_tool_override_grant(console, key, allow_tool_override)
+    if allow_outbound_messaging is not None:
+        _set_plugin_entry_flag(
+            key, "allow_outbound_messaging", allow_outbound_messaging
+        )
+        if allow_outbound_messaging:
+            console.print(
+                f"[green]✓[/green] Granted [bold]{key}[/bold] permission to "
+                "send messages through configured Hermes platforms."
+            )
+        else:
+            console.print(
+                f"[dim]{key} may not send messages through Hermes platforms.[/dim]"
+            )
 
 
 def _resolve_tool_override_grant(
@@ -2068,7 +2089,16 @@ def plugins_command(args) -> None:
             allow_override = True
         elif getattr(args, "no_allow_tool_override", False):
             allow_override = False
-        cmd_enable(args.name, allow_tool_override=allow_override)
+        allow_outbound = None
+        if getattr(args, "allow_outbound_messaging", False):
+            allow_outbound = True
+        elif getattr(args, "no_allow_outbound_messaging", False):
+            allow_outbound = False
+        cmd_enable(
+            args.name,
+            allow_tool_override=allow_override,
+            allow_outbound_messaging=allow_outbound,
+        )
     elif action == "disable":
         cmd_disable(args.name)
     elif action in {"list", "ls"}:

--- a/hermes_cli/subcommands/plugins.py
+++ b/hermes_cli/subcommands/plugins.py
@@ -98,6 +98,18 @@ def build_plugins_parser(subparsers, *, cmd_plugins: Callable) -> None:
         action="store_true",
         help="Enable without granting built-in tool override (skip prompt).",
     )
+    _enable_outbound_group = plugins_enable.add_mutually_exclusive_group()
+    _enable_outbound_group.add_argument(
+        "--allow-outbound-messaging",
+        action="store_true",
+        help="Grant this plugin permission to send messages through configured "
+        "Hermes platforms.",
+    )
+    _enable_outbound_group.add_argument(
+        "--no-allow-outbound-messaging",
+        action="store_true",
+        help="Revoke this plugin's outbound messaging permission.",
+    )
 
     plugins_disable = plugins_subparsers.add_parser(
         "disable", help="Disable a plugin without removing it"

--- a/plugins/platforms/telegram/web_app.py
+++ b/plugins/platforms/telegram/web_app.py
@@ -1,0 +1,63 @@
+"""Validation helpers for Telegram Mini App URL buttons."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlsplit
+
+
+MAX_WEB_APP_BUTTON_LABEL_LENGTH = 64
+MAX_WEB_APP_URL_LENGTH = 2048
+
+
+def normalize_web_app_button(value: Any) -> dict[str, str] | None:
+    """Validate and normalize an outbound Telegram Web App button payload.
+
+    The public contract is ``{"label": str, "url": str}``.  Telegram only
+    accepts HTTPS Web App URLs.  Credentials and control characters are
+    rejected so an artifact publisher cannot accidentally turn a visible
+    button into a credential-bearing link or malformed Bot API payload.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError("Telegram Web App button must be an object")
+    if set(value) != {"label", "url"}:
+        raise ValueError(
+            "Telegram Web App button must contain exactly 'label' and 'url'"
+        )
+
+    label = value.get("label")
+    url = value.get("url")
+    if not isinstance(label, str) or not label.strip():
+        raise ValueError("Telegram Web App button label must be a non-empty string")
+    label = label.strip()
+    if len(label) > MAX_WEB_APP_BUTTON_LABEL_LENGTH:
+        raise ValueError(
+            f"Telegram Web App button label must be at most "
+            f"{MAX_WEB_APP_BUTTON_LABEL_LENGTH} characters"
+        )
+    if any(ord(char) < 0x20 or ord(char) == 0x7F for char in label):
+        raise ValueError(
+            "Telegram Web App button label must not contain control characters"
+        )
+
+    if not isinstance(url, str) or not url.strip():
+        raise ValueError("Telegram Web App button URL must be a non-empty string")
+    url = url.strip()
+    if len(url) > MAX_WEB_APP_URL_LENGTH:
+        raise ValueError(
+            f"Telegram Web App button URL must be at most {MAX_WEB_APP_URL_LENGTH} characters"
+        )
+    if any(ord(char) < 0x20 or ord(char) == 0x7F for char in url):
+        raise ValueError(
+            "Telegram Web App button URL must not contain control characters"
+        )
+
+    parsed = urlsplit(url)
+    if parsed.scheme.lower() != "https" or not parsed.hostname:
+        raise ValueError("Telegram Web App button URL must use HTTPS")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("Telegram Web App button URL must not contain credentials")
+
+    return {"label": label, "url": url}

--- a/plugins/platforms/telegram/web_app.py
+++ b/plugins/platforms/telegram/web_app.py
@@ -2,12 +2,55 @@
 
 from __future__ import annotations
 
+import ipaddress
 from typing import Any
 from urllib.parse import urlsplit
 
 
 MAX_WEB_APP_BUTTON_LABEL_LENGTH = 64
 MAX_WEB_APP_URL_LENGTH = 2048
+
+
+def _parse_legacy_ipv4_address(hostname: str) -> ipaddress.IPv4Address | None:
+    """Parse browser-compatible IPv4 spellings that ``ip_address`` rejects.
+
+    WHATWG URL parsers accept one-to-four decimal, octal, or hexadecimal
+    components (for example ``2130706433``, ``0177.0.0.1``, and
+    ``0x7f000001``) and normalize each of them to ``127.0.0.1``. Telegram
+    opens this URL in a client WebView, so validating only dotted decimal
+    would let a loopback literal bypass the public-host contract.
+    """
+    parts = hostname.split(".")
+    if not 1 <= len(parts) <= 4 or any(not part for part in parts):
+        return None
+
+    numbers: list[int] = []
+    for part in parts:
+        base = 10
+        digits = part
+        if part.lower().startswith("0x"):
+            base = 16
+            digits = part[2:]
+        elif len(part) > 1 and part.startswith("0"):
+            base = 8
+            digits = part[1:]
+        if not digits:
+            digits = "0"
+        try:
+            numbers.append(int(digits, base))
+        except ValueError:
+            return None
+
+    if any(number > 255 for number in numbers[:-1]):
+        return None
+    last_limit = 256 ** (5 - len(numbers))
+    if numbers[-1] >= last_limit:
+        return None
+
+    value = numbers[-1]
+    for index, number in enumerate(numbers[:-1]):
+        value += number * (256 ** (3 - index))
+    return ipaddress.IPv4Address(value)
 
 
 def normalize_web_app_button(value: Any) -> dict[str, str] | None:
@@ -59,5 +102,20 @@ def normalize_web_app_button(value: Any) -> dict[str, str] | None:
         raise ValueError("Telegram Web App button URL must use HTTPS")
     if parsed.username is not None or parsed.password is not None:
         raise ValueError("Telegram Web App button URL must not contain credentials")
+    hostname = parsed.hostname.rstrip(".").lower()
+    if "%" in hostname:
+        raise ValueError("Telegram Web App button URL must use a public host")
+    if hostname == "localhost" or hostname.endswith(".localhost"):
+        raise ValueError("Telegram Web App button URL must use a public host")
+    try:
+        address = ipaddress.ip_address(hostname)
+    except ValueError:
+        address = _parse_legacy_ipv4_address(hostname)
+    if address is not None and not address.is_global:
+        raise ValueError("Telegram Web App button URL must use a public host")
+    try:
+        parsed.port
+    except ValueError as exc:
+        raise ValueError("Telegram Web App button URL is malformed") from exc
 
     return {"label": label, "url": url}

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1116,9 +1116,9 @@ class TestDispatchToolWithoutCliRef:
 class TestPluginContextSendMessage:
     """Plugins can use the host send engine without exposing a model tool."""
 
-    def _ctx(self):
+    def _ctx(self, *, source="bundled", key=""):
         return PluginContext(
-            PluginManifest(name="test-plugin", source="user"),
+            PluginManifest(name="test-plugin", source=source, key=key),
             PluginManager(),
         )
 
@@ -1149,3 +1149,72 @@ class TestPluginContextSendMessage:
                 "Interface ready.",
                 target="telegram:99999",
             )
+
+    def test_non_bundled_plugin_requires_explicit_outbound_grant(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"plugins": {"entries": {}}},
+        )
+        from hermes_cli.plugins import PluginOutboundMessagingError
+
+        with pytest.raises(
+            PluginOutboundMessagingError, match="allow-outbound-messaging"
+        ):
+            self._ctx(source="user").send_message(
+                "telegram:12345", "Interface ready."
+            )
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            None,
+            [],
+            {"plugins": []},
+            {"plugins": {"entries": []}},
+            {
+                "plugins": {
+                    "entries": {
+                        "test-plugin": {"allow_outbound_messaging": "true"}
+                    }
+                }
+            },
+        ],
+    )
+    def test_non_bundled_plugin_outbound_grant_fails_closed(
+        self, monkeypatch, config
+    ):
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+        from hermes_cli.plugins import PluginOutboundMessagingError
+
+        with pytest.raises(PluginOutboundMessagingError):
+            self._ctx(source="user").send_message(
+                "telegram:12345", "Interface ready."
+            )
+
+    def test_non_bundled_plugin_uses_canonical_key_for_outbound_grant(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "plugins": {
+                    "entries": {
+                        "category/test-plugin": {
+                            "allow_outbound_messaging": True
+                        }
+                    }
+                }
+            },
+        )
+        with patch(
+            "tools.send_message_tool.send_message_tool",
+            return_value='{"success": true}',
+        ) as send:
+            result = self._ctx(
+                source="user", key="category/test-plugin"
+            ).send_message("telegram:12345", "Interface ready.")
+
+        assert result == {"success": True}
+        send.assert_called_once()

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1111,3 +1111,41 @@ class TestDispatchToolWithoutCliRef:
             assert calls[0][1].get("parent_agent") is None
         finally:
             registry.deregister("_test_dispatch_probe")
+
+
+class TestPluginContextSendMessage:
+    """Plugins can use the host send engine without exposing a model tool."""
+
+    def _ctx(self):
+        return PluginContext(
+            PluginManifest(name="test-plugin", source="user"),
+            PluginManager(),
+        )
+
+    def test_routes_structured_delivery_through_host_send_engine(self):
+        button = {"label": "Open UI", "url": "https://example.com/app"}
+        with patch(
+            "tools.send_message_tool.send_message_tool",
+            return_value='{"success": true, "message_id": "42"}',
+        ) as send:
+            result = self._ctx().send_message(
+                "telegram:12345",
+                "Interface ready.",
+                web_app_button=button,
+            )
+
+        assert result == {"success": True, "message_id": "42"}
+        send.assert_called_once_with({
+            "action": "send",
+            "target": "telegram:12345",
+            "message": "Interface ready.",
+            "web_app_button": button,
+        })
+
+    def test_rejects_delivery_options_that_override_host_routing(self):
+        with pytest.raises(ValueError, match="cannot override: target"):
+            self._ctx().send_message(
+                "telegram:12345",
+                "Interface ready.",
+                target="telegram:99999",
+            )

--- a/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
+++ b/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
@@ -10,7 +10,7 @@ nested bundled plugin can actually be toggled.
 
 import sys  # noqa: F401
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 
@@ -146,6 +146,31 @@ class TestEnableToolOverrideConsent:
     privileged ``allow_tool_override`` capability, and persist the operator's
     choice under ``plugins.entries.<key>.allow_tool_override``."""
 
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    @patch("hermes_cli.plugins_cmd._set_plugin_entry_flag")
+    @patch("hermes_cli.plugins_cmd._save_disabled_set")
+    @patch("hermes_cli.plugins_cmd._save_enabled_set")
+    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set())
+    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set())
+    def test_explicit_outbound_flag_grants_separate_capability(
+        self, mock_en, mock_dis, mock_save_en, mock_save_dis, mock_set_flag,
+        mock_user, mock_bundled, nested_plugin_env,
+    ):
+        from hermes_cli.plugins_cmd import cmd_enable
+        mock_user.return_value = nested_plugin_env
+        mock_bundled.return_value = nested_plugin_env / "nonexistent"
+
+        cmd_enable(
+            "disk-cleanup",
+            allow_tool_override=False,
+            allow_outbound_messaging=True,
+        )
+
+        assert mock_set_flag.call_args_list == [
+            call("disk-cleanup", "allow_tool_override", False),
+            call("disk-cleanup", "allow_outbound_messaging", True),
+        ]
 
     @patch("hermes_cli.plugins.get_bundled_plugins_dir")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
@@ -230,4 +255,3 @@ class TestCompositeMenuWritesCanonicalKey:
         saved_dis = mock_save_dis.call_args[0][0]
         assert "web/firecrawl" in saved_dis      # canonical key persisted
         assert "web-firecrawl" not in saved_dis   # never the bare name
-

--- a/tests/hermes_cli/test_subcommands_followup.py
+++ b/tests/hermes_cli/test_subcommands_followup.py
@@ -64,3 +64,20 @@ def test_mcp_and_acp_accept_hooks_flag():
     # acp takes --accept-hooks at top level
     ns = parser.parse_args(["acp", "--accept-hooks"])
     assert ns.accept_hooks is True
+
+
+@pytest.mark.parametrize(
+    ("flag", "attribute"),
+    [
+        ("--allow-outbound-messaging", "allow_outbound_messaging"),
+        ("--no-allow-outbound-messaging", "no_allow_outbound_messaging"),
+    ],
+)
+def test_plugins_enable_accepts_outbound_permission_flags(flag, attribute):
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    build_plugins_parser(sub, cmd_plugins=_h("plugins"))
+
+    ns = parser.parse_args(["plugins", "enable", "example-plugin", flag])
+
+    assert getattr(ns, attribute) is True

--- a/tests/tools/test_send_message_telegram_web_app.py
+++ b/tests/tools/test_send_message_telegram_web_app.py
@@ -1,0 +1,177 @@
+"""Standalone send_message coverage for Telegram Web App buttons."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _install_telegram_mock(
+    monkeypatch: pytest.MonkeyPatch, bot_factory: MagicMock
+) -> None:
+    parse_mode = SimpleNamespace(MARKDOWN_V2="MarkdownV2", HTML="HTML")
+    constants_mod = SimpleNamespace(ParseMode=parse_mode)
+
+    class WebAppInfo:
+        def __init__(self, *, url: str):
+            self.url = url
+
+    class InlineKeyboardButton:
+        def __init__(self, text: str, *, web_app=None):
+            self.text = text
+            self.web_app = web_app
+
+    class InlineKeyboardMarkup:
+        def __init__(self, inline_keyboard):
+            self.inline_keyboard = inline_keyboard
+
+    telegram_mod = SimpleNamespace(
+        Bot=bot_factory,
+        InlineKeyboardButton=InlineKeyboardButton,
+        InlineKeyboardMarkup=InlineKeyboardMarkup,
+        WebAppInfo=WebAppInfo,
+        MessageEntity=lambda **kwargs: SimpleNamespace(**kwargs),
+        constants=constants_mod,
+    )
+    monkeypatch.setitem(sys.modules, "telegram", telegram_mod)
+    monkeypatch.setitem(sys.modules, "telegram.constants", constants_mod)
+
+
+def test_standalone_send_attaches_button_after_private_chat_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tools.send_message_tool import _send_telegram
+
+    bot = MagicMock()
+    bot.get_chat = AsyncMock(return_value=SimpleNamespace(type="private"))
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=7))
+    bot_factory = MagicMock(return_value=bot)
+    _install_telegram_mock(monkeypatch, bot_factory)
+
+    for name in (
+        "TELEGRAM_PROXY",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "HTTP_PROXY",
+        "http_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+        "NO_PROXY",
+        "no_proxy",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    result = asyncio.run(
+        _send_telegram(
+            "token",
+            "12345",
+            "Open the generated UI",
+            web_app_button={
+                "label": "Open UI",
+                "url": "https://example.com/a/opaque-id",
+            },
+        )
+    )
+
+    assert result["success"] is True
+    bot.get_chat.assert_awaited_once_with(12345)
+    kwargs = bot.send_message.await_args.kwargs
+    button = kwargs["reply_markup"].inline_keyboard[0][0]
+    assert button.text == "Open UI"
+    assert button.web_app.url == "https://example.com/a/opaque-id"
+
+
+def test_standalone_send_rejects_button_for_non_private_chat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tools.send_message_tool import _send_telegram
+
+    bot = MagicMock()
+    bot.get_chat = AsyncMock(return_value=SimpleNamespace(type="supergroup"))
+    bot.send_message = AsyncMock()
+    bot_factory = MagicMock(return_value=bot)
+    _install_telegram_mock(monkeypatch, bot_factory)
+
+    for name in (
+        "TELEGRAM_PROXY",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "HTTP_PROXY",
+        "http_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+        "NO_PROXY",
+        "no_proxy",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    result = asyncio.run(
+        _send_telegram(
+            "token",
+            "-100123",
+            "Open the app",
+            web_app_button={
+                "label": "Open app",
+                "url": "https://example.com/app",
+            },
+        )
+    )
+
+    assert "only available in private chats" in result["error"]
+    bot.send_message.assert_not_awaited()
+
+
+def test_web_app_button_is_described_to_the_model_as_delivery_only() -> None:
+    from tools.send_message_tool import SEND_MESSAGE_SCHEMA
+
+    schema = SEND_MESSAGE_SCHEMA["parameters"]["properties"]["web_app_button"]
+    assert schema["required"] == ["label", "url"]
+    assert schema["additionalProperties"] is False
+    description = schema["description"]
+    assert "already-hosted HTTPS URL" in description
+    assert "does not host or deploy" in description
+
+
+@pytest.mark.parametrize(
+    ("target", "button", "expected"),
+    [
+        (
+            "slack:C123",
+            {"label": "Open UI", "url": "https://example.com/app"},
+            "only supported for Telegram",
+        ),
+        (
+            "telegram:12345",
+            {"label": "Open UI", "url": "http://example.com/app"},
+            "must use HTTPS",
+        ),
+        (
+            "telegram:12345",
+            {"label": "Open UI", "url": "https://example.com/app", "extra": True},
+            "exactly 'label' and 'url'",
+        ),
+    ],
+)
+def test_send_rejects_invalid_button_before_loading_gateway_config(
+    target: str,
+    button: dict,
+    expected: str,
+) -> None:
+    from tools.send_message_tool import send_message_tool
+
+    result = json.loads(
+        send_message_tool({
+            "action": "send",
+            "target": target,
+            "message": "Ready",
+            "web_app_button": button,
+        })
+    )
+    assert expected in result["error"]

--- a/tests/tools/test_send_message_telegram_web_app.py
+++ b/tests/tools/test_send_message_telegram_web_app.py
@@ -154,6 +154,61 @@ def test_web_app_button_is_described_to_the_model_as_delivery_only() -> None:
         ),
         (
             "telegram:12345",
+            {"label": "Open UI", "url": "https://localhost/app"},
+            "must use a public host",
+        ),
+        (
+            "telegram:12345",
+            {"label": "Open UI", "url": "https://app.localhost/app"},
+            "must use a public host",
+        ),
+        (
+            "telegram:12345",
+            {"label": "Open UI", "url": "https://127.0.0.1/app"},
+            "must use a public host",
+        ),
+        (
+            "telegram:12345",
+            {"label": "Open UI", "url": "https://192.168.1.10/app"},
+            "must use a public host",
+        ),
+        (
+            "telegram:12345",
+            {"label": "Open UI", "url": "https://[::1]/app"},
+            "must use a public host",
+        ),
+        (
+            "telegram:12345",
+            {"label": "Open UI", "url": "https://2130706433/app"},
+            "must use a public host",
+        ),
+        (
+            "telegram:12345",
+            {"label": "Open UI", "url": "https://0x7f000001/app"},
+            "must use a public host",
+        ),
+        (
+            "telegram:12345",
+            {"label": "Open UI", "url": "https://0177.0.0.1/app"},
+            "must use a public host",
+        ),
+        (
+            "telegram:12345",
+            {"label": "Open UI", "url": "https://127.1/app"},
+            "must use a public host",
+        ),
+        (
+            "telegram:12345",
+            {"label": "Open UI", "url": "https://%31%32%37.0.0.1/app"},
+            "must use a public host",
+        ),
+        (
+            "telegram:12345",
+            {"label": "Open UI", "url": "https://example.com:bad/app"},
+            "is malformed",
+        ),
+        (
+            "telegram:12345",
             {"label": "Open UI", "url": "https://example.com/app", "extra": True},
             "exactly 'label' and 'url'",
         ),

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -224,6 +224,27 @@ SEND_MESSAGE_SCHEMA = {
                 "type": "string",
                 "description": "The message text to send. To send an image or file, include MEDIA:<local_path> (e.g. 'MEDIA:/tmp/report.pdf') in the message — the platform will deliver it as a native media attachment."
             },
+            "web_app_button": {
+                "type": "object",
+                "description": (
+                    "For Telegram private chats only: show an already-hosted HTTPS URL "
+                    "as a Mini App button. Use this when the user asks to open, show, or "
+                    "launch a live web interface inside Telegram. Hermes delivers the URL "
+                    "but does not host or deploy the app. Cannot be combined with MEDIA attachments."
+                ),
+                "properties": {
+                    "label": {
+                        "type": "string",
+                        "description": "Short visible button label, for example 'Open app'.",
+                    },
+                    "url": {
+                        "type": "string",
+                        "description": "Public HTTPS URL of the already-hosted Mini App.",
+                    },
+                },
+                "required": ["label", "url"],
+                "additionalProperties": False,
+            },
             "emoji": {
                 "type": "string",
                 "description": "For action='react': the emoji to react with (e.g. '❤️'). On iMessage, ❤️👍👎😂‼️❓ render as native tapbacks; other emoji use custom-emoji reactions."
@@ -368,6 +389,15 @@ def _handle_send(args):
     chat_id = None
     thread_id = None
 
+    try:
+        from plugins.platforms.telegram.web_app import normalize_web_app_button
+
+        web_app_button = normalize_web_app_button(args.get("web_app_button"))
+    except ValueError as exc:
+        return tool_error(str(exc))
+    if web_app_button is not None and platform_name != "telegram":
+        return tool_error("web_app_button is only supported for Telegram targets")
+
     if target_ref:
         chat_id, thread_id, is_explicit = _parse_target_ref(platform_name, target_ref)
     else:
@@ -441,6 +471,8 @@ def _handle_send(args):
 
     media_files, cleaned_message = BasePlatformAdapter.extract_media(message)
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    if web_app_button is not None and media_files:
+        return tool_error("web_app_button cannot be combined with MEDIA attachments")
     mirror_text = cleaned_message.strip() or _describe_media_for_mirror(media_files)
 
     used_home_channel = False
@@ -487,15 +519,22 @@ def _handle_send(args):
 
     try:
         from model_tools import _run_async
+        send_kwargs = {
+            "thread_id": thread_id,
+            "media_files": media_files,
+            "force_document": force_document_attachments,
+        }
+        # Preserve the long-standing internal sender call shape for every
+        # ordinary send; only Telegram Web App callers opt into the extension.
+        if web_app_button is not None:
+            send_kwargs["web_app_button"] = web_app_button
         result = _run_async(
             _send_to_platform(
                 platform,
                 pconfig,
                 chat_id,
                 cleaned_message,
-                thread_id=thread_id,
-                media_files=media_files,
-                force_document=force_document_attachments,
+                **send_kwargs,
             )
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
@@ -780,7 +819,16 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(
+    platform,
+    pconfig,
+    chat_id,
+    message,
+    thread_id=None,
+    media_files=None,
+    force_document=False,
+    web_app_button=None,
+):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -860,6 +908,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             thread_id=thread_id,
             disable_link_previews=disable_link_previews,
             force_document=force_document,
+            web_app_button=web_app_button,
         )
 
     # --- Discord: chunked delivery via the registry's standalone_sender_fn.
@@ -1173,7 +1222,16 @@ def _is_telegram_thread_not_found(error: Exception) -> bool:
     return "thread not found" in str(error).lower()
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+async def _send_telegram(
+    token,
+    chat_id,
+    message,
+    media_files=None,
+    thread_id=None,
+    disable_link_previews=False,
+    force_document=False,
+    web_app_button=None,
+):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
     Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
@@ -1234,6 +1292,26 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         # Telegram accepts a numeric chat_id OR an @username string; normalize
         # rather than force-int so username home channels don't crash (#13206).
         int_chat_id = normalize_telegram_chat_id(chat_id)
+        web_app_reply_markup = None
+        if web_app_button is not None:
+            from plugins.platforms.telegram.web_app import normalize_web_app_button
+            from telegram import InlineKeyboardButton, InlineKeyboardMarkup, WebAppInfo
+
+            normalized_button = normalize_web_app_button(web_app_button)
+            chat = await bot.get_chat(int_chat_id)
+            raw_chat_type = getattr(chat, "type", "")
+            chat_type = str(getattr(raw_chat_type, "value", raw_chat_type)).lower()
+            if chat_type != "private":
+                raise ValueError(
+                    "Telegram Web App buttons are only available in private chats "
+                    "between a user and the bot"
+                )
+            web_app_reply_markup = InlineKeyboardMarkup(
+                [[InlineKeyboardButton(
+                    normalized_button["label"],
+                    web_app=WebAppInfo(url=normalized_button["url"]),
+                )]]
+            )
         media_files = media_files or []
         thread_kwargs = {}
         if thread_id is not None:
@@ -1297,27 +1375,31 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             text_chunks = BasePlatformAdapter.truncate_message(
                 formatted, 4096, len_fn=utf16_len
             )
-            for chunk in text_chunks:
+            for chunk_index, chunk in enumerate(text_chunks):
+                chunk_kwargs = dict(text_kwargs)
+                if chunk_index == len(text_chunks) - 1 and web_app_reply_markup is not None:
+                    chunk_kwargs["reply_markup"] = web_app_reply_markup
                 try:
                     last_msg = await _send_telegram_message_with_retry(
                         bot,
                         chat_id=int_chat_id, text=chunk,
-                        parse_mode=send_parse_mode, **text_kwargs
+                        parse_mode=send_parse_mode, **chunk_kwargs
                     )
                 except Exception as md_error:
                     # Thread not found — retry without message_thread_id so the
                     # message still delivers (matching the gateway adapter's
                     # fallback behaviour, issue #27012).
-                    if _is_telegram_thread_not_found(md_error) and text_kwargs.get("message_thread_id") is not None:
+                    if _is_telegram_thread_not_found(md_error) and chunk_kwargs.get("message_thread_id") is not None:
                         logger.warning(
                             "Thread %s not found in _send_telegram, retrying without message_thread_id",
-                            text_kwargs.get("message_thread_id"),
+                            chunk_kwargs.get("message_thread_id"),
                         )
                         text_kwargs.pop("message_thread_id", None)
+                        chunk_kwargs.pop("message_thread_id", None)
                         last_msg = await _send_telegram_message_with_retry(
                             bot,
                             chat_id=int_chat_id, text=chunk,
-                            parse_mode=send_parse_mode, **text_kwargs
+                            parse_mode=send_parse_mode, **chunk_kwargs
                         )
                     elif "parse" in str(md_error).lower() or "markdown" in str(md_error).lower() or "html" in str(md_error).lower():
                         logger.warning(
@@ -1336,7 +1418,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                         last_msg = await _send_telegram_message_with_retry(
                             bot,
                             chat_id=int_chat_id, text=plain,
-                            parse_mode=None, **text_kwargs
+                            parse_mode=None, **chunk_kwargs
                         )
                     else:
                         raise

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -277,6 +277,7 @@ def register(ctx):
 - `ctx.register_cli_command()` registers a CLI subcommand (e.g. `hermes my-plugin <subcommand>`)
 - `ctx.register_command()` registers an in-session slash command (e.g. `/myplugin <args>` inside CLI / gateway chat) — see [Register slash commands](#register-slash-commands) below
 - `ctx.dispatch_tool(name, arguments)` — call any other tool (built-in or from another plugin) with the parent agent's context (approvals, credentials, task_id) wired up automatically. Useful from slash-command handlers that need to invoke `terminal`, `read_file`, or any other tool as if the model had called it directly.
+- `ctx.send_message(target, message, **delivery_options)` — deliver through a configured Hermes platform. Non-bundled plugins fail closed unless the operator grants this separately with `hermes plugins enable <name> --allow-outbound-messaging`; enabling a plugin or one of its model-callable tools does not grant outbound messaging authority.
 - If this function crashes, the plugin is disabled but Hermes continues fine
 
 **`dispatch_tool` example — a slash command that runs a tool:**

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -113,6 +113,7 @@ Every `ctx.*` API below is available inside a plugin's `register(ctx)` function.
 | Register a context-compression engine | `ctx.register_context_engine(engine)` — see [Context Engine Plugins](/developer-guide/context-engine-plugin) |
 | Register a memory backend | Subclass `MemoryProvider` in `plugins/memory/<name>/__init__.py` — see [Memory Provider Plugins](/developer-guide/memory-provider-plugin) (uses a separate discovery system) |
 | Run a host-owned LLM call | `ctx.llm.complete(...)` / `ctx.llm.complete_structured(...)` — borrow the user's active model + auth for a one-shot completion with optional JSON schema validation. See [Plugin LLM Access](/developer-guide/plugin-llm-access) |
+| Send through a configured platform | `ctx.send_message(target, message, **delivery_options)` — non-bundled plugins require an explicit `hermes plugins enable <name> --allow-outbound-messaging` operator grant |
 | Register an inference backend (LLM provider) | `register_provider(ProviderProfile(...))` in `plugins/model-providers/<name>/__init__.py` — see [Model Provider Plugins](/developer-guide/model-provider-plugin) (uses a separate discovery system) |
 
 ## Plugin discovery


### PR DESCRIPTION
## What does this PR do?

Adds a host-owned plugin outbound-message facade and extends the existing send engine with an optional `web_app_button` payload for Telegram private chats. This lets a concrete standalone plugin present an already-hosted HTTPS URL as a native Telegram Mini App button, so a user can open a generated live interface inside Telegram instead of receiving an unstructured link.

This deliberately keeps the core narrow: `send_message` remains unavailable as a model-callable tool. Instead, an enabled plugin may call `ctx.send_message(...)` through the existing host transport. This adds no core model tool, gateway hook, configuration key, hosting service, or deployment behavior. The plugin remains responsible for publishing the app; Hermes core only delivers a URL that is already live.

The implementation follows Telegram's [`InlineKeyboardButton.web_app`](https://core.telegram.org/bots/api#inlinekeyboardbutton) contract and [Mini Apps](https://core.telegram.org/bots/webapps) private-chat restriction. The extra `getChat` request occurs only when `web_app_button` is supplied; ordinary sends retain their existing call shape.

Safety and compatibility behavior:

- accepts only public HTTPS URLs with a hostname
- rejects URLs containing embedded credentials or control characters
- verifies the destination is a private Telegram chat before sending
- rejects use on other platforms and with `MEDIA:` attachments
- attaches the button only to the final chunk of a long text message
- preserves the existing Markdown, thread fallback, proxy, and retry paths

## Related Issue

No linked issue. I searched open and closed issues and PRs for Telegram Mini App, Telegram Web App, and `web_app_button` before implementation and found no duplicate.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/plugins.py`: exposes `ctx.send_message(...)` as the generic plugin-facing facade over Hermes's existing host-owned send engine without registering a model tool.
- `tools/send_message_tool.py`: validates, routes, and renders the optional Telegram Mini App URL button through the existing send engine.
- `plugins/platforms/telegram/web_app.py`: adds a small shared validator for the button label and HTTPS URL contract.
- `tests/tools/test_send_message_telegram_web_app.py`: covers private-chat rendering, non-private rejection, model-facing delivery-only semantics, HTTPS enforcement, exact payload shape, and non-Telegram rejection.
- `tests/hermes_cli/test_plugins.py`: covers structured plugin delivery and prevents plugins from overriding host-owned routing fields.

## How to Test

1. Run the focused send-message suite:
   ```bash
   scripts/run_tests.sh tests/tools/test_send_message*.py -q
   ```
   Expected: 192 send-message tests pass, including all 6 new Telegram Mini App tests.
2. Run the plugin-host integration suite:
   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_plugins.py -q
   ```
   Expected: 118 plugin tests pass, including both new outbound-facade tests. The combined focused run is 310/310 passing.
3. Run static and compatibility checks:
   ```bash
   python -m ruff check tools/send_message_tool.py plugins/platforms/telegram/web_app.py tests/tools/test_send_message_telegram_web_app.py
   python -m ruff format --check plugins/platforms/telegram/web_app.py tests/tools/test_send_message_telegram_web_app.py
   python scripts/check-windows-footguns.py
   git diff --check
   ```
4. From an enabled plugin in an authenticated Telegram session, invoke the host facade for a private user chat:
   ```python
   ctx.send_message(
       "telegram:<private-chat-id>",
       "Your interface is ready.",
       web_app_button={
           "label": "Open app",
           "url": "https://example.com/already-hosted-app",
       },
   )
   ```
   Expected: Telegram displays **Open app** as a native Mini App button. A group target, HTTP URL, credential-bearing URL, malformed payload, or `MEDIA:` combination returns an explicit error.

Full-suite disclosure: `scripts/run_tests.sh` completed 42,849 passing tests on this macOS host. Failures outside this change were narrowed after installing the declared optional dependencies; the remaining macOS/Linux-systemd, `/tmp` alias, and platform-command failures reproduce in a detached clean `origin/main` worktree with the same environment. The full-suite checkbox below is intentionally left unchecked rather than claiming an all-green run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 (Apple silicon), Python 3.12.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the host API docstring and send-engine schema document the new behavior and constraints
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys added
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); the staged Windows footgun scan passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior

## Screenshots / Logs

No screenshot is included because the change is Bot API reply markup rather than a Hermes UI surface. The focused mocked Bot API tests assert the exact native button label and URL, the private-chat check, plugin-host routing, and the failure contracts described above. A real standalone plugin loader contract was also run against this checkout and passed.
