### PR TITLE
feat(telegram): coordinate shared group bot ingress

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7289,6 +7289,126 @@ class TelegramAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES", "false").lower() in {"true", "1", "yes", "on"}
 
+    def _telegram_group_config_map(self, key: str) -> dict[str, Any]:
+        """Return a chat-id map with YAML keys normalized to strings.
+
+        A configured non-mapping value is represented by a wildcard invalid
+        entry so security-sensitive routing fails closed instead of reverting
+        to the legacy dispatch path.
+        """
+        raw = self.config.extra.get(key)
+        if raw is None:
+            return {}
+        if not isinstance(raw, dict):
+            warned = getattr(self, "_telegram_invalid_group_map_warnings", set())
+            if key not in warned:
+                logger.warning("[%s] Invalid Telegram %s mapping; failing closed", self.name, key)
+                warned.add(key)
+                self._telegram_invalid_group_map_warnings = warned
+            return {"*": None}
+        return {
+            str(chat_id).strip(): value
+            for chat_id, value in raw.items()
+            if str(chat_id).strip()
+        }
+
+    def _telegram_group_bot_message_policy(self, message: Message) -> str:
+        """Return ``observe``, ``drop``, or empty for an unconfigured chat.
+
+        Any explicit but unsupported value fails closed to ``drop`` so a typo
+        cannot restore dispatch-capable legacy bot routing.
+        """
+        policies = self._telegram_group_config_map("bot_message_policies")
+        chat_id = str(getattr(getattr(message, "chat", None), "id", ""))
+        if chat_id not in policies and "*" not in policies:
+            return ""
+        policy = str(policies.get(chat_id, policies.get("*"))).lower().strip()
+        return "observe" if policy == "observe" else "drop"
+
+    def _is_policy_observed_bot_message(self, message: Message) -> bool:
+        """Return True only for peer-bot input explicitly scoped to observation."""
+        from_user = getattr(message, "from_user", None)
+        return bool(
+            self._is_group_chat(message)
+            and from_user is not None
+            and getattr(from_user, "is_bot", False)
+            and not self._is_own_message(message)
+            and self._telegram_group_bot_message_policy(message) == "observe"
+        )
+
+    def _is_self_group_message(self, message: Message) -> bool:
+        """Reject a bot's own group update before it can claim dedupe state."""
+        return self._is_group_chat(message) and self._is_own_message(message)
+
+    def _telegram_group_stop_authority(self, message: Message) -> Optional[bool]:
+        """Return whether this bot owns a shared ``/stop`` command in the group.
+
+        ``None`` means the message is not a centrally-routed stop command and
+        normal Telegram routing must continue.  Bare ``/stop`` and ``/stop@all``
+        are equivalent; explicitly bot-addressed variants keep legacy routing.
+        """
+        if not self._is_group_chat(message):
+            return None
+        text = (getattr(message, "text", None) or "").strip()
+        match = re.match(r"^/stop(?:@([a-z0-9_]+))?(?=\s|$)", text, re.IGNORECASE)
+        if not match:
+            return None
+        target = (match.group(1) or "").lower()
+        if target not in {"", "all"}:
+            return None
+
+        authorities = self._telegram_group_config_map("group_stop_authorities")
+        chat_id = str(getattr(getattr(message, "chat", None), "id", ""))
+        if chat_id not in authorities and "*" not in authorities:
+            return None
+        authority = str(authorities.get(chat_id, authorities.get("*")) or "").lstrip("@").lower().strip()
+        if not authority:
+            # An explicit but invalid entry suppresses shared stop routing.
+            return False
+        own_username = str(getattr(getattr(self, "_bot", None), "username", "") or "").lstrip("@").lower()
+        return bool(own_username and own_username == authority)
+
+    def _normalize_group_stop_command_text(self, message: Message, text: Optional[str]) -> Optional[str]:
+        """Normalize the shared ``/stop@all`` alias before command dispatch."""
+        if not text or self._telegram_group_stop_authority(message) is not True:
+            return text
+        return re.sub(r"^/stop@all(?=\s|$)", "/stop", text, count=1, flags=re.IGNORECASE)
+
+    def _claim_team_group_update(self, update_id: Optional[int], message: Message) -> bool:
+        """Claim one Telegram update for configured team-group processing.
+
+        PTB normally advances offsets exactly once, but a restart or failed ACK
+        can redeliver an update.  Keep a small process-local cache so the team
+        group cannot create a second agent turn from the same update.  Other
+        chats preserve the existing behavior.
+        """
+        if (
+            update_id is None
+            or not self._is_group_chat(message)
+            or getattr(message, "from_user", None) is None
+        ):
+            return True
+        chat_id = str(getattr(getattr(message, "chat", None), "id", ""))
+        policies = self._telegram_group_config_map("bot_message_policies")
+        authorities = self._telegram_group_config_map("group_stop_authorities")
+        policy_active = str(policies.get(chat_id, "")).lower().strip() == "observe"
+        authority_active = bool(
+            str(authorities.get(chat_id, "")).lstrip("@").lower().strip()
+        )
+        if not policy_active and not authority_active:
+            return True
+
+        seen = getattr(self, "_telegram_team_group_update_ids", None)
+        if seen is None:
+            seen = {}
+            self._telegram_team_group_update_ids = seen
+        if update_id in seen:
+            return False
+        seen[update_id] = None
+        while len(seen) > 2048:
+            seen.pop(next(iter(seen)))
+        return True
+
     def _telegram_guest_mode(self) -> bool:
         """Return whether non-allowlisted groups may trigger via direct @mention."""
         configured = self.config.extra.get("guest_mode")
