### PR TITLE
feat(usage): show SuperGrok subscription limits

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -797,6 +797,101 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
     )
 
 
+XAI_CLI_BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing?format=credits"
+
+
+def _parse_xai_percent(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    try:
+        percent = float(value)
+    except (TypeError, ValueError):
+        return None
+    return percent if math.isfinite(percent) and 0 <= percent <= 100 else None
+
+
+def _parse_xai_amount(value: Any) -> Optional[float]:
+    raw: Any = value.get("val") if isinstance(value, dict) else value
+    if isinstance(raw, bool):
+        return None
+    try:
+        amount = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return amount if math.isfinite(amount) and amount >= 0 else None
+
+
+def _fetch_xai_oauth_account_usage() -> Optional[AccountUsageSnapshot]:
+    """Fetch SuperGrok subscription usage from the Grok CLI billing API.
+
+    This is separate from metered xAI API usage. Only stored xAI OAuth
+    credentials may be sent to the subscription billing host.
+    """
+    from tools.xai_http import resolve_xai_http_credentials
+
+    runtime = resolve_xai_http_credentials()
+    if runtime.get("provider") != "xai-oauth":
+        return None
+    token = str(runtime.get("api_key", "") or "").strip()
+    if not token:
+        return None
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "X-XAI-Token-Auth": "xai-grok-cli",
+    }
+    with httpx.Client(timeout=15.0, follow_redirects=False) as client:
+        response = client.get(XAI_CLI_BILLING_URL, headers=headers)
+        response.raise_for_status()
+    payload = response.json() or {}
+    config = payload.get("config") if isinstance(payload, dict) else None
+    if not isinstance(config, dict):
+        return AccountUsageSnapshot(
+            provider="xai-oauth", source="billing_api", fetched_at=_utc_now(),
+            title="Grok limits",
+            unavailable_reason="The Grok billing response contained no usage configuration.",
+        )
+
+    period = config.get("currentPeriod")
+    period_end = _parse_dt(period.get("end")) if isinstance(period, dict) else None
+    windows: list[AccountUsageWindow] = []
+    credit_percent = _parse_xai_percent(config.get("creditUsagePercent"))
+    if credit_percent is not None:
+        windows.append(AccountUsageWindow(
+            label="SuperGrok weekly credits", used_percent=credit_percent, reset_at=period_end,
+        ))
+
+    products = config.get("productUsage")
+    if isinstance(products, list):
+        for item in products:
+            if not isinstance(item, dict):
+                continue
+            product = str(item.get("product", "")).strip()
+            percent = _parse_xai_percent(item.get("usagePercent"))
+            if not product or percent is None:
+                continue
+            label = {"GrokBuild": "Grok Build", "Api": "API"}.get(product, product)
+            windows.append(AccountUsageWindow(
+                label=f"{label} weekly", used_percent=percent, reset_at=period_end,
+            ))
+
+    details: list[str] = []
+    cap = _parse_xai_amount(config.get("onDemandCap"))
+    used = _parse_xai_amount(config.get("onDemandUsed"))
+    if cap is not None and cap > 0 and used is not None:
+        details.append(f"On-demand: {max(0.0, cap - used):g} of {cap:g} remaining")
+    if not windows and not details:
+        return AccountUsageSnapshot(
+            provider="xai-oauth", source="billing_api", fetched_at=_utc_now(),
+            title="Grok limits",
+            unavailable_reason="The Grok billing response contained no recognized usage fields.",
+        )
+    return AccountUsageSnapshot(
+        provider="xai-oauth", source="billing_api", fetched_at=_utc_now(),
+        title="Grok limits", windows=tuple(windows), details=tuple(details),
+    )
+
+
 def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[str]) -> Optional[AccountUsageSnapshot]:
     runtime = resolve_runtime_provider(
         requested="openrouter",
@@ -883,6 +978,8 @@ def fetch_account_usage(
             return _fetch_codex_account_usage(base_url=base_url, api_key=api_key)
         if normalized == "anthropic":
             return _fetch_anthropic_account_usage()
+        if normalized == "xai-oauth":
+            return _fetch_xai_oauth_account_usage()
         if normalized == "openrouter":
             return _fetch_openrouter_account_usage(base_url, api_key)
     except Exception:

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -821,18 +821,22 @@ def _parse_xai_amount(value: Any) -> Optional[float]:
     return amount if math.isfinite(amount) and amount >= 0 else None
 
 
-def _fetch_xai_oauth_account_usage() -> Optional[AccountUsageSnapshot]:
+def _fetch_xai_oauth_account_usage(
+    api_key: Optional[str] = None,
+) -> Optional[AccountUsageSnapshot]:
     """Fetch SuperGrok subscription usage from the Grok CLI billing API.
 
-    This is separate from metered xAI API usage. Only stored xAI OAuth
+    This is separate from metered xAI API usage. Only live or stored xAI OAuth
     credentials may be sent to the subscription billing host.
     """
-    from tools.xai_http import resolve_xai_http_credentials
+    token = str(api_key or "").strip()
+    if not token:
+        from tools.xai_http import resolve_xai_http_credentials
 
-    runtime = resolve_xai_http_credentials()
-    if runtime.get("provider") != "xai-oauth":
-        return None
-    token = str(runtime.get("api_key", "") or "").strip()
+        runtime = resolve_xai_http_credentials()
+        if runtime.get("provider") != "xai-oauth":
+            return None
+        token = str(runtime.get("api_key", "") or "").strip()
     if not token:
         return None
     headers = {
@@ -979,7 +983,7 @@ def fetch_account_usage(
         if normalized == "anthropic":
             return _fetch_anthropic_account_usage()
         if normalized == "xai-oauth":
-            return _fetch_xai_oauth_account_usage()
+            return _fetch_xai_oauth_account_usage(api_key=api_key)
         if normalized == "openrouter":
             return _fetch_openrouter_account_usage(base_url, api_key)
     except Exception:

--- a/cli.py
+++ b/cli.py
@@ -9859,8 +9859,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         agent = self.agent
         calls = agent.session_api_calls
+        provider = getattr(agent, "provider", None) or getattr(self, "provider", None)
 
-        if calls == 0:
+        if calls == 0 and provider != "xai-oauth":
             if self._print_nous_credits_block():
                 self._print_usage_cta()
             else:
@@ -9911,7 +9912,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         # Account limits -- fetched off-thread with a hard timeout so slow
         # provider APIs don't hang the prompt.
-        provider = getattr(agent, "provider", None) or getattr(self, "provider", None)
         base_url = getattr(agent, "base_url", None) or getattr(self, "base_url", None)
         api_key = getattr(agent, "api_key", None) or getattr(self, "api_key", None)
         # Lazy import — pulls the OpenAI SDK chain, only needed here.

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -30,10 +30,15 @@ def _attach_agent(
     context_tokens: int,
     context_length: int,
     compressions: int = 0,
+    provider: str | None = None,
 ):
     cli_obj.agent = SimpleNamespace(
         model=cli_obj.model,
-        provider="anthropic" if cli_obj.model.startswith("anthropic/") else None,
+        provider=(
+            provider
+            if provider is not None
+            else ("anthropic" if cli_obj.model.startswith("anthropic/") else None)
+        ),
         base_url="",
         session_input_tokens=input_tokens if input_tokens is not None else prompt_tokens,
         session_output_tokens=output_tokens if output_tokens is not None else completion_tokens,
@@ -536,6 +541,30 @@ class TestCLIUsageReport:
         assert "Cost source:" not in output
         assert "Cache read tokens:" not in output
         assert "Cache write tokens:" not in output
+
+    def test_show_usage_fetches_grok_limits_before_first_api_call(self, capsys, monkeypatch):
+        cli_obj = _attach_agent(
+            _make_cli(model="xai-oauth/grok-4.5"),
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            api_calls=0,
+            context_tokens=0,
+            context_length=200_000,
+            provider="xai-oauth",
+        )
+        cli_obj.verbose = False
+        snapshot = MagicMock()
+        snapshot_lines = ["📈 Grok limits", "SuperGrok weekly credits: 82% remaining"]
+        monkeypatch.setattr("agent.account_usage.fetch_account_usage", lambda *args, **kwargs: snapshot)
+        monkeypatch.setattr("agent.account_usage.render_account_usage_lines", lambda value: snapshot_lines)
+        monkeypatch.setattr(cli_obj, "_print_nous_credits_block", lambda: False)
+
+        cli_obj._show_usage()
+        output = capsys.readouterr().out
+
+        assert "Grok limits" in output
+        assert "No API calls made yet" not in output
 
 
 class TestStatusBarWidthSource:

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -118,6 +118,70 @@ def test_render_account_usage_lines_includes_reset_and_provider():
     assert "Credits balance: $9.99" in lines[3]
 
 
+def test_fetch_account_usage_xai_oauth_billing(monkeypatch):
+    monkeypatch.setattr(
+        "tools.xai_http.resolve_xai_http_credentials",
+        lambda: {
+            "provider": "xai-oauth",
+            "api_key": "oauth-token",
+            "base_url": "https://api.x.ai/v1",
+        },
+        raising=False,
+    )
+    payload = {
+        "config": {
+            "creditUsagePercent": 18,
+            "currentPeriod": {
+                "start": "2026-07-13T14:45:00Z",
+                "end": "2026-07-20T14:45:00Z",
+                "type": "USAGE_PERIOD_TYPE_WEEKLY",
+            },
+            "productUsage": [
+                {"product": "GrokBuild", "usagePercent": 16},
+                {"product": "Api", "usagePercent": 2},
+            ],
+            "onDemandCap": {"val": 50},
+            "onDemandUsed": {"val": 10},
+        }
+    }
+
+    class _XaiClient(_Client):
+        def get(self, url, headers=None):
+            assert url == "https://cli-chat-proxy.grok.com/v1/billing?format=credits"
+            assert headers == {
+                "Authorization": "Bearer oauth-token",
+                "Accept": "application/json",
+                "X-XAI-Token-Auth": "xai-grok-cli",
+            }
+            return _Response(payload)
+
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda **kwargs: _XaiClient(payload),
+    )
+
+    snapshot = fetch_account_usage("xai-oauth")
+
+    assert snapshot is not None
+    assert snapshot.title == "Grok limits"
+    assert [window.label for window in snapshot.windows] == [
+        "SuperGrok weekly credits", "Grok Build weekly", "API weekly"
+    ]
+    assert snapshot.windows[0].used_percent == 18.0
+    assert snapshot.windows[0].reset_at == datetime(2026, 7, 20, 14, 45, tzinfo=timezone.utc)
+    assert "On-demand: 40 of 50 remaining" in snapshot.details
+
+
+def test_fetch_account_usage_xai_oauth_never_uses_api_key(monkeypatch):
+    monkeypatch.setattr(
+        "tools.xai_http.resolve_xai_http_credentials",
+        lambda: {"provider": "xai", "api_key": "api-key"},
+        raising=False,
+    )
+    snapshot = fetch_account_usage("xai-oauth")
+    assert snapshot is None
+
+
 def test_fetch_account_usage_openrouter_uses_limit_remaining_and_ignores_deprecated_rate_limit(monkeypatch):
     monkeypatch.setattr(
         "agent.account_usage.resolve_runtime_provider",

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -172,6 +172,36 @@ def test_fetch_account_usage_xai_oauth_billing(monkeypatch):
     assert "On-demand: 40 of 50 remaining" in snapshot.details
 
 
+def test_fetch_account_usage_xai_oauth_closes_client_on_request_error(monkeypatch):
+    monkeypatch.setattr(
+        "tools.xai_http.resolve_xai_http_credentials",
+        lambda: {"provider": "xai-oauth", "api_key": "oauth-token"},
+        raising=False,
+    )
+    exited = False
+
+    class _FailingClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            nonlocal exited
+            exited = True
+            return False
+
+        def get(self, url, headers=None):
+            raise RuntimeError("request failed")
+
+    def client_factory(**kwargs):
+        assert kwargs == {"timeout": 15.0, "follow_redirects": False}
+        return _FailingClient()
+
+    monkeypatch.setattr("agent.account_usage.httpx.Client", client_factory)
+
+    assert fetch_account_usage("xai-oauth") is None
+    assert exited is True
+
+
 def test_fetch_account_usage_xai_oauth_never_uses_api_key(monkeypatch):
     monkeypatch.setattr(
         "tools.xai_http.resolve_xai_http_credentials",

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -172,6 +172,37 @@ def test_fetch_account_usage_xai_oauth_billing(monkeypatch):
     assert "On-demand: 40 of 50 remaining" in snapshot.details
 
 
+def test_fetch_account_usage_xai_oauth_prefers_live_token(monkeypatch):
+    resolver_calls = 0
+
+    def resolve_credentials():
+        nonlocal resolver_calls
+        resolver_calls += 1
+        return {"provider": "xai-oauth", "api_key": "pool-other-token"}
+
+    monkeypatch.setattr(
+        "tools.xai_http.resolve_xai_http_credentials",
+        resolve_credentials,
+        raising=False,
+    )
+
+    class _XaiClient(_Client):
+        def get(self, url, headers=None):
+            assert url == "https://cli-chat-proxy.grok.com/v1/billing?format=credits"
+            assert headers["Authorization"] == "Bearer active-session-token"
+            return _Response({"config": {}})
+
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda **kwargs: _XaiClient({}),
+    )
+
+    snapshot = fetch_account_usage("xai-oauth", api_key="active-session-token")
+
+    assert snapshot is not None
+    assert resolver_calls == 0
+
+
 def test_fetch_account_usage_xai_oauth_closes_client_on_request_error(monkeypatch):
     monkeypatch.setattr(
         "tools.xai_http.resolve_xai_http_credentials",


### PR DESCRIPTION
## Summary

- Add xAI OAuth/SuperGrok usage reporting to the existing account-limits path used by `/usage`.
- Query the Grok CLI billing endpoint with stored `xai-oauth` credentials only.
- Display weekly SuperGrok credits, product limits (including Grok Build/API), on-demand balance, and reset timestamps.
- Keep direct `XAI_API_KEY` credentials off the subscription billing host.
- Allow `/usage` to fetch Grok limits before the first model call in a session.

## Security

- The billing request is pinned to `https://cli-chat-proxy.grok.com/v1/billing?format=credits`.
- Redirects are disabled for the bearer-authenticated request.
- The request requires the resolved credential source to be `xai-oauth`; regular xAI API keys return no subscription usage.
- No credential values are included in output or error messages.

## Verification

- `python -m pytest tests/test_account_usage.py tests/cli/test_cli_status_bar.py -o 'addopts=' -q` — 52 passed
- `python -m pytest tests/hermes_cli/test_xai_oauth_profile_auth.py tests/tools/test_x_search_tool.py -o 'addopts=' -q` — 28 passed
- `ruff check agent/account_usage.py cli.py tests/test_account_usage.py tests/cli/test_cli_status_bar.py` — passed
- `python scripts/check-windows-footguns.py agent/account_usage.py tests/test_account_usage.py` — passed
- `git diff --check` — passed

The broad test run was also attempted, but was stopped after environment-dependent failures involving temporary Hermes log paths and missing auxiliary providers; the focused changed-path tests pass.
