### PR TITLE
fix(lazy_deps): key active_features() on distinctive packages, not any-present

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -317,14 +317,96 @@ class TestActiveFeatures:
         assert "platform.slack" not in active
 
     def test_multi_package_feature_active_if_any_present(self, monkeypatch):
-        # platform.slack has 3 packages; only one needs to be present
-        # for the feature to count as active (user activated it before,
-        # one transitive may have been uninstalled separately).
+        # platform.slack has 3 packages; a distinctive one present means the
+        # user activated it before (another transitive may have been
+        # uninstalled separately). slack-bolt is listed only by slack.
         monkeypatch.setattr(
             ld, "_is_present",
             lambda spec: ld._pkg_name_from_spec(spec) == "slack-bolt",
         )
         assert "platform.slack" in ld.active_features()
+
+    def test_shared_cve_pin_does_not_activate_messaging_feature(self, monkeypatch):
+        # The aiohttp CVE floor is pinned into several messaging features AND
+        # ships in the base install — its presence alone must not mark any
+        # platform active, or every `hermes update` tries to install
+        # platforms the user never enabled (e.g. Matrix's python-olm chain).
+        monkeypatch.setattr(
+            ld, "_is_present",
+            lambda spec: ld._pkg_name_from_spec(spec) == "aiohttp",
+        )
+        active = ld.active_features()
+        assert "platform.matrix" not in active
+        assert "platform.slack" not in active
+        assert "platform.discord" not in active
+        assert "platform.teams" not in active
+
+    def test_distinctive_package_activates_feature(self, monkeypatch):
+        # mautrix is listed only by platform.matrix — a genuine signal.
+        monkeypatch.setattr(
+            ld, "_is_present",
+            lambda spec: ld._pkg_name_from_spec(spec) == "mautrix",
+        )
+        assert "platform.matrix" in ld.active_features()
+
+    def test_core_package_does_not_activate_feature(self, monkeypatch):
+        # numpy is listed only by stt.faster_whisper, but when the base
+        # install already ships it, presence can't mean the user opted in.
+        monkeypatch.setattr(ld, "_core_requirement_names", lambda: frozenset({"numpy"}))
+        monkeypatch.setattr(
+            ld, "_is_present",
+            lambda spec: ld._pkg_name_from_spec(spec) == "numpy",
+        )
+        assert "stt.faster_whisper" not in ld.active_features()
+
+    def test_unshared_non_core_package_still_activates(self, monkeypatch):
+        # sounddevice: listed only by stt.faster_whisper and not a core dep.
+        monkeypatch.setattr(ld, "_core_requirement_names", lambda: frozenset({"numpy"}))
+        monkeypatch.setattr(
+            ld, "_is_present",
+            lambda spec: ld._pkg_name_from_spec(spec) == "sounddevice",
+        )
+        assert "stt.faster_whisper" in ld.active_features()
+
+    def test_all_shared_feature_falls_back_to_any_present(self, monkeypatch):
+        # tts.mistral and stt.mistral pin the same SDK — no distinctive
+        # package exists, so any-present remains the only possible signal.
+        monkeypatch.setattr(
+            ld, "_is_present",
+            lambda spec: ld._pkg_name_from_spec(spec) == "mistralai",
+        )
+        active = ld.active_features()
+        assert "tts.mistral" in active
+        assert "stt.mistral" in active
+
+
+class TestCoreRequirementNames:
+    def test_excludes_extra_gated_requirements(self, monkeypatch):
+        import importlib.metadata as md
+
+        monkeypatch.setattr(
+            md, "requires",
+            lambda dist: [
+                "aiohttp>=3.7.4,<4",
+                "uvicorn[standard]>=0.41.0; extra == 'web'",
+                'starlette==1.0.1; extra == "computer-use"',
+                "uvloop>=0.21; sys_platform != 'win32'",
+            ],
+        )
+        core = ld._core_requirement_names()
+        assert "aiohttp" in core
+        assert "uvloop" in core  # env markers are still core, not extras
+        assert "uvicorn" not in core
+        assert "starlette" not in core
+
+    def test_metadata_unavailable_returns_empty(self, monkeypatch):
+        import importlib.metadata as md
+
+        def _boom(dist):
+            raise md.PackageNotFoundError(dist)
+
+        monkeypatch.setattr(md, "requires", _boom)
+        assert ld._core_requirement_names() == frozenset()
 
 
 class TestRefreshActiveFeatures:

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -855,19 +855,84 @@ def feature_install_command(feature: str) -> Optional[str]:
     return "uv pip install " + " ".join(repr(s) for s in specs)
 
 
