### PR TITLE
fix(desktop): keep dialog actions visible with long content

### DIFF
--- a/apps/desktop/src/components/ui/dialog.test.tsx
+++ b/apps/desktop/src/components/ui/dialog.test.tsx
@@ -6,6 +6,20 @@ import { Dialog, DialogContent, DialogTitle, preventCloseButtonAutoFocus } from 
 afterEach(cleanup)
 
 describe('DialogContent close button', () => {
+  it('keeps long content from widening the dialog grid and clipping footer actions', () => {
+    render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>New project</DialogTitle>
+          <div>{'/Users/example/Developer/Projects/a-very-long-folder-name-that-must-not-widen-the-dialog'}</div>
+          <button type="button">Create</button>
+        </DialogContent>
+      </Dialog>
+    )
+
+    expect(screen.getByRole('dialog').className).toContain('grid-cols-[minmax(0,1fr)]')
+  })
+
   it('closes the dialog when clicked', () => {
     const onOpenChange = vi.fn()
     render(

--- a/apps/desktop/src/components/ui/dialog.tsx
+++ b/apps/desktop/src/components/ui/dialog.tsx
@@ -161,7 +161,7 @@ function DialogContent({
           // Cap height at 85vh and let long content scroll inside the dialog
           // instead of overflowing off-screen (long cron titles, tool detail
           // dumps, etc.). Individual dialogs can still override via className.
-          'fixed left-1/2 top-1/2 z-[130] pointer-events-auto grid max-h-[85vh] -translate-x-1/2 -translate-y-1/2 gap-3 overflow-y-auto rounded-xl border border-(--stroke-nous) bg-(--ui-chat-bubble-background) p-4 text-[length:var(--conversation-text-font-size)] text-foreground shadow-nous duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          'fixed left-1/2 top-1/2 z-[130] pointer-events-auto grid grid-cols-[minmax(0,1fr)] max-h-[85vh] -translate-x-1/2 -translate-y-1/2 gap-3 overflow-y-auto rounded-xl border border-(--stroke-nous) bg-(--ui-chat-bubble-background) p-4 text-[length:var(--conversation-text-font-size)] text-foreground shadow-nous duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           widthClass,
           className
         )}


### PR DESCRIPTION
## What does this PR do?

Constrains the shared Desktop dialog grid to a zero-minimum single column so long unbroken content cannot widen the grid's scrollable area and push footer actions outside the visible dialog.

The New Project dialog in #67919 reproduces this with a long folder path: the dialog shell remains visible, but the primary Create button is pushed to the right and clipped to a narrow strip. `minmax(0, 1fr)` keeps the path inside the dialog column, where the existing child truncation can take effect.

## Related Issue

Fixes #67919

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Add `grid-cols-[minmax(0,1fr)]` to the shared non-banner `DialogContent` grid.
- Add a focused regression test covering long content followed by a footer action.

## How to Test

1. Open Hermes Desktop and create a new Project.
2. Add a folder with a long absolute path.
3. Confirm the Create button remains fully visible inside the dialog.

Automated verification:

- `npm --workspace apps/desktop run test:ui -- src/components/ui/dialog.test.tsx`
- `npm --workspace apps/desktop exec eslint -- src/components/ui/dialog.tsx src/components/ui/dialog.test.tsx`
- `npm --workspace apps/desktop run typecheck`
- `npm --workspace apps/desktop run build`
- `git diff --check`

## Checklist

- [x] I've read the Contributing Guide.
- [x] My commit follows Conventional Commits.
- [x] I searched open PRs and found no existing fix for #67919.
- [x] The PR contains only the dialog sizing fix and its regression test.
- [x] I tested on macOS.
- [x] I considered cross-platform impact; this is platform-independent CSS grid behavior.
