### PR TITLE
fix(model-switch): preserve per-model metadata dict in _save_discovered_models_to_config (#67841)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -133,6 +133,11 @@ def _save_discovered_models_to_config(
             if entry_url.rstrip("/").lower() != norm_url:
                 continue
             existing = entry.get("models")
+            # Preserve per-model metadata: when ``models`` is a mapping
+            # (e.g. ``{"model-a": {"context_length": 8192}}``), the user
+            # has curated metadata per model — do not replace it.
+            if isinstance(existing, dict):
+                continue
             # Only update when models are stale — avoids unnecessary
             # config writes on every picker open.
             if isinstance(existing, list) and existing == model_ids:

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -1479,3 +1479,40 @@ def test_save_discovered_models_noop_on_empty_args(monkeypatch):
     _save_discovered_models_to_config("", [])
 
     assert load_calls == 0, "load_config must not be called for empty args"
+
+
+def test_save_discovered_models_preserves_dict_form(monkeypatch):
+    """``_save_discovered_models_to_config`` must not replace a dict-form
+    ``models`` mapping (per-model metadata like ``context_length``) with
+    a flat list of strings (#67841)."""
+    from hermes_cli.model_switch import _save_discovered_models_to_config
+
+    save_calls = []
+
+    def fake_save(config):
+        save_calls.append(dict(config))
+
+    monkeypatch.setattr("hermes_cli.config.save_config", fake_save)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "my-gateway",
+                    "base_url": "https://gateway.example.com/v1",
+                    "models": {
+                        "configured-model": {"context_length": 8192},
+                    },
+                }
+            ]
+        },
+    )
+
+    # Dict-form models must NOT be overwritten by discovered models
+    _save_discovered_models_to_config(
+        "https://gateway.example.com/v1",
+        ["configured-model", "discovered-model"],
+    )
+    assert save_calls == [], (
+        "Dict-form models must not be replaced with a flat list"
+    )


### PR DESCRIPTION
## What does this PR do?

When `custom_providers[].models` uses the mapping form to store per-model metadata (e.g. `context_length`), the `_save_discovered_models_to_config` helper added by PR #65652 unconditionally replaces it with a flat list of strings — silently deleting the users curated metadata.

This fix adds a guard: when the existing `models` value is a `dict` (the mapping form), the entry is skipped and no write occurs. The list-form `models` continues to be updated as before.

## Related Issue

Fixes #67841

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_switch.py`: skip dict-form `models` entries in `_save_discovered_models_to_config`
- `tests/hermes_cli/test_model_switch_custom_providers.py`: add `test_save_discovered_models_preserves_dict_form` regression test

## How to Test

1. `python -m pytest tests/hermes_cli/test_model_switch_custom_providers.py -q` → 47 passed (46 existing + 1 new)
2. Manual: a `custom_providers` entry with `models: {"configured-model": {"context_length": 8192}}` is no longer replaced by the prewarm path.

## Checklist

### Code

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isnt a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] Ive run `pytest tests/hermes_cli/test_model_switch_custom_providers.py -q` and all tests pass
- [x] Ive added tests for my changes