### PR TITLE
fix(kanban): apply goal_mode judge gate to CLI complete command

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2015,7 +2015,11 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                     verdict = "done"
                     reason = ""
                     try:
-                        verdict, reason, _ = judge_goal(
+                        # judge_goal returns (verdict, reason, parse_failed,
+                        # wait_directive) — see hermes_cli/goals.py. Unpacking
+                        # fewer raises ValueError into the fail-open handler
+                        # below, silently disabling the gate.
+                        verdict, reason, _, _ = judge_goal(
                             goal=f"{task.title}\n\n{task.body or ''}".strip(),
                             last_response=(summary or args.result or "").strip(),
                         )

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1996,6 +1996,45 @@ def _cmd_complete(args: argparse.Namespace) -> int:
     failed: list[str] = []
     with kb.connect_closing() as conn:
         for tid in ids:
+            # Goal-mode pre-completion judge gate (mirrors the gate in
+            # tools/kanban_tools.py:_handle_complete — Issue #38367).
+            # Without this, a goal_mode worker can call
+            # `hermes kanban complete <id>` from the terminal tool and
+            # bypass the auxiliary judge that the tool-call path enforces.
+            task = kb.get_task(conn, tid)
+            if task and task.goal_mode:
+                judge_available = False
+                try:
+                    from agent.auxiliary_client import get_text_auxiliary_client
+                    _client, _model = get_text_auxiliary_client("goal_judge")
+                    judge_available = _client is not None and bool(_model)
+                except Exception:
+                    pass
+                if judge_available:
+                    from hermes_cli.goals import judge_goal
+                    verdict = "done"
+                    reason = ""
+                    try:
+                        verdict, reason, _ = judge_goal(
+                            goal=f"{task.title}\n\n{task.body or ''}".strip(),
+                            last_response=(summary or args.result or "").strip(),
+                        )
+                    except Exception as judge_exc:
+                        import logging as _logging
+                        _logging.getLogger(__name__).warning(
+                            "goal judge check failed, allowing completion: %s",
+                            judge_exc,
+                            exc_info=True,
+                        )
+                    if verdict != "done":
+                        print(
+                            f"kanban: goal completion of {tid} rejected by judge: {reason}. "
+                            f"Provide evidence matching the task's acceptance criteria.",
+                            file=sys.stderr,
+                        )
+                        failed.append(tid)
+                        continue
+
             if not kb.complete_task(
                 conn, tid,
                 result=args.result,

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -296,3 +296,102 @@ def test_loop_stops_if_task_reclaimed(monkeypatch):
         first_response="x",
     )
     assert res["outcome"] == "stopped"
+
+
+# ---------------------------------------------------------------------------
+# CLI judge gate tests (hermes kanban complete bypass fix)
+# ---------------------------------------------------------------------------
+
+def _make_goal_task(tmp_path):
+    """Create a SQLite kanban DB with one goal_mode task and return (db_path, task_id)."""
+    db_path = tmp_path / "kanban.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            title TEXT,
+            body TEXT,
+            status TEXT DEFAULT 'todo',
+            goal_mode INTEGER DEFAULT 0,
+            result TEXT,
+            summary TEXT,
+            metadata TEXT,
+            run_id TEXT,
+            created_at TEXT,
+            updated_at TEXT
+        )
+    """)
+    conn.execute(
+        "INSERT INTO tasks (id, title, body, status, goal_mode) VALUES (?, ?, ?, ?, ?)",
+        ("t-goal", "Finish the report", "Body details", "running", 1),
+    )
+    conn.commit()
+    conn.close()
+    return db_path, "t-goal"
+
+
+class TestCLIJudgeGate:
+    """hermes kanban complete must apply the same goal_mode judge gate as the
+    kanban_complete tool (Issue #38367 sibling gap).
+
+    Uses mocks for kb.get_task and kb.complete_task to avoid depending on the
+    full kanban_db schema; the gate logic is the unit under test.
+    """
+
+    def _run(self, monkeypatch, *, goal_mode=True, judge_available=True,
+             verdict="done", reason="", complete_ok=True, summary="done"):
+        import argparse
+        import types
+        from unittest.mock import MagicMock, patch
+        from hermes_cli.kanban import _cmd_complete
+
+        fake_task = types.SimpleNamespace(
+            goal_mode=goal_mode,
+            title="Finish report",
+            body="acceptance: criteria",
+        )
+        fake_conn = MagicMock()
+
+        def fake_connect_closing():
+            from contextlib import contextmanager
+            @contextmanager
+            def _cm():
+                yield fake_conn
+            return _cm()
+
+        monkeypatch.setattr("hermes_cli.kanban.kb.get_task", lambda conn, tid: fake_task)
+        monkeypatch.setattr("hermes_cli.kanban.kb.complete_task",
+                            lambda conn, tid, **kw: complete_ok)
+        monkeypatch.setattr("hermes_cli.kanban.kb.connect_closing", fake_connect_closing)
+        monkeypatch.setattr("hermes_cli.kanban._worker_run_id_for", lambda _: None)
+
+        _aux_client = (object(), "judge-model") if judge_available else (None, None)
+        monkeypatch.setattr(
+            "agent.auxiliary_client.get_text_auxiliary_client",
+            lambda name: _aux_client,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.goals.judge_goal",
+            lambda **kw: (verdict, reason, {}),
+        )
+
+        args = argparse.Namespace(task_ids=["t1"], summary=summary, result=None, metadata=None)
+        return _cmd_complete(args)
+
+    def test_judge_rejects_premature_completion(self, monkeypatch):
+        rc = self._run(monkeypatch, verdict="continue", reason="criteria not met")
+        assert rc != 0, "judge rejection must produce non-zero exit code"
+
+    def test_judge_allows_accepted_completion(self, monkeypatch):
+        rc = self._run(monkeypatch, verdict="done")
+        assert rc == 0
+
+    def test_judge_unavailable_fails_open(self, monkeypatch):
+        """No auxiliary client configured → gate skipped, task completes."""
+        rc = self._run(monkeypatch, judge_available=False)
+        assert rc == 0
+
+    def test_non_goal_mode_task_skips_gate(self, monkeypatch):
+        """Plain (non-goal_mode) tasks are never sent to the judge."""
+        rc = self._run(monkeypatch, goal_mode=False)
+        assert rc == 0

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -302,34 +302,6 @@ def test_loop_stops_if_task_reclaimed(monkeypatch):
 # CLI judge gate tests (hermes kanban complete bypass fix)
 # ---------------------------------------------------------------------------
 
-def _make_goal_task(tmp_path):
-    """Create a SQLite kanban DB with one goal_mode task and return (db_path, task_id)."""
-    db_path = tmp_path / "kanban.db"
-    conn = sqlite3.connect(str(db_path))
-    conn.execute("""
-        CREATE TABLE tasks (
-            id TEXT PRIMARY KEY,
-            title TEXT,
-            body TEXT,
-            status TEXT DEFAULT 'todo',
-            goal_mode INTEGER DEFAULT 0,
-            result TEXT,
-            summary TEXT,
-            metadata TEXT,
-            run_id TEXT,
-            created_at TEXT,
-            updated_at TEXT
-        )
-    """)
-    conn.execute(
-        "INSERT INTO tasks (id, title, body, status, goal_mode) VALUES (?, ?, ?, ?, ?)",
-        ("t-goal", "Finish the report", "Body details", "running", 1),
-    )
-    conn.commit()
-    conn.close()
-    return db_path, "t-goal"
-
-
 class TestCLIJudgeGate:
     """hermes kanban complete must apply the same goal_mode judge gate as the
     kanban_complete tool (Issue #38367 sibling gap).
@@ -342,7 +314,7 @@ class TestCLIJudgeGate:
              verdict="done", reason="", complete_ok=True, summary="done"):
         import argparse
         import types
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import MagicMock
         from hermes_cli.kanban import _cmd_complete
 
         fake_task = types.SimpleNamespace(
@@ -351,6 +323,7 @@ class TestCLIJudgeGate:
             body="acceptance: criteria",
         )
         fake_conn = MagicMock()
+        complete_calls: list = []
 
         def fake_connect_closing():
             from contextlib import contextmanager
@@ -359,9 +332,12 @@ class TestCLIJudgeGate:
                 yield fake_conn
             return _cm()
 
+        def fake_complete_task(conn, tid, **kw):
+            complete_calls.append(tid)
+            return complete_ok
+
         monkeypatch.setattr("hermes_cli.kanban.kb.get_task", lambda conn, tid: fake_task)
-        monkeypatch.setattr("hermes_cli.kanban.kb.complete_task",
-                            lambda conn, tid, **kw: complete_ok)
+        monkeypatch.setattr("hermes_cli.kanban.kb.complete_task", fake_complete_task)
         monkeypatch.setattr("hermes_cli.kanban.kb.connect_closing", fake_connect_closing)
         monkeypatch.setattr("hermes_cli.kanban._worker_run_id_for", lambda _: None)
 
@@ -370,28 +346,38 @@ class TestCLIJudgeGate:
             "agent.auxiliary_client.get_text_auxiliary_client",
             lambda name: _aux_client,
         )
