### PR TITLE
feat(plugins): pin installs to verified provenance

### DIFF
--- a/hermes_cli/plugin_supply_chain.py
+++ b/hermes_cli/plugin_supply_chain.py
@@ -14,7 +14,7 @@ import stat
 import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
-from typing import Any, Mapping
+from typing import Any, Mapping, cast
 from urllib.parse import urlsplit
 
 LOCK_FILENAME = ".hermes-plugin-lock.json"
@@ -70,7 +70,8 @@ def _required_env_names(value: object) -> tuple[str, ...]:
         if isinstance(item, str) and item:
             names.add(item)
         elif isinstance(item, Mapping):
-            name = item.get("name")
+            item_mapping = cast(Mapping[object, object], item)
+            name = item_mapping.get("name")
             if isinstance(name, str) and name:
                 names.add(name)
     return tuple(sorted(names))

--- a/hermes_cli/plugin_supply_chain.py
+++ b/hermes_cli/plugin_supply_chain.py
@@ -106,7 +106,8 @@ def _validate_subdir(value: object) -> str | None:
     return value
 
 
-def _validate_source_url(value: object) -> str:
+def validate_source_url(value: object) -> str:
+    """Return a clone-safe provenance URL, rejecting secrets and URL metadata."""
     if not isinstance(value, str) or not value:
         raise ValueError("provenance source_url must be a non-empty string")
     if "://" in value:
