### PR TITLE
fix(config): mask inline fallback provider keys in hermes dump

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -37,6 +37,26 @@ _SENSITIVE_QUERY_PARAMS = frozenset({
     "x-amz-signature",
 })
 
+
+def is_sensitive_query_param(name: str) -> bool:
+    """True when a URL query parameter name is known to carry a credential.
+
+    The public way to ask that question, so callers outside this module —
+    ``hermes dump`` masks fallback-provider endpoints this way — follow the
+    set above instead of keeping a second list that drifts away from it.
+
+    Both spellings are consulted: the plain fold reaches the one hyphenated
+    entry (``x-amz-signature``), while the canonical form folds "-" to "_" so
+    ``access-token`` reaches the underscored entries.
+    """
+    if not isinstance(name, str):
+        return False
+    return (
+        name.casefold() in _SENSITIVE_QUERY_PARAMS
+        or _canonical_url_param_name(name) in _SENSITIVE_QUERY_PARAMS
+    )
+
+
 # Sensitive form-urlencoded / JSON body key names (case-insensitive exact match).
 # Exact match, NOT substring — "token_count" and "session_id" must NOT match.
 # Ported from nearai/ironclaw#2529.

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -321,7 +321,8 @@ def _mask_url_credentials(value: str) -> str:
     delimiters), so a policy that stopped at ``?`` would just be a hole with a
     good excuse.
     """
-    from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+    import re
+    from urllib.parse import unquote_plus, urlsplit, urlunsplit
 
     try:
         parts = urlsplit(value)
@@ -339,21 +340,38 @@ def _mask_url_credentials(value: str) -> str:
         return value
 
     def _mask_params(component: str) -> tuple[str, bool]:
-        """Redact credential-named pairs in one parameter component."""
+        """Redact credential-named pairs in one parameter component.
+
+        Split on ``&`` *and* ``;``. ``parse_qsl`` stopped honouring ``;`` in
+        CPython 3.9.2 (bpo-42967) because a *request parser* that accepts both
+        separators can be induced to disagree with the proxy in front of it.
+        A masker carries no such exposure — reading both can only mask more,
+        never less, and its output never re-enters request handling — and
+        ``agent/redact.py`` already calls ``;`` a separator
+        (``_STRICT_URL_PARAM_RE``). Left to ``parse_qsl``,
+        ``?region=eu;signature=<secret>`` is one pair named ``region`` and the
+        secret ships whole.
+
+        Separators and untouched pairs are copied through verbatim rather than
+        re-encoded, so the endpoint stays the URL the user typed.
+        """
         if not component:
             return component, False
-        pairs = parse_qsl(component, keep_blank_values=True)
-        if not any(_is_sensitive_query_param(name) for name, _ in pairs):
+        out: list[str] = []
+        changed = False
+        for token in re.split(r"([&;])", component):
+            if token in ("&", ";"):
+                out.append(token)
+                continue
+            name, sep, val = token.partition("=")
+            if sep and val and _is_sensitive_query_param(unquote_plus(name)):
+                out.append(f"{name}={_redact(val)}")
+                changed = True
+            else:
+                out.append(token)
+        if not changed:
             return component, False
-        return (
-            urlencode(
-                [
-                    (name, _redact(val) if val and _is_sensitive_query_param(name) else val)
-                    for name, val in pairs
-                ]
-            ),
-            True,
-        )
+        return "".join(out), True
 
     netloc = parts.netloc
     changed = False

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -312,7 +312,15 @@ def _is_sensitive_query_param(name) -> bool:
 
 
 def _mask_url_credentials(value: str) -> str:
-    """Strip userinfo and redact secret query parameters from a URL."""
+    """Strip userinfo and redact secret parameters from a URL.
+
+    Both parameter-bearing components are masked. A credential does not care
+    which separator introduced it: OAuth implicit-flow hands back its token
+    after ``#``, and ``agent/redact.py`` classifies query and fragment pairs
+    with the same set (``_STRICT_URL_PARAM_RE`` carries ``#`` among its
+    delimiters), so a policy that stopped at ``?`` would just be a hole with a
+    good excuse.
+    """
     from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
     try:
@@ -324,8 +332,28 @@ def _mask_url_credentials(value: str) -> str:
     except ValueError:
         # Unparseable (e.g. a bad port) — refuse rather than guess.
         return _FALLBACK_OMITTED
-    if not parts.scheme or not parts.netloc:
+    # A scheme-relative reference (``//user:pass@host/v1``) has no scheme and
+    # still carries userinfo, so the authority — not the scheme — is what makes
+    # this a URL worth masking.
+    if not parts.netloc:
         return value
+
+    def _mask_params(component: str) -> tuple[str, bool]:
+        """Redact credential-named pairs in one parameter component."""
+        if not component:
+            return component, False
+        pairs = parse_qsl(component, keep_blank_values=True)
+        if not any(_is_sensitive_query_param(name) for name, _ in pairs):
+            return component, False
+        return (
+            urlencode(
+                [
+                    (name, _redact(val) if val and _is_sensitive_query_param(name) else val)
+                    for name, val in pairs
+                ]
+            ),
+            True,
+        )
 
     netloc = parts.netloc
     changed = False
@@ -336,21 +364,13 @@ def _mask_url_credentials(value: str) -> str:
         netloc = f"***@{host}" if host else "***"
         changed = True
 
-    query = parts.query
-    if query:
-        pairs = parse_qsl(query, keep_blank_values=True)
-        if any(_is_sensitive_query_param(name) for name, _ in pairs):
-            query = urlencode(
-                [
-                    (name, _redact(val) if val and _is_sensitive_query_param(name) else val)
-                    for name, val in pairs
-                ]
-            )
-            changed = True
+    query, query_masked = _mask_params(parts.query)
+    fragment, fragment_masked = _mask_params(parts.fragment)
+    changed = changed or query_masked or fragment_masked
 
     if not changed:
         return value
-    return urlunsplit((parts.scheme, netloc, parts.path, query, parts.fragment))
+    return urlunsplit((parts.scheme, netloc, parts.path, query, fragment))
 
 
 def _mask_fallback_value(name, value, depth: int):

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -291,6 +291,26 @@ def _fallback_placeholder(value) -> str:
     return f"<omitted: {type(value).__name__}>"
 
 
+def _is_sensitive_query_param(name) -> bool:
+    """True when a URL query parameter name carries a credential.
+
+    The repository already owns this policy in ``agent.redact``, and it lists
+    names the field-name markers above cannot reach — ``signature``,
+    ``x-amz-signature``, ``code`` — so a pre-signed URL or an OAuth callback
+    would otherwise print its secret in full. Ask that policy first, so this
+    path stays in step with it as it grows, and fall back to the markers for
+    names it doesn't list (``access_key``, ``auth_token``, ``client_secret``).
+    """
+    if not isinstance(name, str):
+        return False
+
+    from agent.redact import is_sensitive_query_param
+
+    if is_sensitive_query_param(name):
+        return True
+    return _is_fallback_secret_field(name)
+
+
 def _mask_url_credentials(value: str) -> str:
     """Strip userinfo and redact secret query parameters from a URL."""
     from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
@@ -319,10 +339,10 @@ def _mask_url_credentials(value: str) -> str:
     query = parts.query
     if query:
         pairs = parse_qsl(query, keep_blank_values=True)
-        if any(_is_fallback_secret_field(name) for name, _ in pairs):
+        if any(_is_sensitive_query_param(name) for name, _ in pairs):
             query = urlencode(
                 [
-                    (name, _redact(val) if val and _is_fallback_secret_field(name) else val)
+                    (name, _redact(val) if val and _is_sensitive_query_param(name) else val)
                     for name, val in pairs
                 ]
             )

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -223,9 +223,41 @@ def _get_model_and_provider(config: dict) -> tuple[str, str]:
     return model, provider
 
 
+# Fallback-provider entry fields whose VALUES are secrets. Env-var *names*
+# (``key_env`` / ``api_key_env``) are intentionally excluded — they name a
+# variable, not a secret, and are safe to show.
+_FALLBACK_SECRET_KEYS = frozenset(
+    {"api_key", "apikey", "key", "token", "secret", "password"}
+)
+
+
+def _mask_fallback_secrets(fallbacks):
+    """Copy the fallback-provider list with inline credential values masked.
+
+    ``hermes dump`` output is copy-pasted into public bug reports and uploaded
+    verbatim by ``hermes debug share``, so an inline ``api_key`` must never
+    appear in full. Values are masked through :func:`_redact` (head/tail only),
+    matching how the dump shows every other key. Non-dict entries and non-string
+    values pass through unchanged.
+    """
+    if not isinstance(fallbacks, list):
+        return fallbacks
+    masked = []
+    for entry in fallbacks:
+        if not isinstance(entry, dict):
+            masked.append(entry)
+            continue
+        safe = dict(entry)
+        for field, value in safe.items():
+            if field.lower() in _FALLBACK_SECRET_KEYS and isinstance(value, str) and value:
+                safe[field] = _redact(value)
+        masked.append(safe)
+    return masked
+
+
 def _config_overrides(config: dict) -> dict[str, str]:
     """Find non-default config values worth reporting.
