### PR TITLE
fix(telegram): serialize post-reconnect recovery

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1739,12 +1739,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
 
     def _schedule_polling_recovery(self, error: Exception, *, reason: str) -> None:
-        """Schedule polling recovery without failing gateway startup.
+        """Schedule exactly one polling-recovery task.
 
-        A Telegram bootstrap failure (deleteWebhook / initial start_polling)
-        caused by a transient network error should degrade only the Telegram
-        adapter: the gateway process stays alive and the existing reconnect
-        ladder (``_handle_polling_network_error``) recovers in the background.
+        Bootstrap failures, PTB callbacks, the persistent heartbeat, and delayed
+        post-reconnect probes can all observe the same outage. They must pass
+        through this shared guard; directly awaiting the recovery coroutine
+        bypasses ``_polling_error_task`` and permits concurrent stop/start cycles.
         """
         if self.has_fatal_error:
             return
@@ -2128,8 +2128,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 "[%s] Updater not running %ds after reconnect — treating as wedged",
                 self.name, HEARTBEAT_PROBE_DELAY,
             )
-            await self._handle_polling_network_error(
-                RuntimeError("Updater not running after reconnect heartbeat")
+            self._schedule_polling_recovery(
+                RuntimeError("Updater not running after reconnect heartbeat"),
+                reason="post-reconnect heartbeat",
             )
             return
 
@@ -2141,7 +2142,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 "[%s] Polling heartbeat probe failed %ds after reconnect: %s",
                 self.name, HEARTBEAT_PROBE_DELAY, probe_err,
             )
-            await self._handle_polling_network_error(probe_err)
+            self._schedule_polling_recovery(
+                probe_err,
+                reason="post-reconnect heartbeat",
+            )
 
     def _disarm_ptb_retry_loop(self) -> None:
         """Synchronously stop PTB's internal polling retry loop.

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -377,14 +377,14 @@ async def test_heartbeat_probe_reenters_ladder_when_updater_not_running():
     mock_app.bot.get_me = AsyncMock()
     adapter._app = mock_app
 
-    adapter._handle_polling_network_error = AsyncMock()
+    adapter._schedule_polling_recovery = MagicMock()
 
     with patch("asyncio.sleep", new_callable=AsyncMock):
         await adapter._verify_polling_after_reconnect()
 
     mock_app.bot.get_me.assert_not_called()
-    adapter._handle_polling_network_error.assert_awaited_once()
-    err = adapter._handle_polling_network_error.await_args.args[0]
+    adapter._schedule_polling_recovery.assert_called_once()
+    err = adapter._schedule_polling_recovery.call_args.args[0]
     assert isinstance(err, RuntimeError)
     assert "not running" in str(err).lower()
 
@@ -408,7 +408,7 @@ async def test_heartbeat_probe_reenters_ladder_when_get_me_times_out():
     mock_app.bot.get_me = AsyncMock(side_effect=hang_forever)
     adapter._app = mock_app
 
-    adapter._handle_polling_network_error = AsyncMock()
+    adapter._schedule_polling_recovery = MagicMock()
 
     async def fast_wait_for(coro, timeout):
         if asyncio.iscoroutine(coro):
@@ -419,7 +419,7 @@ async def test_heartbeat_probe_reenters_ladder_when_get_me_times_out():
         with patch("plugins.platforms.telegram.adapter.asyncio.wait_for", new=fast_wait_for):
             await adapter._verify_polling_after_reconnect()
 
-    adapter._handle_polling_network_error.assert_awaited_once()
+    adapter._schedule_polling_recovery.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -438,15 +438,56 @@ async def test_heartbeat_probe_reenters_ladder_on_get_me_network_error():
     mock_app.bot.get_me = AsyncMock(side_effect=ConnectionError("pool wedged"))
     adapter._app = mock_app
 
-    adapter._handle_polling_network_error = AsyncMock()
+    adapter._schedule_polling_recovery = MagicMock()
 
     with patch("asyncio.sleep", new_callable=AsyncMock):
         await adapter._verify_polling_after_reconnect()
 
-    adapter._handle_polling_network_error.assert_awaited_once()
+    adapter._schedule_polling_recovery.assert_called_once()
     assert isinstance(
-        adapter._handle_polling_network_error.await_args.args[0], ConnectionError
+        adapter._schedule_polling_recovery.call_args.args[0], ConnectionError
     )
+
+
+@pytest.mark.asyncio
+async def test_overlapping_post_reconnect_probes_schedule_one_recovery():
+    """Overlapping failed probes must collapse to one recovery task.
+
+    Successful reconnects can leave multiple delayed probes behind. A failed
+    probe must use `_polling_error_task` as the single-flight boundary rather
+    than calling the recovery coroutine directly.
+    """
+    adapter = _make_adapter()
+    mock_updater = MagicMock()
+    mock_updater.running = False
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    adapter._app = mock_app
+
+    recovery_started = asyncio.Event()
+    release_recovery = asyncio.Event()
+
+    async def blocked_recovery(_error):
+        recovery_started.set()
+        await release_recovery.wait()
+
+    adapter._handle_polling_network_error = AsyncMock(side_effect=blocked_recovery)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await asyncio.gather(
+            adapter._verify_polling_after_reconnect(),
+            adapter._verify_polling_after_reconnect(),
+        )
+
+    await recovery_started.wait()
+    recovery_task = adapter._polling_error_task
+    assert recovery_task is not None
+    assert recovery_task in adapter._background_tasks
+    assert adapter._send_path_degraded is True
+    adapter._handle_polling_network_error.assert_awaited_once()
+
+    release_recovery.set()
+    await recovery_task
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Routes failed deferred post-reconnect probes through the adapter's existing single-flight recovery helper instead of directly awaiting the reconnect coroutine.

`_verify_polling_after_reconnect()` runs after a successful reconnect. Before this change, its two failure branches (`updater.running == False` and a failed `bot.get_me()`) called `_handle_polling_network_error()` directly. That bypassed `_polling_error_task`, the coordination guard used by the PTB callback and persistent heartbeat.

During an outage, overlapping delayed probes could therefore race another recovery source into concurrent `stop() → drain → start_polling()` cycles for the same updater.

## Related Issue

Fixes #67912

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/telegram/adapter.py`
  - Route both post-reconnect probe failure paths through `_schedule_polling_recovery(..., reason="post-reconnect heartbeat")`.
  - Document that the helper is the shared recovery single-flight boundary.
- `tests/gateway/test_telegram_network_reconnect.py`
  - Update probe tests to assert scheduling through the shared guard.
  - Add a regression test that overlapping stopped-updater probes collapse to one recovery task.

## How to Test

```bash
venv/bin/python -m pytest \
  tests/gateway/test_telegram_network_reconnect.py \
  tests/gateway/test_telegram_pending_update_probe.py \
  tests/gateway/test_telegram_conflict.py \
  -q -o 'addopts='

venv/bin/python -m py_compile plugins/platforms/telegram/adapter.py
```

Result: `50 passed`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing issues and PRs for this failure mode.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass. (Focused affected suites passed; full suite not run.)
- [x] I've added regression coverage for this bug fix.
- [x] I've tested on macOS 15.7.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no public config or user-facing behavior changes.
- [x] `cli-config.yaml.example`: N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A.
- [x] Cross-platform impact considered: asyncio scheduling only; no OS-specific path.
- [x] Tool descriptions/schemas: N/A.
