### PR TITLE
fix(bedrock): 1M context for current-gen Claude on Bedrock (salvage #24059/#54918)

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1324,11 +1324,14 @@ BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     # Anthropic Claude models on Bedrock.
     # Context windows per Anthropic's official models comparison
     # (https://platform.claude.com/docs/en/about-claude/models/overview).
-    # Sonnet 5 / Opus 4.7 / Opus 4.6 / Sonnet 4.6 have 1M generally
+    # Sonnet 5 / Opus 4.8 / 4.7 / 4.6 / Sonnet 4.6 have 1M generally
     # available (no beta header required as of April 2026). Sonnet 4.5 and
     # Sonnet 4 had their `context-1m-2025-08-07` beta retired on
     # April 30, 2026, so they are standard 200K; Haiku 4.5 is 200K.
+    # Keys are matched by longest-substring, so the versioned 4-6/4-7/4-8
+    # entries win over the generic "anthropic.claude-opus-4" fallback.
     "anthropic.claude-sonnet-5":     1_000_000,
+    "anthropic.claude-opus-4-8":     1_000_000,
     "anthropic.claude-opus-4-7":     1_000_000,
     "anthropic.claude-opus-4-6":     1_000_000,
     "anthropic.claude-sonnet-4-6":   1_000_000,

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1322,15 +1322,18 @@ def classify_bedrock_error(error_message: str) -> str:
 
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     # Anthropic Claude models on Bedrock.
-    # Claude 4.x (opus/sonnet/haiku) support a 1M-token context window via the
-    # ``context-1m-2025-08-07`` beta header, which Hermes injects automatically
-    # in ``build_anthropic_bedrock_client`` (see agent/anthropic_adapter.py).
+    # Context windows per Anthropic's official models comparison
+    # (https://platform.claude.com/docs/en/about-claude/models/overview).
+    # Sonnet 5 / Opus 4.7 / Opus 4.6 / Sonnet 4.6 have 1M generally
+    # available (no beta header required as of April 2026). Sonnet 4.5 and
+    # Sonnet 4 had their `context-1m-2025-08-07` beta retired on
+    # April 30, 2026, so they are standard 200K; Haiku 4.5 is 200K.
     "anthropic.claude-sonnet-5":     1_000_000,
     "anthropic.claude-opus-4-7":     1_000_000,
     "anthropic.claude-opus-4-6":     1_000_000,
     "anthropic.claude-sonnet-4-6":   1_000_000,
-    "anthropic.claude-sonnet-4-5":   1_000_000,
-    "anthropic.claude-haiku-4-5":    1_000_000,
+    "anthropic.claude-sonnet-4-5":   200_000,
+    "anthropic.claude-haiku-4-5":    200_000,
     "anthropic.claude-opus-4":       200_000,
     "anthropic.claude-sonnet-4":     200_000,
     "anthropic.claude-3-5-sonnet":   200_000,

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1321,12 +1321,16 @@ def classify_bedrock_error(error_message: str) -> str:
 # detection is unavailable.
 
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
-    # Anthropic Claude models on Bedrock
+    # Anthropic Claude models on Bedrock.
+    # Claude 4.x (opus/sonnet/haiku) support a 1M-token context window via the
+    # ``context-1m-2025-08-07`` beta header, which Hermes injects automatically
+    # in ``build_anthropic_bedrock_client`` (see agent/anthropic_adapter.py).
     "anthropic.claude-sonnet-5":     1_000_000,
-    "anthropic.claude-opus-4-6":     200_000,
-    "anthropic.claude-sonnet-4-6":   200_000,
-    "anthropic.claude-sonnet-4-5":   200_000,
-    "anthropic.claude-haiku-4-5":    200_000,
+    "anthropic.claude-opus-4-7":     1_000_000,
+    "anthropic.claude-opus-4-6":     1_000_000,
+    "anthropic.claude-sonnet-4-6":   1_000_000,
+    "anthropic.claude-sonnet-4-5":   1_000_000,
+    "anthropic.claude-haiku-4-5":    1_000_000,
     "anthropic.claude-opus-4":       200_000,
     "anthropic.claude-sonnet-4":     200_000,
     "anthropic.claude-3-5-sonnet":   200_000,

--- a/contributors/emails/patrickmuller@outlook.com
+++ b/contributors/emails/patrickmuller@outlook.com
@@ -1,0 +1,1 @@
+patrick-muller

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1165,13 +1165,33 @@ class TestBedrockErrorClassification:
 class TestBedrockContextLength:
     """Test Bedrock model context length lookup."""
 
+    def test_claude_opus_4_7(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        # Opus 4.7 has 1M context generally available (no beta header required)
+        # per https://platform.claude.com/docs/en/about-claude/models/overview
+        assert get_bedrock_context_length("anthropic.claude-opus-4-7") == 1_000_000
+
     def test_claude_opus_4_6(self):
         from agent.bedrock_adapter import get_bedrock_context_length
-        assert get_bedrock_context_length("anthropic.claude-opus-4-6-20250514-v1:0") == 200_000
+        # Opus 4.6 has 1M context generally available (no beta header required).
+        assert get_bedrock_context_length("anthropic.claude-opus-4-6-20250514-v1:0") == 1_000_000
 
     def test_claude_sonnet_versioned(self):
         from agent.bedrock_adapter import get_bedrock_context_length
-        assert get_bedrock_context_length("anthropic.claude-sonnet-4-6-20250514-v1:0") == 200_000
+        # Sonnet 4.6 has 1M context generally available (no beta header required).
+        assert get_bedrock_context_length("anthropic.claude-sonnet-4-6-20250514-v1:0") == 1_000_000
+
+    def test_claude_sonnet_4_5_is_200k(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        # Sonnet 4.5's 1M beta was retired on April 30, 2026;
+        # it is now standard 200K.
+        # https://platform.claude.com/docs/en/release-notes/overview
+        assert get_bedrock_context_length("anthropic.claude-sonnet-4-5") == 200_000
+
+    def test_claude_haiku_4_5_is_200k(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        # Haiku 4.5 is a 200K-context model per the Anthropic models overview.
+        assert get_bedrock_context_length("anthropic.claude-haiku-4-5-20251001-v1:0") == 200_000
 
     def test_nova_pro(self):
         from agent.bedrock_adapter import get_bedrock_context_length
@@ -1187,8 +1207,9 @@ class TestBedrockContextLength:
 
     def test_inference_profile_resolves(self):
         from agent.bedrock_adapter import get_bedrock_context_length
-        # Cross-region inference profiles contain the base model ID
-        assert get_bedrock_context_length("us.anthropic.claude-sonnet-4-6") == 200_000
+        # Cross-region inference profiles contain the base model ID.
+        # Sonnet 4.6 is 1M, so a 'us.' profile of it should also resolve to 1M.
+        assert get_bedrock_context_length("us.anthropic.claude-sonnet-4-6") == 1_000_000
 
     def test_longest_prefix_wins(self):
         from agent.bedrock_adapter import get_bedrock_context_length

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1165,6 +1165,11 @@ class TestBedrockErrorClassification:
 class TestBedrockContextLength:
     """Test Bedrock model context length lookup."""
 
+    def test_claude_opus_4_8(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        # Opus 4.8 exposes the 1M window on Bedrock (matches native Anthropic).
+        assert get_bedrock_context_length("anthropic.claude-opus-4-8-20250514-v1:0") == 1_000_000
+
     def test_claude_opus_4_7(self):
         from agent.bedrock_adapter import get_bedrock_context_length
         # Opus 4.7 has 1M context generally available (no beta header required)
@@ -1186,11 +1191,12 @@ class TestBedrockContextLength:
         # Sonnet 4.5's 1M beta was retired on April 30, 2026;
         # it is now standard 200K.
         # https://platform.claude.com/docs/en/release-notes/overview
-        assert get_bedrock_context_length("anthropic.claude-sonnet-4-5") == 200_000
+        assert get_bedrock_context_length("anthropic.claude-sonnet-4-5-20250514-v1:0") == 200_000
 
     def test_claude_haiku_4_5_is_200k(self):
         from agent.bedrock_adapter import get_bedrock_context_length
-        # Haiku 4.5 is a 200K-context model per the Anthropic models overview.
+        # Haiku 4.5 has no 1M window — must stay at the 200K Bedrock limit and
+        # not get swept up by the opus/sonnet bump.
         assert get_bedrock_context_length("anthropic.claude-haiku-4-5-20251001-v1:0") == 200_000
 
     def test_nova_pro(self):


### PR DESCRIPTION
## Summary
Bedrock context-length table now reports the 1M window for current-gen Claude (Sonnet 5, Opus 4.8/4.7/4.6, Sonnet 4.6) instead of capping everything at 200K — the resolver short-circuits into this static table before the 1M-aware defaults in `model_metadata.py`, so the wrong table made compression fire ~5x too early on Bedrock. Addresses the resolver half of #31277.

Salvages the context-table cluster: #24059 (@patrick-muller, May 11, earliest — all 3 commits cherry-picked), #54918 (@iizotov — Opus 4.8 row + longest-substring guard tests). #26769 (@bcwilsondotcom) overlapped the same table flip and is closed with credit; its SDK-bump half remains covered by #63650.

## Changes
- `agent/bedrock_adapter.py` `BEDROCK_CONTEXT_LENGTHS`: sonnet-5 (already 1M on main via #67932) joined by opus-4-8/4-7/4-6 and sonnet-4-6 at 1M (GA per Anthropic model docs, no beta header since April 2026); sonnet-4-5 / haiku-4-5 stay 200K (1M beta retired 2026-04-30); dropped speculative sonnet-4-7/4-8 rows (models don't exist)
- `tests/agent/test_bedrock_adapter.py`: per-generation context assertions incl. versioned-ID shapes and the 200K holdouts

## Validation
| Check | Result |
|---|---|
| `tests/agent/test_bedrock_adapter.py` | 140/140 pass |
| E2E: versioned IDs (`us.…opus-4-8-20260115-v1:0`) → 1M; 4-5/haiku/opus-4 → 200K | pass |
| E2E: full `get_model_context_length(provider="bedrock")` resolver chain | 1M for opus-4-8 and sonnet-5 |

Closes #24059, closes #54918, closes #26769.
Note for #66167: its context-table half conflicted with current main (sonnet-5 at 200K, speculative opus-5/haiku-5 rows) and is superseded by this PR; its whitespace-block fix is salvaged separately.

## Infographic

![bedrock-context-lengths](https://v3b.fal.media/files/b/0aa2fecf/dS3kCliRqNKdQUQEAN4RC_NzmstgK7.png)
