### PR TITLE
fix(lazy_deps): stop an exact pin on a shared transitive dep from downgrading the core

### DIFF
--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -239,7 +239,16 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "starlette==1.0.1",  # CVE-2026-48710 — keep in sync with pyproject [computer-use]
     ),
     # HF Agent Trace Viewer upload (hermes trace upload / /upload-trace).
-    "tool.trace_upload": ("huggingface-hub==1.2.3",),
+    # RANGE, not an exact pin, ON PURPOSE: huggingface-hub is also a shared
+    # transitive dependency of the embedding stack (transformers /
+    # sentence_transformers) that local/local_embedded Hindsight needs. An exact
+    # "==" pin here satisfies nothing but itself, so on every `hermes update` the
+    # lazy-refresh pass reinstalls (DOWNGRADES) it to the pinned version — even
+    # when the core already installed a newer one it depends on — which silently
+    # breaks that unrelated core feature. Track the compatibility range the
+    # trace-upload client actually needs. (See also the no-downgrade guard in
+    # _is_satisfied, which backstops this for any shared-dep pin.)
+    "tool.trace_upload": ("huggingface-hub>=1.5,<2.0",),
 }
 
 
@@ -544,10 +553,50 @@ def _is_satisfied(spec: str) -> bool:
         return True
 
     try:
-        return Version(installed) in SpecifierSet(spec_tail)
+        iv = Version(installed)
+        ss = SpecifierSet(spec_tail)
+        if iv in ss:
+            return True
+        # No-downgrade guard. The installed version is outside the spec — but if
+        # installing this spec would move the package BACKWARDS, refuse. A lazy,
+        # opt-in backend must never downgrade a package that the core (or another
+        # backend) already installed at a higher version: that is exactly how an
+        # exact "==" pin on a SHARED transitive dependency (e.g. huggingface-hub,
+        # pulled by transformers) silently bricks an unrelated core feature on
+        # `hermes update`. Treat "already newer than this pin allows" as
+        # satisfied, leave the higher version in place, and warn the maintainer
+        # to widen the pin instead of churning a shared dependency.
+        if _would_downgrade(iv, ss):
+            logger.warning(
+                "Lazy spec %r would DOWNGRADE already-installed %s==%s; leaving the "
+                "installed version in place. Widen this pin to a range that includes "
+                "the installed version if the downgrade is not intended.",
+                spec, pkg, installed,
+            )
+            return True
+        return False
     except (InvalidSpecifier, InvalidVersion, Exception):
         # Malformed spec or installed version we can't parse — don't churn.
         return True
+
+
+def _would_downgrade(installed, spec_set) -> bool:
+    """True if ``spec_set`` permits no version >= ``installed``.
+
+    ``installed`` is already known to fall outside ``spec_set``. If every
+    upper-bounding operator (``==``, ``<``, ``<=``, ``~=``) in the spec sits
+    below the installed version, the only way to satisfy the spec is to install
+    something older — a downgrade. Purely local version arithmetic; no network.
+    """
+    try:
+        from packaging.version import Version
+        for s in spec_set:
+            if s.operator in ("==", "<", "<=", "~="):
+                if installed > Version(s.version):
+                    return True
+        return False
+    except Exception:
+        return False
 
 
 def _is_present(spec: str) -> bool:


### PR DESCRIPTION


## What does this PR do?

`LAZY_DEPS["tool.trace_upload"]` pinned `huggingface-hub==1.2.3`. `huggingface-hub`
is not private to the trace-upload feature — it is a **shared transitive
dependency of the embedding stack** (`transformers` / `sentence_transformers`)
that the local / local_embedded Hindsight memory backend needs. `transformers`
requires `huggingface-hub>=1.5.0,<2.0`.

Because the pin is an exact `==`, it satisfies nothing but itself: `_is_satisfied`
returns `False` for any other installed version. So the moment the feature is
"active" (its package present) and `hermes update` runs its `refresh_active_features`
lazy-refresh pass, pip **reinstalls — i.e. DOWNGRADES — huggingface-hub back to
1.2.3**, even though the core just resolved a newer one it depends on. That
silently breaks `import sentence_transformers`, and the local Hindsight embedded
daemon aborts at startup on every retain/recall. The existing `_is_satisfied`
version guard cannot prevent this: an `==` pin *is* a downgrade instruction
whenever the installed version differs.

This PR fixes it in two layers:

1. **Range, not exact pin** for `tool.trace_upload`: `huggingface-hub>=1.5,<2.0`,
   which brackets what the trace-upload client needs *and* what the embedding
   stack requires, so an already-healthy shared version is left untouched.

2. **A general no-downgrade guard in `_is_satisfied`.** When the installed
   version is outside a spec but every upper bound in that spec sits *below* the
   installed version — i.e. satisfying the spec would require going backwards —
   the guard treats the already-installed higher version as satisfied, leaves it
   in place, and logs a `warning` telling the maintainer to widen the pin. This
   backstops the whole failure class: no lazy, opt-in backend can ever silently
   downgrade a package the core (or another backend) already installed at a
   higher version. Legitimate upgrades (installed *below* the floor) are
   unaffected — those still install. It is pure local version arithmetic; no
   network, no behavior change for specs that are already satisfied.

## Reproduction

With `transformers`/`sentence_transformers` installed (pulling `huggingface-hub`
≥1.5), activate the trace-upload feature and run the update refresh pass (or
`ensure("tool.trace_upload")`): huggingface-hub is downgraded to 1.2.3 and
`python -c "import sentence_transformers"` then raises
`ImportError: huggingface-hub>=1.5.0,<2.0 is required ... but found huggingface-hub==1.2.3`.

## Related Issue

No existing issue — found during an operational memory-outage investigation and
reproduced directly against `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Notes for maintainers

- The `tools/lazy_deps.py` module docstring / TTS comment references a
  "no-ranges policy to match pyproject extras." That policy is right for
  feature-private packages; the point of this change is that `huggingface-hub`
  is **not** feature-private. If you prefer to keep the literal pin exact, the
  no-downgrade guard alone still prevents the outage — but the range is the more
  honest description of the real constraint.
- Consider auditing the rest of `LAZY_DEPS` for other exact pins on packages
  that also appear in the core dependency tree (`aiohttp`, `starlette`,
  `numpy`, `Pillow`); those already carry security rationale, but the same
  downgrade risk applies if the core ever floats above the pinned version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MN8RMDLwxCfFxwtADoEJJf
