### PR TITLE
test(model): isolate custom-provider grouping tests from live discovery (salvages #62421)

### DIFF
--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -664,6 +664,7 @@ def test_list_authenticated_providers_groups_same_endpoint(monkeypatch):
              "api_key": "ollama", "model": "qwen3-coder"},
         ],
         max_models=50,
+        probe_custom_providers=False,
     )
 
     custom_groups = [p for p in providers if p.get("is_user_defined")]
@@ -748,6 +749,7 @@ def test_list_authenticated_providers_distinct_endpoints_stay_separate(monkeypat
              "api_key": "ollama", "model": "qwen3-coder"},
         ],
         max_models=50,
+        probe_custom_providers=False,
     )
 
     custom_groups = [p for p in providers if p.get("is_user_defined")]
@@ -841,6 +843,7 @@ def test_list_authenticated_providers_total_models_reflects_grouped_count(monkey
         user_providers={},
         custom_providers=entries,
         max_models=4,
+        probe_custom_providers=False,
     )
 
     groups = [p for p in providers if p.get("is_user_defined")]


### PR DESCRIPTION
## Summary
Three custom-provider grouping tests are now deterministic on hosts running a real Ollama at `localhost:11434`. Salvages #62421 (@virtualex-itv) onto current main with authorship preserved.

## Changes
- `tests/hermes_cli/test_model_switch_custom_providers.py`: `probe_custom_providers=False` on the three grouping tests whose fixtures point at `http://localhost:11434/v1` — without it, a live Ollama's catalog replaces the fixture models and the tests assert against the host's install instead of the grouping invariant. Dedicated live-probe tests are unchanged.

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/hermes_cli/test_model_switch_custom_providers.py` | 47/47 pass |

## Infographic
![picker-test-hermeticity](https://v3b.fal.media/files/b/0aa2fb83/tNPiCzQ5PHRgFdJC0fuy6_dfm1U1s7.png)
