### PR TITLE
test: pin judge_goal's return contract against arity drift

### DIFF
--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -149,6 +149,51 @@ class TestParseJudgeResponse:
 
 
 class TestJudgeGoal:
+    def test_return_contract_is_a_4_tuple(self):
+        """Pin judge_goal's signature so an arity change fails loudly here.
+
+        Every completion gate unpacks this function's return positionally
+        (``verdict, reason, _, _ = judge_goal(...)``). When the return went to
+        four values, two gates kept unpacking three; the resulting ValueError
+        was swallowed by a broad handler that left a pre-initialised
+        ``verdict = "done"``, so goal-mode completions were approved without
+        ever being evaluated. It shipped twice, 23 minutes apart.
+
+        The unit suite stayed green through all of it because the gate tests
+        mock ``judge_goal`` and therefore assert the mock's shape, not this
+        one. This test talks to the real function so the next signature edit
+        breaks a test instead of silently disabling the gate in production.
+        """
+        import inspect
+        import typing
+
+        from hermes_cli.goals import judge_goal
+
+        sig = inspect.signature(judge_goal)
+        params = list(sig.parameters.values())
+
+        positional = [p.name for p in params if p.kind is p.POSITIONAL_OR_KEYWORD]
+        keyword_only = {p.name for p in params if p.kind is p.KEYWORD_ONLY}
+        assert positional == ["goal", "last_response"]
+        assert keyword_only == {
+            "timeout",
+            "subgoals",
+            "background_processes",
+            "contract",
+        }
+
+        # The load-bearing assertion: what callers actually unpack. Both of
+        # these hit guard clauses that return before the auxiliary-client
+        # import, so neither touches the network.
+        assert len(judge_goal("", "x")) == 4
+        assert len(judge_goal("x", "")) == 4
+
+        # Cheap tripwire on the declared type. goals.py uses
+        # `from __future__ import annotations`, so the raw annotation is a
+        # string — resolve it before inspecting, or get_args() returns ().
+        hints = typing.get_type_hints(judge_goal)
+        assert len(typing.get_args(hints["return"])) == 4
+
     def test_empty_goal_skipped(self):
         from hermes_cli.goals import judge_goal
 


### PR DESCRIPTION
## What

One test pinning `judge_goal`'s real signature: parameter names and kinds, the runtime return arity, and the declared return annotation.

## Why

`judge_goal` returns a 4-tuple. Two completion gates unpacked three. The resulting `ValueError` was caught by a broad handler that left a pre-initialised `verdict = "done"`, so goal-mode `kanban_complete` calls were approved without ever being evaluated — the acceptance gate was silently disabled in production.

Both sites were fixed on 2026-07-20: 9ca8ce4 (`tools/kanban_tools.py`, #67973) and 34a304abb (`hermes_cli/kanban.py`), 23 minutes apart.

The unit suite was green through all of it. Roughly 45 hand-written stubs across 5 test files mock `judge_goal` with their own return shapes, so they assert the mock's contract, not the real one. Nothing in the suite would have caught the arity change, and nothing today prevents the next one from re-disabling the gate the same way.

## The assertions

- **Parameter names and kinds** — `goal`/`last_response` positional-or-keyword; `timeout`/`subgoals`/`background_processes`/`contract` keyword-only.
- **Runtime return arity** (load-bearing) — `judge_goal("", "x")` and `judge_goal("x", "")` both return 4 values. Both hit guard clauses that return before the auxiliary-client import, so this is network-free; `test_goals.py:155,161` already call them unpatched in CI.
- **Declared annotation** — a cheap tripwire. Resolved through `typing.get_type_hints` rather than reading `sig.return_annotation` directly: `goals.py` has `from __future__ import annotations`, so the raw annotation is the *string* `'Tuple[str, str, bool, Optional[Dict[str, Any]]]'` and `typing.get_args()` on it returns `()`.

## Verification

```
scripts/run_tests.sh tests/hermes_cli/test_goals.py -q
=== Summary: 1 files, 102 tests passed, 0 failed ===
```

Mutation-checked both ways against a locally modified `goals.py`:

- 3-tuple annotation → `AssertionError: assert 3 == 4` on the annotation check
- 3-tuple runtime return → `AssertionError: assert 3 == 4` on `assert len(judge_goal("", "x")) == 4`

Reverted clean afterwards.

## Scope

Deliberately not an autospec retrofit. `create_autospec` is unused repo-wide, and `patch.object(..., autospec=True)` appears only on class methods, never module-level functions; converting 45 call sites is a different change.

The honest framing: this converts a *silent production* failure into a *loud test* failure. It does **not** make the existing mocks correct — two already drift from the real signature (`tests/tools/test_kanban_tools.py:650,709` omit `background_processes` and `contract`).

Follows the contract-test precedent in `tests/test_slash_worker_watchdog.py:16-23` and `tests/hermes_cli/test_inventory.py:322-331`.

A follow-up PR makes the gate reject rather than approve when `judge_goal` raises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
