### PR TITLE
fix(tui): include apps/shared in npm build source for @hermes/shared workspace dependency

### DIFF
--- a/nix/tui.nix
+++ b/nix/tui.nix
@@ -1,7 +1,7 @@
 # nix/tui.nix — Hermes TUI (Ink/React) compiled with tsc and bundled
 { pkgs, hermesNpmLib, ... }:
 let
-  npm = hermesNpmLib.mkNpmPassthru { dirs = [ "ui-tui" ]; };
+  npm = hermesNpmLib.mkNpmPassthru { dirs = [ "ui-tui" "apps/shared" ]; };
 
   packageJson = builtins.fromJSON (builtins.readFile (npm.src + "/ui-tui/package.json"));
   version = packageJson.version;


### PR DESCRIPTION
## What does this PR do?

The TUI build (`nix/tui.nix`) only passes `dirs = [ "ui-tui" ]` to `mkNpmPassthru`. While `apps/shared/package.json` is included for npm workspace resolution, the `apps/shared/src/` directory (with the actual TypeScript source files) is not — causing esbuild to fail resolving `@hermes/shared/charge-settlement`.

Adds `"apps/shared"` to the dirs list, matching the existing pattern used by `apps/desktop` (`dirs = [ "apps/desktop" "apps/shared" ]`).

## Related Issue

Fixes #67056
Fixes #67079

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `nix/tui.nix:4` — add `"apps/shared"` to `mkNpmPassthru` dirs

## How to Test

1. `nix build .#tui` — previously failed with `ERROR: Could not resolve "@hermes/shared/charge-settlement"`, now succeeds
2. `nix build .#packages.x86_64-linux.default` — full hermes-agent package builds correctly

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS x86_64-linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A