### PR TITLE
fix(config): stop doctor flagging all Hermes-written top-level config keys

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5516,6 +5516,10 @@ _EXTRA_KNOWN_ROOT_KEYS = {
     "session_reset",         # top-level form read by gateway/config.py + setup
     "group_sessions_per_user",   # top-level form bridged by gateway/config.py
     "thread_sessions_per_user",  # top-level form bridged by gateway/config.py
+    "stt_echo_transcripts",      # top-level form bridged by gateway/config.py
+    "reset_triggers",            # top-level form bridged by gateway/config.py
+    "always_log_local",          # top-level form bridged by gateway/config.py
+    "filter_silence_narration",  # top-level form bridged by gateway/config.py
     "multiplex_profiles",    # top-level form accepted alongside gateway.multiplex_profiles
     "profile_routes",        # top-level form accepted alongside gateway.profile_routes
     "platforms",             # top-level per-platform map merged by gateway/config.py

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5512,7 +5512,10 @@ _EXTRA_KNOWN_ROOT_KEYS = {
     "plugins",           # plugin enable/disable lists (hermes_cli/plugins_cmd.py)
     "smart_model_routing",   # written by the setup wizard (hermes_cli/setup.py)
     "platform_toolsets",     # written by the setup wizard (hermes_cli/setup.py)
+    "known_plugin_toolsets", # written/read by hermes_cli/tools_config.py toolset-save flow
     "session_reset",         # top-level form read by gateway/config.py + setup
+    "group_sessions_per_user",   # top-level form bridged by gateway/config.py
+    "thread_sessions_per_user",  # top-level form bridged by gateway/config.py
     "multiplex_profiles",    # top-level form accepted alongside gateway.multiplex_profiles
     "profile_routes",        # top-level form accepted alongside gateway.profile_routes
     "platforms",             # top-level per-platform map merged by gateway/config.py

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -260,12 +260,20 @@ class TestUnknownTopLevelKeys:
             "known_plugin_toolsets": {"cli": ["spotify"]},
             "group_sessions_per_user": True,
             "thread_sessions_per_user": False,
+            "stt_echo_transcripts": True,
+            "reset_triggers": ["/new"],
+            "always_log_local": True,
+            "filter_silence_narration": True,
         })
         unknown = [i for i in issues if "Unknown top-level config key" in i.message]
         messages = " ".join(i.message for i in unknown)
         assert "known_plugin_toolsets" not in messages
         assert "group_sessions_per_user" not in messages
         assert "thread_sessions_per_user" not in messages
+        assert "stt_echo_transcripts" not in messages
+        assert "reset_triggers" not in messages
+        assert "always_log_local" not in messages
+        assert "filter_silence_narration" not in messages
 
     def test_provider_like_unknown_root_keeps_misplaced_message(self):
         """Preserve existing base_url/api_key root-level guidance (not generic unknown)."""

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -253,6 +253,20 @@ class TestUnknownTopLevelKeys:
         assert _EXTRA_KNOWN_ROOT_KEYS.issubset(_KNOWN_ROOT_KEYS)
         assert _KNOWN_ROOT_KEYS == frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 
+    def test_hermes_written_roots_not_flagged_as_unknown(self):
+        """Roots Hermes itself writes/reads must not warn as unknown (#67397)."""
+        issues = validate_config_structure({
+            "model": {"provider": "openrouter"},
+            "known_plugin_toolsets": {"cli": ["spotify"]},
+            "group_sessions_per_user": True,
+            "thread_sessions_per_user": False,
+        })
+        unknown = [i for i in issues if "Unknown top-level config key" in i.message]
+        messages = " ".join(i.message for i in unknown)
+        assert "known_plugin_toolsets" not in messages
+        assert "group_sessions_per_user" not in messages
+        assert "thread_sessions_per_user" not in messages
+
     def test_provider_like_unknown_root_keeps_misplaced_message(self):
         """Preserve existing base_url/api_key root-level guidance (not generic unknown)."""
         issues = validate_config_structure({


### PR DESCRIPTION
## Summary
Stops `hermes doctor` from falsely warning "Unknown top-level config key — it will be ignored" for all 7 top-level config keys that Hermes itself reads/writes but that are absent from `DEFAULT_CONFIG`.

PR #67447 (@HexLab98) fixed 3 of the 7 keys; this salvage adds the remaining 4 sibling keys in the same bug class and extends the regression test to cover all of them.

## Changes
- `hermes_cli/config.py`: added 7 keys to `_EXTRA_KNOWN_ROOT_KEYS` (3 from #67447 + 4 new: `stt_echo_transcripts`, `reset_triggers`, `always_log_local`, `filter_silence_narration`)
- `tests/hermes_cli/test_config_validation.py`: regression test now covers all 7 keys

## Validation
| | Before | After |
|---|---|---|
| Unknown-key warnings for Hermes-owned roots | 7 | 0 |
| Unknown-key warnings for real typos | 1 | 1 |
| Targeted tests (test_config_validation.py) | — | 27/27 pass |

Closes #67397
