### PR TITLE
fix(plugins): improve hook error logging with module name and traceback

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1919,10 +1919,13 @@ class PluginManager:
                     results.append(ret)
             except Exception as exc:
                 logger.warning(
-                    "Hook '%s' callback %s raised: %s",
+                    "Hook '%s' callback %s (module: %s) raised: %s",
                     hook_name,
                     getattr(cb, "__name__", repr(cb)),
+                    getattr(getattr(cb, "__module__", None), "__name__", None)
+                    or getattr(cb, "__module__", "unknown"),
                     exc,
+                    exc_info=True,
                 )
         return results
 


### PR DESCRIPTION
## What does this PR do?

Improves `PluginManager.invoke_hook()` error logging so debugging silent hook failures no longer requires reading the source code.

**Before:** `Hook 'post_llm_call' callback <lambda> raised: TypeError(...)`

**After:** `Hook 'post_llm_call' callback my_handler (module: my_plugin.helpers) raised: TypeError(...)` with full traceback in logs (via `exc_info=True`)

The old log message lacked two critical pieces of information: which plugin registered the failing callback, and where in the code the exception originated. For plugin authors debugging "my hook never fires" issues, this made it unnecessarily hard to determine which plugin's callback failed and what went wrong.

The fix is minimal: resolve `cb.__module__` and include it in the warning string (falling back to `"unknown"` when unavailable), and pass `exc_info=True` so Python's logging framework captures the full traceback. Lambdas sometimes lack a meaningful module attribute; even in that case the fallback produces more useful output than before.

## Related Issue

No issue filed. Identified operationally: multiple afternoons spent debugging hook registration failures that produced zero log signal.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/plugins.py` — `PluginManager.invoke_hook()`: added module name resolution (`getattr(cb, "__module__", "unknown")`) and `exc_info=True` to the `logger.warning()` call

## How to Test

1. Install a plugin whose hook callback raises an exception
2. Trigger the hook (e.g. `post_tool_call`)
3. Check the agent log — the warning should include the module name and a full traceback
4. Verify that other callbacks continue to execute normally (exception isolation is unchanged)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: Debian 13 Trixie, Linux 7.0.7+deb13-amd64

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [ ] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [ ] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — logging change only.