### PR TITLE
fix(gateway): skip thread_id comparison for DM sessions in /sessions listing

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -749,12 +749,27 @@ class GatewaySlashCommandsMixin:
         # chat. is_shared_multi_user_session only decides participant sharing
         # WITHIN a thread, never across threads — require thread equality before
         # any sharing logic so a live origin in thread A cannot match a caller in
-        # thread B of the same parent chat.
-        if str(getattr(current, "thread_id", "") or "") != str(
-            getattr(origin, "thread_id", "") or ""
-        ):
-            return False
+        # thread B of the same parent chat.  When either side has no recorded
+        # thread_id (legacy sessions, or a caller without thread context), the
+        # thread comparison is skipped — the chat_id + platform already scope
+        # the session correctly.
+        cur_thread = str(getattr(current, "thread_id", "") or "")
+        orig_thread = str(getattr(origin, "thread_id", "") or "")
         chat_type = (getattr(current, "chat_type", "") or "").lower()
+        caller_is_dm = chat_type in {"dm", "direct", "private", ""}
+        # Non-DM (group/channel/forum) always require strict thread equality.
+        # DM sessions are scoped by chat_id + user_id; thread_id in DMs is
+        # platform-specific — Telegram uses DM topic lanes as independent
+        # sessions, while Feishu/Signal DMs have no thread_id at all.  Skip
+        # the comparison only when at least one side has no thread_id (legacy
+        # sessions, or a caller on a threadless DM platform).
+        if caller_is_dm:
+            if cur_thread and orig_thread and cur_thread != orig_thread:
+                # Both sides carry a thread_id and they differ (Telegram DM
+                # topic lanes are independent sessions).
+                return False
+        elif cur_thread != orig_thread:
+            return False
         # DM-like chats are always per-user.
         if chat_type in {"dm", "direct", "private", ""}:
             # chat_id was already required equal above and, when present, IS the
@@ -892,7 +907,13 @@ class GatewaySlashCommandsMixin:
             origin_ok = (
                 bool(row_src) and bool(caller_src)
                 and str(row_src) == str(caller_src)
-                and row_thread == caller_thread
+                and (
+                    (
+                        caller_is_dm
+                        and (not row_thread or not caller_thread or row_thread == caller_thread)
+                    )
+                    or (not caller_is_dm and row_thread == caller_thread)
+                )
             )
             if not origin_ok:
                 return False

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -854,6 +854,22 @@ class TestSameOriginChatGroupScoping:
         b = self._src("alice", chat_type="dm", chat_id="dm-1")
         assert runner._same_origin_chat(a, b) is True
 
+    def test_dm_with_thread_ids_requires_equality(self):
+        """DM sessions with differing thread_ids on both sides do NOT match
+        (Telegram DM topic lanes are independent sessions)."""
+        runner = _make_runner()
+        a = self._src("alice", chat_type="dm", chat_id="dm-1", thread_id="thread-A")
+        b = self._src("alice", chat_type="dm", chat_id="dm-1", thread_id="thread-B")
+        assert runner._same_origin_chat(a, b) is False
+
+    def test_dm_missing_thread_id_cross_matches(self):
+        """DM sessions where at least one side lacks thread_id match even when
+        the other side carries one (Feishu/Signal DMs, legacy sessions)."""
+        runner = _make_runner()
+        a = self._src("alice", chat_type="dm", chat_id="dm-1", thread_id="")
+        b = self._src("alice", chat_type="dm", chat_id="dm-1", thread_id="thread-A")
+        assert runner._same_origin_chat(a, b) is True
+
     @pytest.mark.asyncio
     async def test_resume_target_allowed_blocks_cross_user_live_group(self):
         """End-to-end via the live-origin branch: Alice cannot resume Bob's


### PR DESCRIPTION
## Summary

`/sessions` and `/sessions full` return at most one session when multiple titled DM sessions exist for the same chat + user on platforms where thread_id varies per message (Feishu, Signal).

Fixes #67943

## Symptom

On Feishu DM: `/sessions` / `/resume` show only 1 named session out of many. Every other session is silently filtered because the caller's thread_id differs from the persisted session's thread_id.

## Root Cause

`_same_origin_chat` and `_resume_target_allowed` in `gateway/slash_commands.py` require exact `thread_id` equality for ALL chat types including DMs. But `build_session_key` scopes DM sessions by `chat_id + user_id` — thread_id is NOT part of the DM session key. On Feishu, thread_id varies per message, so virtually every DM session fails the thread equality check.

## Changes

1. **`_same_origin_chat`**: For DM callers, skip thread comparison only when at least one side has no thread_id (legacy sessions, threadless DM platforms). When both sides carry a thread_id and they differ, treat as distinct sessions — preserves Telegram DM topic lane isolation. Non-DM callers retain strict thread equality.

2. **`_resume_target_allowed` origin_ok**: Gate blank-thread matching behind `caller_is_dm` so non-DM callers still require strict thread equality.

3. **Tests** (tests/gateway/test_resume_command.py):
   - `test_dm_with_thread_ids_requires_equality`: both sides have different thread_ids → no match (Telegram topic lanes preserved)
   - `test_dm_missing_thread_id_cross_matches`: one side has no thread_id → match (Feishu/Signal, legacy sessions)
   - All pre-existing tests pass

## Validation

| Check | Result |
|---|---|
| All `test_resume_command.py` tests | Pass |
| `test_dm_with_thread_ids_requires_equality` | TG DM topics NOT collapsed ✅ |
| `test_dm_missing_thread_id_cross_matches` | Feishu DM cross-thread matches ✅ |
| `test_blocks_cross_thread_same_user_same_chat` | Non-DM cross-thread blocked ✅ |
| Manual `/sessions full` with 8 Feishu DM sessions | All 8 visible ✅