### PR TITLE
fix: clean up tracked background processes on worker exit

### DIFF
--- a/tests/tools/test_zombie_process_cleanup.py
+++ b/tests/tools/test_zombie_process_cleanup.py
@@ -342,3 +342,42 @@ class TestDelegationCleanup:
         child.close.assert_called_once()
         assert child not in parent._active_children
         assert result["status"] == "error"
+
+
+class TestAtexitProcessCleanup:
+    """Verify _atexit_cleanup() kills tracked background processes
+    before tearing down environments (issue: orphan-process leak)."""
+
+    def test_atexit_calls_kill_all_before_env_cleanup(self):
+        """_atexit_cleanup must call process_registry.kill_all() before
+        cleanup_all_environments() so tracked bg processes are reaped."""
+        import tools.terminal_tool  # ensure module is loaded for patch
+        from unittest.mock import call, patch
+
+        with patch.object(tools.terminal_tool, "_stop_cleanup_thread"), \
+             patch.object(tools.terminal_tool, "_active_environments", {"task-1": object()}), \
+             patch.object(tools.terminal_tool, "cleanup_all_environments") as mock_env_cleanup, \
+             patch("tools.process_registry.process_registry") as mock_registry, \
+             patch.object(tools.terminal_tool, "logger"):
+            tools.terminal_tool._atexit_cleanup()
+
+            mock_registry.kill_all.assert_called_once()
+            mock_env_cleanup.assert_called_once()
+
+    def test_atexit_env_cleanup_runs_when_kill_all_raises(self):
+        """Environment cleanup must still run even if process_registry.kill_all()
+        raises — never leave orphan containers/Docker resources behind."""
+        import tools.terminal_tool  # ensure module is loaded for patch
+        from unittest.mock import patch
+
+        with patch.object(tools.terminal_tool, "_stop_cleanup_thread"), \
+             patch.object(tools.terminal_tool, "_active_environments", {"task-1": object()}), \
+             patch.object(tools.terminal_tool, "cleanup_all_environments") as mock_env_cleanup, \
+             patch("tools.process_registry.process_registry") as mock_registry, \
+             patch.object(tools.terminal_tool, "logger"):
+            mock_registry.kill_all.side_effect = RuntimeError("boom")
+
+            tools.terminal_tool._atexit_cleanup()
+
+            # env cleanup must still run despite kill_all failure
+            mock_env_cleanup.assert_called_once()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1856,6 +1856,16 @@ def cleanup_vm(task_id: str, *, force_remove: bool = False):
 def _atexit_cleanup():
     """Stop cleanup thread and shut down all remaining sandboxes on exit."""
     _stop_cleanup_thread()
+    # Kill tracked background processes (vite, playwright, workerd, etc.)
+    # BEFORE tearing down environments — prevents orphan accumulation
+    # in shared Docker containers when the worker exits.
+    try:
+        from tools.process_registry import process_registry
+        killed = process_registry.kill_all()
+        if killed:
+            logger.info("Atexit: killed %d tracked background process(es)", killed)
+    except Exception as e:
+        logger.warning("Atexit: process_registry.kill_all() failed: %s", e)
     if _active_environments:
         count = len(_active_environments)
         logger.info("Shutting down %d remaining sandbox(es)...", count)


### PR DESCRIPTION
## Problem

Background processes (Vite, Playwright, workerd) tracked by `process_registry` survive Hermes worker exit, accumulating until Docker PidsLimit exhaustion.

Root cause: `_atexit_cleanup()` calls `cleanup_all_environments()` but never calls `process_registry.kill_all()`, so tracked subprocesses outlive the worker.

## Fix

Call `process_registry.kill_all()` in `_atexit_cleanup()` before `cleanup_all_environments()`, wrapped in try/except so environment cleanup always runs even if process cleanup raises.

- `kill_all()` operates on `self._running` (in-memory dict) — registry-local, no cross-worker risk
- Exception-safe: env cleanup runs regardless
- Existing logger conventions, local import pattern

## Changes

- `tools/terminal_tool.py` — +10 lines in `_atexit_cleanup()`
- `tests/tools/test_zombie_process_cleanup.py` — +39 lines, 2 regression tests

## Tests

- RED: `test_atexit_calls_kill_all_before_env_cleanup` failed before fix (kill_all never called)
- GREEN: both new tests pass after fix
- `test_zombie_process_cleanup.py`: 13/14 pass (1 pre-existing unrelated failure)
- Related test files: 108/108 pass
- `git diff --check` clean, `py_compile` ok

## Deliberately skipped

- Task-id isolation (separate issue)
- Docker persistence defaults
- Idle reaper policy / PidsLimit config
- Profile config / s6 services / live container changes