@@ -141,7 +142,7 @@ def _validated_provenance(data: Mapping[str, object]) -> PluginProvenance:
     if not isinstance(inspected_at, str) or not inspected_at:
         raise ValueError("provenance inspected_at must be a non-empty string")
     return PluginProvenance(
-        source_url=_validate_source_url(data["source_url"]),
+        source_url=validate_source_url(data["source_url"]),
         subdir=_validate_subdir(data["subdir"]),
         resolved_commit=validate_full_commit_sha(data["resolved_commit"]),
         requested_ref=requested_ref,

--- a/hermes_cli/plugin_supply_chain.py
+++ b/hermes_cli/plugin_supply_chain.py
@@ -210,6 +210,8 @@ def read_provenance_lock(
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode):
             raise ValueError("provenance lock must be a regular file")
+        if metadata.st_nlink != 1:
+            raise ValueError("provenance lock must have a single link")
         if before is not None and (
             stat.S_ISLNK(before.st_mode)
             or (before.st_dev, before.st_ino) != (metadata.st_dev, metadata.st_ino)

--- a/hermes_cli/plugin_supply_chain.py
+++ b/hermes_cli/plugin_supply_chain.py
@@ -109,6 +109,8 @@ def _validate_source_url(value: object) -> str:
     parsed = urlsplit(value)
     if parsed.username is not None or parsed.password is not None:
         raise ValueError("provenance source_url must not contain credentials")
+    if parsed.query or parsed.fragment:
+        raise ValueError("provenance source_url must not contain a query or fragment")
     return value
 
 

--- a/hermes_cli/plugin_supply_chain.py
+++ b/hermes_cli/plugin_supply_chain.py
@@ -1,0 +1,183 @@
+"""Pure plugin provenance and declared-capability reporting helpers.
+
+This module inspects manifest data and filesystem markers only.  It never imports
+plugin code, reads environment/configuration files, or performs network access.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping
+from urllib.parse import urlsplit
+
+LOCK_FILENAME = ".hermes-plugin-lock.json"
+_CAPABILITY_WARNING = "CAPABILITY_REPORT_IS_NOT_SECURITY_AUDIT"
+_FULL_COMMIT_SHA = re.compile(r"[0-9a-f]{40}\Z")
+_PROVENANCE_FIELDS = {
+    "source_url",
+    "subdir",
+    "resolved_commit",
+    "requested_ref",
+    "inspected_at",
+}
+
+
+@dataclass(frozen=True)
+class PluginProvenance:
+    source_url: str
+    subdir: str | None
+    resolved_commit: str
+    requested_ref: str | None
+    inspected_at: str
+
+
+@dataclass(frozen=True)
+class PluginCapabilityReport:
+    hooks: tuple[str, ...]
+    tools: tuple[str, ...]
+    required_env: tuple[str, ...]
+    has_dashboard: bool
+    has_after_install: bool
+    warnings: tuple[str, ...]
+
+
+def validate_full_commit_sha(value: object) -> str:
+    """Return *value* if it is a canonical full Git commit SHA."""
+    if not isinstance(value, str) or _FULL_COMMIT_SHA.fullmatch(value) is None:
+        raise ValueError("commit SHA must be exactly 40 lowercase hexadecimal characters")
+    return value
+
+
+def _sorted_strings(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(sorted({item for item in value if isinstance(item, str) and item}))
+
+
+def _required_env_names(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    names: set[str] = set()
+    for item in value:
+        if isinstance(item, str) and item:
+            names.add(item)
+        elif isinstance(item, Mapping):
+            name = item.get("name")
+            if isinstance(name, str) and name:
+                names.add(name)
+    return tuple(sorted(names))
+
+
+def build_capability_report(
+    plugin_dir: str | os.PathLike[str], manifest: Mapping[str, Any]
+) -> PluginCapabilityReport:
+    """Report declared capabilities without importing or executing plugin code."""
+    root = Path(plugin_dir)
+    return PluginCapabilityReport(
+        hooks=_sorted_strings(manifest.get("hooks")),
+        tools=_sorted_strings(manifest.get("provides_tools")),
+        required_env=_required_env_names(manifest.get("requires_env")),
+        has_dashboard=(root / "dashboard" / "manifest.json").is_file(),
+        has_after_install=(root / "after-install.md").is_file(),
+        warnings=(_CAPABILITY_WARNING,),
+    )
+
+
+def _validate_subdir(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("provenance subdir must be a string or null")
+    if value == "":
+        return value
+    if "\\" in value:
+        raise ValueError("provenance subdir must use safe relative path segments")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {".", ".."} for part in path.parts):
+        raise ValueError("provenance subdir must use safe relative path segments")
+    return value
+
+
+def _validate_source_url(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError("provenance source_url must be a non-empty string")
+    parsed = urlsplit(value)
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("provenance source_url must not contain credentials")
+    return value
+
+
+def _validated_provenance(data: Mapping[str, object]) -> PluginProvenance:
+    if set(data) != _PROVENANCE_FIELDS:
+        raise ValueError("provenance lock has missing or unexpected fields")
+    requested_ref = data["requested_ref"]
+    inspected_at = data["inspected_at"]
+    if requested_ref is not None and not isinstance(requested_ref, str):
+        raise ValueError("provenance requested_ref must be a string or null")
+    if not isinstance(inspected_at, str) or not inspected_at:
+        raise ValueError("provenance inspected_at must be a non-empty string")
+    return PluginProvenance(
+        source_url=_validate_source_url(data["source_url"]),
+        subdir=_validate_subdir(data["subdir"]),
+        resolved_commit=validate_full_commit_sha(data["resolved_commit"]),
+        requested_ref=requested_ref,
+        inspected_at=inspected_at,
+    )
+
+
+def _lock_path(plugin_dir: str | os.PathLike[str]) -> Path:
+    root = Path(plugin_dir)
+    lock_path = root / LOCK_FILENAME
+    if lock_path.parent.resolve() != root.resolve():
+        raise ValueError("provenance lock location must remain under plugin_dir")
+    return lock_path
+
+
+def write_provenance_lock(
+    plugin_dir: str | os.PathLike[str], provenance: PluginProvenance
+) -> Path:
+    """Atomically write deterministic, credential-free provenance JSON."""
+    validated = _validated_provenance(asdict(provenance))
+    lock_path = _lock_path(plugin_dir)
+    payload = json.dumps(asdict(validated), sort_keys=True, indent=2) + "\n"
+    temporary_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=lock_path.parent,
+            prefix=f"{LOCK_FILENAME}.",
+            delete=False,
+        ) as temporary:
+            temporary.write(payload)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            temporary_name = temporary.name
+        os.replace(temporary_name, lock_path)
+    finally:
+        if temporary_name is not None:
+            Path(temporary_name).unlink(missing_ok=True)
+    return lock_path
+
+
+def read_provenance_lock(
+    plugin_dir: str | os.PathLike[str],
+) -> PluginProvenance | None:
+    """Read a lock, returning ``None`` only when absent and rejecting bad data."""
+    lock_path = _lock_path(plugin_dir)
+    if not lock_path.exists():
+        return None
+    if not lock_path.is_file() or lock_path.is_symlink():
+        raise ValueError("provenance lock must be a regular file")
+    try:
+        data = json.loads(lock_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError("provenance lock is malformed or unreadable") from exc
+    if not isinstance(data, dict):
+        raise ValueError("provenance lock must contain a JSON object")
+    return _validated_provenance(data)

--- a/hermes_cli/plugin_supply_chain.py
+++ b/hermes_cli/plugin_supply_chain.py
@@ -6,9 +6,11 @@ plugin code, reads environment/configuration files, or performs network access.
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import re
+import stat
 import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
@@ -16,6 +18,7 @@ from typing import Any, Mapping
 from urllib.parse import urlsplit
 
 LOCK_FILENAME = ".hermes-plugin-lock.json"
+MAX_LOCK_BYTES = 64 * 1024
 _CAPABILITY_WARNING = "CAPABILITY_REPORT_IS_NOT_SECURITY_AUDIT"
 _FULL_COMMIT_SHA = re.compile(r"[0-9a-f]{40}\Z")
 _PROVENANCE_FIELDS = {
@@ -106,11 +109,25 @@ def _validate_subdir(value: object) -> str | None:
 def _validate_source_url(value: object) -> str:
     if not isinstance(value, str) or not value:
         raise ValueError("provenance source_url must be a non-empty string")
-    parsed = urlsplit(value)
-    if parsed.username is not None or parsed.password is not None:
-        raise ValueError("provenance source_url must not contain credentials")
-    if parsed.query or parsed.fragment:
-        raise ValueError("provenance source_url must not contain a query or fragment")
+    if "://" in value:
+        parsed = urlsplit(value)
+        if parsed.query or parsed.fragment:
+            raise ValueError("provenance source_url must not contain a query or fragment")
+        if parsed.password is not None or (
+            parsed.username is not None
+            and not (parsed.scheme.lower() == "ssh" and parsed.username == "git")
+        ):
+            raise ValueError("provenance source_url must not contain credentials")
+    elif "@" in value:
+        if (
+            re.fullmatch(r"git@[^\s@:/?#]+:[^\s?#]+", value) is None
+            or value.count("@") != 1
+        ):
+            raise ValueError("provenance source_url contains unsafe or malformed userinfo")
+    else:
+        parsed = urlsplit(value)
+        if parsed.query or parsed.fragment:
+            raise ValueError("provenance source_url must not contain a query or fragment")
     return value
 
 
@@ -156,6 +173,7 @@ def write_provenance_lock(
             prefix=f"{LOCK_FILENAME}.",
             delete=False,
         ) as temporary:
+            os.chmod(temporary.name, 0o600)
             temporary.write(payload)
             temporary.flush()
             os.fsync(temporary.fileno())
@@ -172,14 +190,46 @@ def read_provenance_lock(
 ) -> PluginProvenance | None:
     """Read a lock, returning ``None`` only when absent and rejecting bad data."""
     lock_path = _lock_path(plugin_dir)
-    if not lock_path.exists():
-        return None
-    if not lock_path.is_file() or lock_path.is_symlink():
-        raise ValueError("provenance lock must be a regular file")
+    flags = os.O_RDONLY
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    flags |= nofollow
     try:
-        data = json.loads(lock_path.read_text(encoding="utf-8"))
+        before = None if nofollow else lock_path.lstat()
+        if before is not None and stat.S_ISLNK(before.st_mode):
+            raise ValueError("provenance lock must be a regular file")
+        descriptor = os.open(lock_path, flags)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        if exc.errno == errno.ENOENT:
+            return None
+        raise ValueError("provenance lock is malformed or unreadable") from exc
+
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ValueError("provenance lock must be a regular file")
+        if before is not None and (
+            stat.S_ISLNK(before.st_mode)
+            or (before.st_dev, before.st_ino) != (metadata.st_dev, metadata.st_ino)
+        ):
+            raise ValueError("provenance lock must be a regular file")
+        chunks: list[bytes] = []
+        remaining = MAX_LOCK_BYTES + 1
+        while remaining:
+            chunk = os.read(descriptor, remaining)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        payload = b"".join(chunks)
+        if len(payload) > MAX_LOCK_BYTES:
+            raise ValueError("provenance lock is malformed or unreadable")
+        data = json.loads(payload.decode("utf-8"))
     except (OSError, UnicodeError, json.JSONDecodeError) as exc:
         raise ValueError("provenance lock is malformed or unreadable") from exc
+    finally:
+        os.close(descriptor)
     if not isinstance(data, dict):
         raise ValueError("provenance lock must contain a JSON object")
     return _validated_provenance(data)

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -10,6 +10,7 @@ rendered with Rich Markdown.  Otherwise a default confirmation is shown.
 from __future__ import annotations
 
 import functools
+import hashlib
 import importlib.metadata
 import json
 import logging
@@ -20,6 +21,8 @@ import stat
 import subprocess
 import sys
 import tempfile
+import threading
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -40,6 +43,9 @@ from hermes_cli.plugin_supply_chain import (
 )
 
 logger = logging.getLogger(__name__)
+
+_OPERATION_MUTEXES_GUARD = threading.Lock()
+_OPERATION_MUTEXES: dict[str, threading.Lock] = {}
 
 
 @functools.lru_cache(maxsize=1)
@@ -109,6 +115,78 @@ def _plugins_dir() -> Path:
     plugins = get_hermes_home() / "plugins"
     plugins.mkdir(parents=True, exist_ok=True)
     return plugins
+
+
+@contextmanager
+def _plugin_operation_lock(target: Path):
+    """Serialize all Hermes install/update operations for one canonical target."""
+    canonical_target = target.resolve(strict=False)
+    plugins_root = _plugins_dir().resolve(strict=True)
+    try:
+        canonical_target.relative_to(plugins_root)
+    except ValueError:
+        raise PluginOperationError("Plugin operation lock target must remain under plugins root.")
+    key = hashlib.sha256(os.fsencode(str(canonical_target))).hexdigest()
+    with _OPERATION_MUTEXES_GUARD:
+        mutex = _OPERATION_MUTEXES.setdefault(key, threading.Lock())
+
+    with mutex:
+        lock_dir = plugins_root / ".operation-locks"
+        try:
+            lock_dir.mkdir(mode=0o700, exist_ok=True)
+            directory_metadata = lock_dir.lstat()
+            if stat.S_ISLNK(directory_metadata.st_mode) or not stat.S_ISDIR(directory_metadata.st_mode):
+                raise PluginOperationError("Plugin operation lock directory is unsafe.")
+            if os.name == "posix":
+                os.chmod(lock_dir, 0o700)
+            lock_path = lock_dir / f"{key}.lock"
+            nofollow = getattr(os, "O_NOFOLLOW", 0)
+            before = None
+            if not nofollow:
+                try:
+                    before = lock_path.lstat()
+                except FileNotFoundError:
+                    pass
+                if before is not None and not stat.S_ISREG(before.st_mode):
+                    raise PluginOperationError("Plugin operation lock must be a regular file.")
+            flags = os.O_RDWR | os.O_CREAT | nofollow
+            descriptor = os.open(lock_path, flags, 0o600)
+        except (OSError, ValueError) as exc:
+            raise PluginOperationError("Plugin operation lock is unsafe or unavailable.") from exc
+        try:
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISREG(metadata.st_mode):
+                raise PluginOperationError("Plugin operation lock must be a regular file.")
+            if metadata.st_nlink != 1:
+                raise PluginOperationError("Plugin operation lock must have a single link.")
+            if before is not None and (before.st_dev, before.st_ino) != (
+                metadata.st_dev,
+                metadata.st_ino,
+            ):
+                raise PluginOperationError("Plugin operation lock must be a regular file.")
+            if os.name == "posix":
+                os.fchmod(descriptor, 0o600)
+                import fcntl
+
+                fcntl.flock(descriptor, fcntl.LOCK_EX)
+            else:
+                import msvcrt
+
+                if metadata.st_size == 0:
+                    os.write(descriptor, b"\0")
+                    os.fsync(descriptor)
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                msvcrt.locking(descriptor, msvcrt.LK_LOCK, 1)
+            try:
+                yield
+            finally:
+                if os.name == "posix":
+                    fcntl.flock(descriptor, fcntl.LOCK_UN)
+                else:
+                    os.lseek(descriptor, 0, os.SEEK_SET)
+                    msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+        finally:
+            os.close(descriptor)
 
 
 def _sanitize_plugin_name(
@@ -913,15 +991,8 @@ def _install_plugin_core(
                     f"but this installer only supports up to {_SUPPORTED_MANIFEST_VERSION}. "
                     f"Run {recommended_update_command()} to update Hermes."
                 ) from None
-        if target.exists() and not force:
-            raise PluginOperationError(
-                f"Plugin '{plugin_name}' already exists. Use force reinstall "
-                f"or run `hermes plugins update {plugin_name}`."
-            )
-
         staging_root = Path(tempfile.mkdtemp(prefix=".install-", dir=plugins_dir))
         staged = staging_root / "payload"
-        backup: Path | None = None
         try:
             shutil.copytree(source_dir, staged, symlinks=True)
             from rich.console import Console
@@ -940,24 +1011,30 @@ def _install_plugin_core(
                 write_provenance_lock(staged, provenance)
             except Exception as exc:
                 raise PluginOperationError("Failed to write plugin provenance lock.") from exc
-
-            try:
-                if target.exists():
-                    backup = Path(tempfile.mkdtemp(prefix=".backup-", dir=plugins_dir))
-                    backup.rmdir()
-                    os.replace(target, backup)
-                os.replace(staged, target)
-            except OSError as exc:
-                if backup is not None and backup.exists():
-                    _restore_plugin_backup(backup, target)
-                raise PluginOperationError("Failed to publish plugin installation.") from exc
-
-            if backup is not None and backup.exists():
+            with _plugin_operation_lock(target):
+                if target.exists() and not force:
+                    raise PluginOperationError(
+                        f"Plugin '{plugin_name}' already exists. Use force reinstall "
+                        f"or run `hermes plugins update {plugin_name}`."
+                    )
+                backup: Path | None = None
                 try:
-                    shutil.rmtree(backup)
-                except OSError:
-                    logger.warning("Installed plugin, but failed to clean up previous installation backup")
-            return InstallResult(target, installed_manifest, installed_name, provenance, capabilities)
+                    if target.exists():
+                        backup = Path(tempfile.mkdtemp(prefix=".backup-", dir=plugins_dir))
+                        backup.rmdir()
+                        os.replace(target, backup)
+                    os.replace(staged, target)
+                except OSError as exc:
+                    if backup is not None and backup.exists():
+                        _restore_plugin_backup(backup, target)
+                    raise PluginOperationError("Failed to publish plugin installation.") from exc
+
+                if backup is not None and backup.exists():
+                    try:
+                        shutil.rmtree(backup)
+                    except OSError:
+                        logger.warning("Installed plugin, but failed to clean up previous installation backup")
+                return InstallResult(target, installed_manifest, installed_name, provenance, capabilities)
         finally:
             shutil.rmtree(staging_root, ignore_errors=True)
 
@@ -1068,45 +1145,39 @@ def cmd_update(name: str) -> None:
         sys.exit(1)
 
     try:
-        provenance = _update_provenance_preflight(target, name)
+        with _plugin_operation_lock(target):
+            provenance = _update_provenance_preflight(target, name)
+            if not (target / ".git").exists():
+                console.print(
+                    f"[red]Error:[/red] Plugin '{name}' was not installed from git "
+                    f"(no .git directory). Cannot update."
+                )
+                sys.exit(1)
+            console.print(f"[dim]Updating {name}...[/dim]")
+            ok, output = _git_pull_plugin_dir(target)
+            if not ok:
+                console.print(f"[red]Error:[/red] {output}")
+                sys.exit(1)
+            if provenance is not None:
+                try:
+                    _refresh_update_provenance(target, provenance)
+                except Exception:
+                    console.print(
+                        "[red]Error:[/red] Plugin updated, but provenance lock refresh failed."
+                    )
+                    sys.exit(1)
+            _copy_example_files(target, console)
+            out = output.strip()
+            if "Already up to date" in out:
+                console.print(
+                    f"[green]✓[/green] Plugin [bold]{name}[/bold] is already up to date."
+                )
+            else:
+                console.print(f"[green]✓[/green] Plugin [bold]{name}[/bold] updated.")
+                console.print(f"[dim]{out}[/dim]")
     except PluginOperationError as exc:
         console.print(f"[red]Error:[/red] {exc}")
         sys.exit(1)
-
-    if not (target / ".git").exists():
-        console.print(
-            f"[red]Error:[/red] Plugin '{name}' was not installed from git "
-            f"(no .git directory). Cannot update."
-        )
-        sys.exit(1)
-
-    console.print(f"[dim]Updating {name}...[/dim]")
-
-    ok, output = _git_pull_plugin_dir(target)
-    if not ok:
-        console.print(f"[red]Error:[/red] {output}")
-        sys.exit(1)
-
-    if provenance is not None:
-        try:
-            _refresh_update_provenance(target, provenance)
-        except Exception:
-            console.print(
-                "[red]Error:[/red] Plugin updated, but provenance lock refresh failed."
-            )
-            sys.exit(1)
-
-    # Copy any new .example files
-    _copy_example_files(target, console)
-
-    out = output.strip()
-    if "Already up to date" in out:
-        console.print(
-            f"[green]✓[/green] Plugin [bold]{name}[/bold] is already up to date."
-        )
-    else:
-        console.print(f"[green]✓[/green] Plugin [bold]{name}[/bold] updated.")
-        console.print(f"[dim]{out}[/dim]")
 
 
 def cmd_remove(name: str) -> None:
@@ -2422,36 +2493,33 @@ def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
         }
 
     try:
-        provenance = _update_provenance_preflight(target, name)
+        with _plugin_operation_lock(target):
+            provenance = _update_provenance_preflight(target, name)
+            if not (target / ".git").exists():
+                return {
+                    "ok": False,
+                    "error": f"Plugin '{name}' is not a git checkout; cannot pull updates.",
+                }
+            ok, msg = _git_pull_plugin_dir(target)
+            if not ok:
+                return {"ok": False, "error": msg}
+            if provenance is not None:
+                try:
+                    _refresh_update_provenance(target, provenance)
+                except Exception:
+                    return {
+                        "ok": False,
+                        "updated": True,
+                        "error": "Plugin updated, but provenance lock refresh failed.",
+                        "name": name,
+                    }
+            from rich.console import Console
+
+            _copy_example_files(target, Console())
+            unchanged = "Already up to date" in msg
+            return {"ok": True, "name": name, "output": msg, "unchanged": unchanged}
     except PluginOperationError as exc:
         return {"ok": False, "error": str(exc), "name": name}
-
-    if not (target / ".git").exists():
-        return {
-            "ok": False,
-            "error": f"Plugin '{name}' is not a git checkout; cannot pull updates.",
-        }
-
-    ok, msg = _git_pull_plugin_dir(target)
-    if not ok:
-        return {"ok": False, "error": msg}
-
-    if provenance is not None:
-        try:
-            _refresh_update_provenance(target, provenance)
-        except Exception:
-            return {
-                "ok": False,
-                "updated": True,
-                "error": "Plugin updated, but provenance lock refresh failed.",
-                "name": name,
-            }
-
-    from rich.console import Console
-
-    _copy_example_files(target, Console())
-    unchanged = "Already up to date" in msg
-    return {"ok": True, "name": name, "output": msg, "unchanged": unchanged}
 
 
 def _update_provenance_preflight(

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -14,6 +14,7 @@ import importlib.metadata
 import json
 import logging
 import os
+import shlex
 import shutil
 import stat
 import subprocess
@@ -28,9 +29,11 @@ from hermes_constants import get_hermes_home
 from hermes_cli.config import cfg_get
 from hermes_cli.secret_prompt import masked_secret_prompt
 from hermes_cli.plugin_supply_chain import (
+    LOCK_FILENAME,
     PluginCapabilityReport,
     PluginProvenance,
     build_capability_report,
+    read_provenance_lock,
     validate_full_commit_sha,
     validate_source_url,
     write_provenance_lock,
@@ -1064,6 +1067,12 @@ def cmd_update(name: str) -> None:
         console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
 
+    try:
+        provenance = _update_provenance_preflight(target, name)
+    except PluginOperationError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        sys.exit(1)
+
     if not (target / ".git").exists():
         console.print(
             f"[red]Error:[/red] Plugin '{name}' was not installed from git "
@@ -1077,6 +1086,15 @@ def cmd_update(name: str) -> None:
     if not ok:
         console.print(f"[red]Error:[/red] {output}")
         sys.exit(1)
+
+    if provenance is not None:
+        try:
+            _refresh_update_provenance(target, provenance)
+        except Exception:
+            console.print(
+                "[red]Error:[/red] Plugin updated, but provenance lock refresh failed."
+            )
+            sys.exit(1)
 
     # Copy any new .example files
     _copy_example_files(target, console)
@@ -2403,6 +2421,11 @@ def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
             "error": f"Plugin '{name}' was not found under {_plugins_dir()}.",
         }
 
+    try:
+        provenance = _update_provenance_preflight(target, name)
+    except PluginOperationError as exc:
+        return {"ok": False, "error": str(exc), "name": name}
+
     if not (target / ".git").exists():
         return {
             "ok": False,
@@ -2413,11 +2436,76 @@ def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
     if not ok:
         return {"ok": False, "error": msg}
 
+    if provenance is not None:
+        try:
+            _refresh_update_provenance(target, provenance)
+        except Exception:
+            return {
+                "ok": False,
+                "updated": True,
+                "error": "Plugin updated, but provenance lock refresh failed.",
+                "name": name,
+            }
+
     from rich.console import Console
 
     _copy_example_files(target, Console())
     unchanged = "Already up to date" in msg
     return {"ok": True, "name": name, "output": msg, "unchanged": unchanged}
+
+
+def _update_provenance_preflight(
+    target: Path, name: str
+) -> PluginProvenance | None:
+    """Fail closed on unsafe locks and reject drift of pinned installs."""
+    lock_path = target / LOCK_FILENAME
+    try:
+        lock_path.lstat()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise PluginOperationError(
+            "Plugin provenance lock is malformed or unreadable."
+        ) from exc
+    try:
+        provenance = read_provenance_lock(target)
+    except (OSError, ValueError) as exc:
+        raise PluginOperationError(
+            "Plugin provenance lock is malformed or unreadable."
+        ) from exc
+    if provenance is None:
+        raise PluginOperationError("Plugin provenance lock is malformed or unreadable.")
+    if provenance.requested_ref is not None:
+        source = provenance.source_url
+        if provenance.subdir:
+            source = f"{source}#{provenance.subdir}"
+        raise PluginOperationError(
+            "Pinned plugins cannot be updated in place. Reinstall with a new exact SHA: "
+            f"`hermes plugins install {shlex.quote(source)} "
+            "--ref <40-char-sha> --force`."
+        )
+    return provenance
+
+
+def _refresh_update_provenance(target: Path, provenance: PluginProvenance) -> None:
+    """Atomically advance an unpinned install lock after a successful pull."""
+    git_exe = _resolve_git_executable()
+    if not git_exe:
+        raise PluginOperationError("git is not installed or not in PATH.")
+    head = _run_inspect_git(
+        [git_exe, "rev-parse", "HEAD"], operation="resolve commit", cwd=target
+    )
+    head = validate_full_commit_sha(head)
+    write_provenance_lock(
+        target,
+        PluginProvenance(
+            source_url=provenance.source_url,
+            subdir=provenance.subdir,
+            resolved_commit=head,
+            requested_ref=None,
+            inspected_at=datetime.now(timezone.utc).isoformat(),
+        ),
+    )
 
 
 def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
@@ -2426,11 +2514,12 @@ def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
         return False, "git is not installed or not in PATH."
     try:
         result = subprocess.run(
-            [git_exe, "pull", "--ff-only"],
+            [git_exe, "-c", f"core.hooksPath={os.devnull}", "pull", "--ff-only"],
             capture_output=True,
             text=True,
             timeout=60,
             cwd=str(target),
+            env=_inspection_git_env(),
         )
     except FileNotFoundError:
         return False, "git is not installed or not in PATH."
@@ -2438,9 +2527,10 @@ def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
         return False, "Git pull timed out after 60 seconds."
 
     if result.returncode != 0:
-        err = (result.stderr or "").strip() or result.stdout.strip()
-        return False, err or "git pull failed."
-    return True, result.stdout.strip()
+        return False, "Git pull failed."
+    if "Already up to date" in result.stdout:
+        return True, "Already up to date."
+    return True, "Updated."
 
 
 def dashboard_remove_user_plugin(name: str) -> dict[str, Any]:

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -448,23 +449,109 @@ def _require_installed_plugin(name: str, plugins_dir: Path, console) -> Path:
 # ---------------------------------------------------------------------------
 
 
-def _run_inspect_git(command: list[str], *, cwd: Path | None = None) -> str:
+MAX_INSPECT_MANIFEST_BYTES = 256 * 1024
+
+
+def _inspection_git_env() -> dict[str, str]:
+    """Return an environment that cannot inherit Git execution configuration."""
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith(("GIT_", "GCM_")) and key != "SSH_ASKPASS"
+    }
+    env.update(
+        {
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_TERMINAL_PROMPT": "0",
+            "GCM_INTERACTIVE": "Never",
+            "GIT_ALLOW_PROTOCOL": "file:https:http:ssh",
+        }
+    )
+    return env
+
+
+def _run_inspect_git(
+    command: list[str], *, operation: str, cwd: Path | None = None
+) -> str:
+    failures = {
+        "clone": "Git clone failed.",
+        "checkout": "Git checkout failed.",
+        "resolve commit": "Git resolve commit failed.",
+    }
+    failure = failures.get(operation, "Git operation failed.")
+    safe_command = [command[0], "-c", f"core.hooksPath={os.devnull}", *command[1:]]
     try:
         result = subprocess.run(
-            command,
+            safe_command,
             cwd=str(cwd) if cwd else None,
             capture_output=True,
             text=True,
             timeout=60,
+            env=_inspection_git_env(),
         )
     except FileNotFoundError as exc:
         raise PluginOperationError("git is not installed or not in PATH.") from exc
     except subprocess.TimeoutExpired as exc:
-        raise PluginOperationError("Git operation timed out after 60 seconds.") from exc
+        raise PluginOperationError(f"{failure[:-1]} (timed out).") from exc
     if result.returncode != 0:
-        detail = (result.stderr or result.stdout or "").strip()
-        raise PluginOperationError(f"Git operation failed:\n{detail}")
+        raise PluginOperationError(failure)
     return result.stdout.strip()
+
+
+def _read_inspection_manifest(plugin_dir: Path) -> dict[str, Any]:
+    """Read an untrusted manifest through a bounded, non-following descriptor."""
+    manifest_path = plugin_dir / "plugin.yaml"
+    try:
+        before = manifest_path.lstat()
+    except OSError as exc:
+        raise PluginOperationError("Plugin manifest plugin.yaml is missing.") from exc
+    if stat.S_ISLNK(before.st_mode):
+        raise PluginOperationError("Plugin manifest plugin.yaml must not be a symlink.")
+    if not stat.S_ISREG(before.st_mode):
+        raise PluginOperationError("Plugin manifest plugin.yaml must be a regular file.")
+
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NONBLOCK", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(manifest_path, flags)
+        try:
+            opened = os.fstat(descriptor)
+            if not stat.S_ISREG(opened.st_mode):
+                raise PluginOperationError("Plugin manifest plugin.yaml must be a regular file.")
+            if (before.st_dev, before.st_ino) != (opened.st_dev, opened.st_ino):
+                raise PluginOperationError("Plugin manifest plugin.yaml changed during inspection.")
+            chunks: list[bytes] = []
+            remaining = MAX_INSPECT_MANIFEST_BYTES + 1
+            while remaining:
+                chunk = os.read(descriptor, min(65536, remaining))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+        finally:
+            os.close(descriptor)
+    except PluginOperationError:
+        raise
+    except OSError as exc:
+        raise PluginOperationError("Plugin manifest plugin.yaml could not be read safely.") from exc
+
+    raw = b"".join(chunks)
+    if len(raw) > MAX_INSPECT_MANIFEST_BYTES:
+        raise PluginOperationError("Plugin manifest plugin.yaml is too large.")
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise PluginOperationError("Plugin manifest plugin.yaml is not valid UTF-8.") from exc
+    try:
+        import yaml
+
+        manifest = yaml.safe_load(text)
+    except Exception as exc:
+        raise PluginOperationError("Plugin manifest plugin.yaml is malformed.") from exc
+    if not isinstance(manifest, dict) or not manifest:
+        raise PluginOperationError("Plugin manifest plugin.yaml is malformed.")
+    return manifest
 
 
 def inspect_plugin_source(
@@ -494,13 +581,17 @@ def inspect_plugin_source(
 
     with tempfile.TemporaryDirectory() as temporary:
         clone_root = Path(temporary) / "plugin"
-        _run_inspect_git([git_exe, "clone", source_url, str(clone_root)])
+        _run_inspect_git(
+            [git_exe, "clone", source_url, str(clone_root)], operation="clone"
+        )
         if requested_ref is not None:
             _run_inspect_git(
-                [git_exe, "checkout", "--detach", requested_ref], cwd=clone_root
+                [git_exe, "checkout", "--detach", requested_ref],
+                operation="checkout",
+                cwd=clone_root,
             )
         resolved_commit = _run_inspect_git(
-            [git_exe, "rev-parse", "HEAD"], cwd=clone_root
+            [git_exe, "rev-parse", "HEAD"], operation="resolve commit", cwd=clone_root
         )
         try:
             resolved_commit = validate_full_commit_sha(resolved_commit)
@@ -514,12 +605,7 @@ def inspect_plugin_source(
         plugin_dir = (
             _resolve_subdir_within(clone_root, subdir) if subdir else clone_root
         )
-        manifest_path = plugin_dir / "plugin.yaml"
-        if not manifest_path.is_file():
-            raise PluginOperationError("Plugin manifest plugin.yaml is missing.")
-        manifest = _read_manifest(plugin_dir)
-        if not isinstance(manifest, dict) or not manifest:
-            raise PluginOperationError("Plugin manifest plugin.yaml is malformed.")
+        manifest = _read_inspection_manifest(plugin_dir)
         capability = asdict(build_capability_report(plugin_dir, manifest))
         capability = {
             key: list(value) if isinstance(value, tuple) else value
@@ -555,7 +641,7 @@ def inspect_plugin_source(
         }
 
 
-def cmd_inspect(
+def _cmd_inspect_impl(
     identifier: str, *, requested_ref: str | None = None, json_output: bool = False
 ) -> dict[str, Any]:
     """Inspect and print a remote plugin's declared metadata."""
@@ -569,6 +655,15 @@ def cmd_inspect(
 
             Console().print(f"[red]Error:[/red] {exc}")
         raise SystemExit(1) from exc
+    except Exception:
+        message = "Plugin inspection failed unexpectedly."
+        if json_output:
+            print(json.dumps({"error": message}, sort_keys=True))
+        else:
+            from rich.console import Console
+
+            Console().print(f"[red]Error:[/red] {message}")
+        raise SystemExit(1) from None
 
     if json_output:
         try:
@@ -597,6 +692,25 @@ def cmd_inspect(
         console.print(f"Tools: {', '.join(capabilities['tools']) or '(none)'}")
         console.print("[yellow]This inspection is not a security audit.[/yellow]")
     return result
+
+
+def cmd_inspect(
+    identifier: str, *, requested_ref: str | None = None, json_output: bool = False
+) -> dict[str, Any]:
+    """Inspect a plugin while containing unexpected boundary failures."""
+    try:
+        return _cmd_inspect_impl(
+            identifier, requested_ref=requested_ref, json_output=json_output
+        )
+    except Exception:
+        message = "Plugin inspection failed unexpectedly."
+        if json_output:
+            print(json.dumps({"error": message}, sort_keys=True))
+        else:
+            from rich.console import Console
+
+            Console().print(f"[red]Error:[/red] {message}")
+        raise SystemExit(1) from None
 
 
 def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, str]:

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -17,6 +17,8 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
+from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Optional
 
@@ -444,6 +446,136 @@ def _require_installed_plugin(name: str, plugins_dir: Path, console) -> Path:
 # ---------------------------------------------------------------------------
 # Commands
 # ---------------------------------------------------------------------------
+
+
+def _run_inspect_git(command: list[str], *, cwd: Path | None = None) -> str:
+    try:
+        result = subprocess.run(
+            command,
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except FileNotFoundError as exc:
+        raise PluginOperationError("git is not installed or not in PATH.") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise PluginOperationError("Git operation timed out after 60 seconds.") from exc
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        raise PluginOperationError(f"Git operation failed:\n{detail}")
+    return result.stdout.strip()
+
+
+def inspect_plugin_source(
+    identifier: str, *, requested_ref: str | None = None
+) -> dict[str, Any]:
+    """Inspect source metadata in a temporary clone without loading or installing it."""
+    from hermes_cli.plugin_supply_chain import (
+        build_capability_report,
+        validate_full_commit_sha,
+        validate_source_url,
+    )
+
+    if requested_ref is not None:
+        try:
+            requested_ref = validate_full_commit_sha(requested_ref)
+        except ValueError as exc:
+            raise PluginOperationError(str(exc)) from exc
+    try:
+        git_url, subdir = _resolve_git_url(identifier)
+        source_url = validate_source_url(git_url)
+    except ValueError as exc:
+        raise PluginOperationError(str(exc)) from exc
+
+    git_exe = _resolve_git_executable()
+    if not git_exe:
+        raise PluginOperationError("git is not installed or not in PATH.")
+
+    with tempfile.TemporaryDirectory() as temporary:
+        clone_root = Path(temporary) / "plugin"
+        _run_inspect_git([git_exe, "clone", source_url, str(clone_root)])
+        if requested_ref is not None:
+            _run_inspect_git(
+                [git_exe, "checkout", "--detach", requested_ref], cwd=clone_root
+            )
+        resolved_commit = _run_inspect_git(
+            [git_exe, "rev-parse", "HEAD"], cwd=clone_root
+        )
+        try:
+            resolved_commit = validate_full_commit_sha(resolved_commit)
+        except ValueError as exc:
+            raise PluginOperationError(f"Git returned an invalid commit: {exc}") from exc
+        if requested_ref is not None and resolved_commit != requested_ref:
+            raise PluginOperationError(
+                "Checked out commit does not exactly match the requested ref."
+            )
+
+        plugin_dir = (
+            _resolve_subdir_within(clone_root, subdir) if subdir else clone_root
+        )
+        manifest_path = plugin_dir / "plugin.yaml"
+        if not manifest_path.is_file():
+            raise PluginOperationError("Plugin manifest plugin.yaml is missing.")
+        manifest = _read_manifest(plugin_dir)
+        if not isinstance(manifest, dict) or not manifest:
+            raise PluginOperationError("Plugin manifest plugin.yaml is malformed.")
+        capability = asdict(build_capability_report(plugin_dir, manifest))
+        capability = {
+            key: list(value) if isinstance(value, tuple) else value
+            for key, value in capability.items()
+        }
+        fallback_name = (
+            subdir.rstrip("/").rsplit("/", 1)[-1]
+            if subdir
+            else _repo_name_from_url(source_url)
+        )
+        return {
+            "source_url": source_url,
+            "subdir": subdir,
+            "requested_ref": requested_ref,
+            "resolved_commit": resolved_commit,
+            "plugin": {
+                "name": manifest.get("name") or fallback_name,
+                "version": manifest.get("version"),
+                "description": manifest.get("description"),
+            },
+            "capabilities": capability,
+        }
+
+
+def cmd_inspect(
+    identifier: str, *, requested_ref: str | None = None, json_output: bool = False
+) -> dict[str, Any]:
+    """Inspect and print a remote plugin's declared metadata."""
+    try:
+        result = inspect_plugin_source(identifier, requested_ref=requested_ref)
+    except PluginOperationError as exc:
+        if json_output:
+            print(json.dumps({"error": str(exc)}, sort_keys=True))
+        else:
+            from rich.console import Console
+
+            Console().print(f"[red]Error:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    if json_output:
+        print(json.dumps(result, sort_keys=True))
+    else:
+        from rich.console import Console
+
+        console = Console()
+        plugin = result["plugin"]
+        capabilities = result["capabilities"]
+        console.print(f"[bold]{plugin['name']}[/bold] {plugin['version'] or ''}")
+        if plugin["description"]:
+            console.print(plugin["description"])
+        console.print(f"[dim]Source:[/dim] {result['source_url']}")
+        console.print(f"[dim]Commit:[/dim] {result['resolved_commit']}")
+        console.print(f"Hooks: {', '.join(capabilities['hooks']) or '(none)'}")
+        console.print(f"Tools: {', '.join(capabilities['tools']) or '(none)'}")
+        console.print("[yellow]This inspection is not a security audit.[/yellow]")
+    return result
 
 
 def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, str]:
@@ -2020,6 +2152,12 @@ def plugins_command(args) -> None:
         )
     elif action == "update":
         cmd_update(args.name)
+    elif action == "inspect":
+        cmd_inspect(
+            args.identifier,
+            requested_ref=getattr(args, "requested_ref", None),
+            json_output=getattr(args, "json", False),
+        )
     elif action in {"remove", "rm", "uninstall"}:
         cmd_remove(args.name)
     elif action == "enable":

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -15,6 +15,7 @@ import importlib.metadata
 import json
 import logging
 import os
+import re
 import shlex
 import shutil
 import stat
@@ -1154,6 +1155,7 @@ def cmd_update(name: str) -> None:
                 )
                 sys.exit(1)
             console.print(f"[dim]Updating {name}...[/dim]")
+            _validate_update_local_git_config(target, provenance)
             ok, output = _git_pull_plugin_dir(target)
             if not ok:
                 console.print(f"[red]Error:[/red] {output}")
@@ -1163,7 +1165,7 @@ def cmd_update(name: str) -> None:
                     _refresh_update_provenance(target, provenance)
                 except Exception:
                     console.print(
-                        "[red]Error:[/red] Plugin updated, but provenance lock refresh failed."
+                        "[red]Error:[/red] Git pull succeeded, but provenance lock refresh failed."
                     )
                     sys.exit(1)
             _copy_example_files(target, console)
@@ -2500,6 +2502,7 @@ def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
                     "ok": False,
                     "error": f"Plugin '{name}' is not a git checkout; cannot pull updates.",
                 }
+            _validate_update_local_git_config(target, provenance)
             ok, msg = _git_pull_plugin_dir(target)
             if not ok:
                 return {"ok": False, "error": msg}
@@ -2507,10 +2510,12 @@ def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
                 try:
                     _refresh_update_provenance(target, provenance)
                 except Exception:
+                    unchanged = "Already up to date" in msg
                     return {
                         "ok": False,
-                        "updated": True,
-                        "error": "Plugin updated, but provenance lock refresh failed.",
+                        "pull_succeeded": True,
+                        "unchanged": unchanged,
+                        "error": "Git pull succeeded, but provenance lock refresh failed.",
                         "name": name,
                     }
             from rich.console import Console
@@ -2547,12 +2552,91 @@ def _update_provenance_preflight(
         source = provenance.source_url
         if provenance.subdir:
             source = f"{source}#{provenance.subdir}"
+        if os.name == "nt":
+            guidance = (
+                f"Source: {source}. Run `hermes plugins install <source-shown-above> "
+                "--ref <40-char-sha> --force`."
+            )
+        else:
+            guidance = (
+                "Reinstall with a new exact SHA: "
+                f"`hermes plugins install {shlex.quote(source)} "
+                "--ref <40-char-sha> --force`."
+            )
         raise PluginOperationError(
-            "Pinned plugins cannot be updated in place. Reinstall with a new exact SHA: "
-            f"`hermes plugins install {shlex.quote(source)} "
-            "--ref <40-char-sha> --force`."
+            "Pinned plugins cannot be updated in place. " + guidance
         )
     return provenance
+
+
+_UNSAFE_LOCAL_GIT_CONFIG = re.compile(
+    r"(?:"
+    r"filter\..+\.(?:clean|smudge|process|required)|"
+    r"core\.(?:fsmonitor|sshcommand|gitproxy|hookspath)|"
+    r"credential(?:\..+)?\.helper|"
+    r"include\.path|includeif\..+\.path|"
+    r"remote\..+\.(?:uploadpack|receivepack|proxy)|"
+    r"url\..+\.(?:insteadof|pushinsteadof)|"
+    r"protocol\..+\.allow|"
+    r"diff\..+\.command|merge\..+\.driver|"
+    r"difftool\..+\.cmd|mergetool\..+\.cmd|"
+    r"alias\..+"
+    r")\Z",
+    re.IGNORECASE,
+)
+_UNSAFE_LOCAL_GIT_MESSAGE = "Unsafe local Git configuration; reinstall the plugin instead."
+
+
+def _safe_local_git_config_query(target: Path, args: list[str]) -> bytes:
+    """Run a local-only, no-includes config query without exposing its output on failure."""
+    git_exe = _resolve_git_executable()
+    if not git_exe:
+        raise PluginOperationError(_UNSAFE_LOCAL_GIT_MESSAGE)
+    try:
+        result = subprocess.run(
+            [git_exe, "-c", f"core.hooksPath={os.devnull}", "config", "--local", "--no-includes", *args],
+            cwd=str(target),
+            capture_output=True,
+            timeout=60,
+            env=_inspection_git_env(),
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired) as exc:
+        raise PluginOperationError(_UNSAFE_LOCAL_GIT_MESSAGE) from exc
+    if result.returncode != 0:
+        raise PluginOperationError(_UNSAFE_LOCAL_GIT_MESSAGE)
+    return result.stdout
+
+
+def _validate_update_local_git_config(
+    target: Path, provenance: PluginProvenance | None
+) -> None:
+    """Reject local Git configuration that can execute, rewrite, or drift an update."""
+    names = _safe_local_git_config_query(target, ["--name-only", "--null", "--list"])
+    try:
+        decoded_names = [name.decode("utf-8") for name in names.split(b"\0") if name]
+    except UnicodeDecodeError as exc:
+        raise PluginOperationError(_UNSAFE_LOCAL_GIT_MESSAGE) from exc
+    if any(_UNSAFE_LOCAL_GIT_CONFIG.fullmatch(name) for name in decoded_names):
+        raise PluginOperationError(_UNSAFE_LOCAL_GIT_MESSAGE)
+
+    # Legacy installs retain their historical remote compatibility. Provenance-backed
+    # installs must still point exactly at the source Hermes inspected and locked.
+    if provenance is not None:
+        raw_urls = _safe_local_git_config_query(
+            target, ["--null", "--get-all", "remote.origin.url"]
+        )
+        try:
+            values = raw_urls.split(b"\0")
+            if values[-1:] == [b""]:
+                values.pop()
+            if len(values) != 1:
+                raise ValueError("origin must have exactly one URL")
+            remote_url = values[0].decode("utf-8")
+            validated_url = validate_source_url(remote_url)
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise PluginOperationError(_UNSAFE_LOCAL_GIT_MESSAGE) from exc
+        if validated_url != provenance.source_url:
+            raise PluginOperationError(_UNSAFE_LOCAL_GIT_MESSAGE)
 
 
 def _refresh_update_provenance(target: Path, provenance: PluginProvenance) -> None:

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1156,7 +1156,10 @@ def cmd_update(name: str) -> None:
                 sys.exit(1)
             console.print(f"[dim]Updating {name}...[/dim]")
             _validate_update_local_git_config(target, provenance)
-            ok, output = _git_pull_plugin_dir(target)
+            ok, output = _git_pull_plugin_dir(
+                target,
+                source_url=provenance.source_url if provenance is not None else None,
+            )
             if not ok:
                 console.print(f"[red]Error:[/red] {output}")
                 sys.exit(1)
@@ -2503,7 +2506,10 @@ def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
                     "error": f"Plugin '{name}' is not a git checkout; cannot pull updates.",
                 }
             _validate_update_local_git_config(target, provenance)
-            ok, msg = _git_pull_plugin_dir(target)
+            ok, msg = _git_pull_plugin_dir(
+                target,
+                source_url=provenance.source_url if provenance is not None else None,
+            )
             if not ok:
                 return {"ok": False, "error": msg}
             if provenance is not None:
@@ -2660,10 +2666,62 @@ def _refresh_update_provenance(target: Path, provenance: PluginProvenance) -> No
     )
 
 
