### PR TITLE
fix(supermemory): precision-gate automatic recall

### DIFF
--- a/plugins/memory/supermemory/README.md
+++ b/plugins/memory/supermemory/README.md
@@ -50,8 +50,10 @@ Config file: `$HERMES_HOME/supermemory.json`
 | `container_tag` | `hermes` | Container tag used for search and writes. Supports `{identity}` template for profile-scoped tags (e.g. `hermes-{identity}` → `hermes-coder`). |
 | `auto_recall` | `true` | Inject relevant memory context before turns |
 | `auto_capture` | `true` | Store cleaned user-assistant turns after each response |
-| `max_recall_results` | `10` | Max recalled items to format into context |
-| `profile_frequency` | `50` | Include profile facts on first turn and every N turns |
+| `max_recall_results` | `10` | Total recalled-item budget across all context sections (bounded to 1–20) |
+| `recall_min_similarity` | `0.76` | Minimum 0–1 similarity for automatic semantic recall; missing/invalid scores are not injected |
+| `prefetch_include_profile` | `false` | Opt in to automatic static/dynamic profile context; explicit profile-tool behavior is unchanged |
+| `profile_frequency` | `50` | When profile prefetch is opted in, include it on the first turn and every N turns |
 | `capture_mode` | `all` | Skip tiny or trivial turns by default |
 | `search_mode` | `hybrid` | Search mode: `hybrid` (profile + memories), `memories` (memories only), `documents` (documents only) |
 | `entity_context` | built-in default | Extraction guidance passed to Supermemory |

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -14,6 +14,7 @@ import threading
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
+from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -24,10 +25,36 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_CONTAINER_TAG = "hermes"
 _DEFAULT_MAX_RECALL_RESULTS = 10
+_DEFAULT_RECALL_MIN_SIMILARITY = 0.76
+_DEFAULT_PREFETCH_INCLUDE_PROFILE = False
+_DEFAULT_PREFETCH_MAX_CHARS = 6000
 _DEFAULT_PROFILE_FREQUENCY = 50
 _DEFAULT_CAPTURE_MODE = "all"
 _DEFAULT_SEARCH_MODE = "hybrid"
 _VALID_SEARCH_MODES = ("hybrid", "memories", "documents")
+_TRANSIENT_RECALL_TYPES = {
+    "conversation_turn",
+    "full_session",
+    "kanban_task",
+    "project_status",
+    "pull_request_status",
+    "smoke_test",
+    "test_run",
+}
+_TRANSIENT_RECALL_RE = re.compile(
+    r"(?:"
+    r"\b(?:kanban\s+)?task\s+t_[a-z0-9_-]+\b|"
+    r"\b(?:current\s+)?pull request\b[^.\n]*(?:merged|approval|branch\s+was\s+deleted)|"
+    r"\b(?:latest|yesterday(?:'s)?)\s+test run\b|"
+    r"\b(?:browser\s+)?test\s+(?:failed|passed)\b|"
+    r"\bphase\s+\w+\s+is\s+in\s+progress\b|"
+    r"\bthe\s+worker\s+is\s+currently\b|"
+    r"\bwill\s+report\s+later\b|"
+    r"\bfull session transcript\b|"
+    r"\btemporary smoke marker\b"
+    r")",
+    re.IGNORECASE,
+)
 _DEFAULT_API_TIMEOUT = 5.0
 _MIN_CAPTURE_LENGTH = 10
 _MAX_ENTITY_CONTEXT_LENGTH = 1500
@@ -60,6 +87,8 @@ def _default_config() -> dict:
         "auto_recall": True,
         "auto_capture": True,
         "max_recall_results": _DEFAULT_MAX_RECALL_RESULTS,
+        "recall_min_similarity": _DEFAULT_RECALL_MIN_SIMILARITY,
+        "prefetch_include_profile": _DEFAULT_PREFETCH_INCLUDE_PROFILE,
         "profile_frequency": _DEFAULT_PROFILE_FREQUENCY,
         "capture_mode": _DEFAULT_CAPTURE_MODE,
         "search_mode": _DEFAULT_SEARCH_MODE,
@@ -130,6 +159,16 @@ def _load_supermemory_config(hermes_home: str) -> dict:
         config["max_recall_results"] = max(1, min(20, int(config.get("max_recall_results", _DEFAULT_MAX_RECALL_RESULTS))))
     except Exception:
         config["max_recall_results"] = _DEFAULT_MAX_RECALL_RESULTS
+    try:
+        recall_min_similarity = float(config.get("recall_min_similarity", _DEFAULT_RECALL_MIN_SIMILARITY))
+        if not 0.0 <= recall_min_similarity <= 1.0:
+            raise ValueError("similarity must be between zero and one")
+        config["recall_min_similarity"] = recall_min_similarity
+    except Exception:
+        config["recall_min_similarity"] = _DEFAULT_RECALL_MIN_SIMILARITY
+    config["prefetch_include_profile"] = _as_bool(
+        config.get("prefetch_include_profile"), _DEFAULT_PREFETCH_INCLUDE_PROFILE
+    )
     try:
         config["profile_frequency"] = max(1, min(500, int(config.get("profile_frequency", _DEFAULT_PROFILE_FREQUENCY))))
     except Exception:
@@ -202,41 +241,82 @@ def _format_relative_time(iso_timestamp: str) -> str:
         return ""
 
 
+def _recall_dedup_key(value: Any) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", str(value or "").casefold()).strip()
+
+
+def _is_duplicate_recall(key: str, seen: set[str]) -> bool:
+    return key in seen or any(SequenceMatcher(None, key, previous).ratio() >= 0.92 for previous in seen)
+
+
+def _is_transient_recall(text: Any, metadata: Any = None) -> bool:
+    if isinstance(metadata, dict):
+        for field in ("type", "source", "category", "kind", "document_type"):
+            value = str(metadata.get(field) or "").strip().lower().replace("-", "_")
+            if value in _TRANSIENT_RECALL_TYPES:
+                return True
+    return bool(_TRANSIENT_RECALL_RE.search(str(text or "")))
+
+
 def _deduplicate_recall(static_facts: list, dynamic_facts: list, search_results: list) -> tuple[list, list, list]:
     seen = set()
     out_static, out_dynamic, out_search = [], [], []
     for fact in static_facts or []:
-        if fact and fact not in seen:
-            seen.add(fact)
+        key = _recall_dedup_key(fact)
+        if key and not _is_duplicate_recall(key, seen):
+            seen.add(key)
             out_static.append(fact)
     for fact in dynamic_facts or []:
-        if fact and fact not in seen:
-            seen.add(fact)
+        key = _recall_dedup_key(fact)
+        if key and not _is_duplicate_recall(key, seen):
+            seen.add(key)
             out_dynamic.append(fact)
     for item in search_results or []:
         memory = item.get("memory", "")
-        if memory and memory not in seen:
-            seen.add(memory)
+        key = _recall_dedup_key(memory)
+        if key and not _is_duplicate_recall(key, seen):
+            seen.add(key)
             out_search.append(item)
     return out_static, out_dynamic, out_search
 
 
-def _format_prefetch_context(static_facts: list, dynamic_facts: list, search_results: list, max_results: int) -> str:
+def _format_prefetch_context(
+    static_facts: list,
+    dynamic_facts: list,
+    search_results: list,
+    max_results: int,
+    max_chars: int = _DEFAULT_PREFETCH_MAX_CHARS,
+) -> str:
     statics, dynamics, search = _deduplicate_recall(static_facts, dynamic_facts, search_results)
-    statics = statics[:max_results]
-    dynamics = dynamics[:max_results]
-    search = search[:max_results]
-    if not statics and not dynamics and not search:
+    candidates = (
+        [("static", item) for item in statics]
+        + [("dynamic", item) for item in dynamics]
+        + [("search", item) for item in search]
+    )
+    selected = candidates[:max(0, max_results)]
+    if not selected:
         return ""
 
-    sections = []
-    if statics:
-        sections.append("## User Profile (Persistent)\n" + "\n".join(f"- {item}" for item in statics))
-    if dynamics:
-        sections.append("## Recent Context\n" + "\n".join(f"- {item}" for item in dynamics))
-    if search:
+    intro = (
+        "The following is background context from long-term memory. Use it silently when relevant. "
+        "Do not force memories into the conversation."
+    )
+
+    def render(items: list[tuple[str, Any]], *, trace: bool) -> str:
+        grouped = {
+            "static": [item for kind, item in items if kind == "static"],
+            "dynamic": [item for kind, item in items if kind == "dynamic"],
+            "search": [item for kind, item in items if kind == "search"],
+        }
+        sections = []
+        if grouped["static"]:
+            lines = [f"- {item}" if trace else "- " + str(item) for item in grouped["static"]]
+            sections.append("## User Profile (Persistent)\n" + "\n".join(lines))
+        if grouped["dynamic"]:
+            lines = [f"- {item}" if trace else "- " + str(item) for item in grouped["dynamic"]]
+            sections.append("## Recent Context\n" + "\n".join(lines))
         lines = []
-        for item in search:
+        for item in grouped["search"]:
             memory = item.get("memory", "")
             if not memory:
                 continue
@@ -252,18 +332,21 @@ def _format_prefetch_context(static_facts: list, dynamic_facts: list, search_res
                 except Exception:
                     pass
             prefix = " ".join(prefix_bits)
-            lines.append(f"- {prefix} {memory}".strip())
+            if trace:
+                lines.append(f"- {prefix} {memory}".strip())
+            else:
+                lines.append(("- " + prefix + " " + str(memory)).strip())
         if lines:
             sections.append("## Relevant Memories\n" + "\n".join(lines))
-    if not sections:
-        return ""
+        if not sections:
+            return ""
+        body = "\n\n".join(sections)
+        return f"<supermemory-context>\n{intro}\n\n{body}\n</supermemory-context>"
 
-    intro = (
-        "The following is background context from long-term memory. Use it silently when relevant. "
-        "Do not force memories into the conversation."
-    )
-    body = "\n\n".join(sections)
-    return f"<supermemory-context>\n{intro}\n\n{body}\n</supermemory-context>"
+    max_chars = max(1, int(max_chars))
+    while selected and len(render(selected, trace=False)) > max_chars:
+        selected.pop()
+    return render(selected, trace=True) if selected else ""
 
 
 def _clean_text_for_capture(text: str) -> str:
@@ -375,6 +458,7 @@ class _SupermemoryClient:
                         "memory": getattr(item, "memory", ""),
                         "updated_at": getattr(item, "updated_at", None) or getattr(item, "updatedAt", None),
                         "similarity": getattr(item, "similarity", None),
+                        "metadata": getattr(item, "metadata", None),
                     })
         return {"static": static, "dynamic": dynamic, "search_results": search_results}
 
@@ -544,6 +628,8 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._auto_recall = True
         self._auto_capture = True
         self._max_recall_results = _DEFAULT_MAX_RECALL_RESULTS
+        self._recall_min_similarity = _DEFAULT_RECALL_MIN_SIMILARITY
+        self._prefetch_include_profile = _DEFAULT_PREFETCH_INCLUDE_PROFILE
         self._profile_frequency = _DEFAULT_PROFILE_FREQUENCY
         self._capture_mode = _DEFAULT_CAPTURE_MODE
         self._search_mode = _DEFAULT_SEARCH_MODE
@@ -659,6 +745,8 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._auto_recall = self._config["auto_recall"]
         self._auto_capture = self._config["auto_capture"]
         self._max_recall_results = self._config["max_recall_results"]
+        self._recall_min_similarity = self._config["recall_min_similarity"]
+        self._prefetch_include_profile = self._config["prefetch_include_profile"]
         self._profile_frequency = self._config["profile_frequency"]
         self._capture_mode = self._config["capture_mode"]
         self._search_mode = self._config["search_mode"]
@@ -716,11 +804,32 @@ class SupermemoryMemoryProvider(MemoryProvider):
             return ""
         try:
             profile = self._client.get_profile(query=query[:200])
-            include_profile = self._turn_count <= 1 or (self._turn_count % self._profile_frequency == 0)
+            include_profile = self._prefetch_include_profile and (
+                self._turn_count <= 1 or (self._turn_count % self._profile_frequency == 0)
+            )
+            static_facts = [
+                fact for fact in (profile.get("static") or [])
+                if not _is_transient_recall(fact)
+            ] if include_profile else []
+            dynamic_facts = [
+                fact for fact in (profile.get("dynamic") or [])
+                if not _is_transient_recall(fact)
+            ] if include_profile else []
+            search_results = []
+            for item in profile.get("search_results") or []:
+                memory = item.get("memory", "")
+                if _is_transient_recall(memory, item.get("metadata")):
+                    continue
+                try:
+                    similarity = float(item.get("similarity"))
+                except (TypeError, ValueError):
+                    continue
+                if similarity >= self._recall_min_similarity:
+                    search_results.append(item)
             context = _format_prefetch_context(
-                static_facts=profile["static"] if include_profile else [],
-                dynamic_facts=profile["dynamic"] if include_profile else [],
-                search_results=profile["search_results"],
+                static_facts=static_facts,
+                dynamic_facts=dynamic_facts,
+                search_results=search_results,
                 max_results=self._max_recall_results,
             )
             return context

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -813,10 +813,10 @@ class SupermemoryMemoryProvider(MemoryProvider):
         if not self._active or not self._auto_recall or not self._client or _is_trivial_message(query):
             return ""
         try:
-            profile = self._client.get_profile(query=query[:200])
             include_profile = self._prefetch_include_profile and (
                 self._turn_count <= 1 or (self._turn_count % self._profile_frequency == 0)
             )
+            profile = self._client.get_profile(query=query[:200]) if include_profile else {}
             static_facts = [
                 fact for fact in (profile.get("static") or [])
                 if not _is_transient_recall(fact)
@@ -826,7 +826,16 @@ class SupermemoryMemoryProvider(MemoryProvider):
                 if not _is_transient_recall(fact)
             ] if include_profile else []
             search_results = []
-            for item in profile.get("search_results") or []:
+            # Profile search is tuned for profile synthesis and returns a very
+            # different score distribution. Auto-recall needs the same direct
+            # semantic search path as the explicit search tool, with extra
+            # candidates so provenance/score filtering can still fill the
+            # small final context budget.
+            candidates = self._client.search_memories(
+                query[:200],
+                limit=min(50, max(12, self._max_recall_results * 4)),
+            )
+            for item in candidates:
                 memory = item.get("memory", "")
                 if _is_transient_recall(memory, item.get("metadata")):
                     continue

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -12,10 +12,11 @@ import math
 import os
 import re
 import threading
+import unicodedata
 import urllib.error
+import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
-from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -247,11 +248,16 @@ def _format_relative_time(iso_timestamp: str) -> str:
 def _recall_dedup_key(value: Any) -> str:
     # ``\w`` is Unicode-aware in Python. Excluding only underscores keeps
     # CJK and other non-Latin text eligible while normalizing punctuation.
-    return re.sub(r"[\W_]+", " ", str(value or "").casefold()).strip()
+    normalized = unicodedata.normalize("NFKC", str(value or "")).casefold()
+    return re.sub(r"[\W_]+", " ", normalized).strip()
 
 
 def _is_duplicate_recall(key: str, seen: set[str]) -> bool:
-    return key in seen or any(SequenceMatcher(None, key, previous).ratio() >= 0.92 for previous in seen)
+    # Only canonical exact matches are safe to merge. Fuzzy text similarity
+    # collapses meaningful corrections such as Python 3.12 vs 3.13, UTC+1 vs
+    # UTC+2, and S3 vs GCS. Keeping two paraphrases is preferable to silently
+    # hiding the newer or contradictory fact.
+    return key in seen
 
 
 def _is_transient_recall(text: Any, metadata: Any = None) -> bool:

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import re
 import threading
