### PR TITLE
docs: improve notion skill structure guidance

### DIFF
--- a/skills/productivity/notion/SKILL.md
+++ b/skills/productivity/notion/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: notion
 description: "Notion API + ntn CLI: pages, databases, markdown, Workers."
-version: 2.0.0
+version: 2.1.0
 author: community
 license: MIT
 platforms: [linux, macos, windows]
@@ -67,6 +67,40 @@ Windows users: skip step 2 entirely until native `ntn` ships — Path B works fi
 ## API Basics
 
 `Notion-Version: 2025-09-03` is required on all HTTP requests. `ntn` handles this for you. In this version, what users call "databases" are called **data sources** in the API.
+
+## Look things up before guessing
+
+When `ntn` is installed, prefer asking the CLI for the exact shape of an endpoint instead of guessing:
+
+```bash
+ntn api ls                       # list public endpoints
+ntn api <path> --help            # usage and methods
+ntn api <path> --docs            # full official docs for that endpoint
+ntn api <path> --spec            # reduced OpenAPI fragment
+ntn pages get <page-id>          # read a page as Markdown
+```
+
+## Notion object model, short version
+
+Think in four objects:
+- **Page**: the core object, both normal docs and rows in a structured collection.
+- **Block**: content inside a page body, including paragraphs, toggles, lists, and `child_page` entries.
+- **Data source**: the API term for what users still call a database.
+- **Page in a data source**: still a page, just with typed properties.
+
+Useful rule:
+- `GET /pages/{id}` = properties / metadata
+- `GET /blocks/{id}/children` = body content and child pages
+- `POST /data_sources/{id}/query` = structured records
+
+In the sampled Alpic workspace, Notion is a hybrid of:
+- top-level hub pages like `Marketing`, `Sales`, and `Welcome to Alpic`
+- nested doc pages like `Skybridge weekly`
+- structured data sources like `People` and `Event calendar`
+- record pages inside those data sources, like people, events, and meeting entries
+
+Read `references/workspace-structure.md` when the task depends on how a real workspace is likely organized, not just on the raw API.
+Read `references/troubleshooting.md` for the common confusions, especially page-vs-block and `database_id` vs `data_source_id`.
 
 ## Path A — `ntn` CLI (preferred, macOS / Linux)
 
@@ -395,37 +429,7 @@ When asked to build a Worker, scaffold with `ntn workers new`, write the code in
 
 ## Notion-Flavored Markdown (used by `/markdown` endpoints)
 
-Standard CommonMark plus XML-like tags for Notion-specific blocks. Use **tabs** for indentation.
-
-**Blocks beyond CommonMark:**
-```
-<callout icon="🎯" color="blue_bg">
-	Ship the MVP by **Friday**.
-</callout>
-
-<details color="gray">
-<summary>Toggle title</summary>
-	Children indented one tab
-</details>
-
-<columns>
-	<column>Left side</column>
-	<column>Right side</column>
-</columns>
-
-<table_of_contents color="gray"/>
-```
-
-**Inline:**
-- Mentions: `<mention-user url="..."/>`, `<mention-page url="...">Title</mention-page>`, `<mention-date start="2026-05-15"/>`
-- Underline: `<span underline="true">text</span>`
-- Color: `<span color="blue">text</span>` or block-level `{color="blue"}` on the first line
-- Math: inline `$x^2$`, block `$$ ... $$`
-- Citations: `[^https://example.com]`
-
-**Colors:** `gray brown orange yellow green blue purple pink red`, plus `*_bg` variants for backgrounds.
-
-Headings 5/6 collapse to H4. Multiple `>` lines render as separate quote blocks — use `<br>` inside a single `>` for multi-line quotes.
+Notion's Markdown support is strong, but the edge cases are not worth carrying inline in the main skill. Use standard CommonMark first, then load `references/notion-flavored-markdown.md` when you need Notion-specific tags like callouts, toggles, columns, mentions, colors, or table-of-contents blocks.
 
 ## Choosing the Right Path
 

