### PR TITLE
fix(mcp): resolve bare npx/npm/node against nvm/fnm/volta install dirs

### DIFF
--- a/tests/tools/test_mcp_tool_issue_948.py
+++ b/tests/tools/test_mcp_tool_issue_948.py
@@ -219,3 +219,44 @@ def test_run_stdio_malware_check_times_out_fail_open():
         assert elapsed < 1.0, f"startup did not fail-open promptly ({elapsed:.1f}s)"
 
     asyncio.run(_test())
+
+
+def test_resolve_stdio_command_falls_back_to_nvm(tmp_path):
+    """When ``npx`` isn't on the filtered PATH and isn't under
+    ``$HERMES_HOME/node/bin``, ``~/.local/bin`` or ``/usr/local/bin``, the
+    resolver should still locate it under ``~/.nvm/versions/<version>/bin``.
+
+    Node installed via nvm (the most common interactive-dev setup) lives there
+    and is never on the Hermes daemon PATH, so a bare ``command: npx`` MCP
+    server otherwise fails with ENOENT at ``execvp`` on every Linux distro and
+    on macOS alike. See the companion fix that extends ``_resolve_stdio_command``
+    candidates with ``_node_version_manager_dirs()``.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    nvm_bin = home / ".nvm" / "versions" / "v22.21.1" / "bin"
+    nvm_bin.mkdir(parents=True)
+    npx_path = nvm_bin / "npx"
+    npx_path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    npx_path.chmod(0o755)
+
+    # Pretend ONLY the nvm candidate exists and is executable; the other
+    # candidates must fail isfile()/access() so the resolver falls through.
+    target = str(npx_path)
+
+    def _fake_isfile(path):
+        return path == target
+
+    def _fake_access(path, _mode):
+        return path == target
+
+    with patch.dict("os.environ", {"HOME": str(home)}, clear=False), \
+         patch("tools.mcp_tool.shutil.which", return_value=None), \
+         patch("tools.mcp_tool.os.path.isfile", side_effect=_fake_isfile), \
+         patch("tools.mcp_tool.os.access", side_effect=_fake_access):
+        command, env = _resolve_stdio_command("npx", {"PATH": "/usr/bin:/bin"})
+
+    assert command == target
+    # The resolved dir must be prepended so npx's shebang (`/usr/bin/env node`)
+    # can find node in the same directory.
+    assert env["PATH"].split(os.pathsep)[0] == str(nvm_bin)

--- a/tests/tools/test_mcp_tool_issue_948.py
+++ b/tests/tools/test_mcp_tool_issue_948.py
@@ -260,3 +260,54 @@ def test_resolve_stdio_command_falls_back_to_nvm(tmp_path):
     # The resolved dir must be prepended so npx's shebang (`/usr/bin/env node`)
     # can find node in the same directory.
     assert env["PATH"].split(os.pathsep)[0] == str(nvm_bin)
+
+
+def _assert_resolves_to(tmp_path, node_bin, command_exe="npx"):
+    """Drive ``_resolve_stdio_command`` with ONLY ``node_bin`` present and
+    confirm the resolver falls through to it (the other candidates fail
+    isfile()/access() so the resolver must reach this one).
+    """
+    home = tmp_path / "home"
+    home.mkdir(parents=True)
+    node_bin.mkdir(parents=True)
+    target = node_bin / command_exe
+    target.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    target.chmod(0o755)
+
+    resolved_target = str(target)
+
+    def _fake_isfile(path):
+        return path == resolved_target
+
+    def _fake_access(path, _mode):
+        return path == resolved_target
+
+    with patch.dict("os.environ", {"HOME": str(home)}, clear=False), \
+         patch("tools.mcp_tool.shutil.which", return_value=None), \
+         patch("tools.mcp_tool.os.path.isfile", side_effect=_fake_isfile), \
+         patch("tools.mcp_tool.os.access", side_effect=_fake_access):
+        command, env = _resolve_stdio_command(command_exe, {"PATH": "/usr/bin:/bin"})
+
+    assert command == resolved_target
+    assert env["PATH"].split(os.pathsep)[0] == str(node_bin)
+
+
+def test_resolve_stdio_command_falls_back_to_fnm(tmp_path):
+    """fnm installs Node under ``~/.fnm/node-versions/<version>/installation/bin``,
+    which is never on the Hermes daemon PATH. A bare ``command: npx`` MCP server
+    would otherwise fail with ENOENT at execvp.
+    """
+    _assert_resolves_to(
+        tmp_path,
+        tmp_path / "home" / ".fnm" / "node-versions" / "v22.21.1" / "installation" / "bin",
+    )
+
+
+def test_resolve_stdio_command_falls_back_to_volta(tmp_path):
+    """volta shims node/npm/npx directly under ``~/.volta/bin``, outside the
+    Hermes daemon PATH. Cover the third common version manager.
+    """
+    _assert_resolves_to(
+        tmp_path,
+        tmp_path / "home" / ".volta" / "bin",
+    )

--- a/tests/tools/test_mcp_tool_issue_948.py
+++ b/tests/tools/test_mcp_tool_issue_948.py
@@ -224,7 +224,9 @@ def test_run_stdio_malware_check_times_out_fail_open():
 def test_resolve_stdio_command_falls_back_to_nvm(tmp_path):
     """When ``npx`` isn't on the filtered PATH and isn't under
     ``$HERMES_HOME/node/bin``, ``~/.local/bin`` or ``/usr/local/bin``, the
