### PR TITLE
fix(tools): bound env probe subprocess so a Windows inherited pipe can't wedge sessions (#67964)

### DIFF
--- a/tests/tools/test_env_probe.py
+++ b/tests/tools/test_env_probe.py
@@ -155,3 +155,43 @@ class TestRobustness:
         result = env_probe.get_environment_probe_line()
         # Whatever the result is, it must be a string
         assert isinstance(result, str)
+
+
+class TestRunBoundedByTimeout:
+    """``_run`` must return as soon as the *direct* child exits, even when a
+    descendant inherited the captured stdout/stderr handles and outlives it.
+
+    This is the deadlock from #67964: on native Windows a ``pip.exe`` launcher
+    can leave a grandchild holding the captured pipe open, and ``capture_output``
+    reader threads then block far past the timeout while ``_CACHE_LOCK`` is held,
+    wedging every new session. Capturing through temp files removes the reader
+    threads, so a lingering grandchild can't block the parent's ``wait()``.
+
+    Cross-platform repro: the direct child prints ``ok`` and exits immediately
+    after spawning a long-sleeping grandchild that inherits its stdout. With the
+    old pipe-based capture, ``_run`` blocks until the grandchild exits (or hits
+    the 3s timeout and returns ``-1``); with temp-file capture it returns the
+    child's real output within a few milliseconds.
+    """
+
+    def test_returns_before_inheriting_grandchild_exits(self):
+        import time
+
+        grandchild_sleep = 20  # far longer than _run's timeout
+        # Direct child: emit "ok", spawn a detached grandchild that inherits
+        # this process's stdout (no stdout= redirect), then exit right away.
+        child_code = (
+            "import subprocess, sys; "
+            "subprocess.Popen([sys.executable, '-c', "
+            f"'import time; time.sleep({grandchild_sleep})']); "
+            "sys.stdout.write('ok'); sys.stdout.flush()"
+        )
+
+        start = time.monotonic()
+        rc, out, err = env_probe._run([sys.executable, "-c", child_code], timeout=3.0)
+        elapsed = time.monotonic() - start
+
+        # Must not wait on the grandchild, and must not have hit the timeout.
+        assert elapsed < 3.0, f"_run blocked on grandchild for {elapsed:.1f}s"
+        assert rc == 0, f"expected clean exit, got rc={rc} err={err!r}"
+        assert out == "ok"

--- a/tools/env_probe.py
+++ b/tools/env_probe.py
@@ -34,6 +34,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 from typing import Optional
 
@@ -57,21 +58,41 @@ def _run(cmd: list[str], timeout: float = 3.0) -> tuple[int, str, str]:
     """Run a short subprocess.  Returns (returncode, stdout, stderr).
 
     Failures (binary missing, timeout, OSError) return (-1, "", "<reason>").
+
+    Output is captured through temporary files rather than ``capture_output``
+    pipes so ``timeout`` bounds the *whole* call — even on native Windows.  A
+    console-script launcher (e.g. ``pip.exe``) can spawn a descendant that
+    inherits the captured stdout/stderr handles and outlives its parent.  With
+    OS pipes, the reader threads inside ``subprocess.communicate()`` then block
+    until that descendant closes the write end — which the timeout does *not*
+    cover, because killing the direct child leaves the grandchild holding the
+    pipe.  A whole warm probe could hang for ~28 min this way while holding
+    ``_CACHE_LOCK``, wedging every new session's system-prompt build.
+
+    Temp files have no reader threads, so ``wait()`` only ever waits on the
+    direct child; a lingering grandchild holding the handle can't block us, and
+    the probe genuinely fails open on timeout.
     """
     try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            check=False,
-            stdin=subprocess.DEVNULL,
-        )
-        return result.returncode, (result.stdout or "").strip(), (result.stderr or "").strip()
+        with tempfile.TemporaryFile() as out_f, tempfile.TemporaryFile() as err_f:
+            try:
+                result = subprocess.run(
+                    cmd,
+                    stdout=out_f,
+                    stderr=err_f,
+                    timeout=timeout,
+                    check=False,
+                    stdin=subprocess.DEVNULL,
+                )
+            except subprocess.TimeoutExpired:
+                return -1, "", "timeout"
+            out_f.seek(0)
+            err_f.seek(0)
+            out = out_f.read().decode("utf-8", "replace").strip()
+            err = err_f.read().decode("utf-8", "replace").strip()
+            return result.returncode, out, err
     except FileNotFoundError:
         return -1, "", "not found"
-    except subprocess.TimeoutExpired:
-        return -1, "", "timeout"
     except OSError as exc:
         return -1, "", f"oserror: {exc}"
 


### PR DESCRIPTION
## What does this PR do?

Fixes #67964. On native Windows, the local Python toolchain probe can deadlock every new session's system-prompt build.

`tools/env_probe.py::_run` captures subprocess output with `capture_output=True` (OS pipes). A console-script launcher such as `pip.exe` spawns a descendant (`python.exe … pip --version`) that **inherits the captured stdout/stderr write ends** and can outlive its parent. With pipes, the reader threads inside `subprocess.communicate()` then block until that grandchild closes the write end — which the 3s `timeout` does **not** bound, because killing the direct child leaves the grandchild holding the pipe. In the reported incident the warm-probe thread stayed blocked ~28 min.

Because `get_environment_probe_line()` holds the module-level `_CACHE_LOCK` across the probe, every new session that needs a system prompt then waits on that lock indefinitely — a partial outage (new chats stuck `working`, zero API calls; older sessions with a persisted prompt unaffected).

## Fix

Capture through `tempfile.TemporaryFile()` instead of `capture_output` pipes. Temp files have no reader threads, so `subprocess`'s `timeout`/`wait()` only ever waits on the **direct** child. A lingering grandchild holding an inherited handle can no longer block the parent, the documented 3s timeout genuinely bounds the whole call, and the probe fails open — satisfying the issue's stated expectation. This mirrors the "don't wait on a Windows-inherited pipe handle" pattern already used in #67373 for `BaseEnvironment.execute()`.

Single-purpose change confined to `_run`; the happy-path return contract `(returncode, stdout, stderr)` is unchanged, so `_CACHE_LOCK` is now held for at most the bounded probe duration.

## Testing

- New `TestRunBoundedByTimeout` in `tests/tools/test_env_probe.py`: a direct child prints `ok`, spawns a 20s-sleeping grandchild inheriting its stdout, then exits. Asserts `_run` returns `rc=0`, `out="ok"` in `< 3.0s`. Verified this test **fails on the old `capture_output` path** (blocks the full 3s → `rc=-1`) and passes with temp-file capture.
- Full `tests/tools/test_env_probe.py` (11) + `tests/run_agent/test_run_agent.py` — 447 passed.
- `ruff check` clean (incl. PLW1514); `check-windows-footguns.py` and `check_subprocess_stdin.py` pass.

The arm64-fork-Docker CI job is expected to fail on fork PRs.