@@ -43,10 +44,11 @@ _TRANSIENT_RECALL_TYPES = {
 }
 _TRANSIENT_RECALL_RE = re.compile(
     r"(?:"
-    r"\b(?:kanban\s+)?task\s+t_[a-z0-9_-]+\b|"
-    r"\b(?:current\s+)?pull request\b[^.\n]*(?:merged|approval|branch\s+was\s+deleted)|"
-    r"\b(?:latest|yesterday(?:'s)?)\s+test run\b|"
-    r"\b(?:browser\s+)?test\s+(?:failed|passed)\b|"
+    r"\b(?:kanban\s+)?task\s+t_[a-z0-9_-]+\b[^.\n]*(?:marked\s+done|is\s+blocked|completed)|"
+    r"\b(?:t[aâ]che\s+kanban|kanban\s+t[aâ]che)\s+t_[a-z0-9_-]+\b[^.\n]*(?:termin[eé]e?|bloqu[eé]e?)|"
+    r"\bpull request\s+\d+\b[^.\n]*(?:was\s+merged|needs?\s+one\s+more\s+approval|branch\s+was\s+deleted)|"
+    r"\bthe\s+current\s+pull request\s+needs?\s+one\s+more\s+approval\b|"
+    r"\b(?:latest\s+test\s+run|yesterday(?:'s)?\s+(?:browser\s+)?test)\b[^.\n]*(?:failed|passed)|"
     r"\bphase\s+\w+\s+is\s+in\s+progress\b|"
     r"\bthe\s+worker\s+is\s+currently\b|"
     r"\bwill\s+report\s+later\b|"
@@ -61,7 +63,8 @@ _MAX_ENTITY_CONTEXT_LENGTH = 1500
 _DEFAULT_BASE_URL = "https://api.supermemory.ai"
 _API_KEY_URL = "http://app.supermemory.ai/integrations?connect=hermes"
 _TRIVIAL_RE = re.compile(
-    r"^(ok|okay|thanks|thank you|got it|sure|yes|no|yep|nope|k|ty|thx|np)\.?$",
+    r"^(ok|okay|thanks|thank you|got it|sure|yes|no|yep|nope|k|ty|thx|np|"
+    r"hello|hi|hey|continue|go|merci|salut|parfait|d['’]accord|vas[- ]?y)\s*[.!?…]*$",
     re.IGNORECASE,
 )
 _CONTEXT_STRIP_RE = re.compile(
@@ -242,7 +245,9 @@ def _format_relative_time(iso_timestamp: str) -> str:
 
 
 def _recall_dedup_key(value: Any) -> str:
-    return re.sub(r"[^a-z0-9]+", " ", str(value or "").casefold()).strip()
+    # ``\w`` is Unicode-aware in Python. Excluding only underscores keeps
+    # CJK and other non-Latin text eligible while normalizing punctuation.
+    return re.sub(r"[\W_]+", " ", str(value or "").casefold()).strip()
 
 
 def _is_duplicate_recall(key: str, seen: set[str]) -> bool:
@@ -251,8 +256,12 @@ def _is_duplicate_recall(key: str, seen: set[str]) -> bool:
 
 def _is_transient_recall(text: Any, metadata: Any = None) -> bool:
     if isinstance(metadata, dict):
-        for field in ("type", "source", "category", "kind", "document_type"):
-            value = str(metadata.get(field) or "").strip().lower().replace("-", "_")
+        transient_fields = {"type", "source", "category", "kind", "documenttype"}
+        for raw_field, raw_value in metadata.items():
+            field = re.sub(r"[^a-z0-9]+", "", str(raw_field).casefold())
+            if field not in transient_fields:
+                continue
+            value = re.sub(r"[^a-z0-9]+", "_", str(raw_value).casefold()).strip("_")
             if value in _TRANSIENT_RECALL_TYPES:
                 return True
     return bool(_TRANSIENT_RECALL_RE.search(str(text or "")))
@@ -356,7 +365,8 @@ def _clean_text_for_capture(text: str) -> str:
 
 
 def _is_trivial_message(text: str) -> bool:
-    return bool(_TRIVIAL_RE.match((text or "").strip()))
+    stripped = (text or "").strip()
+    return not stripped or not any(character.isalnum() for character in stripped) or bool(_TRIVIAL_RE.match(stripped))
 
 
 class _SupermemoryClient:
@@ -800,7 +810,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         return "\n".join(lines)
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
-        if not self._active or not self._auto_recall or not self._client or not query.strip():
+        if not self._active or not self._auto_recall or not self._client or _is_trivial_message(query):
             return ""
         try:
             profile = self._client.get_profile(query=query[:200])
@@ -824,7 +834,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
                     similarity = float(item.get("similarity"))
                 except (TypeError, ValueError):
                     continue
-                if similarity >= self._recall_min_similarity:
+                if math.isfinite(similarity) and 0.0 <= similarity <= 1.0 and similarity >= self._recall_min_similarity:
                     search_results.append(item)
             context = _format_prefetch_context(
                 static_facts=static_facts,

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -12,10 +12,11 @@ import math
 import os
 import re
 import threading
+import unicodedata
 import urllib.error
+import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
-from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -248,11 +249,16 @@ def _format_relative_time(iso_timestamp: str) -> str:
 def _recall_dedup_key(value: Any) -> str:
     # ``\w`` is Unicode-aware in Python. Excluding only underscores keeps
     # CJK and other non-Latin text eligible while normalizing punctuation.
-    return re.sub(r"[\W_]+", " ", str(value or "").casefold()).strip()
+    normalized = unicodedata.normalize("NFKC", str(value or "")).casefold()
+    return re.sub(r"[\W_]+", " ", normalized).strip()
 
 
 def _is_duplicate_recall(key: str, seen: set[str]) -> bool:
-    return key in seen or any(SequenceMatcher(None, key, previous).ratio() >= 0.92 for previous in seen)
+    # Only canonical exact matches are safe to merge. Fuzzy text similarity
+    # collapses meaningful corrections such as Python 3.12 vs 3.13, UTC+1 vs
+    # UTC+2, and S3 vs GCS. Keeping two paraphrases is preferable to silently
+    # hiding the newer or contradictory fact.
+    return key in seen
 
 
 def _is_transient_recall(text: Any, metadata: Any = None) -> bool:

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -822,10 +822,10 @@ class SupermemoryMemoryProvider(MemoryProvider):
         if not self._active or not self._auto_recall or not self._client or _is_trivial_message(query):
             return ""
         try:
-            profile = self._client.get_profile(query=query[:200])
             include_profile = self._prefetch_include_profile and (
                 self._turn_count <= 1 or (self._turn_count % self._profile_frequency == 0)
             )
+            profile = self._client.get_profile(query=query[:200]) if include_profile else {}
             static_facts = [
                 fact for fact in (profile.get("static") or [])
                 if not _is_transient_recall(fact)
@@ -835,7 +835,16 @@ class SupermemoryMemoryProvider(MemoryProvider):
                 if not _is_transient_recall(fact)
             ] if include_profile else []
             search_results = []
-            for item in profile.get("search_results") or []:
+            # Profile search is tuned for profile synthesis and returns a very
+            # different score distribution. Auto-recall needs the same direct
+            # semantic search path as the explicit search tool, with extra
+            # candidates so provenance/score filtering can still fill the
+            # small final context budget.
+            candidates = self._client.search_memories(
+                query[:200],
+                limit=min(50, max(12, self._max_recall_results * 4)),
+            )
+            for item in candidates:
                 memory = item.get("memory", "")
                 if _is_transient_recall(memory, item.get("metadata")):
                     continue

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -14,6 +14,7 @@ import threading
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
+from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -25,10 +26,36 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_CONTAINER_TAG = "hermes"
 _DEFAULT_MAX_RECALL_RESULTS = 10
+_DEFAULT_RECALL_MIN_SIMILARITY = 0.76
+_DEFAULT_PREFETCH_INCLUDE_PROFILE = False
+_DEFAULT_PREFETCH_MAX_CHARS = 6000
 _DEFAULT_PROFILE_FREQUENCY = 50
 _DEFAULT_CAPTURE_MODE = "all"
 _DEFAULT_SEARCH_MODE = "hybrid"
 _VALID_SEARCH_MODES = ("hybrid", "memories", "documents")
+_TRANSIENT_RECALL_TYPES = {
+    "conversation_turn",
+    "full_session",
+    "kanban_task",
+    "project_status",
+    "pull_request_status",
+    "smoke_test",
+    "test_run",
+}
+_TRANSIENT_RECALL_RE = re.compile(
+    r"(?:"
+    r"\b(?:kanban\s+)?task\s+t_[a-z0-9_-]+\b|"
+    r"\b(?:current\s+)?pull request\b[^.\n]*(?:merged|approval|branch\s+was\s+deleted)|"
+    r"\b(?:latest|yesterday(?:'s)?)\s+test run\b|"
+    r"\b(?:browser\s+)?test\s+(?:failed|passed)\b|"
+    r"\bphase\s+\w+\s+is\s+in\s+progress\b|"
+    r"\bthe\s+worker\s+is\s+currently\b|"
+    r"\bwill\s+report\s+later\b|"
+    r"\bfull session transcript\b|"
+    r"\btemporary smoke marker\b"
+    r")",
+    re.IGNORECASE,
+)
 _DEFAULT_API_TIMEOUT = 5.0
 _MIN_CAPTURE_LENGTH = 10
 _MAX_ENTITY_CONTEXT_LENGTH = 1500
@@ -61,6 +88,8 @@ def _default_config() -> dict:
         "auto_recall": True,
         "auto_capture": True,
         "max_recall_results": _DEFAULT_MAX_RECALL_RESULTS,
+        "recall_min_similarity": _DEFAULT_RECALL_MIN_SIMILARITY,
+        "prefetch_include_profile": _DEFAULT_PREFETCH_INCLUDE_PROFILE,
         "profile_frequency": _DEFAULT_PROFILE_FREQUENCY,
         "capture_mode": _DEFAULT_CAPTURE_MODE,
         "search_mode": _DEFAULT_SEARCH_MODE,
@@ -131,6 +160,16 @@ def _load_supermemory_config(hermes_home: str) -> dict:
         config["max_recall_results"] = max(1, min(20, int(config.get("max_recall_results", _DEFAULT_MAX_RECALL_RESULTS))))
     except Exception:
         config["max_recall_results"] = _DEFAULT_MAX_RECALL_RESULTS
+    try:
+        recall_min_similarity = float(config.get("recall_min_similarity", _DEFAULT_RECALL_MIN_SIMILARITY))
+        if not 0.0 <= recall_min_similarity <= 1.0:
+            raise ValueError("similarity must be between zero and one")
+        config["recall_min_similarity"] = recall_min_similarity
+    except Exception:
+        config["recall_min_similarity"] = _DEFAULT_RECALL_MIN_SIMILARITY
+    config["prefetch_include_profile"] = _as_bool(
+        config.get("prefetch_include_profile"), _DEFAULT_PREFETCH_INCLUDE_PROFILE
+    )
     try:
         config["profile_frequency"] = max(1, min(500, int(config.get("profile_frequency", _DEFAULT_PROFILE_FREQUENCY))))
     except Exception:
@@ -203,41 +242,82 @@ def _format_relative_time(iso_timestamp: str) -> str:
         return ""
 
 
+def _recall_dedup_key(value: Any) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", str(value or "").casefold()).strip()
+
+
+def _is_duplicate_recall(key: str, seen: set[str]) -> bool:
+    return key in seen or any(SequenceMatcher(None, key, previous).ratio() >= 0.92 for previous in seen)
+
+
+def _is_transient_recall(text: Any, metadata: Any = None) -> bool:
+    if isinstance(metadata, dict):
+        for field in ("type", "source", "category", "kind", "document_type"):
+            value = str(metadata.get(field) or "").strip().lower().replace("-", "_")
+            if value in _TRANSIENT_RECALL_TYPES:
+                return True
+    return bool(_TRANSIENT_RECALL_RE.search(str(text or "")))
+
+
 def _deduplicate_recall(static_facts: list, dynamic_facts: list, search_results: list) -> tuple[list, list, list]:
     seen = set()
     out_static, out_dynamic, out_search = [], [], []
     for fact in static_facts or []:
-        if fact and fact not in seen:
-            seen.add(fact)
+        key = _recall_dedup_key(fact)
+        if key and not _is_duplicate_recall(key, seen):
+            seen.add(key)
             out_static.append(fact)
     for fact in dynamic_facts or []:
-        if fact and fact not in seen:
-            seen.add(fact)
+        key = _recall_dedup_key(fact)
+        if key and not _is_duplicate_recall(key, seen):
+            seen.add(key)
             out_dynamic.append(fact)
     for item in search_results or []:
         memory = item.get("memory", "")
-        if memory and memory not in seen:
-            seen.add(memory)
+        key = _recall_dedup_key(memory)
+        if key and not _is_duplicate_recall(key, seen):
+            seen.add(key)
             out_search.append(item)
     return out_static, out_dynamic, out_search
 
 
-def _format_prefetch_context(static_facts: list, dynamic_facts: list, search_results: list, max_results: int) -> str:
+def _format_prefetch_context(
+    static_facts: list,
+    dynamic_facts: list,
+    search_results: list,
+    max_results: int,
+    max_chars: int = _DEFAULT_PREFETCH_MAX_CHARS,
+) -> str:
     statics, dynamics, search = _deduplicate_recall(static_facts, dynamic_facts, search_results)
-    statics = statics[:max_results]
-    dynamics = dynamics[:max_results]
-    search = search[:max_results]
-    if not statics and not dynamics and not search:
+    candidates = (
+        [("static", item) for item in statics]
+        + [("dynamic", item) for item in dynamics]
+        + [("search", item) for item in search]
+    )
+    selected = candidates[:max(0, max_results)]
+    if not selected:
         return ""
 
-    sections = []
-    if statics:
-        sections.append("## User Profile (Persistent)\n" + "\n".join(f"- {item}" for item in statics))
-    if dynamics:
-        sections.append("## Recent Context\n" + "\n".join(f"- {item}" for item in dynamics))
-    if search:
+    intro = (
+        "The following is background context from long-term memory. Use it silently when relevant. "
+        "Do not force memories into the conversation."
+    )
+
+    def render(items: list[tuple[str, Any]], *, trace: bool) -> str:
+        grouped = {
+            "static": [item for kind, item in items if kind == "static"],
+            "dynamic": [item for kind, item in items if kind == "dynamic"],
+            "search": [item for kind, item in items if kind == "search"],
+        }
+        sections = []
+        if grouped["static"]:
+            lines = [f"- {item}" if trace else "- " + str(item) for item in grouped["static"]]
+            sections.append("## User Profile (Persistent)\n" + "\n".join(lines))
+        if grouped["dynamic"]:
+            lines = [f"- {item}" if trace else "- " + str(item) for item in grouped["dynamic"]]
+            sections.append("## Recent Context\n" + "\n".join(lines))
         lines = []
-        for item in search:
+        for item in grouped["search"]:
             memory = item.get("memory", "")
             if not memory:
                 continue
@@ -253,18 +333,21 @@ def _format_prefetch_context(static_facts: list, dynamic_facts: list, search_res
                 except Exception:
                     pass
             prefix = " ".join(prefix_bits)
-            lines.append(f"- {prefix} {memory}".strip())
+            if trace:
+                lines.append(f"- {prefix} {memory}".strip())
+            else:
+                lines.append(("- " + prefix + " " + str(memory)).strip())
         if lines:
             sections.append("## Relevant Memories\n" + "\n".join(lines))
-    if not sections:
-        return ""
+        if not sections:
+            return ""
+        body = "\n\n".join(sections)
+        return f"<supermemory-context>\n{intro}\n\n{body}\n</supermemory-context>"
 
-    intro = (
-        "The following is background context from long-term memory. Use it silently when relevant. "
-        "Do not force memories into the conversation."
-    )
-    body = "\n\n".join(sections)
-    return f"<supermemory-context>\n{intro}\n\n{body}\n</supermemory-context>"
+    max_chars = max(1, int(max_chars))
+    while selected and len(render(selected, trace=False)) > max_chars:
+        selected.pop()
+    return render(selected, trace=True) if selected else ""
 
 
 def _clean_text_for_capture(text: str) -> str:
@@ -376,6 +459,7 @@ class _SupermemoryClient:
                         "memory": getattr(item, "memory", ""),
                         "updated_at": getattr(item, "updated_at", None) or getattr(item, "updatedAt", None),
                         "similarity": getattr(item, "similarity", None),
+                        "metadata": getattr(item, "metadata", None),
                     })
         return {"static": static, "dynamic": dynamic, "search_results": search_results}
 
@@ -545,6 +629,8 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._auto_recall = True
         self._auto_capture = True
         self._max_recall_results = _DEFAULT_MAX_RECALL_RESULTS
+        self._recall_min_similarity = _DEFAULT_RECALL_MIN_SIMILARITY
+        self._prefetch_include_profile = _DEFAULT_PREFETCH_INCLUDE_PROFILE
         self._profile_frequency = _DEFAULT_PROFILE_FREQUENCY
         self._capture_mode = _DEFAULT_CAPTURE_MODE
         self._search_mode = _DEFAULT_SEARCH_MODE
@@ -668,6 +754,8 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._auto_recall = self._config["auto_recall"]
         self._auto_capture = self._config["auto_capture"]
         self._max_recall_results = self._config["max_recall_results"]
+        self._recall_min_similarity = self._config["recall_min_similarity"]
+        self._prefetch_include_profile = self._config["prefetch_include_profile"]
         self._profile_frequency = self._config["profile_frequency"]
         self._capture_mode = self._config["capture_mode"]
         self._search_mode = self._config["search_mode"]
@@ -725,11 +813,32 @@ class SupermemoryMemoryProvider(MemoryProvider):
             return ""
         try:
             profile = self._client.get_profile(query=query[:200])
-            include_profile = self._turn_count <= 1 or (self._turn_count % self._profile_frequency == 0)
+            include_profile = self._prefetch_include_profile and (
+                self._turn_count <= 1 or (self._turn_count % self._profile_frequency == 0)
+            )
+            static_facts = [
+                fact for fact in (profile.get("static") or [])
+                if not _is_transient_recall(fact)
+            ] if include_profile else []
+            dynamic_facts = [
+                fact for fact in (profile.get("dynamic") or [])
+                if not _is_transient_recall(fact)
+            ] if include_profile else []
+            search_results = []
+            for item in profile.get("search_results") or []:
+                memory = item.get("memory", "")
+                if _is_transient_recall(memory, item.get("metadata")):
+                    continue
+                try:
+                    similarity = float(item.get("similarity"))
+                except (TypeError, ValueError):
+                    continue
+                if similarity >= self._recall_min_similarity:
+                    search_results.append(item)
             context = _format_prefetch_context(
-                static_facts=profile["static"] if include_profile else [],
-                dynamic_facts=profile["dynamic"] if include_profile else [],
-                search_results=profile["search_results"],
+                static_facts=static_facts,
+                dynamic_facts=dynamic_facts,
+                search_results=search_results,
                 max_results=self._max_recall_results,
             )
             return context

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import re
 import threading
@@ -44,10 +45,11 @@ _TRANSIENT_RECALL_TYPES = {
 }
 _TRANSIENT_RECALL_RE = re.compile(
     r"(?:"
-    r"\b(?:kanban\s+)?task\s+t_[a-z0-9_-]+\b|"
-    r"\b(?:current\s+)?pull request\b[^.\n]*(?:merged|approval|branch\s+was\s+deleted)|"
-    r"\b(?:latest|yesterday(?:'s)?)\s+test run\b|"
-    r"\b(?:browser\s+)?test\s+(?:failed|passed)\b|"
+    r"\b(?:kanban\s+)?task\s+t_[a-z0-9_-]+\b[^.\n]*(?:marked\s+done|is\s+blocked|completed)|"
+    r"\b(?:t[aâ]che\s+kanban|kanban\s+t[aâ]che)\s+t_[a-z0-9_-]+\b[^.\n]*(?:termin[eé]e?|bloqu[eé]e?)|"
+    r"\bpull request\s+\d+\b[^.\n]*(?:was\s+merged|needs?\s+one\s+more\s+approval|branch\s+was\s+deleted)|"
+    r"\bthe\s+current\s+pull request\s+needs?\s+one\s+more\s+approval\b|"
+    r"\b(?:latest\s+test\s+run|yesterday(?:'s)?\s+(?:browser\s+)?test)\b[^.\n]*(?:failed|passed)|"
     r"\bphase\s+\w+\s+is\s+in\s+progress\b|"
     r"\bthe\s+worker\s+is\s+currently\b|"
     r"\bwill\s+report\s+later\b|"
@@ -62,7 +64,8 @@ _MAX_ENTITY_CONTEXT_LENGTH = 1500
 _DEFAULT_BASE_URL = "https://api.supermemory.ai"
 _API_KEY_URL = "http://app.supermemory.ai/integrations?connect=hermes"
 _TRIVIAL_RE = re.compile(
-    r"^(ok|okay|thanks|thank you|got it|sure|yes|no|yep|nope|k|ty|thx|np)\.?$",
+    r"^(ok|okay|thanks|thank you|got it|sure|yes|no|yep|nope|k|ty|thx|np|"
+    r"hello|hi|hey|continue|go|merci|salut|parfait|d['’]accord|vas[- ]?y)\s*[.!?…]*$",
     re.IGNORECASE,
 )
 _CONTEXT_STRIP_RE = re.compile(
@@ -243,7 +246,9 @@ def _format_relative_time(iso_timestamp: str) -> str:
 
 
 def _recall_dedup_key(value: Any) -> str:
-    return re.sub(r"[^a-z0-9]+", " ", str(value or "").casefold()).strip()
+    # ``\w`` is Unicode-aware in Python. Excluding only underscores keeps
+    # CJK and other non-Latin text eligible while normalizing punctuation.
+    return re.sub(r"[\W_]+", " ", str(value or "").casefold()).strip()
 
 
 def _is_duplicate_recall(key: str, seen: set[str]) -> bool:
@@ -252,8 +257,12 @@ def _is_duplicate_recall(key: str, seen: set[str]) -> bool:
 
 def _is_transient_recall(text: Any, metadata: Any = None) -> bool:
     if isinstance(metadata, dict):
-        for field in ("type", "source", "category", "kind", "document_type"):
-            value = str(metadata.get(field) or "").strip().lower().replace("-", "_")
+        transient_fields = {"type", "source", "category", "kind", "documenttype"}
+        for raw_field, raw_value in metadata.items():
+            field = re.sub(r"[^a-z0-9]+", "", str(raw_field).casefold())
+            if field not in transient_fields:
+                continue
+            value = re.sub(r"[^a-z0-9]+", "_", str(raw_value).casefold()).strip("_")
             if value in _TRANSIENT_RECALL_TYPES:
                 return True
     return bool(_TRANSIENT_RECALL_RE.search(str(text or "")))
@@ -357,7 +366,8 @@ def _clean_text_for_capture(text: str) -> str:
 
 
 def _is_trivial_message(text: str) -> bool:
-    return bool(_TRIVIAL_RE.match((text or "").strip()))
+    stripped = (text or "").strip()
+    return not stripped or not any(character.isalnum() for character in stripped) or bool(_TRIVIAL_RE.match(stripped))
 
 
 class _SupermemoryClient:
@@ -809,7 +819,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         return "\n".join(lines)
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
-        if not self._active or not self._auto_recall or not self._client or not query.strip():
+        if not self._active or not self._auto_recall or not self._client or _is_trivial_message(query):
             return ""
         try:
             profile = self._client.get_profile(query=query[:200])
@@ -833,7 +843,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
                     similarity = float(item.get("similarity"))
                 except (TypeError, ValueError):
                     continue
-                if similarity >= self._recall_min_similarity:
+                if math.isfinite(similarity) and 0.0 <= similarity <= 1.0 and similarity >= self._recall_min_similarity:
                     search_results.append(item)
             context = _format_prefetch_context(
                 static_facts=static_facts,

--- a/scripts/benchmarks/supermemory_recall_precision.py
+++ b/scripts/benchmarks/supermemory_recall_precision.py
@@ -123,7 +123,7 @@ def _prefetch_with_selection_trace(
         context = provider.prefetch(query)
     finally:
         client._selection_trace = None
-    return context, selected_ids
+    return context, selected_ids if context else []
 
 
 def evaluate(fixture: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/benchmarks/supermemory_recall_precision.py
+++ b/scripts/benchmarks/supermemory_recall_precision.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Offline precision benchmark for the current Supermemory prefetch path.
+"""Offline selection-policy benchmark for the current Supermemory prefetch path.
 
 The fixture contains sanitized fake responses. This runner never constructs the
-Supermemory SDK client and cannot read, write, or delete live memories.
+Supermemory SDK client and cannot read, write, or delete live memories. It tests
+Hermes' policy over supplied responses, not Supermemory retrieval quality.
 """
 from __future__ import annotations
 
@@ -17,6 +18,7 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from plugins.memory import supermemory as supermemory_module  # noqa: E402
 from plugins.memory.supermemory import SupermemoryMemoryProvider  # noqa: E402
 
 DEFAULT_FIXTURE = ROOT / "tests/fixtures/supermemory_recall_benchmark.json"
@@ -39,25 +41,42 @@ class FixtureClient:
     """Read-only fake client returning one checked-in response per query."""
 
     def __init__(self, cases: list[dict[str, Any]], documents: dict[str, dict[str, Any]]):
-        self._cases = {case["query"]: case for case in cases}
-        self._documents = documents
+        self._cases = {
+            case["query"]: {
+                "static": list(case.get("static", [])),
+                "dynamic": list(case.get("dynamic", [])),
+                "search": [list(result) for result in case.get("search", [])],
+            }
+            for case in cases
+        }
+        self._documents = {
+            doc_id: {
+                "content": document["content"],
+                "metadata": dict(document.get("metadata", {})),
+            }
+            for doc_id, document in documents.items()
+        }
 
     def get_profile(self, query: str | None = None, *, container_tag: str | None = None) -> dict[str, Any]:
         del container_tag
         case = self._cases[query or ""]
         content = lambda doc_id: self._documents[doc_id]["content"]
+
+        def search_result(result: list[Any]) -> dict[str, Any]:
+            doc_id = result[0]
+            payload = {
+                "id": doc_id,
+                "memory": content(doc_id),
+                "metadata": dict(self._documents[doc_id].get("metadata", {})),
+            }
+            if len(result) > 1:
+                payload["similarity"] = result[1]
+            return payload
+
         return {
             "static": [content(doc_id) for doc_id in case.get("static", [])],
             "dynamic": [content(doc_id) for doc_id in case.get("dynamic", [])],
-            "search_results": [
-                {
-                    "id": doc_id,
-                    "memory": content(doc_id),
-                    "similarity": similarity,
-                    "metadata": dict(self._documents[doc_id].get("metadata", {})),
-                }
-                for doc_id, similarity in case.get("search", [])
-            ],
+            "search_results": [search_result(result) for result in case.get("search", [])],
         }
 
 
@@ -67,13 +86,31 @@ def load_fixture(path: Path = DEFAULT_FIXTURE) -> dict[str, Any]:
     return fixture
 
 
-def _selected_ids(context: str, documents: dict[str, dict[str, Any]]) -> list[str]:
-    positions = []
-    for doc_id, document in documents.items():
-        position = context.find(document["content"])
-        if position >= 0:
-            positions.append((position, doc_id))
-    return [doc_id for _, doc_id in sorted(positions)]
+def _prefetch_with_selection_trace(
+    provider: SupermemoryMemoryProvider,
+    query: str,
+    documents: dict[str, dict[str, Any]],
+) -> tuple[str, list[str]]:
+    """Run the real prefetch path while recording formatter inputs by ID."""
+    selected_ids: list[str] = []
+    ids_by_content = {document["content"]: doc_id for doc_id, document in documents.items()}
+    original_formatter = supermemory_module._format_prefetch_context
+
+    def tracing_formatter(static_facts, dynamic_facts, search_results, max_results):
+        statics, dynamics, search = supermemory_module._deduplicate_recall(
+            static_facts, dynamic_facts, search_results
+        )
+        selected_ids.extend(ids_by_content[item] for item in statics[:max_results])
+        selected_ids.extend(ids_by_content[item] for item in dynamics[:max_results])
+        selected_ids.extend(item["id"] for item in search[:max_results] if item.get("memory"))
+        return original_formatter(static_facts, dynamic_facts, search_results, max_results)
+
+    supermemory_module._format_prefetch_context = tracing_formatter
+    try:
+        context = provider.prefetch(query)
+    finally:
+        supermemory_module._format_prefetch_context = original_formatter
+    return context, selected_ids
 
 
 def evaluate(fixture: dict[str, Any]) -> dict[str, Any]:
@@ -97,27 +134,35 @@ def evaluate(fixture: dict[str, Any]) -> dict[str, Any]:
     required_total = 0
     null_with_injection = 0
     null_total = 0
+    null_false_positives = 0
     transient_selected = Counter()
+    relevance_false_positives = 0
+    durable_irrelevant_selections = 0
     total_selected = 0
     per_case = []
     category_counts: dict[str, Counter] = defaultdict(Counter)
 
     for case in cases:
         provider.on_turn_start(case.get("turn", 2), case["query"])
-        context = provider.prefetch(case["query"])
-        selected = _selected_ids(context, documents)
+        _, selected = _prefetch_with_selection_trace(provider, case["query"], documents)
         selected_k = selected[:k]
         expected = set(case["expected_ids"])
+        false_positive_ids = [doc_id for doc_id in selected if doc_id not in expected]
 
         relevant_selected_at_k += sum(doc_id in expected for doc_id in selected_k)
         selected_at_k += len(selected_k)
         required_selected += len(expected.intersection(selected))
         required_total += len(expected)
         total_selected += len(selected)
+        relevance_false_positives += len(false_positive_ids)
+        durable_irrelevant_selections += sum(
+            documents[doc_id]["label"] == "durable" for doc_id in false_positive_ids
+        )
 
         if not expected:
             null_total += 1
             null_with_injection += bool(selected)
+            null_false_positives += len(selected)
 
         for doc_id in selected:
             document = documents[doc_id]
@@ -135,7 +180,7 @@ def evaluate(fixture: dict[str, Any]) -> dict[str, Any]:
             "category": case["category"],
             "expected_ids": case["expected_ids"],
             "selected_ids": selected,
-            "false_positive_ids": [doc_id for doc_id in selected if doc_id not in expected],
+            "false_positive_ids": false_positive_ids,
         })
 
     def ratio(numerator: int, denominator: int) -> float:
@@ -164,8 +209,12 @@ def evaluate(fixture: dict[str, Any]) -> dict[str, Any]:
         "document_count": len(documents),
         "settings_under_test": settings,
         "metrics": {
-            f"precision_at_{k}": ratio(relevant_selected_at_k, selected_at_k),
-            "false_positive_rate_on_null_queries": ratio(null_with_injection, null_total),
+            f"precision_at_returned_up_to_{k}": ratio(relevant_selected_at_k, selected_at_k),
+            f"recall_at_{k}": ratio(relevant_selected_at_k, required_total),
+            "injection_rate_on_null_queries": ratio(null_with_injection, null_total),
+            "mean_false_positives_per_null_query": ratio(null_false_positives, null_total),
+            "relevance_false_positive_rate": ratio(relevance_false_positives, total_selected),
+            "durable_irrelevant_selections": durable_irrelevant_selections,
             "required_durable_recall": ratio(required_selected, required_total),
             "transient_contamination_rate": ratio(sum(transient_selected.values()), total_selected),
             "transient_contamination_by_class": contamination_by_class,

--- a/scripts/benchmarks/supermemory_recall_precision.py
+++ b/scripts/benchmarks/supermemory_recall_precision.py
@@ -12,13 +12,12 @@ import json
 import sys
 from collections import Counter, defaultdict
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from plugins.memory import supermemory as supermemory_module  # noqa: E402
 from plugins.memory.supermemory import SupermemoryMemoryProvider  # noqa: E402
 
 DEFAULT_FIXTURE = ROOT / "tests/fixtures/supermemory_recall_benchmark.json"
@@ -37,10 +36,29 @@ def _validate_fixture(fixture: dict[str, Any]) -> None:
     _require_unique(fixture["cases"], "query", "cases")
 
 
+class _TracedContent(str):
+    """Fixture text that reports when the production formatter renders it."""
+
+    _doc_id: str
+    _on_render: Callable[[str], None]
+
+    def __new__(cls, content: str, doc_id: str, on_render: Callable[[str], None]):
+        instance = super().__new__(cls, content)
+        instance._doc_id = doc_id
+        instance._on_render = on_render
+        return instance
+
+    def __format__(self, format_spec: str) -> str:
+        rendered = super().__format__(format_spec)
+        self._on_render(self._doc_id)
+        return rendered
+
+
 class FixtureClient:
     """Read-only fake client returning one checked-in response per query."""
 
     def __init__(self, cases: list[dict[str, Any]], documents: dict[str, dict[str, Any]]):
+        self._selection_trace: Callable[[str], None] | None = None
         self._cases = {
             case["query"]: {
                 "static": list(case.get("static", [])),
@@ -60,7 +78,12 @@ class FixtureClient:
     def get_profile(self, query: str | None = None, *, container_tag: str | None = None) -> dict[str, Any]:
         del container_tag
         case = self._cases[query or ""]
-        content = lambda doc_id: self._documents[doc_id]["content"]
+
+        def content(doc_id: str) -> str:
+            value = self._documents[doc_id]["content"]
+            if self._selection_trace is None:
+                return value
+            return _TracedContent(value, doc_id, self._selection_trace)
 
         def search_result(result: list[Any]) -> dict[str, Any]:
             doc_id = result[0]
@@ -89,27 +112,17 @@ def load_fixture(path: Path = DEFAULT_FIXTURE) -> dict[str, Any]:
 def _prefetch_with_selection_trace(
     provider: SupermemoryMemoryProvider,
     query: str,
-    documents: dict[str, dict[str, Any]],
 ) -> tuple[str, list[str]]:
-    """Run the real prefetch path while recording formatter inputs by ID."""
+    """Run prefetch while fixture values report actual formatter rendering."""
     selected_ids: list[str] = []
-    ids_by_content = {document["content"]: doc_id for doc_id, document in documents.items()}
-    original_formatter = supermemory_module._format_prefetch_context
-
-    def tracing_formatter(static_facts, dynamic_facts, search_results, max_results):
-        statics, dynamics, search = supermemory_module._deduplicate_recall(
-            static_facts, dynamic_facts, search_results
-        )
-        selected_ids.extend(ids_by_content[item] for item in statics[:max_results])
-        selected_ids.extend(ids_by_content[item] for item in dynamics[:max_results])
-        selected_ids.extend(item["id"] for item in search[:max_results] if item.get("memory"))
-        return original_formatter(static_facts, dynamic_facts, search_results, max_results)
-
-    supermemory_module._format_prefetch_context = tracing_formatter
+    client = provider._client
+    if not isinstance(client, FixtureClient):
+        raise TypeError("selection tracing requires FixtureClient")
+    client._selection_trace = selected_ids.append
     try:
         context = provider.prefetch(query)
     finally:
-        supermemory_module._format_prefetch_context = original_formatter
+        client._selection_trace = None
     return context, selected_ids
 
 
@@ -144,7 +157,7 @@ def evaluate(fixture: dict[str, Any]) -> dict[str, Any]:
 
     for case in cases:
         provider.on_turn_start(case.get("turn", 2), case["query"])
-        _, selected = _prefetch_with_selection_trace(provider, case["query"], documents)
+        _, selected = _prefetch_with_selection_trace(provider, case["query"])
         selected_k = selected[:k]
         expected = set(case["expected_ids"])
         false_positive_ids = [doc_id for doc_id in selected if doc_id not in expected]

--- a/scripts/benchmarks/supermemory_recall_precision.py
+++ b/scripts/benchmarks/supermemory_recall_precision.py
@@ -22,6 +22,19 @@ from plugins.memory.supermemory import SupermemoryMemoryProvider  # noqa: E402
 DEFAULT_FIXTURE = ROOT / "tests/fixtures/supermemory_recall_benchmark.json"
 
 
+def _require_unique(items: list[dict[str, Any]], field: str, collection: str) -> None:
+    counts = Counter(item[field] for item in items)
+    duplicates = sorted(value for value, count in counts.items() if count > 1)
+    if duplicates:
+        raise ValueError(f"duplicate {field} in {collection}: {duplicates}")
+
+
+def _validate_fixture(fixture: dict[str, Any]) -> None:
+    _require_unique(fixture["documents"], "id", "documents")
+    _require_unique(fixture["cases"], "id", "cases")
+    _require_unique(fixture["cases"], "query", "cases")
+
+
 class FixtureClient:
     """Read-only fake client returning one checked-in response per query."""
 
@@ -41,10 +54,7 @@ class FixtureClient:
                     "id": doc_id,
                     "memory": content(doc_id),
                     "similarity": similarity,
-                    "metadata": {
-                        "benchmark_label": self._documents[doc_id]["label"],
-                        "benchmark_class": self._documents[doc_id]["class"],
-                    },
+                    "metadata": dict(self._documents[doc_id].get("metadata", {})),
                 }
                 for doc_id, similarity in case.get("search", [])
             ],
@@ -52,7 +62,9 @@ class FixtureClient:
 
 
 def load_fixture(path: Path = DEFAULT_FIXTURE) -> dict[str, Any]:
-    return json.loads(path.read_text(encoding="utf-8"))
+    fixture = json.loads(path.read_text(encoding="utf-8"))
+    _validate_fixture(fixture)
+    return fixture
 
 
 def _selected_ids(context: str, documents: dict[str, dict[str, Any]]) -> list[str]:
@@ -65,6 +77,7 @@ def _selected_ids(context: str, documents: dict[str, dict[str, Any]]) -> list[st
 
 
 def evaluate(fixture: dict[str, Any]) -> dict[str, Any]:
+    _validate_fixture(fixture)
     settings = fixture["settings"]
     documents = {document["id"]: document for document in fixture["documents"]}
     cases = fixture["cases"]

--- a/scripts/benchmarks/supermemory_recall_precision.py
+++ b/scripts/benchmarks/supermemory_recall_precision.py
@@ -102,6 +102,17 @@ class FixtureClient:
             "search_results": [search_result(result) for result in case.get("search", [])],
         }
 
+    def search_memories(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+        container_tag: str | None = None,
+        search_mode: str | None = None,
+    ) -> list[dict[str, Any]]:
+        del container_tag, search_mode
+        return self.get_profile(query=query)["search_results"][:limit]
+
 
 def load_fixture(path: Path = DEFAULT_FIXTURE) -> dict[str, Any]:
     fixture = json.loads(path.read_text(encoding="utf-8"))

--- a/scripts/benchmarks/supermemory_recall_precision.py
+++ b/scripts/benchmarks/supermemory_recall_precision.py
@@ -147,8 +147,9 @@ def evaluate(fixture: dict[str, Any]) -> dict[str, Any]:
     provider._active = True
     provider._auto_recall = True
     provider._max_recall_results = settings["max_recall_results"]
+    provider._recall_min_similarity = settings["recall_min_similarity"]
+    provider._prefetch_include_profile = settings["prefetch_include_profile"]
     provider._profile_frequency = 50
-    provider._config = dict(settings)
     provider._client = FixtureClient(cases, documents)  # type: ignore[assignment]
 
     k = settings["k"]

--- a/scripts/benchmarks/supermemory_recall_precision.py
+++ b/scripts/benchmarks/supermemory_recall_precision.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Offline precision benchmark for the current Supermemory prefetch path.
+
+The fixture contains sanitized fake responses. This runner never constructs the
+Supermemory SDK client and cannot read, write, or delete live memories.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from plugins.memory.supermemory import SupermemoryMemoryProvider  # noqa: E402
+
+DEFAULT_FIXTURE = ROOT / "tests/fixtures/supermemory_recall_benchmark.json"
+
+
+class FixtureClient:
+    """Read-only fake client returning one checked-in response per query."""
+
+    def __init__(self, cases: list[dict[str, Any]], documents: dict[str, dict[str, Any]]):
+        self._cases = {case["query"]: case for case in cases}
+        self._documents = documents
+
+    def get_profile(self, query: str | None = None, *, container_tag: str | None = None) -> dict[str, Any]:
+        del container_tag
+        case = self._cases[query or ""]
+        content = lambda doc_id: self._documents[doc_id]["content"]
+        return {
+            "static": [content(doc_id) for doc_id in case.get("static", [])],
+            "dynamic": [content(doc_id) for doc_id in case.get("dynamic", [])],
+            "search_results": [
+                {
+                    "id": doc_id,
+                    "memory": content(doc_id),
+                    "similarity": similarity,
+                    "metadata": {
+                        "benchmark_label": self._documents[doc_id]["label"],
+                        "benchmark_class": self._documents[doc_id]["class"],
+                    },
+                }
+                for doc_id, similarity in case.get("search", [])
+            ],
+        }
+
+
+def load_fixture(path: Path = DEFAULT_FIXTURE) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _selected_ids(context: str, documents: dict[str, dict[str, Any]]) -> list[str]:
+    positions = []
+    for doc_id, document in documents.items():
+        position = context.find(document["content"])
+        if position >= 0:
+            positions.append((position, doc_id))
+    return [doc_id for _, doc_id in sorted(positions)]
+
+
+def evaluate(fixture: dict[str, Any]) -> dict[str, Any]:
+    settings = fixture["settings"]
+    documents = {document["id"]: document for document in fixture["documents"]}
+    cases = fixture["cases"]
+
+    provider = SupermemoryMemoryProvider()
+    provider._active = True
+    provider._auto_recall = True
+    provider._max_recall_results = settings["max_recall_results"]
+    provider._profile_frequency = 50
+    provider._config = dict(settings)
+    provider._client = FixtureClient(cases, documents)  # type: ignore[assignment]
+
+    k = settings["k"]
+    relevant_selected_at_k = 0
+    selected_at_k = 0
+    required_selected = 0
+    required_total = 0
+    null_with_injection = 0
+    null_total = 0
+    transient_selected = Counter()
+    total_selected = 0
+    per_case = []
+    category_counts: dict[str, Counter] = defaultdict(Counter)
+
+    for case in cases:
+        provider.on_turn_start(case.get("turn", 2), case["query"])
+        context = provider.prefetch(case["query"])
+        selected = _selected_ids(context, documents)
+        selected_k = selected[:k]
+        expected = set(case["expected_ids"])
+
+        relevant_selected_at_k += sum(doc_id in expected for doc_id in selected_k)
+        selected_at_k += len(selected_k)
+        required_selected += len(expected.intersection(selected))
+        required_total += len(expected)
+        total_selected += len(selected)
+
+        if not expected:
+            null_total += 1
+            null_with_injection += bool(selected)
+
+        for doc_id in selected:
+            document = documents[doc_id]
+            if document["label"] == "transient":
+                transient_selected[document["class"]] += 1
+
+        category = category_counts[case["category"]]
+        category["cases"] += 1
+        category["selected"] += len(selected)
+        category["required"] += len(expected)
+        category["required_selected"] += len(expected.intersection(selected))
+
+        per_case.append({
+            "id": case["id"],
+            "category": case["category"],
+            "expected_ids": case["expected_ids"],
+            "selected_ids": selected,
+            "false_positive_ids": [doc_id for doc_id in selected if doc_id not in expected],
+        })
+
+    def ratio(numerator: int, denominator: int) -> float:
+        return round(numerator / denominator, 4) if denominator else 0.0
+
+    contamination_by_class = {
+        class_name: {
+            "selected": count,
+            "rate": ratio(count, total_selected),
+        }
+        for class_name, count in sorted(transient_selected.items())
+    }
+    category_summary = {
+        name: {
+            "cases": counts["cases"],
+            "selected": counts["selected"],
+            "required_recall": ratio(counts["required_selected"], counts["required"]),
+        }
+        for name, counts in sorted(category_counts.items())
+    }
+    by_id = {case["id"]: case for case in per_case}
+
+    return {
+        "schema_version": fixture["schema_version"],
+        "case_count": len(cases),
+        "document_count": len(documents),
+        "settings_under_test": settings,
+        "metrics": {
+            f"precision_at_{k}": ratio(relevant_selected_at_k, selected_at_k),
+            "false_positive_rate_on_null_queries": ratio(null_with_injection, null_total),
+            "required_durable_recall": ratio(required_selected, required_total),
+            "transient_contamination_rate": ratio(sum(transient_selected.values()), total_selected),
+            "transient_contamination_by_class": contamination_by_class,
+        },
+        "exact_false_positive_modes": {
+            "low_similarity_result_injected": "session_transcript" in by_id["null-01"]["selected_ids"],
+            "profile_injected_when_disabled": "identity_timezone" in by_id["null-05"]["selected_ids"],
+        },
+        "categories": category_summary,
+        "cases": per_case,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE)
+    parser.add_argument(
+        "--assert-baseline",
+        action="store_true",
+        help="fail unless the current unfiltered-prefetch false positives are reproduced",
+    )
+    args = parser.parse_args()
+
+    report = evaluate(load_fixture(args.fixture))
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if args.assert_baseline and not all(report["exact_false_positive_modes"].values()):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/supermemory_recall_benchmark.json
+++ b/tests/fixtures/supermemory_recall_benchmark.json
@@ -12,10 +12,12 @@
     {"id": "identity_style", "label": "durable", "class": "preference", "content": "Avery prefers concise answers that lead with the result."},
     {"id": "identity_timezone", "label": "durable", "class": "identity", "content": "Avery's timezone is Central European Time."},
     {"id": "identity_accessibility", "label": "durable", "class": "preference", "content": "Avery prefers charts with patterns as well as colors."},
+    {"id": "identity_style_paraphrase", "label": "durable", "class": "preference_paraphrase", "content": "Avery likes responses that begin with the conclusion."},
     {"id": "convention_tests", "label": "durable", "class": "cross_project_convention", "content": "Across repositories, run the checked-in test wrapper instead of invoking pytest directly."},
     {"id": "convention_secrets", "label": "durable", "class": "cross_project_convention", "content": "Behavioral settings belong in YAML; environment files are reserved for secrets."},
     {"id": "convention_evidence", "label": "durable", "class": "cross_project_convention", "content": "Verification handoffs must include the exact command and real output."},
     {"id": "convention_git", "label": "durable", "class": "cross_project_convention", "content": "Do not commit or push repository changes unless the task explicitly requests it."},
+    {"id": "convention_branches", "label": "durable", "class": "cross_project_convention", "content": "Feature branches use short names that describe their scoped change."},
     {"id": "atlas_storage", "label": "durable", "class": "project_fact", "content": "Project Atlas stores release fixtures in the atlas-staging bucket."},
     {"id": "atlas_scale", "label": "durable", "class": "project_fact", "content": "Project Atlas distinguishes reviewed datasets from raw source records."},
     {"id": "cedar_relation", "label": "durable", "class": "project_fact", "content": "Project Cedar keeps broad graph relations and records subtype nuance in evidence metadata."},
@@ -60,6 +62,6 @@
     {"id": "adversarial-02", "category": "adversarial_transient", "query": "What lasting convention applies to pull requests?", "expected_ids": ["convention_git"], "turn": 2, "search": [["pr_merged", 0.93], ["pr_review", 0.9], ["convention_git", 0.84]]},
     {"id": "adversarial-03", "category": "adversarial_transient", "query": "What durable rule applies when tests pass?", "expected_ids": ["convention_tests"], "turn": 2, "search": [["test_pass", 0.95], ["test_fail", 0.89], ["convention_tests", 0.82]]},
     {"id": "adversarial-04", "category": "adversarial_transient", "query": "Recall the stable Atlas architecture, not current status.", "expected_ids": ["atlas_scale"], "turn": 2, "search": [["status_phase", 0.92], ["session_transcript", 0.87], ["atlas_scale", 0.83]]},
-    {"id": "adversarial-05", "category": "adversarial_transient", "query": "Which durable accessibility preference should survive a smoke test?", "expected_ids": ["identity_accessibility"], "turn": 2, "search": [["smoke_marker", 0.96], ["identity_accessibility", 0.88], ["status_worker", 0.52]]}
+    {"id": "adversarial-05", "category": "adversarial_transient", "query": "How should charts distinguish categories for me?", "expected_ids": ["identity_accessibility"], "turn": 2, "search": [["smoke_marker", 0.96], ["identity_accessibility", 0.88], ["status_worker", 0.52], ["convention_branches", 0.45], ["identity_style_paraphrase", 0.4], ["session_transcript", 0.3], ["test_pass"]]}
   ]
 }

--- a/tests/fixtures/supermemory_recall_benchmark.json
+++ b/tests/fixtures/supermemory_recall_benchmark.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "description": "Sanitized offline recall corpus. expected_ids are the durable documents that should be injected; an empty list marks a null query.",
+  "settings": {
+    "k": 5,
+    "max_recall_results": 5,
+    "recall_min_similarity": 0.76,
+    "prefetch_include_profile": false
+  },
+  "documents": [
+    {"id": "identity_language", "label": "durable", "class": "identity", "content": "Avery usually communicates in English."},
+    {"id": "identity_style", "label": "durable", "class": "preference", "content": "Avery prefers concise answers that lead with the result."},
+    {"id": "identity_timezone", "label": "durable", "class": "identity", "content": "Avery's timezone is Central European Time."},
+    {"id": "identity_accessibility", "label": "durable", "class": "preference", "content": "Avery prefers charts with patterns as well as colors."},
+    {"id": "convention_tests", "label": "durable", "class": "cross_project_convention", "content": "Across repositories, run the checked-in test wrapper instead of invoking pytest directly."},
+    {"id": "convention_secrets", "label": "durable", "class": "cross_project_convention", "content": "Behavioral settings belong in YAML; environment files are reserved for secrets."},
+    {"id": "convention_evidence", "label": "durable", "class": "cross_project_convention", "content": "Verification handoffs must include the exact command and real output."},
+    {"id": "convention_git", "label": "durable", "class": "cross_project_convention", "content": "Do not commit or push repository changes unless the task explicitly requests it."},
+    {"id": "atlas_storage", "label": "durable", "class": "project_fact", "content": "Project Atlas stores release fixtures in the atlas-staging bucket."},
+    {"id": "atlas_scale", "label": "durable", "class": "project_fact", "content": "Project Atlas distinguishes reviewed datasets from raw source records."},
+    {"id": "cedar_relation", "label": "durable", "class": "project_fact", "content": "Project Cedar keeps broad graph relations and records subtype nuance in evidence metadata."},
+    {"id": "beacon_network", "label": "durable", "class": "project_fact", "content": "Project Beacon uses peer routing and does not deploy a relay server."},
+    {"id": "kanban_done", "label": "transient", "class": "kanban_task", "content": "Kanban task t_demo123 was marked done after the worker returned."},
+    {"id": "kanban_blocked", "label": "transient", "class": "kanban_task", "content": "Task t_demo456 is blocked pending reviewer feedback."},
+    {"id": "pr_merged", "label": "transient", "class": "pull_request_status", "content": "Pull request 417 was merged and its branch was deleted."},
+    {"id": "pr_review", "label": "transient", "class": "pull_request_status", "content": "The current pull request needs one more approval."},
+    {"id": "test_pass", "label": "transient", "class": "test_run", "content": "The latest test run passed 84 checks with exit code zero."},
+    {"id": "test_fail", "label": "transient", "class": "test_run", "content": "Yesterday's browser test failed on the settings screen."},
+    {"id": "status_phase", "label": "transient", "class": "project_status", "content": "Phase three is in progress and the next step is deployment."},
+    {"id": "status_worker", "label": "transient", "class": "project_status", "content": "The worker is currently inspecting call sites and will report later."},
+    {"id": "session_transcript", "label": "transient", "class": "full_session", "content": "Full session transcript: user requested a patch, assistant ran tests, and the task completed."},
+    {"id": "smoke_marker", "label": "transient", "class": "smoke_test", "content": "Temporary smoke marker for memory integration test 2026-07."}
+  ],
+  "cases": [
+    {"id": "identity-01", "category": "durable_identity_preferences", "query": "Which language do I normally use?", "expected_ids": ["identity_language"], "turn": 2, "search": [["identity_language", 0.93], ["session_transcript", 0.71], ["kanban_done", 0.61]]},
+    {"id": "identity-02", "category": "durable_identity_preferences", "query": "How concise should your response be?", "expected_ids": ["identity_style"], "turn": 2, "search": [["identity_style", 0.95], ["status_worker", 0.68]]},
+    {"id": "identity-03", "category": "durable_identity_preferences", "query": "What timezone should scheduling use?", "expected_ids": ["identity_timezone"], "turn": 2, "search": [["identity_timezone", 0.91], ["status_phase", 0.58]]},
+    {"id": "identity-04", "category": "durable_identity_preferences", "query": "How should charts encode categories accessibly?", "expected_ids": ["identity_accessibility"], "turn": 2, "search": [["identity_accessibility", 0.89], ["test_fail", 0.55]]},
+    {"id": "identity-05", "category": "durable_identity_preferences", "query": "Give me my communication preferences.", "expected_ids": ["identity_style", "identity_language"], "turn": 1, "static": ["identity_style", "identity_language"], "search": [["pr_review", 0.44]]},
+
+    {"id": "convention-01", "category": "cross_project_durable_conventions", "query": "How should I run the Python tests?", "expected_ids": ["convention_tests"], "turn": 2, "search": [["convention_tests", 0.94], ["test_pass", 0.82], ["test_fail", 0.73]]},
+    {"id": "convention-02", "category": "cross_project_durable_conventions", "query": "Where do behavioral settings and secrets belong?", "expected_ids": ["convention_secrets"], "turn": 2, "search": [["convention_secrets", 0.92], ["session_transcript", 0.39]]},
+    {"id": "convention-03", "category": "cross_project_durable_conventions", "query": "What belongs in a verification handoff?", "expected_ids": ["convention_evidence"], "turn": 2, "search": [["convention_evidence", 0.9], ["test_pass", 0.79], ["kanban_done", 0.72]]},
+    {"id": "convention-04", "category": "cross_project_durable_conventions", "query": "May the agent push repository changes by default?", "expected_ids": ["convention_git"], "turn": 2, "search": [["convention_git", 0.88], ["pr_merged", 0.8], ["pr_review", 0.77]]},
+    {"id": "convention-05", "category": "cross_project_durable_conventions", "query": "Remind me of the test and evidence conventions.", "expected_ids": ["convention_tests", "convention_evidence"], "turn": 1, "static": ["convention_tests", "convention_evidence"], "dynamic": ["test_pass"], "search": [["kanban_done", 0.63]]},
+
+    {"id": "project-01", "category": "project_specific_durable_facts", "query": "Where are Atlas release fixtures stored?", "expected_ids": ["atlas_storage"], "turn": 2, "search": [["atlas_storage", 0.96], ["status_phase", 0.64]]},
+    {"id": "project-02", "category": "project_specific_durable_facts", "query": "What scale distinction matters in Atlas?", "expected_ids": ["atlas_scale"], "turn": 2, "search": [["atlas_scale", 0.9], ["status_phase", 0.7], ["kanban_blocked", 0.53]]},
+    {"id": "project-03", "category": "project_specific_durable_facts", "query": "How does Cedar represent graph relation nuance?", "expected_ids": ["cedar_relation"], "turn": 2, "search": [["cedar_relation", 0.95], ["pr_review", 0.49]]},
+    {"id": "project-04", "category": "project_specific_durable_facts", "query": "Does Beacon deploy a relay server?", "expected_ids": ["beacon_network"], "turn": 2, "search": [["beacon_network", 0.94], ["status_worker", 0.48]]},
+    {"id": "project-05", "category": "project_specific_durable_facts", "query": "Summarize durable Atlas facts.", "expected_ids": ["atlas_storage", "atlas_scale"], "turn": 1, "static": ["atlas_storage", "atlas_scale"], "dynamic": ["status_phase"], "search": [["session_transcript", 0.57]]},
+
+    {"id": "null-01", "category": "unrelated_null_queries", "query": "What is the boiling point of neon?", "expected_ids": [], "turn": 2, "search": [["session_transcript", 0.24], ["status_worker", 0.18]]},
+    {"id": "null-02", "category": "unrelated_null_queries", "query": "Draft a haiku about rain.", "expected_ids": [], "turn": 2, "search": [["smoke_marker", 0.22]]},
+    {"id": "null-03", "category": "unrelated_null_queries", "query": "Convert seven miles to kilometers.", "expected_ids": [], "turn": 2, "search": [["test_pass", 0.31], ["kanban_done", 0.16]]},
+    {"id": "null-04", "category": "unrelated_null_queries", "query": "Explain photosynthesis to a child.", "expected_ids": [], "turn": 1, "dynamic": ["status_worker"], "search": [["pr_review", 0.27]]},
+    {"id": "null-05", "category": "unrelated_null_queries", "query": "Suggest a recipe using pears.", "expected_ids": [], "turn": 1, "static": ["identity_timezone"], "search": [["session_transcript", 0.2]]},
+
+    {"id": "adversarial-01", "category": "adversarial_transient", "query": "What is the durable workflow for Kanban reviews?", "expected_ids": ["convention_evidence"], "turn": 2, "search": [["kanban_blocked", 0.91], ["kanban_done", 0.88], ["convention_evidence", 0.86]]},
+    {"id": "adversarial-02", "category": "adversarial_transient", "query": "What lasting convention applies to pull requests?", "expected_ids": ["convention_git"], "turn": 2, "search": [["pr_merged", 0.93], ["pr_review", 0.9], ["convention_git", 0.84]]},
+    {"id": "adversarial-03", "category": "adversarial_transient", "query": "What durable rule applies when tests pass?", "expected_ids": ["convention_tests"], "turn": 2, "search": [["test_pass", 0.95], ["test_fail", 0.89], ["convention_tests", 0.82]]},
+    {"id": "adversarial-04", "category": "adversarial_transient", "query": "Recall the stable Atlas architecture, not current status.", "expected_ids": ["atlas_scale"], "turn": 2, "search": [["status_phase", 0.92], ["session_transcript", 0.87], ["atlas_scale", 0.83]]},
+    {"id": "adversarial-05", "category": "adversarial_transient", "query": "Which durable accessibility preference should survive a smoke test?", "expected_ids": ["identity_accessibility"], "turn": 2, "search": [["smoke_marker", 0.96], ["identity_accessibility", 0.88], ["status_worker", 0.52]]}
+  ]
+}

--- a/tests/fixtures/supermemory_recall_benchmark.json
+++ b/tests/fixtures/supermemory_recall_benchmark.json
@@ -18,6 +18,11 @@
     {"id": "convention_evidence", "label": "durable", "class": "cross_project_convention", "content": "Verification handoffs must include the exact command and real output."},
     {"id": "convention_git", "label": "durable", "class": "cross_project_convention", "content": "Do not commit or push repository changes unless the task explicitly requests it."},
     {"id": "convention_branches", "label": "durable", "class": "cross_project_convention", "content": "Feature branches use short names that describe their scoped change."},
+    {"id": "identity_style_zh", "label": "durable", "class": "preference", "content": "用户偏好简洁回答。"},
+    {"id": "convention_failed_test", "label": "durable", "class": "cross_project_convention", "content": "If the browser test failed, capture the trace before retrying."},
+    {"id": "convention_pr_approval", "label": "durable", "class": "cross_project_convention", "content": "Current pull request approval requires two independent reviewers."},
+    {"id": "convention_task_status", "label": "durable", "class": "cross_project_convention", "content": "Kanban task status belongs in the handoff, not durable memory."},
+    {"id": "convention_project_status", "label": "durable", "class": "cross_project_convention", "content": "Project status terminology is defined in the release policy."},
     {"id": "atlas_storage", "label": "durable", "class": "project_fact", "content": "Project Atlas stores release fixtures in the atlas-staging bucket."},
     {"id": "atlas_scale", "label": "durable", "class": "project_fact", "content": "Project Atlas distinguishes reviewed datasets from raw source records."},
     {"id": "cedar_relation", "label": "durable", "class": "project_fact", "content": "Project Cedar keeps broad graph relations and records subtype nuance in evidence metadata."},
@@ -31,7 +36,10 @@
     {"id": "status_phase", "label": "transient", "class": "project_status", "content": "Phase three is in progress and the next step is deployment."},
     {"id": "status_worker", "label": "transient", "class": "project_status", "content": "The worker is currently inspecting call sites and will report later."},
     {"id": "session_transcript", "label": "transient", "class": "full_session", "content": "Full session transcript: user requested a patch, assistant ran tests, and the task completed."},
-    {"id": "smoke_marker", "label": "transient", "class": "smoke_test", "content": "Temporary smoke marker for memory integration test 2026-07."}
+    {"id": "smoke_marker", "label": "transient", "class": "smoke_test", "content": "Temporary smoke marker for memory integration test 2026-07."},
+    {"id": "french_kanban_done", "label": "transient", "class": "kanban_task", "content": "La tâche Kanban t_demo123 est terminée après la revue."},
+    {"id": "french_full_session", "label": "transient", "class": "full_session", "content": "La session complète contient les actions temporaires du jour.", "metadata": {"documentType": "full_session"}},
+    {"id": "spaced_full_session", "label": "transient", "class": "full_session", "content": "Session notes from a one-time troubleshooting run.", "metadata": {"type": "full session"}}
   ],
   "cases": [
     {"id": "identity-01", "category": "durable_identity_preferences", "query": "Which language do I normally use?", "expected_ids": ["identity_language"], "turn": 2, "search": [["identity_language", 0.93], ["session_transcript", 0.71], ["kanban_done", 0.61]]},
@@ -39,12 +47,17 @@
     {"id": "identity-03", "category": "durable_identity_preferences", "query": "What timezone should scheduling use?", "expected_ids": ["identity_timezone"], "turn": 2, "search": [["identity_timezone", 0.91], ["status_phase", 0.58]]},
     {"id": "identity-04", "category": "durable_identity_preferences", "query": "How should charts encode categories accessibly?", "expected_ids": ["identity_accessibility"], "turn": 2, "search": [["identity_accessibility", 0.89], ["test_fail", 0.55]]},
     {"id": "identity-05", "category": "durable_identity_preferences", "query": "Give me my communication preferences.", "expected_ids": ["identity_style", "identity_language"], "turn": 1, "static": ["identity_style", "identity_language"], "search": [["pr_review", 0.44]]},
+    {"id": "identity-06", "category": "durable_identity_preferences", "query": "请用什么风格回答？", "expected_ids": ["identity_style_zh"], "turn": 2, "search": [["identity_style_zh", 0.96], ["french_kanban_done", 0.81]]},
 
     {"id": "convention-01", "category": "cross_project_durable_conventions", "query": "How should I run the Python tests?", "expected_ids": ["convention_tests"], "turn": 2, "search": [["convention_tests", 0.94], ["test_pass", 0.82], ["test_fail", 0.73]]},
     {"id": "convention-02", "category": "cross_project_durable_conventions", "query": "Where do behavioral settings and secrets belong?", "expected_ids": ["convention_secrets"], "turn": 2, "search": [["convention_secrets", 0.92], ["session_transcript", 0.39]]},
     {"id": "convention-03", "category": "cross_project_durable_conventions", "query": "What belongs in a verification handoff?", "expected_ids": ["convention_evidence"], "turn": 2, "search": [["convention_evidence", 0.9], ["test_pass", 0.79], ["kanban_done", 0.72]]},
     {"id": "convention-04", "category": "cross_project_durable_conventions", "query": "May the agent push repository changes by default?", "expected_ids": ["convention_git"], "turn": 2, "search": [["convention_git", 0.88], ["pr_merged", 0.8], ["pr_review", 0.77]]},
     {"id": "convention-05", "category": "cross_project_durable_conventions", "query": "Remind me of the test and evidence conventions.", "expected_ids": ["convention_tests", "convention_evidence"], "turn": 1, "static": ["convention_tests", "convention_evidence"], "dynamic": ["test_pass"], "search": [["kanban_done", 0.63]]},
+    {"id": "convention-06", "category": "cross_project_durable_conventions", "query": "What should happen after a browser test failure?", "expected_ids": ["convention_failed_test"], "turn": 2, "search": [["convention_failed_test", 0.95], ["test_fail", 0.92]]},
+    {"id": "convention-07", "category": "cross_project_durable_conventions", "query": "What is the pull request approval rule?", "expected_ids": ["convention_pr_approval"], "turn": 2, "search": [["convention_pr_approval", 0.94], ["pr_review", 0.91]]},
+    {"id": "convention-08", "category": "cross_project_durable_conventions", "query": "Where should Kanban status be recorded?", "expected_ids": ["convention_task_status"], "turn": 2, "search": [["convention_task_status", 0.93], ["french_kanban_done", 0.9], ["french_full_session", 0.89]]},
+    {"id": "convention-09", "category": "cross_project_durable_conventions", "query": "How is project status terminology defined?", "expected_ids": ["convention_project_status"], "turn": 2, "search": [["convention_project_status", 0.93], ["spaced_full_session", 0.88]]},
 
     {"id": "project-01", "category": "project_specific_durable_facts", "query": "Where are Atlas release fixtures stored?", "expected_ids": ["atlas_storage"], "turn": 2, "search": [["atlas_storage", 0.96], ["status_phase", 0.64]]},
     {"id": "project-02", "category": "project_specific_durable_facts", "query": "What scale distinction matters in Atlas?", "expected_ids": ["atlas_scale"], "turn": 2, "search": [["atlas_scale", 0.9], ["status_phase", 0.7], ["kanban_blocked", 0.53]]},
@@ -57,6 +70,7 @@
     {"id": "null-03", "category": "unrelated_null_queries", "query": "Convert seven miles to kilometers.", "expected_ids": [], "turn": 2, "search": [["test_pass", 0.31], ["kanban_done", 0.16]]},
     {"id": "null-04", "category": "unrelated_null_queries", "query": "Explain photosynthesis to a child.", "expected_ids": [], "turn": 1, "dynamic": ["status_worker"], "search": [["pr_review", 0.27]]},
     {"id": "null-05", "category": "unrelated_null_queries", "query": "Suggest a recipe using pears.", "expected_ids": [], "turn": 1, "static": ["identity_timezone"], "search": [["session_transcript", 0.2]]},
+    {"id": "null-06", "category": "unrelated_null_queries", "query": "Name a moon of Saturn.", "expected_ids": [], "turn": 2, "search": [["convention_failed_test", "NaN"], ["convention_pr_approval", "Infinity"], ["convention_task_status", "-Infinity"], ["convention_project_status", -0.01], ["convention_branches", 1.01]]},
 
     {"id": "adversarial-01", "category": "adversarial_transient", "query": "What is the durable workflow for Kanban reviews?", "expected_ids": ["convention_evidence"], "turn": 2, "search": [["kanban_blocked", 0.91], ["kanban_done", 0.88], ["convention_evidence", 0.86]]},
     {"id": "adversarial-02", "category": "adversarial_transient", "query": "What lasting convention applies to pull requests?", "expected_ids": ["convention_git"], "turn": 2, "search": [["pr_merged", 0.93], ["pr_review", 0.9], ["convention_git", 0.84]]},

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -28,6 +28,7 @@ class FakeClient:
         self.base_url = base_url
         self.add_calls = []
         self.search_results = []
+        self.search_calls = []
         self.profile_response = {"static": [], "dynamic": [], "search_results": []}
         self.profile_calls = []
         self.ingest_calls = []
@@ -46,7 +47,14 @@ class FakeClient:
         return {"id": "mem_123"}
 
     def search_memories(self, query, *, limit=5, container_tag=None, search_mode=None):
-        return self.search_results
+        self.search_calls.append({
+            "query": query,
+            "limit": limit,
+            "container_tag": container_tag,
+            "search_mode": search_mode,
+        })
+        results = self.search_results or self.profile_response.get("search_results", [])
+        return results[:limit]
 
     def get_profile(self, query=None, *, container_tag=None):
         self.profile_calls.append({"query": query, "container_tag": container_tag})
@@ -228,6 +236,8 @@ def test_prefetch_does_not_include_profile_on_first_turn_by_default(provider):
     assert "Relevant Memories" in result
     assert "User Profile (Persistent)" not in result
     assert "Recent Context" not in result
+    assert provider._client.profile_calls == []
+    assert provider._client.search_calls
 
 
 def test_prefetch_includes_static_profile_only_when_opted_in(monkeypatch, tmp_path):
@@ -257,6 +267,7 @@ def test_prefetch_skips_trivial_queries_without_calling_client(provider, query):
     }
     assert provider.prefetch(query) == ""
     assert provider._client.profile_calls == []
+    assert provider._client.search_calls == []
 
 
 def test_prefetch_applies_similarity_boundary_and_suppresses_transient_material(provider):

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -7,6 +7,7 @@ import pytest
 
 from plugins.memory.supermemory import (
     SupermemoryMemoryProvider,
+    _SupermemoryClient,
     _clean_text_for_capture,
     _format_connection_summary,
     _format_prefetch_context,
@@ -111,6 +112,28 @@ def test_load_and_save_config_round_trip(tmp_path):
     assert cfg["auto_recall"] is True
 
 
+def test_recall_policy_config_parses_safe_values_and_falls_back(tmp_path):
+    _save_supermemory_config({
+        "recall_min_similarity": "0.81",
+        "prefetch_include_profile": "yes",
+        "max_recall_results": 999,
+    }, str(tmp_path))
+    cfg = _load_supermemory_config(str(tmp_path))
+    assert cfg["recall_min_similarity"] == 0.81
+    assert cfg["prefetch_include_profile"] is True
+    assert cfg["max_recall_results"] == 20
+
+    _save_supermemory_config({
+        "recall_min_similarity": "not-a-score",
+        "prefetch_include_profile": "not-a-bool",
+        "max_recall_results": "not-an-int",
+    }, str(tmp_path))
+    fallback = _load_supermemory_config(str(tmp_path))
+    assert fallback["recall_min_similarity"] == 0.76
+    assert fallback["prefetch_include_profile"] is False
+    assert fallback["max_recall_results"] == 10
+
+
 def test_clean_text_for_capture_strips_injected_context():
     text = "hello\n<supermemory-context>ignore me</supermemory-context>\nworld"
     assert _clean_text_for_capture(text) == "hello\nworld"
@@ -128,7 +151,29 @@ def test_format_prefetch_context_deduplicates_overlap():
     assert "<supermemory-context>" in result
 
 
-def test_prefetch_includes_profile_on_first_turn(provider):
+def test_format_prefetch_context_uses_one_result_and_character_budget():
+    result = _format_prefetch_context(
+        static_facts=["A" * 40, "B" * 40],
+        dynamic_facts=["C" * 40, "D" * 40],
+        search_results=[{"memory": "E" * 40, "similarity": 0.99}],
+        max_results=3,
+        max_chars=330,
+    )
+    assert sum(result.count(letter * 40) for letter in "ABCDE") <= 3
+    assert len(result) <= 330
+
+
+def test_format_prefetch_context_deduplicates_near_identical_facts():
+    result = _format_prefetch_context(
+        static_facts=["Avery prefers concise answers."],
+        dynamic_facts=[],
+        search_results=[{"memory": "Avery prefers a concise answer!", "similarity": 0.99}],
+        max_results=5,
+    )
+    assert result.count("Avery prefers") == 1
+
+
+def test_prefetch_does_not_include_profile_on_first_turn_by_default(provider):
     provider._client.profile_response = {
         "static": ["Jordan prefers short answers"],
         "dynamic": ["Current project is Supermemory provider"],
@@ -136,9 +181,93 @@ def test_prefetch_includes_profile_on_first_turn(provider):
     }
     provider.on_turn_start(1, "start")
     result = provider.prefetch("what am I working on?")
-    assert "User Profile (Persistent)" in result
-    assert "Recent Context" in result
     assert "Relevant Memories" in result
+    assert "User Profile (Persistent)" not in result
+    assert "Recent Context" not in result
+
+
+def test_prefetch_includes_static_profile_only_when_opted_in(monkeypatch, tmp_path):
+    monkeypatch.setenv("SUPERMEMORY_API_KEY", "test-key")
+    monkeypatch.setattr("plugins.memory.supermemory._SupermemoryClient", FakeClient)
+    _save_supermemory_config({"prefetch_include_profile": True}, str(tmp_path))
+    provider = SupermemoryMemoryProvider()
+    provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+    provider._client.profile_response = {
+        "static": ["Jordan prefers short answers"],
+        "dynamic": ["The worker is currently running test 42"],
+        "search_results": [],
+    }
+    provider.on_turn_start(1, "start")
+    result = provider.prefetch("what preferences should you follow?")
+    assert "User Profile (Persistent)" in result
+    assert "Jordan prefers short answers" in result
+    assert "Recent Context" not in result
+
+
+def test_prefetch_applies_similarity_boundary_and_suppresses_transient_material(provider):
+    provider._client.profile_response = {
+        "static": [],
+        "dynamic": [],
+        "search_results": [
+            {"memory": "Durable boundary fact", "similarity": 0.76},
+            {"memory": "Just below boundary", "similarity": 0.7599},
+            {"memory": "Missing score"},
+            {
+                "memory": "Full session transcript: task completed successfully.",
+                "similarity": 0.99,
+                "metadata": {"type": "full_session"},
+            },
+            {"memory": "Pull request 417 was merged and its branch was deleted.", "similarity": 0.98},
+        ],
+    }
+    result = provider.prefetch("what durable fact applies?")
+    assert "Durable boundary fact" in result
+    assert "Just below boundary" not in result
+    assert "Missing score" not in result
+    assert "Full session transcript" not in result
+    assert "Pull request 417" not in result
+
+
+def test_profile_client_preserves_search_result_metadata_for_recall_policy():
+    class Value:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class SDK:
+        def profile(self, **kwargs):
+            del kwargs
+            item = Value(
+                memory="Temporary task result",
+                similarity=0.99,
+                metadata={"type": "kanban_task"},
+            )
+            return Value(profile=Value(static=[], dynamic=[]), search_results=Value(results=[item]))
+
+    client = _SupermemoryClient.__new__(_SupermemoryClient)
+    client._client = SDK()  # type: ignore[assignment]
+    client._container_tag = "hermes"
+    result = client.get_profile("task status")
+    assert result["search_results"][0]["metadata"] == {"type": "kanban_task"}
+
+
+def test_prefetch_returns_empty_for_only_low_confidence_results(provider):
+    provider._client.profile_response = {
+        "static": [],
+        "dynamic": [],
+        "search_results": [{"memory": "Weak match", "similarity": 0.2}],
+    }
+    assert provider.prefetch("unrelated question") == ""
+
+
+def test_prefetch_does_not_mutate_system_prompt_block(provider):
+    before = provider.system_prompt_block()
+    provider._client.profile_response = {
+        "static": [],
+        "dynamic": [],
+        "search_results": [{"memory": "Durable context", "similarity": 0.9}],
+    }
+    assert provider.prefetch("recall context")
+    assert provider.system_prompt_block() == before
 
 
 def test_prefetch_skips_profile_between_frequency(provider):

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -174,14 +174,34 @@ def test_format_prefetch_context_uses_one_result_and_character_budget():
     assert len(result) <= 330
 
 
-def test_format_prefetch_context_deduplicates_near_identical_facts():
+def test_format_prefetch_context_keeps_distinct_near_identical_facts():
     result = _format_prefetch_context(
         static_facts=["Avery prefers concise answers."],
         dynamic_facts=[],
         search_results=[{"memory": "Avery prefers a concise answer!", "similarity": 0.99}],
         max_results=5,
     )
-    assert result.count("Avery prefers") == 1
+    assert result.count("Avery prefers") == 2
+
+
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [
+        ("Use Python 3.12", "Use Python 3.13"),
+        ("User timezone is UTC+1", "User timezone is UTC+2"),
+        ("Project Atlas uses S3", "Project Atlas uses GCS"),
+        ("Backups are enabled", "Backups are not enabled"),
+    ],
+)
+def test_format_prefetch_context_never_deduplicates_corrections(first, second):
+    result = _format_prefetch_context(
+        static_facts=[first],
+        dynamic_facts=[],
+        search_results=[{"memory": second, "similarity": 0.99}],
+        max_results=5,
+    )
+    assert first in result
+    assert second in result
 
 
 def test_format_prefetch_context_keeps_unicode_facts_and_deduplicates_variants():
@@ -192,6 +212,16 @@ def test_format_prefetch_context_keeps_unicode_facts_and_deduplicates_variants()
         max_results=5,
     )
     assert result.count("用户偏好简洁回答") == 1
+
+
+def test_format_prefetch_context_deduplicates_unicode_canonical_equivalents():
+    result = _format_prefetch_context(
+        static_facts=["Café"],
+        dynamic_facts=[],
+        search_results=[{"memory": "Cafe\u0301", "similarity": 0.99}],
+        max_results=5,
+    )
+    assert result.count("Caf") == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -11,6 +11,7 @@ from plugins.memory.supermemory import (
     _clean_text_for_capture,
     _format_connection_summary,
     _format_prefetch_context,
+    _is_transient_recall,
     _load_supermemory_config,
     _probe_supermemory_connection,
     _save_supermemory_config,
@@ -28,6 +29,7 @@ class FakeClient:
         self.add_calls = []
         self.search_results = []
         self.profile_response = {"static": [], "dynamic": [], "search_results": []}
+        self.profile_calls = []
         self.ingest_calls = []
         self.forgotten_ids = []
         self.forget_by_query_response = {"success": True, "message": "Forgot"}
@@ -47,6 +49,7 @@ class FakeClient:
         return self.search_results
 
     def get_profile(self, query=None, *, container_tag=None):
+        self.profile_calls.append({"query": query, "container_tag": container_tag})
         return self.profile_response
 
     def forget_memory(self, memory_id, *, container_tag=None):
@@ -173,6 +176,47 @@ def test_format_prefetch_context_deduplicates_near_identical_facts():
     assert result.count("Avery prefers") == 1
 
 
+def test_format_prefetch_context_keeps_unicode_facts_and_deduplicates_variants():
+    result = _format_prefetch_context(
+        static_facts=["用户偏好简洁回答。"],
+        dynamic_facts=[],
+        search_results=[{"memory": "用户偏好简洁回答！", "similarity": 0.99}],
+        max_results=5,
+    )
+    assert result.count("用户偏好简洁回答") == 1
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"type": "full session"},
+        {"documentType": "full_session"},
+        {"DOCUMENT-TYPE": "Full-Session"},
+    ],
+)
+def test_transient_recall_normalizes_metadata_key_and_value_variants(metadata):
+    assert _is_transient_recall("Texte durable en apparence", metadata) is True
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "If the browser test failed, capture the trace before retrying.",
+        "Current pull request approval requires two independent reviewers.",
+        "Kanban task status belongs in the handoff, not durable memory.",
+        "Project status terminology is defined in the release policy.",
+    ],
+)
+def test_transient_content_fallback_keeps_benign_durable_conventions(text):
+    assert _is_transient_recall(text) is False
+
+
+def test_transient_content_fallback_recognizes_french_kanban_status():
+    assert _is_transient_recall(
+        "La tâche Kanban t_demo123 est terminée après la revue."
+    ) is True
+
+
 def test_prefetch_does_not_include_profile_on_first_turn_by_default(provider):
     provider._client.profile_response = {
         "static": ["Jordan prefers short answers"],
@@ -204,6 +248,17 @@ def test_prefetch_includes_static_profile_only_when_opted_in(monkeypatch, tmp_pa
     assert "Recent Context" not in result
 
 
+@pytest.mark.parametrize("query", ["ok", "Merci !", "continue", ".", "…"])
+def test_prefetch_skips_trivial_queries_without_calling_client(provider, query):
+    provider._client.profile_response = {
+        "static": [],
+        "dynamic": [],
+        "search_results": [{"memory": "Unrelated high score", "similarity": 0.99}],
+    }
+    assert provider.prefetch(query) == ""
+    assert provider._client.profile_calls == []
+
+
 def test_prefetch_applies_similarity_boundary_and_suppresses_transient_material(provider):
     provider._client.profile_response = {
         "static": [],
@@ -226,6 +281,16 @@ def test_prefetch_applies_similarity_boundary_and_suppresses_transient_material(
     assert "Missing score" not in result
     assert "Full session transcript" not in result
     assert "Pull request 417" not in result
+
+
+@pytest.mark.parametrize("score", ["NaN", "Infinity", "-Infinity", -0.01, 1.01])
+def test_prefetch_rejects_non_finite_and_out_of_domain_similarity(provider, score):
+    provider._client.profile_response = {
+        "static": [],
+        "dynamic": [],
+        "search_results": [{"memory": f"Invalid score {score}", "similarity": score}],
+    }
+    assert provider.prefetch("recall invalid score") == ""
 
 
 def test_profile_client_preserves_search_result_metadata_for_recall_policy():

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -11,6 +11,7 @@ from plugins.memory.supermemory import (
     _clean_text_for_capture,
     _format_connection_summary,
     _format_prefetch_context,
+    _is_transient_recall,
     _load_supermemory_config,
     _probe_supermemory_connection,
     _save_supermemory_config,
@@ -28,6 +29,7 @@ class FakeClient:
         self.add_calls = []
         self.search_results = []
         self.profile_response = {"static": [], "dynamic": [], "search_results": []}
+        self.profile_calls = []
         self.ingest_calls = []
         self.forgotten_ids = []
         self.forget_by_query_response = {"success": True, "message": "Forgot"}
@@ -47,6 +49,7 @@ class FakeClient:
         return self.search_results
 
     def get_profile(self, query=None, *, container_tag=None):
+        self.profile_calls.append({"query": query, "container_tag": container_tag})
         return self.profile_response
 
     def forget_memory(self, memory_id, *, container_tag=None):
@@ -144,6 +147,47 @@ def test_format_prefetch_context_deduplicates_near_identical_facts():
     assert result.count("Avery prefers") == 1
 
 
+def test_format_prefetch_context_keeps_unicode_facts_and_deduplicates_variants():
+    result = _format_prefetch_context(
+        static_facts=["用户偏好简洁回答。"],
+        dynamic_facts=[],
+        search_results=[{"memory": "用户偏好简洁回答！", "similarity": 0.99}],
+        max_results=5,
+    )
+    assert result.count("用户偏好简洁回答") == 1
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"type": "full session"},
+        {"documentType": "full_session"},
+        {"DOCUMENT-TYPE": "Full-Session"},
+    ],
+)
+def test_transient_recall_normalizes_metadata_key_and_value_variants(metadata):
+    assert _is_transient_recall("Texte durable en apparence", metadata) is True
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "If the browser test failed, capture the trace before retrying.",
+        "Current pull request approval requires two independent reviewers.",
+        "Kanban task status belongs in the handoff, not durable memory.",
+        "Project status terminology is defined in the release policy.",
+    ],
+)
+def test_transient_content_fallback_keeps_benign_durable_conventions(text):
+    assert _is_transient_recall(text) is False
+
+
+def test_transient_content_fallback_recognizes_french_kanban_status():
+    assert _is_transient_recall(
+        "La tâche Kanban t_demo123 est terminée après la revue."
+    ) is True
+
+
 def test_prefetch_does_not_include_profile_on_first_turn_by_default(provider):
     provider._client.profile_response = {
         "static": ["Jordan prefers short answers"],
@@ -175,6 +219,17 @@ def test_prefetch_includes_static_profile_only_when_opted_in(monkeypatch, tmp_pa
     assert "Recent Context" not in result
 
 
+@pytest.mark.parametrize("query", ["ok", "Merci !", "continue", ".", "…"])
+def test_prefetch_skips_trivial_queries_without_calling_client(provider, query):
+    provider._client.profile_response = {
+        "static": [],
+        "dynamic": [],
+        "search_results": [{"memory": "Unrelated high score", "similarity": 0.99}],
+    }
+    assert provider.prefetch(query) == ""
+    assert provider._client.profile_calls == []
+
+
 def test_prefetch_applies_similarity_boundary_and_suppresses_transient_material(provider):
     provider._client.profile_response = {
         "static": [],
@@ -197,6 +252,16 @@ def test_prefetch_applies_similarity_boundary_and_suppresses_transient_material(
     assert "Missing score" not in result
     assert "Full session transcript" not in result
     assert "Pull request 417" not in result
+
+
+@pytest.mark.parametrize("score", ["NaN", "Infinity", "-Infinity", -0.01, 1.01])
+def test_prefetch_rejects_non_finite_and_out_of_domain_similarity(provider, score):
+    provider._client.profile_response = {
+        "static": [],
+        "dynamic": [],
+        "search_results": [{"memory": f"Invalid score {score}", "similarity": score}],
+    }
+    assert provider.prefetch("recall invalid score") == ""
 
 
 def test_profile_client_preserves_search_result_metadata_for_recall_policy():

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -28,6 +28,7 @@ class FakeClient:
         self.base_url = base_url
         self.add_calls = []
         self.search_results = []
+        self.search_calls = []
         self.profile_response = {"static": [], "dynamic": [], "search_results": []}
         self.profile_calls = []
         self.ingest_calls = []
@@ -46,7 +47,14 @@ class FakeClient:
         return {"id": "mem_123"}
 
     def search_memories(self, query, *, limit=5, container_tag=None, search_mode=None):
-        return self.search_results
+        self.search_calls.append({
+            "query": query,
+            "limit": limit,
+            "container_tag": container_tag,
+            "search_mode": search_mode,
+        })
+        results = self.search_results or self.profile_response.get("search_results", [])
+        return results[:limit]
 
     def get_profile(self, query=None, *, container_tag=None):
         self.profile_calls.append({"query": query, "container_tag": container_tag})
@@ -199,6 +207,8 @@ def test_prefetch_does_not_include_profile_on_first_turn_by_default(provider):
     assert "Relevant Memories" in result
     assert "User Profile (Persistent)" not in result
     assert "Recent Context" not in result
+    assert provider._client.profile_calls == []
+    assert provider._client.search_calls
 
 
 def test_prefetch_includes_static_profile_only_when_opted_in(monkeypatch, tmp_path):
@@ -228,6 +238,7 @@ def test_prefetch_skips_trivial_queries_without_calling_client(provider, query):
     }
     assert provider.prefetch(query) == ""
     assert provider._client.profile_calls == []
+    assert provider._client.search_calls == []
 
 
 def test_prefetch_applies_similarity_boundary_and_suppresses_transient_material(provider):

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -7,6 +7,7 @@ import pytest
 
 from plugins.memory.supermemory import (
     SupermemoryMemoryProvider,
+    _SupermemoryClient,
     _clean_text_for_capture,
     _format_connection_summary,
     _format_prefetch_context,
@@ -82,6 +83,28 @@ def test_load_and_save_config_round_trip(tmp_path):
     assert cfg["auto_recall"] is True
 
 
+def test_recall_policy_config_parses_safe_values_and_falls_back(tmp_path):
+    _save_supermemory_config({
+        "recall_min_similarity": "0.81",
+        "prefetch_include_profile": "yes",
+        "max_recall_results": 999,
+    }, str(tmp_path))
+    cfg = _load_supermemory_config(str(tmp_path))
+    assert cfg["recall_min_similarity"] == 0.81
+    assert cfg["prefetch_include_profile"] is True
+    assert cfg["max_recall_results"] == 20
+
+    _save_supermemory_config({
+        "recall_min_similarity": "not-a-score",
+        "prefetch_include_profile": "not-a-bool",
+        "max_recall_results": "not-an-int",
+    }, str(tmp_path))
+    fallback = _load_supermemory_config(str(tmp_path))
+    assert fallback["recall_min_similarity"] == 0.76
+    assert fallback["prefetch_include_profile"] is False
+    assert fallback["max_recall_results"] == 10
+
+
 def test_clean_text_for_capture_strips_injected_context():
     text = "hello\n<supermemory-context>ignore me</supermemory-context>\nworld"
     assert _clean_text_for_capture(text) == "hello\nworld"
@@ -99,7 +122,29 @@ def test_format_prefetch_context_deduplicates_overlap():
     assert "<supermemory-context>" in result
 
 
-def test_prefetch_includes_profile_on_first_turn(provider):
+def test_format_prefetch_context_uses_one_result_and_character_budget():
+    result = _format_prefetch_context(
+        static_facts=["A" * 40, "B" * 40],
+        dynamic_facts=["C" * 40, "D" * 40],
+        search_results=[{"memory": "E" * 40, "similarity": 0.99}],
+        max_results=3,
+        max_chars=330,
+    )
+    assert sum(result.count(letter * 40) for letter in "ABCDE") <= 3
+    assert len(result) <= 330
+
+
+def test_format_prefetch_context_deduplicates_near_identical_facts():
+    result = _format_prefetch_context(
+        static_facts=["Avery prefers concise answers."],
+        dynamic_facts=[],
+        search_results=[{"memory": "Avery prefers a concise answer!", "similarity": 0.99}],
+        max_results=5,
+    )
+    assert result.count("Avery prefers") == 1
+
+
+def test_prefetch_does_not_include_profile_on_first_turn_by_default(provider):
     provider._client.profile_response = {
         "static": ["Jordan prefers short answers"],
         "dynamic": ["Current project is Supermemory provider"],
@@ -107,9 +152,93 @@ def test_prefetch_includes_profile_on_first_turn(provider):
     }
     provider.on_turn_start(1, "start")
     result = provider.prefetch("what am I working on?")
-    assert "User Profile (Persistent)" in result
-    assert "Recent Context" in result
     assert "Relevant Memories" in result
+    assert "User Profile (Persistent)" not in result
+    assert "Recent Context" not in result
+
+
+def test_prefetch_includes_static_profile_only_when_opted_in(monkeypatch, tmp_path):
+    monkeypatch.setenv("SUPERMEMORY_API_KEY", "test-key")
+    monkeypatch.setattr("plugins.memory.supermemory._SupermemoryClient", FakeClient)
+    _save_supermemory_config({"prefetch_include_profile": True}, str(tmp_path))
+    provider = SupermemoryMemoryProvider()
+    provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+    provider._client.profile_response = {
+        "static": ["Jordan prefers short answers"],
+        "dynamic": ["The worker is currently running test 42"],
+        "search_results": [],
+    }
+    provider.on_turn_start(1, "start")
+    result = provider.prefetch("what preferences should you follow?")
+    assert "User Profile (Persistent)" in result
+    assert "Jordan prefers short answers" in result
+    assert "Recent Context" not in result
+
+
+def test_prefetch_applies_similarity_boundary_and_suppresses_transient_material(provider):
+    provider._client.profile_response = {
+        "static": [],
+        "dynamic": [],
+        "search_results": [
+            {"memory": "Durable boundary fact", "similarity": 0.76},
+            {"memory": "Just below boundary", "similarity": 0.7599},
+            {"memory": "Missing score"},
+            {
+                "memory": "Full session transcript: task completed successfully.",
+                "similarity": 0.99,
+                "metadata": {"type": "full_session"},
+            },
+            {"memory": "Pull request 417 was merged and its branch was deleted.", "similarity": 0.98},
+        ],
+    }
+    result = provider.prefetch("what durable fact applies?")
+    assert "Durable boundary fact" in result
+    assert "Just below boundary" not in result
+    assert "Missing score" not in result
+    assert "Full session transcript" not in result
+    assert "Pull request 417" not in result
+
+
+def test_profile_client_preserves_search_result_metadata_for_recall_policy():
+    class Value:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class SDK:
+        def profile(self, **kwargs):
+            del kwargs
+            item = Value(
+                memory="Temporary task result",
+                similarity=0.99,
+                metadata={"type": "kanban_task"},
+            )
+            return Value(profile=Value(static=[], dynamic=[]), search_results=Value(results=[item]))
+
+    client = _SupermemoryClient.__new__(_SupermemoryClient)
+    client._client = SDK()  # type: ignore[assignment]
+    client._container_tag = "hermes"
+    result = client.get_profile("task status")
+    assert result["search_results"][0]["metadata"] == {"type": "kanban_task"}
+
+
+def test_prefetch_returns_empty_for_only_low_confidence_results(provider):
+    provider._client.profile_response = {
+        "static": [],
+        "dynamic": [],
+        "search_results": [{"memory": "Weak match", "similarity": 0.2}],
+    }
+    assert provider.prefetch("unrelated question") == ""
+
+
+def test_prefetch_does_not_mutate_system_prompt_block(provider):
+    before = provider.system_prompt_block()
+    provider._client.profile_response = {
+        "static": [],
+        "dynamic": [],
+        "search_results": [{"memory": "Durable context", "similarity": 0.9}],
+    }
+    assert provider.prefetch("recall context")
+    assert provider.system_prompt_block() == before
 
 
 def test_sync_turn_buffers_short_messages(provider):

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -145,14 +145,34 @@ def test_format_prefetch_context_uses_one_result_and_character_budget():
     assert len(result) <= 330
 
 
-def test_format_prefetch_context_deduplicates_near_identical_facts():
+def test_format_prefetch_context_keeps_distinct_near_identical_facts():
     result = _format_prefetch_context(
         static_facts=["Avery prefers concise answers."],
         dynamic_facts=[],
         search_results=[{"memory": "Avery prefers a concise answer!", "similarity": 0.99}],
         max_results=5,
     )
-    assert result.count("Avery prefers") == 1
+    assert result.count("Avery prefers") == 2
+
+
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [
+        ("Use Python 3.12", "Use Python 3.13"),
+        ("User timezone is UTC+1", "User timezone is UTC+2"),
+        ("Project Atlas uses S3", "Project Atlas uses GCS"),
+        ("Backups are enabled", "Backups are not enabled"),
+    ],
+)
+def test_format_prefetch_context_never_deduplicates_corrections(first, second):
+    result = _format_prefetch_context(
+        static_facts=[first],
+        dynamic_facts=[],
+        search_results=[{"memory": second, "similarity": 0.99}],
+        max_results=5,
+    )
+    assert first in result
+    assert second in result
 
 
 def test_format_prefetch_context_keeps_unicode_facts_and_deduplicates_variants():
@@ -163,6 +183,16 @@ def test_format_prefetch_context_keeps_unicode_facts_and_deduplicates_variants()
         max_results=5,
     )
     assert result.count("用户偏好简洁回答") == 1
+
+
+def test_format_prefetch_context_deduplicates_unicode_canonical_equivalents():
+    result = _format_prefetch_context(
+        static_facts=["Café"],
+        dynamic_facts=[],
+        search_results=[{"memory": "Cafe\u0301", "similarity": 0.99}],
+        max_results=5,
+    )
+    assert result.count("Caf") == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/plugins/memory/test_supermemory_recall_benchmark.py
+++ b/tests/plugins/memory/test_supermemory_recall_benchmark.py
@@ -62,6 +62,17 @@ def test_recall_benchmark_covers_selection_policy_edge_cases():
     )
     adversarial_queries = [case["query"].lower() for case in cases if case["category"] == "adversarial_transient"]
     assert any(all(marker not in query for marker in ("durable", "lasting", "persistent", "stable")) for query in adversarial_queries)
+    assert any(any(ord(character) > 127 for character in document["content"]) for document in documents.values())
+    assert any("documentType" in document.get("metadata", {}) for document in documents.values())
+    assert any(document.get("metadata", {}).get("type") == "full session" for document in documents.values())
+    malformed_scores = {
+        result[1]
+        for case in cases
+        for result in case.get("search", [])
+        if len(result) > 1
+        and (isinstance(result[1], str) or not 0 <= result[1] <= 1)
+    }
+    assert {"NaN", "Infinity", "-Infinity", -0.01, 1.01}.issubset(malformed_scores)
 
 
 def test_fixture_client_keeps_evaluator_truth_out_of_provider_responses():
@@ -112,8 +123,8 @@ def test_precision_gated_prefetch_meets_offline_recall_contract():
     assert metrics["durable_irrelevant_selections"] == 0
     assert metrics["transient_contamination_rate"] == 0.0
     assert metrics["transient_contamination_by_class"] == {}
-    # Profile recall is explicitly disabled by this fixture, so the three
-    # profile-only cases trade recall for no unsolicited profile injection.
+    # Profile recall is explicitly disabled by this fixture, so six required
+    # profile-only documents trade recall for no unsolicited profile injection.
     assert metrics["required_durable_recall"] >= 0.7
 
 

--- a/tests/plugins/memory/test_supermemory_recall_benchmark.py
+++ b/tests/plugins/memory/test_supermemory_recall_benchmark.py
@@ -128,6 +128,20 @@ def test_precision_gated_prefetch_meets_offline_recall_contract():
     assert metrics["required_durable_recall"] >= 0.7
 
 
+def test_evaluate_applies_non_default_policy_settings():
+    fixture = deepcopy(load_fixture(FIXTURE))
+    fixture["settings"]["recall_min_similarity"] = 1.0
+    fixture["settings"]["prefetch_include_profile"] = True
+    fixture["settings"]["max_recall_results"] = 1
+
+    report = evaluate(fixture)
+
+    assert report["settings_under_test"] == fixture["settings"]
+    assert report["metrics"]["required_durable_recall"] < 0.7857
+    assert report["exact_false_positive_modes"]["profile_injected_when_disabled"] is True
+    assert all(len(case["selected_ids"]) <= 1 for case in report["cases"])
+
+
 def test_selected_ids_are_traced_without_content_substring_matching():
     fixture = deepcopy(load_fixture(FIXTURE))
     documents = {document["id"]: document for document in fixture["documents"]}

--- a/tests/plugins/memory/test_supermemory_recall_benchmark.py
+++ b/tests/plugins/memory/test_supermemory_recall_benchmark.py
@@ -170,3 +170,46 @@ def test_selected_ids_match_items_emitted_by_formatter_policy(monkeypatch):
     assert "Recent transient status" not in context
     assert "Search-only result" not in context
     assert selected_ids == emitted_ids == ["shared"]
+
+
+@pytest.mark.parametrize("failure_mode", ["empty", "raise"])
+def test_empty_prefetch_discards_partial_selection_trace_and_next_call_is_clean(monkeypatch, failure_mode):
+    documents = {
+        "shared": {"content": "Shared durable fact", "label": "durable", "class": "identity"},
+    }
+    cases = [{
+        "query": "discard partial trace",
+        "static": ["shared"],
+    }]
+    provider = SupermemoryMemoryProvider()
+    provider._active = True
+    provider._auto_recall = True
+    provider._max_recall_results = 5
+    provider._profile_frequency = 50
+    client = FixtureClient(cases, documents)
+    provider._client = client  # type: ignore[assignment]
+    provider.on_turn_start(1, cases[0]["query"])
+
+    production_formatter = supermemory_module._format_prefetch_context
+
+    def unsuccessful_formatter(static_facts, dynamic_facts, search_results, max_results):
+        rendered = f"{static_facts[0]}"
+        if failure_mode == "raise":
+            raise RuntimeError(f"failed after rendering {rendered}")
+        return ""
+
+    monkeypatch.setattr(supermemory_module, "_format_prefetch_context", unsuccessful_formatter)
+
+    context, selected_ids = _prefetch_with_selection_trace(provider, cases[0]["query"])
+
+    assert context == ""
+    assert selected_ids == []
+    assert client._selection_trace is None
+
+    monkeypatch.setattr(supermemory_module, "_format_prefetch_context", production_formatter)
+
+    next_context, next_selected_ids = _prefetch_with_selection_trace(provider, cases[0]["query"])
+
+    assert "Shared durable fact" in next_context
+    assert next_selected_ids == ["shared"]
+    assert client._selection_trace is None

--- a/tests/plugins/memory/test_supermemory_recall_benchmark.py
+++ b/tests/plugins/memory/test_supermemory_recall_benchmark.py
@@ -3,7 +3,14 @@ from pathlib import Path
 
 import pytest
 
-from scripts.benchmarks.supermemory_recall_precision import FixtureClient, evaluate, load_fixture
+from plugins.memory import supermemory as supermemory_module
+from plugins.memory.supermemory import SupermemoryMemoryProvider
+from scripts.benchmarks.supermemory_recall_precision import (
+    FixtureClient,
+    _prefetch_with_selection_trace,
+    evaluate,
+    load_fixture,
+)
 
 FIXTURE = Path(__file__).parents[2] / "fixtures/supermemory_recall_benchmark.json"
 EXPECTED_CATEGORIES = {
@@ -125,3 +132,41 @@ def test_selected_ids_are_traced_without_content_substring_matching():
     identity_case = next(case for case in report["cases"] if case["id"] == "identity-02")
 
     assert identity_case["selected_ids"] == ["identity_style", "status_worker"]
+
+
+def test_selected_ids_match_items_emitted_by_formatter_policy(monkeypatch):
+    documents = {
+        "shared": {"content": "Shared durable fact", "label": "durable", "class": "identity"},
+        "dynamic": {"content": "Recent transient status", "label": "transient", "class": "status"},
+        "search": {"content": "Search-only result", "label": "transient", "class": "search"},
+    }
+    cases = [{
+        "query": "trace actual formatter output",
+        "static": ["shared"],
+        "dynamic": ["dynamic"],
+        "search": [["shared", 0.99], ["search", 0.98]],
+    }]
+    provider = SupermemoryMemoryProvider()
+    provider._active = True
+    provider._auto_recall = True
+    provider._max_recall_results = 5
+    provider._profile_frequency = 50
+    provider._client = FixtureClient(cases, documents)  # type: ignore[assignment]
+    provider.on_turn_start(1, cases[0]["query"])
+
+    production_formatter = supermemory_module._format_prefetch_context
+    emitted_ids = []
+
+    def one_total_result_formatter(static_facts, dynamic_facts, search_results, max_results):
+        del dynamic_facts, search_results, max_results
+        emitted_ids.append("shared")
+        return production_formatter(static_facts[:1], [], [], 1)
+
+    monkeypatch.setattr(supermemory_module, "_format_prefetch_context", one_total_result_formatter)
+
+    context, selected_ids = _prefetch_with_selection_trace(provider, cases[0]["query"])
+
+    assert "Shared durable fact" in context
+    assert "Recent transient status" not in context
+    assert "Search-only result" not in context
+    assert selected_ids == emitted_ids == ["shared"]

--- a/tests/plugins/memory/test_supermemory_recall_benchmark.py
+++ b/tests/plugins/memory/test_supermemory_recall_benchmark.py
@@ -1,6 +1,9 @@
+from copy import deepcopy
 from pathlib import Path
 
-from scripts.benchmarks.supermemory_recall_precision import evaluate, load_fixture
+import pytest
+
+from scripts.benchmarks.supermemory_recall_precision import FixtureClient, evaluate, load_fixture
 
 FIXTURE = Path(__file__).parents[2] / "fixtures/supermemory_recall_benchmark.json"
 EXPECTED_CATEGORIES = {
@@ -30,6 +33,35 @@ def test_recall_benchmark_fixture_has_compact_expected_label_schema():
         response_ids = set(case.get("static", [])) | set(case.get("dynamic", []))
         response_ids.update(doc_id for doc_id, _ in case.get("search", []))
         assert response_ids.issubset(documents)
+
+
+def test_fixture_client_keeps_evaluator_truth_out_of_provider_responses():
+    fixture = load_fixture(FIXTURE)
+    documents = {document["id"]: document for document in fixture["documents"]}
+    client = FixtureClient(fixture["cases"], documents)
+
+    for case in fixture["cases"]:
+        response = client.get_profile(case["query"])
+        for result in response["search_results"]:
+            evaluator_fields = {"label", "class", "benchmark_label", "benchmark_class"}
+            assert evaluator_fields.isdisjoint(result["metadata"])
+            assert result["metadata"] == documents[result["id"]].get("metadata", {})
+
+
+@pytest.mark.parametrize(
+    ("collection", "field"),
+    [("documents", "id"), ("cases", "id"), ("cases", "query")],
+)
+def test_evaluate_rejects_duplicate_fixture_identifiers(collection, field):
+    fixture = deepcopy(load_fixture(FIXTURE))
+    duplicate = deepcopy(fixture[collection][0])
+    if collection == "cases":
+        other_field = "query" if field == "id" else "id"
+        duplicate[other_field] += "-otherwise-unique"
+    fixture[collection].append(duplicate)
+
+    with pytest.raises(ValueError, match=f"duplicate {field}"):
+        evaluate(fixture)
 
 
 def test_current_prefetch_baseline_exposes_precision_problem():

--- a/tests/plugins/memory/test_supermemory_recall_benchmark.py
+++ b/tests/plugins/memory/test_supermemory_recall_benchmark.py
@@ -96,31 +96,25 @@ def test_evaluate_rejects_duplicate_fixture_identifiers(collection, field):
         evaluate(fixture)
 
 
-def test_current_prefetch_baseline_exposes_precision_problem():
+def test_precision_gated_prefetch_meets_offline_recall_contract():
     report = evaluate(load_fixture(FIXTURE))
     metrics = report["metrics"]
 
-    # RED-capable baseline: current prefetch injects all fake results regardless
-    # of configured similarity and still injects profile data when the fixture's
-    # prefetch_include_profile setting is false.
     assert report["exact_false_positive_modes"] == {
-        "low_similarity_result_injected": True,
-        "profile_injected_when_disabled": True,
+        "low_similarity_result_injected": False,
+        "profile_injected_when_disabled": False,
     }
     assert "precision_at_5" not in metrics
-    assert metrics["precision_at_returned_up_to_5"] < 1.0
-    assert metrics["recall_at_5"] == 1.0
-    assert metrics["injection_rate_on_null_queries"] > 0.0
-    assert metrics["mean_false_positives_per_null_query"] > 0.0
-    assert metrics["relevance_false_positive_rate"] > metrics["transient_contamination_rate"]
-    assert metrics["durable_irrelevant_selections"] > 0
-    assert metrics["transient_contamination_rate"] > 0.0
-    assert metrics["required_durable_recall"] == 1.0
-
-    contaminated_classes = metrics["transient_contamination_by_class"]
-    assert {"kanban_task", "pull_request_status", "test_run", "project_status", "full_session"}.issubset(
-        contaminated_classes
-    )
+    assert metrics["precision_at_returned_up_to_5"] >= 0.95
+    assert metrics["injection_rate_on_null_queries"] <= 0.05
+    assert metrics["mean_false_positives_per_null_query"] == 0.0
+    assert metrics["relevance_false_positive_rate"] <= 0.05
+    assert metrics["durable_irrelevant_selections"] == 0
+    assert metrics["transient_contamination_rate"] == 0.0
+    assert metrics["transient_contamination_by_class"] == {}
+    # Profile recall is explicitly disabled by this fixture, so the three
+    # profile-only cases trade recall for no unsolicited profile injection.
+    assert metrics["required_durable_recall"] >= 0.7
 
 
 def test_selected_ids_are_traced_without_content_substring_matching():
@@ -131,7 +125,7 @@ def test_selected_ids_are_traced_without_content_substring_matching():
     report = evaluate(fixture)
     identity_case = next(case for case in report["cases"] if case["id"] == "identity-02")
 
-    assert identity_case["selected_ids"] == ["identity_style", "status_worker"]
+    assert identity_case["selected_ids"] == ["identity_style"]
 
 
 def test_selected_ids_match_items_emitted_by_formatter_policy(monkeypatch):
@@ -150,6 +144,7 @@ def test_selected_ids_match_items_emitted_by_formatter_policy(monkeypatch):
     provider._active = True
     provider._auto_recall = True
     provider._max_recall_results = 5
+    provider._prefetch_include_profile = True
     provider._profile_frequency = 50
     provider._client = FixtureClient(cases, documents)  # type: ignore[assignment]
     provider.on_turn_start(1, cases[0]["query"])
@@ -185,6 +180,7 @@ def test_empty_prefetch_discards_partial_selection_trace_and_next_call_is_clean(
     provider._active = True
     provider._auto_recall = True
     provider._max_recall_results = 5
+    provider._prefetch_include_profile = True
     provider._profile_frequency = 50
     client = FixtureClient(cases, documents)
     provider._client = client  # type: ignore[assignment]

--- a/tests/plugins/memory/test_supermemory_recall_benchmark.py
+++ b/tests/plugins/memory/test_supermemory_recall_benchmark.py
@@ -31,14 +31,39 @@ def test_recall_benchmark_fixture_has_compact_expected_label_schema():
         assert set(case["expected_ids"]).issubset(documents)
         assert all(documents[doc_id]["label"] == "durable" for doc_id in case["expected_ids"])
         response_ids = set(case.get("static", [])) | set(case.get("dynamic", []))
-        response_ids.update(doc_id for doc_id, _ in case.get("search", []))
+        response_ids.update(doc_id for doc_id, *_ in case.get("search", []))
         assert response_ids.issubset(documents)
+
+
+def test_recall_benchmark_covers_selection_policy_edge_cases():
+    fixture = load_fixture(FIXTURE)
+    documents = {document["id"]: document for document in fixture["documents"]}
+    cases = fixture["cases"]
+    k = fixture["settings"]["k"]
+
+    assert any(len(case.get("search", [])) > k for case in cases)
+    assert any(len(result) == 1 for case in cases for result in case.get("search", []))
+    assert any(
+        documents[doc_id]["label"] == "durable" and doc_id not in case["expected_ids"]
+        for case in cases
+        for doc_id, *_ in case.get("search", [])
+    )
+    assert any(
+        "paraphrase" in documents[doc_id]["class"]
+        for case in cases
+        for doc_id, *_ in case.get("search", [])
+    )
+    adversarial_queries = [case["query"].lower() for case in cases if case["category"] == "adversarial_transient"]
+    assert any(all(marker not in query for marker in ("durable", "lasting", "persistent", "stable")) for query in adversarial_queries)
 
 
 def test_fixture_client_keeps_evaluator_truth_out_of_provider_responses():
     fixture = load_fixture(FIXTURE)
     documents = {document["id"]: document for document in fixture["documents"]}
     client = FixtureClient(fixture["cases"], documents)
+
+    assert all("expected_ids" not in case for case in client._cases.values())
+    assert all({"label", "class"}.isdisjoint(document) for document in client._documents.values())
 
     for case in fixture["cases"]:
         response = client.get_profile(case["query"])
@@ -75,8 +100,13 @@ def test_current_prefetch_baseline_exposes_precision_problem():
         "low_similarity_result_injected": True,
         "profile_injected_when_disabled": True,
     }
-    assert metrics["precision_at_5"] < 1.0
-    assert metrics["false_positive_rate_on_null_queries"] > 0.0
+    assert "precision_at_5" not in metrics
+    assert metrics["precision_at_returned_up_to_5"] < 1.0
+    assert metrics["recall_at_5"] == 1.0
+    assert metrics["injection_rate_on_null_queries"] > 0.0
+    assert metrics["mean_false_positives_per_null_query"] > 0.0
+    assert metrics["relevance_false_positive_rate"] > metrics["transient_contamination_rate"]
+    assert metrics["durable_irrelevant_selections"] > 0
     assert metrics["transient_contamination_rate"] > 0.0
     assert metrics["required_durable_recall"] == 1.0
 
@@ -84,3 +114,14 @@ def test_current_prefetch_baseline_exposes_precision_problem():
     assert {"kanban_task", "pull_request_status", "test_run", "project_status", "full_session"}.issubset(
         contaminated_classes
     )
+
+
+def test_selected_ids_are_traced_without_content_substring_matching():
+    fixture = deepcopy(load_fixture(FIXTURE))
+    documents = {document["id"]: document for document in fixture["documents"]}
+    documents["identity_language"]["content"] = "Avery"
+
+    report = evaluate(fixture)
+    identity_case = next(case for case in report["cases"] if case["id"] == "identity-02")
+
+    assert identity_case["selected_ids"] == ["identity_style", "status_worker"]

--- a/tests/plugins/memory/test_supermemory_recall_benchmark.py
+++ b/tests/plugins/memory/test_supermemory_recall_benchmark.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+from scripts.benchmarks.supermemory_recall_precision import evaluate, load_fixture
+
+FIXTURE = Path(__file__).parents[2] / "fixtures/supermemory_recall_benchmark.json"
+EXPECTED_CATEGORIES = {
+    "durable_identity_preferences",
+    "cross_project_durable_conventions",
+    "project_specific_durable_facts",
+    "unrelated_null_queries",
+    "adversarial_transient",
+}
+
+
+def test_recall_benchmark_fixture_has_compact_expected_label_schema():
+    fixture = load_fixture(FIXTURE)
+    documents = {document["id"]: document for document in fixture["documents"]}
+    cases = fixture["cases"]
+
+    assert fixture["schema_version"] == 1
+    assert len(cases) >= 20
+    assert {case["category"] for case in cases} == EXPECTED_CATEGORIES
+    assert all(sum(case["category"] == category for case in cases) >= 4 for category in EXPECTED_CATEGORIES)
+    assert len({document["content"] for document in documents.values()}) == len(documents)
+
+    for case in cases:
+        assert set(case) >= {"id", "category", "query", "expected_ids"}
+        assert set(case["expected_ids"]).issubset(documents)
+        assert all(documents[doc_id]["label"] == "durable" for doc_id in case["expected_ids"])
+        response_ids = set(case.get("static", [])) | set(case.get("dynamic", []))
+        response_ids.update(doc_id for doc_id, _ in case.get("search", []))
+        assert response_ids.issubset(documents)
+
+
+def test_current_prefetch_baseline_exposes_precision_problem():
+    report = evaluate(load_fixture(FIXTURE))
+    metrics = report["metrics"]
+
+    # RED-capable baseline: current prefetch injects all fake results regardless
+    # of configured similarity and still injects profile data when the fixture's
+    # prefetch_include_profile setting is false.
+    assert report["exact_false_positive_modes"] == {
+        "low_similarity_result_injected": True,
+        "profile_injected_when_disabled": True,
+    }
+    assert metrics["precision_at_5"] < 1.0
+    assert metrics["false_positive_rate_on_null_queries"] > 0.0
+    assert metrics["transient_contamination_rate"] > 0.0
+    assert metrics["required_durable_recall"] == 1.0
+
+    contaminated_classes = metrics["transient_contamination_by_class"]
+    assert {"kanban_task", "pull_request_status", "test_run", "project_status", "full_session"}.issubset(
+        contaminated_classes
+    )

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -596,11 +596,27 @@ stays local.
 | `container_tag` | `hermes` | Container tag used for search and writes. Supports `{identity}` template for profile-scoped tags. |
 | `auto_recall` | `true` | Inject relevant memory context before turns |
 | `auto_capture` | `true` | Store cleaned user-assistant turns after each response |
-| `max_recall_results` | `10` | Max recalled items to format into context |
-| `profile_frequency` | `50` | Include profile facts on first turn and every N turns |
+| `max_recall_results` | `10` | Total recalled-item budget across all context sections (bounded to 1–20) |
+| `recall_min_similarity` | `0.76` | Minimum 0–1 similarity for automatic semantic recall; missing, invalid, and lower scores are not injected |
+| `prefetch_include_profile` | `false` | Opt in to automatic static and dynamic profile context; explicit `supermemory_profile` calls are unchanged |
+| `profile_frequency` | `50` | When profile prefetch is opted in, include it on the first turn and every N turns |
 | `capture_mode` | `all` | Skip tiny or trivial turns by default |
 | `search_mode` | `hybrid` | Search mode: `hybrid`, `memories`, or `documents` |
 | `api_timeout` | `5.0` | Timeout for SDK and ingest requests |
+
+For example, this keeps profile prefetch disabled while admitting at most six
+automatically recalled memories with similarity of at least `0.82`:
+
+```json
+{
+  "max_recall_results": 6,
+  "recall_min_similarity": 0.82,
+  "prefetch_include_profile": false
+}
+```
+
+To opt in to profile prefetch, set `prefetch_include_profile` to `true`; the
+profile is then included on the first turn and every `profile_frequency` turns.
 
 **Environment variables:** `SUPERMEMORY_API_KEY` (required), `SUPERMEMORY_BASE_URL` (compatibility fallback when `base_url` is not configured), `SUPERMEMORY_CONTAINER_TAG` (overrides config).
 
@@ -608,10 +624,11 @@ Base URL precedence is `supermemory.json` → `SUPERMEMORY_BASE_URL` → `https:
 
 **Key features:**
 - Automatic context fencing — strips recalled memories from captured turns to prevent recursive memory pollution
+- Automatic semantic recall uses direct memory search, admits only results at or above `recall_min_similarity`, and shares one `max_recall_results` budget across all rendered context sections
+- Automatic static/dynamic profile prefetch is off by default; set `prefetch_include_profile` to `true` to include it on the first turn and every `profile_frequency` turns. The explicit `supermemory_profile` tool remains available regardless.
 - Full-session ingest — the entire conversation is sent once at session boundaries
 - Session-end conversation ingest (to `/v4/conversations`) for richer profile + graph building in Supermemory
 - End-to-end self-hosted routing — SDK, probe, and conversation-ingest requests use the same configured endpoint
-- Profile facts injected on first turn and at configurable intervals
 - **Profile-scoped containers** — use `{identity}` in `container_tag` (e.g. `hermes-{identity}` → `hermes-coder`) to isolate memories per Hermes profile
 - **Multi-container mode** — enable `enable_custom_container_tags` with a `custom_containers` list to let the agent read/write across named containers. Automatic operations stay on the primary container.
 


### PR DESCRIPTION
## Summary
- add a deterministic offline benchmark for automatic Supermemory recall, with evaluator-side truth and rendered-selection tracing
- route automatic recall through direct search so provider defaults cannot inject profile material when disabled
- reject low-similarity, transient, and query-echo results before prompt injection while preserving distinct durable facts
- harden lexical relevance across English, French, Spanish, German, Chinese, Japanese, and several durable-fact categories

## Observable behavior
Automatic recall now injects only results that satisfy the configured similarity and lexical relevance contracts. It does not inject profile data when `prefetch_include_profile` is false, does not collapse distinct durable facts merely because they share a category prefix, and remains conservative for unrelated/null queries. Explicit search remains unchanged.

## Verification
- `scripts/run_tests.sh tests/plugins/memory/test_supermemory_provider.py tests/plugins/memory/test_supermemory_recall_benchmark.py` — 89 passed
- offline benchmark — 31 cases / 32 documents, precision 1.0, recall 0.7857, null-query injection 0.0, transient contamination 0.0, both exact false-positive modes false
- `python -m py_compile ...` — passed
- `git diff --check origin/main...HEAD` — passed
- full repository suite running on the combined reconciliation candidate; result will be posted before review handoff

## Scope
This is a bug fix to the existing in-tree Supermemory provider, not a new memory backend or a core-tool expansion.