### PR TITLE
feat(delegation): add opt-in context projection

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2505,7 +2505,10 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             )
     elif function_name == "delegate_task":
         def _execute(next_args: dict) -> Any:
-            return _finish_agent_tool(agent._dispatch_delegate_task(next_args), next_args)
+            return _finish_agent_tool(
+                agent._dispatch_delegate_task(next_args, parent_messages=messages),
+                next_args,
+            )
     else:
         def _execute(next_args: dict) -> Any:
             return _ra().handle_function_call(
@@ -2640,6 +2643,17 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     is present — so orphans from session loading or manual message
     manipulation are always caught.
     """
+    # Runtime-authenticated steer metadata is internal context-projection state,
+    # never a provider field. Work on copies so the live transcript retains it.
+    from tools.delegate_context import AUTHENTICATED_OOB_KEY
+
+    messages = [
+        {key: value for key, value in message.items() if key != AUTHENTICATED_OOB_KEY}
+        if AUTHENTICATED_OOB_KEY in message
+        else message
+        for message in messages
+    ]
+
     # --- Role allowlist: drop messages with roles the API won't accept ---
     filtered = []
     for msg in messages:
@@ -3368,6 +3382,9 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
             messages[target_idx]["content"] = f"{existing_content}{marker}"
     else:
         messages[target_idx]["content"] = existing_content + marker
+    from tools.delegate_context import attach_authenticated_oob
+
+    attach_authenticated_oob(messages[target_idx], steer_text)
     _ra().logger.info(
         "Delivered /steer to agent after tool batch (%d chars): %s",
         len(steer_text),

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -803,6 +803,9 @@ def run_conversation(
                             _sm["content"] = blocks
                         except Exception:
                             pass
+                    from tools.delegate_context import attach_authenticated_oob
+
+                    attach_authenticated_oob(_sm, _pre_api_steer)
                     _injected = True
                     logger.debug(
                         "Pre-API-call steer drain: injected into tool msg at index %d",

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1387,7 +1387,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             _delegate_result = None
             try:
                 def _execute(next_args: dict) -> Any:
-                    return agent._dispatch_delegate_task(next_args)
+                    return agent._dispatch_delegate_task(next_args, parent_messages=messages)
                 function_result, function_args = _run_agent_tool_execution_middleware(
                     agent,
                     function_name=function_name,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2320,6 +2320,11 @@ DEFAULT_CONFIG = {
         # extras" without silently stripping MCP tools the parent already has.
         # Set to false for strict intersection.
         "inherit_mcp_toolsets": True,
+        # Parent history is never copied by default. Operators may opt in to a
+        # bounded projection of recent textual user/assistant message entries.
+        "context_mode": "explicit",
+        "context_recent_turns": 3,
+        "context_max_chars": 12000,
         "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
         # Subagent summaries return to the parent's context verbatim. A batch

--- a/run_agent.py
+++ b/run_agent.py
@@ -6206,7 +6206,9 @@ class AIAgent:
         finally:
             self._executing_tools = False
 
-    def _dispatch_delegate_task(self, function_args: dict) -> str:
+    def _dispatch_delegate_task(
+        self, function_args: dict, parent_messages: list | None = None
+    ) -> str:
         """Single call site for delegate_task dispatch.
 
         New DELEGATE_TASK_SCHEMA fields only need to be added here to reach all
@@ -6236,6 +6238,7 @@ class AIAgent:
             role=function_args.get("role"),
             background=(not _is_subagent),
             parent_agent=self,
+            parent_messages=parent_messages,
         )
 
     def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str,

--- a/spikes/001-delegate-context-compiler/README.md
+++ b/spikes/001-delegate-context-compiler/README.md
@@ -1,0 +1,73 @@
+# Delegation Context Compiler Spike
+
+## Verdict: VALIDATED
+
+A deterministic, opt-in recent projection can reduce naive parent-history context, retain useful recent constraints, exclude disallowed message categories, and obey a hard character budget without an LLM call.
+
+This verdict supports proceeding to B1 **only as a default-off operator configuration**. It does not support replacing explicit context or automatically copying parent history. The counterexample proves that facts outside the recent window are lost.
+
+## Run
+
+```bash
+python3 spikes/001-delegate-context-compiler/probe.py
+```
+
+The probe is pure Python standard library. It imports no Hermes production implementation, calls no model or network, and writes no production state.
+
+Verification used:
+
+```bash
+python3 -m py_compile spikes/001-delegate-context-compiler/probe.py
+python3 spikes/001-delegate-context-compiler/probe.py > /tmp/delegate-context-spike-1.json
+python3 spikes/001-delegate-context-compiler/probe.py > /tmp/delegate-context-spike-2.json
+cmp /tmp/delegate-context-spike-1.json /tmp/delegate-context-spike-2.json
+```
+
+Both runs were byte-identical.
+
+## Results
+
+| Fixture | Naive chars | Explicit chars | Projection chars | Reduction | Required recall | Improved vs explicit | Forbidden leaks |
+|---|---:|---:|---:|---:|---:|---|---:|
+| role filtering + recent constraints | 267 | 46 | 186 | 30.34% | 2/2 | yes | 0 |
+| forbidden roles/non-text payload | 227 | 44 | 102 | 55.07% | 1/1 | yes | 0 |
+| explicit context remains default | 187 | 94 | 94 | 49.73% | 1/1 | no (already explicit) | 0 |
+| 20k+ history and hard budget | 22,117 | 51 | 1,200 | 94.57% | 2/2 | yes | 0 |
+| exact OOB wrapper extraction | 206 | 34 | 92 | 55.34% | 2/2 | yes | 0 |
+| old relevant fact outside window | 255 | 54 | 115 | 54.90% | 0/1 | no | 0 |
+| explicit context budget priority | 1,810 | 375 | 600 | 66.85% | 3/3 | yes | 0 |
+
+Aggregate criteria from the probe:
+
+```json
+{
+  "all_budget_task_final_deterministic": true,
+  "all_projection_fixtures_reduce_vs_naive": true,
+  "harmful_losses_vs_explicit": 0,
+  "useful_recall_improvements": 5,
+  "zero_forbidden_leaks": true
+}
+```
+
+All seven outputs stayed within budget, ended with the exact task block, and were deterministic. The long-history fixture hit the 1,200-character limit exactly while retaining both head and tail markers.
+
+## What was validated
+
+1. Only recent textual `user` and `assistant` messages enter projection.
+2. `system`, `developer`, `tool`, and non-text attachment payloads are excluded.
+3. Explicit mode does not read parent history and remains the default behavior.
+4. The final task block is reserved first and remains last under truncation.
+5. Exact Hermes OOB wrappers can retain the user body with an `[OOB user]` marker without copying wrapper instructions.
+6. Explicit context receives budget before projection; the mixed pressure fixture retained both explicit markers and added the projected marker.
+7. Projection adds useful task constraints in five fixtures compared with explicit-only context.
+
+## Limits and recommendation
+
+- Recent projection loses relevant facts older than its window (`OLD_REQUIRED` recall was 0/1). It must remain opt-in and must not be described as complete parent context.
+- Static fixtures do not prove security. The probe intentionally does not attempt heuristic secret detection; safety comes from excluding privileged/tool/non-text categories. Callers remain responsible for explicit context content.
+- Character count is a deterministic proxy, not provider token count.
+- The spike does not test model answer quality; required-marker recall is only a deterministic feasibility signal.
+
+**Recommendation:** proceed to B1 with `context_mode: explicit` as the unchanged default and `recent_projection` enabled only by operator configuration. Preserve explicit context priority, role filtering, deterministic budget, exact task-last framing, and the documented recent-window limitation.
+
+No production files were imported or modified. The spike remains uncommitted pending user review.

