### PR TITLE
fix(agent): drop tool_calls key when dedup removes every call

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2810,7 +2810,14 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                     seen_assistant_call_ids.add(cid)
                 kept_tcs.append(tc)
             if len(kept_tcs) != len(msg.get("tool_calls") or []):
-                msg = {**msg, "tool_calls": kept_tcs}
+                # If every tool_call in this assistant turn was a duplicate,
+                # drop the key entirely rather than leaving ``tool_calls: []``.
+                # Strict OpenAI-compatible providers (Alibaba Qwen, DeepSeek v4)
+                # reject an empty array on assistant messages.
+                if kept_tcs:
+                    msg = {**msg, "tool_calls": kept_tcs}
+                else:
+                    msg = {k: v for k, v in msg.items() if k != "tool_calls"}
             deduped.append(msg)
         elif role == "tool":
             cid = (msg.get("tool_call_id") or "").strip()

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -770,3 +770,33 @@ def test_sanitize_preserves_populated_tool_calls():
     out = sanitize_api_messages(list(messages))
     assistant = [m for m in out if m.get("role") == "assistant"][0]
     assert [tc["id"] for tc in assistant["tool_calls"]] == ["call_Z"]
+
+
+def test_sanitize_dedup_across_assistants_drops_empty_tool_calls():
+    """When every tool_call in an assistant turn is a duplicate of an earlier
+    id, the deduplication step must drop the ``tool_calls`` key entirely
+    instead of leaving ``tool_calls: []``. Strict OpenAI-compatible providers
+    such as Alibaba Qwen reject the empty array with:
+    "Empty tool_calls is not supported in message."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "call_1", "type": "function",
+             "function": {"name": "foo", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "call_1", "content": "r1"},
+        # A later assistant turn re-uses the same call_id (e.g. retry or
+        # crash-resume). Deduplication removes both tool_calls; the key must
+        # be dropped rather than left as an empty array.
+        {"role": "assistant", "content": "retry", "tool_calls": [
+            {"id": "call_1", "type": "function",
+             "function": {"name": "foo", "arguments": "{}"}},
+        ]},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assistants = [m for m in out if m.get("role") == "assistant"]
+    assert [tc["id"] for tc in assistants[0]["tool_calls"]] == ["call_1"]
+    assert "tool_calls" not in assistants[1]
+    assert assistants[1]["content"] == "retry"


### PR DESCRIPTION
## Summary

`sanitize_api_messages()` Step 3 (tool_call_id deduplication, added in #58327) can leave an assistant message with `tool_calls: []` when every tool_call in that turn is a duplicate of an already-seen id. Strict OpenAI-compatible providers such as Alibaba Cloud Qwen reject the empty array with:

> Empty tool_calls is not supported in message.

This PR drops the `tool_calls` key entirely in that case.

## Root cause

Commit `dba585c17` / PR #58327 introduced cross-message deduplication of `tool_call_id` to satisfy DeepSeek's strict duplicate-id validation. The dedup loop builds `kept_tcs` and, when its length differs from the original list, unconditionally assigns:

```python
msg = {**msg, "tool_calls": kept_tcs}
```

If all tool_calls in the assistant turn were duplicates, `kept_tcs == []`, so the message ends up with `tool_calls: []`. Step 1 of the same sanitizer already drops pre-existing empty arrays, but it runs before Step 3, so it cannot catch arrays produced by deduplication.

## Reproduction

A session where a later assistant turn re-uses a previously-seen `tool_call_id` (e.g. retry, crash-resume, or context compression re-emitting a call) hits the bug:

```python
messages = [
    {"role": "user", "content": "first"},
    {"role": "assistant", "content": None, "tool_calls": [
        {"id": "call_1", "type": "function",
         "function": {"name": "foo", "arguments": "{}"}},
    ]},
    {"role": "tool", "tool_call_id": "call_1", "content": "r1"},
    # retry re-uses call_1
    {"role": "assistant", "content": "retry", "tool_calls": [
        {"id": "call_1", "type": "function",
         "function": {"name": "foo", "arguments": "{}"}},
    ]},
]
```

Before this PR the second assistant message becomes `{..., "tool_calls": []}`; after this PR the `tool_calls` key is removed.

## Fix

In `agent/agent_runtime_helpers.py`, when deduplication changed the tool_calls list but none survived, delete the key instead of assigning an empty list:

```python
if len(kept_tcs) != len(msg.get("tool_calls") or []):
    if kept_tcs:
        msg = {**msg, "tool_calls": kept_tcs}
    else:
        msg = {k: v for k, v in msg.items() if k != "tool_calls"}
```

## Test

Added `test_sanitize_dedup_across_assistants_drops_empty_tool_calls` in `tests/run_agent/test_message_sequence_repair.py` to cover the cross-assistant duplicate-id case.

`uv run pytest tests/run_agent/test_message_sequence_repair.py -q` → **38 passed**.

## Affected versions

Bug introduced in `v2026.7.7` by #58327 and present in `v2026.7.7.2` (v0.18.2). Earlier releases such as `v2026.7.1` are not affected.

## Related

- Introduced by #58327
- Similar strict-provider symptom, different root cause: #31583
