### PR TITLE
fix(desktop): extend read aloud + transcription timeouts (salvage of #39286)

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -3,7 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   AUDIO_SPEAK_MAX_REQUEST_TIMEOUT_MS,
   AUDIO_SPEAK_MIN_REQUEST_TIMEOUT_MS,
+  AUDIO_TRANSCRIBE_MAX_REQUEST_TIMEOUT_MS,
+  AUDIO_TRANSCRIBE_MIN_REQUEST_TIMEOUT_MS,
   audioSpeakRequestTimeoutMs,
+  audioTranscribeRequestTimeoutMs,
   getCronJobs,
   getGlobalModelInfo,
   getGlobalModelOptions,
@@ -16,7 +19,8 @@ import {
   listSessions,
   listSidebarSessions,
   resetSidebarBatchCapability,
-  speakText
+  speakText,
+  transcribeAudio
 } from './hermes'
 import { refreshActiveProfile } from './store/profile'
 
@@ -352,6 +356,33 @@ describe('Hermes REST helpers', () => {
       method: 'POST',
       path: '/api/audio/speak',
       timeoutMs: AUDIO_SPEAK_MIN_REQUEST_TIMEOUT_MS
+    })
+  })
+
+  it('bounds blocking transcription timeouts by payload length', () => {
+    expect(audioTranscribeRequestTimeoutMs('data:audio/webm;base64,AA==')).toBe(AUDIO_TRANSCRIBE_MIN_REQUEST_TIMEOUT_MS)
+    expect(audioTranscribeRequestTimeoutMs('x'.repeat(3_000_000))).toBe(300_000)
+    expect(audioTranscribeRequestTimeoutMs('x'.repeat(9_000_000))).toBe(AUDIO_TRANSCRIBE_MAX_REQUEST_TIMEOUT_MS)
+  })
+
+  it('uses an extended timeout for blocking transcription', async () => {
+    api.mockResolvedValueOnce({
+      ok: true,
+      provider: 'openai',
+      text: 'transcribed text'
+    })
+
+    await expect(transcribeAudio('data:audio/webm;base64,AA==', 'audio/webm')).resolves.toEqual({
+      ok: true,
+      provider: 'openai',
+      text: 'transcribed text'
+    })
+
+    expect(api).toHaveBeenCalledWith({
+      body: { data_url: 'data:audio/webm;base64,AA==', mime_type: 'audio/webm' },
+      method: 'POST',
+      path: '/api/audio/transcribe',
+      timeoutMs: AUDIO_TRANSCRIBE_MIN_REQUEST_TIMEOUT_MS
     })
   })
 

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  AUDIO_SPEAK_MAX_REQUEST_TIMEOUT_MS,
+  AUDIO_SPEAK_MIN_REQUEST_TIMEOUT_MS,
+  audioSpeakRequestTimeoutMs,
   getCronJobs,
   getGlobalModelInfo,
   getGlobalModelOptions,
@@ -12,7 +15,8 @@ import {
   listAllProfileSessions,
   listSessions,
   listSidebarSessions,
-  resetSidebarBatchCapability
+  resetSidebarBatchCapability,
+  speakText
 } from './hermes'
 import { refreshActiveProfile } from './store/profile'
 
@@ -23,7 +27,7 @@ const emptySessionsResponse = {
   total: 0
 }
 
