### PR TITLE
feat(provider): add claude-code-acp — Claude Code on your plan via the ACP bridge

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -516,7 +516,9 @@ def init_agent(
         api_mode is None
         and agent.api_mode == "chat_completions"
         and agent.provider != "copilot-acp"
+        and agent.provider != "claude-code-acp"
         and not str(agent.base_url or "").lower().startswith("acp://copilot")
+        and not str(agent.base_url or "").lower().startswith("acp://claude")
         and not str(agent.base_url or "").lower().startswith("acp+tcp://")
         and not agent._is_azure_openai_url()
         and (
@@ -764,7 +766,7 @@ def init_agent(
     # Claude uses its own timeout path and is not covered here.
     _provider_timeout = get_provider_request_timeout(agent.provider, agent.model)
 
-    if agent.api_mode == "anthropic_messages":
+    if agent.api_mode == "anthropic_messages" and agent.provider != "claude-code-acp":
         from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
         # Bedrock + Claude → use AnthropicBedrock SDK for full feature parity
         # (prompt caching, thinking budgets, adaptive thinking).
@@ -940,7 +942,7 @@ def init_agent(
                 client_kwargs = {"api_key": api_key, "base_url": base_url}
             if _provider_timeout is not None:
                 client_kwargs["timeout"] = _provider_timeout
-            if agent.provider == "copilot-acp":
+            if agent.provider in ("copilot-acp", "claude-code-acp"):
                 client_kwargs["command"] = agent.acp_command
                 client_kwargs["args"] = agent.acp_args
             effective_base = base_url

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1702,6 +1702,17 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent._client_log_context(),
         )
         return client
+    if agent.provider == "claude-code-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://claude"):
+        from agent.claude_code_acp_client import ClaudeCodeACPClient
+
+        client = ClaudeCodeACPClient(**client_kwargs)
+        _ra().logger.info(
+            "Claude Code ACP client created (%s, shared=%s) %s",
+            reason,
+            shared,
+            agent._client_log_context(),
+        )
+        return client
     if agent.provider == "gemini":
         from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5046,6 +5046,31 @@ def resolve_provider_client(
             logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                     else (client, final_model))
+        if provider == "claude-code-acp":
+            # Claude Code ACP authenticates through the local Claude Code login
+            # (keychain / ~/.claude), so no api_key is required — the bridge
+            # subprocess handles auth. Fall back to sane ACP defaults.
+            api_key = str(creds.get("api_key", "")).strip() or "claude-code-acp"
+            base_url = str(creds.get("base_url", "")).strip() or "acp://claude"
+            command = str(creds.get("command", "")).strip() or None
+            args = list(creds.get("args") or [])
+            if not final_model:
+                logger.warning(
+                    "resolve_provider_client: claude-code-acp requested but no "
+                    "model was provided or configured"
+                )
+                return None, None
+            from agent.claude_code_acp_client import ClaudeCodeACPClient
+
+            client = ClaudeCodeACPClient(
+                api_key=api_key,
+                base_url=base_url,
+                command=command,
+                args=args,
+            )
+            logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+            return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                    else (client, final_model))
         if provider not in _LOGGED_UNSUPPORTED_EXTPROC_KEYS:
             _LOGGED_UNSUPPORTED_EXTPROC_KEYS.add(provider)
             logger.debug("resolve_provider_client: external-process provider %s not "

--- a/agent/claude_code_acp_client.py
+++ b/agent/claude_code_acp_client.py
@@ -1,0 +1,744 @@
+"""OpenAI-compatible shim that forwards Hermes requests to the Claude Code ACP adapter.
+
+This adapter lets Hermes treat the Claude Code CLI as a chat-style backend by
+driving it through the official ``@zed-industries/claude-code-acp`` ACP bridge
+(Agent Client Protocol over stdio). Each request starts a short-lived ACP
+session, sends the formatted conversation as a single prompt, collects text
+chunks, and converts the result back into the minimal shape Hermes expects from
+an OpenAI client.
+
+Why ACP (subprocess) instead of the HTTP ``anthropic`` transport: the local
+Claude Code CLI authenticates against the user's Claude subscription
+(Pro/Max) and its inference is billed against the plan. Calling
+``api.anthropic.com`` directly with the same OAuth token is treated as
+third-party API usage and now fails with HTTP 400 ("third-party apps draw from
+your extra usage, not your plan limits"). Driving the vendor-maintained ACP
+adapter keeps inference on the plan and sidesteps the compliance concerns that
+blocked raw ``claude --print`` subprocess proposals (see upstream #33462, #5257,
+and the compliance discussion on #3660).
+
+The ACP wire protocol is identical to the one spoken by the Copilot ACP backend
+(`agent/copilot_acp_client.py`); this module differs only in the command that is
+spawned and the auth model (Claude Code credentials in the keychain /
+``~/.claude/.credentials.json``, inherited by the subprocess).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import re
+import shlex
+import subprocess
+import threading
+import time
+from collections import deque
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+    Function,
+)
+
+from agent.file_safety import get_read_block_error, is_write_denied
+from agent.redact import redact_sensitive_text
+from tools.environments.local import hermes_subprocess_env
+
+ACP_MARKER_BASE_URL = "acp://claude"
+_DEFAULT_TIMEOUT_SECONDS = 900.0
+
+_TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
+_TOOL_CALL_JSON_RE = re.compile(r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}", re.DOTALL)
+
+
+def _resolve_command() -> str:
+    return (
+        os.getenv("HERMES_CLAUDE_ACP_COMMAND", "").strip()
+        or os.getenv("CLAUDE_CODE_ACP_PATH", "").strip()
+        or "claude-code-acp"
+    )
+
+
+def _resolve_args() -> list[str]:
+    raw = os.getenv("HERMES_CLAUDE_ACP_ARGS", "").strip()
+    if not raw:
+        # The @zed-industries/claude-code-acp bridge speaks ACP over stdio with
+        # no positional arguments (Zed invokes `claude-code-acp` directly).
+        return []
+    return shlex.split(raw)
+
+
+def _resolve_home_dir() -> str:
+    """Return a stable HOME for child ACP processes."""
+    home = os.environ.get("HOME", "").strip()
+    if home:
+        return home
+
+    expanded = os.path.expanduser("~")
+    if expanded and expanded != "~":
+        return expanded
+
+    try:
+        import pwd
+
+        resolved = pwd.getpwuid(os.getuid()).pw_dir.strip()  # windows-footgun: ok — POSIX fallback inside try/except (pwd import fails on Windows)
+        if resolved:
+            return resolved
+    except Exception:
+        pass
+
+    return "/tmp"
+
+
+def _build_subprocess_env() -> dict[str, str]:
+    # The Claude Code ACP bridge is a model-driving CLI executor: it
+    # legitimately needs the user's Claude Code credentials (keychain /
+    # ~/.claude/.credentials.json). Route through the central helper so Tier-1
+    # secrets (gateway bot tokens, GitHub auth, infra) are still stripped
+    # (#29157), while HOME is preserved so the bridge finds the local login.
+    env = hermes_subprocess_env(inherit_credentials=True)
+    home = _resolve_home_dir()
+    env["HOME"] = home
+    from hermes_constants import apply_subprocess_home_env
+    apply_subprocess_home_env(env)
+    # The claude-code-acp bridge launches Claude Code under the hood and refuses
+    # to start "inside another Claude Code session" (a shared-runtime crash
+    # guard keyed off these markers). Strip them so Hermes can drive the bridge
+    # even when the gateway itself was started from within a Claude Code
+    # terminal — the child is a distinct, isolated session.
+    for _session_marker in (
+        "CLAUDECODE",
+        "CLAUDE_CODE_ENTRYPOINT",
+        "CLAUDE_CODE_SSE_PORT",
+    ):
+        env.pop(_session_marker, None)
+    return env
+
+
+def _jsonrpc_error(message_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "error": {
+            "code": code,
+            "message": message,
+        },
+    }
+
+
+def _permission_denied(message_id: Any) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "result": {
+            "outcome": {
+                "outcome": "cancelled",
+            }
+        },
+    }
+
+
+def _format_messages_as_prompt(
+    messages: list[dict[str, Any]],
+    model: str | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: Any = None,
+) -> str:
+    sections: list[str] = [
+        "You are being used as the active ACP agent backend for Hermes.",
+        "Use ACP capabilities to complete tasks.",
+        "IMPORTANT: If you take an action with a tool, you MUST output tool calls using <tool_call>{...}</tool_call> blocks with JSON exactly in OpenAI function-call shape.",
+        "If no tool is needed, answer normally.",
+    ]
+    if model:
+        sections.append(f"Hermes requested model hint: {model}")
+
+    if isinstance(tools, list) and tools:
+        tool_specs: list[dict[str, Any]] = []
+        for t in tools:
+            if not isinstance(t, dict):
+                continue
+            fn = t.get("function") or {}
+            if not isinstance(fn, dict):
+                continue
+            name = fn.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            tool_specs.append(
+                {
+                    "name": name.strip(),
+                    "description": fn.get("description", ""),
+                    "parameters": fn.get("parameters", {}),
+                }
+            )
+        if tool_specs:
+            sections.append(
+                "Available tools (OpenAI function schema). "
+                "When using a tool, emit ONLY <tool_call>{...}</tool_call> with one JSON object "
+                "containing id/type/function{name,arguments}. arguments must be a JSON string.\n"
+                + json.dumps(tool_specs, ensure_ascii=False)
+            )
+
+    if tool_choice is not None:
+        sections.append(f"Tool choice hint: {json.dumps(tool_choice, ensure_ascii=False)}")
+
+    transcript: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "unknown").strip().lower()
+        if role == "tool":
+            role = "tool"
+        elif role not in {"system", "user", "assistant"}:
+            role = "context"
+
+        content = message.get("content")
+        rendered = _render_message_content(content)
+        if not rendered:
+            continue
+
+        label = {
+            "system": "System",
+            "user": "User",
+            "assistant": "Assistant",
+            "tool": "Tool",
+            "context": "Context",
+        }.get(role, role.title())
+        transcript.append(f"{label}:\n{rendered}")
+
+    if transcript:
+        sections.append("Conversation transcript:\n\n" + "\n\n".join(transcript))
+
+    sections.append("Continue the conversation from the latest user request.")
+    return "\n\n".join(section.strip() for section in sections if section and section.strip())
+
+
+def _render_message_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, dict):
+        if "text" in content:
+            return str(content.get("text") or "").strip()
+        if "content" in content and isinstance(content.get("content"), str):
+            return str(content.get("content") or "").strip()
+        return json.dumps(content, ensure_ascii=True)
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str) and text.strip():
+                    parts.append(text.strip())
+        return "\n".join(parts).strip()
+    return str(content).strip()
+
+
+def _build_openai_tool_call(
+    *,
+    call_id: str,
+    name: str,
+    arguments: str,
+) -> ChatCompletionMessageToolCall:
+    """Build an OpenAI-compatible tool-call object for downstream handling."""
+    return ChatCompletionMessageToolCall(
+        id=call_id,
+        call_id=call_id,
+        response_item_id=None,
+        type="function",
+        function=Function(name=name, arguments=arguments),
+    )
+
+
+def _completion_to_stream_chunks(completion: SimpleNamespace) -> list[SimpleNamespace]:
+    """Convert a one-shot ACP response into OpenAI-style stream chunks."""
+    choice = completion.choices[0]
+    message = choice.message
+    tool_call_deltas = None
+    if message.tool_calls:
+        tool_call_deltas = []
+        for index, tool_call in enumerate(message.tool_calls):
+            tool_call_deltas.append(
+                SimpleNamespace(
+                    index=index,
+                    id=getattr(tool_call, "id", None),
+                    type=getattr(tool_call, "type", "function"),
+                    function=SimpleNamespace(
+                        name=getattr(tool_call.function, "name", None),
+                        arguments=getattr(tool_call.function, "arguments", None),
+                    ),
+                )
+            )
+
+    delta = SimpleNamespace(
+        role="assistant",
+        content=message.content or None,
+        tool_calls=tool_call_deltas,
+        reasoning_content=message.reasoning_content,
+        reasoning=message.reasoning,
+    )
+    data_chunk = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                index=0,
+                delta=delta,
+                finish_reason=choice.finish_reason,
+            )
+        ],
+        model=completion.model,
+        usage=None,
+    )
+    usage_chunk = SimpleNamespace(
+        choices=[],
+        model=completion.model,
+        usage=completion.usage,
+    )
+    return [data_chunk, usage_chunk]
+
+
+def _extract_tool_calls_from_text(text: str) -> tuple[list[ChatCompletionMessageToolCall], str]:
+    if not isinstance(text, str) or not text.strip():
+        return [], ""
+
+    extracted: list[ChatCompletionMessageToolCall] = []
+    consumed_spans: list[tuple[int, int]] = []
+
+    def _try_add_tool_call(raw_json: str) -> None:
+        try:
+            obj = json.loads(raw_json)
+        except Exception:
+            return
+        if not isinstance(obj, dict):
+            return
+        fn = obj.get("function")
+        if not isinstance(fn, dict):
+            return
+        fn_name = fn.get("name")
+        if not isinstance(fn_name, str) or not fn_name.strip():
+            return
+        fn_args = fn.get("arguments", "{}")
+        if not isinstance(fn_args, str):
+            fn_args = json.dumps(fn_args, ensure_ascii=False)
+        call_id = obj.get("id")
+        if not isinstance(call_id, str) or not call_id.strip():
+            call_id = f"acp_call_{len(extracted)+1}"
+
+        extracted.append(
+            _build_openai_tool_call(
+                call_id=call_id,
+                name=fn_name.strip(),
+                arguments=fn_args,
+            )
+        )
+
+    for m in _TOOL_CALL_BLOCK_RE.finditer(text):
+        raw = m.group(1)
+        _try_add_tool_call(raw)
+        consumed_spans.append((m.start(), m.end()))
+
+    # Only try bare-JSON fallback when no XML blocks were found.
+    if not extracted:
+        for m in _TOOL_CALL_JSON_RE.finditer(text):
+            raw = m.group(0)
+            _try_add_tool_call(raw)
+            consumed_spans.append((m.start(), m.end()))
+
+    if not consumed_spans:
+        return extracted, text.strip()
+
+    consumed_spans.sort()
+    merged: list[tuple[int, int]] = []
+    for start, end in consumed_spans:
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+        else:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+
+    parts: list[str] = []
+    cursor = 0
+    for start, end in merged:
+        if cursor < start:
+            parts.append(text[cursor:start])
+        cursor = max(cursor, end)
+    if cursor < len(text):
+        parts.append(text[cursor:])
+
+    cleaned = "\n".join(p.strip() for p in parts if p and p.strip()).strip()
+    return extracted, cleaned
+
+
+def _ensure_path_within_cwd(path_text: str, cwd: str) -> Path:
+    candidate = Path(path_text)
+    if not candidate.is_absolute():
+        raise PermissionError("ACP file-system paths must be absolute.")
+    resolved = candidate.resolve()
+    root = Path(cwd).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise PermissionError(f"Path '{resolved}' is outside the session cwd '{root}'.") from exc
+    return resolved
+
+
+class _ACPChatCompletions:
+    def __init__(self, client: "ClaudeCodeACPClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _ACPChatNamespace:
+    def __init__(self, client: "ClaudeCodeACPClient"):
+        self.completions = _ACPChatCompletions(client)
+
+
+class ClaudeCodeACPClient:
+    """Minimal OpenAI-client-compatible facade for the Claude Code ACP bridge."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        acp_command: str | None = None,
+        acp_args: list[str] | None = None,
+        acp_cwd: str | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        **_: Any,
+    ):
+        self.api_key = api_key or "claude-code-acp"
+        self.base_url = base_url or ACP_MARKER_BASE_URL
+        self._default_headers = dict(default_headers or {})
+        self._acp_command = acp_command or command or _resolve_command()
+        self._acp_args = list(acp_args or args or _resolve_args())
+        self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
+        self.chat = _ACPChatNamespace(self)
+        self.is_closed = False
+        self._active_process: subprocess.Popen[str] | None = None
+        self._active_process_lock = threading.Lock()
+
+    def close(self) -> None:
+        proc: subprocess.Popen[str] | None
+        with self._active_process_lock:
+            proc = self._active_process
+            self._active_process = None
+        self.is_closed = True
+        if proc is None:
+            return
+        try:
+            proc.terminate()
+            proc.wait(timeout=2)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: Any = None,
+        stream: bool = False,
+        **_: Any,
+    ) -> Any:
+        prompt_text = _format_messages_as_prompt(
+            messages or [],
+            model=model,
+            tools=tools,
+            tool_choice=tool_choice,
+        )
+        # Normalise timeout: run_agent.py may pass an httpx.Timeout object
+        # (used natively by the OpenAI SDK) rather than a plain float.
+        if timeout is None:
+            _effective_timeout = _DEFAULT_TIMEOUT_SECONDS
+        elif isinstance(timeout, (int, float)):
+            _effective_timeout = float(timeout)
+        else:
+            _candidates = [
+                getattr(timeout, attr, None)
+                for attr in ("read", "write", "connect", "pool", "timeout")
+            ]
+            _numeric = [float(v) for v in _candidates if isinstance(v, (int, float))]
+            _effective_timeout = max(_numeric) if _numeric else _DEFAULT_TIMEOUT_SECONDS
+
+        response_text, reasoning_text = self._run_prompt(
+            prompt_text,
+            timeout_seconds=_effective_timeout,
+        )
+
+        tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
+
+        usage = SimpleNamespace(
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+        )
+        assistant_message = SimpleNamespace(
+            content=cleaned_text,
+            tool_calls=tool_calls,
+            reasoning=reasoning_text or None,
+            reasoning_content=reasoning_text or None,
+            reasoning_details=None,
+        )
+        finish_reason = "tool_calls" if tool_calls else "stop"
+        choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
+        completion = SimpleNamespace(
+            choices=[choice],
+            usage=usage,
+            model=model or "claude-code-acp",
+        )
+        if stream:
+            return _completion_to_stream_chunks(completion)
+        return completion
+
+    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+        try:
+            proc = subprocess.Popen(
+                [self._acp_command] + self._acp_args,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+                cwd=self._acp_cwd,
+                env=_build_subprocess_env(),
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Could not start the Claude Code ACP bridge '{self._acp_command}'. "
+                "Install it with `npm install -g @zed-industries/claude-code-acp` "
+                "and make sure the Claude Code CLI is logged in (`claude` / "
+                "`claude setup-token`), or point Hermes at the bridge explicitly "
+                "with HERMES_CLAUDE_ACP_COMMAND / CLAUDE_CODE_ACP_PATH."
+            ) from exc
+
+        if proc.stdin is None or proc.stdout is None:
+            proc.kill()
+            raise RuntimeError("Claude Code ACP process did not expose stdin/stdout pipes.")
+
+        self.is_closed = False
+        with self._active_process_lock:
+            self._active_process = proc
+
+        inbox: queue.Queue[dict[str, Any]] = queue.Queue()
+        stderr_tail: deque[str] = deque(maxlen=40)
+
+        def _stdout_reader() -> None:
+            if proc.stdout is None:
+                return
+            for line in proc.stdout:
+                try:
+                    inbox.put(json.loads(line))
+                except Exception:
+                    inbox.put({"raw": line.rstrip("\n")})
+
+        def _stderr_reader() -> None:
+            if proc.stderr is None:
+                return
+            for line in proc.stderr:
+                stderr_tail.append(line.rstrip("\n"))
+
+        out_thread = threading.Thread(target=_stdout_reader, daemon=True)
+        err_thread = threading.Thread(target=_stderr_reader, daemon=True)
+        out_thread.start()
+        err_thread.start()
+
+        next_id = 0
+
+        def _request(method: str, params: dict[str, Any], *, text_parts: list[str] | None = None, reasoning_parts: list[str] | None = None) -> Any:
+            nonlocal next_id
+            next_id += 1
+            request_id = next_id
+            payload = {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": method,
+                "params": params,
+            }
+            proc.stdin.write(json.dumps(payload) + "\n")
+            proc.stdin.flush()
+
+            deadline = time.monotonic() + timeout_seconds
+            while time.monotonic() < deadline:
+                if proc.poll() is not None:
+                    break
+                try:
+                    msg = inbox.get(timeout=0.1)
+                except queue.Empty:
+                    continue
+
+                if self._handle_server_message(
+                    msg,
+                    process=proc,
+                    cwd=self._acp_cwd,
+                    text_parts=text_parts,
+                    reasoning_parts=reasoning_parts,
+                ):
+                    continue
+
+                if msg.get("id") != request_id:
+                    continue
+                if "error" in msg:
+                    err = msg.get("error") or {}
+                    raise RuntimeError(
+                        f"Claude Code ACP {method} failed: {err.get('message') or err}"
+                    )
+                return msg.get("result")
+
+            stderr_text = "\n".join(stderr_tail).strip()
+            if proc.poll() is not None and stderr_text:
+                raise RuntimeError(f"Claude Code ACP process exited early: {stderr_text}")
+            raise TimeoutError(f"Timed out waiting for Claude Code ACP response to {method}.")
+
+        try:
+            _request(
+                "initialize",
+                {
+                    "protocolVersion": 1,
+                    "clientCapabilities": {
+                        "fs": {
+                            "readTextFile": True,
+                            "writeTextFile": True,
+                        }
+                    },
+                    "clientInfo": {
+                        "name": "hermes-agent",
+                        "title": "Hermes Agent",
+                        "version": "0.0.0",
+                    },
+                },
+            )
+            session = _request(
+                "session/new",
+                {
+                    "cwd": self._acp_cwd,
+                    "mcpServers": [],
+                },
+            ) or {}
+            session_id = str(session.get("sessionId") or "").strip()
+            if not session_id:
+                raise RuntimeError("Claude Code ACP did not return a sessionId.")
+
+            text_parts: list[str] = []
+            reasoning_parts: list[str] = []
+            _request(
+                "session/prompt",
+                {
+                    "sessionId": session_id,
+                    "prompt": [
+                        {
+                            "type": "text",
+                            "text": prompt_text,
+                        }
+                    ],
+                },
+                text_parts=text_parts,
+                reasoning_parts=reasoning_parts,
+            )
+            return "".join(text_parts), "".join(reasoning_parts)
+        finally:
+            self.close()
+
+    def _handle_server_message(
+        self,
+        msg: dict[str, Any],
+        *,
+        process: subprocess.Popen[str],
+        cwd: str,
+        text_parts: list[str] | None,
+        reasoning_parts: list[str] | None,
+    ) -> bool:
+        method = msg.get("method")
+        if not isinstance(method, str):
+            return False
+
+        if method == "session/update":
+            params = msg.get("params") or {}
+            update = params.get("update") or {}
+            kind = str(update.get("sessionUpdate") or "").strip()
+            content = update.get("content") or {}
+            chunk_text = ""
+            if isinstance(content, dict):
+                chunk_text = str(content.get("text") or "")
+            if kind == "agent_message_chunk" and chunk_text and text_parts is not None:
+                text_parts.append(chunk_text)
+            elif kind == "agent_thought_chunk" and chunk_text and reasoning_parts is not None:
+                reasoning_parts.append(chunk_text)
+            return True
+
+        if process.stdin is None:
+            return True
+
+        message_id = msg.get("id")
+        params = msg.get("params") or {}
+
+        if method == "session/request_permission":
+            response = _permission_denied(message_id)
+        elif method == "fs/read_text_file":
+            try:
+                path = _ensure_path_within_cwd(str(params.get("path") or ""), cwd)
+                block_error = get_read_block_error(str(path))
+                if block_error:
+                    raise PermissionError(block_error)
+                try:
+                    content = path.read_text()
+                except FileNotFoundError:
+                    content = ""
+                line = params.get("line")
+                limit = params.get("limit")
+                if isinstance(line, int) and line > 1:
+                    lines = content.splitlines(keepends=True)
+                    start = line - 1
+                    end = start + limit if isinstance(limit, int) and limit > 0 else None
+                    content = "".join(lines[start:end])
+                if content:
+                    content = redact_sensitive_text(content, force=True)
+                response = {
+                    "jsonrpc": "2.0",
+                    "id": message_id,
+                    "result": {
+                        "content": content,
+                    },
+                }
+            except Exception as exc:
+                response = _jsonrpc_error(message_id, -32602, str(exc))
+        elif method == "fs/write_text_file":
+            try:
+                path = _ensure_path_within_cwd(str(params.get("path") or ""), cwd)
+                if is_write_denied(str(path)):
+                    raise PermissionError(
+                        f"Write denied: '{path}' is a protected system/credential file."
+                    )
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(str(params.get("content") or ""))
+                response = {
+                    "jsonrpc": "2.0",
+                    "id": message_id,
+                    "result": None,
+                }
+            except Exception as exc:
+                response = _jsonrpc_error(message_id, -32602, str(exc))
+        else:
+            response = _jsonrpc_error(
+                message_id,
+                -32601,
+                f"ACP client method '{method}' is not supported by Hermes yet.",
+            )
+
+        process.stdin.write(json.dumps(response) + "\n")
+        process.stdin.flush()
+        return True

