### PR TITLE
fix(telegram): pass explicit filename basename to bot.send_document

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1342,7 +1342,10 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                             )
                         else:
                             last_msg = await bot.send_document(
-                                chat_id=int_chat_id, document=f, **media_kwargs
+                                chat_id=int_chat_id,
+                                document=f,
+                                filename=os.path.basename(media_path),
+                                **media_kwargs,
                             )
                     except Exception as media_err:
                         if _is_telegram_thread_not_found(media_err) and media_kwargs.get("message_thread_id"):
@@ -1373,7 +1376,10 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                                 )
                             else:
                                 last_msg = await bot.send_document(
-                                    chat_id=int_chat_id, document=f, **media_kwargs
+                                    chat_id=int_chat_id,
+                                    document=f,
+                                    filename=os.path.basename(media_path),
+                                    **media_kwargs,
                                 )
                         elif media_kwargs.get("parse_mode") and (
                             "parse" in str(media_err).lower()
@@ -1404,7 +1410,10 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                                 )
                             else:
                                 last_msg = await bot.send_document(
-                                    chat_id=int_chat_id, document=f, **media_kwargs
+                                    chat_id=int_chat_id,
+                                    document=f,
+                                    filename=os.path.basename(media_path),
+                                    **media_kwargs,
                                 )
                         else:
                             raise


### PR DESCRIPTION
Files delivered via MEDIA:<path> on Telegram failed silently when the basename was long. python-telegram-bot derives the multipart filename from f.name when none is provided, and f.name is the full host path. Long paths in the Content-Disposition header get rejected by Telegram servers with no error surfaced, so the agent believed the file was delivered while the user never received it (#67552).

This adds filename=os.path.basename(media_path) at all three send_document call sites in the inline-media send path of tools/send_message_tool.py (initial send, thread-not-found retry, and caption-parse retry). The adapter-level TelegramAdapter.send_document already derived the basename correctly via display_name; these are the direct bot.send_document calls in the send tool that bypassed it and leaked the full path.

Verified the three sites are the only direct bot.send_document(document=f) calls missing a filename. No behavior change for short filenames — only the Content-Disposition filename changes from the full path to the basename.

Fixes #67552