### PR TITLE
fix: reject rather than approve when the goal judge raises

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2012,23 +2012,38 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                     pass
                 if judge_available:
                     from hermes_cli.goals import judge_goal
-                    verdict = "done"
-                    reason = ""
+                    # No pre-initialised verdict. Every path below assigns
+                    # one explicitly, so a future return-before-assignment
+                    # raises UnboundLocalError instead of silently
+                    # approving. The pre-init is what turned "failed to
+                    # evaluate" into "evaluated and approved" when this gate
+                    # shipped broken.
                     try:
                         # judge_goal returns (verdict, reason, parse_failed,
                         # wait_directive) — see hermes_cli/goals.py. Unpacking
-                        # fewer raises ValueError into the fail-open handler
-                        # below, silently disabling the gate.
+                        # fewer raises ValueError.
                         verdict, reason, _, _ = judge_goal(
                             goal=f"{task.title}\n\n{task.body or ''}".strip(),
                             last_response=(summary or args.result or "").strip(),
                         )
                     except Exception as judge_exc:
+                        # judge_goal already fails open internally for every
+                        # infrastructure fault it knows about — no auxiliary
+                        # client and transport/API errors both return
+                        # ("continue", ...). So anything escaping it is not
+                        # an unreachable judge; it is a programming error at
+                        # this call site. Reject rather than approve.
                         import logging as _logging
