### PR TITLE
fix(discord): make outage catch-up durable

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2551,6 +2551,8 @@ DEFAULT_CONFIG = {
             "limit": 100,                 # Global cap on messages scanned per reconnect
             "max_dispatches": 10,         # Cap on recovered messages dispatched per reconnect
         },
+        "startup_catchup": True,          # Replay unseen post-checkpoint triggers after a Discord gateway outage
+        "startup_catchup_limit": 50,      # Bounded recent-history scan per channel during startup catch-up
         "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
         # Discord Gateway transport health. These settings inspect the active
         # WebSocket's ready/open/heartbeat state; they never use Discord REST as

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1353,7 +1353,19 @@ class DiscordAdapter(BasePlatformAdapter):
                     except asyncio.TimeoutError:
                         pass
 
-                await adapter_self._startup_catchup_complete.wait()
+                # asyncio.Event.set() releases waiters permanently. A reconnect
+                # can arm a newer generation and clear this shared event before
+                # a waiter released by the older generation resumes. Keep
+                # waiting until the generation captured for this wait still
+                # owns a set catch-up barrier.
+                while True:
+                    catchup_generation = adapter_self._startup_catchup_generation
+                    await adapter_self._startup_catchup_complete.wait()
+                    if (
+                        catchup_generation == adapter_self._startup_catchup_generation
+                        and adapter_self._startup_catchup_complete.is_set()
+                    ):
+                        break
                 await adapter_self._dispatch_discord_message(message)
 
             @self._client.event

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -226,7 +226,11 @@ async def _wait_for_ready_or_bot_exit(
             exc = bot_task.exception()
             if exc is not None:
                 raise exc
-            if not ready_task.done():
+            # A bot may finish immediately after on_ready sets the event,
+            # before the separately scheduled wait task has run. Check the
+            # event itself to avoid treating that valid ordering as startup
+            # failure.
+            if not ready_event.is_set():
                 raise RuntimeError("Discord bot task exited before ready")
         await ready_task
     finally:
@@ -311,12 +315,15 @@ class _DiscordNonConversationalMessageTracker:
 
 
 class _DiscordStartupCatchupTracker:
-    """Persist bounded Discord startup catch-up progress across restarts."""
+    """Persist per-channel startup catch-up checkpoints across restarts.
 
-    _MAX_TRACKED = 2000
+    A global bounded message-ID list is not enough for durable at-most-once
+    delivery: evicting a still-relevant ID makes it eligible for replay after
+    restart. Discord snowflakes are ordered, so retain one durable high-water
+    checkpoint per channel instead.
+    """
 
-    def __init__(self, max_tracked: int = _MAX_TRACKED):
-        self._max_tracked = max_tracked
+    def __init__(self):
         self._state = self._load()
 
     def _state_path(self) -> _Path:
@@ -328,41 +335,86 @@ class _DiscordStartupCatchupTracker:
         try:
             data = json.loads(self._state_path().read_text(encoding="utf-8"))
             if isinstance(data, dict):
+                checkpoints = data.get("channel_checkpoints", {})
+                if not isinstance(checkpoints, dict):
+                    checkpoints = {}
+                # Keep legacy IDs only for the one-way format migration. New
+                # progress is never recorded in a globally-evictable list.
+                legacy_ids = data.get(
+                    "legacy_processed_message_ids", data.get("processed_message_ids", [])
+                )
+                if not isinstance(legacy_ids, list):
+                    legacy_ids = []
+                for channel_id in data.get("initialized_channels", []):
+                    checkpoints.setdefault(str(channel_id), None)
                 return {
-                    "initialized_channels": [str(item) for item in data.get("initialized_channels", [])],
-                    "processed_message_ids": [str(item) for item in data.get("processed_message_ids", [])],
+                    "channel_checkpoints": {
+                        str(channel_id): str(message_id) if message_id is not None else None
+                        for channel_id, message_id in checkpoints.items()
+                    },
+                    "legacy_processed_message_ids": [str(item) for item in legacy_ids],
                 }
         except FileNotFoundError:
             pass
         except Exception:
             logger.debug("[%s] Failed to load Discord startup catch-up state", "Discord")
-        return {"initialized_channels": [], "processed_message_ids": []}
+        return {"channel_checkpoints": {}, "legacy_processed_message_ids": []}
 
-    def _save(self) -> None:
-        for key in ("initialized_channels", "processed_message_ids"):
-            self._state[key] = self._state[key][-self._max_tracked:]
+    def _save(self, state: dict) -> bool:
         try:
-            atomic_json_write(self._state_path(), self._state, indent=None)
+            atomic_json_write(self._state_path(), state, indent=None)
+            return True
         except Exception:
             logger.debug("[%s] Failed to save Discord startup catch-up state", "Discord", exc_info=True)
+            return False
 
     def initialized(self, channel_id: str) -> bool:
-        return str(channel_id) in self._state["initialized_channels"]
+        return str(channel_id) in self._state["channel_checkpoints"]
 
-    def mark_initialized(self, channel_id: str) -> None:
+    def mark_initialized(self, channel_id: str, high_water_message_id: Optional[str]) -> bool:
         key = str(channel_id)
-        if key not in self._state["initialized_channels"]:
-            self._state["initialized_channels"].append(key)
-            self._save()
+        if key in self._state["channel_checkpoints"]:
+            return True
+        state = {
+            **self._state,
+            "channel_checkpoints": {
+                **self._state["channel_checkpoints"],
+                key: str(high_water_message_id) if high_water_message_id is not None else None,
+            },
+        }
+        if not self._save(state):
+            return False
+        self._state = state
+        return True
 
-    def processed(self, message_id: str) -> bool:
-        return str(message_id) in self._state["processed_message_ids"]
-
-    def mark_processed(self, message_id: str) -> None:
+    def processed(self, channel_id: str, message_id: str) -> bool:
         key = str(message_id)
-        if key not in self._state["processed_message_ids"]:
-            self._state["processed_message_ids"].append(key)
-            self._save()
+        if key in self._state["legacy_processed_message_ids"]:
+            return True
+        checkpoint = self._state["channel_checkpoints"].get(str(channel_id))
+        if checkpoint is None:
+            return False
+        try:
+            return int(key) <= int(checkpoint)
+        except (TypeError, ValueError):
+            return key == checkpoint
+
+    def mark_processed(self, channel_id: str, message_id: str) -> bool:
+        channel_key = str(channel_id)
+        key = str(message_id)
+        if self.processed(channel_key, key):
+            return True
+        state = {
+            **self._state,
+            "channel_checkpoints": {
+                **self._state["channel_checkpoints"],
+                channel_key: key,
+            },
+        }
+        if not self._save(state):
+            return False
+        self._state = state
+        return True
 
 
 def _metadata_marks_nonconversational(metadata: Optional[Dict[str, Any]]) -> bool:
@@ -1029,6 +1081,15 @@ class DiscordAdapter(BasePlatformAdapter):
         # should not act as conversational history boundaries after restart.
         self._nonconversational_messages = _DiscordNonConversationalMessageTracker()
         self._startup_catchup = _DiscordStartupCatchupTracker()
+        # Live messages wait for the initial catch-up scan on each connection,
+        # so a newer live snowflake cannot advance a channel checkpoint past
+        # older missed history still waiting to be replayed.
+        self._startup_catchup_complete = asyncio.Event()
+        self._startup_catchup_complete.set()
+        # Incremented for every on_ready cycle. A post-connect task only owns
+        # the barrier generation that created it, so a stale task cannot
+        # unblock live messages during a later reconnect.
+        self._startup_catchup_generation = 0
         # Last truncated mid-stream preview delivered per (chat_id, message_id).
         # Once an oversized streaming edit saturates at the 2000-char preview
         # cap, every subsequent progressive edit truncates to the SAME text;
@@ -1255,20 +1316,44 @@ class DiscordAdapter(BasePlatformAdapter):
             async def on_ready():
                 logger.info("[%s] Connected as %s", adapter_self.name, adapter_self._client.user)
 
+                # discord.py invokes on_ready again after an internal gateway
+                # reconnect while both events may still be set from the prior
+                # connection. Arm the live-message barrier before the first
+                # await so a message arriving during username resolution
+                # cannot advance its durable checkpoint ahead of catch-up.
+                adapter_self._startup_catchup_generation += 1
+                catchup_generation = adapter_self._startup_catchup_generation
+                adapter_self._ready_event.clear()
+                adapter_self._startup_catchup_complete.clear()
                 # Resolve any usernames in the allowed list to numeric IDs
                 await adapter_self._resolve_allowed_usernames()
+                # A later on_ready may have started while username resolution
+                # yielded. This stale handler must not publish readiness or
+                # replace the newer generation's post-connect task.
+                if catchup_generation != adapter_self._startup_catchup_generation:
+                    return
                 adapter_self._ready_event.set()
 
                 if adapter_self._post_connect_task and not adapter_self._post_connect_task.done():
                     adapter_self._post_connect_task.cancel()
                 adapter_self._post_connect_task = asyncio.create_task(
-                    adapter_self._run_post_connect_initialization()
+                    adapter_self._run_post_connect_initialization(catchup_generation)
                 )
                 if adapter_self._missed_message_backfill_enabled():
                     adapter_self._ensure_missed_message_backfill_task()
 
             @self._client.event
             async def on_message(message: DiscordMessage):
+                # Block until _resolve_allowed_usernames has swapped
+                # any raw usernames in DISCORD_ALLOWED_USERS for numeric
+                # IDs (otherwise on_message's author.id lookup can miss).
+                if not adapter_self._ready_event.is_set():
+                    try:
+                        await asyncio.wait_for(adapter_self._ready_event.wait(), timeout=30.0)
+                    except asyncio.TimeoutError:
+                        pass
+
+                await adapter_self._startup_catchup_complete.wait()
                 await adapter_self._dispatch_discord_message(message)
 
             @self._client.event
@@ -1930,12 +2015,28 @@ class DiscordAdapter(BasePlatformAdapter):
         if interval > 0:
             await asyncio.sleep(interval)
 
-    async def _run_post_connect_initialization(self) -> None:
+    async def _run_post_connect_initialization(self, catchup_generation: Optional[int] = None) -> None:
         """Finish non-critical startup work after Discord is connected."""
         if not self._client:
+            if (
+                catchup_generation is None
+                or catchup_generation == self._startup_catchup_generation
+            ):
+                self._startup_catchup_complete.set()
             return
         try:
-            await self._catch_up_missed_mentions()
+            try:
+                await self._catch_up_missed_mentions()
+            finally:
+                # Do not make live traffic wait for slash command sync. A
+                # failed catch-up still unblocks it after preserving whatever
+                # durable state was safely written. A stale reconnect task
+                # does not own a newer generation's barrier.
+                if (
+                    catchup_generation is None
+                    or catchup_generation == self._startup_catchup_generation
+                ):
+                    self._startup_catchup_complete.set()
             sync_policy = self._get_discord_command_sync_policy()
             if sync_policy == "off":
                 logger.info("[%s] Skipping Discord slash command sync (policy=off)", self.name)
@@ -5994,30 +6095,92 @@ class DiscordAdapter(BasePlatformAdapter):
         except (TypeError, ValueError):
             return 50
 
-    async def _dispatch_discord_message(self, message: DiscordMessage) -> None:
-        """Dispatch catch-up traffic through the same message gate as live traffic."""
+    def _admit_discord_message(self, message: DiscordMessage) -> Tuple[bool, bool]:
+        """Apply the complete live-message admission gate.
+
+        Startup catch-up calls this shared gate before dispatching historical
+        events, so replayed traffic cannot bypass live bot, authorization, or
+        multi-agent mention policy.
+        """
         if not self._client or message.author == self._client.user:
-            return
+            return False, False
         if getattr(message, "type", None) not in {discord.MessageType.default, discord.MessageType.reply}:
-            return
+            return False, False
+        role_authorized = False
         if getattr(message.author, "bot", False):
             allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
             if allow_bots == "none":
-                return
+                return False, False
             if allow_bots == "mentions" and not self._self_is_explicitly_mentioned(message):
-                return
+                return False, False
             if self._discord_bots_require_inline_mention() and not self._self_is_raw_mentioned(message):
-                return
-            await self._handle_message(message)
-            return
-        is_dm = isinstance(message.channel, discord.DMChannel) or getattr(message, "guild", None) is None
-        channel_ids = None if is_dm else self._discord_channel_keys(message, self._get_parent_channel_id(message.channel))
-        if not self._is_allowed_user(
-            str(message.author.id), message.author, guild=getattr(message, "guild", None),
-            is_dm=is_dm, channel_ids=channel_ids,
-        ):
-            return
-        await self._handle_message(message, role_authorized=bool(getattr(self, "_allowed_role_ids", set())))
+                return False, False
+        else:
+            message_guild = getattr(message, "guild", None)
+            is_dm = isinstance(message.channel, discord.DMChannel) or message_guild is None
+            channel_ids = None
+            if not is_dm:
+                channel_ids = {str(message.channel.id)}
+                parent_id = self._get_parent_channel_id(message.channel)
+                if parent_id:
+                    channel_ids.add(parent_id)
+            if not self._is_allowed_user(
+                str(message.author.id), message.author, guild=message_guild,
+                is_dm=is_dm, channel_ids=channel_ids,
+            ):
+                self._warn_if_fail_closed_default()
+                return False, False
+            role_authorized = bool(getattr(self, "_allowed_role_ids", set()))
+
+        raw_self_mention = self._self_is_explicitly_mentioned(message)
+        if not isinstance(message.channel, discord.DMChannel) and (message.mentions or raw_self_mention):
+            other_bots_mentioned = any(
+                getattr(mentioned, "bot", False) and mentioned != self._client.user
+                for mentioned in message.mentions
+            )
+            if other_bots_mentioned and not raw_self_mention:
+                return False, False
+            ignore_no_mention = os.getenv("DISCORD_IGNORE_NO_MENTION", "true").lower() in {"true", "1", "yes"}
+            if ignore_no_mention and not raw_self_mention and not other_bots_mentioned:
+                free_channels = self._discord_free_response_channels()
+                channel_keys = self._discord_channel_keys(
+                    message, self._get_parent_channel_id(message.channel)
+                )
+                if "*" not in free_channels and not (channel_keys & free_channels):
+                    return False, False
+        return True, role_authorized
+
+    async def _dispatch_discord_message(self, message: DiscordMessage) -> bool:
+        """Durably dispatch live and catch-up traffic through one message gate.
+
+        Returns ``False`` only when an admitted message cannot be checkpointed.
+        Callers use that signal to avoid advancing a channel past an event that
+        could not be made durable.
+        """
+        admitted, role_authorized = self._admit_discord_message(message)
+        if not admitted:
+            return True
+
+        channel_id = str(getattr(getattr(message, "channel", None), "id", ""))
+        message_id = str(getattr(message, "id", ""))
+        if not channel_id or not message_id:
+            logger.warning("[%s] Refusing Discord dispatch without a durable channel checkpoint", self.name)
+            return False
+        if self._startup_catchup.processed(channel_id, message_id):
+            return True
+        # Persist before dispatch for both live and historical traffic. This
+        # makes a process crash or adapter restart unable to replay a turn.
+        if not self._startup_catchup.mark_processed(channel_id, message_id):
+            return False
+        # Discord RESUME can replay an event while startup history catches up.
+        # The durable write above happens before either path can await, so the
+        # per-channel checkpoint provides the common high-water race barrier.
+        # Keep the short-lived cache for events deliberately pre-marked by
+        # auto-thread setup, without poisoning retries after a failed write.
+        if self._dedup.is_duplicate(message_id):
+            return True
+        await self._handle_message(message, role_authorized=role_authorized)
+        return True
 
     async def _catch_up_missed_mentions(self) -> None:
         """Boundedly replay unseen post-checkpoint channel events exactly once."""
@@ -6043,17 +6206,17 @@ class DiscordAdapter(BasePlatformAdapter):
                 logger.warning("[%s] Startup catch-up history fetch failed for %s: %s", self.name, channel_id, exc)
                 continue
             if not self._startup_catchup.initialized(channel_id):
-                for message in messages:
-                    self._startup_catchup.mark_processed(str(message.id))
-                self._startup_catchup.mark_initialized(channel_id)
+                high_water_message_id = str(messages[-1].id) if messages else None
+                self._startup_catchup.mark_initialized(channel_id, high_water_message_id)
                 continue
             for message in messages:
                 message_id = str(getattr(message, "id", ""))
-                if not message_id or self._startup_catchup.processed(message_id):
+                if not message_id or self._startup_catchup.processed(channel_id, message_id):
                     continue
-                # Persist before dispatch so a crash/restart cannot replay the turn.
-                self._startup_catchup.mark_processed(message_id)
-                await self._dispatch_discord_message(message)
+                if not await self._dispatch_discord_message(message):
+                    # Do not advance to a later message when the shared
+                    # dispatch protocol could not checkpoint this one.
+                    break
 
     async def _fetch_channel_context(
         self,
@@ -6247,15 +6410,23 @@ class DiscordAdapter(BasePlatformAdapter):
             starter_collected: List[str] = []
             if is_thread_channel:
                 parent = getattr(channel, "parent", None)
-                fetch_message = getattr(parent, "fetch_message", None)
-                if callable(fetch_message):
+                # Forum posts are threads, but ForumChannel itself has no
+                # fetch_message(). Their starter must be fetched through the
+                # thread. Text-channel threads retain the parent-first path.
+                starter_sources = (channel, parent) if self._is_forum_parent(parent) else (parent, channel)
+                for starter_source in starter_sources:
+                    fetch_message = getattr(starter_source, "fetch_message", None)
+                    if not callable(fetch_message):
+                        continue
                     try:
                         starter = await fetch_message(int(getattr(channel, "id", 0)))
                         line = _keep(starter)
                         if line is not None and str(getattr(starter, "id", "")) not in seen_ids:
                             starter_collected.append(line)
+                        break
                     except discord.Forbidden:
                         logger.debug("[%s] Missing permissions to fetch thread starter", self.name)
+                        break
                     except Exception as exc:
                         logger.debug("[%s] Failed to fetch thread starter: %s", self.name, exc)
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -52,7 +52,7 @@ _DISCORD_COMMAND_SYNC_POLICIES = {"safe", "bulk", "off"}
 _DISCORD_COMMAND_SYNC_STATE_SUBDIR = "gateway"
 _DISCORD_COMMAND_SYNC_STATE_FILENAME = "discord_command_sync_state.json"
 _DISCORD_NONCONVERSATIONAL_STATE_FILENAME = "discord_nonconversational_messages.json"
-
+_DISCORD_STARTUP_CATCHUP_STATE_FILENAME = "discord_startup_catchup_state.json"
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
 # Discord enforces a hard cap of 100 global application (slash) commands per
@@ -308,6 +308,61 @@ class _DiscordNonConversationalMessageTracker:
 
     def __contains__(self, message_id: str) -> bool:
         return str(message_id or "") in self._ids
+
+
+class _DiscordStartupCatchupTracker:
+    """Persist bounded Discord startup catch-up progress across restarts."""
+
+    _MAX_TRACKED = 2000
+
+    def __init__(self, max_tracked: int = _MAX_TRACKED):
+        self._max_tracked = max_tracked
+        self._state = self._load()
+
+    def _state_path(self) -> _Path:
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home() / _DISCORD_COMMAND_SYNC_STATE_SUBDIR / _DISCORD_STARTUP_CATCHUP_STATE_FILENAME
+
+    def _load(self) -> dict:
+        try:
+            data = json.loads(self._state_path().read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                return {
+                    "initialized_channels": [str(item) for item in data.get("initialized_channels", [])],
+                    "processed_message_ids": [str(item) for item in data.get("processed_message_ids", [])],
+                }
+        except FileNotFoundError:
+            pass
+        except Exception:
+            logger.debug("[%s] Failed to load Discord startup catch-up state", "Discord")
+        return {"initialized_channels": [], "processed_message_ids": []}
+
+    def _save(self) -> None:
+        for key in ("initialized_channels", "processed_message_ids"):
+            self._state[key] = self._state[key][-self._max_tracked:]
+        try:
+            atomic_json_write(self._state_path(), self._state, indent=None)
+        except Exception:
+            logger.debug("[%s] Failed to save Discord startup catch-up state", "Discord", exc_info=True)
+
+    def initialized(self, channel_id: str) -> bool:
+        return str(channel_id) in self._state["initialized_channels"]
+
+    def mark_initialized(self, channel_id: str) -> None:
+        key = str(channel_id)
+        if key not in self._state["initialized_channels"]:
+            self._state["initialized_channels"].append(key)
+            self._save()
+
+    def processed(self, message_id: str) -> bool:
+        return str(message_id) in self._state["processed_message_ids"]
+
+    def mark_processed(self, message_id: str) -> None:
+        key = str(message_id)
+        if key not in self._state["processed_message_ids"]:
+            self._state["processed_message_ids"].append(key)
+            self._save()
 
 
 def _metadata_marks_nonconversational(metadata: Optional[Dict[str, Any]]) -> bool:
@@ -973,6 +1028,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # Persistent set of bot-authored lifecycle/status message IDs that
         # should not act as conversational history boundaries after restart.
         self._nonconversational_messages = _DiscordNonConversationalMessageTracker()
+        self._startup_catchup = _DiscordStartupCatchupTracker()
         # Last truncated mid-stream preview delivered per (chat_id, message_id).
         # Once an oversized streaming edit saturates at the 2000-char preview
         # cap, every subsequent progressive edit truncates to the SAME text;
@@ -1879,6 +1935,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not self._client:
             return
         try:
+            await self._catch_up_missed_mentions()
             sync_policy = self._get_discord_command_sync_policy()
             if sync_policy == "off":
                 logger.info("[%s] Skipping Discord slash command sync (policy=off)", self.name)
@@ -5924,6 +5981,80 @@ class DiscordAdapter(BasePlatformAdapter):
         except (ValueError, TypeError):
             return 50
 
+    def _discord_startup_catchup(self) -> bool:
+        configured = self.config.extra.get("startup_catchup")
+        if configured is not None:
+            return str(configured).lower() not in {"false", "0", "no", "off"}
+        return os.getenv("DISCORD_STARTUP_CATCHUP", "true").lower() in {"true", "1", "yes"}
+
+    def _discord_startup_catchup_limit(self) -> int:
+        configured = self.config.extra.get("startup_catchup_limit")
+        try:
+            return max(1, min(int(configured if configured is not None else os.getenv("DISCORD_STARTUP_CATCHUP_LIMIT", "50")), 200))
+        except (TypeError, ValueError):
+            return 50
+
+    async def _dispatch_discord_message(self, message: DiscordMessage) -> None:
+        """Dispatch catch-up traffic through the same message gate as live traffic."""
+        if not self._client or message.author == self._client.user:
+            return
+        if getattr(message, "type", None) not in {discord.MessageType.default, discord.MessageType.reply}:
+            return
+        if getattr(message.author, "bot", False):
+            allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
+            if allow_bots == "none":
+                return
+            if allow_bots == "mentions" and not self._self_is_explicitly_mentioned(message):
+                return
+            if self._discord_bots_require_inline_mention() and not self._self_is_raw_mentioned(message):
+                return
+            await self._handle_message(message)
+            return
+        is_dm = isinstance(message.channel, discord.DMChannel) or getattr(message, "guild", None) is None
+        channel_ids = None if is_dm else self._discord_channel_keys(message, self._get_parent_channel_id(message.channel))
+        if not self._is_allowed_user(
+            str(message.author.id), message.author, guild=getattr(message, "guild", None),
+            is_dm=is_dm, channel_ids=channel_ids,
+        ):
+            return
+        await self._handle_message(message, role_authorized=bool(getattr(self, "_allowed_role_ids", set())))
+
+    async def _catch_up_missed_mentions(self) -> None:
+        """Boundedly replay unseen post-checkpoint channel events exactly once."""
+        if not self._client or not self._discord_startup_catchup():
+            return
+        limit = self._discord_startup_catchup_limit()
+        channels = []
+        for guild in getattr(self._client, "guilds", []) or []:
+            channels.extend(getattr(guild, "text_channels", []) or [])
+            channels.extend(getattr(guild, "threads", []) or [])
+        for channel in channels:
+            channel_id = str(getattr(channel, "id", ""))
+            if not channel_id:
+                continue
+            try:
+                messages = [message async for message in channel.history(
+                    limit=limit, before=_Snowflake((1 << 63) - 1), oldest_first=True,
+                )]
+            except discord.Forbidden:
+                logger.debug("[%s] Missing permissions for startup catch-up in %s", self.name, channel_id)
+                continue
+            except Exception as exc:
+                logger.warning("[%s] Startup catch-up history fetch failed for %s: %s", self.name, channel_id, exc)
+                continue
+            if not self._startup_catchup.initialized(channel_id):
+                for message in messages:
+                    self._startup_catchup.mark_processed(str(message.id))
+                self._startup_catchup.mark_initialized(channel_id)
+                continue
+            for message in messages:
+                message_id = str(getattr(message, "id", ""))
+                if not message_id or self._startup_catchup.processed(message_id):
+                    continue
+                # Persist before dispatch so a crash/restart cannot replay the turn.
+                self._startup_catchup.mark_processed(message_id)
+                await self._dispatch_discord_message(message)
+
     async def _fetch_channel_context(
         self,
         channel: Any,
@@ -6113,7 +6244,22 @@ class DiscordAdapter(BasePlatformAdapter):
                     if mid:
                         seen_ids.add(mid)
 
-            if not collected and not reply_collected:
+            starter_collected: List[str] = []
+            if is_thread_channel:
+                parent = getattr(channel, "parent", None)
+                fetch_message = getattr(parent, "fetch_message", None)
+                if callable(fetch_message):
+                    try:
+                        starter = await fetch_message(int(getattr(channel, "id", 0)))
+                        line = _keep(starter)
+                        if line is not None and str(getattr(starter, "id", "")) not in seen_ids:
+                            starter_collected.append(line)
+                    except discord.Forbidden:
+                        logger.debug("[%s] Missing permissions to fetch thread starter", self.name)
+                    except Exception as exc:
+                        logger.debug("[%s] Failed to fetch thread starter: %s", self.name, exc)
+
+            if not collected and not reply_collected and not starter_collected:
                 return ""
 
             # channel.history returns newest-first; reverse each window for
@@ -6135,6 +6281,8 @@ class DiscordAdapter(BasePlatformAdapter):
                     "[Context around the replied-to message]\n"
                     + "\n".join(line for _id, line in reply_collected)
                 )
+            if starter_collected:
+                blocks.append("[Thread starter message]\n" + "\n".join(starter_collected))
             if collected:
                 blocks.append(
                     "[Recent channel messages]\n"
@@ -9434,6 +9582,11 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     hbl = discord_cfg.get("history_backfill_limit")
     if hbl is not None and not os.getenv("DISCORD_HISTORY_BACKFILL_LIMIT"):
         os.environ["DISCORD_HISTORY_BACKFILL_LIMIT"] = str(hbl)
+    if "startup_catchup" in discord_cfg and not os.getenv("DISCORD_STARTUP_CATCHUP"):
+        os.environ["DISCORD_STARTUP_CATCHUP"] = str(discord_cfg["startup_catchup"]).lower()
+    scl = discord_cfg.get("startup_catchup_limit")
+    if scl is not None and not os.getenv("DISCORD_STARTUP_CATCHUP_LIMIT"):
+        os.environ["DISCORD_STARTUP_CATCHUP_LIMIT"] = str(scl)
     # allow_mentions: granular control over what the bot can ping.
     # Safe defaults (no @everyone/roles) are applied in the adapter;
     # these YAML keys only override when set and let users opt back

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -580,6 +580,101 @@ async def test_reconnect_stale_catchup_cannot_release_new_generation_barrier(mon
 
 
 @pytest.mark.asyncio
+async def test_reconnect_rearms_barrier_before_old_waiter_can_dispatch(monkeypatch):
+    """An old Event waiter cannot dispatch after a reconnect clears the barrier."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+    monkeypatch.setattr(
+        discord_platform.Intents,
+        "default",
+        lambda: SimpleNamespace(
+            message_content=False,
+            dm_messages=False,
+            guild_messages=False,
+            members=False,
+            voice_states=False,
+        ),
+    )
+
+    created = {}
+    monkeypatch.setattr(
+        discord_platform.commands,
+        "Bot",
+        lambda **kwargs: created.setdefault("bot", FakeBot(
+            intents=kwargs["intents"],
+            proxy=kwargs.get("proxy"),
+            allowed_mentions=kwargs.get("allowed_mentions"),
+        )),
+    )
+
+    resolution_started = asyncio.Event()
+    release_resolution = asyncio.Event()
+    resolution_calls = 0
+
+    async def resolve_allowed_usernames():
+        nonlocal resolution_calls
+        resolution_calls += 1
+        if resolution_calls == 2:
+            resolution_started.set()
+            await release_resolution.wait()
+
+    first_catchup_started = asyncio.Event()
+    second_catchup_started = asyncio.Event()
+    release_first_catchup = asyncio.Event()
+    release_second_catchup = asyncio.Event()
+    catchup_calls = 0
+
+    async def catch_up_missed_mentions():
+        nonlocal catchup_calls
+        catchup_calls += 1
+        if catchup_calls == 1:
+            first_catchup_started.set()
+            await release_first_catchup.wait()
+        else:
+            second_catchup_started.set()
+            await release_second_catchup.wait()
+
+    dispatched = AsyncMock()
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", resolve_allowed_usernames)
+    monkeypatch.setattr(adapter, "_catch_up_missed_mentions", catch_up_missed_mentions)
+    monkeypatch.setattr(adapter, "_get_discord_command_sync_policy", lambda: "off")
+    monkeypatch.setattr(adapter, "_dispatch_discord_message", dispatched)
+
+    assert await adapter.connect() is True
+    await asyncio.wait_for(first_catchup_started.wait(), timeout=1.0)
+
+    bot = created["bot"]
+    live_message = SimpleNamespace(id=123)
+    live_dispatch = asyncio.create_task(bot._events["on_message"](live_message))
+    await asyncio.sleep(0)
+    assert not live_dispatch.done()
+
+    # Set the old generation's barrier, then start the reconnect before the
+    # released live waiter can resume. The new on_ready clears the shared Event.
+    release_first_catchup.set()
+    reconnect_ready = asyncio.create_task(bot._events["on_ready"]())
+    await asyncio.wait_for(resolution_started.wait(), timeout=1.0)
+
+    assert not adapter._startup_catchup_complete.is_set()
+    assert not live_dispatch.done()
+    dispatched.assert_not_awaited()
+
+    release_resolution.set()
+    await reconnect_ready
+    await asyncio.wait_for(second_catchup_started.wait(), timeout=1.0)
+    assert not live_dispatch.done()
+    dispatched.assert_not_awaited()
+
+    release_second_catchup.set()
+    await asyncio.wait_for(live_dispatch, timeout=1.0)
+    dispatched.assert_awaited_once_with(live_message)
+
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_connect_respects_slash_commands_opt_out(monkeypatch):
     adapter = DiscordAdapter(
         PlatformConfig(enabled=True, token="test-token", extra={"slash_commands": False})

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -485,6 +485,101 @@ async def test_connect_does_not_wait_for_slash_sync(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_reconnect_stale_catchup_cannot_release_new_generation_barrier(monkeypatch):
+    """A completed older catch-up cannot admit traffic during a new reconnect."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+    monkeypatch.setattr(
+        discord_platform.Intents,
+        "default",
+        lambda: SimpleNamespace(
+            message_content=False,
+            dm_messages=False,
+            guild_messages=False,
+            members=False,
+            voice_states=False,
+        ),
+    )
+
+    created = {}
+    monkeypatch.setattr(
+        discord_platform.commands,
+        "Bot",
+        lambda **kwargs: created.setdefault("bot", FakeBot(
+            intents=kwargs["intents"],
+            proxy=kwargs.get("proxy"),
+            allowed_mentions=kwargs.get("allowed_mentions"),
+        )),
+    )
+
+    resolution_started = asyncio.Event()
+    release_resolution = asyncio.Event()
+    resolution_calls = 0
+
+    async def resolve_allowed_usernames():
+        nonlocal resolution_calls
+        resolution_calls += 1
+        if resolution_calls == 2:
+            resolution_started.set()
+            await release_resolution.wait()
+
+    first_catchup_started = asyncio.Event()
+    second_catchup_started = asyncio.Event()
+    release_first_catchup = asyncio.Event()
+    release_second_catchup = asyncio.Event()
+    catchup_calls = 0
+
+    async def catch_up_missed_mentions():
+        nonlocal catchup_calls
+        catchup_calls += 1
+        if catchup_calls == 1:
+            first_catchup_started.set()
+            await release_first_catchup.wait()
+        else:
+            second_catchup_started.set()
+            await release_second_catchup.wait()
+
+    dispatched = AsyncMock()
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", resolve_allowed_usernames)
+    monkeypatch.setattr(adapter, "_catch_up_missed_mentions", catch_up_missed_mentions)
+    monkeypatch.setattr(adapter, "_get_discord_command_sync_policy", lambda: "off")
+    monkeypatch.setattr(adapter, "_dispatch_discord_message", dispatched)
+
+    assert await adapter.connect() is True
+    await asyncio.wait_for(first_catchup_started.wait(), timeout=1.0)
+    assert adapter._ready_event.is_set()
+
+    bot = created["bot"]
+    reconnect_ready = asyncio.create_task(bot._events["on_ready"]())
+    await asyncio.wait_for(resolution_started.wait(), timeout=1.0)
+
+    # The first task completes naturally while the second on_ready is still
+    # resolving usernames. It must not set the newer generation's barrier.
+    release_first_catchup.set()
+    await asyncio.wait_for(adapter._post_connect_task, timeout=1.0)
+
+    live_message = SimpleNamespace(id=123)
+    live_dispatch = asyncio.create_task(bot._events["on_message"](live_message))
+    await asyncio.sleep(0)
+    assert not live_dispatch.done()
+    dispatched.assert_not_awaited()
+
+    release_resolution.set()
+    await reconnect_ready
+    await asyncio.wait_for(second_catchup_started.wait(), timeout=1.0)
+    assert not live_dispatch.done()
+    dispatched.assert_not_awaited()
+
+    release_second_catchup.set()
+    await asyncio.wait_for(live_dispatch, timeout=1.0)
+    dispatched.assert_awaited_once_with(live_message)
+
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_connect_respects_slash_commands_opt_out(monkeypatch):
     adapter = DiscordAdapter(
         PlatformConfig(enabled=True, token="test-token", extra={"slash_commands": False})

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -1486,3 +1486,64 @@ async def test_discord_non_reply_free_channel_skips_backfill(adapter, monkeypatc
 
     adapter._fetch_channel_context.assert_not_awaited()
 
+
+
+@pytest.mark.asyncio
+async def test_discord_thread_context_includes_parent_starter_message(adapter, monkeypatch):
+    """A public thread mention can recover the parent request that started it."""
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    adapter.config.extra["history_backfill_limit"] = 10
+    author = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
+    parent = FakeTextChannel(channel_id=100, name="requests")
+    parent.fetch_message = AsyncMock(return_value=make_history_message(author=author, content="Please analyze the missed opportunity.", msg_id=200))
+    thread = FakeThread(channel_id=200, parent=parent)
+    thread.history = FakeHistoryChannel([], channel_id=200).history
+    trigger = make_message(channel=thread, content="<@999>", mentions=[adapter._client.user])
+    trigger.id = 201
+
+    result = await adapter._fetch_channel_context(thread, before=trigger)
+
+    assert "[Thread starter message]" in result
+    assert "Please analyze the missed opportunity." in result
+
+
+@pytest.mark.asyncio
+async def test_discord_bare_thread_mention_dispatches_when_parent_starter_is_context(adapter, monkeypatch):
+    """The empty-turn guard permits a bare mention only when starter context exists."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    adapter.config.extra["history_backfill"] = True
+    adapter._fetch_channel_context = AsyncMock(
+        return_value="[Thread starter message]\n[Alice] Actual request"
+    )
+    thread = FakeThread(channel_id=200, parent=FakeTextChannel(channel_id=100, name="requests"))
+    message = make_message(channel=thread, content=f"<@{adapter._client.user.id}>", mentions=[adapter._client.user])
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == ""
+    assert event.channel_context == "[Thread starter message]\n[Alice] Actual request"
+
+
+@pytest.mark.asyncio
+async def test_discord_startup_catchup_primes_then_dispatches_missed_mention_once(adapter, tmp_path, monkeypatch):
+    """A restart processes one unseen trigger but never replays it again."""
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+    adapter.config.extra["startup_catchup"] = True
+    adapter.config.extra["startup_catchup_limit"] = 10
+    bot_user = adapter._client.user
+    channel = FakeHistoryChannel([], channel_id=321)
+    adapter._client.guilds = [SimpleNamespace(text_channels=[channel], threads=[])]
+    adapter._dispatch_discord_message = AsyncMock()
+
+    await adapter._catch_up_missed_mentions()
+    missed = make_message(channel=channel, content=f"<@{bot_user.id}> offline request", mentions=[bot_user])
+    missed.id = 456
+    channel._history_messages.append(missed)
+
+    await adapter._catch_up_missed_mentions()
+    await adapter._catch_up_missed_mentions()
+
+    adapter._dispatch_discord_message.assert_awaited_once_with(missed)

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -1508,6 +1508,28 @@ async def test_discord_thread_context_includes_parent_starter_message(adapter, m
 
 
 @pytest.mark.asyncio
+async def test_discord_forum_thread_context_fetches_starter_from_thread(adapter, monkeypatch):
+    """Forum posts hydrate their starter through the thread, not the parent forum."""
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    adapter.config.extra["history_backfill_limit"] = 10
+    author = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
+    forum = FakeForumChannel(channel_id=100, name="support-forum")
+    thread = FakeThread(channel_id=200, parent=forum)
+    thread.history = FakeHistoryChannel([], channel_id=200).history
+    thread.fetch_message = AsyncMock(
+        return_value=make_history_message(author=author, content="Forum post request", msg_id=200)
+    )
+    trigger = make_message(channel=thread, content="<@999>", mentions=[adapter._client.user])
+    trigger.id = 201
+
+    result = await adapter._fetch_channel_context(thread, before=trigger)
+
+    thread.fetch_message.assert_awaited_once_with(200)
+    assert "[Thread starter message]" in result
+    assert "Forum post request" in result
+
+
+@pytest.mark.asyncio
 async def test_discord_bare_thread_mention_dispatches_when_parent_starter_is_context(adapter, monkeypatch):
     """The empty-turn guard permits a bare mention only when starter context exists."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
@@ -1528,15 +1550,16 @@ async def test_discord_bare_thread_mention_dispatches_when_parent_starter_is_con
 
 
 @pytest.mark.asyncio
-async def test_discord_startup_catchup_primes_then_dispatches_missed_mention_once(adapter, tmp_path, monkeypatch):
-    """A restart processes one unseen trigger but never replays it again."""
+async def test_discord_startup_catchup_persists_checkpoint_before_restart(adapter, tmp_path, monkeypatch):
+    """A fresh adapter loads the checkpoint and cannot replay an already-dispatched event."""
     monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
     adapter.config.extra["startup_catchup"] = True
     adapter.config.extra["startup_catchup_limit"] = 10
     bot_user = adapter._client.user
     channel = FakeHistoryChannel([], channel_id=321)
     adapter._client.guilds = [SimpleNamespace(text_channels=[channel], threads=[])]
-    adapter._dispatch_discord_message = AsyncMock()
 
     await adapter._catch_up_missed_mentions()
     missed = make_message(channel=channel, content=f"<@{bot_user.id}> offline request", mentions=[bot_user])
@@ -1544,6 +1567,150 @@ async def test_discord_startup_catchup_primes_then_dispatches_missed_mention_onc
     channel._history_messages.append(missed)
 
     await adapter._catch_up_missed_mentions()
+    adapter.handle_message.assert_awaited_once()
+
+    restarted = DiscordAdapter(adapter.config)
+    restarted._client = SimpleNamespace(user=bot_user, guilds=[SimpleNamespace(text_channels=[channel], threads=[])])
+    restarted._handle_message = AsyncMock()
+
+    await restarted._catch_up_missed_mentions()
+
+    restarted._handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_startup_catchup_does_not_dispatch_when_checkpoint_write_fails(adapter, tmp_path, monkeypatch):
+    """An event is never dispatched until its checkpoint is durably written."""
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    adapter.config.extra["startup_catchup"] = True
+    bot_user = adapter._client.user
+    channel = FakeHistoryChannel([], channel_id=321)
+    adapter._client.guilds = [SimpleNamespace(text_channels=[channel], threads=[])]
     await adapter._catch_up_missed_mentions()
 
-    adapter._dispatch_discord_message.assert_awaited_once_with(missed)
+    missed = make_message(channel=channel, content=f"<@{bot_user.id}> offline request", mentions=[bot_user])
+    missed.id = 456
+    channel._history_messages.append(missed)
+    original_write = discord_platform.atomic_json_write
+
+    def fail_write(*args, **kwargs):
+        raise OSError("disk unavailable")
+
+    monkeypatch.setattr(discord_platform, "atomic_json_write", fail_write)
+    await adapter._catch_up_missed_mentions()
+    adapter.handle_message.assert_not_awaited()
+
+    monkeypatch.setattr(discord_platform, "atomic_json_write", original_write)
+    restarted = DiscordAdapter(adapter.config)
+    restarted._client = SimpleNamespace(user=bot_user, guilds=[SimpleNamespace(text_channels=[channel], threads=[])])
+    restarted._handle_message = AsyncMock()
+    await restarted._catch_up_missed_mentions()
+
+    restarted._handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_discord_catchup_reuses_multi_agent_mention_gate(adapter, monkeypatch):
+    """Free-response catch-up ignores other-bot-only mentions but accepts human mentions."""
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "321")
+    adapter._allowed_user_ids = {"*"}
+    adapter._handle_message = AsyncMock()
+    channel = FakeTextChannel(channel_id=321)
+    other_bot = SimpleNamespace(id=1000, bot=True)
+
+    other_bot_only = make_message(channel=channel, content="<@1000> can you help?", mentions=[other_bot])
+    await adapter._dispatch_discord_message(other_bot_only)
+    adapter._handle_message.assert_not_awaited()
+
+    human = SimpleNamespace(id=2000, bot=False)
+    human_only = make_message(channel=channel, content="<@2000> can you help?", mentions=[human])
+    human_only.id = 124
+    await adapter._dispatch_discord_message(human_only)
+    adapter._handle_message.assert_awaited_once_with(human_only, role_authorized=False)
+
+
+@pytest.mark.asyncio
+async def test_discord_startup_catchup_skips_message_already_dispatched_live(adapter, tmp_path, monkeypatch):
+    """A fresh adapter cannot replay a live event after startup catch-up."""
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    adapter.config.extra["startup_catchup"] = True
+    bot_user = adapter._client.user
+    channel = FakeHistoryChannel([], channel_id=321)
+    adapter._client.guilds = [SimpleNamespace(text_channels=[channel], threads=[])]
+
+    await adapter._catch_up_missed_mentions()
+    message = make_message(
+        channel=channel,
+        content=f"<@{bot_user.id}> reconnect request",
+        mentions=[bot_user],
+    )
+    message.id = 456
+    channel._history_messages.append(message)
+
+    await adapter._dispatch_discord_message(message)
+    adapter.handle_message.assert_awaited_once()
+
+    restarted = DiscordAdapter(adapter.config)
+    restarted._client = SimpleNamespace(
+        user=bot_user,
+        guilds=[SimpleNamespace(text_channels=[channel], threads=[])],
+    )
+    restarted._handle_message = AsyncMock()
+    await restarted._catch_up_missed_mentions()
+
+    restarted._handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_live_dispatch_does_not_run_when_checkpoint_write_fails(adapter, tmp_path, monkeypatch):
+    """Live traffic is suppressed until its per-channel checkpoint is durable."""
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "true")
+    channel = FakeHistoryChannel([], channel_id=321)
+    message = make_message(
+        channel=channel,
+        content=f"<@{adapter._client.user.id}> live request",
+        mentions=[adapter._client.user],
+    )
+    message.id = 456
+
+    def fail_write(*args, **kwargs):
+        raise OSError("disk unavailable")
+
+    monkeypatch.setattr(discord_platform, "atomic_json_write", fail_write)
+
+    dispatched = await adapter._dispatch_discord_message(message)
+
+    assert not dispatched
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_startup_catchup_permission_failure_leaves_channel_uninitialized(adapter, tmp_path, monkeypatch):
+    """A denied history scan does not mark a channel caught up or dispatch an event."""
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+    forbidden = type("Forbidden", (Exception,), {})
+    monkeypatch.setattr(discord_platform.discord, "Forbidden", forbidden, raising=False)
+    adapter.config.extra["startup_catchup"] = True
+    channel = FakeTextChannel(channel_id=321)
+
+    def denied_history(**kwargs):
+        async def _iter():
+            raise forbidden()
+            yield
+
+        return _iter()
+
+    channel.history = denied_history
+    adapter._client.guilds = [SimpleNamespace(text_channels=[channel], threads=[])]
+    adapter._dispatch_discord_message = AsyncMock()
+
+    await adapter._catch_up_missed_mentions()
+
+    assert not adapter._startup_catchup.initialized("321")
+    adapter._dispatch_discord_message.assert_not_awaited()


### PR DESCRIPTION
Fix Discord startup catch-up durability and reconnect ordering.

This uses per-channel durable checkpoints, keeps live delivery behind the active catch-up generation, and covers forum thread starters.

Tests:
- C:/Users/DanSiegel/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe -m pytest -q tests/gateway/test_discord_connect.py tests/gateway/test_discord_free_response.py (95 passed)
- python -m py_compile plugins/platforms/discord/adapter.py hermes_cli/config.py tests/gateway/test_discord_connect.py tests/gateway/test_discord_free_response.py
- git diff --check origin/main...HEAD
