### PR TITLE
feat(skills): add Strudel + Hydra live-coding optional skill (strudel-hydra)

### DIFF
--- a/optional-skills/creative/strudel-hydra/SKILL.md
+++ b/optional-skills/creative/strudel-hydra/SKILL.md
@@ -14,15 +14,15 @@ metadata:
 # Strudel + Hydra Skill
 
 Drive a synchronized audio/visual liveset in a browser and hot-swap it while it
-runs. A tiny standard-library HTTP server hosts one page that loads Strudel
-(pattern-based audio) and Hydra (audio-reactive visuals); the agent pushes new
-"sets" over Server-Sent Events (SSE) and the running page evaluates them without
-a reload. Same DNA as `pd-patching` and `supercollider` — no MCP, no npm, no
-compiled bridge, driving a live instance over a thin protocol — here the
-transport is SSE and both sound *and* picture come from one push. The page also
-**measures what it produces** (audio/visual features) and reports them back,
-closing the live-coding loop so the agent can score a set and evolve it. It
-exports a standalone self-contained `.html`. It does **not** cover the Strudel
+runs. A tiny standard-library HTTP server hosts one page that runs Strudel
+(pattern-based audio) in the page and Hydra (audio-reactive visuals) in an
+isolated iframe; the agent pushes new "sets" over Server-Sent Events (SSE) and
+the running page evaluates them without a reload. Same DNA as `pd-patching` and
+`supercollider` — no MCP, no npm, no compiled bridge, driving a live instance
+over a thin protocol — here the transport is SSE and both sound *and* picture
+come from one push. The page also **measures its own audio output** and reports
+it back, closing the live-coding loop so the agent can score a set and evolve it.
+It exports a standalone self-contained `.html`. It does **not** cover the Strudel
 CodeMirror editor, the TidalCycles Haskell stack, or compiling Hydra.
 
 ## When to Use
@@ -32,6 +32,19 @@ pulse with a strobing kaleidoscope, an ambient drone under drifting noise,
 audio-reactive visuals, a VJ loop — described in words, produced as running
 sound and picture. Skip it for audio-only DSP (use `supercollider` or
 `pd-patching`) or for a static rendered video file.
+
+## Example Requests
+
+What a user might say to Hermes, and what the agent does:
+
+| User says | Agent does |
+|-----------|------------|
+| "Play a dark techno set with a strobing kaleidoscope" | boot the server, open the page, push an `--audio`/`--visual` set |
+| "Make it an ambient drone with slow drifting visuals" | hot-swap a calm pad + slow Hydra set (one push) |
+| "More red, and speed up the beat" | re-push the running set with tweaked color/tempo |
+| "Export this acid set as a web page" | `sh_examples.py acid --export acid.html` |
+| "VJ on your own and keep making it more energetic" | headless browser + audio-fitness `sh_evolve.py` on `/loop` |
+| "Too loud — stop" | `sh_client.py --hush` |
 
 ## Prerequisites
 
