### PR TITLE
fix(kanban): make reviewer-lane completion policy opt-in instead of reversing the default

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1414,10 +1414,15 @@ def init_agent(
     # Resolving the ~835-token block once here avoids re-running the
     # membership test + reference on every system-prompt rebuild
     # (init + each context compression).
-    from agent.prompt_builder import KANBAN_GUIDANCE
-    agent._kanban_worker_guidance = (
-        KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
-    )
+    if "kanban_show" in agent.valid_tool_names:
+        from agent.prompt_builder import build_kanban_guidance
+        from hermes_cli.config import load_config, resolve_kanban_review_policy
+
+        agent._kanban_worker_guidance = build_kanban_guidance(
+            resolve_kanban_review_policy(load_config())
+        )
+    else:
+        agent._kanban_worker_guidance = ""
 
     # Check tool requirements
     if agent.tools and not agent.quiet_mode:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -206,7 +206,7 @@ SKILLS_GUIDANCE = (
     "4. **DEDUP** — After reloading a pruned skill, **ignore any remaining `[SKILL_PRUNED]` markers for that same skill** — they are historical artifacts from previous compactions and do not need further action."
 )
 
-KANBAN_GUIDANCE = (
+_KANBAN_GUIDANCE_PREFIX = (
     "# Kanban task execution protocol\n"
     "You have been assigned ONE task from "
     "the shared board at `~/.hermes/kanban.db`. Your task id is in "
@@ -237,6 +237,9 @@ KANBAN_GUIDANCE = (
     "infer (missing credentials, UX choice, paywalled source, peer output you "
     "need first), call `kanban_block(reason=\"...\")` and stop. Don't guess. "
     "The user will unblock with context and the dispatcher will respawn you.\n"
+)
+
+_KANBAN_REVIEW_REQUIRED_HANDOFF = (
     "5. **Complete with structured handoff.** Call `kanban_complete(summary=..., "
     "metadata=...)`. `summary` is 1–3 human-readable sentences naming concrete "
     "artifacts. `metadata` is machine-readable facts "
@@ -251,6 +254,25 @@ KANBAN_GUIDANCE = (
     "reviewer can approve+unblock or request changes. Reviewing-then-"
     "completing is more honest than auto-completing work that still needs "
     "eyes on it.\n"
+)
+
+_KANBAN_COMPLETE_WITH_EVIDENCE_HANDOFF = (
+    "5. **Complete with structured evidence.** Your task should complete with "
+    "structured evidence by calling `kanban_complete(summary=..., metadata=...)` "
+    "when your work is complete and verification passes. In an "
+    "explicit `kanban.review_policy: complete-with-evidence` coding lane, "
+    "downstream reviewer/QA lanes are the review path; your honest handoff is "
+    "the completed run plus evidence (changed_files, tests/checks run, "
+    "pass/fail counts or command summary, diff/PR/worktree reference, "
+    "decisions, and created follow-up cards). Still block with a concrete "
+    "`review-required: ...` reason for human-only concerns: "
+    "security/credential work, schema/migration work, deploy/push/provision "
+    "or other external-network actions, or unresolved ambiguity. Name the "
+    "specific concern in the block reason; never use vague \"needs review\" "
+    "as a substitute for evidence.\n"
+)
+
+_KANBAN_GUIDANCE_SUFFIX = (
     "6. **If follow-up work appears, create it; don't do it.** Use "
     "`kanban_create(title=..., assignee=<right-profile>, parents=[your-task-id])` "
     "to spawn a child task for the appropriate specialist profile instead of "
@@ -305,6 +327,19 @@ KANBAN_GUIDANCE = (
     "for short reasoning subtasks inside your own run; board tasks are for "
     "cross-agent handoffs that outlive one API loop."
 )
+
+
+def build_kanban_guidance(review_policy: str = "review-required") -> str:
+    """Build session-static Kanban worker lifecycle guidance for a review policy."""
+    handoff = (
+        _KANBAN_COMPLETE_WITH_EVIDENCE_HANDOFF
+        if review_policy == "complete-with-evidence"
+        else _KANBAN_REVIEW_REQUIRED_HANDOFF
+    )
+    return _KANBAN_GUIDANCE_PREFIX + handoff + _KANBAN_GUIDANCE_SUFFIX
+
+
+KANBAN_GUIDANCE = build_kanban_guidance("review-required")
 
 TOOL_USE_ENFORCEMENT_GUIDANCE = (
     "# Tool-use enforcement\n"

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -36,6 +36,31 @@ from hermes_cli.secret_prompt import masked_secret_prompt
 
 logger = logging.getLogger(__name__)
 
+KANBAN_REVIEW_POLICY_REVIEW_REQUIRED = "review-required"
+KANBAN_REVIEW_POLICY_COMPLETE_WITH_EVIDENCE = "complete-with-evidence"
+KANBAN_REVIEW_POLICIES = frozenset({
+    KANBAN_REVIEW_POLICY_REVIEW_REQUIRED,
+    KANBAN_REVIEW_POLICY_COMPLETE_WITH_EVIDENCE,
+})
+
+
+def resolve_kanban_review_policy(config: Optional[Dict[str, Any]]) -> str:
+    """Resolve the explicit Kanban worker review policy from config.
+
+    The safe/backward-compatible behavior is ``review-required``. Invalid,
+    missing, null, or non-string values must never opt a worker into the more
+    permissive reviewer-lane completion contract.
+    """
+    if not isinstance(config, dict):
+        return KANBAN_REVIEW_POLICY_REVIEW_REQUIRED
+    kanban_config = config.get("kanban", {})
+    if not isinstance(kanban_config, dict):
+        return KANBAN_REVIEW_POLICY_REVIEW_REQUIRED
+    policy = kanban_config.get("review_policy")
+    if isinstance(policy, str) and policy in KANBAN_REVIEW_POLICIES:
+        return policy
+    return KANBAN_REVIEW_POLICY_REVIEW_REQUIRED
+
 # Track which (config_path, mtime_ns, size) tuples we've already warned about
 # so concurrent CLI/gateway loads of a broken config.yaml don't spam stderr
 # every time. Cleared automatically when the file changes (different mtime).

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2148,6 +2148,11 @@ DEFAULT_CONFIG = {
         # behaviour — e.g. for a profile that prefers explicit
         # ``kanban_notify-subscribe`` calls per task.
         "auto_subscribe_on_create": True,
+        # Worker handoff policy for Kanban sessions. The default keeps the
+        # conservative review-required convention; only the exact explicit
+        # value ``complete-with-evidence`` opts a profile into completing
+        # coding tasks with evidence for downstream reviewer/QA lanes.
+        "review_policy": "review-required",
         # Run the dispatcher inside the gateway process. On by default —
         # the cost is ~300µs every `dispatch_interval_seconds` when idle,
         # and gateway is the supervisor users already have. Set to false

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -550,6 +550,240 @@ def test_worker_lifecycle_through_tools(worker_env):
 # System-prompt guidance injection
 # ---------------------------------------------------------------------------
 
+def _reset_kanban_prompt_test_env(monkeypatch, tmp_path, *, task_id="t_fake", config_text=""):
+    if task_id is None:
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    else:
+        monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    if config_text:
+        (home / "config.yaml").write_text(config_text, encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from pathlib import Path as _P
+    monkeypatch.setattr(_P, "home", lambda: tmp_path)
+
+    from tools.registry import invalidate_check_fn_cache
+    from model_tools import _clear_tool_defs_cache
+    invalidate_check_fn_cache()
+    _clear_tool_defs_cache()
+
+
+def _build_quiet_test_agent_prompt(monkeypatch):
+    monkeypatch.setattr("agent.context_compressor.get_model_context_length", lambda *a, **k: 128_000)
+    from run_agent import AIAgent
+    a = AIAgent(
+        api_key="test",
+        base_url="https://openrouter.ai/api/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    return a._build_system_prompt()
+
+
+@pytest.mark.parametrize("config", [
+    None,
+    {},
+    {"kanban": None},
+    {"kanban": True},
+    {"kanban": []},
+    {"kanban": "complete-with-evidence"},
+])
+def test_resolve_kanban_review_policy_missing_or_non_dict_kanban_falls_back(config):
+    from hermes_cli.config import resolve_kanban_review_policy
+
+    assert resolve_kanban_review_policy(config) == "review-required"
+
+
+@pytest.mark.parametrize("raw_policy", [None, True, "complete", "", [], {}])
+def test_resolve_kanban_review_policy_invalid_values_fall_back(raw_policy):
+    from hermes_cli.config import resolve_kanban_review_policy
+
+    cfg = {"kanban": {"review_policy": raw_policy}}
+    assert resolve_kanban_review_policy(cfg) == "review-required"
+
+
+def test_resolve_kanban_review_policy_accepts_explicit_opt_in():
+    from hermes_cli.config import resolve_kanban_review_policy
+
+    assert (
+        resolve_kanban_review_policy({"kanban": {"review_policy": "complete-with-evidence"}})
+        == "complete-with-evidence"
+    )
+
+
+def test_load_config_default_merge_preserves_review_required(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("kanban:\n  dispatch_interval_seconds: 5\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from pathlib import Path as _P
+    monkeypatch.setattr(_P, "home", lambda: tmp_path)
+
+    from hermes_cli.config import load_config, resolve_kanban_review_policy
+
+    assert resolve_kanban_review_policy(load_config()) == "review-required"
+
+
+def test_build_kanban_guidance_preserves_default_review_required():
+    from agent.prompt_builder import build_kanban_guidance
+
+    guidance = build_kanban_guidance()
+
+    assert "review-required" in guidance
+    assert "most coding tasks" in guidance
+    assert "downstream reviewer/QA lanes are the review path" not in guidance
+
+
+def test_build_kanban_guidance_invalid_policy_falls_back_to_review_required():
+    from agent.prompt_builder import build_kanban_guidance
+
+    guidance = build_kanban_guidance("complete")
+
+    assert "most coding tasks" in guidance
+    assert "downstream reviewer/QA lanes are the review path" not in guidance
+
+
+def test_build_kanban_guidance_complete_with_evidence_variant():
+    from agent.prompt_builder import build_kanban_guidance
+
+    guidance = build_kanban_guidance("complete-with-evidence")
+
+    assert "complete with structured evidence" in guidance
+    assert "downstream reviewer/QA lanes are the review path" in guidance
+    assert "security/credential" in guidance
+    assert "schema/migration" in guidance
+    assert "deploy/push/provision" in guidance
+    assert "unresolved ambiguity" in guidance
+
+
+def test_kanban_guidance_not_in_normal_prompt(monkeypatch, tmp_path):
+    """A normal chat session (no HERMES_KANBAN_TASK) must NOT have
+    KANBAN_GUIDANCE in its system prompt."""
+    _reset_kanban_prompt_test_env(
+        monkeypatch,
+        tmp_path,
+        task_id=None,
+        config_text="kanban:\n  review_policy: complete-with-evidence\n",
+    )
+    prompt = _build_quiet_test_agent_prompt(monkeypatch)
+    assert "You are a Kanban worker" not in prompt
+    assert "kanban_show()" not in prompt
+    assert "kanban_complete" not in prompt
+    assert "kanban_block" not in prompt
+
+
+def test_kanban_guidance_in_worker_prompt(monkeypatch, tmp_path):
+    """A worker session (HERMES_KANBAN_TASK set) MUST have the full
+    lifecycle guidance in its system prompt."""
+    _reset_kanban_prompt_test_env(monkeypatch, tmp_path)
+    prompt = _build_quiet_test_agent_prompt(monkeypatch)
+    # Header phrase (identity-free — SOUL.md owns identity, layer 3 is protocol)
+    assert "Kanban task execution protocol" in prompt
+    # Lifecycle signals
+    assert "kanban_show()" in prompt
+    assert "kanban_complete" in prompt
+    assert "kanban_block" in prompt
+    assert "kanban_create" in prompt
+    assert "most coding tasks" in prompt
+    assert "downstream reviewer/QA lanes are the review path" not in prompt
+    # Anti-shell guidance
+    assert "Do not shell out" in prompt or "tools — they work" in prompt
+
+
+def test_kanban_guidance_opt_in_worker_prompt(monkeypatch, tmp_path):
+    _reset_kanban_prompt_test_env(
+        monkeypatch,
+        tmp_path,
+        config_text="kanban:\n  review_policy: complete-with-evidence\n",
+    )
+    prompt = _build_quiet_test_agent_prompt(monkeypatch)
+
+    assert "Kanban task execution protocol" in prompt
+    assert "complete with structured evidence" in prompt
+    assert "downstream reviewer/QA lanes are the review path" in prompt
+    assert "security/credential" in prompt
+    assert "schema/migration" in prompt
+    assert "deploy/push/provision" in prompt
+    assert "unresolved ambiguity" in prompt
+
+
+@pytest.mark.parametrize("config_text", [
+    "kanban:\n  review_policy: complete\n",
+    "kanban:\n  review_policy: true\n",
+    "kanban:\n  review_policy:\n",
+])
+def test_kanban_guidance_invalid_policy_worker_prompt_falls_back(monkeypatch, tmp_path, config_text):
+    _reset_kanban_prompt_test_env(monkeypatch, tmp_path, config_text=config_text)
+    prompt = _build_quiet_test_agent_prompt(monkeypatch)
+
+    assert "most coding tasks" in prompt
+    assert "downstream reviewer/QA lanes are the review path" not in prompt
+
+
+def test_kanban_guidance_fallback_path_is_review_required(monkeypatch):
+    from types import SimpleNamespace
+
+    from agent.system_prompt import build_system_prompt
+
+    agent = SimpleNamespace(
+        load_soul_identity=False,
+        skip_context_files=True,
+        valid_tool_names={"kanban_show"},
+        _task_completion_guidance=False,
+        _tool_use_enforcement=False,
+        model="",
+        platform="cli",
+        provider="test",
+        session_id="test-session",
+        skip_memory=True,
+        memory_content="",
+        user_profile="",
+        external_memory_context="",
+        _memory_store=None,
+        _memory_manager=None,
+        _current_project_guidance="",
+        ephemeral_system_prompt="",
+        _kanban_worker_guidance=None,
+        pass_session_id=False,
+    )
+
+    monkeypatch.setattr("run_agent.load_soul_md", lambda: "")
+    monkeypatch.setattr("run_agent.build_nous_subscription_prompt", lambda valid_tool_names: "")
+    monkeypatch.setattr("run_agent.build_environment_hints", lambda: "")
+    monkeypatch.setattr("run_agent.build_context_files_prompt", lambda *a, **k: "")
+    monkeypatch.setattr("run_agent.build_skills_system_prompt", lambda *a, **k: "")
+
+    prompt = build_system_prompt(agent)
+
+    assert "most coding tasks" in prompt
+    assert "downstream reviewer/QA lanes are the review path" not in prompt
+
+
+def test_kanban_guidance_prompt_size_bounded(monkeypatch, tmp_path):
+    """Sanity: the guidance block stays lean so it doesn't blow up the
+    cached prompt.
+
+    The ceiling guards against unbounded growth, not against any growth.
+    The block absorbed the load-bearing worker/orchestrator reference
+    details (workspace kinds, deliverable artifacts, created-card claims,
+    profile discovery) when the standalone kanban-worker / kanban-orchestrator
+    skills were removed and folded into this always-injected guidance, so the
+    ceiling is sized to fit that content with a little headroom.
+    """
+    _reset_kanban_prompt_test_env(monkeypatch, tmp_path)
+
+    from agent.prompt_builder import KANBAN_GUIDANCE, build_kanban_guidance
+    for policy in ("review-required", "complete-with-evidence"):
+        guidance = build_kanban_guidance(policy)
+        assert 1_500 < len(guidance) < 5_500, (
+            f"{policy} Kanban guidance is {len(guidance)} chars — too short (missing?) or too long"
+        )
+        for step in ("1.", "2.", "3.", "4.", "5.", "6."):
+            assert step in guidance
+    assert KANBAN_GUIDANCE == build_kanban_guidance("review-required")
+
 
 # ---------------------------------------------------------------------------
 # Worker task-ownership enforcement (regression tests for #19534)

--- a/website/docs/user-guide/features/kanban-worker-lanes.md
+++ b/website/docs/user-guide/features/kanban-worker-lanes.md
@@ -56,7 +56,11 @@ Every claim must end in exactly one of:
 
 The kanban kernel enforces that exactly one of these terminates each run. A worker that calls neither and exits normally is treated as crashed.
 
-## Outputs and the review-required convention
+## Outputs and the review policy convention
+
+Kanban workers resolve their review handoff policy from the active worker profile's `kanban.review_policy` config once at session start. The default is `review-required`, and missing, null, non-string, or invalid values all fall back to that conservative default. The only alternative is the exact explicit reviewer/QA-lane opt-in `complete-with-evidence`. The resolver does not infer policy from task title/body, board, assignee, comments, child cards, PR labels, profile name, or GitHub metadata.
+
+### Default: `review-required`
 
 For most code-changing tasks, the work isn't truly *done* the moment the worker finishes — it needs a human reviewer. The kanban kernel doesn't enforce this distinction (a "code-changing task" is fuzzy and forcing block-instead-of-complete on every code worker would break flows where no review is wanted). It's a convention layered on top:
 
@@ -65,6 +69,19 @@ For most code-changing tasks, the work isn't truly *done* the moment the worker 
 - **Reviewer either approves and unblocks**, which respawns the worker with the comment thread for follow-ups; or asks for changes via another comment, which the next worker run sees as part of `kanban_show`'s context.
 
 The injected `KANBAN_GUIDANCE` covers both `kanban_complete` (truly terminal tasks — typo fixes, docs changes, research writeups) and the `review-required` block pattern.
+
+### Opt-in reviewer/QA lane: `complete-with-evidence`
+
+Dedicated reviewer/QA-lane workflows can opt a coding profile into completing with evidence when the downstream reviewer/QA cards are the review path. Configure that coding profile (not the board, not the task body) with:
+
+```yaml
+kanban:
+  review_policy: complete-with-evidence
+```
+
+Under this policy, passing code changes call `kanban_complete(summary=..., metadata=...)` with evidence such as changed files, tests/checks run, pass/fail counts or command summaries, diff/PR/worktree references, decisions, and follow-up cards created. The worker still blocks with a concrete `review-required: ...` reason for security/credential work, schema/migration work, deploy/push/provision actions, or unresolved task ambiguity.
+
+Do **not** set `complete-with-evidence` on a single-lane board that relies on worker self-blocks for human review. Without an explicit downstream reviewer/QA lane, leave the default `review-required` policy in place.
 
 ## Logs and audit trail
 
@@ -80,7 +97,7 @@ The dashboard renders run history with summaries, metadata blocks, and exit-stat
 
 ### Hermes profile lane (default)
 
-The shape every kanban worker takes today: the assignee is a profile name, the dispatcher spawns `hermes -p <profile>`, the worker gets the `KANBAN_GUIDANCE` system-prompt block injected automatically, and uses the `kanban_*` tools to terminate the run. No setup beyond defining the profile.
+The shape every kanban worker takes today: the assignee is a profile name, the dispatcher spawns `hermes -p <profile>`, the worker gets the `KANBAN_GUIDANCE` system-prompt block injected automatically, resolves `kanban.review_policy` from that profile's config, and uses the `kanban_*` tools to terminate the run. No setup beyond defining the profile is required unless you intentionally opt a reviewer/QA lane into `complete-with-evidence`.
 
 When you create profiles for your fleet, choose names that match the *role* you want the orchestrator to route to. The orchestrator (when there is one) discovers your profile names via `hermes profile list` — there's no fixed roster the system assumes (the orchestrator side of the contract is part of the injected `KANBAN_GUIDANCE`).
 


### PR DESCRIPTION
## Problem

PR #44375 proposed reversing the global Kanban default from `review-required` to `complete-with-evidence`, but this overrode an intentional design decision: code-changing workers should self-block by default until a human or downstream lane reviews their work.

## Solution

Instead of reversing the default, add an explicit, documented per-profile opt-in `kanban.review_policy: complete-with-evidence` that lets reviewer/QA-lane workflows complete with structured evidence while preserving the conservative default (`review-required`) for everything else.

## What changed

- **`hermes_cli/config.py`** — Add `resolve_kanban_review_policy()` that returns `review-required` for missing/null/invalid config, and `complete-with-evidence` only when explicitly configured.
- **`agent/prompt_builder.py`** — Add `build_kanban_guidance()` that produces the appropriate lifecycle guidance variant depending on the resolved policy.
- **`agent/agent_init.py`** — Gate Kanban guidance injection behind `kanban_show` tool presence and read policy from the active profile config.
- **`tests/tools/test_kanban_tools.py`** — 18 new focused tests covering default behavior, explicit opt-in, invalid policy fallback, normal prompts, fallback paths, and guidance size bounds (191 new lines).
- **`skills/devops/kanban-worker/SKILL.md`** — Document the opt-in policy contract and prohibit prose/assignee/board inference.
- **`skills/devops/kanban-orchestrator/SKILL.md`** — Same contract for the orchestrator role.
- **`website/docs/user-guide/features/kanban-worker-lanes.md`** — Document `kanban.review_policy` config option.

## Design invariants

1. **Preserved default.** Every worker that does not explicitly opt in keeps `review-required`.
2. **No code-side inference.** Policy is read from the active profile config only — never from task bodies, assignee names, comments, or board state.
3. **Prompt caching preserved.** Guidance is resolved once at agent initialization and is session-static.
4. **Human-only concerns remain blocked.** The opt-in guidance explicitly lists credential/security, schema/migration, deploy/push/provision, and unresolved ambiguity as blocking conditions even with `complete-with-evidence`.
5. **Conservative fallback.** If `kanban_show` is absent from tools (non-Kanban sessions) or `_kanban_worker_guidance` is None, the system prompt uses the original `review-required` guidance.

## Verification

- 220 focused + config tests pass (0 failed)
- `git status --short` is clean
- Diff limited to 7 files: 286 insertions, 42 deletions
- No DB schema, dispatcher, or task lifecycle changes