-def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
+def _git_pull_plugin_dir(
+    target: Path, *, source_url: str | None = None
+) -> tuple[bool, str]:
+    """Fast-forward a plugin, binding provenance updates to their locked URL."""
+    if source_url is not None:
+        try:
+            source_url = validate_source_url(source_url)
+        except ValueError:
+            return False, "Git fetch failed."
     git_exe = _resolve_git_executable()
     if not git_exe:
         return False, "git is not installed or not in PATH."
+
+    if source_url is not None:
+        def run_fixed(args: list[str], failure: str) -> tuple[bool, str]:
+            try:
+                result = subprocess.run(
+                    [git_exe, "-c", f"core.hooksPath={os.devnull}", *args],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                    cwd=str(target),
+                    env=_inspection_git_env(),
+                )
+            except (FileNotFoundError, OSError):
+                return False, failure
+            except subprocess.TimeoutExpired:
+                return False, f"{failure[:-1]} (timed out)."
+            if result.returncode != 0:
+                return False, failure
+            return True, result.stdout.strip()
+
+        ok, old_head = run_fixed(["rev-parse", "--verify", "HEAD^{commit}"], "Git resolve commit failed.")
+        if not ok:
+            return False, old_head
+        try:
+            old_head = validate_full_commit_sha(old_head)
+        except ValueError:
+            return False, "Git resolve commit failed."
+        ok, message = run_fixed(
+            ["fetch", "--no-tags", "--", source_url, "HEAD"], "Git fetch failed."
+        )
+        if not ok:
+            return False, message
+        ok, message = run_fixed(["merge", "--ff-only", "FETCH_HEAD"], "Git merge failed.")
+        if not ok:
+            return False, message
+        ok, new_head = run_fixed(["rev-parse", "--verify", "HEAD^{commit}"], "Git resolve commit failed.")
+        if not ok:
+            return False, new_head
+        try:
+            new_head = validate_full_commit_sha(new_head)
+        except ValueError:
+            return False, "Git resolve commit failed."
+        return (True, "Already up to date.") if old_head == new_head else (True, "Updated.")
+
     try:
         result = subprocess.run(
             [git_exe, "-c", f"core.hooksPath={os.devnull}", "pull", "--ff-only"],

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -19,13 +19,22 @@ import stat
 import subprocess
 import sys
 import tempfile
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_cli.config import cfg_get
 from hermes_cli.secret_prompt import masked_secret_prompt
+from hermes_cli.plugin_supply_chain import (
+    PluginCapabilityReport,
+    PluginProvenance,
+    build_capability_report,
+    validate_full_commit_sha,
+    validate_source_url,
+    write_provenance_lock,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +76,23 @@ def _resolve_git_executable() -> Optional[str]:
 
 class PluginOperationError(Exception):
     """Recoverable plugin install/update failure (CLI exits; HTTP maps to 4xx)."""
+
+
+@dataclass(frozen=True)
+class InstallResult:
+    """Complete result of a successfully published plugin installation."""
+
+    target: Path
+    manifest: dict[str, Any]
+    name: str
+    provenance: PluginProvenance
+    capabilities: PluginCapabilityReport
+
+    def __iter__(self):
+        """Keep the historical three-value unpacking contract for callers."""
+        yield self.target
+        yield self.manifest
+        yield self.name
 
 
 # Minimum manifest version this installer understands.
@@ -713,111 +739,134 @@ def cmd_inspect(
         raise SystemExit(1) from None
 
 
-def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, str]:
-    """Clone Git plugin into ``~/.hermes/plugins``.
-
-    Returns ``(target_dir, installed_manifest, canonical_name)``.
-    Raises ``PluginOperationError`` on failure.
-    """
-    import tempfile
-
+def _install_plugin_core(
+    identifier: str, *, force: bool, requested_ref: str | None = None
+) -> InstallResult:
+    """Clone, inspect, and atomically publish a Git plugin."""
+    if requested_ref is not None:
+        try:
+            requested_ref = validate_full_commit_sha(requested_ref)
+        except ValueError as exc:
+            raise PluginOperationError(str(exc)) from exc
     try:
         git_url, subdir = _resolve_git_url(identifier)
-    except ValueError as e:
-        raise PluginOperationError(str(e)) from e
+        source_url = validate_source_url(git_url)
+    except ValueError as exc:
+        raise PluginOperationError(str(exc)) from exc
 
     plugins_dir = _plugins_dir()
+    git_exe = _resolve_git_executable()
+    if not git_exe:
+        raise PluginOperationError("git is not installed or not in PATH.")
 
     with tempfile.TemporaryDirectory() as tmp:
-        tmp_clone = Path(tmp) / "plugin"
-
-        git_exe = _resolve_git_executable()
-        if not git_exe:
-            raise PluginOperationError("git is not installed or not in PATH.")
-
-        try:
-            result = subprocess.run(
-                [git_exe, "clone", "--depth", "1", git_url, str(tmp_clone)],
-                capture_output=True,
-                text=True,
-                timeout=60,
+        clone_root = Path(tmp) / "plugin"
+        _run_inspect_git([git_exe, "clone", source_url, str(clone_root)], operation="clone")
+        if requested_ref is not None:
+            _run_inspect_git(
+                [git_exe, "checkout", "--detach", requested_ref],
+                operation="checkout",
+                cwd=clone_root,
             )
-        except FileNotFoundError as e:
-            raise PluginOperationError(
-                "git is not installed or not in PATH.",
-            ) from e
-        except subprocess.TimeoutExpired as e:
-            raise PluginOperationError(
-                "Git clone timed out after 60 seconds.",
-            ) from e
-
-        if result.returncode != 0:
-            err = (result.stderr or result.stdout or "").strip()
-            raise PluginOperationError(f"Git clone failed:\n{err}")
-
-        # Resolve the directory within the clone that holds the plugin.
-        if subdir:
-            tmp_target = _resolve_subdir_within(tmp_clone, subdir)
-        else:
-            tmp_target = tmp_clone
-
-        manifest = _read_manifest(tmp_target)
-        plugin_name = manifest.get("name") or (
-            subdir.rstrip("/").rsplit("/", 1)[-1] if subdir else _repo_name_from_url(git_url)
+        resolved_commit = _run_inspect_git(
+            [git_exe, "rev-parse", "HEAD"], operation="resolve commit", cwd=clone_root
         )
+        try:
+            resolved_commit = validate_full_commit_sha(resolved_commit)
+        except ValueError as exc:
+            raise PluginOperationError(f"Git returned an invalid commit: {exc}") from exc
+        if requested_ref is not None and resolved_commit != requested_ref:
+            raise PluginOperationError("Checked out commit does not exactly match the requested ref.")
+
+        source_dir = _resolve_subdir_within(clone_root, subdir) if subdir else clone_root
+        manifest = _read_inspection_manifest(source_dir)
+        fallback_name = subdir.rstrip("/").rsplit("/", 1)[-1] if subdir else _repo_name_from_url(source_url)
+        plugin_name = manifest.get("name")
+        if plugin_name is None or plugin_name == "":
+            plugin_name = fallback_name
+        elif not isinstance(plugin_name, str):
+            raise PluginOperationError("Plugin manifest field 'name' must be a string.")
+        for field in ("version", "description"):
+            value = manifest.get(field)
+            if value is not None and not isinstance(value, str):
+                raise PluginOperationError(f"Plugin manifest field '{field}' must be a string.")
 
         try:
             target = _sanitize_plugin_name(plugin_name, plugins_dir)
-        except ValueError as e:
-            raise PluginOperationError(str(e)) from e
-
+        except ValueError as exc:
+            raise PluginOperationError(str(exc)) from exc
         mv = manifest.get("manifest_version")
         if mv is not None:
             try:
                 mv_int = int(mv)
             except (ValueError, TypeError):
                 raise PluginOperationError(
-                    f"Plugin '{plugin_name}' has invalid manifest_version "
-                    f"'{mv}' (expected an integer).",
+                    f"Plugin '{plugin_name}' has invalid manifest_version '{mv}' (expected an integer)."
                 ) from None
             if mv_int > _SUPPORTED_MANIFEST_VERSION:
                 from hermes_cli.config import recommended_update_command
-
                 raise PluginOperationError(
                     f"Plugin '{plugin_name}' requires manifest_version {mv}, "
                     f"but this installer only supports up to {_SUPPORTED_MANIFEST_VERSION}. "
-                    f"Run {recommended_update_command()} to update Hermes.",
+                    f"Run {recommended_update_command()} to update Hermes."
                 ) from None
+        if target.exists() and not force:
+            raise PluginOperationError(
+                f"Plugin '{plugin_name}' already exists. Use force reinstall "
+                f"or run `hermes plugins update {plugin_name}`."
+            )
 
-        if target.exists():
-            if not force:
-                raise PluginOperationError(
-                    f"Plugin '{plugin_name}' already exists. Use force reinstall "
-                    f"or run `hermes plugins update {plugin_name}`.",
-                )
-            shutil.rmtree(target)
+        staging_root = Path(tempfile.mkdtemp(prefix=".install-", dir=plugins_dir))
+        staged = staging_root / "payload"
+        backup: Path | None = None
+        try:
+            shutil.copytree(source_dir, staged, symlinks=True)
+            from rich.console import Console
+            _copy_example_files(staged, Console())
+            installed_manifest = _read_inspection_manifest(staged)
+            installed_name = installed_manifest.get("name") or target.name
+            capabilities = build_capability_report(staged, installed_manifest)
+            provenance = PluginProvenance(
+                source_url=source_url,
+                subdir=subdir,
+                resolved_commit=resolved_commit,
+                requested_ref=requested_ref,
+                inspected_at=datetime.now(timezone.utc).isoformat(),
+            )
+            try:
+                write_provenance_lock(staged, provenance)
+            except Exception as exc:
+                raise PluginOperationError("Failed to write plugin provenance lock.") from exc
 
-        shutil.move(str(tmp_target), str(target))
+            try:
+                if target.exists():
+                    backup = Path(tempfile.mkdtemp(prefix=".backup-", dir=plugins_dir))
+                    backup.rmdir()
+                    os.replace(target, backup)
+                os.replace(staged, target)
+            except OSError as exc:
+                if backup is not None and backup.exists() and not target.exists():
+                    try:
+                        os.replace(backup, target)
+                    except OSError:
+                        logger.error("Failed to restore previous plugin after publication failure")
+                raise PluginOperationError("Failed to publish plugin installation.") from exc
 
-    has_yaml = (target / "plugin.yaml").exists() or (target / "plugin.yml").exists()
-    if not has_yaml and not (target / "__init__.py").exists():
-        logger.warning(
-            "%s has no plugin.yaml / __init__.py; may not be a valid plugin",
-            plugin_name,
-        )
-
-    from rich.console import Console
-
-    _copy_example_files(target, Console())
-    installed_manifest = _read_manifest(target)
-    installed_name = installed_manifest.get("name") or target.name
-    return target, installed_manifest, installed_name
+            if backup is not None and backup.exists():
+                try:
+                    shutil.rmtree(backup)
+                except OSError:
+                    logger.warning("Installed plugin, but failed to clean up previous installation backup")
+            return InstallResult(target, installed_manifest, installed_name, provenance, capabilities)
+        finally:
+            shutil.rmtree(staging_root, ignore_errors=True)
 
 
 def cmd_install(
     identifier: str,
     force: bool = False,
     enable: Optional[bool] = None,
+    requested_ref: str | None = None,
 ) -> None:
     """Install a plugin from a Git URL or owner/repo shorthand.
 
@@ -846,14 +895,18 @@ def cmd_install(
         console.print(f"[dim]Cloning {git_url}...[/dim]")
 
     try:
-        target, installed_manifest, installed_name = _install_plugin_core(
+        install_result = _install_plugin_core(
             identifier,
             force=force,
+            requested_ref=requested_ref,
         )
     except PluginOperationError as e:
         console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
 
+    target = install_result.target
+    installed_manifest = install_result.manifest
+    installed_name = install_result.name
     if not (target / "plugin.yaml").exists() and not (target / "plugin.yml").exists() and not (
         target / "__init__.py"
     ).exists():
@@ -2031,6 +2084,7 @@ def dashboard_install_plugin(
     *,
     force: bool,
     enable: bool,
+    requested_ref: str | None = None,
 ) -> dict[str, Any]:
     """Non-interactive install for the web dashboard. Returns a JSON-serializable dict."""
     warnings: list[str] = []
@@ -2044,13 +2098,17 @@ def dashboard_install_plugin(
         pass
 
     try:
-        target, installed_manifest, installed_name = _install_plugin_core(
+        install_result = _install_plugin_core(
             identifier,
             force=force,
+            requested_ref=requested_ref,
         )
     except PluginOperationError as exc:
         return {"ok": False, "error": str(exc)}
 
+    target = install_result.target
+    installed_manifest = install_result.manifest
+    installed_name = install_result.name
     missing_env = _missing_requires_env_names(installed_manifest)
     if enable:
         en = _get_enabled_set()
@@ -2072,6 +2130,11 @@ def dashboard_install_plugin(
         "missing_env": missing_env,
         "after_install_path": hint,
         "enabled": enable,
+        "provenance": asdict(install_result.provenance),
+        "capabilities": {
+            key: list(value) if isinstance(value, tuple) else value
+            for key, value in asdict(install_result.capabilities).items()
+        },
     }
 
 
@@ -2284,6 +2347,7 @@ def plugins_command(args) -> None:
             args.identifier,
             force=getattr(args, "force", False),
             enable=enable_arg,
+            requested_ref=getattr(args, "requested_ref", None),
         )
     elif action == "update":
         cmd_update(args.name)

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -739,6 +739,44 @@ def cmd_inspect(
         raise SystemExit(1) from None
 
 
+def _remove_partial_plugin_target(target: Path) -> None:
+    """Best-effort removal of a failed publication, never its backup."""
+    try:
+        if target.is_symlink() or target.is_file():
+            target.unlink()
+        elif target.exists():
+            shutil.rmtree(target)
+    except OSError:
+        logger.warning("Failed to remove partial plugin publication at %s", target)
+
+
+def _restore_plugin_backup(backup: Path, target: Path) -> None:
+    """Restore *backup* canonically, preserving it when recovery cannot finish."""
+    _remove_partial_plugin_target(target)
+    try:
+        os.replace(backup, target)
+        return
+    except OSError:
+        pass
+
+    try:
+        shutil.copytree(backup, target, symlinks=True)
+        if not target.exists():
+            raise OSError("restored target is unavailable after copy")
+    except OSError as exc:
+        _remove_partial_plugin_target(target)
+        recovery_path = backup.resolve()
+        raise PluginOperationError(
+            "PLUGIN_BACKUP_PRESERVED: automatic restoration failed; the old plugin "
+            f"is preserved at {recovery_path}. Manual recovery is required."
+        ) from exc
+
+    try:
+        shutil.rmtree(backup)
+    except OSError:
+        logger.warning("Restored previous plugin, but failed to clean up its backup at %s", backup)
+
+
 def _install_plugin_core(
     identifier: str, *, force: bool, requested_ref: str | None = None
 ) -> InstallResult:
@@ -845,11 +883,8 @@ def _install_plugin_core(
                     os.replace(target, backup)
                 os.replace(staged, target)
             except OSError as exc:
-                if backup is not None and backup.exists() and not target.exists():
-                    try:
-                        os.replace(backup, target)
-                    except OSError:
-                        logger.error("Failed to restore previous plugin after publication failure")
+                if backup is not None and backup.exists():
+                    _restore_plugin_backup(backup, target)
                 raise PluginOperationError("Failed to publish plugin installation.") from exc
 
             if backup is not None and backup.exists():

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -240,10 +240,18 @@ def _resolve_git_url(identifier: str) -> tuple[str, Optional[str]]:
         return git_url, (subdir or None)
 
     raise ValueError(
-        f"Invalid plugin identifier: '{identifier}'. "
-        "Use a Git URL or 'owner/repo' shorthand (optionally with a subdirectory: "
-        "'owner/repo/path/to/plugin')."
+        "Invalid plugin identifier. Use a Git URL or 'owner/repo' shorthand "
+        "(optionally with a subdirectory: 'owner/repo/path/to/plugin')."
     )
+
+
+def _resolve_validated_plugin_source(identifier: str) -> tuple[str, Optional[str]]:
+    """Resolve an identifier and reject unsafe source metadata uniformly."""
+    try:
+        git_url, subdir = _resolve_git_url(identifier)
+        return validate_source_url(git_url), subdir
+    except ValueError as exc:
+        raise PluginOperationError(str(exc)) from exc
 
 
 def _resolve_subdir_within(clone_root: Path, subdir: str) -> Path:
@@ -311,18 +319,43 @@ def _copy_example_files(plugin_dir: Path, console) -> None:
     Skips files that already exist to avoid overwriting user config on reinstall.
     """
     for example_file in plugin_dir.glob("*.example"):
-        real_name = example_file.stem  # e.g. "config.yaml" from "config.yaml.example"
+        real_name = example_file.stem
         real_path = plugin_dir / real_name
-        if not real_path.exists():
+        try:
+            real_path.lstat()
+            continue
+        except FileNotFoundError:
+            pass
+        except OSError:
+            console.print("[yellow]Warning:[/yellow] Skipped an unsafe example destination.")
+            continue
+        try:
+            content = _read_bounded_regular_file(example_file, 1024 * 1024)
+            assert content is not None
+            descriptor = os.open(
+                real_path,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0),
+                0o600,
+            )
             try:
-                shutil.copy2(example_file, real_path)
-                console.print(
-                    f"[dim]  Created {real_name} from {example_file.name}[/dim]"
-                )
-            except OSError as e:
-                console.print(
-                    f"[yellow]Warning:[/yellow] Failed to copy {example_file.name}: {e}"
-                )
+                try:
+                    destination = os.fdopen(descriptor, "wb")
+                except Exception:
+                    os.close(descriptor)
+                    raise
+                with destination:
+                    destination.write(content)
+            except Exception:
+                try:
+                    real_path.unlink()
+                except OSError:
+                    pass
+                raise
+            console.print(f"[dim]  Created {real_name} from {example_file.name}[/dim]")
+        except (OSError, PluginOperationError):
+            console.print(
+                "[yellow]Warning:[/yellow] Skipped an unsafe or unreadable example file."
+            )
 
 
 def _missing_requires_env_names(manifest: dict) -> list[str]:
@@ -427,13 +460,12 @@ def _display_after_install(plugin_dir: Path, identifier: str) -> None:
     console = Console()
     after_install = plugin_dir / "after-install.md"
 
-    if after_install.exists():
-        content = after_install.read_text(encoding="utf-8")
-        md = Markdown(content)
-        console.print()
-        console.print(Panel(md, border_style="green", expand=False))
-        console.print()
-    else:
+    try:
+        raw = _read_bounded_regular_file(after_install, 256 * 1024, missing_ok=True)
+    except PluginOperationError:
+        console.print("[yellow]Warning:[/yellow] Skipped unsafe after-install instructions.")
+        return
+    if raw is None:
         console.print()
         console.print(
             Panel(
@@ -445,6 +477,16 @@ def _display_after_install(plugin_dir: Path, identifier: str) -> None:
             )
         )
         console.print()
+        return
+    try:
+        content = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        console.print("[yellow]Warning:[/yellow] Skipped invalid after-install instructions.")
+        return
+    md = Markdown(content)
+    console.print()
+    console.print(Panel(md, border_style="green", expand=False))
+    console.print()
 
 
 def _display_removed(name: str, plugins_dir: Path) -> None:
@@ -476,6 +518,67 @@ def _require_installed_plugin(name: str, plugins_dir: Path, console) -> Path:
 
 
 MAX_INSPECT_MANIFEST_BYTES = 256 * 1024
+
+
+def _read_bounded_regular_file(
+    path: Path, max_bytes: int, *, missing_ok: bool = False
+) -> bytes | None:
+    """Read a bounded regular file without following its final path component."""
+    try:
+        before = path.lstat()
+    except FileNotFoundError as exc:
+        if missing_ok:
+            return None
+        raise PluginOperationError("Required file is missing.") from exc
+    except OSError as exc:
+        raise PluginOperationError("File could not be read safely.") from exc
+    if stat.S_ISLNK(before.st_mode) or not stat.S_ISREG(before.st_mode):
+        raise PluginOperationError("File must be a regular file.")
+
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NONBLOCK", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+        try:
+            opened = os.fstat(descriptor)
+            if not stat.S_ISREG(opened.st_mode):
+                raise PluginOperationError("File must be a regular file.")
+            if (before.st_dev, before.st_ino) != (opened.st_dev, opened.st_ino):
+                raise PluginOperationError("File changed while being read.")
+            chunks: list[bytes] = []
+            remaining = max_bytes + 1
+            while remaining:
+                chunk = os.read(descriptor, min(65536, remaining))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+        finally:
+            os.close(descriptor)
+    except PluginOperationError:
+        raise
+    except OSError as exc:
+        raise PluginOperationError("File could not be read safely.") from exc
+    raw = b"".join(chunks)
+    if len(raw) > max_bytes:
+        raise PluginOperationError("File is too large.")
+    return raw
+
+
+def _parse_manifest_file(path: Path) -> dict[str, Any]:
+    """Safely read and parse one explicit manifest candidate."""
+    raw = _read_bounded_regular_file(path, MAX_INSPECT_MANIFEST_BYTES)
+    assert raw is not None
+    try:
+        text = raw.decode("utf-8")
+        import yaml
+
+        manifest = yaml.safe_load(text)
+    except Exception as exc:
+        raise PluginOperationError("Plugin manifest is malformed.") from exc
+    if not isinstance(manifest, dict) or not manifest:
+        raise PluginOperationError("Plugin manifest is malformed.")
+    return manifest
 
 
 def _inspection_git_env() -> dict[str, str]:
@@ -526,58 +629,25 @@ def _run_inspect_git(
 
 
 def _read_inspection_manifest(plugin_dir: Path) -> dict[str, Any]:
-    """Read an untrusted manifest through a bounded, non-following descriptor."""
-    manifest_path = plugin_dir / "plugin.yaml"
+    """Strictly read plugin.yaml for remote inspection."""
     try:
-        before = manifest_path.lstat()
-    except OSError as exc:
-        raise PluginOperationError("Plugin manifest plugin.yaml is missing.") from exc
-    if stat.S_ISLNK(before.st_mode):
-        raise PluginOperationError("Plugin manifest plugin.yaml must not be a symlink.")
-    if not stat.S_ISREG(before.st_mode):
-        raise PluginOperationError("Plugin manifest plugin.yaml must be a regular file.")
+        return _parse_manifest_file(plugin_dir / "plugin.yaml")
+    except PluginOperationError as exc:
+        raise PluginOperationError(f"Plugin manifest plugin.yaml is invalid: {exc}") from exc
 
-    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NONBLOCK", 0)
-    flags |= getattr(os, "O_NOFOLLOW", 0)
-    try:
-        descriptor = os.open(manifest_path, flags)
+
+def _read_install_manifest(plugin_dir: Path) -> dict[str, Any]:
+    """Read plugin.yaml, legacy plugin.yml, or accept a manifestless plugin."""
+    for filename in ("plugin.yaml", "plugin.yml"):
+        candidate = plugin_dir / filename
         try:
-            opened = os.fstat(descriptor)
-            if not stat.S_ISREG(opened.st_mode):
-                raise PluginOperationError("Plugin manifest plugin.yaml must be a regular file.")
-            if (before.st_dev, before.st_ino) != (opened.st_dev, opened.st_ino):
-                raise PluginOperationError("Plugin manifest plugin.yaml changed during inspection.")
-            chunks: list[bytes] = []
-            remaining = MAX_INSPECT_MANIFEST_BYTES + 1
-            while remaining:
-                chunk = os.read(descriptor, min(65536, remaining))
-                if not chunk:
-                    break
-                chunks.append(chunk)
-                remaining -= len(chunk)
-        finally:
-            os.close(descriptor)
-    except PluginOperationError:
-        raise
-    except OSError as exc:
-        raise PluginOperationError("Plugin manifest plugin.yaml could not be read safely.") from exc
-
-    raw = b"".join(chunks)
-    if len(raw) > MAX_INSPECT_MANIFEST_BYTES:
-        raise PluginOperationError("Plugin manifest plugin.yaml is too large.")
-    try:
-        text = raw.decode("utf-8")
-    except UnicodeDecodeError as exc:
-        raise PluginOperationError("Plugin manifest plugin.yaml is not valid UTF-8.") from exc
-    try:
-        import yaml
-
-        manifest = yaml.safe_load(text)
-    except Exception as exc:
-        raise PluginOperationError("Plugin manifest plugin.yaml is malformed.") from exc
-    if not isinstance(manifest, dict) or not manifest:
-        raise PluginOperationError("Plugin manifest plugin.yaml is malformed.")
-    return manifest
+            candidate.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise PluginOperationError("Plugin manifest could not be inspected safely.") from exc
+        return _parse_manifest_file(candidate)
+    return {}
 
 
 def inspect_plugin_source(
@@ -595,11 +665,7 @@ def inspect_plugin_source(
             requested_ref = validate_full_commit_sha(requested_ref)
         except ValueError as exc:
             raise PluginOperationError(str(exc)) from exc
-    try:
-        git_url, subdir = _resolve_git_url(identifier)
-        source_url = validate_source_url(git_url)
-    except ValueError as exc:
-        raise PluginOperationError(str(exc)) from exc
+    source_url, subdir = _resolve_validated_plugin_source(identifier)
 
     git_exe = _resolve_git_executable()
     if not git_exe:
@@ -786,11 +852,7 @@ def _install_plugin_core(
             requested_ref = validate_full_commit_sha(requested_ref)
         except ValueError as exc:
             raise PluginOperationError(str(exc)) from exc
-    try:
-        git_url, subdir = _resolve_git_url(identifier)
-        source_url = validate_source_url(git_url)
-    except ValueError as exc:
-        raise PluginOperationError(str(exc)) from exc
+    source_url, subdir = _resolve_validated_plugin_source(identifier)
 
     plugins_dir = _plugins_dir()
     git_exe = _resolve_git_executable()
@@ -817,7 +879,7 @@ def _install_plugin_core(
             raise PluginOperationError("Checked out commit does not exactly match the requested ref.")
 
         source_dir = _resolve_subdir_within(clone_root, subdir) if subdir else clone_root
-        manifest = _read_inspection_manifest(source_dir)
+        manifest = _read_install_manifest(source_dir)
         fallback_name = subdir.rstrip("/").rsplit("/", 1)[-1] if subdir else _repo_name_from_url(source_url)
         plugin_name = manifest.get("name")
         if plugin_name is None or plugin_name == "":
@@ -861,7 +923,7 @@ def _install_plugin_core(
             shutil.copytree(source_dir, staged, symlinks=True)
             from rich.console import Console
             _copy_example_files(staged, Console())
-            installed_manifest = _read_inspection_manifest(staged)
+            installed_manifest = _read_install_manifest(staged)
             installed_name = installed_manifest.get("name") or target.name
             capabilities = build_capability_report(staged, installed_manifest)
             provenance = PluginProvenance(
@@ -913,8 +975,8 @@ def cmd_install(
     console = Console()
 
     try:
-        git_url, _subdir = _resolve_git_url(identifier)
-    except ValueError as e:
+        git_url, _subdir = _resolve_validated_plugin_source(identifier)
+    except PluginOperationError as e:
         console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
 

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -530,15 +530,26 @@ def inspect_plugin_source(
             if subdir
             else _repo_name_from_url(source_url)
         )
+        name = manifest.get("name")
+        if name is None or name == "":
+            name = fallback_name
+        elif not isinstance(name, str):
+            raise PluginOperationError("Plugin manifest field 'name' must be a string.")
+        version = manifest.get("version")
+        if version is not None and not isinstance(version, str):
+            raise PluginOperationError("Plugin manifest field 'version' must be a string.")
+        description = manifest.get("description")
+        if description is not None and not isinstance(description, str):
+            raise PluginOperationError("Plugin manifest field 'description' must be a string.")
         return {
             "source_url": source_url,
             "subdir": subdir,
             "requested_ref": requested_ref,
             "resolved_commit": resolved_commit,
             "plugin": {
-                "name": manifest.get("name") or fallback_name,
-                "version": manifest.get("version"),
-                "description": manifest.get("description"),
+                "name": name,
+                "version": version,
+                "description": description,
             },
             "capabilities": capability,
         }
@@ -560,7 +571,17 @@ def cmd_inspect(
         raise SystemExit(1) from exc
 
     if json_output:
-        print(json.dumps(result, sort_keys=True))
+        try:
+            serialized = json.dumps(result, sort_keys=True)
+        except (TypeError, ValueError):
+            print(
+                json.dumps(
+                    {"error": "Inspection result could not be serialized as JSON."},
+                    sort_keys=True,
+                )
+            )
+            raise SystemExit(1) from None
+        print(serialized)
     else:
         from rich.console import Console
 

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1030,12 +1030,13 @@ def cmd_install(
             should_enable = False
 
     if should_enable:
-        enabled = _get_enabled_set()
-        disabled = _get_disabled_set()
-        enabled.add(installed_name)
-        disabled.discard(installed_name)
-        _save_enabled_set(enabled)
-        _save_disabled_set(disabled)
+        try:
+            _set_plugin_activation(installed_name, enabled=True)
+        except Exception:
+            console.print(
+                "[red]Error:[/red] Plugin installed, but activation could not be saved."
+            )
+            sys.exit(1)
         console.print(
             f"[green]✓[/green] Plugin [bold]{installed_name}[/bold] enabled.",
         )
@@ -1184,6 +1185,31 @@ def _save_enabled_set(enabled: set) -> None:
     if "plugins" not in config:
         config["plugins"] = {}
     config["plugins"]["enabled"] = sorted(enabled)
+    save_config(config)
+
+
+def _set_plugin_activation(name: str, *, enabled: bool) -> None:
+    """Atomically update both plugin activation lists with one config save."""
+    from hermes_cli.config import load_config, save_config
+
+    config = load_config()
+    plugins_cfg = config.get("plugins")
+    if not isinstance(plugins_cfg, dict):
+        plugins_cfg = {}
+        config["plugins"] = plugins_cfg
+
+    enabled_values = plugins_cfg.get("enabled", [])
+    disabled_values = plugins_cfg.get("disabled", [])
+    enabled_set = set(enabled_values) if isinstance(enabled_values, list) else set()
+    disabled_set = set(disabled_values) if isinstance(disabled_values, list) else set()
+    if enabled:
+        enabled_set.add(name)
+        disabled_set.discard(name)
+    else:
+        enabled_set.discard(name)
+        disabled_set.add(name)
+    plugins_cfg["enabled"] = sorted(enabled_set)
+    plugins_cfg["disabled"] = sorted(disabled_set)
     save_config(config)
 
 
@@ -2207,31 +2233,37 @@ def dashboard_install_plugin(
     installed_manifest = install_result.manifest
     installed_name = install_result.name
     missing_env = _missing_requires_env_names(installed_manifest)
-    if enable:
-        en = _get_enabled_set()
-        dis = _get_disabled_set()
-        en.add(installed_name)
-        dis.discard(installed_name)
-        _save_enabled_set(en)
-        _save_disabled_set(dis)
-
     hint: str | None = None
     ap = target / "after-install.md"
     if ap.exists():
         hint = str(ap)
-
-    return {
-        "ok": True,
+    details = {
+        "installed": True,
         "plugin_name": installed_name,
         "warnings": warnings,
         "missing_env": missing_env,
         "after_install_path": hint,
-        "enabled": enable,
         "provenance": asdict(install_result.provenance),
         "capabilities": {
             key: list(value) if isinstance(value, tuple) else value
             for key, value in asdict(install_result.capabilities).items()
         },
+    }
+    if enable:
+        try:
+            _set_plugin_activation(installed_name, enabled=True)
+        except Exception:
+            return {
+                "ok": False,
+                **details,
+                "enabled": False,
+                "error": "Plugin installed, but activation could not be saved.",
+            }
+
+    return {
+        "ok": True,
+        **details,
+        "enabled": enable,
     }
 
 

--- a/hermes_cli/subcommands/plugins.py
+++ b/hermes_cli/subcommands/plugins.py
@@ -31,6 +31,9 @@ def build_plugins_parser(subparsers, *, cmd_plugins: Callable) -> None:
         action="store_true",
         help="Remove existing plugin and reinstall",
     )
+    plugins_install.add_argument(
+        "--ref", dest="requested_ref", help="Exact 40-character lowercase commit SHA"
+    )
     _install_enable_group = plugins_install.add_mutually_exclusive_group()
     _install_enable_group.add_argument(
         "--enable",

--- a/hermes_cli/subcommands/plugins.py
+++ b/hermes_cli/subcommands/plugins.py
@@ -48,6 +48,17 @@ def build_plugins_parser(subparsers, *, cmd_plugins: Callable) -> None:
     )
     plugins_update.add_argument("name", help="Plugin name to update")
 
+    plugins_inspect = plugins_subparsers.add_parser(
+        "inspect", help="Inspect plugin source without installing or running it"
+    )
+    plugins_inspect.add_argument("identifier", help="Git URL or owner/repo shorthand")
+    plugins_inspect.add_argument(
+        "--ref", dest="requested_ref", help="Exact 40-character lowercase commit SHA"
+    )
+    plugins_inspect.add_argument(
+        "--json", action="store_true", help="Print machine-readable JSON only"
+    )
+
     plugins_remove = plugins_subparsers.add_parser(
         "remove", aliases=["rm", "uninstall"], help="Remove an installed plugin"
     )

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17886,6 +17886,7 @@ class _AgentPluginInstallBody(BaseModel):
     identifier: str
     force: bool = False
     enable: bool = True
+    requested_ref: str | None = None
 
 
 def _strip_dashboard_manifest(p: Dict[str, Any]) -> Dict[str, Any]:
@@ -18027,6 +18028,7 @@ async def post_agent_plugin_install(request: Request, body: _AgentPluginInstallB
         body.identifier.strip(),
         force=body.force,
         enable=body.enable,
+        requested_ref=body.requested_ref,
     )
     if not result.get("ok"):
         raise HTTPException(

--- a/tests/hermes_cli/test_plugin_install_provenance.py
+++ b/tests/hermes_cli/test_plugin_install_provenance.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import subprocess
+from argparse import ArgumentParser
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import plugins_cmd as pc
+from hermes_cli.plugin_supply_chain import LOCK_FILENAME, read_provenance_lock
+from hermes_cli.subcommands.plugins import build_plugins_parser
+
+
+def _repo(path: Path, *, name: str = "pinned-plugin", valid_manifest: bool = True) -> str:
+    path.mkdir()
+    if valid_manifest:
+        (path / "plugin.yaml").write_text(
+            f"name: {name}\nmanifest_version: 1\nhooks: [pre_tool_call]\nprovides_tools: [demo]\n"
+        )
+    else:
+        (path / "plugin.yaml").write_text(": malformed [[")
+    (path / "config.yaml.example").write_text("ready: true\n")
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=path, check=True)
+    subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "one"],
+        cwd=path,
+        check=True,
+    )
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=path, check=True, text=True, capture_output=True
+    ).stdout.strip()
+
+
+def _install(tmp_path: Path, monkeypatch, repo: Path, **kwargs):
+    plugins = tmp_path / "plugins"
+    plugins.mkdir(exist_ok=True)
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins)
+    return pc._install_plugin_core(f"file://{repo}", force=False, **kwargs)
+
+
+def test_invalid_ref_fails_before_any_git_or_state_change(tmp_path, monkeypatch):
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    old = plugins / "pinned-plugin"
+    old.mkdir()
+    (old / "old").write_text("preserved")
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins)
+    with patch.object(pc, "_resolve_git_executable") as resolve_git:
+        with pytest.raises(pc.PluginOperationError, match="40 lowercase"):
+            pc._install_plugin_core("owner/repo", force=True, requested_ref="BAD")
+    resolve_git.assert_not_called()
+    assert (old / "old").read_text() == "preserved"
+
+
+def test_exact_ref_checkout_writes_lock_and_capability_report(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    requested = _repo(repo)
+    (repo / "plugin.yaml").write_text("name: later\nmanifest_version: 1\n")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "two"], cwd=repo, check=True)
+
+    result = _install(tmp_path, monkeypatch, repo, requested_ref=requested)
+
+    assert result.target.name == "pinned-plugin"
+    assert result.provenance.resolved_commit == requested
+    assert result.provenance.requested_ref == requested
+    assert read_provenance_lock(result.target) == result.provenance
+    assert result.capabilities.tools == ("demo",)
+    assert result.capabilities.warnings == ("CAPABILITY_REPORT_IS_NOT_SECURITY_AUDIT",)
+    assert (result.target / "config.yaml").exists()
+
+
+def test_no_ref_records_resolved_head(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    head = _repo(repo)
+    result = _install(tmp_path, monkeypatch, repo)
+    assert result.provenance.resolved_commit == head
+    assert result.provenance.requested_ref is None
+
+
+def test_rev_parse_mismatch_leaves_no_target(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    requested = _repo(repo)
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins)
+    real_run = pc._run_inspect_git
+
+    def mismatch(command, *, operation, cwd=None):
+        if operation == "resolve commit":
+            return "0" * 40
+        return real_run(command, operation=operation, cwd=cwd)
+
+    monkeypatch.setattr(pc, "_run_inspect_git", mismatch)
+    with pytest.raises(pc.PluginOperationError, match="exactly match"):
+        pc._install_plugin_core(f"file://{repo}", force=False, requested_ref=requested)
+    assert not (plugins / "pinned-plugin").exists()
+
+
+def test_manifest_failure_leaves_no_target(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    _repo(repo, valid_manifest=False)
+    with pytest.raises(pc.PluginOperationError, match="manifest"):
+        _install(tmp_path, monkeypatch, repo)
+    assert not (tmp_path / "plugins" / "pinned-plugin").exists()
+
+
+def test_lock_write_failure_preserves_force_replacement(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    _repo(repo)
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    old = plugins / "pinned-plugin"
+    old.mkdir()
+    (old / "old").write_text("yes")
+    (old / LOCK_FILENAME).write_text("old-lock")
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins)
+    monkeypatch.setattr(pc, "write_provenance_lock", lambda *_: (_ for _ in ()).throw(OSError("disk")))
+    with pytest.raises(pc.PluginOperationError, match="provenance lock"):
+        pc._install_plugin_core(f"file://{repo}", force=True)
+    assert (old / "old").read_text() == "yes"
+    assert (old / LOCK_FILENAME).read_text() == "old-lock"
+
+
+def test_lock_write_failure_leaves_no_new_target(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    _repo(repo)
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins)
+    monkeypatch.setattr(pc, "write_provenance_lock", lambda *_: (_ for _ in ()).throw(OSError("disk")))
+    with pytest.raises(pc.PluginOperationError, match="provenance lock"):
+        pc._install_plugin_core(f"file://{repo}", force=False)
+    assert not (plugins / "pinned-plugin").exists()
+
+
+def test_publication_failure_restores_force_replacement(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    _repo(repo)
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    old = plugins / "pinned-plugin"
+    old.mkdir()
+    (old / "old").write_text("yes")
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins)
+    real_replace = pc.os.replace
+    calls = 0
+
+    def fail_publish(src, dst):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("rename failed")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(pc.os, "replace", fail_publish)
+    with pytest.raises(pc.PluginOperationError, match="publish"):
+        pc._install_plugin_core(f"file://{repo}", force=True)
+    assert (old / "old").read_text() == "yes"
+
+
+@pytest.mark.parametrize("identifier", [
+    "https://user:secret@example.com/repo.git",
+    "https://example.com/repo.git?token=secret",
+])
+def test_unsafe_source_rejected_before_git(identifier):
+    with patch.object(pc, "_resolve_git_executable") as resolve_git:
+        with pytest.raises(pc.PluginOperationError, match="credentials|query"):
+            pc._install_plugin_core(identifier, force=False)
+    resolve_git.assert_not_called()
+
+
+def test_dashboard_returns_json_provenance_capabilities_and_enables_after_success(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    sha = _repo(repo)
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins)
+    enabled: set[str] = set()
+    monkeypatch.setattr(pc, "_get_enabled_set", lambda: set(enabled))
+    monkeypatch.setattr(pc, "_get_disabled_set", set)
+    monkeypatch.setattr(pc, "_save_enabled_set", lambda value: enabled.update(value))
+    monkeypatch.setattr(pc, "_save_disabled_set", lambda value: None)
+    result = pc.dashboard_install_plugin(f"file://{repo}", force=False, enable=True, requested_ref=sha)
+    json.dumps(result)
+    assert result["ok"] is True
+    assert result["provenance"]["resolved_commit"] == sha
+    assert result["capabilities"]["warnings"] == ["CAPABILITY_REPORT_IS_NOT_SECURITY_AUDIT"]
+    assert "pinned-plugin" in enabled
+
+    enabled.clear()
+    failed = pc.dashboard_install_plugin(f"file://{repo}", force=False, enable=True, requested_ref="bad")
+    assert failed["ok"] is False
+    assert enabled == set()
+
+
+def test_cli_install_parser_dispatches_requested_ref():
+    parser = ArgumentParser()
+    subs = parser.add_subparsers()
+    handler = patch.object(pc, "cmd_install").start()
+    try:
+        build_plugins_parser(subs, cmd_plugins=pc.plugins_command)
+        sha = "a" * 40
+        args = parser.parse_args(["plugins", "install", "owner/repo", "--ref", sha, "--no-enable"])
+        args.func(args)
+        handler.assert_called_once_with("owner/repo", force=False, enable=False, requested_ref=sha)
+    finally:
+        patch.stopall()

--- a/tests/hermes_cli/test_plugin_install_provenance.py
+++ b/tests/hermes_cli/test_plugin_install_provenance.py
@@ -164,6 +164,112 @@ def test_publication_failure_restores_force_replacement(tmp_path, monkeypatch):
     assert (old / "old").read_text() == "yes"
 
 
+def test_publication_and_rename_restore_fail_falls_back_to_copy(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    _repo(repo)
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    old = plugins / "pinned-plugin"
+    old.mkdir()
+    (old / "old").write_text("yes")
+    (old / LOCK_FILENAME).write_text("old-lock")
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins)
+    real_replace = pc.os.replace
+
+    def fail_publish_and_restore(src, dst):
+        src_path = Path(src)
+        dst_path = Path(dst)
+        if dst_path == old and (
+            src_path.name == "payload" or src_path.name.startswith(".backup-")
+        ):
+            raise OSError("rename failed")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(pc.os, "replace", fail_publish_and_restore)
+    with pytest.raises(pc.PluginOperationError, match="publish"):
+        pc._install_plugin_core(f"file://{repo}", force=True)
+
+    assert (old / "old").read_text() == "yes"
+    assert (old / LOCK_FILENAME).read_text() == "old-lock"
+    assert not list(plugins.glob(".backup-*"))
+
+
+def test_failed_copy_restore_preserves_backup_and_reports_recovery_path(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    _repo(repo)
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    old = plugins / "pinned-plugin"
+    old.mkdir()
+    (old / "old").write_text("yes")
+    (old / LOCK_FILENAME).write_text("old-lock")
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins)
+    real_replace = pc.os.replace
+    real_copytree = pc.shutil.copytree
+
+    def fail_publish_and_restore(src, dst):
+        src_path = Path(src)
+        dst_path = Path(dst)
+        if dst_path == old and (
+            src_path.name == "payload" or src_path.name.startswith(".backup-")
+        ):
+            raise OSError("rename failed")
+        return real_replace(src, dst)
+
+    def fail_backup_copy(src, dst, *args, **kwargs):
+        if Path(src).name.startswith(".backup-"):
+            raise OSError("copy failed")
+        return real_copytree(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(pc.os, "replace", fail_publish_and_restore)
+    monkeypatch.setattr(pc.shutil, "copytree", fail_backup_copy)
+    with pytest.raises(pc.PluginOperationError) as raised:
+        pc._install_plugin_core(f"file://{repo}", force=True)
+
+    backups = list(plugins.glob(".backup-*"))
+    assert len(backups) == 1
+    backup = backups[0]
+    assert (backup / "old").read_text() == "yes"
+    assert (backup / LOCK_FILENAME).read_text() == "old-lock"
+    assert not old.exists()
+    message = str(raised.value)
+    assert "PLUGIN_BACKUP_PRESERVED" in message
+    assert str(backup.resolve()) in message
+    assert "manual recovery" in message.lower()
+
+
+def test_force_publish_failure_leaves_config_bytes_unchanged(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    config = home / "config.yaml"
+    original = b"plugins:\n  enabled: [pinned-plugin]\n  disabled: [other]\n# preserve me\n"
+    config.write_bytes(original)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    repo = tmp_path / "repo"
+    _repo(repo)
+    plugins = home / "plugins"
+    plugins.mkdir()
+    old = plugins / "pinned-plugin"
+    old.mkdir()
+    (old / "old").write_text("yes")
+    real_replace = pc.os.replace
+    calls = 0
+
+    def fail_publish(src, dst):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("publish failed")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(pc.os, "replace", fail_publish)
+    with pytest.raises(pc.PluginOperationError, match="publish"):
+        pc._install_plugin_core(f"file://{repo}", force=True)
+
+    assert config.read_bytes() == original
+
+
 @pytest.mark.parametrize("identifier", [
     "https://user:secret@example.com/repo.git",
     "https://example.com/repo.git?token=secret",

--- a/tests/hermes_cli/test_plugin_install_provenance.py
+++ b/tests/hermes_cli/test_plugin_install_provenance.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import dataclasses
 import json
 import os
+import stat
 import subprocess
+from contextlib import contextmanager
 from argparse import ArgumentParser
 from pathlib import Path
 from unittest.mock import patch
@@ -462,3 +464,88 @@ def test_cli_install_parser_dispatches_requested_ref():
         handler.assert_called_once_with("owner/repo", force=False, enable=False, requested_ref=sha)
     finally:
         patch.stopall()
+
+
+def test_force_install_publication_uses_target_operation_lock(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    _repo(repo)
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    target = plugins / "pinned-plugin"
+    target.mkdir()
+    (target / "old").write_text("yes")
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins)
+    events = []
+
+    @contextmanager
+    def recording_lock(locked_target):
+        events.append(("enter", locked_target))
+        yield
+        events.append(("exit", locked_target))
+
+    monkeypatch.setattr(pc, "_plugin_operation_lock", recording_lock)
+    real_replace = pc.os.replace
+
+    def assert_locked_during_publish(src, dst):
+        if Path(dst) == target:
+            assert events == [("enter", target)]
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(pc.os, "replace", assert_locked_during_publish)
+    pc._install_plugin_core(f"file://{repo}", force=True)
+
+    assert events == [("enter", target), ("exit", target)]
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX permission bits only")
+def test_operation_lock_is_stable_and_owner_only(tmp_path, monkeypatch):
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    target = plugins / "demo"
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins)
+
+    with pc._plugin_operation_lock(target):
+        lock_dir = plugins / ".operation-locks"
+        lock_path = next(lock_dir.glob("*.lock"))
+        inode = lock_path.stat().st_ino
+        assert stat.S_IMODE(lock_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(lock_path.stat().st_mode) == 0o600
+
+    assert lock_path.is_file()
+    with pc._plugin_operation_lock(target):
+        assert lock_path.stat().st_ino == inode
+
+
+def test_operation_lock_fallback_rejects_dangling_symlink_lock_path(tmp_path, monkeypatch):
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    target = plugins / "demo"
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins)
+    with pc._plugin_operation_lock(target):
+        lock_path = next((plugins / ".operation-locks").glob("*.lock"))
+    lock_path.unlink()
+    outside = tmp_path / "outside"
+    lock_path.symlink_to(outside)
+    monkeypatch.delattr(pc.os, "O_NOFOLLOW", raising=False)
+
+    with pytest.raises(pc.PluginOperationError, match="unsafe|regular"):
+        with pc._plugin_operation_lock(target):
+            pass
+    assert not outside.exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "link"), reason="hardlinks unavailable")
+def test_operation_lock_rejects_hardlinked_lock_path(tmp_path, monkeypatch):
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    target = plugins / "demo"
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins)
+    with pc._plugin_operation_lock(target):
+        lock_path = next((plugins / ".operation-locks").glob("*.lock"))
+    os.link(lock_path, tmp_path / "second-link")
+
+    with pytest.raises(pc.PluginOperationError, match="single link"):
+        with pc._plugin_operation_lock(target):
+            pass
+
+    assert lock_path.is_file()

--- a/tests/hermes_cli/test_plugin_install_provenance.py
+++ b/tests/hermes_cli/test_plugin_install_provenance.py
@@ -43,6 +43,26 @@ def _install(tmp_path: Path, monkeypatch, repo: Path, **kwargs):
     return pc._install_plugin_core(f"file://{repo}", force=False, **kwargs)
 
 
+def test_set_plugin_activation_saves_both_lists_once(monkeypatch):
+    config = {
+        "plugins": {
+            "enabled": ["existing"],
+            "disabled": ["pinned-plugin", "blocked"],
+        }
+    }
+    saved: list[dict] = []
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+    monkeypatch.setattr(
+        "hermes_cli.config.save_config", lambda value: saved.append(value)
+    )
+
+    pc._set_plugin_activation("pinned-plugin", enabled=True)
+
+    assert len(saved) == 1
+    assert saved[0]["plugins"]["enabled"] == ["existing", "pinned-plugin"]
+    assert saved[0]["plugins"]["disabled"] == ["blocked"]
+
+
 def test_invalid_ref_fails_before_any_git_or_state_change(tmp_path, monkeypatch):
     plugins = tmp_path / "plugins"
     plugins.mkdir()
@@ -346,22 +366,88 @@ def test_dashboard_returns_json_provenance_capabilities_and_enables_after_succes
     plugins = tmp_path / "plugins"
     plugins.mkdir()
     monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins)
-    enabled: set[str] = set()
-    monkeypatch.setattr(pc, "_get_enabled_set", lambda: set(enabled))
-    monkeypatch.setattr(pc, "_get_disabled_set", set)
-    monkeypatch.setattr(pc, "_save_enabled_set", lambda value: enabled.update(value))
-    monkeypatch.setattr(pc, "_save_disabled_set", lambda value: None)
-    result = pc.dashboard_install_plugin(f"file://{repo}", force=False, enable=True, requested_ref=sha)
+    activations: list[tuple[str, bool]] = []
+    monkeypatch.setattr(
+        pc,
+        "_set_plugin_activation",
+        lambda name, *, enabled: activations.append((name, enabled)),
+    )
+    result = pc.dashboard_install_plugin(
+        f"file://{repo}", force=False, enable=True, requested_ref=sha
+    )
     json.dumps(result)
     assert result["ok"] is True
     assert result["provenance"]["resolved_commit"] == sha
     assert result["capabilities"]["warnings"] == ["CAPABILITY_REPORT_IS_NOT_SECURITY_AUDIT"]
-    assert "pinned-plugin" in enabled
+    assert activations == [("pinned-plugin", True)]
 
-    enabled.clear()
-    failed = pc.dashboard_install_plugin(f"file://{repo}", force=False, enable=True, requested_ref="bad")
+    activations.clear()
+    failed = pc.dashboard_install_plugin(
+        f"file://{repo}", force=False, enable=True, requested_ref="bad"
+    )
     assert failed["ok"] is False
-    assert enabled == set()
+    assert activations == []
+
+
+def test_dashboard_activation_failure_is_explicit_partial_success(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    plugins = home / "plugins"
+    plugins.mkdir()
+    config_path = home / "config.yaml"
+    original = b"plugins:\n  enabled: [existing]\n  disabled: [pinned-plugin]\n# unchanged\n"
+    config_path.write_bytes(original)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins)
+    save_calls = 0
+
+    def fail_save(_value):
+        nonlocal save_calls
+        save_calls += 1
+        raise RuntimeError("RAW_SAVE_SECRET")
+
+    monkeypatch.setattr("hermes_cli.config.save_config", fail_save)
+    repo = tmp_path / "repo"
+    sha = _repo(repo)
+
+    result = pc.dashboard_install_plugin(
+        f"file://{repo}", force=False, enable=True, requested_ref=sha
+    )
+
+    json.dumps(result)
+    target = plugins / "pinned-plugin"
+    assert result["ok"] is False
+    assert result["installed"] is True
+    assert result["enabled"] is False
+    assert result["error"] == "Plugin installed, but activation could not be saved."
+    assert result["provenance"]["resolved_commit"] == sha
+    assert target.is_dir()
+    assert (target / LOCK_FILENAME).is_file()
+    assert save_calls == 1
+    assert config_path.read_bytes() == original
+
+
+def test_cli_activation_failure_exits_cleanly_after_install(tmp_path, monkeypatch, capsys):
+    repo = tmp_path / "repo"
+    _repo(repo)
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins)
+    monkeypatch.setattr(
+        pc,
+        "_set_plugin_activation",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("RAW_SAVE_SECRET")),
+    )
+
+    with pytest.raises(SystemExit) as raised:
+        pc.cmd_install(f"file://{repo}", enable=True)
+
+    output = capsys.readouterr().out
+    assert raised.value.code == 1
+    assert "Plugin installed, but activation could not be saved." in output
+    assert "enabled" not in output.lower()
+    assert "RAW_SAVE_SECRET" not in output
+    assert (plugins / "pinned-plugin" / LOCK_FILENAME).is_file()
 
 
 def test_cli_install_parser_dispatches_requested_ref():

--- a/tests/hermes_cli/test_plugin_install_provenance.py
+++ b/tests/hermes_cli/test_plugin_install_provenance.py
@@ -281,6 +281,65 @@ def test_unsafe_source_rejected_before_git(identifier):
     resolve_git.assert_not_called()
 
 
+@pytest.mark.parametrize("identifier, secret", [
+    ("https://user:CLI_SECRET@example.com/repo.git", "CLI_SECRET"),
+    ("https://example.com/repo.git?token=QUERY_SECRET", "QUERY_SECRET"),
+    ("invalid-identifier-RAW_SECRET", "RAW_SECRET"),
+])
+def test_cli_rejects_unsafe_source_without_display_or_git(identifier, secret, capsys):
+    with patch.object(pc, "_resolve_git_executable") as resolve_git:
+        with pytest.raises(SystemExit) as raised:
+            pc.cmd_install(identifier, enable=False)
+    assert raised.value.code == 1
+    output = capsys.readouterr()
+    assert secret not in output.out + output.err
+    resolve_git.assert_not_called()
+
+
+@pytest.mark.parametrize("manifest_name", ["plugin.yml", None])
+def test_install_supports_legacy_or_manifestless_plugin(tmp_path, monkeypatch, manifest_name):
+    repo = tmp_path / ("legacy-yml" if manifest_name else "init-only")
+    repo.mkdir()
+    if manifest_name:
+        (repo / manifest_name).write_text("name: legacy-plugin\nprovides_tools: [legacy]\n")
+    (repo / "__init__.py").write_text("def register(ctx): pass\n")
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "one"], cwd=repo, check=True)
+
+    result = _install(tmp_path, monkeypatch, repo)
+
+    assert result.name == ("legacy-plugin" if manifest_name else "init-only")
+    expected = {"name": "legacy-plugin", "provides_tools": ["legacy"]} if manifest_name else {}
+    assert result.manifest == expected
+    assert read_provenance_lock(result.target) == result.provenance
+    assert result.capabilities.tools == (("legacy",) if manifest_name else ())
+
+
+def test_unsafe_optional_files_are_skipped_without_host_read(tmp_path, monkeypatch, capsys):
+    secret = "HOST_FILE_SECRET_7d21"
+    outside = tmp_path / "outside-secret"
+    outside.write_text(secret)
+    repo = tmp_path / "unsafe-files"
+    repo.mkdir()
+    (repo / "plugin.yaml").write_text("name: unsafe-files\n")
+    (repo / "config.yaml.example").symlink_to(outside)
+    (repo / "relative.example").symlink_to("../outside-secret")
+    (repo / "after-install.md").symlink_to(outside)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "one"], cwd=repo, check=True)
+
+    result = _install(tmp_path, monkeypatch, repo)
+    pc._display_after_install(result.target, "safe-identifier")
+
+    output = capsys.readouterr()
+    assert secret not in output.out + output.err
+    assert not (result.target / "config.yaml").exists()
+    assert not (result.target / "relative").exists()
+    assert "Warning" in output.out
+
+
 def test_dashboard_returns_json_provenance_capabilities_and_enables_after_success(tmp_path, monkeypatch):
     repo = tmp_path / "repo"
     sha = _repo(repo)

--- a/tests/hermes_cli/test_plugin_supply_chain.py
+++ b/tests/hermes_cli/test_plugin_supply_chain.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import os
+import stat
 from pathlib import Path
 
 import pytest
 
 from hermes_cli.plugin_supply_chain import (
     LOCK_FILENAME,
+    MAX_LOCK_BYTES,
     PluginCapabilityReport,
     PluginProvenance,
     build_capability_report,
@@ -188,3 +191,78 @@ def test_write_provenance_lock_rejects_credentials_and_traversal(tmp_path: Path)
         )
     with pytest.raises(ValueError):
         write_provenance_lock(tmp_path, _provenance(subdir="plugin/../secret"))
+
+
+@pytest.mark.parametrize(
+    "source_url",
+    [
+        "git@github.com:owner/repo.git",
+        "ssh://git@github.com/owner/repo.git",
+    ],
+)
+def test_provenance_lock_accepts_conventional_git_transport_identity(
+    tmp_path: Path, source_url: str
+) -> None:
+    provenance = _provenance(source_url=source_url)
+
+    write_provenance_lock(tmp_path, provenance)
+
+    assert read_provenance_lock(tmp_path) == provenance
+
+
+@pytest.mark.parametrize(
+    "source_url",
+    [
+        "TOKEN@github.com:owner/repo.git",
+        "oauth2:SECRET@gitlab.example.com:owner/repo.git",
+        "git@@github.com:owner/repo.git",
+        "git@:owner/repo.git",
+        "git@github.com:",
+        "git@github.com/owner/repo.git",
+        "git@github.com:owner/repo.git?token=secret",
+        "git@github.com:owner/repo.git#secret",
+        "git@github.com:owner/repo git",
+        "https://token@github.com/owner/repo.git",
+        "ssh://other@github.com/owner/repo.git",
+        "ssh://git:secret@github.com/owner/repo.git",
+    ],
+)
+def test_write_provenance_lock_rejects_credential_or_malformed_remote(
+    tmp_path: Path, source_url: str
+) -> None:
+    with pytest.raises(ValueError, match="source_url"):
+        write_provenance_lock(tmp_path, _provenance(source_url=source_url))
+
+
+@pytest.mark.parametrize(
+    "source_url",
+    [
+        "TOKEN@github.com:owner/repo.git",
+        "oauth2:SECRET@gitlab.example.com:owner/repo.git",
+        "git@@github.com:owner/repo.git",
+        "git@:owner/repo.git",
+        "git@github.com:",
+    ],
+)
+def test_read_provenance_lock_rejects_credential_or_malformed_scp_remote(
+    tmp_path: Path, source_url: str
+) -> None:
+    data = dataclasses.asdict(_provenance(source_url=source_url))
+    (tmp_path / LOCK_FILENAME).write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="source_url"):
+        read_provenance_lock(tmp_path)
+
+
+def test_read_provenance_lock_rejects_oversized_real_file(tmp_path: Path) -> None:
+    (tmp_path / LOCK_FILENAME).write_bytes(b" " * (MAX_LOCK_BYTES + 1))
+
+    with pytest.raises(ValueError, match="malformed or unreadable"):
+        read_provenance_lock(tmp_path)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX permission bits only")
+def test_write_provenance_lock_is_owner_only(tmp_path: Path) -> None:
+    lock_path = write_provenance_lock(tmp_path, _provenance())
+
+    assert stat.S_IMODE(lock_path.stat().st_mode) == 0o600

--- a/tests/hermes_cli/test_plugin_supply_chain.py
+++ b/tests/hermes_cli/test_plugin_supply_chain.py
@@ -16,11 +16,37 @@ from hermes_cli.plugin_supply_chain import (
     build_capability_report,
     read_provenance_lock,
     validate_full_commit_sha,
+    validate_source_url,
     write_provenance_lock,
 )
 
 
 SHA = "0123456789abcdef0123456789abcdef01234567"
+
+
+@pytest.mark.parametrize(
+    "source_url",
+    [
+        "https://github.com/owner/repo.git",
+        "git@github.com:owner/repo.git",
+        "ssh://git@github.com/owner/repo.git",
+        "file:///tmp/plugin-repo",
+    ],
+)
+def test_validate_source_url_preserves_supported_clone_urls(source_url: str) -> None:
+    assert validate_source_url(source_url) == source_url
+
+
+@pytest.mark.parametrize(
+    "source_url",
+    [
+        "https://user:secret@github.com/owner/repo.git",
+        "https://github.com/owner/repo.git?token=secret",
+    ],
+)
+def test_validate_source_url_rejects_credentials_and_query(source_url: str) -> None:
+    with pytest.raises(ValueError, match="credentials|query"):
+        validate_source_url(source_url)
 
 
 def _provenance(**overrides: str | None) -> PluginProvenance:

--- a/tests/hermes_cli/test_plugin_supply_chain.py
+++ b/tests/hermes_cli/test_plugin_supply_chain.py
@@ -292,3 +292,12 @@ def test_write_provenance_lock_is_owner_only(tmp_path: Path) -> None:
     lock_path = write_provenance_lock(tmp_path, _provenance())
 
     assert stat.S_IMODE(lock_path.stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(os.name != "posix" or not hasattr(os, "link"), reason="hardlinks require POSIX")
+def test_read_provenance_lock_rejects_hardlinked_file(tmp_path: Path) -> None:
+    lock_path = write_provenance_lock(tmp_path, _provenance())
+    os.link(lock_path, tmp_path / "second-link")
+
+    with pytest.raises(ValueError, match="single link"):
+        read_provenance_lock(tmp_path)

--- a/tests/hermes_cli/test_plugin_supply_chain.py
+++ b/tests/hermes_cli/test_plugin_supply_chain.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.plugin_supply_chain import (
+    LOCK_FILENAME,
+    PluginCapabilityReport,
+    PluginProvenance,
+    build_capability_report,
+    read_provenance_lock,
+    validate_full_commit_sha,
+    write_provenance_lock,
+)
+
+
+SHA = "0123456789abcdef0123456789abcdef01234567"
+
+
+def _provenance(**overrides: str | None) -> PluginProvenance:
+    values: dict[str, str | None] = {
+        "source_url": "https://github.com/owner/repo.git",
+        "subdir": "plugins/example",
+        "resolved_commit": SHA,
+        "requested_ref": "main",
+        "inspected_at": "2026-07-19T12:00:00Z",
+    }
+    values.update(overrides)
+    return PluginProvenance(**values)
+
+
+def test_models_are_frozen_dataclasses() -> None:
+    provenance = _provenance()
+    report = PluginCapabilityReport((), (), (), False, False, ())
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        provenance.source_url = "changed"  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        report.has_dashboard = True  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "a" * 39,
+        "a" * 41,
+        "A" * 40,
+        "g" * 40,
+        "0" * 39 + " ",
+        "",
+        None,
+        123,
+    ],
+)
+def test_validate_full_commit_sha_rejects_noncanonical_values(value: object) -> None:
+    with pytest.raises(ValueError, match="40 lowercase hexadecimal"):
+        validate_full_commit_sha(value)
+
+
+def test_validate_full_commit_sha_accepts_exact_lowercase_sha() -> None:
+    assert validate_full_commit_sha(SHA) == SHA
+
+
+def test_build_capability_report_uses_manifest_schema_without_executing_code(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "dashboard").mkdir()
+    (tmp_path / "dashboard" / "manifest.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "after-install.md").write_text("instructions", encoding="utf-8")
+    (tmp_path / "plugin.py").write_text("raise RuntimeError('must not execute')")
+    manifest = {
+        "hooks": ["post_tool_call", "pre_tool_call", "post_tool_call"],
+        "provides_tools": ["z_tool", "a_tool", "z_tool"],
+        "requires_env": [
+            {"name": "Z_TOKEN", "secret": True},
+            "A_TOKEN",
+            {"name": "A_TOKEN"},
+            {"description": "ignored without a name"},
+        ],
+        "tools": ["unsupported_field"],
+        "required_env": ["unsupported_field"],
+    }
+
+    report = build_capability_report(tmp_path, manifest)
+
+    assert report.hooks == ("post_tool_call", "pre_tool_call")
+    assert report.tools == ("a_tool", "z_tool")
+    assert report.required_env == ("A_TOKEN", "Z_TOKEN")
+    assert report.has_dashboard is True
+    assert report.has_after_install is True
+    assert report.warnings == ("CAPABILITY_REPORT_IS_NOT_SECURITY_AUDIT",)
+
+
+def test_build_capability_report_requires_actual_presence_markers(tmp_path: Path) -> None:
+    (tmp_path / "dashboard").mkdir()
+    (tmp_path / "after_install.py").write_text("raise RuntimeError")
+
+    report = build_capability_report(tmp_path, {})
+
+    assert report.has_dashboard is False
+    assert report.has_after_install is False
+
+
+def test_provenance_lock_round_trips_as_deterministic_json(tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugin"
+    plugin_dir.mkdir()
+    provenance = _provenance()
+
+    lock_path = write_provenance_lock(plugin_dir, provenance)
+
+    assert lock_path == plugin_dir / LOCK_FILENAME
+    assert lock_path.name == ".hermes-plugin-lock.json"
+    expected = json.dumps(dataclasses.asdict(provenance), sort_keys=True, indent=2) + "\n"
+    assert lock_path.read_text(encoding="utf-8") == expected
+    assert read_provenance_lock(plugin_dir) == provenance
+
+
+def test_read_provenance_lock_returns_none_when_absent(tmp_path: Path) -> None:
+    assert read_provenance_lock(tmp_path) is None
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"resolved_commit": "abc123"},
+        {"subdir": "../escape"},
+        {"subdir": "/absolute"},
+        {"source_url": "https://user:secret@example.com/repo.git"},
+        {"unexpected": "field"},
+    ],
+)
+def test_read_provenance_lock_fails_closed_on_unsafe_content(
+    tmp_path: Path, change: dict[str, str]
+) -> None:
+    data = dataclasses.asdict(_provenance())
+    data.update(change)
+    (tmp_path / LOCK_FILENAME).write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        read_provenance_lock(tmp_path)
+
+
+def test_read_provenance_lock_fails_closed_on_malformed_json(tmp_path: Path) -> None:
+    (tmp_path / LOCK_FILENAME).write_text("not json", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        read_provenance_lock(tmp_path)
+
+
+def test_write_provenance_lock_rejects_credentials_and_traversal(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        write_provenance_lock(
+            tmp_path, _provenance(source_url="https://token@example.com/repo.git")
+        )
+    with pytest.raises(ValueError):
+        write_provenance_lock(tmp_path, _provenance(subdir="plugin/../secret"))

--- a/tests/hermes_cli/test_plugin_supply_chain.py
+++ b/tests/hermes_cli/test_plugin_supply_chain.py
@@ -143,6 +143,37 @@ def test_read_provenance_lock_fails_closed_on_unsafe_content(
         read_provenance_lock(tmp_path)
 
 
+@pytest.mark.parametrize(
+    "source_url",
+    [
+        "https://github.com/owner/repo.git?token=secret",
+        "https://github.com/owner/repo.git#access_token=secret",
+    ],
+)
+def test_read_provenance_lock_rejects_source_url_query_or_fragment(
+    tmp_path: Path, source_url: str
+) -> None:
+    data = dataclasses.asdict(_provenance(source_url=source_url))
+    (tmp_path / LOCK_FILENAME).write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="query or fragment"):
+        read_provenance_lock(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "source_url",
+    [
+        "https://github.com/owner/repo.git?token=secret",
+        "https://github.com/owner/repo.git#access_token=secret",
+    ],
+)
+def test_write_provenance_lock_rejects_source_url_query_or_fragment(
+    tmp_path: Path, source_url: str
+) -> None:
+    with pytest.raises(ValueError, match="query or fragment"):
+        write_provenance_lock(tmp_path, _provenance(source_url=source_url))
+
+
 def test_read_provenance_lock_fails_closed_on_malformed_json(tmp_path: Path) -> None:
     (tmp_path / LOCK_FILENAME).write_text("not json", encoding="utf-8")
 

--- a/tests/hermes_cli/test_plugin_update_provenance.py
+++ b/tests/hermes_cli/test_plugin_update_provenance.py
@@ -144,7 +144,11 @@ def test_unsafe_lock_fails_closed_before_git(tmp_path, monkeypatch, kind, capsys
 
 def test_legacy_no_lock_update_still_pulls_without_creating_lock(tmp_path, monkeypatch):
     target = _installed(tmp_path, monkeypatch)
-    monkeypatch.setattr(pc, "_git_pull_plugin_dir", lambda _: (True, "Already up to date."))
+    monkeypatch.setattr(
+        pc,
+        "_git_pull_plugin_dir",
+        lambda _, *, source_url=None: (True, "Already up to date."),
+    )
     monkeypatch.setattr(pc, "_copy_example_files", lambda *_: None)
 
     pc.cmd_update("demo")
@@ -246,6 +250,88 @@ def test_unpinned_update_refreshes_lock_to_real_remote_head(tmp_path, monkeypatc
     assert lock.source_url == f"file://{remote}"
 
 
+def test_provenance_update_ignores_branch_upstream_and_fetches_locked_source(
+    tmp_path, monkeypatch
+):
+    good, clone = _real_update_repo(tmp_path, monkeypatch)
+    seed = tmp_path / "seed"
+    evil = tmp_path / "evil.git"
+    subprocess.run(["git", "init", "--bare", str(evil)], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(clone), "remote", "add", "evil", str(evil)], check=True)
+    subprocess.run(["git", "-C", str(clone), "push", "evil", "HEAD"], check=True, capture_output=True)
+    current = subprocess.run(
+        ["git", "-C", str(clone), "branch", "--show-current"],
+        check=True, text=True, capture_output=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "-C", str(clone), "config", f"branch.{current}.remote", "evil"], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(clone), "config", f"branch.{current}.merge", f"refs/heads/{current}"],
+        check=True,
+    )
+    initial = subprocess.run(
+        ["git", "-C", str(clone), "rev-parse", "HEAD"],
+        check=True, text=True, capture_output=True,
+    ).stdout.strip()
+    write_provenance_lock(clone, _provenance(commit=initial, source=str(good)))
+
+    evil_seed = tmp_path / "evil-seed"
+    subprocess.run(["git", "clone", str(evil), str(evil_seed)], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(evil_seed), "config", "user.email", "evil@example.com"], check=True)
+    subprocess.run(["git", "-C", str(evil_seed), "config", "user.name", "Evil"], check=True)
+    (evil_seed / "plugin.yaml").write_text("name: demo\nsource: evil\n")
+    subprocess.run(["git", "-C", str(evil_seed), "commit", "-am", "evil"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(evil_seed), "push"], check=True, capture_output=True)
+    evil_head = subprocess.run(
+        ["git", "-C", str(evil_seed), "rev-parse", "HEAD"],
+        check=True, text=True, capture_output=True,
+    ).stdout.strip()
+
+    (seed / "plugin.yaml").write_text("name: demo\nsource: locked\n")
+    subprocess.run(["git", "-C", str(seed), "commit", "-am", "good"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(seed), "push"], check=True, capture_output=True)
+    good_head = subprocess.run(
+        ["git", "-C", str(seed), "rev-parse", "HEAD"],
+        check=True, text=True, capture_output=True,
+    ).stdout.strip()
+
+    pc.cmd_update("demo")
+
+    actual = subprocess.run(
+        ["git", "-C", str(clone), "rev-parse", "HEAD"],
+        check=True, text=True, capture_output=True,
+    ).stdout.strip()
+    assert actual == good_head
+    assert actual not in {initial, evil_head}
+
+
+def test_explicit_source_fetch_failure_is_sanitized_and_does_not_refresh(
+    tmp_path, monkeypatch
+):
+    target = _installed(tmp_path, monkeypatch)
+    provenance = _provenance()
+    write_provenance_lock(target, provenance)
+    before = (target / LOCK_FILENAME).read_bytes()
+    run = Mock(
+        side_effect=[
+            Mock(returncode=0, stdout="1" * 40, stderr=""),
+            Mock(returncode=1, stdout="", stderr="token=raw-secret"),
+        ]
+    )
+    monkeypatch.setattr(pc.subprocess, "run", run)
+    monkeypatch.setattr(pc, "_resolve_git_executable", lambda: "/usr/bin/git")
+    refresh = Mock()
+    monkeypatch.setattr(pc, "_refresh_update_provenance", refresh)
+
+    result = pc.dashboard_update_user_plugin("demo")
+
+    assert result == {"ok": False, "error": "Git fetch failed."}
+    assert "raw-secret" not in result["error"]
+    refresh.assert_not_called()
+    assert (target / LOCK_FILENAME).read_bytes() == before
+
+
 def test_update_rejects_smudge_filter_without_executing_or_pulling(tmp_path, monkeypatch, capsys):
     remote, clone = _real_update_repo(tmp_path, monkeypatch)
     marker = tmp_path / "executed"
