### PR TITLE
fix(agent): resolve kimi-k3 context window to 1M in fallback table

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -317,6 +317,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     "grok-2": 131072,           # grok-2, grok-2-1212, grok-2-latest
     "grok": 131072,             # catch-all (grok-beta, unknown grok-*)
     # Kimi
+    "kimi-k3": 1048576,     # kimi-k3 — 1M context per Moonshot launch specs
     "kimi": 262144,
     # Upstage Solar — api.upstage.ai/v1/models does not return context_length,
     # so these fallbacks keep token budgeting / compression from probing down


### PR DESCRIPTION
## Motivation

Kimi K3 (Moonshot AI, 2.8T MoE) ships with a **1M-token context window** — models.dev agrees: `kimi-for-coding/k3`, `moonshotai/kimi-k3`, and `moonshotai-cn/kimi-k3` all report `context: 1048576`.

However, `DEFAULT_CONTEXT_LENGTHS` in `agent/model_metadata.py` had only the K2-generation catch-all `"kimi": 262144`. Longest-prefix matching resolves `kimi-k3` → `kimi` → 256K, so for configurations where the models.dev provider lookup misses — e.g. `provider: kimi-for-coding` with `base_url: https://api.moonshot.ai/v1` — the stale fallback wins and Hermes budgets/compacts at **a quarter of K3's actual working memory**.

## Change

One line: `"kimi-k3": 1048576` ahead of the `"kimi"` catch-all (longest-first matching makes it win). Fallback-table only; no change to live-metadata resolution paths.

## Verification

```
agent.model_metadata.get_model_context_length('kimi-k3', base_url='https://api.moonshot.ai/v1')
  pre-patch:  262144
  post-patch: 1048576
```

`kimi-k2.6` and other K2-family ids still resolve via the `kimi` catch-all to 262144, unchanged.

## Risk

None identified — additive, more-specific fallback entry; live metadata (models.dev / provider endpoints) still takes precedence where available.