--- a/skills/productivity/notion/references/notion-flavored-markdown.md
+++ b/skills/productivity/notion/references/notion-flavored-markdown.md
@@ -1,0 +1,104 @@
+# Notion-Flavored Markdown
+
+This reference covers the Notion-specific extensions supported by the `/markdown` endpoints.
+
+Standard CommonMark works first. Load this file only when you need Notion-specific constructs.
+
+## Formatting model
+
+- Standard Markdown is supported.
+- Notion adds XML-like tags for some block types.
+- Use **tabs** for indentation in nested Notion-flavored constructs.
+
+## Block-level constructs
+
+### Callout
+
+```md
+<callout icon="🎯" color="blue_bg">
+	Ship the MVP by **Friday**.
+</callout>
+```
+
+### Toggle / details
+
+```md
+<details color="gray">
+<summary>Toggle title</summary>
+	Children indented one tab
+</details>
+```
+
+### Columns
+
+```md
+<columns>
+	<column>Left side</column>
+	<column>Right side</column>
+</columns>
+```
+
+### Table of contents
+
+```md
+<table_of_contents color="gray"/>
+```
+
+## Inline constructs
+
+### Mentions
+
+- User: `<mention-user url="..."/>`
+- Page: `<mention-page url="...">Title</mention-page>`
+- Date: `<mention-date start="2026-05-15"/>`
+
+### Underline
+
+```md
+<span underline="true">text</span>
+```
+
+### Color
+
+```md
+<span color="blue">text</span>
+```
+
+Or block-level color on the first line when supported.
+
+### Math
+
+- Inline: `$x^2$`
+- Block:
+
+```md
+$$
+a^2 + b^2 = c^2
+$$
+```
+
+### Citations
+
+```md
+[^https://example.com]
+```
+
+## Colors
+
+Supported color names:
+- `gray`
+- `brown`
+- `orange`
+- `yellow`
+- `green`
+- `blue`
+- `purple`
+- `pink`
+- `red`
+- plus `*_bg` background variants
+
+## Small gotchas
+
+- Headings 5 and 6 collapse to H4.
+- Multiple `>` lines render as separate quote blocks; use `<br>` inside one quote for a multi-line quote.
+- If plain Markdown is enough, prefer plain Markdown. It is easier to generate and maintain.

--- a/skills/productivity/notion/references/troubleshooting.md
+++ b/skills/productivity/notion/references/troubleshooting.md
@@ -1,0 +1,95 @@
+# Troubleshooting and Common Confusions
+
+Use this reference when the Notion API behaves in a way that looks wrong but usually is not.
+
+## 404 even though the page exists
+
+Most common cause: the integration is not shared on that page or data source.
+
+Fix:
+- Open the page or data source in Notion
+- Click `...` or `Share`
+- Connect the integration
+
+This is the most common false-negative in Notion API work.
+
+## I read the page, but I did not get the content
+
+`GET /v1/pages/{page_id}` returns metadata and properties, not the page body.
+
+Use instead:
+- `GET /v1/blocks/{page_id}/children`, or
+- `GET /v1/pages/{page_id}/markdown`
+
+## I need the records in a table, not the text on a page
+
+You probably want a data source query, not a page read.
+
+Use:
+- `GET /v1/data_sources/{data_source_id}` to inspect schema
+- `POST /v1/data_sources/{data_source_id}/query` to retrieve records
+
+## I found a row in search, but I do not know what it is
+
+A database row is still a page.
+
+Clues:
+- `object == "page"` means page
+- `parent.data_source_id` means the page is a record inside a data source
+- `object == "data_source"` means query the collection itself
+
+## database_id vs data_source_id
+
+This is a major source of confusion in the 2025-09-03 API version.
+
+Rule of thumb:
+- use `data_source_id` for query and retrieval workflows on structured collections
+- use `database_id` in parent payloads when creating a page inside a structured collection
+
+When the API docs and examples disagree, check the live endpoint docs via `ntn api <path> --docs` or `--spec`.
+
+## Search returned a page, but the real target is the collection
+
+Common pattern:
+- search finds a record page like an event, person, or meeting
+- the task actually needs all matching records or the schema
+
+Fix:
+- inspect `parent`
+- if the page has `parent.data_source_id`, switch to querying that data source
+
+## Reading a hub page misses the structure
+
+Many workspace landing pages are mostly `child_page` blocks.
+
+Symptoms:
+- `/pages/{id}` returns almost nothing useful
+- `/blocks/{id}/children` reveals many subpages
+
+Fix:
+- treat it like a directory page, not a plain note
+
+## Rate limited
+
+Expected average rate is about 3 requests per second.
+
+Fix:
+- slow down
+- batch less aggressively
+- honor `Retry-After` on `429`
+
+## Large properties look truncated
+
+Some property item payloads paginate, especially relations, people, and other multi-value properties.
+
+Use:
+- `GET /v1/pages/{page_id}/properties/{property_id}`
+
+## Good operating order
+
+When a task is unclear, this order is usually right:
+1. search
+2. identify whether the result is a page or data source
+3. if page, decide properties vs body
+4. if data source, inspect schema then query
+5. only then mutate content or properties

