### PR TITLE
fix(kanban): freeze repeated identical failures

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1161,7 +1161,7 @@ class GatewayKanbanWatchersMixin:
                 try:
                     os.environ["HERMES_KANBAN_BOARD"] = slug
                     try:
-                        triage_ids = _decomp.list_triage_ids()
+                        triage_ids = _decomp.list_triage_ids(auto_only=True)
                     except Exception as exc:
                         logger.debug(
                             "kanban auto-decompose: list_triage_ids failed on board %s (%s)",
@@ -1174,7 +1174,9 @@ class GatewayKanbanWatchersMixin:
                         attempted += 1
                         try:
                             outcome = _decomp.decompose_task(
-                                tid, author="auto-decomposer",
+                                tid,
+                                author="auto-decomposer",
+                                automatic=True,
                             )
                         except Exception:
                             logger.exception(

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -80,6 +80,10 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
+        "failure_fingerprint": t.failure_fingerprint,
+        "failure_recurrences": t.failure_recurrences,
+        "failure_frozen_at": t.failure_frozen_at,
+        "failure_frozen": t.failure_frozen_at is not None,
     }
 
 
@@ -2154,7 +2158,9 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
         for tid in ids:
             if reason:
                 kb.add_comment(conn, tid, author, f"UNBLOCK: {reason}")
-            if not kb.unblock_task(conn, tid):
+            if not kb.unblock_task(
+                conn, tid, actor=author or _profile_author(), reason=reason,
+            ):
                 failed.append(tid)
                 print(f"cannot unblock {tid} (not blocked/scheduled?)", file=sys.stderr)
             else:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5174,8 +5174,12 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     state) holds for the rest of this function's lifetime.
     """
     now = int(time.time())
-    frozen_triage = is_block_loop_frozen(conn, task_id)
     with write_txn(conn):
+        # The circuit-breaker state and the transition must share one SQLite
+        # write snapshot. Reading it before BEGIN IMMEDIATE lets a newer loop
+        # event land while this call is waiting and then be released by stale
+        # state from the previous generation.
+        frozen_triage = is_block_loop_frozen(conn, task_id)
         stale = conn.execute(
             "SELECT current_run_id FROM tasks WHERE id = ? "
             "AND (status IN ('blocked', 'scheduled') OR (status = 'triage' AND ?))",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3497,6 +3497,8 @@ def claim_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        if is_block_loop_frozen(conn, task_id):
+            return None
         # Structural invariant: never transition ready -> running while any
         # parent is not yet 'done'. This is the single enforcement point
         # regardless of which writer (create_task, link_tasks, unblock_task,
@@ -3626,6 +3628,8 @@ def claim_review_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        if is_block_loop_frozen(conn, task_id):
+            return None
         cur = conn.execute(
             """
             UPDATE tasks
@@ -5160,7 +5164,7 @@ def promote_task(
 
 
 def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
-    """Transition ``blocked``/``scheduled`` -> ready or todo.
+    """Transition ``blocked``/``scheduled`` or a frozen triage task.
 
     Defensively closes any stale ``current_run_id`` pointer before flipping
     status. In the common path (``block_task`` closed the run already) this
@@ -5170,10 +5174,12 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     state) holds for the rest of this function's lifetime.
     """
     now = int(time.time())
+    frozen_triage = is_block_loop_frozen(conn, task_id)
     with write_txn(conn):
         stale = conn.execute(
-            "SELECT current_run_id FROM tasks WHERE id = ? AND status IN ('blocked', 'scheduled')",
-            (task_id,),
+            "SELECT current_run_id FROM tasks WHERE id = ? "
+            "AND (status IN ('blocked', 'scheduled') OR (status = 'triage' AND ?))",
+            (task_id, int(frozen_triage)),
         ).fetchone()
         if stale and stale["current_run_id"]:
             conn.execute(
@@ -5213,8 +5219,9 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         cur = conn.execute(
             "UPDATE tasks SET status = ?, current_run_id = NULL, "
             "consecutive_failures = 0, last_failure_error = NULL "
-            "WHERE id = ? AND status IN ('blocked', 'scheduled')",
-            (new_status, task_id),
+            "WHERE id = ? AND (status IN ('blocked', 'scheduled') "
+            "OR (status = 'triage' AND ?))",
+            (new_status, task_id, int(frozen_triage)),
         )
         if cur.rowcount != 1:
             return False
@@ -5233,6 +5240,7 @@ def specify_triage_task(
     body: Optional[str] = None,
     assignee: Optional[str] = None,
     author: Optional[str] = None,
+    respect_block_loop_freeze: bool = False,
 ) -> bool:
     """Flesh out a triage task and promote it to ``todo``.
 
@@ -5254,6 +5262,8 @@ def specify_triage_task(
         raise ValueError("title cannot be blank")
     assignee = _canonical_assignee(assignee)
     with write_txn(conn):
+        if respect_block_loop_freeze and is_block_loop_frozen(conn, task_id):
+            return False
         existing = conn.execute(
             "SELECT title, body, assignee FROM tasks WHERE id = ? AND status = 'triage'",
             (task_id,),
@@ -5324,6 +5334,7 @@ def decompose_triage_task(
     children: list[dict],
     author: Optional[str] = None,
     auto_promote: bool = True,
+    respect_block_loop_freeze: bool = False,
 ) -> Optional[list[str]]:
     """Fan a triage task out into child tasks and promote the root to ``todo``.
 
@@ -5408,6 +5419,8 @@ def decompose_triage_task(
     now = int(time.time())
     child_ids: list[str] = []
     with write_txn(conn):
+        if respect_block_loop_freeze and is_block_loop_frozen(conn, task_id):
+            return None
         root_row = conn.execute(
             "SELECT id, status, tenant, workspace_kind, workspace_path "
             "FROM tasks WHERE id = ?",
@@ -7244,6 +7257,29 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
 _clear_spawn_failures = _clear_failure_counter
 
 
+def is_block_loop_frozen(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Return whether the block-loop breaker still forbids automation.
+
+    ``block_loop_detected`` is a circuit breaker, not merely another triage
+    reason. Once emitted, automation must not recycle the task. Only a later
+    authoritative ``unblocked`` event releases it; comments and cosmetic
+    status/body/specification events deliberately do not.
+    """
+    loop = conn.execute(
+        "SELECT MAX(id) AS event_id FROM task_events "
+        "WHERE task_id = ? AND kind = 'block_loop_detected'",
+        (task_id,),
+    ).fetchone()
+    loop_event_id = int(loop["event_id"] or 0) if loop else 0
+    if not loop_event_id:
+        return False
+    rearm = conn.execute(
+        "SELECT 1 FROM task_events WHERE task_id = ? AND kind = 'unblocked' "
+        "AND id > ? LIMIT 1",
+        (task_id, loop_event_id),
+    ).fetchone()
+    return rearm is None
+
 def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
     """Return a guard reason if ``task_id`` should NOT be re-spawned, else None.
 
@@ -7284,14 +7320,14 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
 
     ``"active_pr"``
         A GitHub PR URL appears in a recent task comment (within
-        ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
+        ``_RESPAWN_GUARD_PR_WINDOW`` seconds). A prior worker already
         opened a PR; re-spawning risks a duplicate PR on the same task.
 
-    Stale / dead claim locks are NOT a guard reason — they are handled
-    by ``release_stale_claims`` and ``detect_crashed_workers`` which
-    reset the task to ``ready`` only after verifying the lock is
-    genuinely dead (no live PID on this host).
+    Stale / dead claim locks are handled separately by the dispatcher.
     """
+    if is_block_loop_frozen(conn, task_id):
+        return "block_loop_frozen"
+
     row = conn.execute(
         "SELECT last_failure_error FROM tasks WHERE id = ?",
         (task_id,),
@@ -7840,6 +7876,16 @@ def _dispatch_once_locked(
             break
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
+            continue
+        guard_reason = check_respawn_guard(conn, row["id"])
+        if guard_reason is not None:
+            result.respawn_guarded.append((row["id"], guard_reason))
+            if not dry_run:
+                with write_txn(conn):
+                    _append_event(
+                        conn, row["id"], "respawn_guarded",
+                        {"reason": guard_reason},
+                    )
             continue
         try:
             from hermes_cli.profiles import profile_exists

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -71,6 +71,7 @@ new locking.
 from __future__ import annotations
 
 import contextlib
+import errno
 import hashlib
 import json
 import os
@@ -124,14 +125,13 @@ VALID_INITIAL_STATUSES = {"running", "blocked"}
 # ``None`` = legacy/un-typed block (treated as a generic human blocker).
 VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 
-# After a task has been blocked, unblocked, and re-blocked this many times for
-# the same (truly-blocked) reason, the unblock-loop breaker stops trusting the
-# unblocker (usually a cron) and routes the task to ``triage`` instead of back
-# to ``blocked`` — breaking the infinite unblock↔re-block loop and forcing a
-# human-in-the-loop decision. Mirrors the dispatcher's ``DEFAULT_FAILURE_LIMIT``
-# spirit (default 2) but counts a different signal: manual unblock recurrences,
-# not dispatcher spawn/crash/timeout failures.
-BLOCK_RECURRENCE_LIMIT = 2
+# A materially identical failure/block outcome may run three times. The third
+# occurrence atomically freezes the task; there is never a fourth automatic
+# attempt. This is deliberately independent from ``failure_limit`` (the retry
+# budget for process/spawn failures, not a durable same-root-cause breaker).
+FAILURE_RECURRENCE_LIMIT = 3
+# Backward-compatible name used by older callers/tests.
+BLOCK_RECURRENCE_LIMIT = FAILURE_RECURRENCE_LIMIT
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
@@ -915,6 +915,13 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Durable recurring-outcome circuit breaker. The fingerprint hashes
+    # normalized kind/reason/error, so volatile ids and timestamps do not split
+    # one root cause into fake uniques. A non-NULL frozen timestamp forbids all
+    # automatic claims/rearms until an audited operator rearm.
+    failure_fingerprint: Optional[str] = None
+    failure_recurrences: int = 0
+    failure_frozen_at: Optional[int] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -998,6 +1005,21 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            failure_fingerprint=(
+                row["failure_fingerprint"]
+                if "failure_fingerprint" in keys and row["failure_fingerprint"]
+                else None
+            ),
+            failure_recurrences=(
+                int(row["failure_recurrences"])
+                if "failure_recurrences" in keys and row["failure_recurrences"] is not None
+                else 0
+            ),
+            failure_frozen_at=(
+                int(row["failure_frozen_at"])
+                if "failure_frozen_at" in keys and row["failure_frozen_at"] is not None
+                else None
             ),
         )
 
@@ -1176,7 +1198,12 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Stable recurring failure/block state. Unlike consecutive_failures this
+    -- survives ordinary unblock/reclaim cycles and freezes on occurrence 3.
+    failure_fingerprint TEXT,
+    failure_recurrences INTEGER NOT NULL DEFAULT 0,
+    failure_frozen_at   INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1985,6 +2012,20 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "tasks",
             "block_recurrences",
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
+        )
+
+    if "failure_fingerprint" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "failure_fingerprint", "failure_fingerprint TEXT"
+        )
+    if "failure_recurrences" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "failure_recurrences",
+            "failure_recurrences INTEGER NOT NULL DEFAULT 0",
+        )
+    if "failure_frozen_at" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "failure_frozen_at", "failure_frozen_at INTEGER"
         )
 
     # Indexes over additive ``tasks`` columns must be created after the
