### PR TITLE
fix(desktop): survive older backends missing the batched sidebar endpoint

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -105,13 +105,13 @@ function fakeDesktop() {
   }
 }
 
-function Harness() {
+function Harness({ refreshSessions }: { refreshSessions?: () => Promise<void> } = {}) {
   useGatewayBoot({
     handleGatewayEvent: () => undefined,
     onConnectionReady: () => undefined,
     onGatewayReady: () => undefined,
     refreshHermesConfig: async () => undefined,
-    refreshSessions: async () => undefined
+    refreshSessions: refreshSessions ?? (async () => undefined)
   })
 
   return null
@@ -266,5 +266,26 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
 
     expect($gatewayState.get()).toBe('open')
     expect($desktopBoot.get().error).toBeNull()
+  })
+
+  it('FIX: a failed session-list fetch during boot is non-fatal — the app still boots', async () => {
+    // The version-skew report: gateway WS connects fine, but refreshSessions()
+    // rejects (e.g. older backend 404s an endpoint the fallback didn't cover,
+    // or a transient read error). That must NOT reject boot() into
+    // failDesktopBoot's "Hermes couldn't start" overlay — the socket is open
+    // and the app is fully usable with an empty sidebar.
+    const refreshSessions = vi.fn(async () => {
+      throw new Error('404: {"detail":"No such API endpoint: /api/profiles/sessions/sidebar"}')
+    })
+
+    render(<Harness refreshSessions={refreshSessions} />)
+    await flushAsync()
+
+    expect(refreshSessions).toHaveBeenCalled()
+    expect($gatewayState.get()).toBe('open')
+    // Boot completed: no error, overlay dismissed.
+    expect($desktopBoot.get().error).toBeNull()
+    expect($desktopBoot.get().visible).toBe(false)
+    expect($desktopBoot.get().phase).toBe('renderer.ready')
   })
 })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -480,7 +480,15 @@ export function useGatewayBoot({
         await Promise.all([
           seedDefaultCwd(),
           callbacksRef.current.refreshHermesConfig(),
-          callbacksRef.current.refreshSessions()
+          // Session-list population is never boot-fatal. The gateway WS is
+          // already open by this point — a failed sidebar fetch (transient
+          // blip, or an endpoint the fallback couldn't cover) must leave the
+          // app usable with an empty sidebar (the reconnect/turn refreshes
+          // retry it), not brick boot behind the "Hermes couldn't start"
+          // overlay. Matches the reconnect + softSwitch call sites.
+          callbacksRef.current.refreshSessions().catch(() => {
+            setSessionsLoading(false)
+          })
         ])
 
         if (cancelled) {

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -11,7 +11,8 @@ import {
   getStatus,
   listAllProfileSessions,
   listSessions,
-  listSidebarSessions
+  listSidebarSessions,
+  resetSidebarBatchCapability
 } from './hermes'
 import { refreshActiveProfile } from './store/profile'
 
@@ -26,6 +27,7 @@ describe('Hermes REST session helpers', () => {
   let api: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
+    resetSidebarBatchCapability()
     api = vi.fn().mockResolvedValue(emptySessionsResponse)
     Object.defineProperty(window, 'hermesDesktop', {
       configurable: true,
@@ -97,6 +99,149 @@ describe('Hermes REST session helpers', () => {
     expect(result.recents.sessions).toEqual([])
     expect(result.cron.sessions).toEqual([])
     expect(result.messaging.sessions).toEqual([])
+  })
+
+  it('falls back to the per-slice endpoint when the batched route 404s on an older backend', async () => {
+    const row = (id: string) => ({ id, title: id, profile: 'default' })
+
+    api.mockImplementation(({ path }: { path: string }) => {
+      if (path.startsWith('/api/profiles/sessions/sidebar')) {
+        // The exact skew failure: Electron surfaces the backend catch-all.
+        return Promise.reject(
+          new Error('Error invoking remote method \'hermes:api\': Error: 404: {"detail":"No such API endpoint: /api/profiles/sessions/sidebar"}')
+        )
+      }
+
+      if (path.includes('source=cron')) {
+        return Promise.resolve({ ...emptySessionsResponse, sessions: [row('cron-1')], total: 1 })
+      }
+
+      if (path.includes('exclude_sources=cron%2Cdesktop')) {
+        return Promise.resolve({ ...emptySessionsResponse, sessions: [row('msg-1')], total: 1 })
+      }
+
+      return Promise.resolve({
+        ...emptySessionsResponse,
+        sessions: [row('recent-1')],
+        total: 7,
+        profile_totals: { default: 7 }
+      })
+    })
+
+    const result = await listSidebarSessions({
+      recentsProfile: 'work',
+      recentsLimit: 30,
+      recentsExclude: ['cron', 'tool'],
+      cronLimit: 50,
+      messagingLimit: 100,
+      messagingExclude: ['cron', 'desktop']
+    })
+
+    // Slices reassembled from the legacy per-slice route with the same
+    // scoping: recents on the caller's profile, cron + messaging cross-profile.
+    expect(result.recents.sessions.map(s => s.id)).toEqual(['recent-1'])
+    expect(result.recents.total).toBe(7)
+    expect(result.recents.profile_totals).toEqual({ default: 7 })
+    expect(result.cron.sessions.map(s => s.id)).toEqual(['cron-1'])
+    expect(result.messaging.sessions.map(s => s.id)).toEqual(['msg-1'])
+
+    const paths = api.mock.calls.map(call => (call[0] as { path: string }).path)
+    expect(paths.filter(p => p.startsWith('/api/profiles/sessions/sidebar'))).toHaveLength(1)
+    expect(paths.filter(p => p.startsWith('/api/profiles/sessions?'))).toHaveLength(3)
+    expect(paths).toContainEqual(expect.stringContaining('profile=work'))
+    expect(paths).toContainEqual(expect.stringContaining('source=cron'))
+    expect(paths).toContainEqual(expect.stringContaining('exclude_sources=cron%2Ctool'))
+  })
+
+  it('remembers endpoint-missing and skips re-probing the batched route on later refreshes', async () => {
+    api.mockImplementation(({ path }: { path: string }) =>
+      path.startsWith('/api/profiles/sessions/sidebar')
+        ? Promise.reject(new Error('404: {"detail":"No such API endpoint: /api/profiles/sessions/sidebar"}'))
+        : Promise.resolve(emptySessionsResponse)
+    )
+
+    const req = {
+      recentsProfile: 'all' as const,
+      recentsLimit: 20,
+      recentsExclude: [],
+      cronLimit: 50,
+      messagingLimit: 100,
+      messagingExclude: []
+    }
+
+    await listSidebarSessions(req)
+    await listSidebarSessions(req)
+
+    const batchedProbes = api.mock.calls.filter(call =>
+      (call[0] as { path: string }).path.startsWith('/api/profiles/sessions/sidebar')
+    )
+
+    // First refresh probes once and learns; the second goes straight to the
+    // per-slice route (3 calls each refresh, no repeated dead probe).
+    expect(batchedProbes).toHaveLength(1)
+    expect(api.mock.calls.length).toBe(1 + 3 + 3)
+  })
+
+  it('re-probes the batched route after a gateway switch resets the capability flag', async () => {
+    api.mockImplementation(({ path }: { path: string }) =>
+      path.startsWith('/api/profiles/sessions/sidebar')
+        ? Promise.reject(new Error('404: {"detail":"No such API endpoint: /api/profiles/sessions/sidebar"}'))
+        : Promise.resolve(emptySessionsResponse)
+    )
+
+    const req = {
+      recentsProfile: 'all' as const,
+      recentsLimit: 20,
+      recentsExclude: [],
+      cronLimit: 50,
+      messagingLimit: 100,
+      messagingExclude: []
+    }
+
+    await listSidebarSessions(req)
+    // Soft gateway switch: the next backend may support the batched route.
+    resetSidebarBatchCapability()
+    api.mockResolvedValue({ recents: { sessions: [] }, cron: { sessions: [] }, messaging: { sessions: [] } })
+
+    const result = await listSidebarSessions(req)
+
+    const batchedProbes = api.mock.calls.filter(call =>
+      (call[0] as { path: string }).path.startsWith('/api/profiles/sessions/sidebar')
+    )
+
+    expect(batchedProbes).toHaveLength(2)
+    expect(result.recents.sessions).toEqual([])
+  })
+
+  it('does NOT fall back on transient failures — only endpoint-missing shapes trigger legacy mode', async () => {
+    api.mockRejectedValue(new Error('Request timed out after 60000ms'))
+
+    await expect(
+      listSidebarSessions({
+        recentsProfile: 'all',
+        recentsLimit: 20,
+        recentsExclude: [],
+        cronLimit: 50,
+        messagingLimit: 100,
+        messagingExclude: []
+      })
+    ).rejects.toThrow('timed out')
+
+    // One call: the batched probe. No legacy fan-out, no sticky degradation.
+    expect(api).toHaveBeenCalledTimes(1)
+
+    // And the next refresh still uses the batched route.
+    api.mockResolvedValue({ recents: { sessions: [] }, cron: { sessions: [] }, messaging: { sessions: [] } })
+    await listSidebarSessions({
+      recentsProfile: 'all',
+      recentsLimit: 20,
+      recentsExclude: [],
+      cronLimit: 50,
+      messagingLimit: 100,
+      messagingExclude: []
+    })
+
+    expect((api.mock.calls[1][0] as { path: string }).path).toMatch(/^\/api\/profiles\/sessions\/sidebar\?/)
   })
 
   it('uses a longer timeout for profile listing during desktop startup', async () => {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -394,7 +394,72 @@ export interface SidebarSessionsRequest {
   messagingExclude: string[]
 }
 
+// The batched /sidebar endpoint shipped later than the per-slice route, so a
+// newer desktop can meet an older backend that 404s it ("No such API
+// endpoint"). Endpoint-missing is a capability signal, not a transient
+// failure: remember it (per renderer lifetime — a runtime home change reloads
+// the window and re-probes) and serve every subsequent refresh straight from
+// the three proven per-slice calls instead of re-probing a known-dead route
+// once per turn/broadcast.
+let sidebarBatchEndpointMissing = false
+
+// Capability flags are per-backend facts. A hard re-home reloads the window
+// (module state resets naturally), but a soft gateway switch re-dials in
+// place — the next backend may well have the batched route, so the switch
+// paths call this to re-probe rather than leak the old backend's capability.
+export function resetSidebarBatchCapability() {
+  sidebarBatchEndpointMissing = false
+}
+
+// True only for "the route does not exist on this backend" shapes: the
+// backend catch-all ('404: {"detail":"No such API endpoint: ...}'), FastAPI's
+// bare 404 on headless serve (surfaces as '404: ...' directly or as
+// "Error invoking remote method 'hermes:api': Error: 404: ..." through the
+// IPC bridge), and the Electron JSON-guard ("endpoint is likely missing").
+// This GET has no path params, so a 404 status can only mean route-missing —
+// but transient failures (timeouts, 5xx, connection refused) must NOT match,
+// or one blip would silently degrade the fast path for the whole session.
+function isEndpointMissingError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err)
+
+  return (
+    /no such api endpoint/i.test(message) ||
+    /endpoint is likely missing/i.test(message) ||
+    /(?:^\s*|error:\s*)404\b/i.test(message)
+  )
+}
+
+// Compatibility fallback: reassemble the three sidebar slices from the
+// per-slice endpoint, mirroring the batched route's semantics (min_messages=1,
+// archived excluded, recency order; recents scoped to the caller's profile,
+// cron + messaging cross-profile). Rides the same Electron remote-splice
+// interception as the pre-batching desktop, so remote profiles stay correct.
+async function listSidebarSessionsLegacy(req: SidebarSessionsRequest): Promise<SidebarSessionsResponse> {
+  const [recents, cron, messaging] = await Promise.all([
+    listAllProfileSessions(req.recentsLimit, 1, 'exclude', 'recent', req.recentsProfile, {
+      excludeSources: req.recentsExclude
+    }),
+    listAllProfileSessions(req.cronLimit, 1, 'exclude', 'recent', 'all', { source: 'cron' }),
+    listAllProfileSessions(req.messagingLimit, 1, 'exclude', 'recent', 'all', {
+      excludeSources: req.messagingExclude
+    })
+  ])
+
+  const errors = [...(recents.errors ?? []), ...(cron.errors ?? []), ...(messaging.errors ?? [])]
+
+  return {
+    recents: { profile_totals: recents.profile_totals, sessions: recents.sessions, total: recents.total },
+    cron: { sessions: cron.sessions },
+    messaging: { sessions: messaging.sessions },
+    ...(errors.length ? { errors } : {})
+  }
+}
+
 export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<SidebarSessionsResponse> {
+  if (sidebarBatchEndpointMissing) {
+    return listSidebarSessionsLegacy(req)
+  }
+
   const params = new URLSearchParams({
     recents_profile: req.recentsProfile,
     recents_limit: String(Math.max(1, req.recentsLimit)),
@@ -410,10 +475,23 @@ export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<
     params.set('messaging_exclude', req.messagingExclude.join(','))
   }
 
-  const result = await window.hermesDesktop.api<SidebarSessionsResponse>({
-    path: `/api/profiles/sessions/sidebar?${params.toString()}`,
-    timeoutMs: SESSION_LIST_REQUEST_TIMEOUT_MS
-  })
+  let result: SidebarSessionsResponse
+
+  try {
+    result = await window.hermesDesktop.api<SidebarSessionsResponse>({
+      path: `/api/profiles/sessions/sidebar?${params.toString()}`,
+      timeoutMs: SESSION_LIST_REQUEST_TIMEOUT_MS
+    })
+  } catch (err) {
+    if (!isEndpointMissingError(err)) {
+      throw err
+    }
+
+    // Older backend without the batched route (desktop/runtime version skew).
+    sidebarBatchEndpointMissing = true
+
+    return listSidebarSessionsLegacy(req)
+  }
 
   return {
     recents: { ...result.recents, sessions: result.recents?.sessions ?? [] },

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -1,5 +1,6 @@
 import { atom } from 'nanostores'
 
+import { resetSidebarBatchCapability } from '@/hermes'
 import { invalidateProfileScopedQueries } from '@/lib/query-client'
 import { resetSessionsLimit } from '@/store/layout'
 import {
@@ -37,6 +38,9 @@ export const $gatewaySwitching = atom(false)
  * alone so the user stays where they were (e.g. mid-Gateway settings).
  */
 export function wipeSessionListsForGatewaySwitch(): void {
+  // The next backend is a different runtime — don't carry the old one's
+  // "batched sidebar endpoint missing" capability verdict across the switch.
+  resetSidebarBatchCapability()
   setSessions([])
   setSessionsTotal(0)
   setSessionProfileTotals({})


### PR DESCRIPTION
## Summary
The desktop app no longer bricks boot with "Hermes couldn't start" when it meets an older backend runtime missing the batched sidebar endpoint — it falls back to the legacy per-slice route, and a failed session-list fetch during boot is never fatal.

Root cause (user report, screenshot of the boot-failure overlay): commit 40160e2a0 (Jul 18) added `GET /api/profiles/sessions/sidebar` and switched the renderer's `refreshSessions()` to call it exclusively. A newer desktop against a pre-Jul-18 backend got the backend catch-all 404 (`No such API endpoint`), and `boot()` awaited `refreshSessions()` unguarded inside its `Promise.all` — unlike the reconnect and softSwitch call sites which `.catch()` it — so a session-LIST failure rejected the entire boot and raised `failDesktopBoot()` even though the gateway WS was already open and the app was fully usable.

## Changes
- `apps/desktop/src/hermes.ts`: `listSidebarSessions()` detects endpoint-missing errors (backend catch-all, IPC-wrapped `Error: 404:`, Electron HTML-guard "endpoint is likely missing") and falls back to three `listAllProfileSessions()` calls with identical scoping (recents on the caller's profile; cron + messaging cross-profile), reassembling the same `SidebarSessionsResponse` shape including `profile_totals` and merged per-profile `errors`. The verdict is cached so later refreshes skip the dead probe. Transient failures (timeout, 5xx, ECONNREFUSED) still throw — one blip never silently degrades the fast path.
- `apps/desktop/src/store/gateway-switch.ts`: `wipeSessionListsForGatewaySwitch()` resets the capability flag — a soft gateway switch re-probes the next backend instead of leaking the previous backend's verdict (hard re-homes reload the window and reset module state anyway).
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts`: `boot()` treats `refreshSessions()` as non-fatal, matching its two sibling call sites (reconnect at L174, softSwitch at L293). Worst case is an empty sidebar repopulated by the next reconnect/turn refresh — never a bricked boot.

## Validation
| Scenario | Before | After |
|---|---|---|
| New desktop + pre-Jul-18 backend | "Hermes couldn't start" overlay, app unusable | Sidebar populated via per-slice fallback, boot completes |
| Batched route 404s repeatedly | n/a (fatal) | Probed once, verdict cached, 3 slice calls per refresh |
| Soft gateway switch to newer backend | n/a | Capability re-probed, batched fast path restored |
| Transient timeout/5xx on batched route | fatal at boot | Throws (no fallback, no sticky degradation), boot survives |
| Any refreshSessions failure during boot | boot-fatal | Non-fatal; `phase: renderer.ready`, overlay dismissed |

Tests: 6 new — fallback slice reassembly + scoping params, sticky endpoint-missing verdict (no re-probe), re-probe after gateway-switch reset, transient errors NOT triggering fallback (and next refresh still batched), and a real-hook harness test (`use-gateway-boot.test.tsx`) proving a rejecting `refreshSessions` still completes boot with no error overlay. Targeted files 28/28; full desktop suite 246 files / 2121 tests green; `npm run typecheck` clean; eslint clean on changed files.

## Infographic

![sidebar-endpoint-fallback](https://v3b.fal.media/files/b/0aa2ff43/NDh3XcHnsX1FMdPpY3i80_288GpHBr.png)
