### PR TITLE
fix(gateway): reference MAX_ATTEMPTS in redelivery comment

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6983,7 +6983,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return 0
             # Only claim rows we can actually send this boot: self.adapters
             # holds a platform only after its connect() succeeded, and each
-            # claim spends one of the row's three redelivery attempts.
+            # claim spends one of the row's MAX_ATTEMPTS redelivery attempts.
             _deliverable = {
                 getattr(p, "value", str(p)) for p in self.adapters
             }


### PR DESCRIPTION
## Summary

- Rewrite the delivery-ledger claim comment to name `MAX_ATTEMPTS` instead of the hard-coded word \"three\".

## Motivation

Closes #67664 and #67663 (duplicate reports of the same drift).

PR #67568 documented redelivery as \"three attempts\" in `gateway/run.py`, but the durable control is `MAX_ATTEMPTS` in `gateway/delivery_ledger.py`. If that constant changes, the old comment becomes a lie. Naming the constant keeps prose and policy in lockstep.

## Verification

- Comment-only change; no runtime behavior change
- Manual: confirmed `MAX_ATTEMPTS = 3` remains the single source of truth in `gateway/delivery_ledger.py`

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 48h