-    
+
     Returns a flat dict of dotpath -> value for interesting overrides.
     """
     from hermes_cli.config import DEFAULT_CONFIG
@@ -267,10 +299,11 @@ def _config_overrides(config: dict) -> dict[str, str]:
     if user_toolsets != default_toolsets:
         overrides["toolsets"] = str(user_toolsets)
 
-    # Fallback providers
+    # Fallback providers — mask inline credentials before serializing; this
+    # block is uploaded verbatim by ``hermes debug share``.
     fallbacks = config.get("fallback_providers", [])
     if fallbacks:
-        overrides["fallback_providers"] = str(fallbacks)
+        overrides["fallback_providers"] = str(_mask_fallback_secrets(fallbacks))
 
     return overrides
 

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -223,36 +223,174 @@ def _get_model_and_provider(config: dict) -> tuple[str, str]:
     return model, provider
 
 
-# Fallback-provider entry fields whose VALUES are secrets. Env-var *names*
-# (``key_env`` / ``api_key_env``) are intentionally excluded — they name a
-# variable, not a secret, and are safe to show.
-_FALLBACK_SECRET_KEYS = frozenset(
-    {"api_key", "apikey", "key", "token", "secret", "password"}
+# Substrings marking a fallback-provider field as carrying a secret VALUE.
+# Matched against the lowercased field name so siblings of ``api_key`` —
+# ``access_key``, ``auth_token``, ``client_secret`` — are covered too.
+_FALLBACK_SECRET_MARKERS = (
+    "key",
+    "token",
+    "secret",
+    "password",
+    "passwd",
+    "credential",
+    "auth",
 )
+
+# Fields matching a marker above that are nonetheless safe to show. ``key_env``
+# and ``api_key_env`` NAME an environment variable rather than holding its
+# value, and operators need them to diagnose routing; the ``*_tokens`` limits
+# are numeric budgets. Anything not listed here fails closed: an unrecognized
+# field whose name matches a marker is masked, costing a diagnostic rather
+# than leaking a credential.
+_FALLBACK_SAFE_FIELDS = frozenset(
+    {
+        "key_env",
+        "api_key_env",
+        "max_tokens",
+        "max_output_tokens",
+        "max_completion_tokens",
+        "token_limit",
+    }
+)
+
+# Fields whose string values are URLs. Credentials hide in userinfo
+# (``https://user:KEY@host``) and in query parameters (``?api_key=KEY``), so
+# these are cleaned rather than shown verbatim.
+_FALLBACK_URL_MARKERS = ("url", "endpoint")
+
+# Stand-in for a value we cannot render safely. Handing an unknown object to
+# ``str()`` would run its ``__repr__``, which may print the very key we are
+# trying to hide.
+_FALLBACK_OMITTED = "<omitted>"
+
+# Bound on nested-container recursion, so a deep or self-referencing config
+# cannot turn the dump into a stack overflow.
+_FALLBACK_MAX_DEPTH = 6
+
+
+def _is_fallback_secret_field(name) -> bool:
+    """True when a field name marks its value as a credential."""
+    if not isinstance(name, str):
+        return False
+    lowered = name.lower()
+    if lowered in _FALLBACK_SAFE_FIELDS:
+        return False
+    return any(marker in lowered for marker in _FALLBACK_SECRET_MARKERS)
+
+
+def _is_fallback_url_field(name) -> bool:
+    """True when a field name marks its value as a URL."""
+    if not isinstance(name, str):
+        return False
+    lowered = name.lower()
+    return any(marker in lowered for marker in _FALLBACK_URL_MARKERS)
+
+
+def _fallback_placeholder(value) -> str:
+    """Describe a value by type instead of rendering it."""
+    return f"<omitted: {type(value).__name__}>"
+
+
+def _mask_url_credentials(value: str) -> str:
+    """Strip userinfo and redact secret query parameters from a URL."""
+    from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+    try:
+        parts = urlsplit(value)
+        username = parts.username
+        password = parts.password
+        hostname = parts.hostname
+        port = parts.port
+    except ValueError:
+        # Unparseable (e.g. a bad port) — refuse rather than guess.
+        return _FALLBACK_OMITTED
+    if not parts.scheme or not parts.netloc:
+        return value
+
+    netloc = parts.netloc
+    changed = False
+    if username or password:
+        host = hostname or ""
+        if port:
+            host = f"{host}:{port}"
+        netloc = f"***@{host}" if host else "***"
+        changed = True
+
+    query = parts.query
+    if query:
+        pairs = parse_qsl(query, keep_blank_values=True)
+        if any(_is_fallback_secret_field(name) for name, _ in pairs):
+            query = urlencode(
+                [
+                    (name, _redact(val) if val and _is_fallback_secret_field(name) else val)
+                    for name, val in pairs
+                ]
+            )
+            changed = True
+
+    if not changed:
+        return value
+    return urlunsplit((parts.scheme, netloc, parts.path, query, parts.fragment))
+
+
+def _mask_fallback_value(name, value, depth: int):
+    """Return a safely renderable copy of one fallback-provider field value."""
+    if depth > _FALLBACK_MAX_DEPTH:
+        return _FALLBACK_OMITTED
+
+    if _is_fallback_secret_field(name):
+        # Only a non-empty string can be shown in the dump's head/tail form.
+        # Bytes, numbers, nested containers and custom objects are dropped —
+        # each of them still stringifies to the credential in full.
+        if isinstance(value, str):
+            return _redact(value) if value else value
+        if value is None or isinstance(value, bool):
+            return value
+        return _FALLBACK_OMITTED
+
+    if isinstance(value, str):
+        return _mask_url_credentials(value) if _is_fallback_url_field(name) else value
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, dict):
+        return _mask_fallback_entry(value, depth + 1)
+    if isinstance(value, (list, tuple)):
+        return [_mask_fallback_value(name, item, depth + 1) for item in value]
+    return _fallback_placeholder(value)
+
+
+def _mask_fallback_entry(entry: dict, depth: int = 0):
+    """Copy one fallback-provider entry with credential values masked."""
+    if depth > _FALLBACK_MAX_DEPTH:
+        return _FALLBACK_OMITTED
+    return {
+        name: _mask_fallback_value(name, value, depth) for name, value in entry.items()
+    }
 
 
 def _mask_fallback_secrets(fallbacks):
-    """Copy the fallback-provider list with inline credential values masked.
+    """Copy the fallback-provider config with inline credential values masked.
 
     ``hermes dump`` output is copy-pasted into public bug reports and uploaded
     verbatim by ``hermes debug share``, so an inline ``api_key`` must never
-    appear in full. Values are masked through :func:`_redact` (head/tail only),
-    matching how the dump shows every other key. Non-dict entries and non-string
-    values pass through unchanged.
+    appear in full. Secret values are masked through :func:`_redact` (head/tail
+    only), matching how the dump shows every other key.
+
+    Both container shapes ``fallback_config._iter_fallback_entries`` accepts are
+    handled: a list of entries, and a single entry given as a bare mapping.
+    Whatever is left cannot be shown safely — ``str()`` on an arbitrary object
+    runs its ``__repr__`` — so it is replaced by a type marker.
     """
