### PR TITLE
feat(models): add Claude Sonnet 5 across curated lists, pricing, and metadata (salvage #55848/#55853/#60410)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -127,6 +127,8 @@ _FAST_MODE_SUPPORTED_SUBSTRINGS = ("opus-4-6", "opus-4.6")
 _ANTHROPIC_OUTPUT_LIMITS = {
     # Mythos-class named models (claude-fable-5, …) — 1M context, reasoning
     "claude-fable":      128_000,
+    # Claude Sonnet 5
+    "claude-sonnet-5":   128_000,
     # Claude 4.8
     "claude-opus-4-8":   128_000,
     # Claude 4.7

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1322,6 +1322,7 @@ def classify_bedrock_error(error_message: str) -> str:
 
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     # Anthropic Claude models on Bedrock
+    "anthropic.claude-sonnet-5":     1_000_000,
     "anthropic.claude-opus-4-6":     200_000,
     "anthropic.claude-sonnet-4-6":   200_000,
     "anthropic.claude-sonnet-4-5":   200_000,

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -213,6 +213,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     # OpenRouter-prefixed models resolve via OpenRouter live API or models.dev.
     "claude-fable-5": 1000000,
     "claude-fable": 1000000,
+    "claude-sonnet-5": 1000000,
     "claude-opus-4-8": 1000000,
     "claude-opus-4.8": 1000000,
     "claude-opus-4-7": 1000000,

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -102,6 +102,7 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
     # ``claude-opus-4`` so non-thinking Claude 3.x or future
     # non-reasoning Claude variants don't match.
     ("claude-opus-4", 240),
+    ("claude-sonnet-5", 180),
     ("claude-sonnet-4.5", 180),
     ("claude-sonnet-4.6", 180),
     # xAI Grok reasoning variants.  Explicit reasoning-only keys

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -179,6 +179,23 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://openrouter.ai/anthropic/claude-opus-4.8-fast",
         pricing_version="anthropic-pricing-2026-05",
     ),
+    # ── Anthropic Claude Sonnet 5 ────────────────────────────────────────
+    # Launched 2026-06-30. Introductory pricing ($2/$10 per MTok) runs
+    # through 2026-08-31, after which it reverts to $3/$15 (matching
+    # Sonnet 4.6). Update this entry when the intro window closes.
+    # Source: https://platform.claude.com/docs/en/about-claude/pricing
+    (
+        "anthropic",
+        "claude-sonnet-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("2.00"),
+        output_cost_per_million=Decimal("10.00"),
+        cache_read_cost_per_million=Decimal("0.20"),
+        cache_write_cost_per_million=Decimal("2.50"),
+        source="official_docs_snapshot",
+        source_url="https://platform.claude.com/docs/en/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-06-intro",
+    ),
     # ── Anthropic Claude 4.7 ─────────────────────────────────────────────
     # Opus 4.5/4.6/4.7 share $5/$25 pricing (new tokenizer, up to 35% more
     # tokens for the same text).

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -251,18 +251,6 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
     ),
     (
         "anthropic",
-        "claude-sonnet-5",
-    ): PricingEntry(
-        input_cost_per_million=Decimal("3.00"),
-        output_cost_per_million=Decimal("15.00"),
-        cache_read_cost_per_million=Decimal("0.30"),
-        cache_write_cost_per_million=Decimal("3.75"),
-        source="official_docs_snapshot",
-        source_url="https://platform.claude.com/docs/en/about-claude/pricing",
-        pricing_version="anthropic-pricing-2026-06",
-    ),
-    (
-        "anthropic",
         "claude-sonnet-4-6",
     ): PricingEntry(
         input_cost_per_million=Decimal("3.00"),

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -234,6 +234,18 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
     ),
     (
         "anthropic",
+        "claude-sonnet-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("3.00"),
+        output_cost_per_million=Decimal("15.00"),
+        cache_read_cost_per_million=Decimal("0.30"),
+        cache_write_cost_per_million=Decimal("3.75"),
+        source="official_docs_snapshot",
+        source_url="https://platform.claude.com/docs/en/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-06",
+    ),
+    (
+        "anthropic",
         "claude-sonnet-4-6",
     ): PricingEntry(
         input_cost_per_million=Decimal("3.00"),
@@ -539,6 +551,18 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source="official_docs_snapshot",
         source_url="https://aws.amazon.com/bedrock/pricing/",
         pricing_version="bedrock-pricing-2026-04",
+    ),
+    (
+        "bedrock",
+        "anthropic.claude-sonnet-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("3.00"),
+        output_cost_per_million=Decimal("15.00"),
+        cache_read_cost_per_million=Decimal("0.30"),
+        cache_write_cost_per_million=Decimal("3.75"),
+        source="official_docs_snapshot",
+        source_url="https://aws.amazon.com/bedrock/pricing/",
+        pricing_version="bedrock-pricing-2026-06",
     ),
     (
         "bedrock",

--- a/contributors/emails/ariel@vortexradar.com
+++ b/contributors/emails/ariel@vortexradar.com
@@ -1,0 +1,1 @@
+vortexopenclaw

--- a/contributors/emails/dan.brunsdon@gmail.com
+++ b/contributors/emails/dan.brunsdon@gmail.com
@@ -1,0 +1,1 @@
+brunz-me

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -281,6 +281,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gpt-4o",
         "gpt-4o-mini",
         "claude-sonnet-4.6",
+        "claude-sonnet-5",
         "claude-sonnet-4",
         "claude-sonnet-4.5",
         "claude-haiku-4.5",
@@ -366,6 +367,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "MiniMax-M2",
     ],
     "anthropic": [
+        "claude-sonnet-5",
         "claude-fable-5",
         "claude-sonnet-5",
         "claude-opus-4-8",
@@ -406,6 +408,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "google/gemini-3.1-flash-lite-preview",
         "anthropic/claude-sonnet-5",
         "anthropic/claude-sonnet-4.6",
+        "anthropic/claude-sonnet-5",
         "openai/gpt-5.4",
     ],
     "opencode-zen": [

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -367,7 +367,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "MiniMax-M2",
     ],
     "anthropic": [
-        "claude-sonnet-5",
         "claude-fable-5",
         "claude-sonnet-5",
         "claude-opus-4-8",
@@ -408,7 +407,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "google/gemini-3.1-flash-lite-preview",
         "anthropic/claude-sonnet-5",
         "anthropic/claude-sonnet-4.6",
-        "anthropic/claude-sonnet-5",
         "openai/gpt-5.4",
     ],
     "opencode-zen": [

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -367,6 +367,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "anthropic": [
         "claude-fable-5",
+        "claude-sonnet-5",
         "claude-opus-4-8",
         "claude-opus-4-7",
         "claude-opus-4-6",
@@ -403,6 +404,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "deepseek-ai/DeepSeek-V3.2",
         "moonshotai/Kimi-K2.5",
         "google/gemini-3.1-flash-lite-preview",
+        "anthropic/claude-sonnet-5",
         "anthropic/claude-sonnet-4.6",
         "openai/gpt-5.4",
     ],
@@ -427,6 +429,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gpt-5-codex",
         "gpt-5-nano",
         "claude-fable-5",
+        "claude-sonnet-5",
         "claude-opus-4-8",
         "claude-opus-4-7",
         "claude-opus-4-6",
@@ -535,6 +538,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # prefers live discovery via ListFoundationModels + ListInferenceProfiles.
     # Use inference profile IDs (us.*) since most models require them.
     "bedrock": [
+        "us.anthropic.claude-sonnet-5",
         "us.anthropic.claude-sonnet-4-6",
         "us.anthropic.claude-opus-4-6-v1",
         "us.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -3380,6 +3384,7 @@ _COPILOT_MODEL_ALIASES = {
     "openai/o3-mini": "gpt-5-mini",
     "openai/o4-mini": "gpt-5-mini",
     "anthropic/claude-opus-4.6": "claude-opus-4.6",
+    "anthropic/claude-sonnet-5": "claude-sonnet-5",
     "anthropic/claude-sonnet-4.6": "claude-sonnet-4.6",
     "anthropic/claude-sonnet-4": "claude-sonnet-4",
     "anthropic/claude-sonnet-4.5": "claude-sonnet-4.5",
@@ -3389,12 +3394,14 @@ _COPILOT_MODEL_ALIASES = {
     # dot-notation.  Accept both so users who configure copilot + a
     # default hyphenated Claude model don't hit HTTP 400
     # "model_not_supported".  See issue #6879.
+    "claude-sonnet-5": "claude-sonnet-5",
     "claude-opus-4-6": "claude-opus-4.6",
     "claude-sonnet-4-6": "claude-sonnet-4.6",
     "claude-sonnet-4-0": "claude-sonnet-4",
     "claude-sonnet-4-5": "claude-sonnet-4.5",
     "claude-haiku-4-5": "claude-haiku-4.5",
     "anthropic/claude-opus-4-6": "claude-opus-4.6",
+    "anthropic/claude-sonnet-5": "claude-sonnet-5",
     "anthropic/claude-sonnet-4-6": "claude-sonnet-4.6",
     "anthropic/claude-sonnet-4-0": "claude-sonnet-4",
     "anthropic/claude-sonnet-4-5": "claude-sonnet-4.5",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -84,6 +84,7 @@ _DEFAULT_PROVIDER_MODELS = {
         "gpt-4o",
         "gpt-4o-mini",
         "claude-opus-4.6",
+        "claude-sonnet-5",
         "claude-sonnet-4.6",
         "claude-sonnet-4.5",
         "claude-haiku-4.5",
@@ -105,8 +106,8 @@ _DEFAULT_PROVIDER_MODELS = {
     "arcee": ["trinity-large-thinking", "trinity-large-preview", "trinity-mini"],
     "minimax": ["MiniMax-M2.7", "MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2"],
     "minimax-cn": ["MiniMax-M2.7", "MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2"],
-    "kilocode": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
-    "opencode-zen": ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-4-6", "gemini-3-flash", "glm-5", "kimi-k2.5", "minimax-m2.7"],
+    "kilocode": ["anthropic/claude-sonnet-5", "anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
+    "opencode-zen": ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-5", "claude-sonnet-4-6", "gemini-3-flash", "glm-5", "kimi-k2.5", "minimax-m2.7"],
     "opencode-go": ["kimi-k2.6", "kimi-k2.5", "glm-5.1", "glm-5", "mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.7", "minimax-m2.5", "qwen3.7-max", "qwen3.6-plus", "qwen3.5-plus"],
     "huggingface": [
         "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3-235B-A22B-Thinking-2507",

--- a/plugins/model-providers/gmi/__init__.py
+++ b/plugins/model-providers/gmi/__init__.py
@@ -24,6 +24,7 @@ gmi = ProviderProfile(
         "moonshotai/Kimi-K2.5",
         "google/gemini-3.1-flash-lite-preview",
         "anthropic/claude-sonnet-4.6",
+        "anthropic/claude-sonnet-5",
         "openai/gpt-5.4",
     ),
 )

--- a/plugins/model-providers/gmi/__init__.py
+++ b/plugins/model-providers/gmi/__init__.py
@@ -23,8 +23,8 @@ gmi = ProviderProfile(
         "deepseek-ai/DeepSeek-V3.2",
         "moonshotai/Kimi-K2.5",
         "google/gemini-3.1-flash-lite-preview",
-        "anthropic/claude-sonnet-4.6",
         "anthropic/claude-sonnet-5",
+        "anthropic/claude-sonnet-4.6",
         "openai/gpt-5.4",
     ),
 )

--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -330,6 +330,7 @@ class TestMinimaxMaxOutput:
         from agent.anthropic_adapter import _get_anthropic_max_output
         # Sanity: Claude limits are not broken by the MiniMax entry
         assert _get_anthropic_max_output("claude-sonnet-4-6") == 64_000
+        assert _get_anthropic_max_output("claude-sonnet-5") == 128_000
 
 
 class TestMinimaxPreserveDots:

--- a/tests/hermes_cli/test_anthropic_picker_curated.py
+++ b/tests/hermes_cli/test_anthropic_picker_curated.py
@@ -20,6 +20,7 @@ def test_anthropic_curated_alias_survives_when_live_omits_it():
     """A curated alias missing from /v1/models still surfaces (first)."""
     curated = M._PROVIDER_MODELS["anthropic"]
     assert "claude-fable-5" in curated  # sanity: the alias is curated
+    assert "claude-sonnet-5" in curated  # newest Sonnet alias is curated
 
     # Live catalog the API would actually return — no fable-5.
     live = ["claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"]
@@ -27,6 +28,7 @@ def test_anthropic_curated_alias_survives_when_live_omits_it():
         result = M.provider_model_ids("anthropic")
 
     assert "claude-fable-5" in result
+    assert "claude-sonnet-5" in result
     # Curated order is preserved at the front.
     assert result[:len(curated)] == list(curated)
 

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -976,3 +976,20 @@ class TestCodexSoftAcceptPlausibilityGate:
         r = validate_requested_model("gpt-5.5", "openai-codex")
         assert r["accepted"] is True
         assert r["recognized"] is True
+
+
+class TestClaudeSonnet5InCuratedLists:
+    """Regression: Claude Sonnet 5 must appear in curated model lists (#55846)."""
+
+    def test_anthropic_native_list_includes_sonnet_5(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+        assert "claude-sonnet-5" in _PROVIDER_MODELS["anthropic"]
+
+    def test_openrouter_fallback_includes_sonnet_5(self):
+        from hermes_cli.models import OPENROUTER_MODELS
+        ids = [mid for mid, _ in OPENROUTER_MODELS]
+        assert "anthropic/claude-sonnet-5" in ids
+
+    def test_nous_list_includes_sonnet_5(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+        assert "anthropic/claude-sonnet-5" in _PROVIDER_MODELS["nous"]

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -29,6 +29,10 @@
           "description": ""
         },
         {
+          "id": "anthropic/claude-sonnet-5",
+          "description": ""
+        },
+        {
           "id": "anthropic/claude-haiku-4.5",
           "description": ""
         },
@@ -182,6 +186,9 @@
         },
         {
           "id": "anthropic/claude-opus-4.8"
+        },
+        {
+          "id": "anthropic/claude-sonnet-5"
         },
         {
           "id": "anthropic/claude-sonnet-5"

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-07-16T19:45:30Z",
+  "updated_at": "2026-07-20T08:23:45Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -23,10 +23,6 @@
         {
           "id": "anthropic/claude-opus-4.8-fast",
           "description": "2x price, higher output speed"
-        },
-        {
-          "id": "anthropic/claude-sonnet-5",
-          "description": ""
         },
         {
           "id": "anthropic/claude-sonnet-5",
@@ -186,9 +182,6 @@
         },
         {
           "id": "anthropic/claude-opus-4.8"
-        },
-        {
-          "id": "anthropic/claude-sonnet-5"
         },
         {
           "id": "anthropic/claude-sonnet-5"


### PR DESCRIPTION
## Summary
Claude Sonnet 5 now appears in every curated provider model list — including Anthropic-direct (`_PROVIDER_MODELS["anthropic"]`), which is what the desktop model picker falls back to — plus pricing, context metadata, output limits, and reasoning timeouts. Fixes #67815 and #55846.

Salvages three contributor PRs onto current main with authorship preserved:

- **#55848** (@vortexopenclaw, earliest + most complete): anthropic/openrouter/nous/gmi/opencode-zen/bedrock/copilot curated lists, copilot dot↔hyphen aliases, setup defaults, 128K output limit, 1M context (direct + bedrock), 180s reasoning stale timeout, anthropic + bedrock pricing entries, tests.
- **#55853** (@liuhao1024): additional list coverage (openai-compat list, model-catalog.json), GMI plugin `fallback_models`, regression tests.
- **#60410** (@brunz-me): introductory pricing entry ($2/$10 per MTok through 2026-08-31) with reversion note.

## Changes
- `hermes_cli/models.py`: claude-sonnet-5 in curated lists for anthropic, openrouter fallback, nous, openai-compat, copilot, gmi, opencode-zen, bedrock + copilot aliases
- `agent/usage_pricing.py`: (anthropic, claude-sonnet-5) intro pricing $2/$10 (+ bedrock entry $3/$15); deduped the conflicting standard-rate entry in favor of intro (later dict key silently wins otherwise)
- `agent/anthropic_adapter.py` / `agent/model_metadata.py` / `agent/bedrock_adapter.py` / `agent/reasoning_timeouts.py`: 128K max output, 1M context, 180s stale timeout
- `hermes_cli/setup.py`: kilocode/opencode-zen/openai default lists
- `plugins/model-providers/gmi/__init__.py`: fallback_models
- Follow-ups (ours): dedupe of double-added list entries from the overlapping salvages; contributor email mappings
- Tests: `test_models.py` regression class (curated-list invariants), picker/minimax assertions

## Validation
| Check | Result |
|---|---|
| Targeted suites (test_models, test_anthropic_picker_curated, test_minimax_provider, test_usage_pricing) | 164/164 pass |
| E2E: `provider_model_ids("anthropic")` with temp HERMES_HOME, no creds (curated fallback path = the desktop scenario) | sonnet-5 present, ordered, no dupes |
| E2E: `estimate_usage_cost("claude-sonnet-5", 1M in + 1M out, provider=anthropic)` | $12.00 (intro rate) |
| E2E: bedrock cost chain, copilot aliases, 128K output, 1M context | all pass |

Closes #55848, closes #55853, closes #60410, closes #67840 (1-line subset). Credit: @vortexopenclaw (first submitter), @liuhao1024, @brunz-me, @kyssta-exe (re-reported via #67815).

## Infographic

![claude-sonnet-5-catalog-integration](https://v3b.fal.media/files/b/0aa2fc01/pMKR-VjLFNL_aO3kedYJm_epY9zb5Z.png)
