### PR TITLE
fix(display): stop web_extract false failures from generic error heuristic

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1302,6 +1302,19 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
         if err and (data.get("success") is False or "error" in data):
             return True, f" [{_trim_error(str(err))}]"
 
+        # web_extract returns an ``error`` field for every URL, including an
+        # empty one on success. Judge the result values instead of matching
+        # the serialized key name below.
+        if tool_name == "web_extract" and isinstance(data.get("results"), list):
+            results = data["results"]
+            failed = [
+                item for item in results
+                if isinstance(item, dict) and item.get("error") and not item.get("content")
+            ]
+            if results and len(failed) == len(results):
+                return True, f" [{_trim_error(str(failed[0]['error']))}]"
+            return False, ""
+
     # Generic heuristic for non-terminal tools
     # Multimodal tool results (dicts with _multimodal=True) are not strings —
     # treat them as successes since failures would be JSON-encoded strings.
@@ -1506,5 +1519,4 @@ def get_cute_tool_message(
 # =========================================================================
 # Honcho session line (one-liner with clickable OSC 8 hyperlink)
 # =========================================================================
-
 

--- a/agent/display.py
+++ b/agent/display.py
@@ -17,7 +17,10 @@ from typing import Any
 
 from utils import safe_json_loads
 from agent.redact import redact_sensitive_text
-from agent.tool_result_classification import file_mutation_result_landed
+from agent.tool_result_classification import (
+    classify_web_extract_failure,
+    file_mutation_result_landed,
+)
 
 # ANSI escape codes for coloring tool failure indicators
 _RED = "\033[31m"
@@ -1305,15 +1308,13 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
         # web_extract returns an ``error`` field for every URL, including an
         # empty one on success. Judge the result values instead of matching
         # the serialized key name below.
-        if tool_name == "web_extract" and isinstance(data.get("results"), list):
-            results = data["results"]
-            failed = [
-                item for item in results
-                if isinstance(item, dict) and item.get("error") and not item.get("content")
-            ]
-            if results and len(failed) == len(results):
-                return True, f" [{_trim_error(str(failed[0]['error']))}]"
-            return False, ""
+        if tool_name == "web_extract":
+            classification = classify_web_extract_failure(data)
+            if classification is not None:
+                failed, error = classification
+                if failed:
+                    return True, f" [{_trim_error(error)}]"
+                return False, ""
 
     # Generic heuristic for non-terminal tools
     # Multimodal tool results (dicts with _multimodal=True) are not strings —
@@ -1519,4 +1520,3 @@ def get_cute_tool_message(
 # =========================================================================
 # Honcho session line (one-liner with clickable OSC 8 hyperlink)
 # =========================================================================
-

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -14,7 +14,10 @@ from dataclasses import dataclass, field
 from typing import Any, Mapping
 
 from utils import safe_json_loads
-from agent.tool_result_classification import file_mutation_result_landed
+from agent.tool_result_classification import (
+    classify_web_extract_failure,
+    file_mutation_result_landed,
+)
 
 
 IDEMPOTENT_TOOL_NAMES = frozenset(
@@ -262,6 +265,12 @@ def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str
         if isinstance(data, dict):
             if data.get("success") is False and "exceed the limit" in data.get("error", ""):
                 return True, " [full]"
+
+    if tool_name == "web_extract":
+        classification = classify_web_extract_failure(safe_json_loads(result))
+        if classification is not None:
+            failed, error = classification
+            return (True, f" [{error}]") if failed else (False, "")
 
     lower = result[:500].lower()
     if '"error"' in lower or '"failed"' in lower or result.startswith("Error"):

--- a/agent/tool_result_classification.py
+++ b/agent/tool_result_classification.py
@@ -38,3 +38,19 @@ def file_mutation_result_landed(tool_name: str, result: Any) -> bool:
     if tool_name == "patch":
         return data.get("success") is True
     return False
+
+
+def classify_web_extract_failure(data: Any) -> tuple[bool, str] | None:
+    """Classify a parsed web_extract envelope, or return None if not applicable."""
+    if not isinstance(data, dict) or not isinstance(data.get("results"), list):
+        return None
+
+    results = data["results"]
+    failed = [
+        item
+        for item in results
+        if isinstance(item, dict) and item.get("error") and not item.get("content")
+    ]
+    if results and len(failed) == len(results):
+        return True, str(failed[0]["error"])
+    return False, ""

--- a/tests/agent/test_display_tool_failure.py
+++ b/tests/agent/test_display_tool_failure.py
@@ -99,7 +99,7 @@ class TestDetectToolFailureStructured:
 
     def test_web_extract_empty_error_field_is_success(self):
         result = json.dumps({
-            "results": [{"url": "https://example.com", "content": "Example", "error": ""}],
+            "results": [{"url": "https://example.com", "content": "Example", "error": None}],
         })
         assert _detect_tool_failure("web_extract", result) == (False, "")
 

--- a/tests/agent/test_display_tool_failure.py
+++ b/tests/agent/test_display_tool_failure.py
@@ -97,6 +97,18 @@ class TestDetectToolFailureStructured:
         assert _detect_tool_failure("web_search", result) == (False, "")
 
 
+    def test_web_extract_empty_error_field_is_success(self):
+        result = json.dumps({
+            "results": [{"url": "https://example.com", "content": "Example", "error": ""}],
+        })
+        assert _detect_tool_failure("web_extract", result) == (False, "")
+
+    def test_web_extract_all_failed_is_failure(self):
+        result = json.dumps({
+            "results": [{"url": "https://example.com", "content": "", "error": "404"}],
+        })
+        assert _detect_tool_failure("web_extract", result) == (True, " [404]")
+
 
 class TestGetCuteToolMessageFailureSuffix:
     """End-to-end: failure suffix is appended by get_cute_tool_message."""

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -111,6 +111,27 @@ def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution()
 
 
 
+def test_web_extract_null_error_is_success_in_after_call_fallback():
+    result = json.dumps({
+        "results": [{"url": "https://example.com", "content": "Example", "error": None}],
+    })
+
+    assert classify_tool_failure("web_extract", result) == (False, "")
+
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(exact_failure_warn_after=1, no_progress_warn_after=99)
+    )
+    decision = controller.after_call("web_extract", {"urls": ["https://example.com"]}, result)
+
+    assert decision.action == "allow"
+
+
+def test_web_extract_error_without_content_is_failure_in_after_call_fallback():
+    result = json.dumps({
+        "results": [{"url": "https://example.com/missing", "content": "", "error": "404"}],
+    })
+
+    assert classify_tool_failure("web_extract", result) == (True, " [404]")
 
 
 
@@ -167,7 +188,6 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
     assert decision.action == "block"
     assert decision.code == "loop_web_search_cap"
     assert decision.should_halt is True
-
 
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes false failure reporting for successful `web_extract` results.

A successful `web_extract` response can contain extracted content together with `"error": null`. The previous generic error heuristic treated the presence of the `error` key as a failure even when its value was null.

This PR introduces shared `web_extract` result classification so the display and tool guardrail paths apply the same rules:

- Content with no meaningful error is treated as successful.
- An error without content is treated as a failure.
- Available error details are preserved in failure messages.

## Related Issue

No linked issue.

Related open PR: #75363 overlaps with the display symptom. This PR was opened earlier and additionally keeps the display and `ToolCallGuardrailController.after_call()` fallback classifications aligned, as requested in review.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added shared `web_extract` result classification in `agent/tool_result_classification.py`.
- Updated `agent/display.py` to use the shared classification logic.
- Updated the fallback path in `agent/tool_guardrails.py` to use the same classification when `after_call()` receives no explicit `failed` value.
- Added display regression coverage in `tests/agent/test_display_tool_failure.py`.
- Added guardrail fallback regression coverage in `tests/agent/test_tool_guardrails.py`.

## How to Test

1. Run the focused regression tests:

   ```bash
   scripts/run_tests.sh -j 4 tests/agent/test_display_tool_failure.py tests/agent/test_tool_guardrails.py
   ```

2. Confirm that a result containing content and `"error": null` is classified as successful in both the display and guardrail paths.

3. Confirm that a result containing an error without content is classified as a failure and preserves the error detail.

Expected result:

```text
22 tests passed, 0 failed
```

Additional checks performed:

```text
Ruff: passed
Windows footgun check: passed
Git diff check: passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate; see the overlap note for #75363 above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 27.0, Python 3.11.15

The full suite was run locally but did not complete cleanly because of unrelated environment- and configuration-dependent failures. Re-running the affected files against the latest `main` reproduced 48 failures. One additional Kanban test reads the local `photon` channel configuration and is outside this PR's changed paths.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing documentation change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema change

## Screenshots / Logs

Focused regression test result:

```text
22 tests passed, 0 failed
```

No UI changes.
