### PR TITLE
fix(slack): preserve commands in new thread context

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3422,7 +3422,7 @@ class SlackAdapter(BasePlatformAdapter):
                 current_ts=ts,
                 team_id=team_id,
             )
-            if thread_context:
+            if thread_context and not (original_text or "").startswith("/"):
                 text = thread_context + text
 
         # Determine message type

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1333,6 +1333,42 @@ class TestBangPrefixCommands:
         assert msg_event.source.thread_id == "1111111111.000001"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("command", ["!new", "!compress"])
+    async def test_bang_command_in_new_thread_skips_thread_context(self, adapter, command):
+        """Thread context must not hide a bang-normalized gateway command."""
+        thread_context = "[Prior thread context]\n"
+        event = self._make_event(command, thread_ts="1111111111.000001")
+
+        with patch.object(
+            adapter,
+            "_fetch_thread_context",
+            new=AsyncMock(return_value=thread_context),
+        ):
+            await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args.args[0]
+        assert msg_event.text == "/" + command[1:]
+        assert msg_event.message_type == MessageType.COMMAND
+        assert msg_event.get_command() == command[1:]
+
+    @pytest.mark.asyncio
+    async def test_plain_text_in_new_thread_keeps_thread_context(self, adapter):
+        """Thread context remains prepended for ordinary thread messages."""
+        thread_context = "[Prior thread context]\n"
+        event = self._make_event("please summarize", thread_ts="1111111111.000001")
+
+        with patch.object(
+            adapter,
+            "_fetch_thread_context",
+            new=AsyncMock(return_value=thread_context),
+        ):
+            await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args.args[0]
+        assert msg_event.text == thread_context + "please summarize"
+        assert msg_event.message_type == MessageType.TEXT
+
+    @pytest.mark.asyncio
     async def test_bang_unknown_token_passes_through_unchanged(self, adapter):
         """``!nice work`` is just a casual message — must NOT be rewritten."""
         await adapter._handle_slack_message(self._make_event("!nice work"))


### PR DESCRIPTION
## Summary

Fix Slack thread commands being routed to the agent as ordinary messages when a thread has no active Hermes session.

When Slack thread context was prepended before a command, a bang-normalized command such as `!compress` became:

```text
[Thread context — ...]
/compress
```

`MessageEvent.get_command()` requires the command text to start with `/`, so the gateway did not dispatch it and instead sent the whole text to the model.

This change skips thread-context injection for native slash commands and known `!` commands normalized to slash commands. Ordinary Slack thread messages retain their existing context behavior.

## Changes

- Preserve the leading slash for thread commands in `SlackAdapter`.
- Add regression coverage for `!new` and `!compress` with non-empty thread context.
- Assert ordinary thread replies still receive the context prefix.

## Validation

- `PYTHONPATH=. python -m pytest tests/gateway/test_slack.py -q -o 'addopts=' --tb=short`
  - `250 passed` (existing AsyncMock warnings only)
- `PYTHONPATH=. python -m ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack.py`
  - passed
- `git diff --check`
  - passed
- Live Slack verification: `!compress` in a DM thread dispatched successfully after the fix and gateway restart.

## Related

Related to #55239, which concerns stale session detection suppressing thread-context reseeding. This PR addresses the separate inverse failure mode: valid thread context hiding gateway commands from dispatch.