### PR TITLE
fix(mcp): shut down one-shot MCP runtime cleanly

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -126,7 +126,7 @@ def _cleanup_oneshot_runtime() -> None:
         pass
     try:
         from tools.mcp_tool import shutdown_mcp_servers
-        shutdown_mcp_servers()
+        shutdown_mcp_servers(final=True)
     except BaseException:
         pass
     try:

--- a/tests/hermes_cli/test_mcp_security.py
+++ b/tests/hermes_cli/test_mcp_security.py
@@ -207,7 +207,7 @@ def test_explicit_registration_skips_dangerous_entry_before_connect(monkeypatch)
     import tools.mcp_tool as mcp_tool
 
     monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
-    monkeypatch.setattr(mcp_tool, "_ensure_mcp_loop", lambda: None)
+    monkeypatch.setattr(mcp_tool, "_ensure_mcp_loop", lambda: True)
 
     connected = []
 

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -890,7 +890,10 @@ def test_run_and_exit_oneshot_cleans_global_runtime_before_hard_exit(
     monkeypatch.setitem(
         sys.modules,
         "tools.mcp_tool",
-        _mod("tools.mcp_tool", shutdown_mcp_servers=lambda: events.append("mcp")),
+        _mod(
+            "tools.mcp_tool",
+            shutdown_mcp_servers=lambda *, final=False: events.append(f"mcp:{final}"),
+        ),
     )
     monkeypatch.setitem(
         sys.modules,
@@ -903,7 +906,9 @@ def test_run_and_exit_oneshot_cleans_global_runtime_before_hard_exit(
 
     main_mod._run_and_exit_oneshot("hello")
 
-    assert events == ["run", "terminal", "delegation", "browser", "mcp", "aux", "exit:0"]
+    assert events == [
+        "run", "terminal", "delegation", "browser", "mcp:True", "aux", "exit:0",
+    ]
 
 
 def test_run_and_exit_oneshot_still_exits_when_global_cleanup_raises(
@@ -911,7 +916,7 @@ def test_run_and_exit_oneshot_still_exits_when_global_cleanup_raises(
 ):
     events = []
 
-    def _raise_mcp():
+    def _raise_mcp(*, final=False):
         raise RuntimeError("mcp boom")
 
     monkeypatch.setitem(

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1666,6 +1666,103 @@ class TestShutdown:
         # Parallel: ~1s, not ~3s. Allow some margin.
         assert elapsed < 2.5, f"Shutdown took {elapsed:.1f}s, expected ~1s (parallel)"
 
+    def test_run_on_loop_schedules_atomically_with_shutdown_state(self):
+        """The lifecycle lock must cover validation and task submission."""
+        import concurrent.futures
+        import threading
+
+        import agent.async_utils as async_utils
+        import tools.mcp_tool as mcp_mod
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+        mcp_mod._mcp_loop = loop
+        probe_acquired_lock = []
+
+        async def operation():
+            return "ok"
+
+        def observe_schedule_lock(coro, scheduled_loop, **kwargs):
+            del kwargs
+            assert scheduled_loop is loop
+
+            def probe_lock():
+                acquired = mcp_mod._lock.acquire(blocking=False)
+                probe_acquired_lock.append(acquired)
+                if acquired:
+                    mcp_mod._lock.release()
+
+            probe = threading.Thread(target=probe_lock)
+            probe.start()
+            probe.join(timeout=1)
+            coro.close()
+            future = concurrent.futures.Future()
+            future.set_result("ok")
+            return future
+
+        try:
+            with patch.object(
+                async_utils,
+                "safe_schedule_threadsafe",
+                side_effect=observe_schedule_lock,
+            ):
+                assert mcp_mod._run_on_mcp_loop(operation) == "ok"
+        finally:
+            mcp_mod._mcp_loop = None
+
+        assert probe_acquired_lock == [False]
+
+    def test_shutdown_cancels_connecting_server_task_before_loop_close(self):
+        """A one-shot exit must drain an MCP task still connecting in background.
+
+        CLI startup discovers MCP servers on a daemon thread. A fast one-shot
+        can finish before that thread publishes its server into ``_servers``.
+        Closing the loop while ``MCPServerTask.run`` is still pending leaves the
+        coroutine to be finalized after loop close, producing the observed
+        ``RuntimeError: Event loop is closed`` cleanup traceback.
+        """
+        import concurrent.futures
+        import threading
+
+        import tools.mcp_tool as mcp_mod
+        from tools.mcp_tool import MCPServerTask, shutdown_mcp_servers, _servers
+
+        _servers.clear()
+        entered = threading.Event()
+        cleaned_up = threading.Event()
+        server = MCPServerTask("still-connecting")
+        mcp_mod._server_connecting.add(server.name)
+
+        async def wait_forever(self, config):
+            entered.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                # This must execute while the owning loop is still alive.
+                asyncio.get_running_loop().call_soon(cleaned_up.set)
+
+        mcp_mod._ensure_mcp_loop()
+        loop = mcp_mod._mcp_loop
+        assert loop is not None
+        with patch.object(MCPServerTask, "_run_stdio", wait_forever):
+            future = asyncio.run_coroutine_threadsafe(
+                server.run({"command": "test"}), loop
+            )
+            assert entered.wait(timeout=2)
+
+            try:
+                shutdown_mcp_servers()
+            finally:
+                mcp_mod._stop_mcp_loop()
+                mcp_mod._mcp_loop = None
+                mcp_mod._mcp_thread = None
+
+        assert cleaned_up.wait(timeout=1)
+        assert future.done()
+        with pytest.raises(concurrent.futures.CancelledError):
+            future.result()
+        assert not mcp_mod._server_connecting
+
 
 # ---------------------------------------------------------------------------
 # _build_safe_env

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1552,12 +1552,35 @@ class TestGracefulFallback:
 # ---------------------------------------------------------------------------
 
 class TestShutdown:
+    def test_final_shutdown_prevents_late_loop_restart(self):
+        """One-shot teardown must not let stale discovery recreate the loop."""
+        import tools.mcp_tool as mcp_mod
+
+        mcp_mod._servers.clear()
+        mcp_mod._mcp_final_shutdown = False
+        try:
+            mcp_mod.shutdown_mcp_servers(final=True)
+
+            assert mcp_mod._ensure_mcp_loop() is False
+            assert mcp_mod.register_mcp_servers(
+                {"late": {"command": "late-discovery"}}
+            ) == []
+            assert mcp_mod._mcp_loop is None
+            assert not mcp_mod._server_connecting
+        finally:
+            mcp_mod._mcp_final_shutdown = False
+
     def test_no_servers_safe(self):
         """shutdown_mcp_servers with no servers does nothing."""
+        import tools.mcp_tool as mcp_mod
         from tools.mcp_tool import shutdown_mcp_servers, _servers
 
         _servers.clear()
         shutdown_mcp_servers()  # Should not raise
+        try:
+            assert mcp_mod._ensure_mcp_loop() is True
+        finally:
+            mcp_mod._stop_mcp_loop()
 
     def test_shutdown_clears_servers(self):
         """shutdown_mcp_servers calls shutdown() on each server and clears dict."""

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3859,31 +3859,34 @@ def _run_on_mcp_loop(coro_or_factory, timeout: float = 30):
 
     with _lock:
         loop = _mcp_loop
-    if loop is None or not loop.is_running():
-        if asyncio.iscoroutine(coro_or_factory):
-            coro_or_factory.close()
-        raise RuntimeError("MCP event loop is not running")
+        if loop is None or not loop.is_running():
+            if asyncio.iscoroutine(coro_or_factory):
+                coro_or_factory.close()
+            raise RuntimeError("MCP event loop is not running")
 
-    coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+        coro: Any = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
 
-    # Propagate the context-local HERMES_HOME override onto the MCP loop.
-    # Tasks scheduled via run_coroutine_threadsafe are created INSIDE the
-    # loop thread, so they copy the loop thread's context — not the
-    # scheduling thread's. A per-request profile scope (the dashboard's
-    # ?profile= endpoints, e.g. the MCP "Test server" probe) would silently
-    # vanish here: OAuth token stores and any other get_hermes_home()
-    # resolution inside the coroutine would read the process home instead
-    # of the selected profile's. Re-establish the override inside the
-    # task's own context (task-local — concurrent calls carrying different
-    # scopes don't interfere). No-op when no override is active.
-    coro = _wrap_with_home_override(coro)
-    coro = _wrap_with_dashboard_oauth_flow(coro)
+        # Propagate the context-local HERMES_HOME override onto the MCP loop.
+        # Tasks scheduled via run_coroutine_threadsafe are created INSIDE the
+        # loop thread, so they copy the loop thread's context — not the
+        # scheduling thread's. A per-request profile scope (the dashboard's
+        # ?profile= endpoints, e.g. the MCP "Test server" probe) would silently
+        # vanish here: OAuth token stores and any other get_hermes_home()
+        # resolution inside the coroutine would read the process home instead
+        # of the selected profile's. Re-establish the override inside the
+        # task's own context (task-local — concurrent calls carrying different
+        # scopes don't interfere). No-op when no override is active.
+        coro = _wrap_with_home_override(coro)
+        coro = _wrap_with_dashboard_oauth_flow(coro)
 
-    future = safe_schedule_threadsafe(
-        coro, loop,
-        logger=logger,
-        log_message="MCP scheduling failed",
-    )
+        # Scheduling and loop invalidation must be atomic. Otherwise one-shot
+        # shutdown can drain an empty task snapshot while a discovery thread
+        # that already captured ``loop`` schedules a new connection afterward.
+        future = safe_schedule_threadsafe(
+            coro, loop,
+            logger=logger,
+            log_message="MCP scheduling failed",
+        )
     if future is None:
         raise RuntimeError("MCP event loop unavailable (failed to schedule)")
     start_time = time.monotonic()
@@ -5876,7 +5879,7 @@ def _kill_orphaned_mcp_children(
 
 
 def _stop_mcp_loop_if_idle() -> bool:
-    """Stop the MCP loop only when no registered server still owns it.
+    """Stop the shared MCP loop only when no registered/connect-in-flight work exists.
 
     Probe paths create temporary MCPServerTask instances that are not placed in
     ``_servers``.  They should clean up an otherwise-idle loop, but must not
@@ -5887,8 +5890,37 @@ def _stop_mcp_loop_if_idle() -> bool:
     return _stop_mcp_loop(only_if_idle=True)
 
 
+async def _cancel_pending_mcp_tasks() -> None:
+    """Cancel and drain every remaining task on the dedicated MCP loop.
+
+    A fast one-shot CLI invocation can finish while background MCP discovery is
+    still connecting. Those ``MCPServerTask.run`` instances are not yet present
+    in ``_servers``, so the normal graceful server shutdown cannot see them.
+    They must still unwind on their owning loop before it is closed; otherwise
+    their transport context managers are finalized later and raise
+    ``RuntimeError: Event loop is closed`` (or ``no running event loop``).
+    """
+    current = asyncio.current_task()
+    # Cancellation cleanup (notably anyio/subprocess teardown) may spawn a
+    # follow-up task. Re-snapshot a few times so those helpers are drained too,
+    # without allowing a cancellation-resistant task to hang shutdown forever.
+    for _ in range(3):
+        pending = [
+            task
+            for task in asyncio.all_tasks()
+            if task is not current and not task.done()
+        ]
+        if not pending:
+            break
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+
+    await asyncio.get_running_loop().shutdown_asyncgens()
+
+
 def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
-    """Stop the background event loop and join its thread."""
+    """Drain pending MCP work, then stop the background loop and join its thread."""
     global _mcp_loop, _mcp_thread
     with _lock:
         if only_if_idle and (_servers or _server_connecting):
@@ -5896,9 +5928,26 @@ def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
             return False
         loop = _mcp_loop
         thread = _mcp_thread
+        # Publish the stopped state before draining so no new callers can race
+        # onto this loop after the pending-task snapshot is taken.
         _mcp_loop = None
         _mcp_thread = None
+        _server_connecting.clear()
     if loop is not None:
+        if loop.is_running():
+            drain_coro = _cancel_pending_mcp_tasks()
+            try:
+                drain_future = asyncio.run_coroutine_threadsafe(drain_coro, loop)
+            except Exception:
+                drain_coro.close()
+                logger.debug("Could not schedule MCP pending-task drain", exc_info=True)
+            else:
+                try:
+                    drain_future.result(timeout=5)
+                except concurrent.futures.TimeoutError:
+                    logger.warning("Timed out draining pending MCP tasks before loop shutdown")
+                except Exception:
+                    logger.debug("Error draining pending MCP tasks", exc_info=True)
         loop.call_soon_threadsafe(loop.stop)
         if thread is not None:
             thread.join(timeout=5)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3651,6 +3651,7 @@ _mcp_tool_server_names: Dict[str, str] = {}
 # Dedicated event loop running in a background daemon thread.
 _mcp_loop: Optional[asyncio.AbstractEventLoop] = None
 _mcp_thread: Optional[threading.Thread] = None
+_mcp_final_shutdown = False
 
 # Protects _mcp_loop, _mcp_thread, _servers, MCP connection status maps,
 # _parallel_safe_servers, _mcp_tool_server_names, and _stdio_pids.
@@ -3775,12 +3776,14 @@ def _mcp_loop_exception_handler(loop, context):
     loop.default_exception_handler(context)
 
 
-def _ensure_mcp_loop():
+def _ensure_mcp_loop() -> bool:
     """Start the background event loop thread if not already running."""
     global _mcp_loop, _mcp_thread
     with _lock:
+        if _mcp_final_shutdown:
+            return False
         if _mcp_loop is not None and _mcp_loop.is_running():
-            return
+            return True
         _mcp_loop = asyncio.new_event_loop()
         _mcp_loop.set_exception_handler(_mcp_loop_exception_handler)
         _mcp_thread = threading.Thread(
@@ -3789,6 +3792,7 @@ def _ensure_mcp_loop():
             daemon=True,
         )
         _mcp_thread.start()
+        return True
 
 
 def _wrap_with_home_override(coro: "Coroutine") -> "Coroutine":
@@ -5186,6 +5190,8 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     # Only attempt servers that aren't already connected and are enabled
     # (enabled: false skips the server entirely without removing its config)
     with _lock:
+        if _mcp_final_shutdown:
+            return []
         new_servers = {
             k: v
             for k, v in servers.items()
@@ -5218,7 +5224,10 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         return _existing_tool_names()
 
     # Start the background event loop for MCP connections
-    _ensure_mcp_loop()
+    if not _ensure_mcp_loop():
+        with _lock:
+            _server_connecting.difference_update(new_servers)
+        return []
 
     async def _discover_one(name: str, cfg: dict) -> List[str]:
         """Connect to a single server and return its registered tool names."""
@@ -5704,14 +5713,20 @@ def _reinject_post_build_tools(agent, tools_list: list, name_set: set) -> set:
     return staged_engine_names
 
 
-def shutdown_mcp_servers():
+def shutdown_mcp_servers(*, final: bool = False):
     """Close all MCP server connections and stop the background loop.
 
     Each server Task is signalled to exit its ``async with`` block so that
     the anyio cancel-scope cleanup happens in the same Task that opened it.
     All servers are shut down in parallel via ``asyncio.gather``.
+
+    ``final=True`` also prevents late background discovery from recreating the
+    loop during one-shot process teardown. Normal shutdown remains restartable.
     """
+    global _mcp_final_shutdown
     with _lock:
+        if final:
+            _mcp_final_shutdown = True
         servers_snapshot = list(_servers.values())
 
     # Fast path: nothing to shut down.


### PR DESCRIPTION
## Summary
- add deterministic one-shot runtime cleanup before the hard process exit
- drain and cancel pending MCP loop tasks before closing the loop
- prevent late background MCP discovery from recreating the loop during final teardown while keeping normal shutdown restartable
- cover pending-task, late-discovery, restart, cleanup ordering, and MCP security paths

## Verification
- targeted 7-file MCP/one-shot suite: 344 passed
- `ruff check` on all changed Python files
- `git diff --check`
- 5/5 final-shutdown race smokes plus normal restart smoke
- independent Claude Fable 5 review: APPROVE, no blocking/high/medium findings

## Notes
Normal `shutdown_mcp_servers()` remains restartable for persistent gateway/TUI reconnect flows. Only one-shot process teardown uses `final=True`.