### PR TITLE
fix(honcho): unify pinned single-user memory by position-aware session-id swap

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -416,8 +416,12 @@ class HonchoMemoryProvider(MemoryProvider):
                 # Under strict pinning the runtime user segment is stripped from
                 # the Honcho session name (MC-7827); pass the gateway identity so
                 # resolve_session_name can locate and swap that exact segment.
+                # chat_id/thread_id disambiguate the identity's grammar position
+                # so a coincidentally-equal chat/thread id is never rewritten.
                 user_id=kwargs.get("user_id"),
                 user_id_alt=kwargs.get("user_id_alt"),
+                chat_id=kwargs.get("chat_id"),
+                thread_id=kwargs.get("thread_id"),
             )
             or session_id
             or "hermes-default"

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -413,6 +413,11 @@ class HonchoMemoryProvider(MemoryProvider):
                 session_title=session_title,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                # Under strict pinning the runtime user segment is stripped from
+                # the Honcho session name (MC-7827); pass the gateway identity so
+                # resolve_session_name can locate and swap that exact segment.
+                user_id=kwargs.get("user_id"),
+                user_id_alt=kwargs.get("user_id_alt"),
             )
             or session_id
             or "hermes-default"

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -789,29 +789,63 @@ class HonchoClientConfig:
         gateway_session_key: str,
         runtime_user_ids: list[str],
         pinned_identity: str,
+        chat_id: str | None = None,
+        thread_id: str | None = None,
     ) -> str:
-        """Replace platform-native runtime user segments with the pinned peer.
+        """Swap the platform-native runtime user segment for the pinned peer.
 
-        Gateway session keys are ``:``-delimited (e.g.
-        ``agent:main:telegram:dm:<uid>:<thread>``).  Under strict single-user
-        pinning the runtime user segment (Telegram UID, Discord snowflake, …)
-        is redundant with the pinned peer, so it's swapped out while every
-        other discriminator (platform, chat kind, thread/topic id, profile) is
-        preserved.  Only a whole, delimiter-bounded segment equal to a supplied
-        runtime user id is replaced — a UID that merely appears as a substring
-        of another id (a thread/topic number) is left intact.
+        Position-aware, driven by the ``build_session_key`` grammar
+        (``gateway/session.py``) rather than a blind across-all-segments regex,
+        so a chat/thread/topic id that *coincidentally* equals the runtime UID
+        is never rewritten.  Keys are ``:``-delimited with a fixed prefix
+        ``agent:<ns>:<platform>:<chat_type>`` (indices 0-3):
+
+          - DM (``…:dm:<identity>[:<thread>]``): only the identity slot right
+            after ``dm`` is swapped.  A following thread discriminator is
+            preserved even when its value equals the UID.
+          - Group/channel: the per-user participant is a single trailing
+            segment appended after the ``chat_id``/``thread_id`` prefix, and
+            only under per-user isolation.  It is swapped only when the key has
+            exactly one segment beyond the known prefix; a shared thread/topic
+            id sitting in the last slot is left intact.
+
+        If the identity position cannot be proven, the key is returned
+        unchanged (no-op beats rewriting another discriminator).
         """
-        import re
+        uids = {u for u in runtime_user_ids if u}
+        if not uids:
+            return gateway_session_key
 
-        result = gateway_session_key
-        for uid in runtime_user_ids:
-            if not uid:
-                continue
-            # (?<![^:]) -> preceded by ':' or start; (?![^:]) -> followed by ':'
-            # or end.  Bounds the match to a full identity segment only.
-            pattern = r"(?<![^:])" + re.escape(uid) + r"(?![^:])"
-            result = re.sub(pattern, pinned_identity, result)
-        return result
+        parts = gateway_session_key.split(":")
+        # parts[0]=agent parts[1]=namespace parts[2]=platform parts[3]=chat_type
+        if len(parts) < 5:
+            return gateway_session_key
+        chat_type = parts[3]
+
+        if chat_type == "dm":
+            idx = 4  # identity/chat slot immediately after "dm"
+            # Fallback DM key (no chat_id, no participant) carries thread_id in
+            # this slot — not an identity, so never rewrite it.
+            if (
+                thread_id is not None
+                and idx == len(parts) - 1
+                and parts[idx] == str(thread_id)
+            ):
+                return gateway_session_key
+            if parts[idx] in uids:
+                parts[idx] = pinned_identity
+            return ":".join(parts)
+
+        # Group/channel: participant is the lone trailing segment appended after
+        # the chat_id/thread_id prefix. Prove its position from the known grammar.
+        prefix_len = 4  # agent, namespace, platform, chat_type
+        if chat_id:
+            prefix_len += 1
+        if thread_id:
+            prefix_len += 1
+        if len(parts) == prefix_len + 1 and parts[-1] in uids:
+            parts[-1] = pinned_identity
+        return ":".join(parts)
 
     def resolve_session_name(
         self,
@@ -821,6 +855,8 @@ class HonchoClientConfig:
         gateway_session_key: str | None = None,
         user_id: str | None = None,
         user_id_alt: str | None = None,
+        chat_id: str | None = None,
+        thread_id: str | None = None,
     ) -> str | None:
         """Resolve Honcho session name.
 