@@ -307,7 +393,9 @@ def test_update_rejects_multiple_origin_urls_from_provenance_without_pull(tmp_pa
 def test_lock_refresh_failure_is_partial_for_cli_and_dashboard(tmp_path, monkeypatch, capsys):
     target = _installed(tmp_path, monkeypatch)
     write_provenance_lock(target, _provenance())
-    monkeypatch.setattr(pc, "_git_pull_plugin_dir", lambda _: (True, "updated"))
+    monkeypatch.setattr(
+        pc, "_git_pull_plugin_dir", lambda _, *, source_url=None: (True, "updated")
+    )
     monkeypatch.setattr(pc, "_refresh_update_provenance", lambda *_: (_ for _ in ()).throw(RuntimeError("raw-secret")))
     copy = Mock()
     monkeypatch.setattr(pc, "_copy_example_files", copy)

--- a/tests/hermes_cli/test_plugin_update_provenance.py
+++ b/tests/hermes_cli/test_plugin_update_provenance.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from hermes_cli import plugins_cmd as pc
+from hermes_cli.plugin_supply_chain import (
+    LOCK_FILENAME,
+    PluginProvenance,
+    read_provenance_lock,
+    write_provenance_lock,
+)
+
+
+def _provenance(
+    *, requested_ref=None, commit="1" * 40,
+    source="https://example.invalid/owner/repo.git", subdir=None
+):
+    return PluginProvenance(source, subdir, commit, requested_ref, "2026-01-01T00:00:00+00:00")
+
+
+def _installed(tmp_path: Path, monkeypatch) -> Path:
+    plugins = tmp_path / "plugins"
+    target = plugins / "demo"
+    (target / ".git").mkdir(parents=True)
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins)
+    return target
+
+
+def test_pinned_cli_refuses_without_pull_and_preserves_target(tmp_path, monkeypatch, capsys):
+    target = _installed(tmp_path, monkeypatch)
+    (target / "payload").write_bytes(b"old")
+    pin = "a" * 40
+    write_provenance_lock(target, _provenance(requested_ref=pin))
+    before_lock = (target / LOCK_FILENAME).read_bytes()
+    pull = Mock()
+    monkeypatch.setattr(pc, "_git_pull_plugin_dir", pull)
+
+    with pytest.raises(SystemExit) as exc:
+        pc.cmd_update("demo")
+
+    assert exc.value.code == 1
+    pull.assert_not_called()
+    assert (target / "payload").read_bytes() == b"old"
+    assert (target / LOCK_FILENAME).read_bytes() == before_lock
+    out = capsys.readouterr().out
+    compact = "".join(out.split())
+    assert (
+        "hermespluginsinstallhttps://example.invalid/owner/repo.git"
+        "--ref<40-char-sha>--force"
+    ) in compact
+
+
+def test_pinned_dashboard_refuses_without_pull(tmp_path, monkeypatch):
+    target = _installed(tmp_path, monkeypatch)
+    write_provenance_lock(target, _provenance(requested_ref="a" * 40))
+    before = (target / LOCK_FILENAME).read_bytes()
+    pull = Mock()
+    monkeypatch.setattr(pc, "_git_pull_plugin_dir", pull)
+
+    result = pc.dashboard_update_user_plugin("demo")
+
+    assert result["ok"] is False
+    assert "https://example.invalid/owner/repo.git" in result["error"]
+    pull.assert_not_called()
+    assert (target / LOCK_FILENAME).read_bytes() == before
+
+
+@pytest.mark.parametrize("surface", ["cli", "dashboard"])
+def test_pinned_subdir_without_git_refuses_from_lock_before_checkout_check(
+    tmp_path, monkeypatch, capsys, surface
+):
+    target = _installed(tmp_path, monkeypatch)
+    (target / ".git").rmdir()
+    source = f"file://{tmp_path}/source repo"
+    write_provenance_lock(
+        target,
+        _provenance(requested_ref="a" * 40, source=source, subdir="plugins/demo"),
+    )
+    pull = Mock()
+    monkeypatch.setattr(pc, "_git_pull_plugin_dir", pull)
+
+    if surface == "cli":
+        with pytest.raises(SystemExit):
+            pc.cmd_update("demo")
+        message = capsys.readouterr().out
+    else:
+        result = pc.dashboard_update_user_plugin("demo")
+        assert result["ok"] is False
+        message = result["error"]
+
+    assert "Pinned plugins cannot be updated in place" in message
+    compact = "".join(message.split())
+    assert f"'{''.join(source.split())}#plugins/demo'" in compact
+    assert "--ref<40-char-sha>--force" in compact
+    assert "no .git" not in message
+    assert "not a git checkout" not in message
+    pull.assert_not_called()
+
+
+@pytest.mark.parametrize("kind", ["malformed", "symlink", "dangling"])
+def test_unsafe_lock_fails_closed_before_git(tmp_path, monkeypatch, kind, capsys):
+    target = _installed(tmp_path, monkeypatch)
+    lock = target / LOCK_FILENAME
+    if kind == "malformed":
+        lock.write_text("secret-token-not-json")
+    else:
+        lock.symlink_to(target / ("missing" if kind == "dangling" else "payload"))
+        if kind == "symlink":
+            (target / "payload").write_text("{}")
+    pull = Mock()
+    monkeypatch.setattr(pc, "_git_pull_plugin_dir", pull)
+
+    with pytest.raises(SystemExit):
+        pc.cmd_update("demo")
+
+    pull.assert_not_called()
+    assert "secret-token" not in capsys.readouterr().out
+
+
+def test_legacy_no_lock_update_still_pulls_without_creating_lock(tmp_path, monkeypatch):
+    target = _installed(tmp_path, monkeypatch)
+    monkeypatch.setattr(pc, "_git_pull_plugin_dir", lambda _: (True, "Already up to date."))
+    monkeypatch.setattr(pc, "_copy_example_files", lambda *_: None)
+
+    pc.cmd_update("demo")
+
+    assert not (target / LOCK_FILENAME).exists()
+
+
+def test_pull_uses_sanitized_git_environment_and_hides_stderr(tmp_path, monkeypatch):
+    target = tmp_path / "demo"
+    target.mkdir()
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", "/tmp/evil")
+    monkeypatch.setenv("GIT_ASKPASS", "steal")
+    run = Mock(return_value=Mock(returncode=1, stdout="", stderr="token=raw-secret"))
+    monkeypatch.setattr(pc.subprocess, "run", run)
+    monkeypatch.setattr(pc, "_resolve_git_executable", lambda: "/usr/bin/git")
+
+    ok, message = pc._git_pull_plugin_dir(target)
+
+    assert ok is False
+    assert message == "Git pull failed."
+    kwargs = run.call_args.kwargs
+    assert run.call_args.args[0][:3] == ["/usr/bin/git", "-c", f"core.hooksPath={os.devnull}"]
+    assert kwargs["env"]["GIT_CONFIG_GLOBAL"] == os.devnull
+    assert "GIT_ASKPASS" not in kwargs["env"]
+    assert kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
+
+
+@pytest.mark.parametrize(
+    ("stdout", "expected"),
+    [
+        ("\x1b[31mAlready up to date. raw-secret\x1b[0m", "Already up to date."),
+        ("\x1b[31mupdated raw-secret\x1b[0m", "Updated."),
+    ],
+)
+def test_pull_success_maps_raw_output_to_fixed_message(
+    tmp_path, monkeypatch, stdout, expected
+):
+    target = tmp_path / "demo"
+    target.mkdir()
+    run = Mock(return_value=Mock(returncode=0, stdout=stdout, stderr=""))
+    monkeypatch.setattr(pc.subprocess, "run", run)
+    monkeypatch.setattr(pc, "_resolve_git_executable", lambda: "/usr/bin/git")
+
+    ok, message = pc._git_pull_plugin_dir(target)
+
+    assert ok is True
+    assert message == expected
+    assert "raw-secret" not in message
+    assert "\x1b" not in message
+
+
+def test_cli_success_does_not_print_raw_git_output(tmp_path, monkeypatch, capsys):
+    _installed(tmp_path, monkeypatch)
+    monkeypatch.setattr(pc, "_copy_example_files", lambda *_: None)
+    monkeypatch.setattr(pc, "_resolve_git_executable", lambda: "/usr/bin/git")
+    monkeypatch.setattr(
+        pc.subprocess,
+        "run",
+        Mock(return_value=Mock(returncode=0, stdout="\x1b[31mraw-secret\x1b[0m", stderr="")),
+    )
+
+    pc.cmd_update("demo")
+
+    output = capsys.readouterr().out
+    assert "raw-secret" not in output
+    assert "\x1b" not in output
+    assert "Plugin demo updated." in output
+    assert "Updated." in output
+
+
+def test_unpinned_update_refreshes_lock_to_real_remote_head(tmp_path, monkeypatch):
+    remote = tmp_path / "remote.git"
+    seed = tmp_path / "seed"
+    clone = tmp_path / "plugins" / "demo"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+    subprocess.run(["git", "clone", str(remote), str(seed)], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(seed), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "-C", str(seed), "config", "user.name", "Test"], check=True)
+    (seed / "plugin.yaml").write_text("name: demo\n")
+    subprocess.run(["git", "-C", str(seed), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(seed), "commit", "-m", "one"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(seed), "push", "origin", "HEAD"], check=True, capture_output=True)
+    subprocess.run(["git", "clone", str(remote), str(clone)], check=True, capture_output=True)
+    old = subprocess.run(["git", "-C", str(clone), "rev-parse", "HEAD"], check=True, text=True, capture_output=True).stdout.strip()
+    write_provenance_lock(clone, _provenance(commit=old, source=f"file://{remote}"))
+    (seed / "plugin.yaml").write_text("name: demo\nversion: 2\n")
+    subprocess.run(["git", "-C", str(seed), "commit", "-am", "two"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(seed), "push"], check=True, capture_output=True)
+    expected = subprocess.run(["git", "-C", str(seed), "rev-parse", "HEAD"], check=True, text=True, capture_output=True).stdout.strip()
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: tmp_path / "plugins")
+    monkeypatch.setattr(pc, "_copy_example_files", lambda *_: None)
+
+    pc.cmd_update("demo")
+
+    lock = read_provenance_lock(clone)
+    assert lock is not None
+    assert lock.requested_ref is None
+    assert lock.resolved_commit == expected
+    assert lock.source_url == f"file://{remote}"
+
+
+def test_lock_refresh_failure_is_partial_for_cli_and_dashboard(tmp_path, monkeypatch, capsys):
+    target = _installed(tmp_path, monkeypatch)
+    write_provenance_lock(target, _provenance())
+    monkeypatch.setattr(pc, "_git_pull_plugin_dir", lambda _: (True, "updated"))
+    monkeypatch.setattr(pc, "_refresh_update_provenance", lambda *_: (_ for _ in ()).throw(RuntimeError("raw-secret")))
+    copy = Mock()
+    monkeypatch.setattr(pc, "_copy_example_files", copy)
+
+    with pytest.raises(SystemExit) as exc:
+        pc.cmd_update("demo")
+    assert exc.value.code == 1
+    output = capsys.readouterr().out
+    assert "Plugin updated, but provenance lock refresh failed." in output
+    assert "raw-secret" not in output
+    copy.assert_not_called()
+
+    result = pc.dashboard_update_user_plugin("demo")
+    assert result == {"ok": False, "updated": True, "error": "Plugin updated, but provenance lock refresh failed.", "name": "demo"}
+    copy.assert_not_called()