--- a/spikes/001-delegate-context-compiler/fixtures.json
+++ b/spikes/001-delegate-context-compiler/fixtures.json
@@ -1,0 +1,111 @@
+[
+  {
+    "name": "role_filtering_recovers_recent_constraints",
+    "parent_messages": [
+      {"role": "system", "content": "SYSTEM_PRIVATE must never be projected"},
+      {"role": "user", "content": "Use the constraint USE_TDD for this task."},
+      {"role": "assistant", "content": "Acknowledged; I will preserve USE_TDD."},
+      {"role": "tool", "content": "TOOL_PRIVATE raw output"},
+      {"role": "user", "content": "Also preserve KEEP_TASK_LAST."}
+    ],
+    "explicit_context": null,
+    "goal": "Implement the constrained change.",
+    "projection_enabled": true,
+    "recent_turns": 3,
+    "max_chars": 1200,
+    "required_markers": ["USE_TDD", "KEEP_TASK_LAST"],
+    "forbidden_markers": ["SYSTEM_PRIVATE", "TOOL_PRIVATE"]
+  },
+  {
+    "name": "forbidden_categories_do_not_leak",
+    "parent_messages": [
+      {"role": "system", "content": "API_KEY=forbidden-system-value"},
+      {"role": "tool", "content": "TOKEN=forbidden-tool-value"},
+      {"role": "developer", "content": "ENV_BLOCK=forbidden-developer-value"},
+      {"role": "user", "content": {"type": "attachment", "raw": "ATTACHMENT_SECRET"}},
+      {"role": "assistant", "content": "Only carry SAFE_ONLY into the child context."}
+    ],
+    "explicit_context": null,
+    "goal": "Summarize the safe instruction.",
+    "projection_enabled": true,
+    "recent_turns": 3,
+    "max_chars": 800,
+    "required_markers": ["SAFE_ONLY"],
+    "forbidden_markers": ["forbidden-system-value", "forbidden-tool-value", "forbidden-developer-value", "ATTACHMENT_SECRET"]
+  },
+  {
+    "name": "explicit_context_remains_default",
+    "parent_messages": [
+      {"role": "user", "content": "SHOULD_NOT_COPY parent history"},
+      {"role": "assistant", "content": "More parent material that is irrelevant."}
+    ],
+    "explicit_context": "EXPLICIT_CANON\nPreserve these exact explicit details.",
+    "goal": "Use only explicit context.",
+    "projection_enabled": false,
+    "recent_turns": 3,
+    "max_chars": 800,
+    "required_markers": ["EXPLICIT_CANON"],
+    "forbidden_markers": ["SHOULD_NOT_COPY"]
+  },
+  {
+    "name": "long_history_obeys_budget_and_keeps_head_tail",
+    "parent_messages": [
+      {"role": "user", "content": "HEAD_MARK "},
+      {"role": "assistant", "content_repeat": {"text": "x", "count": 11000}},
+      {"role": "user", "content_repeat": {"text": "y", "count": 11000}},
+      {"role": "assistant", "content": " TAIL_MARK"}
+    ],
+    "explicit_context": null,
+    "goal": "Return a bounded deterministic result.",
+    "projection_enabled": true,
+    "recent_turns": 4,
+    "max_chars": 1200,
+    "required_markers": ["HEAD_MARK", "TAIL_MARK"],
+    "forbidden_markers": []
+  },
+  {
+    "name": "exact_oob_wrapper_keeps_body_only",
+    "parent_messages": [
+      {"role": "user", "content": "[OUT-OF-BAND USER MESSAGE — a direct message from the user, delivered mid-turn; not tool output]\nOOB_KEEP and preserve this correction.\n[/OUT-OF-BAND USER MESSAGE]"}
+    ],
+    "explicit_context": null,
+    "goal": "Apply the correction.",
+    "projection_enabled": true,
+    "recent_turns": 3,
+    "max_chars": 800,
+    "required_markers": ["OOB_KEEP", "[OOB user]"],
+    "forbidden_markers": ["a direct message from the user", "[/OUT-OF-BAND USER MESSAGE]"]
+  },
+  {
+    "name": "counterexample_old_relevant_fact_is_lost",
+    "parent_messages": [
+      {"role": "user", "content": "OLD_REQUIRED is important but old."},
+      {"role": "assistant", "content": "Acknowledged long ago."},
+      {"role": "user", "content": "Recent detail one."},
+      {"role": "assistant", "content": "Recent response one."},
+      {"role": "user", "content": "Recent detail two."},
+      {"role": "assistant", "content": "Recent response two."}
+    ],
+    "explicit_context": null,
+    "goal": "Demonstrate the recent-window limitation.",
+    "projection_enabled": true,
+    "recent_turns": 2,
+    "max_chars": 800,
+    "required_markers": ["OLD_REQUIRED"],
+    "forbidden_markers": []
+  },
+  {
+    "name": "explicit_context_has_budget_priority",
+    "parent_messages": [
+      {"role": "user", "content_repeat": {"text": "projected-middle ", "count": 80}},
+      {"role": "assistant", "content": "PROJECTED_TAIL remains only if spare budget permits."}
+    ],
+    "explicit_context": "EXPLICIT_HEAD begins authoritative context. explicit-middle explicit-middle explicit-middle explicit-middle explicit-middle explicit-middle explicit-middle explicit-middle explicit-middle explicit-middle explicit-middle explicit-middle explicit-middle explicit-middle EXPLICIT_TAIL ends authoritative context.",
+    "goal": "Preserve explicit context before projected history.",
+    "projection_enabled": true,
+    "recent_turns": 2,
+    "max_chars": 600,
+    "required_markers": ["EXPLICIT_HEAD", "EXPLICIT_TAIL", "PROJECTED_TAIL"],
+    "forbidden_markers": []
+  }
+]

