### PR TITLE
fix(model-switch): preserve per-model metadata in _save_discovered_models_to_config (#67841)

### DIFF
--- a/contributors/emails/kshitij@users.noreply.github.com
+++ b/contributors/emails/kshitij@users.noreply.github.com
@@ -1,0 +1,1 @@
+kshitijk4poor

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -133,6 +133,11 @@ def _save_discovered_models_to_config(
             if entry_url.rstrip("/").lower() != norm_url:
                 continue
             existing = entry.get("models")
+            # Preserve per-model metadata: when ``models`` is a mapping
+            # (e.g. ``{"model-a": {"context_length": 8192}}``), the user
+            # has curated metadata per model — do not replace it.
+            if isinstance(existing, dict):
+                continue
             # Only update when models are stale — avoids unnecessary
             # config writes on every picker open.
             if isinstance(existing, list) and existing == model_ids:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -134,9 +134,14 @@ def _save_discovered_models_to_config(
                 continue
             existing = entry.get("models")
             # Preserve per-model metadata: when ``models`` is a mapping
-            # (e.g. ``{"model-a": {"context_length": 8192}}``), the user
-            # has curated metadata per model — do not replace it.
+            # (e.g. ``{"model-a": {"context_length": 8192}}``) or a list of
+            # dicts (e.g. ``[{"id": "model-a", "context_length": 8192}]``),
+            # the user has curated metadata per model — do not replace it.
             if isinstance(existing, dict):
+                continue
+            if isinstance(existing, list) and any(
+                isinstance(m, dict) for m in existing
+            ):
                 continue
             # Only update when models are stale — avoids unnecessary
             # config writes on every picker open.

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -1516,3 +1516,41 @@ def test_save_discovered_models_preserves_dict_form(monkeypatch):
     assert save_calls == [], (
         "Dict-form models must not be replaced with a flat list"
     )
+
+
+def test_save_discovered_models_preserves_list_of_dicts_form(monkeypatch):
+    """``_save_discovered_models_to_config`` must not replace a list-of-dicts
+    ``models`` form (per-model metadata via ``[{id: ...}]``) with a flat list
+    of strings (#67841 sibling site)."""
+    from hermes_cli.model_switch import _save_discovered_models_to_config
+
+    save_calls = []
+
+    def fake_save(config):
+        save_calls.append(dict(config))
+
+    monkeypatch.setattr("hermes_cli.config.save_config", fake_save)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "my-gateway",
+                    "base_url": "https://gateway.example.com/v1",
+                    "models": [
+                        {"id": "configured-model", "context_length": 8192},
+                        {"id": "other-model", "context_length": 4096},
+                    ],
+                }
+            ]
+        },
+    )
+
+    # List-of-dicts models must NOT be overwritten by discovered models
+    _save_discovered_models_to_config(
+        "https://gateway.example.com/v1",
+        ["configured-model", "discovered-model"],
+    )
+    assert save_calls == [], (
+        "List-of-dicts models must not be replaced with a flat list"
+    )

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -1479,3 +1479,40 @@ def test_save_discovered_models_noop_on_empty_args(monkeypatch):
     _save_discovered_models_to_config("", [])
 
     assert load_calls == 0, "load_config must not be called for empty args"
+
+
+def test_save_discovered_models_preserves_dict_form(monkeypatch):
+    """``_save_discovered_models_to_config`` must not replace a dict-form
+    ``models`` mapping (per-model metadata like ``context_length``) with
+    a flat list of strings (#67841)."""
+    from hermes_cli.model_switch import _save_discovered_models_to_config
+
+    save_calls = []
+
+    def fake_save(config):
+        save_calls.append(dict(config))
+
+    monkeypatch.setattr("hermes_cli.config.save_config", fake_save)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "my-gateway",
+                    "base_url": "https://gateway.example.com/v1",
+                    "models": {
+                        "configured-model": {"context_length": 8192},
+                    },
+                }
+            ]
+        },
+    )
+
+    # Dict-form models must NOT be overwritten by discovered models
+    _save_discovered_models_to_config(
+        "https://gateway.example.com/v1",
+        ["configured-model", "discovered-model"],
+    )
+    assert save_calls == [], (
+        "Dict-form models must not be replaced with a flat list"
+    )


### PR DESCRIPTION
## Summary
Salvage of PR #67878 (by @kyssta-exe) — `_save_discovered_models_to_config` no longer destroys curated per-model metadata in `custom_providers[].models`.

PR #65652 added `_save_discovered_models_to_config()` which runs on CLI startup prewarm and unconditionally replaces `custom_providers[].models` with a flat list of discovered model IDs. When the user has curated per-model metadata (e.g. `context_length`), this silently deletes it.

## Changes
- `hermes_cli/model_switch.py`: guard skips dict-form and list-of-dicts-form `models` entries (both carry per-model metadata); list-of-strings and no-models-key still get updated as before
- `tests/hermes_cli/test_model_switch_custom_providers.py`: two regression tests (dict-form + list-of-dicts-form)

## What the contributor's PR covered vs what we added
- @kyssta-exe's commit: dict-mapping form guard (`{"model": {"context_length": ...}}`) + regression test
- Follow-up commit: list-of-dicts form guard (`[{"id": "model", "context_length": ...}]`) — also a supported config shape per `_declared_model_ids`, was still being clobbered. Sibling site for #67841.

## Validation
| | Before | After |
|---|---|---|
| dict-form `models` | replaced with flat list (metadata lost) | preserved |
| list-of-dicts `models` | replaced with flat list (metadata lost) | preserved |
| list-of-strings `models` | updated with discovered models | unchanged |
| no `models` key | set to discovered models | unchanged |
| 46 existing tests | pass | pass (47 total with new test) |
| E2E with real imports | dict-form clobbered | all 4 forms correct |
| ruff lint | clean | clean |

Closes #67841
