### PR TITLE
fix(memory/hindsight): availability probe must check the embedding stack, not just the API modules

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -131,10 +131,19 @@ def _check_local_runtime() -> tuple[bool, str | None]:
     error from NumPy before the daemon starts. Treat that as "unavailable"
     so Hermes can degrade gracefully instead of repeatedly trying to start
     a broken local memory backend.
+
+    The embedded daemon computes embeddings via ``sentence_transformers``
+    (transformers + huggingface-hub). Importing ``hindsight`` /
+    ``hindsight_embed`` alone succeeds even when that stack is broken, so
+    without importing it here the probe would falsely report the backend
+    healthy and ``hermes memory status`` would stay green while the daemon
+    aborts at startup on every retain/recall. Import it too so the probe (and
+    status) reports the real ImportError.
     """
     try:
         importlib.import_module("hindsight")
         importlib.import_module("hindsight_embed.daemon_embed_manager")
+        importlib.import_module("sentence_transformers")
         return True, None
     except Exception as exc:
         return False, str(exc)


### PR DESCRIPTION


## What does this PR do?

`_check_local_runtime()` decides whether the local / local_embedded Hindsight
backend is available (it backs `HindsightMemoryProvider.is_available()` and
`hermes memory status`). It imports `hindsight` and
`hindsight_embed.daemon_embed_manager` — but **not** the embedding stack the
embedded daemon actually runs on.

The embedded daemon computes embeddings via `sentence_transformers`
(`transformers` + `huggingface-hub`). Those two `hindsight*` imports succeed
even when `sentence_transformers` is broken (e.g. a shared dependency was
downgraded out of its supported range). So the probe returns `available=True`,
`hermes memory status` shows green, and the operator has no signal — while the
daemon aborts at startup on every retain and every `sync_turn` fails silently.
This masked a multi-day local-memory outage.

This PR adds `importlib.import_module("sentence_transformers")` to the same
`try` block. The existing `except Exception as exc: return False, str(exc)`
already surfaces the real ImportError in the returned reason, so `memory status`
goes **red with the actionable error** the moment the embedding stack is broken.
Minimal, matches the function's existing style, and does not change the cloud /
local_external paths.

## Related Issue

No existing issue — found during an operational memory-outage investigation and
reproduced directly against `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Notes for maintainers

- The extra import runs only in the local / local_embedded availability path,
  which already imports the heavier `hindsight` / `hindsight_embed` modules, so
  it adds no import cost to cloud users.
- Pairs naturally with the `lazy_deps` shared-dependency fix (separate PR): that
  one stops the downgrade that breaks the stack; this one makes the breakage
  observable if it ever happens again by another route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MN8RMDLwxCfFxwtADoEJJf
