### PR TITLE
fix(config): skip symlinked HERMES_HOME subdirs in _secure_dir (#68055)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -834,8 +834,18 @@ def _secure_dir(path):
     vars are set (#34107 — Docker deployments need this so profile subdirs
     created at runtime by kanban workers don't land as root:root and block
     subsequent uid-mapped workers).
+
+    Symlinked subdirs are left alone. If an operator symlinks a HERMES_HOME
+    subdir (e.g. ``skills`` -> a group-shared library) to storage they own
+    deliberately, the target's permissions are theirs to set, not ours to
+    normalize (#68055). ``os.chmod`` follows symlinks, so securing the link
+    would clamp the *target* to 0700 on every ``load_config()`` and strip a
+    shared group's r+x. ``follow_symlinks=False`` is not an option — Linux has
+    no ``lchmod`` and raises ``NotImplementedError``.
     """
     if is_managed():
+        return
+    if os.path.islink(path):
         return
     try:
         mode_str = os.environ.get("HERMES_HOME_MODE", "").strip()

--- a/tests/hermes_cli/test_secure_dir_symlink_68055.py
+++ b/tests/hermes_cli/test_secure_dir_symlink_68055.py
@@ -1,0 +1,54 @@
+"""Regression test for #68055 — _secure_dir() must not chmod through symlinks.
+
+``os.chmod`` follows symlinks. ``ensure_hermes_home()`` runs ``_secure_dir()``
+over a fixed subdir list (including ``skills``) on every ``load_config()``. When
+a HERMES_HOME subdir is a symlink to a group-shared library, securing the link
+clamps the *target* to 0700 and strips the shared group's r+x — silently, on
+every CLI invocation. ``follow_symlinks=False`` is not a fix: Linux has no
+``lchmod`` and raises ``NotImplementedError``. The guard is to skip symlinked
+entries entirely, leaving the target's permissions to the operator.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX mode bits / symlink chmod semantics do not apply on Windows",
+)
+
+
+def test_secure_dir_leaves_symlink_target_untouched(tmp_path, monkeypatch):
+    """A symlinked subdir keeps its group-shared target mode (0750), not 0700."""
+    monkeypatch.delenv("HERMES_HOME_MODE", raising=False)
+    from hermes_cli.config import _secure_dir
+
+    target = tmp_path / "shared_skills"
+    target.mkdir()
+    os.chmod(target, 0o750)  # group-shared: owner rwx, group r-x
+
+    link = tmp_path / "skills"
+    link.symlink_to(target, target_is_directory=True)
+
+    _secure_dir(link)
+
+    # Target mode must survive — the operator owns the shared dir's perms.
+    assert (target.stat().st_mode & 0o777) == 0o750
+
+
+def test_secure_dir_still_secures_real_directories(tmp_path, monkeypatch):
+    """A real (non-symlinked) directory is still clamped to 0700."""
+    monkeypatch.delenv("HERMES_HOME_MODE", raising=False)
+    from hermes_cli.config import _secure_dir
+
+    real = tmp_path / "sessions"
+    real.mkdir()
+    os.chmod(real, 0o755)
+
+    _secure_dir(real)
+
+    assert (real.stat().st_mode & 0o777) == 0o700


### PR DESCRIPTION
## What does this PR do?

`hermes_cli/config.py::_secure_dir()` calls `os.chmod(path, 0o700)`, and `os.chmod` **follows symlinks**. `ensure_hermes_home()` runs `_secure_dir()` over a fixed subdir list that includes `skills`, and it runs on **every `load_config()`**. So if `$HERMES_HOME/skills` (or any of those subdirs) is a symlink to a group-shared directory, every Hermes CLI invocation silently clamps the *symlink target* to `0700`, stripping the shared group's `r+x`. A bare `hermes doctor` is enough to break a shared skills library — and because each command re-clamps the target, a manual repair appears not to hold.

The fix skips symlinked entries: if an operator has symlinked a `$HERMES_HOME` subdir to shared storage, the target's permissions are theirs to own, not Hermes's to normalize. Real (non-symlinked) directories are still secured exactly as before.

`follow_symlinks=False` is deliberately **not** used — Linux has no `lchmod`, so `os.chmod(..., follow_symlinks=False)` raises `NotImplementedError` on the very platform that has the bug (per the issue, verified on Linux 6.x / CPython 3.13).

## Related Issue

Fixes #68055

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py` — `_secure_dir()` returns early when `os.path.islink(path)` is true (after the existing `is_managed()` guard, before the chmod/chown). Docstring updated to document that symlinked subdirs are left to the operator and why `follow_symlinks=False` isn't viable.
- `tests/hermes_cli/test_secure_dir_symlink_68055.py` — regression tests: a symlinked subdir keeps its group-shared `0750` target mode; a real directory is still clamped to `0700`.

## How to Test

```
scripts/run_tests.sh tests/hermes_cli/test_secure_dir_symlink_68055.py
```

Result: `2 passed`. Reverting the `os.path.islink` guard makes `test_secure_dir_leaves_symlink_target_untouched` fail (target clamped to `0700`), confirming the test catches the regression. Existing permission/home tests (`test_ensure_hermes_home_uid_34107.py`, `test_ensure_hermes_home_memo.py`, `tests/cron/test_file_permissions.py`) still pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstring) — the `_secure_dir` docstring now notes the symlink case
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform impact considered — POSIX-only concern; no-op on Windows (mode bits don't apply), and the fix avoids the Linux `lchmod` `NotImplementedError` trap
- [x] Tool descriptions/schemas — N/A