--- a/skills/productivity/notion/references/workspace-structure.md
+++ b/skills/productivity/notion/references/workspace-structure.md
@@ -1,0 +1,147 @@
+# Workspace Structure, Practical Mental Model
+
+This reference captures the shape of a real Notion workspace sampled from the Alpic environment. It is not the Notion API spec. It is the operator mental model that helps decide which endpoint to use.
+
+## What showed up in the sampled workspace
+
+Top-level workspace pages included:
+- `Marketing`
+- `Sales`
+- `Welcome to Alpic`
+- `Build - (Customer Projects)`
+
+Structured data sources included:
+- `People`
+- `Event calendar`
+- `Weekly meetings marketing`
+- `Weekly Sales meeting`
+
+Sample pages inside data sources included:
+- `Brendan Jowett`
+- `MCP Release Party`
+- `Platform pricing overhaul`
+- `Marketing meeting #1`
+- `Weekly Sales July 20th`
+
+Sample nested doc pages included:
+- `Skybridge weekly`
+- `Weekly Tech Priorities`
+
+## What this means
+
+This workspace is a hybrid of four patterns:
+
+1. **Hub pages**
+   - Top-level pages act as navigation and context hubs.
+   - `Welcome to Alpic` is a good example.
+
+2. **Child pages inside hub pages**
+   - A page body can contain many `child_page` blocks.
+   - In the sample, `Welcome to Alpic` had many `child_page` entries, which means it behaves more like a directory or wiki home than a plain note.
+
+3. **Structured data sources**
+   - Collections like `People` and `Event calendar` are typed record stores.
+   - Query them with `data_source_id`, not by crawling prose pages.
+
+4. **Record pages inside data sources**
+   - Every row is still a page.
+   - Those pages have typed properties and may also have body content.
+
+## Real schema examples
+
+### `People`
+Observed properties:
+- `Name`, title
+- `About`, rich_text
+- `Person`, people
+- `Membership Type`, select
+
+Interpretation:
+- This is a lightweight people directory.
+- Start with property queries, then inspect page body only if the task requires richer notes.
+
+### `Event calendar`
+Observed properties included:
+- `Marketing point person`, people
+- `Date`, date
+- `Link`, url
+- `Format`, select
+- `GOING`, select
+- `Notes`, rich_text
+- `Type`, select
+- `Ticket cost`, rich_text
+- `CFP link`, url
+- `Sponsoring cost`, number
+- `People Going`, people
+- `CFP Deadline`, date
+
+Interpretation:
+- This is a structured operational tracker.
+- Query and sort the data source first; use page body only for long-form notes.
+
+## Body content examples
+
+### `Welcome to Alpic`
+Observed child blocks were mostly:
+- `child_page`
+- plus at least one `paragraph`
+
+Interpretation:
+- Reading only `GET /pages/{id}` will miss the actual structure.
+- Read `GET /blocks/{id}/children` when the page acts like a hub.
+
+### `Skybridge weekly`
+Observed body blocks included:
+- `paragraph`
+- `heading_1`
+- `toggle`
+- `bulleted_list_item`
+
+Interpretation:
+- This is a document-style page.
+- Use block reads or Markdown reads, not only metadata.
+
+## Endpoint decision guide
+
+### If the thing looks like a note, wiki page, or project memo
+Use:
+- `GET /v1/pages/{page_id}` for metadata
+- `GET /v1/blocks/{page_id}/children` or `/markdown` for actual content
+
+### If the thing looks like a table of people, meetings, or events
+Use:
+- `GET /v1/data_sources/{data_source_id}` for schema
+- `POST /v1/data_sources/{data_source_id}/query` for records
+
+### If you have a search result and need to decide what it is
+Check:
+- `object == "page"`, treat it as a page
+- `object == "data_source"`, treat it as a structured collection
+- `page.parent.data_source_id`, it is a record page inside a data source
+- `page.parent.page_id`, it is nested under another page
+- `page.parent.workspace`, it is top-level
+
+## Common mistakes in a workspace like this
+
+1. Reading a hub page as if it were only text
+   - Many hub pages are mostly `child_page` blocks.
+
+2. Treating data source rows as a separate object type
+   - They are still pages.
+
+3. Querying by page when a data source query is the real operation
+   - Records belong to a typed collection; query the collection first.
+
+4. Assuming `GET /pages/{id}` returns the document body
+   - It does not. Use blocks or Markdown.
+
+5. Mixing `database_id` and `data_source_id`
+   - Query with `data_source_id`.
+   - Create records with the parent form expected by the API shape in use.
+
+## Fast mental shortcut
+
+- **Hub page**: blocks matter.
+- **Doc page**: Markdown or blocks matter.
+- **Data source**: schema and query matter.
+- **Row in data source**: properties first, body second.

