### PR TITLE
fix(kanban): cap auto-decompose retries so a poison card can't spin

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -57,6 +57,58 @@ def _resolve_auto_decompose_settings(
     return enabled, per_tick
 
 
+# Consecutive auto-decompose failures tolerated per triage card before the
+# dispatcher stops re-attempting it. Mirrors the attempt cap the delivery
+# ledger uses for the same reason ("poison rows cannot spin" —
+# ``gateway/delivery_ledger.py``): an automatic path that retries on a timer
+# needs a ceiling, or one permanently-undecomposable card retries forever.
+MAX_AUTO_DECOMPOSE_FAILURES = 3
+
+# task_id -> consecutive failure count. Process-local on purpose: the budget
+# this protects is aux-LLM spend by THIS gateway, and a restart is a natural
+# retry boundary (the same rationale the delivery ledger states for treating
+# a restart as a fresh attempt window).
+_AUTO_DECOMPOSE_FAILURES: "dict[str, int]" = {}
+
+
+def _auto_decompose_is_poisoned(task_id: str) -> bool:
+    """True once a card has failed auto-decomposition too many times.
+
+    Failures that leave the card in triage (``LLM error``, ``LLM returned
+    malformed JSON``) are invisible to the block-loop circuit breaker, which
+    only ever sees terminal outcomes of tasks that actually RAN. Without this
+    ceiling such a card is re-listed by ``list_triage_ids()`` on every tick
+    and re-sent to the aux model forever — silently, since the failure logs
+    at debug level.
+    """
+    return _AUTO_DECOMPOSE_FAILURES.get(task_id, 0) >= MAX_AUTO_DECOMPOSE_FAILURES
+
+
+# Outcomes that must NOT count toward the ceiling. "auxiliary client
+# unavailable" is returned BEFORE any model call, so it spends nothing, is
+# identical for every card, and clears globally the moment an aux model is
+# configured. Penalising cards for it would leave a user who configures aux
+# later with a triage column that stays inert until the gateway restarts.
+_UNPENALISED_DECOMPOSE_REASONS = frozenset({"auxiliary client unavailable"})
+
+
+def _auto_decompose_record_result(task_id: str, ok: bool, reason: str = "") -> int:
+    """Record one auto-decompose attempt; return the running failure count.
+
+    A success clears the card's history so a card that fails transiently
+    (aux provider blip) is not penalised once it finally decomposes.
+    """
+    if ok:
+        _AUTO_DECOMPOSE_FAILURES.pop(task_id, None)
+        return 0
+    if reason in _UNPENALISED_DECOMPOSE_REASONS:
+        # Not the card's fault and free to retry — leave the count untouched.
+        return _AUTO_DECOMPOSE_FAILURES.get(task_id, 0)
+    count = _AUTO_DECOMPOSE_FAILURES.get(task_id, 0) + 1
+    _AUTO_DECOMPOSE_FAILURES[task_id] = count
+    return count
+
+
 def _acquire_singleton_lock(lock_path) -> "tuple[Optional[object], str]":
     """Take an exclusive, non-blocking advisory lock for the sole dispatcher.
 
@@ -1171,6 +1223,13 @@ class GatewayKanbanWatchersMixin:
                     for tid in triage_ids:
                         if attempted >= auto_decompose_per_tick:
                             break
+                        # Checked BEFORE the per-tick budget is spent: a card
+                        # that can never decompose must not crowd out the ones
+                        # that can. ``triage_ids`` is ordered, so poisoned
+                        # cards at the head would otherwise consume the whole
+                        # budget every tick and starve the rest of the column.
+                        if _auto_decompose_is_poisoned(tid):
+                            continue
                         attempted += 1
                         try:
                             outcome = _decomp.decompose_task(
@@ -1181,7 +1240,11 @@ class GatewayKanbanWatchersMixin:
                                 "kanban auto-decompose: decompose_task crashed on %s",
                                 tid,
                             )
+                            _auto_decompose_record_result(tid, False)
                             continue
+                        failure_count = _auto_decompose_record_result(
+                            tid, outcome.ok, outcome.reason or "",
+                        )
                         if outcome.ok:
                             successes += 1
                             if outcome.fanout and outcome.child_ids:
@@ -1194,6 +1257,18 @@ class GatewayKanbanWatchersMixin:
                                     "kanban auto-decompose [%s]: %s → single task (no fanout)",
                                     slug, tid,
                                 )
+                        elif failure_count >= MAX_AUTO_DECOMPOSE_FAILURES:
+                            # Give-up is the one auto-decompose outcome that
+                            # must not be silent: the card stays in triage
+                            # looking merely un-processed, so say once, at
+                            # warning, that nothing further will retry it.
+                            logger.warning(
+                                "kanban auto-decompose [%s]: %s failed %d times "
+                                "(%s); not retrying automatically. Decompose it "
+                                "manually with `hermes kanban decompose %s` once "
+                                "the cause is addressed.",
+                                slug, tid, failure_count, outcome.reason, tid,
+                            )
                         else:
                             # Common no-op reasons (no aux client configured) shouldn't
                             # spam logs every tick. Log at debug.

--- a/tests/gateway/test_kanban_auto_decompose_live.py
+++ b/tests/gateway/test_kanban_auto_decompose_live.py
@@ -9,9 +9,18 @@ called every tick, reading the current config.
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 
-from gateway.kanban_watchers import _resolve_auto_decompose_settings
+from gateway import kanban_watchers
+from gateway.kanban_watchers import (
+    _AUTO_DECOMPOSE_FAILURES,
+    MAX_AUTO_DECOMPOSE_FAILURES,
+    _auto_decompose_is_poisoned,
+    _auto_decompose_record_result,
+    _resolve_auto_decompose_settings,
+)
 
 
 def test_enabled_by_default_when_key_absent():
@@ -81,3 +90,85 @@ def test_live_toggle_takes_effect_between_calls():
     # User edits config.yaml mid-run.
     state["kanban"]["auto_decompose"] = False
     assert _resolve_auto_decompose_settings(lambda: state)[0] is False
+
+
+# ── Poison-card ceiling ────────────────────────────────────────────────────
+# A decompose failure that leaves the card in triage ("LLM error", "LLM
+# returned malformed JSON") is invisible to the block-loop circuit breaker,
+# which only sees terminal outcomes of tasks that actually ran. Without a
+# ceiling the dispatcher re-sends such a card to the aux model every tick,
+# forever, at debug log level.
+
+
+@pytest.fixture(autouse=True)
+def _clear_failure_ledger():
+    _AUTO_DECOMPOSE_FAILURES.clear()
+    yield
+    _AUTO_DECOMPOSE_FAILURES.clear()
+
+
+def test_card_is_retried_up_to_the_cap_then_skipped():
+    assert _auto_decompose_is_poisoned("t_poison") is False
+    for expected in range(1, MAX_AUTO_DECOMPOSE_FAILURES):
+        assert _auto_decompose_record_result("t_poison", False) == expected
+        # Still eligible — transient aux failures deserve another chance.
+        assert _auto_decompose_is_poisoned("t_poison") is False
+    assert (
+        _auto_decompose_record_result("t_poison", False)
+        == MAX_AUTO_DECOMPOSE_FAILURES
+    )
+    assert _auto_decompose_is_poisoned("t_poison") is True
+
+
+def test_success_clears_failure_history():
+    """A card that fails transiently then decomposes must not stay penalised."""
+    _auto_decompose_record_result("t_flaky", False)
+    _auto_decompose_record_result("t_flaky", False)
+    assert _auto_decompose_record_result("t_flaky", True) == 0
+    assert _auto_decompose_is_poisoned("t_flaky") is False
+    # And the next failure starts counting from scratch.
+    assert _auto_decompose_record_result("t_flaky", False) == 1
+
+
+def test_unconfigured_aux_client_never_poisons_a_card():
+    """"auxiliary client unavailable" is returned before any model call: it
+    spends nothing and is identical for every card. Counting it would leave a
+    user who configures an aux model later with an inert triage column."""
+    for _ in range(MAX_AUTO_DECOMPOSE_FAILURES * 2):
+        assert (
+            _auto_decompose_record_result(
+                "t_noaux", False, "auxiliary client unavailable",
+            )
+            == 0
+        )
+    assert _auto_decompose_is_poisoned("t_noaux") is False
+    # A genuine failure on the same card still counts from zero.
+    assert (
+        _auto_decompose_record_result(
+            "t_noaux", False, "LLM returned malformed JSON",
+        )
+        == 1
+    )
+
+
+def test_failure_counts_are_per_card():
+    for _ in range(MAX_AUTO_DECOMPOSE_FAILURES):
+        _auto_decompose_record_result("t_bad", False)
+    assert _auto_decompose_is_poisoned("t_bad") is True
+    assert _auto_decompose_is_poisoned("t_good") is False
+
+
+def test_poison_skip_precedes_the_per_tick_budget_spend():
+    """Ordering invariant: the poison check must run BEFORE ``attempted += 1``.
+
+    ``triage_ids`` is ordered, so if poisoned cards spent the per-tick budget
+    they would sit at the head of the column and starve every decomposable
+    card behind them — the cost bug would become a liveness bug.
+    """
+    src = inspect.getsource(kanban_watchers)
+    body = src.split("def _auto_decompose_tick(")[1]
+    skip = body.index("_auto_decompose_is_poisoned(tid)")
+    spend = body.index("attempted += 1")
+    assert skip < spend, (
+        "poisoned cards must be skipped before the per-tick budget is spent"
+    )


### PR DESCRIPTION
## What

A triage card whose decomposition fails at the LLM step is left in triage by
design, so `list_triage_ids()` re-lists it on the next dispatcher tick and it
is sent to the aux model again. Nothing bounds that. The two failure branches
that leave the card in triage —

```
"LLM error: {type}"            (call raised)
"LLM returned malformed JSON"  (model answered; tokens WERE spent)
```

— record nothing, so the block-loop circuit breaker never sees them: it only
fingerprints terminal outcomes of tasks that actually **ran**, and this card
never runs.

With `kanban.auto_decompose` defaulting to `true` and a 60s dispatch interval,
one permanently-undecomposable card is re-sent to the aux model every 60
seconds, indefinitely, at 4000 `max_tokens` a call. The failure logs at
`debug`, so the spend is silent.

The per-tick cap (`auto_decompose_per_tick`, default 3) bounds the burst but
not the total — and it makes the liveness side worse: `triage_ids` is ordered,
so poison cards at the head consume the whole per-tick budget every tick and
starve every decomposable card behind them.

Reproduced against the real decomposer (aux client patched to return a
non-JSON body): 10 calls burned, `outcome.reason == "LLM returned malformed
JSON"`, and the card still returned by `list_triage_ids()` every time.

## Fix

Give each card a consecutive-failure ceiling, mirroring the attempt cap the
delivery ledger already uses for the same reason (*"poison rows cannot spin"* —
`gateway/delivery_ledger.py`).

- The check runs **before** the per-tick budget is spent, so a poisoned card no
  longer crowds out decomposable ones.
- Reaching the ceiling logs once at `warning` with the manual
  `hermes kanban decompose` escape hatch — giving up is the one outcome that
  must not stay silent, since the card just sits in triage looking
  un-processed.
- A success clears the card's history, so a transient aux blip costs nothing.
- `"auxiliary client unavailable"` is excluded from the ceiling: it returns
  before any model call, spends nothing, is identical for every card, and
  clears globally once an aux model is configured — counting it would leave a
  user who configures aux later with an inert triage column.
- The counter is process-local: the budget it protects is this gateway's aux
  spend, and a restart is a natural retry boundary.

## Tests

`tests/gateway/test_kanban_auto_decompose_live.py` (11 passed):

- retried up to the cap, then skipped
- success clears failure history
- an unconfigured aux client never poisons a card
- failure counts are per-card
- ordering invariant: the poison check precedes the per-tick budget spend

Regression: `test_kanban_auto_decompose_live.py`, `test_kanban_watchers_mixin.py`,
`test_kanban_decompose.py`, `test_kanban_decompose_db.py` — 36 passed.