@@ -7658,9 +7778,18 @@ class TelegramAdapter(BasePlatformAdapter):
         """Return True when a group message should be stored but not dispatched."""
         if self._is_own_message(message):
             return False
-        if not self._telegram_observe_unmentioned_group_messages():
-            return False
         if not self._is_group_chat(message):
+            return False
+
+        from_user = getattr(message, "from_user", None)
+        policy_observe = bool(
+            from_user is not None
+            and getattr(from_user, "is_bot", False)
+            and self._telegram_group_bot_message_policy(message) == "observe"
+        )
+        if from_user is None:
+            return False
+        if not policy_observe and not self._telegram_observe_unmentioned_group_messages():
             return False
 
         thread_id = getattr(message, "message_thread_id", None)
@@ -7678,15 +7807,21 @@ class TelegramAdapter(BasePlatformAdapter):
                 return False
 
         chat_id_str = str(getattr(getattr(message, "chat", None), "id", ""))
-        if self._telegram_exclusive_bot_mentions() and self._explicit_bot_mentions_exclude_self(message):
+        if (
+            not policy_observe
+            and self._telegram_exclusive_bot_mentions()
+            and self._explicit_bot_mentions_exclude_self(message)
+        ):
             return False
 
+        if policy_observe:
+            return True
+
         allowed = self._telegram_observe_allowed_chats()
-        # Observed context is shared at chat/topic scope so a later trigger from
-        # another user can see it.  Require an explicit chat allowlist; that
-        # keeps shared observed history limited to operator-approved groups and
-        # lets gateway authorization pass even after the shared session source
-        # drops the per-sender user_id.
+        # Ordinary observed human context is shared at chat/topic scope so a
+        # later trigger from another user can see it. Require an explicit chat
+        # allowlist for that broader mode. A bot_message_policies entry is itself
+        # the exact-chat allow for passive peer-bot observation and returned above.
         if not allowed or chat_id_str not in allowed:
             return False
 
@@ -7730,15 +7865,18 @@ class TelegramAdapter(BasePlatformAdapter):
 
     def _apply_telegram_group_observe_attribution(self, event: MessageEvent) -> MessageEvent:
         """Align triggered group turns with observed-history attribution."""
-        if not self._telegram_observe_unmentioned_group_messages():
-            return event
         raw_message = getattr(event, "raw_message", None)
         if not raw_message or not self._is_group_chat(raw_message):
             return event
-        chat_id_str = str(getattr(getattr(raw_message, "chat", None), "id", ""))
-        allowed = self._telegram_observe_allowed_chats()
-        if not allowed or chat_id_str not in allowed:
+        policy_observe = self._telegram_group_bot_message_policy(raw_message) == "observe"
+        ordinary_observe = self._telegram_observe_unmentioned_group_messages()
+        if not policy_observe and not ordinary_observe:
             return event
+        chat_id_str = str(getattr(getattr(raw_message, "chat", None), "id", ""))
+        if not policy_observe:
+            allowed = self._telegram_observe_allowed_chats()
+            if not allowed or chat_id_str not in allowed:
+                return event
         shared_source = self._telegram_group_observe_shared_source(event.source)
         observe_prompt = self._telegram_group_observe_channel_prompt()
         channel_prompt = f"{event.channel_prompt}\n\n{observe_prompt}" if event.channel_prompt else observe_prompt
@@ -8044,6 +8182,12 @@ class TelegramAdapter(BasePlatformAdapter):
 
         chat_id_str = str(getattr(getattr(message, "chat", None), "id", ""))
 
+        bot_policy = self._telegram_group_bot_message_policy(message)
+        if bot_policy in {"observe", "drop"}:
+            from_user = getattr(message, "from_user", None)
+            if from_user is None or getattr(from_user, "is_bot", False):
+                return False
+
         if self._telegram_exclusive_bot_mentions() and self._explicit_bot_mentions_exclude_self(message):
             return False
 
@@ -8057,6 +8201,10 @@ class TelegramAdapter(BasePlatformAdapter):
         allowed = self._telegram_allowed_chats()
         if allowed and chat_id_str not in allowed:
             return guest_mention
+
+        stop_authority = self._telegram_group_stop_authority(message)
+        if stop_authority is not None:
+            return stop_authority
 
         if guest_mention:
             return True
@@ -8120,15 +8268,22 @@ class TelegramAdapter(BasePlatformAdapter):
         if not msg or not msg.text:
             return
         # Early user-level auth check: reject unauthorized users before any
