### PR TITLE
fix(streaming): detect text-only stream drops with no finish_reason (#32086)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2197,6 +2197,36 @@ def cleanup_task_resources(agent, task_id: str) -> None:
             logger.warning(f"Failed to cleanup browser for task {task_id}: {e}")
 
 
+def _build_partial_stream_stub(
+    role, full_content, full_reasoning, model_name, usage_obj, *,
+    dropped_tool_names=None,
+):
+    """Build a partial-stream-stub response for mid-stream drop scenarios.
+
+    Used when the SSE stream ends without a ``finish_reason`` after
+    delivering content (text-only drops, tool-call-arg drops).  The stub
+    is tagged ``PARTIAL_STREAM_STUB_ID`` with ``FINISH_REASON_LENGTH`` so
+    the conversation loop enters its continuation/retry path instead of
+    silently accepting truncated output as a complete turn (#32086).
+    """
+    mock_message = SimpleNamespace(
+        role=role,
+        content=full_content,
+        tool_calls=None,
+        reasoning_content=full_reasoning,
+    )
+    mock_choice = SimpleNamespace(
+        index=0,
+        message=mock_message,
+        finish_reason=FINISH_REASON_LENGTH,
+    )
+    return SimpleNamespace(
+        id=PARTIAL_STREAM_STUB_ID,
+        model=model_name,
+        choices=[mock_choice],
+        usage=usage_obj,
+        _dropped_tool_names=dropped_tool_names or None,
+    )
 
 
 def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=None):
@@ -2978,24 +3008,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 "mid-tool-call stream drop, not an output-length truncation.",
                 _dropped_names,
             )
-            full_reasoning = "".join(reasoning_parts) or None
-            mock_message = SimpleNamespace(
-                role=role,
-                content=full_content,
-                tool_calls=None,
-                reasoning_content=full_reasoning,
-            )
-            mock_choice = SimpleNamespace(
-                index=0,
-                message=mock_message,
-                finish_reason=FINISH_REASON_LENGTH,
-            )
-            return SimpleNamespace(
-                id=PARTIAL_STREAM_STUB_ID,
-                model=model_name,
-                choices=[mock_choice],
-                usage=usage_obj,
-                _dropped_tool_names=_dropped_names or None,
+            return _build_partial_stream_stub(
+                role, full_content,
+                "".join(reasoning_parts) or None,
+                model_name, usage_obj,
+                dropped_tool_names=_dropped_names or None,
             )
 
         # Text-only stream drop: the upstream closed the connection (or the
@@ -3013,23 +3030,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 "Stream ended with no finish_reason after delivering text "
                 "with no tool calls; treating as a mid-stream drop."
             )
-            full_reasoning = "".join(reasoning_parts) or None
-            mock_message = SimpleNamespace(
-                role=role,
-                content=full_content,
-                tool_calls=None,
-                reasoning_content=full_reasoning,
-            )
-            mock_choice = SimpleNamespace(
-                index=0,
-                message=mock_message,
-                finish_reason=FINISH_REASON_LENGTH,
-            )
-            return SimpleNamespace(
-                id=PARTIAL_STREAM_STUB_ID,
-                model=model_name,
-                choices=[mock_choice],
-                usage=usage_obj,
+            return _build_partial_stream_stub(
+                role, full_content,
+                "".join(reasoning_parts) or None,
+                model_name, usage_obj,
             )
 
         effective_finish_reason = finish_reason or "stop"

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2998,6 +2998,40 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 _dropped_tool_names=_dropped_names or None,
             )
 
