### PR TITLE
fix(gateway): key-presence precedence for quick_commands nested fallback

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1199,7 +1199,7 @@ def load_gateway_config() -> GatewayConfig:
                 gw_data["default_reset_policy"] = sr
 
             qc = yaml_cfg.get("quick_commands")
-            if qc is None and isinstance(gateway_section, dict):
+            if "quick_commands" not in yaml_cfg and isinstance(gateway_section, dict):
                 qc = gateway_section.get("quick_commands")
             if qc is not None:
                 if isinstance(qc, dict):

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1241,9 +1241,11 @@ def load_gateway_config() -> GatewayConfig:
 
             # Profile-based routing rules: accept either top-level
             # ``profile_routes`` or the nested ``gateway.profile_routes`` form
-            # (matching the multiplex_profiles parity above).
+            # (matching the multiplex_profiles parity above). Key-presence
+            # precedence: the top-level key wins even when null/empty, and the
+            # nested form is consulted only when the top-level key is absent.
             _pr = yaml_cfg.get("profile_routes")
-            if _pr is None and isinstance(gateway_section, dict):
+            if "profile_routes" not in yaml_cfg and isinstance(gateway_section, dict):
                 _pr = gateway_section.get("profile_routes")
             if isinstance(_pr, list):
                 gw_data["profile_routes"] = _pr
@@ -1263,7 +1265,7 @@ def load_gateway_config() -> GatewayConfig:
                 gw_data["max_concurrent_sessions"] = yaml_cfg["max_concurrent_sessions"]
 
             streaming_cfg = yaml_cfg.get("streaming")
-            if not isinstance(streaming_cfg, dict) and isinstance(gateway_section, dict):
+            if "streaming" not in yaml_cfg and isinstance(gateway_section, dict):
                 # Fall back to nested gateway.streaming written by
                 # ``hermes config set gateway.streaming.*``
                 streaming_cfg = gateway_section.get("streaming")

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -869,6 +869,54 @@ class TestLoadGatewayConfig:
         # gateway.stt.enabled=false must NOT win over the present top-level stt.
         assert config.stt_enabled is True
 
+    def test_present_empty_top_level_quick_commands_blocks_nested_fallback(self, tmp_path, monkeypatch):
+        """Key-presence precedence for quick_commands: a present (even empty)
+        top-level quick_commands must NOT be replaced by gateway.quick_commands
+        — the fallback fires only when the top-level key is absent. Mirrors the
+        session_reset/stt precedence contract from #73543744b."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "quick_commands: null\n"
+            "gateway:\n"
+            "  quick_commands:\n"
+            "    limits:\n"
+            "      type: exec\n"
+            "      command: echo nested\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        # The nested gateway.quick_commands must NOT leak through the present
+        # (null) top-level key — quick_commands stays at its default (empty).
+        assert "limits" not in (config.quick_commands or {})
+
+    def test_absent_top_level_quick_commands_falls_back_to_nested(self, tmp_path, monkeypatch):
+        """Sanity: when quick_commands is genuinely absent at the top level,
+        the nested gateway.quick_commands fallback still applies (regression
+        guard so the precedence fix doesn't over-correct and break the
+        legitimate nested path)."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  quick_commands:\n"
+            "    limits:\n"
+            "      type: exec\n"
+            "      command: echo nested\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        # Absent top-level key → nested fallback fires normally.
+        assert config.quick_commands.get("limits", {}).get("command") == "echo nested"
+
     def test_relay_platform_enabled_from_env_url(self, tmp_path, monkeypatch):
         """GATEWAY_RELAY_URL must enable Platform.RELAY in config.platforms so
         start_gateway()'s connect loop actually dials the connector. Registering

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -917,6 +917,92 @@ class TestLoadGatewayConfig:
         # Absent top-level key → nested fallback fires normally.
         assert config.quick_commands.get("limits", {}).get("command") == "echo nested"
 
+    def test_present_empty_top_level_profile_routes_blocks_nested_fallback(self, tmp_path, monkeypatch):
+        """Key-presence precedence for profile_routes: a present (even empty)
+        top-level profile_routes must NOT be replaced by gateway.profile_routes
+        — the fallback fires only when the top-level key is absent. Mirrors the
+        session_reset/stt/quick_commands precedence contract."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "profile_routes: null\n"
+            "gateway:\n"
+            "  profile_routes:\n"
+            "    - name: work\n"
+            "      platform: telegram\n"
+            "      profile: work\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        # The nested gateway.profile_routes must NOT leak through the present
+        # (null) top-level key — profile_routes stays at its default (empty).
+        assert config.profile_routes == []
+
+    def test_absent_top_level_profile_routes_falls_back_to_nested(self, tmp_path, monkeypatch):
+        """Sanity: when profile_routes is genuinely absent at the top level,
+        the nested gateway.profile_routes fallback still applies."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  profile_routes:\n"
+            "    - name: work\n"
+            "      platform: telegram\n"
+            "      profile: work\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert any(r.name == "work" for r in config.profile_routes)
+
+    def test_present_empty_top_level_streaming_blocks_nested_fallback(self, tmp_path, monkeypatch):
+        """Key-presence precedence for streaming: a present (even empty)
+        top-level streaming must NOT be replaced by gateway.streaming — the
+        fallback fires only when the top-level key is absent. Mirrors the
+        session_reset/stt/quick_commands precedence contract."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "streaming: null\n"
+            "gateway:\n"
+            "  streaming:\n"
+            "    transport: websocket\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        # The nested gateway.streaming must NOT leak through the present (null)
+        # top-level key — streaming stays at its default.
+        assert config.streaming.transport == "auto"
+
+    def test_absent_top_level_streaming_falls_back_to_nested(self, tmp_path, monkeypatch):
+        """Sanity: when streaming is genuinely absent at the top level,
+        the nested gateway.streaming fallback still applies."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  streaming:\n"
+            "    transport: websocket\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.streaming.transport == "websocket"
+
     def test_relay_platform_enabled_from_env_url(self, tmp_path, monkeypatch):
         """GATEWAY_RELAY_URL must enable Platform.RELAY in config.platforms so
         start_gateway()'s connect loop actually dials the connector. Registering


### PR DESCRIPTION
Follow-up to 73543744b. That commit established a key-presence precedence contract for load_gateway_config(): a present (even empty/falsy) top-level value must NOT be silently replaced by the nested gateway.* form, and it fixed session_reset and stt to use `"key" not in yaml_cfg` gating instead of truthiness checks. quick_commands was left on the old `qc is None` gate, so it's the one remaining sibling that doesn't honor that contract.

Concretely, `quick_commands: null` at the top level alongside a populated `gateway.quick_commands` block causes the nested value to leak through, because yaml_cfg.get("quick_commands") returns None for both "absent" and "present-null". The fix switches the gate to `"quick_commands" not in yaml_cfg`, matching session_reset/stt exactly. The legitimate nested-only path (top-level key genuinely absent) still falls back normally.

I added two regression tests mirroring the session_reset/stt ones: one asserting a present-null top-level blocks the nested fallback, and one sanity check that the nested fallback still fires when the top-level key is absent. I verified the first test fails on the pre-fix code and passes after, and the full tests/gateway/test_config.py suite (132 tests) stays green.