### PR TITLE
fix(streaming): preserve provider response ID in Chat Completions stream aggregation (#67957)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2753,6 +2753,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         role = "assistant"
         reasoning_parts: list = []
         usage_obj = None
+        provider_response_id: str = ""
         for chunk in stream:
             # Stop the moment a newer attempt has claimed the delta sink
             # (#65991): this attempt has been superseded, so it must neither
@@ -2768,6 +2769,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 break
             last_chunk_time["t"] = time.time()
             agent._touch_activity("receiving stream response")
+
+            # Capture the provider-supplied response ID from the first
+            # chunk that carries one.  Providers (OpenAI, vLLM, etc.)
+            # send a stable ID across all chunks in one call; we
+            # preserve it so callers can correlate with provider-side
+            # logs and response records (#67957).
+            if not provider_response_id:
+                _chunk_id = getattr(chunk, "id", None)
+                if isinstance(_chunk_id, str) and _chunk_id:
+                    provider_response_id = _chunk_id
 
             # Update per-attempt diagnostic counters.  Best-effort —
             # failures are swallowed so the streaming hot path is never
@@ -3053,7 +3064,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             finish_reason=effective_finish_reason,
         )
         return SimpleNamespace(
-            id="stream-" + str(uuid.uuid4()),
+            id=provider_response_id or ("stream-" + str(uuid.uuid4())),
             model=model_name,
             choices=[mock_choice],
             usage=usage_obj,


### PR DESCRIPTION
## Problem

When Hermes aggregates an OpenAI-compatible Chat Completions stream, it discards the provider-supplied `chunk.id` and returns a newly generated `stream-<uuid>` ID. This prevents callers from correlating the final response with provider-side logs and response records.

Fixes #67957

## Root Cause

`_call_chat_completions()` accumulates content, tool calls, model and usage from each chunk, but never captures `chunk.id`. The final `SimpleNamespace` unconditionally sets `id="stream-" + str(uuid.uuid4())`.

## Fix

- Capture the first non-empty `chunk.id` during stream iteration (after single-writer and active-attempt checks).
- Return the provider ID when present; preserve the existing synthetic `stream-<uuid>` ID as fallback.
- Anthropic Messages and Responses API streaming paths already preserve their native IDs — this brings Chat Completions to parity.

## Changes

`agent/chat_completion_helpers.py`:
- Add `provider_response_id` accumulator before the stream loop.
- Capture `chunk.id` on the first chunk that carries one.
- Use `provider_response_id or ("stream-" + str(uuid.uuid4()))` in the final response.

## Acceptance Criteria

- [x] Provider response IDs are preserved for Chat Completions streams.
- [x] A usage-only final chunk without an ID does not erase the captured ID.
- [x] Streams without IDs retain the existing `stream-*` fallback.
- [x] Retry and superseded-stream attempts cannot leak IDs into each other (capture is per-attempt).
- [x] Non-streaming, Anthropic Messages and Responses API behavior unchanged.