### PR TITLE
fix(tui): recover from spurious stdin EOF caused by child O_NONBLOCK flip

### DIFF
--- a/scripts/check_subprocess_stdin.py
+++ b/scripts/check_subprocess_stdin.py
@@ -38,13 +38,15 @@ TUI_CONTEXT_DIRS = [
 ]
 
 # User plugin roots — scanned at runtime if they exist.  Plugins load from
-# ~/.hermes/plugins/ and ./.hermes/plugins/ (hermes_cli/plugins.py:10-12),
-# but the guard only checked the bundled plugins/ dir, missing user-installed
-# code that spawns subprocesses (gap reported in #67639).
-USER_PLUGIN_DIRS = [
-    Path.home() / ".hermes" / "plugins",
-    Path.cwd() / ".hermes" / "plugins",
-]
+# ``get_hermes_home() / "plugins"`` (user) and ``./.hermes/plugins/`` (project,
+# gated behind ``HERMES_ENABLE_PROJECT_PLUGINS``) — see
+# ``hermes_cli/plugins.py:10-12``.  The guard only checked the bundled
+# ``plugins/`` dir, missing user-installed code that spawns subprocesses
+# (gap reported in #67639).
+#
+# Import is deferred to ``main()`` (after ``os.chdir(repo_root)``) because
+# this script runs as a standalone subprocess — ``hermes_constants`` isn't
+# on ``sys.path`` until the repo root is added.
 
 # subprocess and os APIs that inherit stdin by default when called without
 # an explicit stdin= argument.  The original regex only covered run/Popen
@@ -155,6 +157,11 @@ def main() -> int:
     repo_root = Path(__file__).resolve().parent.parent
     os.chdir(repo_root)
 
+    # Add repo root to sys.path so we can import hermes_constants (this script
+    # runs as a standalone subprocess, not as a module).
+    sys.path.insert(0, str(repo_root))
+    from hermes_constants import get_hermes_home
+
     all_violations = []
 
     for tui_dir in TUI_CONTEXT_DIRS:
@@ -178,11 +185,15 @@ def main() -> int:
             violations = find_subprocess_calls(content, rel)
             all_violations.extend(violations)
 
-    # Scan user plugin directories (Gap 1: guard missed ~/.hermes/plugins/
-    # and ./.hermes/plugins/, where user-installed plugins like ori/hooks.py
-    # can spawn subprocesses with inherited stdin — #67639).
+    # Scan user plugin directories (Gap 1: guard missed user-installed
+    # plugins in get_hermes_home()/plugins/ and project plugins in
+    # ./.hermes/plugins/, where code like ori/hooks.py can spawn
+    # subprocesses with inherited stdin — #67639).
+    plugin_roots: list[Path] = [get_hermes_home() / "plugins"]
+    if os.environ.get("HERMES_ENABLE_PROJECT_PLUGINS"):
+        plugin_roots.append(Path.cwd() / ".hermes" / "plugins")
     seen_roots: set[Path] = set()
-    for plugin_root in USER_PLUGIN_DIRS:
+    for plugin_root in plugin_roots:
         resolved = plugin_root.resolve()
         if resolved in seen_roots or not resolved.is_dir():
             continue

--- a/scripts/check_subprocess_stdin.py
+++ b/scripts/check_subprocess_stdin.py
@@ -37,6 +37,25 @@ TUI_CONTEXT_DIRS = [
     "tui_gateway/",
 ]
 
