### PR TITLE
fix(gateway): keep shared-group sender prefix outermost

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11477,23 +11477,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             group_sessions_per_user=_group_sessions_per_user,
             thread_sessions_per_user=_thread_sessions_per_user,
         )
-        if _is_shared_multi_user and source.user_name:
-            # source.user_name is the platform display name — attacker-
-            # influenceable on any platform that lets participants set their
-            # own name. Neutralize embedded newlines/control chars before
-            # interpolating it into every message in the shared session, or
-            # a hostile name can masquerade as a fake markdown section
-            # (mirrors the same field's treatment in
-            # build_session_context_prompt via _format_untrusted_prompt_value).
-            _safe_user_name = neutralize_untrusted_inline_text(source.user_name)
-            message_text = f"[{_safe_user_name}] {message_text}"
-
-        # Prepend channel context from history backfill (if any).  This
-        # happens after sender-prefix so the prefix only applies to the
-        # trigger message, not the backfill block.
-        if getattr(event, "channel_context", None):
-            message_text = f"{event.channel_context}\n\n[New message]\n{message_text}"
-
         # Declare at outer scope so the audio-file-paths handling block below
         # remains safe when ``event.media_urls`` is empty (no inner block runs).
         audio_file_paths: list[str] = []
@@ -11816,6 +11799,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as exc:
                 logger.warning("@ context reference expansion failed: %s", exc)
                 logger.debug("@ context reference expansion failure detail", exc_info=True)
+
+        if _is_shared_multi_user and source.user_name:
+            # source.user_name is the platform display name — attacker-
+            # influenceable on any platform that lets participants set their
+            # own name. Neutralize embedded newlines/control chars before
+            # interpolating it into every message in the shared session, or
+            # a hostile name can masquerade as a fake markdown section
+            # (mirrors the same field's treatment in
+            # build_session_context_prompt via _format_untrusted_prompt_value).
+            _safe_user_name = neutralize_untrusted_inline_text(source.user_name)
+            message_text = f"[{_safe_user_name}] {message_text}"
+
+        # Prepend channel context from history backfill (if any) after sender
+        # attribution so the prefix only applies to the triggering turn, not
+        # the backfill block.
+        if getattr(event, "channel_context", None):
+            message_text = f"{event.channel_context}\n\n[New message]\n{message_text}"
 
         return message_text
 

--- a/tests/gateway/test_shared_group_sender_prefix.py
+++ b/tests/gateway/test_shared_group_sender_prefix.py
@@ -1,7 +1,9 @@
+from unittest.mock import patch
+
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
-from gateway.platforms.base import MessageEvent
+from gateway.platforms.base import MessageEvent, MessageType
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
 
@@ -44,6 +46,61 @@ async def test_preprocess_prefixes_sender_for_shared_non_thread_group_session():
 
 
 @pytest.mark.asyncio
+async def test_shared_sender_prefix_wraps_enriched_turn_before_channel_context():
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake"),
+            },
+            group_sessions_per_user=False,
+        )
+    )
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1002285219667",
+        chat_name="Test Group",
+        chat_type="group",
+        user_name="Ali\nce",
+    )
+    event = MessageEvent(
+        text="please review",
+        message_type=MessageType.AUDIO,
+        source=source,
+        media_urls=["/tmp/cache_123_recording.mp3"],
+        media_types=["audio/mpeg"],
+        reply_to_message_id="42",
+        reply_to_text="Earlier message",
+        channel_context="[Recent channel context]\nBob: background",
+    )
+
+    with patch(
+        "tools.credential_files.to_agent_visible_cache_path",
+        side_effect=lambda path: path,
+    ):
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    media_note = (
+        "[The user sent an audio file attachment: 'recording.mp3'. "
+        "It is saved at: /tmp/cache_123_recording.mp3. "
+        "Its content is not inlined here. If the user's request involves "
+        "what the audio contains, transcribe or process it yourself — for "
+        "example by passing the path to a transcription or media tool — "
+        "instead of asking the user to describe it. Only ask what to do "
+        "with it if their intent is genuinely unclear.]"
+    )
+    assert result == (
+        "[Recent channel context]\nBob: background\n\n[New message]\n"
+        "[Ali ce] [Replying to: \"Earlier message\"]\n\n"
+        f"{media_note}\n\nplease review"
+    )
+    assert result.count("[Ali ce] ") == 1
+
+
+@pytest.mark.asyncio
 async def test_preprocess_keeps_plain_text_for_default_group_sessions():
     runner = _make_runner(
         GatewayConfig(
@@ -58,6 +115,26 @@ async def test_preprocess_keeps_plain_text_for_default_group_sessions():
         chat_name="Test Group",
         chat_type="group",
         user_name="Alice",
+    )
+    event = MessageEvent(text="hello", source=source)
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result == "hello"
+
+
+@pytest.mark.asyncio
+async def test_preprocess_keeps_shared_group_untagged_without_sender_name():
+    runner = _make_runner(GatewayConfig(group_sessions_per_user=False))
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1002285219667",
+        chat_type="group",
+        user_name=None,
     )
     event = MessageEvent(text="hello", source=source)
 


### PR DESCRIPTION
## Summary

Fix shared-group sender attribution when inbound messages receive prepend-style enrichment.

Previously `_prepare_inbound_message_text()` applied `[DisplayName]` before image/STT/audio/video/document, Discord, and reply context processing. Later enrichment could prepend text ahead of the sender tag, so media turns no longer began with the sender identity.

This change:
- applies the sanitized sender prefix once after all inbound enrichments (including reply and `@` context expansion),
- keeps `channel_context` outermost, so only the triggering turn is attributed,
- preserves untagged behavior for per-user group sessions and missing sender names.

## Regression coverage

Adds a shared-group regression covering an audio attachment, reply-to context, channel backfill, control-character sanitization, and exactly-once sender attribution. Also covers missing sender names.

## Verification

- `python -m pytest -q tests/gateway/test_shared_group_sender_prefix.py tests/gateway/test_reply_to_injection.py tests/gateway/test_video_context_note.py`
  - 11 passed
- `python -m compileall -q gateway/run.py`
- `git diff --check`


