### PR TITLE
fix(agent): initialize Bedrock clients on model switch

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1985,6 +1985,8 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             "_anthropic_api_key",
             "_anthropic_base_url",
             "_is_anthropic_oauth",
+            "_bedrock_region",
+            "_bedrock_guardrail_config",
             "_config_context_length",
         )
     }
@@ -2080,6 +2082,56 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             agent.base_url = "moa://local"
             agent._client_kwargs = {}
             agent.client = MoAClient(agent.model or "default")
+        elif (new_provider or "").strip().lower() == "bedrock":
+            # Bedrock does not expose an OpenAI-compatible endpoint. Mirror
+            # the startup initialization so /model switches use the Bedrock
+            # SDK routes instead of constructing an OpenAI client.
+            _region_match = re.search(
+                r"bedrock-runtime\.([a-z0-9-]+)\.", agent.base_url or ""
+            )
+            agent._bedrock_region = (
+                _region_match.group(1) if _region_match else "us-east-1"
+            )
+            agent._bedrock_guardrail_config = None
+            agent.api_key = "aws-sdk"
+            agent._is_anthropic_oauth = False
+            agent.client = None
+            agent._client_kwargs = {}
+
+            if api_mode == "anthropic_messages":
+                from agent.anthropic_adapter import build_anthropic_bedrock_client
+
+                agent._anthropic_client = build_anthropic_bedrock_client(
+                    agent._bedrock_region
+                )
+                agent._anthropic_api_key = "aws-sdk"
+                agent._anthropic_base_url = agent.base_url
+            elif api_mode == "bedrock_converse":
+                agent._anthropic_client = None
+                agent._anthropic_api_key = ""
+                agent._anthropic_base_url = None
+                try:
+                    from hermes_cli.config import load_config as _load_br_cfg
+
+                    _gr = _load_br_cfg().get("bedrock", {}).get("guardrail", {})
+                    if _gr.get("guardrail_identifier") and _gr.get("guardrail_version"):
+                        agent._bedrock_guardrail_config = {
+                            "guardrailIdentifier": _gr["guardrail_identifier"],
+                            "guardrailVersion": _gr["guardrail_version"],
+                        }
+                        if _gr.get("stream_processing_mode"):
+                            agent._bedrock_guardrail_config["streamProcessingMode"] = _gr[
+                                "stream_processing_mode"
+                            ]
+                        if _gr.get("trace"):
+                            agent._bedrock_guardrail_config["trace"] = _gr["trace"]
+                except Exception:
+                    pass
+            else:
+                raise ValueError(
+                    "switch_model: Bedrock requires anthropic_messages or "
+                    "bedrock_converse api_mode"
+                )
         elif api_mode == "anthropic_messages":
             from agent.anthropic_adapter import (
                 build_anthropic_client,

--- a/tests/run_agent/test_switch_model_rollback.py
+++ b/tests/run_agent/test_switch_model_rollback.py
@@ -202,3 +202,111 @@ def test_successful_switch_still_works_after_rollback_refactor():
     assert agent.provider == "openrouter"
     assert agent.api_key == "or-key-new"
     assert agent.client is new_client
+
+
+def test_switch_to_bedrock_anthropic_builds_regional_sdk_client():
+    """A live switch to Bedrock Claude must not build an OpenAI client."""
+    agent = _make_agent_openrouter()
+    bedrock_client = MagicMock(name="BedrockAnthropicClient")
+    agent._create_openai_client = MagicMock(
+        side_effect=AssertionError("Bedrock must not use an OpenAI client")
+    )
+
+    with (
+        patch(
+            "agent.anthropic_adapter.build_anthropic_bedrock_client",
+            return_value=bedrock_client,
+        ) as build_bedrock_client,
+        patch("agent.credential_pool.load_pool", return_value=None),
+    ):
+        agent.switch_model(
+            new_model="jp.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            new_provider="bedrock",
+            api_key="ignored-by-aws-sdk",
+            base_url="https://bedrock-runtime.ap-northeast-1.amazonaws.com",
+            api_mode="anthropic_messages",
+        )
+
+    build_bedrock_client.assert_called_once_with("ap-northeast-1")
+    assert agent._bedrock_region == "ap-northeast-1"
+    assert agent.api_key == "aws-sdk"
+    assert agent._anthropic_client is bedrock_client
+    assert agent._anthropic_api_key == "aws-sdk"
+    assert agent._anthropic_base_url == "https://bedrock-runtime.ap-northeast-1.amazonaws.com"
+    assert agent.client is None
+    assert agent._client_kwargs == {}
+
+
+def test_switch_to_bedrock_converse_loads_guardrails_without_openai_client():
+    """Bedrock Converse switches retain its SDK-only and guardrail setup."""
+    agent = _make_agent_anthropic()
+    agent._create_openai_client = MagicMock(
+        side_effect=AssertionError("Bedrock Converse must not use an OpenAI client")
+    )
+    guardrail_config = {
+        "bedrock": {
+            "guardrail": {
+                "guardrail_identifier": "gr-123",
+                "guardrail_version": "7",
+                "stream_processing_mode": "SYNC",
+                "trace": "enabled",
+            }
+        }
+    }
+
+    with (
+        patch("agent.credential_pool.load_pool", return_value=None),
+        patch("hermes_cli.config.load_config", return_value=guardrail_config),
+    ):
+        agent.switch_model(
+            new_model="amazon.nova-pro-v1:0",
+            new_provider="bedrock",
+            api_key="ignored-by-aws-sdk",
+            base_url="https://bedrock-runtime.eu-west-1.amazonaws.com",
+            api_mode="bedrock_converse",
+        )
+
+    assert agent._bedrock_region == "eu-west-1"
+    assert agent._bedrock_guardrail_config == {
+        "guardrailIdentifier": "gr-123",
+        "guardrailVersion": "7",
+        "streamProcessingMode": "SYNC",
+        "trace": "enabled",
+    }
+    assert agent.api_key == "aws-sdk"
+    assert agent._anthropic_client is None
+    assert agent.client is None
+    assert agent._client_kwargs == {}
+
+
+def test_failed_bedrock_switch_restores_region_and_guardrails():
+    """Bedrock-specific state is restored when its Anthropic SDK build fails."""
+    agent = _make_agent_openrouter()
+    agent._bedrock_region = "eu-west-1"
+    agent._bedrock_guardrail_config = {
+        "guardrailIdentifier": "existing-guardrail",
+        "guardrailVersion": "1",
+    }
+
+    with (
+        patch("agent.credential_pool.load_pool", return_value=None),
+        patch(
+            "agent.anthropic_adapter.build_anthropic_bedrock_client",
+            side_effect=RuntimeError("simulated Bedrock client build failure"),
+        ),
+        pytest.raises(RuntimeError, match="simulated Bedrock client build failure"),
+    ):
+        agent.switch_model(
+            new_model="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            new_provider="bedrock",
+            api_key="ignored-by-aws-sdk",
+            base_url="https://bedrock-runtime.us-east-1.amazonaws.com",
+            api_mode="anthropic_messages",
+        )
+
+    assert agent.provider == "openrouter"
+    assert agent._bedrock_region == "eu-west-1"
+    assert agent._bedrock_guardrail_config == {
+        "guardrailIdentifier": "existing-guardrail",
+        "guardrailVersion": "1",
+    }


### PR DESCRIPTION
## Summary

Fixes #41296 for the remaining initialization gap when switching to AWS Bedrock during a live session.

- route Bedrock Claude switches to `AnthropicBedrock` with the region parsed from the Bedrock runtime URL
- route Bedrock Converse switches to the SDK-only path and reload configured guardrails
- restore Bedrock region and guardrail state if the client rebuild fails

## Validation

- `git diff --check`
- parsed the changed Python modules with `ast.parse`
- verified the Bedrock runtime URL regex against an `ap-northeast-1` endpoint
- attempted the repository-prescribed `scripts/run_tests.sh` target; this Windows environment has no installed WSL distribution, and its Python lacks the project test dependencies (`pytest`, `PyYAML`), so the targeted pytest suite could not run locally.