@@ -849,7 +885,10 @@ class HonchoClientConfig:
             # kind discriminators (MC-7827).  Peer resolution (session.py) and
             # the gateway's own routing keys are untouched — only the Honcho
             # session name changes.  Multi-user (pin off) keeps the raw UID.
-            if self.pin_peer_name and self.peer_name:
+            # Strict gate: only a real boolean True enables pinning, matching the
+            # peer resolver (session.py::_resolve_user_peer_id) so a MagicMock or
+            # other truthy non-bool config never silently rewrites identity.
+            if self.pin_peer_name is True and self.peer_name:
                 runtime_ids = [
                     str(u).strip()
                     for u in (user_id, user_id_alt)
@@ -857,7 +896,11 @@ class HonchoClientConfig:
                 ]
                 if runtime_ids:
                     key = self._pin_runtime_user_segment(
-                        key, runtime_ids, self.peer_name.strip()
+                        key,
+                        runtime_ids,
+                        self.peer_name.strip(),
+                        chat_id=chat_id,
+                        thread_id=thread_id,
                     )
             sanitized = re.sub(r'[^a-zA-Z0-9_-]+', '-', key).strip('-')
             if sanitized:

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -784,12 +784,43 @@ class HonchoClientConfig:
         prefix = sanitized[:prefix_len].rstrip("-")
         return f"{prefix}-{digest}"
 