--- a/website/docs/user-guide/skills/bundled/productivity/productivity-notion.md
+++ b/website/docs/user-guide/skills/bundled/productivity/productivity-notion.md
@@ -16,7 +16,7 @@ Notion API + ntn CLI: pages, databases, markdown, Workers.
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/productivity/notion` |
-| Version | `2.0.0` |
+| Version | `2.1.0` |
 | Author | community |
 | License | MIT |
 | Platforms | linux, macos, windows |
@@ -82,6 +82,40 @@ Windows users: skip step 2 entirely until native `ntn` ships — Path B works fi
 ## API Basics
 
 `Notion-Version: 2025-09-03` is required on all HTTP requests. `ntn` handles this for you. In this version, what users call "databases" are called **data sources** in the API.
+
+## Look things up before guessing
+
+When `ntn` is installed, prefer asking the CLI for the exact shape of an endpoint instead of guessing:
+
+```bash
+ntn api ls                       # list public endpoints
+ntn api <path> --help            # usage and methods
+ntn api <path> --docs            # full official docs for that endpoint
+ntn api <path> --spec            # reduced OpenAPI fragment
+ntn pages get <page-id>          # read a page as Markdown
+```
+
+## Notion object model, short version
+
+Think in four objects:
+- **Page**: the core object, both normal docs and rows in a structured collection.
+- **Block**: content inside a page body, including paragraphs, toggles, lists, and `child_page` entries.
+- **Data source**: the API term for what users still call a database.
+- **Page in a data source**: still a page, just with typed properties.
+
+Useful rule:
+- `GET /pages/{id}` = properties / metadata
+- `GET /blocks/{id}/children` = body content and child pages
+- `POST /data_sources/{id}/query` = structured records
+
+In the sampled Alpic workspace, Notion is a hybrid of:
+- top-level hub pages like `Marketing`, `Sales`, and `Welcome to Alpic`
+- nested doc pages like `Skybridge weekly`
+- structured data sources like `People` and `Event calendar`
+- record pages inside those data sources, like people, events, and meeting entries
+
+Read `references/workspace-structure.md` when the task depends on how a real workspace is likely organized, not just on the raw API.
+Read `references/troubleshooting.md` for the common confusions, especially page-vs-block and `database_id` vs `data_source_id`.
 
 ## Path A — `ntn` CLI (preferred, macOS / Linux)
 
@@ -410,37 +444,7 @@ When asked to build a Worker, scaffold with `ntn workers new`, write the code in
 
 ## Notion-Flavored Markdown (used by `/markdown` endpoints)
 
-Standard CommonMark plus XML-like tags for Notion-specific blocks. Use **tabs** for indentation.
-
-**Blocks beyond CommonMark:**
-```
-<callout icon="🎯" color="blue_bg">
-	Ship the MVP by **Friday**.
-</callout>
-
-<details color="gray">
-<summary>Toggle title</summary>
-	Children indented one tab
-</details>
-
-<columns>
-	<column>Left side</column>
-	<column>Right side</column>
-</columns>
-
-<table_of_contents color="gray"/>
-```
-
-**Inline:**
-- Mentions: `<mention-user url="..."/>`, `<mention-page url="...">Title</mention-page>`, `<mention-date start="2026-05-15"/>`
-- Underline: `<span underline="true">text</span>`
-- Color: `<span color="blue">text</span>` or block-level `{color="blue"}` on the first line
-- Math: inline `$x^2$`, block `$$ ... $$`
-- Citations: `[^https://example.com]`
-
-**Colors:** `gray brown orange yellow green blue purple pink red`, plus `*_bg` variants for backgrounds.
-
-Headings 5/6 collapse to H4. Multiple `>` lines render as separate quote blocks — use `<br>` inside a single `>` for multi-line quotes.
+Notion's Markdown support is strong, but the edge cases are not worth carrying inline in the main skill. Use standard CommonMark first, then load `references/notion-flavored-markdown.md` when you need Notion-specific tags like callouts, toggles, columns, mentions, colors, or table-of-contents blocks.
 
 ## Choosing the Right Path
 


### PR DESCRIPTION
Closed. Removing workspace-specific details from the public record.