### PR TITLE
fix(file_ops): keep native Windows paths for rg search (#67629)

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -494,6 +494,35 @@ class TestShellFileOpsHelpers:
             "C:/Users/alice/notes.txt"
         ) == "'/c/Users/alice/notes.txt'"
 
+    def test_escape_native_exe_arg_keeps_windows_drive_forward_slash(self, monkeypatch, file_ops):
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert file_ops._escape_native_exe_arg(r"D:\Ivo\ai-costs.json") == "'D:/Ivo/ai-costs.json'"
+        assert file_ops._escape_native_exe_arg("D:/Ivo/ai-costs.json") == "'D:/Ivo/ai-costs.json'"
+        assert file_ops._escape_native_exe_arg("/d/Ivo/ai-costs.json") == "'D:/Ivo/ai-costs.json'"
+
+    def test_search_with_rg_uses_native_windows_path(self, mock_env, monkeypatch):
+        """Absolute Windows paths must not be MSYS-rewritten for native rg (#67629)."""
+        import tools.environments.local as local_mod
+        from tools.file_operations import ShellFileOperations
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        ops = ShellFileOperations(mock_env)
+        ops._has_command = lambda cmd: cmd == "rg"
+        captured = {}
+
+        def _capture(command, cwd=None, timeout=None, stdin_data=None):
+            captured["cmd"] = command
+            from tools.file_operations import ExecuteResult
+            return ExecuteResult(stdout="", exit_code=1)
+
+        ops._exec = _capture
+        ops._search_with_rg("subscription", r"D:\Ivo\ai-costs.json", None, 10, 0, "content", 0)
+        assert "D:/Ivo/ai-costs.json" in captured["cmd"]
+        assert "/d/Ivo/ai-costs.json" not in captured["cmd"]
+
+
     def test_read_file_uses_bash_safe_windows_paths(self, mock_env, monkeypatch):
         import tools.environments.local as local_mod
 

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -498,9 +498,31 @@ class TestShellFileOpsHelpers:
         import tools.environments.local as local_mod
 
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        # Native drive rewrite only applies to the local backend.
+        monkeypatch.setattr(file_ops, "_is_local_backend", lambda: True)
         assert file_ops._escape_native_exe_arg(r"D:\Ivo\ai-costs.json") == "'D:/Ivo/ai-costs.json'"
         assert file_ops._escape_native_exe_arg("D:/Ivo/ai-costs.json") == "'D:/Ivo/ai-costs.json'"
         assert file_ops._escape_native_exe_arg("/d/Ivo/ai-costs.json") == "'D:/Ivo/ai-costs.json'"
+
+    def test_escape_native_exe_arg_preserves_non_local_backend_paths(self, monkeypatch, file_ops):
+        """A non-local backend (e.g. SSH) owns its own path namespace: a
+        POSIX path such as ``/mnt/d/project`` must NOT be reinterpreted as a
+        host Windows drive form even when the host is Windows (#67914)."""
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(file_ops, "_is_local_backend", lambda: False)
+        # /mnt/d/... matches an MSYS/WSL drive form but belongs to the
+        # remote namespace — it must pass through untouched.
+        assert (
+            file_ops._escape_native_exe_arg("/mnt/d/Projects/tools")
+            == "'/mnt/d/Projects/tools'"
+        )
+        # Plain POSIX paths were always safe and stay unchanged.
+        assert (
+            file_ops._escape_native_exe_arg("/home/user/project")
+            == "'/home/user/project'"
+        )
 
     def test_search_with_rg_uses_native_windows_path(self, mock_env, monkeypatch):
         """Absolute Windows paths must not be MSYS-rewritten for native rg (#67629)."""
@@ -509,6 +531,7 @@ class TestShellFileOpsHelpers:
 
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
         ops = ShellFileOperations(mock_env)
+        ops._is_local_backend = lambda: True
         ops._has_command = lambda cmd: cmd == "rg"
         captured = {}
 

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -545,6 +545,57 @@ class TestShellFileOpsHelpers:
         assert "D:/Ivo/ai-costs.json" in captured["cmd"]
         assert "/d/Ivo/ai-costs.json" not in captured["cmd"]
 