-    if not isinstance(fallbacks, list):
-        return fallbacks
-    masked = []
-    for entry in fallbacks:
-        if not isinstance(entry, dict):
-            masked.append(entry)
-            continue
-        safe = dict(entry)
-        for field, value in safe.items():
-            if field.lower() in _FALLBACK_SECRET_KEYS and isinstance(value, str) and value:
-                safe[field] = _redact(value)
-        masked.append(safe)
-    return masked
+    if isinstance(fallbacks, dict):
+        return _mask_fallback_entry(fallbacks)
+    if isinstance(fallbacks, (list, tuple)):
+        return [
+            _mask_fallback_entry(entry)
+            if isinstance(entry, dict)
+            else _fallback_placeholder(entry)
+            for entry in fallbacks
+        ]
+    return _fallback_placeholder(fallbacks)
 
 
 def _config_overrides(config: dict) -> dict[str, str]:

--- a/tests/agent/test_redact_query_param_policy.py
+++ b/tests/agent/test_redact_query_param_policy.py
@@ -1,0 +1,37 @@
+"""One place decides whether a URL query parameter carries a credential.
+
+``_SENSITIVE_QUERY_PARAMS`` is the repository's answer to that question, and
+`hermes dump` masks fallback-provider endpoints through it rather than keeping
+a second name list of its own — a second list drifts, and the drift is silent
+until a secret is already on a public paste. These tests pin the predicate that
+makes the sharing possible.
+"""
+
+from agent.redact import is_sensitive_query_param
+
+
+def test_listed_names_match_regardless_of_case_or_separator():
+    for name in (
+        "signature",
+        "SIGNATURE",
+        "x-amz-signature",
+        "X-Amz-Signature",
+        "code",
+        "access_token",
+        "access-token",
+        "api_key",
+        "client_secret",
+    ):
+        assert is_sensitive_query_param(name), name
+
+
+def test_public_parameters_are_left_alone():
+    # Masking these would cost diagnostics and buy no safety.
+    for name in ("region", "model", "max_tokens", "version", "stream"):
+        assert not is_sensitive_query_param(name), name
+
+
+def test_non_string_names_do_not_raise():
+    # Query names come from parsed config, which is whatever the user wrote.
+    assert not is_sensitive_query_param(None)
+    assert not is_sensitive_query_param(42)