--- a/tests/hermes_cli/test_plugin_update_provenance.py
+++ b/tests/hermes_cli/test_plugin_update_provenance.py
@@ -29,7 +29,26 @@ def _installed(tmp_path: Path, monkeypatch) -> Path:
     target = plugins / "demo"
     (target / ".git").mkdir(parents=True)
     monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins)
+    monkeypatch.setattr(pc, "_validate_update_local_git_config", lambda *_: None)
     return target
+
+
+def _real_update_repo(tmp_path: Path, monkeypatch) -> tuple[Path, Path]:
+    remote = tmp_path / "remote.git"
+    seed = tmp_path / "seed"
+    clone = tmp_path / "plugins" / "demo"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+    subprocess.run(["git", "clone", str(remote), str(seed)], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(seed), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "-C", str(seed), "config", "user.name", "Test"], check=True)
+    (seed / "plugin.yaml").write_text("name: demo\n")
+    subprocess.run(["git", "-C", str(seed), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(seed), "commit", "-m", "one"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(seed), "push", "origin", "HEAD"], check=True, capture_output=True)
+    subprocess.run(["git", "clone", str(remote), str(clone)], check=True, capture_output=True)
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: tmp_path / "plugins")
+    monkeypatch.setattr(pc, "_copy_example_files", lambda *_: None)
+    return remote, clone
 
 
 def test_pinned_cli_refuses_without_pull_and_preserves_target(tmp_path, monkeypatch, capsys):
