### PR TITLE
fix(bedrock): don't cache the static table when the context probe fails

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2293,6 +2293,7 @@ def get_model_context_length(
         try:
             from agent.bedrock_adapter import (
                 get_bedrock_context_length,
+                probe_bedrock_context_length,
                 resolve_bedrock_region,
             )
         except ImportError:
@@ -2320,13 +2321,27 @@ def get_model_context_length(
                     region = resolve_bedrock_region()
                 except Exception:
                     region = ""
-            ctx = get_bedrock_context_length(model, region=region, probe=bool(region))
-            if ctx and region:
-                # Only persist probe-derived values (region present); a pure
-                # table fallback shouldn't poison the cache against a later
-                # successful probe.
-                save_context_length(model, cache_key_url, ctx)
-            return ctx
+            # Probe directly rather than through get_bedrock_context_length():
+            # that helper silently falls back to the static table and returns a
+            # plain int, so a caller can't tell a probed window from a table
+            # guess. Persisting on `region` alone therefore cached the TABLE
+            # value whenever the probe merely failed (no creds yet, throttle,
+            # network blip) — and since the cache is consulted first, the probe
+            # could never win afterwards. On a model the table under-reports
+            # (a new opus-4-9 matching the older opus-4 entry) that pins the
+            # window at 200K against a real 1M, permanently and silently.
+            probed = None
+            if region:
+                try:
+                    probed = probe_bedrock_context_length(model, region)
+                except Exception:
+                    probed = None
+            if probed:
+                save_context_length(model, cache_key_url, probed)
+                return probed
+            # Table fallback: correct to return, never durable — a later
+            # successful probe has to be able to beat it.
+            return get_bedrock_context_length(model, probe=False)
 
     if provider == "novita" or (base_url and base_url_host_matches(base_url, "api.novita.ai")):
         ctx = _resolve_endpoint_context_length(model, base_url or "https://api.novita.ai/openai/v1", api_key=api_key)

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1304,6 +1304,94 @@ class TestBedrockContextProbe:
                 "anthropic.claude-opus-4-6", region="eu-central-1") == 1_000_000
 
 
+class TestBedrockProbeCachePersistence:
+    """Only a probe-derived window may be persisted.
+
+    ``get_bedrock_context_length()`` silently falls back to the static table
+    and returns a plain int, so its caller cannot tell a probed window from a
+    table guess. Persisting on "a region was resolved" therefore cached the
+    TABLE value whenever the probe merely failed — no credentials yet, a
+    throttle, a network blip — and because the cache is consulted first, a
+    later successful probe could never win. On a model the table under-reports
+    that pins the window permanently and silently.
+    """
+
+    # Table under-reports this one: it matches the older 'claude-opus-4'
+    # entry at 200K while the real window is 1M — the exact shape the probe
+    # feature exists to fix.
+    MODEL = "anthropic.claude-opus-4-9-20260601-v1:0"
+
+    @contextmanager
+    def _probe(self, result):
+        import agent.bedrock_adapter as bedrock_adapter
+        import agent.model_metadata as model_metadata
+
+        with patch.object(
+            bedrock_adapter, "probe_bedrock_context_length", return_value=result
+        ), patch.object(
+            model_metadata, "probe_bedrock_context_length", return_value=result,
+            create=True,
+        ), patch.object(
+            bedrock_adapter, "resolve_bedrock_region", return_value="us-east-1"
+        ):
+            yield
+
+    def test_failed_probe_is_not_cached(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from agent.model_metadata import (
+            get_cached_context_length,
+            get_model_context_length,
+        )
+
+        with self._probe(None):
+            ctx = get_model_context_length(self.MODEL, provider="bedrock")
+
+        # Returning the table value is right; persisting it is not.
+        assert ctx == 200_000
+        assert get_cached_context_length(self.MODEL, "bedrock://") is None
+
+    def test_probe_still_wins_after_an_earlier_failure(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from agent.model_metadata import get_model_context_length
+
+        with self._probe(None):
+            get_model_context_length(self.MODEL, provider="bedrock")
+        with self._probe(1_000_000):
+            ctx = get_model_context_length(self.MODEL, provider="bedrock")
+
+        assert ctx == 1_000_000, "a transient probe failure capped the window forever"
+
+    def test_successful_probe_is_cached_once(self, tmp_path, monkeypatch):
+        """The caching benefit must survive the fix — one probe, not one per turn."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        import agent.bedrock_adapter as bedrock_adapter
+        import agent.model_metadata as model_metadata
+        from agent.model_metadata import get_model_context_length
+
+        calls = []
+
+        def _counting_probe(model_id, region):
+            calls.append(model_id)
+            return 1_000_000
+
+        with patch.object(
+            bedrock_adapter, "probe_bedrock_context_length", side_effect=_counting_probe
+        ), patch.object(
+            model_metadata, "probe_bedrock_context_length",
+            side_effect=_counting_probe, create=True,
+        ), patch.object(
+            bedrock_adapter, "resolve_bedrock_region", return_value="us-east-1"
+        ):
+            results = [
+                get_model_context_length(self.MODEL, provider="bedrock")
+                for _ in range(4)
+            ]
+
+        assert results == [1_000_000] * 4
+        assert len(calls) == 1
+
+
+
 # ---------------------------------------------------------------------------
 # Tool-calling capability detection
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The Bedrock branch persists the resolved window so the probe is paid for once:

```python
ctx = get_bedrock_context_length(model, region=region, probe=bool(region))
if ctx and region:
    # Only persist probe-derived values (region present); a pure
    # table fallback shouldn't poison the cache against a later
    # successful probe.
    save_context_length(model, cache_key_url, ctx)
```

The comment states the right rule, but the condition can't enforce it.
`get_bedrock_context_length()` falls back to the static table *internally* and
returns a plain int, so the caller can't tell a probed window from a table guess —
`region` only says a region was resolved, not that the probe worked.

Any transient probe failure — credentials not resolved yet, a throttle, a network
blip — therefore writes the **table** value into the cache. The cache is consulted
first, so the probe can never win afterwards. On a model the table under-reports
that's permanent and silent:

```
anthropic.claude-opus-4-9-...   table 200,000 (matches the older opus-4 entry),
                                real window 1,000,000

call #1  probe FAILS  ->   200,000   cached
call #2  probe WORKS  ->   200,000   <- should be 1,000,000
call #3  probe WORKS  ->   200,000
```

80% of the context window lost, from one failed probe, with no way back — exactly
the stale-table capping this probe feature was added to fix.

## Fix

Probe directly instead of through the fallback helper, so success is
distinguishable: persist only a real probe result, and return the table value
without caching it.

The probe still runs **once** per model — verified as one invocation across four
calls — so the caching benefit is unchanged.

## Tests

`TestBedrockProbeCachePersistence` — a failed probe isn't cached; a later probe
still wins after an earlier failure; a successful probe is cached exactly once.

The first two **fail on `main`**. The third passes both ways on purpose: it pins
that the fix doesn't trade the poisoning bug for a probe-every-turn regression.

Bedrock / model-metadata / models-dev suites baseline-compared against a clean
`origin/main` worktree: identical single pre-existing failure, `306 → 309` passed.