### PR TITLE
fix(codex): surface completed-only native tool calls

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -509,6 +509,14 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
         item_id = item.get("id") or ""
         name = _codex_item_to_tool_name(item)
         prior = started.pop(item_id, None)
+        # Codex can omit item/started for fast MCP and dynamic tool calls.
+        # Synthesize the missing start so progress consumers always receive
+        # a lifecycle pair. Keep commandExecution and fileChange completion
+        # behavior unchanged: their existing completed-only handling is
+        # intentionally not broadened here.
+        if prior is None and item.get("type") in {"mcpToolCall", "dynamicToolCall"}:
+            _fire_tool_started(item)
+            prior = started.pop(item_id, None)
         # Prefer codex's own durationMs when present so the bubble shows
         # exact tool wall-time; fall back to our started timestamp; fall
         # back to None if we never saw an item/started (some codex

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -384,6 +384,65 @@ class TestToolProgressDispatch:
         assert completed.kwargs["is_error"] is False
         assert "results" in completed.kwargs["result"]
 
+    @pytest.mark.parametrize(
+        ("item", "expected_name"),
+        [
+            (
+                {
+                    "type": "mcpToolCall",
+                    "id": "mcp-completed-only",
+                    "server": "fs",
+                    "tool": "read_file",
+                    "arguments": {"path": "/tmp/a.py"},
+                    "result": {"content": "ok"},
+                },
+                "mcp.fs.read_file",
+            ),
+            (
+                {
+                    "type": "dynamicToolCall",
+                    "id": "dynamic-completed-only",
+                    "tool": "web_search",
+                    "arguments": {"query": "hermes"},
+                    "success": True,
+                },
+                "web_search",
+            ),
+        ],
+    )
+    def test_completed_only_native_tool_synthesizes_start(self, item, expected_name):
+        """Fast native calls may arrive as item/completed without a start."""
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+
+        bridge(_item_completed(item))
+
+        calls = agent.tool_progress_callback.call_args_list
+        assert [call.args[:2] for call in calls] == [
+            ("tool.started", expected_name),
+            ("tool.completed", expected_name),
+        ]
+
+    def test_started_native_tool_is_not_synthesized_again_on_completion(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        item = {
+            "type": "mcpToolCall",
+            "id": "mcp-normal-pair",
+            "server": "fs",
+            "tool": "read_file",
+            "arguments": {"path": "/tmp/a.py"},
+            "result": {"content": "ok"},
+        }
+
+        bridge(_item_started(item))
+        bridge(_item_completed(item))
+
+        assert [call.args[0] for call in agent.tool_progress_callback.call_args_list] == [
+            "tool.started",
+            "tool.completed",
+        ]
+
     def test_web_search_builtin_fires_started_and_completed(self):
         """Codex's built-in webSearch produces a start/complete bubble pair
         with the query as preview and args (#26541)."""


### PR DESCRIPTION
# Draft: `fix(codex): surface completed-only native tool calls`

Draft only. Do not open a GitHub PR.

Candidate branch: `codex/prready-native-tool-progress`

## What does this PR do?

Fixes a native Codex app-server progress gap. Fast MCP and dynamic tool calls
can arrive as `item/completed` without a preceding `item/started`. Telegram
renders the started event as the visible progress card, so those calls were
invisible even though their completion reached Hermes.

The event bridge now synthesizes exactly one `tool.started` event for a
completed-only `mcpToolCall` or `dynamicToolCall`, immediately before forwarding
its completion. Calls which already sent `item/started` remain unchanged.

## Related Issue

No public issue. Reproduced in the native Codex Telegram progress path.

## Type of Change

- [x] 🐛 Bug fix
- [x] ✅ Tests

## Changes Made

- In `agent/codex_runtime.py`, synthesize the missing lifecycle start for
  completed-only native MCP and dynamic tool calls.
- In `tests/agent/test_codex_app_server_event_bridge.py`, cover both
  completed-only paths and prove normal start/completion pairs are not doubled.

## How to Test

```text
/home/agent/.hermes/hermes-agent/venv/bin/python -m pytest -q \
  tests/agent/test_codex_app_server_event_bridge.py

49 passed in 0.71s
```

This is hermetic. It sends no live model or Codex request.

## Checklist

### Code

- [x] Read the Contributing Guide and PR template.
- [x] Conventional commit: `fix(codex): synthesize native tool starts`.
- [x] Searched open and closed PRs/issues for `mcpToolCall`, `tool progress`,
  and `completed-only`; no duplicate found.
- [x] Focused two-file bug-fix scope, with no config, dependency, or tool-schema change.
- [x] Added behavioral regressions.
- [ ] Ran the full repository suite. Not run: the user requested hermetic,
  non-LLM targeted verification only.
- [x] Tested on Linux with the shared Hermes test venv.

### Documentation & Housekeeping

- [x] External documentation: N/A. No configuration or user workflow changes.
- [x] Config example: N/A.
- [x] Architecture/workflow docs: N/A.
- [x] Cross-platform impact: protocol-only event projection; no platform-specific API.
- [x] Tool descriptions/schemas: N/A. This preserves the existing callback API.

## Screenshots / Logs

The regression asserts the observable callback lifecycle:

```text
tool.started  ->  tool.completed
```

for a completed-only native MCP or dynamic tool item.