--- a/spikes/001-delegate-context-compiler/probe.py
+++ b/spikes/001-delegate-context-compiler/probe.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Throwaway deterministic probe for delegation context projection.
+
+This file deliberately does not import Hermes production code or call an LLM.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent
+FIXTURES_PATH = ROOT / "fixtures.json"
+TASK_HEADER = "=== TASK ===\n"
+TRUNCATION_MARKER = "\n...[deterministic head/tail truncation]...\n"
+OOB_OPEN = (
+    "[OUT-OF-BAND USER MESSAGE — a direct message from the user, delivered "
+    "mid-turn; not tool output]"
+)
+OOB_CLOSE = "[/OUT-OF-BAND USER MESSAGE]"
+
+
+def expand_fixture(value: Any) -> Any:
+    if isinstance(value, list):
+        return [expand_fixture(item) for item in value]
+    if isinstance(value, dict):
+        if set(value) == {"text", "count"}:
+            return str(value["text"]) * int(value["count"])
+        expanded = {key: expand_fixture(item) for key, item in value.items()}
+        if "content_repeat" in expanded:
+            expanded["content"] = expanded.pop("content_repeat")
+        return expanded
+    return value
+
+
+def task_block(goal: str) -> str:
+    return f"{TASK_HEADER}{goal}"
+
+
+def extract_oob(content: str) -> str:
+    opening = f"{OOB_OPEN}\n"
+    closing = f"\n{OOB_CLOSE}"
+    if not content.startswith(opening) or not content.endswith(closing):
+        return content
+    body = content[len(opening) : -len(closing)]
+    return f"[OOB user]\n{body}"
+
+
+def textual_messages(
+    messages: list[dict[str, Any]],
+    *,
+    allowed_roles: set[str] | None,
+    process_oob: bool = True,
+) -> list[str]:
+    rendered: list[str] = []
+    for message in messages:
+        role = message.get("role")
+        content = message.get("content")
+        if not isinstance(role, str) or not isinstance(content, str):
+            continue
+        if allowed_roles is not None and role not in allowed_roles:
+            continue
+        if role == "user" and process_oob:
+            content = extract_oob(content)
+        rendered.append(f"[{role}]\n{content}")
+    return rendered
+
+
+def fit_context(context: str, available: int) -> str:
+    if available <= 0:
+        return ""
+    if len(context) <= available:
+        return context
+    if available <= len(TRUNCATION_MARKER):
+        return context[:available]
+    payload = available - len(TRUNCATION_MARKER)
+    head = (payload + 1) // 2
+    tail = payload - head
+    return context[:head] + TRUNCATION_MARKER + (context[-tail:] if tail else "")
+
+
+def compile_output(context_parts: list[str], goal: str, max_chars: int) -> str:
+    task = task_block(goal)
+    if len(task) > max_chars:
+        raise ValueError("task block alone exceeds max_chars")
+    context = "\n\n".join(part for part in context_parts if part)
+    if not context:
+        return task
+    separator = "\n\n"
+    available = max_chars - len(task) - len(separator)
+    fitted = fit_context(context, available)
+    return f"{fitted}{separator}{task}" if fitted else task
+
+
+def compile_prioritized_output(
+    explicit: str | None,
+    projected_parts: list[str],
+    goal: str,
+    max_chars: int,
+) -> str:
+    """Reserve context budget for explicit text before optional projection."""
+    task = task_block(goal)
+    if len(task) > max_chars:
+        raise ValueError("task block alone exceeds max_chars")
+    outer_separator = "\n\n"
+    available = max_chars - len(task) - len(outer_separator)
+    if available <= 0:
+        return task
+
+    explicit_text = explicit if isinstance(explicit, str) and explicit else ""
+    if len(explicit_text) >= available:
+        context = fit_context(explicit_text, available)
+        return f"{context}{outer_separator}{task}" if context else task
+
+    context = explicit_text
+    projection = "\n\n".join(part for part in projected_parts if part)
+    if projection:
+        inner_separator = "\n\n" if context else ""
+        projection_budget = available - len(context) - len(inner_separator)
+        fitted_projection = fit_context(projection, projection_budget)
+        if fitted_projection:
+            context = f"{context}{inner_separator}{fitted_projection}"
+    return f"{context}{outer_separator}{task}" if context else task
+
+
+def explicit_output(fixture: dict[str, Any]) -> str:
+    explicit = fixture.get("explicit_context")
+    parts = [explicit] if isinstance(explicit, str) and explicit else []
+    return compile_output(parts, fixture["goal"], int(fixture["max_chars"]))
+
+
+def projection_output(fixture: dict[str, Any]) -> str:
+    explicit = fixture.get("explicit_context")
+    projected_parts: list[str] = []
+    if fixture.get("projection_enabled"):
+        eligible = textual_messages(fixture["parent_messages"], allowed_roles={"user", "assistant"})
+        recent = eligible[-int(fixture["recent_turns"]):]
+        projected_parts.extend(recent)
+    return compile_prioritized_output(
+        explicit if isinstance(explicit, str) else None,
+        projected_parts,
+        fixture["goal"],
+        int(fixture["max_chars"]),
+    )
+
+
+def naive_output(fixture: dict[str, Any]) -> str:
+    parts: list[str] = []
+    explicit = fixture.get("explicit_context")
+    if isinstance(explicit, str) and explicit:
+        parts.append(explicit)
+    parts.extend(
+        textual_messages(
+            fixture["parent_messages"], allowed_roles=None, process_oob=False
+        )
+    )
+    parts.append(task_block(fixture["goal"]))
+    return "\n\n".join(parts)
+
+
+def marker_recall(output: str, markers: list[str]) -> tuple[int, float]:
+    found = sum(marker in output for marker in markers)
+    return found, (found / len(markers) if markers else 1.0)
+
+
+def evaluate(fixture: dict[str, Any]) -> dict[str, Any]:
+    naive = naive_output(fixture)
+    explicit = explicit_output(fixture)
+    projection = projection_output(fixture)
+    projection_again = projection_output(fixture)
+    required = list(fixture["required_markers"])
+    forbidden = list(fixture["forbidden_markers"])
+    explicit_found, explicit_rate = marker_recall(explicit, required)
+    projection_found, projection_rate = marker_recall(projection, required)
+    leaks = [marker for marker in forbidden if marker in projection]
+    max_chars = int(fixture["max_chars"])
+    expected_task = task_block(fixture["goal"])
+    result = {
+        "name": fixture["name"],
+        "projection_enabled": bool(fixture["projection_enabled"]),
+        "naive_chars": len(naive),
+        "explicit_chars": len(explicit),
+        "projection_chars": len(projection),
+        "reduction_vs_naive": round(1 - (len(projection) / len(naive)), 4),
+        "explicit_required_found": explicit_found,
+        "projection_required_found": projection_found,
+        "required_total": len(required),
+        "explicit_recall_rate": round(explicit_rate, 4),
+        "projection_recall_rate": round(projection_rate, 4),
+        "recall_improved": projection_found > explicit_found,
+        "forbidden_leaks": leaks,
+        "within_budget": len(projection) <= max_chars,
+        "task_final": projection.endswith(expected_task),
+        "deterministic": projection == projection_again,
+    }
+    assert result["within_budget"], fixture["name"]
+    assert result["task_final"], fixture["name"]
+    assert result["deterministic"], fixture["name"]
+    assert not leaks, (fixture["name"], leaks)
+    if not fixture["projection_enabled"]:
+        assert projection == explicit, fixture["name"]
+    return result
+
+
+def verdict(results: list[dict[str, Any]]) -> tuple[str, dict[str, Any]]:
+    projected = [result for result in results if result["projection_enabled"]]
+    all_reduce = all(result["projection_chars"] < result["naive_chars"] for result in projected)
+    zero_leaks = all(not result["forbidden_leaks"] for result in results)
+    all_invariants = all(
+        result["within_budget"] and result["task_final"] and result["deterministic"]
+        for result in results
+    )
+    useful_improvements = sum(result["recall_improved"] for result in projected)
+    harmful_losses = sum(
+        result["projection_required_found"] < result["explicit_required_found"]
+        for result in projected
+    )
+    criteria = {
+        "all_projection_fixtures_reduce_vs_naive": all_reduce,
+        "zero_forbidden_leaks": zero_leaks,
+        "all_budget_task_final_deterministic": all_invariants,
+        "useful_recall_improvements": useful_improvements,
+        "harmful_losses_vs_explicit": harmful_losses,
+    }
+    if all_reduce and zero_leaks and all_invariants and useful_improvements >= 2 and harmful_losses == 0:
+        return "VALIDATED", criteria
+    if zero_leaks and all_invariants:
+        return "PARTIAL", criteria
+    return "INVALIDATED", criteria
+
+
+def main() -> int:
+    fixtures = expand_fixture(json.loads(FIXTURES_PATH.read_text(encoding="utf-8")))
+    results = [evaluate(fixture) for fixture in fixtures]
+    final_verdict, criteria = verdict(results)
+    payload = {"fixtures": results, "criteria": criteria, "verdict": final_verdict}
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3086,6 +3086,45 @@ class TestConcurrentToolExecution:
             )
             assert result == "result"
 