+    @staticmethod
+    def _pin_runtime_user_segment(
+        gateway_session_key: str,
+        runtime_user_ids: list[str],
+        pinned_identity: str,
+    ) -> str:
+        """Replace platform-native runtime user segments with the pinned peer.
+
+        Gateway session keys are ``:``-delimited (e.g.
+        ``agent:main:telegram:dm:<uid>:<thread>``).  Under strict single-user
+        pinning the runtime user segment (Telegram UID, Discord snowflake, …)
+        is redundant with the pinned peer, so it's swapped out while every
+        other discriminator (platform, chat kind, thread/topic id, profile) is
+        preserved.  Only a whole, delimiter-bounded segment equal to a supplied
+        runtime user id is replaced — a UID that merely appears as a substring
+        of another id (a thread/topic number) is left intact.
+        """
+        import re
+
+        result = gateway_session_key
+        for uid in runtime_user_ids:
+            if not uid:
+                continue
+            # (?<![^:]) -> preceded by ':' or start; (?![^:]) -> followed by ':'
+            # or end.  Bounds the match to a full identity segment only.
+            pattern = r"(?<![^:])" + re.escape(uid) + r"(?![^:])"
+            result = re.sub(pattern, pinned_identity, result)
+        return result
+
     def resolve_session_name(
         self,
         cwd: str | None = None,
         session_title: str | None = None,
         session_id: str | None = None,
         gateway_session_key: str | None = None,
+        user_id: str | None = None,
+        user_id_alt: str | None = None,
     ) -> str | None:
         """Resolve Honcho session name.
 
@@ -811,9 +842,29 @@ class HonchoClientConfig:
         # Gateway per-chat key wins everywhere — gateways (telegram/discord/…)
         # need per-chat isolation no cwd/strategy name can provide.
         if gateway_session_key:
-            sanitized = re.sub(r'[^a-zA-Z0-9_-]+', '-', gateway_session_key).strip('-')
+            key = gateway_session_key
+            # Strict single-user pinning: the runtime user segment is redundant
+            # with the pinned peer, so swap it for peerName to keep memory
+            # unified across platforms/DMs while preserving thread/topic/chat
+            # kind discriminators (MC-7827).  Peer resolution (session.py) and
+            # the gateway's own routing keys are untouched — only the Honcho
+            # session name changes.  Multi-user (pin off) keeps the raw UID.
+            if self.pin_peer_name and self.peer_name:
+                runtime_ids = [
+                    str(u).strip()
+                    for u in (user_id, user_id_alt)
+                    if u is not None and str(u).strip()
+                ]
+                if runtime_ids:
+                    key = self._pin_runtime_user_segment(
+                        key, runtime_ids, self.peer_name.strip()
+                    )
+            sanitized = re.sub(r'[^a-zA-Z0-9_-]+', '-', key).strip('-')
             if sanitized:
-                return self._enforce_session_id_limit(sanitized, gateway_session_key)
+                # Hash seed is the pinned key so two users pinned to the same
+                # peer on the same long thread collapse to one session even
+                # after truncation (unification is the point of pinning).
+                return self._enforce_session_id_limit(sanitized, key)
 
         # per-session: the run's session_id IS the identity — resolve before the
         # cwd map / title so an auto-generated title can't remap a live

--- a/tests/agent/test_memory_user_id.py
+++ b/tests/agent/test_memory_user_id.py
@@ -305,6 +305,51 @@ class TestHonchoUserIdScoping:
 
         assert session.user_peer_id == "discord_user_789"
 
+    def test_resolve_session_key_forwards_gateway_identity_kwargs(self):
+        """_resolve_session_key must forward the live gateway identity kwargs
+        (user_id, user_id_alt, chat_id, thread_id) into cfg.resolve_session_name.
+
+        This is the plumbing the MC-7827 fix depends on: resolve_session_name
+        can only locate and pin-swap the exact runtime-user segment if the
+        gateway identity reaches it. If _resolve_session_key drops any of these
+        kwargs, strict pinning silently regresses to a coincidence match.
+        """
+        from plugins.memory.honcho import HonchoMemoryProvider
+
+        provider = HonchoMemoryProvider()
+
+        mock_cfg = MagicMock()
+        mock_cfg.enabled = True
+        mock_cfg.api_key = "test-key"
+        mock_cfg.base_url = None
+        mock_cfg.peer_name = "static-user"
+        mock_cfg.dialectic_depth = 1
+        # tools-mode + init_on_session_start=False keeps initialize() network-free:
+        # _resolve_session_key runs once, then it returns before any session init.
+        mock_cfg.recall_mode = "tools"
+        mock_cfg.init_on_session_start = False
+        mock_cfg.resolve_session_name.return_value = "resolved-key"
+
+        with patch(
+            "plugins.memory.honcho.client.HonchoClientConfig.from_global_config",
+            return_value=mock_cfg,
+        ):
+            provider.initialize(
+                session_id="sess-abc",
+                platform="discord",
+                user_id="discord_user_789",
+                user_id_alt="discord_alt_101",
+                chat_id="1485316232612941897",
+                thread_id="1491249007475949698",
+            )
+
+        forwarded = mock_cfg.resolve_session_name.call_args.kwargs
+        assert forwarded["user_id"] == "discord_user_789"
+        assert forwarded["user_id_alt"] == "discord_alt_101"
+        assert forwarded["chat_id"] == "1485316232612941897"
+        assert forwarded["thread_id"] == "1491249007475949698"
+        assert forwarded["session_id"] == "sess-abc"
+
     def test_no_user_id_preserves_config_peer_name(self):
         """Without user_id, the config peer_name should be preserved."""
         from plugins.memory.honcho import HonchoMemoryProvider

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -1342,3 +1342,109 @@ class TestGetHonchoClientBaseUrlDoublePrefixFix:
         assert passed_base_url == "http://127.0.0.1:38000", (
             f"Expected 'http://127.0.0.1:38000', got {passed_base_url!r}"
         )
+
+
+class TestResolveSessionNamePinnedGatewayKey:
+    """Regression tests for MC-7827.
+
+    When strict single-user pinning is on (``pin_peer_name`` + ``peer_name``),
+    the Honcho session NAME derived from a gateway session key must replace the
+    platform-native runtime user segment (Telegram UID, Discord snowflake, ...)
+    with the pinned peer, while preserving every other discriminator (platform,
+    chat kind, thread/topic IDs, profile). Only exact, ':'-delimited identity
+    segments equal to a supplied runtime user id are swapped -- never a numeric
+    substring inside another discriminator. Multi-user (non-pinned) behavior is
+    unchanged.
+
+    Synthetic numeric IDs stand in for the real Telegram UID: the reproduction
+    is structural, so a synthetic UID proves the bug without committing the real
+    identifier. The real-world repro is recorded in MC-7827-IMPLEMENTATION.md.
+    """
+
+    # Structurally identical to the real repro (agent:main:telegram:dm:<uid>:<thread>).
+    UID = "918273645"
+    THREAD = "1245684"
+
+    def _pinned(self):
+        return HonchoClientConfig(peer_name="elmar", pin_peer_name=True)
+
+    def test_pinned_telegram_dm_replaces_uid_with_peer(self):
+        """Exact Telegram DM case: UID segment -> pinned peer, thread preserved."""
+        result = self._pinned().resolve_session_name(
+            gateway_session_key=f"agent:main:telegram:dm:{self.UID}:{self.THREAD}",
+            user_id=self.UID,
+        )
+        assert result == "agent-main-telegram-dm-elmar-1245684"
+        assert "elmar" in result
+        assert self.THREAD in result
+        assert self.UID not in result
+
+    def test_non_pinned_preserves_uid(self):
+        """Multi-user (pin off): UID is retained so memory forks per user."""
+        cfg = HonchoClientConfig(peer_name="elmar", pin_peer_name=False)
+        result = cfg.resolve_session_name(
+            gateway_session_key=f"agent:main:telegram:dm:{self.UID}:{self.THREAD}",
+            user_id=self.UID,
+        )
+        assert result == f"agent-main-telegram-dm-{self.UID}-{self.THREAD}"
+
+    def test_uid_substring_of_thread_not_replaced(self):
+        """A UID that only appears as a substring of another segment is intact."""
+        # UID '42' also is a prefix of thread '4212' -- only the bounded segment swaps.
+        result = HonchoClientConfig(
+            peer_name="elmar", pin_peer_name=True
+        ).resolve_session_name(
+            gateway_session_key="agent:main:telegram:dm:42:4212",
+            user_id="42",
+        )
+        assert result == "agent-main-telegram-dm-elmar-4212"
+        assert "4212" in result
+
+    def test_pinned_group_thread_preserves_topic(self):
+        """Group/topic discriminators survive the UID swap."""
+        result = self._pinned().resolve_session_name(
+            gateway_session_key=f"agent:main:telegram:group:{self.UID}:topic:9988",
+            user_id=self.UID,
+        )
+        assert result == "agent-main-telegram-group-elmar-topic-9988"
+        assert "9988" in result
+        assert self.UID not in result
+
+    def test_pinned_uses_alt_runtime_id(self):
+        """The alternate runtime identity is also matched and replaced."""
+        result = self._pinned().resolve_session_name(
+            gateway_session_key=f"agent:main:discord:dm:{self.UID}:{self.THREAD}",
+            user_id=None,
+            user_id_alt=self.UID,
+        )
+        assert self.UID not in result
+        assert "elmar" in result
+        assert self.THREAD in result
+
+    def test_pinned_without_runtime_id_is_noop(self):
+        """No runtime id supplied -> key sanitized unchanged (no false swap)."""
+        result = self._pinned().resolve_session_name(
+            gateway_session_key=f"agent:main:telegram:dm:{self.UID}:{self.THREAD}",
+        )
+        assert result == f"agent-main-telegram-dm-{self.UID}-{self.THREAD}"
+
+    def test_pinned_uid_absent_from_key_is_noop(self):
+        """UID not present as a segment -> nothing replaced (no false positive)."""
+        result = self._pinned().resolve_session_name(
+            gateway_session_key=f"agent:main:telegram:dm:{self.UID}:{self.THREAD}",
+            user_id="555000111",
+        )
+        assert result == f"agent-main-telegram-dm-{self.UID}-{self.THREAD}"
+        assert "elmar" not in result
+
+    def test_pinned_long_key_unifies_after_truncation(self):
+        """Two users pinned to elmar on the same long thread collapse to one id."""
+        long_thread = "t" * 300
+        key_a = f"agent:main:telegram:dm:{self.UID}:{long_thread}"
+        key_b = f"agent:main:telegram:dm:555000111:{long_thread}"
+        cfg = self._pinned()
+        res_a = cfg.resolve_session_name(gateway_session_key=key_a, user_id=self.UID)
+        res_b = cfg.resolve_session_name(gateway_session_key=key_b, user_id="555000111")
+        # Same pinned identity + same thread -> same Honcho session, even truncated.
+        assert res_a == res_b
+        assert len(res_a) == 100

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -1347,68 +1347,66 @@ class TestGetHonchoClientBaseUrlDoublePrefixFix:
 class TestResolveSessionNamePinnedGatewayKey:
     """Regression tests for MC-7827.
 