-        # text batching, observe-buffer persistence, event building, or response
-        # generation. This prevents removed/blocked users from injecting prompts
-        # into the agent path or the observed transcript context (#40863).
-        if not self._is_user_authorized_from_message(msg):
+        # text batching, dedupe state, observe-buffer persistence, event building,
+        # or response generation. This prevents removed/blocked users from
+        # injecting prompts or evicting valid dedupe claims (#40863).
+        if (
+            not self._is_user_authorized_from_message(msg)
+            and not self._is_policy_observed_bot_message(msg)
+        ):
             logger.warning(
                 "[Telegram] Blocked unauthorized user %s in chat %s",
                 getattr(getattr(msg, "from_user", None), "id", None),
                 getattr(getattr(msg, "chat", None), "id", None),
             )
+            return
+        if self._is_self_group_message(msg):
+            return
+        if not self._claim_team_group_update(getattr(update, "update_id", None), msg):
             return
         if not self._should_process_message(msg):
             if self._should_observe_unmentioned_group_message(msg):
@@ -8147,19 +8302,29 @@ class TelegramAdapter(BasePlatformAdapter):
         msg = self._effective_update_message(update)
         if not msg or not msg.text:
             return
-        if not self._should_process_message(msg, is_command=True):
-            return
-        if not self._is_user_authorized_from_message(msg):
+        if (
+            not self._is_user_authorized_from_message(msg)
+            and not self._is_policy_observed_bot_message(msg)
+        ):
             logger.warning(
                 "[Telegram] Blocked unauthorized user %s in chat %s",
                 getattr(getattr(msg, "from_user", None), "id", None),
                 getattr(getattr(msg, "chat", None), "id", None),
             )
             return