+        # Match the real judge_goal contract:
+        # (verdict, reason, parse_failed, wait_directive)
         monkeypatch.setattr(
             "hermes_cli.goals.judge_goal",
-            lambda **kw: (verdict, reason, {}),
+            lambda **kw: (verdict, reason, False, None),
         )
 
         args = argparse.Namespace(task_ids=["t1"], summary=summary, result=None, metadata=None)
-        return _cmd_complete(args)
+        return _cmd_complete(args), complete_calls
 
     def test_judge_rejects_premature_completion(self, monkeypatch):
-        rc = self._run(monkeypatch, verdict="continue", reason="criteria not met")
+        rc, complete_calls = self._run(
+            monkeypatch, verdict="continue", reason="criteria not met"
+        )
         assert rc != 0, "judge rejection must produce non-zero exit code"
+        assert complete_calls == [], (
+            "complete_task must NOT be invoked when the judge rejects"
+        )
 
     def test_judge_allows_accepted_completion(self, monkeypatch):
-        rc = self._run(monkeypatch, verdict="done")
+        rc, complete_calls = self._run(monkeypatch, verdict="done")
         assert rc == 0
+        assert complete_calls == ["t1"]
 
     def test_judge_unavailable_fails_open(self, monkeypatch):
         """No auxiliary client configured → gate skipped, task completes."""
