### PR TITLE
docs(sms): correct translated webhook host default (#4260)

### DIFF
--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
@@ -302,7 +302,7 @@ description: "Hermes Agent 使用的所有环境变量完整参考"
 | `TWILIO_PHONE_NUMBER` | E.164 格式的 Twilio 手机号码（与电话技能共享） |
 | `SMS_WEBHOOK_URL` | Twilio 签名验证的公共 URL——必须与 Twilio Console 中的 webhook URL 一致（必填） |
 | `SMS_WEBHOOK_PORT` | 入站 SMS 的 webhook 监听端口（默认：`8080`） |
-| `SMS_WEBHOOK_HOST` | webhook 绑定地址（默认：`0.0.0.0`） |
+| `SMS_WEBHOOK_HOST` | webhook 绑定地址（默认：`127.0.0.1`） |
 | `SMS_INSECURE_NO_SIGNATURE` | 设为 `true` 可禁用 Twilio 签名验证（仅用于本地开发——不适用于生产环境） |
 | `SMS_ALLOWED_USERS` | 允许聊天的逗号分隔 E.164 手机号码 |
 | `SMS_ALLOW_ALL_USERS` | 无需白名单允许所有 SMS 发送者 |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
@@ -309,7 +309,7 @@ description: "Hermes Agent 使用的所有环境变量完整参考"
 | `TWILIO_PHONE_NUMBER` | E.164 格式的 Twilio 手机号码（与电话技能共享） |
 | `SMS_WEBHOOK_URL` | Twilio 签名验证的公共 URL——必须与 Twilio Console 中的 webhook URL 一致（必填） |
 | `SMS_WEBHOOK_PORT` | 入站 SMS 的 webhook 监听端口（默认：`8080`） |
-| `SMS_WEBHOOK_HOST` | webhook 绑定地址（默认：`0.0.0.0`） |
+| `SMS_WEBHOOK_HOST` | webhook 绑定地址（默认：`127.0.0.1`） |
 | `SMS_INSECURE_NO_SIGNATURE` | 设为 `true` 可禁用 Twilio 签名验证（仅用于本地开发——不适用于生产环境） |
 | `SMS_ALLOWED_USERS` | 允许聊天的逗号分隔 E.164 手机号码 |
 | `SMS_ALLOW_ALL_USERS` | 无需白名单允许所有 SMS 发送者 |


### PR DESCRIPTION
## Summary

- Correct the Chinese environment-variable reference for `SMS_WEBHOOK_HOST` from `0.0.0.0` to the current `127.0.0.1` runtime default.
- Address only the translated documentation drift within #4260; this PR does not claim to resolve the issue's broader adapter-binding scope.

## Context

The SMS adapter's loopback default was implemented in #19745, but the translated environment-variable reference still documented the previous wildcard bind. The generic Webhook work discussed in #4260 was tracked separately by now-closed PR #35206.

Related #4260

## Agent Disclosure

- Created by: GPT-5.6-Sol-high in Codex
- The account owner loosely reviews these actions and receives the usual GitHub notifications.