--- a/agent/claude_code_acp_client.py
+++ b/agent/claude_code_acp_client.py
@@ -55,11 +55,19 @@ _TOOL_CALL_JSON_RE = re.compile(r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*
 
 
 def _resolve_command() -> str:
-    return (
+    override = (
         os.getenv("HERMES_CLAUDE_ACP_COMMAND", "").strip()
         or os.getenv("CLAUDE_CODE_ACP_PATH", "").strip()
-        or "claude-code-acp"
     )
+    if override:
+        return override
+    import shutil
+    # Prefer the maintained package bin (@agentclientprotocol/claude-agent-acp);
+    # fall back to the original @zed-industries/claude-code-acp bin.
+    for candidate in ("claude-agent-acp", "claude-code-acp"):
+        if shutil.which(candidate):
+            return candidate
+    return "claude-agent-acp"
 
 
 def _resolve_args() -> list[str]:
@@ -520,7 +528,7 @@ class ClaudeCodeACPClient:
         except FileNotFoundError as exc:
             raise RuntimeError(
                 f"Could not start the Claude Code ACP bridge '{self._acp_command}'. "
-                "Install it with `npm install -g @zed-industries/claude-code-acp` "
+                "Install it with `npm install -g @agentclientprotocol/claude-agent-acp` "
                 "and make sure the Claude Code CLI is logged in (`claude` / "
                 "`claude setup-token`), or point Hermes at the bridge explicitly "
                 "with HERMES_CLAUDE_ACP_COMMAND / CLAUDE_CODE_ACP_PATH."

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -232,6 +232,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "claude-code-acp": ProviderConfig(
+        id="claude-code-acp",
+        name="Claude Code ACP",
+        auth_type="external_process",
+        inference_base_url="acp://claude",
+        base_url_env_var="CLAUDE_ACP_BASE_URL",
+    ),
     "gemini": ProviderConfig(
         id="gemini",
         name="Google AI Studio",
@@ -1681,7 +1688,7 @@ def resolve_provider(
         "minimax-portal": "minimax-oauth", "minimax-global": "minimax-oauth", "minimax_oauth": "minimax-oauth",
         "alibaba_coding": "alibaba-coding-plan", "alibaba-coding": "alibaba-coding-plan",
         "alibaba_coding_plan": "alibaba-coding-plan",
-        "claude": "anthropic", "claude-code": "anthropic",
+        "claude": "anthropic", "claude-code": "claude-code-acp",
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
@@ -6517,20 +6524,38 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     if not base_url:
         base_url = pconfig.inference_base_url
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    if provider_id == "claude-code-acp":
+        command = (
+            os.getenv("HERMES_CLAUDE_ACP_COMMAND", "").strip()
+            or os.getenv("CLAUDE_CODE_ACP_PATH", "").strip()
+            or "claude-code-acp"
+        )
+        raw_args = os.getenv("HERMES_CLAUDE_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else []
+        _cli_label = "Claude Code ACP bridge"
+        _install_hint = (
+            "Install it with `npm install -g @zed-industries/claude-code-acp` "
+            "(and log in with the Claude Code CLI), or set "
+            "HERMES_CLAUDE_ACP_COMMAND/CLAUDE_CODE_ACP_PATH."
+        )
+        _missing_code = "missing_claude_code_acp_cli"
+    else:
+        command = (
+            os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+            or os.getenv("COPILOT_CLI_PATH", "").strip()
+            or "copilot"
+        )
+        raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+        _cli_label = "Copilot CLI command"
+        _install_hint = "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
+        _missing_code = "missing_copilot_cli"
     resolved_command = shutil.which(command) if command else None
     if not resolved_command and not base_url.startswith("acp+tcp://"):
         raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+            f"Could not find the {_cli_label} '{command}'. " + _install_hint,
             provider=provider_id,
-            code="missing_copilot_cli",
+            code=_missing_code,
         )
 
     return {

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -6528,13 +6528,18 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
         command = (
             os.getenv("HERMES_CLAUDE_ACP_COMMAND", "").strip()
             or os.getenv("CLAUDE_CODE_ACP_PATH", "").strip()
-            or "claude-code-acp"
         )
+        if not command:
+            # Prefer the maintained package bin, fall back to the original.
+            command = next(
+                (c for c in ("claude-agent-acp", "claude-code-acp") if shutil.which(c)),
+                "claude-agent-acp",
+            )
         raw_args = os.getenv("HERMES_CLAUDE_ACP_ARGS", "").strip()
         args = shlex.split(raw_args) if raw_args else []
         _cli_label = "Claude Code ACP bridge"
         _install_hint = (
-            "Install it with `npm install -g @zed-industries/claude-code-acp` "
+            "Install it with `npm install -g @agentclientprotocol/claude-agent-acp` "
             "(and log in with the Claude Code CLI), or set "
             "HERMES_CLAUDE_ACP_COMMAND/CLAUDE_CODE_ACP_PATH."
         )

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -273,9 +273,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
-    "claude-code-acp": [
-        "claude-code-acp",
-    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -273,6 +273,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "claude-code-acp": [
+        "claude-code-acp",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -557,6 +560,12 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "qwen/qwen3-235b-a22b-fp8",
     ],
 }
+
+# claude-code-acp drives the local Claude Code CLI, which serves the full
+# Anthropic model family on the user's plan. Mirror the anthropic catalog so
+# (provider=claude-code-acp, model=claude-*) resolves to this provider instead
+# of falling back to a generic aggregator.
+_PROVIDER_MODELS["claude-code-acp"] = list(_PROVIDER_MODELS["anthropic"])
 
 # ---------------------------------------------------------------------------
 # Nous Portal free-model helper
@@ -1066,6 +1075,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models via build.nvidia.com or local NIM)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (Uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (Spawns copilot --acp --stdio)"),
+    ProviderEntry("claude-code-acp", "Claude Code ACP",         "Claude Code on your Claude plan (Pro/Max) via the ACP bridge — no metered API"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Native Gemini API)"),
     ProviderEntry("vertex",         "Google Vertex AI",         "Google Vertex AI (Gemini via GCP; OAuth2 service account or ADC, GCP billing/quotas)"),
@@ -1144,6 +1154,7 @@ PROVIDER_GROUPS: dict[str, tuple[str, str, list[str]]] = {
     "openai":   ("OpenAI",          "Codex CLI or direct OpenAI API",                  ["openai-codex", "openai-api"]),
     "opencode": ("OpenCode",        "Zen pay-as-you-go or Go subscription",            ["opencode-zen", "opencode-go"]),
     "copilot":  ("GitHub Copilot",  "GitHub token API or copilot --acp process",       ["copilot", "copilot-acp"]),
+    "anthropic": ("Anthropic Claude", "Direct API key, or Claude Code plan via ACP",   ["anthropic", "claude-code-acp"]),
 }
 
 # Reverse index: member slug -> group_id. Built once at import.
@@ -1228,6 +1239,8 @@ _PROVIDER_ALIASES = {
     "github-model": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "claude-acp": "claude-code-acp",
+    "claude-code-acp-agent": "claude-code-acp",
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",
@@ -1253,7 +1266,7 @@ _PROVIDER_ALIASES = {
     "minimax-global": "minimax-oauth",
     "minimax_oauth": "minimax-oauth",
     "claude": "anthropic",
-    "claude-code": "anthropic",
+    "claude-code": "claude-code-acp",
     "deep-seek": "deepseek",
     "opencode": "opencode-zen",
     "zen": "opencode-zen",
@@ -2328,6 +2341,10 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             pass
         if normalized == "copilot-acp":
             return list(_PROVIDER_MODELS.get("copilot", []))
+    if normalized == "claude-code-acp":
+        # The ACP bridge drives Claude Code, which exposes the Anthropic model
+        # family; reuse the anthropic catalog for the picker.
+        return list(_PROVIDER_MODELS.get("anthropic", []))
     if normalized == "nous":
         # Try live Nous Portal /models endpoint
         try:

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -94,6 +94,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "claude-code-acp": HermesOverlay(
+        transport="codex_responses",
+        auth_type="external_process",
+        base_url_override="acp://claude",
+        base_url_env_var="CLAUDE_ACP_BASE_URL",
+    ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
@@ -283,7 +289,11 @@ ALIASES: Dict[str, str] = {
 
     # anthropic
     "claude": "anthropic",
-    "claude-code": "anthropic",
+    # claude-code drives the local Claude Code CLI via the ACP bridge so
+    # inference stays on the user's Claude plan (Pro/Max) instead of failing as
+    # third-party API usage. Use "claude" for the direct HTTP/API-key path.
+    "claude-code": "claude-code-acp",
+    "claude-acp": "claude-code-acp",
 
     # github-copilot (models.dev ID)
     "copilot": "github-copilot",
@@ -373,6 +383,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "claude-code-acp": "Claude Code ACP",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1864,6 +1864,19 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
+    if provider == "claude-code-acp":
+        creds = resolve_external_process_provider_credentials(provider)
+        return {
+            "provider": "claude-code-acp",
+            "api_mode": "chat_completions",
+            "base_url": (creds.get("base_url") or "acp://claude").rstrip("/"),
+            "api_key": creds.get("api_key") or "claude-code-acp",
+            "command": creds.get("command", ""),
+            "args": list(creds.get("args") or []),
+            "source": creds.get("source", "process"),
+            "requested_provider": requested_provider,
+        }
+
     # Anthropic (native Messages API)
     if provider == "anthropic":
         # Allow base URL override from config.yaml model.base_url, but only

--- a/plugins/model-providers/claude-code-acp/__init__.py
+++ b/plugins/model-providers/claude-code-acp/__init__.py
@@ -1,0 +1,39 @@
+"""Claude Code ACP provider profile.
+
+claude-code-acp drives the local Claude Code CLI through the vendor-maintained
+``@zed-industries/claude-code-acp`` ACP bridge (an external subprocess) — NOT
+the standard HTTP transport. This keeps inference billed against the user's
+Claude subscription (Pro/Max) instead of failing as third-party API usage.
+``api_mode="chat_completions"`` is used for routing; the actual ACP handling is
+dispatched in agent_runtime_helpers.py based on provider / base_url. The profile
+captures auth + endpoint metadata for registry migration.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class ClaudeCodeACPProfile(ProviderProfile):
+    """Claude Code ACP — external process, no REST models endpoint."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Model listing is handled by the ACP subprocess."""
+        return None
+
+
+claude_code_acp = ClaudeCodeACPProfile(
+    name="claude-code-acp",
+    aliases=("claude-acp", "claude-code-acp-agent"),
+    api_mode="chat_completions",  # ACP subprocess uses chat_completions routing
+    env_vars=(),  # Managed by ACP subprocess (Claude Code keychain / ~/.claude)
+    base_url="acp://claude",  # ACP internal scheme
+    auth_type="external_process",
+)
+
+register_provider(claude_code_acp)

--- a/plugins/model-providers/claude-code-acp/plugin.yaml
+++ b/plugins/model-providers/claude-code-acp/plugin.yaml
@@ -1,0 +1,5 @@
+name: claude-code-acp-provider
+kind: model-provider
+version: 1.0.0
+description: Claude Code (Claude Max/Pro plan) via the ACP subprocess bridge
+author: samuelsoaress

--- a/tests/agent/test_claude_code_acp_client.py
+++ b/tests/agent/test_claude_code_acp_client.py
@@ -1,0 +1,353 @@
+"""Focused regressions for the Claude Code ACP shim safety layer.
+
+Mirrors tests/agent/test_copilot_acp_client.py — the Claude Code ACP client is a
+near-clone of the Copilot ACP client (same ACP wire protocol) — plus a couple of
+Claude-specific checks (session-marker stripping, dual-bin resolution).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agent.claude_code_acp_client import ClaudeCodeACPClient
+
+
+class _FakeProcess:
+    def __init__(self) -> None:
+        self.stdin = io.StringIO()
+
+
+class ClaudeCodeACPClientSafetyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = ClaudeCodeACPClient(acp_cwd="/tmp")
+
+    def test_extracted_tool_calls_match_openai_sdk_shape(self) -> None:
+        tool_response = (
+            "I'll inspect that.\n"
+            "<tool_call>"
+            '{"id":"call_read","type":"function",'
+            '"function":{"name":"read_file","arguments":"{\\"path\\":\\"README.md\\"}"}}'
+            "</tool_call>"
+        )
+
+        with patch.object(self.client, "_run_prompt", return_value=(tool_response, "")):
+            response = self.client._create_chat_completion(
+                model="claude-code-acp",
+                messages=[{"role": "user", "content": "read README.md"}],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {"name": "read_file", "parameters": {}},
+                    }
+                ],
+            )
+
+        choice = response.choices[0]
+        self.assertEqual(choice.finish_reason, "tool_calls")
+        tool_call = choice.message.tool_calls[0]
+        self.assertEqual(tool_call.id, "call_read")
+        self.assertEqual(tool_call.function.name, "read_file")
+        self.assertEqual(
+            json.loads(tool_call.function.arguments),
+            {"path": "README.md"},
+        )
+        self.assertEqual(choice.message.content, "I'll inspect that.")
+
+    def test_stream_true_returns_iterable_text_chunks(self) -> None:
+        with patch.object(self.client, "_run_prompt", return_value=("Hello from ACP", "")):
+            stream = self.client._create_chat_completion(
+                model="claude-code-acp",
+                messages=[{"role": "user", "content": "hello"}],
+                stream=True,
+            )
+
+        chunks = list(stream)
+        self.assertEqual(len(chunks), 2)
+        self.assertEqual(chunks[0].choices[0].delta.content, "Hello from ACP")
+        self.assertIsNone(chunks[0].choices[0].delta.tool_calls)
+        self.assertEqual(chunks[0].choices[0].finish_reason, "stop")
+        self.assertEqual(chunks[1].choices, [])
+        self.assertEqual(chunks[1].usage.total_tokens, 0)
+
+    def test_stream_true_preserves_tool_call_deltas(self) -> None:
+        tool_response = (
+            "<tool_call>"
+            '{"id":"call_read","type":"function",'
+            '"function":{"name":"read_file","arguments":"{\\"path\\":\\"README.md\\"}"}}'
+            "</tool_call>"
+        )
+
+        with patch.object(self.client, "_run_prompt", return_value=(tool_response, "")):
+            stream = self.client._create_chat_completion(
+                model="claude-code-acp",
+                messages=[{"role": "user", "content": "read README.md"}],
+                stream=True,
+            )
+
+        chunks = list(stream)
+        delta = chunks[0].choices[0].delta
+        self.assertIsNone(delta.content)
+        self.assertEqual(chunks[0].choices[0].finish_reason, "tool_calls")
+        self.assertEqual(len(delta.tool_calls), 1)
+        tool_delta = delta.tool_calls[0]
+        self.assertEqual(tool_delta.index, 0)
+        self.assertEqual(tool_delta.id, "call_read")
+        self.assertEqual(tool_delta.function.name, "read_file")
+        self.assertEqual(
+            json.loads(tool_delta.function.arguments),
+            {"path": "README.md"},
+        )
+        self.assertEqual(chunks[1].choices, [])
+
+    def test_timeout_object_is_coerced_for_streaming_requests(self) -> None:
+        captured: dict[str, float] = {}
+
+        def fake_run_prompt(prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+            captured["timeout"] = timeout_seconds
+            return "ok", ""
+
+        timeout = type(
+            "TimeoutLike",
+            (),
+            {"read": 12.0, "write": 5.0, "connect": 3.0, "pool": 1.0},
+        )()
+
+        with patch.object(self.client, "_run_prompt", side_effect=fake_run_prompt):
+            list(
+                self.client._create_chat_completion(
+                    model="claude-code-acp",
+                    messages=[{"role": "user", "content": "hello"}],
+                    timeout=timeout,
+                    stream=True,
+                )
+            )
+
+        self.assertEqual(captured["timeout"], 12.0)
+
+    def _dispatch(self, message: dict, *, cwd: str) -> dict:
+        process = _FakeProcess()
+        handled = self.client._handle_server_message(
+            message,
+            process=process,
+            cwd=cwd,
+            text_parts=[],
+            reasoning_parts=[],
+        )
+        self.assertTrue(handled)
+        payload = process.stdin.getvalue().strip()
+        self.assertTrue(payload)
+        return json.loads(payload)
+
+    def test_request_permission_is_not_auto_allowed(self) -> None:
+        response = self._dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "session/request_permission",
+                "params": {},
+            },
+            cwd="/tmp",
+        )
+
+        outcome = (((response.get("result") or {}).get("outcome") or {}).get("outcome"))
+        self.assertEqual(outcome, "cancelled")
+
+    def test_read_text_file_blocks_internal_hermes_hub_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir) / "home"
+            blocked = home / ".hermes" / "skills" / ".hub" / "index-cache" / "entry.json"
+            blocked.parent.mkdir(parents=True, exist_ok=True)
+            blocked.write_text('{"token":"sk-test-secret-1234567890"}')
+
+            with patch.dict(
+                os.environ,
+                {"HOME": str(home), "HERMES_HOME": str(home / ".hermes")},
+                clear=False,
+            ):
+                response = self._dispatch(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "method": "fs/read_text_file",
+                        "params": {"path": str(blocked)},
+                    },
+                    cwd=str(home),
+                )
+
+        self.assertIn("error", response)
+
+    def test_read_text_file_redacts_sensitive_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            secret_file = root / "config.env"
+            secret_file.write_text("OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012")
+
+            with patch("agent.redact._REDACT_ENABLED", True):
+                response = self._dispatch(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 3,
+                        "method": "fs/read_text_file",
+                        "params": {"path": str(secret_file)},
+                    },
+                    cwd=str(root),
+                )
+
+        content = ((response.get("result") or {}).get("content") or "")
+        self.assertNotIn("abc123def456", content)
+        self.assertIn("OPENAI_API_KEY=", content)
+
+    def test_write_text_file_reuses_write_denylist(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir) / "home"
+            target = home / ".ssh" / "id_rsa"
+            target.parent.mkdir(parents=True, exist_ok=True)
+
+            with patch("agent.claude_code_acp_client.is_write_denied", return_value=True, create=True):
+                response = self._dispatch(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 4,
+                        "method": "fs/write_text_file",
+                        "params": {
+                            "path": str(target),
+                            "content": "fake-private-key",
+                        },
+                    },
+                    cwd=str(home),
+                )
+
+        self.assertIn("error", response)
+        self.assertFalse(target.exists())
+
+    def test_write_text_file_rejects_paths_outside_cwd(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            outside = root / "outside.txt"
+
+            response = self._dispatch(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 5,
+                    "method": "fs/write_text_file",
+                    "params": {
+                        "path": str(outside),
+                        "content": "should-not-write",
+                    },
+                },
+                cwd=str(workspace),
+            )
+
+        self.assertIn("error", response)
+        self.assertFalse(outside.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+# ── Claude-specific behaviour ───────────────────────────────────────
+
+from unittest.mock import patch as _patch
+import pytest
+
+
+def test_build_subprocess_env_strips_claude_code_session_markers(monkeypatch):
+    """The bridge refuses to launch Claude Code inside another Claude Code
+    session, so the child env must not carry the session markers."""
+    from agent.claude_code_acp_client import _build_subprocess_env
+
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "cli")
+    monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "12345")
+
+    env = _build_subprocess_env()
+
+    assert "CLAUDECODE" not in env
+    assert "CLAUDE_CODE_ENTRYPOINT" not in env
+    assert "CLAUDE_CODE_SSE_PORT" not in env
+
+
+def test_resolve_command_prefers_maintained_bin(monkeypatch):
+    from agent import claude_code_acp_client as m
+
+    monkeypatch.delenv("HERMES_CLAUDE_ACP_COMMAND", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_ACP_PATH", raising=False)
+    # Both bins resolvable → prefer the maintained one.
+    monkeypatch.setattr(shutil, "which", lambda c: f"/usr/local/bin/{c}")
+    assert m._resolve_command() == "claude-agent-acp"
+
+    # Only the legacy bin present → fall back to it.
+    monkeypatch.setattr(
+        shutil, "which", lambda c: f"/usr/local/bin/{c}" if c == "claude-code-acp" else None
+    )
+    assert m._resolve_command() == "claude-code-acp"
+
+
+def test_resolve_command_env_override_wins(monkeypatch):
+    from agent import claude_code_acp_client as m
+
+    monkeypatch.setenv("HERMES_CLAUDE_ACP_COMMAND", "/opt/custom/claude-acp")
+    assert m._resolve_command() == "/opt/custom/claude-acp"
+
+
+def _make_home_client(tmp_path):
+    return ClaudeCodeACPClient(
+        api_key="claude-code-acp",
+        base_url="acp://claude",
+        acp_command="claude-agent-acp",
+        acp_args=[],
+        acp_cwd=str(tmp_path),
+    )
+
+
+def _fake_popen_capture(captured):
+    def _fake(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        raise FileNotFoundError("claude-agent-acp not found")
+    return _fake
+
+
+def test_run_prompt_preserves_real_home_when_profile_home_available(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes"
+    (hermes_home / "home").mkdir(parents=True)
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+
+    monkeypatch.setenv("HOME", str(real_home))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    captured = {}
+    client = _make_home_client(tmp_path)
+
+    with _patch("agent.claude_code_acp_client.subprocess.Popen", side_effect=_fake_popen_capture(captured)):
+        with pytest.raises(RuntimeError, match="Could not start the Claude Code ACP bridge"):
+            client._run_prompt("hello", timeout_seconds=1)
+
+    assert captured["kwargs"]["env"]["HOME"] == str(real_home)
+    assert captured["kwargs"]["env"]["HERMES_REAL_HOME"] == str(real_home)
+
+
+def test_run_prompt_passes_home_when_parent_env_is_clean(monkeypatch, tmp_path):
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+
+    captured = {}
+    client = _make_home_client(tmp_path)
+
+    with _patch("agent.claude_code_acp_client.subprocess.Popen", side_effect=_fake_popen_capture(captured)):
+        with pytest.raises(RuntimeError, match="Could not start the Claude Code ACP bridge"):
+            client._run_prompt("hello", timeout_seconds=1)
+
+    assert "env" in captured["kwargs"]
+    assert captured["kwargs"]["env"]["HOME"]

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -18,6 +18,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **OpenAI Codex** | `hermes model` (ChatGPT OAuth, uses Codex models) |
 | **GitHub Copilot** | `hermes model` (OAuth device code flow, `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth token`) |
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
+| **Claude Code ACP** | `hermes model` (drives the local Claude Code CLI via the ACP bridge — inference stays on your Claude plan, no metered API) |
 | **Anthropic** | `hermes model` (Claude Max + extra usage credits via OAuth; also supports Anthropic API key or manual setup-token — see note below) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
 | **Fireworks AI** | `FIREWORKS_API_KEY` in `~/.hermes/.env` (provider: `fireworks`; aliases: `fireworks-ai`, `fw`) |
@@ -209,6 +210,28 @@ model:
 | `COPILOT_GITHUB_TOKEN` | GitHub token for Copilot API (first priority) |
 | `HERMES_COPILOT_ACP_COMMAND` | Override the Copilot CLI binary path (default: `copilot`) |
 | `HERMES_COPILOT_ACP_ARGS` | Override ACP args (default: `--acp --stdio`) |
+
+**`claude-code-acp` — Claude Code on your Claude plan (ACP)**. Drives the local Claude Code CLI through the vendor ACP bridge, so inference is billed against your Claude Pro/Max plan instead of the metered API:
+
+```bash
+hermes chat --provider claude-code-acp --model claude-sonnet-4-6
+# Requires: npm install -g @agentclientprotocol/claude-agent-acp
+# and a logged-in Claude Code CLI (`claude` / `claude setup-token`)
+```
+
+Why not the plain `anthropic` provider: pointing the HTTP `anthropic` transport at a Claude Code OAuth token is treated as third-party API usage and fails with HTTP 400 (*"third-party apps draw from your extra usage, not your plan limits"*). The ACP bridge runs the real Claude Code CLI, keeping inference on your plan. No API key is used — auth is your existing local Claude Code login (keychain / `~/.claude`).
+
+**Permanent config:**
+```yaml
+model:
+  provider: "claude-code-acp"
+  default: "claude-sonnet-4-6"
+```
+
+| Environment variable | Description |
+|---------------------|-------------|
+| `HERMES_CLAUDE_ACP_COMMAND` | Override the ACP bridge binary (default: `claude-agent-acp`, falls back to `claude-code-acp`) |
+| `HERMES_CLAUDE_ACP_ARGS` | Override ACP args (default: none) |
 
 ### First-Class API-Key Providers
 
@@ -1479,7 +1502,7 @@ fallback_model:
 
 When activated, the fallback swaps the model and provider mid-session without losing your conversation. The chain is tried entry-by-entry; activation is one-shot per session.
 
-Supported providers: `openrouter`, `nous`, `novita`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `bedrock`, `azure-foundry`, `opencode-zen`, `opencode-go`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `stepfun`, `lmstudio`, `alibaba`, `alibaba-coding-plan`, `tencent-tokenhub`, `custom`.
+Supported providers: `openrouter`, `nous`, `novita`, `openai-codex`, `copilot`, `copilot-acp`, `claude-code-acp`, `anthropic`, `gemini`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `bedrock`, `azure-foundry`, `opencode-zen`, `opencode-go`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `stepfun`, `lmstudio`, `alibaba`, `alibaba-coding-plan`, `tencent-tokenhub`, `custom`.
 
 :::tip
 Fallback is configured exclusively through `config.yaml` — or interactively via `hermes fallback`. For full details on when it triggers, how the chain advances, and how it interacts with auxiliary tasks and delegation, see [Fallback Providers](/user-guide/features/fallback-providers).


### PR DESCRIPTION
## Summary

Adds **`claude-code-acp`** as a first-class subprocess provider that drives the local Claude Code CLI through the official vendor ACP bridge (`@agentclientprotocol/claude-agent-acp`), so inference is billed against the user's **Claude Pro/Max plan** instead of failing as third-party API usage.

Today `claude-code` is a plain alias of `anthropic` ([`hermes_cli/providers.py`](https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/providers.py) — `"claude-code": "anthropic"`), so on a Claude Max user's gateway **every turn makes a useless HTTP 400 round-trip** to `api.anthropic.com`:

> `Third-party apps now draw from your extra usage, not your plan limits. Add more at claude.ai/settings/usage.`

Routing through the local CLI over ACP keeps inference on the plan. Verified end-to-end: no API key, no 400, the response comes back on the plan (default model resolves to the plan's Opus tier, not the metered API).

## Why this approach

This implements the direction discussed in #5257 and requested in #33462, **using the vendor-maintained ACP adapter rather than a raw `claude --print` subprocess** — the raw-subprocess approach raised compliance concerns on #3660.

- Uses the **official ACP bridge** (`@agentclientprotocol/claude-agent-acp`; falls back to the older `@zed-industries/claude-code-acp` bin), not a hand-rolled subprocess.
- Reuses the user's **own local Claude Code login** (keychain / `~/.claude`). Nothing is materialized to disk, proxied, or resold — it's the same login the user already runs locally.
- Wire protocol is standard ACP (JSON-RPC 2.0 over stdio), **identical to the in-tree `copilot-acp`**.

## Implementation

`agent/claude_code_acp_client.py` mirrors `agent/copilot_acp_client.py` almost verbatim — an OpenAI-compatible facade over the ACP session (`initialize` → `session/new` → `session/prompt`), with the same fs-safety and permission handling. One Claude-specific addition: it strips the `CLAUDECODE` / `CLAUDE_CODE_*` session markers from the child env so the bridge can launch even when the gateway itself runs inside a Claude Code session.

Provider is wired through the resolution stack the same way `copilot-acp` is:
- `plugins/model-providers/claude-code-acp/` — provider profile registration.
- `hermes_cli/providers.py` — `HERMES_OVERLAYS` entry, aliases, display name.
- `hermes_cli/auth.py` — `PROVIDER_REGISTRY` entry + external-process command resolution.
- `hermes_cli/models.py` — model catalog (mirrors the anthropic family) + aliases.
- `hermes_cli/runtime_provider.py` — external-process runtime resolution.
- `agent/auxiliary_client.py` + `agent/agent_runtime_helpers.py` — client dispatch on `acp://claude`.
- `agent/agent_init.py` — skip the anthropic HTTP path for this provider.

## Tests & checks

- `tests/agent/test_claude_code_acp_client.py` — mirrors the `copilot-acp` safety suite (tool-call extraction, streaming, timeout coercion, ACP permission + fs read/write safety, HOME propagation) plus Claude-specific checks (session-marker stripping, dual-bin resolution). **14 new tests pass.**
- Provider-registry / catalog / model-validation / overlay regression suites: **green** (no regressions; `copilot-acp` still resolves).
- `ruff`: clean. `ty`: at parity with `copilot_acp_client.py` (same tolerated `IO | None` diagnostics).
- Docs added to `website/docs/integrations/providers.md`.

## Usage

```bash
npm install -g @agentclientprotocol/claude-agent-acp   # + a logged-in Claude Code CLI
hermes config set model.provider claude-code-acp
hermes config set model.default claude-sonnet-4-6
```

## A note on placement

CONTRIBUTING says third-party product integrations should ship as standalone plugins. But **model-provider CLI backends are treated as core** here: `copilot-acp`, `copilot`, and `openai-codex` all live in-tree under `plugins/model-providers/`. `claude-code-acp` is the direct analogue — a model-provider backend, not a SaaS connector or memory provider. Filed alongside `copilot-acp` for that reason; happy to move it to a standalone plugin if you'd prefer that placement instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
