### PR TITLE
fix(state): exclude expiry-finalized sessions from stale-route recovery (#67781)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2310,7 +2310,10 @@ class SessionDB:
         cleanup's ``agent_close`` bug or a mistaken TUI ``ws_orphan_reap``
         (dashboard viewer disconnect before #60609) are treated as recoverable;
         explicit conversation boundaries such as /new, /resume switches, and
-        compression splits are not.
+        compression splits are not.  Rows that have been expiry-finalized
+        (``expiry_finalized = 1``) are excluded: even if ``promote_to_session_reset``
+        silently failed, the expiry watcher already declared the session dead
+        and recovery would resurrect a stale transcript (#67781).
         """
         if not session_key:
             return None
@@ -2321,6 +2324,7 @@ class SessionDB:
                 WHERE session_key = ?
                   AND source = ?
                   AND (ended_at IS NULL OR end_reason IN ('agent_close', 'ws_orphan_reap'))
+                  AND COALESCE(expiry_finalized, 0) = 0
                   AND (COALESCE(message_count, 0) > 0 OR EXISTS (
                       SELECT 1 FROM messages WHERE messages.session_id = sessions.id LIMIT 1
                   ))
@@ -2346,6 +2350,7 @@ class SessionDB:
                   AND COALESCE(chat_type, '') = COALESCE(?, '')
                   AND COALESCE(thread_id, '') = COALESCE(?, '')
                   AND (ended_at IS NULL OR end_reason IN ('agent_close', 'ws_orphan_reap'))
+                  AND COALESCE(expiry_finalized, 0) = 0
                   AND (COALESCE(message_count, 0) > 0 OR EXISTS (
                       SELECT 1 FROM messages WHERE messages.session_id = sessions.id LIMIT 1
                   ))


### PR DESCRIPTION
## Problem

After the daily/idle `session_reset` expiry watcher fires, `promote_to_session_reset()` is supposed to convert `end_reason` from `agent_close` to `session_reset` (which is NOT in the recovery-allowed set). If the promote fails silently (SQLite contention, missing row, etc.), `end_reason` stays `agent_close` and the next user message triggers stale-route recovery — `reopen_session()` clears the end marker and resurrects the full expired transcript.

In one reported incident, the session kept running for 23 hours, accumulating ~$12 in costs from context that should have been cleared.

## Root Cause

`find_latest_gateway_session_for_peer()` has a SQL filter:
```sql
AND (ended_at IS NULL OR end_reason IN ('agent_close', 'ws_orphan_reap'))
```

This correctly excludes `session_reset`, `compression`, `/new`, etc. But it relies entirely on `promote_to_session_reset()` having successfully converted `agent_close` → `session_reset`. If promote fails silently (it catches all exceptions), the session remains recoverable and the stale-route path resurrects it.

The `expiry_finalized` column is set by `set_expiry_finalized()` **before** `promote_to_session_reset()` is called, making it the most reliable signal that the session was intentionally closed by the expiry watcher.

## Fix

Add `AND COALESCE(expiry_finalized, 0) = 0` to both recovery queries in `find_latest_gateway_session_for_peer()`. This is a defensive filter — even if promote never ran, the expiry_finalized flag prevents resurrection.

## Reproduction

1. Set `session_reset.mode: both`, `at_hour: 4`
2. Create a Telegram session with conversation history
3. Wait for the 4 AM expiry watcher to fire
4. (Assuming promote fails silently due to SQLite contention)
5. Send a message hours later
6. Before fix: session resurrected with full history
7. After fix: session NOT recovered, fresh session created

Fixes #67781
