### PR TITLE
fix(web_server): preserve repeat count when creating cron jobs from dashboard

### DIFF
--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -570,6 +570,7 @@ export interface CronJobCreatePayload {
   deliver?: string
   name?: string
   prompt: string
+  repeat?: number
   schedule: string
 }
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -99,7 +99,7 @@ try:
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
     from fastapi.staticfiles import StaticFiles
-    from pydantic import BaseModel, SecretStr
+    from pydantic import BaseModel, SecretStr, model_validator
     from starlette.concurrency import run_in_threadpool
 except ImportError:
     # First try lazy-installing the dashboard extras. Only the user actually
@@ -115,7 +115,7 @@ except ImportError:
         from fastapi.middleware.cors import CORSMiddleware
         from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
         from fastapi.staticfiles import StaticFiles
-        from pydantic import BaseModel, SecretStr
+        from pydantic import BaseModel, SecretStr, model_validator
         from starlette.concurrency import run_in_threadpool
     except Exception:
         raise SystemExit(
@@ -10420,6 +10420,7 @@ class CronJobCreate(BaseModel):
     prompt: str = ""
     schedule: str
     name: str = ""
+    repeat: Optional[int] = None
     deliver: str = "local"
     skills: Optional[List[str]] = None
     model: Optional[str] = None
@@ -10430,6 +10431,12 @@ class CronJobCreate(BaseModel):
     enabled_toolsets: Optional[List[str]] = None
     workdir: Optional[str] = None
     no_agent: bool = False
+
+    @model_validator(mode="after")
+    def _check_repeat(self):
+        if self.repeat is not None and self.repeat < 1:
+            raise ValueError("repeat must be a positive integer")
+        return self
 
 
 class CronJobUpdate(BaseModel):
@@ -10443,6 +10450,24 @@ def _cron_optional_text(value: Any, *, strip_trailing_slash: bool = False) -> Op
     if strip_trailing_slash:
         text = text.rstrip("/")
     return text or None
+
+
+def _cron_optional_int(value: Any) -> Optional[int]:
+    """Return an Optional[int] or None, matching cron.jobs.create_job semantics.
+
+    ``cron.jobs.create_job`` treats ``repeat=None`` as unlimited and
+    ``repeat <= 0`` as unlimited, so we normalise here: None is passed through,
+    zero and negatives are passed through as zero so the core normalises to
+    None itself (we don't want two normalisation sites), and non-integer
+    garbage raises ValueError.
+    """
+    if value is None:
+        return None
+    try:
+        ival = int(value)
+    except (TypeError, ValueError):
+        raise ValueError("repeat must be a positive integer, or omitted")
+    return ival
 
 
 def _cron_string_list(value: Any) -> Optional[List[str]]:
@@ -10742,6 +10767,7 @@ def _create_cron_job_sync(body: CronJobCreate, profile: str = "default"):
             prompt=body.prompt or "",
             schedule=body.schedule,
             name=body.name,
+            repeat=_cron_optional_int(body.repeat),
             deliver=_cron_optional_text(body.deliver) or "local",
             skills=skills,
             model=_cron_optional_text(body.model),


### PR DESCRIPTION
## Problem

`POST /api/cron/jobs` silently drops finite `repeat` counts. A caller submitting `{"prompt":"run check","schedule":"every 1h","repeat":2}` gets back a job with `"repeat":{"times":null,"completed":0}` instead of `"repeat":{"times":2,"completed":0}`.

## Root cause

`CronJobCreate` in `hermes_cli/web_server.py` did not declare a `repeat` field — Pydantic's default extra-field behavior removed it during parsing. `_create_cron_job_sync()` also never forwarded a repeat value to `cron.jobs.create_job()`.

The parallel gateway endpoint (`POST /api/jobs`) already handled repeat correctly.

## Fix

1. Add `repeat: Optional[int] = None` to `CronJobCreate` with a `@model_validator` rejecting non-positive values
2. Add `_cron_optional_int()` helper for safe type coercion
3. Forward `repeat` from `_create_cron_job_sync()` to `create_job()`
4. Add `repeat?: number` to `CronJobCreatePayload` TypeScript type

## Behavior

| Scenario | Before | After |
|---|---|---|
| `repeat: 2` | stored as `null` (unlimited) | stored as `2` |
| omit `repeat` | `null` (unlimited) | `null` (unlimited) — unchanged |
| `repeat: 0` | silently dropped | 400: "repeat must be a positive integer" |
| `repeat: -1` | silently dropped | 400: "repeat must be a positive integer" |

Closes #68012