### PR TITLE
fix: provider retry for silent failures + fallback indicator snapshot

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -68,116 +68,22 @@ def _ra():
     return run_agent
 
 
-def _build_codex_gpt5_autoraise_notice(autoraise: Dict[str, Any]) -> str:
-    """Build the one-time notice shown when Codex gpt-5.x raises compaction.
+def _build_codex_gpt55_autoraise_notice(autoraise: Dict[str, float]) -> str:
+    """Build the one-time notice shown when Codex gpt-5.5 raises compaction.
 
-    ``autoraise`` is ``{"model": <slug>, "from": <old_ratio>, "to": <new_ratio>}``.
-    The same text is printed inline for CLI users and replayed via
-    ``status_callback`` for gateway users, so it must be self-contained and
-    include the exact opt-back-out command.
+    ``autoraise`` is ``{"from": <old_ratio>, "to": <new_ratio>}``. The same
+    text is printed inline for CLI users and replayed via ``status_callback``
+    for gateway users, so it must be self-contained and include the exact
+    opt-back-out command.
     """
-    model = str(autoraise.get("model") or "gpt-5.4/5.5").strip().lower().rsplit("/", 1)[-1]
-    # gpt-5.3-codex-spark has a native 128K window; the gpt-5.4/5.5/5.6 family
-    # is capped at 272K by the Codex OAuth backend.
-    cap = "128K" if model.startswith("gpt-5.3-codex-spark") else "272K"
     from_pct = int(round(autoraise["from"] * 100))
     to_pct = int(round(autoraise["to"] * 100))
     return (
-        f"ℹ Codex {model} caps context at {cap}, so auto-compaction was raised "
+        f"ℹ Codex gpt-5.5 caps context at 272K, so auto-compaction was raised "
         f"to {to_pct}% (from {from_pct}%) to use more of the window before "
         f"summarizing.\n"
         f"  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
     )
-
-
-def _resolve_compression_threshold(
-    global_threshold: float,
-    model_cthresh: Optional[float],
-    *,
-    model: Optional[str] = None,
-    is_codex_autoraise: bool,
-) -> tuple[float, Optional[Dict[str, Any]]]:
-    """Combine the user's global compaction threshold with a per-model override.
-
-    Returns ``(effective_threshold, autoraise_notice)``. ``autoraise_notice`` is
-    ``{"model": <slug>, "from": <old>, "to": <new>}`` only when a Codex
-    autoraise (gpt-5.4/5.5 272K family or gpt-5.3-codex-spark) actually raises
-    the threshold, otherwise ``None``.
-
-    The Codex overrides are *autoraises*: they must never LOWER a higher
-    user-configured threshold. A user who already set ``compression.threshold``
-    above the raised value deliberately keeps more raw context, and silently
-    dropping them would both waste usable window and contradict the feature's
-    purpose (use more of the window). Other overrides (e.g. Arcee Trinity)
-    keep their existing unconditional behaviour.
-    """
-    if model_cthresh is None:
-        return global_threshold, None
-    if is_codex_autoraise:
-        if model_cthresh <= global_threshold + 1e-9:
-            # Autoraise never lowers; keep the user's higher/equal threshold.
-            return global_threshold, None
-        return model_cthresh, {
-            "model": model,
-            "from": global_threshold,
-            "to": model_cthresh,
-        }
-    return model_cthresh, None
-
-
-def _codex_gpt55_autoraise_notice_marker():
-    """Path to the per-profile marker recording that the autoraise notice ran.
-
-    Lives under ``$HERMES_HOME`` (which is profile-scoped) alongside the other
-    internal markers like ``.container-mode`` — so it is not a user-facing config
-    key, and every profile tracks its own notice state independently.
-    """
-    return get_hermes_home() / ".codex_gpt55_autoraise_notice"
-
-
-def _codex_gpt55_autoraise_notice_state(autoraise: Dict[str, Any]) -> str:
-    """Stable identity for one autoraise notice, keyed on what it displays.
-
-    Uses the model slug plus the same from→to percentages the notice text
-    shows, so an unchanged threshold stays silent across restarts while a
-    later change (the user edits their global ``threshold``, or switches to a
-    different autoraised Codex model) re-notifies once.
-    """
-    model = str(autoraise.get("model") or "").strip().lower().rsplit("/", 1)[-1]
-    from_pct = int(round(float(autoraise["from"]) * 100))
-    to_pct = int(round(float(autoraise["to"]) * 100))
-    return f"{model}:{from_pct}:{to_pct}"
-
-
-def _codex_gpt55_autoraise_notice_seen(autoraise: Dict[str, Any]) -> bool:
-    """True if this exact autoraise notice was already shown for this profile.
-
-    A missing/unreadable marker (or one recording a different threshold) reads
-    as unseen, so the notice shows.
-    """
-    try:
-        current = _codex_gpt55_autoraise_notice_state(autoraise)
-        return _codex_gpt55_autoraise_notice_marker().read_text(
-            encoding="utf-8"
-        ).strip() == current
-    except (OSError, KeyError, TypeError, ValueError):
-        return False
-
-
-def _record_codex_gpt55_autoraise_notice(autoraise: Dict[str, Any]) -> None:
-    """Persist that the autoraise notice was shown for this profile/config state.
-
-    Best-effort: a read-only or missing ``$HERMES_HOME`` just means the notice
-    may show again next init, which is preferable to breaking agent init.
-    """
-    try:
-        marker = _codex_gpt55_autoraise_notice_marker()
-        marker.parent.mkdir(parents=True, exist_ok=True)
-        marker.write_text(
-            _codex_gpt55_autoraise_notice_state(autoraise), encoding="utf-8"
-        )
-    except (OSError, KeyError, TypeError, ValueError):
-        pass
 
 
 def _normalized_custom_base_url(value: Any) -> str:
@@ -187,26 +93,10 @@ def _normalized_custom_base_url(value: Any) -> str:
 
 
 def _custom_provider_model_matches(agent_model: str, entry: Dict[str, Any]) -> bool:
-    agent_model_norm = str(agent_model or "").strip().lower()
-    # Multi-model entries (v12+ `providers.<name>.models` mapping / legacy
-    # `models:` list): the agent's model matching ANY catalog entry counts.
-    # Without this, a provider whose `model`/`default_model` differs from the
-    # session model silently fails to match and per-provider request settings
-    # (extra_body, e.g. OpenAI service_tier) are dropped — billing the whole
-    # session at the wrong tier (July 2026 sweeper incident: flex config
-    # ignored, ~2.3x overbilling).
-    models = entry.get("models")
-    catalog: List[str] = []
-    if isinstance(models, dict):
-        catalog = [str(k).strip().lower() for k in models.keys()]
-    elif isinstance(models, (list, tuple)):
-        catalog = [str(m).strip().lower() for m in models]
-    if catalog and agent_model_norm in catalog:
-        return True
     provider_model = str(entry.get("model", "") or "").strip().lower()
-    if not provider_model and not catalog:
+    if not provider_model:
         return True
-    return provider_model == agent_model_norm
+    return provider_model == str(agent_model or "").strip().lower()
 
 
 def _custom_provider_extra_body_for_agent(
@@ -318,7 +208,6 @@ def init_agent(
     notice_callback: callable = None,
     notice_clear_callback: callable = None,
     event_callback: Optional[Callable[[str, dict], None]] = None,
-    reaction_callback: Optional[Callable[[str], None]] = None,
     max_tokens: int = None,
     reasoning_config: Dict[str, Any] = None,
     service_tier: str = None,
@@ -398,7 +287,9 @@ def init_agent(
     """
     _install_safe_stdio()
 
-    agent.model = model
+    # Defensive: strip accidentally duplicated model-name prefix (see #54511).
+    from agent.chat_completion_helpers import _dedupe_model_name
+    agent.model = _dedupe_model_name(model)
     agent.max_iterations = max_iterations
     # Shared iteration budget — parent creates, children inherit.
     # Consumed by every LLM turn across parent + all subagents.