+        # Text-only stream drop: the upstream closed the connection (or the
+        # SSE stream simply ended) with no finish_reason after delivering
+        # text content but no tool calls.  Without this guard the partial
+        # text is silently stamped finish_reason="stop" and the turn ends as
+        # if complete — the model's intended next step is lost (#32086).
+        _text_only_dropped_no_finish = (
+            finish_reason is None
+            and content_parts
+            and not tool_calls_acc
+        )
+        if _text_only_dropped_no_finish:
+            logger.warning(
+                "Stream ended with no finish_reason after delivering text "
+                "with no tool calls; treating as a mid-stream drop."
+            )
+            full_reasoning = "".join(reasoning_parts) or None
+            mock_message = SimpleNamespace(
+                role=role,
+                content=full_content,
+                tool_calls=None,
+                reasoning_content=full_reasoning,
+            )
+            mock_choice = SimpleNamespace(
+                index=0,
+                message=mock_message,
+                finish_reason=FINISH_REASON_LENGTH,
+            )
+            return SimpleNamespace(
+                id=PARTIAL_STREAM_STUB_ID,
+                model=model_name,
+                choices=[mock_choice],
+                usage=usage_obj,
+            )
+
         effective_finish_reason = finish_reason or "stop"
         if has_truncated_tool_args:
             effective_finish_reason = "length"

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -230,6 +230,45 @@ class TestCleanStreamEndMidToolCall:
         assert response.id.startswith("stream-")
         assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
 
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_no_finish_reason_text_only_routes_to_stub(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        """A clean stream-end with no finish_reason after text-only
+        delivery must route through the partial-stream-stub path so the
+        conversation loop continues instead of silently accepting
+        truncated text as a complete response (#32086)."""
+
+        def _clean_ending_stream():
+            yield _make_stream_chunk(content="Let me compare the ")
+            yield _make_stream_chunk(content="vision configs:")
+            # falls off the end — clean close, no terminator
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _clean_ending_stream()
+        )
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent._fire_stream_delta = lambda text: None
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID, (
+            "A clean stream-end with no finish_reason after text-only "
+            "delivery must be tagged as a partial-stream stub, not "
+            "silently accepted as complete (#32086)."
+        )
+        assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
+        assert response.choices[0].message.content == "Let me compare the vision configs:"
+        assert response.choices[0].message.tool_calls is None
+        assert getattr(response, "_dropped_tool_names", None) is None, (
+            "Text-only drops must not carry dropped tool names — there "
+            "were no tool calls in flight."
+        )
+
 
 # ── Length-continuation prompt branching ──────────────────────────────────
 


### PR DESCRIPTION
## Summary
Detects text-only stream drops where the SSE stream ends cleanly (HTTP 200) with no `finish_reason` after delivering text content but no tool calls, routing them through the partial-stream-stub path so the conversation loop triggers continuation/retry instead of silently accepting truncated text as a complete response.

## What this fixes
Issue #32086 — providers (DeepSeek/CloudFront, xiaomi mimo, Z.AI) sometimes close the SSE stream cleanly without sending `[DONE]` or `finish_reason` after delivering partial text. The chunk collector silently stamped `finish_reason='stop'`, the turn ended as if complete, and the model's intended next step was lost with no user-visible indication of failure.

Three stream-drop paths existed in `interruptible_streaming_api_call`:

| Path | Condition | Handled? |
|------|-----------|----------|
| 1. Zero-chunk | No content, no reasoning, no tool calls | ✓ EmptyStreamError, retried |
| 2. Tool-call in progress | Incomplete tool args, no finish_reason | ✓ Partial-stream-stub (#32012) |
| 3. Text-only | Text content, no tool calls, no finish_reason | ✗ **Silently stamped as stop** → now fixed |

## Changes
- `agent/chat_completion_helpers.py`: add text-only stream-drop guard between the tool-call drop check and the `effective_finish_reason` fallthrough; extract `_build_partial_stream_stub()` helper to deduplicate the stub construction between the tool-call-drop and text-only-drop paths
- `tests/run_agent/test_partial_stream_finish_reason.py`: new test `test_no_finish_reason_text_only_routes_to_stub`

## Validation
| | Before | After |
|---|---|---|
| Text-only stream drop | Silently stamped `stop`, turn ends | Routes to stub, continuation retry |
| Tool-call drop | Already handled ✓ | Unchanged ✓ |
| Normal `finish_reason='stop'` | Normal response ✓ | Unchanged ✓ |

- 88 targeted tests pass (4 stream test files)
- 2101 tests pass (full `tests/run_agent/` suite)
- E2E with real imports: 3/3 scenarios pass (text-only drop → stub, normal stop → normal response, text+tool_calls → tool-drop path)
- ruff clean

Salvage of #67616 by @ajzrva-sys — original fix cherry-picked with authorship preserved, refactor follow-up added on top.

Closes #67616
Fixes #32086
