### PR TITLE
fix(skills): tolerate non-UTF-8 bytes in hub lock.json (#68053)

### DIFF
--- a/tests/tools/test_hub_lock_non_utf8_68053.py
+++ b/tests/tools/test_hub_lock_non_utf8_68053.py
@@ -1,0 +1,65 @@
+"""Regression test for #68053 — hub lock.json with Windows-1252 bytes.
+
+`_read_hub_installed_names()` reads `~/.hermes/skills/.hub/lock.json` with a
+strict UTF-8 decode. A hub skill description carrying a Windows-1252 typographic
+byte (em-dash `0x97`, smart quotes, bullets) makes `read_text(encoding="utf-8")`
+raise `UnicodeDecodeError` — a `ValueError` sibling that is NOT caught by the
+function's `except (OSError, json.JSONDecodeError)`, so it escapes and returns
+HTTP 500 from the entire `/api/skills` endpoint, blanking the desktop Skills
+panel. The fix decodes with `errors="replace"`, so the offending byte degrades
+to U+FFFD and every skill name in the (structurally valid) lock stays readable.
+"""
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def skills_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "skills").mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import tools.skill_usage as mod
+    importlib.reload(mod)
+    return home
+
+
+def _write_hub_lock(home: Path, raw: bytes) -> None:
+    hub_dir = home / "skills" / ".hub"
+    hub_dir.mkdir(parents=True, exist_ok=True)
+    (hub_dir / "lock.json").write_bytes(raw)
+
+
+def test_windows_1252_em_dash_does_not_raise(skills_home):
+    """A 0x97 em-dash byte in a description must not blow up the reader."""
+    import tools.skill_usage as mod
+
+    # Valid JSON structure, but the description value contains a raw cp1252
+    # em-dash byte (0x97) instead of the UTF-8 sequence.
+    raw = (
+        b'{"installed": {"supply-chain": '
+        b'{"description": "guidance: safe \x97 3 finding(s)"}}}'
+    )
+    _write_hub_lock(skills_home, raw)
+
+    names = mod._read_hub_installed_names()
+
+    # The skill name is still recovered; no UnicodeDecodeError / 500.
+    assert "supply-chain" in names
+
+
+def test_clean_utf8_lock_still_read(skills_home):
+    """A well-formed UTF-8 lock keeps working unchanged."""
+    import tools.skill_usage as mod
+
+    raw = '{"installed": {"alpha": {}, "beta": {}}}'.encode("utf-8")
+    _write_hub_lock(skills_home, raw)
+
+    names = mod._read_hub_installed_names()
+
+    assert {"alpha", "beta"} <= names

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -210,7 +210,15 @@ def _read_hub_installed_names() -> Set[str]:
     if not lock_path.exists():
         return set()
     try:
-        data = json.loads(lock_path.read_text(encoding="utf-8"))
+        # Tolerate non-UTF-8 bytes in the lock file. Hub descriptions can carry
+        # Windows-1252 typographic chars (em-dash 0x97, smart quotes, bullets)
+        # written as single high bytes; a strict utf-8 read raises
+        # UnicodeDecodeError, which is a ValueError sibling (not OSError/
+        # JSONDecodeError) so it escapes the handler below and 500s the whole
+        # /api/skills endpoint. errors="replace" degrades the offending byte to
+        # U+FFFD, keeping the (structurally valid) JSON — and every other
+        # skill — readable. See #68053.
+        data = json.loads(lock_path.read_text(encoding="utf-8", errors="replace"))
         if isinstance(data, dict):
             installed = data.get("installed") or {}
             if isinstance(installed, dict):


### PR DESCRIPTION
## What does this PR do?

`tools/skill_usage.py::_read_hub_installed_names()` reads `~/.hermes/skills/.hub/lock.json` with a strict UTF-8 decode: `json.loads(lock_path.read_text(encoding="utf-8"))`. Hub skill descriptions can contain Windows-1252 typographic characters (em-dash `0x97`, smart quotes, bullets) written as single high bytes. `read_text(encoding="utf-8")` then raises `UnicodeDecodeError`.

`UnicodeDecodeError` is a `ValueError` sibling — it is **not** caught by the function's `except (OSError, json.JSONDecodeError)`, so it escapes and propagates up through `web_server.py`'s `get_skills` handler, returning **HTTP 500 for the entire `/api/skills` endpoint**. The result: the desktop Capabilities/Skills panel goes blank and users can't see or toggle any skill, all because of one bad byte in a description field.

This decodes the lock file with `errors="replace"`, so the offending byte degrades to `U+FFFD` and the structurally valid JSON — including every other skill name — stays readable. This heals both existing corrupted lock files and any written in the future, regardless of where the cp1252 byte originated.

## Related Issue

Fixes #68053

(Addresses Problem 1 — the `/api/skills` 500. Problem 2 in that issue, stale `hermes-agent.broken-*` backup-dir cleanup, is a separate concern and out of scope for this focused fix.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skill_usage.py` — `_read_hub_installed_names()` now reads `lock.json` with `read_text(encoding="utf-8", errors="replace")` instead of a strict decode, with a comment explaining why `UnicodeDecodeError` would otherwise escape the handler.
- `tests/tools/test_hub_lock_non_utf8_68053.py` — regression tests: a lock file with a raw `0x97` em-dash byte no longer raises and the skill name is still recovered; a clean UTF-8 lock still reads unchanged.

## How to Test

```
scripts/run_tests.sh tests/tools/test_hub_lock_non_utf8_68053.py
```

Result: `2 passed`. Reverting the `errors="replace"` change makes `test_windows_1252_em_dash_does_not_raise` fail with the exact `UnicodeDecodeError: 'utf-8' codec can't decode byte 0x97` from the issue traceback. Existing `tests/tools/test_skill_usage.py` (47 tests) still pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] Documentation — N/A (internal reader hardening; behavior for valid files unchanged)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform impact considered — the corruption originates from Windows-1252 bytes; the fix makes the reader tolerant on every platform
- [x] Tool descriptions/schemas — N/A