### PR TITLE
feat(mcp): add Cloudflare's official API MCP server to the catalog

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -112,6 +112,14 @@ class ToolsSpec:
     # pre-checked (or no filter is written when probe fails).
     default_enabled: Optional[List[str]] = None
 
+    # Exclude-mode counterpart: tool names/glob patterns written to
+    # ``mcp_servers.<name>.tools.exclude`` at install time. Everything NOT
+    # matching stays enabled — including tools the server adds later. Use for
+    # huge auto-generated surfaces (OpenAPI-derived MCPs) where an include
+    # list would be thousands of lines and freeze out new endpoints.
+    # Mutually exclusive with ``default_enabled``.
+    default_excluded: Optional[List[str]] = None
+
 
 @dataclass
 class CatalogEntry:
@@ -241,7 +249,22 @@ def _parse_manifest(path: Path) -> CatalogEntry:
             raise CatalogError(
                 f"{path}: tools.default_enabled must be a list of strings"
             )
-    tools_spec = ToolsSpec(default_enabled=default_enabled)
+    default_excluded = tools_raw.get("default_excluded")
+    if default_excluded is not None:
+        if not isinstance(default_excluded, list) or not all(
+            isinstance(t, str) for t in default_excluded
+        ):
+            raise CatalogError(
+                f"{path}: tools.default_excluded must be a list of strings"
+            )
+    if default_enabled is not None and default_excluded is not None:
+        raise CatalogError(
+            f"{path}: tools.default_enabled and tools.default_excluded are "
+            "mutually exclusive"
+        )
+    tools_spec = ToolsSpec(
+        default_enabled=default_enabled, default_excluded=default_excluded
+    )
 
     install: Optional[InstallSpec] = None
     install_raw = data.get("install")
@@ -555,6 +578,22 @@ def _write_tools_include(name: str, include: Optional[List[str]]) -> None:
     save_config(cfg)
 
 
+def _write_tools_exclude(name: str, exclude: List[str]) -> None:
+    """Persist ``mcp_servers.<name>.tools.exclude`` (names or glob patterns)."""
+    cfg = load_config()
+    servers = cfg.setdefault("mcp_servers", {})
+    server_entry = servers.get(name) or {}
+    tools_block = server_entry.get("tools") or {}
+    if not isinstance(tools_block, dict):
+        tools_block = {}
+    tools_block["exclude"] = list(exclude)
+    tools_block.pop("include", None)
+    server_entry["tools"] = tools_block
+    servers[name] = server_entry
+    cfg["mcp_servers"] = servers
+    save_config(cfg)
+
+
 def _apply_tool_selection(
     entry: CatalogEntry, *, prior_selection: Optional[List[str]]
 ) -> None:
