### PR TITLE
fix(codex): preserve live model catalog authority

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5360,23 +5360,44 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             current_model = slug
             changed = True
 
-        # 2. Replace untouched default with a Codex model
-        if self._model_is_default:
-            fallback_model = "gpt-5.3-codex"
-            try:
-                from hermes_cli.codex_models import get_codex_model_ids
+        # 2. Resolve the account catalog once per runtime credential. A
+        # successful live response is exact authority even when empty; only
+        # discovery failure is allowed to expose offline fallback IDs.
+        try:
+            from hermes_cli.codex_models import discover_codex_models
 
-                available = get_codex_model_ids(
+            discovery = None
+            if getattr(self, "_codex_discovery_api_key", object()) == self.api_key:
+                discovery = getattr(self, "_codex_model_discovery", None)
+            if discovery is None:
+                discovery = discover_codex_models(
                     access_token=self.api_key if self.api_key else None,
                 )
-                if available:
-                    fallback_model = available[0]
-            except Exception:
-                pass
+                self._codex_discovery_api_key = self.api_key
+                self._codex_model_discovery = discovery
+        except Exception as exc:
+            raise RuntimeError(
+                "Could not resolve the OpenAI Codex model catalog; refusing to "
+                "synthesize a model ID."
+            ) from exc
 
-            if current_model != fallback_model:
-                self.model = fallback_model
+        available = list(discovery.model_ids)
+        if self._model_is_default:
+            if not available:
+                raise RuntimeError(
+                    "The OpenAI Codex account catalog was fetched successfully but "
+                    "contains no selectable models."
+                )
+            selected_model = available[0]
+            if current_model != selected_model:
+                self.model = selected_model
+                current_model = selected_model
                 changed = True
+        elif discovery.live_authoritative and current_model not in set(available):
+            raise RuntimeError(
+                f"OpenAI Codex model '{current_model}' was not advertised by this "
+                "account's successful live catalog."
+            )
 
         return changed
 

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -76,8 +76,8 @@ def _dedupe_model_ids(
     return ordered
 
 
-def _fetch_models_from_api(access_token: str) -> List[str]:
-    """Fetch available models from the Codex API. Returns visible models sorted by priority."""
+def _fetch_models_from_api(access_token: str) -> Optional[List[str]]:
+    """Fetch the live catalog; ``None`` means the fetch was not authoritative."""
     try:
         import httpx
         resp = httpx.get(
@@ -86,12 +86,14 @@ def _fetch_models_from_api(access_token: str) -> List[str]:
             timeout=10,
         )
         if resp.status_code != 200:
-            return []
+            return None
         data = resp.json()
-        entries = data.get("models", []) if isinstance(data, dict) else []
+        if not isinstance(data, dict) or not isinstance(data.get("models"), list):
+            return None
+        entries = data["models"]
     except Exception as exc:
         logger.debug("Failed to fetch Codex models from API: %s", exc)
-        return []
+        return None
 
     sortable = []
     for item in entries:
@@ -186,7 +188,7 @@ def get_codex_model_ids(access_token: Optional[str] = None) -> List[str]:
     # Try live API if we have a token
     if access_token:
         api_models = _fetch_models_from_api(access_token)
-        if api_models:
+        if api_models is not None:
             return _dedupe_model_ids(api_models)
 
     # Fall back to local sources

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -12,14 +12,10 @@ import os
 logger = logging.getLogger(__name__)
 
 DEFAULT_CODEX_MODELS: List[str] = [
-    # GPT-5.6 series (Sol/Terra/Luna + -pro high-effort modes) — GA 2026-07-09
-    # (previewed 2026-06-26).
+    # GPT-5.6 series exposed by the ChatGPT Codex OAuth backend.
     "gpt-5.6-sol",
-    "gpt-5.6-sol-pro",
     "gpt-5.6-terra",
-    "gpt-5.6-terra-pro",
     "gpt-5.6-luna",
-    "gpt-5.6-luna-pro",
     "gpt-5.5",
     "gpt-5.4-mini",
     "gpt-5.4",
@@ -51,45 +47,32 @@ DEFAULT_CODEX_MODELS: List[str] = [
     # live discovery will pick them up automatically via _fetch_models_from_api.
 ]
 
-_FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
-    ("gpt-5.6-sol", ("gpt-5.5", "gpt-5.4")),
-    ("gpt-5.6-sol-pro", ("gpt-5.5", "gpt-5.4")),
-    ("gpt-5.6-terra", ("gpt-5.5", "gpt-5.4")),
-    ("gpt-5.6-terra-pro", ("gpt-5.5", "gpt-5.4")),
-    ("gpt-5.6-luna", ("gpt-5.5", "gpt-5.4")),
-    ("gpt-5.6-luna-pro", ("gpt-5.5", "gpt-5.4")),
-    ("gpt-5.5", ("gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex")),
-    ("gpt-5.4-mini", ("gpt-5.3-codex",)),
-    ("gpt-5.4", ("gpt-5.3-codex",)),
-    # Surface Spark whenever any compatible Codex template is present so
-    # accounts hitting the live endpoint with an older lineup still see
-    # Spark in the picker. Backend gates real availability by ChatGPT Pro
-    # entitlement; Hermes does not.
-    ("gpt-5.3-codex-spark", ("gpt-5.3-codex",)),
-]
+# These slugs are valid on other OpenAI product/API surfaces but the ChatGPT
+# Codex OAuth endpoint has returned HTTP 400 for them.  Keep them out of
+# offline config/cache fallbacks.  This is deliberately *not* applied to a
+# successful live response: if the Codex endpoint starts advertising one of
+# them for an account, live provider authority immediately re-enables it.
+_LIVE_ONLY_CODEX_MODELS = frozenset(
+    {
+        "gpt-5.6-sol-pro",
+        "gpt-5.6-terra-pro",
+        "gpt-5.6-luna-pro",
+    }
+)
 
 
-def _add_forward_compat_models(model_ids: List[str]) -> List[str]:
-    """Add Clawdbot-style synthetic forward-compat Codex models.
-
-    If a newer Codex slug isn't returned by live discovery, surface it when an
-    older compatible template model is present. This mirrors Clawdbot's
-    synthetic catalog / forward-compat behavior for GPT-5 Codex variants.
-    """
+def _dedupe_model_ids(
+    model_ids: List[str], *, exclude_live_only: bool = False
+) -> List[str]:
+    """Return model IDs once, preserving provider order."""
     ordered: List[str] = []
     seen: set[str] = set()
     for model_id in model_ids:
+        if exclude_live_only and model_id in _LIVE_ONLY_CODEX_MODELS:
+            continue
         if model_id not in seen:
             ordered.append(model_id)
             seen.add(model_id)
-
-    for synthetic_model, template_models in _FORWARD_COMPAT_TEMPLATE_MODELS:
-        if synthetic_model in seen:
-            continue
-        if any(template in seen for template in template_models):
-            ordered.append(synthetic_model)
-            seen.add(synthetic_model)
-
     return ordered
 
 
@@ -130,7 +113,9 @@ def _fetch_models_from_api(access_token: str) -> List[str]:
         sortable.append((rank, slug))
 
     sortable.sort(key=lambda x: (x[0], x[1]))
-    return _add_forward_compat_models([slug for _, slug in sortable])
+    # A successful live response is authoritative.  Do not synthesize models
+    # that the account-specific endpoint did not advertise.
+    return _dedupe_model_ids([slug for _, slug in sortable])
 
 
 def _read_default_model(codex_home: Path) -> Optional[str]:
@@ -202,14 +187,16 @@ def get_codex_model_ids(access_token: Optional[str] = None) -> List[str]:
     if access_token:
         api_models = _fetch_models_from_api(access_token)
         if api_models:
-            return _add_forward_compat_models(api_models)
+            return _dedupe_model_ids(api_models)
 
     # Fall back to local sources
     default_model = _read_default_model(codex_home)
-    if default_model:
+    if default_model and default_model not in _LIVE_ONLY_CODEX_MODELS:
         ordered.append(default_model)
 
     for model_id in _read_cache_models(codex_home):
+        if model_id in _LIVE_ONLY_CODEX_MODELS:
+            continue
         if model_id not in ordered:
             ordered.append(model_id)
 
@@ -217,4 +204,4 @@ def get_codex_model_ids(access_token: Optional[str] = None) -> List[str]:
         if model_id not in ordered:
             ordered.append(model_id)
 
-    return _add_forward_compat_models(ordered)
+    return _dedupe_model_ids(ordered, exclude_live_only=True)

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
@@ -47,18 +48,30 @@ DEFAULT_CODEX_MODELS: List[str] = [
     # live discovery will pick them up automatically via _fetch_models_from_api.
 ]
 
-# These slugs are valid on other OpenAI product/API surfaces but the ChatGPT
-# Codex OAuth endpoint has returned HTTP 400 for them.  Keep them out of
-# offline config/cache fallbacks.  This is deliberately *not* applied to a
-# successful live response: if the Codex endpoint starts advertising one of
-# them for an account, live provider authority immediately re-enables it.
-_LIVE_ONLY_CODEX_MODELS = frozenset(
+# These slugs are valid on other OpenAI product/API surfaces or appeared in
+# older Codex catalogs, but the ChatGPT Codex OAuth endpoint has returned HTTP
+# 400 for them. Keep them out of every offline config/cache/default fallback.
+# This is deliberately *not* applied to a successful live response: if the
+# account endpoint advertises one again, live authority immediately re-enables
+# it.
+_OFFLINE_BLOCKED_CODEX_MODELS = frozenset(
     {
         "gpt-5.6-sol-pro",
         "gpt-5.6-terra-pro",
         "gpt-5.6-luna-pro",
+        "gpt-5.2-codex",
+        "gpt-5.1-codex-max",
+        "gpt-5.1-codex-mini",
     }
 )
+
+
+@dataclass(frozen=True)
+class CodexModelDiscovery:
+    """Resolved model IDs plus whether a successful live response owns them."""
+
+    model_ids: List[str]
+    live_authoritative: bool
 
 
 def _dedupe_model_ids(
@@ -68,7 +81,7 @@ def _dedupe_model_ids(
     ordered: List[str] = []
     seen: set[str] = set()
     for model_id in model_ids:
-        if exclude_live_only and model_id in _LIVE_ONLY_CODEX_MODELS:
+        if exclude_live_only and model_id in _OFFLINE_BLOCKED_CODEX_MODELS:
             continue
         if model_id not in seen:
             ordered.append(model_id)
@@ -96,6 +109,7 @@ def _fetch_models_from_api(access_token: str) -> Optional[List[str]]:
         return None
 
     sortable = []
+    valid_slug_entries = 0
     for item in entries:
         if not isinstance(item, dict):
             continue
@@ -103,6 +117,7 @@ def _fetch_models_from_api(access_token: str) -> Optional[List[str]]:
         if not isinstance(slug, str) or not slug.strip():
             continue
         slug = slug.strip()
+        valid_slug_entries += 1
         # Codex CLI's catalog uses ``supported_in_api`` for the public OpenAI
         # API, not for the OAuth-backed Codex backend that this provider uses.
         # Some valid Codex CLI models (for example gpt-5.3-codex-spark) are
@@ -113,6 +128,12 @@ def _fetch_models_from_api(access_token: str) -> Optional[List[str]]:
         priority = item.get("priority")
         rank = int(priority) if isinstance(priority, (int, float)) else 10_000
         sortable.append((rank, slug))
+
+    # An empty list and a list containing only well-formed hidden entries are
+    # valid authoritative catalogs. A non-empty list in which every entry is
+    # structurally unusable is a schema failure and must use the offline path.
+    if entries and valid_slug_entries == 0:
+        return None
 
     sortable.sort(key=lambda x: (x[0], x[1]))
     # A successful live response is authoritative.  Do not synthesize models
@@ -175,11 +196,12 @@ def _read_cache_models(codex_home: Path) -> List[str]:
     return deduped
 
 
-def get_codex_model_ids(access_token: Optional[str] = None) -> List[str]:
-    """Return available Codex model IDs, trying API first, then local sources.
-    
-    Resolution order: API (live, if token provided) > config.toml default >
-    local cache > hardcoded defaults.
+def discover_codex_models(access_token: Optional[str] = None) -> CodexModelDiscovery:
+    """Resolve Codex models without discarding live-authority provenance.
+
+    ``live_authoritative`` is true for every structurally valid HTTP-200 live
+    catalog, including an empty or all-hidden one. Only transport, HTTP, JSON,
+    or schema failure permits config/cache/default fallback.
     """
     codex_home_str = os.getenv("CODEX_HOME", "").strip() or str(Path.home() / ".codex")
     codex_home = Path(codex_home_str).expanduser()
@@ -189,15 +211,18 @@ def get_codex_model_ids(access_token: Optional[str] = None) -> List[str]:
     if access_token:
         api_models = _fetch_models_from_api(access_token)
         if api_models is not None:
-            return _dedupe_model_ids(api_models)
+            return CodexModelDiscovery(
+                model_ids=_dedupe_model_ids(api_models),
+                live_authoritative=True,
+            )
 
     # Fall back to local sources
     default_model = _read_default_model(codex_home)
-    if default_model and default_model not in _LIVE_ONLY_CODEX_MODELS:
+    if default_model and default_model not in _OFFLINE_BLOCKED_CODEX_MODELS:
         ordered.append(default_model)
 
     for model_id in _read_cache_models(codex_home):
-        if model_id in _LIVE_ONLY_CODEX_MODELS:
+        if model_id in _OFFLINE_BLOCKED_CODEX_MODELS:
             continue
         if model_id not in ordered:
             ordered.append(model_id)
@@ -206,4 +231,13 @@ def get_codex_model_ids(access_token: Optional[str] = None) -> List[str]:
         if model_id not in ordered:
             ordered.append(model_id)
 
-    return _dedupe_model_ids(ordered, exclude_live_only=True)
+    return CodexModelDiscovery(
+        model_ids=_dedupe_model_ids(ordered, exclude_live_only=True),
+        live_authoritative=False,
+    )
+
+
+def get_codex_model_ids(access_token: Optional[str] = None) -> List[str]:
+    """Return model IDs while preserving the historical list-only API."""
+
+    return discover_codex_models(access_token=access_token).model_ids

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5512,6 +5512,8 @@ _EXTRA_KNOWN_ROOT_KEYS = {
     "plugins",           # plugin enable/disable lists (hermes_cli/plugins_cmd.py)
     "smart_model_routing",   # written by the setup wizard (hermes_cli/setup.py)
     "platform_toolsets",     # written by the setup wizard (hermes_cli/setup.py)
+    "known_plugin_toolsets", # written by hermes tools to preserve explicit plugin toggles
+    "group_sessions_per_user",  # documented top-level gateway session-isolation policy
     "session_reset",         # top-level form read by gateway/config.py + setup
     "multiplex_profiles",    # top-level form accepted alongside gateway.multiplex_profiles
     "profile_routes",        # top-level form accepted alongside gateway.profile_routes

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5514,6 +5514,7 @@ _EXTRA_KNOWN_ROOT_KEYS = {
     "platform_toolsets",     # written by the setup wizard (hermes_cli/setup.py)
     "known_plugin_toolsets", # written by hermes tools to preserve explicit plugin toggles
     "group_sessions_per_user",  # documented top-level gateway session-isolation policy
+    "thread_sessions_per_user",  # documented sibling policy read by gateway/config.py
     "session_reset",         # top-level form read by gateway/config.py + setup
     "multiplex_profiles",    # top-level form accepted alongside gateway.multiplex_profiles
     "profile_routes",        # top-level form accepted alongside gateway.profile_routes

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5515,6 +5515,11 @@ _EXTRA_KNOWN_ROOT_KEYS = {
     "known_plugin_toolsets", # written by hermes tools to preserve explicit plugin toggles
     "group_sessions_per_user",  # documented top-level gateway session-isolation policy
     "thread_sessions_per_user",  # documented sibling policy read by gateway/config.py
+    "reset_triggers",       # documented top-level gateway reset command list
+    "write_sessions_json",  # top-level gateway legacy-mirror policy
+    "always_log_local",     # top-level gateway delivery persistence policy
+    "filter_silence_narration",  # top-level outbound message filter
+    "stt_echo_transcripts", # top-level gateway STT echo policy
     "session_reset",         # top-level form read by gateway/config.py + setup
     "multiplex_profiles",    # top-level form accepted alongside gateway.multiplex_profiles
     "profile_routes",        # top-level form accepted alongside gateway.profile_routes

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1914,6 +1914,13 @@ def curated_models_for_provider(
     if normalized == "openrouter":
         return fetch_openrouter_models(force_refresh=force_refresh)
 
+    # provider_model_ids() already performs the complete Codex resolution:
+    # authoritative live catalog (including an empty one), then offline
+    # fallbacks only when live discovery failed. Do not re-synthesize the
+    # static catalog when that authoritative result is empty.
+    if normalized == "openai-codex":
+        return [(m, "") for m in provider_model_ids(normalized)]
+
     # Try live API first (Codex, Nous, etc. all support /models)
     live = provider_model_ids(normalized)
     if live:
@@ -2407,6 +2414,23 @@ def _merge_with_models_dev(provider: str, curated: list[str]) -> list[str]:
     return merged
 
 
+def _resolve_codex_model_discovery(access_token: Optional[str] = None):
+    """Resolve Codex models together with successful-live provenance."""
+
+    from hermes_cli.codex_models import discover_codex_models
+
+    token = access_token
+    if not token:
+        try:
+            from hermes_cli.auth import resolve_codex_runtime_credentials
+
+            creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
+            token = creds.get("api_key")
+        except Exception:
+            token = None
+    return discover_codex_models(access_token=token)
+
+
 def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) -> list[str]:
     """Return the best known model catalog for a provider.
 
@@ -2420,21 +2444,10 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
     if normalized == "openrouter":
         return model_ids(force_refresh=force_refresh)
     if normalized == "openai-codex":
-        from hermes_cli.codex_models import get_codex_model_ids
-
-        # Pass the live OAuth access token so the picker matches whatever
-        # ChatGPT lists for this account right now (new models appear without
-        # a Hermes release). Falls back to the hardcoded catalog if no token
-        # or the endpoint is unreachable.
-        access_token = None
-        try:
-            from hermes_cli.auth import resolve_codex_runtime_credentials
-
-            creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
-            access_token = creds.get("api_key")
-        except Exception:
-            access_token = None
-        return get_codex_model_ids(access_token=access_token)
+        # The discovery object preserves whether an empty result came from a
+        # successful live account catalog. The list-only provider API returns
+        # it verbatim; callers must not layer another static fallback on top.
+        return list(_resolve_codex_model_discovery().model_ids)
     if normalized == "xai-oauth":
         return list(_PROVIDER_MODELS.get("xai-oauth", _PROVIDER_MODELS.get("xai", [])))
     if normalized in {"copilot", "copilot-acp"}:
@@ -2792,6 +2805,13 @@ def cached_provider_model_ids(
     normalized = normalize_provider(provider) or (provider or "")
     if not normalized:
         return []
+
+    # Codex has an account-scoped authoritative catalog and its own explicit
+    # live->offline resolver. The generic cache stores only a bare non-empty
+    # list, so it cannot distinguish live failure from authoritative empty and
+    # could resurrect stale models. Bypass it completely for this provider.
+    if normalized == "openai-codex":
+        return provider_model_ids(normalized, force_refresh=force_refresh)
 
     cache = _load_provider_models_cache()
     fp = _credential_fingerprint(normalized)
@@ -4347,10 +4367,18 @@ def validate_requested_model(
 
     # Providers with non-standard catalog validation — /v1/models probing is not the right path.
     if normalized in {"openai-codex", "xai-oauth"}:
+        live_authoritative = False
         try:
-            catalog_models = provider_model_ids(normalized)
+            if normalized == "openai-codex":
+                discovery = _resolve_codex_model_discovery(access_token=api_key)
+                catalog_models = list(discovery.model_ids)
+                live_authoritative = discovery.live_authoritative
+            else:
+                catalog_models = provider_model_ids(normalized)
         except Exception:
             catalog_models = []
+
+        suggestions: list[str] = []
         if catalog_models:
             if requested_for_lookup in set(catalog_models):
                 return {
@@ -4370,51 +4398,63 @@ def validate_requested_model(
                     "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
                 }
             suggestions = get_close_matches(requested_for_lookup, catalog_models, n=3, cutoff=0.5)
-            suggestion_text = ""
-            if suggestions:
-                suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
-            provider_label = "OpenAI Codex" if normalized == "openai-codex" else "xAI Grok OAuth (SuperGrok / Premium+)"
-            # Plausibility gate (#45006): the soft-accept (#16172 / #19729) exists
-            # for entitlement-gated *hidden* slugs the curated listing hasn't
-            # caught up with — but those are always the provider's own family
-            # (openai-codex -> gpt-*; xai-oauth -> grok-*). Accepting an
-            # unrelated typed name (e.g. `qwen3.5-4b`, `llama-3.1-8b`) here turns
-            # what should be an actionable "did you mean --provider <x>?" error
-            # into a confusing success that 400s on the next turn. Only soft-
-            # accept names that share the provider's family prefix; reject the
-            # rest with guidance to pin the right provider.
-            _family_prefixes = {
-                "openai-codex": ("gpt-", "codex-", "o1", "o3", "o4"),
-                "xai-oauth": ("grok-",),
-            }.get(normalized, ())
-            _lower = requested_for_lookup.strip().lower()
-            _plausible = (not _family_prefixes) or any(
-                _lower.startswith(p) for p in _family_prefixes
-            )
-            if not _plausible:
-                return {
-                    "accepted": False,
-                    "persist": False,
-                    "recognized": False,
-                    "message": (
-                        f"`{requested}` doesn't look like a {provider_label} model "
-                        f"and isn't in its listing, so it was not accepted. If it "
-                        f"belongs to another configured provider, switch with "
-                        f"`--provider <slug>` (or select it from the `/model` "
-                        f"picker)."
-                        f"{suggestion_text}"
-                    ),
-                }
+
+        suggestion_text = ""
+        if suggestions:
+            suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
+        provider_label = "OpenAI Codex" if normalized == "openai-codex" else "xAI Grok OAuth (SuperGrok / Premium+)"
+
+        # A successful account-scoped Codex catalog is exact authority. A slug
+        # absent from it is rejected even when it looks plausible; soft-accept
+        # is reserved for discovery failure/offline operation.
+        if normalized == "openai-codex" and live_authoritative:
             return {
-                "accepted": True,
-                "persist": True,
+                "accepted": False,
+                "persist": False,
                 "recognized": False,
                 "message": (
-                    f"Note: `{requested}` was not found in the {provider_label} model listing. "
-                    "It may still work if your account has access to a newer or hidden model ID."
+                    f"`{requested}` was not advertised by this account's successful "
+                    f"{provider_label} model listing, so it was not accepted."
                     f"{suggestion_text}"
                 ),
             }
+
+        # Plausibility gate (#45006): during offline/failure fallback, accept
+        # only provider-family names that may be entitlement-gated or newer
+        # than the curated snapshot.
+        _family_prefixes = {
+            "openai-codex": ("gpt-", "codex-", "o1", "o3", "o4"),
+            "xai-oauth": ("grok-",),
+        }.get(normalized, ())
+        _lower = requested_for_lookup.strip().lower()
+        _plausible = (not _family_prefixes) or any(
+            _lower.startswith(p) for p in _family_prefixes
+        )
+        if not _plausible:
+            return {
+                "accepted": False,
+                "persist": False,
+                "recognized": False,
+                "message": (
+                    f"`{requested}` doesn't look like a {provider_label} model "
+                    f"and isn't in its listing, so it was not accepted. If it "
+                    f"belongs to another configured provider, switch with "
+                    f"`--provider <slug>` (or select it from the `/model` "
+                    f"picker)."
+                    f"{suggestion_text}"
+                ),
+            }
+        return {
+            "accepted": True,
+            "persist": True,
+            "recognized": False,
+            "message": (
+                f"Note: `{requested}` was not found in the {provider_label} model listing. "
+                "Live discovery was unavailable; it may still work if your account "
+                "has access to a newer or hidden model ID."
+                f"{suggestion_text}"
+            ),
+        }
 
     # MiniMax providers don't expose a /models endpoint — validate against
     # the static catalog instead, similar to openai-codex.

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -104,12 +104,11 @@ _openrouter_catalog_cache: list[tuple[str, str]] | None = None
 def _codex_curated_models() -> list[str]:
     """Derive the openai-codex curated list from codex_models.py.
 
-    Single source of truth: DEFAULT_CODEX_MODELS + forward-compat synthesis.
-    This keeps the gateway /model picker in sync with the CLI `hermes model`
-    flow without maintaining a separate static list.
+    The static picker fallback intentionally contains only models that the
+    Codex OAuth route is known to accept. Live discovery may expose more.
     """
-    from hermes_cli.codex_models import DEFAULT_CODEX_MODELS, _add_forward_compat_models
-    return _add_forward_compat_models(list(DEFAULT_CODEX_MODELS))
+    from hermes_cli.codex_models import DEFAULT_CODEX_MODELS
+    return list(DEFAULT_CODEX_MODELS)
 
 
 # Static fallback for xAI when the models.dev disk cache is empty (fresh

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -253,11 +253,16 @@ def test_codex_provider_replaces_incompatible_default_model(monkeypatch):
             "source": "env/config",
         }
 
+    from hermes_cli.codex_models import CodexModelDiscovery
+
     monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
     monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
     monkeypatch.setattr(
-        "hermes_cli.codex_models.get_codex_model_ids",
-        lambda access_token=None: ["gpt-5.2-codex", "gpt-5.1-codex-mini"],
+        "hermes_cli.codex_models.discover_codex_models",
+        lambda access_token=None: CodexModelDiscovery(
+            ["gpt-5.2-codex", "gpt-5.1-codex-mini"],
+            True,
+        ),
     )
 
     shell = cli.HermesCLI(compact=True, max_turns=1)

--- a/tests/hermes_cli/test_codex_cli_model_picker.py
+++ b/tests/hermes_cli/test_codex_cli_model_picker.py
@@ -85,12 +85,11 @@ def test_codex_picker_uses_live_codex_catalog(hermes_auth_only_env, tmp_path, mo
         ]
     }))
     monkeypatch.setenv("CODEX_HOME", str(codex_home))
-    # Force the cache fallback path — without this the test issues a real
-    # 10s HTTP probe to chatgpt.com/backend-api/codex/models which is both
-    # slow and non-deterministic in CI/sandboxed environments.
+    # Force the cache fallback path — ``None`` denotes an unavailable live
+    # catalog, whereas ``[]`` is a successful authoritative empty catalog.
     monkeypatch.setattr(
         "hermes_cli.codex_models._fetch_models_from_api",
-        lambda access_token: [],
+        lambda access_token: None,
     )
 
     providers = list_authenticated_providers(

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -68,6 +68,73 @@ def test_get_codex_model_ids_uses_live_api_as_exact_authority(monkeypatch):
     assert models == ["gpt-5.3-codex"]
 
 
+def test_successful_empty_live_catalog_does_not_fall_back(monkeypatch):
+    import sys
+
+    class _Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"models": []}
+
+    class _Httpx:
+        @staticmethod
+        def get(*_args, **_kwargs):
+            return _Response()
+
+    monkeypatch.setitem(sys.modules, "httpx", _Httpx)
+    assert get_codex_model_ids(access_token="codex-access-token") == []
+
+
+def test_successful_all_hidden_live_catalog_does_not_fall_back(monkeypatch):
+    import sys
+
+    class _Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"models": [{"slug": "gpt-hidden", "visibility": "hidden"}]}
+
+    class _Httpx:
+        @staticmethod
+        def get(*_args, **_kwargs):
+            return _Response()
+
+    monkeypatch.setitem(sys.modules, "httpx", _Httpx)
+    assert get_codex_model_ids(access_token="codex-access-token") == []
+
+
+def test_non_200_live_catalog_uses_offline_fallback(tmp_path, monkeypatch):
+    import sys
+
+    class _Response:
+        status_code = 503
+
+    class _Httpx:
+        @staticmethod
+        def get(*_args, **_kwargs):
+            return _Response()
+
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    monkeypatch.setitem(sys.modules, "httpx", _Httpx)
+    assert get_codex_model_ids(access_token="codex-access-token") == DEFAULT_CODEX_MODELS
+
+
+def test_live_catalog_transport_failure_uses_offline_fallback(tmp_path, monkeypatch):
+    import sys
+
+    class _Httpx:
+        @staticmethod
+        def get(*_args, **_kwargs):
+            raise OSError("fixture transport failure")
+
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    monkeypatch.setitem(sys.modules, "httpx", _Httpx)
+    assert get_codex_model_ids(access_token="codex-access-token") == DEFAULT_CODEX_MODELS
+
+
 def test_offline_fallback_suppresses_live_only_pro_models(tmp_path, monkeypatch):
     codex_home = tmp_path / "codex-home"
     codex_home.mkdir(parents=True, exist_ok=True)

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -57,23 +57,50 @@ def test_get_codex_model_ids_falls_back_to_curated_defaults(tmp_path, monkeypatc
     assert "gpt-5.3-codex-spark" in models
 
 
-def test_get_codex_model_ids_adds_forward_compat_models_from_templates(monkeypatch):
+def test_get_codex_model_ids_uses_live_api_as_exact_authority(monkeypatch):
     monkeypatch.setattr(
         "hermes_cli.codex_models._fetch_models_from_api",
-        lambda access_token: ["gpt-5.3-codex"],
+        lambda access_token: ["gpt-5.3-codex", "gpt-5.3-codex"],
     )
 
     models = get_codex_model_ids(access_token="codex-access-token")
 
-    # When live discovery only returns gpt-5.3-codex, forward-compat synthesis
-    # should surface gpt-5.5, gpt-5.4, gpt-5.4-mini, and gpt-5.3-codex-spark
-    # (each is templated off gpt-5.3-codex).
-    assert models == [
-        "gpt-5.3-codex",
-        "gpt-5.5",
-        "gpt-5.4-mini",
-        "gpt-5.4",
-        "gpt-5.3-codex-spark",
+    assert models == ["gpt-5.3-codex"]
+
+
+def test_offline_fallback_suppresses_live_only_pro_models(tmp_path, monkeypatch):
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir(parents=True, exist_ok=True)
+    (codex_home / "config.toml").write_text('model = "gpt-5.6-sol-pro"\n')
+    (codex_home / "models_cache.json").write_text(
+        json.dumps(
+            {
+                "models": [
+                    {"slug": "gpt-5.6-sol-pro", "priority": 0},
+                    {"slug": "gpt-5.6-sol", "priority": 1},
+                ]
+            }
+        )
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    models = get_codex_model_ids()
+
+    assert "gpt-5.6-sol" in models
+    assert "gpt-5.6-sol-pro" not in models
+    assert "gpt-5.6-terra-pro" not in models
+    assert "gpt-5.6-luna-pro" not in models
+
+
+def test_live_api_can_reenable_a_live_only_model(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.codex_models._fetch_models_from_api",
+        lambda access_token: ["gpt-5.6-sol-pro", "gpt-5.6-sol"],
+    )
+
+    assert get_codex_model_ids(access_token="codex-access-token") == [
+        "gpt-5.6-sol-pro",
+        "gpt-5.6-sol",
     ]
 
 
@@ -108,9 +135,7 @@ def test_fetch_from_api_keeps_supported_in_api_false_models(monkeypatch):
 
     models = codex_models._fetch_models_from_api(access_token="tok")
 
-    assert "gpt-5.5" in models
-    assert "gpt-5.3-codex-spark" in models
-    assert "gpt-5-internal" not in models
+    assert models == ["gpt-5.5", "gpt-5.3-codex-spark"]
 
 
 def test_model_command_uses_runtime_access_token_for_codex_list(monkeypatch):

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -1,7 +1,14 @@
 import json
 from unittest.mock import patch
 
-from hermes_cli.codex_models import DEFAULT_CODEX_MODELS, get_codex_model_ids
+import pytest
+
+from hermes_cli.codex_models import (
+    DEFAULT_CODEX_MODELS,
+    CodexModelDiscovery,
+    discover_codex_models,
+    get_codex_model_ids,
+)
 
 
 def test_get_codex_model_ids_prioritizes_default_and_cache(tmp_path, monkeypatch):
@@ -25,7 +32,8 @@ def test_get_codex_model_ids_prioritizes_default_and_cache(tmp_path, monkeypatch
 
     models = get_codex_model_ids()
 
-    assert models[0] == "gpt-5.2-codex"
+    assert models[0] == "gpt-5.4"
+    assert "gpt-5.2-codex" not in models
     assert "gpt-5.1-codex" in models
     assert "gpt-5.3-codex" in models
     # Codex CLI marks Spark unsupported in the public API, but the Codex
@@ -84,7 +92,9 @@ def test_successful_empty_live_catalog_does_not_fall_back(monkeypatch):
             return _Response()
 
     monkeypatch.setitem(sys.modules, "httpx", _Httpx)
-    assert get_codex_model_ids(access_token="codex-access-token") == []
+    discovery = discover_codex_models(access_token="codex-access-token")
+    assert discovery.model_ids == []
+    assert discovery.live_authoritative is True
 
 
 def test_successful_all_hidden_live_catalog_does_not_fall_back(monkeypatch):
@@ -103,7 +113,58 @@ def test_successful_all_hidden_live_catalog_does_not_fall_back(monkeypatch):
             return _Response()
 
     monkeypatch.setitem(sys.modules, "httpx", _Httpx)
-    assert get_codex_model_ids(access_token="codex-access-token") == []
+    discovery = discover_codex_models(access_token="codex-access-token")
+    assert discovery.model_ids == []
+    assert discovery.live_authoritative is True
+
+
+def test_all_malformed_live_entries_use_offline_fallback(tmp_path, monkeypatch):
+    import sys
+
+    class _Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"models": [None, {}, {"slug": ""}]}
+
+    class _Httpx:
+        @staticmethod
+        def get(*_args, **_kwargs):
+            return _Response()
+
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    monkeypatch.setitem(sys.modules, "httpx", _Httpx)
+    discovery = discover_codex_models(access_token="codex-access-token")
+    assert discovery.model_ids == DEFAULT_CODEX_MODELS
+    assert discovery.live_authoritative is False
+
+
+def test_mixed_valid_and_malformed_live_entries_keep_valid_authority(monkeypatch):
+    import sys
+
+    class _Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {
+                "models": [
+                    None,
+                    {"slug": ""},
+                    {"slug": "gpt-5.6-sol", "priority": 1},
+                ]
+            }
+
+    class _Httpx:
+        @staticmethod
+        def get(*_args, **_kwargs):
+            return _Response()
+
+    monkeypatch.setitem(sys.modules, "httpx", _Httpx)
+    discovery = discover_codex_models(access_token="codex-access-token")
+    assert discovery.model_ids == ["gpt-5.6-sol"]
+    assert discovery.live_authoritative is True
 
 
 def test_non_200_live_catalog_uses_offline_fallback(tmp_path, monkeypatch):
@@ -144,6 +205,9 @@ def test_offline_fallback_suppresses_live_only_pro_models(tmp_path, monkeypatch)
             {
                 "models": [
                     {"slug": "gpt-5.6-sol-pro", "priority": 0},
+                    {"slug": "gpt-5.2-codex", "priority": 0},
+                    {"slug": "gpt-5.1-codex-max", "priority": 0},
+                    {"slug": "gpt-5.1-codex-mini", "priority": 0},
                     {"slug": "gpt-5.6-sol", "priority": 1},
                 ]
             }
@@ -157,6 +221,9 @@ def test_offline_fallback_suppresses_live_only_pro_models(tmp_path, monkeypatch)
     assert "gpt-5.6-sol-pro" not in models
     assert "gpt-5.6-terra-pro" not in models
     assert "gpt-5.6-luna-pro" not in models
+    assert "gpt-5.2-codex" not in models
+    assert "gpt-5.1-codex-max" not in models
+    assert "gpt-5.1-codex-mini" not in models
 
 
 def test_live_api_can_reenable_a_live_only_model(monkeypatch):
@@ -169,6 +236,67 @@ def test_live_api_can_reenable_a_live_only_model(monkeypatch):
         "gpt-5.6-sol-pro",
         "gpt-5.6-sol",
     ]
+
+
+def test_curated_picker_preserves_authoritative_empty_catalog(monkeypatch):
+    from hermes_cli.models import curated_models_for_provider
+
+    monkeypatch.setattr(
+        "hermes_cli.models._resolve_codex_model_discovery",
+        lambda access_token=None: CodexModelDiscovery([], True),
+    )
+
+    assert curated_models_for_provider("openai-codex") == []
+
+
+def test_generic_disk_cache_cannot_resurrect_stale_codex_models(monkeypatch):
+    from hermes_cli.models import cached_provider_model_ids
+
+    monkeypatch.setattr(
+        "hermes_cli.models.provider_model_ids",
+        lambda provider, force_refresh=False: [],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models._load_provider_models_cache",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("generic disk cache must be bypassed for Codex")
+        ),
+    )
+
+    assert cached_provider_model_ids("openai-codex") == []
+
+
+def test_validation_rejects_slug_absent_from_successful_live_catalog(monkeypatch):
+    from hermes_cli.models import validate_requested_model
+
+    monkeypatch.setattr(
+        "hermes_cli.models._resolve_codex_model_discovery",
+        lambda access_token=None: CodexModelDiscovery(["gpt-5.6-sol"], True),
+    )
+
+    result = validate_requested_model(
+        "gpt-5.6-sol-pro",
+        "openai-codex",
+        api_key="codex-access-token",
+    )
+    assert result["accepted"] is False
+    assert result["persist"] is False
+    assert "not advertised" in result["message"]
+
+
+def test_validation_soft_accepts_plausible_slug_only_offline(monkeypatch):
+    from hermes_cli.models import validate_requested_model
+
+    monkeypatch.setattr(
+        "hermes_cli.models._resolve_codex_model_discovery",
+        lambda access_token=None: CodexModelDiscovery(["gpt-5.6-sol"], False),
+    )
+
+    result = validate_requested_model("gpt-future-codex", "openai-codex")
+    assert result["accepted"] is True
+    assert result["persist"] is True
+    assert result["recognized"] is False
+    assert "Live discovery was unavailable" in result["message"]
 
 
 def test_fetch_from_api_keeps_supported_in_api_false_models(monkeypatch):
@@ -352,13 +480,21 @@ def _make_cli(model="anthropic/claude-opus-4.6", **kwargs):
 
 
 class TestNormalizeModelForProvider:
-    """_normalize_model_for_provider() trusts user-selected models.
+    """_normalize_model_for_provider() trusts explicit models only offline.
 
-    Only two things happen:
-    1. Provider prefixes are stripped (API needs bare slugs)
-    2. The *untouched default* model is swapped for a Codex model
-    Everything else passes through — the API is the judge.
+    Provider prefixes are stripped, untouched defaults use the resolved Codex
+    catalog, and a successful account catalog rejects absent explicit slugs.
     """
+
+    @pytest.fixture(autouse=True)
+    def _offline_discovery(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.codex_models.discover_codex_models",
+            lambda access_token=None: CodexModelDiscovery(
+                model_ids=list(DEFAULT_CODEX_MODELS),
+                live_authoritative=False,
+            ),
+        )
 
     def test_non_codex_provider_is_noop(self):
         cli = _make_cli(model="gpt-5.4")
@@ -448,16 +584,19 @@ class TestNormalizeModelForProvider:
 
         assert cli._model_is_default is True
         with patch(
-            "hermes_cli.codex_models.get_codex_model_ids",
-            return_value=["gpt-5.3-codex", "gpt-5.4"],
+            "hermes_cli.codex_models.discover_codex_models",
+            return_value=CodexModelDiscovery(
+                model_ids=["gpt-5.3-codex", "gpt-5.4"],
+                live_authoritative=True,
+            ),
         ):
             changed = cli._normalize_model_for_provider("openai-codex")
         assert changed is True
         # Uses first from available list
         assert cli.model == "gpt-5.3-codex"
 
-    def test_default_fallback_when_api_fails(self):
-        """No model configured falls back to gpt-5.3-codex when API unreachable."""
+    def test_default_uses_offline_discovery_when_api_fails(self):
+        """Offline discovery may choose a fallback; CLI never invents one."""
         import cli as _cli_mod
         _clean_config = {
             "model": {
@@ -478,9 +617,29 @@ class TestNormalizeModelForProvider:
             cli = HermesCLI()
 
         with patch(
-            "hermes_cli.codex_models.get_codex_model_ids",
-            side_effect=Exception("offline"),
+            "hermes_cli.codex_models.discover_codex_models",
+            return_value=CodexModelDiscovery(
+                model_ids=["gpt-5.6-sol"],
+                live_authoritative=False,
+            ),
         ):
             changed = cli._normalize_model_for_provider("openai-codex")
         assert changed is True
-        assert cli.model == "gpt-5.3-codex"
+        assert cli.model == "gpt-5.6-sol"
+
+    def test_successful_empty_catalog_rejects_synthetic_default(self):
+        cli = _make_cli()
+        cli._model_is_default = True
+        with patch(
+            "hermes_cli.codex_models.discover_codex_models",
+            return_value=CodexModelDiscovery([], True),
+        ), pytest.raises(RuntimeError, match="contains no selectable models"):
+            cli._normalize_model_for_provider("openai-codex")
+
+    def test_successful_live_catalog_rejects_absent_explicit_slug(self):
+        cli = _make_cli(model="gpt-5.6-sol-pro")
+        with patch(
+            "hermes_cli.codex_models.discover_codex_models",
+            return_value=CodexModelDiscovery(["gpt-5.6-sol"], True),
+        ), pytest.raises(RuntimeError, match="was not advertised"):
+            cli._normalize_model_for_provider("openai-codex")

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -247,6 +247,14 @@ class TestUnknownTopLevelKeys:
         unknown = [i for i in issues if "Unknown top-level config key" in i.message]
         assert unknown == [], f"Unexpected unknown-key warnings: {[i.message for i in unknown]}"
 
+    def test_runtime_written_optional_roots_are_accepted(self):
+        """Gateway isolation and saved plugin-toolset roots are valid user config."""
+        issues = validate_config_structure({
+            "group_sessions_per_user": True,
+            "known_plugin_toolsets": {"cli": ["spotify"]},
+        })
+        assert not any("Unknown top-level config key" in issue.message for issue in issues)
+
     def test_known_root_keys_derived_from_default_config(self):
         """_KNOWN_ROOT_KEYS must be DEFAULT_CONFIG.keys() plus extras — single source of truth."""
         assert set(DEFAULT_CONFIG.keys()).issubset(_KNOWN_ROOT_KEYS)

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -248,10 +248,15 @@ class TestUnknownTopLevelKeys:
         assert unknown == [], f"Unexpected unknown-key warnings: {[i.message for i in unknown]}"
 
     def test_runtime_written_optional_roots_are_accepted(self):
-        """Gateway isolation and saved plugin-toolset roots are valid user config."""
+        """Gateway and saved runtime roots consumed by loaders are valid config."""
         issues = validate_config_structure({
             "group_sessions_per_user": True,
             "thread_sessions_per_user": True,
+            "reset_triggers": ["/new", "/reset"],
+            "write_sessions_json": False,
+            "always_log_local": True,
+            "filter_silence_narration": True,
+            "stt_echo_transcripts": False,
             "known_plugin_toolsets": {"cli": ["spotify"]},
         })
         assert not any("Unknown top-level config key" in issue.message for issue in issues)

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -251,6 +251,7 @@ class TestUnknownTopLevelKeys:
         """Gateway isolation and saved plugin-toolset roots are valid user config."""
         issues = validate_config_structure({
             "group_sessions_per_user": True,
+            "thread_sessions_per_user": True,
             "known_plugin_toolsets": {"cli": ["spotify"]},
         })
         assert not any("Unknown top-level config key" in issue.message for issue in issues)

--- a/tests/hermes_cli/test_openai_codex_model_validation_fallback.py
+++ b/tests/hermes_cli/test_openai_codex_model_validation_fallback.py
@@ -9,14 +9,15 @@ behavior so it doesn't regress.
 
 Note: gpt-5.3-codex-spark itself is now in the curated catalog (PR #22991),
 so the real-world Spark request takes the `recognized=True` fast path. This
-test still uses Spark as the example slug but explicitly mocks
-``provider_model_ids`` to omit it, exercising the soft-accept path generically
-for any future entitlement-gated Codex slug that ships before Hermes catalogs
-it.
+test still uses Spark as the example slug but explicitly mocks an unavailable
+live discovery plus an offline fallback that omits it. That exercises the
+soft-accept path generically for a future entitlement-gated Codex slug while
+preserving successful-live account authority.
 """
 
 from unittest.mock import patch
 
+from hermes_cli.codex_models import CodexModelDiscovery
 from hermes_cli.model_switch import switch_model
 from hermes_cli.models import validate_requested_model
 
@@ -26,8 +27,11 @@ def test_openai_codex_unknown_but_plausible_model_is_accepted_with_warning():
     with a warning instead of hard-rejecting it.
     """
     with patch(
-        "hermes_cli.models.provider_model_ids",
-        return_value=["gpt-5.5", "gpt-5.4", "gpt-5.3-codex"],
+        "hermes_cli.models._resolve_codex_model_discovery",
+        return_value=CodexModelDiscovery(
+            ["gpt-5.5", "gpt-5.4", "gpt-5.3-codex"],
+            False,
+        ),
     ):
         result = validate_requested_model("gpt-5.3-codex-spark", "openai-codex")
 
@@ -45,8 +49,11 @@ def test_switch_model_allows_openai_codex_model_missing_from_listing():
     even when the listing has not caught up yet.
     """
     with patch(
-        "hermes_cli.models.provider_model_ids",
-        return_value=["gpt-5.5", "gpt-5.4", "gpt-5.3-codex"],
+        "hermes_cli.models._resolve_codex_model_discovery",
+        return_value=CodexModelDiscovery(
+            ["gpt-5.5", "gpt-5.4", "gpt-5.3-codex"],
+            False,
+        ),
     ):
         result = switch_model(
             "gpt-5.3-codex-spark",


### PR DESCRIPTION
## Summary

- preserve successful account-specific Codex catalog authority end to end, including empty/all-hidden catalogs
- distinguish live discovery failures from authoritative empty catalogs and reject absent configured/requested slugs only when live authority exists
- prevent generic provider-cache fallback from resurrecting stale Codex models
- filter six retired/offline-only Codex slugs while allowing a live catalog to re-advertise them
- accept documented gateway/runtime root configuration keys in strict validation

## Verification

- `940 passed` across all Codex-related test files plus config validation, model validation, provider-resolution, model-switch, and inventory contracts
- Ruff passed on every changed Python file
- `git diff --check` passed
- live account probe returned one authoritative catalog used identically by discovery, picker, and cached-provider paths; `gpt-5.6-sol` validated and absent `gpt-5.6-sol-pro` failed closed
- active config validation returned zero issues

The installed Hermes checkout and running gateway were not modified by this change.