-    When strict single-user pinning is on (``pin_peer_name`` + ``peer_name``),
-    the Honcho session NAME derived from a gateway session key must replace the
+    Under strict single-user pinning (``pin_peer_name is True`` + ``peer_name``)
+    the Honcho session NAME derived from a gateway session key must swap the
     platform-native runtime user segment (Telegram UID, Discord snowflake, ...)
-    with the pinned peer, while preserving every other discriminator (platform,
-    chat kind, thread/topic IDs, profile). Only exact, ':'-delimited identity
-    segments equal to a supplied runtime user id are swapped -- never a numeric
-    substring inside another discriminator. Multi-user (non-pinned) behavior is
-    unchanged.
+    for the pinned peer while preserving every other discriminator. The swap is
+    grammar/position-aware (mirrors ``gateway.session.build_session_key``): only
+    the DM identity slot or a real trailing group participant is replaced. A
+    chat/thread/topic id that coincidentally equals the UID is never rewritten,
+    and multi-user (non-pinned) behavior is unchanged.
 
-    Synthetic numeric IDs stand in for the real Telegram UID: the reproduction
-    is structural, so a synthetic UID proves the bug without committing the real
-    identifier. The real-world repro is recorded in MC-7827-IMPLEMENTATION.md.
+    Keys are structurally identical to real ``build_session_key`` output:
+      - DM:            ``agent:main:<platform>:dm:<identity>[:<thread>]``
+      - group per-user ``agent:main:<platform>:group:<chat_id>[:<thread>]:<uid>``
+      - shared thread  ``agent:main:<platform>:group:<chat_id>:<thread>``
+    Synthetic numeric IDs stand in for real identifiers; the bug is structural.
     """
 
-    # Structurally identical to the real repro (agent:main:telegram:dm:<uid>:<thread>).
     UID = "918273645"
     THREAD = "1245684"
 
     def _pinned(self):
         return HonchoClientConfig(peer_name="elmar", pin_peer_name=True)
 
-    def test_pinned_telegram_dm_replaces_uid_with_peer(self):
-        """Exact Telegram DM case: UID segment -> pinned peer, thread preserved."""
+    # ---- DM ---------------------------------------------------------------
+    def test_pinned_dm_replaces_uid_retains_following_thread(self):
+        """DM identity slot -> pinned peer; the following thread is preserved."""
         result = self._pinned().resolve_session_name(
             gateway_session_key=f"agent:main:telegram:dm:{self.UID}:{self.THREAD}",
             user_id=self.UID,
+            thread_id=self.THREAD,
         )
-        assert result == "agent-main-telegram-dm-elmar-1245684"
-        assert "elmar" in result
-        assert self.THREAD in result
+        assert result == f"agent-main-telegram-dm-elmar-{self.THREAD}"
         assert self.UID not in result
 
-    def test_non_pinned_preserves_uid(self):
-        """Multi-user (pin off): UID is retained so memory forks per user."""
-        cfg = HonchoClientConfig(peer_name="elmar", pin_peer_name=False)
-        result = cfg.resolve_session_name(
-            gateway_session_key=f"agent:main:telegram:dm:{self.UID}:{self.THREAD}",
+    def test_pinned_dm_thread_value_equal_to_uid_retained(self):
+        """DM thread whose value equals the UID is retained; only slot 4 swaps."""
+        result = self._pinned().resolve_session_name(
+            # chat_id == UID (identity) AND thread == UID (following discriminator)
+            gateway_session_key=f"agent:main:telegram:dm:{self.UID}:{self.UID}",
+            user_id=self.UID,
+            thread_id=self.UID,
+        )
+        # Identity slot replaced, trailing thread (== UID) kept verbatim.
+        assert result == f"agent-main-telegram-dm-elmar-{self.UID}"
+
+    def test_pinned_dm_no_thread_replaces_identity(self):
+        """DM with only an identity segment (no thread) is swapped."""
+        result = self._pinned().resolve_session_name(
+            gateway_session_key=f"agent:main:telegram:dm:{self.UID}",
             user_id=self.UID,
         )
-        assert result == f"agent-main-telegram-dm-{self.UID}-{self.THREAD}"
+        assert result == "agent-main-telegram-dm-elmar"
 
     def test_uid_substring_of_thread_not_replaced(self):
         """A UID that only appears as a substring of another segment is intact."""
-        # UID '42' also is a prefix of thread '4212' -- only the bounded segment swaps.
-        result = HonchoClientConfig(
-            peer_name="elmar", pin_peer_name=True
-        ).resolve_session_name(
+        result = self._pinned().resolve_session_name(
             gateway_session_key="agent:main:telegram:dm:42:4212",
             user_id="42",
+            thread_id="4212",
         )
         assert result == "agent-main-telegram-dm-elmar-4212"
-        assert "4212" in result
-
-    def test_pinned_group_thread_preserves_topic(self):
-        """Group/topic discriminators survive the UID swap."""
-        result = self._pinned().resolve_session_name(
-            gateway_session_key=f"agent:main:telegram:group:{self.UID}:topic:9988",
-            user_id=self.UID,
-        )
-        assert result == "agent-main-telegram-group-elmar-topic-9988"
-        assert "9988" in result
-        assert self.UID not in result
 
     def test_pinned_uses_alt_runtime_id(self):
         """The alternate runtime identity is also matched and replaced."""
@@ -1416,10 +1414,63 @@ class TestResolveSessionNamePinnedGatewayKey:
             gateway_session_key=f"agent:main:discord:dm:{self.UID}:{self.THREAD}",
             user_id=None,
             user_id_alt=self.UID,
+            thread_id=self.THREAD,
         )
-        assert self.UID not in result
-        assert "elmar" in result
-        assert self.THREAD in result
+        assert result == f"agent-main-discord-dm-elmar-{self.THREAD}"
+
+    # ---- Group / channel --------------------------------------------------
+    def test_pinned_group_replaces_only_trailing_participant(self):
+        """Real per-user group layout: parent chat kept, trailing participant swapped."""
+        result = self._pinned().resolve_session_name(
+            gateway_session_key=f"agent:main:telegram:group:100200:{self.UID}",
+            user_id=self.UID,
+            chat_id="100200",
+        )
+        assert result == "agent-main-telegram-group-100200-elmar"
+        assert "100200" in result  # parent chat id untouched
+
+    def test_pinned_group_parent_chat_equal_to_uid_not_replaced(self):
+        """Parent chat id equal to the UID is preserved; only participant swaps."""
+        result = self._pinned().resolve_session_name(
+            gateway_session_key=f"agent:main:telegram:group:{self.UID}:{self.UID}",
+            user_id=self.UID,
+            chat_id=self.UID,
+        )
+        # chat_id slot (== UID) retained, trailing participant -> pinned peer.
+        assert result == f"agent-main-telegram-group-{self.UID}-elmar"
+
+    def test_pinned_shared_group_thread_ending_in_uid_no_replacement(self):
+        """Shared thread ending in an id equal to the UID: no participant, no swap."""
+        result = self._pinned().resolve_session_name(
+            gateway_session_key=f"agent:main:telegram:group:100200:{self.UID}",
+            user_id=self.UID,
+            chat_id="100200",
+            thread_id=self.UID,  # trailing slot is the shared thread, not a participant
+        )
+        assert result == f"agent-main-telegram-group-100200-{self.UID}"
+        assert "elmar" not in result
+
+    # ---- Guards -----------------------------------------------------------
+    def test_non_pinned_preserves_uid(self):
+        """Multi-user (pin off): UID is retained so memory forks per user."""
+        cfg = HonchoClientConfig(peer_name="elmar", pin_peer_name=False)
+        result = cfg.resolve_session_name(
+            gateway_session_key=f"agent:main:telegram:dm:{self.UID}:{self.THREAD}",
+            user_id=self.UID,
+            thread_id=self.THREAD,
+        )
+        assert result == f"agent-main-telegram-dm-{self.UID}-{self.THREAD}"
+
+    def test_strict_pin_gate_ignores_truthy_non_bool(self):
+        """A truthy non-bool pin_peer_name (MagicMock) must not trigger a swap."""
+        cfg = HonchoClientConfig(peer_name="elmar", pin_peer_name=MagicMock())
+        result = cfg.resolve_session_name(
+            gateway_session_key=f"agent:main:telegram:dm:{self.UID}:{self.THREAD}",
+            user_id=self.UID,
+            thread_id=self.THREAD,
+        )
+        assert result == f"agent-main-telegram-dm-{self.UID}-{self.THREAD}"
+        assert "elmar" not in result
 
     def test_pinned_without_runtime_id_is_noop(self):
         """No runtime id supplied -> key sanitized unchanged (no false swap)."""
@@ -1433,6 +1484,7 @@ class TestResolveSessionNamePinnedGatewayKey:
         result = self._pinned().resolve_session_name(
             gateway_session_key=f"agent:main:telegram:dm:{self.UID}:{self.THREAD}",
             user_id="555000111",
+            thread_id=self.THREAD,
         )
         assert result == f"agent-main-telegram-dm-{self.UID}-{self.THREAD}"
         assert "elmar" not in result
@@ -1443,8 +1495,12 @@ class TestResolveSessionNamePinnedGatewayKey:
         key_a = f"agent:main:telegram:dm:{self.UID}:{long_thread}"
         key_b = f"agent:main:telegram:dm:555000111:{long_thread}"
         cfg = self._pinned()
-        res_a = cfg.resolve_session_name(gateway_session_key=key_a, user_id=self.UID)
-        res_b = cfg.resolve_session_name(gateway_session_key=key_b, user_id="555000111")
+        res_a = cfg.resolve_session_name(
+            gateway_session_key=key_a, user_id=self.UID, thread_id=long_thread
+        )
+        res_b = cfg.resolve_session_name(
+            gateway_session_key=key_b, user_id="555000111", thread_id=long_thread
+        )
         # Same pinned identity + same thread -> same Honcho session, even truncated.
         assert res_a == res_b
         assert len(res_a) == 100


### PR DESCRIPTION
## Summary

When Honcho is pinned to a single peer (`pin_peer_name: true` with a configured
`peer_name`), gateway-driven chats still had the platform-native **runtime user
id** baked into the Honcho *session name*. Because the session name carries the
runtime UID, the same human talking to the agent across a DM and a group — or
across two platforms — landed in **separate Honcho sessions**, so pinned memory
never actually unified. The runtime UID in the session name is redundant with
the pinned peer, but stripping it naively is dangerous: a chat/thread/topic id
that happens to equal the UID must not be rewritten.

This change strips the runtime-user segment from the pinned session name in a
**position-aware** way, driven by the gateway `build_session_key` grammar rather
than a blind across-all-segments regex. Peer resolution and the gateway's own
routing keys are untouched — only the Honcho session name changes.

## Behavior

**Strict pin-only semantics.** The swap runs only when `pin_peer_name is True`
(a real boolean, matching the peer resolver's strict gate) **and** a non-empty
`peer_name` is configured. Any other config — pin off, or a truthy non-bool —
leaves the raw runtime UID in place, so multi-user deployments are unchanged.

**Position-aware identity swap.** The gateway key is `:`-delimited with a fixed
`agent:<ns>:<platform>:<chat_type>` prefix:

- **DM** (`…:dm:<identity>[:<thread>]`): only the identity slot immediately after
  `dm` is swapped for the pinned peer. A trailing thread discriminator is
  preserved even when its value equals the UID. The fallback DM key that carries
  a `thread_id` in the identity slot is never rewritten.
- **Group/channel**: the per-user participant is the lone trailing segment
  appended after the `chat_id`/`thread_id` prefix, and only under per-user
  isolation. It is swapped only when the key has exactly one segment beyond the
  known prefix; a shared thread/topic id sitting in the last slot is left intact.

If the identity position cannot be proven from the grammar, the key is returned
unchanged — a no-op beats rewriting the wrong discriminator. The
`chat_id`/`thread_id` context is what disambiguates a coincidentally-equal id
from the real participant slot, which is why the provider forwards them.

## Regression coverage

Tests use **synthetic** platform ids only.

- `tests/honcho_plugin/test_client.py` — `resolve_session_name` /
  `_pin_runtime_user_segment` unit coverage: DM identity swap, DM thread-slot
  preservation, group trailing-participant swap, shared-thread no-op,
  coincidental-id no-op, strict `pin_peer_name is True` gate, and pin-off /
  multi-user raw-UID preservation.
- `tests/agent/test_memory_user_id.py` — integration regression proving the
  provider forwards the live gateway identity kwargs (`user_id`, `user_id_alt`,
  `chat_id`, `thread_id`) into `resolve_session_name`. Reverting that plumbing
  turns this test red while the rest stay green, so a silent regression back to
  a coincidence match is caught.

## Tests

Run via the canonical per-file runner:

```
scripts/run_tests.sh \
  tests/honcho_plugin/test_client.py \
  tests/honcho_plugin/test_async_memory.py \
  tests/agent/test_memory_user_id.py
# => 3 files, 174 tests passed, 0 failed

ruff check <changed files>          # All checks passed!
python -m py_compile <changed files>  # OK
git diff --check                     # clean
```

## Scope

Code + tests only. No config default changes, no dependency upgrade, no
deploy/runtime mutation. Multi-user (pin off) behavior is preserved.