-        rc = self._run(monkeypatch, judge_available=False)
+        rc, complete_calls = self._run(monkeypatch, judge_available=False)
         assert rc == 0
+        assert complete_calls == ["t1"]
 
     def test_non_goal_mode_task_skips_gate(self, monkeypatch):
         """Plain (non-goal_mode) tasks are never sent to the judge."""
-        rc = self._run(monkeypatch, goal_mode=False)
+        rc, complete_calls = self._run(monkeypatch, goal_mode=False)
         assert rc == 0
+        assert complete_calls == ["t1"]


### PR DESCRIPTION
## Summary
`hermes kanban complete` now applies the same goal-mode judge gate as the `kanban_complete` tool — previously a goal_mode worker could bypass the acceptance judge entirely by completing tasks via the CLI from the terminal tool.

## Changes
- `hermes_cli/kanban.py`: goal-mode pre-completion judge gate in `_cmd_complete`, mirroring `tools/kanban_tools.py:_handle_complete` (availability probe → judge → reject with non-zero exit and keep the task alive). Uses the correct 4-value `judge_goal` unpack (the fail-open class fixed on the tool path in #67973).
- `tests/hermes_cli/test_kanban_goal_mode.py`: 4 gate tests — rejection, acceptance, judge-unavailable fail-open, non-goal skip. The rejection test asserts `complete_task` is never invoked; mock matches the real 4-value judge contract.

## Validation
| | Before | After |
|---|---|---|
| CLI completion of goal_mode task | writes unconditionally | judged; rejection exits non-zero, no write |
| Judge unreachable / non-goal task | completes | completes (unchanged, deliberate fail-open) |
| `tests/hermes_cli/test_kanban_goal_mode.py` | — | all pass |
| E2E (real imports, real `judge_goal` early-return path) | — | 4-tuple flows through gate; rejection blocks the write |

Sibling audit: dashboard completion calls (`plugins/kanban/dashboard/plugin_api.py:845` and the bulk path) remain ungated — that surface is human-driven (a person clicking "done" on the board), which reads as an intentional override rather than a worker bypass vector; flagging rather than changing it here.

## Credit
Gap identified and gate implemented by @srojk34 in #55854 — commit cherry-picked with authorship preserved. Follow-up commit fixes the 3-value `judge_goal` unpack the original carried (same fail-open class as #67973) and hardens the tests.

Closes #55854.

## Infographic

![cli-completion-gate-sealed](https://v3b.fal.media/files/b/0aa2ff1f/lGRo_lx8rtPe_LC5Mc0M9_hPP6kYn0.png)