+def _normalized_pkg_name(spec_or_name: str) -> str:
+    """PEP 503-normalized package name for cross-spec comparisons."""
+    return re.sub(r"[-_.]+", "-", _pkg_name_from_spec(spec_or_name)).lower()
+
+
+def _core_requirement_names() -> frozenset:
+    """Package names installed by the base ``hermes-agent`` distribution.
+
+    Reads the installed dist's ``Requires-Dist`` and keeps only requirements
+    that are NOT gated behind an extra — i.e. pyproject's ``dependencies``.
+    These ship on every install, so their presence says nothing about which
+    lazy backends the user has activated. Returns an empty frozenset when
+    metadata is unavailable (bare source trees, partial installs) — callers
+    then fall back to cross-feature sharing alone.
+    """
+    try:
+        from importlib.metadata import requires
+    except ImportError:
+        return frozenset()
+    try:
+        reqs = requires("hermes-agent") or []
+    except Exception:
+        return frozenset()
+    core = set()
+    for req in reqs:
+        if "extra ==" in req:
+            continue
+        name = re.split(r"[ ;\[<>=!~(]", req, maxsplit=1)[0].strip()
+        if name:
+            core.add(_normalized_pkg_name(name))
+    return frozenset(core)
+
+
+def _activation_specs(
+    feature: str, shared_counts: dict, core_names: frozenset
+) -> tuple:
+    """Specs whose presence indicates the user actually activated ``feature``.
+
+    A package only counts as an activation signal when it is *distinctive*:
+    listed by no other lazy feature AND not part of the base install.
+    Shared pins (the aiohttp CVE floor lives in four messaging features) and
+    core packages are present whether or not the user ever enabled the
+    backend — treating them as activation made every ``hermes update`` try
+    to install platforms the user never turned on (e.g. Matrix's
+    mautrix/python-olm source build on machines without cmake).
+
+    Features whose packages are ALL shared (``tts.mistral`` /
+    ``stt.mistral`` pin the same SDK) fall back to their full spec list —
+    any-present is the only signal available for those.
+    """
+    specs = LAZY_DEPS[feature]
+    distinctive = tuple(
+        s for s in specs
+        if shared_counts.get(_normalized_pkg_name(s), 0) <= 1
+        and _normalized_pkg_name(s) not in core_names
+    )
+    return distinctive or specs
+
+
 def active_features() -> list[str]:
     """Return the list of features the user has ever lazy-installed.
 
-    A feature counts as "active" if at least one of its declared packages
-    is currently installed in the venv (presence check, ignoring version).
-    Features the user has never enabled stay quiet.
+    A feature counts as "active" if at least one of its *distinctive*
+    packages (see :func:`_activation_specs`) is currently installed in the
+    venv (presence check, ignoring version). Features the user has never
+    enabled stay quiet.
 
     Used by ``hermes update`` to figure out which lazy backends need a
     refresh pass when pins move in :data:`LAZY_DEPS`.
     """
+    shared_counts: dict = {}
+    for specs in LAZY_DEPS.values():
+        for name in {_normalized_pkg_name(s) for s in specs}:
+            shared_counts[name] = shared_counts.get(name, 0) + 1
+    core_names = _core_requirement_names()
     active = []
-    for feature, specs in LAZY_DEPS.items():
-        if any(_is_present(s) for s in specs):
+    for feature in LAZY_DEPS:
+        if any(_is_present(s) for s in _activation_specs(feature, shared_counts, core_names)):
             active.append(feature)
     return active
 


### PR DESCRIPTION
## Problem

`lazy_deps.active_features()` counts a lazy backend as "active" (previously installed, so `hermes update` should refresh its pins) if **any** of its declared packages is present in the venv. Several pins are deliberately shared across features — the `aiohttp==3.14.1` CVE floor is declared in `platform.discord`, `platform.slack`, `platform.matrix`, and `platform.teams` — and `aiohttp` also ships in the base install.

The result: every install reports those four messaging platforms as active whether or not the user ever enabled them, and every `hermes update` tries to (re)install them:

- On machines **without** build tooling, the Matrix refresh fails on every update — `mautrix[encryption]` → `python-olm` builds its bundled libolm from source and needs `cmake`. The updater prints `⚠ platform.matrix failed to refresh` plus a misleading "rerun `hermes update` once the upstream issue is resolved" note, forever. (Observed failing on 7+ consecutive update runs on a machine where Matrix was never installed or configured.)
- On machines **with** `cmake`, the update silently installs messaging platforms the user never turned on.

### Reproduction

On any install without the Matrix backend (no `mautrix`/`aiosqlite`/`asyncpg`/`aiohttp-socks`) but with `aiohttp` (i.e. every install):

```python
from tools import lazy_deps
"platform.matrix" in lazy_deps.active_features()   # True — should be False
```

`hermes update` then attempts the refresh and fails inside the `python-olm` build (`PermissionError`/`FileNotFoundError: cmake` depending on PATH contents).

## Fix

A package now only counts as an activation signal when it is **distinctive**:

1. listed by no other feature in `LAZY_DEPS` (excludes the shared CVE pins), **and**
2. not part of the base install (read from the distribution's `Requires-Dist`, extra-gated requirements excluded — new `_core_requirement_names()` helper).

Features whose packages are *all* shared (`tts.mistral` / `stt.mistral` pin the same `mistralai` SDK) fall back to the previous any-present behavior — for those, any-present is the only signal available.

`refresh_active_features()` and `ensure()` are unchanged; this only narrows which features the refresh pass selects.

## Verification

- **Live install** (the machine that exhibited the bug): active set drops 20 → 19, with `platform.matrix` — never installed, unconfigured — the only removal. `platform.discord`/`slack`/`teams` correctly remain active via their genuine SDKs (`discord.py`, `slack-bolt`, `microsoft-teams-apps` are installed there).
- **Tests**: 8 new cases in `tests/tools/test_lazy_deps.py`:
  - shared `aiohttp` pin alone does not activate any of the four messaging features
  - distinctive package (`mautrix`) does activate `platform.matrix`
  - core package (mocked `numpy`) does not activate `stt.faster_whisper`; its non-core unshared package (`sounddevice`) does
  - all-shared feature (`mistralai`) still activates both mistral features (fallback)
  - `_core_requirement_names` parsing: extras excluded, env markers kept, missing metadata → empty
- `tests/tools/test_lazy_deps.py`: 71 passed; sibling lazy-install suites (`test_lazy_deps_durable_target`, `test_lazy_session_regressions`, `test_memory_lazy_install`, `test_discord_lazy_install_views`): all green.