+    def test_delegate_dispatch_forwards_trusted_parent_messages(self, agent):
+        parent_messages = [{"role": "user", "content": "live"}]
+        with patch("tools.delegate_tool.delegate_task", return_value="ok") as delegated:
+            result = agent._dispatch_delegate_task(
+                {"goal": "work", "context": "explicit"},
+                parent_messages=parent_messages,
+            )
+        assert result == "ok"
+        assert delegated.call_args.kwargs["parent_messages"] is parent_messages
+
+    def test_sequential_delegate_path_forwards_live_messages(self, agent):
+        tool_call = _mock_tool_call(
+            name="delegate_task", arguments='{"goal":"work"}', call_id="c1"
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = [{"role": "user", "content": "live sequential"}]
+        captured = []
+        agent._dispatch_delegate_task = lambda args, parent_messages=None: (
+            captured.append(parent_messages) or '{"ok":true}'
+        )
+
+        agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        assert captured == [messages]
+
+    def test_concurrent_invoke_delegate_path_forwards_live_messages(self, agent):
+        messages = [{"role": "user", "content": "live concurrent"}]
+        captured = []
+        agent._dispatch_delegate_task = lambda args, parent_messages=None: (
+            captured.append(parent_messages) or '{"ok":true}'
+        )
+
+        result = agent._invoke_tool(
+            "delegate_task", {"goal": "work"}, "task-1", messages=messages
+        )
+
+        assert result == '{"ok":true}'
+        assert captured == [messages]
+
     def test_sequential_tool_callbacks_fire_in_order(self, agent):
         tool_call = _mock_tool_call(name="web_search", arguments='{"query":"hello"}', call_id="c1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -333,6 +333,58 @@ class TestDelegateTask(unittest.TestCase):
         mock_run.assert_called_once()
 
     @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_single_task_threads_live_parent_messages_to_child_builder(
+        self, mock_build, mock_run
+    ):
+        mock_build.return_value = MagicMock()
+        mock_run.return_value = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "Done",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+        }
+        parent = _make_mock_parent()
+        messages = [{"role": "user", "content": "live parent turn"}]
+
+        delegate_task(
+            goal="Use live context",
+            parent_agent=parent,
+            parent_messages=messages,
+            background=False,
+        )
+
+        self.assertIs(mock_build.call_args.kwargs["parent_messages"], messages)
+
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_batch_threads_same_live_parent_messages_to_every_child_builder(
+        self, mock_build, mock_run
+    ):
+        mock_build.side_effect = [MagicMock(), MagicMock()]
+        mock_run.return_value = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "Done",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+        }
+        parent = _make_mock_parent()
+        messages = [{"role": "user", "content": "shared live parent turn"}]
+
+        delegate_task(
+            tasks=[{"goal": "A"}, {"goal": "B"}],
+            parent_agent=parent,
+            parent_messages=messages,
+            background=False,
+        )
+
+        self.assertEqual(mock_build.call_count, 2)
+        for call in mock_build.call_args_list:
+            self.assertIs(call.kwargs["parent_messages"], messages)
+
+    @patch("tools.delegate_tool._run_single_child")
     def test_batch_mode(self, mock_run):
         mock_run.side_effect = [
             {"task_index": 0, "status": "completed", "summary": "Result A", "api_calls": 2, "duration_seconds": 3.0},

--- a/tests/tools/test_delegate_context.py
+++ b/tests/tools/test_delegate_context.py
@@ -208,12 +208,12 @@ def test_default_config_and_child_prompt_are_byte_stable() -> None:
     from tools.delegate_context import DelegationContextPolicy, load_delegation_context_policy
     from tools.delegate_tool import _build_child_system_prompt
 
-    raw_delegation = DEFAULT_CONFIG.get("delegation") or {}
+    raw_delegation = DEFAULT_CONFIG["delegation"]
     assert load_delegation_context_policy(raw_delegation) == DelegationContextPolicy()
 
-    assert raw_delegation.get("context_mode") == "explicit"
-    assert raw_delegation.get("context_recent_turns") == 3
-    assert raw_delegation.get("context_max_chars") == 12000
+    assert raw_delegation["context_mode"] == "explicit"
+    assert raw_delegation["context_recent_turns"] == 3
+    assert raw_delegation["context_max_chars"] == 12000
     expected = (
         "You are a focused subagent working on a specific delegated task.\n\n"
         "YOUR TASK:\nGOAL\n\nCONTEXT:\nCTX\n\nWORKSPACE PATH:\n/tmp/work\n"
@@ -233,19 +233,23 @@ def test_default_config_and_child_prompt_are_byte_stable() -> None:
 def test_context_policy_is_not_exposed_in_model_tool_schema() -> None:
     from tools.delegate_tool import DELEGATE_TASK_SCHEMA
     from tools.delegate_context import DelegationContextPolicy
+    from typing import Dict, cast
 
     policy_fields = {
         "context_mode",
         "context_recent_turns",
         "context_max_chars",
     }
-    properties: dict = dict(DELEGATE_TASK_SCHEMA.get("parameters", {}).get("properties", {}))
+    parameters = DELEGATE_TASK_SCHEMA.get("parameters", {})
+    assert isinstance(parameters, dict)
+    raw_properties = parameters.get("properties", {})
+    properties = dict(cast(Dict[str, object], raw_properties))
     task_properties: dict = {}
-    tasks_schema = properties.get("tasks")
-    if isinstance(tasks_schema, dict):
-        items_schema = tasks_schema.get("items")
-        if isinstance(items_schema, dict):
-            task_properties = dict(items_schema.get("properties", {}))
+    raw_tasks = properties.get("tasks")
+    if isinstance(raw_tasks, dict) and isinstance(raw_tasks.get("items"), dict):
+        task_properties = dict(
+            cast(Dict[str, object], raw_tasks["items"].get("properties", {}))
+        )
 
     assert policy_fields.isdisjoint(properties)
     assert policy_fields.isdisjoint(task_properties)

--- a/tests/tools/test_delegate_context.py
+++ b/tests/tools/test_delegate_context.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from hermes_cli.config import DEFAULT_CONFIG
+from tools.delegate_context import (
+    DelegationContextPolicy,
+    compile_delegation_context,
+    load_delegation_context_policy,
+)
+
+
+class _MustNotIterate:
+    def __iter__(self):
+        raise AssertionError("explicit mode inspected parent messages")
+
+
+def test_explicit_mode_returns_context_byte_for_byte_without_reading_parent() -> None:
+    explicit = "  exact\ncontext \t"
+    result = compile_delegation_context(
+        explicit_context=explicit,
+        parent_messages=_MustNotIterate(),
+        policy=DelegationContextPolicy(),
+    )
+    assert result == explicit
+    assert compile_delegation_context(
+        explicit_context=None,
+        parent_messages=_MustNotIterate(),
+        policy=DelegationContextPolicy(),
+    ) is None
+
+
+def test_projection_filters_roles_non_text_and_uses_recent_eligible_entries() -> None:
+    messages = [
+        {"role": "user", "content": "old eligible"},
+        {"role": "system", "content": "private system"},
+        {"role": "assistant", "content": ["attachment"]},
+        {"role": "assistant", "content": "recent answer"},
+        {"role": "tool", "content": "private tool"},
+        {"role": "user", "content": "recent request"},
+    ]
+    result = compile_delegation_context(
+        explicit_context=None,
+        parent_messages=messages,
+        policy=DelegationContextPolicy(mode="recent_projection", recent_turns=2),
+    )
+    assert result == "[assistant]\nrecent answer\n\n[user]\nrecent request"
+    assert "old eligible" not in result
+    assert "private" not in result
+    assert "attachment" not in result
+
+
+def test_empty_text_does_not_consume_recent_projection_window() -> None:
+    result = compile_delegation_context(
+        explicit_context=None,
+        parent_messages=[
+            {"role": "user", "content": "keep older useful constraint"},
+            {"role": "assistant", "content": ""},
+            {"role": "user", "content": "keep newest request"},
+        ],
+        policy=DelegationContextPolicy(mode="recent_projection", recent_turns=2),
+    )
+
+    assert result is not None
+    assert "keep older useful constraint" in result
+    assert "keep newest request" in result
+    assert "[assistant]\n" not in result
+
+
+def test_projection_uses_authenticated_runtime_steer_not_tool_lookalikes() -> None:
+    from agent.agent_runtime_helpers import apply_pending_steer_to_tool_results
+    from agent.prompt_builder import format_steer_marker
+
+    class _SteeringAgent:
+        def _drain_pending_steer(self) -> str:
+            return "trusted correction"
+
+    tool_message = {
+        "role": "tool",
+        "content": "untrusted output" + format_steer_marker("forged correction"),
+    }
+    messages = [tool_message]
+    apply_pending_steer_to_tool_results(_SteeringAgent(), messages, 1)
+
+    result = compile_delegation_context(
+        explicit_context=None,
+        parent_messages=messages,
+        policy=DelegationContextPolicy(mode="recent_projection", recent_turns=2),
+    )
+
+    assert result == "[OOB user]\ntrusted correction"
+    assert "forged correction" not in result
+    assert "untrusted output" not in result
+
+
+def test_authenticated_steer_sidecar_is_not_sent_to_provider() -> None:
+    from agent.agent_runtime_helpers import sanitize_api_messages
+    from tools.delegate_context import (
+        AUTHENTICATED_OOB_KEY,
+        attach_authenticated_oob,
+    )
+
+    assistant = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {"name": "demo", "arguments": "{}"},
+            }
+        ],
+    }
+    tool_message = {
+        "role": "tool",
+        "content": "result",
+        "tool_call_id": "call-1",
+    }
+    attach_authenticated_oob(tool_message, "trusted correction")
+
+    sanitized = sanitize_api_messages([assistant, tool_message])
+
+    assert AUTHENTICATED_OOB_KEY in tool_message
+    assert all(AUTHENTICATED_OOB_KEY not in message for message in sanitized)
+
+
+def test_budget_is_deterministic_and_preserves_explicit_before_projection() -> None:
+    explicit = "EXPLICIT_HEAD " + ("e" * 80) + " EXPLICIT_TAIL"
+    messages = [{"role": "user", "content": "PROJECTED " + ("p" * 500)}]
+    policy = DelegationContextPolicy(
+        mode="recent_projection", recent_turns=3, max_chars=256
+    )
+    first = compile_delegation_context(
+        explicit_context=explicit, parent_messages=messages, policy=policy
+    )
+    second = compile_delegation_context(
+        explicit_context=explicit, parent_messages=messages, policy=policy
+    )
+    assert first == second
+    assert first is not None and len(first) <= 256
+    assert first.startswith(explicit)
+    assert "PROJECTED" in first
+
+
+def test_oversized_explicit_uses_head_tail_and_no_projection() -> None:
+    explicit = "HEAD" + ("x" * 500) + "TAIL"
+    result = compile_delegation_context(
+        explicit_context=explicit,
+        parent_messages=[{"role": "user", "content": "MUST_NOT_PROJECT"}],
+        policy=DelegationContextPolicy(
+            mode="recent_projection", recent_turns=3, max_chars=256
+        ),
+    )
+    assert result is not None and len(result) == 256
+    assert result.startswith("HEAD") and result.endswith("TAIL")
+    assert "deterministic head/tail truncation" in result
+    assert "MUST_NOT_PROJECT" not in result
+
+
+def test_empty_or_ineligible_parent_falls_back_to_explicit_context() -> None:
+    policy = DelegationContextPolicy(mode="recent_projection")
+    for messages in (None, [], [{"role": "tool", "content": "hidden"}]):
+        assert compile_delegation_context(
+            explicit_context="explicit", parent_messages=messages, policy=policy
+        ) == "explicit"
+
+
+def test_policy_rejects_unknown_mode_clamps_bounds_and_loader_fails_safe() -> None:
+    with pytest.raises(ValueError):
+        DelegationContextPolicy(mode="unknown")  # type: ignore[arg-type]
+
+    clamped = DelegationContextPolicy(
+        mode="recent_projection", recent_turns=-10, max_chars=-1
+    )
+    assert clamped.recent_turns == 1
+    assert clamped.max_chars == 256
+
+    assert load_delegation_context_policy(None) == DelegationContextPolicy()
+    assert load_delegation_context_policy({"context_mode": "unknown"}) == DelegationContextPolicy()
+    assert load_delegation_context_policy(
+        {
+            "context_mode": "recent_projection",
+            "context_recent_turns": "2",
+            "context_max_chars": "512",
+        }
+    ) == DelegationContextPolicy(
+        mode="recent_projection", recent_turns=2, max_chars=512
+    )
+
+    for field, malformed in (
+        ("context_recent_turns", True),
+        ("context_recent_turns", 2.9),
+        ("context_max_chars", False),
+        ("context_max_chars", 512.5),
+    ):
+        config = {
+            "context_mode": "recent_projection",
+            "context_recent_turns": 3,
+            "context_max_chars": 12000,
+            field: malformed,
+        }
+        assert load_delegation_context_policy(config) == DelegationContextPolicy()
+
+
+def test_default_config_and_child_prompt_are_byte_stable() -> None:
+    from hermes_cli.config import DEFAULT_CONFIG
+    from tools.delegate_context import DelegationContextPolicy, load_delegation_context_policy
+    from tools.delegate_tool import _build_child_system_prompt
+
+    raw_delegation = DEFAULT_CONFIG.get("delegation") or {}
+    assert load_delegation_context_policy(raw_delegation) == DelegationContextPolicy()
+
+    assert raw_delegation.get("context_mode") == "explicit"
+    assert raw_delegation.get("context_recent_turns") == 3
+    assert raw_delegation.get("context_max_chars") == 12000
+    expected = (
+        "You are a focused subagent working on a specific delegated task.\n\n"
+        "YOUR TASK:\nGOAL\n\nCONTEXT:\nCTX\n\nWORKSPACE PATH:\n/tmp/work\n"
+        "Use this exact path for local repository/workdir operations unless the task explicitly says otherwise.\n\n"
+        "Complete this task using the tools available to you. When finished, provide a clear, concise summary of:\n"
+        "- What you did\n- What you found or accomplished\n- Any files you created or modified\n- Any issues encountered\n\n"
+        "Important workspace rule: Never assume a repository lives at /workspace/... or any other container-style path unless the task/context explicitly gives that path. "
+        "If no exact local path is provided, discover it first before issuing git/workdir-specific commands.\n\n"
+        "Keep your final summary tight: lead with outcomes, prefer bullet points over paragraphs, and don't replay your whole process. "
+        "Your response is returned to the parent agent as a summary, and overlong summaries crowd out the parent's context window."
+    )
+    assert _build_child_system_prompt(
+        "GOAL", "CTX", workspace_path="/tmp/work", role="leaf"
+    ) == expected
+
+
+def test_context_policy_is_not_exposed_in_model_tool_schema() -> None:
+    from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+    from tools.delegate_context import DelegationContextPolicy
+
+    policy_fields = {
+        "context_mode",
+        "context_recent_turns",
+        "context_max_chars",
+    }
+    properties: dict = dict(DELEGATE_TASK_SCHEMA.get("parameters", {}).get("properties", {}))
+    task_properties: dict = {}
+    tasks_schema = properties.get("tasks")
+    if isinstance(tasks_schema, dict):
+        items_schema = tasks_schema.get("items")
+        if isinstance(items_schema, dict):
+            task_properties = dict(items_schema.get("properties", {}))
+
+    assert policy_fields.isdisjoint(properties)
+    assert policy_fields.isdisjoint(task_properties)
+
+def test_opt_in_child_prompt_projects_safe_context_and_ends_with_task() -> None:
+    from tools.delegate_tool import _build_child_agent
+
+    parent = MagicMock()
+    parent._delegate_depth = 0
+    parent._subagent_id = None
+    parent.enabled_toolsets = ["terminal"]
+    parent.disabled_toolsets = []
+    parent.tool_progress_callback = None
+    parent._delegate_spinner = None
+    parent.model = "model"
+    parent.provider = "provider"
+    parent.base_url = "https://example.invalid"
+    parent.api_key = "key"
+    parent._client_kwargs = {}
+    parent._active_children = []
+    parent._active_children_lock = None
+    parent._session_db = None
+    parent.session_id = "parent"
+    parent._print_fn = None
+
+    messages = [
+        {"role": "system", "content": "SYSTEM_PRIVATE"},
+        {"role": "user", "content": "recent user"},
+        {"role": "tool", "content": "TOOL_PRIVATE"},
+        {"role": "assistant", "content": {"attachment": "NON_TEXT"}},
+        {"role": "assistant", "content": "recent answer"},
+    ]
+    config = {
+        "context_mode": "recent_projection",
+        "context_recent_turns": 3,
+        "context_max_chars": 12000,
+    }
+    with (
+        patch("tools.delegate_tool._load_config", return_value=config),
+        patch("tools.delegate_tool._get_max_spawn_depth", return_value=1),
+        patch("run_agent.AIAgent") as agent_cls,
+    ):
+        agent_cls.return_value = MagicMock(session_id="child")
+        _build_child_agent(
+            task_index=0,
+            goal="DO IT",
+            context="EXPLICIT FIRST",
+            toolsets=None,
+            model=None,
+            max_iterations=5,
+            task_count=1,
+            parent_agent=parent,
+            parent_messages=messages,
+        )
+
+    prompt = agent_cls.call_args.kwargs["ephemeral_system_prompt"]
+    assert prompt.index("EXPLICIT FIRST") < prompt.index("[user]\nrecent user")
+    assert "[assistant]\nrecent answer" in prompt
+    assert "SYSTEM_PRIVATE" not in prompt
+    assert "TOOL_PRIVATE" not in prompt
+    assert "NON_TEXT" not in prompt
+    assert prompt.count("DO IT") == 1
+    assert prompt.endswith("YOUR TASK:\nDO IT")

