### PR TITLE
fix(cron): preserve dashboard repeat counts

### DIFF
--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import math
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, SecretStr, field_validator
+from pydantic import BaseModel, Field, SecretStr, field_validator
 
 
 # --- from web_server.py (originally lines 1273-1372) ---
@@ -363,6 +363,7 @@ class CronJobCreate(BaseModel):
     schedule: str
     name: str = ""
     deliver: str = "local"
+    repeat: Optional[int] = Field(default=None, ge=1, strict=True)
     skills: Optional[List[str]] = None
     model: Optional[str] = None
     provider: Optional[str] = None
@@ -706,4 +707,3 @@ class _PluginProvidersPutBody(BaseModel):
 
 class _PluginVisibilityBody(BaseModel):
     hidden: bool
-

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11567,6 +11567,7 @@ def _create_cron_job_sync(body: CronJobCreate, profile: Optional[str] = None):
             prompt=body.prompt or "",
             schedule=body.schedule,
             name=body.name,
+            repeat=body.repeat,
             deliver=_cron_optional_text(body.deliver) or "local",
             skills=skills,
             model=_cron_optional_text(body.model),

--- a/tests/hermes_cli/test_web_server_cron_repeat.py
+++ b/tests/hermes_cli/test_web_server_cron_repeat.py
@@ -1,0 +1,87 @@
+"""Regression coverage for finite repeat counts in the dashboard cron API."""
+
+import pytest
+
+
+@pytest.fixture()
+def isolated_profiles(tmp_path, monkeypatch, _isolate_hermes_home):
+    """Route dashboard cron storage to an isolated default profile."""
+    from hermes_cli import profiles
+
+    default_home = tmp_path / ".hermes"
+    (default_home / "cron").mkdir(parents=True)
+    (default_home / "config.yaml").write_text(
+        "model: test-model\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: default_home)
+    monkeypatch.setattr(profiles, "_get_profiles_root", lambda: default_home / "profiles")
+    return default_home
+
+
+@pytest.fixture()
+def client(monkeypatch, isolated_profiles):
+    from starlette.testclient import TestClient
+
+    import hermes_state
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    monkeypatch.setattr(
+        hermes_state,
+        "DEFAULT_DB_PATH",
+        isolated_profiles / "state.db",
+    )
+    test_client = TestClient(app)
+    test_client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    return test_client
+
+
+def test_create_preserves_finite_repeat_count(client):
+    response = client.post(
+        "/api/cron/jobs",
+        json={
+            "prompt": "run the check",
+            "schedule": "every 1h",
+            "name": "two checks",
+            "repeat": 2,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["repeat"] == {"times": 2, "completed": 0}
+
+
+def test_create_without_repeat_remains_unlimited(client):
+    response = client.post(
+        "/api/cron/jobs",
+        json={
+            "prompt": "run forever",
+            "schedule": "every 1h",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["repeat"] == {"times": None, "completed": 0}
+
+
+@pytest.mark.parametrize("repeat", [0, -1, True, 1.5, "2", "not-a-count"])
+def test_create_rejects_invalid_repeat_count(client, repeat):
+    response = client.post(
+        "/api/cron/jobs",
+        json={
+            "prompt": "must not run forever",
+            "schedule": "every 1h",
+            "repeat": repeat,
+        },
+    )
+
+    assert response.status_code == 422
+    assert any(
+        error["loc"][-1] == "repeat"
+        for error in response.json()["detail"]
+    )
+    assert client.get(
+        "/api/cron/jobs",
+        params={"profile": "default"},
+    ).json() == []


### PR DESCRIPTION
## What does this PR do?

The dashboard `POST /api/cron/jobs` endpoint accepted payloads containing a finite `repeat` count but silently stripped the field during Pydantic parsing. The resulting job used the core default `repeat=None` and ran forever.

This change declares `repeat` as an optional strict positive integer and forwards it to `cron.jobs.create_job()`. Omitting the field keeps the existing unlimited behavior. Invalid values are rejected before a job is stored.

## Related Issue

Fixes #68012

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py`: validate and forward finite dashboard cron repeat counts.
- `tests/hermes_cli/test_web_server_cron_repeat.py`: cover finite, omitted, non-positive, boolean, fractional, and string values; verify invalid requests create no job.

## How to Test

1. POST a job with `repeat: 2`; verify the response contains `{"times": 2, "completed": 0}`.
2. Omit `repeat`; verify `times` remains `null`.
3. Submit invalid values; verify HTTP 422 identifies `repeat` and no job is stored.

```bash
python -m pytest   tests/cron/test_jobs.py   tests/hermes_cli/test_web_server_cron_repeat.py   tests/hermes_cli/test_web_server_cron_profiles.py   tests/hermes_cli/test_web_server_skill_editor.py   -q -o addopts=
# 189 passed

python -m ruff check   hermes_cli/web_server.py   tests/hermes_cli/test_web_server_cron_repeat.py
# All checks passed
```

The exact commit was also reviewed on the contributor fork by both an independent Codex pass and GitHub Codex; neither found an actionable issue.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (focused affected suites pass locally; full CI is left to Actions)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1 arm64

### Documentation & Housekeeping

- [x] Documentation update: N/A — no user-facing configuration or workflow changed
- [x] `cli-config.yaml.example` update: N/A — no config key changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A — no architecture or workflow changed
- [x] Cross-platform impact considered: request validation and forwarding are platform-independent
- [x] Tool descriptions/schemas update: N/A — no agent tool contract changed

## Screenshots / Logs

Not applicable; this is an HTTP request-contract fix with regression coverage.