--- a/tests/hermes_cli/test_dump_fallback_key_redaction.py
+++ b/tests/hermes_cli/test_dump_fallback_key_redaction.py
@@ -1,0 +1,96 @@
+"""`hermes dump` / `hermes debug share` must not emit inline fallback keys.
+
+``_config_overrides`` used to serialize the raw ``fallback_providers`` list
+verbatim (``str(fallbacks)``), so an inline ``api_key`` landed in the dump —
+which the bug-report template tells users to paste publicly and which
+``hermes debug share`` uploads to a public paste service. Redaction on the
+upload path never covered the dump text, and the downstream text redactor
+misses custom-endpoint keys that carry no vendor prefix. The fix masks inline
+credential values at the source, where the field names are known.
+"""
+
+from types import SimpleNamespace
+
+from hermes_cli import dump
+
+# A vendor-prefixed key and a prefix-less custom-endpoint key. The second is
+# the case a pattern-based text redactor cannot catch — it only works because
+# we mask by field name at the source.
+_SK_KEY = "sk-live-abcdef0123456789-DO-NOT-SHIP"
+_CUSTOM_KEY = "Zx9Qw3Rt7Kp2Mn5Bv8Lc4Hs1Df6Gj0"
+
+
+def _fallback_entry(**extra):
+    entry = {
+        "name": "my-backup",
+        "provider": "openai",
+        "model": "gpt-4o",
+        "base_url": "https://api.example.com/v1",
+    }
+    entry.update(extra)
+    return entry
+
+
+def test_config_overrides_masks_inline_api_key():
+    out = dump._config_overrides(
+        {"fallback_providers": [_fallback_entry(api_key=_SK_KEY)]}
+    )
+    rendered = out["fallback_providers"]
+    assert _SK_KEY not in rendered
+    # masked form keeps head/tail only, per the dump's own convention
+    assert "sk-l" in rendered and "SHIP" in rendered
+    # non-secret structure is preserved so the dump stays useful
+    assert "my-backup" in rendered and "https://api.example.com/v1" in rendered
+
+
+def test_config_overrides_masks_prefixless_custom_key():
+    # The downstream text redactor misses this shape; source masking catches it.
+    out = dump._config_overrides(
+        {"fallback_providers": [_fallback_entry(provider="custom", api_key=_CUSTOM_KEY)]}
+    )
+    assert _CUSTOM_KEY not in out["fallback_providers"]
+
+
+def test_config_overrides_preserves_key_env_name():
+    # key_env names an environment variable, not a secret — it must stay intact.
+    out = dump._config_overrides(
+        {"fallback_providers": [_fallback_entry(key_env="MY_PROVIDER_KEY")]}
+    )
+    assert "MY_PROVIDER_KEY" in out["fallback_providers"]
+
+
+def test_config_overrides_masks_sibling_secret_fields():
+    out = dump._config_overrides(
+        {"fallback_providers": [_fallback_entry(token="tok-secret-value-1234567890")]}
+    )
+    assert "tok-secret-value-1234567890" not in out["fallback_providers"]
+
+
+def test_dump_output_never_contains_raw_fallback_key(monkeypatch, capsys, tmp_path):
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
+
+    home = get_hermes_home()
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "model: gpt-4o\n"
+        "provider: openai\n"
+        "fallback_providers:\n"
+        "  - name: my-backup\n"
+        "    provider: openai\n"
+        "    model: gpt-4o\n"
+        "    base_url: https://api.example.com/v1\n"
+        f"    api_key: {_SK_KEY}\n",
+        encoding="utf-8",
+    )
+
+    dump.run_dump(SimpleNamespace(show_keys=False))
+    out = capsys.readouterr().out
+
+    # Only a real pass: the block rendered (masked marker present) AND the raw
+    # key is absent. If the block never rendered, the masked marker is missing
+    # and this fails rather than passing vacuously.
+    assert "fallback_providers" in out
+    assert "sk-l...SHIP" in out
+    assert _SK_KEY not in out

