### PR TITLE
fix(feishu): card action callbacks use group policy instead of interactive operator auth

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2715,8 +2715,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        if not self._is_interactive_operator_authorized(open_id):
             logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
@@ -2775,8 +2774,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        if not self._is_interactive_operator_authorized(open_id):
             logger.warning("[Feishu] Unauthorized update prompt click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
@@ -2867,8 +2865,7 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.debug("[Feishu] Update prompt %s already resolved or unknown", prompt_id)
             return
         if open_id:
-            sender_id = SimpleNamespace(open_id=open_id, user_id="")
-            if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+            if not self._is_interactive_operator_authorized(open_id):
                 logger.warning("[Feishu] Unauthorized update prompt click by %s for prompt %s", open_id, prompt_id)
                 return
         expected_chat_id = str(state.get("chat_id", "") or "")


### PR DESCRIPTION
## Bug

Feishu approval card buttons (Allow Once / Session / Always / Deny) and update prompt card buttons are silently rejected for all DM users in pairing mode.

## Symptom

When a user clicks any button on the approval card in a Feishu DM, the card briefly refreshes back to its default state with no feedback. Gateway logs show:

```
[Feishu] Unauthorized approval click by ou_xxx
```

Every button click is rejected regardless of which button is pressed.

## Root Cause

Three card-action callback handlers use `_allow_group_message()` for authorization, which is designed for **group chat** message gating with a default `allowlist` policy. In **DM pairing mode** (empty `FEISHU_ALLOWED_USERS`), the allowlist is empty, so every click is rejected.

Meanwhile, `_resolve_approval()` already uses `_is_interactive_operator_authorized()`, which returns `True` when no admins/allowlist are configured — consistent with DM message policy.

## Fix

Replace `_allow_group_message()` with `_is_interactive_operator_authorized()` in:
- `_handle_approval_card_action()`
- `_handle_update_prompt_card_action()`
- `_resolve_update_prompt()`

## Verification

- Before: every click logged `WARNING: Unauthorized approval click`, card refreshed to default
- After: click logs `INFO: Feishu button resolved`, card updates to green Approved state