### PR TITLE
fix(gateway): scope GET /api/config to config-only profile to unwedge the event loop (#67936)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6716,7 +6716,13 @@ async def update_memory_provider_config(
 
 @app.get("/api/config")
 async def get_config(profile: Optional[str] = None):
-    with _profile_scope(profile):
+    # Config-only scope: this async handler runs on the event-loop thread and
+    # only resolves configuration through the task-local HERMES_HOME override.
+    # Using the skills-aware _profile_scope() here would acquire the
+    # process-global _SKILLS_PROFILE_LOCK synchronously, so a worker thread
+    # holding that lock (e.g. slow model/skills discovery) could wedge the
+    # event loop and stall Desktop startup. Matches sibling get_schema(). (#67936)
+    with _config_profile_scope(profile):
         config = _normalize_config_for_web(load_config())
     # Strip internal keys that the frontend shouldn't see or send back
     return {k: v for k, v in config.items() if not k.startswith("_")}

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -773,3 +773,49 @@ class TestProfileScopedAudio:
         assert resp.status_code == 404
         resp = client.post("/api/audio/speak?profile=ghost", json={"text": "x"})
         assert resp.status_code == 404
+
+
+class TestConfigEndpointNonBlocking:
+    """`GET /api/config` must not wait on the skills-global lock (#67936).
+
+    `get_config()` is an ``async def`` running on the event-loop thread and
+    only needs the task-local, config-only profile scope. If it used the
+    skills-aware ``_profile_scope()`` it would acquire the process-global
+    ``_SKILLS_PROFILE_LOCK`` synchronously — so a worker thread holding that
+    lock (slow model/skills discovery) would wedge the event loop and stall
+    Desktop startup. This pins the invariant: while another thread holds the
+    skills lock, ``get_config()`` still returns promptly.
+    """
+
+    def test_get_config_does_not_wait_on_skills_lock(self, isolated_profiles):
+        import asyncio
+        import threading
+        import time
+
+        import hermes_cli.web_server as web_server
+
+        acquired = threading.Event()
+        release = threading.Event()
+
+        def hold_skills_lock():
+            with web_server._SKILLS_PROFILE_LOCK:
+                acquired.set()
+                release.wait(timeout=5)
+
+        holder = threading.Thread(target=hold_skills_lock)
+        holder.start()
+        try:
+            assert acquired.wait(timeout=2), "holder never took the skills lock"
+
+            started = time.monotonic()
+            config = asyncio.run(web_server.get_config())
+            elapsed = time.monotonic() - started
+
+            assert isinstance(config, dict)
+            # Config-only scope never touches the skills lock, so this returns
+            # immediately. The old _profile_scope() path blocked for the full
+            # hold duration. Generous bound keeps CI non-flaky.
+            assert elapsed < 1.0, f"get_config blocked for {elapsed:.3f}s"
+        finally:
+            release.set()
+            holder.join(timeout=5)


### PR DESCRIPTION
## What does this PR do?

`GET /api/config` is an `async def` handler that runs on the asyncio
event-loop thread, but it entered `_profile_scope(profile)` — the
skills-aware scope that acquires the process-global `_SKILLS_PROFILE_LOCK`
**synchronously**. When a worker thread holds that lock (e.g. slow
model-option / skills discovery during Desktop setup), the event loop
blocks inside `get_config()` and can no longer flush queued
JSON-RPC/WebSocket responses or serve HTTP probes — remote Desktop startup
times out at "Loading Hermes settings".

`get_config()` only resolves configuration through the task-local
`HERMES_HOME` override; it never touches the skills module globals that
`_SKILLS_PROFILE_LOCK` protects. The sibling `get_schema()` handler
directly below it already uses the await-safe, config-only
`_config_profile_scope()`. This aligns `get_config()` with that pattern.

## Related Issue

Fixes #67936

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: `get_config()` now uses
  `_config_profile_scope(profile)` instead of `_profile_scope(profile)`,
  so the async handler never waits on `_SKILLS_PROFILE_LOCK`. Added a
  comment explaining the event-loop hazard.
- `tests/hermes_cli/test_web_server_profile_unification.py`: new
  `TestConfigEndpointNonBlocking` regression — while another thread holds
  `_SKILLS_PROFILE_LOCK`, `get_config()` still returns promptly. On the old
  `_profile_scope()` path this blocked for the full lock-hold duration.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_web_server_profile_unification.py -q`
   → passes (includes the new
   `TestConfigEndpointNonBlocking::test_get_config_does_not_wait_on_skills_lock`).
2. Manual: hold `_SKILLS_PROFILE_LOCK` in a background thread and call
   `asyncio.run(web_server.get_config())` — returns in ~0.001s with the fix
   vs. the full hold duration before it.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal handler scope change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — fix is platform-independent (asyncio + threading lock semantics)
