### PR TITLE
fix(windows): search_files passes native C:/... to rg.exe instead of unusable /c/...

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -920,10 +920,17 @@ _WINDOWS_BASH_SHELL_HINT = (
     "Shell: on this Windows host your `terminal` tool runs commands through "
     "bash (git-bash / MSYS), NOT PowerShell or cmd.exe. Use POSIX shell "
     "syntax (`ls`, `$HOME`, `&&`, `|`, single-quoted strings) inside terminal "
-    "calls. MSYS-style paths like `/c/Users/<user>/...` work alongside "
-    "native `C:\\Users\\<user>\\...` paths. PowerShell builtins "
-    "(`Get-ChildItem`, `$env:FOO`, `Select-String`) will NOT work — use their "
-    "POSIX equivalents (`ls`, `$FOO`, `grep`)."
+    "calls. MSYS paths such as `/c/Users/<user>/...` are for use inside "
+    "`terminal` command strings. For Hermes tool path parameters, native "
+    "Python/subprocess calls, and tool `workdir`, prefer forward-slash Windows "
+    "paths such as `C:/Users/<user>/...`; do not assume `/c/...` is "
+    "interchangeable there. If an absolute path passed to `search_files` "
+    "fails or unexpectedly returns zero (for example on an older or not-yet-"
+    "restarted native-Windows process), set the terminal cwd to that directory "
+    "and retry with `search_files(path=\".\")`, then verify directly before "
+    "concluding the path or files are missing. "
+    "PowerShell builtins (`Get-ChildItem`, `$env:FOO`, `Select-String`) will "
+    "NOT work — use their POSIX equivalents (`ls`, `$FOO`, `grep`)."
 )
 
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1185,6 +1185,15 @@ class TestEnvironmentHints:
         assert "NOT the username" in result
         assert "bash" in result
         assert "PowerShell" in result
+        # Path syntax is execution-bound on native Windows. Git-Bash paths are
+        # valid inside terminal command strings, but must not be advertised as
+        # interchangeable with native paths for Python-backed file tools.
+        assert "inside `terminal` command strings" in result
+        assert "Hermes tool path parameters" in result
+        assert "`C:/Users/<user>/...`" in result
+        assert "`/c/Users/<user>/...`" in result
+        assert "`search_files(path=\".\")`" in result
+        assert "work alongside" not in result
 
     def test_build_environment_hints_on_macos_local(self, monkeypatch):
         import agent.prompt_builder as _pb

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -494,6 +494,75 @@ class TestShellFileOpsHelpers:
             "C:/Users/alice/notes.txt"
         ) == "'/c/Users/alice/notes.txt'"
 
