### PR TITLE
fix(desktop): preserve new-chat and rail restore intent (#67859)

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
@@ -149,6 +149,40 @@ describe('useDesktopIntegrations', () => {
       expect(navigate).toHaveBeenCalledWith('/remembered-session', { replace: true })
     })
 
+    it('preserves remembered New Chat instead of restoring a stale session', () => {
+      window.localStorage.setItem('hermes.desktop.lastRoute.profile.default', '/')
+      window.localStorage.setItem('hermes.desktop.lastSessionId.profile.default', 'remembered-session')
+
+      const sessions = [session({ id: 'remembered-session', profile: 'default' })]
+
+      render({ profileReady: true, sessions })
+
+      expect(navigate).not.toHaveBeenCalled()
+      expect(window.localStorage.getItem('hermes.desktop.lastSessionId.profile.default')).toBeNull()
+    })
+
+    it('preserves remembered New Chat after waiting for sessions to load', () => {
+      window.localStorage.setItem('hermes.desktop.lastRoute.profile.default', '/')
+      window.localStorage.setItem('hermes.desktop.lastSessionId.profile.default', 'remembered-session')
+
+      const result = render({ profileReady: true, sessions: [] })
+
+      expect(navigate).not.toHaveBeenCalled()
+      expect(window.localStorage.getItem('hermes.desktop.lastSessionId.profile.default')).toBe('remembered-session')
+
+      result.rerender({
+        activeProfile: 'default',
+        locationPathname: '/',
+        profileReady: true,
+        resumeExhaustedSessionId: null,
+        routedSessionId: null,
+        sessions: [session({ id: 'remembered-session', profile: 'default' })]
+      })
+
+      expect(navigate).not.toHaveBeenCalled()
+      expect(window.localStorage.getItem('hermes.desktop.lastSessionId.profile.default')).toBeNull()
+    })
+
     it('waits for sessions before validating a remembered session route', () => {
       window.localStorage.setItem('hermes.desktop.lastRoute.profile.default', '/remembered-session')
 

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -107,9 +107,16 @@ export function useDesktopIntegrations({
 
         restoredRef.current = true
 
+        if (route === NEW_CHAT_ROUTE) {
+          if (last) {
+            setRememberedSessionId(null, activeProfile)
+          }
+
+          return
+        }
+
         if (
           route &&
-          route !== NEW_CHAT_ROUTE &&
           !isOverlayView(appViewForPath(route)) &&
           (!routeSession || sessionBelongsToProfile(sessions, routeSession, activeProfile))
         ) {


### PR DESCRIPTION
Closes #67859

## What changed

- capture remembered desktop navigation before the initial `/` route can overwrite it
- treat a remembered New Chat route as authoritative instead of falling back to a stale session
- clear the remembered session when the user explicitly returns to New Chat
- restore a session-owned preview without leaving a user-collapsed right rail expanded
- preserve ordinary explicit preview behavior, so a deliberate preview open still reveals the rail

## Why

The startup effect could persist `/` before reading prior navigation, and `/` then fell through to the stale `lastSessionId`. Preview restoration also used the explicit-open path, whose synchronous controller listener expanded the right side even when the user had collapsed it before quitting.

## Verification

- RED proof before the reviewed production revision: **2 failed, 10 passed**
  - remembered `/` navigated to the stale session
  - restored preview changed the right-side state from closed to open
- focused + nearby regression suite: **33 passed**
- full desktop UI suite: **1,647 passed, 1 skipped, 1 unrelated order-sensitive failure**
- isolated rerun of that unrelated settings test file: **25/25 passed**
- renderer and Electron TypeScript typecheck: **passed**
- desktop ESLint: **passed**
- Prettier on all five changed files: **passed**
- `git diff --check`: **passed**
- branch is exactly **1 commit** ahead of current `upstream/main`

## Related PR audit

PR #67823 overlaps the remembered-navigation file but addresses profile ownership and boot/profile adoption. Its restore path still falls through from remembered `/` to the session, and it does not touch preview/right-rail restoration; it therefore does not cover #67859.

Auto-published by Moonsong via Path B automated pipeline.
