### PR TITLE
feat(desktop): collapsible provider groups in model picker (salvages #64690)

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -3,8 +3,8 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { DropdownMenu, DropdownMenuContent } from '@/components/ui/dropdown-menu'
-import { $activeSessionId, $currentModel, $currentProvider } from '@/store/session'
 import { $collapsedProviders, toggleCollapsedProvider } from '@/store/provider-collapse'
+import { $activeSessionId, $currentModel, $currentProvider } from '@/store/session'
 
 import { ModelMenuPanel } from './model-menu-panel'
 

--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -1,9 +1,10 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, fireEvent, render } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { DropdownMenu, DropdownMenuContent } from '@/components/ui/dropdown-menu'
 import { $activeSessionId, $currentModel, $currentProvider } from '@/store/session'
+import { $collapsedProviders } from '@/store/provider-collapse'
 
 import { ModelMenuPanel } from './model-menu-panel'
 
@@ -26,11 +27,26 @@ vi.mock('@/hermes', () => ({
 // REST config.
 const MOA_PROVIDER = { models: ['default', 'BeastMode'], name: 'Mixture of Agents', slug: 'moa' }
 
+const DEEPSEEK_PROVIDER = {
+  models: ['deepseek-v4-pro', 'deepseek-chat', 'deepseek-reasoner'],
+  name: 'DeepSeek',
+  slug: 'deepseek'
+}
+
+const GOOGLE_PROVIDER = {
+  models: ['gemini-3.1-pro', 'gemini-2.5-flash', 'gemini-2.5-pro'],
+  name: 'Google',
+  slug: 'google'
+}
+
+const MOCK_PROVIDERS = [DEEPSEEK_PROVIDER, GOOGLE_PROVIDER, MOA_PROVIDER]
+
 beforeEach(() => {
   $activeSessionId.set('runtime-1')
   $currentModel.set('')
   $currentProvider.set('')
-  getGlobalModelOptions.mockResolvedValue({ providers: [MOA_PROVIDER] })
+  $collapsedProviders.set([])
+  getGlobalModelOptions.mockResolvedValue({ providers: MOCK_PROVIDERS })
 })
 
 afterEach(() => {
@@ -105,5 +121,80 @@ describe('ModelMenuPanel MoA presets', () => {
     // Pre-session picks are UI state shipped on the next session.create — the
     // row must not be disabled and must still route through onSelectModel.
     expect(onSelectModel).toHaveBeenCalledWith({ model: 'BeastMode', provider: 'moa', sessionId: null })
+  })
+})
+
+describe('ModelMenuPanel provider collapse', () => {
+  it('shows all provider models by default (none collapsed)', async () => {
+    const { content } = renderPanel()
+
+    await content.findByText('DeepSeek')
+    expect(content.queryByText('Deepseek V4 Pro')).not.toBeNull()
+    expect(content.queryByText('Deepseek Chat')).not.toBeNull()
+  })
+
+  it('collapses provider models when header is clicked', async () => {
+    const { content } = renderPanel()
+
+    const header = await content.findByText('DeepSeek')
+    fireEvent.click(header)
+
+    // Models should disappear but header stays
+    expect(content.queryByText('Deepseek V4 Pro')).toBeNull()
+    expect(content.queryByText('DeepSeek')).not.toBeNull()
+  })
+
+  it('expands provider models when header is clicked again', async () => {
+    const { content } = renderPanel()
+
+    const header = await content.findByText('DeepSeek')
+    // Collapse
+    fireEvent.click(header)
+    expect(content.queryByText('Deepseek V4 Pro')).toBeNull()
+    // Expand
+    fireEvent.click(header)
+    await vi.waitFor(() => {
+      expect(content.queryByText('Deepseek V4 Pro')).not.toBeNull()
+    })
+  })
+
+  it('auto-expands the active provider even when collapsed', async () => {
+    $currentProvider.set('deepseek')
+    $currentModel.set('deepseek-v4-pro')
+    const { content } = renderPanel()
+
+    const header = await content.findByText('DeepSeek')
+    fireEvent.click(header)
+
+    // Should still show models because it's the active provider
+    expect(content.queryByText('Deepseek V4 Pro')).not.toBeNull()
+  })
+
+  it('bypasses collapse when search is active', async () => {
+    const { content } = renderPanel()
+
+    const header = await content.findByText('DeepSeek')
+    fireEvent.click(header)
+    expect(content.queryByText('Deepseek V4 Pro')).toBeNull()
+
+    // Type in the search bar (auto-focused by DropdownMenuSearch)
+    const input = screen.getByRole('textbox', { name: 'Search models' })
+    expect(input).not.toBeNull()
+    fireEvent.change(input, { target: { value: 'deepseek' } })
+
+    // Should show models — search bypasses collapse
+    await vi.waitFor(() => {
+      expect(content.queryByText('Deepseek V4 Pro')).not.toBeNull()
+    })
+  })
+
+  it('toggles collapse via keyboard Enter on header', async () => {
+    const { content } = renderPanel()
+
+    const header = await content.findByText('DeepSeek')
+    // Radix DropdownMenuItem fires onSelect on Enter from the onKeyDown handler
+    fireEvent.keyDown(header.closest('[role="menuitem"]') ?? header, { key: 'Enter' })
+
+    expect(content.queryByText('Deepseek V4 Pro')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 
 import { DropdownMenu, DropdownMenuContent } from '@/components/ui/dropdown-menu'
 import { $activeSessionId, $currentModel, $currentProvider } from '@/store/session'
-import { $collapsedProviders } from '@/store/provider-collapse'
+import { $collapsedProviders, toggleCollapsedProvider } from '@/store/provider-collapse'
 
 import { ModelMenuPanel } from './model-menu-panel'
 
@@ -196,5 +196,56 @@ describe('ModelMenuPanel provider collapse', () => {
     fireEvent.keyDown(header.closest('[role="menuitem"]') ?? header, { key: 'Enter' })
 
     expect(content.queryByText('Deepseek V4 Pro')).toBeNull()
+  })
+
+  // The collapsed-providers set is a global presentation preference
+  // (`hermes.desktop.collapsed-providers`), but the catalog the picker renders
+  // is profile-scoped (`getGlobalModelOptions` routes through
+  // `profileScoped()`). Pruning the global set against only the active catalog
+  // would silently delete a user's collapse preference on every profile switch
+  // whose configured providers don't include the slug — the bug the maintainer
+  // flagged. The set must survive catalog changes; if the same provider shows
+  // up again later, the previous collapse is preserved.
+  it('preserves the collapsed set across a profile switch whose catalog lacks the slug', async () => {
+    toggleCollapsedProvider('deepseek')
+    toggleCollapsedProvider('google')
+    expect($collapsedProviders.get()).toEqual(['deepseek', 'google'])
+
+    // Profile A: both providers present, render + unmount.
+    getGlobalModelOptions.mockResolvedValueOnce({ providers: MOCK_PROVIDERS })
+    const a = renderPanel()
+    await a.content.findByText('DeepSeek')
+    a.content.unmount()
+
+    // Profile B: google is not in the catalog (simulates a profile whose
+    // configured providers differ). The previously-collapsed 'google' slug
+    // must survive — pruning it would lose state across a profile switch.
+    getGlobalModelOptions.mockResolvedValueOnce({ providers: [DEEPSEEK_PROVIDER, MOA_PROVIDER] })
+    const b = renderPanel()
+    await b.content.findByText('DeepSeek')
+
+    expect($collapsedProviders.get()).toEqual(['deepseek', 'google'])
+  })
+
+  it('preserves the collapsed set when Refresh Models drops a provider', async () => {
+    toggleCollapsedProvider('deepseek')
+    toggleCollapsedProvider('google')
+
+    // First load: both providers present.
+    getGlobalModelOptions.mockResolvedValueOnce({ providers: MOCK_PROVIDERS })
+    const a = renderPanel()
+    await a.content.findByText('DeepSeek')
+    a.content.unmount()
+
+    // Refresh Models returns a catalog that drops google (revoked key,
+    // plugin disabled, backend policy change). 'google' must survive — the
+    // user explicitly collapsed it, and the global set is not tied to any
+    // single refresh.
+    getGlobalModelOptions.mockResolvedValueOnce({ providers: [DEEPSEEK_PROVIDER, MOA_PROVIDER] })
+    const b = renderPanel()
+    await b.content.findByText('DeepSeek')
+
+    expect($collapsedProviders.get()).toContain('google')
+    expect($collapsedProviders.get()).toContain('deepseek')
   })
 })

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -18,6 +18,7 @@ import {
 import { Skeleton } from '@/components/ui/skeleton'
 import type { HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { ChevronDown, ChevronRight } from '@/lib/icons'
 import { requestModelOptions } from '@/lib/model-options'
 import {
   currentPickerSelection,
@@ -27,7 +28,6 @@ import {
 } from '@/lib/model-status-label'
 import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
-import { ChevronDown, ChevronRight } from '@/lib/icons'
 import { $modelPresets, applyModelPreset, modelPresetKey } from '@/store/model-presets'
 import {
   $visibleModels,
@@ -245,6 +245,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
         <div className="max-h-[max(150px,30dvh)] overflow-y-auto py-0.5">
           {groups.map(group => {
             const slug = group.provider.slug
+
             // Collapsed when stored + no active search + not the current provider.
             const collapsed =
               collapsedProviders.includes(slug) && !search && slug !== optionsProvider

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { createContext, useContext, useMemo, useState } from 'react'
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
 
 import { useSessionView } from '@/app/chat/session-view'
 import { Codicon } from '@/components/ui/codicon'
@@ -27,6 +27,7 @@ import {
 } from '@/lib/model-status-label'
 import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
+import { ChevronDown, ChevronRight } from '@/lib/icons'
 import { $modelPresets, applyModelPreset, modelPresetKey } from '@/store/model-presets'
 import {
   $visibleModels,
@@ -37,6 +38,7 @@ import {
   modelVisibilityKey,
   setModelVisibilityOpen
 } from '@/store/model-visibility'
+import { $collapsedProviders, pruneStaleCollapsed, toggleCollapsedProvider } from '@/store/provider-collapse'
 import type { ModelOptionProvider, ModelOptionsResponse } from '@/types/hermes'
 
 import { ModelEditSubmenu, resolveFastControl } from './model-edit-submenu'
@@ -82,6 +84,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
   const currentReasoningEffort = useStore(view.$reasoningEffort)
   const modelPresets = useStore($modelPresets)
   const visibleModels = useStore($visibleModels)
+  const collapsedProviders = useStore($collapsedProviders)
 
   const modelOptions = useQuery({
     queryKey: ['model-options', activeSessionId || 'global'],
@@ -119,6 +122,14 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
     () => providers?.filter(provider => provider.slug.toLowerCase() !== 'moa') ?? [],
     [providers]
   )
+
+  // Drop stale collapsed provider slugs when the provider list changes
+  // (e.g. after Refresh Models, plugin install/uninstall).
+  useEffect(() => {
+    if (pickerProviders.length > 0) {
+      pruneStaleCollapsed(pickerProviders.map(p => p.slug))
+    }
+  }, [pickerProviders])
 
   const effectiveVisibleModels = useMemo(
     () => effectiveVisibleKeys(visibleModels, pickerProviders),
@@ -240,10 +251,33 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
         </DropdownMenuItem>
       ) : (
         <div className="max-h-[max(150px,30dvh)] overflow-y-auto py-0.5">
-          {groups.map(group => (
-            <DropdownMenuGroup className="py-0.5" key={group.provider.slug}>
-              <DropdownMenuLabel className={dropdownMenuSectionLabel}>{group.provider.name}</DropdownMenuLabel>
-              {group.families.map(family => {
+          {groups.map(group => {
+            const slug = group.provider.slug
+            // Collapsed when stored + no active search + not the current provider.
+            const collapsed =
+              collapsedProviders.includes(slug) && !search && slug !== optionsProvider
+
+            return (
+              <DropdownMenuGroup className="py-0.5" key={slug}>
+                <DropdownMenuItem
+                  className={cn(
+                    dropdownMenuSectionLabel,
+                    'cursor-pointer hover:bg-(--ui-control-active-background)'
+                  )}
+                  onSelect={event => {
+                    event.preventDefault()
+                    toggleCollapsedProvider(slug)
+                  }}
+                  textValue=""
+                >
+                  {collapsed ?
+                    <ChevronRight className="size-2.5 shrink-0" /> :
+                    <ChevronDown className="size-2.5 shrink-0" />
+                  }
+                  {group.provider.name}
+                </DropdownMenuItem>
+                {!collapsed &&
+                  group.families.map(family => {
                 // The active id may be the base or its -fast sibling; either
                 // way this one family row represents both.
                 const activeId =
@@ -328,7 +362,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
                 )
               })}
             </DropdownMenuGroup>
-          ))}
+          )})}
         </div>
       )}
 

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import { createContext, useContext, useMemo, useState } from 'react'
 
 import { useSessionView } from '@/app/chat/session-view'
 import { Codicon } from '@/components/ui/codicon'
@@ -38,7 +38,7 @@ import {
   modelVisibilityKey,
   setModelVisibilityOpen
 } from '@/store/model-visibility'
-import { $collapsedProviders, pruneStaleCollapsed, toggleCollapsedProvider } from '@/store/provider-collapse'
+import { $collapsedProviders, toggleCollapsedProvider } from '@/store/provider-collapse'
 import type { ModelOptionProvider, ModelOptionsResponse } from '@/types/hermes'
 
 import { ModelEditSubmenu, resolveFastControl } from './model-edit-submenu'
@@ -122,14 +122,6 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
     () => providers?.filter(provider => provider.slug.toLowerCase() !== 'moa') ?? [],
     [providers]
   )
-
-  // Drop stale collapsed provider slugs when the provider list changes
-  // (e.g. after Refresh Models, plugin install/uninstall).
-  useEffect(() => {
-    if (pickerProviders.length > 0) {
-      pruneStaleCollapsed(pickerProviders.map(p => p.slug))
-    }
-  }, [pickerProviders])
 
   const effectiveVisibleModels = useMemo(
     () => effectiveVisibleKeys(visibleModels, pickerProviders),

--- a/apps/desktop/src/store/provider-collapse.ts
+++ b/apps/desktop/src/store/provider-collapse.ts
@@ -1,0 +1,34 @@
+import { Codecs, persistentAtom } from '@/lib/persisted'
+
+const STORAGE_KEY = 'hermes.desktop.collapsed-providers'
+
+/** Set of provider slugs whose model groups are currently collapsed in the
+ *  model picker dropdown. Persisted to localStorage globally — this is a
+ *  presentation-layer preference, not a per-profile setting. */
+export const $collapsedProviders = persistentAtom<string[]>(
+  STORAGE_KEY,
+  [],
+  Codecs.stringArray
+)
+
+/** Toggle a provider slug in/out of the collapsed set. */
+export function toggleCollapsedProvider(slug: string): void {
+  const current = $collapsedProviders.get()
+  $collapsedProviders.set(
+    current.includes(slug)
+      ? current.filter(s => s !== slug)
+      : [...current, slug]
+  )
+}
+
+/** Remove slugs from the collapsed set that no longer match any current
+ *  provider. Call this after provider list changes (e.g. Refresh Models,
+ *  plugin install/uninstall) to prevent unbounded growth. */
+export function pruneStaleCollapsed(slugs: string[]): void {
+  const valid = new Set(slugs)
+  const next = $collapsedProviders.get().filter(s => valid.has(s))
+
+  if (next.length !== $collapsedProviders.get().length) {
+    $collapsedProviders.set(next)
+  }
+}

--- a/apps/desktop/src/store/provider-collapse.ts
+++ b/apps/desktop/src/store/provider-collapse.ts
@@ -4,7 +4,21 @@ const STORAGE_KEY = 'hermes.desktop.collapsed-providers'
 
 /** Set of provider slugs whose model groups are currently collapsed in the
  *  model picker dropdown. Persisted to localStorage globally — this is a
- *  presentation-layer preference, not a per-profile setting. */
+ *  presentation-layer preference, not a per-profile setting.
+ *
+ *  We deliberately do NOT prune this set when the active provider catalog
+ *  changes (e.g. profile switch, Refresh Models, API key revoked). The catalog
+ *  the picker renders is profile-scoped (`getGlobalModelOptions` routes through
+ *  `profileScoped()`), so pruning against only the active catalog would delete
+ *  a user's collapse preference every time they switch to a profile whose
+ *  configured providers don't include it — silently losing state across what
+ *  is otherwise a pure presentational toggle.
+ *
+ *  Provider slugs come from a small bounded configured set (not user input),
+ *  so dead entries in the array cost a few bytes and have no observable effect:
+ *  the render loop only visits providers present in the active `groups`, and
+ *  `collapsedProviders.includes(slug)` against an absent slug is a no-op.
+ */
 export const $collapsedProviders = persistentAtom<string[]>(
   STORAGE_KEY,
   [],
@@ -19,16 +33,4 @@ export function toggleCollapsedProvider(slug: string): void {
       ? current.filter(s => s !== slug)
       : [...current, slug]
   )
-}
-
-/** Remove slugs from the collapsed set that no longer match any current
- *  provider. Call this after provider list changes (e.g. Refresh Models,
- *  plugin install/uninstall) to prevent unbounded growth. */
-export function pruneStaleCollapsed(slugs: string[]): void {
-  const valid = new Set(slugs)
-  const next = $collapsedProviders.get().filter(s => valid.has(s))
-
-  if (next.length !== $collapsedProviders.get().length) {
-    $collapsedProviders.set(next)
-  }
 }


### PR DESCRIPTION
## Summary
Provider headers in the desktop model picker are now clickable collapse/expand toggles, with the collapsed set persisted globally in localStorage. Salvages #64690 (@DavidMetcalfe, both commits) onto current main with authorship preserved.

## Changes
- `apps/desktop/src/store/provider-collapse.ts` (new): `$collapsedProviders` persistent atom (`hermes.desktop.collapsed-providers`) + `toggleCollapsedProvider()`. Deliberately never pruned against the active catalog — the catalog is profile-scoped, so pruning would delete a user's preference on every profile switch (the sweeper-flagged bug, fixed by the author's second commit)
- `apps/desktop/src/app/shell/model-menu-panel.tsx`: provider headers become clickable `DropdownMenuItem`s with chevron indicators; active provider never collapses; typing in search bypasses collapse; `textValue=""` keeps headers out of Radix typeahead
- Conflict resolution ours: main's `useSessionView` refactor (per-tile session binding) landed since the PR branched — kept main's structure, added only the collapse import/hook

## Validation
| Check | Result |
|---|---|
| `npx vitest run src/app/shell/model-menu-panel.test.tsx` | 12/12 pass (6 new collapse tests + 2 persistence-across-catalog-change tests) |
| `npm run typecheck` (tsc app + electron) | clean |
| `npx eslint` on touched files | clean |

## Infographic
![desktop-provider-collapse](https://v3b.fal.media/files/b/0aa2fa41/D4Wer83e2yuXjd34PQLZO_yjdrBJUd.png)