@@ -3432,6 +3473,8 @@ def recompute_ready(
         for row in todo_rows:
             task_id = row["id"]
             cur_status = row["status"]
+            if is_task_frozen(conn, task_id):
+                continue
             if cur_status == "blocked" and _has_sticky_block(conn, task_id):
                 # Worker / operator asked for human review — do not
                 # silently auto-recover.  ``unblock_task`` is the only
@@ -3877,6 +3920,8 @@ def reclaim_task(
     Returns True if a reclaim happened, False if the task isn't in a
     reclaimable state (not running, or doesn't exist).
     """
+    if is_task_frozen(conn, task_id):
+        return False
     row = conn.execute(
         "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?",
         (task_id,),
@@ -4177,7 +4222,10 @@ def complete_task(
                        claim_expires= NULL,
                        worker_pid   = NULL,
                        block_kind   = NULL,
-                       block_recurrences = 0
+                       block_recurrences = 0,
+                       failure_fingerprint = NULL,
+                       failure_recurrences = 0,
+                       failure_frozen_at = NULL
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked')
                 """,
@@ -4194,7 +4242,10 @@ def complete_task(
                        claim_expires= NULL,
                        worker_pid   = NULL,
                        block_kind   = NULL,
-                       block_recurrences = 0
+                       block_recurrences = 0,
+                       failure_fingerprint = NULL,
+                       failure_recurrences = 0,
+                       failure_frozen_at = NULL
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked')
                    AND current_run_id = ?
@@ -4877,6 +4928,121 @@ def edit_completed_task_result(
     return True
 
 
+_ISO_TIMESTAMP_RE = re.compile(
+    r"\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?\b",
+    re.IGNORECASE,
+)
+_UUID_RE = re.compile(
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b",
+    re.IGNORECASE,
+)
+_VOLATILE_LABELED_REQUEST_ID_RE = re.compile(
+    r"\b(?:request|req)[\s_-]*id\b\s*(?:=|:)?\s*"
+    r"[a-z0-9][a-z0-9._-]{5,}\b",
+    re.IGNORECASE,
+)
+_VOLATILE_NAMED_ID_RE = re.compile(
+    r"\b(?:t|req(?:uest)?|run|job|trace|span)[_:\-][a-z0-9_-]{6,}\b",
+    re.IGNORECASE,
+)
+_ATTACHED_DIAGNOSTIC_SUFFIX_RE = re.compile(r"([.-])([A-Z][A-Z0-9_]{2,})$")
+_ERRNO_NAMES = frozenset(errno.errorcode.values())
+
+
+def _replace_volatile_id(match: re.Match[str], replacement: str) -> str:
+    """Replace an id while retaining an attached POSIX-style error code."""
+    diagnostic = _ATTACHED_DIAGNOSTIC_SUFFIX_RE.search(match.group(0))
+    if diagnostic and diagnostic.group(2) in _ERRNO_NAMES:
+        return replacement + diagnostic.group(1) + diagnostic.group(2)
+    return replacement
+
+
+def _normalize_failure_text(value: Optional[str]) -> str:
+    """Remove volatile identity/time noise while preserving root-cause text."""
+    # Preserve case until IDs are replaced: punctuation-attached POSIX error
+    # codes are diagnostic, while ordinary dotted/hyphenated ID parts remain
+    # part of the volatile identifier.
+    text = " ".join((value or "").strip().split())
+    text = _ISO_TIMESTAMP_RE.sub("<timestamp>", text)
+    text = _UUID_RE.sub("<uuid>", text)
+    text = _VOLATILE_LABELED_REQUEST_ID_RE.sub(
+        lambda match: _replace_volatile_id(match, "request id <id>"), text,
+    )
+    text = _VOLATILE_NAMED_ID_RE.sub(
+        lambda match: _replace_volatile_id(match, "<id>"), text,
+    )
+    text = text.lower()
+    text = re.sub(r"\bpid\s*[=:]?\s*\d+\b", "pid <n>", text)
+    text = re.sub(r"\b0x[0-9a-f]+\b", "<address>", text)
+    text = re.sub(r"\b\d{10,}\b", "<number>", text)
+    max_length = 2000
+    if len(text) <= max_length:
+        return text
+    omission_marker = " <...> "
+    head_length = (max_length - len(omission_marker)) // 2
+    tail_length = max_length - len(omission_marker) - head_length
+    return text[:head_length] + omission_marker + text[-tail_length:]
+
+
+def failure_fingerprint(
+    *, kind: Optional[str], reason: Optional[str] = None,
+    error: Optional[str] = None,
+) -> str:
+    """Return a stable digest for one structured failure/block outcome."""
+    canonical = json.dumps(
+        {
+            "kind": (kind or "unknown").strip().lower(),
+            "reason": _normalize_failure_text(reason),
+            "error": _normalize_failure_text(error),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _record_failure_recurrence_locked(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    kind: str,
+    reason: Optional[str] = None,
+    error: Optional[str] = None,
+) -> tuple[str, int, Optional[int]]:
+    """Persist one outcome under the caller's write transaction."""
+    row = conn.execute(
+        "SELECT failure_fingerprint, failure_recurrences, failure_frozen_at "
+        "FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if row is None:
+        return "", 0, None
+    fingerprint = failure_fingerprint(kind=kind, reason=reason, error=error)
+    same = row["failure_fingerprint"] == fingerprint
+    recurrences = int(row["failure_recurrences"] or 0) + 1 if same else 1
+    frozen_at = row["failure_frozen_at"]
+    if frozen_at is None and recurrences >= FAILURE_RECURRENCE_LIMIT:
+        frozen_at = int(time.time())
+    conn.execute(
+        "UPDATE tasks SET failure_fingerprint = ?, failure_recurrences = ?, "
+        "failure_frozen_at = ? WHERE id = ?",
+        (fingerprint, recurrences, frozen_at, task_id),
+    )
+    payload = {
+        "fingerprint": fingerprint,
+        "recurrences": recurrences,
+        "limit": FAILURE_RECURRENCE_LIMIT,
+        "outcome_kind": kind,
+    }
+    _append_event(conn, task_id, "failure_recurrence_recorded", payload)
+    if frozen_at is not None and not row["failure_frozen_at"]:
+        _append_event(
+            conn, task_id, "failure_frozen",
+            {**payload, "reason": reason, "error": error, "frozen_at": frozen_at},
+        )
+    return fingerprint, recurrences, int(frozen_at) if frozen_at is not None else None
+
+
 def block_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4920,24 +5086,31 @@ def block_task(
     recurrences = 0
     with write_txn(conn):
         cur_row = conn.execute(
-            "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
+            "SELECT status, current_run_id, block_kind, block_recurrences "
+            "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         if cur_row is None:
             return False
-        prev_kind = cur_row["block_kind"] if "block_kind" in cur_row.keys() else None
-        prev_recurrences = (
-            int(cur_row["block_recurrences"])
-            if "block_recurrences" in cur_row.keys()
-            and cur_row["block_recurrences"] is not None
-            else 0
+        if cur_row["status"] not in ("running", "ready"):
+            return False
+        if (
+            expected_run_id is not None
+            and cur_row["current_run_id"] != int(expected_run_id)
+        ):
+            return False
+        fingerprint, recurrences, frozen_at = _record_failure_recurrence_locked(
+            conn,
+            task_id,
+            kind=f"blocked:{kind or 'legacy'}",
+            reason=reason,
         )
 
         # Dependency blocks never enter the human ``blocked`` bucket — they
         # wait in ``todo`` and let ``recompute_ready`` gate on parents. Routing
         # here (rather than ``blocked``) is what keeps a cron from ever seeing
         # a dependency-wait as something to "unblock".
-        if kind == "dependency":
+        if kind == "dependency" and frozen_at is None:
             cur = conn.execute(
                 """
                 UPDATE tasks
@@ -4979,16 +5152,7 @@ def block_task(
             )
             return True
 
-        # Truly-blocked kinds. Increment the unblock-loop counter when this is a
-        # re-block for the SAME reason after a prior unblock. block_task only
-        # fires from running/ready (i.e. AFTER an unblock returned the task to
-        # the work pool), so a stored block_kind that matches the incoming kind
-        # means: blocked → unblocked → about-to-re-block for the same cause.
-        # An un-typed (None) block compares as "same" to a prior un-typed block.
-        same_cause = prev_kind == kind
-        recurrences = prev_recurrences + 1 if same_cause else 1
-
-        if recurrences >= BLOCK_RECURRENCE_LIMIT:
+        if frozen_at is not None:
             # Loop detected — stop letting the unblocker spin this task. Route
             # to triage for a human-in-the-loop decision instead of blocked.
             cur = conn.execute(
@@ -5022,8 +5186,9 @@ def block_task(
                 {
                     "reason": reason,
                     "kind": kind,
+                    "fingerprint": fingerprint,
                     "recurrences": recurrences,
-                    "limit": BLOCK_RECURRENCE_LIMIT,
+                    "limit": FAILURE_RECURRENCE_LIMIT,
                 },
                 run_id=run_id,
             )
@@ -5112,6 +5277,11 @@ def promote_task(
     ``(False, reason)`` if refused. ``dry_run=True`` validates the
     promotion would succeed without mutating state.
     """
+    if is_task_frozen(conn, task_id):
+        return False, (
+            "task is frozen after three materially identical outcomes; "
+            "explicit rearm required"
+        )
     row = conn.execute(
         "SELECT status FROM tasks WHERE id = ?", (task_id,)
     ).fetchone()
@@ -5163,7 +5333,13 @@ def promote_task(
     return True, None
 
 
-def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
+def unblock_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    actor: Optional[str] = None,
+    reason: Optional[str] = None,
+) -> bool:
     """Transition ``blocked``/``scheduled`` or a frozen triage task.
 
     Defensively closes any stale ``current_run_id`` pointer before flipping
@@ -5179,10 +5355,33 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         # write snapshot. Reading it before BEGIN IMMEDIATE lets a newer loop
         # event land while this call is waiting and then be released by stale
         # state from the previous generation.
-        frozen_triage = is_block_loop_frozen(conn, task_id)
+        frozen_triage = is_task_frozen(conn, task_id)
+        authoritative_change = False
+        if frozen_triage:
+            freeze_event = conn.execute(
+                "SELECT MAX(id) AS event_id FROM task_events WHERE task_id = ? "
+                "AND kind IN ('failure_frozen', 'block_loop_detected')",
+                (task_id,),
+            ).fetchone()
+            freeze_event_id = int(freeze_event["event_id"] or 0) if freeze_event else 0
+            changed = conn.execute(
+                "SELECT payload FROM task_events WHERE task_id = ? AND id > ? "
+                "AND kind = 'specified' ORDER BY id DESC LIMIT 1",
+                (task_id, freeze_event_id),
+            ).fetchone()
+            if changed and changed["payload"]:
+                try:
+                    authoritative_change = bool(
+                        json.loads(changed["payload"]).get("changed_fields")
+                    )
+                except (TypeError, ValueError):
+                    authoritative_change = False
+            if not (reason and reason.strip()) and not authoritative_change:
+                return False
         stale = conn.execute(
             "SELECT current_run_id FROM tasks WHERE id = ? "
-            "AND (status IN ('blocked', 'scheduled') OR (status = 'triage' AND ?))",
+            "AND (status IN ('blocked', 'scheduled') "
+            "OR (status IN ('triage', 'todo') AND ?))",
             (task_id, int(frozen_triage)),
         ).fetchone()
         if stale and stale["current_run_id"]:
@@ -5222,16 +5421,41 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         # start for the dispatcher's retry budget.
         cur = conn.execute(
             "UPDATE tasks SET status = ?, current_run_id = NULL, "
-            "consecutive_failures = 0, last_failure_error = NULL "
+            "consecutive_failures = 0, last_failure_error = NULL, "
+            "failure_fingerprint = CASE WHEN ? THEN NULL ELSE failure_fingerprint END, "
+            "failure_recurrences = CASE WHEN ? THEN 0 ELSE failure_recurrences END, "
+            "failure_frozen_at = CASE WHEN ? THEN NULL ELSE failure_frozen_at END, "
+            "block_recurrences = CASE WHEN ? THEN 0 ELSE block_recurrences END "
             "WHERE id = ? AND (status IN ('blocked', 'scheduled') "
-            "OR (status = 'triage' AND ?))",
-            (new_status, task_id, int(frozen_triage)),
+            "OR (status IN ('triage', 'todo') AND ?))",
+            (
+                new_status,
+                int(frozen_triage), int(frozen_triage),
+                int(frozen_triage), int(frozen_triage),
+                task_id, int(frozen_triage),
+            ),
         )
         if cur.rowcount != 1:
             return False
+        if frozen_triage:
+            _append_event(
+                conn,
+                task_id,
+                "failure_rearmed",
+                {
+                    "actor": (actor or "operator").strip(),
+                    "reason": reason.strip() if reason else None,
+                    "authoritative_change": authoritative_change,
+                },
+            )
         _append_event(
             conn, task_id, "unblocked",
-            {"status": new_status} if new_status != "ready" else None,
+            {
+                "status": new_status,
+                "actor": actor,
+                "reason": reason,
+                "rearmed": frozen_triage,
+            },
         )
         return True
 
@@ -7101,8 +7325,12 @@ def _record_task_failure(
         ).fetchone()
         if row is None:
             return False
+        if row["status"] not in ("running", "ready"):
+            return False
         failures = int(row["consecutive_failures"]) + 1
-        cur_status = row["status"]
+        fingerprint, recurrences, frozen_at = _record_failure_recurrence_locked(
+            conn, task_id, kind=outcome, error=error,
+        )
 
         # Per-task override wins over both caller-supplied and default
         # thresholds. None (the common case) falls through.
@@ -7116,26 +7344,27 @@ def _record_task_failure(
             effective_limit = int(failure_limit)
             limit_source = "dispatcher"
 
-        if force_trip or failures >= effective_limit:
+        if force_trip or failures >= effective_limit or frozen_at is not None:
             # Trip the breaker.
+            terminal_status = "triage" if frozen_at is not None else "blocked"
             if release_claim:
                 # Spawn path: still running, also clear claim state.
                 conn.execute(
-                    "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
+                    "UPDATE tasks SET status = ?, claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status IN ('running', 'ready')",
-                    (failures, error[:500], task_id),
+                    (terminal_status, failures, error[:500], task_id),
                 )
             else:
                 # Timeout/crash path: task is already at ``ready``
                 # with claim cleared; just flip to blocked + update
                 # counter fields.
                 conn.execute(
-                    "UPDATE tasks SET status = 'blocked', "
+                    "UPDATE tasks SET status = ?, "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status IN ('ready', 'running')",
-                    (failures, error[:500], task_id),
+                    (terminal_status, failures, error[:500], task_id),
                 )
             run_id = None
             if end_run:
@@ -7157,6 +7386,9 @@ def _record_task_failure(
                 "limit_source": limit_source,
                 "error": error[:500],
                 "trigger_outcome": outcome,
+                "fingerprint": fingerprint,
+                "recurrences": recurrences,
+                "frozen": frozen_at is not None,
             }
             if event_payload_extra:
                 payload.update(event_payload_extra)
@@ -7261,14 +7493,18 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
 _clear_spawn_failures = _clear_failure_counter
 
 
-def is_block_loop_frozen(conn: sqlite3.Connection, task_id: str) -> bool:
-    """Return whether the block-loop breaker still forbids automation.
+def is_task_frozen(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Return whether the durable recurring-outcome breaker forbids automation.
 
-    ``block_loop_detected`` is a circuit breaker, not merely another triage
-    reason. Once emitted, automation must not recycle the task. Only a later
-    authoritative ``unblocked`` event releases it; comments and cosmetic
-    status/body/specification events deliberately do not.
+    New boards use the persisted ``failure_frozen_at`` state. The event query is
+    retained as a compatibility fallback for boards frozen by pre-migration
+    versions, where a later explicit ``unblocked`` event was the rearm marker.
     """
+    row = conn.execute(
+        "SELECT failure_frozen_at FROM tasks WHERE id = ?", (task_id,),
+    ).fetchone()
+    if row and row["failure_frozen_at"] is not None:
+        return True
     loop = conn.execute(
         "SELECT MAX(id) AS event_id FROM task_events "
         "WHERE task_id = ? AND kind = 'block_loop_detected'",
@@ -7283,6 +7519,11 @@ def is_block_loop_frozen(conn: sqlite3.Connection, task_id: str) -> bool:
         (task_id, loop_event_id),
     ).fetchone()
     return rearm is None
+
+
+def is_block_loop_frozen(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Backward-compatible alias for :func:`is_task_frozen`."""
+    return is_task_frozen(conn, task_id)
 
 def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
     """Return a guard reason if ``task_id`` should NOT be re-spawned, else None.

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -273,6 +273,7 @@ def decompose_task(
     *,
     author: Optional[str] = None,
     timeout: Optional[int] = None,
+    automatic: bool = False,
 ) -> DecomposeOutcome:
     """Decompose a triage task into a graph of child tasks.
 
@@ -362,6 +363,10 @@ def decompose_task(
                 task_id, False, "decomposer returned fanout=false with no title/body",
             )
         with kb.connect_closing() as conn:
+            if automatic and kb.is_block_loop_frozen(conn, task_id):
+                return DecomposeOutcome(
+                    task_id, False, "task acquired a block-loop freeze during decomposition",
+                )
             ok = kb.specify_triage_task(
                 conn,
                 task_id,
@@ -369,8 +374,15 @@ def decompose_task(
                 body=body_val,
                 assignee=assignee_val,
                 author=audit_author,
+                respect_block_loop_freeze=automatic,
             )
         if not ok:
+            if automatic:
+                with kb.connect_closing() as conn:
+                    if kb.is_block_loop_frozen(conn, task_id):
+                        return DecomposeOutcome(
+                            task_id, False, "task acquired a block-loop freeze during decomposition",
+                        )
             return DecomposeOutcome(
                 task_id, False, "task moved out of triage before promotion",
             )
@@ -431,6 +443,10 @@ def decompose_task(
 
     try:
         with kb.connect_closing() as conn:
+            if automatic and kb.is_block_loop_frozen(conn, task_id):
+                return DecomposeOutcome(
+                    task_id, False, "task acquired a block-loop freeze during decomposition",
+                )
             child_ids = kb.decompose_triage_task(
                 conn,
                 task_id,
@@ -438,6 +454,7 @@ def decompose_task(
                 children=children,
                 author=audit_author,
                 auto_promote=auto_promote,
+                respect_block_loop_freeze=automatic,
             )
     except ValueError as exc:
         return DecomposeOutcome(task_id, False, f"DB rejected graph: {exc}")
@@ -446,6 +463,12 @@ def decompose_task(
         return DecomposeOutcome(task_id, False, f"DB error: {type(exc).__name__}")
 
     if child_ids is None:
+        if automatic:
+            with kb.connect_closing() as conn:
+                if kb.is_block_loop_frozen(conn, task_id):
+                    return DecomposeOutcome(
+                        task_id, False, "task acquired a block-loop freeze during decomposition",
+                    )
         return DecomposeOutcome(
             task_id, False, "task moved out of triage before decomposition",
         )
@@ -456,8 +479,10 @@ def decompose_task(
     )
 
 
-def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
-    """Return task ids currently in the triage column."""
+def list_triage_ids(
+    *, tenant: Optional[str] = None, auto_only: bool = False,
+) -> list[str]:
+    """Return triage ids, optionally excluding circuit-breaker escalations."""
     with kb.connect_closing() as conn:
         rows = kb.list_tasks(
             conn,
@@ -465,4 +490,9 @@ def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
             tenant=tenant,
             limit=1000,
         )
+        if auto_only:
+            rows = [
+                row for row in rows
+                if not kb.is_block_loop_frozen(conn, row.id)
+            ]
     return [row.id for row in rows]

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -855,8 +855,16 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
             elif s == "ready":
                 # Re-open a blocked/scheduled task, or just an explicit status set.
                 current = kanban_db.get_task(conn, task_id)
-                if current and current.status in ("blocked", "scheduled", "triage"):
-                    ok = kanban_db.unblock_task(conn, task_id)
+                if current and (
+                    current.status in ("blocked", "scheduled")
+                    or kanban_db.is_task_frozen(conn, task_id)
+                ):
+                    ok = kanban_db.unblock_task(
+                        conn,
+                        task_id,
+                        actor="dashboard-operator",
+                        reason=payload.block_reason,
+                    )
                 else:
                     # Direct status write for drag-drop (todo -> ready etc).
                     ok = _set_status_direct(conn, task_id, "ready")
@@ -1152,6 +1160,7 @@ class BulkTaskBody(BaseModel):
     priority: Optional[int] = None
     archive: bool = False
     result: Optional[str] = None
+    block_reason: Optional[str] = None
     summary: Optional[str] = None
     metadata: Optional[dict] = None
     reclaim_first: bool = False
@@ -1195,8 +1204,16 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                         ok = kanban_db.block_task(conn, tid)
                     elif s == "ready":
                         cur = kanban_db.get_task(conn, tid)
-                        if cur and cur.status in ("blocked", "scheduled"):
-                            ok = kanban_db.unblock_task(conn, tid)
+                        if cur and (
+                            cur.status in ("blocked", "scheduled")
+                            or kanban_db.is_task_frozen(conn, tid)
+                        ):
+                            ok = kanban_db.unblock_task(
+                                conn,
+                                tid,
+                                actor="dashboard-operator",
+                                reason=payload.block_reason,
+                            )
                         else:
                             ok = _set_status_direct(conn, tid, "ready")
                     elif s == "running":

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -855,7 +855,7 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
             elif s == "ready":
                 # Re-open a blocked/scheduled task, or just an explicit status set.
                 current = kanban_db.get_task(conn, task_id)
-                if current and current.status in ("blocked", "scheduled"):
+                if current and current.status in ("blocked", "scheduled", "triage"):
                     ok = kanban_db.unblock_task(conn, task_id)
                 else:
                     # Direct status write for drag-drop (todo -> ready etc).

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -78,27 +78,29 @@ def test_unblock_does_not_reset_recurrence_counter(kanban_home: Path) -> None:
         assert t.block_kind == "needs_input"  # kind preserved for comparison
 
 
-def test_same_cause_reblock_routes_to_triage(kanban_home: Path) -> None:
-    """Dale's loop: block → unblock → re-block same kind → triage."""
+def test_same_cause_third_block_routes_to_triage(kanban_home: Path) -> None:
+    """Dale's loop gets exactly three attempts before terminal triage."""
     with kb.connect_closing() as conn:
         tid = _running_task(conn)
-        kb.block_task(conn, tid, reason="need creds", kind="needs_input")
-        kb.unblock_task(conn, tid)
-        _make_running_again(conn, tid)
-        kb.block_task(conn, tid, reason="still need creds", kind="needs_input")
+        for attempt in range(3):
+            kb.block_task(conn, tid, reason="need creds", kind="needs_input")
+            if attempt < 2:
+                kb.unblock_task(conn, tid)
+                _make_running_again(conn, tid)
         t = kb.get_task(conn, tid)
         assert t.status == "triage"
-        assert t.block_recurrences == 2
+        assert t.block_recurrences == 3
 
 
 def test_untyped_block_loop_also_protected(kanban_home: Path) -> None:
     """Legacy un-typed blocks (kind=None) still trip the breaker."""
     with kb.connect_closing() as conn:
         tid = _running_task(conn)
-        kb.block_task(conn, tid, reason="a")
-        kb.unblock_task(conn, tid)
-        _make_running_again(conn, tid)
-        kb.block_task(conn, tid, reason="a again")
+        for attempt in range(3):
+            kb.block_task(conn, tid, reason="a")
+            if attempt < 2:
+                kb.unblock_task(conn, tid)
+                _make_running_again(conn, tid)
         assert kb.get_task(conn, tid).status == "triage"
 
 
@@ -118,15 +120,16 @@ def test_different_kinds_do_not_compound(kanban_home: Path) -> None:
 def test_block_loop_detected_event_emitted(kanban_home: Path) -> None:
     with kb.connect_closing() as conn:
         tid = _running_task(conn)
-        kb.block_task(conn, tid, reason="x", kind="capability")
-        kb.unblock_task(conn, tid)
-        _make_running_again(conn, tid)
-        kb.block_task(conn, tid, reason="x", kind="capability")
+        for attempt in range(3):
+            kb.block_task(conn, tid, reason="x", kind="capability")
+            if attempt < 2:
+                kb.unblock_task(conn, tid)
+                _make_running_again(conn, tid)
         events = [e for e in kb.list_events(conn, tid)
                   if e.kind == "block_loop_detected"]
         assert events, "expected a block_loop_detected event"
         payload = events[-1].payload or {}
-        assert payload.get("recurrences") == 2
+        assert payload.get("recurrences") == 3
         assert payload.get("kind") == "capability"
 
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -357,7 +357,8 @@ def test_workspace_resolution_failure_also_counts(kanban_home, all_assignees_spa
         res = kb.dispatch_once(conn, failure_limit=3)
         assert tid in res.auto_blocked
         task = kb.get_task(conn, tid)
-        assert task.status == "blocked"
+        assert task.status == "triage"
+        assert task.failure_frozen_at is not None
     finally:
         conn.close()
 
@@ -1607,9 +1608,10 @@ def test_run_on_block_with_reason(kanban_home):
         conn.close()
 
 
-def test_run_on_spawn_failure_records_failed_runs(kanban_home, all_assignees_spawnable):
-    """Each spawn_failed event closes a run with outcome='spawn_failed',
-    and the Nth failure closes a run with outcome='gave_up'."""
+def test_run_on_spawn_failure_freezes_after_three_identical_runs(
+    kanban_home, all_assignees_spawnable,
+):
+    """The durable recurrence breaker caps identical spawn failures at three."""
     def _bad(task, ws):
         raise RuntimeError("no PATH")
 
@@ -1620,12 +1622,15 @@ def test_run_on_spawn_failure_records_failed_runs(kanban_home, all_assignees_spa
             kb.dispatch_once(conn, spawn_fn=_bad, failure_limit=5)
 
         runs = kb.list_runs(conn, tid)
-        # 5 claim attempts → 5 runs. Final one is gave_up, earlier ones
-        # are spawn_failed.
-        assert len(runs) == 5
+        # failure_limit=5 remains a process retry budget; the recurring-root-
+        # cause breaker independently guarantees no fourth identical run.
+        assert len(runs) == 3
         assert runs[-1].outcome == "gave_up"
         assert all(r.outcome == "spawn_failed" for r in runs[:-1])
         assert runs[-1].error and "no PATH" in runs[-1].error
+        task = kb.get_task(conn, tid)
+        assert task.status == "triage"
+        assert task.failure_frozen_at is not None
     finally:
         conn.close()
 
@@ -4368,10 +4373,11 @@ def test_repeated_timeouts_trip_the_circuit_breaker(kanban_home, monkeypatch):
             kb.enforce_max_runtime(conn, signal_fn=_signal)
 
         final = kb.get_task(conn, tid)
-        # After 3 consecutive timeouts with failure_limit=3, task should
-        # be auto-blocked, not looping forever as ``ready``.
-        assert final.status == "blocked", \
-            f"expected blocked after 3 timeouts, got {final.status}"
+        # After three materially identical timeouts the durable breaker
+        # freezes terminally rather than entering the ordinary blocked bucket.
+        assert final.status == "triage", \
+            f"expected triage after 3 timeouts, got {final.status}"
+        assert final.failure_frozen_at is not None
         assert final.consecutive_failures >= 3
         # ``gave_up`` event emitted (plus 3 ``timed_out`` events).
         kinds = [

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1809,6 +1809,111 @@ def test_dispatch_reclaims_stale_before_spawning(kanban_home):
 # Respawn guard (check_respawn_guard + dispatch_once integration)
 # ---------------------------------------------------------------------------
 
+def test_respawn_guard_freezes_block_loop_even_if_task_is_forced_ready(kanban_home):
+    """A cosmetic promotion cannot cause a third identical worker launch."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="looping", assignee="alice")
+        conn.execute("UPDATE tasks SET block_recurrences = 2 WHERE id = ?", (t,))
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'block_loop_detected', '{}', 100)",
+            (t,),
+        )
+        assert kb.check_respawn_guard(conn, t) == "block_loop_frozen"
+
+
+def test_respawn_guard_explicit_rearm_releases_block_loop(kanban_home):
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="looping", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET status = 'triage', block_recurrences = 2 WHERE id = ?",
+            (t,),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'block_loop_detected', '{}', 100)",
+            (t,),
+        )
+        assert kb.unblock_task(conn, t) is True
+        assert kb.check_respawn_guard(conn, t) is None
+
+
+def test_respawn_guard_worker_cannot_self_rearm_block_loop(kanban_home):
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="looping", assignee="dev")
+        conn.execute("UPDATE tasks SET block_recurrences = 2 WHERE id = ?", (t,))
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'block_loop_detected', '{}', 100)",
+            (t,),
+        )
+        kb.add_comment(conn, t, "dev", "rearm-approved: trust me")
+        assert kb.check_respawn_guard(conn, t) == "block_loop_frozen"
+
+
+def test_dispatch_does_not_spawn_block_loop_after_cosmetic_promotion(
+    kanban_home, all_assignees_spawnable
+):
+    spawned = []
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="looping", assignee="alice")
+        conn.execute("UPDATE tasks SET block_recurrences = 2 WHERE id = ?", (t,))
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'block_loop_detected', '{}', 100)",
+            (t,),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'specified', '{}', 101)",
+            (t,),
+        )
+        result = kb.dispatch_once(
+            conn, spawn_fn=lambda task, workspace: spawned.append(task.id)
+        )
+
+    assert spawned == []
+    assert (t, "block_loop_frozen") in result.respawn_guarded
+
+
+def test_dispatch_does_not_spawn_frozen_review_task(
+    kanban_home, all_assignees_spawnable
+):
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="looping review", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET status = 'review', block_recurrences = 2 WHERE id = ?",
+            (t,),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'block_loop_detected', '{}', 100)",
+            (t,),
+        )
+        result = kb.dispatch_once(conn, dry_run=True)
+
+    assert all(spawned[0] != t for spawned in result.spawned)
+    assert (t, "block_loop_frozen") in result.respawn_guarded
+
+def test_claim_primitives_refuse_frozen_tasks(kanban_home):
+    with kb.connect() as conn:
+        ready = kb.create_task(conn, title="ready loop", assignee="alice")
+        review = kb.create_task(conn, title="review loop", assignee="alice")
+        conn.execute("UPDATE tasks SET status='review' WHERE id=?", (review,))
+        for task_id in (ready, review):
+            conn.execute(
+                "INSERT INTO task_events (task_id, kind, payload, created_at) "
+                "VALUES (?, 'block_loop_detected', '{}', 100)",
+                (task_id,),
+            )
+
+        assert kb.claim_task(conn, ready) is None
+        assert kb.claim_review_task(conn, review) is None
+
+        assert kb.get_task(conn, ready).status == "ready"
+        assert kb.get_task(conn, review).status == "review"
+
+
 def test_respawn_guard_none_on_fresh_task(kanban_home):
     """A fresh task with no failures or runs is not guarded."""
     with kb.connect() as conn:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -7,6 +7,7 @@ import os
 import sqlite3
 import subprocess
 import sys
+import threading
 import time
 import types
 import unittest.mock
@@ -1805,6 +1806,375 @@ def test_dispatch_reclaims_stale_before_spawning(kanban_home):
     assert res.reclaimed == 1
 
 
+def test_identical_block_loop_runs_exactly_three_times_then_freezes(
+    kanban_home, all_assignees_spawnable
+):
+    """The recurring-outcome breaker trips on attempt three, never attempt two."""
+    attempts = []
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="looping", assignee="alice")
+
+        for attempt in range(1, 4):
+            claimed = kb.claim_task(conn, task_id, claimer=f"host:{attempt}")
+            assert claimed is not None
+            attempts.append(claimed.current_run_id)
+            assert kb.block_task(
+                conn,
+                task_id,
+                kind="needs_input",
+                reason=(
+                    f"upstream request req-{attempt:08d} failed at "
+                    f"2026-07-16T10:0{attempt}:00Z"
+                ),
+            )
+            if attempt < 3:
+                task = kb.get_task(conn, task_id)
+                assert task.status == "blocked"
+                assert task.failure_frozen_at is None
+                assert kb.unblock_task(conn, task_id) is True
+
+        frozen = kb.get_task(conn, task_id)
+        assert frozen.status == "triage"
+        assert frozen.failure_recurrences == 3
+        assert frozen.failure_fingerprint
+        assert frozen.failure_frozen_at is not None
+
+        # Every automatic/direct path must leave the third-attempt freeze intact.
+        assert kb.claim_task(conn, task_id) is None
+        assert kb.promote_task(conn, task_id, actor="cron", force=True)[0] is False
+        assert kb.reclaim_task(conn, task_id, reason="periodic sweep") is False
+        assert kb.recompute_ready(conn) == 0
+        assert kb.unblock_task(conn, task_id) is False
+        result = kb.dispatch_once(conn, dry_run=True)
+
+    assert len(attempts) == 3
+    assert all(row[0] != task_id for row in result.spawned)
+
+
+def test_materially_different_block_reason_starts_a_new_recurrence(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="changing failure", assignee="alice")
+        for reason in ("database unavailable", "missing OAuth approval"):
+            assert kb.claim_task(conn, task_id) is not None
+            assert kb.block_task(
+                conn, task_id, kind="capability", reason=reason,
+            ) is True
+            task = kb.get_task(conn, task_id)
+            assert task.failure_recurrences == 1
+            assert task.failure_frozen_at is None
+            assert kb.unblock_task(conn, task_id) is True
+
+
+def test_frozen_task_requires_audited_rearm_reason(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="looping", assignee="alice")
+        for attempt in range(3):
+            assert kb.claim_task(conn, task_id) is not None
+            assert kb.block_task(
+                conn, task_id, kind="needs_input", reason="same blocker",
+            ) is True
+            if attempt < 2:
+                assert kb.unblock_task(conn, task_id) is True
+
+        assert kb.unblock_task(conn, task_id) is False
+        assert kb.unblock_task(
+            conn,
+            task_id,
+            actor="cto",
+            reason="credentials were rotated and verified",
+        ) is True
+
+        task = kb.get_task(conn, task_id)
+        assert task.status == "ready"
+        assert task.failure_fingerprint is None
+        assert task.failure_recurrences == 0
+        assert task.failure_frozen_at is None
+        rearm = [e for e in kb.list_events(conn, task_id) if e.kind == "failure_rearmed"]
+        assert rearm[-1].payload == {
+            "actor": "cto",
+            "reason": "credentials were rotated and verified",
+            "authoritative_change": False,
+        }
+
+
+def test_authoritative_spec_change_can_rearm_without_free_text_reason(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="looping", assignee="alice")
+        for attempt in range(3):
+            assert kb.claim_task(conn, task_id) is not None
+            assert kb.block_task(
+                conn, task_id, kind="capability", reason="missing binary",
+            )
+            if attempt < 2:
+                assert kb.unblock_task(conn, task_id)
+
+        assert kb.specify_triage_task(
+            conn,
+            task_id,
+            body="Use the bundled binary at /opt/tool/bin/tool.",
+            author="operator",
+            respect_block_loop_freeze=False,
+        )
+        assert kb.get_task(conn, task_id).status == "todo"
+        assert kb.unblock_task(conn, task_id, actor="operator")
+
+        task = kb.get_task(conn, task_id)
+        assert task.status == "ready"
+        assert task.failure_frozen_at is None
+        rearm = [e for e in kb.list_events(conn, task_id) if e.kind == "failure_rearmed"][-1]
+        assert rearm.payload["authoritative_change"] is True
+
+
+def test_task_failure_fingerprint_normalizes_volatile_values(kanban_home):
+    first = kb.failure_fingerprint(
+        kind="blocked",
+        reason="task t_deadbeef request 550e8400-e29b-41d4-a716-446655440000 "
+        "failed at 2026-07-16T10:01:02Z pid 1234",
+    )
+    second = kb.failure_fingerprint(
+        kind="blocked",
+        reason="task t_cafebabe request 123e4567-e89b-12d3-a456-426614174000 "
+        "failed at 2026-07-17T11:12:13+00:00 pid 9876",
+    )
+    assert first == second
+
+
+def test_task_failure_fingerprint_normalizes_labeled_request_ids(kanban_home):
+    """Common request_id syntax must not evade same-root-cause detection."""
+    fingerprints = {
+        kb.failure_fingerprint(
+            kind="crashed",
+            error=f"{label} failed at {timestamp}: connection reset",
+        )
+        for label, timestamp in (
+            ("request_id=01J2ABCDEF1234567890", "2026-07-16T10:01:02Z"),
+            ("request id 01J2ZZZZZZ9876543210", "2026-07-17T11:12:13Z"),
+            ("request-id: 01J2QQQQQQ1234567890", "2026-07-18T12:13:14Z"),
+        )
+    }
+    assert len(fingerprints) == 1
+
+
+def test_task_failure_fingerprint_preserves_changed_root_cause(kanban_home):
+    shared_noise = (
+        "request_id=01J2ABCDEF1234567890 at "
+        "2026-07-16T10:01:02Z"
+    )
+    connection_reset = kb.failure_fingerprint(
+        kind="crashed", error=f"{shared_noise}: connection reset",
+    )
+    permission_denied = kb.failure_fingerprint(
+        kind="crashed", error=f"{shared_noise}: permission denied",
+    )
+    assert connection_reset != permission_denied
+
+
+def test_task_failure_fingerprint_preserves_attached_request_error_suffix(
+    kanban_home,
+):
+    connection_reset = kb.failure_fingerprint(
+        kind="crashed",
+        error="request_id=01J2ABCDEF1234567890:ECONNRESET",
+    )
+    permission_denied = kb.failure_fingerprint(
+        kind="crashed",
+        error="request_id=01J2ZZZZZZ9876543210:EPERM",
+    )
+
+    assert connection_reset != permission_denied
+
+
+@pytest.mark.parametrize("separator", [".", "-"])
+def test_task_failure_fingerprint_preserves_punctuation_attached_error_suffix(
+    kanban_home,
+    separator,
+):
+    connection_reset = kb.failure_fingerprint(
+        kind="crashed",
+        error=f"request_id=01J2ABCDEF1234567890{separator}ECONNRESET",
+    )
+    permission_denied = kb.failure_fingerprint(
+        kind="crashed",
+        error=f"request_id=01J2ZZZZZZ9876543210{separator}EPERM",
+    )
+
+    assert connection_reset != permission_denied
+
+
+def test_task_failure_fingerprint_preserves_named_id_error_suffix(kanban_home):
+    connection_reset = kb.failure_fingerprint(
+        kind="crashed",
+        error="req-00000001-ECONNRESET",
+    )
+    permission_denied = kb.failure_fingerprint(
+        kind="crashed",
+        error="req-00000002-EPERM",
+    )
+
+    assert connection_reset != permission_denied
+
+
+def test_task_failure_fingerprint_normalizes_dotted_and_hyphenated_ids(kanban_home):
+    fingerprints = {
+        kb.failure_fingerprint(
+            kind="crashed",
+            error=f"request_id={request_id}: connection reset",
+        )
+        for request_id in (
+            "build.release-000001",
+            "deploy.candidate-000002",
+            "ABC123.RELEASE",
+            "XYZ987-CANDIDATE",
+            "ABC123.EXAMPLE",
+            "XYZ987-EXPERIMENT",
+        )
+    }
+
+    assert len(fingerprints) == 1
+
+
+def test_task_failure_fingerprint_preserves_long_diagnostic_tail(kanban_home):
+    shared_prefix = "trace frame: shared diagnostic context\n" * 80
+    assert len(shared_prefix) > 2000
+
+    connection_reset = kb.failure_fingerprint(
+        kind="crashed",
+        error=f"{shared_prefix}RootCause: ECONNRESET",
+    )
+    permission_denied = kb.failure_fingerprint(
+        kind="crashed",
+        error=f"{shared_prefix}RootCause: EPERM",
+    )
+
+    assert connection_reset != permission_denied
+
+
+def test_concurrent_third_failure_freezes_once(kanban_home):
+    """Racing reports for attempt three cannot double-count or permit attempt four."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="racing failure", assignee="alice")
+        for _ in range(2):
+            claimed = kb.claim_task(conn, task_id)
+            assert claimed is not None
+            assert kb.block_task(
+                conn,
+                task_id,
+                kind="transient",
+                reason="upstream connection reset",
+                expected_run_id=claimed.current_run_id,
+            )
+            assert kb.unblock_task(conn, task_id)
+        third = kb.claim_task(conn, task_id)
+        assert third is not None
+
+    barrier = threading.Barrier(2)
+
+    def report_third_failure() -> bool:
+        with kb.connect() as conn:
+            barrier.wait(timeout=5)
+            return kb.block_task(
+                conn,
+                task_id,
+                kind="transient",
+                reason="upstream connection reset",
+                expected_run_id=third.current_run_id,
+            )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(lambda _: report_third_failure(), range(2)))
+
+    assert sorted(results) == [False, True]
+    with kb.connect() as conn:
+        frozen = kb.get_task(conn, task_id)
+        assert frozen is not None
+        assert frozen.status == "triage"
+        assert frozen.failure_recurrences == 3
+        assert frozen.failure_frozen_at is not None
+        assert kb.claim_task(conn, task_id) is None
+        assert len([
+            event for event in kb.list_events(conn, task_id)
+            if event.kind == "failure_frozen"
+        ]) == 1
+
+
+def test_unrelated_progress_does_not_rearm_frozen_task(kanban_home):
+    with kb.connect() as conn:
+        frozen_id = kb.create_task(conn, title="frozen", assignee="alice")
+        for attempt in range(3):
+            claimed = kb.claim_task(conn, frozen_id)
+            assert claimed is not None
+            assert kb.block_task(
+                conn,
+                frozen_id,
+                kind="capability",
+                reason="missing credential",
+                expected_run_id=claimed.current_run_id,
+            )
+            if attempt < 2:
+                assert kb.unblock_task(conn, frozen_id)
+
+        unrelated_id = kb.create_task(conn, title="unrelated", assignee="bob")
+        assert kb.claim_task(conn, unrelated_id) is not None
+        assert kb.complete_task(conn, unrelated_id, result="done")
+        kb.add_comment(conn, frozen_id, "operator", "unrelated board work completed")
+        kb.recompute_ready(conn)
+
+        frozen = kb.get_task(conn, frozen_id)
+        assert frozen is not None
+        assert frozen.status == "triage"
+        assert frozen.failure_recurrences == 3
+        assert frozen.failure_frozen_at is not None
+        assert kb.claim_task(conn, frozen_id) is None
+        assert kb.unblock_task(conn, frozen_id) is False
+
+
+def test_process_failure_breaker_freezes_on_third_identical_root_cause(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="crashing", assignee="alice")
+        for attempt, pid in enumerate((1111, 2222, 3333), start=1):
+            assert kb.claim_task(conn, task_id) is not None
+            kb._record_task_failure(
+                conn,
+                task_id,
+                error=f"pid {pid} exited with code 17 at 1784218{attempt:03d}",
+                outcome="crashed",
+                release_claim=True,
+            )
+            task = kb.get_task(conn, task_id)
+            if attempt == 1:
+                assert task.status == "ready"
+            elif attempt == 2:
+                assert task.status == "blocked"
+                assert task.failure_frozen_at is None
+                assert kb.unblock_task(conn, task_id) is True
+            else:
+                assert task.status == "triage"
+                assert task.failure_recurrences == 3
+                assert task.failure_frozen_at is not None
+
+
+def test_three_identical_rejected_review_rounds_are_terminal(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="review loop", assignee="reviewer")
+        for round_number in range(1, 4):
+            assert kb.claim_task(conn, task_id) is not None
+            assert kb.block_task(
+                conn,
+                task_id,
+                kind="needs_input",
+                reason="review rejected: requested regression test still missing",
+            )
+            task = kb.get_task(conn, task_id)
+            if round_number < 3:
+                assert task.status == "blocked"
+                assert kb.unblock_task(conn, task_id)
+
+        task = kb.get_task(conn, task_id)
+        assert task.status == "triage"
+        assert task.failure_recurrences == 3
+        assert kb.claim_review_task(conn, task_id) is None
+
+
 # ---------------------------------------------------------------------------
 # Respawn guard (check_respawn_guard + dispatch_once integration)
 # ---------------------------------------------------------------------------
@@ -1834,7 +2204,9 @@ def test_respawn_guard_explicit_rearm_releases_block_loop(kanban_home):
             "VALUES (?, 'block_loop_detected', '{}', 100)",
             (t,),
         )
-        assert kb.unblock_task(conn, t) is True
+        assert kb.unblock_task(
+            conn, t, actor="operator", reason="root cause was corrected",
+        ) is True
         assert kb.check_respawn_guard(conn, t) is None
 
 
@@ -1874,14 +2246,16 @@ def test_unblock_rechecks_frozen_triage_inside_write_transaction(
             (t,),
         )
         calls = []
-        original = kb.is_block_loop_frozen
+        original = kb.is_task_frozen
 
         def observed(c, task_id):
             calls.append(c.in_transaction)
             return original(c, task_id)
 
-        monkeypatch.setattr(kb, "is_block_loop_frozen", observed)
-        assert kb.unblock_task(conn, t) is True
+        monkeypatch.setattr(kb, "is_task_frozen", observed)
+        assert kb.unblock_task(
+            conn, t, actor="operator", reason="root cause was corrected",
+        ) is True
 
     assert calls == [True]
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1838,6 +1838,30 @@ def test_respawn_guard_explicit_rearm_releases_block_loop(kanban_home):
         assert kb.check_respawn_guard(conn, t) is None
 
 
+def test_respawn_guard_same_second_event_order_controls_rearm(kanban_home):
+    """Second-resolution timestamps must not let stale rearm release a new loop."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="looping", assignee="alice")
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'unblocked', '{}', 100)",
+            (t,),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'block_loop_detected', '{}', 100)",
+            (t,),
+        )
+        assert kb.is_block_loop_frozen(conn, t) is True
+
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'unblocked', '{}', 100)",
+            (t,),
+        )
+        assert kb.is_block_loop_frozen(conn, t) is False
+
+
 def test_respawn_guard_worker_cannot_self_rearm_block_loop(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="looping", assignee="dev")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1862,6 +1862,30 @@ def test_respawn_guard_same_second_event_order_controls_rearm(kanban_home):
         assert kb.is_block_loop_frozen(conn, t) is False
 
 
+def test_unblock_rechecks_frozen_triage_inside_write_transaction(
+    kanban_home, monkeypatch,
+):
+    """Unblock must not reuse a frozen-state snapshot read before its txn."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="looping", assignee="alice", triage=True)
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'block_loop_detected', '{}', 100)",
+            (t,),
+        )
+        calls = []
+        original = kb.is_block_loop_frozen
+
+        def observed(c, task_id):
+            calls.append(c.in_transaction)
+            return original(c, task_id)
+
+        monkeypatch.setattr(kb, "is_block_loop_frozen", observed)
+        assert kb.unblock_task(conn, t) is True
+
+    assert calls == [True]
+
+
 def test_respawn_guard_worker_cannot_self_rearm_block_loop(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="looping", assignee="dev")

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -311,6 +311,58 @@ def test_decompose_handles_malformed_llm_json(kanban_home):
     assert "malformed JSON" in outcome.reason
 
 
+def test_auto_triage_list_skips_block_loop_until_explicit_rearm(kanban_home):
+    """Gateway auto-decompose must not undo the block-loop circuit breaker."""
+    with kb.connect() as conn:
+        fresh = kb.create_task(conn, title="fresh", triage=True)
+        frozen = kb.create_task(conn, title="looping", triage=True)
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'block_loop_detected', '{}', 100)",
+            (frozen,),
+        )
+
+    assert decomp.list_triage_ids(auto_only=True) == [fresh]
+
+    with kb.connect() as conn:
+        assert kb.unblock_task(conn, frozen) is True
+        assert kb.is_block_loop_frozen(conn, frozen) is False
+
+    assert decomp.list_triage_ids(auto_only=True) == [fresh]
+
+
+def test_auto_decompose_rechecks_freeze_after_llm_call(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="race", triage=True, assignee="dev")
+
+    payload = jsonlib.dumps({"fanout": False, "title": "rewritten", "body": "body"})
+    client = _mock_client_returning(payload)
+
+    def freeze_then_return(*args, **kwargs):
+        with kb.connect() as conn:
+            conn.execute(
+                "INSERT INTO task_events (task_id, kind, payload, created_at) "
+                "VALUES (?, 'block_loop_detected', '{}', 100)",
+                (tid,),
+            )
+        return _fake_aux_response(payload)
+
+    client.chat.completions.create.side_effect = freeze_then_return
+    with (
+        patch(
+            "agent.auxiliary_client.get_text_auxiliary_client",
+            return_value=(client, "test-model"),
+        ),
+        _patch_extra_body(),
+    ):
+        outcome = decomp.decompose_task(tid, author="auto-decomposer", automatic=True)
+
+    assert outcome.ok is False
+    assert "block-loop" in outcome.reason
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "triage"
+
+
 def test_decompose_returns_false_when_task_not_triage(kanban_home):
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="x")  # ready, not triage

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -317,15 +317,20 @@ def test_auto_triage_list_skips_block_loop_until_explicit_rearm(kanban_home):
         fresh = kb.create_task(conn, title="fresh", triage=True)
         frozen = kb.create_task(conn, title="looping", triage=True)
         conn.execute(
-            "INSERT INTO task_events (task_id, kind, payload, created_at) "
-            "VALUES (?, 'block_loop_detected', '{}', 100)",
+            "UPDATE tasks SET failure_fingerprint = 'same-root-cause', "
+            "failure_recurrences = 3, failure_frozen_at = 100 WHERE id = ?",
             (frozen,),
         )
 
     assert decomp.list_triage_ids(auto_only=True) == [fresh]
 
     with kb.connect() as conn:
-        assert kb.unblock_task(conn, frozen) is True
+        assert kb.unblock_task(
+            conn,
+            frozen,
+            actor="operator",
+            reason="root cause was corrected",
+        ) is True
         assert kb.is_block_loop_frozen(conn, frozen) is False
 
     assert decomp.list_triage_ids(auto_only=True) == [fresh]
@@ -336,22 +341,19 @@ def test_auto_decompose_rechecks_freeze_after_llm_call(kanban_home):
         tid = kb.create_task(conn, title="race", triage=True, assignee="dev")
 
     payload = jsonlib.dumps({"fanout": False, "title": "rewritten", "body": "body"})
-    client = _mock_client_returning(payload)
-
     def freeze_then_return(*args, **kwargs):
         with kb.connect() as conn:
             conn.execute(
-                "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                "VALUES (?, 'block_loop_detected', '{}', 100)",
+                "UPDATE tasks SET failure_fingerprint = 'same-root-cause', "
+                "failure_recurrences = 3, failure_frozen_at = 100 WHERE id = ?",
                 (tid,),
             )
         return _fake_aux_response(payload)
 
-    client.chat.completions.create.side_effect = freeze_then_return
     with (
         patch(
-            "agent.auxiliary_client.get_text_auxiliary_client",
-            return_value=(client, "test-model"),
+            "agent.auxiliary_client.call_llm",
+            side_effect=freeze_then_return,
         ),
         _patch_extra_body(),
     ):

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -813,8 +813,14 @@ def test_dashboard_ready_rearms_frozen_triage_with_unblocked_event(client):
             (task_id,),
         )
 
-    response = client.patch(
+    refused = client.patch(
         f"/api/plugins/kanban/tasks/{task_id}", json={"status": "ready"},
+    )
+    assert refused.status_code == 409
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task_id}",
+        json={"status": "ready", "block_reason": "root cause was corrected"},
     )
     assert response.status_code == 200
     with _kb.connect() as conn:
@@ -1165,6 +1171,40 @@ def test_bulk_status_ready(client):
     ready = next(col for col in board["columns"] if col["name"] == "ready")
     ids = {t["id"] for t in ready["tasks"]}
     assert {a["id"], b["id"], c2["id"]}.issubset(ids)
+
+
+def test_bulk_ready_requires_reason_to_rearm_frozen_task(client):
+    task = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "frozen", "triage": True},
+    ).json()["task"]
+    import hermes_cli.kanban_db as _kb
+    with _kb.connect() as conn:
+        conn.execute(
+            "UPDATE tasks SET failure_fingerprint = 'same-root-cause', "
+            "failure_recurrences = 3, failure_frozen_at = 100 WHERE id = ?",
+            (task["id"],),
+        )
+
+    refused = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={"ids": [task["id"]], "status": "ready"},
+    ).json()["results"][0]
+    assert refused["ok"] is False
+
+    rearmed = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={
+            "ids": [task["id"]],
+            "status": "ready",
+            "block_reason": "operator corrected the task input",
+        },
+    ).json()["results"][0]
+    assert rearmed["ok"] is True
+    with _kb.connect() as conn:
+        current = _kb.get_task(conn, task["id"])
+        assert current.status == "ready"
+        assert current.failure_frozen_at is None
 
 
 def test_bulk_status_done_forwards_completion_summary(client):

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -799,6 +799,34 @@ def test_triage_task_not_promoted_to_ready(client):
     assert len(ready["tasks"]) == 0
 
 
+def test_dashboard_ready_rearms_frozen_triage_with_unblocked_event(client):
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "frozen loop", "triage": True, "assignee": "worker"},
+    ).json()
+    task_id = created["task"]["id"]
+    import hermes_cli.kanban_db as _kb
+    with _kb.connect() as conn:
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'block_loop_detected', '{}', 100)",
+            (task_id,),
+        )
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task_id}", json={"status": "ready"},
+    )
+    assert response.status_code == 200
+    with _kb.connect() as conn:
+        assert _kb.get_task(conn, task_id).status == "ready"
+        assert _kb.is_block_loop_frozen(conn, task_id) is False
+        latest = conn.execute(
+            "SELECT kind FROM task_events WHERE task_id=? ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        assert latest["kind"] == "unblocked"
+
+
 def test_patch_status_triage_works(client):
     """A user (or specifier) can push a task back into triage, and out of it."""
     t = client.post(

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -180,6 +180,10 @@ def test_show_defaults_to_env_task_id(worker_env):
     assert "task" in d
     assert d["task"]["id"] == worker_env
     assert d["task"]["status"] == "running"
+    assert d["task"]["failure_frozen"] is False
+    assert d["task"]["failure_recurrences"] == 0
+    assert "failure_fingerprint" in d["task"]
+    assert "failure_frozen_at" in d["task"]
     assert "worker_context" in d
     assert "runs" in d
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -353,6 +353,10 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
         "completed_at": task.completed_at,
         "current_run_id": task.current_run_id,
         "model_override": task.model_override,
+        "failure_fingerprint": task.failure_fingerprint,
+        "failure_recurrences": task.failure_recurrences,
+        "failure_frozen_at": task.failure_frozen_at,
+        "failure_frozen": task.failure_frozen_at is not None,
         "parents": parents,
         "children": children,
         "parent_count": len(parents),
@@ -398,6 +402,10 @@ def _handle_show(args: dict, **kw) -> str:
                     "result": t.result,
                     "current_run_id": t.current_run_id,
                     "model_override": t.model_override,
+                    "failure_fingerprint": t.failure_fingerprint,
+                    "failure_recurrences": t.failure_recurrences,
+                    "failure_frozen_at": t.failure_frozen_at,
+                    "failure_frozen": t.failure_frozen_at is not None,
                 }
 
             def _run_dict(r):
@@ -1295,7 +1303,12 @@ def _handle_unblock(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
-            ok = kb.unblock_task(conn, str(tid))
+            ok = kb.unblock_task(
+                conn,
+                str(tid),
+                actor=os.environ.get("HERMES_PROFILE") or "orchestrator",
+                reason=(str(args.get("reason")).strip() if args.get("reason") else None),
+            )
             if not ok:
                 return tool_error(f"could not unblock {tid} (not blocked or unknown)")
             task = kb.get_task(conn, str(tid))
@@ -1891,6 +1904,13 @@ KANBAN_UNBLOCK_SCHEMA = {
             "task_id": {
                 "type": "string",
                 "description": "Blocked task id to move to ready or parent-gated todo.",
+            },
+            "reason": {
+                "type": "string",
+                "description": (
+                    "Audited rearm reason. Required when the task was frozen "
+                    "after three materially identical outcomes."
+                ),
             },
             "board": _board_schema_prop(),
         },


### PR DESCRIPTION
## Summary
- persist a normalized failure fingerprint and freeze a task after its third materially identical terminal outcome
- enforce the freeze across claim, review, reclaim, promotion, ready recomputation, auto-decomposition, dashboard, and tool paths
- require an audited operator/CTO rearm, while keeping punctuation-only diagnostics equivalent and distinct root causes separate
- retain backward compatibility for boards frozen by the earlier block-loop event circuit breaker

## Observable behavior
Attempts one and two may be explicitly retried. The third materially identical failure atomically routes the card to triage and makes every automatic launch/reclaim/promotion/decomposition path ineligible. A reasoned operator rearm clears the breaker and restores eligibility.

## Test plan
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_block_kinds.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_decompose.py tests/plugins/test_kanban_dashboard_plugin.py tests/tools/test_kanban_tools.py` — 679 passed
- `python3 -m py_compile ...` — passed
- `git diff --check origin/main...HEAD` — passed
- full repository suite running on the combined reconciliation candidate; result will be posted before review handoff

## Provenance
This semantically ports the accepted local block-loop chain and the independently reviewed third-identical-failure hardening onto current `main`, preserving original commit authorship.