### PR TITLE
fix(mcp): stop false-positive config-watcher reloads + add cache-safe auto-reload opt-out

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10030,6 +10030,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return
 
         new_mcp = new_cfg.get("mcp_servers") or {}
+        # Expand ${VAR} templates so the comparison is consistent with the
+        # init snapshot (self._config_mcp_servers), which was populated from
+        # the deep-merged + expanded config.  Without this, any
+        # save_config_value() that rewrites config.yaml (even for unrelated
+        # keys) triggers a false-positive MCP reload because the raw yaml
+        # still has "${POWERMEM_API_KEY}" while the snapshot has the
+        # expanded value.
+        from hermes_cli.config import _expand_env_vars
+        new_mcp = _expand_env_vars(new_mcp)
         if new_mcp == self._config_mcp_servers:
             return  # mcp_servers unchanged (some other section was edited)
 

--- a/cli.py
+++ b/cli.py
@@ -10062,18 +10062,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # next message re-sends the full input prefix, which is expensive on
         # long-context / high-reasoning models).
         #
-        # The toggle lives under ``auxiliary.mcp.auto_reload_on_config_change``
-        # in DEFAULT_CONFIG (same section as the MCP aux-task provider
-        # settings), so resolve it through that path, not a top-level ``mcp``
-        # key that does not exist in the loaded config shape.
-        try:
-            from hermes_cli.config import load_config as _load_cfg
-            _cfg = _load_cfg()
-            _aux = _cfg.get("auxiliary") if isinstance(_cfg, dict) else None
-            _mcp = _aux.get("mcp") if isinstance(_aux, dict) else None
-            _auto = _mcp.get("auto_reload_on_config_change", True) if isinstance(_mcp, dict) else True
-        except Exception:
-            _auto = True
+        # The toggle is the top-level ``mcp.auto_reload_on_config_change``
+        # key (see DEFAULT_CONFIG).  Read it from the config we just parsed
+        # so the user can flip it in the same edit that changes mcp_servers;
+        # missing key means default-on.
+        _mcp_cfg = new_cfg.get("mcp")
+        _auto = (
+            _mcp_cfg.get("auto_reload_on_config_change", True)
+            if isinstance(_mcp_cfg, dict)
+            else True
+        )
 
         self._config_mcp_servers = new_mcp
 

--- a/cli.py
+++ b/cli.py
@@ -10061,10 +10061,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # agent tool surface and INVALIDATES the provider prompt cache (the
         # next message re-sends the full input prefix, which is expensive on
         # long-context / high-reasoning models).
+        #
+        # The toggle lives under ``auxiliary.mcp.auto_reload_on_config_change``
+        # in DEFAULT_CONFIG (same section as the MCP aux-task provider
+        # settings), so resolve it through that path, not a top-level ``mcp``
+        # key that does not exist in the loaded config shape.
         try:
             from hermes_cli.config import load_config as _load_cfg
             _cfg = _load_cfg()
-            _mcp = _cfg.get("mcp") if isinstance(_cfg, dict) else None
+            _aux = _cfg.get("auxiliary") if isinstance(_cfg, dict) else None
+            _mcp = _aux.get("mcp") if isinstance(_aux, dict) else None
             _auto = _mcp.get("auto_reload_on_config_change", True) if isinstance(_mcp, dict) else True
         except Exception:
             _auto = True

--- a/cli.py
+++ b/cli.py
@@ -9992,13 +9992,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             print(f"  Error generating insights: {e}")
 
     def _check_config_mcp_changes(self) -> None:
-        """Detect mcp_servers changes in config.yaml and auto-reload MCP connections.
+        """Detect mcp_servers changes in config.yaml and react.
 
         Called from process_loop every CONFIG_WATCH_INTERVAL seconds.
         Compares config.yaml mtime + mcp_servers section against the last
