### PR TITLE
feat(people): Phase 1 messages.db + iMessage adapter + People files (#12323)

### DIFF
--- a/plugins/people/__init__.py
+++ b/plugins/people/__init__.py
@@ -1,0 +1,11 @@
+"""People message store + identity + People-file writer (Phase 1 of #12323)."""
+
+from plugins.people.store import PeopleMessageStore
+from plugins.people.identity import IdentityResolver
+from plugins.people.writer import write_people_markdown
+
+__all__ = [
+    "PeopleMessageStore",
+    "IdentityResolver",
+    "write_people_markdown",
+]

--- a/plugins/people/adapters/__init__.py
+++ b/plugins/people/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Channel ingestion adapters for the People message store."""
+
+from plugins.people.adapters.imessage import IMessageAdapter
+
+__all__ = ["IMessageAdapter"]

--- a/plugins/people/adapters/imessage.py
+++ b/plugins/people/adapters/imessage.py
@@ -1,0 +1,131 @@
+"""Read-only iMessage adapter — macOS chat.db (Phase 1, #12323).
+
+Never writes to chat.db. Callers pass an explicit path (tests use fixtures;
+production uses ``~/Library/Messages/chat.db`` when the user has granted
+Full Disk Access).
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, List, Optional
+
+from plugins.people.identity import IdentityResolver, infer_kind
+from plugins.people.store import IngestMessage, PeopleMessageStore
+
+CHANNEL = "imessage"
+
+
+@dataclass(frozen=True)
+class RawIMessage:
+    ext_msg_id: str
+    ts: float
+    body: str
+    is_from_me: bool
+    handle: str
+    thread_id: str
+
+
+def _apple_ns_to_unix(ns_since_2001: Optional[int]) -> float:
+    """Apple Core Data timestamp → unix seconds."""
+    if ns_since_2001 is None:
+        return time.time()
+    v = float(ns_since_2001)
+    if abs(v) > 1e12:
+        v = v / 1e9
+    return v + 978307200.0
+
+
+class IMessageAdapter:
+    """Incremental reader for Apple Messages ``chat.db``."""
+
+    def __init__(self, chat_db_path: os.PathLike | str) -> None:
+        self.chat_db_path = Path(chat_db_path)
+
+    def iter_messages(
+        self,
+        *,
+        since_unix: Optional[float] = None,
+        limit: int = 5000,
+    ) -> Iterator[RawIMessage]:
+        if not self.chat_db_path.is_file():
+            return
+            yield  # pragma: no cover — makes this a generator
+        uri = f"file:{self.chat_db_path}?mode=ro"
+        conn = sqlite3.connect(uri, uri=True)
+        conn.row_factory = sqlite3.Row
+        try:
+            sql = """
+            SELECT
+                m.ROWID AS rowid,
+                m.guid AS guid,
+                m.text AS text,
+                m.is_from_me AS is_from_me,
+                m.date AS date,
+                m.cache_roomnames AS room,
+                h.id AS handle
+            FROM message m
+            LEFT JOIN handle h ON m.handle_id = h.ROWID
+            WHERE m.text IS NOT NULL AND TRIM(m.text) != ''
+            """
+            params: list = []
+            if since_unix is not None:
+                cocoa = float(since_unix) - 978307200.0
+                sql += (
+                    " AND (CASE WHEN ABS(m.date) > 1e12 THEN m.date/1e9 "
+                    "ELSE m.date END) > ?"
+                )
+                params.append(cocoa)
+            sql += " ORDER BY m.date ASC LIMIT ?"
+            params.append(int(limit))
+            cur = conn.execute(sql, params)
+            for row in cur:
+                guid = row["guid"] or f"row-{row['rowid']}"
+                handle = (row["handle"] or "").strip() or "unknown"
+                yield RawIMessage(
+                    ext_msg_id=str(guid),
+                    ts=_apple_ns_to_unix(row["date"]),
+                    body=str(row["text"] or ""),
+                    is_from_me=bool(row["is_from_me"]),
+                    handle=handle,
+                    thread_id=str(row["room"] or handle),
+                )
+        finally:
+            conn.close()
+
+    def sync_to_store(
+        self,
+        store: PeopleMessageStore,
+        *,
+        resolver: Optional[IdentityResolver] = None,
+        since_unix: Optional[float] = None,
+        limit: int = 5000,
+    ) -> tuple[int, int]:
+        """Ingest messages with store-level dedupe. Returns (inserted, skipped)."""
+        resolver = resolver or IdentityResolver(store)
+        batch: List[IngestMessage] = []
+        for raw in self.iter_messages(since_unix=since_unix, limit=limit):
+            person_id = None
+            if raw.handle and raw.handle != "unknown":
+                person_id = resolver.resolve(
+                    raw.handle,
+                    kind=infer_kind(raw.handle),
+                    source="imessage",
+                )
+            batch.append(
+                IngestMessage(
+                    channel=CHANNEL,
+                    ext_msg_id=raw.ext_msg_id,
+                    direction="out" if raw.is_from_me else "in",
+                    ts=raw.ts,
+                    body=raw.body,
+                    thread_id=raw.thread_id,
+                    raw_handle=raw.handle,
+                    person_id=person_id,
+                )
+            )
+        return store.ingest_many(batch)

--- a/plugins/people/identity.py
+++ b/plugins/people/identity.py
@@ -1,0 +1,94 @@
+"""Deterministic identity normalization + resolution v1 (#12323 Phase 1)."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from plugins.people.store import PeopleMessageStore
+
+
+_PHONE_RE = re.compile(r"[^\d+]")
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def normalize_identity(kind: str, value: str) -> str:
+    """Normalize identity values for durable unique keys."""
+    kind_l = (kind or "").strip().lower()
+    raw = (value or "").strip()
+    if kind_l in ("phone", "imessage") and raw:
+        # keep leading + if present; strip formatting
+        digits = _PHONE_RE.sub("", raw)
+        if digits.startswith("00"):
+            digits = "+" + digits[2:]
+        if raw.startswith("+") and not digits.startswith("+"):
+            digits = "+" + digits.lstrip("+")
+        # US-ish 10-digit → +1
+        if digits.isdigit() and len(digits) == 10:
+            digits = "+1" + digits
+        elif digits.isdigit() and len(digits) == 11 and digits.startswith("1"):
+            digits = "+" + digits
+        return digits
+    if kind_l == "email":
+        return raw.lower()
+    if kind_l == "handle":
+        return raw.lstrip("@").lower()
+    return raw.lower()
+
+
+def infer_kind(value: str) -> str:
+    v = (value or "").strip()
+    if not v:
+        return "handle"
+    if _EMAIL_RE.match(v):
+        return "email"
+    digits = _PHONE_RE.sub("", v)
+    if digits.isdigit() and len(digits) >= 10:
+        return "phone"
+    if v.startswith("+") and any(c.isdigit() for c in v):
+        return "phone"
+    return "handle"
+
+
+def slugify_name(name: str) -> str:
+    base = re.sub(r"[^a-z0-9]+", "-", (name or "").lower()).strip("-")
+    return base or f"person-{uuid.uuid4().hex[:10]}"
+
+
+class IdentityResolver:
+    """Resolve handles → person_id with override > existing link > create."""
+
+    def __init__(self, store: "PeopleMessageStore") -> None:
+        self.store = store
+
+    def resolve(
+        self,
+        value: str,
+        *,
+        kind: Optional[str] = None,
+        display_name: Optional[str] = None,
+        source: Optional[str] = None,
+    ) -> str:
+        k = kind or infer_kind(value)
+        # 1) manual override
+        ov = self.store.get_override_person(k, value)
+        if ov:
+            return ov
+        # 2) existing identity
+        existing = self.store.find_person_by_identity(k, value)
+        if existing:
+            return existing
+        # 3) create person + link
+        person_id = f"person-{uuid.uuid4().hex[:12]}"
+        slug = slugify_name(display_name or value)
+        self.store.upsert_person(
+            person_id,
+            display_name=display_name or value,
+            slug=slug,
+        )
+        self.store.link_identity(
+            person_id, k, value, source=source or "identity_resolver"
+        )
+        return person_id

--- a/plugins/people/store.py
+++ b/plugins/people/store.py
@@ -1,0 +1,272 @@
+"""Normalized SQLite store for cross-channel personal messages.
+
+Default path: ``~/.hermes/people/messages.db`` (on-device only).
+Incremental sync via UNIQUE(channel, ext_msg_id).
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, List, Optional, Sequence, Tuple
+
+
+SCHEMA_VERSION = 1
+
+_SCHEMA_SQL = """
+PRAGMA journal_mode=WAL;
+
+CREATE TABLE IF NOT EXISTS schema_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS people (
+    person_id TEXT PRIMARY KEY,
+    display_name TEXT,
+    slug TEXT UNIQUE,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS identities (
+    identity_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    person_id TEXT NOT NULL REFERENCES people(person_id),
+    kind TEXT NOT NULL,          -- phone | email | handle | imessage | manual
+    value TEXT NOT NULL,
+    normalized TEXT NOT NULL,
+    source TEXT,
+    created_at REAL NOT NULL,
+    UNIQUE(kind, normalized)
+);
+
+CREATE TABLE IF NOT EXISTS identity_overrides (
+    override_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind TEXT NOT NULL,
+    normalized TEXT NOT NULL,
+    person_id TEXT NOT NULL REFERENCES people(person_id),
+    note TEXT,
+    created_at REAL NOT NULL,
+    UNIQUE(kind, normalized)
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+    msg_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    person_id TEXT REFERENCES people(person_id),
+    channel TEXT NOT NULL,
+    ext_msg_id TEXT NOT NULL,
+    direction TEXT NOT NULL CHECK(direction IN ('in', 'out', 'unknown')),
+    ts REAL NOT NULL,
+    body TEXT,
+    thread_id TEXT,
+    attachments_json TEXT,
+    raw_handle TEXT,
+    ingested_at REAL NOT NULL,
+    UNIQUE(channel, ext_msg_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_person_ts ON messages(person_id, ts);
+CREATE INDEX IF NOT EXISTS idx_messages_channel_ts ON messages(channel, ts);
+CREATE INDEX IF NOT EXISTS idx_identities_person ON identities(person_id);
+"""
+
+
+def default_db_path() -> Path:
+    hermes_home = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
+    return Path(hermes_home) / "people" / "messages.db"
+
+
+@dataclass(frozen=True)
+class IngestMessage:
+    channel: str
+    ext_msg_id: str
+    direction: str  # in | out | unknown
+    ts: float
+    body: Optional[str] = None
+    thread_id: Optional[str] = None
+    attachments_json: Optional[str] = None
+    raw_handle: Optional[str] = None
+    person_id: Optional[str] = None
+
+
+class PeopleMessageStore:
+    def __init__(self, db_path: Optional[os.PathLike | str] = None) -> None:
+        self.db_path = Path(db_path) if db_path else default_db_path()
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self.db_path))
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        self._init_schema()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __enter__(self) -> "PeopleMessageStore":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+    def _init_schema(self) -> None:
+        self._conn.executescript(_SCHEMA_SQL)
+        cur = self._conn.execute(
+            "SELECT value FROM schema_meta WHERE key = 'version'"
+        )
+        row = cur.fetchone()
+        if row is None:
+            self._conn.execute(
+                "INSERT INTO schema_meta(key, value) VALUES ('version', ?)",
+                (str(SCHEMA_VERSION),),
+            )
+            self._conn.commit()
+
+    def upsert_person(
+        self,
+        person_id: str,
+        *,
+        display_name: Optional[str] = None,
+        slug: Optional[str] = None,
+    ) -> str:
+        now = time.time()
+        cur = self._conn.execute(
+            "SELECT person_id FROM people WHERE person_id = ?", (person_id,)
+        )
+        if cur.fetchone() is None:
+            self._conn.execute(
+                "INSERT INTO people(person_id, display_name, slug, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (person_id, display_name, slug, now, now),
+            )
+        else:
+            self._conn.execute(
+                "UPDATE people SET display_name = COALESCE(?, display_name), "
+                "slug = COALESCE(?, slug), updated_at = ? WHERE person_id = ?",
+                (display_name, slug, now, person_id),
+            )
+        self._conn.commit()
+        return person_id
+
+    def link_identity(
+        self,
+        person_id: str,
+        kind: str,
+        value: str,
+        *,
+        normalized: Optional[str] = None,
+        source: Optional[str] = None,
+    ) -> None:
+        from plugins.people.identity import normalize_identity
+
+        norm = normalized or normalize_identity(kind, value)
+        now = time.time()
+        self.upsert_person(person_id)
+        try:
+            self._conn.execute(
+                "INSERT INTO identities(person_id, kind, value, normalized, source, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (person_id, kind, value, norm, source, now),
+            )
+            self._conn.commit()
+        except sqlite3.IntegrityError:
+            # Already linked — leave as-is (deterministic identity resolution).
+            self._conn.rollback()
+
+    def set_manual_override(
+        self,
+        kind: str,
+        value: str,
+        person_id: str,
+        *,
+        note: Optional[str] = None,
+    ) -> None:
+        from plugins.people.identity import normalize_identity
+
+        norm = normalize_identity(kind, value)
+        now = time.time()
+        self.upsert_person(person_id)
+        self._conn.execute(
+            "INSERT INTO identity_overrides(kind, normalized, person_id, note, created_at) "
+            "VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT(kind, normalized) DO UPDATE SET "
+            "person_id = excluded.person_id, note = excluded.note",
+            (kind, norm, person_id, note, now),
+        )
+        self._conn.commit()
+
+    def get_override_person(self, kind: str, value: str) -> Optional[str]:
+        from plugins.people.identity import normalize_identity
+
+        norm = normalize_identity(kind, value)
+        cur = self._conn.execute(
+            "SELECT person_id FROM identity_overrides WHERE kind = ? AND normalized = ?",
+            (kind, norm),
+        )
+        row = cur.fetchone()
+        return str(row["person_id"]) if row else None
+
+    def find_person_by_identity(self, kind: str, value: str) -> Optional[str]:
+        from plugins.people.identity import normalize_identity
+
+        norm = normalize_identity(kind, value)
+        cur = self._conn.execute(
+            "SELECT person_id FROM identities WHERE kind = ? AND normalized = ?",
+            (kind, norm),
+        )
+        row = cur.fetchone()
+        return str(row["person_id"]) if row else None
+
+    def ingest_many(self, messages: Sequence[IngestMessage]) -> Tuple[int, int]:
+        """Insert messages with dedupe. Returns (inserted, skipped)."""
+        inserted = 0
+        skipped = 0
+        now = time.time()
+        for m in messages:
+            direction = m.direction if m.direction in ("in", "out", "unknown") else "unknown"
+            try:
+                self._conn.execute(
+                    "INSERT INTO messages("
+                    "person_id, channel, ext_msg_id, direction, ts, body, "
+                    "thread_id, attachments_json, raw_handle, ingested_at"
+                    ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        m.person_id,
+                        m.channel,
+                        m.ext_msg_id,
+                        direction,
+                        float(m.ts),
+                        m.body,
+                        m.thread_id,
+                        m.attachments_json,
+                        m.raw_handle,
+                        now,
+                    ),
+                )
+                inserted += 1
+            except sqlite3.IntegrityError:
+                skipped += 1
+        self._conn.commit()
+        return inserted, skipped
+
+    def list_people(self) -> List[sqlite3.Row]:
+        return list(
+            self._conn.execute(
+                "SELECT * FROM people ORDER BY updated_at DESC"
+            ).fetchall()
+        )
+
+    def messages_for_person(
+        self, person_id: str, *, limit: int = 200
+    ) -> List[sqlite3.Row]:
+        return list(
+            self._conn.execute(
+                "SELECT * FROM messages WHERE person_id = ? ORDER BY ts DESC LIMIT ?",
+                (person_id, int(limit)),
+            ).fetchall()
+        )
+
+    def message_count(self) -> int:
+        row = self._conn.execute("SELECT COUNT(*) AS c FROM messages").fetchone()
+        return int(row["c"])

