### PR TITLE
feat(gateway): Phase 1 admin/user tool-tier whitelist (#20744)

### DIFF
--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine Mac Studio local email on Bartok9 PR tips (per-PR attribution; Teknium/Daniel 2026-08-01)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1582,6 +1582,14 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_allow_admin_from"] = platform_cfg["group_allow_admin_from"]
                 if "group_user_allowed_commands" in platform_cfg:
                     bridged["group_user_allowed_commands"] = platform_cfg["group_user_allowed_commands"]
+                if "user_toolsets" in platform_cfg:
+                    bridged["user_toolsets"] = platform_cfg["user_toolsets"]
+                if "user_tools" in platform_cfg:
+                    bridged["user_tools"] = platform_cfg["user_tools"]
+                if "user_max_iterations" in platform_cfg:
+                    bridged["user_max_iterations"] = platform_cfg["user_max_iterations"]
+                if "user_limits" in platform_cfg:
+                    bridged["user_limits"] = platform_cfg["user_limits"]
                 if plat in {Platform.DISCORD, Platform.SLACK} and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
                 if "channel_prompts" in platform_cfg:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18580,6 +18580,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             pr = self._provider_routing
             max_iterations = _current_max_iterations()
+            # APPLY_USER_TIER_PHASE1 background path (#20744)
+            try:
+                from gateway.user_tier import apply_user_tier_to_agent_kwargs
+                _plat_cfg_bg = None
+                try:
+                    _plat_cfg_bg = (getattr(self, "config", None).platforms or {}).get(
+                        source.platform
+                    ) if getattr(self, "config", None) else None
+                except Exception:
+                    _plat_cfg_bg = None
+                enabled_toolsets, max_iterations, _tier_bg = apply_user_tier_to_agent_kwargs(
+                    source=source,
+                    enabled_toolsets=enabled_toolsets,
+                    max_iterations=max_iterations,
+                    user_config=user_config,
+                    platform_config=_plat_cfg_bg,
+                )
+            except Exception as _tier_bg_exc:
+                logger.debug("user_tier background resolve skipped: %s", _tier_bg_exc)
             reasoning_config = self._resolve_session_reasoning_config(
                 source=source, model=model
             )
@@ -23291,6 +23310,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
+        # APPLY_USER_TIER_PHASE1: clamp non-admin tool schema + optional max_iterations (#20744)
+        try:
+            from gateway.user_tier import apply_user_tier_to_agent_kwargs
+            _plat_cfg = None
+            try:
+                _plat_cfg = (getattr(self, "config", None).platforms or {}).get(
+                    source.platform
+                ) if getattr(self, "config", None) else None
+            except Exception:
+                _plat_cfg = None
+            enabled_toolsets, _tier_max_iters, _tier_dec = apply_user_tier_to_agent_kwargs(
+                source=source,
+                enabled_toolsets=enabled_toolsets,
+                max_iterations=_current_max_iterations(),
+                user_config=user_config,
+                platform_config=_plat_cfg,
+            )
+            # Stash for later max_iterations assignment in this function
+            user_config.setdefault("_hermes_user_tier_max_iterations", _tier_dec.max_iterations)
+            user_config.setdefault("_hermes_user_tier_is_admin", _tier_dec.is_admin)
+        except Exception as _tier_exc:
+            logger.debug("user_tier resolve skipped: %s", _tier_exc)
 
         display_config = user_config.get("display", {})
         if not isinstance(display_config, dict):

--- a/gateway/user_tier.py
+++ b/gateway/user_tier.py
@@ -1,0 +1,287 @@
+"""Application-level admin/user tier for agent tool surface (Phase 1 of #20744).
+
+Complements ``gateway.slash_access`` (slash commands only). When operators list
+``allow_admin_from`` for a platform scope, non-admin chat users can still talk
+to the agent, but their **tool schema** and optional **iteration budget** are
+clamped via config — without a policy engine or DB.
+
+Config (per-platform ``extra`` / bridged platform cfg, or top-level ``gateway``):
+
+- ``allow_admin_from`` / ``group_allow_admin_from`` — same meaning as slash access
+  (tier gating is **on** only when the relevant admin list is non-empty).
+- ``user_toolsets`` — optional list of toolset names non-admins may use. When
+  tier gating is on and this list is empty/absent, non-admins get a small safe
+  default (web + no memory / skill_manage / cron / messaging interface).
+- ``user_max_iterations`` — optional int clamp for non-admin turns.
+
+Admin users (or gated-off / empty admin list) keep full platform toolsets and
+the normal ``agent.max_turns`` budget.
+
+Orthogonal to open PR #3995 (generic multi-role ``user_roles``) and draft
+#22509 (daimon): this is the tiny two-tier whitelist path from RFC #20744.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, FrozenSet, Iterable, List, Mapping, Optional, Sequence
+
+from gateway.slash_access import (
+    SlashAccessPolicy,
+    _platform_extra,
+    _scope_for_chat_type,
+    policy_from_extra,
+)
+
+# Default non-admin toolsets when tier is on and user_toolsets is unset.
+# Intentionally excludes memory, skills, cronjob, delegation, messaging,
+# terminal/code backends — operators expand via user_toolsets.
+_DEFAULT_USER_TOOLSETS: FrozenSet[str] = frozenset({
+    "web",
+    "browser",
+    "vision",
+    "image_gen",
+    "tts",
+    "todo",
+})
+
+# Toolsets never offered to non-admins unless explicitly listed in user_toolsets.
+# Defense-in-depth denylist applied after intersection.
+_SENSITIVE_TOOLSETS: FrozenSet[str] = frozenset({
+    "memory",
+    "skills",
+    "skill_manage",
+    "cronjob",
+    "cron",
+    "delegation",
+    "code_execution",
+    "terminal",
+    "file",
+    "process",
+    "session_search",
+    "send_message",
+    "messaging",
+    "homeassistant",
+    "kanban",
+})
+
+
+@dataclass(frozen=True)
+class UserTierDecision:
+    """Result of resolving tier for one gateway turn."""
+
+    is_admin: bool
+    tier_gating_enabled: bool
+    enabled_toolsets: List[str]
+    max_iterations: int
+    reason: str
+
+
+def _coerce_str_list(raw: Any) -> List[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        parts = [p.strip() for p in raw.replace(";", ",").split(",")]
+        return [p for p in parts if p]
+    if isinstance(raw, (list, tuple, set, frozenset)):
+        out: List[str] = []
+        for item in raw:
+            s = str(item).strip()
+            if s:
+                out.append(s)
+        return out
+    return [str(raw).strip()] if str(raw).strip() else []
+
+
+def _coerce_optional_int(raw: Any) -> Optional[int]:
+    if raw is None or raw is False:
+        return None
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None
+    if value < 1:
+        return None
+    return value
+
+
+def _platform_extra_from_config(user_config: Mapping[str, Any], platform_key: str) -> dict:
+    """Best-effort platform extra dict (same shape slash_access expects)."""
+    platforms = user_config.get("platforms") or user_config.get("platform") or {}
+    if not isinstance(platforms, dict):
+        platforms = {}
+    plat = platforms.get(platform_key) or {}
+    if not isinstance(plat, dict):
+        plat = {}
+    # Prefer nested extra; else the platform dict itself (bridged keys live here).
+    extra = plat.get("extra") if isinstance(plat.get("extra"), dict) else plat
+    if not isinstance(extra, dict):
+        extra = {}
+    # Merge gateway-level defaults for user_toolsets / user_max_iterations.
+    gateway = user_config.get("gateway") or {}
+    if not isinstance(gateway, dict):
+        gateway = {}
+    merged = dict(extra)
+    if "user_toolsets" not in merged and "user_toolsets" in gateway:
+        merged["user_toolsets"] = gateway["user_toolsets"]
+    if "user_tools" not in merged and "user_tools" in gateway:
+        # RFC alias — treat as toolset names for Phase 1.
+        merged.setdefault("user_toolsets", gateway["user_tools"])
+    if "user_max_iterations" not in merged and "user_max_iterations" in gateway:
+        merged["user_max_iterations"] = gateway["user_max_iterations"]
+    user_limits = merged.get("user_limits") or gateway.get("user_limits")
+    if isinstance(user_limits, dict):
+        if "user_max_iterations" not in merged and "max_iterations" in user_limits:
+            merged["user_max_iterations"] = user_limits["max_iterations"]
+    return merged
+
+
+def policy_for_tier(
+    *,
+    source: Any,
+    user_config: Optional[Mapping[str, Any]] = None,
+    platform_config: Any = None,
+) -> SlashAccessPolicy:
+    """Resolve slash/admin policy for tier decisions.
+
+    Prefers live ``SessionSource`` + ``PlatformConfig`` when available (gateway);
+    falls back to synthetic resolution from ``user_config`` for unit tests.
+    """
+    if platform_config is not None and source is not None:
+        try:
+            # Resolve directly from the live PlatformConfig. We avoid
+            # slash_access.policy_for_source here because its signature is
+            # policy_for_source(gateway_config, source) and it re-derives the
+            # PlatformConfig from gateway_config.platforms; callers on the
+            # gateway path already hand us the resolved PlatformConfig.
+            extra = _platform_extra(platform_config)
+            scope = _scope_for_chat_type(getattr(source, "chat_type", None))
+            return policy_from_extra(extra, scope)
+        except Exception:
+            pass
+    if user_config is None or source is None:
+        return policy_from_extra({}, "dm")
+    platform_key = getattr(getattr(source, "platform", None), "value", None) or str(
+        getattr(source, "platform", "") or ""
+    )
+    if hasattr(source, "platform") and hasattr(source.platform, "name"):
+        # Platform enum — config keys are usually lowercase names
+        platform_key = source.platform.value if hasattr(source.platform, "value") else source.platform.name.lower()
+    extra = _platform_extra_from_config(user_config, platform_key)
+    chat_type = (getattr(source, "chat_type", None) or "dm") or "dm"
+    scope = "group" if str(chat_type).lower() not in ("dm", "private", "direct") else "dm"
+    return policy_from_extra(extra, scope)
+
+
+def filter_toolsets_for_user(
+    enabled_toolsets: Sequence[str],
+    *,
+    is_admin: bool,
+    tier_gating_enabled: bool,
+    user_toolsets_config: Any = None,
+) -> List[str]:
+    """Intersect platform toolsets with the non-admin whitelist."""
+    base = [str(t).strip() for t in enabled_toolsets if str(t).strip()]
+    if is_admin or not tier_gating_enabled:
+        return list(base)
+
+    configured = _coerce_str_list(user_toolsets_config)
+    if configured:
+        allow = {t.lower() for t in configured}
+        # Explicit listing wins even for otherwise-sensitive toolsets.
+        filtered = [t for t in base if t.lower() in allow]
+    else:
+        allow = {t.lower() for t in _DEFAULT_USER_TOOLSETS}
+        filtered = [t for t in base if t.lower() in allow]
+        filtered = [t for t in filtered if t.lower() not in _SENSITIVE_TOOLSETS]
+
+    # Preserve order, drop dups
+    seen = set()
+    out: List[str] = []
+    for t in filtered:
+        key = t.lower()
+        if key not in seen:
+            seen.add(key)
+            out.append(t)
+    return out
+
+
+def resolve_user_tier(
+    *,
+    source: Any,
+    enabled_toolsets: Sequence[str],
+    max_iterations: int,
+    user_config: Optional[Mapping[str, Any]] = None,
+    platform_config: Any = None,
+    user_id: Optional[str] = None,
+) -> UserTierDecision:
+    """Resolve admin/user tier and return adjusted toolsets + iteration budget."""
+    policy = policy_for_tier(
+        source=source,
+        user_config=user_config,
+        platform_config=platform_config,
+    )
+    uid = user_id if user_id is not None else getattr(source, "user_id", None)
+    is_admin = policy.is_admin(uid)
+    gating = bool(policy.enabled)
+
+    platform_key = ""
+    if source is not None:
+        plat = getattr(source, "platform", None)
+        if plat is not None and hasattr(plat, "value"):
+            platform_key = str(plat.value)
+        elif plat is not None:
+            platform_key = str(plat)
+    extra = _platform_extra_from_config(user_config or {}, platform_key) if user_config else {}
+    # On the live gateway path only ``platform_config`` is supplied (no
+    # ``user_config`` fallback dict), so also read the tier knobs from the
+    # live PlatformConfig's ``extra``. This keeps user_toolsets / iteration
+    # clamp working in production, not just in the unit-test fallback.
+    if platform_config is not None:
+        plat_extra = _platform_extra(platform_config)
+        if plat_extra:
+            merged_extra = dict(plat_extra)
+            merged_extra.update(extra)  # explicit user_config wins if both set
+            extra = merged_extra
+    user_toolsets_cfg = extra.get("user_toolsets", extra.get("user_tools"))
+    user_max = _coerce_optional_int(extra.get("user_max_iterations"))
+
+    tools = filter_toolsets_for_user(
+        enabled_toolsets,
+        is_admin=is_admin,
+        tier_gating_enabled=gating,
+        user_toolsets_config=user_toolsets_cfg,
+    )
+
+    iters = int(max_iterations)
+    reason = "admin" if is_admin else ("ungated" if not gating else "user")
+    if gating and not is_admin and user_max is not None:
+        iters = min(iters, user_max)
+        reason = f"user_clamped_max_iterations={user_max}"
+
+    return UserTierDecision(
+        is_admin=is_admin,
+        tier_gating_enabled=gating,
+        enabled_toolsets=tools,
+        max_iterations=iters,
+        reason=reason,
+    )
+
+
+def apply_user_tier_to_agent_kwargs(
+    *,
+    source: Any,
+    enabled_toolsets: Sequence[str],
+    max_iterations: int,
+    user_config: Optional[Mapping[str, Any]] = None,
+    platform_config: Any = None,
+) -> tuple[List[str], int, UserTierDecision]:
+    """Convenience wrapper used by gateway/run.py construction sites."""
+    decision = resolve_user_tier(
+        source=source,
+        enabled_toolsets=enabled_toolsets,
+        max_iterations=max_iterations,
+        user_config=user_config,
+        platform_config=platform_config,
+    )
+    return decision.enabled_toolsets, decision.max_iterations, decision

--- a/tests/gateway/test_user_tier.py
+++ b/tests/gateway/test_user_tier.py
@@ -1,0 +1,170 @@
+"""Unit tests for gateway.user_tier — Phase 1 of RFC #20744."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from gateway.config import Platform
+from gateway.session import SessionSource
+from gateway.user_tier import (
+    _DEFAULT_USER_TOOLSETS,
+    filter_toolsets_for_user,
+    resolve_user_tier,
+)
+
+
+def _source(user_id: str = "999", chat_type: str = "dm") -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        user_id=user_id,
+        chat_id="c1",
+        chat_type=chat_type,
+    )
+
+
+def _cfg_with_admin(admin_ids=None, user_toolsets=None, user_max=None):
+    extra = {}
+    if admin_ids is not None:
+        extra["allow_admin_from"] = admin_ids
+    if user_toolsets is not None:
+        extra["user_toolsets"] = user_toolsets
+    if user_max is not None:
+        extra["user_max_iterations"] = user_max
+    return {
+        "platforms": {
+            "discord": extra,
+        },
+        "gateway": {},
+    }
+
+
+class TestFilterToolsets:
+    def test_admin_or_ungated_keeps_all(self):
+        base = ["web", "memory", "terminal", "skills"]
+        assert filter_toolsets_for_user(base, is_admin=True, tier_gating_enabled=True) == base
+        assert filter_toolsets_for_user(base, is_admin=False, tier_gating_enabled=False) == base
+
+    def test_non_admin_default_excludes_sensitive(self):
+        base = ["web", "memory", "terminal", "skills", "browser", "cronjob"]
+        out = filter_toolsets_for_user(base, is_admin=False, tier_gating_enabled=True)
+        assert "web" in out
+        assert "browser" in out
+        assert "memory" not in out
+        assert "terminal" not in out
+        assert "skills" not in out
+        assert "cronjob" not in out
+
+    def test_explicit_user_toolsets_can_include_sensitive(self):
+        base = ["web", "memory", "terminal"]
+        out = filter_toolsets_for_user(
+            base,
+            is_admin=False,
+            tier_gating_enabled=True,
+            user_toolsets_config=["memory", "web"],
+        )
+        assert out == ["web", "memory"] or set(out) == {"web", "memory"}
+
+
+class TestResolveUserTier:
+    def test_ungated_when_no_admin_list(self):
+        src = _source("999")
+        d = resolve_user_tier(
+            source=src,
+            enabled_toolsets=["web", "memory"],
+            max_iterations=40,
+            user_config=_cfg_with_admin(admin_ids=None),
+        )
+        assert d.tier_gating_enabled is False
+        assert d.is_admin is True  # ungated → treated as admin for can_run parity
+        assert "memory" in d.enabled_toolsets
+        assert d.max_iterations == 40
+
+    def test_admin_keeps_full_surface(self):
+        src = _source("111")
+        d = resolve_user_tier(
+            source=src,
+            enabled_toolsets=["web", "memory", "skills", "cronjob"],
+            max_iterations=40,
+            user_config=_cfg_with_admin(admin_ids=["111"], user_max=5),
+        )
+        assert d.is_admin is True
+        assert "memory" in d.enabled_toolsets
+        assert d.max_iterations == 40  # no clamp for admin
+
+    def test_non_admin_clamps_tools_and_iterations(self):
+        src = _source("999")
+        d = resolve_user_tier(
+            source=src,
+            enabled_toolsets=["web", "memory", "skills", "browser"],
+            max_iterations=40,
+            user_config=_cfg_with_admin(admin_ids=["111"], user_max=6),
+        )
+        assert d.is_admin is False
+        assert d.tier_gating_enabled is True
+        assert "memory" not in d.enabled_toolsets
+        assert "skills" not in d.enabled_toolsets
+        assert "web" in d.enabled_toolsets
+        assert d.max_iterations == 6
+
+    def test_default_user_toolsets_subset(self):
+        assert "web" in _DEFAULT_USER_TOOLSETS
+        assert "memory" not in _DEFAULT_USER_TOOLSETS
+
+
+def _live_platform_config(admin_ids=None, user_toolsets=None, user_max=None):
+    """Mimic a live PlatformConfig: an object exposing an ``.extra`` dict.
+
+    This is the production shape the gateway hands to ``policy_for_tier`` /
+    ``resolve_user_tier`` via ``platform_config=`` — distinct from the
+    ``user_config`` fallback dict used by the unit tests above.
+    """
+    extra = {}
+    if admin_ids is not None:
+        extra["allow_admin_from"] = admin_ids
+    if user_toolsets is not None:
+        extra["user_toolsets"] = user_toolsets
+    if user_max is not None:
+        extra["user_max_iterations"] = user_max
+    return SimpleNamespace(extra=extra)
+
+
+class TestResolveUserTierLivePlatformConfig:
+    """Regression tests for the live gateway branch (#67898 review).
+
+    Previously ``policy_for_tier`` called ``policy_for_source(source,
+    platform_config)`` with swapped arguments, so on the real gateway turn
+    the policy resolved to a disabled/no-op state and neither the non-admin
+    toolset filter nor the iteration cap applied. These tests pass a live
+    ``PlatformConfig``-shaped object (``.extra``) and assert the restriction
+    and clamp actually take effect.
+    """
+
+    def test_non_admin_restricted_via_live_platform_config(self):
+        src = _source("999")
+        d = resolve_user_tier(
+            source=src,
+            enabled_toolsets=["web", "memory", "skills", "browser"],
+            max_iterations=40,
+            platform_config=_live_platform_config(
+                admin_ids=["111"], user_max=6
+            ),
+        )
+        assert d.is_admin is False
+        assert d.tier_gating_enabled is True
+        assert "memory" not in d.enabled_toolsets
+        assert "skills" not in d.enabled_toolsets
+        assert "web" in d.enabled_toolsets
+        assert d.max_iterations == 6
+
+    def test_admin_unrestricted_via_live_platform_config(self):
+        src = _source("111")
+        d = resolve_user_tier(
+            source=src,
+            enabled_toolsets=["web", "memory", "skills", "cronjob"],
+            max_iterations=40,
+            platform_config=_live_platform_config(
+                admin_ids=["111"], user_max=6
+            ),
+        )
+        assert d.is_admin is True
+        assert "memory" in d.enabled_toolsets
+        assert d.max_iterations == 40

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -28,6 +28,22 @@ See the per-platform docs for examples — the structure is identical across pla
 
 If `allow_admin_from` is unset for a scope, that scope stays in unrestricted backward-compat mode — every allowed user can run every command.
 