-        known state.  When a change is detected, triggers _reload_mcp() and
-        informs the user so they know the tool list has been refreshed.
+        known state.  When a change is detected:
+
+        * By default (``mcp.auto_reload_on_config_change: true``) it
+          auto-triggers ``_reload_mcp()`` and informs the user — legacy
+          behaviour from #1474.
+        * When opted out (``mcp.auto_reload_on_config_change: false``) it
+          does NOT reload.  Instead it notifies the user that the config
+          changed and that they can apply it with ``/reload-mcp`` — while
+          warning that ``/reload-mcp`` rebuilds the tool surface and
+          **invalidates the provider prompt cache** (the next message
+          re-sends the full input prefix, expensive on long-context /
+          high-reasoning models).  This stops silent cache-breaking reloads
+          when config.yaml is rewritten frequently by external tooling or
+          other Hermes instances.
         """
+
         import yaml as _yaml
 
         CONFIG_WATCH_INTERVAL = 5.0  # seconds between config.yaml stat() calls
@@ -10042,7 +10055,34 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if new_mcp == self._config_mcp_servers:
             return  # mcp_servers unchanged (some other section was edited)
 
+        # Detected a change in the mcp_servers section.  By default we
+        # auto-reload (legacy behaviour), but if the user has opted out we
+        # notify instead of reloading — because every reload rebuilds the
+        # agent tool surface and INVALIDATES the provider prompt cache (the
+        # next message re-sends the full input prefix, which is expensive on
+        # long-context / high-reasoning models).
+        try:
+            from hermes_cli.config import load_config as _load_cfg
+            _cfg = _load_cfg()
+            _mcp = _cfg.get("mcp") if isinstance(_cfg, dict) else None
+            _auto = _mcp.get("auto_reload_on_config_change", True) if isinstance(_mcp, dict) else True
+        except Exception:
+            _auto = True
+
         self._config_mcp_servers = new_mcp
+
+        if not _auto:
+            # Notify the user that the config changed but do NOT auto-reload.
+            # They can apply the new settings on their own terms with
+            # /reload-mcp — which we explicitly warn may invalidate the cache.
+            print()
+            print("🔄 MCP server config changed — reload skipped (auto-reload disabled).")
+            print("   New settings are NOT applied yet. To apply them now, run:")
+            print("     /reload-mcp")
+            print("   ⚠️  Note: /reload-mcp rebuilds the tool set and invalidates the")
+            print("   provider prompt cache (next message re-sends full input tokens).")
+            return
+
         # Notify user and reload.  Run in a separate thread with a hard
         # timeout so a hung MCP server cannot block the process_loop
         # indefinitely (which would freeze the entire TUI).

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1409,6 +1409,20 @@ DEFAULT_CONFIG = {
     # small so a slow/dead server adds little to first-response latency.
     "mcp_discovery_timeout": 1.5,
 
+    # MCP runtime behavior (distinct from the per-server definitions in
+    # mcp_servers: and from the auxiliary.mcp side-LLM task settings).
+    "mcp": {
+        # Auto-reload MCP connections when config.yaml's mcp_servers section
+        # changes at runtime (CLI file watcher, default on).
+        # Set to false to stop the automatic reload: every automatic reload
+        # rebuilds the agent tool surface and INVALIDATES the provider
+        # prompt cache (the next message re-sends the full input prefix),
+        # which is expensive on long-context / high-reasoning models.
+        # When disabled, the watcher still detects the change and prints
+        # guidance to apply it deliberately via /reload-mcp.
+        "auto_reload_on_config_change": True,
+    },
+
     # Tool-output truncation thresholds. When terminal output or a
     # single read_file page exceeds these limits, Hermes truncates the
     # payload sent to the model (keeping head + tail for terminal,
@@ -1670,14 +1684,6 @@ DEFAULT_CONFIG = {
             "timeout": 30,
             "extra_body": {},
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
-            # Auto-reload MCP connections when config.yaml's mcp_servers section
-            # changes at runtime (default on, matches pre-#1474 behaviour).
-            # Set to False to stop the automatic reload: every automatic reload
-            # rebuilds the agent tool surface and INVALIDATES the provider
-            # prompt cache (the next message re-sends the full input prefix),
-            # which is expensive on long-context / high-reasoning models.
-            # MCP servers can still be reloaded manually via /reload-mcp.
-            "auto_reload_on_config_change": True,
         },
         "title_generation": {
             "enabled": True,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1670,6 +1670,14 @@ DEFAULT_CONFIG = {
             "timeout": 30,
             "extra_body": {},
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
+            # Auto-reload MCP connections when config.yaml's mcp_servers section
+            # changes at runtime (default on, matches pre-#1474 behaviour).
+            # Set to False to stop the automatic reload: every automatic reload
+            # rebuilds the agent tool surface and INVALIDATES the provider
+            # prompt cache (the next message re-sends the full input prefix),
+            # which is expensive on long-context / high-reasoning models.
+            # MCP servers can still be reloaded manually via /reload-mcp.
+            "auto_reload_on_config_change": True,
         },
         "title_generation": {
             "enabled": True,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -779,6 +779,11 @@ _CATEGORY_MERGE: Dict[str, str] = {
     # with the other messaging-platform config (discord) so it isn't an
     # orphan tab of one field.
     "telegram": "discord",
+    # `mcp.auto_reload_on_config_change` is the only schema-surfaced mcp
+    # runtime field (server definitions live under mcp_servers, edited via
+    # the MCP tab) — fold it into the agent tab rather than spawning a
+    # one-field orphan category.
+    "mcp": "agent",
     # `computer_use.cua_telemetry` is the only schema-surfaced computer_use
     # field — fold it into the agent tab rather than spawning a one-field
     # orphan category.

--- a/tests/cli/test_cli_mcp_config_watch.py
+++ b/tests/cli/test_cli_mcp_config_watch.py
@@ -4,11 +4,14 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 
-def _make_cli(tmp_path, mcp_servers=None):
+def _make_cli(tmp_path, mcp_servers=None, extra_config=None):
     """Create a minimal HermesCLI instance with mocked config."""
     import cli as cli_mod
     obj = object.__new__(cli_mod.HermesCLI)
-    obj.config = {"mcp_servers": mcp_servers or {}}
+    cfg = {"mcp_servers": mcp_servers or {}}
+    if extra_config:
+        cfg.update(extra_config)
+    obj.config = cfg
     obj._agent_running = False
     obj._last_config_check = 0.0
     obj._config_mcp_servers = mcp_servers or {}
@@ -101,3 +104,35 @@ class TestMCPConfigWatch:
             obj._check_config_mcp_changes()  # should not raise
 
         obj._reload_mcp.assert_not_called()
+
+    def test_optout_disables_auto_reload(self, tmp_path, capsys):
+        """When mcp.auto_reload_on_config_change is False, a changed
+        mcp_servers section must NOT trigger an automatic reload — but the
+        change is still detected and the user is told how to apply it.
+
+        This protects the provider prompt cache: every automatic reload
+        rebuilds the agent tool surface and invalidates cached prefixes.
+        """
+        import yaml
+        obj, cfg_file = _make_cli(
+            tmp_path,
+            mcp_servers={},
+        )
+
+        # Simulate a changed mcp_servers section
+        cfg_file.write_text(yaml.dump({"mcp_servers": {"github": {"url": "https://mcp.github.com"}}}))
+        obj._config_mtime = 0.0  # force stale mtime
+
+        # Opt out via the loaded config (the watcher reads load_config(),
+        # not obj.config, so we patch the loader).
+        mocked_cfg = {"mcp": {"auto_reload_on_config_change": False}}
+        with patch("hermes_cli.config.get_config_path", return_value=cfg_file), \
+             patch("hermes_cli.config.load_config", return_value=mocked_cfg):
+            obj._check_config_mcp_changes()
+
+        obj._reload_mcp.assert_not_called()
+
+        out = capsys.readouterr().out
+        assert "reload skipped" in out
+        assert "/reload-mcp" in out
+        assert "prompt cache" in out

--- a/tests/cli/test_cli_mcp_config_watch.py
+++ b/tests/cli/test_cli_mcp_config_watch.py
@@ -106,12 +106,17 @@ class TestMCPConfigWatch:
         obj._reload_mcp.assert_not_called()
 
     def test_optout_disables_auto_reload(self, tmp_path, capsys):
-        """When mcp.auto_reload_on_config_change is False, a changed
+        """When auxiliary.mcp.auto_reload_on_config_change is False, a changed
         mcp_servers section must NOT trigger an automatic reload — but the
         change is still detected and the user is told how to apply it.
 
         This protects the provider prompt cache: every automatic reload
         rebuilds the agent tool surface and invalidates cached prefixes.
+
+        The toggle lives under ``auxiliary.mcp`` in DEFAULT_CONFIG (alongside
+        the MCP aux-task provider settings), so the mocked config must mirror
+        that shape — a top-level ``mcp`` key does not exist in the loaded
+        config and the watcher resolves through ``auxiliary.mcp``.
         """
         import yaml
         obj, cfg_file = _make_cli(
@@ -124,8 +129,9 @@ class TestMCPConfigWatch:
         obj._config_mtime = 0.0  # force stale mtime
 
         # Opt out via the loaded config (the watcher reads load_config(),
-        # not obj.config, so we patch the loader).
-        mocked_cfg = {"mcp": {"auto_reload_on_config_change": False}}
+        # not obj.config, so we patch the loader).  Match the real shape:
+        # DEFAULT_CONFIG["auxiliary"]["mcp"]["auto_reload_on_config_change"].
+        mocked_cfg = {"auxiliary": {"mcp": {"auto_reload_on_config_change": False}}}
         with patch("hermes_cli.config.get_config_path", return_value=cfg_file), \
              patch("hermes_cli.config.load_config", return_value=mocked_cfg):
             obj._check_config_mcp_changes()
@@ -136,3 +142,33 @@ class TestMCPConfigWatch:
         assert "reload skipped" in out
         assert "/reload-mcp" in out
         assert "prompt cache" in out
+
+    def test_optout_path_is_auxiliary_mcp_not_top_level(self, tmp_path, capsys):
+        """Regression guard: the opt-out toggle lives under
+        ``auxiliary.mcp.auto_reload_on_config_change`` in DEFAULT_CONFIG,
+        NOT under a top-level ``mcp`` key.
+
+        A config that sets ONLY ``mcp.auto_reload_on_config_change: false``
+        (top-level, wrong path) must NOT disable the reload — otherwise the
+        watcher is reading the wrong key and the declared default never
+        takes effect at runtime.  This test pins the config-path contract
+        so a future regression to ``_cfg.get("mcp")`` is caught.
+        """
+        import yaml
+        obj, cfg_file = _make_cli(
+            tmp_path,
+            mcp_servers={},
+        )
+
+        cfg_file.write_text(yaml.dump({"mcp_servers": {"github": {"url": "https://mcp.github.com"}}}))
+        obj._config_mtime = 0.0
+
+        # Wrong shape: top-level "mcp" (not where DEFAULT_CONFIG puts the
+        # toggle).  The watcher must NOT honour this, so a reload is expected.
+        wrong_shape_cfg = {"mcp": {"auto_reload_on_config_change": False}}
+        with patch("hermes_cli.config.get_config_path", return_value=cfg_file), \
+             patch("hermes_cli.config.load_config", return_value=wrong_shape_cfg):
+            obj._check_config_mcp_changes()
+
+        # Reload happened because the wrong-path opt-out is ignored.
+        obj._reload_mcp.assert_called()

--- a/tests/cli/test_cli_mcp_config_watch.py
+++ b/tests/cli/test_cli_mcp_config_watch.py
@@ -106,17 +106,17 @@ class TestMCPConfigWatch:
         obj._reload_mcp.assert_not_called()
 
     def test_optout_disables_auto_reload(self, tmp_path, capsys):
-        """When auxiliary.mcp.auto_reload_on_config_change is False, a changed
+        """When mcp.auto_reload_on_config_change is False, a changed
         mcp_servers section must NOT trigger an automatic reload — but the
         change is still detected and the user is told how to apply it.
 
         This protects the provider prompt cache: every automatic reload
         rebuilds the agent tool surface and invalidates cached prefixes.
 
-        The toggle lives under ``auxiliary.mcp`` in DEFAULT_CONFIG (alongside
-        the MCP aux-task provider settings), so the mocked config must mirror
-        that shape — a top-level ``mcp`` key does not exist in the loaded
-        config and the watcher resolves through ``auxiliary.mcp``.
+        The toggle is the top-level ``mcp:`` section in config.yaml, and the
+        watcher reads it from the same freshly-parsed file it diffs — so
+        flipping the toggle and editing mcp_servers in one edit behaves
+        correctly.
         """
         import yaml
         obj, cfg_file = _make_cli(
@@ -124,16 +124,14 @@ class TestMCPConfigWatch:
             mcp_servers={},
         )
 
-        # Simulate a changed mcp_servers section
-        cfg_file.write_text(yaml.dump({"mcp_servers": {"github": {"url": "https://mcp.github.com"}}}))
+        # Simulate a changed mcp_servers section with auto-reload opted out.
+        cfg_file.write_text(yaml.dump({
+            "mcp": {"auto_reload_on_config_change": False},
+            "mcp_servers": {"github": {"url": "https://mcp.github.com"}},
+        }))
         obj._config_mtime = 0.0  # force stale mtime
 
-        # Opt out via the loaded config (the watcher reads load_config(),
-        # not obj.config, so we patch the loader).  Match the real shape:
-        # DEFAULT_CONFIG["auxiliary"]["mcp"]["auto_reload_on_config_change"].
-        mocked_cfg = {"auxiliary": {"mcp": {"auto_reload_on_config_change": False}}}
-        with patch("hermes_cli.config.get_config_path", return_value=cfg_file), \
-             patch("hermes_cli.config.load_config", return_value=mocked_cfg):
+        with patch("hermes_cli.config.get_config_path", return_value=cfg_file):
             obj._check_config_mcp_changes()
 
         obj._reload_mcp.assert_not_called()
@@ -143,32 +141,95 @@ class TestMCPConfigWatch:
         assert "/reload-mcp" in out
         assert "prompt cache" in out
 
-    def test_optout_path_is_auxiliary_mcp_not_top_level(self, tmp_path, capsys):
-        """Regression guard: the opt-out toggle lives under
-        ``auxiliary.mcp.auto_reload_on_config_change`` in DEFAULT_CONFIG,
-        NOT under a top-level ``mcp`` key.
+    def test_optout_updates_snapshot_so_reload_mcp_applies_cleanly(self, tmp_path):
+        """After an opted-out change, the watcher must not re-notify every
+        tick: the snapshot is updated so the same content compares equal on
+        the next pass."""
+        import yaml
+        obj, cfg_file = _make_cli(tmp_path, mcp_servers={})
 
-        A config that sets ONLY ``mcp.auto_reload_on_config_change: false``
-        (top-level, wrong path) must NOT disable the reload — otherwise the
-        watcher is reading the wrong key and the declared default never
-        takes effect at runtime.  This test pins the config-path contract
-        so a future regression to ``_cfg.get("mcp")`` is caught.
-        """
+        cfg_file.write_text(yaml.dump({
+            "mcp": {"auto_reload_on_config_change": False},
+            "mcp_servers": {"github": {"url": "https://mcp.github.com"}},
+        }))
+        obj._config_mtime = 0.0
+
+        with patch("hermes_cli.config.get_config_path", return_value=cfg_file):
+            obj._check_config_mcp_changes()
+            # Second pass: same file content, new mtime — no reload, no change.
+            obj._last_config_check = 0.0
+            obj._config_mtime = 0.0
+            obj._check_config_mcp_changes()
+
+        obj._reload_mcp.assert_not_called()
+        assert obj._config_mcp_servers == {"github": {"url": "https://mcp.github.com"}}
+
+    def test_optout_path_is_top_level_mcp_not_auxiliary(self, tmp_path):
+        """Regression guard: the opt-out toggle is the top-level
+        ``mcp.auto_reload_on_config_change`` key, NOT ``auxiliary.mcp``
+        (which holds side-LLM task provider settings).
+
+        A config that sets ONLY ``auxiliary.mcp.auto_reload_on_config_change:
+        false`` must NOT disable the reload."""
         import yaml
         obj, cfg_file = _make_cli(
             tmp_path,
             mcp_servers={},
         )
 
-        cfg_file.write_text(yaml.dump({"mcp_servers": {"github": {"url": "https://mcp.github.com"}}}))
+        cfg_file.write_text(yaml.dump({
+            "auxiliary": {"mcp": {"auto_reload_on_config_change": False}},
+            "mcp_servers": {"github": {"url": "https://mcp.github.com"}},
+        }))
         obj._config_mtime = 0.0
 
-        # Wrong shape: top-level "mcp" (not where DEFAULT_CONFIG puts the
-        # toggle).  The watcher must NOT honour this, so a reload is expected.
-        wrong_shape_cfg = {"mcp": {"auto_reload_on_config_change": False}}
-        with patch("hermes_cli.config.get_config_path", return_value=cfg_file), \
-             patch("hermes_cli.config.load_config", return_value=wrong_shape_cfg):
+        with patch("hermes_cli.config.get_config_path", return_value=cfg_file):
             obj._check_config_mcp_changes()
 
-        # Reload happened because the wrong-path opt-out is ignored.
+        # Reload happened because the aux-task path is not the toggle.
         obj._reload_mcp.assert_called()
+
+    def test_env_var_templates_do_not_false_positive_on_unrelated_saves(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Regression for the '/reasoning triggers MCP reload' bug (#55701).
+
+        Init snapshots mcp_servers from the loaded config, which has been
+        through _expand_env_vars() — so ``${MCP_GH_API_KEY}`` is stored
+        expanded.  The watcher re-parses the RAW yaml.  Without expanding the
+        watcher side too, the comparison is always unequal whenever any
+        template is in use, so EVERY config.yaml rewrite (e.g.
+        save_config_value('agent.reasoning_effort', ...) from /reasoning)
+        fired a full MCP reconnect.
+        """
+        import yaml
+        monkeypatch.setenv("MCP_GH_API_KEY", "sekrit-token")
+
+        raw_servers = {
+            "github": {
+                "url": "https://mcp.github.com",
+                "headers": {"Authorization": "Bearer ${MCP_GH_API_KEY}"},
+            }
+        }
+        expanded_servers = {
+            "github": {
+                "url": "https://mcp.github.com",
+                "headers": {"Authorization": "Bearer sekrit-token"},
+            }
+        }
+        # Init snapshot holds the EXPANDED form (as load_cli_config produces).
+        obj, cfg_file = _make_cli(tmp_path, mcp_servers=expanded_servers)
+
+        # Unrelated-key save: mcp_servers content identical (raw templates),
+        # only reasoning_effort changed — mtime moves.
+        cfg_file.write_text(yaml.dump({
+            "agent": {"reasoning_effort": "high"},
+            "mcp_servers": raw_servers,
+        }))
+        obj._config_mtime = 0.0
+
+        with patch("hermes_cli.config.get_config_path", return_value=cfg_file):
+            obj._check_config_mcp_changes()
+
+        obj._reload_mcp.assert_not_called()
+        assert "MCP server config changed" not in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Fixes the CLI MCP config watcher firing a full MCP reconnect (and prompt-cache invalidation) on **every** config.yaml save — including `/reasoning <level>` — and adds an opt-out for the automatic reload. Salvages #55701 (@OYLFLMH) and #67449 (@TurgutKural) onto current main.

## Root cause (the /reasoning trigger)

`_check_config_mcp_changes()` compared `mcp_servers` from two inconsistent representations:

- **Init snapshot**: `self.config.get("mcp_servers")` — from `load_cli_config()`, which runs `_expand_env_vars()` → `${MCP_X_API_KEY}` stored **expanded**
- **Watcher**: `yaml.safe_load(config.yaml)` → **raw** `${VAR}` templates

With any templated server config (every bearer-auth MCP server), the comparison is permanently unequal — so any `save_config_value()` rewrite (e.g. `/reasoning high` saving `agent.reasoning_effort`) moved the mtime and fired "MCP server config changed — reloading connections", reconnecting all servers and breaking the prompt cache.

## Changes

- **cli.py** (from #55701): watcher expands `${VAR}` templates before comparing, so both sides use the same representation. Real add/remove still reloads.
- **cli.py + hermes_cli/config.py** (from #67449 + follow-up): new `mcp.auto_reload_on_config_change` toggle (default `true`, top-level `mcp:` runtime section — NOT `auxiliary.mcp`, which is the side-LLM task provider block). When `false`, the change is still detected and the user is told to apply it deliberately via `/reload-mcp`, with an explicit cache-cost warning. Toggle is read from the same freshly-parsed YAML the watcher diffs — no extra `load_config()` per tick.
- **tests/cli/test_cli_mcp_config_watch.py**: 4 new tests — opt-out behavior, snapshot stability (no re-notify loop), toggle-path regression guard (aux path must NOT work), and the `${VAR}`-template false-positive regression (the /reasoning scenario).

## Validation

| | Before | After |
|---|---|---|
| `/reasoning high` with templated MCP servers | full MCP reconnect + cache break | no reload |
| Real mcp_servers change, default config | reload | reload (unchanged) |
| Real change with `mcp.auto_reload_on_config_change: false` | reload | notification + `/reload-mcp` guidance |

- `scripts/run_tests.sh tests/cli/test_cli_mcp_config_watch.py tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_mcp_startup.py` — all green
- E2E with real temp `HERMES_HOME` + real config.yaml writes: default merge, doctor accepts top-level `mcp:`, unrelated-save no-reload, real-change reload, opt-out notification — all pass

Credits: @OYLFLMH (#55701, earliest fix for the false-positive), @TurgutKural (#67449, opt-out toggle). Both commits cherry-picked with authorship preserved.

## Infographic

![mcp-config-watcher-cache-safe](https://v3b.fal.media/files/b/0aa2fa43/g1xEoIRpYfC-aQ4OZkY7g_y5tzAvSX.png)