--- a/plugins/people/sync.py
+++ b/plugins/people/sync.py
@@ -1,0 +1,43 @@
+"""CLI-friendly sync entrypoint for People Phase 1."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from plugins.people.adapters.imessage import IMessageAdapter
+from plugins.people.store import PeopleMessageStore
+from plugins.people.writer import write_people_markdown
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Hermes People message sync (Phase 1)")
+    p.add_argument(
+        "--db",
+        default=None,
+        help="Path to people messages.db (default: ~/.hermes/people/messages.db)",
+    )
+    p.add_argument(
+        "--imessage-db",
+        default=str(Path.home() / "Library" / "Messages" / "chat.db"),
+        help="Read-only path to macOS chat.db",
+    )
+    p.add_argument("--people-dir", default=None, help="Output dir for <slug>.md")
+    p.add_argument("--limit", type=int, default=5000)
+    p.add_argument("--skip-imessage", action="store_true")
+    p.add_argument("--write-only", action="store_true", help="Only rewrite markdown")
+    args = p.parse_args(argv)
+
+    with PeopleMessageStore(args.db) as store:
+        if not args.write_only and not args.skip_imessage:
+            adapter = IMessageAdapter(args.imessage_db)
+            inserted, skipped = adapter.sync_to_store(store, limit=args.limit)
+            print(f"imessage: inserted={inserted} skipped={skipped}")
+        n = write_people_markdown(store, people_dir=args.people_dir)
+        print(f"people markdown files written: {n}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/people/writer.py
+++ b/plugins/people/writer.py
@@ -1,0 +1,80 @@
+"""Write ``~/.hermes/people/<slug>.md`` files from the People DB.
+
+Schema intentionally converges with notes-extract People entries (#32720):
+YAML front matter + Facts / Commitments / Topics sections. Phase 1 fills a
+**Messages** summary block; notes-extract fences remain for sibling skill.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from plugins.people.store import PeopleMessageStore
+
+
+def default_people_dir() -> Path:
+    hermes_home = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
+    return Path(hermes_home) / "people"
+
+
+def write_people_markdown(
+    store: "PeopleMessageStore",
+    *,
+    people_dir: Optional[os.PathLike | str] = None,
+    message_preview: int = 12,
+) -> int:
+    """Rewrite People markdown files for all people rows. Returns count written."""
+    out_dir = Path(people_dir) if people_dir else default_people_dir()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written = 0
+    for person in store.list_people():
+        person_id = person["person_id"]
+        slug = person["slug"] or person_id
+        name = person["display_name"] or slug
+        updated = time.strftime("%Y-%m-%d", time.localtime(person["updated_at"] or time.time()))
+        msgs = store.messages_for_person(person_id, limit=message_preview)
+        lines = [
+            "---",
+            "type: person",
+            f"id: {person_id}",
+            f"name: {name}",
+            "aliases: []",
+            f"updated: {updated}",
+            "---",
+            "",
+            "## Facts",
+            "<!-- notes-extract:begin facts -->",
+            "<!-- notes-extract:end facts -->",
+            "",
+            "## Commitments",
+            "<!-- notes-extract:begin commitments -->",
+            "<!-- notes-extract:end commitments -->",
+            "",
+            "## Topics",
+            "<!-- notes-extract:begin topics -->",
+            "<!-- notes-extract:end topics -->",
+            "",
+            "## Messages",
+            "<!-- people-store:begin messages -->",
+        ]
+        if not msgs:
+            lines.append("_No messages ingested yet._")
+        else:
+            for m in reversed(list(msgs)):
+                ts = time.strftime("%Y-%m-%d %H:%M", time.localtime(m["ts"]))
+                direction = m["direction"] or "?"
+                channel = m["channel"] or "?"
+                body = (m["body"] or "").replace("\n", " ").strip()
+                if len(body) > 200:
+                    body = body[:197] + "..."
+                lines.append(f"- [{ts}] ({channel}/{direction}) {body}")
+        lines.append("<!-- people-store:end messages -->")
+        lines.append("")
+        path = out_dir / f"{slug}.md"
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        written += 1
+    return written

--- a/tests/plugins/people/test_people_store.py
+++ b/tests/plugins/people/test_people_store.py
@@ -1,0 +1,115 @@
+"""Tests for People message store / identity / iMessage adapter / writer (#12323)."""
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from plugins.people.adapters.imessage import IMessageAdapter, _apple_ns_to_unix
+from plugins.people.identity import IdentityResolver, normalize_identity, slugify_name
+from plugins.people.store import IngestMessage, PeopleMessageStore
+from plugins.people.writer import write_people_markdown
+
+
+@pytest.fixture()
+def store(tmp_path: Path):
+    db = tmp_path / "messages.db"
+    s = PeopleMessageStore(db)
+    yield s
+    s.close()
+
+
+class TestNormalize:
+    def test_phone_us_ten_digit(self):
+        assert normalize_identity("phone", "(415) 555-1212") == "+14155551212"
+
+    def test_email_lower(self):
+        assert normalize_identity("email", "A@B.Com") == "a@b.com"
+
+    def test_handle_strip_at(self):
+        assert normalize_identity("handle", "@Alice") == "alice"
+
+    def test_slugify(self):
+        assert "alice" in slugify_name("Alice Smith")
+
+
+class TestStoreDedupe:
+    def test_incremental_dedupe(self, store: PeopleMessageStore):
+        m = IngestMessage(
+            channel="imessage",
+            ext_msg_id="guid-1",
+            direction="in",
+            ts=time.time(),
+            body="hi",
+            raw_handle="+14155551212",
+        )
+        ins, skip = store.ingest_many([m])
+        assert ins == 1 and skip == 0
+        ins2, skip2 = store.ingest_many([m])
+        assert ins2 == 0 and skip2 == 1
+        assert store.message_count() == 1
+
+
+class TestIdentityResolver:
+    def test_merge_same_phone(self, store: PeopleMessageStore):
+        r = IdentityResolver(store)
+        a = r.resolve("415-555-1212", kind="phone", display_name="Alice")
+        b = r.resolve("+14155551212", kind="phone")
+        assert a == b
+
+    def test_manual_override(self, store: PeopleMessageStore):
+        r = IdentityResolver(store)
+        p1 = r.resolve("a@example.com", kind="email", display_name="A")
+        store.set_manual_override("email", "b@example.com", p1)
+        p2 = r.resolve("b@example.com", kind="email")
+        assert p2 == p1
+
+
+class TestIMessageAdapter:
+    def test_apple_ts(self):
+        # known: cocoa 0 → 2001-01-01
+        assert abs(_apple_ns_to_unix(0) - 978307200.0) < 0.1
+
+    def test_sync_fixture_db(self, store: PeopleMessageStore, tmp_path: Path):
+        chat = tmp_path / "chat.db"
+        conn = sqlite3.connect(str(chat))
+        conn.executescript(
+            """
+            CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT);
+            CREATE TABLE message (
+                ROWID INTEGER PRIMARY KEY,
+                guid TEXT,
+                text TEXT,
+                is_from_me INTEGER,
+                date INTEGER,
+                cache_roomnames TEXT,
+                handle_id INTEGER
+            );
+            INSERT INTO handle(ROWID, id) VALUES (1, '+14155550100');
+            INSERT INTO message(ROWID, guid, text, is_from_me, date, cache_roomnames, handle_id)
+            VALUES (1, 'G-1', 'hello from alice', 0, 0, NULL, 1);
+            INSERT INTO message(ROWID, guid, text, is_from_me, date, cache_roomnames, handle_id)
+            VALUES (2, 'G-2', 'hi alice', 1, 10, NULL, 1);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        adapter = IMessageAdapter(chat)
+        ins, skip = adapter.sync_to_store(store)
+        assert ins == 2 and skip == 0
+        # second sync dedupes
+        ins2, skip2 = adapter.sync_to_store(store)
+        assert ins2 == 0 and skip2 == 2
+
+        people_dir = tmp_path / "people_md"
+        n = write_people_markdown(store, people_dir=people_dir)
+        assert n >= 1
+        files = list(people_dir.glob("*.md"))
+        assert files
+        text = files[0].read_text()
+        assert "type: person" in text
+        assert "hello from alice" in text
+        assert "notes-extract:begin facts" in text


### PR DESCRIPTION
## Summary

Phase 1 of [#12323](https://github.com/NousResearch/hermes-agent/issues/12323) — personal message ingestion foundation.

Scoping comment: https://github.com/NousResearch/hermes-agent/issues/12323#issuecomment-5014674296  
No maintainer placement steer after >24h — shipping Phase 1 as a **plugin-shaped** library under `plugins/people/` (store + writer + thin iMessage adapter), without claiming gateway/background-job placement.

### What's in
1. **SQLite** default `~/.hermes/people/messages.db` — `people`, `identities`, `identity_overrides`, `messages` with `UNIQUE(channel, ext_msg_id)` incremental sync.
2. **One adapter** — read-only macOS `chat.db` (`plugins/people/adapters/imessage.py`). Never writes Apple's DB.
3. **Identity v1** — normalize phone/email/handle; override table beats auto-merge.
4. **People markdown** — `~/.hermes/people/<slug>.md` with notes-extract-compatible front matter + fences (converge with open **#32720**), plus a Messages preview section.
5. **CLI** — `python -m plugins.people.sync` (optional `--imessage-db`, `--db`, `--write-only`).

### Explicit non-goals (later phases)
Signal/Gmail/WhatsApp adapters, LLM extraction, calendar/meeting prep, proactive loops.

### Privacy
On-device only; no PII denylist (treat bodies as sensitive; user enables path/Full Disk Access).

### Test plan
- [x] `pytest tests/plugins/people/test_people_store.py` (fixture chat.db, dedupe, override, markdown)
- [ ] CI green

Happy to relocate into a skill shell or align schema field names 1:1 with #32720 on maintainer steer.