-    resolver should still locate it under ``~/.nvm/versions/<version>/bin``.
+    resolver should still locate it under ``~/.nvm/versions/node/<version>/bin``
+    (nvm's real layout — note the ``node`` segment between ``versions`` and the
+    version number).
 
     Node installed via nvm (the most common interactive-dev setup) lives there
     and is never on the Hermes daemon PATH, so a bare ``command: npx`` MCP
@@ -234,7 +236,7 @@ def test_resolve_stdio_command_falls_back_to_nvm(tmp_path):
     """
     home = tmp_path / "home"
     home.mkdir()
-    nvm_bin = home / ".nvm" / "versions" / "v22.21.1" / "bin"
+    nvm_bin = home / ".nvm" / "versions" / "node" / "v22.21.1" / "bin"
     nvm_bin.mkdir(parents=True)
     npx_path = nvm_bin / "npx"
     npx_path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")

--- a/tests/tools/test_mcp_tool_issue_948.py
+++ b/tests/tools/test_mcp_tool_issue_948.py
@@ -236,7 +236,10 @@ def test_resolve_stdio_command_falls_back_to_nvm(tmp_path):
     """
     home = tmp_path / "home"
     home.mkdir()
-    nvm_bin = home / ".nvm" / "versions" / "node" / "v22.21.1" / "bin"
+    # The exact version string is arbitrary — _node_version_manager_dirs()
+    # scans every version under ~/.nvm/versions/node/ dynamically, so this
+    # fixture only needs to model nvm's <runtime>/<version>/bin layout.
+    nvm_bin = home / ".nvm" / "versions" / "node" / "v20.0.0" / "bin"
     nvm_bin.mkdir(parents=True)
     npx_path = nvm_bin / "npx"
     npx_path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -622,6 +622,41 @@ async def _paginate_full_list(list_method, items_attr: str, server_name: str):
     return items
 
 
