### PR TITLE
fix(gateway): avoid signal-zero delivery liveness checks

### DIFF
--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -127,14 +127,11 @@ def _owner_alive(pid: Any, started_at: Any) -> bool:
         # No such process (or unreadable) — treat unreadable-but-extant
         # processes as alive only if the pid exists.
         try:
-            os.kill(pid, 0)  # windows-footgun: ok — EPERM counts as alive below
-        except ProcessLookupError:
+            from gateway.status import _pid_exists
+
+            return _pid_exists(pid)
+        except Exception:
             return False
-        except PermissionError:
-            return True
-        except OSError:
-            return False
-        return True
     if started_at is None:
         return True
     try:

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -97,6 +97,27 @@ class TestObligationId:
         assert len(a) == 24
 
 
+class TestOwnerAlive:
+    @pytest.mark.parametrize(("pid_exists", "expected"), [(True, True), (False, False)])
+    def test_missing_start_time_delegates_to_pid_exists(self, pid_exists, expected):
+        with (
+            patch("gateway.status.get_process_start_time", return_value=None),
+            patch("gateway.status._pid_exists", return_value=pid_exists) as exists,
+            patch.object(dl.os, "kill") as kill,
+        ):
+            assert dl._owner_alive(1234, 5678) is expected
+
+        exists.assert_called_once_with(1234)
+        kill.assert_not_called()
+
+    def test_pid_exists_failure_is_fail_safe(self):
+        with (
+            patch("gateway.status.get_process_start_time", return_value=None),
+            patch("gateway.status._pid_exists", side_effect=OSError),
+        ):
+            assert dl._owner_alive(1234, 5678) is False
+
+
 class TestSweep:
     def test_live_owner_rows_never_claimed(self):
         _record()  # owner = this (live) process


### PR DESCRIPTION
## What

Replace the delivery ledger's direct `os.kill(pid, 0)` fallback with the repository's canonical cross-platform `gateway.status._pid_exists()` helper.

The PID start-time fingerprint remains the primary liveness check, so PID-reuse detection is unchanged. Only the fallback used when start time is unavailable is replaced.

## Why this is a bug

`gateway.delivery_ledger._owner_alive()` currently falls back to `os.kill(pid, 0)`. On Windows, CPython does not provide POSIX signal-0 probe semantics; this path can map to a console control event instead of a harmless existence check. A recovery sweep should never risk signalling the process whose liveness it is inspecting.

Hermes already centralizes this platform behavior in `gateway.status._pid_exists()`: it prefers `psutil.pid_exists()` and has platform-aware fallbacks, including access-denied-as-alive behavior. Reusing that helper removes the Windows footgun without adding a second process-liveness policy.

## Reproduction / root cause

1. Make `get_process_start_time(pid)` return `None`, which enters the delivery-ledger fallback.
2. Before this change, `_owner_alive()` invokes `os.kill(pid, 0)` directly.
3. On Windows that is not a safe portable existence probe.

The regression test patches `os.kill` and proves it is never called while exercising both alive and dead helper results.

## How to test

```bash
HOME=/tmp/hermes-pr01-test-home \
HERMES_PYTHON=/tmp/hermes-pr01-test-venv/bin/python \
scripts/run_tests.sh tests/gateway/test_delivery_ledger.py -q

/tmp/hermes-pr01-test-venv/bin/python -m ruff check \
  gateway/delivery_ledger.py tests/gateway/test_delivery_ledger.py

git diff --check origin/main...HEAD
```

Observed: 32 tests passed, Ruff passed, and `git diff --check` passed. Independent adversarial QA also covered matching/mismatched start times, invalid PIDs, unreadable process metadata, helper failures, both import orders, and absence of direct `os.kill` calls.

## Platform scope

- Tested on Linux.
- Windows behavior is supported by static path analysis and the canonical helper's existing tests; I did not claim a native-Windows runtime run.
- No macOS-specific behavior changes.

## Duplicate search

Fresh all-state searches for `_owner_alive`, `"delivery ledger" liveness`, and `delivery_ledger _pid_exists` found no equivalent implementation. PR #67181 is provenance for the ledger and introduced the current fallback; it does not contain this fix.

## Security / operational impact

This is cross-platform robustness hardening: a read-only liveness check no longer risks becoming a control signal. Failure remains fail-safe (`False`) and existing PID-reuse protection is preserved.

## Rollback

Revert this single commit to restore the previous fallback. There are no schema, configuration, dependency, or data migrations.