### PR TITLE
feat(security): add allow_unsafe_file_operations config toggle

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -97,6 +97,17 @@ def get_safe_write_roots() -> set[str]:
 
 def _classify_write_denial(path: str) -> Optional[str]:
     """Return ``'credential'``, ``'safe_root'``, or ``None`` if writes are allowed."""
+
+    # Config-level escape hatch: when security.allow_unsafe_file_operations
+    # is true, skip ALL write denials.
+    try:
+        from hermes_cli.config import load_config
+        _cfg = load_config() or {}
+        if _cfg.get("security", {}).get("allow_unsafe_file_operations", False):
+            return None
+    except Exception:
+        pass  # config unavailable — fall through to normal enforcement
+
     home = os.path.realpath(os.path.expanduser("~"))
     resolved = os.path.realpath(os.path.expanduser(str(path)))
 
@@ -233,6 +244,17 @@ def get_read_block_error(path: str) -> Optional[str]:
     ``"auth.json"`` would otherwise miss the denylist when the task's
     terminal cwd differs from the process cwd.
     """
+
+    # Config-level escape hatch: when security.allow_unsafe_file_operations
+    # is true, skip read blocks too (same as _classify_write_denial).
+    try:
+        from hermes_cli.config import load_config
+        _cfg = load_config() or {}
+        if _cfg.get("security", {}).get("allow_unsafe_file_operations", False):
+            return None
+    except Exception:
+        pass
+
     resolved = Path(path).expanduser().resolve()
 
     # Resolve BOTH the active HERMES_HOME (profile-aware) AND the global

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2723,6 +2723,21 @@ DEFAULT_CONFIG = {
 
     # Pre-exec security scanning via tirith
     "security": {
+        # Allow the agent to write to and read from paths normally blocked by the
+        # file safety denylist (SSH keys, .env files, auth.json, etc.) and bypass
+        # the hardline command floor (rm -rf /, mkfs, shutdown/reboot, fork bomb).
+        #
+        # false (default): hard blocks are enforced — the agent cannot write to
+        #     ~/.hermes/.env, ~/.ssh/id_rsa, etc., and catastrophic shell commands
+        #     are unconditionally denied regardless of --yolo / approvals.mode=off.
+        # true: file safety and hardline checks are bypassed — the agent can write
+        #     anywhere a shell open to the same user can write, and destructive
+        #     system commands are permitted. Use with extreme caution.
+        #
+        # This is distinct from --yolo / /yolo / approvals.mode=off which skip
+        # approval prompts but still enforce file-level safety rules. This toggle
+        # removes the safety floor itself for users who explicitly opt in.
+        "allow_unsafe_file_operations": False,
         "allow_private_urls": False,  # Allow requests to private/internal IPs (for OpenWrt, proxies, VPNs)
         "redact_secrets": True,
         "tirith_enabled": True,

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3170,6 +3170,21 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     return {"resolved": resolved, "choice": choice, "reason": entry.reason}
 
 
+def _hardline_is_bypassed() -> bool:
+    """Return True when the hardline command floor should be skipped.
+
+    Checks security.allow_unsafe_file_operations in config.yaml — the
+    explicit user opt-in that overrides the unconditional hardline floor.
+    Gracefully returns False if config can't be loaded.
+    """
+    try:
+        from hermes_cli.config import load_config
+        _cfg = load_config() or {}
+        return bool(_cfg.get("security", {}).get("allow_unsafe_file_operations", False))
+    except Exception:
+        return False
+
+
 def check_all_command_guards(command: str, env_type: str,
                              approval_callback=None,
                              has_host_access: bool = False) -> dict:
@@ -3192,11 +3207,18 @@ def check_all_command_guards(command: str, env_type: str,
     # Hardline floor: unconditional block for catastrophic commands
     # (rm -rf /, mkfs, dd to raw device, shutdown/reboot, fork bomb,
     # kill -1). Applies BEFORE yolo / mode=off / cron approve-mode so
-    # no session-level setting can bypass it.
-    is_hardline, hardline_desc = detect_hardline_command(command)
-    if is_hardline:
-        logger.warning("Hardline block: %s (command: %s)", hardline_desc, command[:200])
-        return _hardline_block_result(hardline_desc)
+    # no session-level setting can bypass it — EXCEPT when the user
+    # has explicitly opted in via security.allow_unsafe_file_operations.
+    if _hardline_is_bypassed():
+        logger.info(
+            "Hardline bypassed: security.allow_unsafe_file_operations=true "
+            "— skipping hardline check for: %s", command[:200],
+        )
+    else:
+        is_hardline, hardline_desc = detect_hardline_command(command)
+        if is_hardline:
+            logger.warning("Hardline block: %s (command: %s)", hardline_desc, command[:200])
+            return _hardline_block_result(hardline_desc)
 
     # == Sudo stdin guard ==
     # Like the hardline floor above, this is unconditional: there is never a


### PR DESCRIPTION
## What does this PR do?

Adds a new `security.allow_unsafe_file_operations` config option (default: `false`) that, when set to `true`, bypasses three safety layers:

1. **Write denylist** — `is_write_denied()` returns `False` immediately, allowing writes to `.env`, SSH keys, `auth.json`, `.netrc`, `.pgpass`, and other normally-blocked paths.
2. **Read blocklist** — `get_read_block_error()` returns `None` immediately, allowing reads of credential stores and project env files.
3. **Hardline command floor** — `check_all_command_guards()` skips the unconditional blocklist (`rm -rf /`, `mkfs`, `dd` to raw block devices, `shutdown`/`reboot`, fork bombs, `kill -1`).

This is distinct from `--yolo` / `approvals.mode=off` which only skip approval **prompts** while still enforcing file-level safety rules and the hardline floor. The new toggle removes the safety floor itself — designed for automated environments (Docker, CI, dedicated sandboxes) where the operator has explicitly decided the agent can operate with the same filesystem access as a shell open to the same user.

The approach was to add a single config key and propagate it through the three enforcement points. Each bypass point fails closed: if `load_config()` fails or the key is absent, normal enforcement continues unchanged.

## Related Issue

No issue filed — this is a feature request that emerged from operational experience where `--yolo` was insufficient for sandboxed environments.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix

## Changes Made

- `hermes_cli/config.py` — added `allow_unsafe_file_operations: False` under the `security:` dict with full docstring explaining semantics and distinction from `--yolo`
- `agent/file_safety.py` — `is_write_denied()` now checks the toggle before iterating the denylist; `get_read_block_error()` does the same before checking credential/env-file paths
- `tools/approval.py` — added `_hardline_is_bypassed()` helper function; `check_all_command_guards()` now evaluates the toggle before running hardline pattern detection

## How to Test

1. Set `security.allow_unsafe_file_operations: true` in config.yaml
2. Attempt a write to `~/.hermes/.env` — should succeed (was: denied)
3. Attempt a read of a project `.env` file — should succeed (was: blocked)
4. Run `rm -rf /tmp/test_dir` — should execute (rm of a safe path was already allowed, but the hardline floor for `/` itself is bypassed)
5. Set the toggle back to `false` — all denials resume

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: Debian 13 Trixie, Linux 7.0.7+deb13-amd64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [ ] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — config-driven behaviour change, no UI component.