--- a/tests/hermes_cli/test_dump_fallback_key_redaction.py
+++ b/tests/hermes_cli/test_dump_fallback_key_redaction.py
@@ -376,6 +376,80 @@ def test_debug_share_upload_never_carries_a_fragment_credential(monkeypatch, tmp
     assert any("state=public-xyz" in payload for payload in uploaded)
 
 
+def test_debug_share_upload_never_carries_a_semicolon_delimited_credential(
+    monkeypatch, tmp_path
+):
+    """Same boundary, for a secret introduced by ``;`` instead of ``&``.
+
+    ``parse_qsl`` splits on ``&`` only since CPython 3.9.2 (bpo-42967), so
+    ``?region=eu;signature=<secret>`` used to parse as the single pair
+    ``region`` — a name nobody classifies as sensitive — and the credential
+    reached the paste intact.
+    """
+    from hermes_cli import debug
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
+
+    home = get_hermes_home()
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "model: gpt-4o\n"
+        "provider: openai\n"
+        "fallback_providers:\n"
+        "  - name: my-backup\n"
+        "    provider: openai\n"
+        "    model: gpt-4o\n"
+        f"    base_url: https://api.example.com/v1?region=eu;signature={_SK_KEY}\n",
+        encoding="utf-8",
+    )
+
+    uploaded: list[str] = []
+
+    def _capture(content: str, expiry_days: int = 7) -> str:
+        uploaded.append(content)
+        return f"https://paste.example/{len(uploaded)}"
+
+    monkeypatch.setattr(debug, "upload_to_pastebin", _capture)
+    monkeypatch.setattr(debug, "_best_effort_sweep_expired_pastes", lambda: None)
+    monkeypatch.setattr(debug, "_schedule_auto_delete", lambda urls: None)
+
+    debug.build_debug_share(log_lines=5, redact=True)
+
+    assert uploaded, "nothing was uploaded — the boundary was never reached"
+    for payload in uploaded:
+        assert _SK_KEY not in payload
+    # Non-vacuous on both sides, and the separator itself survives: a masked
+    # endpoint the user cannot read back is a worse diagnostic than none.
+    assert any("signature=sk-l...SHIP" in payload for payload in uploaded)
+    assert any("region=eu;signature=" in payload for payload in uploaded)
+
+
+def test_semicolon_delimited_fragment_credential_is_masked():
+    """The ``;`` policy holds in the fragment too, not only after ``?``."""
+    out = dump._config_overrides(
+        {
+            "fallback_providers": [
+                _fallback_entry(
+                    base_url=f"https://api.example.com/cb#state=public-xyz;access_token={_SK_KEY}"
+                )
+            ]
+        }
+    )
+
+    assert _SK_KEY not in out["fallback_providers"]
+    assert "access_token=sk-l...SHIP" in out["fallback_providers"]
+    assert "state=public-xyz;" in out["fallback_providers"]
+
+
+def test_ordinary_semicolon_parameters_are_left_alone():
+    """Splitting on ``;`` must not rewrite URLs that carry no credential."""
+    url = "https://api.example.com/v1?a=1;b=2&c=3"
+    out = dump._config_overrides({"fallback_providers": [_fallback_entry(base_url=url)]})
+
+    assert url in out["fallback_providers"]
+
+
 def test_numeric_token_budgets_are_not_mistaken_for_secrets():
     # The name-marker rule fails closed, so the few known-safe fields that
     # contain a marker word must stay readable or the dump loses diagnostics.

--- a/tests/hermes_cli/test_dump_fallback_key_redaction.py
+++ b/tests/hermes_cli/test_dump_fallback_key_redaction.py
@@ -213,6 +213,79 @@ def test_masks_query_credentials_named_by_the_repository_policy():
     assert "eu-west-1" in out["fallback_providers"]
 
 