+        if self._is_self_group_message(msg):
+            return
+        if not self._claim_team_group_update(getattr(update, "update_id", None), msg):
+            return
+        if not self._should_process_message(msg, is_command=True):
+            if self._should_observe_unmentioned_group_message(msg):
+                self._observe_unmentioned_group_message(msg, MessageType.COMMAND, update_id=update.update_id)
+            return
         await self._ensure_forum_commands(msg)
 
         event = self._build_message_event(msg, MessageType.COMMAND, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
+        event.text = self._normalize_group_stop_command_text(msg, event.text)
         await self._cache_replied_media(msg, event)
         event = self._apply_telegram_group_observe_attribution(event)
         await self.handle_message(event)
@@ -8169,21 +8334,20 @@ class TelegramAdapter(BasePlatformAdapter):
         msg = self._effective_update_message(update)
         if not msg:
             return
-        if not self._is_user_authorized_from_message(msg):
+        if (
+            not self._is_user_authorized_from_message(msg)
+            and not self._is_policy_observed_bot_message(msg)
+        ):
             logger.warning(
                 "[Telegram] Blocked unauthorized user %s in chat %s",
                 getattr(getattr(msg, "from_user", None), "id", None),
                 getattr(getattr(msg, "chat", None), "id", None),
             )
             return
-        if not self._should_process_message(msg):
-            if self._should_observe_unmentioned_group_message(msg):
-                self._observe_unmentioned_group_message(msg, MessageType.LOCATION, update_id=update.update_id)
+        if self._is_self_group_message(msg):
             return
-
         venue = getattr(msg, "venue", None)
         location = getattr(venue, "location", None) if venue else getattr(msg, "location", None)
-
         if not location:
             return
 
@@ -8192,7 +8356,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if lat is None or lon is None:
             return
 
-        # Build a text message with coordinates and context
+        # Build the payload before branching so passive observation retains it.
         parts = ["[The user shared a location pin.]"]
         if venue:
             title = getattr(venue, "title", None)
@@ -8208,6 +8372,18 @@ class TelegramAdapter(BasePlatformAdapter):
 
         event = self._build_message_event(msg, MessageType.LOCATION, update_id=update.update_id)
         event.text = "\n".join(parts)
+        if not self._claim_team_group_update(getattr(update, "update_id", None), msg):
+            return
+        if not self._should_process_message(msg):
+            if self._should_observe_unmentioned_group_message(msg):
+                self._observe_unmentioned_group_message(
+                    msg,
+                    MessageType.LOCATION,
+                    update_id=update.update_id,
+                    event=event,
+                )
+            return
+
         event = self._apply_telegram_group_observe_attribution(event)
         await self.handle_message(event)
 
@@ -8373,12 +8549,19 @@ class TelegramAdapter(BasePlatformAdapter):
         """Handle incoming media messages, downloading images to local cache."""
         if not update.message:
             return
-        if not self._is_user_authorized_from_message(update.message):
+        if (
+            not self._is_user_authorized_from_message(update.message)
+            and not self._is_policy_observed_bot_message(update.message)
+        ):
             logger.info(
                 "[Telegram] Blocked media from unauthorized user %s in chat %s",
                 getattr(getattr(update.message, "from_user", None), "id", None),
                 getattr(getattr(update.message, "chat", None), "id", None),
             )
+            return
+        if self._is_self_group_message(update.message):
+            return
+        if not self._claim_team_group_update(getattr(update, "update_id", None), update.message):
             return
         if not self._should_process_message(update.message):
             if self._should_observe_unmentioned_group_message(update.message):
@@ -9372,9 +9555,26 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
         if isinstance(group_allowed_chats, list):
             group_allowed_chats = ",".join(str(v) for v in group_allowed_chats)
         os.environ["TELEGRAM_GROUP_ALLOWED_CHATS"] = str(group_allowed_chats)
-    for _key in ("guest_mode", "disable_link_previews", "observe_unmentioned_group_messages", "free_response_topics"):
+    for _key in (
+        "guest_mode",
+        "disable_link_previews",
+        "observe_unmentioned_group_messages",
+        "free_response_topics",
+        "bot_message_policies",
+        "group_stop_authorities",
+    ):
         if _key in telegram_cfg:
             extras.setdefault(_key, telegram_cfg[_key])
+    for _map_key in ("bot_message_policies", "group_stop_authorities"):
+        _map_value = extras.get(_map_key)
+        if isinstance(_map_value, dict):
+            extras[_map_key] = {
+                str(_chat_id).strip(): _value
+                for _chat_id, _value in _map_value.items()
+                if str(_chat_id).strip()
+            }
+        elif _map_value is not None:
+            logger.warning("Invalid Telegram %s mapping in config; runtime will fail closed", _map_key)
     # Pass through telegram-specific extra keys (e.g. base_url proxy override),
     # but EXCLUDE the generic shared-config keys that _merge_platform_map in
     # gateway/config.py already merges with correct top-level-over-nested

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -22,6 +22,8 @@ def _make_adapter(
     group_allowed_chats=None,
     guest_mode=None,
     observe_unmentioned_group_messages=None,
+    bot_message_policies=None,
+    group_stop_authorities=None,
     bot_username="hermes_bot",
 ):
     from plugins.platforms.telegram.adapter import TelegramAdapter
@@ -65,6 +67,10 @@ def _make_adapter(
         extra["guest_mode"] = guest_mode
     if observe_unmentioned_group_messages is not None:
         extra["observe_unmentioned_group_messages"] = observe_unmentioned_group_messages
+    if bot_message_policies is not None:
+        extra["bot_message_policies"] = bot_message_policies
+    if group_stop_authorities is not None:
+        extra["group_stop_authorities"] = group_stop_authorities
 
     adapter = object.__new__(TelegramAdapter)
     adapter.platform = Platform.TELEGRAM
@@ -94,6 +100,7 @@ def _group_message(
     chat_id=-100,
     from_user_id=111,
     from_user_name="Alice Example",
+    from_user_is_bot=False,
     thread_id=None,
     reply_to_bot=False,
     entities=None,
@@ -112,7 +119,12 @@ def _group_message(
         message_thread_id=thread_id,
         is_topic_message=thread_id is not None,
         chat=SimpleNamespace(id=chat_id, type="group", title="Test Group", is_forum=thread_id is not None),
-        from_user=SimpleNamespace(id=from_user_id, full_name=from_user_name, first_name=from_user_name.split()[0]),
+        from_user=SimpleNamespace(
+            id=from_user_id,
+            full_name=from_user_name,
+            first_name=from_user_name.split()[0],
+            is_bot=from_user_is_bot,
+        ),
         reply_to_message=reply_to_message,
         date=None,
     )
@@ -157,6 +169,506 @@ def test_group_messages_can_be_opened_via_config():
     adapter = _make_adapter(require_mention=False)
 
     assert adapter._should_process_message(_group_message("hello everyone")) is True
+
+
+def test_group_bot_observe_policy_blocks_dispatch_even_when_directly_mentioned():
+    adapter = _make_adapter(
+        require_mention=False,
+        free_response_chats=["-200"],
+        bot_message_policies={"-200": "observe"},
+    )
+    text = "@hermes_bot please continue"
+    peer = _group_message(
+        text,
+        chat_id=-200,
+        from_user_id=555,
+        from_user_is_bot=True,
+        entities=[_mention_entity(text)],
+    )
+
+    assert adapter._should_process_message(peer) is False
+    assert adapter._should_observe_unmentioned_group_message(peer) is True
+
+
+def test_group_bot_observe_policy_preserves_human_dispatch():
+    adapter = _make_adapter(
+        require_mention=False,
+        free_response_chats=["-200"],
+        bot_message_policies={"-200": "observe"},
+    )
+    owner = _group_message("What should we do next?", chat_id=-200)
+
+    assert adapter._should_process_message(owner) is True
+    assert adapter._should_observe_unmentioned_group_message(owner) is False
+
+
+def test_group_bot_observe_policy_can_pass_auth_only_for_passive_observation():
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=False,
+            free_response_chats=["-200"],
+            bot_message_policies={"-200": "observe"},
+        )
+        adapter._is_user_authorized_from_message = lambda _message: False
+        store = _FakeSessionStore()
+        adapter._session_store = store
+        peer = _group_message(
+            "peer bot update",
+            chat_id=-200,
+            from_user_id=555,
+            from_user_is_bot=True,
+        )
+        update = SimpleNamespace(update_id=5001, message=peer, effective_message=None)
+
+        await adapter._handle_text_message(update, SimpleNamespace())
+
+        adapter._message_handler.assert_not_awaited()
+        assert len(store.messages) == 1
+        assert store.messages[0][1]["observed"] is True
+
+    asyncio.run(_run())
+
+
+def test_group_bot_observe_policy_does_not_bypass_auth_for_humans():
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=False,
+            free_response_chats=["-200"],
+            bot_message_policies={"-200": "observe"},
+        )
+        adapter._is_user_authorized_from_message = lambda _message: False
+        store = _FakeSessionStore()
+        adapter._session_store = store
+        owner = _group_message("owner update", chat_id=-200)
+        update = SimpleNamespace(update_id=5002, message=owner, effective_message=None)
+
+        await adapter._handle_text_message(update, SimpleNamespace())
+
+        adapter._message_handler.assert_not_awaited()
+        assert store.messages == []
+
+    asyncio.run(_run())
+
+
+def test_group_bot_observe_policy_never_bypasses_auth_in_dms():
+    adapter = _make_adapter(bot_message_policies={"111": "observe"})
+    direct = _dm_message(from_user_id=111)
+    direct.from_user.is_bot = True
+
+    assert adapter._is_policy_observed_bot_message(direct) is False
+
+
+def test_group_security_maps_accept_numeric_chat_ids():
+    adapter = _make_adapter(
+        require_mention=False,
+        free_response_chats=["-200"],
+        bot_message_policies={-200: "observe"},
+        group_stop_authorities={-200: "dart_look_for_bot"},
+        bot_username="dart_look_for_bot",
+    )
+    peer = _group_message(
+        "peer update",
+        chat_id=-200,
+        from_user_id=555,
+        from_user_is_bot=True,
+    )
+    stop = _group_message("/stop@all", chat_id=-200)
+
+    assert adapter._telegram_group_bot_message_policy(peer) == "observe"
+    assert adapter._should_process_message(peer) is False
+    assert adapter._should_observe_unmentioned_group_message(peer) is True
+    assert adapter._telegram_group_stop_authority(stop) is True
+
+
+def test_invalid_group_security_values_fail_closed_without_enabling_dedupe():
+    peer_adapter = _make_adapter(
+        require_mention=False,
+        free_response_chats=["-200"],
+        bot_message_policies={"-200": "obesrve"},
+    )
+    peer = _group_message(
+        "peer update",
+        chat_id=-200,
+        from_user_id=555,
+        from_user_is_bot=True,
+    )
+    peer_adapter._is_user_authorized_from_message = Mock(return_value=True)
+
+    assert peer_adapter._telegram_group_bot_message_policy(peer) == "drop"
+    assert peer_adapter._should_process_message(peer) is False
+    assert peer_adapter._claim_team_group_update(4900, peer) is True
+    assert peer_adapter._claim_team_group_update(4900, peer) is True
+
+    stop_adapter = _make_adapter(
+        require_mention=False,
+        free_response_chats=["-200"],
+        group_stop_authorities={"-200": ""},
+        bot_username="cronbuster_bot",
+    )
+    stop = _group_message("/stop", chat_id=-200)
+
+    assert stop_adapter._telegram_group_stop_authority(stop) is False
+    assert stop_adapter._should_process_message(stop, is_command=True) is False
+    assert stop_adapter._claim_team_group_update(4901, stop) is True
+    assert stop_adapter._claim_team_group_update(4901, stop) is True
+
+    malformed_policy = _make_adapter(
+        require_mention=False,
+        free_response_chats=["-200"],
+        bot_message_policies=["not-a-map"],
+    )
+    assert malformed_policy._telegram_group_bot_message_policy(peer) == "drop"
+    assert malformed_policy._should_process_message(peer) is False
+
+    malformed_authority = _make_adapter(
+        require_mention=False,
+        free_response_chats=["-200"],
+        group_stop_authorities=["not-a-map"],
+        bot_username="cronbuster_bot",
+    )
+    assert malformed_authority._telegram_group_stop_authority(stop) is False
+    assert malformed_authority._should_process_message(stop, is_command=True) is False
+
+
+def test_group_bot_observe_policy_observes_peer_commands_without_dispatch():
+    async def _run():
+        adapter = _make_adapter(bot_message_policies={"-200": "observe"})
+        adapter._is_user_authorized_from_message = lambda _message: False
+        store = _FakeSessionStore()
+        adapter._session_store = store
+        command = "/status@hermes_bot"
+        peer = _group_message(
+            command,
+            chat_id=-200,
+            from_user_id=555,
+            from_user_is_bot=True,
+            entities=[_bot_command_entity(command, command)],
+        )
+        update = SimpleNamespace(update_id=5003, message=peer, effective_message=None)
+
+        await adapter._handle_command(update, SimpleNamespace())
+
+        adapter._message_handler.assert_not_awaited()
+        assert len(store.messages) == 1
+        assert store.messages[0][1]["observed"] is True
+        assert store.messages[0][1]["content"] == "[Alice Example|555]\n/status@hermes_bot"
+
+    asyncio.run(_run())
+
+
+def test_group_bot_observe_policy_shares_context_with_later_human_turn():
+    adapter = _make_adapter(bot_message_policies={"-200": "observe"})
+    human = _group_message("What did the team say?", chat_id=-200)
+    event = adapter._build_message_event(human, MessageType.TEXT, update_id=5004)
+
+    attributed = adapter._apply_telegram_group_observe_attribution(event)
+
+    assert attributed.source.user_id is None
+    assert attributed.source.user_name is None
+    assert attributed.text == "[Alice Example|111]\nWhat did the team say?"
+    assert "observed Telegram group context" in attributed.channel_prompt
+
+
+def test_unauthorized_team_update_does_not_claim_dedupe_state():
+    async def _run():
+        adapter = _make_adapter(bot_message_policies={"-200": "observe"})
+        adapter._is_user_authorized_from_message = lambda _message: False
+        owner = _group_message("unauthorized", chat_id=-200)
+        update = SimpleNamespace(update_id=5005, message=owner, effective_message=None)
+
+        await adapter._handle_text_message(update, SimpleNamespace())
+
+        assert adapter._claim_team_group_update(5005, owner) is True
+
+    asyncio.run(_run())
+
+
+def test_group_bot_observe_policy_preserves_peer_location_payload():
+    async def _run():
+        adapter = _make_adapter(bot_message_policies={"-200": "observe"})
+        adapter._is_user_authorized_from_message = lambda _message: False
+        store = _FakeSessionStore()
+        adapter._session_store = store
+        peer = _group_message(
+            None,
+            chat_id=-200,
+            from_user_id=555,
+            from_user_is_bot=True,
+        )
+        peer.location = SimpleNamespace(latitude=23.1291, longitude=113.2644)
+        peer.venue = None
+        update = SimpleNamespace(update_id=5006, message=peer, effective_message=None)
+
+        await adapter._handle_location_message(update, SimpleNamespace())
+
+        adapter._message_handler.assert_not_awaited()
+        assert len(store.messages) == 1
+        observed = store.messages[0][1]
+        assert observed["observed"] is True
+        assert "latitude: 23.1291" in observed["content"]
+        assert "longitude: 113.2644" in observed["content"]
+        assert "maps/search/?api=1&query=23.1291,113.2644" in observed["content"]
+
+    asyncio.run(_run())
+
+
+def test_self_and_service_updates_do_not_claim_dedupe_in_any_handler():
+    async def _run():
+        handlers = (
+            "_handle_text_message",
+            "_handle_command",
+            "_handle_location_message",
+            "_handle_media_message",
+        )
+        for handler_offset, handler_name in enumerate(handlers):
+            for sender_offset, sender_kind in enumerate(("self", "service")):
+                adapter = _make_adapter(
+                    require_mention=False,
+                    free_response_chats=["-200"],
+                    bot_message_policies={"-200": "observe"},
+                )
+                adapter._bot.id = 999
+                adapter._is_user_authorized_from_message = Mock(return_value=True)
+                message = _group_message(
+                    "/status",
+                    chat_id=-200,
+                    from_user_id=999,
+                    from_user_is_bot=True,
+                )
+                if sender_kind == "service":
+                    message.from_user = None
+                update = SimpleNamespace(
+                    update_id=5100 + handler_offset * 10 + sender_offset,
+                    message=message,
+                    effective_message=None,
+                )
+
+                await getattr(adapter, handler_name)(update, SimpleNamespace())
+
+                assert getattr(adapter, "_telegram_team_group_update_ids", {}) == {}
+
+    asyncio.run(_run())
+
+
+def test_group_bot_observe_policy_is_scoped_to_configured_chat():
+    adapter = _make_adapter(
+        require_mention=False,
+        free_response_chats=["-200", "-201"],
+        bot_message_policies={"-200": "observe"},
+    )
+    peer_elsewhere = _group_message(
+        "peer update",
+        chat_id=-201,
+        from_user_id=555,
+        from_user_is_bot=True,
+    )
+
+    assert adapter._should_process_message(peer_elsewhere) is True
+
+
+def test_group_bot_observe_policy_drops_service_messages_without_observing():
+    adapter = _make_adapter(
+        require_mention=False,
+        free_response_chats=["-200"],
+        bot_message_policies={"-200": "observe"},
+    )
+    service = _group_message("Alice pinned a message", chat_id=-200)
+    service.from_user = None
+
+    assert adapter._should_process_message(service) is False
+    assert adapter._should_observe_unmentioned_group_message(service) is False
+
+
+def test_group_stop_authority_accepts_stop_and_stop_all_only_on_coordinator():
+    authority = {"-200": "dart_look_for_bot"}
+    coordinator = _make_adapter(
+        require_mention=False,
+        free_response_chats=["-200"],
+        group_stop_authorities=authority,
+        bot_username="dart_look_for_bot",
+    )
+    worker = _make_adapter(
+        require_mention=False,
+        free_response_chats=["-200"],
+        group_stop_authorities=authority,
+        bot_username="cronbuster_bot",
+    )
+
+    for command in ("/stop", "/stop@all"):
+        message = _group_message(command, chat_id=-200)
+        assert coordinator._should_process_message(message, is_command=True) is True
+        assert worker._should_process_message(message, is_command=True) is False
+
+
+def test_group_stop_all_normalizes_to_stop_for_authority():
+    adapter = _make_adapter(
+        group_stop_authorities={"-200": "dart_look_for_bot"},
+        bot_username="dart_look_for_bot",
+    )
+    message = _group_message("/stop@all now", chat_id=-200)
+
+    assert adapter._normalize_group_stop_command_text(message, message.text) == "/stop now"
+
+
+def test_group_stop_authority_does_not_change_other_groups():
+    adapter = _make_adapter(
+        require_mention=False,
+        free_response_chats=["-201"],
+        group_stop_authorities={"-200": "dart_look_for_bot"},
+        bot_username="cronbuster_bot",
+    )
+
+    assert adapter._should_process_message(
+        _group_message("/stop", chat_id=-201),
+        is_command=True,
+    ) is True
+
+
+def test_group_stop_and_dedupe_helpers_ignore_dms_and_channels():
+    adapter = _make_adapter(
+        bot_message_policies={"111": "observe", "-200": "observe"},
+        group_stop_authorities={"111": "dart_look_for_bot", "-200": "dart_look_for_bot"},
+        bot_username="dart_look_for_bot",
+    )
+    direct = _dm_message("/stop@all", from_user_id=111)
+    channel = _group_message("/stop@all", chat_id=-200)
+    channel.chat.type = "channel"
+
+    for update_id, message in enumerate((direct, channel), start=6100):
+        assert adapter._telegram_group_stop_authority(message) is None
+        assert adapter._normalize_group_stop_command_text(message, message.text) == "/stop@all"
+        assert adapter._claim_team_group_update(update_id, message) is True
+        assert adapter._claim_team_group_update(update_id, message) is True
+
+
+def test_group_stop_all_handler_dispatches_once_only_from_authority():
+    async def _run():
+        authority = {"-200": "dart_look_for_bot"}
+        coordinator = _make_adapter(
+            require_mention=False,
+            free_response_chats=["-200"],
+            group_stop_authorities=authority,
+            bot_username="dart_look_for_bot",
+        )
+        worker = _make_adapter(
+            require_mention=False,
+            free_response_chats=["-200"],
+            group_stop_authorities=authority,
+            bot_username="cronbuster_bot",
+        )
+        coordinator.handle_message = AsyncMock()
+        worker.handle_message = AsyncMock()
+        command = "/stop@all"
+        message = _group_message(
+            command,
+            chat_id=-200,
+            entities=[_bot_command_entity(command, command)],
+        )
+        update = SimpleNamespace(update_id=6001, message=message, effective_message=None)
+
+        await coordinator._handle_command(update, SimpleNamespace())
+        await worker._handle_command(update, SimpleNamespace())
+
+        coordinator.handle_message.assert_awaited_once()
+        dispatched = coordinator.handle_message.await_args.args[0]
+        assert dispatched.text == "/stop"
+        worker.handle_message.assert_not_awaited()
+
+    asyncio.run(_run())
+
+
+def test_team_group_update_ids_are_deduplicated_without_affecting_other_chats():
+    adapter = _make_adapter(
+        bot_message_policies={"-200": "observe"},
+        group_stop_authorities={"-200": "dart_look_for_bot"},
+    )
+    team_message = _group_message("owner turn", chat_id=-200)
+    other_message = _group_message("other turn", chat_id=-201)
+
+    assert adapter._claim_team_group_update(7001, team_message) is True
+    assert adapter._claim_team_group_update(7001, team_message) is False
+    assert adapter._claim_team_group_update(7001, other_message) is True
+    assert adapter._claim_team_group_update(7001, other_message) is True
+
+
+def test_duplicate_team_update_reaches_text_ingress_only_once():
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=False,
+            free_response_chats=["-200"],
+            bot_message_policies={"-200": "observe"},
+        )
+        adapter._enqueue_text_event = Mock()
+        message = _group_message("owner turn", chat_id=-200)
+        update = SimpleNamespace(update_id=7002, message=message, effective_message=None)
+
+        await adapter._handle_text_message(update, SimpleNamespace())
+        await adapter._handle_text_message(update, SimpleNamespace())
+
+        adapter._enqueue_text_event.assert_called_once()
+
+    asyncio.run(_run())
+
+
+def test_team_group_command_location_and_media_handlers_drop_duplicate_updates():
+    async def _run():
+        handlers = (
+            "_handle_command",
+            "_handle_location_message",
+            "_handle_media_message",
+        )
+        for offset, handler_name in enumerate(handlers, start=1):
+            adapter = _make_adapter(
+                require_mention=False,
+                free_response_chats=["-200"],
+                bot_message_policies={"-200": "observe"},
+            )
+            adapter._should_process_message = Mock(return_value=False)
+            adapter._should_observe_unmentioned_group_message = Mock(return_value=False)
+            message = _group_message("/status", chat_id=-200)
+            if handler_name == "_handle_location_message":
+                message.location = SimpleNamespace(latitude=23.1291, longitude=113.2644)
+                message.venue = None
+            update = SimpleNamespace(
+                update_id=7100 + offset,
+                message=message,
+                effective_message=None,
+            )
+
+            handler = getattr(adapter, handler_name)
+            await handler(update, None)
+            await handler(update, None)
+
+            adapter._should_process_message.assert_called_once()
+
+    asyncio.run(_run())
+
+
+def test_team_group_update_claim_has_one_async_winner():
+    async def _run():
+        adapter = _make_adapter(bot_message_policies={"-200": "observe"})
+        message = _group_message("hello", chat_id=-200)
+
+        async def _claim():
+            return adapter._claim_team_group_update(7201, message)
+
+        results = await asyncio.gather(*(_claim() for _ in range(16)))
+        assert results.count(True) == 1
+        assert results.count(False) == 15
+
+    asyncio.run(_run())
+
+
+def test_team_group_update_cache_is_bounded_to_2048_entries():
+    adapter = _make_adapter(bot_message_policies={"-200": "observe"})
+    message = _group_message("owner turn", chat_id=-200)
+
+    for update_id in range(2049):
+        assert adapter._claim_team_group_update(update_id, message) is True
+
+    assert len(adapter._telegram_team_group_update_ids) == 2048
+    assert adapter._claim_team_group_update(2048, message) is False
+    assert adapter._claim_team_group_update(0, message) is True
 
 
 def test_unmentioned_group_messages_can_be_observed_without_dispatching():