@@ -60,8 +73,8 @@ python3 sh_server.py &                 # http://127.0.0.1:8765
 open http://127.0.0.1:8765             # Linux: xdg-open http://127.0.0.1:8765
 ```
 
-**Click "start" in the page.** Browsers require a user gesture before audio and
-the mic-based analyser can begin; the overlay handles that once.
+**Click "start" in the page.** Browsers require a user gesture before audio can
+begin; the overlay handles that once. No microphone is used or requested.
 
 Push a gallery set, or arbitrary code, in one stdin-free command:
 
@@ -88,7 +101,7 @@ Helper scripts (all in `scripts/`, standard library only):
 | `sh_client.py` | Push a set (`--audio`/`--visual`/`--audio-file`/`--visual-file`/`--label`), `--hush`, `--status`, `--observe [--target … --wait …]`. Exposes `push_set()`, `observe()`, `score()`. |
 | `sh_examples.py` | Gallery (`pulse`, `bells`, `drone`, `acid`) + `--list` and `--export FILE`. |
 | `sh_evolve.py` | Score + rank one generation of candidate sets against a fitness `--target` (the evaluation/selection step of the self-improving loop). |
-| `templates/page.html` | The host page: loads Strudel + Hydra, opens the SSE stream, hot-swaps each set, and posts telemetry. Also the export scaffold. |
+| `templates/page.html` | The host page: runs Strudel in the page and Hydra in an isolated iframe, opens the SSE stream, hot-swaps each set, and posts audio telemetry. Also the export scaffold. |
 
 A **set** is JSON — `audio` (Strudel code), `visual` (Hydra code), both, or
 neither with `cmd:"hush"`:
@@ -132,26 +145,19 @@ agent uses as a fitness signal. Reported each ~0.75 s:
 | `level` | overall audio energy (mean of bins) | Strudel output tap |
 | `bands` | per-band FFT magnitudes (8) | Strudel output tap |
 | `centroid` | spectral brightness, 0–1 | Strudel output tap |
-| `brightness` | mean screen luminance, 0–1 | canvas grab † |
-| `rgb` | mean R/G/B, 0–1 each | canvas grab † |
-| `motion` | per-frame visual change, 0–1 | canvas grab † |
 
-**Audio is the dependable fitness signal** — the output tap works headless,
-muted, and mic-free (verified in a live browser). † **Visual features need a
-real, focused, GPU-backed window**: headless SwiftShader can't composite the
-WebGL canvas, and a backgrounded/occluded window throttles Hydra's frame loop —
-both read `brightness`/`motion` ≈ 0. So for an **unattended** evolving loop, run
-the browser headless and target the audio features; visual features are a bonus
-when a person has the window up front.
+**Telemetry is audio-only** — the output tap works headless, muted, and mic-free
+(verified in a live browser). There is no visual telemetry: Hydra's WebGL canvas
+can't be read back in-page (the drawing buffer isn't preserved), so visuals are
+judged by eye. An unattended evolving loop can therefore run the browser
+headless and score on the audio features alone.
 
 The agent runs the loop (it is the mutation operator; the scripts measure,
 score, and select):
 
-1. **Set a fitness target** — a feature vector for the mood. Lead with audio
-   (always reliable), e.g. `{"level":0.6,"centroid":0.4}`; add `brightness`/
-   `motion` only when a focused GPU window is up. `score()` is `1/(1+distance)`
-   over the shared scalar keys (`level`, `centroid`, `brightness`, `motion`);
-   higher is closer.
+1. **Set a fitness target** — an audio feature vector for the mood, e.g.
+   `{"level":0.6,"centroid":0.4}`. `score()` is `1/(1+distance)` over the shared
+   scalar keys (`level`, `centroid`); higher is closer.
 2. **Read the current set:** `python3 sh_client.py --observe --target '{…}'`.
 3. **Mutate:** write 2–4 variations of the best set (nudge patterns, filters,
    Hydra ops) into a candidates JSON list.
@@ -164,7 +170,7 @@ score, and select):
 Run it unattended with the `/loop` skill so the VJ set evolves on its own; use
 `--hush` to stop. This is the `darwinian-evolver` shape with the code as
 organism, the agent as mutator, and telemetry as the evaluator — but here the
-fitness signal comes free from the analyser and canvas.
+fitness signal comes free from the analyser.
 
 ## [CRITICAL] Safety
 
@@ -185,12 +191,17 @@ Two failure modes need active care — both have a one-command escape via
 - **Audio needs the start click.** Strudel's AudioContext stays suspended until
   the user gesture; a set pushed before clicking "start" is retained and applies
   on click. If nothing sounds, confirm the overlay was clicked.
-- **Visual `a.fft` reactivity needs `detectAudio` + mic.** The page inits Hydra
-  with `detectAudio:true` so `a.fft[...]` (used in the *visual* code) reacts to
-  sound; the browser gates it behind the start gesture and a mic prompt, and it
-  hears the room, not a clean tap. Telemetry does **not** depend on this — audio
-  features come from the output tap below. Without the mic, `a.fft[...]` reads
-  zeros and visuals still run, just unreactive.
+- **Hydra is isolated in an iframe on purpose.** Strudel's `initStrudel()` spins
+  up a WebGL context that invalidates Hydra's shader program in the *same*
+  document — the canvas goes blank/gray with `useProgram: program not valid` in
+  the console. Hydra therefore runs in its own `srcdoc` iframe (separate GL
+  context); visual code and `a.fft` cross via `postMessage`. Do not move Hydra
+  back into the main page.
+- **Visuals react to the music with no mic.** Hydra runs `detectAudio:false`; the
+  page feeds `a.fft` from the Strudel-output tap into the iframe every frame, so
+  `a.fft[...]` in visual code reacts to the actual sound. No mic is requested, and
+  `a.fft` is always an 8-element array — a visual referencing it can't throw and
+  blank the render (the mic-less failure mode this replaced).
 - **A bad set shows in the HUD, not the terminal.** Evaluation happens in the
   browser; a syntax error prints `visual error:` / `audio error: …` on the page
   HUD. Watch it, or keep sets small and incremental.
@@ -204,14 +215,13 @@ Two failure modes need active care — both have a one-command escape via
   if you repin.
 - **One set = one screen.** Pushing a new set replaces the whole liveset on
   every connected browser; there is no per-client targeting.
-- **Telemetry is only as good as its sources.** Audio features tap Strudel's
-  output directly (an analyser inserted before the speakers), so they work muted
-  and need no mic — but they read low while a pattern sits between hits, so give
-  each candidate enough `--wait` to settle. The visual grab reads Hydra inside
-  its own frame, but only a real, **focused, GPU-backed** window renders for it:
-  headless SwiftShader and backgrounded/occluded windows (Hydra's frame loop
-  throttled) read blank (`brightness` ≈ 0). Make audio the fitness signal, treat
-  visual as opportunistic, and read all scores as a relative ranking, not truth.
+- **Telemetry is audio-only.** Features tap Strudel's output directly (an
+  analyser before the speakers), so they work muted and need no mic — but they
+  read low while a pattern sits between hits, so give each candidate enough
+  `--wait` to settle. There is **no visual telemetry**: Hydra's WebGL drawing
+  buffer isn't preserved, so in-page readback is black on every browser tried
+  (real GPU included) — judge visuals by eye. Read scores as a relative ranking,
+  not truth.
 
 ## Verification
 

--- a/optional-skills/creative/strudel-hydra/SKILL.md
+++ b/optional-skills/creative/strudel-hydra/SKILL.md
@@ -129,9 +129,9 @@ agent uses as a fitness signal. Reported each ~0.75 s:
 
 | Field | Meaning | Source |
 |-------|---------|--------|
-| `level` | overall audio energy (mean of bins) | analyser |
-| `bands` | per-band FFT magnitudes | analyser |
-| `centroid` | spectral brightness, 0–1 | analyser |
+| `level` | overall audio energy (mean of bins) | Strudel output tap |
+| `bands` | per-band FFT magnitudes (8) | Strudel output tap |
+| `centroid` | spectral brightness, 0–1 | Strudel output tap |
 | `brightness` | mean screen luminance, 0–1 | canvas grab |
 | `rgb` | mean R/G/B, 0–1 each | canvas grab |
 | `motion` | per-frame visual change, 0–1 | canvas grab |
@@ -176,25 +176,32 @@ Two failure modes need active care — both have a one-command escape via
 - **Audio needs the start click.** Strudel's AudioContext stays suspended until
   the user gesture; a set pushed before clicking "start" is retained and applies
   on click. If nothing sounds, confirm the overlay was clicked.
-- **`a.fft` needs `detectAudio` + mic permission.** The page inits Hydra with
-  `detectAudio:true`; audio-reactivity reads the analyser, which the browser
-  gates behind the same start gesture (and a mic prompt on some setups). Without
-  it, `a.fft[...]` reads zeros and visuals still run, just unreactive.
+- **Visual `a.fft` reactivity needs `detectAudio` + mic.** The page inits Hydra
+  with `detectAudio:true` so `a.fft[...]` (used in the *visual* code) reacts to
+  sound; the browser gates it behind the start gesture and a mic prompt, and it
+  hears the room, not a clean tap. Telemetry does **not** depend on this — audio
+  features come from the output tap below. Without the mic, `a.fft[...]` reads
+  zeros and visuals still run, just unreactive.
 - **A bad set shows in the HUD, not the terminal.** Evaluation happens in the
   browser; a syntax error prints `visual error:` / `audio error: …` on the page
   HUD. Watch it, or keep sets small and incremental.
 - **Function names track the pinned versions.** The gallery uses common Strudel
   (`note`, `s`, `lpf`, `room`, `sine.range`) and Hydra (`osc`, `voronoi`,
-  `kaleid`, `modulateScale`) names for the versions pinned in `page.html`; adapt
+  `kaleid`, `color`, `rotate`, `modulateRotate`, `modulateScale`,
+  `modulatePixelate`) names verified against the bundles pinned in `page.html`.
+  Not every documented Hydra op exists in that build — `scale`, `repeat`,
+  `colorama` and the `noise`/`shape` sources threw `… is not a function` — so
+  the HUD names any bad op; prefer the ops the gallery already uses, and adapt
   if you repin.
 - **One set = one screen.** Pushing a new set replaces the whole liveset on
   every connected browser; there is no per-client targeting.
-- **Telemetry is only as good as its sources.** Audio features come from the
-  same mic-fed analyser that drives `a.fft`, so they need the mic permission and
-  reflect the room, not a clean output tap. The visual grab composites the WebGL
-  canvas best-effort; some browser/driver combos read it as blank (`brightness`
-  ≈ 0). Treat scores as a relative signal for ranking, not absolute truth, and
-  give each candidate enough `--wait` to settle before observing.
+- **Telemetry is only as good as its sources.** Audio features tap Strudel's
+  output directly (an analyser inserted before the speakers), so they work muted
+  and need no mic — but they read low while a pattern sits between hits, so give
+  each candidate enough `--wait` to settle. The visual grab composites the WebGL
+  canvas best-effort; some setups (notably **headless SwiftShader**) read it as
+  blank (`brightness` ≈ 0), so visual telemetry wants a real-GPU desktop browser.
+  Treat scores as a relative ranking signal, not absolute truth.
 
 ## Verification
 

--- a/optional-skills/creative/strudel-hydra/SKILL.md
+++ b/optional-skills/creative/strudel-hydra/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: strudel-hydra
+description: Live-code and self-evolve synchronized Strudel audio + Hydra visuals.
+version: 1.0.0
+author: mrev-lab
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [strudel, hydra, live-coding, audio-visual, generative-audio, generative-visuals, creative-coding, sse, self-improving, evolution, tidalcycles, vj]
+    related_skills: [supercollider, pd-patching, songwriting-and-ai-music, darwinian-evolver]
+---
+
+# Strudel + Hydra Skill
+
+Drive a synchronized audio/visual liveset in a browser and hot-swap it while it
+runs. A tiny standard-library HTTP server hosts one page that loads Strudel
+(pattern-based audio) and Hydra (audio-reactive visuals); the agent pushes new
+"sets" over Server-Sent Events (SSE) and the running page evaluates them without
+a reload. Same DNA as `pd-patching` and `supercollider` — no MCP, no npm, no
+compiled bridge, driving a live instance over a thin protocol — here the
+transport is SSE and both sound *and* picture come from one push. The page also
+**measures what it produces** (audio/visual features) and reports them back,
+closing the live-coding loop so the agent can score a set and evolve it. It
+exports a standalone self-contained `.html`. It does **not** cover the Strudel
+CodeMirror editor, the TidalCycles Haskell stack, or compiling Hydra.
+
+## When to Use
+
+Use when the user wants a generative or live-coded audio/visual set: a techno
+pulse with a strobing kaleidoscope, an ambient drone under drifting noise,
+audio-reactive visuals, a VJ loop — described in words, produced as running
+sound and picture. Skip it for audio-only DSP (use `supercollider` or
+`pd-patching`) or for a static rendered video file.
+
+## Prerequisites
+
+- A **modern browser** (Chrome/Firefox) open on a desktop session — this drives
+  real Web Audio + WebGL, so it needs a display and speakers, not a headless box.
+- **Internet on first load**: the page fetches the pinned `@strudel/web` and
+  `hydra-synth` bundles from a CDN (the browser fetches them, not npm).
+- The `terminal` tool, to run the server and push scripts. No Python packages —
+  standard library only.
+- A way to open a URL: `open <url>` (macOS) / `xdg-open <url>` (Linux).
+
+## How to Run
+
+Run every command through the `terminal` tool. Locate the installed skill first
+(the scripts import each other by name, so run them from `scripts/`):
+
+```bash
+SKILL="${HERMES_HOME:-$HOME/.hermes}/skills/creative/strudel-hydra"
+cd "$SKILL/scripts"
+```
+
+Boot the server once (leave it running) and open the page:
+
+```bash
+python3 sh_server.py &                 # http://127.0.0.1:8765
+open http://127.0.0.1:8765             # Linux: xdg-open http://127.0.0.1:8765
+```
+
+**Click "start" in the page.** Browsers require a user gesture before audio and
+the mic-based analyser can begin; the overlay handles that once.
+
+Push a gallery set, or arbitrary code, in one stdin-free command:
+
+```bash
+python3 sh_examples.py pulse                              # push a gallery set
+python3 sh_client.py \
+  --audio 'note("c3 e3 g3 b3").s("sawtooth").lpf(700).gain(.5)' \
+  --visual 'osc(20, 0.1, 0.8).kaleid(5).rotate(0, 0.1).out()' \
+  --label riff
+python3 sh_client.py --hush                               # panic: stop + clear
+```
+
+> Pass code as **arguments**, never via a heredoc — an agent terminal often
+> fails to deliver heredoc stdin and the call hangs. For a long set, write the
+> code to a file and use `--audio-file` / `--visual-file`.
+
+## Quick Reference
+
+Helper scripts (all in `scripts/`, standard library only):
+
+| File | Purpose |
+|------|---------|
+| `sh_server.py` | HTTP host + SSE broker. Serves the page, fans the latest set out to every browser, retains it for late joiners. `--host`/`--port`. |
+| `sh_client.py` | Push a set (`--audio`/`--visual`/`--audio-file`/`--visual-file`/`--label`), `--hush`, `--status`, `--observe [--target … --wait …]`. Exposes `push_set()`, `observe()`, `score()`. |
+| `sh_examples.py` | Gallery (`pulse`, `bells`, `drone`, `acid`) + `--list` and `--export FILE`. |
+| `sh_evolve.py` | Score + rank one generation of candidate sets against a fitness `--target` (the evaluation/selection step of the self-improving loop). |
+| `templates/page.html` | The host page: loads Strudel + Hydra, opens the SSE stream, hot-swaps each set, and posts telemetry. Also the export scaffold. |
+
+A **set** is JSON — `audio` (Strudel code), `visual` (Hydra code), both, or
+neither with `cmd:"hush"`:
+
+| Field | Runs via | Example |
+|-------|----------|---------|
+| `audio` | Strudel `evaluate()` | `note("c3 e3 g3").s("sawtooth")` |
+| `visual` | Hydra (globals) | `osc(20).kaleid(5).out()` |
+| `label` | HUD tag | `"riff"` |
+| `cmd:"hush"` | stop audio + black screen | via `--hush` |
+
+## Procedure
+
+The agent turns a request into a running liveset like this:
+
+1. **Ensure the server is up and a browser is attached.** `python3 sh_client.py
+   --status` reports `subscribers`; `0` means no browser is on the page yet
+   (open it and click start).
+2. **Pick the cheapest path.** Canned vibe → a gallery name; a tweak → push a
+   modified `--audio`/`--visual`; novel → write the set from scratch.
+3. **Push audio and visual together.** Keep them synchronized by sending one set;
+   drive visuals from the sound with `a.fft[0..3]` in the Hydra code.
+4. **Verify it landed.** `--status` and the server's `subscribers` count confirm
+   delivery; the page HUD shows `applied · <label>` or an error string.
+
+**Share an artifact.** Export a standalone page that plays without the server
+(the set is baked into the HTML, no SSE):
+
+```bash
+python3 sh_examples.py acid --export acid.html      # open acid.html anywhere
+```
+
+## Self-Improving Loop
+
+Live-coding is already an observe→modify→repeat loop; the page closes it by
+reporting **telemetry** — features it measures from the running set — which the
+agent uses as a fitness signal. Reported each ~0.75 s:
+
+| Field | Meaning | Source |
+|-------|---------|--------|
+| `level` | overall audio energy (mean of bins) | analyser |
+| `bands` | per-band FFT magnitudes | analyser |
+| `centroid` | spectral brightness, 0–1 | analyser |
+| `brightness` | mean screen luminance, 0–1 | canvas grab |
+| `rgb` | mean R/G/B, 0–1 each | canvas grab |
+| `motion` | per-frame visual change, 0–1 | canvas grab |
+
+The agent runs the loop (it is the mutation operator; the scripts measure,
+score, and select):
+
+1. **Set a fitness target** — a feature vector for the mood, e.g.
+   `{"brightness":0.5,"motion":0.35,"level":0.6}`. `score()` is
+   `1/(1+distance)` over the shared scalar keys (`level`, `centroid`,
+   `brightness`, `motion`); higher is closer.
+2. **Read the current set:** `python3 sh_client.py --observe --target '{…}'`.
+3. **Mutate:** write 2–4 variations of the best set (nudge patterns, filters,
+   Hydra ops) into a candidates JSON list.
+4. **Evaluate + select:** `python3 sh_evolve.py cands.json --target '{…}'
+   --wait 1.5` pushes each, lets it settle, and prints them ranked best-first.
+5. **Keep the winner and repeat.** For novelty (open-ended evolution with no
+   fixed target), also reward distance from recent sets — track that history
+   yourself between rounds.
+
+Run it unattended with the `/loop` skill so the VJ set evolves on its own; use
+`--hush` to stop. This is the `darwinian-evolver` shape with the code as
+organism, the agent as mutator, and telemetry as the evaluator — but here the
+fitness signal comes free from the analyser and canvas.
+
+## [CRITICAL] Safety
+
+Two failure modes need active care — both have a one-command escape via
+`--hush`:
+
+- **Loud audio.** Keep master level sane: chain `.gain(<= 0.8)` on audio
+  patterns and never stack many full-gain voices. `python3 sh_client.py --hush`
+  cuts all sound immediately. If a request implies danger ("make it deafening"),
+  keep the gain bounded.
+- **Photosensitive epilepsy.** Full-field luminance flashing faster than ~3 Hz
+  can trigger seizures. Do not build rapid full-screen black↔white/red strobes.
+  Prefer motion, hue shifts, and partial-frame changes; keep fast `a.fft`-driven
+  brightness swings local, not full-frame. `--hush` also blacks the screen.
+
+## Pitfalls
+
+- **Audio needs the start click.** Strudel's AudioContext stays suspended until
+  the user gesture; a set pushed before clicking "start" is retained and applies
+  on click. If nothing sounds, confirm the overlay was clicked.
+- **`a.fft` needs `detectAudio` + mic permission.** The page inits Hydra with
+  `detectAudio:true`; audio-reactivity reads the analyser, which the browser
+  gates behind the same start gesture (and a mic prompt on some setups). Without
+  it, `a.fft[...]` reads zeros and visuals still run, just unreactive.
+- **A bad set shows in the HUD, not the terminal.** Evaluation happens in the
+  browser; a syntax error prints `visual error:` / `audio error: …` on the page
+  HUD. Watch it, or keep sets small and incremental.
+- **Function names track the pinned versions.** The gallery uses common Strudel
+  (`note`, `s`, `lpf`, `room`, `sine.range`) and Hydra (`osc`, `voronoi`,
+  `kaleid`, `modulateScale`) names for the versions pinned in `page.html`; adapt
+  if you repin.
+- **One set = one screen.** Pushing a new set replaces the whole liveset on
+  every connected browser; there is no per-client targeting.
+- **Telemetry is only as good as its sources.** Audio features come from the
+  same mic-fed analyser that drives `a.fft`, so they need the mic permission and
+  reflect the room, not a clean output tap. The visual grab composites the WebGL
+  canvas best-effort; some browser/driver combos read it as blank (`brightness`
+  ≈ 0). Treat scores as a relative signal for ranking, not absolute truth, and
+  give each candidate enough `--wait` to settle before observing.
+
+## Verification
+
+1. **Server up:** `curl -s 127.0.0.1:8765/status` returns `{"subscribers": N}`;
+   no answer means `sh_server.py` is not running.
+2. **Browser attached:** after opening the page, `subscribers` is `>= 1`.
+3. **Push delivered:** `sh_client.py` / `sh_examples.py` print
+   `{"ok": true, "subscribers": N}`; the page HUD flips to `applied · <label>`.
+4. **Stream sanity (headless):** `curl -sN 127.0.0.1:8765/events` prints
+   `: connected`, then each pushed set as a `data: {…}` frame — proves the SSE
+   relay without a browser.
+5. **Telemetry flowing:** with a browser on the page, `sh_client.py --observe`
+   returns `data` (not null) with a small `age`; a null `data` means the page
+   is not posting (not started, or blocked). The endpoint itself round-trips
+   headlessly: `POST` a JSON body to `/telemetry`, then `--observe` echoes it.
+6. **Export:** `sh_examples.py <name> --export out.html` writes a file
+   containing `window.__SET__`; opening it plays the set with no server.
+
+## Security
+
+The server binds `127.0.0.1` only — keep it there; do not bind `0.0.0.0`. The
+page **evaluates pushed code** (Strudel `evaluate`, and `eval` of Hydra code),
+so anything reaching `/push` runs in the browser: only push sets you author, and
+never expose the port beyond loopback. The CDN bundles are version-pinned in
+`templates/page.html`; review a bump before trusting it.

--- a/optional-skills/creative/strudel-hydra/SKILL.md
+++ b/optional-skills/creative/strudel-hydra/SKILL.md
@@ -132,17 +132,26 @@ agent uses as a fitness signal. Reported each ~0.75 s:
 | `level` | overall audio energy (mean of bins) | Strudel output tap |
 | `bands` | per-band FFT magnitudes (8) | Strudel output tap |
 | `centroid` | spectral brightness, 0–1 | Strudel output tap |
-| `brightness` | mean screen luminance, 0–1 | canvas grab |
-| `rgb` | mean R/G/B, 0–1 each | canvas grab |
-| `motion` | per-frame visual change, 0–1 | canvas grab |
+| `brightness` | mean screen luminance, 0–1 | canvas grab † |
+| `rgb` | mean R/G/B, 0–1 each | canvas grab † |
+| `motion` | per-frame visual change, 0–1 | canvas grab † |
+
+**Audio is the dependable fitness signal** — the output tap works headless,
+muted, and mic-free (verified in a live browser). † **Visual features need a
+real, focused, GPU-backed window**: headless SwiftShader can't composite the
+WebGL canvas, and a backgrounded/occluded window throttles Hydra's frame loop —
+both read `brightness`/`motion` ≈ 0. So for an **unattended** evolving loop, run
+the browser headless and target the audio features; visual features are a bonus
+when a person has the window up front.
 
 The agent runs the loop (it is the mutation operator; the scripts measure,
 score, and select):
 
-1. **Set a fitness target** — a feature vector for the mood, e.g.
-   `{"brightness":0.5,"motion":0.35,"level":0.6}`. `score()` is
-   `1/(1+distance)` over the shared scalar keys (`level`, `centroid`,
-   `brightness`, `motion`); higher is closer.
+1. **Set a fitness target** — a feature vector for the mood. Lead with audio
+   (always reliable), e.g. `{"level":0.6,"centroid":0.4}`; add `brightness`/
+   `motion` only when a focused GPU window is up. `score()` is `1/(1+distance)`
+   over the shared scalar keys (`level`, `centroid`, `brightness`, `motion`);
+   higher is closer.
 2. **Read the current set:** `python3 sh_client.py --observe --target '{…}'`.
 3. **Mutate:** write 2–4 variations of the best set (nudge patterns, filters,
    Hydra ops) into a candidates JSON list.
@@ -198,10 +207,11 @@ Two failure modes need active care — both have a one-command escape via
 - **Telemetry is only as good as its sources.** Audio features tap Strudel's
   output directly (an analyser inserted before the speakers), so they work muted
   and need no mic — but they read low while a pattern sits between hits, so give
-  each candidate enough `--wait` to settle. The visual grab composites the WebGL
-  canvas best-effort; some setups (notably **headless SwiftShader**) read it as
-  blank (`brightness` ≈ 0), so visual telemetry wants a real-GPU desktop browser.
-  Treat scores as a relative ranking signal, not absolute truth.
+  each candidate enough `--wait` to settle. The visual grab reads Hydra inside
+  its own frame, but only a real, **focused, GPU-backed** window renders for it:
+  headless SwiftShader and backgrounded/occluded windows (Hydra's frame loop
+  throttled) read blank (`brightness` ≈ 0). Make audio the fitness signal, treat
+  visual as opportunistic, and read all scores as a relative ranking, not truth.
 
 ## Verification
 

--- a/optional-skills/creative/strudel-hydra/SKILL.md
+++ b/optional-skills/creative/strudel-hydra/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: strudel-hydra
-description: Live-code and self-evolve synchronized Strudel audio + Hydra visuals.
+description: Live-code self-evolving Strudel audio + Hydra visuals.
 version: 1.0.0
 author: mrev-lab
 license: MIT
@@ -8,7 +8,7 @@ platforms: [linux, macos]
 metadata:
   hermes:
     tags: [strudel, hydra, live-coding, audio-visual, generative-audio, generative-visuals, creative-coding, sse, self-improving, evolution, tidalcycles, vj]
-    related_skills: [supercollider, pd-patching, songwriting-and-ai-music, darwinian-evolver]
+    related_skills: [songwriting-and-ai-music, darwinian-evolver]
 ---
 
 # Strudel + Hydra Skill
@@ -97,8 +97,8 @@ Helper scripts (all in `scripts/`, standard library only):
 
 | File | Purpose |
 |------|---------|
-| `sh_server.py` | HTTP host + SSE broker. Serves the page, fans the latest set out to every browser, retains it for late joiners. `--host`/`--port`. |
-| `sh_client.py` | Push a set (`--audio`/`--visual`/`--audio-file`/`--visual-file`/`--label`), `--hush`, `--status`, `--observe [--target … --wait …]`. Exposes `push_set()`, `observe()`, `score()`. |
+| `sh_server.py` | HTTP host + SSE broker. Serves the page, fans the latest set out to every browser, retains it for late joiners. `--host`/`--port`/`--allow-remote`; mints the capability token that gates `/push` + `/telemetry`. |
+| `sh_client.py` | Push a set (`--audio`/`--visual`/`--audio-file`/`--visual-file`/`--label`), `--hush`, `--status`, `--observe [--target … --wait …]`, `--token`. Exposes `push_set()`, `observe()`, `score()`. |
 | `sh_examples.py` | Gallery (`pulse`, `bells`, `drone`, `acid`) + `--list` and `--export FILE`. |
 | `sh_evolve.py` | Score + rank one generation of candidate sets against a fitness `--target` (the evaluation/selection step of the self-improving loop). |
 | `templates/page.html` | The host page: runs Strudel in the page and Hydra in an isolated iframe, opens the SSE stream, hot-swaps each set, and posts audio telemetry. Also the export scaffold. |
@@ -235,15 +235,26 @@ Two failure modes need active care — both have a one-command escape via
    relay without a browser.
 5. **Telemetry flowing:** with a browser on the page, `sh_client.py --observe`
    returns `data` (not null) with a small `age`; a null `data` means the page
-   is not posting (not started, or blocked). The endpoint itself round-trips
-   headlessly: `POST` a JSON body to `/telemetry`, then `--observe` echoes it.
+   is not posting (not started, or blocked). `--observe` is an open GET; the
+   write side is token-gated, so a raw `POST /telemetry` must carry
+   `X-SH-Token` (the server prints the token; clients read it automatically).
 6. **Export:** `sh_examples.py <name> --export out.html` writes a file
    containing `window.__SET__`; opening it plays the set with no server.
 
 ## Security
 
-The server binds `127.0.0.1` only — keep it there; do not bind `0.0.0.0`. The
-page **evaluates pushed code** (Strudel `evaluate`, and `eval` of Hydra code),
-so anything reaching `/push` runs in the browser: only push sets you author, and
-never expose the port beyond loopback. The CDN bundles are version-pinned in
+The page **evaluates pushed code** (Strudel `evaluate`, and `eval` of Hydra
+code), so anything reaching `/push` runs in the browser. The server therefore
+gates the write endpoints (`/push`, `/telemetry`):
+
+- **Loopback by default.** `sh_server.py` binds `127.0.0.1`; it refuses a
+  non-loopback `--host` unless you pass `--allow-remote`. Keep it on loopback.
+- **No wildcard CORS + same-origin only.** Cross-origin writes are rejected, so
+  a random page you have open in the same browser cannot push code to the port.
+- **Capability token.** Each run mints a token, injects it into the served page,
+  and writes it to `strudel-hydra-<port>.token` in the temp dir. The client
+  scripts read it automatically (override with `--token` or `$SH_TOKEN`); a
+  request without the token is refused. `--allow-remote` keeps this token gate.
+
+Still, only push sets you author. The CDN bundles are version-pinned in
 `templates/page.html`; review a bump before trusting it.

--- a/optional-skills/creative/strudel-hydra/scripts/sh_client.py
+++ b/optional-skills/creative/strudel-hydra/scripts/sh_client.py
@@ -45,9 +45,9 @@ def observe(base):
     return get(base, "/telemetry")
 
 
-# Scalar feature keys usable as fitness targets (arrays like `bands`/`rgb` are
-# skipped — target those component-wise via `brightness`, `level`, etc.).
-SCORABLE = ("level", "centroid", "brightness", "motion")
+# Scalar audio feature keys usable as fitness targets (the `bands` array is
+# skipped — target overall energy via `level`, spectral tilt via `centroid`).
+SCORABLE = ("level", "centroid")
 
 
 def score(features, target):

--- a/optional-skills/creative/strudel-hydra/scripts/sh_client.py
+++ b/optional-skills/creative/strudel-hydra/scripts/sh_client.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Push audio/visual sets to a running strudel-hydra server.
+
+Standard library only. A "set" is JSON: an `audio` string (strudel pattern
+code), a `visual` string (hydra code), or both, plus an optional `label`. The
+server relays it over SSE and every open browser hot-swaps to it.
+"""
+import argparse
+import json
+import math
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+def post(base, path, data, timeout=5):
+    req = urllib.request.Request(
+        base + path,
+        data=json.dumps(data).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return json.loads(r.read())
+
+
+def get(base, path, timeout=5):
+    with urllib.request.urlopen(base + path, timeout=timeout) as r:
+        return json.loads(r.read())
+
+
+def push_set(base, audio=None, visual=None, label="live"):
+    """Convenience used by sh_examples.py."""
+    payload = {"label": label}
+    if audio is not None:
+        payload["audio"] = audio
+    if visual is not None:
+        payload["visual"] = visual
+    return post(base, "/push", payload)
+
+
+def observe(base):
+    """Latest measured features: {"data": {...} | None, "age": seconds}."""
+    return get(base, "/telemetry")
+
+
+# Scalar feature keys usable as fitness targets (arrays like `bands`/`rgb` are
+# skipped — target those component-wise via `brightness`, `level`, etc.).
+SCORABLE = ("level", "centroid", "brightness", "motion")
+
+
+def score(features, target):
+    """Fitness in (0, 1]: 1 / (1 + euclidean distance) over shared scalar keys.
+    Higher is closer to the target. Returns None if nothing comparable."""
+    if not features or not target:
+        return None
+    sq, used = 0.0, 0
+    for k in SCORABLE:
+        if k in target and isinstance(features.get(k), (int, float)):
+            sq += (float(features[k]) - float(target[k])) ** 2
+            used += 1
+    if not used:
+        return None
+    return round(1.0 / (1.0 + math.sqrt(sq)), 4)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="push a set to the strudel-hydra server")
+    ap.add_argument("--base", default="http://127.0.0.1:8765", help="server base URL")
+    ap.add_argument("--audio", help="strudel pattern code")
+    ap.add_argument("--visual", help="hydra code")
+    ap.add_argument("--audio-file", help="read strudel code from a file")
+    ap.add_argument("--visual-file", help="read hydra code from a file")
+    ap.add_argument("--label", default="live")
+    ap.add_argument("--hush", action="store_true", help="panic: stop audio + clear visuals")
+    ap.add_argument("--status", action="store_true", help="print connected browser count")
+    ap.add_argument("--observe", action="store_true", help="print latest measured features")
+    ap.add_argument("--target", help="JSON target vector; with --observe, adds a fitness score")
+    ap.add_argument("--wait", type=float, default=0.0, help="seconds to sleep before observing")
+    args = ap.parse_args()
+
+    try:
+        if args.status:
+            print(json.dumps(get(args.base, "/status")))
+            return
+        if args.observe:
+            if args.wait:
+                time.sleep(args.wait)
+            resp = observe(args.base)
+            if args.target:
+                resp["score"] = score(resp.get("data"), json.loads(args.target))
+            print(json.dumps(resp))
+            return
+        if args.hush:
+            print(json.dumps(post(args.base, "/push", {"cmd": "hush"})))
+            return
+
+        audio = args.audio
+        if args.audio_file:
+            audio = open(args.audio_file, encoding="utf-8").read()
+        visual = args.visual
+        if args.visual_file:
+            visual = open(args.visual_file, encoding="utf-8").read()
+        if audio is None and visual is None:
+            ap.error("nothing to push: give --audio/--visual (or --hush)")
+
+        print(json.dumps(push_set(args.base, audio, visual, args.label)))
+    except urllib.error.URLError as e:
+        sys.exit(f"cannot reach {args.base}: {e.reason}  (is sh_server.py running?)")
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/creative/strudel-hydra/scripts/sh_client.py
+++ b/optional-skills/creative/strudel-hydra/scripts/sh_client.py
@@ -8,17 +8,46 @@ server relays it over SSE and every open browser hot-swaps to it.
 import argparse
 import json
 import math
+import os
 import sys
+import tempfile
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
+from pathlib import Path
 
 
-def post(base, path, data, timeout=5):
+def token_file_path(port):
+    """Where sh_server.py writes the capability token for this port."""
+    return Path(tempfile.gettempdir()) / f"strudel-hydra-{port}.token"
+
+
+def resolve_token(base):
+    """Discover the server's capability token: `SH_TOKEN` wins, else the per-port
+    file the server writes on startup. Returns None if neither is present."""
+    env = os.environ.get("SH_TOKEN")
+    if env:
+        return env
+    try:
+        port = urllib.parse.urlsplit(base).port or 8765
+    except ValueError:
+        port = 8765
+    try:
+        return token_file_path(port).read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+
+
+def post(base, path, data, timeout=5, token=None):
+    token = token if token is not None else resolve_token(base)
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["X-SH-Token"] = token
     req = urllib.request.Request(
         base + path,
         data=json.dumps(data).encode("utf-8"),
-        headers={"Content-Type": "application/json"},
+        headers=headers,
         method="POST",
     )
     with urllib.request.urlopen(req, timeout=timeout) as r:
@@ -30,14 +59,14 @@ def get(base, path, timeout=5):
         return json.loads(r.read())
 
 
-def push_set(base, audio=None, visual=None, label="live"):
+def push_set(base, audio=None, visual=None, label="live", token=None):
     """Convenience used by sh_examples.py."""
     payload = {"label": label}
     if audio is not None:
         payload["audio"] = audio
     if visual is not None:
         payload["visual"] = visual
-    return post(base, "/push", payload)
+    return post(base, "/push", payload, token=token)
 
 
 def observe(base):
@@ -78,6 +107,7 @@ def main():
     ap.add_argument("--observe", action="store_true", help="print latest measured features")
     ap.add_argument("--target", help="JSON target vector; with --observe, adds a fitness score")
     ap.add_argument("--wait", type=float, default=0.0, help="seconds to sleep before observing")
+    ap.add_argument("--token", help="capability token (default: $SH_TOKEN or the server's per-port file)")
     args = ap.parse_args()
 
     try:
@@ -93,7 +123,7 @@ def main():
             print(json.dumps(resp))
             return
         if args.hush:
-            print(json.dumps(post(args.base, "/push", {"cmd": "hush"})))
+            print(json.dumps(post(args.base, "/push", {"cmd": "hush"}, token=args.token)))
             return
 
         audio = args.audio
@@ -105,7 +135,7 @@ def main():
         if audio is None and visual is None:
             ap.error("nothing to push: give --audio/--visual (or --hush)")
 
-        print(json.dumps(push_set(args.base, audio, visual, args.label)))
+        print(json.dumps(push_set(args.base, audio, visual, args.label, token=args.token)))
     except urllib.error.URLError as e:
         sys.exit(f"cannot reach {args.base}: {e.reason}  (is sh_server.py running?)")
 

--- a/optional-skills/creative/strudel-hydra/scripts/sh_evolve.py
+++ b/optional-skills/creative/strudel-hydra/scripts/sh_evolve.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Evaluate one generation of candidate sets against a fitness target.
+
+The agent is the mutation operator: it writes candidate sets (variations of the
+current best) and calls this to *measure and rank* them. It pushes each
+candidate, lets it settle, reads the telemetry the page reports, scores it
+against the target vector, and prints the candidates sorted best-first. The
+agent then keeps the winner, mutates again, and repeats — a closed
+perception→action→selection loop. Run it on an interval with the `/loop` skill
+for an autonomous, self-improving VJ.
+
+Candidates JSON (a file, or stdin with `-`) is a list of objects:
+    [{"label": "a", "audio": "...", "visual": "..."}, ...]
+
+Example:
+    python3 sh_evolve.py --target '{"brightness":0.5,"motion":0.35,"level":0.6}' \
+        --wait 1.5 cands.json
+"""
+import argparse
+import json
+import sys
+import time
+
+from sh_client import observe, push_set, score
+
+
+def evaluate(base, candidates, target, wait):
+    ranked = []
+    for c in candidates:
+        push_set(base, c.get("audio"), c.get("visual"), c.get("label", "cand"))
+        time.sleep(wait)  # let the set play + the page report a fresh measurement
+        resp = observe(base)
+        features = resp.get("data")
+        ranked.append({
+            "label": c.get("label", "cand"),
+            "score": score(features, target),
+            "features": features,
+            "age": resp.get("age"),
+        })
+    # Unscored candidates (no telemetry yet) sort last.
+    ranked.sort(key=lambda r: (r["score"] is None, -(r["score"] or 0)))
+    return ranked
+
+
+def main():
+    ap = argparse.ArgumentParser(description="score + rank one generation of candidate sets")
+    ap.add_argument("candidates", help="JSON file of candidate sets, or - for stdin")
+    ap.add_argument("--target", required=True, help="JSON fitness target, e.g. '{\"brightness\":0.5}'")
+    ap.add_argument("--base", default="http://127.0.0.1:8765")
+    ap.add_argument("--wait", type=float, default=1.5, help="settle seconds between push and observe")
+    args = ap.parse_args()
+
+    raw = sys.stdin.read() if args.candidates == "-" else open(args.candidates, encoding="utf-8").read()
+    candidates = json.loads(raw)
+    if not isinstance(candidates, list) or not candidates:
+        sys.exit("candidates must be a non-empty JSON list")
+    target = json.loads(args.target)
+
+    ranked = evaluate(args.base, candidates, target, args.wait)
+    print(json.dumps({"target": target, "ranked": ranked}, indent=2))
+    best = ranked[0]
+    print(f"\nbest: {best['label']}  score={best['score']}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/creative/strudel-hydra/scripts/sh_examples.py
+++ b/optional-skills/creative/strudel-hydra/scripts/sh_examples.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Gallery of strudel-hydra livesets: push one to a running server, or export
+one as a standalone self-contained .html.
+
+Each set pairs strudel audio with audio-reactive hydra visuals (`a.fft[...]`
+reads the running sound). Function availability tracks the pinned strudel/hydra
+versions in templates/page.html — treat these as starting points to adapt, not
+frozen APIs.
+
+Run from this directory:  cd "$SKILL/scripts"
+    python3 sh_examples.py --list
+    python3 sh_examples.py pulse
+    python3 sh_examples.py acid --export acid.html
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sh_client import push_set
+
+TEMPLATE = Path(__file__).resolve().parent.parent / "templates" / "page.html"
+
+SETS = {
+    "pulse": {
+        "label": "four-on-the-floor pulse + kaleidoscope",
+        "audio": (
+            'stack('
+            '  note("c1*4").s("sawtooth").lpf(320).decay(.12).sustain(0).gain(.8),'
+            '  note("~ c4 ~ c4").s("square").decay(.05).sustain(0).gain(.3)'
+            ')'
+        ),
+        "visual": (
+            "osc(30, 0.05, 0.9).kaleid(4)"
+            ".modulateScale(osc(4).rotate(0.3), () => 0.2 + a.fft[0])"
+            ".rotate(0, 0.05).out()"
+        ),
+    },
+    "bells": {
+        "label": "euclidean bells + voronoi pixelate",
+        "audio": (
+            'note("<c5 e5 g5 b5>(3,8)").s("triangle")'
+            '.room(.6).decay(.3).sustain(0).gain(.5)'
+        ),
+        "visual": (
+            "voronoi(8, 0.3, 0.2).color(0.9, 0.4, 1)"
+            ".modulatePixelate(noise(3), () => 10 + a.fft[1] * 40).out()"
+        ),
+    },
+    "drone": {
+        "label": "sawtooth drone + drifting noise",
+        "audio": (
+            'note("c2").add(note("0,7,12")).s("sawtooth")'
+            '.lpf(sine.range(200, 900).slow(8)).gain(.4)'
+        ),
+        "visual": (
+            "noise(2, 0.1).colorama(() => 0.1 + a.fft[0] * 0.5)"
+            ".modulateRotate(osc(1), 0.2).out()"
+        ),
+    },
+    "acid": {
+        "label": "303 acid line + reactive shapes",
+        "audio": (
+            'note("c2 eb2 g2 c3 bb2 g2 eb2 c2".fast(2)).s("sawtooth")'
+            '.lpf(sine.range(300, 1500).fast(4)).resonance(15)'
+            '.decay(.1).sustain(.2).gain(.5)'
+        ),
+        "visual": (
+            "shape(200, 0.5, 0.01).scale(() => 1 + a.fft[0])"
+            ".repeat(20, 10).modulateRotate(osc(4), 0.5).out()"
+        ),
+    },
+}
+
+
+def export(name, out_path):
+    """Bake a set into a standalone page that plays without the server."""
+    s = SETS[name]
+    html = TEMPLATE.read_text(encoding="utf-8")
+    inject = "<script>window.__SET__ = " + json.dumps(s) + ";</script>\n</body>"
+    if "</body>" not in html:
+        raise SystemExit("template has no </body> to inject before")
+    html = html.replace("</body>", inject, 1)
+    Path(out_path).write_text(html, encoding="utf-8")
+    print(f"exported '{name}' -> {out_path}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="strudel-hydra liveset gallery")
+    ap.add_argument("name", nargs="?", help="set to push (see --list)")
+    ap.add_argument("--list", action="store_true", help="list gallery sets")
+    ap.add_argument("--base", default="http://127.0.0.1:8765", help="server base URL")
+    ap.add_argument("--export", metavar="FILE", help="write a standalone .html instead of pushing")
+    args = ap.parse_args()
+
+    if args.list or not args.name:
+        for k, v in SETS.items():
+            print(f"{k:8} {v['label']}")
+        if not args.name:
+            return
+        return
+
+    if args.name not in SETS:
+        sys.exit(f"unknown set '{args.name}'. Try: {', '.join(SETS)}")
+
+    if args.export:
+        export(args.name, args.export)
+        return
+
+    s = SETS[args.name]
+    print(json.dumps(push_set(args.base, s.get("audio"), s.get("visual"), s["label"])))
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/creative/strudel-hydra/scripts/sh_examples.py
+++ b/optional-skills/creative/strudel-hydra/scripts/sh_examples.py
@@ -48,14 +48,14 @@ SETS = {
         ),
     },
     "drone": {
-        "label": "sawtooth drone + drifting noise",
+        "label": "sawtooth drone + slow kaleidoscope drift",
         "audio": (
             'note("c2").add(note("0,7,12")).s("sawtooth")'
             '.lpf(sine.range(200, 900).slow(8)).gain(.4)'
         ),
         "visual": (
-            "noise(2, 0.1).colorama(() => 0.1 + a.fft[0] * 0.5)"
-            ".modulateRotate(osc(1), 0.2).out()"
+            "osc(4, 0.1, 0.6).kaleid(3).color(0.4, 0.3, 0.9)"
+            ".modulateRotate(osc(1), () => 0.2 + a.fft[0]).out()"
         ),
     },
     "acid": {
@@ -66,8 +66,9 @@ SETS = {
             '.decay(.1).sustain(.2).gain(.5)'
         ),
         "visual": (
-            "shape(200, 0.5, 0.01).scale(() => 1 + a.fft[0])"
-            ".repeat(20, 10).modulateRotate(osc(4), 0.5).out()"
+            "osc(40, 0.15, 0.4).kaleid(6).color(1, 0.3, 0.6)"
+            ".modulateRotate(osc(2), () => 0.3 + a.fft[0])"
+            ".modulateScale(noise(2), 0.2).out()"
         ),
     },
 }

--- a/optional-skills/creative/strudel-hydra/scripts/sh_server.py
+++ b/optional-skills/creative/strudel-hydra/scripts/sh_server.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""strudel-hydra liveset server.
+
+Serves the host page and a Server-Sent Events (SSE) stream, and relays pushed
+audio/visual "sets" to every connected browser. This is the thin protocol that
+lets an agent hot-swap a running liveset, the same way pd-patching drives a
+`[netreceive]` socket and supercollider drives `scsynth` over OSC — here the
+transport is SSE over plain HTTP, so it needs nothing beyond the standard
+library.
+
+Run it in the background, open http://127.0.0.1:8765 in a browser, then push
+sets with sh_client.py / sh_examples.py.
+"""
+import argparse
+import json
+import queue
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+TEMPLATE = Path(__file__).resolve().parent.parent / "templates" / "page.html"
+
+
+class Telemetry:
+    """Latest measured features reported by the page (the perception channel
+    that closes the live-coding loop)."""
+
+    def __init__(self):
+        self._data = None
+        self._ts = None
+        self._lock = threading.Lock()
+
+    def set(self, data):
+        with self._lock:
+            self._data = data
+            self._ts = time.time()
+
+    def get(self):
+        with self._lock:
+            if self._data is None:
+                return {"data": None, "age": None}
+            return {"data": self._data, "age": round(time.time() - self._ts, 3)}
+
+
+telemetry = Telemetry()
+
+
+class Broker:
+    """Fan-out of the latest set to all open SSE streams.
+
+    The most recent set is retained so a browser that connects *after* a push
+    still receives the current liveset instead of a blank page.
+    """
+
+    def __init__(self):
+        self._subs = set()
+        self._lock = threading.Lock()
+        self._last = None
+
+    def subscribe(self):
+        q = queue.Queue()
+        with self._lock:
+            self._subs.add(q)
+            if self._last is not None:
+                q.put(self._last)
+        return q
+
+    def unsubscribe(self, q):
+        with self._lock:
+            self._subs.discard(q)
+
+    def publish(self, data):
+        payload = json.dumps(data)
+        with self._lock:
+            self._last = payload
+            for q in list(self._subs):
+                q.put(payload)
+            return len(self._subs)
+
+    def count(self):
+        with self._lock:
+            return len(self._subs)
+
+
+broker = Broker()
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *_a):  # keep the terminal quiet
+        pass
+
+    def _send(self, code, ctype, body=b""):
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path in ("/", "/index.html"):
+            try:
+                body = TEMPLATE.read_bytes()
+            except OSError as e:
+                self._send(500, "text/plain", f"template missing: {e}".encode())
+                return
+            self._send(200, "text/html; charset=utf-8", body)
+            return
+
+        if self.path == "/status":
+            body = json.dumps({"subscribers": broker.count()}).encode()
+            self._send(200, "application/json", body)
+            return
+
+        if self.path == "/telemetry":
+            self._send(200, "application/json", json.dumps(telemetry.get()).encode())
+            return
+
+        if self.path == "/events":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("Connection", "keep-alive")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            q = broker.subscribe()
+            try:
+                self.wfile.write(b": connected\n\n")
+                self.wfile.flush()
+                while True:
+                    try:
+                        payload = q.get(timeout=15)
+                    except queue.Empty:
+                        self.wfile.write(b": ping\n\n")  # keep proxies from timing out
+                        self.wfile.flush()
+                        continue
+                    # SSE frames data line-by-line; prefix every line.
+                    frame = "data: " + payload.replace("\n", "\ndata: ") + "\n\n"
+                    self.wfile.write(frame.encode("utf-8"))
+                    self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            finally:
+                broker.unsubscribe(q)
+            return
+
+        self._send(404, "text/plain", b"not found")
+
+    def do_POST(self):
+        if self.path == "/push":
+            length = int(self.headers.get("Content-Length", "0"))
+            raw = self.rfile.read(length) if length else b"{}"
+            try:
+                data = json.loads(raw or b"{}")
+            except json.JSONDecodeError:
+                self._send(400, "application/json", b'{"error":"bad json"}')
+                return
+            if not isinstance(data, dict):
+                self._send(400, "application/json", b'{"error":"expected object"}')
+                return
+            subs = broker.publish(data)
+            body = json.dumps({"ok": True, "subscribers": subs}).encode()
+            self._send(200, "application/json", body)
+            return
+
+        if self.path == "/telemetry":
+            length = int(self.headers.get("Content-Length", "0"))
+            raw = self.rfile.read(length) if length else b"{}"
+            try:
+                data = json.loads(raw or b"{}")
+            except json.JSONDecodeError:
+                self._send(400, "application/json", b'{"error":"bad json"}')
+                return
+            telemetry.set(data)
+            self._send(200, "application/json", b'{"ok":true}')
+            return
+
+        self._send(404, "text/plain", b"not found")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="strudel-hydra liveset server")
+    ap.add_argument("--host", default="127.0.0.1", help="bind address (keep on loopback)")
+    ap.add_argument("--port", type=int, default=8765)
+    args = ap.parse_args()
+
+    srv = ThreadingHTTPServer((args.host, args.port), Handler)
+    srv.daemon_threads = True
+    print(f"strudel-hydra server on http://{args.host}:{args.port}  (open it in a browser)")
+    sys.stdout.flush()
+    try:
+        srv.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        srv.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/creative/strudel-hydra/scripts/sh_server.py
+++ b/optional-skills/creative/strudel-hydra/scripts/sh_server.py
@@ -10,17 +10,69 @@ library.
 
 Run it in the background, open http://127.0.0.1:8765 in a browser, then push
 sets with sh_client.py / sh_examples.py.
+
+Security: the write endpoints (`/push`, `/telemetry`) deliver code that the page
+evaluates, so they are gated — same-origin only (no wildcard CORS), JSON body
+required, and a per-run capability token. The token is generated at startup,
+injected into the served page, and written to a per-port file that the client
+scripts read automatically. The server refuses to bind a non-loopback address
+unless `--allow-remote` is passed.
 """
 import argparse
+import hmac
 import json
+import os
 import queue
+import secrets
 import sys
+import tempfile
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 TEMPLATE = Path(__file__).resolve().parent.parent / "templates" / "page.html"
+TOKEN_PLACEHOLDER = "__SH_TOKEN__"
+
+# Hosts that keep the code-push transport on the local machine.
+LOOPBACK_HOSTS = {"127.0.0.1", "::1", "localhost", "[::1]"}
+
+
+def is_loopback_host(host):
+    return host in LOOPBACK_HOSTS
+
+
+def validate_bind_host(host, allow_remote):
+    """Loopback binds freely; anything else needs an explicit opt-in because the
+    push transport is unauthenticated at the network layer beyond the token."""
+    if is_loopback_host(host) or allow_remote:
+        return host
+    raise SystemExit(
+        f"refusing to bind non-loopback host {host!r} without --allow-remote "
+        "(the code-push transport would be exposed on the network)"
+    )
+
+
+def token_file_path(port):
+    """Per-port file the client scripts read to discover the capability token."""
+    return Path(tempfile.gettempdir()) / f"strudel-hydra-{port}.token"
+
+
+def origin_allowed(origin, host_header):
+    """A missing Origin means a non-browser client (curl, urllib) — allowed; the
+    token still gates the write. A present Origin must match our own host, which
+    rejects cross-site requests a malicious page would carry."""
+    if not origin:
+        return True
+    return origin in ("http://" + host_header, "https://" + host_header)
+
+
+def content_type_is_json(ctype):
+    return ctype is not None and ctype.split(";")[0].strip().lower() == "application/json"
+
+
+def inject_token(html, token):
+    return html.replace(TOKEN_PLACEHOLDER, token)
 
 
 class Telemetry:
@@ -89,6 +141,7 @@ broker = Broker()
 
 class Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
+    token = ""  # set per-process in main()
 
     def log_message(self, *_a):  # keep the terminal quiet
         pass
@@ -97,18 +150,39 @@ class Handler(BaseHTTPRequestHandler):
         self.send_response(code)
         self.send_header("Content-Type", ctype)
         self.send_header("Content-Length", str(len(body)))
-        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         if body:
             self.wfile.write(body)
 
+    def _authorize_write(self):
+        """Guard the endpoints that deliver evaluable code. Returns True only for
+        a same-origin JSON request bearing the capability token; otherwise it
+        writes the rejection and returns False."""
+        if not origin_allowed(self.headers.get("Origin"), self.headers.get("Host", "")):
+            self._send(403, "application/json", b'{"error":"cross-origin forbidden"}')
+            return False
+        if not content_type_is_json(self.headers.get("Content-Type")):
+            self._send(415, "application/json", b'{"error":"content-type must be application/json"}')
+            return False
+        supplied = self.headers.get("X-SH-Token", "")
+        if not self.token or not hmac.compare_digest(supplied, self.token):
+            self._send(401, "application/json", b'{"error":"missing or invalid token"}')
+            return False
+        return True
+
+    def _read_json(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length) if length else b"{}"
+        return json.loads(raw or b"{}")
+
     def do_GET(self):
         if self.path in ("/", "/index.html"):
             try:
-                body = TEMPLATE.read_bytes()
+                html = TEMPLATE.read_text(encoding="utf-8")
             except OSError as e:
                 self._send(500, "text/plain", f"template missing: {e}".encode())
                 return
+            body = inject_token(html, self.token).encode("utf-8")
             self._send(200, "text/html; charset=utf-8", body)
             return
 
@@ -126,7 +200,6 @@ class Handler(BaseHTTPRequestHandler):
             self.send_header("Content-Type", "text/event-stream")
             self.send_header("Cache-Control", "no-cache")
             self.send_header("Connection", "keep-alive")
-            self.send_header("Access-Control-Allow-Origin", "*")
             self.end_headers()
             q = broker.subscribe()
             try:
@@ -153,10 +226,10 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_POST(self):
         if self.path == "/push":
-            length = int(self.headers.get("Content-Length", "0"))
-            raw = self.rfile.read(length) if length else b"{}"
+            if not self._authorize_write():
+                return
             try:
-                data = json.loads(raw or b"{}")
+                data = self._read_json()
             except json.JSONDecodeError:
                 self._send(400, "application/json", b'{"error":"bad json"}')
                 return
@@ -169,10 +242,10 @@ class Handler(BaseHTTPRequestHandler):
             return
 
         if self.path == "/telemetry":
-            length = int(self.headers.get("Content-Length", "0"))
-            raw = self.rfile.read(length) if length else b"{}"
+            if not self._authorize_write():
+                return
             try:
-                data = json.loads(raw or b"{}")
+                data = self._read_json()
             except json.JSONDecodeError:
                 self._send(400, "application/json", b'{"error":"bad json"}')
                 return
@@ -187,11 +260,28 @@ def main():
     ap = argparse.ArgumentParser(description="strudel-hydra liveset server")
     ap.add_argument("--host", default="127.0.0.1", help="bind address (keep on loopback)")
     ap.add_argument("--port", type=int, default=8765)
+    ap.add_argument(
+        "--allow-remote",
+        action="store_true",
+        help="permit binding a non-loopback --host (exposes the token-gated push transport)",
+    )
     args = ap.parse_args()
+
+    validate_bind_host(args.host, args.allow_remote)
+
+    token = secrets.token_urlsafe(24)
+    Handler.token = token
+    tf = token_file_path(args.port)
+    tf.write_text(token, encoding="utf-8")
+    try:
+        os.chmod(tf, 0o600)
+    except OSError:
+        pass
 
     srv = ThreadingHTTPServer((args.host, args.port), Handler)
     srv.daemon_threads = True
     print(f"strudel-hydra server on http://{args.host}:{args.port}  (open it in a browser)")
+    print(f"push token: {token}  (clients read it from {tf})")
     sys.stdout.flush()
     try:
         srv.serve_forever()
@@ -199,6 +289,10 @@ def main():
         pass
     finally:
         srv.server_close()
+        try:
+            tf.unlink()
+        except OSError:
+            pass
 
 
 if __name__ == "__main__":

--- a/optional-skills/creative/strudel-hydra/templates/page.html
+++ b/optional-skills/creative/strudel-hydra/templates/page.html
@@ -6,7 +6,7 @@
 <title>strudel-hydra liveset</title>
 <style>
   html, body { margin: 0; height: 100%; background: #000; overflow: hidden; }
-  #hydra { position: fixed; inset: 0; width: 100%; height: 100%; display: block; }
+  #hydra { position: fixed; inset: 0; width: 100%; height: 100%; border: 0; display: block; }
   #hud {
     position: fixed; left: 10px; bottom: 10px; z-index: 9;
     font: 12px/1.4 ui-monospace, Menlo, monospace; color: #6f6;
@@ -21,12 +21,14 @@
 </style>
 </head>
 <body>
-<canvas id="hydra"></canvas>
+<!-- Hydra runs in an isolated iframe: Strudel's WebAudio init spawns a WebGL
+     context that otherwise invalidates Hydra's shader program (blank canvas).
+     A separate document = a separate GL context = the two never collide. -->
+<iframe id="hydra"></iframe>
 <div id="hud">strudel-hydra: loading…</div>
 <div id="start">▶ CLICK TO START (enables audio)</div>
 
-<!-- Bundles are fetched by the browser, not npm. Pin exact versions. -->
-<script src="https://unpkg.com/hydra-synth@1.3.29/dist/hydra-synth.js"></script>
+<!-- Parent loads Strudel only; the iframe loads Hydra (see HYDRA_DOC below). -->
 <script src="https://unpkg.com/@strudel/web@1.0.3"></script>
 <script>
   const hudEl = document.getElementById('hud');
@@ -34,22 +36,48 @@
   const LIVE = !window.__SET__;   // exported pages carry a baked-in set instead of an SSE stream
   let started = false;
 
+  // The Hydra document, injected via srcdoc so an exported single file still
+  // works with no server. `<scr'+'ipt>` keeps the outer parser from closing here.
+  const HYDRA_DOC =
+    '<!doctype html><meta charset=utf8>' +
+    '<style>html,body{margin:0;height:100%;background:#000;overflow:hidden}' +
+    'canvas{position:fixed;inset:0;width:100%;height:100%}</style><canvas id=c></canvas>' +
+    '<scr' + 'ipt src="https://unpkg.com/hydra-synth@1.3.29/dist/hydra-synth.js"></scr' + 'ipt>' +
+    '<scr' + 'ipt>' +
+    'window.a={fft:new Array(8).fill(0)};' +                          // visuals read a.fft; always an array
+    'var c=document.getElementById("c");c.width=innerWidth;c.height=innerHeight;' +
+    'addEventListener("resize",function(){c.width=innerWidth;c.height=innerHeight;});' +
+    'new Hydra({canvas:c,detectAudio:false,makeGlobal:true});' +      // no mic: reactivity is fed from the parent
+    'addEventListener("message",function(e){var d=e.data||{};' +
+    'if(d.type==="fft"&&d.fft){for(var i=0;i<d.fft.length;i++)window.a.fft[i]=d.fft[i];return;}' +
+    'if(d.type==="hush"){try{solid(0,0,0).out();}catch(_){}return;}' +
+    'if(d.type==="visual"&&typeof d.code==="string"){try{(0,eval)(d.code);' +
+    'parent.postMessage({type:"vok"},"*");}catch(err){parent.postMessage({type:"verr",msg:err.message},"*");}}' +
+    '});parent.postMessage({type:"ready"},"*");' +
+    '</scr' + 'ipt>';
+
+  let resolveReady;
+  const frameReady = new Promise((r) => { resolveReady = r; });
+  window.addEventListener('message', (e) => {
+    const d = e.data || {};
+    if (d.type === 'ready') resolveReady();
+    else if (d.type === 'verr') hud('visual error: ' + d.msg);
+  });
+  function postFrame(msg) {
+    const f = document.getElementById('hydra');
+    if (f && f.contentWindow) f.contentWindow.postMessage(msg, '*');
+  }
+
   async function boot() {
-    // --- hydra: fill the viewport, react to audio, expose osc()/solid()/o0/… globally
-    const canvas = document.getElementById('hydra');
-    canvas.width = window.innerWidth;
-    canvas.height = window.innerHeight;
-    // eslint-disable-next-line no-new
-    new Hydra({ canvas, detectAudio: true, makeGlobal: true, enableStreamCapture: false });
-    // --- strudel: makes note()/sound()/evaluate()/hush() global
-    await initStrudel();
+    document.getElementById('hydra').srcdoc = HYDRA_DOC;
+    await initStrudel();                                 // makes note()/evaluate()/hush() global
     try { window.__an = tapAudio(getAudioContext()); } catch (_) {}
     hud(LIVE ? 'ready — click to start' : 'exported set — click to start');
   }
 
-  // Tap everything Strudel routes to the speakers with an analyser, so audio
-  // telemetry reflects the actual output (works muted/headless, no mic needed) —
-  // unlike Hydra's mic-fed a.fft, which drives visual reactivity.
+  // Tap everything Strudel routes to the speakers with an analyser. This is the
+  // one true audio signal: it feeds both the telemetry and the visuals' a.fft,
+  // works muted/headless, and needs no microphone.
   function tapAudio(ctx) {
     const an = ctx.createAnalyser();
     an.fftSize = 64;
@@ -68,83 +96,37 @@
     started = true;
     document.getElementById('start').remove();
     try { await getAudioContext().resume(); } catch (_) {}
+    await frameReady;             // the Hydra iframe is now listening
+    driveReactivity();
     if (LIVE) {
       openStream();
-      startTelemetry();   // perception channel: measure what we produce
+      startTelemetry();
     } else {
       await applySet(window.__SET__);
     }
   }
 
-  // Measure the running set and report features back, so an agent can score a
-  // candidate and evolve it. Audio comes from Hydra's analyser (the same signal
-  // that drives a.fft in visuals); the visual grab is best-effort compositing.
-  function startTelemetry() {
-    const hydraCanvas = document.getElementById('hydra');
-    const W = 32, H = 18, N = W * H;
-    const off = document.createElement('canvas');
-    off.width = W; off.height = H;
-    const octx = off.getContext('2d', { willReadFrequently: true });
-    let prev = null;
-    let vis = { brightness: 0, rgb: [0, 0, 0], motion: 0 };
-    try { if (typeof a !== 'undefined' && a.setBins) a.setBins(8); } catch (_) {}
-
-    // Grab pixels INSIDE Hydra's frame via its `update` hook: mid-frame the
-    // drawing buffer is still intact, so compositing reads real pixels — a
-    // setInterval grab runs between frames and reads black (buffer cleared).
-    let acc = 0;
-    try {
-      // eslint-disable-next-line no-global-assign
-      window.update = (dt) => {
-        acc += dt || 16;
-        if (acc < 700) return;
-        acc = 0;
-        try {
-          octx.drawImage(hydraCanvas, 0, 0, W, H);
-          const d = octx.getImageData(0, 0, W, H).data;
-          let r = 0, g = 0, b = 0, diff = 0;
-          for (let i = 0; i < d.length; i += 4) {
-            r += d[i]; g += d[i + 1]; b += d[i + 2];
-            if (prev) diff += Math.abs(d[i] - prev[i]) + Math.abs(d[i + 1] - prev[i + 1]) + Math.abs(d[i + 2] - prev[i + 2]);
-          }
-          const rgb = [+(r / N / 255).toFixed(4), +(g / N / 255).toFixed(4), +(b / N / 255).toFixed(4)];
-          vis = {
-            brightness: +((rgb[0] + rgb[1] + rgb[2]) / 3).toFixed(4),
-            rgb,
-            motion: prev ? +(diff / (N * 3 * 255)).toFixed(4) : 0,
-          };
-          prev = d;
-        } catch (_) {}
-      };
-    } catch (_) {}
-
-    setInterval(async () => {
-      // --- audio features: prefer the Strudel-output tap; fall back to a.fft
-      let bands = [];
+  // Every frame, derive 8 bands from the Strudel tap and push them to the iframe
+  // as a.fft, so visuals react to the actual music (no mic). Latest bands are
+  // cached for telemetry.
+  function driveReactivity() {
+    const tick = () => {
       try {
         if (window.__an) {
           const bins = new Uint8Array(window.__an.frequencyBinCount);
           window.__an.getByteFrequencyData(bins);
-          const B = 8, step = Math.floor(bins.length / B) || 1;
+          const B = 8, step = Math.floor(bins.length / B) || 1, fft = [];
           for (let b = 0; b < B; b++) {
             let s = 0;
             for (let i = 0; i < step; i++) s += bins[b * step + i];
-            bands.push(+(s / step / 255).toFixed(4));
+            fft.push(+(s / step / 255).toFixed(4));
           }
-        } else if (typeof a !== 'undefined' && a.fft) {
-          bands = Array.from(a.fft).map((x) => +x.toFixed(4));
+          postFrame({ type: 'fft', fft });
         }
       } catch (_) {}
-      const level = bands.length ? +(bands.reduce((s, x) => s + x, 0) / bands.length).toFixed(4) : 0;
-      let centroid = 0;
-      if (bands.length > 1) {
-        let num = 0, den = 0;
-        bands.forEach((v, i) => { num += v * i; den += v; });
-        centroid = den ? +(num / den / (bands.length - 1)).toFixed(4) : 0;
-      }
-      const body = JSON.stringify({ level, bands, centroid, ...vis });
-      try { await fetch('/telemetry', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body }); } catch (_) {}
-    }, 750);
+      requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
   }
 
   function openStream() {
@@ -163,19 +145,49 @@
     if (!set || typeof set !== 'object') return;
     if (set.cmd === 'hush') {
       try { hush(); } catch (_) {}
-      try { solid(0, 0, 0).out(); } catch (_) {}
+      postFrame({ type: 'hush' });
       hud('hush');
       return;
     }
+    await frameReady;
     if (typeof set.visual === 'string' && set.visual.trim()) {
-      try { (0, eval)(set.visual); }                       // indirect eval: hydra globals
-      catch (err) { hud('visual error: ' + err.message); return; }
+      postFrame({ type: 'visual', code: set.visual });   // errors come back async as 'verr'
     }
     if (typeof set.audio === 'string' && set.audio.trim()) {
-      try { await evaluate(set.audio); }                   // strudel compiles + schedules
+      try { await evaluate(set.audio); }
       catch (err) { hud('audio error: ' + err.message); return; }
     }
     hud('applied · ' + (set.label || 'live'));
+  }
+
+  // Report audio features back so an agent can score a set and evolve it.
+  // Audio-only: Hydra's WebGL canvas can't be read back in-page (buffer not
+  // preserved), so the visuals are judged by eye, not by telemetry.
+  function startTelemetry() {
+    setInterval(async () => {
+      let bands = [];
+      try {
+        if (window.__an) {
+          const bins = new Uint8Array(window.__an.frequencyBinCount);
+          window.__an.getByteFrequencyData(bins);
+          const B = 8, step = Math.floor(bins.length / B) || 1;
+          for (let b = 0; b < B; b++) {
+            let s = 0;
+            for (let i = 0; i < step; i++) s += bins[b * step + i];
+            bands.push(+(s / step / 255).toFixed(4));
+          }
+        }
+      } catch (_) {}
+      const level = bands.length ? +(bands.reduce((s, x) => s + x, 0) / bands.length).toFixed(4) : 0;
+      let centroid = 0;
+      if (bands.length > 1) {
+        let num = 0, den = 0;
+        bands.forEach((v, i) => { num += v * i; den += v; });
+        centroid = den ? +(num / den / (bands.length - 1)).toFixed(4) : 0;
+      }
+      const body = JSON.stringify({ level, bands, centroid });
+      try { await fetch('/telemetry', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body }); } catch (_) {}
+    }, 750);
   }
 
   document.getElementById('start').addEventListener('click', begin);

--- a/optional-skills/creative/strudel-hydra/templates/page.html
+++ b/optional-skills/creative/strudel-hydra/templates/page.html
@@ -43,7 +43,24 @@
     new Hydra({ canvas, detectAudio: true, makeGlobal: true, enableStreamCapture: false });
     // --- strudel: makes note()/sound()/evaluate()/hush() global
     await initStrudel();
+    try { window.__an = tapAudio(getAudioContext()); } catch (_) {}
     hud(LIVE ? 'ready — click to start' : 'exported set — click to start');
+  }
+
+  // Tap everything Strudel routes to the speakers with an analyser, so audio
+  // telemetry reflects the actual output (works muted/headless, no mic needed) —
+  // unlike Hydra's mic-fed a.fft, which drives visual reactivity.
+  function tapAudio(ctx) {
+    const an = ctx.createAnalyser();
+    an.fftSize = 64;
+    an.smoothingTimeConstant = 0.6;
+    const dest = ctx.destination;
+    const orig = AudioNode.prototype.connect;
+    AudioNode.prototype.connect = function (target, ...rest) {
+      try { if (target === dest) orig.call(this, an); } catch (_) {}
+      return orig.call(this, target, ...rest);
+    };
+    return an;
   }
 
   async function begin() {
@@ -72,9 +89,22 @@
     try { if (typeof a !== 'undefined' && a.setBins) a.setBins(8); } catch (_) {}
 
     setInterval(async () => {
-      // --- audio features from the analyser bins
+      // --- audio features: prefer the Strudel-output tap; fall back to a.fft
       let bands = [];
-      try { if (typeof a !== 'undefined' && a.fft) bands = Array.from(a.fft).map((x) => +x.toFixed(4)); } catch (_) {}
+      try {
+        if (window.__an) {
+          const bins = new Uint8Array(window.__an.frequencyBinCount);
+          window.__an.getByteFrequencyData(bins);
+          const B = 8, step = Math.floor(bins.length / B) || 1;
+          for (let b = 0; b < B; b++) {
+            let s = 0;
+            for (let i = 0; i < step; i++) s += bins[b * step + i];
+            bands.push(+(s / step / 255).toFixed(4));
+          }
+        } else if (typeof a !== 'undefined' && a.fft) {
+          bands = Array.from(a.fft).map((x) => +x.toFixed(4));
+        }
+      } catch (_) {}
       const level = bands.length ? +(bands.reduce((s, x) => s + x, 0) / bands.length).toFixed(4) : 0;
       let centroid = 0;
       if (bands.length > 1) {

--- a/optional-skills/creative/strudel-hydra/templates/page.html
+++ b/optional-skills/creative/strudel-hydra/templates/page.html
@@ -86,7 +86,37 @@
     off.width = W; off.height = H;
     const octx = off.getContext('2d', { willReadFrequently: true });
     let prev = null;
+    let vis = { brightness: 0, rgb: [0, 0, 0], motion: 0 };
     try { if (typeof a !== 'undefined' && a.setBins) a.setBins(8); } catch (_) {}
+
+    // Grab pixels INSIDE Hydra's frame via its `update` hook: mid-frame the
+    // drawing buffer is still intact, so compositing reads real pixels — a
+    // setInterval grab runs between frames and reads black (buffer cleared).
+    let acc = 0;
+    try {
+      // eslint-disable-next-line no-global-assign
+      window.update = (dt) => {
+        acc += dt || 16;
+        if (acc < 700) return;
+        acc = 0;
+        try {
+          octx.drawImage(hydraCanvas, 0, 0, W, H);
+          const d = octx.getImageData(0, 0, W, H).data;
+          let r = 0, g = 0, b = 0, diff = 0;
+          for (let i = 0; i < d.length; i += 4) {
+            r += d[i]; g += d[i + 1]; b += d[i + 2];
+            if (prev) diff += Math.abs(d[i] - prev[i]) + Math.abs(d[i + 1] - prev[i + 1]) + Math.abs(d[i + 2] - prev[i + 2]);
+          }
+          const rgb = [+(r / N / 255).toFixed(4), +(g / N / 255).toFixed(4), +(b / N / 255).toFixed(4)];
+          vis = {
+            brightness: +((rgb[0] + rgb[1] + rgb[2]) / 3).toFixed(4),
+            rgb,
+            motion: prev ? +(diff / (N * 3 * 255)).toFixed(4) : 0,
+          };
+          prev = d;
+        } catch (_) {}
+      };
+    } catch (_) {}
 
     setInterval(async () => {
       // --- audio features: prefer the Strudel-output tap; fall back to a.fft
@@ -112,22 +142,7 @@
         bands.forEach((v, i) => { num += v * i; den += v; });
         centroid = den ? +(num / den / (bands.length - 1)).toFixed(4) : 0;
       }
-      // --- visual features: composite hydra into a tiny buffer (best-effort)
-      let brightness = 0, rgb = [0, 0, 0], motion = 0;
-      try {
-        octx.drawImage(hydraCanvas, 0, 0, W, H);
-        const d = octx.getImageData(0, 0, W, H).data;
-        let r = 0, g = 0, b = 0, diff = 0;
-        for (let i = 0; i < d.length; i += 4) {
-          r += d[i]; g += d[i + 1]; b += d[i + 2];
-          if (prev) diff += Math.abs(d[i] - prev[i]) + Math.abs(d[i + 1] - prev[i + 1]) + Math.abs(d[i + 2] - prev[i + 2]);
-        }
-        rgb = [+(r / N / 255).toFixed(4), +(g / N / 255).toFixed(4), +(b / N / 255).toFixed(4)];
-        brightness = +((rgb[0] + rgb[1] + rgb[2]) / 3).toFixed(4);
-        motion = prev ? +(diff / (N * 3 * 255)).toFixed(4) : 0;
-        prev = d;
-      } catch (_) {}
-      const body = JSON.stringify({ level, bands, centroid, brightness, rgb, motion });
+      const body = JSON.stringify({ level, bands, centroid, ...vis });
       try { await fetch('/telemetry', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body }); } catch (_) {}
     }, 750);
   }

--- a/optional-skills/creative/strudel-hydra/templates/page.html
+++ b/optional-skills/creative/strudel-hydra/templates/page.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>strudel-hydra liveset</title>
+<style>
+  html, body { margin: 0; height: 100%; background: #000; overflow: hidden; }
+  #hydra { position: fixed; inset: 0; width: 100%; height: 100%; display: block; }
+  #hud {
+    position: fixed; left: 10px; bottom: 10px; z-index: 9;
+    font: 12px/1.4 ui-monospace, Menlo, monospace; color: #6f6;
+    opacity: .55; pointer-events: none; white-space: pre; text-shadow: 0 0 4px #000;
+  }
+  #start {
+    position: fixed; inset: 0; z-index: 20; display: flex;
+    align-items: center; justify-content: center; cursor: pointer;
+    background: #000; color: #6f6; font: 600 15px ui-monospace, monospace;
+    letter-spacing: .12em;
+  }
+</style>
+</head>
+<body>
+<canvas id="hydra"></canvas>
+<div id="hud">strudel-hydra: loading…</div>
+<div id="start">▶ CLICK TO START (enables audio)</div>
+
+<!-- Bundles are fetched by the browser, not npm. Pin exact versions. -->
+<script src="https://unpkg.com/hydra-synth@1.3.29/dist/hydra-synth.js"></script>
+<script src="https://unpkg.com/@strudel/web@1.0.3"></script>
+<script>
+  const hudEl = document.getElementById('hud');
+  const hud = (t) => { hudEl.textContent = 'strudel-hydra: ' + t; };
+  const LIVE = !window.__SET__;   // exported pages carry a baked-in set instead of an SSE stream
+  let started = false;
+
+  async function boot() {
+    // --- hydra: fill the viewport, react to audio, expose osc()/solid()/o0/… globally
+    const canvas = document.getElementById('hydra');
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+    // eslint-disable-next-line no-new
+    new Hydra({ canvas, detectAudio: true, makeGlobal: true, enableStreamCapture: false });
+    // --- strudel: makes note()/sound()/evaluate()/hush() global
+    await initStrudel();
+    hud(LIVE ? 'ready — click to start' : 'exported set — click to start');
+  }
+
+  async function begin() {
+    if (started) return;
+    started = true;
+    document.getElementById('start').remove();
+    try { await getAudioContext().resume(); } catch (_) {}
+    if (LIVE) {
+      openStream();
+      startTelemetry();   // perception channel: measure what we produce
+    } else {
+      await applySet(window.__SET__);
+    }
+  }
+
+  // Measure the running set and report features back, so an agent can score a
+  // candidate and evolve it. Audio comes from Hydra's analyser (the same signal
+  // that drives a.fft in visuals); the visual grab is best-effort compositing.
+  function startTelemetry() {
+    const hydraCanvas = document.getElementById('hydra');
+    const W = 32, H = 18, N = W * H;
+    const off = document.createElement('canvas');
+    off.width = W; off.height = H;
+    const octx = off.getContext('2d', { willReadFrequently: true });
+    let prev = null;
+    try { if (typeof a !== 'undefined' && a.setBins) a.setBins(8); } catch (_) {}
+
+    setInterval(async () => {
+      // --- audio features from the analyser bins
+      let bands = [];
+      try { if (typeof a !== 'undefined' && a.fft) bands = Array.from(a.fft).map((x) => +x.toFixed(4)); } catch (_) {}
+      const level = bands.length ? +(bands.reduce((s, x) => s + x, 0) / bands.length).toFixed(4) : 0;
+      let centroid = 0;
+      if (bands.length > 1) {
+        let num = 0, den = 0;
+        bands.forEach((v, i) => { num += v * i; den += v; });
+        centroid = den ? +(num / den / (bands.length - 1)).toFixed(4) : 0;
+      }
+      // --- visual features: composite hydra into a tiny buffer (best-effort)
+      let brightness = 0, rgb = [0, 0, 0], motion = 0;
+      try {
+        octx.drawImage(hydraCanvas, 0, 0, W, H);
+        const d = octx.getImageData(0, 0, W, H).data;
+        let r = 0, g = 0, b = 0, diff = 0;
+        for (let i = 0; i < d.length; i += 4) {
+          r += d[i]; g += d[i + 1]; b += d[i + 2];
+          if (prev) diff += Math.abs(d[i] - prev[i]) + Math.abs(d[i + 1] - prev[i + 1]) + Math.abs(d[i + 2] - prev[i + 2]);
+        }
+        rgb = [+(r / N / 255).toFixed(4), +(g / N / 255).toFixed(4), +(b / N / 255).toFixed(4)];
+        brightness = +((rgb[0] + rgb[1] + rgb[2]) / 3).toFixed(4);
+        motion = prev ? +(diff / (N * 3 * 255)).toFixed(4) : 0;
+        prev = d;
+      } catch (_) {}
+      const body = JSON.stringify({ level, bands, centroid, brightness, rgb, motion });
+      try { await fetch('/telemetry', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body }); } catch (_) {}
+    }, 750);
+  }
+
+  function openStream() {
+    const es = new EventSource('/events');
+    es.onmessage = async (e) => {
+      let set;
+      try { set = JSON.parse(e.data); } catch (_) { return; }
+      await applySet(set);
+    };
+    es.onerror = () => hud('SSE disconnected — is the server up?');
+    hud('stream open — waiting for a set');
+  }
+
+  // A "set" is { audio?: strudel-code, visual?: hydra-code, label?, cmd? }.
+  async function applySet(set) {
+    if (!set || typeof set !== 'object') return;
+    if (set.cmd === 'hush') {
+      try { hush(); } catch (_) {}
+      try { solid(0, 0, 0).out(); } catch (_) {}
+      hud('hush');
+      return;
+    }
+    if (typeof set.visual === 'string' && set.visual.trim()) {
+      try { (0, eval)(set.visual); }                       // indirect eval: hydra globals
+      catch (err) { hud('visual error: ' + err.message); return; }
+    }
+    if (typeof set.audio === 'string' && set.audio.trim()) {
+      try { await evaluate(set.audio); }                   // strudel compiles + schedules
+      catch (err) { hud('audio error: ' + err.message); return; }
+    }
+    hud('applied · ' + (set.label || 'live'));
+  }
+
+  document.getElementById('start').addEventListener('click', begin);
+  boot();
+</script>
+</body>
+</html>

--- a/optional-skills/creative/strudel-hydra/templates/page.html
+++ b/optional-skills/creative/strudel-hydra/templates/page.html
@@ -31,6 +31,10 @@
 <!-- Parent loads Strudel only; the iframe loads Hydra (see HYDRA_DOC below). -->
 <script src="https://unpkg.com/@strudel/web@1.0.3"></script>
 <script>
+  // Capability token the server injects when it serves this page; sent back on
+  // the telemetry write so the gated endpoint accepts it. Exported pages never
+  // reach the server, so the unreplaced placeholder there is harmless.
+  const TOKEN = "__SH_TOKEN__";
   const hudEl = document.getElementById('hud');
   const hud = (t) => { hudEl.textContent = 'strudel-hydra: ' + t; };
   const LIVE = !window.__SET__;   // exported pages carry a baked-in set instead of an SSE stream
@@ -186,7 +190,7 @@
         centroid = den ? +(num / den / (bands.length - 1)).toFixed(4) : 0;
       }
       const body = JSON.stringify({ level, bands, centroid });
-      try { await fetch('/telemetry', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body }); } catch (_) {}
+      try { await fetch('/telemetry', { method: 'POST', headers: { 'Content-Type': 'application/json', 'X-SH-Token': TOKEN }, body }); } catch (_) {}
     }, 750);
   }
 

--- a/tests/skills/test_strudel_hydra_skill.py
+++ b/tests/skills/test_strudel_hydra_skill.py
@@ -1,0 +1,304 @@
+"""Regression tests for the `strudel-hydra` optional skill.
+
+Standard library + pytest only; no browser, no sockets, no network. Covers the
+security gate added for review: the server's write endpoints (`/push`,
+`/telemetry`) require a same-origin JSON request bearing the per-run capability
+token, the bind host is restricted to loopback unless opted out, and the client
+discovers the token automatically. The HTTP handler is driven directly with a
+fake request (no socket); `urllib` in the client is mocked.
+"""
+from __future__ import annotations
+
+import email.message
+import io
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+SKILL = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "creative"
+    / "strudel-hydra"
+)
+SCRIPTS = SKILL / "scripts"
+TEMPLATE = SKILL / "templates" / "page.html"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _add_scripts_to_path():
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        yield
+    finally:
+        sys.path.remove(str(SCRIPTS))
+
+
+# --- sh_server: pure security helpers -------------------------------------
+
+def test_loopback_classification():
+    import sh_server as m
+
+    assert m.is_loopback_host("127.0.0.1")
+    assert m.is_loopback_host("localhost")
+    assert m.is_loopback_host("::1")
+    assert not m.is_loopback_host("0.0.0.0")
+    assert not m.is_loopback_host("192.168.1.5")
+
+
+def test_validate_bind_host_rejects_non_loopback_without_optin():
+    import sh_server as m
+
+    assert m.validate_bind_host("127.0.0.1", allow_remote=False) == "127.0.0.1"
+    with pytest.raises(SystemExit):
+        m.validate_bind_host("0.0.0.0", allow_remote=False)
+    # explicit opt-in permits it
+    assert m.validate_bind_host("0.0.0.0", allow_remote=True) == "0.0.0.0"
+
+
+def test_origin_allowed_rejects_cross_site_only():
+    import sh_server as m
+
+    # no Origin (curl / urllib) is allowed; the token still gates the write
+    assert m.origin_allowed(None, "127.0.0.1:8765")
+    assert m.origin_allowed("", "127.0.0.1:8765")
+    # same-origin browser request matches
+    assert m.origin_allowed("http://127.0.0.1:8765", "127.0.0.1:8765")
+    assert m.origin_allowed("https://127.0.0.1:8765", "127.0.0.1:8765")
+    # a different site is refused
+    assert not m.origin_allowed("http://evil.example", "127.0.0.1:8765")
+    assert not m.origin_allowed("http://127.0.0.1:9999", "127.0.0.1:8765")
+
+
+def test_content_type_must_be_json():
+    import sh_server as m
+
+    assert m.content_type_is_json("application/json")
+    assert m.content_type_is_json("application/json; charset=utf-8")
+    assert not m.content_type_is_json("text/plain")
+    assert not m.content_type_is_json(None)
+
+
+def test_token_file_path_is_per_port():
+    import sh_server as m
+
+    assert "8765" in m.token_file_path(8765).name
+    assert m.token_file_path(9000) != m.token_file_path(8765)
+
+
+def test_template_carries_token_placeholder_and_inject_replaces_it():
+    import sh_server as m
+
+    html = TEMPLATE.read_text(encoding="utf-8")
+    assert m.TOKEN_PLACEHOLDER in html                 # the page ships a slot
+    injected = m.inject_token(html, "s3cret-token")
+    assert m.TOKEN_PLACEHOLDER not in injected
+    assert "s3cret-token" in injected
+
+
+# --- sh_server: the handler's write gate, driven without a socket ----------
+
+def _make_handler(server_mod, *, path, headers, body=b"", token="the-real-token"):
+    """Build a Handler bound to a fake request (no socket) and capture _send."""
+    h = server_mod.Handler.__new__(server_mod.Handler)
+    h.token = token
+    h.path = path
+    msg = email.message.Message()
+    for k, v in headers.items():
+        msg[k] = v
+    h.headers = msg
+    h.rfile = io.BytesIO(body)
+    h.wfile = io.BytesIO()
+    sent = {}
+
+    def _send(code, ctype, resp=b""):
+        sent["code"] = code
+        sent["ctype"] = ctype
+        sent["body"] = resp
+
+    h._send = _send
+    return h, sent
+
+
+def _json_headers(token="the-real-token", origin=None, ctype="application/json", body=b""):
+    hdrs = {"Content-Length": str(len(body))}
+    if ctype is not None:
+        hdrs["Content-Type"] = ctype
+    if token is not None:
+        hdrs["X-SH-Token"] = token
+    if origin is not None:
+        hdrs["Origin"] = origin
+    return hdrs
+
+
+def test_push_without_token_is_rejected():
+    import sh_server as m
+
+    body = b'{"audio":"note(\\"c3\\")"}'
+    h, sent = _make_handler(m, path="/push", headers=_json_headers(token=None, body=body), body=body)
+    h.do_POST()
+    assert sent["code"] == 401
+
+
+def test_push_with_wrong_token_is_rejected():
+    import sh_server as m
+
+    body = b'{"audio":"x"}'
+    h, sent = _make_handler(m, path="/push", headers=_json_headers(token="nope", body=body), body=body)
+    h.do_POST()
+    assert sent["code"] == 401
+
+
+def test_push_from_cross_origin_is_rejected_even_with_token():
+    import sh_server as m
+
+    body = b'{"audio":"x"}'
+    hdrs = _json_headers(origin="http://evil.example", body=body)
+    h, sent = _make_handler(m, path="/push", headers=hdrs, body=body)
+    h.do_POST()
+    assert sent["code"] == 403
+
+
+def test_push_with_non_json_content_type_is_rejected():
+    import sh_server as m
+
+    body = b'{"audio":"x"}'
+    hdrs = _json_headers(ctype="text/plain", body=body)
+    h, sent = _make_handler(m, path="/push", headers=hdrs, body=body)
+    h.do_POST()
+    assert sent["code"] == 415
+
+
+def test_push_non_object_body_is_rejected_after_auth():
+    import sh_server as m
+
+    body = b'["not","an","object"]'
+    h, sent = _make_handler(m, path="/push", headers=_json_headers(body=body), body=body)
+    h.do_POST()
+    assert sent["code"] == 400
+
+
+def test_valid_push_is_accepted_and_fanned_out():
+    import sh_server as m
+
+    q = m.broker.subscribe()  # stand in for a connected browser
+    try:
+        payload = {"audio": "note(\"c3\")", "label": "riff"}
+        body = json.dumps(payload).encode()
+        h, sent = _make_handler(m, path="/push", headers=_json_headers(body=body), body=body)
+        h.do_POST()
+        assert sent["code"] == 200
+        assert json.loads(sent["body"])["ok"] is True
+        delivered = json.loads(q.get_nowait())
+        assert delivered["label"] == "riff"
+    finally:
+        m.broker.unsubscribe(q)
+
+
+def test_valid_telemetry_post_is_recorded():
+    import sh_server as m
+
+    body = json.dumps({"level": 0.4, "bands": [0.1, 0.2], "centroid": 0.5}).encode()
+    h, sent = _make_handler(m, path="/telemetry", headers=_json_headers(body=body), body=body)
+    h.do_POST()
+    assert sent["code"] == 200
+    assert m.telemetry.get()["data"]["level"] == 0.4
+
+
+def test_served_page_has_token_injected_and_placeholder_gone():
+    import sh_server as m
+
+    h, sent = _make_handler(m, path="/", headers={}, token="page-token-xyz")
+    h.do_GET()
+    assert sent["code"] == 200
+    served = sent["body"].decode()
+    assert "page-token-xyz" in served
+    assert m.TOKEN_PLACEHOLDER not in served
+
+
+# --- sh_client: token discovery + transport --------------------------------
+
+def test_resolve_token_prefers_env(monkeypatch):
+    import sh_client as c
+
+    monkeypatch.setenv("SH_TOKEN", "from-env")
+    assert c.resolve_token("http://127.0.0.1:8765") == "from-env"
+
+
+def test_resolve_token_reads_per_port_file(monkeypatch, tmp_path):
+    import sh_client as c
+
+    monkeypatch.delenv("SH_TOKEN", raising=False)
+    monkeypatch.setattr(c, "token_file_path", lambda port: tmp_path / f"tok-{port}")
+    (tmp_path / "tok-8765").write_text("file-token", encoding="utf-8")
+    assert c.resolve_token("http://127.0.0.1:8765") == "file-token"
+
+
+def test_resolve_token_none_when_absent(monkeypatch, tmp_path):
+    import sh_client as c
+
+    monkeypatch.delenv("SH_TOKEN", raising=False)
+    monkeypatch.setattr(c, "token_file_path", lambda port: tmp_path / "missing")
+    assert c.resolve_token("http://127.0.0.1:8765") is None
+
+
+def test_post_attaches_token_header(monkeypatch):
+    import sh_client as c
+
+    captured = {}
+
+    class FakeResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return b'{"ok": true}'
+
+    def fake_urlopen(req, timeout=5):
+        captured["headers"] = dict(req.header_items())
+        captured["data"] = req.data
+        return FakeResp()
+
+    monkeypatch.setattr(c.urllib.request, "urlopen", fake_urlopen)
+    out = c.post("http://127.0.0.1:8765", "/push", {"audio": "x"}, token="explicit-token")
+    assert out == {"ok": True}
+    # header names are title-cased by urllib
+    assert captured["headers"].get("X-sh-token") == "explicit-token"
+    assert captured["headers"].get("Content-type") == "application/json"
+    assert json.loads(captured["data"]) == {"audio": "x"}
+
+
+def test_push_set_builds_payload_and_passes_token(monkeypatch):
+    import sh_client as c
+
+    calls = {}
+
+    def fake_post(base, path, data, timeout=5, token=None):
+        calls.update(base=base, path=path, data=data, token=token)
+        return {"ok": True}
+
+    monkeypatch.setattr(c, "post", fake_post)
+    c.push_set("http://h", audio="A", visual="V", label="riff", token="tk")
+    assert calls["path"] == "/push"
+    assert calls["token"] == "tk"
+    assert calls["data"] == {"label": "riff", "audio": "A", "visual": "V"}
+
+
+# --- sh_examples: standalone export ---------------------------------------
+
+def test_export_writes_standalone_page(tmp_path):
+    import sh_examples as ex
+
+    out = tmp_path / "acid.html"
+    ex.export("acid", str(out))
+    html = out.read_text(encoding="utf-8")
+    assert "window.__SET__" in html
+    assert ex.SETS["acid"]["label"] in html
+    # exported page is self-contained: it carries a baked set, not an SSE hookup
+    assert "__SET__ = {" in html.replace("window.", "")


### PR DESCRIPTION
## What

Adds `optional-skills/creative/strudel-hydra` — drive a synchronized audio/visual
liveset in the browser and hot-swap it while it runs. Strudel (pattern audio) +
Hydra (audio-reactive visuals); the agent pushes "sets" over Server-Sent Events
and the running page evaluates them without a reload. Same DNA as `pd-patching` /
`supercollider`: standard-library only, no MCP, no npm, no compiled bridge —
here the thin transport is SSE, and one push carries both sound and picture.

Exports a standalone self-contained `.html`.

## Self-improving loop

The page taps Strudel's own output with an analyser and reports audio features
(`level`, `bands`, `centroid`) back over `/telemetry`, closing the live-coding
loop: the agent writes candidate sets, `sh_evolve.py` measures + ranks them
against a fitness `--target`, and it keeps the winner and mutates again — the
`darwinian-evolver` shape with code as organism, the agent as mutator, and the
analyser as a free evaluator. Runs unattended via `/loop`.

## Files

- `SKILL.md` — When to Use, Example Requests, Procedure, Self-Improving Loop,
  Safety (loudness + photosensitivity), Pitfalls, Verification, Security.
- `scripts/sh_server.py` — stdlib HTTP host + SSE broker + telemetry endpoint.
- `scripts/sh_client.py` — push sets / `--hush` / `--observe` / `score()`.
- `scripts/sh_examples.py` — gallery (pulse/bells/drone/acid) + `--export`.
- `scripts/sh_evolve.py` — score + rank one generation of candidates.
- `templates/page.html` — host page; Hydra runs in an isolated iframe.

## Live-verified on a real browser (Chrome, macOS)

Driven headless and headful over CDP with screenshots. This surfaced — and the
branch fixes — two issues invisible to headless-only checks:

- **Hydra isolated in an iframe.** In one document, Strudel's `initStrudel()`
  spins up a WebGL context that invalidates Hydra's shader program
  (`useProgram: program not valid`) — blank canvas. Hydra now runs in a `srcdoc`
  iframe (separate GL context); visual code + `a.fft` cross via `postMessage`.
- **No microphone.** Visuals get `a.fft` fed from the Strudel-output tap, so they
  react to the music with no mic prompt and can't throw on an undefined `a.fft`.

All four gallery sets render end-to-end and the output tap reports live audio
energy.

## Safety

`--hush` cuts audio and blacks the screen; docs cap gain and warn against
>3 Hz full-field flashing (photosensitive epilepsy). Server binds loopback only;
the page evals pushed code, so only push sets you author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)