@@ -576,6 +615,23 @@ def _apply_tool_selection(
     """
     print()
     print(color(f"  Probing '{entry.name}' for available tools...", Colors.CYAN))
+
+    # Exclude-mode manifests short-circuit the checklist entirely: the curated
+    # exclude list (names or glob patterns) is written as-is, everything else
+    # stays enabled — including tools the server adds later. A reinstall with
+    # a prior include selection still honours the user's own choice below.
+    if entry.tools.default_excluded and prior_selection is None:
+        _write_tools_exclude(entry.name, entry.tools.default_excluded)
+        print(color(
+            f"  Applied manifest exclude list "
+            f"({len(entry.tools.default_excluded)} entries); everything else "
+            f"stays enabled. Edit mcp_servers.{entry.name}.tools.exclude in "
+            "config.yaml or run "
+            f"`hermes mcp configure {entry.name}` to change.",
+            Colors.GREEN,
+        ))
+        return
+
     probed = _probe_tools(entry.name)
 
     # Probe failure path

--- a/optional-mcps/cloudflare/manifest.yaml
+++ b/optional-mcps/cloudflare/manifest.yaml
@@ -3,24 +3,31 @@
 manifest_version: 1
 
 name: cloudflare
-description: Manage your Cloudflare account via the official API MCP.
+description: Full Cloudflare API access via the official remote MCP.
 source: https://developers.cloudflare.com/agents/model-context-protocol/cloudflare/servers-for-cloudflare/
 
 # Cloudflare's official API MCP server (github.com/cloudflare/mcp) is a
 # managed remote server — nothing to install locally. It fronts the entire
-# Cloudflare API (2,500+ endpoints: DNS, Workers, R2, KV, D1, Zero Trust,
-# WAF, Pages, Queues, ...) through just TWO tools, search() and execute(),
-# using the search-and-execute Code Mode pattern: the model searches a typed
-# representation of the OpenAPI spec, then writes JavaScript against the
-# Cloudflare API client, which runs in an isolated Dynamic Worker sandbox on
-# Cloudflare's side. Cloudflare's published numbers: ~1,000 tokens of tool
-# schema regardless of endpoint count, vs ~1,170,000 tokens if every
-# endpoint were a native MCP tool. That tiny fixed footprint is why this
-# entry is safe to leave enabled — it costs about as much context as one
-# ordinary tool.
+# Cloudflare API: DNS, Workers, R2, KV, D1, Zero Trust, WAF, Pages, Queues,
+# and everything else in the OpenAPI spec.
+#
+# We pin `?codemode=false` deliberately. The server's default mode fronts
+# the API through its own search()/execute() indirection ("Code Mode"),
+# where the model must query a spec index and then write JavaScript that
+# runs in a provider-side sandbox. Hermes already has progressive tool
+# disclosure (tool_search) — stacking a second, server-side search layer
+# on top of it would mean two search hops before any real call, and our
+# tool_search would only ever see 2 opaque meta-tools instead of the real
+# surface. With codemode=false the server registers each API endpoint as
+# its own tool (~3,300 as of July 2026) with a real JSON Schema derived
+# from the endpoint's path/query/body parameters. Hermes's tool_search
+# then defers the whole surface behind its bridge tools and searches the
+# FULL catalog with complete schemas — one disclosure layer, ours, with
+# total information. Calls go straight to the Cloudflare API; no sandbox
+# indirection.
 transport:
   type: http
-  url: https://mcp.cloudflare.com/mcp
+  url: https://mcp.cloudflare.com/mcp?codemode=false
 
 auth:
   type: oauth
@@ -31,9 +38,12 @@ auth:
   # scope exactly which account permissions the agent gets.
 
 # Tool selection at install time:
-# The server intentionally exposes a minimal surface (search/execute-style
-# Code Mode tools), so there is nothing to prune. Leave default_enabled
-# unset — the install-time probe pre-checks whatever the server advertises.
+# The surface is ~3,300 endpoint tools — far too many for a manual
+# checklist, and exactly the case tool_search handles automatically.
+# Leave default_enabled unset: no include filter is written and the full
+# surface stays available behind tool_search's deferral gate. Users who
+# want a hard subset can still write tools.include/exclude in config.yaml
+# by hand (e.g. exclude the server's `docs` documentation-search tool).
 
 post_install: |
   On first connection, Hermes opens a browser to authorize with Cloudflare.
@@ -41,15 +51,25 @@ post_install: |
   what you want the agent to touch. After auth, restart your Hermes session
   so the Cloudflare tools are loaded.
 
+  This entry exposes each Cloudflare API endpoint as an individual tool
+  (~3,300). Hermes's tool_search automatically defers them behind its
+  bridge tools, so your context is not flooded — the agent discovers the
+  right endpoint on demand with full schemas.
+
   Headless / CI alternative: instead of OAuth, create a Cloudflare API token
   at https://dash.cloudflare.com/profile/api-tokens and configure the server
   with a bearer header in ~/.hermes/config.yaml:
 
     mcp_servers:
       cloudflare:
-        url: https://mcp.cloudflare.com/mcp
+        url: "https://mcp.cloudflare.com/mcp?codemode=false"
         headers:
           Authorization: "Bearer ${CLOUDFLARE_API_TOKEN}"
+
+  Prefer the provider-side Code Mode surface instead (2 search/execute
+  meta-tools, ~1k-token schema, sandboxed JS composition)? Drop the
+  `?codemode=false` from the url. Not recommended together with Hermes
+  tool_search — you'd be stacking two tool-discovery layers.
 
   Cloudflare also runs product-specific MCP servers (same OAuth flow, add
   manually via `hermes mcp add <name> --url <url>` if you want a narrower

--- a/optional-mcps/cloudflare/manifest.yaml
+++ b/optional-mcps/cloudflare/manifest.yaml
@@ -1,0 +1,65 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: cloudflare
+description: Manage your Cloudflare account via the official API MCP.
+source: https://developers.cloudflare.com/agents/model-context-protocol/cloudflare/servers-for-cloudflare/
+
+# Cloudflare's official API MCP server (github.com/cloudflare/mcp) is a
+# managed remote server — nothing to install locally. It fronts the entire
+# Cloudflare API (2,500+ endpoints: DNS, Workers, R2, KV, D1, Zero Trust,
+# WAF, Pages, Queues, ...) through just TWO tools, search() and execute(),
+# using the search-and-execute Code Mode pattern: the model searches a typed
+# representation of the OpenAPI spec, then writes JavaScript against the
+# Cloudflare API client, which runs in an isolated Dynamic Worker sandbox on
+# Cloudflare's side. Cloudflare's published numbers: ~1,000 tokens of tool
+# schema regardless of endpoint count, vs ~1,170,000 tokens if every
+# endpoint were a native MCP tool. That tiny fixed footprint is why this
+# entry is safe to leave enabled — it costs about as much context as one
+# ordinary tool.
+transport:
+  type: http
+  url: https://mcp.cloudflare.com/mcp
+
+auth:
+  type: oauth
+  # Native MCP OAuth 2.1 (case 1) — the server publishes AS metadata with
+  # Dynamic Client Registration at https://mcp.cloudflare.com/register.
+  # Hermes's MCP client + mcp_oauth_manager handle discovery, DCR, PKCE,
+  # token exchange, and refresh. During authorization Cloudflare lets you
+  # scope exactly which account permissions the agent gets.
+
+# Tool selection at install time:
+# The server intentionally exposes a minimal surface (search/execute-style
+# Code Mode tools), so there is nothing to prune. Leave default_enabled
+# unset — the install-time probe pre-checks whatever the server advertises.
+
+post_install: |
+  On first connection, Hermes opens a browser to authorize with Cloudflare.
+  You pick the account and the permissions to grant — scope the token to
+  what you want the agent to touch. After auth, restart your Hermes session
+  so the Cloudflare tools are loaded.
+
+  Headless / CI alternative: instead of OAuth, create a Cloudflare API token
+  at https://dash.cloudflare.com/profile/api-tokens and configure the server
+  with a bearer header in ~/.hermes/config.yaml:
+
+    mcp_servers:
+      cloudflare:
+        url: https://mcp.cloudflare.com/mcp
+        headers:
+          Authorization: "Bearer ${CLOUDFLARE_API_TOKEN}"
+
+  Cloudflare also runs product-specific MCP servers (same OAuth flow, add
+  manually via `hermes mcp add <name> --url <url>` if you want a narrower
+  surface): docs search (https://docs.mcp.cloudflare.com/mcp, no auth),
+  Workers observability (https://observability.mcp.cloudflare.com/mcp),
+  Browser Rendering (https://browser.mcp.cloudflare.com/mcp), Radar
+  (https://radar.mcp.cloudflare.com/mcp), GraphQL analytics
+  (https://graphql.mcp.cloudflare.com/mcp), audit logs
+  (https://auditlogs.mcp.cloudflare.com/mcp), and more — full list at the
+  source URL above.
+
+  Re-run the tool checklist any time with:
+    hermes mcp configure cloudflare

--- a/optional-mcps/cloudflare/manifest.yaml
+++ b/optional-mcps/cloudflare/manifest.yaml
@@ -38,12 +38,66 @@ auth:
   # scope exactly which account permissions the agent gets.
 
 # Tool selection at install time:
-# The surface is ~3,300 endpoint tools — far too many for a manual
-# checklist, and exactly the case tool_search handles automatically.
-# Leave default_enabled unset: no include filter is written and the full
-# surface stays available behind tool_search's deferral gate. Users who
-# want a hard subset can still write tools.include/exclude in config.yaml
-# by hand (e.g. exclude the server's `docs` documentation-search tool).
+# The surface is ~3,300 endpoint tools. Rather than a manual checklist (or
+# a frozen include list that would block future endpoints), we ship a
+# curated exclude list of glob patterns targeting product families that are
+# enterprise-contract, org-fleet, or read-only-analytics surfaces — dead
+# weight for the personal/dev accounts the catalog serves. Everything else
+# (~1,900 tools: DNS, Workers, R2, KV, D1, Queues, Pages, WAF, rulesets,
+# tunnels, Access, Stream, Images, AI, Vectorize, ...) stays enabled,
+# including endpoints Cloudflare adds later. Users can re-enable any family
+# by deleting its pattern from mcp_servers.cloudflare.tools.exclude.
+tools:
+  default_excluded:
+    # The server's built-in Cloudflare-docs search tool (not an API
+    # endpoint) — redundant with the agent's own web tools.
+    - docs
+    # Radar: public read-only internet trend analytics (~275 tools).
+    # Cloudflare ships a dedicated Radar MCP for this.
+    - "*_radar_*"
+    # Enterprise networking: Magic Transit/WAN, network monitoring,
+    # interconnects, WAN teamnet. (cloudflared tunnels are NOT excluded.)
+    - "*_accounts_magic_*"
+    - "*_accounts_mnm_*"
+    - "*_accounts_cni_*"
+    - "*_accounts_teamnet_*"
+    # Cloudforce One threat-intel analyst platform (enterprise SOC).
+    - "*_accounts_cloudforceone_*"
+    # Zero Trust org-fleet suite: DLP, managed devices, DEX, data-security
+    # posture, email security, SCIM provisioning, SWG gateway policy.
+    # Access (login policies for your own apps) stays enabled.
+    - "*_accounts_dlp_*"
+    - "*_accounts_devices*"
+    - "*_accounts_dex_*"
+    - "*_accounts_datasecurity_*"
+    - "*_accounts_emailsecurity_*"
+    - "*_accounts_scim_*"
+    - "*_accounts_gateway*"
+    - "*_accounts_zerotrust_*"
+    - "*_accounts_one_*"
+    # Security-intel research products: brand protection, threat intel,
+    # URL scanner, CVE scanner, security center.
+    - "*_accounts_brandprotection_*"
+    - "*_accounts_intel_*"
+    - "*_accounts_urlscanner_*"
+    - "*_accounts_vuln_scanner_*"
+    - "*_zones_securitycenter_*"
+    - "*_accounts_securitycenter_*"
+    # Enterprise API Shield cluster + waiting rooms + BYOIP + data shares.
+    - "*_zones_api_gateway_*"
+    - "*_zones_schema_validation*"
+    - "*_zones_token_validation*"
+    - "*_zones_waiting_rooms*"
+    - "*_accounts_addressing_*"
+    - "*_accounts_shares*"
+    # Legacy / migration / niche: S3-migration slurper, Web3 gateways,
+    # secondary-DNS peering, legacy per-user load balancers.
+    - "*_accounts_slurper_*"
+    - "*_zones_web3_*"
+    - "*_accounts_flagship_*"
+    - "*_zones_secondary_dns_*"
+    - "*_accounts_secondary_dns_*"
+    - "*_user_load_balancers*"
 
 post_install: |
   On first connection, Hermes opens a browser to authorize with Cloudflare.
@@ -51,10 +105,18 @@ post_install: |
   what you want the agent to touch. After auth, restart your Hermes session
   so the Cloudflare tools are loaded.
 
-  This entry exposes each Cloudflare API endpoint as an individual tool
-  (~3,300). Hermes's tool_search automatically defers them behind its
-  bridge tools, so your context is not flooded — the agent discovers the
-  right endpoint on demand with full schemas.
+  This entry exposes each Cloudflare API endpoint as an individual tool.
+  A curated exclude list ships in the manifest (enterprise-contract,
+  org-fleet, and read-only-analytics product families are disabled —
+  ~1,400 tools), leaving ~1,900 tools for the products people actually
+  drive from an agent: DNS, Workers, R2, KV, D1, Queues, Pages, WAF,
+  rulesets, tunnels, Access, Stream, Images, AI, Vectorize. Hermes's
+  tool_search defers them all, so your context is not flooded — the agent
+  discovers the right endpoint on demand with full schemas.
+
+  Run a Zero Trust org or want Radar/Magic/API-Shield surfaces back?
+  Delete their patterns from mcp_servers.cloudflare.tools.exclude in
+  ~/.hermes/config.yaml.
 
   Headless / CI alternative: instead of OAuth, create a Cloudflare API token
   at https://dash.cloudflare.com/profile/api-tokens and configure the server

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -224,6 +224,31 @@ class TestManifestParsing:
 
         assert list_catalog() == []
 
+    def test_tools_default_excluded_parsed(self, catalog_dir):
+        body = _basic_manifest(
+            tools={"default_excluded": ["docs", "*_radar_*"]},
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        e = _entry("demo")
+        assert e.tools.default_excluded == ["docs", "*_radar_*"]
+        assert e.tools.default_enabled is None
+
+    def test_tools_default_excluded_bad_shape_rejected(self, catalog_dir):
+        body = _basic_manifest(tools={"default_excluded": "docs"})  # str, not list
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import list_catalog
+
+        assert list_catalog() == []
+
+    def test_tools_enabled_and_excluded_mutually_exclusive(self, catalog_dir):
+        body = _basic_manifest(
+            tools={"default_enabled": ["a"], "default_excluded": ["b"]},
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import list_catalog
+
+        assert list_catalog() == []
+
 
 # ---------------------------------------------------------------------------
 # Install flow
@@ -244,6 +269,60 @@ class TestInstall:
         assert servers["demo"]["command"] == "npx"
         assert servers["demo"]["args"] == ["-y", "demo-mcp"]
         assert servers["demo"]["enabled"] is True
+
+    def test_install_default_excluded_writes_exclude_without_probe(
+        self, catalog_dir, monkeypatch
+    ):
+        """Exclude-mode manifests skip the probe/checklist and write
+        tools.exclude verbatim (names + glob patterns)."""
+        body = _basic_manifest(
+            tools={"default_excluded": ["docs", "*_radar_*"]},
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        import hermes_cli.mcp_catalog as mc
+        from hermes_cli.config import load_config
+
+        def _fail_probe(name):
+            raise AssertionError("probe must not run for exclude-mode manifests")
+
+        monkeypatch.setattr(mc, "_probe_tools", _fail_probe)
+        mc.install_entry(_entry("demo"), enable=True)
+
+        server = load_config()["mcp_servers"]["demo"]
+        assert server["tools"]["exclude"] == ["docs", "*_radar_*"]
+        assert "include" not in server["tools"]
+
+    def test_reinstall_prior_include_wins_over_default_excluded(
+        self, catalog_dir, monkeypatch
+    ):
+        """A user's prior include selection survives reinstall of an
+        exclude-mode manifest (prior selection > manifest default)."""
+        body = _basic_manifest(
+            tools={"default_excluded": ["*_radar_*"]},
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        import hermes_cli.mcp_catalog as mc
+        from hermes_cli.config import load_config, save_config
+
+        cfg = load_config()
+        cfg.setdefault("mcp_servers", {})["demo"] = {
+            "command": "npx",
+            "args": ["-y", "demo-mcp"],
+            "enabled": True,
+            "tools": {"include": ["tool_a"]},
+        }
+        save_config(cfg)
+
+        import sys as _sys
+        probed = [("tool_a", "a"), ("tool_b", "b")]
+        monkeypatch.setattr(mc, "_probe_tools", lambda name: probed)
+        monkeypatch.setattr(_sys.stdin, "isatty", lambda: False)
+
+        mc.install_entry(_entry("demo"), enable=True)
+
+        server = load_config()["mcp_servers"]["demo"]
+        assert server["tools"]["include"] == ["tool_a"]
+        assert "exclude" not in server["tools"]
 
     def test_install_rejects_exfil_shaped_stdio_manifest(self, catalog_dir):
         body = _basic_manifest(

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -3832,6 +3832,59 @@ class TestMCPSelectiveToolLoading:
             "mcp__ink_exclude__list_services",
         ]
 
+    def test_exclude_filter_supports_glob_patterns(self):
+        """Glob entries in tools.exclude match families of tool names."""
+        config = {
+            "url": "https://mcp.example.com",
+            "tools": {"exclude": ["*_radar_*", "docs"]},
+        }
+        registered, _ = self._run_discover(
+            "ink_glob",
+            [
+                "get_radar_http_summary",
+                "post_radar_scans",
+                "docs",
+                "get_zones_dns_records",
+            ],
+            config,
+            session=SimpleNamespace(),
+        )
+        assert registered == ["mcp__ink_glob__get_zones_dns_records"]
+
+    def test_include_filter_supports_glob_patterns(self):
+        """Glob entries in tools.include whitelist families of tool names."""
+        config = {
+            "url": "https://mcp.example.com",
+            "tools": {"include": ["*_dns_*"]},
+        }
+        registered, _ = self._run_discover(
+            "ink_glob_inc",
+            ["get_zones_dns_records", "post_zones_dns_records", "docs"],
+            config,
+            session=SimpleNamespace(),
+        )
+        assert registered == [
+            "mcp__ink_glob_inc__get_zones_dns_records",
+            "mcp__ink_glob_inc__post_zones_dns_records",
+        ]
+
+    def test_plain_exclude_names_do_not_glob_match(self):
+        """Entries without metacharacters stay exact-match (no surprise hits)."""
+        config = {
+            "url": "https://mcp.example.com",
+            "tools": {"exclude": ["docs"]},
+        }
+        registered, _ = self._run_discover(
+            "ink_exact",
+            ["docs", "docs_search", "get_docs"],
+            config,
+            session=SimpleNamespace(),
+        )
+        assert registered == [
+            "mcp__ink_exact__docs_search",
+            "mcp__ink_exact__get_docs",
+        ]
+
     def test_include_filter_skips_utility_tools_without_capabilities(self):
         config = {
             "url": "https://mcp.example.com",

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -92,6 +92,7 @@ Thread safety:
 import asyncio
 import contextvars
 import concurrent.futures
+import fnmatch
 import inspect
 import json
 import logging
@@ -4862,7 +4863,7 @@ def _build_utility_schemas(server_name: str) -> List[dict]:
 
 
 def _normalize_name_filter(value: Any, label: str) -> set[str]:
-    """Normalize include/exclude config to a set of tool names."""
+    """Normalize include/exclude config to a set of tool names/patterns."""
     if value is None:
         return set()
     if isinstance(value, str):
@@ -4871,6 +4872,23 @@ def _normalize_name_filter(value: Any, label: str) -> set[str]:
         return {str(item) for item in value}
     logger.warning("MCP config %s must be a string or list of strings; ignoring %r", label, value)
     return set()
+
+
+def _name_filter_matches(name: str, filter_set: set) -> bool:
+    """True if *name* matches any entry in a normalized include/exclude set.
+
+    Entries containing a glob metacharacter (``*``, ``?``, ``[``) are matched
+    with :func:`fnmatch.fnmatchcase`; plain entries are exact names. Globs let
+    huge auto-generated surfaces (e.g. an OpenAPI-derived MCP exposing
+    thousands of endpoint tools) be filtered by product family
+    (``*_accounts_magic_*``) instead of thousand-line literal lists.
+    """
+    if name in filter_set:
+        return True
+    for pat in filter_set:
+        if ("*" in pat or "?" in pat or "[" in pat) and fnmatch.fnmatchcase(name, pat):
+            return True
+    return False
 
 
 def _parse_boolish(value: Any, default: bool = True) -> bool:
@@ -5047,9 +5065,9 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
 
     def _should_register(tool_name: str) -> bool:
         if include_set:
-            return tool_name in include_set
+            return _name_filter_matches(tool_name, include_set)
         if exclude_set:
-            return tool_name not in exclude_set
+            return not _name_filter_matches(tool_name, exclude_set)
         return True
 
     for mcp_tool in server._tools:

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -104,6 +104,13 @@ The pre-checked rows come from:
    catalog entries pre-prune mutating or rarely-useful tools)
 3. **Everything** if neither applies
 
+Some entries with very large auto-generated surfaces (e.g. `cloudflare`,
+~3,300 OpenAPI endpoint tools) instead declare `tools.default_excluded` — a
+curated block-list of names and glob patterns. Installing one of these skips
+the checklist entirely and writes `tools.exclude`; everything not matched
+stays enabled, including tools the server adds later. Edit
+`mcp_servers.<name>.tools.exclude` in config.yaml to re-enable a family.
+
 Submit the checklist with ENTER. Only the checked tools end up in
 `mcp_servers.<name>.tools.include`. If you select everything, no filter is
 written (cleanest config shape, identical behavior).
@@ -447,6 +454,12 @@ mcp_servers:
 ```
 
 Only those MCP server tools are registered.
+
+Entries in `include`/`exclude` may also be glob patterns (`*`, `?`, `[...]`,
+matched case-sensitively): `include: ["*_dns_*"]` registers every tool whose
+name contains `_dns_`. Plain entries without metacharacters stay exact-match.
+Globs are the practical way to filter servers that expose thousands of
+auto-generated endpoint tools by product family.
 
 ### Blacklist server tools
 

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -211,7 +211,7 @@ Use HTTP servers when:
 
 ### OAuth-authenticated HTTP servers
 
-Most hosted MCP servers (Linear, Sentry, Atlassian, Asana, Figma, Stripe, …) require OAuth 2.1 instead of a static bearer token. Set `auth: oauth` and Hermes handles discovery, dynamic client registration, PKCE, token exchange, refresh, and step-up auth via the MCP Python SDK.
+Most hosted MCP servers (Cloudflare, Linear, Sentry, Atlassian, Asana, Figma, Stripe, …) require OAuth 2.1 instead of a static bearer token. Set `auth: oauth` and Hermes handles discovery, dynamic client registration, PKCE, token exchange, refresh, and step-up auth via the MCP Python SDK.
 
 ```yaml
 mcp_servers:


### PR DESCRIPTION
## Summary
Adds Cloudflare's official API MCP server to the Nous-approved MCP catalog with a curated exclude list — `hermes mcp install cloudflare` wires the agent to ~1,900 useful Cloudflare API endpoint tools (DNS, Workers, R2, KV, D1, Pages, WAF, tunnels, Access, AI) while pruning ~1,400 enterprise/analytics tools, via a single remote HTTP entry with native OAuth 2.1 and zero local install.

Along the way this teaches MCP `tools.include`/`tools.exclude` filters to accept **glob patterns**, and the catalog manifest schema a **`tools.default_excluded`** field — both needed to curate a 3,300-tool OpenAPI surface without a thousand-line literal list.

## Why this belongs in the catalog

Cloudflare is where a huge share of Hermes users already keep their infrastructure — DNS, Workers, R2, KV, D1, Pages, Zero Trust, WAF, tunnels. Until now, driving any of it from Hermes meant hand-rolling `curl` calls against API docs or pasting a raw `mcp_servers` block. This entry makes the whole account one command away.

## Design decision 1: `?codemode=false` — one tool-discovery layer, not two

Cloudflare's server defaults to a "Code Mode" surface: two meta-tools (`search()` + `execute()`) where the model queries a spec index and then writes JavaScript that runs in a provider-side sandbox. Compact (~1k tokens), but it is itself a tool-search layer — and Hermes already has one. Stacking them would mean two search hops before any real API call, and Hermes's `tool_search` would only ever see 2 opaque meta-tools instead of the actual capability surface.

The server supports disabling this with the `?codemode=false` query parameter, which the manifest pins. In that mode each API endpoint registers as its own MCP tool with a real JSON Schema derived from the endpoint's path/query/body parameters. Hermes's progressive tool disclosure then defers the whole surface behind its bridge tools and searches the **full catalog with complete schemas** — one disclosure layer, ours, with total information. Tool calls go straight to the Cloudflare API; no sandbox indirection.

Verified live against an OAuth'd session: `tools/list` returns **3,320 tools**, all with populated input schemas.

## Design decision 2: curated exclude list — 3,320 → 1,905 tools

A full account-audit of the 3,320-tool surface shows ~43% of it is product families a personal/dev account will never touch. The manifest ships a 34-pattern exclude list (written to `tools.exclude` at install time):

| Excluded family | ~Tools | Rationale |
|---|---|---|
| Zero Trust org-fleet suite (DLP, devices, DEX, CASB, SCIM, SWG) | 396 | org administration; Access itself stays |
| Radar public trend analytics | 275 | read-only public data; has its own dedicated MCP |
| Enterprise networking (Magic Transit/WAN, NetMon, interconnects) | 222 | contract products; cloudflared tunnels stay |
| Cloudforce One threat-intel platform | 173 | enterprise SOC product |
| Security-intel research (brand protection, scanners, intel) | 131 | rarely agent-driven |
| API Shield / waiting rooms / BYOIP / data shares | 133 | enterprise zone products |
| Legacy / migration / niche (slurper, web3, secondary DNS) | 84 | deprecated or one-shot surfaces |
| Server's `docs` search tool | 1 | redundant with the agent's web tools |

Everything users actually drive from an agent survives: DNS, Workers, R2, KV, D1, Queues, Pages, WAF, rulesets, tunnels, Access, Stream, Images, AI, AI Gateway, Vectorize, load balancers, certs, logs, billing. Exclude-mode means **future endpoints Cloudflare ships are enabled by default**; re-enabling a pruned family is deleting one line from config.yaml.

## Enabling changes (mechanism)

- **Glob support in MCP tool filters** (`tools/mcp_tool.py`): entries in `tools.include`/`tools.exclude` containing `*`/`?`/`[` now match via `fnmatch`; plain names stay exact-match. `_name_filter_matches()` + wired into `_should_register()`. Without this, excluding 1,415 tools means a 1,415-line literal list that goes stale on every Cloudflare API release.
- **`tools.default_excluded` manifest field** (`hermes_cli/mcp_catalog.py`): exclude-mode counterpart to `default_enabled` (mutually exclusive, validated). Install writes it to `tools.exclude` directly and skips the probe/checklist — a 3,320-row curses checklist is not a UX. A user's prior include selection still wins on reinstall.

## Use cases

- **"Why is my site down?"** — Hermes checks DNS records, WAF events, and origin health, then fixes the bad record it finds — one conversation, no dashboard.
- **Ship a Worker from chat** — build the Worker locally with terminal/file tools, then deploy, bind KV/R2, and set routes through the same session.
- **DNS on autopilot** — bulk-audit records across zones, add the missing DMARC/SPF entries, verify propagation.
- **Access administration** — review and update login policies for your self-hosted apps.
- **Incident cron jobs** — a scheduled Hermes job that pulls WAF/security analytics and messages you only when something looks wrong.
- **R2/KV/D1 as agent storage** — inspect buckets, query D1, manage namespaces without leaving the conversation.

The OAuth grant is scoped at authorize time — users pick exactly which account permissions the agent gets, and a bearer-token path (documented in `post_install`) covers headless/CI setups.

## Changes
- `optional-mcps/cloudflare/manifest.yaml`: new catalog entry — HTTP transport (`…/mcp?codemode=false`), native MCP OAuth, no install block, 34-pattern `tools.default_excluded` with per-family rationale comments.
- `tools/mcp_tool.py`: glob-pattern matching for `tools.include`/`tools.exclude` (`_name_filter_matches`).
- `hermes_cli/mcp_catalog.py`: `tools.default_excluded` parsing/validation + `_write_tools_exclude` + install-flow short-circuit.
- `tests/tools/test_mcp_tool.py`: glob include/exclude + exact-match-stays-exact tests.
- `tests/hermes_cli/test_mcp_catalog.py`: `default_excluded` parse/validation/mutual-exclusion + install-flow + reinstall-precedence tests.
- `website/docs/user-guide/features/mcp.md`: glob filter docs, `default_excluded` catalog docs, Cloudflare in hosted-OAuth examples.

## Validation
| Check | Result |
|---|---|
| `_parse_manifest()` on the new manifest | ✓ 34 exclude patterns, mutual-exclusion enforced |
| Live filter replay: real `_normalize_name_filter` + `_name_filter_matches` over the live 3,320-tool list | ✓ 3,320 → 1,905 kept / 1,415 excluded, zero overmatch (pattern set verified exact against a per-product target audit) |
| Spot checks | ✓ DNS/Workers/R2/D1/tunnels/Access/AI-gateway kept; radar/magic/CF1/DLP/SWG/API-shield/docs excluded |
| Live endpoint probe (authed) | ✓ `tools/list` → 3,320 tools, 100% with input schemas |
| Live endpoint probe (unauthed) | ✓ 401 + OAuth AS metadata with DCR at `/register` |
| `scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py tests/tools/test_mcp_tool.py` | ✓ 261/261 |

## Infographic

![cloudflare-mcp-catalog](https://v3b.fal.media/files/b/0aa3042f/VcRx7V-eeYLYZJbtBUI1A_IVEQjota.png)