@@ -208,7 +227,7 @@ def test_unpinned_update_refreshes_lock_to_real_remote_head(tmp_path, monkeypatc
     subprocess.run(["git", "-C", str(seed), "add", "."], check=True)
     subprocess.run(["git", "-C", str(seed), "commit", "-m", "one"], check=True, capture_output=True)
     subprocess.run(["git", "-C", str(seed), "push", "origin", "HEAD"], check=True, capture_output=True)
-    subprocess.run(["git", "clone", str(remote), str(clone)], check=True, capture_output=True)
+    subprocess.run(["git", "clone", f"file://{remote}", str(clone)], check=True, capture_output=True)
     old = subprocess.run(["git", "-C", str(clone), "rev-parse", "HEAD"], check=True, text=True, capture_output=True).stdout.strip()
     write_provenance_lock(clone, _provenance(commit=old, source=f"file://{remote}"))
     (seed / "plugin.yaml").write_text("name: demo\nversion: 2\n")
@@ -227,6 +246,64 @@ def test_unpinned_update_refreshes_lock_to_real_remote_head(tmp_path, monkeypatc
     assert lock.source_url == f"file://{remote}"
 
 
+def test_update_rejects_smudge_filter_without_executing_or_pulling(tmp_path, monkeypatch, capsys):
+    remote, clone = _real_update_repo(tmp_path, monkeypatch)
+    marker = tmp_path / "executed"
+    secret = f"touch {marker} secret-value"
+    subprocess.run(["git", "-C", str(clone), "config", "filter.attack.smudge", secret], check=True)
+    before = subprocess.run(["git", "-C", str(clone), "rev-parse", "HEAD"], check=True, text=True, capture_output=True).stdout
+
+    with pytest.raises(SystemExit):
+        pc.cmd_update("demo")
+
+    assert not marker.exists()
+    after = subprocess.run(["git", "-C", str(clone), "rev-parse", "HEAD"], check=True, text=True, capture_output=True).stdout
+    assert after == before
+    output = capsys.readouterr().out
+    assert "Unsafe local Git configuration; reinstall the plugin instead." in output
+    assert "filter.attack" not in output
+    assert "secret-value" not in output
+
+
+@pytest.mark.parametrize("key", ["core.fsmonitor", "credential.example.helper"])
+def test_update_rejects_other_executable_local_config(tmp_path, monkeypatch, key):
+    _remote, clone = _real_update_repo(tmp_path, monkeypatch)
+    subprocess.run(["git", "-C", str(clone), "config", key, "secret-command"], check=True)
+
+    result = pc.dashboard_update_user_plugin("demo")
+
+    assert result["ok"] is False
+    assert result["error"] == "Unsafe local Git configuration; reinstall the plugin instead."
+    assert "secret" not in result["error"]
+
+
+def test_update_rejects_origin_drift_from_provenance_without_pull(tmp_path, monkeypatch):
+    remote, clone = _real_update_repo(tmp_path, monkeypatch)
+    head = subprocess.run(["git", "-C", str(clone), "rev-parse", "HEAD"], check=True, text=True, capture_output=True).stdout.strip()
+    write_provenance_lock(clone, _provenance(commit=head, source=f"file://{remote}"))
+    subprocess.run(["git", "-C", str(clone), "remote", "set-url", "origin", "https://example.invalid/drift.git"], check=True)
+
+    result = pc.dashboard_update_user_plugin("demo")
+
+    assert result["ok"] is False
+    assert result["error"] == "Unsafe local Git configuration; reinstall the plugin instead."
+
+
+def test_update_rejects_multiple_origin_urls_from_provenance_without_pull(tmp_path, monkeypatch):
+    remote, clone = _real_update_repo(tmp_path, monkeypatch)
+    head = subprocess.run(["git", "-C", str(clone), "rev-parse", "HEAD"], check=True, text=True, capture_output=True).stdout.strip()
+    write_provenance_lock(clone, _provenance(commit=head, source=str(remote)))
+    subprocess.run(
+        ["git", "-C", str(clone), "config", "--add", "remote.origin.url", str(remote)],
+        check=True,
+    )
+
+    result = pc.dashboard_update_user_plugin("demo")
+
+    assert result["ok"] is False
+    assert result["error"] == "Unsafe local Git configuration; reinstall the plugin instead."
+
+
 def test_lock_refresh_failure_is_partial_for_cli_and_dashboard(tmp_path, monkeypatch, capsys):
     target = _installed(tmp_path, monkeypatch)
     write_provenance_lock(target, _provenance())
@@ -239,12 +316,12 @@ def test_lock_refresh_failure_is_partial_for_cli_and_dashboard(tmp_path, monkeyp
         pc.cmd_update("demo")
     assert exc.value.code == 1
     output = capsys.readouterr().out
-    assert "Plugin updated, but provenance lock refresh failed." in output
+    assert "Git pull succeeded, but provenance lock refresh failed." in output
     assert "raw-secret" not in output
     copy.assert_not_called()
 
     result = pc.dashboard_update_user_plugin("demo")
-    assert result == {"ok": False, "updated": True, "error": "Plugin updated, but provenance lock refresh failed.", "name": "demo"}
+    assert result == {"ok": False, "pull_succeeded": True, "unchanged": False, "error": "Git pull succeeded, but provenance lock refresh failed.", "name": "demo"}
     copy.assert_not_called()
 
 

--- a/tests/hermes_cli/test_plugin_update_provenance.py
+++ b/tests/hermes_cli/test_plugin_update_provenance.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -245,3 +246,46 @@ def test_lock_refresh_failure_is_partial_for_cli_and_dashboard(tmp_path, monkeyp
     result = pc.dashboard_update_user_plugin("demo")
     assert result == {"ok": False, "updated": True, "error": "Plugin updated, but provenance lock refresh failed.", "name": "demo"}
     copy.assert_not_called()
+
+
+@pytest.mark.parametrize("surface", ["cli", "dashboard"])
+def test_update_rechecks_pin_only_after_operation_lock_is_acquired(
+    tmp_path, monkeypatch, capsys, surface
+):
+    target = _installed(tmp_path, monkeypatch)
+    write_provenance_lock(target, _provenance(requested_ref=None))
+    pull = Mock()
+    monkeypatch.setattr(pc, "_git_pull_plugin_dir", pull)
+
+    @contextmanager
+    def pin_before_yield(locked_target):
+        assert locked_target == target
+        write_provenance_lock(target, _provenance(requested_ref="a" * 40))
+        yield
+
+    monkeypatch.setattr(pc, "_plugin_operation_lock", pin_before_yield)
+
+    if surface == "cli":
+        with pytest.raises(SystemExit):
+            pc.cmd_update("demo")
+        assert "Pinned plugins cannot be updated" in capsys.readouterr().out
+    else:
+        result = pc.dashboard_update_user_plugin("demo")
+        assert result["ok"] is False
+        assert "Pinned plugins cannot be updated" in result["error"]
+    pull.assert_not_called()
+
+
+@pytest.mark.skipif(os.name != "posix" or not hasattr(os, "link"), reason="hardlinks require POSIX")
+def test_update_rejects_hardlinked_provenance_before_git(tmp_path, monkeypatch, capsys):
+    target = _installed(tmp_path, monkeypatch)
+    lock_path = write_provenance_lock(target, _provenance())
+    os.link(lock_path, target / "second-link")
+    pull = Mock()
+    monkeypatch.setattr(pc, "_git_pull_plugin_dir", pull)
+
+    with pytest.raises(SystemExit):
+        pc.cmd_update("demo")
+
+    pull.assert_not_called()
+    assert "malformed or unreadable" in capsys.readouterr().out

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from contextlib import nullcontext
 import shutil
 import subprocess
 from argparse import ArgumentParser
@@ -487,12 +488,13 @@ class TestCmdInstall:
 class TestCmdUpdate:
     """Test the update command."""
 
+    @patch("hermes_cli.plugins_cmd._plugin_operation_lock", side_effect=lambda _target: nullcontext())
     @patch("hermes_cli.plugins_cmd._update_provenance_preflight", return_value=None)
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
     @patch("hermes_cli.plugins_cmd.subprocess.run")
     def test_update_git_pull_success(
-        self, mock_run, mock_plugins_dir, mock_sanitize, mock_preflight
+        self, mock_run, mock_plugins_dir, mock_sanitize, mock_preflight, mock_operation_lock
     ):
         from hermes_cli.plugins_cmd import cmd_update
 
@@ -510,6 +512,7 @@ class TestCmdUpdate:
         cmd_update("test-plugin")
 
         mock_run.assert_called_once()
+        mock_operation_lock.assert_called_once_with(mock_target)
 
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
     @patch("hermes_cli.plugins_cmd._plugins_dir")

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -646,9 +646,9 @@ class TestCopyExampleFiles:
         example_file = tmp_path / "config.yaml.example"
         example_file.write_text("key: value")
 
-        # Mock shutil.copy2 to raise an error
+        # Mock the safe reader to raise an error
         with patch(
-            "hermes_cli.plugins_cmd.shutil.copy2",
+            "hermes_cli.plugins_cmd._read_bounded_regular_file",
             side_effect=OSError("Permission denied"),
         ):
             # Should not raise, just warn
@@ -656,6 +656,29 @@ class TestCopyExampleFiles:
 
         # Should have printed a warning
         assert any("Warning" in str(c) for c in console.print.call_args_list)
+
+    def test_closes_descriptor_if_fdopen_fails(self, tmp_path):
+        console = MagicMock()
+        (tmp_path / "config.yaml.example").write_text("key: value")
+
+        with patch("hermes_cli.plugins_cmd._read_bounded_regular_file", return_value=b"key: value"), \
+             patch("hermes_cli.plugins_cmd.os.open", return_value=123), \
+             patch("hermes_cli.plugins_cmd.os.fdopen", side_effect=OSError("no stream")), \
+             patch("hermes_cli.plugins_cmd.os.close") as close:
+            _copy_example_files(tmp_path, console)
+
+        close.assert_called_once_with(123)
+        assert not (tmp_path / "config.yaml").exists()
+
+
+def test_display_after_install_uses_default_panel_when_instructions_missing(tmp_path, capsys):
+    from hermes_cli.plugins_cmd import _display_after_install
+
+    _display_after_install(tmp_path, "owner/plugin")
+
+    output = capsys.readouterr().out
+    assert "Plugin installed:" in output
+    assert "owner/plugin" in output
 
 
 class TestPromptPluginEnvVars:

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import shutil
@@ -25,13 +26,18 @@ from hermes_cli.plugins_cmd import (
 )
 
 
-def _make_inspect_repo(repo: Path, *, subdir: str | None = None) -> tuple[str, Path]:
+def _make_inspect_repo(
+    repo: Path, *, subdir: str | None = None, manifest: str | None = None
+) -> tuple[str, Path]:
     root = repo / subdir if subdir else repo
     root.mkdir(parents=True)
     (root / "plugin.yaml").write_text(
-        "name: inspect-me\nversion: 1.2.3\ndescription: Safe metadata\n"
-        "hooks: [pre_tool_call]\nprovides_tools: [z_tool, a_tool]\n"
-        "requires_env: [API_KEY, {name: TOKEN}]\n"
+        manifest
+        or (
+            "name: inspect-me\nversion: 1.2.3\ndescription: Safe metadata\n"
+            "hooks: [pre_tool_call]\nprovides_tools: [z_tool, a_tool]\n"
+            "requires_env: [API_KEY, {name: TOKEN}]\n"
+        )
     )
     (root / "after-install.md").write_text("do not render me")
     (root / "dashboard").mkdir()
@@ -992,6 +998,40 @@ class TestInspectPlugin:
         assert not (hermes_home / "plugins").exists()
         assert not (hermes_home / ".hermes-plugin-lock.json").exists()
 
+    @pytest.mark.parametrize(
+        ("manifest", "field"),
+        [
+            ("name: 2026-01-01\n", "name"),
+            ("name: valid\nversion: 2026-01-01\n", "version"),
+            ("name: valid\ndescription: {nested: value}\n", "description"),
+            ("name: valid\ndescription: [one, two]\n", "description"),
+        ],
+    )
+    def test_rejects_non_string_metadata_from_yaml(self, tmp_path, manifest, field):
+        from hermes_cli import plugins_cmd as pc
+
+        repo = tmp_path / "repo"
+        _make_inspect_repo(repo, manifest=manifest)
+
+        with pytest.raises(PluginOperationError, match=rf"\b{field}\b.*string"):
+            pc.inspect_plugin_source(f"file://{repo}")
+
+    @pytest.mark.parametrize("name_line", ["", "name:\n", "name: ''\n"])
+    def test_missing_null_or_empty_name_uses_repository_fallback(self, tmp_path, name_line):
+        from hermes_cli import plugins_cmd as pc
+
+        repo = tmp_path / "fallback-name"
+        _make_inspect_repo(repo, manifest=f"{name_line}version:\ndescription:\n")
+
+        result = pc.inspect_plugin_source(f"file://{repo}")
+
+        assert result["plugin"] == {
+            "name": "fallback-name",
+            "version": None,
+            "description": None,
+        }
+        json.dumps(result)
+
     def test_exact_ref_checkout_is_detached_and_verified(self, tmp_path):
         from hermes_cli import plugins_cmd as pc
 
@@ -1086,8 +1126,32 @@ class TestInspectPlugin:
         build_plugins_parser(subs, cmd_plugins=pc.plugins_command)
         args = parser.parse_args(["plugins", "inspect", f"file://{repo}", "--json"])
         args.func(args)
-        payload = __import__("json").loads(capsys.readouterr().out)
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        assert len(captured.out.splitlines()) == 1
+        payload = json.loads(captured.out)
         assert payload["resolved_commit"] == commit
+
+    def test_cmd_json_serialization_failure_is_one_machine_only_document(self, capsys):
+        from hermes_cli import plugins_cmd as pc
+
+        class SecretValue:
+            def __repr__(self):
+                return "DO_NOT_LEAK_THIS_SECRET"
+
+        with patch.object(pc, "inspect_plugin_source", return_value={"bad": SecretValue()}):
+            with pytest.raises(SystemExit) as exc_info:
+                pc.cmd_inspect("owner/repo", json_output=True)
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        assert len(captured.out.splitlines()) == 1
+        assert json.loads(captured.out) == {
+            "error": "Inspection result could not be serialized as JSON."
+        }
+        assert "DO_NOT_LEAK_THIS_SECRET" not in captured.out
+        assert "Traceback" not in captured.out
 
     def test_human_output_disclaims_security_audit(self, tmp_path, capsys):
         from hermes_cli import plugins_cmd as pc

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -487,10 +487,13 @@ class TestCmdInstall:
 class TestCmdUpdate:
     """Test the update command."""
 
+    @patch("hermes_cli.plugins_cmd._update_provenance_preflight", return_value=None)
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
     @patch("hermes_cli.plugins_cmd.subprocess.run")
-    def test_update_git_pull_success(self, mock_run, mock_plugins_dir, mock_sanitize):
+    def test_update_git_pull_success(
+        self, mock_run, mock_plugins_dir, mock_sanitize, mock_preflight
+    ):
         from hermes_cli.plugins_cmd import cmd_update
 
         mock_plugins_dir_val = MagicMock()

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import subprocess
+from argparse import ArgumentParser
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -21,6 +23,33 @@ from hermes_cli.plugins_cmd import (
     _resolve_subdir_within,
     _sanitize_plugin_name,
 )
+
+
+def _make_inspect_repo(repo: Path, *, subdir: str | None = None) -> tuple[str, Path]:
+    root = repo / subdir if subdir else repo
+    root.mkdir(parents=True)
+    (root / "plugin.yaml").write_text(
+        "name: inspect-me\nversion: 1.2.3\ndescription: Safe metadata\n"
+        "hooks: [pre_tool_call]\nprovides_tools: [z_tool, a_tool]\n"
+        "requires_env: [API_KEY, {name: TOKEN}]\n"
+    )
+    (root / "after-install.md").write_text("do not render me")
+    (root / "dashboard").mkdir()
+    (root / "dashboard" / "manifest.json").write_text("{}")
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+    }
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=env)
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True, env=env)
+    subprocess.run(["git", "commit", "-q", "-m", "initial"], cwd=repo, check=True, env=env)
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, text=True, capture_output=True
+    ).stdout.strip()
+    return commit, root
 
 
 # ── _sanitize_plugin_name ─────────────────────────────────────────────────