+# User plugin roots — scanned at runtime if they exist.  Plugins load from
+# ~/.hermes/plugins/ and ./.hermes/plugins/ (hermes_cli/plugins.py:10-12),
+# but the guard only checked the bundled plugins/ dir, missing user-installed
+# code that spawns subprocesses (gap reported in #67639).
+USER_PLUGIN_DIRS = [
+    Path.home() / ".hermes" / "plugins",
+    Path.cwd() / ".hermes" / "plugins",
+]
+
+# subprocess and os APIs that inherit stdin by default when called without
+# an explicit stdin= argument.  The original regex only covered run/Popen
+# (gap #1 in #67639); call, check_output, check_call, os.system, and
+# asyncio.create_subprocess_* all inherit fd 0 equally.
+_SUBPROCESS_PATTERNS = [
+    r"subprocess\.(run|Popen|call|check_output|check_call)\s*\([\"'a-zA-Z_\[\(]",
+    r"os\.system\s*\([\"'a-zA-Z_\[\(]",
+    r"asyncio\.create_subprocess_(exec|shell)\s*\([\"'a-zA-Z_\[\(]",
+]
+
 # Files with intentional stdin= override (e.g. input= creates a pipe).
 # Format: "filepath:line" or just "filepath" to skip the whole file.
 KNOWN_SAFE = {
@@ -64,16 +83,14 @@ SKIP_DIRS = {
 
 
 def find_subprocess_calls(content: str, filepath: str) -> list[dict]:
-    """Find all subprocess.run/Popen calls missing stdin= in content."""
+    """Find all subprocess/os/asyncio calls missing stdin= in content."""
     violations = []
     lines = content.split("\n")
 
     # Match only actual function calls — not comments, docstrings, or prose.
-    # The pattern requires an opening paren followed by an arg character
-    # (quote, bracket, letter, or closing paren for empty calls).
-    # This excludes ``subprocess.Popen(...)`` in docstrings and
-    # subprocess.run(...) in comments.
-    pattern = re.compile(r'subprocess\.(run|Popen)\s*\(["\'a-zA-Z_\[\(]')
+    # Multiple patterns cover subprocess.run/Popen/call/check_output/check_call,
+    # os.system, and asyncio.create_subprocess_exec/shell.
+    patterns = [re.compile(p) for p in _SUBPROCESS_PATTERNS]
 
     for i, line in enumerate(lines):
         # Skip comments.
@@ -85,7 +102,7 @@ def find_subprocess_calls(content: str, filepath: str) -> list[dict]:
         if "``subprocess" in line:
             continue
 
-        if not pattern.search(line):
+        if not any(p.search(line) for p in patterns):
             continue
 
         # Collect the full call (may span multiple lines).
@@ -158,6 +175,28 @@ def main() -> int:
                 continue
 
             content = py_file.read_text()
+            violations = find_subprocess_calls(content, rel)
+            all_violations.extend(violations)
+
+    # Scan user plugin directories (Gap 1: guard missed ~/.hermes/plugins/
+    # and ./.hermes/plugins/, where user-installed plugins like ori/hooks.py
+    # can spawn subprocesses with inherited stdin — #67639).
+    seen_roots: set[Path] = set()
+    for plugin_root in USER_PLUGIN_DIRS:
+        resolved = plugin_root.resolve()
+        if resolved in seen_roots or not resolved.is_dir():
+            continue
+        seen_roots.add(resolved)
+
+        for py_file in resolved.rglob("*.py"):
+            rel = str(py_file)
+            if py_file.name in ("conftest.py",) or "/tests/" in rel:
+                continue
+
+            try:
+                content = py_file.read_text()
+            except Exception:
+                continue
             violations = find_subprocess_calls(content, rel)
             all_violations.extend(violations)
 

--- a/tui_gateway/_stdin_recovery.py
+++ b/tui_gateway/_stdin_recovery.py
@@ -1,0 +1,151 @@
+"""Shared spurious stdin-EOF recovery for the TUI gateway entry point and slash worker.
+
+When a child process inherits fd 0 (stdin) and sets ``O_NONBLOCK``, the flag
+lands on the **shared open file description** — not just the child's descriptor.
+The gateway's next ``read()`` returns ``EAGAIN``, which CPython's buffered
+``TextIOWrapper`` converts to ``b''`` (apparent EOF), killing the gateway.
+
+This module provides:
+- :func:`diagnose_stdin_state` — forensic diagnostic (``O_NONBLOCK`` / ``SO_RCVTIMEO``)
+- :func:`handle_spurious_eof` — check whether an empty ``readline()`` is a genuine
+  peer-close or a spurious EOF, and recover if spurious.
+
+The recovery is **POSIX-only** (``fcntl``).  On Windows, ``O_NONBLOCK`` on a
+shared file description is not a concern, so the guard simply reports a
+genuine EOF and lets the caller exit.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+try:
+    import fcntl as _fcntl
+    _HAS_FCNTL = True
+except ImportError:
+    _fcntl = None  # type: ignore[assignment]
+    _HAS_FCNTL = False
+
+try:
+    import socket as _socket
+    _HAS_SOCKET = True
+except ImportError:
+    _socket = None  # type: ignore[assignment]
+    _HAS_SOCKET = False
+
+import struct
+
+
+# Rate-limit: at most this many spurious-EOF recoveries per 60-second window.
+# A child aggressively flipping ``O_NONBLOCK`` on the shared fd would otherwise
+# create a tight busy-loop burning CPU.  Exceeding the cap exits the process —
+# the parent (TUI / gateway) respawns it with fresh state, which is safer than
+# fighting forever.
+MAX_RECOVERIES_PER_MINUTE = 10
+
+
+def diagnose_stdin_state() -> str:
+    """Return a diagnostic string about stdin's current state.
+
+    Used for crash-log forensics when stdin iteration falls through.
+    Distinguishes genuine peer-close (flag clear) from spurious EOF
+    caused by a child setting ``O_NONBLOCK`` on the shared file description.
+    """
+    parts: list[str] = []
+    if _HAS_FCNTL and _fcntl is not None:
+        try:
+            flags = _fcntl.fcntl(0, _fcntl.F_GETFL)
+            parts.append(f"O_NONBLOCK={'1' if flags & os.O_NONBLOCK else '0'}")
+        except Exception as e:
+            parts.append(f"F_GETFL error: {e}")
+    else:
+        parts.append("O_NONBLOCK=n/a (no fcntl)")
+    # ``SO_RCVTIMEO`` is a socket option (not a file-status flag), equally
+    # shared on the open file description.  A child setting it via
+    # ``setsockopt`` launders into the same spurious-EOF path with
+    # ``O_NONBLOCK`` clear, so we report it alongside the flag.
+    if _HAS_SOCKET and _socket is not None:
+        try:
+            s = _socket.fromfd(0, _socket.AF_UNIX, _socket.SOCK_STREAM)
+            try:
+                tv = s.getsockopt(_socket.SOL_SOCKET, _socket.SO_RCVTIMEO)
+                parts.append(f"SO_RCVTIMEO={tv!r}")
+            finally:
+                # ``fromfd`` duped the fd; ``close`` releases the dup without
+                # touching the original fd 0.
+                s.close()
+        except Exception:
+            pass
+    return ", ".join(parts) if parts else "unknown"
+
+
+def handle_spurious_eof(
+    recovery_times: list[float],
+    log_fn: object,
+) -> bool:
+    """Check whether an empty ``readline()`` is spurious; recover if so.
+
+    Returns ``True`` if the caller should ``continue`` the read loop
+    (spurious EOF was recovered), ``False`` if it should ``break`` (genuine
+    peer-close or rate limit exceeded).
+
+    ``log_fn`` is called with a diagnostic string — ``_log_exit`` in
+    ``entry.py``, ``print(file=sys.stderr)`` in ``slash_worker.py``.
+    """
+    # Without ``fcntl`` (Windows) we can't check the flag, and the
+    # ``O_NONBLOCK`` shared-description issue is POSIX-specific anyway —
+    # treat it as a genuine EOF.
+    if not (_HAS_FCNTL and _fcntl is not None):
+        log_fn("stdin EOF (peer closed)")  # type: ignore[operator]
+        return False
+
+    try:
+        flags = _fcntl.fcntl(0, _fcntl.F_GETFL)
+        is_nonblock = bool(flags & os.O_NONBLOCK)
+    except Exception:
+        is_nonblock = False
+
+    if not is_nonblock:
+        # Genuine peer-close — no subprocess flag tampering detected.
+        log_fn("stdin EOF (peer closed)")  # type: ignore[operator]
+        return False
+
+    # Spurious EOF: a child set ``O_NONBLOCK`` (and/or ``SO_RCVTIMEO``) on
+    # the shared file description, laundered into ``b''`` / ``EAGAIN`` by
+    # CPython's buffered layer.  Restore blocking mode and resume.
+    now = time.time()
+    recovery_times.append(now)
+    recovery_times[:] = [t for t in recovery_times if t > now - 60]
+    if len(recovery_times) > MAX_RECOVERIES_PER_MINUTE:
+        log_fn(  # type: ignore[operator]
+            f"stdin spurious-EOF recovery rate exceeded "
+            f"({len(recovery_times)}/min, cap {MAX_RECOVERIES_PER_MINUTE})"
+        )
+        return False
+
+    diag = diagnose_stdin_state()
+    log_fn(f"stdin spurious EOF (subprocess O_NONBLOCK flip), recovering: {diag}")  # type: ignore[operator]
+
+    # Clear ``O_NONBLOCK`` on the shared file description.
+    os.set_blocking(0, True)
+
+    # Also clear ``SO_RCVTIMEO`` if it was set by a child on the shared
+    # description.  A non-zero timeout would cause the next ``readline()``
+    # to time out and return ``''`` again, looping until the rate limiter
+    # kicks in.  Clearing it restores fully blocking semantics.
+    if _HAS_SOCKET and _socket is not None:
+        try:
+            s = _socket.fromfd(0, _socket.AF_UNIX, _socket.SOCK_STREAM)
+            try:
+                # Zero timeval: tv_sec=0, tv_usec=0 (struct timeval on most platforms)
+                s.setsockopt(_socket.SOL_SOCKET, _socket.SO_RCVTIMEO, struct.pack("ll", 0, 0))
+            finally:
+                s.close()
+        except Exception:
+            pass
+
+    # ``_io.TextIOWrapper.readline`` returns an empty string on ``EAGAIN``
+    # but does NOT stick EOF; after restoring blocking, the next call will
+    # block until data arrives or the peer truly closes.
+    return True

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -599,7 +599,7 @@ class ComputeHost:
 
 def _rss_mb(pid: int) -> float:
     try:
-        out = subprocess.check_output(["ps", "-o", "rss=", "-p", str(pid)], text=True, stderr=subprocess.DEVNULL, timeout=2).strip()
+        out = subprocess.check_output(["ps", "-o", "rss=", "-p", str(pid)], text=True, stdin=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=2).strip()
         return int(out.splitlines()[-1].strip()) / 1024.0 if out else 0.0
     except Exception:
         return 0.0

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -10,13 +10,13 @@ import hermes_bootstrap
 
 hermes_bootstrap.harden_import_path()
 
-import fcntl
 import json
 import logging
 import signal
-import socket
 import time
 import traceback
+
+from tui_gateway._stdin_recovery import handle_spurious_eof
 
 from tui_gateway import server
 from tui_gateway.server import _CRASH_LOG, dispatch, resolve_skin, write_json
@@ -294,36 +294,6 @@ def join_mcp_discovery(timeout: float | None = None) -> bool:
 
 # Spurious stdin-EOF recovery tracker (shared open-file-description O_NONBLOCK flip).
 _recovery_times: list[float] = []
-_MAX_RECOVERIES_PER_MINUTE = 10
-
-
-def _diagnose_stdin_state() -> str:
-    """Return a diagnostic string about stdin's current state.
-
-    Used for crash-log forensics when stdin iteration falls through.
-    Distinguishes genuine peer-close (flag clear) from spurious EOF
-    caused by a child setting O_NONBLOCK on the shared file description.
-    """
-    parts: list[str] = []
-    try:
-        flags = fcntl.fcntl(0, fcntl.F_GETFL)
-        parts.append(f"O_NONBLOCK={'1' if flags & os.O_NONBLOCK else '0'}")
-    except Exception as e:
-        parts.append(f"F_GETFL error: {e}")
-    # SO_RCVTIMEO is a socket option (not a file-status flag), equally shared
-    # on the open file description. A child setting it via setsockopt launders
-    # into the same spurious-EOF path with O_NONBLOCK clear, so we report it
-    # alongside the flag.
-    try:
-        s = socket.fromfd(0, socket.AF_UNIX, socket.SOCK_STREAM)
-        try:
-            tv = s.getsockopt(socket.SOL_SOCKET, socket.SO_RCVTIMEO)
-            parts.append(f"SO_RCVTIMEO={tv}")
-        finally:
-            s.detach()
-    except Exception:
-        pass
-    return ", ".join(parts) if parts else "unknown"
 
 
 def main():
@@ -393,40 +363,10 @@ def main():
     while True:
         raw = sys.stdin.readline()
         if not raw:
-            # Stdin iteration fell through — check if spurious (O_NONBLOCK flip
-            # by a child on the shared open file description) or genuine EOF.
-            try:
-                flags = fcntl.fcntl(0, fcntl.F_GETFL)
-                is_nonblock = bool(flags & os.O_NONBLOCK)
-            except Exception:
-                is_nonblock = False
-
-            if not is_nonblock:
-                # Genuine peer-close — no subprocess flag tampering detected.
-                _log_exit("stdin EOF (peer closed)")
+            # Stdin fell through — check if spurious (O_NONBLOCK flip by a
+            # child on the shared open file description) or genuine EOF.
+            if not handle_spurious_eof(_recovery_times, _log_exit):
                 break
-
-            # Spurious EOF: a child set O_NONBLOCK (or SO_RCVTIMEO) on the
-            # shared file description, laundered into b''/EAGAIN by CPython's
-            # buffered layer. Restore blocking mode and resume.
-            now = time.time()
-            _recovery_times.append(now)
-            _recovery_times[:] = [t for t in _recovery_times if t > now - 60]
-            if len(_recovery_times) > _MAX_RECOVERIES_PER_MINUTE:
-                _log_exit(
-                    f"stdin spurious-EOF recovery rate exceeded "
-                    f"({len(_recovery_times)}/min, cap {_MAX_RECOVERIES_PER_MINUTE})"
-                )
-                break
-
-            diag = _diagnose_stdin_state()
-            _log_exit(
-                f"stdin spurious EOF (subprocess O_NONBLOCK flip), recovering: {diag}"
-            )
-            os.set_blocking(0, True)
-            # _io.TextIOWrapper readline returns empty string on EAGAIN but
-            # does NOT stick EOF; after restoring blocking, the next call
-            # will block until data arrives or the peer truly closes.
             continue
 
         line = raw.strip()

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -10,9 +10,11 @@ import hermes_bootstrap
 
 hermes_bootstrap.harden_import_path()
 
+import fcntl
 import json
 import logging
 import signal
+import socket
 import time
 import traceback
 
@@ -290,6 +292,40 @@ def join_mcp_discovery(timeout: float | None = None) -> bool:
     return entry_done and startup_done
 
 
+# Spurious stdin-EOF recovery tracker (shared open-file-description O_NONBLOCK flip).
+_recovery_times: list[float] = []
+_MAX_RECOVERIES_PER_MINUTE = 10
+
+
+def _diagnose_stdin_state() -> str:
+    """Return a diagnostic string about stdin's current state.
+
+    Used for crash-log forensics when stdin iteration falls through.
+    Distinguishes genuine peer-close (flag clear) from spurious EOF
+    caused by a child setting O_NONBLOCK on the shared file description.
+    """
+    parts: list[str] = []
+    try:
+        flags = fcntl.fcntl(0, fcntl.F_GETFL)
+        parts.append(f"O_NONBLOCK={'1' if flags & os.O_NONBLOCK else '0'}")
+    except Exception as e:
+        parts.append(f"F_GETFL error: {e}")
+    # SO_RCVTIMEO is a socket option (not a file-status flag), equally shared
+    # on the open file description. A child setting it via setsockopt launders
+    # into the same spurious-EOF path with O_NONBLOCK clear, so we report it
+    # alongside the flag.
+    try:
+        s = socket.fromfd(0, socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            tv = s.getsockopt(socket.SOL_SOCKET, socket.SO_RCVTIMEO)
+            parts.append(f"SO_RCVTIMEO={tv}")
+        finally:
+            s.detach()
+    except Exception:
+        pass
+    return ", ".join(parts) if parts else "unknown"
+
+
 def main():
     _install_sidecar_publisher()
 
@@ -354,7 +390,45 @@ def main():
         _log_exit("startup write failed (broken stdout pipe before first event)")
         sys.exit(0)
 
-    for raw in sys.stdin:
+    while True:
+        raw = sys.stdin.readline()
+        if not raw:
+            # Stdin iteration fell through — check if spurious (O_NONBLOCK flip
+            # by a child on the shared open file description) or genuine EOF.
+            try:
+                flags = fcntl.fcntl(0, fcntl.F_GETFL)
+                is_nonblock = bool(flags & os.O_NONBLOCK)
+            except Exception:
+                is_nonblock = False
+
+            if not is_nonblock:
+                # Genuine peer-close — no subprocess flag tampering detected.
+                _log_exit("stdin EOF (peer closed)")
+                break
+
+            # Spurious EOF: a child set O_NONBLOCK (or SO_RCVTIMEO) on the
+            # shared file description, laundered into b''/EAGAIN by CPython's
+            # buffered layer. Restore blocking mode and resume.
+            now = time.time()
+            _recovery_times.append(now)
+            _recovery_times[:] = [t for t in _recovery_times if t > now - 60]
+            if len(_recovery_times) > _MAX_RECOVERIES_PER_MINUTE:
+                _log_exit(
+                    f"stdin spurious-EOF recovery rate exceeded "
+                    f"({len(_recovery_times)}/min, cap {_MAX_RECOVERIES_PER_MINUTE})"
+                )
+                break
+
+            diag = _diagnose_stdin_state()
+            _log_exit(
+                f"stdin spurious EOF (subprocess O_NONBLOCK flip), recovering: {diag}"
+            )
+            os.set_blocking(0, True)
+            # _io.TextIOWrapper readline returns empty string on EAGAIN but
+            # does NOT stick EOF; after restoring blocking, the next call
+            # will block until data arrives or the peer truly closes.
+            continue
+
         line = raw.strip()
         if not line:
             continue
@@ -373,8 +447,6 @@ def main():
             if not write_json(resp):
                 _log_exit(f"response write failed for method={method!r} (broken stdout pipe)")
                 sys.exit(0)
-
-    _log_exit("stdin EOF (TUI closed the command pipe)")
 
 
 if __name__ == "__main__":

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -18,17 +18,16 @@ hermes_bootstrap.harden_import_path()
 
 import argparse
 import contextlib
-import fcntl
 import io
 import json
 import os
-import socket
 import sys
 import threading
 import time
 
 import cli as cli_mod
 from cli import HermesCLI
+from tui_gateway._stdin_recovery import handle_spurious_eof
 from rich.console import Console
 
 # Env-overridable so the integration test can drive sub-second timing.
@@ -146,60 +145,15 @@ def main():
     # issue as the gateway entry point — any child inheriting fd 0 can flip
     # the flag and launder EAGAIN into an apparent EOF).
     _sw_recovery_times: list[float] = []
-    _SW_MAX_RECOVERIES_PER_MINUTE = 10
 
-    def _sw_diagnose_stdin() -> str:
-        parts: list[str] = []
-        try:
-            flags = fcntl.fcntl(0, fcntl.F_GETFL)
-            parts.append(f"O_NONBLOCK={'1' if flags & os.O_NONBLOCK else '0'}")
-        except Exception as e:
-            parts.append(f"F_GETFL error: {e}")
-        try:
-            s = socket.fromfd(0, socket.AF_UNIX, socket.SOCK_STREAM)
-            try:
-                tv = s.getsockopt(socket.SOL_SOCKET, socket.SO_RCVTIMEO)
-                parts.append(f"SO_RCVTIMEO={tv}")
-            finally:
-                s.detach()
-        except Exception:
-            pass
-        return ", ".join(parts) if parts else "unknown"
+    def _sw_log(reason: str) -> None:
+        print(f"[slash-worker] {reason}", file=sys.stderr, flush=True)
 
     while True:
         raw = sys.stdin.readline()
         if not raw:
-            try:
-                flags = fcntl.fcntl(0, fcntl.F_GETFL)
-                is_nonblock = bool(flags & os.O_NONBLOCK)
-            except Exception:
-                is_nonblock = False
-
-            if not is_nonblock:
-                # Genuine peer-close
+            if not handle_spurious_eof(_sw_recovery_times, _sw_log):
                 break
-
-            # Spurious EOF — recover
-            now = time.time()
-            _sw_recovery_times.append(now)
-            _sw_recovery_times[:] = [t for t in _sw_recovery_times if t > now - 60]
-            if len(_sw_recovery_times) > _SW_MAX_RECOVERIES_PER_MINUTE:
-                print(
-                    f"[slash-worker] stdin spurious-EOF recovery rate exceeded "
-                    f"({len(_sw_recovery_times)}/min)",
-                    file=sys.stderr,
-                    flush=True,
-                )
-                break
-
-            diag = _sw_diagnose_stdin()
-            print(
-                f"[slash-worker] stdin spurious EOF (subprocess O_NONBLOCK flip), "
-                f"recovering: {diag}",
-                file=sys.stderr,
-                flush=True,
-            )
-            os.set_blocking(0, True)
             continue
 
         line = raw.strip()

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -18,9 +18,11 @@ hermes_bootstrap.harden_import_path()
 
 import argparse
 import contextlib
+import fcntl
 import io
 import json
 import os
+import socket
 import sys
 import threading
 import time
@@ -140,7 +142,66 @@ def main():
     with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
         cli = HermesCLI(model=args.model or None, compact=True, resume=args.session_key, verbose=False)
 
-    for raw in sys.stdin:
+    # Spurious stdin-EOF recovery (same O_NONBLOCK shared file-description
+    # issue as the gateway entry point — any child inheriting fd 0 can flip
+    # the flag and launder EAGAIN into an apparent EOF).
+    _sw_recovery_times: list[float] = []
+    _SW_MAX_RECOVERIES_PER_MINUTE = 10
+
+    def _sw_diagnose_stdin() -> str:
+        parts: list[str] = []
+        try:
+            flags = fcntl.fcntl(0, fcntl.F_GETFL)
+            parts.append(f"O_NONBLOCK={'1' if flags & os.O_NONBLOCK else '0'}")
+        except Exception as e:
+            parts.append(f"F_GETFL error: {e}")
+        try:
+            s = socket.fromfd(0, socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                tv = s.getsockopt(socket.SOL_SOCKET, socket.SO_RCVTIMEO)
+                parts.append(f"SO_RCVTIMEO={tv}")
+            finally:
+                s.detach()
+        except Exception:
+            pass
+        return ", ".join(parts) if parts else "unknown"
+
+    while True:
+        raw = sys.stdin.readline()
+        if not raw:
+            try:
+                flags = fcntl.fcntl(0, fcntl.F_GETFL)
+                is_nonblock = bool(flags & os.O_NONBLOCK)
+            except Exception:
+                is_nonblock = False
+
+            if not is_nonblock:
+                # Genuine peer-close
+                break
+
+            # Spurious EOF — recover
+            now = time.time()
+            _sw_recovery_times.append(now)
+            _sw_recovery_times[:] = [t for t in _sw_recovery_times if t > now - 60]
+            if len(_sw_recovery_times) > _SW_MAX_RECOVERIES_PER_MINUTE:
+                print(
+                    f"[slash-worker] stdin spurious-EOF recovery rate exceeded "
+                    f"({len(_sw_recovery_times)}/min)",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                break
+
+            diag = _sw_diagnose_stdin()
+            print(
+                f"[slash-worker] stdin spurious EOF (subprocess O_NONBLOCK flip), "
+                f"recovering: {diag}",
+                file=sys.stderr,
+                flush=True,
+            )
+            os.set_blocking(0, True)
+            continue
+
         line = raw.strip()
         if not line:
             continue


### PR DESCRIPTION
## Summary
TUI gateway recovers from spurious stdin EOF caused by child processes setting `O_NONBLOCK` on the shared open file description of fd 0, instead of crashing silently.

## Root cause
A subprocess inheriting fd 0 (stdin) can set `O_NONBLOCK`, which lands on the **shared open file description** — not just the child's descriptor. The gateway's next `read()` returns `EAGAIN`, which CPython's buffered `TextIOWrapper` converts to `b''` (apparent EOF), killing the gateway. The `for raw in sys.stdin:` iterator protocol sticks EOF permanently via `StopIteration`, making recovery impossible without switching to `readline()`.

## Changes
- **`tui_gateway/_stdin_recovery.py`** (new): Shared recovery utility — `handle_spurious_eof()` checks `O_NONBLOCK` flag, restores blocking mode, clears `SO_RCVTIMEO`, and rate-limits (10/min). `diagnose_stdin_state()` reports forensics. POSIX-only via `try: import fcntl` guard (Windows falls through to genuine EOF — the issue is POSIX-specific).
- **`tui_gateway/entry.py`**: `for raw in sys.stdin:` → `while True: readline()` + `handle_spurious_eof()`. Log message changed from `"TUI closed the command pipe"` (misleading) to `"stdin EOF (peer closed)"` / `"stdin spurious EOF (subprocess O_NONBLOCK flip), recovering: ..."`.
- **`tui_gateway/slash_worker.py`**: Same recovery loop, using shared utility.
- **`tui_gateway/compute_host.py`**: Added `stdin=subprocess.DEVNULL` to the `ps` `check_output` call (was missing).
- **`scripts/check_subprocess_stdin.py`**: Expanded scanner regex to cover `subprocess.call/check_output/check_call`, `os.system`, `asyncio.create_subprocess_*`. Added user plugin dir scanning via `get_hermes_home()` (profile-safe) and project plugins gated behind `HERMES_ENABLE_PROJECT_PLUGINS`.

## Follow-up fixes (on top of contributor commit)
1. **Windows regression**: Bare `import fcntl` at module level broke Windows import. Extracted to shared utility with `try/except ImportError` guard.
2. **fd leak**: `socket.fromfd()` + `s.detach()` leaked a duped fd per recovery. Changed to `s.close()`.
3. **Code duplication**: ~80 lines of recovery loop + diagnostic copy-pasted between entry.py and slash_worker.py. Extracted to `tui_gateway/_stdin_recovery.py`.
4. **Profile-unsafe path**: Scanner used `Path.home() / ".hermes"` instead of `get_hermes_home()`. Fixed to match `hermes_cli/plugins.py` canonical resolution.
5. **SO_RCVTIMEO not cleared**: Recovery only cleared `O_NONBLOCK` but not `SO_RCVTIMEO` (equally shared on the file description). Now clears both.

## Validation
| | Before | After |
|---|---|---|
| stdin guard tests | 3 passed | 3 passed |
| tui_gateway tests | 376 passed, 7 pre-existing failures | 376 passed, 7 pre-existing failures |
| Windows import | CRASH (`import fcntl`) | OK (guarded import) |
| fd leak per recovery | 1 fd leaked | 0 (s.close()) |
| Duplicated recovery code | ~80 lines × 2 files | shared utility |

Closes #67639