-                        _logging.getLogger(__name__).warning(
-                            "goal judge check failed, allowing completion: %s",
+                        _logging.getLogger(__name__).exception(
+                            "goal judge check raised, rejecting completion: %s",
                             judge_exc,
-                            exc_info=True,
+                        )
+                        verdict = "error"
+                        reason = (
+                            f"the goal judge raised {type(judge_exc).__name__}: "
+                            f"{judge_exc}. This is a bug in the gate, not a "
+                            f"verdict on your work — report it rather than "
+                            f"retrying."
                         )
                     if verdict != "done":
                         print(

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -311,7 +311,8 @@ class TestCLIJudgeGate:
     """
 
     def _run(self, monkeypatch, *, goal_mode=True, judge_available=True,
-             verdict="done", reason="", complete_ok=True, summary="done"):
+             verdict="done", reason="", complete_ok=True, summary="done",
+             judge_side_effect=None):
         import argparse
         import types
         from unittest.mock import MagicMock
@@ -348,10 +349,8 @@ class TestCLIJudgeGate:
         )
         # Match the real judge_goal contract:
         # (verdict, reason, parse_failed, wait_directive)
-        monkeypatch.setattr(
-            "hermes_cli.goals.judge_goal",
-            lambda **kw: (verdict, reason, False, None),
-        )
+        _judge = judge_side_effect or (lambda **kw: (verdict, reason, False, None))
+        monkeypatch.setattr("hermes_cli.goals.judge_goal", _judge)
 
         args = argparse.Namespace(task_ids=["t1"], summary=summary, result=None, metadata=None)
         return _cmd_complete(args), complete_calls
@@ -381,3 +380,27 @@ class TestCLIJudgeGate:
         rc, complete_calls = self._run(monkeypatch, goal_mode=False)
         assert rc == 0
         assert complete_calls == ["t1"]
+
+    def test_judge_error_fails_closed(self, monkeypatch):
+        """An exception inside the gate must reject, not approve.
+
+        Reproduces the bug that shipped: judge_goal returning three values
+        while the gate unpacks four. The ValueError was caught by the
+        defensive handler, which left a pre-initialised verdict = "done", so
+        completions were approved without ever being evaluated.
+
+        judge_goal fails open internally for every infrastructure fault it
+        knows about, so anything escaping it is a programming error at this
+        call site — not an unreachable judge.
+        """
+        # Deliberately the WRONG arity: three values where the gate unpacks
+        # four. The verdict is "done" so any swallow-and-continue path
+        # approves, which is what this test must catch.
+        rc, complete_calls = self._run(
+            monkeypatch,
+            judge_side_effect=lambda **kw: ("done", "looks complete", False),
+        )
+        assert rc != 0, "a broken gate must reject, not approve"
+        assert complete_calls == [], (
+            "complete_task must NOT be invoked when the judge raises"
+        )

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -722,6 +722,65 @@ def test_complete_goal_mode_allows_when_judge_unavailable(monkeypatch, tmp_path)
         conn2.close()
 
 
+def test_complete_goal_mode_rejects_when_judge_raises(monkeypatch, tmp_path):
+    """Fail closed: an exception inside the gate must reject, not approve.
+
+    Reproduces the bug that shipped — a judge_goal returning three values
+    while the gate unpacks four. The ValueError was caught by the defensive
+    handler, which left a pre-initialised verdict = "done", so goal-mode
+    completions were approved without ever being evaluated.
+
+    judge_goal fails open internally for every infrastructure fault it knows
+    about (no auxiliary client, transport/API errors both return "continue"),
+    so anything that escapes it is a programming error at this call site, not
+    an unreachable judge. That must never approve.
+    """
+    from pathlib import Path as _Path
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        goal_task_id = kb.create_task(
+            conn, title="goal-mode-test", assignee="test-worker",
+            body="Must achieve X with verified evidence.", goal_mode=True
+        )
+        kb.claim_task(conn, goal_task_id)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", goal_task_id)
+
+    # Deliberately the WRONG arity: three values where the gate unpacks four.
+    # The verdict is "done" so that any swallow-and-continue path approves,
+    # which is exactly what this test must catch.
+    def stale_arity_judge_goal(goal, last_response, **kwargs):
+        return "done", "looks complete", False
+
+    monkeypatch.setattr("tools.kanban_tools.judge_goal", stale_arity_judge_goal)
+    monkeypatch.setattr("tools.kanban_tools._goal_judge_available", lambda: True)
+
+    out = kt._handle_complete({"summary": "I did some stuff"})
+    d = json.loads(out)
+    assert "error" in d, "a broken gate must reject, not approve"
+    assert "Goal completion rejected by judge" in d["error"]
+    assert "ValueError" in d["error"]
+
+    conn2 = kb.connect()
+    try:
+        assert kb.get_task(conn2, goal_task_id).status == "running"
+    finally:
+        conn2.close()
+
+
 def test_block_happy_path(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_block({"reason": "need clarification"})

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -599,25 +599,36 @@ def _handle_complete(args: dict, **kw) -> str:
             # _goal_judge_available for why an unavailable judge fails open.
             task = kb.get_task(conn, tid)
             if task and task.goal_mode and _goal_judge_available():
-                verdict = "done"
-                reason = ""
+                # No pre-initialised verdict. Every path below assigns one
+                # explicitly, so a future return-before-assignment raises
+                # UnboundLocalError instead of silently approving. The
+                # pre-init is what turned "failed to evaluate" into
+                # "evaluated and approved" when this gate shipped broken.
                 try:
                     # judge_goal returns (verdict, reason, parse_failed,
                     # wait_directive) — see hermes_cli/goals.py. Unpacking
-                    # fewer raises ValueError, which the defensive handler
-                    # below swallows, leaving verdict="done" and silently
-                    # disabling the gate.
+                    # fewer raises ValueError.
                     verdict, reason, _, _ = judge_goal(
                         goal=f"{task.title}\n\n{task.body or ''}".strip(),
                         last_response=(summary or result or "").strip(),
                     )
                 except Exception as judge_exc:
-                    # Defensive: judge_goal swallows its own errors, but if
-                    # it ever raises, fail open rather than wedge the worker.
-                    logger.warning(
-                        "goal judge check failed, allowing completion: %s",
+                    # judge_goal already fails open internally for every
+                    # infrastructure fault it knows about — no auxiliary
+                    # client and transport/API errors both return
+                    # ("continue", ...). So anything escaping it is not an
+                    # unreachable judge; it is a programming error at this
+                    # call site. Reject rather than approve.
+                    logger.exception(
+                        "goal judge check raised, rejecting completion: %s",
                         judge_exc,
-                        exc_info=True,
+                    )
+                    verdict = "error"
+                    reason = (
+                        f"the goal judge raised {type(judge_exc).__name__}: "
+                        f"{judge_exc}. This is a bug in the gate, not a "
+                        f"verdict on your work — report it rather than "
+                        f"retrying."
                     )
                 if verdict != "done":
                     return tool_error(


### PR DESCRIPTION
Follow-up to #68032. Land that one first.

## What

Both goal-mode completion gates pre-initialised `verdict = "done"` before calling `judge_goal`, then swallowed any exception with a warning that said "allowing completion". An error inside the gate therefore **approved** the completion.

That pre-init is what made the recent arity bug invisible. `judge_goal` returns four values; two gates unpacked three; the resulting `ValueError` landed in the handler and left `verdict = "done"`. Every goal-mode `kanban_complete` was approved without ever being evaluated. The unpacks were fixed in 9ca8ce4 and 34a304abb — this removes the amplifier that made the breakage silent.

## Why reject rather than fail open

`judge_goal` already fails open internally for every infrastructure fault it knows about: no auxiliary client returns `("continue", ...)` (`goals.py:884`), and transport/API errors do the same (`goals.py:944`). So nothing escaping it is an unreachable judge — it can only be a programming error at the call site. That is exactly the case that must not approve.

## Changes

Applied identically to `tools/kanban_tools.py:601-624` and `hermes_cli/kanban.py:2014-2040`:

- **Delete the `verdict = "done"` / `reason = ""` pre-init.** Every path now assigns explicitly, so a future return-before-assignment raises `UnboundLocalError` instead of silently approving.
- On exception, set `verdict = "error"` with a diagnostic reason, so the existing `if verdict != "done"` rejection path fires.
- `logger.warning` → `logger.exception`, so any occurrence is diagnosable.

## Two deliberate non-changes

**The broad `except Exception` stays**, despite CONTRIBUTING.md:329-334 preferring specific exceptions. The property needed here is "an error must never approve," which is orthogonal to exception type. More concretely: `_cmd_complete` (`hermes_cli/kanban.py:1968-2053`) has no outer handler, so narrowing would let an unanticipated type traceback out mid-loop and abandon already-completed ids. (`_handle_complete` does have outer handlers at `tools/kanban_tools.py:673,675`.)

**No shared helper.** The two clones probe availability differently (`_goal_judge_available()` vs. an inline client probe at `kanban.py:2007-2013`) and report differently (`tool_error` vs. `print` + `failed.append`). Extracting one would create an import edge from `hermes_cli/` into `tools/` — a dedupe refactor wearing a `fix:` label, which CONTRIBUTING.md:944-949 asks us not to do. Same edit made twice; happy to file the dedupe as a follow-up issue.

## Tests

One per gate, each stubbing `judge_goal` with a **3-tuple returning `"done"`** — reproducing exactly what shipped, with the verdict set so that any swallow-and-continue path approves.

Both fail against the pre-fix code and pass only with the fix. Verified by reverting just the two source files and re-running:

```
✗ tests/hermes_cli/test_kanban_goal_mode.py::test_judge_error_fails_closed
    AssertionError: a broken gate must reject, not approve
✗ tests/tools/test_kanban_tools.py::test_complete_goal_mode_rejects_when_judge_raises
    AssertionError: a broken gate must reject, not approve
=== 130 passed, 2 failed ===
```

No existing test regressed in that run — all current gate mocks return well-formed 4-tuples and never reach the `except` branch, and the `"allowing completion"` string is not asserted anywhere.

With the fix:

```
scripts/run_tests.sh tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_goal_mode.py tests/hermes_cli/test_goals.py -q
=== Summary: 3 files, 233 tests passed, 0 failed ===
```

`tests/hermes_cli/test_kanban_goal_mode.py`'s `_run` helper gained a `judge_side_effect=None` kwarg to let a test install its own stub.

### Pre-existing failures

`scripts/run_tests.sh tests/hermes_cli/ tests/cli/ tests/gateway/` reports 273 failing files on this branch. These are **not** from this change — they reproduce identically on unmodified `e89bc58a5` with the same per-file counts (`test_matrix.py` 137, `test_slack.py` 181, `test_personality_none.py` 5, `test_relay_roundtrip.py` 5, `test_gateway_service.py` 4). Verified by stashing all four files and re-running. Looks environmental in my setup rather than a property of the branch.

## Behavior change worth flagging

This is a real one: a silent approve becomes a hard reject. If an unknown exception escapes `judge_goal` in production, goal-mode workers that previously sailed through will now be blocked and need continuation tasks. That is the intent — but it is why #68032 should land first and run a cycle to confirm there is no remaining arity drift. `logger.exception` makes any such case immediately diagnosable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
