### PR TITLE
fix(tools): let an explicit toolset list win over x_search auto-enable

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2309,8 +2309,16 @@ def _get_platform_tools(
         # through ``hermes tools`` to flip the toolset on. Only fires when
         # the user has not yet saved an explicit toolset list — once they
         # do, the saved list is authoritative.
+        #
+        # Gate on ``explicitly_configured`` (a list was saved for this
+        # platform), NOT on reaching this branch. This branch is also entered
+        # for a saved list that happens to contain no configurable keys —
+        # ``[]`` after disabling everything, or a composite-only list — and
+        # auto-enabling there resurrects a toolset the user explicitly turned
+        # off, making a genuinely no-tools profile impossible (#68001).
         x_search_auto_enabled = (
-            _toolset_allowed_for_platform("x_search", platform)
+            not explicitly_configured
+            and _toolset_allowed_for_platform("x_search", platform)
             and _xai_credentials_present()
         )
         if x_search_auto_enabled:

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -117,10 +117,91 @@ def test_discord_toolsets_do_not_leak_to_other_platforms():
     assert "discord_admin" not in enabled
 
 
+def test_get_platform_tools_x_search_off_when_no_xai_credentials(monkeypatch):
+    """Without any xAI credentials, x_search stays off — preserves the
+    "don't ship the schema to users who can't use it" default."""
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._xai_credentials_present", lambda: False
+    )
+
+    cli_enabled = _get_platform_tools({}, "cli")
+    assert "x_search" not in cli_enabled
 
 
+def test_get_platform_tools_x_search_respects_explicit_config(monkeypatch):
+    """Once the user has saved an explicit toolset list via `hermes tools`,
+    that list is authoritative — x_search auto-enable does NOT fire even
+    when xAI creds exist. The saved list represents deliberate choices."""
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._xai_credentials_present", lambda: True
+    )
+
+    # User explicitly opted into spotify but not x_search via `hermes tools`.
+    config = {"platform_toolsets": {"cli": ["hermes-cli", "spotify"]}}
+    enabled = _get_platform_tools(config, "cli")
+    assert "x_search" not in enabled
+    assert "spotify" in enabled
 
 
+def test_x_search_stays_disabled_on_stripped_down_profile(monkeypatch):
+    """Regression for #68001.
+
+    Building a minimal reviewer profile by disabling every configurable
+    toolset leaves a saved list with no configurable keys in it. The resolver
+    treated that as "the user never configured anything" and let the
+    xAI-credential auto-enable fire, so ``x_search`` came back on the next
+    ``tools list`` despite having just been disabled.
+
+    Disabling x_search alongside a still-populated selection already worked
+    (the saved list keeps other configurable keys); this covers the
+    stripped-down profile the reporter was building.
+    """
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._xai_credentials_present", lambda: True
+    )
+
+    config = {}
+    assert "x_search" in _get_platform_tools(config, "cli"), (
+        "precondition: auto-enable fires for an unconfigured profile"
+    )
+
+    all_configurable = [key for key, _, _ in CONFIGURABLE_TOOLSETS]
+    _apply_toolset_change(config, "cli", all_configurable, "disable")
+
+    assert "x_search" not in _get_platform_tools(config, "cli"), (
+        "x_search re-enabled by credential discovery after an explicit disable"
+    )
+
+
+def test_x_search_not_resurrected_on_empty_toolset_list(monkeypatch):
+    """#68001: an explicitly saved empty list is a deliberate no-tools profile.
+
+    Credential-based auto-enable must not inject a toolset into it — otherwise
+    a read-only reviewer profile can't be expressed at the profile level.
+    """
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._xai_credentials_present", lambda: True
+    )
+
+    enabled = _get_platform_tools({"platform_toolsets": {"cli": []}}, "cli")
+    assert "x_search" not in enabled
+
+
+def test_x_search_auto_enable_still_fires_without_saved_list(monkeypatch):
+    """The narrowing must not break the original auto-enable: a platform with
+    no saved toolset list still picks x_search up from xAI credentials."""
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._xai_credentials_present", lambda: True
+    )
+
+    # Another platform's saved list must not suppress this one.
+    config = {"platform_toolsets": {"telegram": []}}
+    assert "x_search" in _get_platform_tools(config, "cli")
 
 
 def test_toolset_has_keys_for_vision_accepts_codex_auth(tmp_path, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

`hermes tools disable x_search` prints `Disabled: x_search`, but `hermes tools list` still shows it enabled whenever xAI credentials are present.

`_get_platform_tools()` splits on `has_explicit_config` — *does the saved list contain at least one configurable toolset key* — and the x_search credential auto-enable lives in the `else` branch. That branch is not only the "user never configured anything" case: it is also entered for a saved list that happens to hold no configurable keys. So on a stripped-down profile the auto-enable fires against a list the user deliberately emptied, and the toolset comes back.

The block's own comment already states the intended rule — *"Only fires when the user has not yet saved an explicit toolset list — once they do, the saved list is authoritative"* — and the function already computes exactly that condition as `explicitly_configured` (`isinstance(toolset_names, list)`, captured before the default-toolset fallback overwrites it). The fix is to gate on it.

Credential discovery still chooses the default for a platform with no saved list — the behavior #35527 added and the existing `test_get_platform_tools_x_search_auto_enabled_when_xai_oauth_present` pins. Once a list exists for that platform, it wins.

Scope note: `homeassistant` has a structurally similar `HASS_TOKEN` carve-out a few lines below. I left it alone — it's reached through a different mechanism (`_DEFAULT_OFF_TOOLSETS` removal rather than direct injection) and isn't what was reported. Happy to follow up separately if you'd like it aligned.

## Related Issue

Fixes #68001

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/tools_config.py`: gate `x_search_auto_enabled` on `not explicitly_configured` in `_get_platform_tools()`, with a comment explaining why reaching the branch is not the same as having no saved config.
- `tests/hermes_cli/test_tools_config.py`:
  - `test_x_search_stays_disabled_on_stripped_down_profile` — disable every configurable toolset via the real `_apply_toolset_change()` writer, then assert `x_search` does not come back.
  - `test_x_search_not_resurrected_on_empty_toolset_list` — an explicitly saved `[]` stays empty.
  - `test_x_search_auto_enable_still_fires_without_saved_list` — a saved list on *another* platform must not suppress auto-enable for an unconfigured one.

## How to Test

1. `uv run python -m pytest tests/hermes_cli/test_tools_config.py -q` → 134 passed, ruff clean. Every other test file touching `_get_platform_tools` / `platform_toolsets` / `x_search` also passes (291 across `test_cli_tools_command`, `test_api_server_toolset`, `test_tools_disable_enable`, `test_toolset_validation`, `test_kanban_worker_spawn_toolsets`, `test_x_search_tool`, `test_tool_search`, `test_budget_config`).
2. Revert the `tools_config.py` hunk and re-run → the two regression tests fail (`x_search` reappears in both).
3. Manual, with xAI OAuth available:

```bash
hermes --profile reviewer tools disable x_search   # plus the rest of the toolsets
hermes --profile reviewer tools list               # x_search now stays off
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 14.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (no user-facing config surface changed; behavior now matches what the docs and the existing tests already describe)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure config resolution, no platform-specific code)
