### PR TITLE
fix(mem0): SelfHostedBackend speaks canonical Mem0 v1 API contract

### DIFF
--- a/plugins/memory/mem0/README.md
+++ b/plugins/memory/mem0/README.md
@@ -26,7 +26,7 @@ Behavioral settings live in `$HERMES_HOME/mem0.json` (set them via `hermes memor
 | Key | Default | Description |
 |-----|---------|-------------|
 | `mode` | `platform` | `platform` (Mem0 Cloud) or `oss` (self-managed, in-process) |
-| `host` | — | Self-hosted Mem0 server URL (the Docker dashboard). When set, connects over HTTP with `X-API-Key`. Don't combine with `mode: oss` |
+| `host` | — | Mem0-compatible server URL (self-hosted or a managed compatible service such as Volcengine Mem0). When set, connects over HTTP with `Authorization: Token`. Don't combine with `mode: oss` |
 | `user_id` | `hermes-user` | User identifier on Mem0 |
 | `agent_id` | `hermes` | Agent identifier |
 | `rerank` | `false` | Rerank search results for relevance (platform mode only) |
@@ -35,6 +35,7 @@ The plugin has three connection modes:
 
 - **Platform** — Mem0's hosted cloud (`api.mem0.ai`). Set `MEM0_API_KEY`. (default)
 - **Self-hosted dashboard** — a Mem0 server you run yourself via Docker. Set `host`. See below.
+- **Managed compatible service** — a hosted Mem0-compatible API (e.g. Volcengine Mem0). Set `host` to the project's connection address.
 - **OSS** — run Mem0 in-process with your own LLM + vector store. Set `mode: oss`. See below.
 
 ## Self-Hosted Dashboard (Server) Mode
@@ -62,7 +63,9 @@ Connect the plugin to a standalone Mem0 server you run yourself — the Docker-s
    ```
 3. Start a fresh Hermes session and call `mem0_search` — it connects to your server.
 
-The plugin authenticates with `X-API-Key` and uses the server's `/search` and `/memories` routes. `api_key` is optional — omit it only for servers running with `AUTH_DISABLED`.
+The plugin authenticates with `Authorization: Token <api_key>` and uses the canonical v1 routes (`/v1/memories/`, `/v1/memories/search/`). `api_key` is optional — omit it only for servers running with auth disabled.
+
+This mode also works for **managed Mem0-compatible services** that expose the v1 API — for example Volcengine Mem0: set `host` to the project connection address from Volcengine Console → Mem0 project → 连接管理, and `api_key` to the project API key. (mem0ai 2.x's SDK uses `/v3/` routes that compatible services may not serve; this backend stays on the stable v1 contract.)
 
 > Setting `host` routes to the self-hosted server automatically. Don't set `mode: oss` — OSS takes precedence and ignores `host`.
 

--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -81,14 +81,15 @@ class PlatformBackend(Mem0Backend):
 
 
 class SelfHostedBackend(Mem0Backend):
-    """Direct HTTP backend for a self-hosted Mem0 server (the FastAPI ``server/``).
+    """Direct HTTP backend for Mem0-compatible server APIs (v1 endpoints).
 
-    mem0.MemoryClient can't be reused for self-hosted: it is hardwired to the
-    cloud API — ``Authorization: Token`` auth and a ``GET /v1/ping/`` validation
-    call in ``__init__`` that the self-hosted server does not expose (it would
-    404 before any real request). This client talks to that server directly,
-    using its actual contract: ``X-API-Key`` auth and the ``/memories`` /
-    ``/search`` routes.
+    Speaks the canonical Mem0 platform v1 contract — ``Authorization: Token``
+    auth and the ``/v1/memories/`` / ``/v1/memories/search/`` routes — which is
+    what managed Mem0-compatible services (e.g. Volcengine Mem0 project
+    connection addresses) expose. mem0.MemoryClient can't be reused here:
+    mem0ai 2.x hardwires the write/search paths to the newer
+    ``/v3/memories/...`` routes, which compatible backends may not serve
+    (404), while their v1 routes remain stable.
     """
 
     def __init__(self, api_key: str, host: str, transport=None):
@@ -96,7 +97,9 @@ class SelfHostedBackend(Mem0Backend):
 
         headers = {"Content-Type": "application/json"}
         if api_key:
-            headers["X-API-Key"] = api_key  # omitted only for AUTH_DISABLED servers
+            # Canonical Mem0 API auth header (Token scheme), accepted by both
+            # the official platform API and compatible managed services.
+            headers["Authorization"] = f"Token {api_key}"
         # Connect-level retries smooth over transient blips so a single
         # dropped SYN doesn't count toward the provider failure breaker.
         # ``transport`` is injectable for tests (httpx.MockTransport).
@@ -113,11 +116,11 @@ class SelfHostedBackend(Mem0Backend):
         return resp.json() if resp.content else {}
 
     def search(self, query: str, *, filters: dict, top_k: int = 10, rerank: bool = False) -> list[dict]:
-        # rerank is a platform-only feature; the self-hosted /search ignores it.
+        # rerank is a platform-only feature; compatible v1 search ignores it.
         body: dict[str, Any] = {"query": query, "top_k": top_k}
         if filters:
             body["filters"] = filters  # user_id belongs in filters (top-level is deprecated)
-        return _unwrap_results(self._json("POST", "/search", json=body))
+        return _unwrap_results(self._json("POST", "/v1/memories/search/", json=body))
 
     def add(
         self,
@@ -134,16 +137,21 @@ class SelfHostedBackend(Mem0Backend):
             "agent_id": agent_id,
             "infer": infer,
         }
+        # Compatible backends (e.g. Volcengine) reject infer=False unless
+        # async_mode is explicitly disabled:
+        # "Async mode is disabled if infer is False. please set async_mode to False."
+        if not infer:
+            body["async_mode"] = False
         if metadata:
             body["metadata"] = metadata
-        return self._json("POST", "/memories", json=body)
+        return self._json("POST", "/v1/memories/", json=body)
 
     def update(self, memory_id: str, text: str) -> dict:
-        self._json("PUT", f"/memories/{memory_id}", json={"text": text})
+        self._json("PUT", f"/v1/memories/{memory_id}/", json={"text": text})
         return {"result": "Memory updated.", "memory_id": memory_id}
 
     def delete(self, memory_id: str) -> dict:
-        self._json("DELETE", f"/memories/{memory_id}")
+        self._json("DELETE", f"/v1/memories/{memory_id}/")
         return {"result": "Memory deleted.", "memory_id": memory_id}
 
     def close(self) -> None:

--- a/tests/plugins/memory/test_mem0_backend.py
+++ b/tests/plugins/memory/test_mem0_backend.py
@@ -236,7 +236,7 @@ httpx = pytest.importorskip("httpx")
 
 
 class _StubServer:
-    """Records requests and serves the real self-hosted server's response shapes."""
+    """Records requests and serves the Mem0 v1 API's response shapes."""
 
     def __init__(self, rows=10):
         self.requests = []
@@ -245,15 +245,15 @@ class _StubServer:
     def handler(self, request):
         self.requests.append(request)
         path, method = request.url.path, request.method
-        if path == "/search" and method == "POST":
+        if path == "/v1/memories/search/" and method == "POST":
             return httpx.Response(200, json={"results": [{"id": "m1", "memory": "tea", "score": 0.9}]})
-        if path == "/memories" and method == "GET":
+        if path == "/v1/memories/" and method == "GET":
             top_k = int(request.url.params.get("top_k", len(self._rows)))
             return httpx.Response(200, json={"results": self._rows[:top_k]})
-        if path == "/memories" and method == "POST":
+        if path == "/v1/memories/" and method == "POST":
             return httpx.Response(200, json={"results": [{"id": "new", "memory": "stored", "event": "ADD"}]})
-        if path.startswith("/memories/") and method in ("PUT", "DELETE"):
-            if path.endswith("/missing"):  # server 404s unknown ids
+        if path.startswith("/v1/memories/") and method in ("PUT", "DELETE"):
+            if path.endswith("/missing/"):  # server 404s unknown ids
                 return httpx.Response(404, json={"detail": "Memory not found"})
             verb = "updated" if method == "PUT" else "Memory deleted successfully"
             return httpx.Response(200, json={"message": verb})
@@ -274,10 +274,10 @@ def _backend(server, api_key="adminkey", host="http://sh:8888"):
 class TestSelfHostedBackend:
     # --- constructor / auth setup (the crux of the bug) -------------------
 
-    def test_init_uses_x_api_key_not_token_auth(self):
+    def test_init_uses_token_auth(self):
         b = SelfHostedBackend("adminkey", "http://sh:8888")
-        assert b._client.headers["x-api-key"] == "adminkey"
-        assert "authorization" not in b._client.headers  # NOT the cloud 'Token' scheme
+        assert b._client.headers["authorization"] == "Token adminkey"
+        assert "x-api-key" not in b._client.headers
 
     def test_init_strips_trailing_slash(self):
         b = SelfHostedBackend("k", "http://sh:8888/")
@@ -285,7 +285,7 @@ class TestSelfHostedBackend:
 
     def test_init_omits_api_key_header_when_blank(self):
         b = SelfHostedBackend("", "http://sh:8888")  # AUTH_DISABLED server
-        assert "x-api-key" not in b._client.headers
+        assert "authorization" not in b._client.headers
 
     # --- search ----------------------------------------------------------
 
@@ -293,18 +293,18 @@ class TestSelfHostedBackend:
         s = _StubServer()
         results = _backend(s).search("drink", filters={"user_id": "u1"}, top_k=5)
         req = s.requests[-1]
-        assert (req.method, req.url.path) == ("POST", "/search")
+        assert (req.method, req.url.path) == ("POST", "/v1/memories/search/")
         import json
         body = json.loads(req.content)
         assert body == {"query": "drink", "top_k": 5, "filters": {"user_id": "u1"}}
         assert results == [{"id": "m1", "memory": "tea", "score": 0.9}]
 
-    def test_search_sends_x_api_key_header(self):
+    def test_search_sends_token_auth_header(self):
         s = _StubServer()
         _backend(s).search("q", filters={"user_id": "u1"})
         req = s.requests[-1]
-        assert req.headers["x-api-key"] == "adminkey"
-        assert "authorization" not in req.headers
+        assert req.headers["authorization"] == "Token adminkey"
+        assert "x-api-key" not in req.headers
 
     # --- add / update / delete ------------------------------------------
 
@@ -313,18 +313,27 @@ class TestSelfHostedBackend:
         msgs = [{"role": "user", "content": "likes tea"}]
         result = _backend(s).add(msgs, user_id="u1", agent_id="hermes", infer=False, metadata={"channel": "cli"})
         req = s.requests[-1]
-        assert (req.method, req.url.path) == ("POST", "/memories")
+        assert (req.method, req.url.path) == ("POST", "/v1/memories/")
         import json
         body = json.loads(req.content)
         assert body == {"messages": msgs, "user_id": "u1", "agent_id": "hermes",
-                        "infer": False, "metadata": {"channel": "cli"}}
+                        "infer": False, "async_mode": False, "metadata": {"channel": "cli"}}
         assert result["results"][0]["id"] == "new"
+
+    def test_add_infer_true_omits_async_mode(self):
+        s = _StubServer()
+        _backend(s).add([{"role": "user", "content": "x"}], user_id="u1",
+                        agent_id="hermes", infer=True)
+        import json
+        body = json.loads(s.requests[-1].content)
+        assert body["infer"] is True
+        assert "async_mode" not in body
 
     def test_update_puts_text_to_memory_id(self):
         s = _StubServer()
         result = _backend(s).update("abc", "new text")
         req = s.requests[-1]
-        assert (req.method, req.url.path) == ("PUT", "/memories/abc")
+        assert (req.method, req.url.path) == ("PUT", "/v1/memories/abc/")
         import json
         assert json.loads(req.content) == {"text": "new text"}
         assert result == {"result": "Memory updated.", "memory_id": "abc"}
@@ -333,7 +342,7 @@ class TestSelfHostedBackend:
         s = _StubServer()
         result = _backend(s).delete("abc")
         req = s.requests[-1]
-        assert (req.method, req.url.path) == ("DELETE", "/memories/abc")
+        assert (req.method, req.url.path) == ("DELETE", "/v1/memories/abc/")
         assert result == {"result": "Memory deleted.", "memory_id": "abc"}
 
     # --- error propagation (feeds the plugin's circuit breaker) ----------


### PR DESCRIPTION
## Problem

`SelfHostedBackend` (selected when `host` is set in `mem0.json` / `MEM0_HOST`) authenticates with `X-API-Key` and calls `/search` + `/memories`. That contract matches neither the official Mem0 API nor managed Mem0-compatible services (e.g. Volcengine Mem0 project connection addresses), so against those hosts every `mem0_search` / `mem0_add` fails with 404/401 and external memory silently stops working.

## Fix

Switch `SelfHostedBackend` to the canonical Mem0 v1 API contract, which is accepted by both the official API and compatible managed services:

- `Authorization: Token <api_key>` header (was `X-API-Key`)
- `POST /v1/memories/search/` for search (was `/search`)
- `POST /v1/memories/` for add (was `/memories`), with `async_mode=False` when `infer=False` (Volcengine rejects `infer=False` otherwise: "Async mode is disabled if infer is False. please set async_mode to False.")
- `PUT/DELETE /v1/memories/<id>/` for update/delete

`mem0.MemoryClient` can't be reused here: mem0ai 2.x hardwires write/search to the newer `/v3/memories/...` routes, which compatible services may not serve (404), while their v1 routes remain stable. The docstring and README now describe the compatible-service use case.

## Verification

- Full mem0 plugin suite passes: 112 tests (`test_mem0_backend.py`, `test_mem0_v3.py`, `test_mem0_setup.py`), including updated `SelfHostedBackend` contract tests + a new `infer=True` case.
- End-to-end against a live Volcengine Mem0 project host: search, add (infer=False), update, delete all succeed; previously search 404'd on `/search`.
