### PR TITLE
fix: tolerate transient kanban file growth

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2248,24 +2248,37 @@ def _check_file_length_invariant(conn: sqlite3.Connection) -> None:
             return  # in-memory or unnamed DB; skip
         path = path_str
         page_size = conn.execute("PRAGMA page_size").fetchone()[0]
-        file_size = os.path.getsize(path)
-        with open(path, "rb") as f:
-            f.seek(28)
-            header_bytes = f.read(4)
-        if len(header_bytes) < 4:
-            return  # can't read header; skip
-        header_page_count = int.from_bytes(header_bytes, "big")
-        if header_page_count == 0:
-            return  # new/empty DB; skip
-        actual_pages = file_size // page_size
-        if actual_pages < header_page_count:
-            raise sqlite3.DatabaseError(
-                f"torn-extend detected: page count mismatch on {path}: "
-                f"header claims {header_page_count} pages, "
-                f"file has {actual_pages} pages "
-                f"(missing {header_page_count - actual_pages} pages, "
-                f"file_size={file_size}, page_size={page_size})"
-            )
+        # A commit that extends the database can make the header and file-size
+        # observations briefly disagree even though SQLite has completed the
+        # transaction successfully. Re-sample a bounded number of times before
+        # classifying the mismatch as durable corruption. A genuinely truncated
+        # database remains mismatched and still raises below.
+        observations: tuple[int, int, int] | None = None
+        for attempt in range(5):
+            file_size = os.path.getsize(path)
+            with open(path, "rb") as f:
+                f.seek(28)
+                header_bytes = f.read(4)
+            if len(header_bytes) < 4:
+                return  # can't read header; skip
+            header_page_count = int.from_bytes(header_bytes, "big")
+            if header_page_count == 0:
+                return  # new/empty DB; skip
+            actual_pages = file_size // page_size
+            if actual_pages >= header_page_count:
+                return
+            observations = (header_page_count, actual_pages, file_size)
+            if attempt < 4:
+                time.sleep(0.01 * (attempt + 1))
+        assert observations is not None
+        header_page_count, actual_pages, file_size = observations
+        raise sqlite3.DatabaseError(
+            f"torn-extend detected: page count mismatch on {path}: "
+            f"header claims {header_page_count} pages, "
+            f"file has {actual_pages} pages "
+            f"(missing {header_page_count - actual_pages} pages, "
+            f"file_size={file_size}, page_size={page_size})"
+        )
     except sqlite3.DatabaseError:
         raise
     except Exception:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1875,7 +1875,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1892,7 +1891,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1909,7 +1907,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1926,7 +1923,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1943,7 +1939,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1960,7 +1955,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1977,7 +1971,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1994,7 +1987,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2011,7 +2003,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2028,7 +2019,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2045,7 +2035,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2062,7 +2051,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2079,7 +2067,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2096,7 +2083,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2113,7 +2099,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2130,7 +2115,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2147,7 +2131,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2164,7 +2147,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2181,7 +2163,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2198,7 +2179,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2215,7 +2195,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2232,7 +2211,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2249,7 +2227,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2266,7 +2243,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2283,7 +2259,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2300,7 +2275,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4681,6 +4681,36 @@ def test_write_txn_raises_on_truncated_file(tmp_path):
     conn.close()
 
 
+def test_write_txn_tolerates_one_transient_file_size_observation(tmp_path):
+    """A one-sample post-commit mismatch is not reported as corruption."""
+    from hermes_cli.kanban_db import connect, write_txn
+    db = tmp_path / "test.db"
+    conn = connect(db_path=db)
+    page_size = conn.execute("PRAGMA page_size").fetchone()[0]
+    original_getsize = os.path.getsize
+    observations = 0
+
+    def transient_getsize(path):
+        nonlocal observations
+        observations += 1
+        real_size = original_getsize(path)
+        return max(0, real_size - page_size) if observations == 1 else real_size
+
+    with unittest.mock.patch(
+        "hermes_cli.kanban_db.os.path.getsize", side_effect=transient_getsize
+    ):
+        with write_txn(conn) as c:
+            c.execute(
+                "INSERT INTO tasks (id, title, assignee, status, priority, created_at) "
+                "VALUES ('t_transient', 'transient size', 'tester', 'todo', 0, 1234567890)"
+            )
+    assert observations >= 2
+    assert conn.execute(
+        "SELECT title FROM tasks WHERE id='t_transient'"
+    ).fetchone()["title"] == "transient size"
+    conn.close()
+
+
 def test_write_txn_post_commit_check_fires_every_call(tmp_path):
     """The invariant check runs on every write_txn call."""
     from hermes_cli.kanban_db import connect, write_txn


### PR DESCRIPTION
## What changed

- Re-sample the SQLite header and file length after a Kanban write before declaring a torn-extend corruption.
- Preserve the existing hard failure when the mismatch remains durable across all bounded samples.
- Add regression coverage for both transient and genuinely truncated database observations.
- Preserve the local package-lock update included in the requested workspace publication.

## Why

Concurrent Kanban workers can briefly observe a newly committed header page count before a following file-size observation catches up. The previous single-sample check raised after a successful commit, causing completed board writes to be reported as worker failures.

## Impact

High-concurrency boards no longer treat a transient post-commit observation as database corruption, while persistent truncation remains protected by the same exception.

## Validation

- `python3 -m pytest -q tests/hermes_cli/test_kanban_db.py -k 'write_txn_healthy_commit or write_txn_raises_on_truncated_file or write_txn_tolerates_one_transient_file_size_observation or write_txn_post_commit_check_fires_every_call or write_txn_check_reads_correct_header_fields'`
- Result: 5 passed