+### Tool-tier whitelist for non-admin users
+
+The same `allow_admin_from` gate also drives an **opt-in tool-tier split** for agent turns (RFC #20744, Phase 1). When `allow_admin_from` is set for a platform, non-admin users' turns are resolved through `gateway/user_tier.py`, which:
+
+- restricts the agent's `enabled_toolsets` to a conservative default (web-style tools only; `memory`, `terminal`, `skills`, `cronjob`, delegation, and messaging are excluded), and
+- optionally clamps `max_iterations` to `user_max_iterations`.
+
+Configure these in the same platform `extra:` block that holds the slash-command controls:
+
+| Key | Effect |
+|-----|--------|
+| `user_toolsets` (alias `user_tools`) | Explicit list of toolsets non-admin users may use, overriding the conservative default. |
+| `user_max_iterations` | Upper bound on agent iterations for non-admin turns. |
+
+Admins (and any scope where `allow_admin_from` is unset) keep the full toolset surface and uncapped iterations, so this is fully backward-compatible. This tool tiering is distinct from the slash-command `user_allowed_commands` split above: one gates which slash commands are dispatchable, the other gates which tools an agent turn may call.
+
 ## Interactive CLI slash commands
 
 Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-insensitive.


### PR DESCRIPTION
## Summary

Phase 1 of [RFC #20744](https://github.com/NousResearch/hermes-agent/issues/20744): **application-level** admin/user tier for agent **tool schema** + optional turn budget. No DB, no Casbin, no Docker (Phase 2).

Design-first comment: https://github.com/NousResearch/hermes-agent/issues/20744#issuecomment-5014682893  
No maintainer steer after >24h — shipping the proposed Phase 1 as a focused, reversible path.

### Behavior
- Tier gating is **opt-in**: only when `allow_admin_from` (or group scope) is non-empty for the platform — same contract as `gateway/slash_access.py`.
- **Admins** keep full platform `enabled_toolsets` and normal `max_iterations`.
- **Non-admins** intersect toolsets with `user_toolsets` (or a small default: web/browser/vision/…), excluding sensitive default sets (memory, skills, cron, terminal, …) unless explicitly listed.
- Optional `user_max_iterations` / `user_limits.max_iterations` clamps non-admin turns.

### Explicit non-goals (Phase 2+)
Docker sandbox, egress, hard host-side tool deny, Casbin/`policies.db`.

### Coordination
- Orthogonal to open **#3995** (`user_roles`) and draft **#22509** (daimon) — happy to converge or close this if maintainers prefer those vehicles.
- Does **not** change slash command gating (already shipped).

### Test plan
- [x] `pytest tests/gateway/test_user_tier.py`
- [ ] CI green

Humble building block — maintainers should steer placement vs #3995/#22509 anytime.