### PR TITLE
fix(cli): keep picker prewarm read-only w.r.t. config.yaml (#67841)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1854,6 +1854,11 @@ def prewarm_picker_cache_async() -> Optional["_threading.Thread"]:
             # Calling this is what populates cached_provider_model_ids() ->
             # provider_models_cache.json for each authed provider. We discard
             # the result; the side effect (warm disk cache) is the point.
+            #
+            # ``persist_discovered=False`` keeps this background warmup
+            # read-only with respect to the user's config.yaml (#67841):
+            # prewarming must never write discovered models back into
+            # user-authored configuration without an explicit user action.
             list_authenticated_providers(
                 current_provider=ctx.current_provider,
                 current_base_url=ctx.current_base_url,
@@ -1861,6 +1866,7 @@ def prewarm_picker_cache_async() -> Optional["_threading.Thread"]:
                 user_providers=ctx.user_providers,
                 custom_providers=ctx.custom_providers,
                 excluded_providers=ctx.excluded_providers or [],
+                persist_discovered=False,
             )
         except Exception:
             # Best-effort warmup — never surface errors into the session.
@@ -1885,6 +1891,7 @@ def list_authenticated_providers(
     probe_current_custom_provider: bool = False,
     for_picker: bool = False,
     excluded_providers: list | None = None,
+    persist_discovered: bool = True,
 ) -> List[dict]:
     """Detect which providers have credentials and list their curated models.
 
@@ -1921,6 +1928,12 @@ def list_authenticated_providers(
     opens: probe only the currently-selected custom endpoint so its model list
     matches the active provider without blocking on every saved/offline custom
     endpoint.
+
+    ``persist_discovered`` controls whether a successful custom-provider probe
+    writes the discovered models back into ``custom_providers`` in config.yaml.
+    Default true for CLI parity. Read-only background callers (e.g. the picker
+    prewarm) pass false so simply starting Hermes never rewrites user-authored
+    configuration without an explicit user action (#67841).
     """
     import os
     from agent.models_dev import (
@@ -2955,9 +2968,12 @@ def list_authenticated_providers(
                         # Auto-save discovered models back to config so
                         # ``discover_models: false`` has a populated cache
                         # on the next read.  A failed save is non-fatal.
-                        _save_discovered_models_to_config(
-                            api_url, live_models
-                        )
+                        # Skipped for read-only callers (e.g. prewarm) so
+                        # startup never rewrites config.yaml (#67841).
+                        if persist_discovered:
+                            _save_discovered_models_to_config(
+                                api_url, live_models
+                            )
                 except Exception:
                     pass
             results.append({

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -472,3 +472,107 @@ def test_excluded_providers_hides_builtin_row(monkeypatch):
     )
 
 
+def test_excluded_providers_empty_is_noop(monkeypatch):
+    """An empty ``excluded_providers`` list must not change picker output."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+    a = list_authenticated_providers(
+        current_provider="openrouter",
+        user_providers={},
+        custom_providers=[],
+        max_models=50,
+    )
+    b = list_authenticated_providers(
+        current_provider="openrouter",
+        user_providers={},
+        custom_providers=[],
+        max_models=50,
+        excluded_providers=[],
+    )
+    assert [p["slug"] for p in a] == [p["slug"] for p in b]
+
+def test_prewarm_probe_is_read_only(monkeypatch):
+    """A successful custom-provider probe with ``persist_discovered=False``
+    (the background prewarm path) must not write discovered models back into
+    config.yaml (#67841)."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    save_calls = []
+
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models",
+        lambda api_key, base_url, **kwargs: ["discovered-a", "discovered-b"],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch._save_discovered_models_to_config",
+        lambda api_url, model_ids: save_calls.append((api_url, model_ids)),
+    )
+
+    custom_providers = [
+        {
+            "name": "my-gateway",
+            "api_key": "***",
+            "base_url": "https://gateway.example.com/v1",
+            "discover_models": True,
+            "model": "only-model",
+            "models": {"only-model": {"context_length": 128000}},
+        }
+    ]
+
+    providers = list_authenticated_providers(
+        current_provider="my-gateway",
+        current_base_url="https://gateway.example.com/v1",
+        custom_providers=custom_providers,
+        max_models=50,
+        probe_custom_providers=True,
+        persist_discovered=False,
+    )
+
+    assert save_calls == [], (
+        "persist_discovered=False must keep the probe read-only w.r.t. config"
+    )
+    # The live catalog is still surfaced for this session — only the write is skipped.
+    gateway_prov = next(
+        (p for p in providers if p.get("api_url") == "https://gateway.example.com/v1"),
+        None,
+    )
+    assert gateway_prov is not None
+    assert gateway_prov["models"] == ["discovered-a", "discovered-b"]
+
+
+def test_prewarm_picker_cache_passes_persist_discovered_false(monkeypatch):
+    """``prewarm_picker_cache_async`` must invoke discovery in read-only mode
+    so simply starting Hermes never rewrites config.yaml (#67841)."""
+    import hermes_cli.model_switch as ms
+
+    # Reset the process-level guard so the prewarm actually runs.
+    ms._picker_prewarm_done.clear()
+
+    captured = {}
+
+    class _Ctx:
+        current_provider = "my-gateway"
+        current_base_url = "https://gateway.example.com/v1"
+        current_model = "only-model"
+        user_providers = {}
+        custom_providers = []
+        excluded_providers = []
+
+    monkeypatch.setattr(
+        "hermes_cli.inventory.load_picker_context", lambda: _Ctx()
+    )
+    monkeypatch.setattr(
+        ms, "list_authenticated_providers",
+        lambda *a, **k: captured.update(k) or [],
+    )
+
+    t = ms.prewarm_picker_cache_async()
+    if t is not None:
+        t.join(timeout=5)
+
+    assert captured.get("persist_discovered") is False, (
+        "prewarm must call list_authenticated_providers with persist_discovered=False"
+    )


### PR DESCRIPTION
## What does this PR do?

Starting the classic Hermes CLI silently rewrote the active profile's `config.yaml`, even when the user never opened `/model` or changed any setting.

`prewarm_picker_cache_async()` runs `list_authenticated_providers()` in the background after the welcome banner. That probes saved custom `/v1/models` endpoints and, on a successful probe, persisted the discovered catalog back into `custom_providers` via `_save_discovered_models_to_config()` — a write triggered from a **read-only background path**, with no `/model` action and no prompt.

> **Scope note:** #67841 reported two defects. The **metadata-destruction** half (mapping-form `models` clobbered by a bare list) is already fixed on `main` by the issue's earlier merged commits (`311bacb5`, `2ae19567`). This PR addresses the **remaining** half: the prewarm should be read-only w.r.t. `config.yaml`. For a list-form `custom_providers[].models`, current `main` still rewrites the file on every launch, which the issue explicitly calls out as unwanted ("CLI startup and background picker prewarming should be read-only").

Fix keeps the smallest surface: a new `persist_discovered` flag on `list_authenticated_providers()` (default `True`, so every existing caller is behaviorally unchanged) gates the config write, and `prewarm_picker_cache_async()` passes `persist_discovered=False`. Live discovery still surfaces the catalog for the session — only the config write is skipped on the read-only path.

## Related Issue

Fixes #67841

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_switch.py`
  - `list_authenticated_providers()`: add `persist_discovered: bool = True`; gate the discovered-models auto-save on it.
  - `prewarm_picker_cache_async()`: call with `persist_discovered=False` (read-only warmup).
- `tests/hermes_cli/test_model_switch_custom_providers.py`: 2 regression tests — a probe with `persist_discovered=False` performs no config write while still surfacing the live catalog; and the prewarm wires `persist_discovered=False`.

## How to Test

1. Profile with a custom provider whose `models` is a **list** (list-form) and an endpoint whose `/v1/models` returns a changed set; run `hermes -p <profile>` and exit without touching `/model`. Before: `config.yaml` rewritten seconds after startup. After: `config.yaml` unchanged.
2. Automated:

   ```
   scripts/run_tests.sh tests/hermes_cli/test_model_switch_custom_providers.py
   ```

   Result: passes (new tests `test_prewarm_probe_is_read_only`, `test_prewarm_picker_cache_passes_persist_discovered_false`).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — documented the new `persist_discovered` flag
- [x] `cli-config.yaml.example` — N/A (no config keys added/changed)
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (pure-Python, no OS-specific paths)
- [x] Tool descriptions/schemas — N/A