+    def test_escape_pattern_arg_preserves_regex_backslashes(self, monkeypatch, file_ops):
+        """Regex patterns must not be MSYS-rewritten even on Windows (#69183 carry)."""
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        # Backslash regex escapes must survive verbatim inside the quotes,
+        # never rewritten to forward slashes the way a drive path would be.
+        assert file_ops._escape_pattern_arg(r"\d+") == r"'\d+'"
+        assert file_ops._escape_pattern_arg(r"foo\w*bar") == r"'foo\w*bar'"
+        assert file_ops._escape_pattern_arg(r"\(group\)") == r"'\(group\)'"
+
+    def test_search_with_rg_preserves_regex_pattern(self, mock_env, monkeypatch):
+        """rg regex patterns keep backslash escapes intact on Windows (#69183 carry)."""
+        import tools.environments.local as local_mod
+        from tools.file_operations import ShellFileOperations, ExecuteResult
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        ops = ShellFileOperations(mock_env)
+        ops._is_local_backend = lambda: True
+        ops._has_command = lambda cmd: cmd == "rg"
+        captured = {}
+
+        def _capture(command, cwd=None, timeout=None, stdin_data=None):
+            captured["cmd"] = command
+            return ExecuteResult(stdout="", exit_code=1)
+
+        ops._exec = _capture
+        ops._search_with_rg(r"\d+", r"D:\Ivo\ai-costs.json", None, 10, 0, "content", 0)
+        assert r"'\d+'" in captured["cmd"]
+        assert "'/d+'" not in captured["cmd"]
+
+    def test_search_with_grep_preserves_regex_pattern(self, mock_env, monkeypatch):
+        """grep fallback regex patterns keep backslash escapes intact (#69183 carry)."""
+        import tools.environments.local as local_mod
+        from tools.file_operations import ShellFileOperations, ExecuteResult
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        ops = ShellFileOperations(mock_env)
+        ops._is_local_backend = lambda: True
+        ops._has_command = lambda cmd: cmd == "grep"
+        captured = {}
+
+        def _capture(command, cwd=None, timeout=None, stdin_data=None):
+            captured["cmd"] = command
+            return ExecuteResult(stdout="", exit_code=1)
+
+        ops._exec = _capture
+        ops._search_with_grep(r"\w+", "/tmp/project", None, 10, 0, "content", 0)
+        assert r"'\w+'" in captured["cmd"]
+        assert "'/w+'" not in captured["cmd"]
+
 
     def test_read_file_uses_bash_safe_windows_paths(self, mock_env, monkeypatch):
         import tools.environments.local as local_mod

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -26,6 +26,7 @@ from tools.environments import local as local_mod
 from tools.environments.local import (
     LocalEnvironment,
     _bash_safe_path,
+    _native_windows_path_for_exe,
     _git_bash_bin_dirs,
     _make_run_env,
     _msys_to_windows_path,
@@ -510,3 +511,22 @@ class TestWrapCommandWindowsNativeCwd:
         script = captured["script"]
         assert "/c/Users/Alexander/AppData/Local/Temp/hermes-snap-deadbeef.sh" in script
         assert r"C:\Users\Alexander\AppData" not in script
+
+
+def test_native_windows_path_for_exe_rewrites_drive_to_forward_slash(monkeypatch):
+    import tools.environments.local as local_mod
+    monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+    assert _native_windows_path_for_exe(r"D:\Ivo\ai-costs.json") == "D:/Ivo/ai-costs.json"
+    assert _native_windows_path_for_exe("D:/Ivo/ai-costs.json") == "D:/Ivo/ai-costs.json"
+
+
+def test_native_windows_path_for_exe_rewrites_msys_form(monkeypatch):
+    import tools.environments.local as local_mod
+    monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+    assert _native_windows_path_for_exe("/d/Ivo/ai-costs.json") == "D:/Ivo/ai-costs.json"
+
+
+def test_native_windows_path_for_exe_leaves_relative(monkeypatch):
+    import tools.environments.local as local_mod
+    monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+    assert _native_windows_path_for_exe("Apps/The-Pulse") == "Apps/The-Pulse"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -129,6 +129,46 @@ def _bash_safe_path(path: str) -> str:
     return path
 
 
+
+
+def _native_windows_path_for_exe(path: str) -> str:
+    r"""Return *path* in forward-slash native Windows form for native EXEs.
+
+    Git Bash is still the process launcher, but tools like ripgrep that ship
+    as Win32 binaries do **not** understand MSYS drive paths (``/d/...``).
+    They *do* accept ``D:/...``.
+
+    - Native ``D:\foo`` / ``D:/foo`` -> ``D:/foo``
+    - MSYS ``/d/foo`` / ``/cygdrive/d/foo`` / ``/mnt/d/foo`` -> ``D:/foo``
+    - Otherwise leave unchanged (relative paths, pure POSIX strings)
+
+    No-op off Windows and for empty input. Pair with
+    ``MSYS_NO_PATHCONV`` / ``MSYS2_ARG_CONV_EXCL`` (already applied to bash
+    env defaults) so Git Bash does not re-mangle the ``D:/`` form.
+    """
+    if not _IS_WINDOWS or not path:
+        return path
+
+    # Already native drive-qualified -> normalize separators only.
+    m = re.match(r'^([a-zA-Z]):[\\/]*(.*)$', path)
+    if m:
+        drive = m.group(1).upper()
+        tail = (m.group(2) or "").replace("\\", "/").lstrip("/")
+        return f"{drive}:/{tail}" if tail else f"{drive}:/"
+
+    # MSYS / Cygwin / WSL drive forms -> native forward-slash.
+    win = _msys_to_windows_path(path)
+    if win != path:
+        m2 = re.match(r'^([a-zA-Z]):[\\/]*(.*)$', win)
+        if m2:
+            drive = m2.group(1).upper()
+            tail = (m2.group(2) or "").replace("\\", "/").lstrip("/")
+            return f"{drive}:/{tail}" if tail else f"{drive}:/"
+
+    if "\\" in path:
+        return path.replace("\\", "/")
+    return path
+
 def _quote_bash_path(path: str) -> str:
     """Quote *path* for safe interpolation into a Git Bash script on Windows."""
     import shlex

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -975,6 +975,22 @@ class ShellFileOperations(FileOperations):
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
+    def _escape_native_exe_arg(self, arg: str) -> str:
+        """Escape a path/arg for a *native Windows* executable launched via bash.
+
+        Unlike :meth:`_escape_shell_arg` (which rewrites drives to MSYS
+        ``/c/...`` for bash builtins / path consumers), this keeps
+        drive-qualified paths in forward-slash native form (``C:/...``)
+        so Win32 tools such as ripgrep can resolve them (#67629).
+        Relative / non-Windows paths still go through plain quoting.
+        """
+        from tools.environments.local import _IS_WINDOWS, _native_windows_path_for_exe
+
+        if _IS_WINDOWS:
+            arg = _native_windows_path_for_exe(arg)
+        return "'" + arg.replace("'", '\'"\'"\'') + "'"
+
+
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":
         """Write ``content`` to ``path`` atomically via temp-file + rename.
 
@@ -2218,7 +2234,7 @@ class ShellFileOperations(FileOperations):
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
         cmd_sorted = (
             f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
-            f"{self._escape_shell_arg(path)} 2>/dev/null "
+            f"{self._escape_native_exe_arg(path)} 2>/dev/null "
             f"| head -n {fetch_limit}"
         )
         result = self._exec(cmd_sorted, timeout=60)
@@ -2229,7 +2245,7 @@ class ShellFileOperations(FileOperations):
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
                 f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
-                f"{self._escape_shell_arg(path)} 2>/dev/null "
+                f"{self._escape_native_exe_arg(path)} 2>/dev/null "
                 f"| head -n {fetch_limit}"
             )
             result = self._exec(cmd_plain, timeout=60)
@@ -2285,7 +2301,7 @@ class ShellFileOperations(FileOperations):
         
         # Add pattern and path
         cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
+        cmd_parts.append(self._escape_native_exe_arg(path))
         
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -983,12 +983,37 @@ class ShellFileOperations(FileOperations):
         drive-qualified paths in forward-slash native form (``C:/...``)
         so Win32 tools such as ripgrep can resolve them (#67629).
         Relative / non-Windows paths still go through plain quoting.
+
+        The native drive rewrite is applied *only* when the host is
+        Windows **and** the command runs against the local backend.  A
+        non-local backend (SSH, Docker, Modal, Daytona) owns its own
+        path namespace: a target-side path such as ``/mnt/d/project``
+        is a valid POSIX path there and must not be reinterpreted as a
+        host Windows drive spelling (``D:/project``) — doing so breaks
+        the remote ``rg`` lookup (backend-boundary bug reported on
+        #67914).
         """
         from tools.environments.local import _IS_WINDOWS, _native_windows_path_for_exe
 
-        if _IS_WINDOWS:
+        if _IS_WINDOWS and self._is_local_backend():
             arg = _native_windows_path_for_exe(arg)
         return "'" + arg.replace("'", '\'"\'"\'') + "'"
+
+    def _is_local_backend(self) -> bool:
+        """Return True iff this FileOperations is wired to the local backend.
+
+        Native Windows drive conversion for ``rg.exe`` is only correct
+        for the host-local environment; remote backends keep their own
+        path semantics.
+        """
+        env = getattr(self, "env", None)
+        if env is None:
+            return False
+        try:
+            from tools.environments.local import LocalEnvironment
+        except Exception:  # noqa: BLE001
+            return False
+        return isinstance(env, LocalEnvironment)
 
 
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -999,6 +999,19 @@ class ShellFileOperations(FileOperations):
             arg = _native_windows_path_for_exe(arg)
         return "'" + arg.replace("'", '\'"\'"\'') + "'"
 
+    def _escape_pattern_arg(self, arg: str) -> str:
+        """Quote a *search pattern* for the shell without path translation.
+
+        Unlike :meth:`_escape_shell_arg`, this must **not** run the value
+        through ``_bash_safe_path``: a regex is not a path, and the MSYS
+        drive rewrite would corrupt regex metacharacters on Windows
+        (e.g. ``\\w`` / ``\\d`` / ``\\(`` getting mangled to ``/w`` / ``/d``
+        / ``/(``). Single-quoting is sufficient to keep backslash escapes
+        intact for both ``rg`` and the ``grep`` fallback (#69183 pattern
+        portion consolidated into #67914 / #63177).
+        """
+        return "'" + arg.replace("'", '\'"\'"\'') + "'"
+
     def _is_local_backend(self) -> bool:
         """Return True iff this FileOperations is wired to the local backend.
 
@@ -2324,8 +2337,9 @@ class ShellFileOperations(FileOperations):
         elif output_mode == "count":
             cmd_parts.append("-c")  # Count per file
         
-        # Add pattern and path
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        # Add pattern and path. The pattern is a regex, not a path, so it
+        # must be quoted without the MSYS drive rewrite (#69183 carry).
+        cmd_parts.append(self._escape_pattern_arg(pattern))
         cmd_parts.append(self._escape_native_exe_arg(path))
         
         # Fetch extra rows so we can report the true total before slicing.
@@ -2454,8 +2468,9 @@ class ShellFileOperations(FileOperations):
         elif output_mode == "count":
             cmd_parts.append("-c")
         
-        # Add pattern and path
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        # Add pattern and path. The pattern is a regex, not a path, so it
+        # must be quoted without the MSYS drive rewrite (#69183 carry).
+        cmd_parts.append(self._escape_pattern_arg(pattern))
         cmd_parts.append(self._escape_shell_arg(path))
         
         # Fetch generously so we can compute total before slicing


### PR DESCRIPTION
## Summary

- `search_files` / `_search_with_rg` now pass drive-qualified Windows paths to ripgrep as `D:/...` instead of MSYS `/d/...`.
- Native Win32 `rg` can resolve absolute paths again on native Windows + Git Bash.

## Motivation

Closes #67629.

On native Windows, `_escape_shell_arg` rewrote `D:\...` / `D:/...` through `_bash_safe_path` into `/d/...` so Git Bash would not mangle drive letters. That form is correct for bash builtins, but the bundled/WinGet `rg` is a native Windows binary and fails with `IO error ... (os error 3)` on `/d/...`. Relative paths worked; absolute paths did not. Agents are steered to prefer `search_files` over raw `rg`, so this was a real footgun.

## Verification

- `pytest tests/tools/test_local_env_windows_msys.py tests/tools/test_file_operations.py -k "native_windows or escape_native or search_with_rg_uses"` — 6 passed, 0 failed
- Did NOT change: bash-builtin path escaping for `cat`/`sed`/`find` (still MSYS-safe via `_escape_shell_arg`)

## Fix details

- Add `tools.environments.local._native_windows_path_for_exe`
- Add `ShellFileOperations._escape_native_exe_arg` and use it only for `rg` path arguments