### PR TITLE
fix(gateway): retry detached restart helper without job breakaway on Windows

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6690,13 +6690,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if watcher_env.get("PYTHONPATH"):
                     pythonpath.append(watcher_env["PYTHONPATH"])
                 watcher_env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(pythonpath))
-            subprocess.Popen(
-                [watcher_python, "-c", watcher, str(current_pid), str(restart_after_s), *cmd_argv],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                env=watcher_env,
-                **windows_detach_popen_kwargs(),
-            )
+            watcher_argv = [watcher_python, "-c", watcher, str(current_pid), str(restart_after_s), *cmd_argv]
+            try:
+                subprocess.Popen(
+                    watcher_argv,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    env=watcher_env,
+                    **windows_detach_popen_kwargs(),
+                )
+            except OSError:
+                # CREATE_BREAKAWAY_FROM_JOB can fail with "access denied"
+                # when the gateway's job object doesn't permit breakaway
+                # (e.g. Task Scheduler jobs). Retry without the breakaway
+                # flag — same fallback as gateway_windows._spawn_detached.
+                # Without this retry the helper never launches and the
+                # gateway stops for the restart but never comes back.
+                from hermes_cli._subprocess_compat import (
+                    windows_detach_flags_without_breakaway,
+                )
+                subprocess.Popen(
+                    watcher_argv,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    env=watcher_env,
+                    creationflags=windows_detach_flags_without_breakaway(),
+                )
             return
 
         cmd = " ".join(shlex.quote(part) for part in hermes_cmd)

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -396,6 +396,57 @@ async def test_windows_detached_restart_uses_pythonw_for_watcher(monkeypatch, tm
     assert kwargs["creationflags"] == 0x08000008
 
 
+@pytest.mark.asyncio
+async def test_windows_detached_restart_retries_without_breakaway(monkeypatch, tmp_path):
+    """When CREATE_BREAKAWAY_FROM_JOB is denied (gateway inside a job
+    object that disallows breakaway, e.g. Task Scheduler), the watcher
+    spawn must retry without the breakaway flag.  Without the retry the
+    helper never launches and the gateway stops for the restart but
+    never comes back."""
+    runner, _adapter = make_restart_runner()
+    popen_calls = []
+    venv_dir = tmp_path / "venv"
+    site_packages = venv_dir / "Lib" / "site-packages"
+    site_packages.mkdir(parents=True)
+
+    monkeypatch.setattr(gateway_run.sys, "platform", "win32")
+    monkeypatch.setattr(gateway_run.sys, "executable", r"C:\venv\Scripts\python.exe")
+    monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["hermes"])
+    monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
+    monkeypatch.setenv("VIRTUAL_ENV", str(venv_dir))
+
+    import hermes_cli._subprocess_compat as subprocess_compat
+
+    monkeypatch.setattr(
+        subprocess_compat,
+        "windows_detach_popen_kwargs",
+        lambda: {"creationflags": 0x09000008},  # includes CREATE_BREAKAWAY_FROM_JOB
+    )
+    monkeypatch.setattr(
+        subprocess_compat,
+        "windows_detach_flags_without_breakaway",
+        lambda: 0x08000008,
+    )
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append((cmd, kwargs))
+        if len(popen_calls) == 1:
+            # CreateProcess -> ERROR_ACCESS_DENIED surfaces as PermissionError
+            raise PermissionError(5, "Access is denied")
+        return MagicMock()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    await runner._launch_detached_restart_command()
+
+    assert len(popen_calls) == 2
+    first_cmd, first_kwargs = popen_calls[0]
+    second_cmd, second_kwargs = popen_calls[1]
+    assert first_kwargs["creationflags"] == 0x09000008
+    assert second_kwargs["creationflags"] == 0x08000008
+    assert first_cmd == second_cmd
+
+
 # ── Shutdown notification tests ──────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

On Windows, when the gateway runs inside a job object that disallows breakaway (no `JOB_OBJECT_LIMIT_BREAKAWAY_OK` — e.g. when started via Task Scheduler), `CreateProcess` with `CREATE_BREAKAWAY_FROM_JOB` fails with `ERROR_ACCESS_DENIED`, which Python surfaces as `PermissionError`.

`GatewayRunner._launch_detached_restart_command` lets that exception escape. The caller in `request_restart` only logs it (`Failed to launch detached gateway restart helper: [WinError 5] Access is denied`) and then proceeds with `stop(restart=True)` anyway — so the gateway shuts down for the planned restart and **never comes back** until someone starts it manually.

This is reproducible in the wild: a messaging-platform plugin auto-update triggers a detached restart, the helper launch fails with WinError 5, and the gateway stays dead for days (the Task Scheduler entry only triggers at logon).

## Fix

Retry the watcher spawn without `CREATE_BREAKAWAY_FROM_JOB` when the first `Popen` raises `OSError` — the exact fallback `gateway_windows._spawn_detached` already implements for the same documented condition, and the pattern `windows_detach_flags_without_breakaway()` was added for. Without the breakaway flag the watcher stays inside the job, which is still far better than no watcher at all.

## Testing

- Added `test_windows_detached_restart_retries_without_breakaway`: first spawn raises `PermissionError(5)`, asserts a second spawn happens with the no-breakaway flags and identical argv.
- `pytest tests/gateway/test_restart_drain.py` — 25 passed.
- Verified on a live Windows install where this bug bit twice: gateway now restarts cleanly through the same code path.