+    @pytest.mark.parametrize(
+        "search_root",
+        [
+            r"C:\Users\alice\测试目录",
+            "C:/Users/alice/测试目录",
+            "/c/Users/alice/测试目录",
+        ],
+    )
+    def test_content_search_keeps_native_windows_path_for_native_rg(
+        self, monkeypatch, mock_env, search_root
+    ):
+        """Native rg.exe must receive C:/..., not an unconverted /c/... path."""
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        commands = []
+
+        def side_effect(command, **kwargs):
+            commands.append(command)
+            if "test -e" in command:
+                return {"output": "exists", "returncode": 0}
+            if "command -v" in command:
+                return {"output": "yes", "returncode": 0}
+            return {"output": "", "returncode": 1}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        monkeypatch.setattr(
+            ops, "_uses_native_windows_search_paths", lambda: True, raising=False
+        )
+
+        result = ops.search("needle", path=search_root)
+
+        assert result.error is None
+        rg_command = next(command for command in commands if "rg --line-number" in command)
+        assert "'C:/Users/alice/测试目录'" in rg_command
+        assert "'/c/Users/alice/测试目录'" not in rg_command
+
+    def test_file_search_keeps_native_windows_path_for_native_rg(
+        self, monkeypatch, mock_env
+    ):
+        """rg --files must receive C:/... for an absolute Windows search root."""
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        commands = []
+
+        def side_effect(command, **kwargs):
+            commands.append(command)
+            if "test -e" in command:
+                return {"output": "exists", "returncode": 0}
+            if "command -v" in command:
+                return {"output": "yes", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        monkeypatch.setattr(
+            ops, "_uses_native_windows_search_paths", lambda: True, raising=False
+        )
+
+        result = ops.search("*.md", path=r"C:\Users\alice\测试目录", target="files")
+
+        assert result.error is None
+        rg_commands = [command for command in commands if "rg --files" in command]
+        assert rg_commands
+        assert all("'C:/Users/alice/测试目录'" in command for command in rg_commands)
+        assert all("'/c/Users/alice/测试目录'" not in command for command in rg_commands)
+
     def test_read_file_uses_bash_safe_windows_paths(self, mock_env, monkeypatch):
         import tools.environments.local as local_mod
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -974,6 +974,32 @@ class ShellFileOperations(FileOperations):
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
+    def _uses_native_windows_search_paths(self) -> bool:
+        """Whether search commands run through local Git Bash on Windows.
+
+        Native Windows executables such as the winget MSVC ``rg.exe`` need a
+        drive-qualified ``C:/...`` argument when Hermes disables MSYS argv
+        conversion. Remote/container backends must retain their own POSIX path
+        semantics even when the Hermes host itself is Windows.
+        """
+        try:
+            from tools.environments.local import LocalEnvironment, _IS_WINDOWS
+
+            return bool(_IS_WINDOWS and isinstance(self.env, LocalEnvironment))
+        except Exception:
+            return False
+
+    def _escape_search_path(self, path: str) -> str:
+        """Quote a search root in a form understood by native Windows rg.exe."""
+        if self._uses_native_windows_search_paths():
+            from tools.environments.local import _msys_to_windows_path
+
+            native = _msys_to_windows_path(path)
+            if re.match(r"^[A-Za-z]:[\\/]", native):
+                native = native.replace("\\", "/")
+                return "'" + native.replace("'", "'\"'\"'") + "'"
+        return self._escape_shell_arg(path)
+
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":
         """Write ``content`` to ``path`` atomically via temp-file + rename.
 
@@ -2210,10 +2236,11 @@ class ShellFileOperations(FileOperations):
             glob_pattern = pattern
 
         fetch_limit = limit + offset
+        escaped_search_path = self._escape_search_path(path)
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
         cmd_sorted = (
             f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
-            f"{self._escape_shell_arg(path)} 2>/dev/null "
+            f"{escaped_search_path} 2>/dev/null "
             f"| head -n {fetch_limit}"
         )
         result = self._exec(cmd_sorted, timeout=60)
@@ -2224,7 +2251,7 @@ class ShellFileOperations(FileOperations):
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
                 f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
-                f"{self._escape_shell_arg(path)} 2>/dev/null "
+                f"{escaped_search_path} 2>/dev/null "
                 f"| head -n {fetch_limit}"
             )
             result = self._exec(cmd_plain, timeout=60)
@@ -2278,9 +2305,11 @@ class ShellFileOperations(FileOperations):
         elif output_mode == "count":
             cmd_parts.append("-c")  # Count per file
         
-        # Add pattern and path
+        # Add pattern and path. The search root needs native-drive quoting on
+        # local Windows because Hermes disables MSYS argv conversion;
+        # otherwise native rg.exe receives an unusable literal /c/... path.
         cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
+        cmd_parts.append(self._escape_search_path(path))
         
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
@@ -815,9 +815,16 @@ suite.
 Git touches it`. Cosmetic — the repo's `.gitattributes` normalizes. Don't
 let editors auto-convert committed POSIX-newline files to CRLF.
 
-**Forward slashes work almost everywhere.** `C:/Users/...` is accepted by
-every Hermes tool and most Windows APIs. Prefer forward slashes in code
-and logs — avoids shell-escaping backslashes in bash.
+**Windows path syntax is execution-bound.** Do not claim that MSYS `/c/...`
+and native `C:/...` forms are interchangeable everywhere. Inside `terminal`
+Git-Bash command strings, `/c/Users/...` is valid and often convenient. For
+Hermes tool path parameters, native Python/subprocess calls, tool `workdir`, and
+Codex `--cd`, use `C:/Users/...`. Older/upstream or not-yet-restarted native-
+Windows `search_files` processes may still have an absolute-root regression
+with native `rg.exe`: if an absolute search errors or unexpectedly returns
+zero, set the terminal cwd to that directory, retry with
+`search_files(path=".")`, and independently verify before concluding anything
+is missing.
 
 ---
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
@@ -719,7 +719,7 @@ export PYTHONPATH="$(pwd)"
 
 **行尾。** Git 可能警告 `LF will be replaced by CRLF the next time Git touches it`。这是外观问题——仓库的 `.gitattributes` 会规范化。不要让编辑器自动将已提交的 POSIX 换行文件转换为 CRLF。
 
-**正斜杠几乎在所有地方都有效。** `C:/Users/...` 被每个 Hermes 工具和大多数 Windows API 接受。在代码和日志中优先使用正斜杠——避免在 bash 中转义反斜杠。
+**Windows 路径格式取决于执行边界。** 不要笼统声称 MSYS `/c/...` 与原生 `C:/...` 在所有位置都可互换。`terminal` 的 Git-Bash 命令字符串内可以使用 `/c/Users/...`；Hermes 工具路径参数、原生 Python/subprocess、工具 `workdir` 和 Codex `--cd` 应使用 `C:/Users/...`。旧版、上游未修或尚未重启的 Windows `search_files` 进程仍可能在绝对路径上触发 native `rg.exe` 回归；若绝对路径搜索报错或意外返回 0，先把 terminal cwd 切到目标目录，再用 `search_files(path=".")` 重试，并通过独立方法确认后才能判定文件不存在。
 
 ---
 


### PR DESCRIPTION
## Problem

On Windows with a native `rg.exe` (e.g. installed via winget), `search_files` fails with `os error 2/3` or silently returns zero results when given an absolute path like `C:/Users/...` or `/c/Users/...`.

**Reproduction:**
```
search_files(pattern="*.txt", path="C:/Users/<user>/Documents")
→ Search failed: rg: /c/Users/<user>/Documents: IO error for operation on /c/Users/<user>/Documents: 系统找不到指定的路径。 (os error 3)
```

The same failure occurs with pure-ASCII paths — this is **not** a Unicode issue.

## Root Cause

Two separately-reasonable behaviors combine to produce a bug:

1. **`ShellFileOperations._escape_shell_arg()`** rewrites absolute paths to Git-Bash form `/c/Users/...` via `_bash_safe_path()`. This is correct for bash builtins (`test -e`, `cd`, `ls`).

2. **Hermes disables MSYS argv conversion** (`MSYS_NO_PATHCONV=1`, `MSYS2_ARG_CONV_EXCL=*`) to protect native Windows slash flags like `taskkill /F` from being mangled into `F:/`.

Result: the native MSVC `rg.exe` receives the literal `/c/Users/...`, which it cannot resolve. Bash's `test -e` passes (it understands `/c/...`), so the existence check doesn't catch the problem — `rg` only fails when it actually runs.

| Mode | Symptom |
|---|---|
| `target='content'` | `rg` reports `os error 2/3` (stderr visible) |
| `target='files'` | `rg` stderr is redirected to `/dev/null`; silently returns 0 results |

## Fix

### `tools/file_operations.py`

Add two methods to `ShellFileOperations`:

- **`_uses_native_windows_search_paths()`** — returns `True` only when `_IS_WINDOWS` and `isinstance(self.env, LocalEnvironment)`. Remote/container backends (Browserbase, Docker, SSH) are unaffected — they retain their own POSIX path semantics. A `try/except` makes it fail-safe to `False`.

- **`_escape_search_path(path)`** — on local Windows, converts the search root to native `C:/...` form (handles `C:\...`, `C:/...`, and `/c/...` inputs). Off-Windows or remote backends fall through to the existing `_escape_shell_arg()`.

Two call sites updated to use `_escape_search_path` instead of `_escape_shell_arg` for the search root argument:
- `_search_files_rg()` (file-name search, `rg --files`)
- `_search_with_rg()` (content search, `rg --line-number`)

**Intentionally unchanged:** `_search_with_grep()` and the `find` fallback. These run as POSIX tools through bash, where `/c/...` is the correct form.

### `agent/prompt_builder.py`

The Windows system-prompt hint previously said:

> MSYS-style paths like `/c/Users/<user>/...` work alongside native `C:\Users\<user>\...` paths.

This implied the two forms are interchangeable everywhere, leading the agent to pass `/c/...` to Python-backed file tools. New wording is **execution-bound**:

- `/c/Users/...` — valid inside `terminal` command strings (Git Bash)
- `C:/Users/...` — for Hermes tool path parameters, `workdir`, Codex `--cd`, Python/subprocess
- Fallback: if `search_files` with an absolute path fails, set cwd to the target and retry with `search_files(path=".")`

### Website docs

The bundled `hermes-agent` skill doc (EN + zh-Hans) had the same "Forward slashes work almost everywhere" wording. Both updated to match.

## Tests

### `tests/tools/test_file_operations.py`

- `test_content_search_keeps_native_windows_path_for_native_rg` — parametrized over `C:\...`, `C:/...`, `/c/...` inputs with a Unicode path segment. Asserts `rg --line-number` receives `'C:/Users/alice/...'` and **not** `'/c/Users/alice/...'`.
- `test_file_search_keeps_native_windows_path_for_native_rg` — same assertions for `rg --files` (file-name search mode).

### `tests/agent/test_prompt_builder.py`

Asserts the Windows environment hint contains execution-bound path guidance (`C:/Users/<user>/...`, `/c/Users/<user>/...`, `search_files(path=".")`) and that the old "work alongside" phrasing is gone.

### E2E verification

Real-process search against a Unicode-named directory (both `C:/...` and `/c/...` forms) succeeded for content and files modes — previously both failed with `os error 3`.

Full `test_file_operations.py`: 94 passed, 2 pre-existing find-fallback failures (unrelated to this change, they exercise the `find` path on Windows).