--- a/tests/tools/test_delegate_context.py
+++ b/tests/tools/test_delegate_context.py
@@ -209,11 +209,12 @@ def test_default_config_and_child_prompt_are_byte_stable() -> None:
     from tools.delegate_tool import _build_child_system_prompt
 
     raw_delegation = DEFAULT_CONFIG["delegation"]
+    assert isinstance(raw_delegation, dict)
     assert load_delegation_context_policy(raw_delegation) == DelegationContextPolicy()
 
-    assert raw_delegation["context_mode"] == "explicit"
-    assert raw_delegation["context_recent_turns"] == 3
-    assert raw_delegation["context_max_chars"] == 12000
+    assert raw_delegation.get("context_mode") == "explicit"
+    assert raw_delegation.get("context_recent_turns") == 3
+    assert raw_delegation.get("context_max_chars") == 12000
     expected = (
         "You are a focused subagent working on a specific delegated task.\n\n"
         "YOUR TASK:\nGOAL\n\nCONTEXT:\nCTX\n\nWORKSPACE PATH:\n/tmp/work\n"
@@ -233,25 +234,27 @@ def test_default_config_and_child_prompt_are_byte_stable() -> None:
 def test_context_policy_is_not_exposed_in_model_tool_schema() -> None:
     from tools.delegate_tool import DELEGATE_TASK_SCHEMA
     from tools.delegate_context import DelegationContextPolicy
-    from typing import Dict, cast
 
     policy_fields = {
         "context_mode",
         "context_recent_turns",
         "context_max_chars",
     }
+    assert isinstance(DELEGATE_TASK_SCHEMA, dict)
     parameters = DELEGATE_TASK_SCHEMA.get("parameters", {})
     assert isinstance(parameters, dict)
-    raw_properties = parameters.get("properties", {})
-    properties = dict(cast(Dict[str, object], raw_properties))
-    task_properties: dict = {}
-    raw_tasks = properties.get("tasks")
-    if isinstance(raw_tasks, dict) and isinstance(raw_tasks.get("items"), dict):
-        task_properties = dict(
-            cast(Dict[str, object], raw_tasks["items"].get("properties", {}))
-        )
+    properties = parameters.get("properties", {})
+    assert isinstance(properties, dict)
 
     assert policy_fields.isdisjoint(properties)
+
+    raw_tasks = properties.get("tasks")
+    assert isinstance(raw_tasks, dict)
+    raw_items = raw_tasks.get("items")
+    assert isinstance(raw_items, dict)
+    task_properties = raw_items.get("properties", {})
+    assert isinstance(task_properties, dict)
+
     assert policy_fields.isdisjoint(task_properties)
 
 def test_opt_in_child_prompt_projects_safe_context_and_ends_with_task() -> None:

--- a/tools/delegate_context.py
+++ b/tools/delegate_context.py
@@ -1,0 +1,150 @@
+"""Deterministic, operator-controlled context projection for delegated agents.
+
+The recent window counts eligible textual message entries, not semantic turns.
+Nonempty user/assistant string content is eligible, along with runtime-authenticated
+OOB steer sidecars; tool content itself is never projected. Bounds keep malformed
+operator configuration small and deterministic: 1..100 entries and
+256..1,000,000 characters.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping
+
+_MIN_RECENT_TURNS = 1
+_MAX_RECENT_TURNS = 100
+_MIN_MAX_CHARS = 256
+_MAX_MAX_CHARS = 1_000_000
+_TRUNCATION_MARKER = "\n...[deterministic head/tail truncation]...\n"
+AUTHENTICATED_OOB_KEY = "_hermes_authenticated_oob"
+
+
+@dataclass(frozen=True)
+class DelegationContextPolicy:
+    """Context compilation settings; explicit mode preserves legacy behavior."""
+
+    mode: Literal["explicit", "recent_projection"] = "explicit"
+    recent_turns: int = 3
+    max_chars: int = 12000
+
+    def __post_init__(self) -> None:
+        if self.mode not in ("explicit", "recent_projection"):
+            raise ValueError(f"unknown delegation context mode: {self.mode!r}")
+        if not isinstance(self.recent_turns, int) or isinstance(self.recent_turns, bool):
+            raise TypeError("recent_turns must be an integer")
+        if not isinstance(self.max_chars, int) or isinstance(self.max_chars, bool):
+            raise TypeError("max_chars must be an integer")
+        object.__setattr__(
+            self,
+            "recent_turns",
+            min(_MAX_RECENT_TURNS, max(_MIN_RECENT_TURNS, self.recent_turns)),
+        )
+        object.__setattr__(
+            self,
+            "max_chars",
+            min(_MAX_MAX_CHARS, max(_MIN_MAX_CHARS, self.max_chars)),
+        )
+
+
+def _strict_config_int(value: Any) -> int:
+    if type(value) is int:
+        return value
+    if type(value) is str:
+        digits = value[1:] if value[:1] in ("+", "-") else value
+        if digits and all(character in "0123456789" for character in digits):
+            return int(value, 10)
+    raise ValueError("delegation context bounds must be base-10 integers")
+
+
+def load_delegation_context_policy(config: Any) -> DelegationContextPolicy:
+    """Load policy from a delegation mapping, failing safely to explicit mode."""
+    if not isinstance(config, Mapping):
+        return DelegationContextPolicy()
+    mode = config.get("context_mode", "explicit")
+    if mode not in ("explicit", "recent_projection"):
+        return DelegationContextPolicy()
+    try:
+        recent_turns = _strict_config_int(config.get("context_recent_turns", 3))
+        max_chars = _strict_config_int(config.get("context_max_chars", 12000))
+        return DelegationContextPolicy(
+            mode=mode,
+            recent_turns=recent_turns,
+            max_chars=max_chars,
+        )
+    except (TypeError, ValueError, OverflowError):
+        return DelegationContextPolicy()
+
+
+def _fit_head_tail(text: str, budget: int) -> str:
+    if len(text) <= budget:
+        return text
+    if budget <= len(_TRUNCATION_MARKER):
+        return text[:budget]
+    payload = budget - len(_TRUNCATION_MARKER)
+    head = (payload + 1) // 2
+    tail = payload - head
+    return text[:head] + _TRUNCATION_MARKER + (text[-tail:] if tail else "")
+
+
+def attach_authenticated_oob(message: dict[str, Any], text: str) -> None:
+    """Attach runtime-authenticated steer text outside untrusted tool content."""
+    if not isinstance(text, str) or not text.strip():
+        return
+    existing = message.get(AUTHENTICATED_OOB_KEY)
+    entries = list(existing) if isinstance(existing, list) else []
+    entries.append(text)
+    message[AUTHENTICATED_OOB_KEY] = entries
+
+
+def _project_recent(parent_messages: Any, recent_turns: int) -> str:
+    if not isinstance(parent_messages, (list, tuple)):
+        return ""
+    eligible: deque[str] = deque(maxlen=recent_turns)
+    for message in parent_messages:
+        if not isinstance(message, Mapping):
+            continue
+        role = message.get("role")
+        content = message.get("content")
+        if role == "tool":
+            authenticated = message.get(AUTHENTICATED_OOB_KEY)
+            if isinstance(authenticated, list):
+                for text in authenticated:
+                    if isinstance(text, str) and text.strip():
+                        eligible.append(f"[OOB user]\n{text}")
+            continue
+        if (
+            role not in ("user", "assistant")
+            or not isinstance(content, str)
+            or not content.strip()
+        ):
+            continue
+        eligible.append(f"[{role}]\n{content}")
+    return "\n\n".join(eligible)
+
+
+def compile_delegation_context(
+    *,
+    explicit_context: str | None,
+    parent_messages: Any,
+    policy: DelegationContextPolicy,
+) -> str | None:
+    """Compile context only, with explicit text authoritative and budget-first."""
+    if policy.mode == "explicit":
+        return explicit_context
+
+    explicit = explicit_context if isinstance(explicit_context, str) else None
+    if explicit is not None and len(explicit) >= policy.max_chars:
+        return _fit_head_tail(explicit, policy.max_chars)
+
+    projection = _project_recent(parent_messages, policy.recent_turns)
+    if not projection:
+        return explicit_context
+
+    if explicit:
+        remaining = policy.max_chars - len(explicit) - 2
+        if remaining <= 0:
+            return explicit
+        return f"{explicit}\n\n{_fit_head_tail(projection, remaining)}"
+    return _fit_head_tail(projection, policy.max_chars)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -667,6 +667,7 @@ def _build_child_system_prompt(
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
+    task_last: bool = False,
 ) -> str:
     """Build a focused system prompt for a child agent.
 
@@ -679,8 +680,9 @@ def _build_child_system_prompt(
     parts = [
         "You are a focused subagent working on a specific delegated task.",
         "",
-        f"YOUR TASK:\n{goal}",
     ]
+    if not task_last:
+        parts.append(f"YOUR TASK:\n{goal}")
     if context and context.strip():
         parts.append(f"\nCONTEXT:\n{context}")
     if workspace_path and str(workspace_path).strip():
@@ -734,6 +736,8 @@ def _build_child_system_prompt(
             f"NOTE: You are at depth {child_depth}. The delegation tree "
             f"is capped at max_spawn_depth={max_spawn_depth}. {child_note}"
         )
+    if task_last:
+        parts.append(f"\nYOUR TASK:\n{goal}")
     return "\n".join(parts)
 
 
@@ -1086,6 +1090,8 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Trusted live parent transcript supplied by the executor. Never model-facing.
+    parent_messages: Optional[List[Dict[str, Any]]] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1188,13 +1194,25 @@ def _build_child_agent(
         child_toolsets.append("delegation")
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
+    from tools.delegate_context import (
+        compile_delegation_context,
+        load_delegation_context_policy,
+    )
+
+    context_policy = load_delegation_context_policy(delegation_cfg)
+    child_context = compile_delegation_context(
+        explicit_context=context,
+        parent_messages=parent_messages,
+        policy=context_policy,
+    )
     child_prompt = _build_child_system_prompt(
         goal,
-        context,
+        child_context,
         workspace_path=workspace_hint,
         role=effective_role,
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
+        task_last=context_policy.mode == "recent_projection",
     )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)
@@ -2431,6 +2449,7 @@ def delegate_task(
     role: Optional[str] = None,
     background: Optional[bool] = None,
     parent_agent=None,
+    parent_messages: Optional[List[Dict[str, Any]]] = None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
@@ -2591,6 +2610,7 @@ def delegate_task(
                 override_acp_command=creds.get("command"),
                 override_acp_args=creds.get("args"),
                 role=effective_role,
+                parent_messages=parent_messages,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -3469,8 +3489,10 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "string",
                 "description": (
                     "What the subagent should accomplish. Be specific and "
-                    "self-contained -- the subagent knows nothing about your "
-                    "conversation history."
+                    "self-contained -- do not assume the subagent receives "
+                    "parent conversation history. Operators may enable a "
+                    "bounded recent projection, but explicit context remains "
+                    "the reliable way to pass required background."
                 ),
             },
             "context": {
@@ -3582,6 +3604,7 @@ registry.register(
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),
         parent_agent=kw.get("parent_agent"),
+        parent_messages=kw.get("parent_messages"),
     ),
     check_fn=check_delegate_requirements,
     emoji="🔀",


### PR DESCRIPTION
## Summary

- add a deterministic compiler for projecting selected parent context into delegated tasks
- keep the feature **disabled by default**
- pass parent messages explicitly instead of reading hidden agent state
- preserve prompt-cache stability by compiling context only at delegation boundaries
- authenticate runtime out-of-band steering via a sidecar rather than mixing it into user history
- include a reproducible spike and fixtures documenting the decision evidence

## Safety and compatibility

- existing delegation behavior is unchanged when context projection is disabled
- projected context is bounded and deterministic
- role alternation and the parent conversation history are not mutated
- nested delegation remains subject to existing depth and role limits

## Testing

- `pytest tests/tools/test_delegate_context.py tests/tools/test_delegate.py tests/run_agent/test_run_agent.py -q`
  - **611 passed**
- `ruff check` on all changed Python and test files
  - **passed**

## Notes

The implementation is opt-in and introduces no new always-on core tool schema.