@@ -428,13 +319,13 @@ def init_agent(
     agent.skip_context_files = skip_context_files
     agent.load_soul_identity = load_soul_identity
     agent.pass_session_id = pass_session_id
+    agent._credential_pool = credential_pool
     agent.log_prefix_chars = log_prefix_chars
     agent.log_prefix = f"{log_prefix} " if log_prefix else ""
     # Store effective base URL for feature detection (prompt caching, reasoning, etc.)
     agent.base_url = base_url or ""
     provider_name = provider.strip().lower() if isinstance(provider, str) and provider.strip() else None
     agent.provider = provider_name or ""
-    agent._credential_pool = credential_pool
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
     if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
@@ -469,24 +360,6 @@ def init_agent(
         agent.api_mode = "bedrock_converse"
     else:
         agent.api_mode = "chat_completions"
-
-    # Credential-pool validation runs AFTER provider auto-detection so
-    # a pool scoped to e.g. "anthropic" is not rejected when the agent
-    # was constructed with provider=None and an anthropic.com URL.
-    # Regression from #63048 which placed this check before the
-    # URL-based auto-detection block above (fixed #63425).
-    if credential_pool is not None:
-        try:
-            from agent.credential_pool import credential_pool_matches_provider
-
-            if not credential_pool_matches_provider(
-                credential_pool,
-                agent.provider,
-                base_url=agent.base_url,
-            ):
-                agent._credential_pool = None
-        except Exception:
-            agent._credential_pool = None
 
     # Eagerly warm the transport cache so import errors surface at init,
     # not mid-conversation.  Also validates the api_mode is registered.
@@ -570,7 +443,6 @@ def init_agent(
     agent.notice_callback = notice_callback
     agent.notice_clear_callback = notice_clear_callback
     agent.event_callback = event_callback
-    agent.reaction_callback = reaction_callback
     agent.tool_gen_callback = tool_gen_callback
 
     
@@ -743,25 +615,6 @@ def init_agent(
     # commentary when the provider later returns it as a completed interim
     # assistant message.
     agent._current_streamed_assistant_text = ""
-    # Completed interim messages delivered during the current user turn.
-    # Unlike token-stream tracking, this spans Codex continuation/tool calls so
-    # repeated commentary is not re-sent before normalization can deduplicate it.
-    agent._delivered_interim_texts: set[str] = set()
-
-    # Single-writer guard for the streaming delta sink (#65991). A stale/
-    # superseded stream (e.g. one the stale-stream detector reconnected past,
-    # whose socket abort raced and never actually stopped the old worker) must
-    # NOT keep writing tokens into the turn alongside the retry's stream —
-    # otherwise two coherent responses interleave token-by-token into one
-    # transcript. Every streaming attempt claims a monotonic writer token; the
-    # delta sink drops chunks whose calling thread holds a stale token. The
-    # threading.local means threads that never claimed (non-streaming callers)
-    # are never fenced, so the guard can only ever drop a superseded stream,
-    # never the single legitimate writer.
-    agent._stream_writer_lock = threading.Lock()
-    agent._stream_writer_token = 0
-    agent._stream_writer_tls = threading.local()
-    agent._stream_writer_dropped = 0
 
     # Optional current-turn user-message override used when the API-facing
     # user message intentionally differs from the persisted transcript
@@ -977,7 +830,7 @@ def init_agent(
                 client_kwargs["default_headers"] = build_nvidia_nim_headers(effective_base)
             elif base_url_host_matches(effective_base, "api.routermint.com"):
                 client_kwargs["default_headers"] = _ra()._routermint_headers()
-            elif base_url_host_matches(effective_base, "githubcopilot.com"):
+            elif base_url_host_matches(effective_base, "api.githubcopilot.com"):
                 from hermes_cli.models import copilot_default_headers
 
                 client_kwargs["default_headers"] = copilot_default_headers()
@@ -1063,6 +916,12 @@ def init_agent(
                             explicit_api_key=_fb_explicit_key,
                         )
                         if _fb_client is not None:
+                            # Snapshot the primary (original) model/provider before swap
+                            # so the UI can show "Fallback: X (primary: Y)"
+                            if not getattr(agent, "_primary_model", ""):
+                                agent._primary_model = model
+                            if not getattr(agent, "_primary_provider", ""):
+                                agent._primary_provider = provider
                             agent.provider = _fb["provider"]
                             agent.model = _fb_model or _fb["model"]
                             agent._fallback_activated = True
@@ -1122,34 +981,6 @@ def init_agent(
         # client_kwargs is the same dict object as agent._client_kwargs, so
         # this mutation is reflected in the client built just below.
         agent._apply_user_default_headers()
-
-        try:
-            from hermes_cli.config import (
-                apply_custom_provider_extra_headers_to_client_kwargs,
-                apply_custom_provider_tls_to_client_kwargs,
-                get_compatible_custom_providers,
-                load_config,
-            )
-
-            _cp_config = load_config()
-            _cp_entries = get_compatible_custom_providers(_cp_config)
-            _cp_base_url = str(client_kwargs.get("base_url") or agent.base_url or "")
-            apply_custom_provider_tls_to_client_kwargs(
-                client_kwargs,
-                _cp_base_url,
-                _cp_entries,
-            )
-            # Per-provider extra HTTP headers (providers.<name>.extra_headers /
-            # custom_providers[].extra_headers) — proxies, gateways, custom
-            # auth. Applied last so the most specific config level wins.
-            # SECURITY: values may carry credentials — never log them.
-            apply_custom_provider_extra_headers_to_client_kwargs(
-                client_kwargs,
-                _cp_base_url,
-                _cp_entries,
-            )
-        except Exception:
-            logger.debug("custom-provider TLS resolution skipped", exc_info=True)
 
         agent.api_key = client_kwargs.get("api_key", "")
         agent.base_url = client_kwargs.get("base_url", agent.base_url)
@@ -1336,14 +1167,6 @@ def init_agent(
     # SQLite session store (optional -- provided by CLI or gateway)
     agent._session_db = session_db
     agent._parent_session_id = parent_session_id
-    # A close flush and the worker's turn-start flush can overlap. The durable
-    # marker is attached to each in-memory message dict, so its test-and-append
-    # sequence must be serialized per agent rather than relying on SQLite alone.
-    agent._session_persist_lock = threading.RLock()
-    # CLI retains its just-accepted user dict until turn setup can reuse it.
-    # This preserves the message-local durable marker if close persistence wins
-    # the race before the agent's normal early turn flush.
-    agent._pending_cli_user_message = None
     agent._last_flushed_db_idx = 0  # tracks DB-write cursor to prevent duplicate writes
     agent._session_db_created = False  # DB row deferred to run_conversation()
     # Most agents own their session row and should finalize it on close().
@@ -1352,11 +1175,6 @@ def init_agent(
     # continuation row that must remain open after the helper is torn down;
     # those callers explicitly set this flag to False.
     agent._end_session_on_close = True
-    # When True, this agent NEVER persists to the canonical session store
-    # (state.db) or the JSON snapshot, regardless of session_id. Set on the
-    # background skill/memory review fork so its harness turn can't leak into
-    # the user's real session and hijack the next live turn. Default False.
-    agent._persist_disabled = False
     agent._session_init_model_config = {
         "max_iterations": agent.max_iterations,
         "reasoning_config": reasoning_config,
@@ -1373,40 +1191,6 @@ def init_agent(
         _agent_cfg = _load_agent_config()
     except Exception:
         _agent_cfg = {}
-
-    # Codex commentary visibility (display.show_commentary, default true).
-    # When true, completed Codex phase=commentary messages are delivered as
-    # visible mid-turn updates through the interim message path. When false,
-    # commentary falls back to the reasoning channel (visible only with
-    # show_reasoning enabled).
-    agent.show_commentary = True
-    try:
-        _display_section = _agent_cfg.get("display", {})
-        if isinstance(_display_section, dict):
-            agent.show_commentary = bool(_display_section.get("show_commentary", True))
-    except Exception:
-        agent.show_commentary = True
-
-    # LM Studio can either be explicitly preloaded through LM Studio's
-    # management API (the historical Hermes behavior) or left to LM Studio's
-    # just-in-time / Auto-Evict chat-completions path.  Keep the default
-    # explicit for backward compatibility; users with LM Studio Auto-Evict can
-    # opt into JIT via ``model.lmstudio_load_mode: jit``.
-    agent.lmstudio_load_mode = "explicit"
-    try:
-        _model_section = _agent_cfg.get("model", {})
-        if isinstance(_model_section, dict):
-            _load_mode = str(_model_section.get("lmstudio_load_mode", "explicit") or "explicit").strip().lower()
-            if _load_mode in {"explicit", "jit"}:
-                agent.lmstudio_load_mode = _load_mode
-            else:
-                logger.warning(
-                    "Invalid model.lmstudio_load_mode=%r; expected 'explicit' or 'jit'. Using explicit.",
-                    _model_section.get("lmstudio_load_mode"),
-                )
-    except Exception:
-        agent.lmstudio_load_mode = "explicit"
-
     try:
         agent._tool_guardrails = ToolCallGuardrailController(
             ToolCallGuardrailConfig.from_mapping(
@@ -1554,17 +1338,6 @@ def init_agent(
     # line).  Useful for users on exotic setups where the probe heuristics
     # are noisy.
     agent._environment_probe = bool(_agent_section.get("environment_probe", True))
-    # Warm the probe off-thread: it shells out to python3/pip (~0.5s of
-    # subprocess round-trips) and its result lands in the FIRST system
-    # prompt build, which sits on the time-to-first-token critical path.
-    # The warm runs during agent init (network/credential setup dominates),
-    # so by the time the first prompt is built the line is already cached.
-    if agent._environment_probe:
-        try:
-            from tools.env_probe import warm_environment_probe_async
-            warm_environment_probe_async()
-        except Exception:
-            pass
 
     # Per-platform prompt-hint overrides (config.yaml → platform_hints).
     # Lets an enterprise admin append to or replace Hermes' built-in
@@ -1600,48 +1373,41 @@ def init_agent(
     if not isinstance(_compression_cfg, dict):
         _compression_cfg = {}
     compression_threshold = float(_compression_cfg.get("threshold", 0.50))
-    # Per-model/route compaction-threshold override. Codex gpt-5.4 / gpt-5.5
-    # raise to 85% (the Codex backend caps both families at 272K, so the
-    # default 50% would compact at ~136K — half the usable context). Gated by
-    # an opt-out config flag so the user can fall back to the global threshold;
-    # when the override fires we stash a one-time notification (replayed on the
-    # first turn) that tells the user what changed and how to revert. The
-    # notice has its own display gate so users can keep the threshold
-    # autoraise without getting the banner on gateway turns.
+    # Per-model/route compaction-threshold override. Codex gpt-5.5 raises to
+    # 85% (the Codex backend caps the window at 272K, so the default 50% would
+    # compact at ~136K — half the usable context). Gated by an opt-out config
+    # flag so the user can fall back to the global threshold; when the override
+    # fires we stash a one-time notification (replayed on the first turn) that
+    # tells the user what changed and how to revert.
     _codex_gpt55_autoraise = str(
         _compression_cfg.get("codex_gpt55_autoraise", True)
-    ).lower() in {"true", "1", "yes"}
-    _codex_gpt55_autoraise_notice = str(
-        _compression_cfg.get("codex_gpt55_autoraise_notice", True)
     ).lower() in {"true", "1", "yes"}
     agent._compression_threshold_autoraised = None
     try:
         from agent.auxiliary_client import (
             _compression_threshold_for_model as _cthresh_fn,
-            _is_codex_gpt54_or_gpt55 as _is_codex_gpt54_or_gpt55_fn,
-            _is_codex_spark as _is_codex_spark_fn,
+            _is_codex_gpt55 as _is_codex_gpt55_fn,
         )
         _model_cthresh = _cthresh_fn(
             agent.model,
             agent.provider,
             allow_codex_gpt55_autoraise=_codex_gpt55_autoraise,
         )
-        # The Codex autoraises (gpt-5.4/5.5 272K family and gpt-5.3-codex-spark)
-        # apply only when they RAISE (never lower a user's higher global
-        # threshold). The notice is populated only when it actually fires, and
-        # carries the model slug so the banner names the right family. Arcee
-        # Trinity keeps its long-standing unconditional behaviour.
-        compression_threshold, agent._compression_threshold_autoraised = (
-            _resolve_compression_threshold(
-                compression_threshold,
-                _model_cthresh,
-                model=agent.model,
-                is_codex_autoraise=(
-                    _is_codex_gpt54_or_gpt55_fn(agent.model, agent.provider)
-                    or _is_codex_spark_fn(agent.model, agent.provider)
-                ),
-            )
-        )
+        if _model_cthresh is not None:
+            _prev_threshold = compression_threshold
+            compression_threshold = _model_cthresh
+            # Notify only for the Codex gpt-5.5 autoraise (the Arcee Trinity
+            # override is a long-standing silent default). Skip the notice when
+            # the user's global threshold already meets/exceeds the raised
+            # value, since nothing actually changed for them.
+            if (
+                _is_codex_gpt55_fn(agent.model, agent.provider)
+                and _model_cthresh > _prev_threshold + 1e-9
+            ):
+                agent._compression_threshold_autoraised = {
+                    "from": _prev_threshold,
+                    "to": _model_cthresh,
+                }
     except Exception:
         pass
     compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}
@@ -1667,16 +1433,6 @@ def init_agent(
     compression_in_place = is_truthy_value(
         _compression_cfg.get("in_place"), default=False
     )
-    codex_app_server_auto_compaction = str(
-        _compression_cfg.get("codex_app_server_auto", "native") or "native"
-    ).lower()
-    if codex_app_server_auto_compaction not in {"native", "hermes", "off"}:
-        _ra().logger.warning(
-            "Invalid compression.codex_app_server_auto=%r; using 'native'. "
-            "Valid values are: native, hermes, off.",
-            codex_app_server_auto_compaction,
-        )
-        codex_app_server_auto_compaction = "native"
 
     # Read optional explicit context_length override for the auxiliary
     # compression model. Custom endpoints often cannot report this via
@@ -1880,12 +1636,6 @@ def init_agent(
 
     if _selected_engine is not None:
         agent.context_compressor = _selected_engine
-        # External engines own compaction policy: the host compression
-        # threshold (including the Codex gpt-5.5 autoraise above) only
-        # configures the built-in ContextCompressor and never reaches the
-        # plugin, so the autoraise notice would announce a change that does
-        # not apply. Drop it. (#44439)
-        agent._compression_threshold_autoraised = None
         # Resolve context_length for plugin engines — mirrors switch_model() path
         from agent.model_metadata import get_model_context_length
         _plugin_ctx_len = get_model_context_length(
@@ -1923,15 +1673,8 @@ def init_agent(
             abort_on_summary_failure=compression_abort_on_summary_failure,
             max_tokens=agent.max_tokens,
         )
-    _bind_session_state = getattr(agent.context_compressor, "bind_session_state", None)
-    if callable(_bind_session_state):
-        try:
-            _bind_session_state(session_db=session_db, session_id=agent.session_id)
-        except Exception:
-            pass
     agent.compression_enabled = compression_enabled
     agent.compression_in_place = compression_in_place
-    agent.codex_app_server_auto_compaction = codex_app_server_auto_compaction
 
     # Reject models whose context window is below the minimum required
     # for reliable tool-calling workflows (64K tokens).
@@ -1946,33 +1689,6 @@ def init_agent(
             f"model.context_length in config.yaml to the real value "
             f"(this must be at least {MINIMUM_CONTEXT_LENGTH // 1000}K)."
         )
-
-    # Nous Hermes 3/4 are chat models, not tool-call-tuned. The interactive
-    # CLI already warns via cli.py show_banner() (richer output + /model hint),
-    # so skip platform=="cli" here to avoid emitting the warning twice per
-    # startup. (Gateway/TUI/cron construct with quiet_mode=True and are already
-    # gated off by the `not agent.quiet_mode` check above; this guard's active
-    # job is the CLI dedup, and it leaves the door open for any non-quiet
-    # non-CLI surface to still surface the warning.)
-    if not agent.quiet_mode and (agent.platform or "cli") != "cli":
-        try:
-            from hermes_cli.model_switch import _check_hermes_model_warning
-
-            _hermes_warn = _check_hermes_model_warning(agent.model or "")
-            if _hermes_warn:
-                _user_msg = (
-                    "⚠ Nous Research Hermes 3 & 4 models are NOT agentic — they "
-                    "lack reliable tool-calling for agent workflows (delegation, "
-                    "cron, proactive tools). Consider an agentic model instead "
-                    "(Claude, GPT, Gemini, Qwen-Coder, etc.)."
-                )
-                if hasattr(agent, "_emit_warning"):
-                    agent._emit_warning(_user_msg)
-                else:
-                    print(f"\n{_user_msg}\n", file=sys.stderr)
-                _ra().logger.warning(_hermes_warn)
-        except Exception:
-            pass
 
     # Inject context engine tool schemas (e.g. lcm_grep, lcm_describe, lcm_expand).
     # Skip names that are already present — the _ra().get_tool_definitions()
@@ -2043,8 +1759,6 @@ def init_agent(
         working_dir=os.getenv("TERMINAL_CWD") or None,
     )
     agent._user_turn_count = 0
-    # Copilot x-initiator flag: first API call of a user turn sends "user" (#3040).
-    agent._is_user_initiated_turn = False
 
     # Cumulative token usage for the session
     agent.session_prompt_tokens = 0
@@ -2109,53 +1823,29 @@ def init_agent(
             agent._ollama_num_ctx,
         )
 
-    # Codex gpt-5.x autoraise notice: show at most once per profile/config
-    # state. Without the persisted marker the notice re-fires on every agent
-    # init — and the gateway rebuilds the agent per inbound message, so Discord
-    # etc. saw it repeatedly (#54432). A change in the raised threshold (or the
-    # autoraised model) updates the marker state and re-notifies once. The
-    # config display gate (compression.codex_gpt55_autoraise_notice) still
-    # suppresses the banner entirely without disabling the threshold autoraise.
-    _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-    _show_autoraise_notice = (
-        bool(_autoraise)
-        and compression_enabled
-        and _codex_gpt55_autoraise_notice
-        and not _codex_gpt55_autoraise_notice_seen(_autoraise)
-    )
-
     if not agent.quiet_mode:
         if compression_enabled:
-            # Report the active engine's own threshold — for a plugin engine
-            # the host compression_threshold is not in effect, and mixing the
-            # two printed a percent that contradicted the token count. (#44439)
-            _active_threshold_pct = getattr(
-                agent.context_compressor, "threshold_percent", compression_threshold
-            )
-            print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (compress at {int(_active_threshold_pct*100)}% = {agent.context_compressor.threshold_tokens:,})")
+            print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {agent.context_compressor.threshold_tokens:,})")
         else:
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (auto-compression disabled)")
-        # Notice with the exact opt-back-out command. Printed inline at startup
-        # for CLI users; gateway users get the same text replayed via
-        # _compression_warning on turn 1 (set below).
-        if _show_autoraise_notice:
-            print(_build_codex_gpt5_autoraise_notice(_autoraise))
+        # One-time notice when the Codex gpt-5.5 autoraise kicked in, with the
+        # exact opt-back-out command. Printed inline at startup for CLI users;
+        # gateway users get the same text replayed via _compression_warning on
+        # turn 1 (set below, after the warning slot is initialized).
+        _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
+        if _autoraise and compression_enabled:
+            print(_build_codex_gpt55_autoraise_notice(_autoraise))
 
     # Check immediately so CLI users see the warning at startup.
     # Gateway status_callback is not yet wired, so any warning is stored
     # in _compression_warning and replayed in the first run_conversation().
     agent._compression_warning = None
-    # Gateway parity for the Codex gpt-5.x autoraise notice: the startup print
+    # Gateway parity for the Codex gpt-5.5 autoraise notice: the startup print
     # above only reaches the CLI, so stash the same text here to be replayed
     # through status_callback on the first turn (Telegram/Discord/Slack/etc.).
-    if _show_autoraise_notice:
-        agent._compression_warning = _build_codex_gpt5_autoraise_notice(_autoraise)
-
-    # Mark shown so repeated inits in this profile (e.g. every gateway message)
-    # stay silent. Recorded once, whether the notice went to the CLI print or
-    # the gateway replay slot.
-    if _show_autoraise_notice:
-        _record_codex_gpt55_autoraise_notice(_autoraise)
+    _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
+    if _autoraise and compression_enabled:
+        agent._compression_warning = _build_codex_gpt55_autoraise_notice(_autoraise)
     # Lazy feasibility check: deferred to the first turn that approaches the
     # compression threshold. Running it eagerly here costs ~400ms cold (network
     # probe of the auxiliary provider chain + /models lookup) on every agent

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import json
 import logging
-import math
 import os
 import re
 import threading
@@ -29,16 +28,11 @@ from typing import Any, Dict, Optional
 from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
-from agent.errors import EmptyStreamError
-from agent.turn_context import substitute_api_content
-from agent.gemini_native_adapter import is_native_gemini_base_url
 from agent.model_metadata import is_local_endpoint
-from agent.message_content import flatten_message_text
 from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,
 )
-from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
 from tools.terminal_tool import is_persistent_env
 from utils import base_url_host_matches, base_url_hostname, env_float, env_int
 
@@ -56,6 +50,17 @@ _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
 # narrower non-rate-limit case.  See issue #24996.
 _FALLBACK_EXHAUSTED_COOLDOWN_S = 5.0
 
+# – Silent provider retry constants –
+# When a provider returns no content and no error, treat this as a silent failure
+# and retry with exponential backoff (up to retry attempts). This covers cases
+# like usage/rate limits that don't return HTTP 429, temporary outages, network
+# blips.
+_PROVIDER_RETRY_MAX_ATTEMPTS = int(os.environ.get("HERMES_PROVIDER_RETRY_MAX_ATTEMPTS", "3"))
+_PROVIDER_RETRY_BASE_DELAY = float(os.environ.get("HERMES_PROVIDER_RETRY_BASE_DELAY", "1.0"))
+_PROVIDER_RETRY_MAX_DELAY = float(os.environ.get("HERMES_PROVIDER_RETRY_MAX_DELAY", "30.0"))
+_PROVIDER_RETRY_BACKOFF = float(os.environ.get("HERMES_PROVIDER_RETRY_BACKOFF", "2.0"))
+_PROVIDER_RETRY_JITTER = float(os.environ.get("HERMES_PROVIDER_RETRY_JITTER", "0.2"))
+
 
 def _ra():
     """Lazy ``run_agent`` reference.
@@ -67,9 +72,32 @@ def _ra():
     import run_agent
     return run_agent
 
+def _is_silent_provider_failure(response: Any) -> bool:
+    """Detect silent provider failures (no content, no error, no tool_calls, no reasoning)."""
+    if response is None:
+        return True
+    if hasattr(response, "choices") and isinstance(response.choices, list) and response.choices and hasattr(response.choices[0], "message") and response.choices[0].message:
+        msg = response.choices[0].message
+        if not (hasattr(msg, "content") and msg.content) and not (hasattr(msg, "tool_calls") and msg.tool_calls) and not (hasattr(msg, "reasoning_content") and msg.reasoning_content):
+            return True
+    return False
+
+
+def _provider_retry_backoff(attempt: int) -> float:
+    """Calculate exponential backoff delay with jitter for provider retry."""
+    # Exponential: delay = BASE_DELAY * (BACKOFF ** (attempt - 1))
+    delay = _PROVIDER_RETRY_BASE_DELAY * (_PROVIDER_RETRY_BACKOFF ** (attempt - 1))
+    # Cap at maximum
+    if delay > _PROVIDER_RETRY_MAX_DELAY:
+        delay = _PROVIDER_RETRY_MAX_DELAY
+    # Add jitter: ±20% range
+    jitter = delay * _PROVIDER_RETRY_JITTER * ((int(time.time()) % 1000) / 1000.0)
+    return max(0.0, delay + jitter)
+
 
 def estimate_request_context_tokens(api_payload: Any) -> int:
     """Estimate context/load tokens from an API payload, dict or messages list.
+
 
     The stale-call detectors historically assumed a Chat Completions request:
     they pulled ``api_kwargs["messages"]`` and ran a cheap char/4 estimate.
@@ -133,25 +161,6 @@ def _is_openai_codex_backend(agent) -> bool:
     )
 
 
-def openai_codex_stale_timeout_floor(est_tokens: int) -> float:
-    """Minimum wall-clock stale timeout for openai-codex by estimated context.
-
-    Gateway/Telegram sessions routinely ship ~15–25k tokens of tools +
-    instructions before the first user message. Subscription-backed Codex can
-    legitimately spend several minutes in backend admission/prefill at that
-    size; the generic 90s non-stream stale default aborts healthy calls. The
-    floor engages above 10k estimated tokens so those gateway-scale payloads
-    are covered; smaller requests keep the generic default.
-    """
-    if est_tokens > 100_000:
-        return 1200.0
-    if est_tokens > 50_000:
-        return 900.0
-    if est_tokens > 10_000:
-        return 600.0
-    return 0.0
-
-
 def _validated_openrouter_provider_sort(raw_sort: Any) -> Optional[str]:
     """Return a normalized OpenRouter provider.sort value or None."""
     if not isinstance(raw_sort, str):
@@ -169,335 +178,11 @@ def _validated_openrouter_provider_sort(raw_sort: Any) -> Optional[str]:
     return None
 
 
-def _provider_preferences_for_agent(agent) -> Dict[str, Any]:
-    """Build the validated provider-routing object shared by request paths."""
-    preferences: Dict[str, Any] = {}
-    if agent.providers_allowed:
-        preferences["only"] = agent.providers_allowed
-    if agent.providers_ignored:
-        preferences["ignore"] = agent.providers_ignored
-    if agent.providers_order:
-        preferences["order"] = agent.providers_order
-    provider_sort = _validated_openrouter_provider_sort(agent.provider_sort)
-    if provider_sort:
-        preferences["sort"] = provider_sort
-    if agent.provider_require_parameters:
-        preferences["require_parameters"] = True
-    if agent.provider_data_collection:
-        preferences["data_collection"] = agent.provider_data_collection
-    return preferences
-
-
 def _env_float(name: str, default: float) -> float:
     try:
         return float(os.getenv(name, str(default)))
     except (TypeError, ValueError):
         return default
-
-
-def _codex_wait_notice_recovery(
-    *,
-    stale_timeout: float,
-    ttfb_enabled: bool,
-    ttfb_timeout: float,
-    last_event_ts: Optional[float],
-    call_start: float,
-    idle_enabled: bool,
-    idle_timeout: float,
-    elapsed: float,
-) -> str:
-    """Describe the earliest enabled Codex watchdog on the call timeline."""
-    deadlines: list[float] = []
-    if math.isfinite(stale_timeout):
-        deadlines.append(stale_timeout)
-    if last_event_ts is None:
-        if ttfb_enabled and math.isfinite(ttfb_timeout):
-            deadlines.append(ttfb_timeout)
-    elif idle_enabled and math.isfinite(idle_timeout):
-        deadlines.append(max(0.0, last_event_ts - call_start) + idle_timeout)
-    if not deadlines or min(deadlines) <= elapsed:
-        return ""
-    return f"; auto-reconnect at {int(min(deadlines))}s"
-
-
-# ── Cross-turn stale-call circuit breaker (#58962) ─────────────────────
-# A session wedged against an unresponsive provider hits the stale detector
-# on every call and loops forever (observed: 494 consecutive failures over
-# 3+ days, each burning the full stale timeout × retries with no response).
-# The agent carries ``_consecutive_stale_streams``: incremented on every
-# stale kill, reset only when a call actually completes (or when the
-# provider is swapped — switch_model / try_activate_fallback /
-# restore_primary_runtime — since the streak measured the OLD provider).
-# Past the give-up threshold, calls abort immediately with an actionable
-# error instead of re-waiting out the stale timeout.
-
-def _stale_streak(agent) -> int:
-    try:
-        return int(getattr(agent, "_consecutive_stale_streams", 0) or 0)
-    except Exception:
-        return 0
-
-
-def _bump_stale_streak(agent) -> None:
-    try:
-        agent._consecutive_stale_streams = _stale_streak(agent) + 1
-    except Exception:
-        pass
-
-
-def _reset_stale_streak(agent) -> None:
-    try:
-        agent._consecutive_stale_streams = 0
-    except Exception:
-        pass
-
-
-def _check_stale_giveup(agent) -> None:
-    """Raise immediately when the consecutive-stale streak is past the
-    give-up threshold — no network attempt, no stale-timeout wait."""
-    _giveup = env_int("HERMES_STREAM_STALE_GIVEUP", 5)
-    _streak = _stale_streak(agent)
-    if _giveup > 0 and _streak >= _giveup:
-        raise RuntimeError(
-            "Provider has been unresponsive (no response received) for "
-            f"{_streak} consecutive stale attempts — aborting this call to "
-            "avoid an indefinite stall. Switch models or start a new "
-            "session, then retry."
-        )
-
-
-def _derive_stream_stale_timeout(agent, api_kwargs: dict) -> float:
-    """Stale-stream patience for a provider that is never a local endpoint.
-
-    Mirrors the main streaming path's derivation — provider config → env base
-    → context-size scaling → reasoning-model floor — minus the local-endpoint
-    ``float('inf')``/900s disable branch, which cannot apply to Bedrock (its
-    endpoint is always the AWS cloud). Factored so the Bedrock streaming
-    watchdog shares the exact same patience budget as the OpenAI/Anthropic
-    stale-stream detector below.
-    """
-    _cfg_stale = get_provider_stale_timeout(agent.provider, agent.model)
-    if _cfg_stale is not None:
-        _base = _cfg_stale
-    else:
-        _base = env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
-    _est_tokens = estimate_request_context_tokens(api_kwargs)
-    if _est_tokens > 100_000:
-        _timeout = max(_base, 300.0)
-    elif _est_tokens > 50_000:
-        _timeout = max(_base, 240.0)
-    else:
-        _timeout = _base
-    from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
-    # Resolve the model id from BOTH the OpenAI/Anthropic key (``model``) and
-    # the Bedrock key (``modelId``). OpenAI/Anthropic wins first via the ``or``
-    # chain, so those paths are unchanged. Bedrock carries the model as a
-    # dotted, region-prefixed inference-profile id (e.g.
-    # ``us.anthropic.claude-opus-4-6-v1:0``) that the floor's start-of-slug
-    # regex cannot match directly — normalize it to a canonical slug first.
-    _model_id = api_kwargs.get("model") or api_kwargs.get("modelId") or ""
-    _reasoning_floor = get_reasoning_stale_timeout_floor(_model_id)
-    if _reasoning_floor is None and api_kwargs.get("modelId"):
-        _reasoning_floor = _bedrock_reasoning_stale_floor(api_kwargs["modelId"])
-    if _reasoning_floor is not None:
-        _timeout = max(_timeout, _reasoning_floor)
-    return _timeout
-
-
-def _bedrock_reasoning_stale_floor(model_id: object) -> "float | None":
-    """Map a Bedrock inference-profile id to its reasoning stale-timeout floor.
-
-    Bedrock carries the model as a dotted, region-prefixed id such as
-    ``us.anthropic.claude-opus-4-6-v1:0``, whereas
-    :func:`get_reasoning_stale_timeout_floor` anchors its slug patterns at the
-    start of a bare slug (``claude-opus-4``). Strip the region prefix
-    (``us.``/``eu.``/``apac.``/...) and try two candidate slugs against the
-    floor:
-
-    * the segment after the provider namespace (``claude-opus-4-6-v1:0``) —
-      matches Anthropic-style slugs whose floor key excludes the provider
-      (``claude-opus-4``); and
-    * the region-stripped id with the provider dot rewritten to a dash
-      (``deepseek-r1-v1:0``) — matches provider-qualified floor keys
-      (``deepseek-r1``).
-
-    The floor's right-anchor (``$`` or ``-``/``.``/``_``) tolerates the
-    trailing date-stamp / ``-v1:0`` version suffix, so no suffix stripping is
-    needed. First non-None wins; returns None for unknown models.
-
-    The floor table mixes version-separator conventions: some keys are
-    keyed with a dashed version (``claude-opus-4``) while others embed a
-    dotted version (``claude-sonnet-4.5``, ``claude-sonnet-4.6``). Bedrock
-    always dashes the version (``claude-sonnet-4-5-v1:0``), so for every
-    candidate slug we also try the alternate version-separator form —
-    digit-dash-digit rewritten to digit-dot-digit and vice-versa — so a
-    dashed Bedrock id matches a dotted floor key (and the reverse). The
-    rewrite only touches version-number separators (a dash/dot flanked by
-    digits), never other dashes in the slug, so ``claude-sonnet`` is left
-    intact while ``4-5`` becomes ``4.5``.
-    """
-    from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
-
-    if not model_id or not isinstance(model_id, str):
-        return None
-    name = model_id.strip().lower()
-    for prefix in ("us.", "eu.", "apac.", "ap.", "global.", "jp."):
-        if name.startswith(prefix):
-            name = name[len(prefix):]
-            break
-    base_candidates = [name]
-    if "." in name:
-        base_candidates.append(name.rsplit(".", 1)[1])   # claude-opus-4-6-v1:0
-        base_candidates.append(name.replace(".", "-", 1))  # deepseek-r1-v1:0
-    candidates: list[str] = []
-    for cand in base_candidates:
-        # Try the slug as-is plus both alternate version-separator forms.
-        # ``4-5`` <-> ``4.5`` only; a dash/dot not flanked by digits is
-        # left alone (e.g. ``claude-sonnet`` stays dashed).
-        dashed_to_dotted = re.sub(r"(?<=\d)-(?=\d)", ".", cand)
-        dotted_to_dashed = re.sub(r"(?<=\d)\.(?=\d)", "-", cand)
-        for form in (cand, dashed_to_dotted, dotted_to_dashed):
-            if form not in candidates:
-                candidates.append(form)
-    for cand in candidates:
-        floor = get_reasoning_stale_timeout_floor(cand)
-        if floor is not None:
-            return floor
-    return None
-
-
-def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
-    """Run one non-streaming LLM request for the active api_mode and return it.
-
-    Shared by the interrupt-worker path (``interruptible_api_call``) and the
-    inline path (``direct_api_call``) so the per-api_mode dispatch — codex /
-    anthropic / bedrock / MoA / OpenAI-compatible — lives in exactly one place.
-
-    ``make_client(reason, kind=...)`` builds the per-request client for the
-    codex / OpenAI-compatible (``kind="openai"``) and anthropic
-    (``kind="anthropic_messages"``) branches; the worker path uses it to
-    register the client with its stranger-thread abort machinery, the inline
-    path uses it to capture the client for its own ``finally`` close. The
-    bedrock / MoA branches manage their own clients and never call it. All
-    interrupt, abort, cancellation, and close semantics stay in the callers —
-    this helper only issues the request.
-    """
-    if agent.api_mode == "codex_responses":
-        request_client = make_client("codex_stream_request")
-        return agent._run_codex_stream(
-            api_kwargs,
-            client=request_client,
-            on_first_delta=getattr(agent, "_codex_on_first_delta", None),
-        )
-    if agent.api_mode == "anthropic_messages":
-        # #67142: use a request-local Anthropic client so the stale/interrupt
-        # watchdog aborts sockets from the stranger thread while the worker
-        # owns the SDK close — never closing the shared client mid-flight.
-        request_client = make_client(
-            "anthropic_messages_request", kind="anthropic_messages"
-        )
-        return agent._anthropic_messages_create(api_kwargs, client=request_client)
-    if agent.api_mode == "bedrock_converse":
-        # Bedrock uses boto3 directly — no OpenAI client needed.
-        # normalize_converse_response produces an OpenAI-compatible
-        # SimpleNamespace so the rest of the agent loop can treat
-        # bedrock responses like chat_completions responses.
-        from agent.bedrock_adapter import (
-            _get_bedrock_runtime_client,
-            invalidate_runtime_client,
-            is_stale_connection_error,
-            normalize_converse_response,
-        )
-        region = api_kwargs.pop("__bedrock_region__", "us-east-1")
-        api_kwargs.pop("__bedrock_converse__", None)
-        client = _get_bedrock_runtime_client(region)
-        try:
-            raw_response = client.converse(**api_kwargs)
-        except Exception as _bedrock_exc:
-            # Evict the cached client on stale-connection failures
-            # so the outer retry loop builds a fresh client/pool.
-            if is_stale_connection_error(_bedrock_exc):
-                invalidate_runtime_client(region)
-            raise
-        return normalize_converse_response(raw_response)
-    if agent.provider == "moa":
-        # MoA is a virtual chat-completions provider backed by the
-        # in-process MoAClient facade. Do not rebuild a request-local
-        # OpenAI client from the virtual runtime metadata.
-        return agent.client.chat.completions.create(**api_kwargs)
-    request_client = make_client("chat_completion_request")
-    return request_client.chat.completions.create(**api_kwargs)
-
-
-def should_use_direct_api_call(agent) -> bool:
-    """Whether a cron OpenAI-wire request should skip the interrupt worker.
-
-    Issue #62151 is specific to OpenRouter's chat-completions path inside the
-    gateway cron thread stack. Keep native/Codex/Bedrock/MoA transports on their
-    established workers: their cancellation and client ownership differ, and
-    the report provides no evidence that those paths share the pre-HTTP wedge.
-    """
-    return (
-        getattr(agent, "platform", None) == "cron"
-        and getattr(agent, "api_mode", None) == "chat_completions"
-        and getattr(agent, "provider", None) != "moa"
-    )
-
-
-def direct_api_call(agent, api_kwargs: dict):
-    """Run a non-streaming LLM call inline on the conversation thread.
-
-    Used when ``should_use_direct_api_call`` is True. Skips the interrupt worker
-    (whose only job is interactive-interrupt responsiveness, which this context
-    does not have) so the nested-pool deadlock (#62151) cannot occur. Because the
-    request runs in-flight normally, the per-request OpenAI client's own httpx
-    timeout (provider ``request_timeout_seconds`` / ``HERMES_API_TIMEOUT``) bounds
-    a genuinely hung provider — the same bound interactive calls already rely on.
-    """
-    _check_stale_giveup(agent)
-    agent._touch_activity("waiting for non-streaming API response")
-    request_client_holder = {"client": None}
-    request_client_lock = threading.Lock()
-
-    def _abort_active_request(reason: str) -> None:
-        """Abort the inline request from cron's watchdog/interrupt thread."""
-        with request_client_lock:
-            request_client = request_client_holder["client"]
-        if request_client is not None:
-            agent._abort_request_openai_client(request_client, reason=reason)
-
-    def _make_client(reason: str, kind: str = "openai"):
-        # direct_api_call only runs for OpenAI-wire chat_completions cron
-        # requests (see should_use_direct_api_call), so the anthropic branch of
-        # the dispatch — the only caller that passes kind — is never reached
-        # here; the ``kind`` parameter exists purely for signature parity.
-        client = agent._create_request_openai_client(reason=reason, api_kwargs=api_kwargs)
-        with request_client_lock:
-            request_client_holder["client"] = client
-        agent._active_request_abort = _abort_active_request
-        return client
-
-    try:
-        response = _dispatch_nonstreaming_api_request(
-            agent, api_kwargs, make_client=_make_client
-        )
-    except Exception:
-        if getattr(agent, "_interrupt_requested", False):
-            raise InterruptedError("Agent interrupted during API call") from None
-        raise
-    else:
-        if getattr(agent, "_interrupt_requested", False):
-            raise InterruptedError("Agent interrupted during API call")
-        _reset_stale_streak(agent)
-        return response
-    finally:
-        if getattr(agent, "_active_request_abort", None) is _abort_active_request:
-            agent._active_request_abort = None
-        with request_client_lock:
-            request_client = request_client_holder["client"]
-            request_client_holder["client"] = None
-        if request_client is not None:
-            agent._close_request_openai_client(request_client, reason="request_complete")
 
 
 def interruptible_api_call(agent, api_kwargs: dict):
@@ -514,473 +199,509 @@ def interruptible_api_call(agent, api_kwargs: dict):
     the main retry loop can try again with backoff / credential rotation /
     provider fallback.
     """
-    # Cron and other non-interactive, nested-pool contexts must not spawn the
-    # interrupt worker — it wedges before the socket opens on the 2nd+ call
-    # (#62151). Run inline instead. See should_use_direct_api_call.
-    if should_use_direct_api_call(agent):
-        return direct_api_call(agent, api_kwargs)
-
-    result = {"response": None, "error": None}
-
-    # Cross-turn stale-call circuit breaker (#58962) — non-streaming sibling
-    # of the guard in interruptible_streaming_api_call.  Quiet-mode /
-    # subagent / no-stream-consumer sessions take THIS path, and a wedged
-    # unattended session here has the same infinite stale-retry class.
-    _check_stale_giveup(agent)
-
-    request_client_holder = {"client": None, "owner_tid": None}
-    # Transport kind of the registered request client ("openai" or
-    # "anthropic_messages") so _close_request_client_once routes to the right
-    # abort/close helpers (#67142).
-    request_client_kind = {"value": "openai"}
-    request_client_lock = threading.Lock()
-    # Request-local cancellation flag. Distinct from agent._interrupt_requested
-    # because that flag is cleared at run_conversation() turn boundaries, but
-    # this daemon worker thread can outlive the turn (the gateway caches
-    # AIAgent instances per session). Tracks whether THIS specific request was
-    # cancelled by the main thread's interrupt handler, so the transport error
-    # that is the expected consequence of our own force-close isn't misread as
-    # a network bug and surfaced to the caller. (PR #6600 — cascading interrupt
-    # hang.)
-    _request_cancelled = {"value": False}
-
-    def _set_request_client(client, *, kind: str = "openai"):
-        with request_client_lock:
-            request_client_holder["client"] = client
-            request_client_kind["value"] = kind
-            # #29507: stamp the owning thread so a stranger-thread interrupt
-            # only shuts the connection down rather than racing the worker
-            # for FD ownership during ``client.close()``.
-            request_client_holder["owner_tid"] = threading.get_ident()
-        return client
-
-    def _close_request_client_once(reason: str) -> None:
-        # #29507: dispatch on the calling thread.
-        #
-        # When ``_call`` (the worker) reaches its ``finally`` it owns the
-        # close and we pop + fully close as before. When a *stranger* thread
-        # (the interrupt-check loop, the stale-call detector) drives the
-        # close, only shut the sockets down so the worker's blocked
-        # ``recv``/``send`` unwinds with an ``EPIPE`` / EOF — and let the
-        # worker close ``client`` from its own thread on its way out. That
-        # avoids the FD-recycling race where the kernel reassigned a
-        # just-closed TLS socket FD to ``kanban.db``, and the still-live SSL
-        # BIO on the worker thread then wrote a 24-byte TLS application-data
-        # record into the SQLite header (#29507).
-        with request_client_lock:
-            request_client = request_client_holder.get("client")
-            owner_tid = request_client_holder.get("owner_tid")
-            stranger_thread = (
-                request_client is not None
-                and owner_tid is not None
-                and owner_tid != threading.get_ident()
-            )
-            if not stranger_thread:
-                # Owning thread (or no recorded owner) → pop and fully close.
-                request_client_holder["client"] = None
-                request_client_holder["owner_tid"] = None
-        if request_client is None:
-            return
-        kind = request_client_kind.get("value", "openai")
-        if kind == "anthropic_messages":
-            if stranger_thread:
-                agent._abort_request_anthropic_client(request_client, reason=reason)
-            else:
-                agent._close_request_anthropic_client(request_client, reason=reason)
-        elif stranger_thread:
-            agent._abort_request_openai_client(request_client, reason=reason)
-        else:
-            agent._close_request_openai_client(request_client, reason=reason)
-
-    def _call():
+    # === RETRY LOOP FOR SILENT PROVIDER FAILURES ===
+    while True:
+        _attempt = getattr(agent, "_provider_retry_attempt", 0) + 1
         try:
-            # _set_request_client registers each per-request client with the
-            # stranger-thread abort machinery above; the shared dispatch helper
-            # builds it via this callback (openai- or anthropic-kind) so the
-            # interrupt / stale-call detectors can force-close the worker's
-            # connection without touching the shared client (#67142).
-            result["response"] = _dispatch_nonstreaming_api_request(
-                agent,
-                api_kwargs,
-                make_client=lambda reason, kind="openai": _set_request_client(
-                    agent._create_request_anthropic_client(reason=reason)
-                    if kind == "anthropic_messages"
-                    else agent._create_request_openai_client(
-                        reason=reason, api_kwargs=api_kwargs
-                    ),
-                    kind=kind,
-                ),
+            result = {"response": None, "error": None}
+            request_client_holder = {"client": None, "owner_tid": None}
+            request_client_lock = threading.Lock()
+            # Request-local cancellation flag. Distinct from agent._interrupt_requested
+            # because that flag is cleared at run_conversation() turn boundaries, but
+            # this daemon worker thread can outlive the turn (the gateway caches
+            # AIAgent instances per session). Tracks whether THIS specific request was
+            # cancelled by the main thread's interrupt handler, so the transport error
+            # that is the expected consequence of our own force-close isn't misread as
+            # a network bug and surfaced to the caller. (PR #6600 — cascading interrupt
+            # hang.)
+            _request_cancelled = {"value": False}
+
+            def _set_request_client(client):
+                with request_client_lock:
+                    request_client_holder["client"] = client
+                    # #29507: stamp the owning thread so a stranger-thread interrupt
+                    # only shuts the connection down rather than racing the worker
+                    # for FD ownership during ``client.close()``.
+                    request_client_holder["owner_tid"] = threading.get_ident()
+                return client
+
+            def _close_request_client_once(reason: str) -> None:
+                # #29507: dispatch on the calling thread.
+                #
+                # When ``_call`` (the worker) reaches its ``finally`` it owns the
+                # close and we pop + fully close as before. When a *stranger* thread
+                # (the interrupt-check loop, the stale-call detector) drives the
+                # close, only shut the sockets down so the worker's blocked
+                # ``recv``/``send`` unwinds with an ``EPIPE`` / EOF — and let the
+                # worker close ``client`` from its own thread on its way out. That
+                # avoids the FD-recycling race where the kernel reassigned a
+                # just-closed TLS socket FD to ``kanban.db``, and the still-live SSL
+                # BIO on the worker thread then wrote a 24-byte TLS application-data
+                # record into the SQLite header (#29507).
+                with request_client_lock:
+                    request_client = request_client_holder.get("client")
+                    owner_tid = request_client_holder.get("owner_tid")
+                    stranger_thread = (
+                        request_client is not None
+                        and owner_tid is not None
+                        and owner_tid != threading.get_ident()
+                    )
+                    if not stranger_thread:
+                        # Owning thread (or no recorded owner) → pop and fully close.
+                        request_client_holder["client"] = None
+                        request_client_holder["owner_tid"] = None
+                if request_client is None:
+                    return
+                if stranger_thread:
+                    agent._abort_request_openai_client(request_client, reason=reason)
+                else:
+                    agent._close_request_openai_client(request_client, reason=reason)
+
+            def _call():
+                try:
+                    if agent.api_mode == "codex_responses":
+                        request_client = _set_request_client(
+                            agent._create_request_openai_client(
+                                reason="codex_stream_request",
+                                api_kwargs=api_kwargs,
+                            )
+                        )
+                        result["response"] = agent._run_codex_stream(
+                            api_kwargs,
+                            client=request_client,
+                            on_first_delta=getattr(agent, "_codex_on_first_delta", None),
+                        )
+                    elif agent.api_mode == "anthropic_messages":
+                        result["response"] = agent._anthropic_messages_create(api_kwargs)
+                    elif agent.api_mode == "bedrock_converse":
+                        # Bedrock uses boto3 directly — no OpenAI client needed.
+                        # normalize_converse_response produces an OpenAI-compatible
+                        # SimpleNamespace so the rest of the agent loop can treat
+                        # bedrock responses like chat_completions responses.
+                        from agent.bedrock_adapter import (
+                            _get_bedrock_runtime_client,
+                            invalidate_runtime_client,
+                            is_stale_connection_error,
+                            normalize_converse_response,
+                        )
+                        region = api_kwargs.pop("__bedrock_region__", "us-east-1")
+                        api_kwargs.pop("__bedrock_converse__", None)
+                        client = _get_bedrock_runtime_client(region)
+                        try:
+                            raw_response = client.converse(**api_kwargs)
+                        except Exception as _bedrock_exc:
+                            # Evict the cached client on stale-connection failures
+                            # so the outer retry loop builds a fresh client/pool.
+                            if is_stale_connection_error(_bedrock_exc):
+                                invalidate_runtime_client(region)
+                            raise
+                        result["response"] = normalize_converse_response(raw_response)
+                    elif agent.provider == "moa":
+                        # MoA is a virtual chat-completions provider backed by the
+                        # in-process MoAClient facade. Do not rebuild a request-local
+                        # OpenAI client from the virtual runtime metadata.
+                        result["response"] = agent.client.chat.completions.create(**api_kwargs)
+                    else:
+                        request_client = _set_request_client(
+                            agent._create_request_openai_client(
+                                reason="chat_completion_request",
+                                api_kwargs=api_kwargs,
+                            )
+                        )
+                        result["response"] = request_client.chat.completions.create(**api_kwargs)
+                except Exception as e:
+                    # If the request was cancelled by the main thread's interrupt
+                    # handler, the transport error is the expected consequence of our
+                    # own force-close, NOT a network bug. Swallow it instead of
+                    # surfacing — the main thread raises InterruptedError. (#6600)
+                    if _request_cancelled["value"]:
+                        logger.debug(
+                            "Non-streaming worker caught %s after request cancellation — "
+                            "exiting without surfacing a network error.",
+                            type(e).__name__,
+                        )
+                        return
+                    result["error"] = e
+                finally:
+                    _close_request_client_once("request_complete")
+
+            # ── Stale-call timeout (mirrors streaming stale detector) ────────
+            # Non-streaming calls return nothing until the full response is
+            # ready.  Without this, a hung provider can block for the full
+            # httpx timeout (default 1800s) with zero feedback.  The stale
+            # detector kills the connection early so the main retry loop can
+            # apply richer recovery (credential rotation, provider fallback).
+            _stale_timeout = agent._compute_non_stream_stale_timeout(api_kwargs)
+
+            # ── Codex Responses stream watchdogs ────────────────────────────────
+            # The chatgpt.com/backend-api/codex endpoint has an intermittent failure
+            # mode where it accepts the connection but never emits a single stream
+            # event (observed directly: 0 events, no HTTP status, the socket just
+            # hangs). A fresh reconnect succeeds in ~2s, but the wall-clock stale
+            # timeout (often 180–900s) makes us wait minutes before retrying. While no
+            # stream event has arrived yet we apply a much shorter TTFB cutoff so the
+            # main retry loop can reconnect promptly. Large subscription-backed Codex
+            # requests can legitimately spend tens of seconds in backend admission /
+            # prompt prefill before the first SSE event, so the no-byte TTFB watchdog
+            # is disabled for large chatgpt.com/backend-api/codex requests. A second
+            # failure mode emits an opening SSE frame and then stalls forever in SSL
+            # read; for that we watch the gap since the last Codex stream event. This
+            # matches Codex CLI's stream_idle_timeout model: any valid SSE event is
+            # activity. Operators can tune via HERMES_CODEX_TTFB_TIMEOUT_SECONDS and
+            # HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS (0 disables each).
+            _codex_watchdog_enabled = agent.api_mode == "codex_responses"
+            _openai_codex_backend = _is_openai_codex_backend(agent)
+            _est_tokens_for_codex_watchdog = estimate_request_context_tokens(api_kwargs)
+            if _codex_watchdog_enabled and _openai_codex_backend:
+                if _est_tokens_for_codex_watchdog > 100_000:
+                    _stale_timeout = max(_stale_timeout, 1200.0)
+                elif _est_tokens_for_codex_watchdog > 50_000:
+                    _stale_timeout = max(_stale_timeout, 900.0)
+                elif _est_tokens_for_codex_watchdog > 25_000:
+                    _stale_timeout = max(_stale_timeout, 600.0)
+
+            if _est_tokens_for_codex_watchdog > 100_000:
+                _codex_idle_timeout_default = 180.0
+            elif _est_tokens_for_codex_watchdog > 50_000:
+                _codex_idle_timeout_default = 120.0
+            elif _est_tokens_for_codex_watchdog > 10_000:
+                _codex_idle_timeout_default = 60.0
+            else:
+                _codex_idle_timeout_default = 12.0
+
+            # No-byte TTFB cutoff. The OpenAI SDK's own streaming read timeout is far
+            # longer (openai 2.x DEFAULT_TIMEOUT.read = 600s), so a tight 12s default
+            # killed subscription-backed Codex requests mid-prefill before the backend
+            # had a chance to emit its first SSE event. Default to 120s — long enough to
+            # clear normal backend admission / prompt prefill, short enough to still
+            # reconnect promptly when the socket is genuinely wedged. Set
+            # HERMES_CODEX_TTFB_TIMEOUT_SECONDS=0 to disable this watchdog entirely.
+            _ttfb_enabled = _codex_watchdog_enabled
+            _ttfb_timeout = _env_float("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", 120.0)
+            if _ttfb_timeout <= 0:
+                _ttfb_enabled = False
+            elif _openai_codex_backend:
+                _ttfb_disable_above = _env_float("HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS", 25_000.0)
+                _ttfb_strict = os.environ.get("HERMES_CODEX_TTFB_STRICT", "").strip().lower() in {
+                    "1", "true", "yes", "on"
+                }
+                if (
+                    not _ttfb_strict
+                    and _ttfb_disable_above > 0
+                    and _est_tokens_for_codex_watchdog >= _ttfb_disable_above
+                ):
+                    _ttfb_enabled = False
+                    logger.info(
+                        "Disabling openai-codex no-byte TTFB watchdog for large request "
+                        "(context=~%s tokens >= %.0f). Waiting for backend response instead. "
+                        "Set HERMES_CODEX_TTFB_STRICT=1 to force early reconnects.",
+                        f"{_est_tokens_for_codex_watchdog:,}",
+                        _ttfb_disable_above,
+                    )
+                else:
+                    _ttfb_cap = _env_float("HERMES_CODEX_TTFB_MAX_SECONDS", 120.0)
+                    if _ttfb_cap > 0 and _ttfb_timeout > _ttfb_cap:
+                        logger.info(
+                            "Capping openai-codex no-byte TTFB timeout from %.0fs to %.0fs "
+                            "(context=~%s tokens). Set HERMES_CODEX_TTFB_MAX_SECONDS to tune.",
+                            _ttfb_timeout,
+                            _ttfb_cap,
+                            f"{_est_tokens_for_codex_watchdog:,}",
+                        )
+                        _ttfb_timeout = _ttfb_cap
+
+            _codex_idle_enabled = _codex_watchdog_enabled
+            _codex_idle_timeout = _env_float(
+                "HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS",
+                _codex_idle_timeout_default,
             )
+            if _codex_idle_timeout <= 0:
+                _codex_idle_enabled = False
+
+            if _codex_watchdog_enabled:
+                # Reset before the worker starts so a marker left over from a previous
+                # call on this agent can't be misread as first-byte for this one.
+                agent._codex_stream_last_event_ts = None
+                agent._codex_stream_last_progress_ts = None
+
+            _call_start = time.time()
+            agent._touch_activity("waiting for non-streaming API response")
+
+            t = threading.Thread(target=_call, daemon=True)
+            t.start()
+            _poll_count = 0
+            while t.is_alive():
+                t.join(timeout=0.3)
+                _poll_count += 1
+
+                # Touch activity every ~30s so the gateway's inactivity
+                # monitor knows we're alive while waiting for the response.
+                if _poll_count % 100 == 0:  # 100 × 0.3s = 30s
+                    _elapsed = time.time() - _call_start
+                    agent._touch_activity(
+                        f"waiting for non-streaming response ({int(_elapsed)}s elapsed)"
+                    )
+
+                _elapsed = time.time() - _call_start
+
+                # TTFB detector: the Codex stream has produced no event at all and
+                # we're past the first-byte cutoff → the backend opened the
+                # connection but isn't responding. Kill it so the retry loop can
+                # reconnect (a fresh connection typically succeeds in seconds),
+                # instead of waiting out the much longer wall-clock stale timeout.
+                if (
+                    _ttfb_enabled
+                    and _elapsed > _ttfb_timeout
+                    and getattr(agent, "_codex_stream_last_event_ts", None) is None
+                ):
+                    _silent_hint: Optional[str] = None
+                    _hint_fn = getattr(agent, "_codex_silent_hang_hint", None)
+                    if callable(_hint_fn):
+                        try:
+                            _silent_hint = _hint_fn(model=api_kwargs.get("model"))
+                        except Exception:
+                            _silent_hint = None
+                    logger.warning(
+                        "Codex stream produced no bytes within TTFB cutoff "
+                        "(%.0fs > %.0fs, model=%s). Backend accepted the connection "
+                        "but sent no stream events. Killing connection so the retry "
+                        "loop can reconnect.",
+                        _elapsed, _ttfb_timeout, api_kwargs.get("model", "unknown"),
+                    )
+                    if _silent_hint:
+                        agent._buffer_status(
+                            f"⚠️ No first byte from provider in {int(_elapsed)}s "
+                            f"(codex stream, model: {api_kwargs.get('model', 'unknown')}). "
+                            f"Reconnecting. {_silent_hint}"
+                        )
+                    else:
+                        agent._buffer_status(
+                            f"⚠️ No first byte from provider in {int(_elapsed)}s "
+                            f"(codex stream, model: {api_kwargs.get('model', 'unknown')}). "
+                            f"Reconnecting."
+                        )
+                    try:
+                        _close_request_client_once("codex_ttfb_kill")
+                    except Exception:
+                        pass
+                    agent._touch_activity(
+                        f"codex stream killed after {int(_elapsed)}s with no first byte"
+                    )
+                    # Wait briefly for the worker to notice the closed connection.
+                    t.join(timeout=2.0)
+                    if result["error"] is None and result["response"] is None:
+                        if _silent_hint:
+                            result["error"] = TimeoutError(
+                                f"Codex stream produced no bytes within {int(_elapsed)}s "
+                                f"(TTFB threshold: {int(_ttfb_timeout)}s). {_silent_hint}"
+                            )
+                        else:
+                            result["error"] = TimeoutError(
+                                f"Codex stream produced no bytes within {int(_elapsed)}s "
+                                f"(TTFB threshold: {int(_ttfb_timeout)}s)"
+                            )
+                    break
+
+                # Stream-idle detector: the Codex backend emitted at least one SSE
+                # frame, then stopped emitting events. Valid keepalive / in_progress
+                # frames refresh _codex_stream_last_event_ts and should not be killed.
+                _last_codex_event_ts = getattr(agent, "_codex_stream_last_event_ts", None)
+                if (
+                    _codex_idle_enabled
+                    and _last_codex_event_ts is not None
+                    and (time.time() - _last_codex_event_ts) > _codex_idle_timeout
+                ):
+                    _event_stale_elapsed = time.time() - _last_codex_event_ts
+                    logger.warning(
+                        "Codex stream produced no SSE events for %.0fs after first byte "
+                        "(threshold %.0fs, model=%s, context=~%s tokens). Killing "
+                        "connection so the retry loop can reconnect.",
+                        _event_stale_elapsed,
+                        _codex_idle_timeout,
+                        api_kwargs.get("model", "unknown"),
+                        f"{_est_tokens_for_codex_watchdog:,}",
+                    )
+                    agent._buffer_status(
+                        f"⚠️ Codex stream sent no events for {int(_event_stale_elapsed)}s "
+                        f"after first byte (model: {api_kwargs.get('model', 'unknown')}). "
+                        f"Reconnecting."
+                    )
+                    try:
+                        _close_request_client_once("codex_stream_idle_kill")
+                    except Exception:
+                        pass
+                    agent._touch_activity(
+                        f"codex stream killed after {int(_event_stale_elapsed)}s with no SSE events"
+                    )
+                    t.join(timeout=2.0)
+                    if result["error"] is None and result["response"] is None:
+                        result["error"] = TimeoutError(
+                            f"Codex stream produced no SSE events for {int(_event_stale_elapsed)}s "
+                            f"after first byte (threshold: {int(_codex_idle_timeout)}s)"
+                        )
+                    break
+
+                # Stale-call detector: kill the connection if no response
+                # arrives within the configured timeout.
+                if _elapsed > _stale_timeout:
+                    _est_ctx = estimate_request_context_tokens(api_kwargs)
+                    _silent_hint: Optional[str] = None
+                    _hint_fn = getattr(agent, "_codex_silent_hang_hint", None)
+                    if callable(_hint_fn):
+                        try:
+                            _silent_hint = _hint_fn(model=api_kwargs.get("model"))
+                        except Exception:
+                            _silent_hint = None
+                    logger.warning(
+                        "Non-streaming API call stale for %.0fs (threshold %.0fs). "
+                        "model=%s context=~%s tokens. Killing connection.",
+                        _elapsed, _stale_timeout,
+                        api_kwargs.get("model", "unknown"), f"{_est_ctx:,}",
+                    )
+                    if _silent_hint:
+                        agent._buffer_status(
+                            f"⚠️ No response from provider for {int(_elapsed)}s "
+                            f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
+                            f"{_silent_hint}"
+                        )
+                    else:
+                        agent._buffer_status(
+                            f"⚠️ No response from provider for {int(_elapsed)}s "
+                            f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
+                            f"Aborting call."
+                        )
+                    try:
+                        if agent.api_mode == "anthropic_messages":
+                            agent._anthropic_client.close()
+                            agent._rebuild_anthropic_client()
+                        else:
+                            _close_request_client_once("stale_call_kill")
+                    except Exception:
+                        pass
+                    agent._touch_activity(
+                        f"stale non-streaming call killed after {int(_elapsed)}s"
+                    )
+                    # Wait briefly for the thread to notice the closed connection.
+                    t.join(timeout=2.0)
+                    if result["error"] is None and result["response"] is None:
+                        if _silent_hint:
+                            result["error"] = TimeoutError(
+                                f"Non-streaming API call timed out after {int(_elapsed)}s "
+                                f"with no response (threshold: {int(_stale_timeout)}s). "
+                                f"{_silent_hint}"
+                            )
+                        else:
+                            result["error"] = TimeoutError(
+                                f"Non-streaming API call timed out after {int(_elapsed)}s "
+                                f"with no response (threshold: {int(_stale_timeout)}s)"
+                            )
+                    break
+
+                if agent._interrupt_requested:
+                    # Mark THIS request cancelled before force-closing so the worker's
+                    # exception handler recognizes the forced transport error as a
+                    # cancel and exits cleanly instead of surfacing a network error or
+                    # (in the streaming path) burning full retry cycles. (#6600)
+                    _request_cancelled["value"] = True
+                    logger.debug(
+                        "Force-closing httpx client due to interrupt (not a network error)."
+                    )
+                    # Force-close the in-flight worker-local HTTP connection to stop
+                    # token generation without poisoning the shared client used to
+                    # seed future retries.
+                    try:
+                        if agent.api_mode == "anthropic_messages":
+                            agent._anthropic_client.close()
+                            agent._rebuild_anthropic_client()
+                        else:
+                            _close_request_client_once("interrupt_abort")
+                    except Exception:
+                        pass
+                    raise InterruptedError("Agent interrupted during API call")
+
+            # === SILENT PROVIDER FAILURE CHECK (BEFORE ERROR RAISE) ===
+            # If we got a response but it's a silent failure (no content, no tool_calls,
+            # no reasoning, no error), check if we should retry.
+            if result["response"] is not None and result["error"] is None:
+                if _is_silent_provider_failure(result["response"]):
+                    if _attempt < _PROVIDER_RETRY_MAX_ATTEMPTS:
+                        # Log retry attempt
+                        logger.info(f"Provider silent failure - retry {_attempt}/{_PROVIDER_RETRY_MAX_ATTEMPTS}")
+                        # Increment retry counter on agent for next iteration
+                        agent._provider_retry_attempt = _attempt
+                        # Interrupt-safe backoff wait
+                        delay = _provider_retry_backoff(_attempt)
+                        wait_start = time.time()
+                        while time.time() - wait_start < delay:
+                            if agent._interrupt_requested:
+                                raise InterruptedError("Agent interrupted during provider retry wait")
+                            time.sleep(min(0.1, delay - (time.time() - wait_start)))
+                        continue  # retry the while True loop
+                    else:
+                        # Max retries exhausted - create error for silent failure
+                        result["error"] = TimeoutError(f"Provider silent failure after {_attempt} retries (no content, no error)")
+                else:
+                    # Not a silent failure - valid response
+                    pass
+
+            if result["error"] is not None:
+                raise result["error"]
+            return result["response"]
+        except InterruptedError:
+            # Re-raise immediately - don't retry on user interrupt
+            raise
         except Exception as e:
-            # If the request was cancelled by the main thread's interrupt
-            # handler, the transport error is the expected consequence of our
-            # own force-close, NOT a network bug. Swallow it instead of
-            # surfacing — the main thread raises InterruptedError. (#6600)
-            if _request_cancelled["value"]:
-                logger.debug(
-                    "Non-streaming worker caught %s after request cancellation — "
-                    "exiting without surfacing a network error.",
-                    type(e).__name__,
-                )
-                return
-            result["error"] = e
-        finally:
-            _close_request_client_once("request_complete")
+            # For other errors, check if it's a silent failure case that should retry
+            # (e.g., connection errors that resulted in no response)
+            if result["response"] is None and result["error"] is None:
+                if _attempt < _PROVIDER_RETRY_MAX_ATTEMPTS:
+                    logger.info(f"Provider call failed with {type(e).__name__} - retry {_attempt}/{_PROVIDER_RETRY_MAX_ATTEMPTS}")
+                    agent._provider_retry_attempt = _attempt
+                    delay = _provider_retry_backoff(_attempt)
+                    wait_start = time.time()
+                    while time.time() - wait_start < delay:
+                        if agent._interrupt_requested:
+                            raise InterruptedError("Agent interrupted during provider retry wait")
+                        time.sleep(min(0.1, delay - (time.time() - wait_start)))
+                    continue
+            raise
 
-    # ── Stale-call timeout (mirrors streaming stale detector) ────────
-    # Non-streaming calls return nothing until the full response is
-    # ready.  Without this, a hung provider can block for the full
-    # httpx timeout (default 1800s) with zero feedback.  The stale
-    # detector kills the connection early so the main retry loop can
-    # apply richer recovery (credential rotation, provider fallback).
-    _stale_timeout = agent._compute_non_stream_stale_timeout(api_kwargs)
 
-    # ── Codex Responses stream watchdogs ────────────────────────────────
-    # The chatgpt.com/backend-api/codex endpoint has an intermittent failure
-    # mode where it accepts the connection but never emits a single stream
-    # event (observed directly: 0 events, no HTTP status, the socket just
-    # hangs). A fresh reconnect succeeds in ~2s, but the wall-clock stale
-    # timeout (often 180–900s) makes us wait minutes before retrying. While no
-    # stream event has arrived yet we apply a much shorter TTFB cutoff so the
-    # main retry loop can reconnect promptly. Large subscription-backed Codex
-    # requests can legitimately spend tens of seconds in backend admission /
-    # prompt prefill before the first SSE event, so the no-byte TTFB watchdog
-    # is disabled for large chatgpt.com/backend-api/codex requests. A second
-    # failure mode emits an opening SSE frame and then stalls forever in SSL
-    # read; for that we watch the gap since the last Codex stream event. This
-    # matches Codex CLI's stream_idle_timeout model: any valid SSE event is
-    # activity. Operators can tune via HERMES_CODEX_TTFB_TIMEOUT_SECONDS and
-    # HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS (0 disables each).
-    _codex_watchdog_enabled = agent.api_mode == "codex_responses"
-    _openai_codex_backend = _is_openai_codex_backend(agent)
-    _est_tokens_for_codex_watchdog = estimate_request_context_tokens(api_kwargs)
-    if _codex_watchdog_enabled and _openai_codex_backend:
-        _codex_floor = openai_codex_stale_timeout_floor(_est_tokens_for_codex_watchdog)
-        if _codex_floor:
-            _stale_timeout = max(_stale_timeout, _codex_floor)
 
-    # ── Codex absolute hard ceiling (#64507) ──────────────────────────
-    # ``openai_codex_stale_timeout_floor`` *raises* the stale timeout (up to
-    # 1200s at >100k tokens) so healthy gateway-scale payloads aren't aborted.
-    # The scaled no-byte TTFB watchdog catches dead streams that never emit a
-    # first byte, but a request that emits SOME bytes and then wedges (the
-    # issue-64507 symptom: vision-inflated request, worker idle, no ended_at)
-    # is only reclaimed at the (high) stale floor. Add a flat, finite hard
-    # ceiling on total request time that ALWAYS applies to openai-codex
-    # requests regardless of the TTFB/stale interaction, so a stalled request
-    # is recovered (retry loop / visible failure) instead of hanging
-    # indefinitely. The default sits ABOVE the maximum stale floor (1200s) so
-    # it never clamps an intentionally-raised timeout for healthy large
-    # requests — it is a backstop against unbounded growth, not a tighter
-    # limit. Tunable via HERMES_CODEX_HARD_TIMEOUT_SECONDS (set to 0 to
-    # disable the ceiling entirely; that restores the pre-fix behavior).
-    _codex_hard_timeout = _env_float("HERMES_CODEX_HARD_TIMEOUT_SECONDS", 1500.0)
-    if (
-        _codex_watchdog_enabled
-        and _openai_codex_backend
-        and _codex_hard_timeout > 0
-    ):
-        _stale_timeout = min(_stale_timeout, _codex_hard_timeout)
+def _dedupe_model_name(name: str) -> str:
+    """Strip accidentally duplicated provider/model prefixes.
 
-    if _est_tokens_for_codex_watchdog > 100_000:
-        _codex_idle_timeout_default = 180.0
-    elif _est_tokens_for_codex_watchdog > 50_000:
-        _codex_idle_timeout_default = 120.0
-    elif _est_tokens_for_codex_watchdog > 10_000:
-        _codex_idle_timeout_default = 60.0
-    else:
-        _codex_idle_timeout_default = 12.0
+    Ollama model tags like ``gemma4:e2b`` can get doubled to
+    ``gemma4:gemma4:e2b`` by an upstream bug (#54511).  A doubled tag is
+    an invalid model name and the API call fails with HTTP 400.
 
-    # No-byte TTFB cutoff. The OpenAI SDK's own streaming read timeout is far
-    # longer (openai 2.x DEFAULT_TIMEOUT.read = 600s), so a tight 12s default
-    # killed subscription-backed Codex requests mid-prefill before the backend
-    # had a chance to emit its first SSE event. Default to 120s — long enough to
-    # clear normal backend admission / prompt prefill, short enough to still
-    # reconnect promptly when the socket is genuinely wedged. Set
-    # HERMES_CODEX_TTFB_TIMEOUT_SECONDS=0 to disable this watchdog entirely.
-    _ttfb_enabled = _codex_watchdog_enabled
-    _ttfb_timeout = _env_float("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", 120.0)
-    if _ttfb_timeout <= 0:
-        _ttfb_enabled = False
-    elif _openai_codex_backend:
-        _ttfb_disable_above = _env_float("HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS", 10_000.0)
-        _ttfb_strict = os.environ.get("HERMES_CODEX_TTFB_STRICT", "").strip().lower() in {
-            "1", "true", "yes", "on"
-        }
-        if (
-            not _ttfb_strict
-            and _ttfb_disable_above > 0
-            and _est_tokens_for_codex_watchdog >= _ttfb_disable_above
-        ):
-            _large_request_ttfb_timeout = _codex_idle_timeout_default
-            if _ttfb_timeout < _large_request_ttfb_timeout:
-                logger.info(
-                    "Scaling openai-codex no-byte TTFB watchdog from %.0fs to %.0fs "
-                    "for large request (context=~%s tokens >= %.0f). "
-                    "Set HERMES_CODEX_TTFB_STRICT=1 to keep the smaller cutoff.",
-                    _ttfb_timeout,
-                    _large_request_ttfb_timeout,
-                    f"{_est_tokens_for_codex_watchdog:,}",
-                    _ttfb_disable_above,
-                )
-                _ttfb_timeout = _large_request_ttfb_timeout
-        _ttfb_cap = _env_float("HERMES_CODEX_TTFB_MAX_SECONDS", 120.0)
-        if _ttfb_cap > 0 and _ttfb_timeout > _ttfb_cap:
-            logger.info(
-                "Capping openai-codex no-byte TTFB timeout from %.0fs to %.0fs "
-                "(context=~%s tokens). Set HERMES_CODEX_TTFB_MAX_SECONDS to tune.",
-                _ttfb_timeout,
-                _ttfb_cap,
-                f"{_est_tokens_for_codex_watchdog:,}",
-            )
-            _ttfb_timeout = _ttfb_cap
-
-    _codex_idle_enabled = _codex_watchdog_enabled
-    _codex_idle_timeout = _env_float(
-        "HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS",
-        _codex_idle_timeout_default,
-    )
-    if _codex_idle_timeout <= 0:
-        _codex_idle_enabled = False
-
-    if _codex_watchdog_enabled:
-        # Reset before the worker starts so a marker left over from a previous
-        # call on this agent can't be misread as first-byte for this one.
-        agent._codex_stream_last_event_ts = None
-        agent._codex_stream_last_progress_ts = None
-
-    _call_start = time.time()
-    agent._touch_activity("waiting for non-streaming API response")
-
-    t = threading.Thread(target=_call, daemon=True)
-    t.start()
-    _poll_count = 0
-    while t.is_alive():
-        t.join(timeout=0.3)
-        _poll_count += 1
-
-        # Every ~30s: touch activity for the gateway inactivity monitor AND
-        # rewrite the live spinner/status line so CLI/TUI/Desktop users see
-        # what the agent is waiting on instead of an unexplained generic
-        # spinner (the "infinite thinking" complaint — the wait itself is
-        # usually a slow/overloaded provider, but the UI never said so).
-        if _poll_count % 100 == 0:  # 100 × 0.3s = 30s
-            _elapsed = time.time() - _call_start
-            try:
-                _recovery = _codex_wait_notice_recovery(
-                    stale_timeout=_stale_timeout,
-                    ttfb_enabled=_ttfb_enabled,
-                    ttfb_timeout=_ttfb_timeout,
-                    last_event_ts=getattr(
-                        agent, "_codex_stream_last_event_ts", None
-                    ),
-                    call_start=_call_start,
-                    idle_enabled=_codex_idle_enabled,
-                    idle_timeout=_codex_idle_timeout,
-                    elapsed=_elapsed,
-                )
-                agent._emit_wait_notice(
-                    f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
-                    f"{int(_elapsed)}s with no response yet (provider may be slow "
-                    f"or overloaded{_recovery})"
-                )
-            except Exception:
-                logger.debug("wait-notice construction failed", exc_info=True)
-
-        _elapsed = time.time() - _call_start
-
-        # TTFB detector: the Codex stream has produced no event at all and
-        # we're past the first-byte cutoff → the backend opened the
-        # connection but isn't responding. Kill it so the retry loop can
-        # reconnect (a fresh connection typically succeeds in seconds),
-        # instead of waiting out the much longer wall-clock stale timeout.
-        if (
-            _ttfb_enabled
-            and _elapsed > _ttfb_timeout
-            and getattr(agent, "_codex_stream_last_event_ts", None) is None
-        ):
-            _silent_hint: Optional[str] = None
-            _hint_fn = getattr(agent, "_codex_silent_hang_hint", None)
-            if callable(_hint_fn):
-                try:
-                    _silent_hint = _hint_fn(model=api_kwargs.get("model"))
-                except Exception:
-                    _silent_hint = None
-            logger.warning(
-                "Codex stream produced no bytes within TTFB cutoff "
-                "(%.0fs > %.0fs, model=%s). Backend accepted the connection "
-                "but sent no stream events. Killing connection so the retry "
-                "loop can reconnect.",
-                _elapsed, _ttfb_timeout, api_kwargs.get("model", "unknown"),
-            )
-            if _silent_hint:
-                agent._buffer_status(
-                    f"⚠️ No first byte from provider in {int(_elapsed)}s "
-                    f"(codex stream, model: {api_kwargs.get('model', 'unknown')}). "
-                    f"Reconnecting. {_silent_hint}"
-                )
-            else:
-                agent._buffer_status(
-                    f"⚠️ No first byte from provider in {int(_elapsed)}s "
-                    f"(codex stream, model: {api_kwargs.get('model', 'unknown')}). "
-                    f"Reconnecting."
-                )
-            try:
-                _close_request_client_once("codex_ttfb_kill")
-            except Exception:
-                pass
-            agent._emit_wait_notice(
-                f"⚠ no response from provider in {int(_elapsed)}s — "
-                f"reconnecting..."
-            )
-            agent._touch_activity(
-                f"codex stream killed after {int(_elapsed)}s with no first byte"
-            )
-            # Wait briefly for the worker to notice the closed connection.
-            t.join(timeout=2.0)
-            if result["error"] is None and result["response"] is None:
-                if _silent_hint:
-                    result["error"] = TimeoutError(
-                        f"Codex stream produced no bytes within {int(_elapsed)}s "
-                        f"(TTFB threshold: {int(_ttfb_timeout)}s). {_silent_hint}"
-                    )
-                else:
-                    result["error"] = TimeoutError(
-                        f"Codex stream produced no bytes within {int(_elapsed)}s "
-                        f"(TTFB threshold: {int(_ttfb_timeout)}s)"
-                    )
-            break
-
-        # Stream-idle detector: the Codex backend emitted at least one SSE
-        # frame, then stopped emitting events. Valid keepalive / in_progress
-        # frames refresh _codex_stream_last_event_ts and should not be killed.
-        _last_codex_event_ts = getattr(agent, "_codex_stream_last_event_ts", None)
-        if (
-            _codex_idle_enabled
-            and _last_codex_event_ts is not None
-            and (time.time() - _last_codex_event_ts) > _codex_idle_timeout
-        ):
-            _event_stale_elapsed = time.time() - _last_codex_event_ts
-            logger.warning(
-                "Codex stream produced no SSE events for %.0fs after first byte "
-                "(threshold %.0fs, model=%s, context=~%s tokens). Killing "
-                "connection so the retry loop can reconnect.",
-                _event_stale_elapsed,
-                _codex_idle_timeout,
-                api_kwargs.get("model", "unknown"),
-                f"{_est_tokens_for_codex_watchdog:,}",
-            )
-            agent._buffer_status(
-                f"⚠️ Codex stream sent no events for {int(_event_stale_elapsed)}s "
-                f"after first byte (model: {api_kwargs.get('model', 'unknown')}). "
-                f"Reconnecting."
-            )
-            try:
-                _close_request_client_once("codex_stream_idle_kill")
-            except Exception:
-                pass
-            agent._touch_activity(
-                f"codex stream killed after {int(_event_stale_elapsed)}s with no SSE events"
-            )
-            t.join(timeout=2.0)
-            if result["error"] is None and result["response"] is None:
-                result["error"] = TimeoutError(
-                    f"Codex stream produced no SSE events for {int(_event_stale_elapsed)}s "
-                    f"after first byte (threshold: {int(_codex_idle_timeout)}s)"
-                )
-            break
-
-        # Stale-call detector: kill the connection if no response
-        # arrives within the configured timeout.
-        if _elapsed > _stale_timeout:
-            _est_ctx = estimate_request_context_tokens(api_kwargs)
-            _silent_hint: Optional[str] = None
-            _hint_fn = getattr(agent, "_codex_silent_hang_hint", None)
-            if callable(_hint_fn):
-                try:
-                    _silent_hint = _hint_fn(model=api_kwargs.get("model"))
-                except Exception:
-                    _silent_hint = None
-            logger.warning(
-                "Non-streaming API call stale for %.0fs (threshold %.0fs). "
-                "model=%s context=~%s tokens. Killing connection.",
-                _elapsed, _stale_timeout,
-                api_kwargs.get("model", "unknown"), f"{_est_ctx:,}",
-            )
-            if _silent_hint:
-                agent._buffer_status(
-                    f"⚠️ No response from provider for {int(_elapsed)}s "
-                    f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
-                    f"{_silent_hint}"
-                )
-            else:
-                agent._buffer_status(
-                    f"⚠️ No response from provider for {int(_elapsed)}s "
-                    f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
-                    f"Aborting call."
-                )
-            try:
-                # #67142: routes by client kind — anthropic now aborts the
-                # request-local client's sockets from this poll (stranger)
-                # thread instead of closing the shared _anthropic_client.
-                _close_request_client_once("stale_call_kill")
-            except Exception:
-                pass
-            # Circuit breaker (#58962): count the stale kill.  See the
-            # canonical comment block above ``_stale_streak()``.
-            _bump_stale_streak(agent)
-            agent._touch_activity(
-                f"stale non-streaming call killed after {int(_elapsed)}s"
-            )
-            # Wait briefly for the thread to notice the closed connection.
-            t.join(timeout=2.0)
-            if result["error"] is None and result["response"] is None:
-                if _silent_hint:
-                    result["error"] = TimeoutError(
-                        f"Non-streaming API call timed out after {int(_elapsed)}s "
-                        f"with no response (threshold: {int(_stale_timeout)}s). "
-                        f"{_silent_hint}"
-                    )
-                else:
-                    result["error"] = TimeoutError(
-                        f"Non-streaming API call timed out after {int(_elapsed)}s "
-                        f"with no response (threshold: {int(_stale_timeout)}s)"
-                    )
-            break
-
-        if agent._interrupt_requested:
-            # Mark THIS request cancelled before force-closing so the worker's
-            # exception handler recognizes the forced transport error as a
-            # cancel and exits cleanly instead of surfacing a network error or
-            # (in the streaming path) burning full retry cycles. (#6600)
-            _request_cancelled["value"] = True
-            logger.debug(
-                "Force-closing httpx client due to interrupt (not a network error)."
-            )
-            # Force-close the in-flight worker-local HTTP connection to stop
-            # token generation without poisoning the shared client used to
-            # seed future retries. #67142: for anthropic this aborts the
-            # request-local client's sockets from this poll (stranger) thread
-            # rather than closing the shared _anthropic_client, which could
-            # release a TLS FD mid-SSL-BIO and corrupt an unrelated SQLite DB.
-            try:
-                _close_request_client_once("interrupt_abort")
-            except Exception:
-                pass
-            raise InterruptedError("Agent interrupted during API call")
-    if result["error"] is not None:
-        raise result["error"]
-    # Success — clear the circuit breaker (#58962): the provider proved
-    # responsive.  See the canonical comment block above ``_stale_streak()``.
-    if result["response"] is not None:
-        _reset_stale_streak(agent)
-    return result["response"]
-
+    Handles one or more duplications: ``a:a:a:b`` → ``a:b``.
+    """
+    if not name or ":" not in name:
+        return name
+    parts = name.split(":")
+    # Walk from the left, collapsing runs where part[i] == part[i+1].
+    deduped = [parts[0]]
+    for p in parts[1:]:
+        if p != deduped[-1]:
+            deduped.append(p)
+    # If the result still has the pattern ``prefix:prefix:model`` after
+    # adjacent-collapse (e.g. ``gemma4:gemma4:e2b``), also strip a leading
+    # duplicate of the final segment's prefix.
+    result = ":".join(deduped)
+    if ":" in result:
+        head, _, tail = result.rpartition(":")
+        if head.endswith(":" + tail) or head == tail:
+            result = tail
+    return result
 
 
 def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
     tools_for_api = agent.tools
+    # Defensive: strip any accidentally duplicated model-name prefix
+    # (see #54511).  This is a no-op for well-formed names.
+    agent.model = _dedupe_model_name(agent.model)
 
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()
@@ -1023,7 +744,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         _ct = agent._get_transport()
         is_github_responses = (
             base_url_host_matches(agent.base_url, "models.github.ai")
-            or base_url_host_matches(agent.base_url, "githubcopilot.com")
+            or base_url_host_matches(agent.base_url, "api.githubcopilot.com")
         )
         is_codex_backend = (
             agent.provider == "openai-codex"
@@ -1093,7 +814,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     _is_or = agent._is_openrouter_url()
     _is_gh = (
         base_url_host_matches(agent._base_url_lower, "models.github.ai")
-        or base_url_host_matches(agent._base_url_lower, "githubcopilot.com")
+        or base_url_host_matches(agent._base_url_lower, "api.githubcopilot.com")
     )
     _is_nous = "nousresearch" in agent._base_url_lower
     _is_nvidia = "integrate.api.nvidia.com" in agent._base_url_lower
@@ -1116,29 +837,30 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         _omit_temp = False
         _fixed_temp = None
 
-    # Provider preferences (aggregator profile decides whether to emit them).
-    _prefs = _provider_preferences_for_agent(agent)
+    # Provider preferences (OpenRouter-style)
+    _prefs: Dict[str, Any] = {}
+    if agent.providers_allowed:
+        _prefs["only"] = agent.providers_allowed
+    if agent.providers_ignored:
+        _prefs["ignore"] = agent.providers_ignored
+    if agent.providers_order:
+        _prefs["order"] = agent.providers_order
+    _provider_sort = _validated_openrouter_provider_sort(agent.provider_sort)
+    if _provider_sort:
+        _prefs["sort"] = _provider_sort
+    if agent.provider_require_parameters:
+        _prefs["require_parameters"] = True
+    if agent.provider_data_collection:
+        _prefs["data_collection"] = agent.provider_data_collection
 
-    # Anthropic-compatible max-output fallback (last resort only — applied in
-    # build_kwargs *after* ephemeral/user/profile max_tokens, never overriding
-    # an explicit value).  Model-gated, not URL-gated: any chat-completions
-    # proxy serving a Claude/MiniMax/Qwen3 model needs max_tokens, because the
-    # Anthropic Messages API treats it as mandatory and proxies that omit it
-    # (AWS Bedrock, NVIDIA, LiteLLM, vLLM, corporate gateways) default as low
-    # as 4096 output tokens — easily exhausted by thinking + large tool calls
-    # like write_file/patch.  OpenRouter/Nous were the only routes covered
-    # before; gating on _ANTHROPIC_OUTPUT_LIMITS membership covers them all.
+    # Claude max-output override on aggregators
     _ant_max = None
-    try:
-        from agent.anthropic_adapter import (
-            _get_anthropic_max_output,
-            _ANTHROPIC_OUTPUT_LIMITS,
-        )
-        _model_norm = (agent.model or "").lower().replace(".", "-")
-        if any(key in _model_norm for key in _ANTHROPIC_OUTPUT_LIMITS):
+    if (_is_or or _is_nous) and "claude" in (agent.model or "").lower():
+        try:
+            from agent.anthropic_adapter import _get_anthropic_max_output
             _ant_max = _get_anthropic_max_output(agent.model)
-    except Exception:
-        pass
+        except Exception:
+            pass
 
     # Qwen session metadata
     _qwen_meta = None
@@ -1252,7 +974,7 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     # reasoning fields are present (some models/providers embed thinking
     # directly in the content rather than returning separate API fields).
     if not reasoning_text:
-        content = flatten_message_text(getattr(assistant_message, "content", None))
+        content = assistant_message.content or ""
         think_blocks = re.findall(r'<think>(.*?)</think>', content, flags=re.DOTALL)
         if think_blocks:
             combined = "\n\n".join(b.strip() for b in think_blocks if b.strip())
@@ -1278,7 +1000,7 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
 
     # Sanitize surrogates from API response — some models (e.g. Kimi/GLM via Ollama)
     # can return invalid surrogate code points that crash json.dumps() on persist.
-    _raw_content = flatten_message_text(getattr(assistant_message, "content", None))
+    _raw_content = assistant_message.content or ""
     _san_content = _sanitize_surrogates(_raw_content)
     if reasoning_text:
         reasoning_text = _sanitize_surrogates(reasoning_text)
@@ -1441,23 +1163,18 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
                     "arguments": tool_call.function.arguments
                 },
             }
-            # Tool-call arguments are intentionally NOT redacted here. This
-            # dict enters the in-memory conversation history that is replayed
-            # to the model on every subsequent turn AND persisted to state.db,
-            # which is itself replayed verbatim on session resume
-            # (get_messages_as_conversation). Masking a credential to `***`
-            # here poisons that replay: the model reads back its own
-            # `PGPASSWORD='***' psql ...` call and copies the placeholder into
-            # the next tool call, breaking every credential-dependent command
-            # on the second turn (#43083). The masking also provided no real
-            # protection — the same secret still leaks verbatim through tool
-            # OUTPUT (file contents, command output, diffs, the compaction
-            # block), none of which this pass ever touched. Keeping secrets
-            # out of the replayable store is a separate tokenization/vault
-            # concern, not something arg-redaction can deliver without
-            # breaking replay. Storage-time redaction remains governed by the
-            # `security.redact_secrets` toggle. (#19798 introduced this;
-            # #43083 removed it.)
+            # Defence-in-depth: redact credentials from tool call arguments
+            # before they enter conversation history. Tool execution uses the
+            # raw API response object, not this dict, so redacting the
+            # persisted shape is safe and only affects storage. Catches the
+            # case where a model accidentally inlines a secret into a tool
+            # call (e.g. `terminal(command="curl -H 'Authorization: Bearer
+            # sk-...'")`). (#19798)
+            if isinstance(tc_dict["function"]["arguments"], str):
+                from agent.redact import redact_sensitive_text
+                tc_dict["function"]["arguments"] = redact_sensitive_text(
+                    tc_dict["function"]["arguments"]
+                )
             # Preserve extra_content (e.g. Gemini thought_signature) so it
             # is sent back on subsequent API calls.  Without this, Gemini 3
             # thinking models reject the request with a 400 error.
@@ -1502,35 +1219,6 @@ def rewrite_prompt_model_identity(agent, model: str, provider: str) -> None:
     agent._cached_system_prompt = sp
 
 
-def _fallback_entry_key(fb: dict) -> tuple[str, str, str]:
-    return (
-        str(fb.get("provider") or "").strip().lower(),
-        str(fb.get("model") or "").strip(),
-        str(fb.get("base_url") or "").strip().rstrip("/"),
-    )
-
-
-def _fallback_entry_unavailable_without_network(agent, fb: dict) -> Optional[str]:
-    """Return a skip reason for fallback entries known to be unusable locally."""
-    fb_provider = (fb.get("provider") or "").strip().lower()
-    if fb_provider != "nous":
-        return None
-    try:
-        from hermes_cli.auth import get_provider_auth_state
-
-        state = get_provider_auth_state("nous") or {}
-    except Exception as exc:
-        return f"nous_auth_unreadable:{type(exc).__name__}"
-    access_value = state.get("access_token")
-    refresh_value = state.get("refresh_token")
-    has_access = isinstance(access_value, str) and bool(access_value.strip())
-    has_refresh = isinstance(refresh_value, str) and bool(refresh_value.strip())
-    if not (has_access or has_refresh):
-        return "nous_token_missing"
-    return None
-
-
-
 def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
     """Switch to the next fallback model/provider in the chain.
 
@@ -1543,7 +1231,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     auth resolution and client construction — no duplicated provider→key
     mappings.
     """
-    if reason in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit}:
+    if reason in {FailoverReason.rate_limit, FailoverReason.billing}:
         # Only start cooldown when leaving the primary provider.  If we're
         # already on a fallback and chain-switching, the primary wasn't the
         # source of the 429 so the cooldown should not be reset/extended.
@@ -1561,7 +1249,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # provider again.  Guards the cross-turn replay storm in #24996.
         if (
             len(agent._fallback_chain) > 0
-            and reason not in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit}
+            and reason not in {FailoverReason.rate_limit, FailoverReason.billing}
         ):
             _existing_cooldown = getattr(agent, "_rate_limited_until", 0) or 0
             agent._rate_limited_until = max(
@@ -1571,29 +1259,10 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         return False
     fb = agent._fallback_chain[agent._fallback_index]
     agent._fallback_index += 1
-    fb_key = _fallback_entry_key(fb)
-    unavailable = getattr(agent, "_unavailable_fallback_keys", None)
-    if unavailable is None:
-        unavailable = set()
-        agent._unavailable_fallback_keys = unavailable
-    if fb_key in unavailable:
-        logger.debug("Fallback skip: %s previously marked unavailable", fb_key)
-        return agent._try_activate_fallback(reason)
     fb_provider = (fb.get("provider") or "").strip().lower()
     fb_model = (fb.get("model") or "").strip()
     if not fb_provider or not fb_model:
-        return agent._try_activate_fallback(reason)  # skip invalid, try next
-
-    local_skip_reason = _fallback_entry_unavailable_without_network(agent, fb)
-    if local_skip_reason:
-        unavailable.add(fb_key)
-        logger.warning(
-            "Fallback skip: %s/%s is not locally usable (%s); suppressing for this session",
-            fb_provider,
-            fb_model,
-            local_skip_reason,
-        )
-        return agent._try_activate_fallback(reason)
+        return agent._try_activate_fallback()  # skip invalid, try next
 
     # Skip entries that resolve to the current (provider, model) — falling
     # back to the same backend that just failed loops the failure. Compare
@@ -1608,7 +1277,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             "Fallback skip: chain entry %s/%s matches current provider/model",
             fb_provider, fb_model,
         )
-        return agent._try_activate_fallback(reason)
+        return agent._try_activate_fallback()
     if (
         fb_base_url_for_dedup
         and current_base_url
@@ -1619,7 +1288,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             "Fallback skip: chain entry base_url %s matches current backend",
             fb_base_url_for_dedup,
         )
-        return agent._try_activate_fallback(reason)
+        return agent._try_activate_fallback()
 
     # Use centralized router for client construction.
     # raw_codex=True because the main agent needs direct responses.stream()
@@ -1650,8 +1319,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             logger.warning(
                 "Fallback to %s failed: provider not configured",
                 fb_provider)
-            unavailable.add(fb_key)
-            return agent._try_activate_fallback(reason)  # try next in chain
+            return agent._try_activate_fallback()  # try next in chain
         try:
             from hermes_cli.model_normalize import normalize_model_for_provider
 
@@ -1668,17 +1336,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
         if fb_provider == "openai-codex":
             fb_api_mode = "codex_responses"
-        elif (
-            fb_provider == "anthropic"
-            or fb_base_url.rstrip("/").lower().endswith("/anthropic")
-            or base_url_hostname(fb_base_url) == "api.anthropic.com"
-        ):
-            # Custom providers (e.g. cron-anthropic) point at the native
-            # api.anthropic.com host with no "/anthropic" path suffix, so the
-            # name/suffix checks above miss them and they default to
-            # chat_completions → POST /v1/chat/completions → 404. Match the
-            # host the same way determine_api_mode() and _detect_api_mode_for_url()
-            # do on the primary path. (#32243, #49247)
+        elif fb_provider == "anthropic" or fb_base_url.rstrip("/").lower().endswith("/anthropic"):
             fb_api_mode = "anthropic_messages"
         elif _fb_is_azure:
             # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
@@ -1701,7 +1359,13 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             fb_api_mode = "bedrock_converse"
 
         old_model = agent.model
-        old_provider = agent.provider
+
+        # Remember the primary (original) model/provider so the UI can show
+        # "Fallback: X (primary: Y)" — stored once, before the swap.
+        if not getattr(agent, "_primary_model", ""):
+            agent._primary_model = getattr(agent, "model", "") or ""
+        if not getattr(agent, "_primary_provider", ""):
+            agent._primary_provider = getattr(agent, "provider", "") or ""
 
         # Clear the per-config context_length override so the fallback
         # model's actual context window is resolved instead of inheriting
@@ -1839,28 +1503,6 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 api_mode=agent.api_mode,
             )
 
-        # Re-resolve reasoning_config for the new fallback model (Closes #21256).
-        # Shared chokepoint: per-model override > global reasoning_effort
-        # (YAML boolean False = disabled). Wrapped in try/except because a
-        # config load failure must not kill the swap.
-        try:
-            from hermes_cli.config import load_config
-            from hermes_constants import resolve_reasoning_config
-
-            agent.reasoning_config = resolve_reasoning_config(
-                load_config() or {}, agent.model
-            )
-            logger.info(
-                "Fallback %s: reasoning_config resolved: %s",
-                agent.model, agent.reasoning_config,
-            )
-        except Exception as _reasoning_err:
-            logger.debug(
-                "Failed to resolve reasoning_config for fallback %s; keeping current: %s",
-                agent.model, _reasoning_err,
-            )
-            # Keep whatever reasoning_config was active — don't break the fallback swap.
-
         # Keep the prompt's self-identity in sync with the model actually
         # answering, so "what model are you?" doesn't report the primary.
         rewrite_prompt_model_identity(agent, fb_model, fb_provider)
@@ -1869,31 +1511,14 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             f"🔄 Primary model failed — switching to fallback: "
             f"{fb_model} via {fb_provider}"
         )
-        # The buffered line above is dropped on successful recovery, but a
-        # provider/model switch is a durable state change operators must see
-        # even when the fallback succeeds.  Record a one-shot notice that the
-        # success path surfaces exactly once via _emit_pending_fallback_notice
-        # (see run_agent.py); it is discarded on terminal failure since the
-        # buffered line is flushed instead.  See fallback-observability fix.
-        agent._pending_fallback_notice = (
-            f"🔄 Switched to fallback model: {old_model} via {old_provider} "
-            f"→ {fb_model} via {fb_provider}"
-        )
         logger.info(
             "Fallback activated: %s → %s (%s)",
             old_model, fb_model, fb_provider,
         )
-        # Reset the stale-call circuit breaker (#58962): the streak measured
-        # the OLD provider's unresponsiveness.  Carrying it over would
-        # short-circuit the freshly activated fallback before it gets a
-        # single stream attempt.
-        _reset_stale_streak(agent)
         return True
     except Exception as e:
-        if fb_provider == "nous":
-            unavailable.add(fb_key)
         logger.error("Failed to activate fallback %s: %s", fb_model, e)
-        return agent._try_activate_fallback(reason)  # try next in chain
+        return agent._try_activate_fallback()  # try next in chain
 
 
 
@@ -1925,20 +1550,9 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             # hand-builds messages and calls chat.completions.create() directly,
             # bypassing the transport — so mirror that sanitization here:
             # tool_name (SQLite FTS bookkeeping), the codex_* reasoning carriers,
-            # timestamp (preserved on gateway user replay entries for the
-            # stale-confirmation expiry check — #47868 rejection class),
             # and every Hermes-internal underscore-prefixed scaffolding key.
-            for schema_foreign in ("tool_name", "codex_reasoning_items", "codex_message_items", "timestamp"):
+            for schema_foreign in ("tool_name", "codex_reasoning_items", "codex_message_items"):
                 api_msg.pop(schema_foreign, None)
-            # api_content (the persist-what-you-send sidecar) carries the
-            # exact bytes every main-loop call sent for this message —
-            # substitute it before dropping the key (Hermes bookkeeping,
-            # never a provider field), mirroring the loop's api_messages
-            # build. Popping without substituting would send CLEAN content
-            # here, diverging the summary request's prefix at the EARLIEST
-            # sidecar-carrying message and re-prefilling the whole transcript
-            # at exactly the moment the context is largest.
-            substitute_api_content(api_msg)
             for internal_key in [k for k in api_msg if isinstance(k, str) and k.startswith("_")]:
                 api_msg.pop(internal_key, None)
             if _needs_sanitize:
@@ -2023,28 +1637,18 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             if _lm_reasoning_effort is not None:
                 summary_kwargs["reasoning_effort"] = _lm_reasoning_effort
 
-            # Merge the profile's canonical body even when routing is unset:
-            # profiles may always emit required metadata such as Portal tags.
-            provider_preferences = _provider_preferences_for_agent(agent)
-            profile_extra_body = {}
-            try:
-                from providers import get_provider_profile
-
-                provider_profile = get_provider_profile(agent.provider)
-                if provider_profile is not None:
-                    profile_extra_body = provider_profile.build_extra_body(
-                        session_id=getattr(agent, "session_id", None),
-                        provider_preferences=provider_preferences or None,
-                        model=agent.model,
-                        base_url=agent.base_url,
-                        reasoning_config=agent.reasoning_config,
-                    )
-            except Exception:
-                pass
-
-            if profile_extra_body:
-                summary_extra_body.update(profile_extra_body)
-            if provider_preferences and "provider" not in profile_extra_body and (
+            # Include provider routing preferences
+            provider_preferences = {}
+            if agent.providers_allowed:
+                provider_preferences["only"] = agent.providers_allowed
+            if agent.providers_ignored:
+                provider_preferences["ignore"] = agent.providers_ignored
+            if agent.providers_order:
+                provider_preferences["order"] = agent.providers_order
+            _provider_sort = _validated_openrouter_provider_sort(agent.provider_sort)
+            if _provider_sort:
+                provider_preferences["sort"] = _provider_sort
+            if provider_preferences and (
                 (agent.provider or "").strip().lower() == "openrouter"
                 or agent._is_openrouter_url()
             ):
@@ -2159,11 +1763,6 @@ def cleanup_task_resources(agent, task_id: str) -> None:
     ``terminal.lifetime_seconds`` is exceeded. Non-persistent backends are
     torn down per-turn as before to prevent resource leakage (the original
     intent of this hook for the Morph backend, see commit fbd3a2fd).
-
-    Skips ``cleanup_browser`` in headed mode so the browser window stays
-    visible between turns. The inactivity reaper in
-    ``browser_tool._cleanup_inactive_browser_sessions`` still handles
-    idle sessions.
     """
     try:
         if is_persistent_env(task_id):
@@ -2178,20 +1777,7 @@ def cleanup_task_resources(agent, task_id: str) -> None:
         if agent.verbose_logging:
             logger.warning(f"Failed to cleanup VM for task {task_id}: {e}")
     try:
-        headed = False
-        try:
-            from tools.browser_tool import _is_headed_mode
-            headed = _is_headed_mode()
-        except Exception:
-            headed = bool(os.environ.get("AGENT_BROWSER_HEADED"))
-        if headed:
-            if agent.verbose_logging:
-                logging.debug(
-                    f"Skipping per-turn cleanup_browser for headed session {task_id}; "
-                    f"idle reaper will handle it."
-                )
-        else:
-            _ra().cleanup_browser(task_id)
+        _ra().cleanup_browser(task_id)
     except Exception as e:
         if agent.verbose_logging:
             logger.warning(f"Failed to cleanup browser for task {task_id}: {e}")
@@ -2218,15 +1804,6 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     if agent._interrupt_requested:
         raise InterruptedError("Agent interrupted before streaming API call")
 
-    # Cron and other non-interactive, nested-pool contexts deadlock on the
-    # spawned worker thread (#62151). They also have no stream consumer, so the
-    # deltas this path produces go nowhere. Delegate to the non-streaming entry
-    # (which runs inline via should_use_direct_api_call) exactly like the codex
-    # branch below — routing through the _interruptible_api_call method keeps the
-    # outer loop's per-request retry/refresh seam intact.
-    if should_use_direct_api_call(agent):
-        return agent._interruptible_api_call(api_kwargs)
-
     if agent.api_mode == "codex_responses":
         # Codex streams internally via _run_codex_stream. The main dispatch
         # in _interruptible_api_call already calls it; we just need to
@@ -2244,24 +1821,6 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         result = {"response": None, "error": None}
         first_delta_fired = {"done": False}
         deltas_were_sent = {"yes": False}
-        # Wire-level liveness for the boto3 converse_stream worker: the worker
-        # thread blocks inside ``for event in event_stream`` with NO read
-        # timeout, so a provider that opens the stream then stops yielding
-        # events wedges the thread forever. on_event stamps this on EVERY
-        # yielded Bedrock event (text/tool/metadata) — the poll loop below
-        # trips a watchdog when the gap exceeds the stale timeout.
-        _bedrock_last_event = {"t": time.time()}
-        # Region captured for the poll-loop client eviction below.  Read
-        # (not popped) here so the worker's own pop inside _bedrock_call still
-        # resolves the same value.
-        _bedrock_region = api_kwargs.get("__bedrock_region__", "us-east-1")
-        # Same patience budget as the OpenAI/Anthropic stale detector.
-        _bedrock_stale_timeout = _derive_stream_stale_timeout(agent, api_kwargs)
-
-        # Cross-turn stale-stream circuit breaker (#58962): a pre-elevated
-        # streak from prior wedged turns aborts before we even start — mirrors
-        # the entry check on the OpenAI/Anthropic path below.
-        _check_stale_giveup(agent)
 
         def _fire_first():
             if not first_delta_fired["done"] and on_first_delta:
@@ -2316,10 +1875,6 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         invalidate_runtime_client(region)
                     raise
 
-                # Claim the delta sink for this bedrock stream (#65991) so a
-                # superseded attempt's callbacks are fenced by the sink guard.
-                claim_stream_writer(agent)
-
                 def _on_text(text):
                     _fire_first()
                     agent._fire_stream_delta(text)
@@ -2339,7 +1894,6 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     on_tool_start=_on_tool,
                     on_reasoning_delta=_on_reasoning if agent.reasoning_callback or agent.stream_delta_callback else None,
                     on_interrupt_check=lambda: agent._interrupt_requested,
-                    on_event=lambda: _bedrock_last_event.__setitem__("t", time.time()),
                 )
             except Exception as e:
                 result["error"] = e
@@ -2350,87 +1904,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             t.join(timeout=0.3)
             if agent._interrupt_requested:
                 raise InterruptedError("Agent interrupted during Bedrock API call")
-            # Liveness watchdog: no Bedrock event for longer than the stale
-            # timeout means the stream has wedged (open socket, keep-alives but
-            # no data, or a silently hung provider).  Without this the worker
-            # blocks in ``for event in event_stream`` indefinitely.
-            _stale_elapsed = time.time() - _bedrock_last_event["t"]
-            if _stale_elapsed > _bedrock_stale_timeout:
-                logger.warning(
-                    "Bedrock stream stale for %.0fs (threshold %.0fs) — no events "
-                    "received. region=%s model=%s. Aborting call.",
-                    _stale_elapsed, _bedrock_stale_timeout,
-                    _bedrock_region, api_kwargs.get("modelId", "unknown"),
-                )
-                agent._buffer_status(
-                    f"⚠️ No events from Bedrock for {int(_stale_elapsed)}s "
-                    f"(model: {api_kwargs.get('modelId', 'unknown')}). Aborting..."
-                )
-                # Count the stale kill in the SAME cross-turn breaker as the
-                # OpenAI/Anthropic path (#58962).
-                _bump_stale_streak(agent)
-                # Best-effort: evict the region's cached bedrock-runtime client
-                # so the NEXT call reconnects with a fresh pool.  NOTE: this does
-                # NOT abort the in-flight botocore EventStream the worker thread
-                # is blocked on — botocore exposes no external cancellation for
-                # it — so the daemon worker keeps reading until its socket read
-                # ultimately errors.  We therefore end THIS call by raising
-                # below and let the streak+give-up breaker escalate across turns.
-                try:
-                    from agent.bedrock_adapter import invalidate_runtime_client
-                    invalidate_runtime_client(_bedrock_region)
-                except Exception as _inval_exc:
-                    logger.debug(
-                        "bedrock: stale client eviction failed: %s", _inval_exc
-                    )
-                # Reset the timer so a repeated trip (should the worker somehow
-                # survive) waits a fresh interval rather than re-firing instantly.
-                _bedrock_last_event["t"] = time.time()
-                # Escalate across turns: raises RuntimeError once the streak
-                # crosses HERMES_STREAM_STALE_GIVEUP, so a persistently wedged
-                # Bedrock provider aborts fast instead of re-waiting the timeout.
-                _check_stale_giveup(agent)
-                # Streak still under the give-up threshold: end THIS call with a
-                # TimeoutError so the outer retry loop / next turn re-evaluates
-                # and the streak carries forward.  Break rather than keep polling
-                # a worker we cannot abort.
-                result["error"] = TimeoutError(
-                    f"Bedrock stream produced no events for {int(_stale_elapsed)}s "
-                    f"(threshold {int(_bedrock_stale_timeout)}s) — aborting stalled "
-                    f"stream so the retry/fallback path can recover."
-                )
-                break
-        # Worker exited before the poll loop observed the interrupt flag. The
-        # Bedrock stream callback breaks out and returns a PARTIAL response
-        # without raising on interrupt (see bedrock_adapter.py
-        # stream_converse_with_callbacks / on_interrupt_check), so result[
-        # "response"] is populated with error=None and the in-loop raise above
-        # never fires. Re-check here so /stop is not silently swallowed on the
-        # Bedrock path — mirrors the post-worker guard on the main streaming
-        # loop. (#59999 area)
-        if agent._interrupt_requested:
-            raise InterruptedError("Agent interrupted during Bedrock API call (post-worker)")
         if result["error"] is not None:
             raise result["error"]
-        # Success — clear the cross-turn breaker (#58962): Bedrock proved
-        # responsive.  Mirrors the OpenAI/Anthropic success reset below so a
-        # recovered provider doesn't carry a stale streak into later turns.
-        if result["response"] is not None:
-            _reset_stale_streak(agent)
         return result["response"]
 
     result = {"response": None, "error": None, "partial_tool_names": []}
-
-    # Cross-turn stale-stream circuit breaker (#58962) — see the canonical
-    # comment block above ``_stale_streak()``.  Raises past the give-up
-    # threshold instead of burning another stale-timeout×retries cycle.
-    _check_stale_giveup(agent)
-
     request_client_holder = {"client": None, "diag": None, "owner_tid": None}
-    # Transport kind of the registered request client — see the non-streaming
-    # variant. Routes _close_request_client_once to anthropic vs openai abort/
-    # close helpers (#67142).
-    request_client_kind = {"value": "openai"}
     request_client_lock = threading.Lock()
     # Request-local cancellation flag — see interruptible_api_call for the full
     # rationale. The streaming retry loop is where the 7-minute cascading-
@@ -2441,10 +1920,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # exit immediately instead of retrying. (PR #6600.)
     _request_cancelled = {"value": False}
 
-    def _set_request_client(client, *, kind: str = "openai"):
+    def _set_request_client(client):
         with request_client_lock:
             request_client_holder["client"] = client
-            request_client_kind["value"] = kind
             # See #29507 explanation in the non-streaming variant above.
             request_client_holder["owner_tid"] = threading.get_ident()
         return client
@@ -2467,13 +1945,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 request_client_holder["owner_tid"] = None
         if request_client is None:
             return
-        kind = request_client_kind.get("value", "openai")
-        if kind == "anthropic_messages":
-            if stranger_thread:
-                agent._abort_request_anthropic_client(request_client, reason=reason)
-            else:
-                agent._close_request_anthropic_client(request_client, reason=reason)
-        elif stranger_thread:
+        if stranger_thread:
             agent._abort_request_openai_client(request_client, reason=reason)
         else:
             agent._close_request_openai_client(request_client, reason=reason)
@@ -2492,68 +1964,6 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # resolved, so the builder degrades to its plain default if it ever runs
     # first.
     _stream_stale_timeout = None
-    stream_attempt_lock = threading.Lock()
-    stream_attempt_state = {
-        "current": 0,
-        "cancelled": set(),
-        "discarded_chunks": 0,
-        "discarded_bytes": 0,
-    }
-
-    def _start_stream_attempt() -> int:
-        with stream_attempt_lock:
-            stream_attempt_state["current"] += 1
-            return int(stream_attempt_state["current"])
-
-    def _cancel_current_stream_attempt(reason: str) -> None:
-        with stream_attempt_lock:
-            current = int(stream_attempt_state.get("current") or 0)
-            if current:
-                stream_attempt_state["cancelled"].add(current)
-        if current:
-            logger.debug(
-                "Marked stream attempt %s cancelled: %s",
-                current,
-                reason,
-            )
-
-    def _stream_attempt_is_active(stream_attempt_id: int) -> bool:
-        with stream_attempt_lock:
-            return (
-                stream_attempt_id == int(stream_attempt_state.get("current") or 0)
-                and stream_attempt_id not in stream_attempt_state["cancelled"]
-            )
-
-    def _stream_attempt_was_cancelled(stream_attempt_id: int) -> bool:
-        with stream_attempt_lock:
-            return stream_attempt_id in stream_attempt_state["cancelled"]
-
-    def _discard_stale_stream_chunk(stream_attempt_id: int, chunk) -> None:
-        try:
-            chunk_bytes = len(repr(chunk))
-        except Exception:
-            chunk_bytes = 0
-        with stream_attempt_lock:
-            stream_attempt_state["discarded_chunks"] += 1
-            stream_attempt_state["discarded_bytes"] += chunk_bytes
-            discarded_chunks = stream_attempt_state["discarded_chunks"]
-            discarded_bytes = stream_attempt_state["discarded_bytes"]
-        if discarded_chunks == 1:
-            logger.warning(
-                "Discarding chunk from superseded stream attempt %s "
-                "(discarded_chunks=%s discarded_bytes=%s)",
-                stream_attempt_id,
-                discarded_chunks,
-                discarded_bytes,
-            )
-        else:
-            logger.debug(
-                "Discarded stale stream chunk from attempt %s "
-                "(discarded_chunks=%s discarded_bytes=%s)",
-                stream_attempt_id,
-                discarded_chunks,
-                discarded_bytes,
-            )
 
     def _fire_first_delta():
         if not first_delta_fired["done"] and on_first_delta:
@@ -2563,7 +1973,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             except Exception:
                 pass
 
-    def _call_chat_completions(stream_attempt_id: int):
+    def _call_chat_completions():
         """Stream a chat completions response."""
         import httpx as _httpx
         # Per-provider / per-model request_timeout_seconds (from config.yaml)
@@ -2616,6 +2026,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         stream_kwargs = {
             **api_kwargs,
             "stream": True,
+            "stream_options": {"include_usage": True},
             "timeout": _httpx.Timeout(
                 connect=_conn_cap,
                 read=_stream_read_timeout,
@@ -2623,14 +2034,6 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 pool=_conn_cap,
             ),
         }
-        # OpenAI's `stream_options={"include_usage": True}` drives usage
-        # accounting on OpenAI-compatible endpoints (incl. the Gemini OpenAI
-        # compat shim and aggregators like OpenRouter).  Google's *native*
-        # Gemini REST endpoint rejects the keyword outright
-        # (`Completions.create() got an unexpected keyword argument
-        # 'stream_options'`), so omit it only for that endpoint.
-        if not is_native_gemini_base_url(agent.base_url):
-            stream_kwargs["stream_options"] = {"include_usage": True}
         request_client = _set_request_client(
             agent._create_request_openai_client(
                 reason="chat_completion_stream_request",
@@ -2647,54 +2050,6 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
         stream = request_client.chat.completions.create(**stream_kwargs)
-        # Claim the delta sink for THIS attempt (#65991). If a prior attempt's
-        # stream is somehow still alive (a stale-stream reconnect whose socket
-        # abort raced), this claim supersedes it so its late chunks are fenced
-        # out of the turn instead of interleaving with ours.
-        _writer_token = claim_stream_writer(agent)
-
-        # Some OpenAI-compatible adapters (for example copilot-acp, and the MoA
-        # openai-codex aggregator) accept stream=True but still return a
-        # completed response object rather than an iterator of chunks.  Treat
-        # that as "streaming unsupported" for the rest of this session instead
-        # of crashing on ``for chunk in stream`` with ``'types.SimpleNamespace'
-        # object is not iterable`` (#11732, #55933).
-        #
-        # Discriminate on the mere PRESENCE of a ``choices`` attribute, not on
-        # it being a non-empty list: an adapter may hand back a completed
-        # response whose ``choices`` is ``None`` or empty (an error /
-        # content-filter / terminal frame), and every such shape is still a
-        # whole response — not a token stream — that would crash iteration just
-        # the same.  A genuine provider stream (SDK ``Stream`` object,
-        # generator) exposes no ``choices`` attribute, so it is left untouched.
-        if hasattr(stream, "choices"):
-            logger.info(
-                "Streaming request returned a final response object instead of "
-                "an iterator; switching %s/%s to non-streaming for this session.",
-                agent.provider or "unknown",
-                agent.model or "unknown",
-            )
-            agent._disable_streaming = True
-            # An empty/None ``choices`` carries no message to surface; return the
-            # completed object as-is so the outer loop's normal invalid-response
-            # validation (conversation_loop.py) handles it via the retry path,
-            # never ``for chunk in stream``.
-            choices = stream.choices
-            first_choice = choices[0] if isinstance(choices, (list, tuple)) and choices else None
-            message = getattr(first_choice, "message", None)
-            if message is not None:
-                reasoning_text = (
-                    getattr(message, "reasoning_content", None)
-                    or getattr(message, "reasoning", None)
-                )
-                if isinstance(reasoning_text, str) and reasoning_text:
-                    _fire_first_delta()
-                    agent._fire_reasoning_delta(reasoning_text)
-                content = getattr(message, "content", None)
-                if isinstance(content, str) and content:
-                    _fire_first_delta()
-                    agent._fire_stream_delta(content)
-            return stream
 
         # Capture rate limit headers from the initial HTTP response.
         # The OpenAI SDK Stream object exposes the underlying httpx
@@ -2724,18 +2079,6 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         reasoning_parts: list = []
         usage_obj = None
         for chunk in stream:
-            # Stop the moment a newer attempt has claimed the delta sink
-            # (#65991): this attempt has been superseded, so it must neither
-            # fire deltas (incl. the tool-suppressed raw-callback path below)
-            # nor keep consuming a stream that would interleave into the turn.
-            if not stream_writer_is_current(agent, _writer_token):
-                logger.warning(
-                    "Streaming attempt superseded by a newer stream; stopping "
-                    "consumption to preserve the single-writer invariant "
-                    "(model=%s).",
-                    api_kwargs.get("model", "unknown"),
-                )
-                break
             last_chunk_time["t"] = time.time()
             agent._touch_activity("receiving stream response")
 
@@ -2759,10 +2102,6 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
             if agent._interrupt_requested:
                 break
-
-            if not _stream_attempt_is_active(stream_attempt_id):
-                _discard_stale_stream_chunk(stream_attempt_id, chunk)
-                continue
 
             if not chunk.choices:
                 if hasattr(chunk, "model") and chunk.model:
@@ -2830,23 +2169,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     idx = _active_slot_by_idx[raw_idx]
 
                     if idx not in tool_calls_acc:
-                        # Poolside may send integer id instead of string
-                        _tc_id = tc_delta.id
-                        if isinstance(_tc_id, int):
-                            _tc_id = str(_tc_id)
                         tool_calls_acc[idx] = {
-                            "id": _tc_id or "",
+                            "id": tc_delta.id or "",
                             "type": "function",
                             "function": {"name": "", "arguments": ""},
                             "extra_content": None,
                         }
                     entry = tool_calls_acc[idx]
-                    if tc_delta.id is not None:
-                        _new_id = tc_delta.id
-                        if isinstance(_new_id, int):
-                            _new_id = str(_new_id)
-                        if _new_id:
-                            entry["id"] = _new_id
+                    if tc_delta.id:
+                        entry["id"] = tc_delta.id
                     if tc_delta.function:
                         if tc_delta.function.name:
                             # Use assignment, not +=.  Function names are
@@ -2862,7 +2193,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             entry["function"]["arguments"] += tc_delta.function.arguments
                     extra = getattr(tc_delta, "extra_content", None)
                     if extra is None and hasattr(tc_delta, "model_extra"):
-                        extra = (tc_delta.model_extra if isinstance(tc_delta.model_extra, dict) else {}).get("extra_content")
+                        extra = (tc_delta.model_extra or {}).get("extra_content")
                     if extra is not None:
                         if hasattr(extra, "model_dump"):
                             extra = extra.model_dump()
@@ -2888,11 +2219,6 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # Usage in the final chunk
             if hasattr(chunk, "usage") and chunk.usage:
                 usage_obj = chunk.usage
-
-        if _stream_attempt_was_cancelled(stream_attempt_id):
-            raise _httpx.RemoteProtocolError(
-                f"stream attempt {stream_attempt_id} was superseded"
-            )
 
         # Build mock response matching non-streaming shape
         full_content = "".join(content_parts) or None
@@ -2941,7 +2267,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             and not reasoning_parts
             and not tool_calls_acc
         ):
-            raise EmptyStreamError(
+            raise RuntimeError(
                 "Provider returned an empty stream with no finish_reason "
                 "(possible upstream error or malformed SSE response)."
             )
@@ -2984,6 +2310,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 content=full_content,
                 tool_calls=None,
                 reasoning_content=full_reasoning,
+                reasoning=full_reasoning,
             )
             mock_choice = SimpleNamespace(
                 index=0,
@@ -3008,6 +2335,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             content=full_content,
             tool_calls=mock_tool_calls,
             reasoning_content=full_reasoning,
+            reasoning=full_reasoning,
         )
         mock_choice = SimpleNamespace(
             index=0,
@@ -3021,31 +2349,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             usage=usage_obj,
         )
 
-    def _call_anthropic(request_client):
+    def _call_anthropic():
         """Stream an Anthropic Messages API response.
 
         Fires delta callbacks for real-time token delivery, but returns
         the native Anthropic Message object from get_final_message() so
         the rest of the agent loop (validation, tool extraction, etc.)
         works unchanged.
-
-        Uses ``request_client`` (a per-request Anthropic client registered with
-        the stranger-thread abort machinery) rather than the shared
-        ``_anthropic_client``, so the stale/interrupt watchdog can abort this
-        stream's socket without closing the shared client mid-flight (#67142).
         """
         has_tool_use = False
-        # Zero-event guard parity with the chat_completions path: track
-        # whether the provider delivered ANY stream event. On an eventless
-        # stream the real Anthropic SDK's get_final_message() raises
-        # AssertionError (no message_start ⇒ no final-message snapshot);
-        # OpenAI-compat shims may instead fabricate a contentless Message
-        # with no stop_reason, or return None under ``python -O`` (assert
-        # stripped). Every one of those shapes is normalized below to
-        # EmptyStreamError so the shared _call() retry loop treats it as
-        # transient instead of surfacing a raw AssertionError or a
-        # fabricated "successful" empty turn.
-        saw_stream_event = False
 
         # Reset stale-stream timer for this attempt
         last_chunk_time["t"] = time.time()
@@ -3061,7 +2373,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             api_kwargs, log_prefix=getattr(agent, "log_prefix", "")
         )
         # Use the Anthropic SDK's streaming context manager
-        with request_client.messages.stream(**api_kwargs) as stream:
+        with agent._anthropic_client.messages.stream(**api_kwargs) as stream:
             # The Anthropic SDK exposes the raw httpx response on
             # ``stream.response``.  Snapshot diagnostic headers
             # immediately so they survive a stream that dies before the
@@ -3072,21 +2384,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 )
             except Exception:
                 pass
-            # Claim the delta sink for THIS attempt (#65991) — parity with the
-            # chat_completions path so a superseded anthropic stream is fenced.
-            _writer_token = claim_stream_writer(agent)
             for event in stream:
-                # Bail the instant a newer attempt supersedes this one so a
-                # stale stream can't interleave tokens into the turn.
-                if not stream_writer_is_current(agent, _writer_token):
-                    logger.warning(
-                        "Anthropic streaming attempt superseded by a newer "
-                        "stream; stopping consumption to preserve the "
-                        "single-writer invariant (model=%s).",
-                        api_kwargs.get("model", "unknown"),
-                    )
-                    break
-                saw_stream_event = True
                 # Update stale-stream timer on every event so the
                 # outer poll loop knows data is flowing.  Without
                 # this, the detector kills healthy long-running
@@ -3138,47 +2436,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                                 _fire_first_delta()
                                 agent._fire_reasoning_delta(thinking_text)
 
-            # Return the native Anthropic Message for downstream processing.
-            # If the stream was interrupted (the event loop broke out above on
-            # agent._interrupt_requested), do NOT call get_final_message() — on
-            # a partially-consumed stream the SDK may hang draining remaining
-            # events or return a Message with incomplete tool_use blocks (partial
-            # JSON in `input`). The outer poll loop raises InterruptedError, so
-            # this return value is discarded anyway.
-            if agent._interrupt_requested:
-                return None
-            # Zero-event guard (parity with the chat_completions zero-chunk
-            # guard above). Real SDK: an eventless stream has no
-            # message_start, so get_final_message() raises AssertionError
-            # (final-message snapshot is None) — normalize that to
-            # EmptyStreamError so it gets the transient retry budget
-            # instead of surfacing raw.
-            try:
-                _final_message = stream.get_final_message()
-            except AssertionError:
-                if not saw_stream_event:
-                    raise EmptyStreamError(
-                        "Provider returned an empty stream with no events "
-                        "(possible upstream error or malformed event stream)."
-                    ) from None
-                raise
-            # Shim variants of the same failure: an OpenAI-compat adapter
-            # may fabricate a contentless Message with no stop_reason, or
-            # return None where the SDK assert would have fired (e.g.
-            # ``python -O``). A real completed response always carries a
-            # stop_reason, so this cannot fire on legitimate turns.
-            if not saw_stream_event and (
-                _final_message is None
-                or (
-                    not getattr(_final_message, "content", None)
-                    and getattr(_final_message, "stop_reason", None) is None
-                )
-            ):
-                raise EmptyStreamError(
-                    "Provider returned an empty stream with no stop_reason "
-                    "(possible upstream error or malformed event stream)."
-                )
-            return _final_message
+            # Return the native Anthropic Message for downstream processing
+            return stream.get_final_message()
 
     def _call():
         import httpx as _httpx
@@ -3187,7 +2446,6 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
         try:
             for _stream_attempt in range(_max_stream_retries + 1):
-                stream_attempt_id = _start_stream_attempt()
                 # Check for interrupt before each retry attempt.  Without
                 # this, /stop closes the HTTP connection (outer poll loop),
                 # but the retry loop opens a FRESH connection — negating the
@@ -3195,22 +2453,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # retry can block for the full stream-read timeout (120s+),
                 # causing multi-minute delays between /stop and response.
                 if agent._interrupt_requested:
-                    _cancel_current_stream_attempt("interrupt_before_stream_retry")
                     raise InterruptedError("Agent interrupted before stream retry")
                 try:
                     if agent.api_mode == "anthropic_messages":
-                        # #67142: per-request client (credential refresh happens
-                        # inside _create_request_anthropic_client) registered so
-                        # the watchdog aborts its socket, not the shared client.
-                        request_client = _set_request_client(
-                            agent._create_request_anthropic_client(
-                                reason="anthropic_stream_request"
-                            ),
-                            kind="anthropic_messages",
-                        )
-                        result["response"] = _call_anthropic(request_client)
+                        agent._try_refresh_anthropic_client_credentials()
+                        result["response"] = _call_anthropic()
                     else:
-                        result["response"] = _call_chat_completions(stream_attempt_id)
+                        result["response"] = _call_chat_completions()
                     return  # success
                 except Exception as e:
                     # If the main poll loop force-closed this request because
@@ -3235,7 +2484,6 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         e, (_httpx.ConnectError, _httpx.RemoteProtocolError, ConnectionError)
                     )
                     _is_stream_parse_err = agent._is_provider_stream_parse_error(e)
-                    _is_empty_stream = isinstance(e, EmptyStreamError)
 
                     # If the stream died AFTER some tokens were delivered:
                     # normally we don't retry (the user already saw text,
@@ -3332,13 +2580,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             mid_tool_call=True,
                             diag=request_client_holder.get("diag"),
                         )
-                        _cancel_current_stream_attempt("stream_mid_tool_retry_cleanup")
                         _close_request_client_once("stream_mid_tool_retry_cleanup")
-                        # #67142: anthropic streams on a request-local client,
-                        # already worker-owned-closed by _close_request_client_once
-                        # above; the next attempt builds a fresh one. The shared
-                        # _anthropic_client is never closed from inside a request.
-                        if agent.api_mode != "anthropic_messages":
+                        if agent.api_mode == "anthropic_messages":
+                            try:
+                                agent._anthropic_client.close()
+                                agent._rebuild_anthropic_client()
+                            except Exception:
+                                pass
+                        else:
                             try:
                                 agent._replace_primary_openai_client(
                                     reason="stream_mid_tool_retry_pool_cleanup"
@@ -3377,13 +2626,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                                 for phrase in _SSE_CONN_PHRASES
                             )
 
-                    if (
-                        _is_timeout
-                        or _is_conn_err
-                        or _is_sse_conn_err
-                        or _is_stream_parse_err
-                        or _is_empty_stream
-                    ):
+                    if _is_timeout or _is_conn_err or _is_sse_conn_err or _is_stream_parse_err:
                         # Transient network / timeout error. Retry the
                         # streaming request with a fresh connection first.
                         if _stream_attempt < _max_stream_retries:
@@ -3395,15 +2638,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                                 diag=request_client_holder.get("diag"),
                             )
                             # Close the stale request client before retry
-                            _cancel_current_stream_attempt("stream_retry_cleanup")
                             _close_request_client_once("stream_retry_cleanup")
-                            # Also rebuild the primary client to purge any dead
-                            # connections from the pool. #67142: anthropic uses a
-                            # request-local client (already worker-owned-closed
-                            # above; next attempt builds fresh), so the shared
-                            # _anthropic_client is never closed from inside a
-                            # request — only the OpenAI-wire primary is refreshed.
-                            if agent.api_mode != "anthropic_messages":
+                            # Also rebuild the primary client to purge
+                            # any dead connections from the pool.
+                            if agent.api_mode == "anthropic_messages":
+                                try:
+                                    agent._anthropic_client.close()
+                                    agent._rebuild_anthropic_client()
+                                except Exception:
+                                    pass
+                            else:
                                 try:
                                     agent._replace_primary_openai_client(
                                         reason="stream_retry_pool_cleanup"
@@ -3425,32 +2669,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             mid_tool_call=False,
                             diag=request_client_holder.get("diag"),
                         )
-                        if _is_stream_parse_err:
-                            _exhausted_msg = (
-                                "❌ Provider returned malformed streaming data after "
-                                f"{_max_stream_retries + 1} attempts. "
-                                "The provider may be experiencing issues — "
-                                "try again in a moment."
-                            )
-                        elif _is_empty_stream:
-                            # The connection SUCCEEDED (stream opened) but the
-                            # provider sent no chunks — saying "connection
-                            # failed" here sends users chasing network issues
-                            # when the problem is the provider/endpoint.
-                            _exhausted_msg = (
-                                "❌ Provider returned an empty response stream "
-                                f"after {_max_stream_retries + 1} attempts. "
-                                "The provider may be experiencing issues — "
-                                "try again in a moment."
-                            )
-                        else:
-                            _exhausted_msg = (
-                                "❌ Connection to provider failed after "
-                                f"{_max_stream_retries + 1} attempts. "
-                                "The provider may be experiencing issues — "
-                                "try again in a moment."
-                            )
-                        agent._buffer_status(_exhausted_msg)
+                        agent._buffer_status(
+                            "❌ Provider returned malformed streaming data after "
+                            f"{_max_stream_retries + 1} attempts. "
+                            "The provider may be experiencing issues — "
+                            "try again in a moment."
+                            if _is_stream_parse_err else
+                            "❌ Connection to provider failed after "
+                            f"{_max_stream_retries + 1} attempts. "
+                            "The provider may be experiencing issues — "
+                            "try again in a moment."
+                        )
                     else:
                         _err_lower = str(e).lower()
                         _is_stream_unsupported = (
@@ -3518,34 +2747,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     else:
         _stream_stale_timeout_base = env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
     # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
-    # for prefill on large contexts, so tolerate far longer silence than
-    # the cloud default — but a wedged local server must EVENTUALLY trip the
-    # detector rather than hang forever (an infinite timeout meant a crashed
-    # or deadlocked local endpoint stalled the session indefinitely).  900s
-    # tolerates slow prefill while still bounding a hung endpoint.  Applies
-    # unless the user explicitly set HERMES_STREAM_STALE_TIMEOUT; override the
-    # local ceiling with HERMES_LOCAL_STREAM_STALE_TIMEOUT (documented in
-    # website/docs/reference/environment-variables.md).
+    # for prefill on large contexts.  Disable the stale detector unless
+    # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.
     if _stream_stale_timeout_base == 180.0 and agent.base_url and is_local_endpoint(agent.base_url):
-        # Read config.yaml ``agent.local_stream_stale_timeout`` (default 900),
-        # env var ``HERMES_LOCAL_STREAM_STALE_TIMEOUT`` overrides for escape-hatch.
-        _local_default = 900.0
-        try:
-            from hermes_cli.config import load_config
-
-            _cfg = load_config()
-            _agent_cfg = _cfg.get("agent") if isinstance(_cfg, dict) else None
-            if isinstance(_agent_cfg, dict):
-                _v = _agent_cfg.get("local_stream_stale_timeout")
-                if isinstance(_v, (int, float)):
-                    _local_default = float(_v)
-        except Exception:
-            pass
-        _stream_stale_timeout = env_float("HERMES_LOCAL_STREAM_STALE_TIMEOUT", _local_default)
-        logger.debug(
-            "Local provider detected (%s) — stale stream timeout set to %.0fs",
-            agent.base_url, _stream_stale_timeout,
-        )
+        _stream_stale_timeout = float("inf")
+        logger.debug("Local provider detected (%s) — stale stream timeout disabled", agent.base_url)
     else:
         # Scale the stale timeout for large contexts: slow models (like Opus)
         # can legitimately think for minutes before producing the first token
@@ -3590,29 +2796,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         if _hb_now - _last_heartbeat >= _HEARTBEAT_INTERVAL:
             _last_heartbeat = _hb_now
             _waiting_secs = int(_hb_now - last_chunk_time["t"])
-            if _waiting_secs >= _HEARTBEAT_INTERVAL:
-                # No chunks for 30s+ — rewrite the live spinner/status line
-                # so CLI/TUI/Desktop users see WHAT the wait is (slow or
-                # overloaded provider / long thinking pause) instead of an
-                # unexplained generic spinner, and WHEN recovery kicks in.
-                if (
-                    _stream_stale_timeout is not None
-                    and _stream_stale_timeout != float("inf")
-                ):
-                    _recovery = f"; auto-reconnect at {int(_stream_stale_timeout)}s"
-                else:
-                    _recovery = ""
-                agent._emit_wait_notice(
-                    f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
-                    f"{_waiting_secs}s with no output yet (provider may be "
-                    f"slow or overloaded, or the model is thinking{_recovery})"
-                )
-            else:
-                # Chunks are flowing — keep the activity tracker fresh but
-                # leave the live display alone.
-                agent._touch_activity(
-                    f"waiting for stream response ({_waiting_secs}s, no chunks yet)"
-                )
+            agent._touch_activity(
+                f"waiting for stream response ({_waiting_secs}s, no chunks yet)"
+            )
 
         # Detect stale streams: connections kept alive by SSE pings
         # but delivering no real chunks.  Kill the client so the
@@ -3633,24 +2819,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 f"Reconnecting..."
             )
             try:
-                _cancel_current_stream_attempt("stale_stream_kill")
                 _close_request_client_once("stale_stream_kill")
             except Exception:
                 pass
-            # Circuit breaker (#58962): count the stale kill.  See the
-            # canonical comment block above ``_stale_streak()``.
-            _bump_stale_streak(agent)
             # Rebuild the primary client too — its connection pool
             # may hold dead sockets from the same provider outage.
             if agent.api_mode == "anthropic_messages":
-                # #67142: the stale stream ran on a request-local anthropic
-                # client, already socket-aborted above via
-                # _close_request_client_once (which unblocks the worker and
-                # preserves the #28161 no-hang guarantee). The shared
-                # _anthropic_client is NOT the in-flight transport, so we must
-                # not close it from this poll (stranger) thread — that was the
-                # FD-recycle corruption vector. Nothing further is needed.
-                pass
+                try:
+                    agent._anthropic_client.close()
+                    agent._rebuild_anthropic_client()
+                except Exception:
+                    pass
             else:
                 try:
                     agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
@@ -3659,10 +2838,6 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # Reset the timer so we don't kill repeatedly while
             # the inner thread processes the closure.
             last_chunk_time["t"] = time.time()
-            agent._emit_wait_notice(
-                f"⚠ no output from provider for {int(_stale_elapsed)}s — "
-                f"reconnecting..."
-            )
             agent._touch_activity(
                 f"stale stream detected after {int(_stale_elapsed)}s, reconnecting"
             )
@@ -3678,21 +2853,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 "(not a network error)."
             )
             try:
-                _cancel_current_stream_attempt("stream_interrupt_abort")
-                # #67142: kind-aware — anthropic aborts the request-local
-                # client's socket from this poll thread; the shared
-                # _anthropic_client is never closed here.
-                _close_request_client_once("stream_interrupt_abort")
+                if agent.api_mode == "anthropic_messages":
+                    agent._anthropic_client.close()
+                    agent._rebuild_anthropic_client()
+                else:
+                    _close_request_client_once("stream_interrupt_abort")
             except Exception:
                 pass
             raise InterruptedError("Agent interrupted during streaming API call")
-    # Worker thread exited before the main thread's poll loop could check
-    # the interrupt flag.  If the worker returned early due to an interrupt
-    # (e.g. _call_anthropic() detected _interrupt_requested and returned
-    # None), the InterruptedError above was never raised.  Re-check the
-    # flag here so /stop is not silently swallowed.  (#59999 area)
-    if agent._interrupt_requested:
-        raise InterruptedError("Agent interrupted during streaming API call (post-worker)")
     if result["error"] is not None:
         if deltas_were_sent["yes"]:
             # Streaming failed AFTER some tokens were already delivered to
@@ -3742,30 +2910,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 role="assistant", content=_partial_text, tool_calls=None,
                 reasoning_content=None,
             )
-            # Detect provider output-layer content filtering (e.g. MiniMax
-            # "output new_sensitive (1027)", Azure/OpenAI content_filter,
-            # Anthropic safety refusal).  The raw error is about to be
-            # swallowed into a finish_reason=length stub, so classify it HERE
-            # while we still have it and stamp the stub.  Retrying such a
-            # content-deterministic filter on the same primary just re-hits
-            # the filter — the conversation loop reads this tag and activates
-            # the fallback chain instead of burning continuation retries.
-            # error_classifier is the single source of truth for "what counts
-            # as a content filter" (#32421).
-            _content_filter_terminated = False
-            try:
-                from agent.error_classifier import classify_api_error, FailoverReason
-                _cls = classify_api_error(
-                    result["error"],
-                    provider=str(getattr(agent, "provider", "") or ""),
-                    model=str(getattr(agent, "model", "") or ""),
-                )
-                _content_filter_terminated = (
-                    _cls.reason == FailoverReason.content_policy_blocked
-                )
-            except Exception:
-                _content_filter_terminated = False
-            _stub = SimpleNamespace(
+            return SimpleNamespace(
                 id=PARTIAL_STREAM_STUB_ID,
                 model=getattr(agent, "model", "unknown"),
                 choices=[SimpleNamespace(
@@ -3774,18 +2919,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 usage=None,
                 _dropped_tool_names=_partial_names or None,
             )
-            if _content_filter_terminated:
-                _stub._content_filter_terminated = True
-            # Partial-stream stub: chunks WERE received (deltas fired), so
-            # the provider is demonstrably responsive — clear the circuit
-            # breaker (#58962) just like the full-success return below.
-            _reset_stale_streak(agent)
-            return _stub
         raise result["error"]
-    # Success — clear the circuit breaker (#58962): the provider proved
-    # responsive.  See the canonical comment block above ``_stale_streak()``.
-    if result["response"] is not None:
-        _reset_stale_streak(agent)
     return result["response"]
 
 # ── Provider fallback ──────────────────────────────────────────────────


### PR DESCRIPTION
This PR adds provider retry for silent failures (with exponential backoff and jitter) and snapshots the primary model/provider before fallback to enable the UI to show 'Fallback: X (primary: Y)'.