### PR TITLE
fix(qqbot): authorize approval clicks for dm sessions

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1100,7 +1100,7 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        if chat_type in {"c2c", "dm"}:
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -97,6 +97,48 @@ class TestQQAdapterInit:
 
 
 # ---------------------------------------------------------------------------
+# Approval interaction authorization
+# ---------------------------------------------------------------------------
+
+class TestApprovalInteractionAuthorization:
+    def _make_adapter(self):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+    @staticmethod
+    def _event(operator_openid):
+        from gateway.platforms.qqbot.keyboards import InteractionEvent
+        return InteractionEvent(user_openid=operator_openid)
+
+    def test_dm_session_authorizes_matching_operator(self):
+        adapter = self._make_adapter()
+        event = self._event("user-123")
+
+        assert adapter._is_authorized_interaction_for_session(
+            event,
+            "agent:main:qqbot:dm:user-123",
+        ) is True
+
+    def test_dm_session_rejects_different_operator(self):
+        adapter = self._make_adapter()
+        event = self._event("attacker-456")
+
+        assert adapter._is_authorized_interaction_for_session(
+            event,
+            "agent:main:qqbot:dm:user-123",
+        ) is False
+
+    def test_c2c_session_still_authorizes_matching_operator(self):
+        adapter = self._make_adapter()
+        event = self._event("user-123")
+
+        assert adapter._is_authorized_interaction_for_session(
+            event,
+            "agent:main:qqbot:c2c:user-123",
+        ) is True
+
+
+# ---------------------------------------------------------------------------
 # _coerce_list
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

QQBot approval interactions validate private sessions as `c2c`, but gateway session keys for QQ direct messages use `dm`. As a result, a legitimate approval click is rejected even when the button operator matches the session chat ID, and the pending command eventually times out.

This change treats `dm` and `c2c` as equivalent private-session labels while preserving the existing fail-closed identity check:

```python
operator_openid == chat_id
```

Group and guild authorization paths are unchanged.

## Tests

Added regression coverage for:

- matching operator on a `dm` session is authorized;
- different operator on a `dm` session is rejected;
- matching operator on an existing `c2c` session remains authorized.

Validation:

```text
Targeted regression tests: 3 passed
Full tests/gateway/test_qqbot.py: 169 passed
```

The four warnings emitted by the full file are pre-existing un-awaited-coroutine warnings unrelated to this change.