@@ -928,3 +957,142 @@ class TestSubdirInstallE2E:
         identifier = f"file://{repo_root}#does-not-exist"
         with pytest.raises(PluginOperationError, match="does not exist"):
             pc._install_plugin_core(identifier, force=False)
+
+
+class TestInspectPlugin:
+    def test_returns_capabilities_and_commit_without_installing(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins_cmd as pc
+
+        repo = tmp_path / "repo"
+        commit, _ = _make_inspect_repo(repo)
+        hermes_home = tmp_path / "home"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        result = pc.inspect_plugin_source(f"file://{repo}")
+
+        assert result == {
+            "source_url": f"file://{repo}",
+            "subdir": None,
+            "requested_ref": None,
+            "resolved_commit": commit,
+            "plugin": {
+                "name": "inspect-me",
+                "version": "1.2.3",
+                "description": "Safe metadata",
+            },
+            "capabilities": {
+                "hooks": ["pre_tool_call"],
+                "tools": ["a_tool", "z_tool"],
+                "required_env": ["API_KEY", "TOKEN"],
+                "has_dashboard": True,
+                "has_after_install": True,
+                "warnings": ["CAPABILITY_REPORT_IS_NOT_SECURITY_AUDIT"],
+            },
+        }
+        assert not (hermes_home / "plugins").exists()
+        assert not (hermes_home / ".hermes-plugin-lock.json").exists()
+
+    def test_exact_ref_checkout_is_detached_and_verified(self, tmp_path):
+        from hermes_cli import plugins_cmd as pc
+
+        repo = tmp_path / "repo"
+        requested, root = _make_inspect_repo(repo)
+        (root / "plugin.yaml").write_text("name: later\n")
+        subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "later"],
+            cwd=repo,
+            check=True,
+        )
+
+        result = pc.inspect_plugin_source(f"file://{repo}", requested_ref=requested)
+
+        assert result["requested_ref"] == requested
+        assert result["resolved_commit"] == requested
+        assert result["plugin"]["name"] == "inspect-me"
+
+    def test_invalid_ref_fails_before_git_resolution(self):
+        from hermes_cli import plugins_cmd as pc
+
+        with patch.object(pc, "_resolve_git_executable") as git:
+            with pytest.raises(PluginOperationError, match="40 lowercase"):
+                pc.inspect_plugin_source("owner/repo", requested_ref="ABC123")
+        git.assert_not_called()
+
+    @pytest.mark.parametrize("manifest", [None, "", "{}\n", ": : malformed [["])
+    def test_missing_or_malformed_manifest_cleans_temp(self, tmp_path, monkeypatch, manifest):
+        from hermes_cli import plugins_cmd as pc
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        if manifest is not None:
+            (repo / "plugin.yaml").write_text(manifest)
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "-c", "user.name=t", "-c", "user.email=t@t", "commit", "--allow-empty", "-q", "-m", "init"],
+            cwd=repo,
+            check=True,
+        )
+        temp_root = tmp_path / "temps"
+        temp_root.mkdir()
+        monkeypatch.setattr(pc.tempfile, "tempdir", str(temp_root))
+
+        with pytest.raises(PluginOperationError, match="manifest"):
+            pc.inspect_plugin_source(f"file://{repo}")
+        assert list(temp_root.iterdir()) == []
+
+    @pytest.mark.parametrize(
+        "identifier",
+        [
+            "https://user:secret@example.com/owner/repo.git",
+            "https://example.com/owner/repo.git?token=secret",
+        ],
+    )
+    def test_credentials_or_query_are_rejected_before_git(self, identifier):
+        from hermes_cli import plugins_cmd as pc
+
+        with patch.object(pc.subprocess, "run") as git:
+            with pytest.raises(PluginOperationError, match="credentials|query"):
+                pc.inspect_plugin_source(identifier)
+        git.assert_not_called()
+
+    def test_subdir_fragment_is_removed_before_source_validation(self, tmp_path):
+        from hermes_cli import plugins_cmd as pc
+
+        repo = tmp_path / "repo"
+        commit, _ = _make_inspect_repo(repo, subdir="plugins/one")
+        result = pc.inspect_plugin_source(f"file://{repo}#plugins/one")
+        assert result["source_url"] == f"file://{repo}"
+        assert result["subdir"] == "plugins/one"
+        assert result["resolved_commit"] == commit
+
+    def test_subdir_escape_is_rejected(self, tmp_path):
+        from hermes_cli import plugins_cmd as pc
+
+        repo = tmp_path / "repo"
+        _make_inspect_repo(repo)
+        with pytest.raises(PluginOperationError, match="escapes the repository"):
+            pc.inspect_plugin_source(f"file://{repo}#../outside")
+
+    def test_cmd_json_is_machine_only_and_dispatches(self, tmp_path, capsys):
+        from hermes_cli import plugins_cmd as pc
+        from hermes_cli.subcommands.plugins import build_plugins_parser
+
+        repo = tmp_path / "repo"
+        commit, _ = _make_inspect_repo(repo)
+        parser = ArgumentParser()
+        subs = parser.add_subparsers()
+        build_plugins_parser(subs, cmd_plugins=pc.plugins_command)
+        args = parser.parse_args(["plugins", "inspect", f"file://{repo}", "--json"])
+        args.func(args)
+        payload = __import__("json").loads(capsys.readouterr().out)
+        assert payload["resolved_commit"] == commit
+
+    def test_human_output_disclaims_security_audit(self, tmp_path, capsys):
+        from hermes_cli import plugins_cmd as pc
+
+        repo = tmp_path / "repo"
+        _make_inspect_repo(repo)
+        pc.cmd_inspect(f"file://{repo}")
+        assert "not a security audit" in capsys.readouterr().out.lower()

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -966,6 +966,127 @@ class TestSubdirInstallE2E:
 
 
 class TestInspectPlugin:
+    def test_inspection_manifest_rejects_absolute_symlink(self, tmp_path):
+        from hermes_cli import plugins_cmd as pc
+
+        outside = tmp_path / "outside.yaml"
+        outside.write_text("name: outside\n")
+        plugin = tmp_path / "plugin"
+        plugin.mkdir()
+        (plugin / "plugin.yaml").symlink_to(outside)
+
+        with pytest.raises(PluginOperationError, match="manifest"):
+            pc._read_inspection_manifest(plugin)
+
+    def test_inspection_manifest_rejects_oversized_regular_file(self, tmp_path):
+        from hermes_cli import plugins_cmd as pc
+
+        plugin = tmp_path / "plugin"
+        plugin.mkdir()
+        (plugin / "plugin.yaml").write_bytes(b"x" * (pc.MAX_INSPECT_MANIFEST_BYTES + 1))
+
+        with pytest.raises(PluginOperationError, match="too large"):
+            pc._read_inspection_manifest(plugin)
+
+    @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO unsupported")
+    def test_inspection_manifest_rejects_nonregular_file(self, tmp_path):
+        from hermes_cli import plugins_cmd as pc
+
+        plugin = tmp_path / "plugin"
+        plugin.mkdir()
+        os.mkfifo(plugin / "plugin.yaml")
+
+        with pytest.raises(PluginOperationError, match="regular file"):
+            pc._read_inspection_manifest(plugin)
+
+    @pytest.mark.parametrize("content", [b"\xff", b": : malformed [[", b"{}\n", b"\n"])
+    def test_inspection_manifest_rejects_unsafe_content(self, tmp_path, content):
+        from hermes_cli import plugins_cmd as pc
+
+        plugin = tmp_path / "plugin"
+        plugin.mkdir()
+        (plugin / "plugin.yaml").write_bytes(content)
+
+        with pytest.raises(PluginOperationError, match="manifest"):
+            pc._read_inspection_manifest(plugin)
+
+    def test_cmd_json_malformed_manifest_is_one_document_with_empty_stderr(self, capsys):
+        from hermes_cli import plugins_cmd as pc
+
+        with patch.object(pc, "inspect_plugin_source", side_effect=PluginOperationError("Plugin manifest plugin.yaml is malformed.")):
+            with pytest.raises(SystemExit, match="1"):
+                pc.cmd_inspect("owner/repo", json_output=True)
+
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        assert len(captured.out.splitlines()) == 1
+        assert json.loads(captured.out) == {"error": "Plugin manifest plugin.yaml is malformed."}
+
+    def test_cmd_json_unexpected_exception_does_not_leak(self, capsys):
+        from hermes_cli import plugins_cmd as pc
+
+        with patch.object(pc, "inspect_plugin_source", side_effect=RuntimeError("SECRET_REPR")):
+            with pytest.raises(SystemExit, match="1"):
+                pc.cmd_inspect("owner/repo", json_output=True)
+
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        assert len(captured.out.splitlines()) == 1
+        assert json.loads(captured.out) == {"error": "Plugin inspection failed unexpectedly."}
+        assert "SECRET_REPR" not in captured.out
+
+    def test_inspect_git_sanitizes_environment_and_failure_details(self, monkeypatch):
+        from hermes_cli import plugins_cmd as pc
+
+        monkeypatch.setenv("GIT_SSH_COMMAND", "helper SECRET_TOKEN")
+        monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+        monkeypatch.setenv("GCM_SECRET", "SECRET_TOKEN")
+        monkeypatch.setenv("SSH_ASKPASS", "SECRET_TOKEN")
+        monkeypatch.setenv("SSH_AUTH_SOCK", "/agent.sock")
+        completed = subprocess.CompletedProcess([], 1, stdout="", stderr="remote SECRET_TOKEN")
+        with patch.object(pc.subprocess, "run", return_value=completed) as run:
+            with pytest.raises(PluginOperationError, match="clone failed") as exc_info:
+                pc._run_inspect_git(["git", "clone"], operation="clone")
+
+        env = run.call_args.kwargs["env"]
+        assert not any(key.startswith("GIT_") for key in env if key not in {
+            "GIT_CONFIG_NOSYSTEM", "GIT_CONFIG_GLOBAL", "GIT_TERMINAL_PROMPT", "GIT_ALLOW_PROTOCOL"
+        })
+        assert not any(key.startswith("GCM_") for key in env if key != "GCM_INTERACTIVE")
+        assert "SSH_ASKPASS" not in env
+        assert env["SSH_AUTH_SOCK"] == "/agent.sock"
+        assert env["GIT_ALLOW_PROTOCOL"] == "file:https:http:ssh"
+        assert "SECRET_TOKEN" not in str(exc_info.value)
+
+    def test_inspect_git_unknown_operation_has_sanitized_failure(self):
+        from hermes_cli import plugins_cmd as pc
+
+        completed = subprocess.CompletedProcess([], 1, stdout="", stderr="SECRET_TOKEN")
+        with patch.object(pc.subprocess, "run", return_value=completed):
+            with pytest.raises(PluginOperationError, match="Git operation failed") as exc_info:
+                pc._run_inspect_git(["git", "status"], operation="status")
+
+        assert "SECRET_TOKEN" not in str(exc_info.value)
+
+    def test_real_inspect_ignores_malicious_global_git_filter(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins_cmd as pc
+
+        repo = tmp_path / "repo"
+        _make_inspect_repo(repo)
+        (repo / ".gitattributes").write_text("payload filter=pwn\n")
+        (repo / "payload").write_text("payload\n")
+        subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+        subprocess.run(["git", "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "payload"], cwd=repo, check=True)
+        marker = tmp_path / "marker"
+        config = tmp_path / "evil.gitconfig"
+        config.write_text(f"[filter \"pwn\"]\n\tsmudge = sh -c 'touch {marker}; cat'\n")
+        monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(config))
+
+        result = pc.inspect_plugin_source(f"file://{repo}")
+
+        assert result["plugin"]["name"] == "inspect-me"
+        assert not marker.exists()
+
     def test_returns_capabilities_and_commit_without_installing(self, tmp_path, monkeypatch):
         from hermes_cli import plugins_cmd as pc
 

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -489,12 +489,19 @@ class TestCmdUpdate:
     """Test the update command."""
 
     @patch("hermes_cli.plugins_cmd._plugin_operation_lock", side_effect=lambda _target: nullcontext())
+    @patch("hermes_cli.plugins_cmd._validate_update_local_git_config")
     @patch("hermes_cli.plugins_cmd._update_provenance_preflight", return_value=None)
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
     @patch("hermes_cli.plugins_cmd.subprocess.run")
     def test_update_git_pull_success(
-        self, mock_run, mock_plugins_dir, mock_sanitize, mock_preflight, mock_operation_lock
+        self,
+        mock_run,
+        mock_plugins_dir,
+        mock_sanitize,
+        mock_preflight,
+        mock_validate,
+        mock_operation_lock,
     ):
         from hermes_cli.plugins_cmd import cmd_update
 
@@ -512,6 +519,7 @@ class TestCmdUpdate:
         cmd_update("test-plugin")
 
         mock_run.assert_called_once()
+        mock_validate.assert_called_once_with(mock_target, None)
         mock_operation_lock.assert_called_once_with(mock_target)
 
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")


### PR DESCRIPTION
## Summary

- add a deterministic plugin source-lock and capability report
- support inspect-only source validation before install
- verify downloaded content against the reviewed commit SHA before activation
- persist install provenance atomically and bind updates to the locked source
- serialize install/update operations and reject executable update configuration
- prevent pinned installs from silently drifting during update

## Security properties

- Git config is treated as untrusted input and cannot inject executable behavior
- local source reads are validated before use
- failed publication preserves the previously installed plugin
- provenance writes and activation use atomic paths
- updates cannot change repository identity or bypass the recorded commit

## Testing

- `pytest tests/hermes_cli/test_plugin_install_provenance.py tests/hermes_cli/test_plugin_supply_chain.py tests/hermes_cli/test_plugin_update_provenance.py tests/hermes_cli/test_plugins_cmd.py -q`
  - **239 passed**
- `ruff check` on all changed Python and test files
  - **passed**

## Notes

This change is confined to plugin installation/update surfaces and does not add a new core model tool.