@@ -798,6 +1310,10 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
         "  require_mention: true\n"
         "  guest_mode: true\n"
         "  exclusive_bot_mentions: true\n"
+        "  bot_message_policies:\n"
+        "    -1004326833898: observe\n"
+        "  group_stop_authorities:\n"
+        "    -1004326833898: dart_look_for_bot\n"
         "  observe_unmentioned_group_messages: true\n"
         "  mention_patterns:\n"
         "    - \"^\\\\s*chompy\\\\b\"\n"
@@ -846,6 +1362,8 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
     assert tg_cfg.extra.get("require_mention") is True
     assert tg_cfg.extra.get("guest_mode") is True
     assert tg_cfg.extra.get("exclusive_bot_mentions") is True
+    assert tg_cfg.extra.get("bot_message_policies") == {"-1004326833898": "observe"}
+    assert tg_cfg.extra.get("group_stop_authorities") == {"-1004326833898": "dart_look_for_bot"}
     assert tg_cfg.extra.get("observe_unmentioned_group_messages") is True
     assert tg_cfg.extra.get("mention_patterns") == [r"^\s*chompy\b"]
     assert tg_cfg.extra.get("allowed_chats") == ["-100"]


### PR DESCRIPTION
## Summary

Coordinate Telegram ingress when several Hermes bot profiles share one configured group/supergroup:

