### PR TITLE
feat(compressor): inject git log as ground truth in compaction summaries

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -19,6 +19,7 @@ Improvements over v2:
 import hashlib
 import json
 import logging
+import os
 import sqlite3
 import re
 import time
@@ -2222,6 +2223,32 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         else:
             _temporal_anchoring_rule = ""
 
+        # Git ground truth: inject recent commit log so the summarizer can
+        # cross-reference claims about completed work against actual git history.
+        # Graceful fallback when not in a git repo or git is unavailable.
+        _git_ground_truth = ""
+        try:
+            import subprocess
+            _git_log = subprocess.run(
+                ["git", "log", "--oneline", "-10", "--no-decorate"],
+                capture_output=True, text=True, timeout=5,
+                cwd=os.getcwd(),
+            )
+            if _git_log.returncode == 0 and _git_log.stdout.strip():
+                _git_ground_truth = (
+                    "\nGIT GROUND TRUTH (recent commits — cross-reference claims "
+                    "about completed work against these):\n"
+                    f"{_git_log.stdout.rstrip()}\n"
+                    "When summarizing, check claims of 'committed', 'fixed', or "
+                    "'completed work' against the log above. If a commit matches "
+                    "the described work, note the abbreviated hash. If the log "
+                    "does NOT contain a matching commit, flag the claim as "
+                    "UNVERIFIED (the work may still be uncommitted locally).\n"
+                )
+        except Exception:
+            # git not available, not a repo, or timeout — skip gracefully
+            pass
+
         # Shared structured template (used by both paths).
         _template_sections = f"""{HISTORICAL_TASK_HEADING}
 [THE SINGLE MOST IMPORTANT FIELD. Capture the user's most recent unfulfilled
@@ -2296,6 +2323,7 @@ Be specific with file paths, commands, line numbers, and results.]
 
 Target ~{summary_budget} tokens. Be CONCRETE — include file paths, command outputs, error messages, line numbers, and specific values. Avoid vague descriptions like "made some changes" — say exactly what changed.
 {_temporal_anchoring_rule}
+{_git_ground_truth}
 Write only the summary body. Do not include any preamble or prefix."""
 
         if self._previous_summary:


### PR DESCRIPTION
## What does this PR do?

Injects the output of `git log --oneline -10 --no-decorate` into the LLM summarizer prompt during context compression, so the summarizer can cross-reference claims of completed work against actual commit history before writing the compaction summary.

The core compaction reliability problem is that LLM summarizers have no mechanism to distinguish "committed" work from "claimed" work — they read agent tool output that says "committed and pushed" and faithfully reproduce it as fact, even when no matching commit exists. This change gives the summarizer a verifiable ground-truth signal: the actual commit log.

When a matching commit exists, the summarizer is directed to note the abbreviated hash. When the log does NOT contain a matching commit, the summarizer flags the claim as UNVERIFIED (the work may still be uncommitted locally, which is valid — but the summary makes the distinction explicit).

The approach is minimal by design: a single `subprocess.run` call that produces an empty string when git is unavailable, the CWD is not a repo, or the command times out. The git ground truth variable sits adjacent to the existing `_temporal_anchoring_rule` in both first-compaction and iterative-update prompt templates.

## Related Issue

No issue filed. Identified operationally: 938-message session lost to compaction where the summary claimed "Phases 1-5 done" when only 1-3 were committed.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/context_compressor.py` — added `import os` (needed for `os.getcwd()`); added `_git_ground_truth` variable construction in `_generate_summary()`; injected `{_git_ground_truth}` into both the first-compaction and iterative-update prompt templates

## How to Test

1. Run a session inside a git repo until context compression triggers
2. Inspect the compaction summary — it should include a `GIT GROUND TRUTH` section listing recent commits
3. Claims in the summary that have matching commits should reference hashes
4. Claims without matching commits should be flagged as UNVERIFIED
5. Run the same outside a git repo — the summary should contain no git section (silent fallback)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: Debian 13 Trixie, Linux 7.0.7+deb13-amd64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [ ] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [ ] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — no UI component.