### PR TITLE
fix(cli): redact secret values in config set and webhook subscribe

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -8253,6 +8253,39 @@ _SECRET_CONFIG_KEYS = frozenset({
     "jwt",
 })
 
+# Suffix forms of the same credential shapes: ``bot_token``, ``app_password``,
+# ``webhook_secret``, ``dashscope_api_key``, ``signing_secret`` … all carry a
+# credential in their VALUE but miss the exact-match set above, so they echoed
+# in plaintext (`hermes config set platforms.telegram.extra.bot_token 123:AAA…`
+# printed the full token). Kept separate from _SECRET_CONFIG_KEYS so
+# identifier-shaped keys that merely *end* in ``_key`` (``provider_key``,
+# ``session_key``, ``field_key``, ``ssh_key`` — names/paths, not credentials)
+# keep printing unmasked; bare ``_key`` and ``_auth`` are deliberately NOT in
+# this tuple for that reason (``basic_auth``/``drain_auth`` are dict nodes and
+# their credential leaves are covered by the exact-match set).
+_SECRET_CONFIG_KEY_SUFFIXES = (
+    "_api_key",
+    "_apikey",
+    "_token",
+    "_secret",
+    "_password",
+    "_passwd",
+    "_credential",
+    "_credentials",
+)
+
+
+def _is_secret_config_key_name(name: str) -> bool:
+    """True when a config key name is credential-shaped.
+
+    Exact match against ``_SECRET_CONFIG_KEYS`` or suffix match against
+    ``_SECRET_CONFIG_KEY_SUFFIXES`` (both case-insensitive). Shared by
+    :func:`redact_config_value` and the ``config set`` echo so the two display
+    paths can never disagree about what counts as a secret.
+    """
+    lowered = name.lower()
+    return lowered in _SECRET_CONFIG_KEYS or lowered.endswith(_SECRET_CONFIG_KEY_SUFFIXES)
+
 
 def redact_config_value(value: Any, _depth: int = 0) -> Any:
     """Return a copy of ``value`` with credential-shaped keys masked for display.
@@ -8273,7 +8306,7 @@ def redact_config_value(value: Any, _depth: int = 0) -> Any:
     if isinstance(value, dict):
         out = {}
         for k, v in value.items():
-            if isinstance(k, str) and k.lower() in _SECRET_CONFIG_KEYS and isinstance(v, str) and v:
+            if isinstance(k, str) and isinstance(v, str) and v and _is_secret_config_key_name(k):
                 out[k] = mask_secret(v)
             else:
                 out[k] = redact_config_value(v, _depth + 1)
@@ -8823,9 +8856,11 @@ def set_config_value(key: str, value: str, force: bool = False):
     # Mask the echoed value when the (possibly nested) key is credential-shaped
     # — e.g. `hermes config set model.api_key cfut_...` routes to config.yaml
     # (lowercase, so it misses the .env api_keys list above) and would otherwise
-    # print the raw secret to the terminal.
-    _leaf_key = key.rsplit(".", 1)[-1].lower()
-    if _leaf_key in _SECRET_CONFIG_KEYS and isinstance(value, str) and value:
+    # print the raw secret to the terminal. Suffix forms count too:
+    # `platforms.webhook.extra.secret`, `platforms.telegram.extra.bot_token`,
+    # `platforms.slack.extra.signing_secret` all carry credentials.
+    _leaf_key = key.rsplit(".", 1)[-1]
+    if _is_secret_config_key_name(_leaf_key) and isinstance(value, str) and value:
         from agent.redact import mask_secret
         _display_value = mask_secret(value)
     else:

--- a/hermes_cli/subcommands/webhook.py
+++ b/hermes_cli/subcommands/webhook.py
@@ -49,6 +49,14 @@ def build_webhook_parser(subparsers, *, cmd_webhook: Callable) -> None:
         "--secret", default="", help="HMAC secret (auto-generated if omitted)"
     )
     wh_sub.add_argument(
+        "--show-secret",
+        action="store_true",
+        help="Print the full HMAC secret instead of a masked form. Off by "
+        "default so the generated secret doesn't land in terminal "
+        "scrollback/logs; it is always saved to "
+        "~/.hermes/webhook_subscriptions.json (mode 0600).",
+    )
+    wh_sub.add_argument(
         "--deliver-only",
         action="store_true",
         help="Skip the agent — deliver the rendered prompt directly as the "

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -203,9 +203,30 @@ def _cmd_subscribe(args):
     base_url = _get_webhook_base_url()
     status = "Updated" if is_update else "Created"
 
+    # Never echo the full HMAC secret by default — `hermes webhook subscribe`
+    # GENERATES the secret itself, so without masking every invocation leaks a
+    # fresh credential into terminal scrollback, shell transcripts, agent
+    # conversation logs, and CI output. Show a masked form; the operator can
+    # opt in with --show-secret at creation time, or read it from the 0600
+    # subscriptions file. (The hint does NOT suggest re-running subscribe:
+    # re-running without --secret regenerates and silently rotates it.)
+    if getattr(args, "show_secret", False):
+        secret_display = secret
+        secret_hint = ""
+    else:
+        from agent.redact import mask_secret
+
+        secret_display = mask_secret(secret)
+        secret_hint = (
+            f"  (masked — full secret is stored in "
+            f"{display_hermes_home()}/{_SUBSCRIPTIONS_FILENAME})"
+        )
+
     print(f"\n  {status} webhook subscription: {name}")
     print(f"  URL:    {base_url}/webhooks/{name}")
-    print(f"  Secret: {secret}")
+    print(f"  Secret: {secret_display}")
+    if secret_hint:
+        print(secret_hint)
     if events:
         print(f"  Events: {', '.join(events)}")
     else:

--- a/skills/autonomous-ai-agents/hermes-agent/references/webhooks.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/webhooks.md
@@ -67,7 +67,9 @@ hermes webhook subscribe <name> \
   --secret "optional-custom-secret"
 ```
 
-Returns the webhook URL and HMAC secret. The user configures their service to POST to that URL.
+Prints the webhook URL and a masked HMAC secret by default. The full secret is stored in the active profile's Hermes home as `webhook_subscriptions.json` (`~/.hermes/webhook_subscriptions.json` for the default profile on Linux/macOS; `%LOCALAPPDATA%\hermes\webhook_subscriptions.json` on Windows). On POSIX, the file is written with mode `0600`. Add `--show-secret` to the original `subscribe` command only when the user intentionally needs the full value in terminal output.
+
+Do not rerun `subscribe` only to reveal an existing secret: when `--secret` is omitted, a rerun generates a new value and replaces the stored subscription. Have the user — not the agent — retrieve only that route's stored secret locally. Never read or print the subscription file or any secret into agent logs.
 
 ### Filter or transform payloads before the agent runs
 
@@ -126,7 +128,7 @@ hermes webhook subscribe github-issues \
 Then in GitHub repo Settings → Webhooks → Add webhook:
 - Payload URL: the returned webhook_url
 - Content type: application/json
-- Secret: the returned secret
+- Secret: the full value printed when the subscription was created with `--show-secret`, or the value stored for that route in the active profile's `webhook_subscriptions.json`
 - Events: "Issues"
 
 ### GitHub: PR reviews
@@ -189,13 +191,14 @@ Requires `--deliver` to be a real target (telegram, discord, slack, github_comme
 ## Security
 
 - Each subscription gets an auto-generated HMAC-SHA256 secret (or provide your own with `--secret`)
+- `subscribe` masks the secret in terminal output by default; `--show-secret` is the explicit opt-in for printing the full value
+- Full secrets persist in the active profile's Hermes home as `webhook_subscriptions.json` (`~/.hermes/webhook_subscriptions.json` for the default profile on Linux/macOS; `%LOCALAPPDATA%\hermes\webhook_subscriptions.json` on Windows); on POSIX, the file is written with mode `0600`
 - The webhook adapter validates signatures on every incoming POST
 - Static routes from config.yaml cannot be overwritten by dynamic subscriptions
-- Subscriptions persist to `~/.hermes/webhook_subscriptions.json`
 
 ## How It Works
 
-1. `hermes webhook subscribe` writes to `~/.hermes/webhook_subscriptions.json`
+1. `hermes webhook subscribe` writes the route and full HMAC secret to the active profile's `webhook_subscriptions.json`
 2. The webhook adapter hot-reloads this file on each incoming request (mtime-gated, negligible overhead)
 3. When a POST arrives matching a route, the adapter formats the prompt and triggers an agent run
 4. The agent's response is delivered to the configured target (Telegram, Discord, GitHub comment, etc.)
@@ -207,6 +210,6 @@ If webhooks aren't working:
 1. **Is the gateway running?** Check with `systemctl --user status hermes-gateway` or `ps aux | grep gateway`
 2. **Is the webhook server listening?** `curl http://localhost:8644/health` should return `{"status": "ok"}`
 3. **Check gateway logs:** `grep webhook ~/.hermes/logs/gateway.log | tail -20`
-4. **Signature mismatch?** Verify the secret in your service matches the one from `hermes webhook list`. GitHub sends `X-Hub-Signature-256`, GitLab sends `X-Gitlab-Token`.
+4. **Signature mismatch?** Have the user verify locally that the sending service uses the secret stored for that route. `hermes webhook list` does not print secrets, and the agent must not read or print the subscription file. GitHub sends `X-Hub-Signature-256`, GitLab sends `X-Gitlab-Token`.
 5. **Firewall/NAT?** The webhook URL must be reachable from the service. For local development, use a tunnel (ngrok, cloudflared).
 6. **Wrong event type?** Check `--events` filter matches what the service sends. Use `hermes webhook test <name>` to verify the route works.

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -459,6 +459,48 @@ class TestSecretRedactionInDisplay:
         assert secret not in captured.out
         assert "Set model.api_key" in captured.out
 
+    @pytest.mark.parametrize("key, secret", [
+        # Suffix-shaped credential keys previously echoed in plaintext:
+        # exact-match against _SECRET_CONFIG_KEYS missed them entirely.
+        ("platforms.webhook.extra.secret", "fabricated-webhook-hmac-0123456789abcdef"),
+        ("platforms.telegram.extra.bot_token", "1234567890:FAKEFAKEFAKEfakefakefake_fake"),
+        ("platforms.slack.extra.signing_secret", "fabricatedslacksigningsecret12345678"),
+        ("platforms.example.extra.app_password", "fabricated-app-password-abcdef123456"),
+        ("some_service.dashscope_api_key", "sk-fabricated1234567890abcdefghij"),
+    ])
+    def test_set_echo_masks_suffix_shaped_secret_keys(
+        self, key, secret, _isolated_hermes_home, capsys
+    ):
+        set_config_value(key, secret)
+
+        captured = capsys.readouterr()
+        assert secret not in captured.out
+        assert f"Set {key}" in captured.out
+
+    @pytest.mark.parametrize("key, value", [
+        # Identifier-shaped keys that merely end in `_key` are NOT credentials
+        # and must keep echoing their value for debuggability.
+        ("dashboard.session_key", "hermes-session"),
+        ("records.record_key", "customer-42"),
+    ])
+    def test_set_echo_keeps_identifier_shaped_key_values(
+        self, key, value, _isolated_hermes_home, capsys
+    ):
+        set_config_value(key, value)
+
+        captured = capsys.readouterr()
+        assert f"= {value}" in captured.out
+
+    def test_redact_config_value_masks_suffix_shaped_keys(self):
+        from hermes_cli.config import redact_config_value
+        secret = "fabricated-signing-secret-1234567890"
+        cfg = {"extra": {"signing_secret": secret, "port": 8644}}
+
+        out = redact_config_value(cfg)
+
+        assert secret not in str(out)
+        assert out["extra"]["port"] == 8644
+
     def test_set_echo_keeps_nonsecret_value(self, _isolated_hermes_home, capsys):
         set_config_value("model.reasoning_effort", "high")
 

--- a/tests/hermes_cli/test_webhook_cli.py
+++ b/tests/hermes_cli/test_webhook_cli.py
@@ -116,6 +116,50 @@ class TestSubscribe:
         assert _load_subscriptions() == {}
 
 
+class TestSecretEcho:
+    """`webhook subscribe` must not print the full HMAC secret by default.
+
+    The command *generates* the secret itself, so an unmasked echo leaks a
+    fresh credential into terminal scrollback and agent/CI transcripts on
+    every invocation — the user cannot avoid it.
+    """
+
+    def test_generated_secret_not_echoed_in_full(self, capsys):
+        webhook_command(_make_args(webhook_action="subscribe", name="masked"))
+        out = capsys.readouterr().out
+        secret = _load_subscriptions()["masked"]["secret"]
+        assert secret not in out
+        assert "Secret:" in out  # masked line is still shown
+
+    def test_custom_secret_not_echoed_in_full(self, capsys):
+        secret = "fabricated-example-secret-value-123456"
+        webhook_command(_make_args(
+            webhook_action="subscribe", name="masked2", secret=secret
+        ))
+        out = capsys.readouterr().out
+        assert secret not in out
+
+    def test_masked_echo_points_at_subscriptions_file(self, capsys):
+        webhook_command(_make_args(webhook_action="subscribe", name="hinted"))
+        out = capsys.readouterr().out
+        assert "webhook_subscriptions.json" in out
+
+    def test_show_secret_flag_prints_full_secret(self, capsys):
+        webhook_command(_make_args(
+            webhook_action="subscribe", name="shown", show_secret=True
+        ))
+        out = capsys.readouterr().out
+        secret = _load_subscriptions()["shown"]["secret"]
+        assert secret in out
+
+    def test_hmac_signature_still_derivable_from_stored_secret(self):
+        """The masked echo must not change what is persisted — the stored
+        secret remains the HMAC key the sender needs."""
+        webhook_command(_make_args(webhook_action="subscribe", name="hmac"))
+        stored = _load_subscriptions()["hmac"]["secret"]
+        assert len(stored) > 20
+
+
 class TestList:
     def test_empty(self, capsys):
         webhook_command(_make_args(webhook_action="list"))

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -659,7 +659,7 @@ Manage dynamic webhook subscriptions for event-driven agent activation. Requires
 
 | Subcommand | Description |
 |------------|-------------|
-| `subscribe` / `add` | Create a webhook route. Returns the URL and HMAC secret to configure on your service. |
+| `subscribe` / `add` | Create a webhook route. Prints the URL and a masked HMAC secret by default; use `--show-secret` only when the full value must be copied to the sending service. |
 | `list` / `ls` | Show all agent-created subscriptions. |
 | `remove` / `rm` | Delete a dynamic subscription. Static routes from config.yaml are not affected. |
 | `test` | Send a test POST to verify a subscription is working. |
@@ -679,10 +679,11 @@ hermes webhook subscribe <name> [options]
 | `--deliver` | Delivery target: `log` (default), `telegram`, `discord`, `slack`, `github_comment`. |
 | `--deliver-chat-id` | Target chat/channel ID for cross-platform delivery. |
 | `--secret` | Custom HMAC secret. Auto-generated if omitted. |
+| `--show-secret` | Print the full HMAC secret instead of the masked default. Use only when you intentionally need to copy it from terminal output. |
 | `--deliver-only` | Skip the agent — deliver the rendered `--prompt` as the literal message. Zero LLM cost, sub-second delivery. Requires `--deliver` to be a real target (not `log`). |
 | `--script` | Filter/transform script under `~/.hermes/scripts/`. The webhook payload is passed as JSON on stdin; JSON stdout replaces the payload, and empty stdout, `[SILENT]`, or a nonzero exit code ignores the webhook. See [Script Filters and Transforms](../user-guide/messaging/webhooks.md#script-filters-and-transforms). |
 
-Subscriptions persist to `~/.hermes/webhook_subscriptions.json` and are hot-reloaded by the webhook adapter without a gateway restart.
+Subscriptions — including their full HMAC secrets — persist in the active profile's Hermes home as `webhook_subscriptions.json` (`~/.hermes/webhook_subscriptions.json` for the default profile on Linux/macOS; `%LOCALAPPDATA%\hermes\webhook_subscriptions.json` on Windows). On POSIX, the file is written with mode `0600` and is hot-reloaded by the webhook adapter without a gateway restart.
 
 ## `hermes doctor`
 

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -410,7 +410,9 @@ hermes webhook subscribe github-issues \
   --description "Triage new GitHub issues"
 ```
 
-This returns the webhook URL and an auto-generated HMAC secret. Configure your service to POST to that URL.
+This prints the webhook URL and a masked form of its HMAC secret by default. The full secret is stored in the active profile's Hermes home as `webhook_subscriptions.json` (`~/.hermes/webhook_subscriptions.json` for the default profile on Linux/macOS; `%LOCALAPPDATA%\hermes\webhook_subscriptions.json` on Windows). On POSIX, the file is written with mode `0600`. Add `--show-secret` to the original `subscribe` command only when you intentionally need the full value in terminal output to configure the sending service.
+
+Do not rerun `subscribe` only to reveal an existing secret: when `--secret` is omitted, a rerun generates a new value and replaces the stored subscription. If an agent is assisting, the user — not the agent — should retrieve only that route's stored secret locally; never print the whole subscription file or secret into agent logs.
 
 ### List subscriptions
 
@@ -433,7 +435,7 @@ hermes webhook test github-issues --payload '{"issue": {"number": 42, "title": "
 
 ### How dynamic subscriptions work
 
-- Subscriptions are stored in `~/.hermes/webhook_subscriptions.json`
+- Subscriptions — including their full HMAC secrets — are stored in the active profile's Hermes home as `webhook_subscriptions.json` (see the platform-specific paths and POSIX permissions above)
 - The webhook adapter hot-reloads this file on each incoming request (mtime-gated, negligible overhead)
 - Static routes from `config.yaml` always take precedence over dynamic ones with the same name
 - Dynamic subscriptions use the same route format and capabilities as static routes (events, prompt templates, skills, delivery)


### PR DESCRIPTION
## Summary

- Consistently redact exact and suffix-shaped credential keys in Hermes config set/show output.
- Mask generated webhook subscription secrets by default.
- Add an explicit --show-secret opt-in.
- Add behavior-contract tests for redaction and identifier-key visibility.

Closes #68040

## Security

All examples and test values are fabricated. No real credentials are included.

## Test plan

- Targeted Hermes CLI suites: 127 passed.
- Rebased cleanly onto current main.