- observe peer-bot text, commands, location, and media as passive shared context without dispatching them;
- preserve sender attribution, location/venue payloads, and cached-media metadata in the shared session;
- route bare `/stop` and `/stop@all` only to the configured coordinator, normalizing the alias before dispatch;
- deduplicate configured-team-group updates after authorization and sender classification with a bounded 2048-entry cache;
- keep DMs, channels, and unrelated chats on their existing paths.

## Security / configuration behavior

- bot-policy authorization bypass is group-only and observation-only;
- unauthorized, self, and senderless/service updates cannot poison team-group dedupe state;
- numeric YAML chat IDs are normalized to strings;
- invalid policy/authority values and malformed security-map shapes fail closed with warnings;
- only validated `observe` policies or non-empty stop authorities activate deduplication.

## Verification

Fresh base: `origin/main@98cadadd8`

- `79 passed` — `tests/gateway/test_telegram_group_gating.py`
- `29 passed` — Telegram auth, bot-auth bypass, and callback fail-closed suites
- `109 passed` — `tests/gateway/test_telegram_format.py`
- `217 passed` total in isolated relevant suites
- `py_compile`, `git diff --check`, and added-line security scan clean
- independent fail-closed review: PASS, no security concerns or logic errors

The combined three-suite process retains six existing order-dependent guest-fixture failures. The same six failures reproduce on clean `origin/main@98cadadd8` (`165 passed, 6 failed`); the candidate run improves the passing count while preserving the same baseline failures (`189 passed, 6 failed`).

No deployment or live Telegram configuration changes are included.