+def test_masks_credentials_carried_in_the_url_fragment():
+    # The separator does not change what the value is. OAuth implicit flow
+    # returns its token after "#", and the repository policy classifies
+    # fragment pairs exactly like query pairs.
+    for param in ("access_token", "signature", "x-amz-signature", "code", "jwt"):
+        out = dump._config_overrides(
+            {
+                "fallback_providers": [
+                    _fallback_entry(
+                        base_url=f"https://api.example.com/callback#{param}={_SK_KEY}"
+                    )
+                ]
+            }
+        )
+        rendered = out["fallback_providers"]
+        assert _SK_KEY not in rendered, param
+        assert "api.example.com" in rendered, param
+
+    # A public fragment parameter beside a secret one must survive, otherwise
+    # the assertion above would also pass on a masker that ate the fragment.
+    out = dump._config_overrides(
+        {
+            "fallback_providers": [
+                _fallback_entry(
+                    base_url=(
+                        f"https://api.example.com/callback#access_token={_SK_KEY}"
+                        "&state=public-xyz"
+                    )
+                )
+            ]
+        }
+    )
+    rendered = out["fallback_providers"]
+    assert _SK_KEY not in rendered
+    assert "state=public-xyz" in rendered
+
+
+def test_masks_userinfo_in_a_scheme_relative_endpoint():
+    # `//user:pass@host/v1` parses with an authority but no scheme. Requiring a
+    # scheme let that form through with the password intact.
+    out = dump._config_overrides(
+        {
+            "fallback_providers": [
+                _fallback_entry(base_url=f"//user:{_SK_KEY}@api.example.com/v1")
+            ]
+        }
+    )
+    rendered = out["fallback_providers"]
+    assert _SK_KEY not in rendered
+    assert "api.example.com" in rendered
+
+
+def test_hyphenated_signature_names_stay_masked():
+    # Guards the reason this path classifies names with
+    # `is_sensitive_query_param` instead of delegating wholesale to
+    # `_redact_strict_url_credentials`: that helper canonicalizes "-" to "_",
+    # so `x-amz-signature` misses the (hyphenated) set entry and survives.
+    from agent import redact
+
+    assert redact.is_sensitive_query_param("x-amz-signature")
+    for component in ("?", "#"):
+        out = dump._config_overrides(
+            {
+                "fallback_providers": [
+                    _fallback_entry(
+                        base_url=f"https://api.example.com/o{component}x-amz-signature={_SK_KEY}"
+                    )
+                ]
+            }
+        )
+        assert _SK_KEY not in out["fallback_providers"], component
+
+
 def test_debug_share_upload_never_carries_the_raw_fallback_key(monkeypatch, tmp_path):
     """The real boundary: what `hermes debug share` hands to the paste service.
 
@@ -256,6 +329,51 @@ def test_debug_share_upload_never_carries_the_raw_fallback_key(monkeypatch, tmp_
         assert _SK_KEY not in payload
     # Non-vacuous: the fallback block really is in what goes out, masked.
     assert any("sk-l...SHIP" in payload for payload in uploaded)
+
+
+def test_debug_share_upload_never_carries_a_fragment_credential(monkeypatch, tmp_path):
+    """The same boundary, for a credential that arrives after ``#``.
+
+    An endpoint field is not obviously a secret field, which is what made this
+    worth pinning at the upload call rather than one layer up.
+    """
+    from hermes_cli import debug
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
+
+    home = get_hermes_home()
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "model: gpt-4o\n"
+        "provider: openai\n"
+        "fallback_providers:\n"
+        "  - name: my-backup\n"
+        "    provider: openai\n"
+        "    model: gpt-4o\n"
+        f"    base_url: https://api.example.com/callback#access_token={_SK_KEY}&state=public-xyz\n",
+        encoding="utf-8",
+    )
+
+    uploaded: list[str] = []
+
+    def _capture(content: str, expiry_days: int = 7) -> str:
+        uploaded.append(content)
+        return f"https://paste.example/{len(uploaded)}"
+
+    monkeypatch.setattr(debug, "upload_to_pastebin", _capture)
+    monkeypatch.setattr(debug, "_best_effort_sweep_expired_pastes", lambda: None)
+    monkeypatch.setattr(debug, "_schedule_auto_delete", lambda urls: None)
+
+    debug.build_debug_share(log_lines=5, redact=True)
+
+    assert uploaded, "nothing was uploaded — the boundary was never reached"
+    for payload in uploaded:
+        assert _SK_KEY not in payload
+    # Non-vacuous on both sides: the masked token is there, and the public
+    # fragment parameter next to it survived the trip.
+    assert any("access_token=sk-l...SHIP" in payload for payload in uploaded)
+    assert any("state=public-xyz" in payload for payload in uploaded)
 
 
 def test_numeric_token_budgets_are_not_mistaken_for_secrets():

--- a/tests/hermes_cli/test_dump_fallback_key_redaction.py
+++ b/tests/hermes_cli/test_dump_fallback_key_redaction.py
@@ -177,6 +177,87 @@ def test_strips_credentials_embedded_in_the_endpoint_url():
     assert "api.example.com" in out["fallback_providers"]
 
 
+def test_masks_query_credentials_named_by_the_repository_policy():
+    # The field-name markers ("key", "token", "secret"...) answer a question
+    # about config fields and miss query names the repository already treats as
+    # sensitive in agent/redact.py: a pre-signed URL signature and an OAuth
+    # code carry no marker word at all.
+    for param in ("signature", "x-amz-signature", "code", "access-token", "jwt"):
+        out = dump._config_overrides(
+            {
+                "fallback_providers": [
+                    _fallback_entry(
+                        base_url=f"https://api.example.com/v1?{param}={_SK_KEY}"
+                    )
+                ]
+            }
+        )
+        rendered = out["fallback_providers"]
+        assert _SK_KEY not in rendered, param
+        # The parameter name itself stays — operators need to see the shape of
+        # the endpoint, only the value goes.
+        assert "api.example.com" in rendered, param
+
+    # A public parameter next to a secret one must survive, or the masking is
+    # just a blunt instrument that costs diagnostics.
+    out = dump._config_overrides(
+        {
+            "fallback_providers": [
+                _fallback_entry(
+                    base_url=f"https://api.example.com/v1?region=eu-west-1&signature={_SK_KEY}"
+                )
+            ]
+        }
+    )
+    assert _SK_KEY not in out["fallback_providers"]
+    assert "eu-west-1" in out["fallback_providers"]
+
+
+def test_debug_share_upload_never_carries_the_raw_fallback_key(monkeypatch, tmp_path):
+    """The real boundary: what `hermes debug share` hands to the paste service.
+
+    The tests above pin `_config_overrides` and `run_dump`, but the credential
+    only becomes public when `build_debug_share` uploads the bundle. This test
+    stands at that exact call and reads the payloads that would go out.
+    """
+    from hermes_cli import debug
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
+
+    home = get_hermes_home()
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "model: gpt-4o\n"
+        "provider: openai\n"
+        "fallback_providers:\n"
+        "  - name: my-backup\n"
+        "    provider: openai\n"
+        "    model: gpt-4o\n"
+        "    base_url: https://api.example.com/v1\n"
+        f"    api_key: {_SK_KEY}\n",
+        encoding="utf-8",
+    )
+
+    uploaded: list[str] = []
+
+    def _capture(content: str, expiry_days: int = 7) -> str:
+        uploaded.append(content)
+        return f"https://paste.example/{len(uploaded)}"
+
+    monkeypatch.setattr(debug, "upload_to_pastebin", _capture)
+    monkeypatch.setattr(debug, "_best_effort_sweep_expired_pastes", lambda: None)
+    monkeypatch.setattr(debug, "_schedule_auto_delete", lambda urls: None)
+
+    debug.build_debug_share(log_lines=5, redact=True)
+
+    assert uploaded, "nothing was uploaded — the boundary was never reached"
+    for payload in uploaded:
+        assert _SK_KEY not in payload
+    # Non-vacuous: the fallback block really is in what goes out, masked.
+    assert any("sk-l...SHIP" in payload for payload in uploaded)
+
+
 def test_numeric_token_budgets_are_not_mistaken_for_secrets():
     # The name-marker rule fails closed, so the few known-safe fields that
     # contain a marker word must stay readable or the dump loses diagnostics.

--- a/tests/hermes_cli/test_dump_fallback_key_redaction.py
+++ b/tests/hermes_cli/test_dump_fallback_key_redaction.py
@@ -94,3 +94,104 @@ def test_dump_output_never_contains_raw_fallback_key(monkeypatch, capsys, tmp_pa
     assert "fallback_providers" in out
     assert "sk-l...SHIP" in out
     assert _SK_KEY not in out
+
+
+# --- shapes that reach the same public paste by a different route -----------
+#
+# Masking the documented list-of-dicts shape is not enough: everything the
+# helper does not explicitly recognize still goes through ``str()``, and
+# ``str()`` on an arbitrary object runs its ``__repr__``. Each test below is
+# a config that works at runtime and used to print its credential in full.
+
+
+def test_masks_single_mapping_not_wrapped_in_a_list():
+    # ``fallback_config._iter_fallback_entries`` accepts a bare mapping as a
+    # one-entry chain, and ``resolve_entry_api_key`` reads its inline key — so
+    # this config routes traffic. It must not skip masking for want of a list.
+    out = dump._config_overrides(
+        {"fallback_providers": _fallback_entry(api_key=_SK_KEY)}
+    )
+    assert _SK_KEY not in out["fallback_providers"]
+
+
+def test_masks_secret_fields_outside_the_canonical_name():
+    # Sibling credential names must be caught by the same rule as ``api_key``.
+    for field in ("access_key", "auth_token", "client_secret", "passwd"):
+        out = dump._config_overrides(
+            {"fallback_providers": [_fallback_entry(**{field: _CUSTOM_KEY})]}
+        )
+        assert _CUSTOM_KEY not in out["fallback_providers"], field
+
+
+def test_masks_non_string_values_under_a_secret_field():
+    # A nested mapping and a bytes value both stringify to the key in full.
+    for value in ({"value": _CUSTOM_KEY}, _CUSTOM_KEY.encode()):
+        out = dump._config_overrides(
+            {"fallback_providers": [_fallback_entry(api_key=value)]}
+        )
+        assert _CUSTOM_KEY not in out["fallback_providers"], type(value).__name__
+
+
+def test_omits_entries_that_are_not_mappings():
+    # A stray scalar in the list is not a usable entry, and its contents cannot
+    # be verified — it is described by type rather than printed.
+    out = dump._config_overrides(
+        {"fallback_providers": [f"openai:{_SK_KEY}"]}
+    )
+    assert _SK_KEY not in out["fallback_providers"]
+    assert "<omitted: str>" in out["fallback_providers"]
+
+
+def test_omits_objects_whose_repr_would_print_the_key():
+    class _Provider:
+        def __repr__(self):
+            return f"_Provider(api_key={_SK_KEY!r})"
+
+    out = dump._config_overrides({"fallback_providers": [_Provider()]})
+    assert _SK_KEY not in out["fallback_providers"]
+    assert "<omitted: _Provider>" in out["fallback_providers"]
+
+
+def test_strips_credentials_embedded_in_the_endpoint_url():
+    # base_url stays visible — it is the field operators actually need — but
+    # userinfo and secret query parameters are cleaned out of it.
+    out = dump._config_overrides(
+        {
+            "fallback_providers": [
+                _fallback_entry(base_url=f"https://user:{_SK_KEY}@api.example.com/v1")
+            ]
+        }
+    )
+    rendered = out["fallback_providers"]
+    assert _SK_KEY not in rendered
+    assert "api.example.com" in rendered
+
+    out = dump._config_overrides(
+        {
+            "fallback_providers": [
+                _fallback_entry(base_url=f"https://api.example.com/v1?api_key={_SK_KEY}")
+            ]
+        }
+    )
+    assert _SK_KEY not in out["fallback_providers"]
+    assert "api.example.com" in out["fallback_providers"]
+
+
+def test_numeric_token_budgets_are_not_mistaken_for_secrets():
+    # The name-marker rule fails closed, so the few known-safe fields that
+    # contain a marker word must stay readable or the dump loses diagnostics.
+    out = dump._config_overrides(
+        {"fallback_providers": [_fallback_entry(max_tokens=4096, key_env="MY_KEY_VAR")]}
+    )
+    rendered = out["fallback_providers"]
+    assert "4096" in rendered
+    assert "MY_KEY_VAR" in rendered
+
+
+def test_self_referencing_config_terminates():
+    # A YAML anchor cycle must not turn the dump into a stack overflow.
+    entry = _fallback_entry(api_key=_SK_KEY)
+    entry["extra"] = entry
+    out = dump._config_overrides({"fallback_providers": [entry]})
+    rendered = out["fallback_providers"]
+    assert _SK_KEY not in rendered


### PR DESCRIPTION
## What does this PR do?

`hermes dump` serialized the raw `fallback_providers` config list — inline `api_key` and all — straight into its `config_overrides` block via `str(fallbacks)`. That block is what the bug-report template tells people to paste into public issues, and what `hermes debug share` uploads to paste.rs. The upload path's redaction (`_redact_log_text`, `force=True`) is wired only into the log snapshots; the dump text is never routed through it. So an operator who configures a fallback provider with an inline `api_key` (the first-choice, documented shape in `fallback_config.py`) leaks a live key to a public paste — under a consent notice that states verbatim that "Cryptographic secrets (API keys, tokens, passwords) are redacted before upload."

This masks the inline credentials at the source, in `_config_overrides`, before the list is serialized. Redacting downstream in the text redactor wouldn't cover it: that redactor keys off vendor prefixes (`sk-`, `ghp_`, `AIza`, …), so a custom-endpoint key with no prefix slips through even if the dump text were routed through it. Masking by field name at the source is prefix-agnostic and complete.

**Updated — the first version of this patch was too narrow.** It masked a fixed list of field names inside a list of mappings, and left `str()` on everything else. Since `str()` on an arbitrary object runs its `__repr__`, every shape the helper didn't explicitly recognize still printed the credential in full. Nine config shapes were probed against the real `_config_overrides`; the original patch closed one of them. The helper now fails closed instead:

| Config shape | before this PR | first patch | now |
|---|---|---|---|
| list of mappings, `api_key` | leaks | **masked** | masked |
| `fallback_providers` as a bare mapping | leaks | leaks | **masked** |
| sibling names (`access_key`, `auth_token`, `client_secret`) | leaks | leaks | **masked** |
| nested mapping under `api_key` | leaks | leaks | **masked** |
| `bytes` under `api_key` | leaks | leaks | **masked** |
| entry that isn't a mapping | leaks | leaks | **omitted** |
| object whose `__repr__` prints the key | leaks | leaks | **omitted** |
| credential in `base_url` userinfo | leaks | leaks | **stripped** |
| credential in a `base_url` query parameter | leaks | leaks | **redacted** |

The bare-mapping row is the one that matters most: `_iter_fallback_entries` accepts a single mapping as a one-entry chain and `resolve_entry_api_key` reads its inline key, so that config routes real traffic — the original patch skipped it only for want of a list, and it leaks the very same inline `api_key` this PR set out to cover.

The mask still reuses the dump's own `_redact` helper (head/tail only — `sk-l...SHIP`), the same form the dump already uses for every other key, so the output stays debuggable and consistent. `key_env` / `api_key_env` name an environment variable rather than holding a secret and are left intact, as are the numeric `*_tokens` budgets; every other field whose name matches a credential marker is masked, so an unrecognized field costs a diagnostic rather than leaking a key. If maintainers prefer full redaction for this public-paste path, that's a one-line change at the `_redact` call.

**Credit:** the broader nested/object disclosure class was surfaced by [@OrionArchitekton](https://github.com/OrionArchitekton)'s fork-side analysis of this patch (`OrionArchitekton/hermes-agent#21`, which contains that fork's own, heavier containment). Their write-up is what prompted this hardening pass. The bare-mapping and URL-userinfo paths came out of probing the shapes `fallback_config` actually accepts.

## Related Issue

Related to #64351 — same tool, different leak source. That report (and its PR #64376) covers credentials that arrive as **chat message bodies** and get logged by the gateway; #64376 redacts the gateway log call site and does not touch the dump path. This PR closes a distinct source: a credential that lives in `config.yaml` under `fallback_providers` and reaches the public paste through `dump_text`, which no redaction covers. #64351's reporter verified `.env`-sourced secrets are safe but did not test the `fallback_providers` config shape — this is that gap.

Deliberately not `Fixes #64351`: that would auto-close #64351 on merge, but its primary path (chat-logged secrets) is still open and handled by #64376, not here.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/dump.py`: `_mask_fallback_secrets()` now handles both container shapes `fallback_config._iter_fallback_entries` accepts (a list of entries, and a single entry given as a bare mapping) and returns a copy in which every credential value is masked through the existing `_redact` helper before `_config_overrides` serializes it.
  - field names match by marker (`key`, `token`, `secret`, `password`, `passwd`, `credential`, `auth`) rather than by exact membership, with a documented exemption list so `key_env` / `api_key_env` and the `max_tokens` family stay readable;
  - a value under a credential field that can't be shown in head/tail form — bytes, a number, a nested container, a custom object — is replaced by `<omitted>` rather than stringified;
  - an entry that isn't a mapping, and any value whose type isn't renderable, becomes `<omitted: TypeName>` instead of being handed to `str()`;
  - `_mask_url_credentials()` strips userinfo and redacts secret query parameters from `base_url`-style fields, so the endpoint stays visible without its credentials;
  - recursion into nested containers is depth-bounded, so a YAML anchor cycle can't overflow the stack.
- `tests/hermes_cli/test_dump_fallback_key_redaction.py`: regression coverage for each shape in the table above, plus the original cases (prefix-less custom-endpoint key, `key_env` preserved, end-to-end `run_dump` assertion) and a guard that numeric token budgets are not mistaken for secrets.

## How to Test

1. Configure a fallback provider with an inline key in `config.yaml`:
   ```yaml
   fallback_providers:
     - name: my-backup
       provider: openai
       model: gpt-4o
       base_url: https://api.example.com/v1
       api_key: sk-live-EXAMPLE-DO-NOT-SHIP
   ```
2. Run `hermes dump`. Before this change the full key appears in the `fallback_providers:` line; after, it shows masked as `sk-l...SHIP`.
3. Repeat with the bare-mapping form (drop the `-` and de-indent), which the runtime also accepts — masked identically now, printed in full before this change.
4. Repeat with the key in the URL: `base_url: https://user:sk-live-EXAMPLE-DO-NOT-SHIP@api.example.com/v1` — the host survives, the credential does not.
5. Run `hermes debug share --local` (same collector as the upload path). The masked form appears in the report; the raw key does not.
6. Regression suite: `pytest tests/hermes_cli/test_dump_fallback_key_redaction.py -q` → 13 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(config):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (no open PR touches `hermes_cli/dump.py`'s config path; #64376 fixes the distinct gateway-log source)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected-area suites (`tests/hermes_cli/test_dump_*.py`, `test_debug.py`) — 125 passed. One pre-existing failure (`test_debug.py::TestCaptureLogSnapshot::test_keeps_first_line_when_truncation_on_boundary`) reproduces identically on unpatched `main`, so it is unrelated to this change. I scoped the run to the touched area because the full `tests/` suite has platform-specific pre-existing failures on native Windows (e.g. `AF_UNIX` socket tests, and `tests/hermes_cli/test_gateway.py` which imports `pty` at module level).
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Python 3.11.9)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (N/A: internal masking; the fix makes the existing `debug share` consent notice accurate rather than requiring a wording change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (N/A: no config keys added or changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (N/A: no architecture or workflow change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure Python string masking, platform-agnostic; verified on Windows)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (N/A: no tool behavior changed)

## Screenshots / Logs

Rebased onto `origin/main` @ `158e9a997`; the vulnerable line (`str(fallbacks)`) is unchanged there, so the premise still holds on current main.

**Shape probe.** Each of the nine configs above was fed to the real `_config_overrides` and the output searched for the canary. Current `main` leaks 9 of 9; the first version of this patch leaked 8 of 9; this branch leaks 0 of 9.

**End-to-end.** The shared upload core `build_debug_share(redact=True)` (the function behind both the `hermes debug share` CLI and the dashboard `POST /api/ops/debug-share`) was driven with the network boundary stubbed out — **nothing was actually sent** — and the outbound POST body it would have sent to paste.rs was inspected for a synthetic canary key.

Before (unpatched `main`) — the live key is in the outbound POST while the tool believes it redacted:
```
POST https://paste.rs/  (1865 bytes)  <== CONTAINS LIVE KEY
result.redacted flag: True
  in POST body: fallback_providers: [{'name': 'my-backup', ..., 'api_key': 'sk-live-CANARY-...'}]
```

After (this branch) — the same POST no longer carries the key:
```
POST https://paste.rs/  (1837 bytes)
result.redacted flag: True
no outbound request contained the canary
```

**Mutation checks.** Each guard was reverted in turn; each time the test written for it failed, and restoring the guard turned it green again:

| reverted guard | result |
|---|---|
| bare mapping returned unmasked | `test_masks_single_mapping_not_wrapped_in_a_list` fails |
| non-mapping entries printed as-is | `test_omits_entries_that_are_not_mappings`, `test_omits_objects_whose_repr_would_print_the_key` fail |
| URL fields left verbatim | `test_strips_credentials_embedded_in_the_endpoint_url` fails |
| non-string secret values passed through | `test_masks_non_string_values_under_a_secret_field` fails |
| marker match reverted to exact membership | 8 of 13 fail |

`ruff check` clean and `scripts/check-windows-footguns.py` clean on both changed files.
