### PR TITLE
fix(gateway): inject message timestamp into clarify text responses (#67825)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10136,6 +10136,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # so the user can retry; if it times out, the agent unblocks
             # with an empty response.
             if _raw_clarify_reply and not _raw_clarify_reply.startswith("/"):
+                # Inject message timestamp so the clarify reply carries the
+                # same [timestamp] prefix as normal user messages (#67825).
+                # Without this, every clarify answer creates a temporal hole
+                # in the LLM's view of the conversation.
+                try:
+                    if _message_timestamps_enabled(_load_gateway_config()):
+                        from hermes_time import get_timezone as _get_clarify_tz
+                        from gateway.message_timestamps import (
+                            coerce_message_timestamp as _coerce_clarify_ts,
+                            render_user_content_with_timestamp as _render_clarify_ts,
+                        )
+                        _clarify_tz = _get_clarify_tz()
+                        _clarify_evt_ts = getattr(event, "timestamp", None)
+                        _clarify_epoch = _coerce_clarify_ts(
+                            _clarify_evt_ts, tz=_clarify_tz,
+                        )
+                        _rendered = _render_clarify_ts(
+                            _raw_clarify_reply, _clarify_epoch, tz=_clarify_tz,
+                        )
+                        if _rendered:
+                            _raw_clarify_reply = _rendered
+                except Exception:
+                    logger.debug(
+                        "Failed to inject timestamp into clarify reply",
+                        exc_info=True,
+                    )
                 _resolved = _clarify_mod.resolve_text_response_for_session(
                     _quick_key, _raw_clarify_reply,
                 )


### PR DESCRIPTION
## Problem

When `gateway.message_timestamps.enabled` is true, normal user messages carry a `[Mon 2026-07-20 10:35:34 CST]` prefix giving the agent temporal awareness. But clarify replies intercepted by `_maybe_intercept_clarify_text` bypass the timestamp injection pipeline entirely — the raw `event.text` is passed to `resolve_text_response_for_session` without going through `render_user_content_with_timestamp`.

This creates a temporal hole in the LLM's view every time the agent asks a clarifying question: surrounding messages have timestamps, but the clarify answer does not.

This is the latest in a known bug family where the clarify interception path bypasses inbound-processing steps (#56739, #62034, #67014).

## Fix

Apply the same `coerce_message_timestamp` + `render_user_content_with_timestamp` pipeline used by the normal message path before passing the clarify reply to `resolve_text_response_for_session`. Gated behind the same `_message_timestamps_enabled` check. Wrapped in `try/except` so a timestamp failure never blocks the clarify response.

## Reproduction

1. `hermes config set gateway.message_timestamps.enabled true`
2. Have the agent call `clarify(...)` with a multi-choice question
3. Answer by typing a message in chat
4. Observe: surrounding user messages carry `[timestamp]` prefix; clarify reply does not (before fix) / does (after fix)

Fixes #67825
