### PR TITLE
fix(tui_gateway): set utf-8 encoding for subprocess pipes on Windows

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -337,6 +337,7 @@ class _SlashWorker:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            encoding='utf-8',
             bufsize=1,
             cwd=os.getcwd(),
             env=env,


### PR DESCRIPTION
## Problem

On Chinese Windows systems (GBK system encoding), `subprocess.Popen` with `text=True` defaults to the system locale for pipe decoding. When the Hermes backend writes UTF-8 bytes to stderr, the `_drain_stderr` thread crashes with `UnicodeDecodeError: 'gbk' codec can't decode byte`. This makes the desktop/TUI backend unresponsive — the user clicks send after uploading a file and nothing happens.

## Root cause

`tui_gateway/server.py` line 339: `text=True` without an explicit `encoding=`. Python uses the locale encoding (GBK on zh-CN Windows), but the backend process outputs UTF-8.

## Fix

Add `encoding='utf-8'` to the Popen call, after `text=True`. This is a one-line change, safe on all platforms — Python ignores unknown encoding parameters on non-Windows systems where UTF-8 is already the default.

## Related logs

```
[gateway-crash] thread Thread-14 (_drain_stderr) raised UnicodeDecodeError:
'gbk' codec can't decode byte 0xa0 in position 7: illegal multibyte sequence
```

And also Python's internal `_readerthread` in `subprocess.py`: `UnicodeDecodeError: 'gbk' codec can't decode byte 0x94 in position 140: illegal multibyte sequence`