-describe('Hermes REST session helpers', () => {
+describe('Hermes REST helpers', () => {
   let api: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
@@ -319,6 +323,35 @@ describe('Hermes REST session helpers', () => {
     expect(api).toHaveBeenCalledWith({
       path: '/api/sessions/session-1/messages?profile=xiaoxuxu',
       profile: 'xiaoxuxu'
+    })
+  })
+
+  it('bounds blocking TTS synthesis timeouts by text length', () => {
+    expect(audioSpeakRequestTimeoutMs('short message')).toBe(AUDIO_SPEAK_MIN_REQUEST_TIMEOUT_MS)
+    expect(audioSpeakRequestTimeoutMs('x'.repeat(8_000))).toBe(280_000)
+    expect(audioSpeakRequestTimeoutMs('x'.repeat(100_000))).toBe(AUDIO_SPEAK_MAX_REQUEST_TIMEOUT_MS)
+  })
+
+  it('uses an extended timeout for blocking TTS synthesis', async () => {
+    api.mockResolvedValueOnce({
+      data_url: 'data:audio/mpeg;base64,AA==',
+      mime_type: 'audio/mpeg',
+      ok: true,
+      provider: 'openai'
+    })
+
+    await expect(speakText('Read this aloud')).resolves.toEqual({
+      data_url: 'data:audio/mpeg;base64,AA==',
+      mime_type: 'audio/mpeg',
+      ok: true,
+      provider: 'openai'
+    })
+
+    expect(api).toHaveBeenCalledWith({
+      body: { text: 'Read this aloud' },
+      method: 'POST',
+      path: '/api/audio/speak',
+      timeoutMs: AUDIO_SPEAK_MIN_REQUEST_TIMEOUT_MS
     })
   })
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -97,6 +97,24 @@ export function audioSpeakRequestTimeoutMs(text: string): number {
   return Math.min(AUDIO_SPEAK_MAX_REQUEST_TIMEOUT_MS, estimated)
 }
 
+export const AUDIO_TRANSCRIBE_MIN_REQUEST_TIMEOUT_MS = 180_000
+export const AUDIO_TRANSCRIBE_MAX_REQUEST_TIMEOUT_MS = 600_000
+// The transcribe payload is the base64 audio data URL itself, so its string
+// length tracks clip size. ~0.1ms/char keeps short clips at the floor while
+// letting multi-minute recordings scale toward the cap (a base64 char is
+// ~0.75 bytes, so at 128kbps ≈ 21k chars/s of audio this budgets ~2s of
+// timeout per 1s of audio before the cap clamps it).
+const AUDIO_TRANSCRIBE_TIMEOUT_MS_PER_CHAR = 0.1
+
+export function audioTranscribeRequestTimeoutMs(dataUrl: string): number {
+  const estimated = Math.max(
+    AUDIO_TRANSCRIBE_MIN_REQUEST_TIMEOUT_MS,
+    Math.ceil(String(dataUrl || '').length * AUDIO_TRANSCRIBE_TIMEOUT_MS_PER_CHAR)
+  )
+
+  return Math.min(AUDIO_TRANSCRIBE_MAX_REQUEST_TIMEOUT_MS, estimated)
+}
+
 export type {
   ActionResponse,
   ActionStatusResponse,
@@ -1358,7 +1376,11 @@ export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<Aud
     body: {
       data_url: dataUrl,
       mime_type: mimeType
-    }
+    },
+    // Transcription blocks until provider STT, file handling, and response
+    // encoding finish. Remote providers and long clips regularly exceed the
+    // default 15s Electron backend timeout.
+    timeoutMs: audioTranscribeRequestTimeoutMs(dataUrl)
   })
 }
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -84,6 +84,18 @@ const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
 // agent-turn ceiling (agent.gateway_timeout = 1800s) so the ack timeout only
 // ever fires when the turn itself would have been abandoned server-side.
 export const PROMPT_SUBMIT_REQUEST_TIMEOUT_MS = 1_800_000
+export const AUDIO_SPEAK_MIN_REQUEST_TIMEOUT_MS = 180_000
+export const AUDIO_SPEAK_MAX_REQUEST_TIMEOUT_MS = 600_000
+const AUDIO_SPEAK_TIMEOUT_MS_PER_CHAR = 35
+
+export function audioSpeakRequestTimeoutMs(text: string): number {
+  const estimated = Math.max(
+    AUDIO_SPEAK_MIN_REQUEST_TIMEOUT_MS,
+    Math.ceil(String(text || '').length * AUDIO_SPEAK_TIMEOUT_MS_PER_CHAR)
+  )
+
+  return Math.min(AUDIO_SPEAK_MAX_REQUEST_TIMEOUT_MS, estimated)
+}
 
 export type {
   ActionResponse,
@@ -1354,7 +1366,11 @@ export function speakText(text: string): Promise<AudioSpeakResponse> {
   return window.hermesDesktop.api<AudioSpeakResponse>({
     path: '/api/audio/speak',
     method: 'POST',
-    body: { text }
+    body: { text },
+    // TTS blocks until provider synthesis, file read, and base64 encoding
+    // finish. Remote providers and large messages regularly exceed the
+    // default 15s Electron backend timeout.
+    timeoutMs: audioSpeakRequestTimeoutMs(text)
   })
 }
 


### PR DESCRIPTION
## Summary

Supersedes #39286 (rebased onto current `main`) and **extends it to close the whole audio-timeout bug class**. Credit to @ruslanvasylev for the original diagnosis/fix (preserved via `Co-authored-by`); the transcription half implements @OutThisLife's review suggestion on #39286.

Two Desktop audio endpoints block the renderer bridge until provider work finishes, and both are capped by the 15s Electron backend default (`DEFAULT_FETCH_TIMEOUT_MS = 15_000` in `apps/desktop/electron/hardening.ts`, honored per-request via `resolveTimeoutMs(options.timeoutMs, …)`):

- **`/api/audio/speak`** (Read Aloud) — blocks on TTS synthesis + file read + base64 encode. Large messages / slow remote providers legitimately exceed 15s, surfacing a false "Read aloud failed" while synthesis actually succeeds.
- **`/api/audio/transcribe`** (the sibling twin) — blocks on provider STT + file handling + encoding behind the same 15s default. Long clips / remote providers hit the identical spurious timeout.

This gives **only** those two blocking requests a bounded, endpoint-specific timeout. Every other Desktop API request keeps the short default so real backend hangs still fail promptly.

## Changes

- `apps/desktop/src/hermes.ts`:
  - `audioSpeakRequestTimeoutMs()` — 180s floor, 600s cap, 35ms/char scaling on message text; wired into `speakText()`.
  - `audioTranscribeRequestTimeoutMs()` — 180s floor, 600s cap, 0.1ms/char scaling on the base64 audio payload; wired into `transcribeAudio()`.
- `apps/desktop/src/hermes.test.ts`: Vitest coverage for both helpers' bounds relationships (behavioral, not snapshots) and both request shapes.

## Why a new PR (vs #39286)

#39286 was `CONFLICTING` against `main`: since it opened, `main` added `STARTUP_REQUEST_TIMEOUT_MS` and `PROMPT_SUBMIT_REQUEST_TIMEOUT_MS` (plus new model-options tests) immediately adjacent to the touched lines. Those conflicts are resolved here (both sets of constants/tests coexist, no behavior change). The premise still holds on current `main`: both audio endpoints are invoked with no `timeoutMs` override and cap at 15s.

## Scope note

#39286's author chose to keep that PR scoped to `/api/audio/speak` (to ship the smaller fix sooner). @OutThisLife's review flagged `transcribeAudio()` as the same bug class and suggested folding it in. This salvage does exactly that — closing both in one shot.

## Validation

From `apps/desktop` (workspace deps installed at repo root):

```text
npm run test:ui -- src/hermes.test.ts   # 19 passed
npm run typecheck                        # clean
npx eslint src/hermes.ts src/hermes.test.ts       # clean
npx prettier --check src/hermes.ts src/hermes.test.ts  # clean
```

Closes #39286.
