### PR TITLE
fix(footer): show runtime provider, not configured primary, in OpenClaw footer

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -418,6 +418,8 @@ def finalize_turn(
                 session_id=agent.session_id or "",
                 model=agent.model,
                 platform=getattr(agent, "platform", None) or "",
+                provider=getattr(agent, "provider", None),
+                agent=getattr(agent, "agent_id", None) or getattr(agent, "id", None),
             )
             for _hook_result in _transform_results:
                 if isinstance(_hook_result, str) and _hook_result:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13085,6 +13085,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
+                    provider=agent_result.get("provider"),
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)
@@ -21016,6 +21017,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
+                    "provider": getattr(_agent, "provider", None),
                     "context_length": _context_length,
                 }
 
@@ -21132,6 +21134,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,
                 "model": _resolved_model,
+                "provider": getattr(_agent, "provider", None),
                 "context_length": _context_length,
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -95,6 +95,7 @@ def format_runtime_footer(
     context_length: Optional[int],
     cwd: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
+    provider: Optional[str] = None,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
 
@@ -107,6 +108,10 @@ def format_runtime_footer(
             m = _model_short(model)
             if m:
                 parts.append(m)
+        elif field == "provider":
+            p = (provider or "").strip()
+            if p:
+                parts.append(p)
         elif field == "context_pct":
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
@@ -130,20 +135,35 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    provider: Optional[str] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
     Returns the footer text (empty string when disabled or no data).  Callers
     append this to the final response themselves, preserving a single blank
     line of separation.
+
+    ``provider`` should be the provider that actually answered the turn (read
+    from the agent_result dict so a fallback switch is reflected correctly).
+    When it is missing we fall back to ``model.provider`` from config so the
+    footer still has something to show rather than an empty slot — this keeps
+    legacy call sites that don't yet propagate a provider populated.
     """
     cfg = resolve_footer_config(user_config, platform_key)
     if not cfg.get("enabled"):
         return ""
+
+    effective_provider = (provider or "").strip()
+    if not effective_provider:
+        model_cfg = (user_config or {}).get("model") or {}
+        if isinstance(model_cfg, dict):
+            effective_provider = str(model_cfg.get("provider") or "").strip()
+
     return format_runtime_footer(
         model=model,
         context_tokens=context_tokens,
         context_length=context_length,
         cwd=cwd,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
+        provider=effective_provider or None,
     )

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -260,3 +260,71 @@ def test_build_footer_no_data_returns_empty_even_when_enabled():
     # With no TERMINAL_CWD env either
     if not os.environ.get("TERMINAL_CWD"):
         assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# Provider propagation — fix for the "footer shows configured primary instead
+# of the runtime provider that actually answered the turn" bug.
+# ---------------------------------------------------------------------------
+
+def test_provider_field_renders_runtime_provider():
+    user = {"display": {"runtime_footer": {
+        "enabled": True,
+        "fields": ["model", "provider"],
+    }}}
+    out = build_footer_line(
+        user_config=user, platform_key="feishu",
+        model="volces-agent/GLM-5.2",
+        context_tokens=0, context_length=None, cwd="",
+        provider="volces-agent",
+    )
+    assert out == "GLM-5.2 · volces-agent"
+
+
+def test_provider_reflects_runtime_fallback_not_config():
+    """The bug: footer showed config's model.provider (kimi) while the agent
+    actually ran volces-agent after a fallback switch.  build_footer_line must
+    prefer the runtime-propagated provider."""
+    user = {"display": {"runtime_footer": {
+        "enabled": True,
+        "fields": ["model", "provider"],
+    }}, "model": {"provider": "kimi"}}  # configured primary, NOT what ran
+    out = build_footer_line(
+        user_config=user, platform_key="feishu",
+        model="GLM-5.2",
+        context_tokens=0, context_length=None, cwd="",
+        provider="volces-agent",  # what actually answered
+    )
+    assert "volces-agent" in out
+    assert "kimi" not in out
+
+
+def test_provider_falls_back_to_config_when_runtime_missing():
+    """Legacy call sites that don't propagate provider yet should still get a
+    populated field from config's model.provider, not an empty slot."""
+    user = {"display": {"runtime_footer": {
+        "enabled": True,
+        "fields": ["model", "provider"],
+    }}, "model": {"provider": "kimi"}}
+    out = build_footer_line(
+        user_config=user, platform_key="feishu",
+        model="k3",
+        context_tokens=0, context_length=None, cwd="",
+        provider=None,  # runtime didn't propagate (old run.py)
+    )
+    assert "kimi" in out
+
+
+def test_provider_omitted_when_neither_runtime_nor_config():
+    user = {"display": {"runtime_footer": {
+        "enabled": True,
+        "fields": ["model", "provider"],
+    }}}
+    out = build_footer_line(
+        user_config=user, platform_key="feishu",
+        model="gpt-5.4",
+        context_tokens=0, context_length=None, cwd="",
+        provider=None,
+    )
+    # No provider anywhere -> field silently dropped, no trailing separator
+    assert out == "gpt-5.4"


### PR DESCRIPTION
## Problem

The footer displayed `model.provider` from config instead of the provider that actually answered the turn. After a fallback switch this was wrong — e.g. showing `Provider: kimi` while the agent ran `volces-agent`.

## Root cause

`agent/turn_finalizer.py` invoked the `transform_llm_output` hook without passing `provider`, so the runtime-footer plugin fell back to `config.model.provider`. `gateway/run.py` likewise did not propagate the runtime provider into the `agent_result` dicts consumed by the built-in footer path.

## Changes (scoped to provider propagation only)

Per triage feedback, this PR is now scoped strictly to the provider-propagation bug. The broader OpenClaw footer formatting / field-behavior work stays in #66372.

- **`agent/turn_finalizer.py`** — pass `provider=getattr(agent, "provider", None)` and the agent id into the `transform_llm_output` hook call. *(root fix)*
- **`gateway/run.py`** — include `"provider": getattr(_agent, "provider", None)` in both `agent_result` dicts; pass `provider` to `build_footer_line`.
- **`gateway/runtime_footer.py`** — add a `provider` param to `format_runtime_footer` and `build_footer_line`; falls back to `config.model.provider` only when the runtime value is missing (legacy call sites stay populated).
- **`tests/gateway/test_runtime_footer.py`** — +4 cases: runtime provider wins over config, config fallback, omitted-when-both-missing.

## Verification

- `venv/bin/python -m pytest tests/gateway/test_runtime_footer.py -q` → **29 passed**
- End-to-end: with `provider="volces-agent"` propagated, the footer now shows `volces-agent` instead of `kimi` (the configured primary).

## Relationship to #66372 / #62277

This PR is now orthogonal to both: it only fixes the provider-display root cause (the `transform_llm_output` hook not receiving the runtime provider). OpenClaw footer formatting and field-behavior enhancements remain in #66372. #62277 (CLI status-bar provider display) is a separate surface.