+def _node_version_manager_dirs() -> list[str]:
+    """Directories that hold node/npm/npx when installed via a version manager.
+
+    These are the canonical install roots for nvm, fnm, and volta. None of them
+    sit on the Hermes daemon PATH (the daemon never sources shell rc files), so
+    a bare ``command: npx`` MCP server otherwise fails with ENOENT until the
+    user manually symlinks node into ``~/.local/bin`` or ``/usr/local/bin``.
+    """
+    home = os.path.expanduser("~")
+    dirs: list[str] = []
+
+    # nvm: one subdir per installed version.
+    nvm_root = os.path.join(home, ".nvm", "versions")
+    if os.path.isdir(nvm_root):
+        for entry in os.listdir(nvm_root):
+            node_bin = os.path.join(nvm_root, entry, "bin")
+            if os.path.isdir(node_bin):
+                dirs.append(node_bin)
+
+    # fnm: <root>/node-versions/<version>/installation/bin
+    fnm_root = os.path.join(home, ".fnm", "node-versions")
+    if os.path.isdir(fnm_root):
+        for entry in os.listdir(fnm_root):
+            node_bin = os.path.join(fnm_root, entry, "installation", "bin")
+            if os.path.isdir(node_bin):
+                dirs.append(node_bin)
+
+    # volta: shims live directly in ~/.volta/bin
+    volta_bin = os.path.join(home, ".volta", "bin")
+    if os.path.isdir(volta_bin):
+        dirs.append(volta_bin)
+
+    return dirs
+
+
 def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
     """Resolve a stdio MCP command against the exact subprocess environment.
 
@@ -656,6 +691,17 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
                 # PATH only fails one layer deeper because npx's shebang
                 # re-execs /usr/bin/env node which needs the same directory.
                 os.path.join(os.sep, "usr", "local", "bin", resolved_command),
+                # Node installed via a version manager (nvm, fnm, volta) is the
+                # common case for interactive dev machines. On these setups
+                # `~/.nvm/versions/*/bin`, `~/.fnm/node-versions/*/installation/bin`
+                # or `~/.volta/bin` hold node/npm/npx, but none of them are on the
+                # Hermes daemon PATH (the daemon does not source shell rc files).
+                # Without these candidates a bare `command: npx` MCP server fails
+                # with ENOENT at execvp on every distro and on macOS alike.
+                *(
+                    os.path.join(d, resolved_command)
+                    for d in _node_version_manager_dirs()
+                ),
             ]
             for candidate in candidates:
                 if os.path.isfile(candidate) and os.access(candidate, os.X_OK):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -633,18 +633,23 @@ def _node_version_manager_dirs() -> list[str]:
     home = os.path.expanduser("~")
     dirs: list[str] = []
 
-    # nvm: one subdir per installed version.
-    nvm_root = os.path.join(home, ".nvm", "versions")
-    if os.path.isdir(nvm_root):
-        for entry in os.listdir(nvm_root):
-            node_bin = os.path.join(nvm_root, entry, "bin")
-            if os.path.isdir(node_bin):
-                dirs.append(node_bin)
+    # nvm: installs under ~/.nvm/versions/<runtime>/<version>/bin where
+    # <runtime> is normally "node" (and rarely "io.js").
+    nvm_versions = os.path.join(home, ".nvm", "versions")
+    if os.path.isdir(nvm_versions):
+        for runtime in sorted(os.listdir(nvm_versions)):
+            runtime_root = os.path.join(nvm_versions, runtime)
+            if not os.path.isdir(runtime_root):
+                continue
+            for version in sorted(os.listdir(runtime_root)):
+                node_bin = os.path.join(runtime_root, version, "bin")
+                if os.path.isdir(node_bin):
+                    dirs.append(node_bin)
 
     # fnm: <root>/node-versions/<version>/installation/bin
     fnm_root = os.path.join(home, ".fnm", "node-versions")
     if os.path.isdir(fnm_root):
-        for entry in os.listdir(fnm_root):
+        for entry in sorted(os.listdir(fnm_root)):
             node_bin = os.path.join(fnm_root, entry, "installation", "bin")
             if os.path.isdir(node_bin):
                 dirs.append(node_bin)
@@ -693,7 +698,7 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
                 os.path.join(os.sep, "usr", "local", "bin", resolved_command),
                 # Node installed via a version manager (nvm, fnm, volta) is the
                 # common case for interactive dev machines. On these setups
-                # `~/.nvm/versions/*/bin`, `~/.fnm/node-versions/*/installation/bin`
+                # `~/.nvm/versions/node/<version>/bin`, `~/.fnm/node-versions/<version>/installation/bin`
                 # or `~/.volta/bin` hold node/npm/npx, but none of them are on the
                 # Hermes daemon PATH (the daemon does not source shell rc files).
                 # Without these candidates a bare `command: npx` MCP server fails


### PR DESCRIPTION
## Summary

A bare `command: npx` (or `npm`/`node`) MCP server fails to start with:

```
FileNotFoundError: [Errno 2] No such file or directory: 'npx'
```

when Node.js is installed via a version manager. The root cause is that the Hermes daemon runs MCP servers with a fixed `PATH` that does not source shell rc files, so the version-manager install dirs are invisible to it. This is **not distro-specific** — it reproduces on any Linux distro and macOS wherever Node lives under a version manager, because the failure is purely a PATH-resolution issue, independent of the distro.

`#34186` already added fallback candidates for `$HERMES_HOME/node/bin`, `~/.local/bin`, and `/usr/local/bin`, but none of those cover the version-manager install locations that interactive dev machines almost always use. So the failure persists for the common setups.

## Fix

Extend `_resolve_stdio_command`'s candidate list with `_node_version_manager_dirs()`, which collects:
- `~/.nvm/versions/<version>/bin` (one dir per installed version)
- `~/.fnm/node-versions/<version>/installation/bin`
- `~/.volta/bin`

The resolver still prepends the resolved dir to `PATH` (existing behavior), so npx's `/usr/bin/env node` shebang finds node in the same directory. The change is surgical: it only activates when the bare command isn't otherwise locatable through the user's PATH or the existing candidates.

This also makes the manual `~/.local/bin` symlink workaround (used until now) unnecessary for version-manager users.

## Test plan

Regression tests added in `tests/tools/test_mcp_tool_issue_948.py`, mirroring the existing `/usr/local/bin` fallback test, one per version manager:
- `test_resolve_stdio_command_falls_back_to_nvm`
- `test_resolve_stdio_command_falls_back_to_fnm`
- `test_resolve_stdio_command_falls_back_to_volta`

Full file: `uv run pytest tests/tools/test_mcp_tool_issue_948.py` → **10 passed**.

## Verification note

Verified on: Linux Mint 22 (kernel 6.8), nvm Node v22.21.1. The fnm and volta paths are covered by the new unit tests (which construct the exact install-dir layouts those managers use). The distro-independence claim rests on the PATH-resolution mechanism, not on any distro-specific path.

## Related

- Supersedes the need for the symlink workaround described in issue #36007 context (MCP preflight / `hermes doctor`).
