### PR TITLE
fix(kanban): unpack judge_goal's 4-tuple at the completion gate

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -648,7 +648,9 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
     # Mock the judge to reject the completion. The gate only runs when a
     # judge is reachable, so force the availability probe True as well.
     def mock_judge_goal(goal, last_response, *, timeout=30.0, subgoals=None):
-        return "continue", "missing verification evidence", False
+        # Match the real judge_goal contract:
+        # (verdict, reason, parse_failed, wait_directive)
+        return "continue", "missing verification evidence", False, None
 
     monkeypatch.setattr("tools.kanban_tools.judge_goal", mock_judge_goal)
     monkeypatch.setattr("tools.kanban_tools._goal_judge_available", lambda: True)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -602,7 +602,12 @@ def _handle_complete(args: dict, **kw) -> str:
                 verdict = "done"
                 reason = ""
                 try:
-                    verdict, reason, _ = judge_goal(
+                    # judge_goal returns (verdict, reason, parse_failed,
+                    # wait_directive) — see hermes_cli/goals.py. Unpacking
+                    # fewer raises ValueError, which the defensive handler
+                    # below swallows, leaving verdict="done" and silently
+                    # disabling the gate.
+                    verdict, reason, _, _ = judge_goal(
                         goal=f"{task.title}\n\n{task.body or ''}".strip(),
                         last_response=(summary or result or "").strip(),
                     )


### PR DESCRIPTION
## Summary
The kanban goal-mode completion gate works again: `tools/kanban_tools.py` now unpacks all four values `judge_goal` returns, so the judge verdict is actually read instead of raising `ValueError` into a fail-open handler.

Root cause: `judge_goal()` grew a fourth return value (`wait_directive`) in `hermes_cli/goals.py`, but the kanban gate still unpacked 3. Every judge call raised, the defensive `except` swallowed it, and the pre-initialized `verdict="done"` let every completion through — the acceptance gate was silently disabled fleet-wide.

## Changes
- `tools/kanban_tools.py`: 3-value → 4-value unpack at the `judge_goal` call site, with a comment documenting the contract and the fail-open hazard
- `tests/tools/test_kanban_tools.py`: judge mock updated to the real 4-value contract (it was masking the bug)

## Validation
| | Before | After |
|---|---|---|
| Real `judge_goal` call at gate | `ValueError: too many values to unpack` → fail-open | verdict read, gate enforces |
| `tests/tools/test_kanban_tools.py` | mock hid the mismatch | 114/114 pass |
| E2E (real import, temp HERMES_HOME) | 3-unpack reproduces the crash | 4-unpack works against real contract |

Sibling audit: the other two `judge_goal` consumers (`hermes_cli/goals.py:1428`, `:1682`) already unpack 4 — this was the only stale site.

## Credit
Reported, diagnosed, and originally fixed by @bill3wits in #57276. Reimplemented under project authorship because the original commit was authored under a non-existent local identity (`bash@hermes.local`) that can't be carried into git history — engineering credit is entirely theirs. Also fixes the duplicate report #58066 by @Gibcity.

Closes #57276. Closes #58066.

## Infographic

![kanban-goal-gate-rearmed](https://v3b.fal.media/files/b/0aa2fe7d/Lz3839oL9gBPTMkqQc9NS_0nwjeddE.png)
