### PR TITLE
feat(desktop): add message avatars with editable names and images

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -33,8 +33,8 @@ import { formatAgo } from '@/lib/time'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
 import { playSpeechText, stopVoicePlayback } from '@/lib/voice-playback'
-import { notifyError } from '@/store/notifications'
 import { $avatarNames, DEFAULT_NAMES } from '@/store/avatar'
+import { notifyError } from '@/store/notifications'
 import { $voicePlayback } from '@/store/voice-playback'
 
 // Stable empty identity for the settled-parts selector — a fresh [] per render
@@ -119,10 +119,6 @@ export const AssistantMessage: FC<{
   const onDoubleClick = useTapbackDoubleClick(messageId, 'assistant')
 
   const assistantName = useNanostore($avatarNames).assistant || DEFAULT_NAMES.assistant
-
-  if (isPlaceholder) {
-    return null
-  }
 
   return (
     <div className="message-row message-row-assistant flex w-full min-w-0 items-start justify-start gap-2" data-slot="message-row">

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -6,7 +6,7 @@ import {
   useAuiState,
   useMessageRuntime
 } from '@assistant-ui/react'
-import { useStore } from '@nanostores/react'
+import { useStore as useNanostore } from '@nanostores/react'
 import { type FC, useCallback, useMemo, useState } from 'react'
 
 import { ChangedFilesCard } from '@/components/assistant-ui/thread/changed-files-card'
@@ -21,6 +21,7 @@ import { ResponseLoadingIndicator, StreamStallIndicator } from '@/components/ass
 import { formatMessageTimestamp } from '@/components/assistant-ui/thread/timestamp'
 import { useMessageReactions, useTapbackDoubleClick } from '@/components/assistant-ui/thread/use-message-reactions'
 import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button'
+import { MessageAvatar } from '@/components/chat/message-avatar'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { Codicon } from '@/components/ui/codicon'
 import { CopyButton } from '@/components/ui/copy-button'
@@ -33,6 +34,7 @@ import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
 import { playSpeechText, stopVoicePlayback } from '@/lib/voice-playback'
 import { notifyError } from '@/store/notifications'
+import { $avatarNames, DEFAULT_NAMES } from '@/store/avatar'
 import { $voicePlayback } from '@/store/voice-playback'
 
 // Stable empty identity for the settled-parts selector — a fresh [] per render
@@ -116,15 +118,27 @@ export const AssistantMessage: FC<{
   // are off, so the root carries no listener at all.
   const onDoubleClick = useTapbackDoubleClick(messageId, 'assistant')
 
+  const assistantName = useNanostore($avatarNames).assistant || DEFAULT_NAMES.assistant
+
+  if (isPlaceholder) {
+    return null
+  }
+
   return (
-    <MessagePrimitive.Root
-      className="group flex w-full min-w-0 max-w-full flex-col gap-0 self-start overflow-hidden"
-      data-role="assistant"
-      data-slot="aui_assistant-message-root"
-      data-streaming={isRunning ? 'true' : undefined}
-      onDoubleClick={onDoubleClick}
-      ref={enterRef}
-    >
+    <div className="message-row message-row-assistant flex w-full min-w-0 items-start justify-start gap-2" data-slot="message-row">
+      <MessageAvatar clickToEdit role="assistant" />
+      <div className="flex min-w-0 flex-1 flex-col items-start">
+        <span className="message-name-label mb-0.5 ml-1 text-[0.6875rem] leading-4 text-(--ui-text-tertiary) select-none">
+          {assistantName}
+        </span>
+        <MessagePrimitive.Root
+          className="group flex w-full min-w-0 max-w-full flex-col gap-0 self-start overflow-hidden"
+          data-role="assistant"
+          data-slot="aui_assistant-message-root"
+          data-streaming={isRunning ? 'true' : undefined}
+          onDoubleClick={onDoubleClick}
+          ref={enterRef}
+        >
       <div
         className="wrap-anywhere min-w-0 max-w-full overflow-hidden text-pretty text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground"
         data-slot="aui_assistant-message-content"
@@ -165,6 +179,8 @@ export const AssistantMessage: FC<{
           turn on its summary rather than burying it above the controls. */}
       <ChangedFilesCard parts={settledParts} />
     </MessagePrimitive.Root>
+      </div>
+    </div>
   )
 }
 
@@ -261,7 +277,7 @@ const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText,
 const ReadAloudButton: FC<{ getText: () => string; messageId: string }> = ({ getText, messageId }) => {
   const { t } = useI18n()
   const copy = t.assistant.thread
-  const voicePlayback = useStore($voicePlayback)
+  const voicePlayback = useNanostore($voicePlayback)
 
   const readAloudStatus =
     voicePlayback.source === 'read-aloud' && voicePlayback.messageId === messageId ? voicePlayback.status : 'idle'

--- a/apps/desktop/src/components/assistant-ui/thread/index.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/index.tsx
@@ -1,5 +1,5 @@
-import { memo, useCallback, useMemo, useRef, useState } from 'react'
 import { useStore } from '@nanostores/react'
+import { memo, useCallback, useMemo, useRef, useState } from 'react'
 
 import { AssistantMessage } from '@/components/assistant-ui/thread/assistant-message'
 import { ThreadMessageList } from '@/components/assistant-ui/thread/list'
@@ -14,8 +14,8 @@ import { Intro, type IntroProps } from '@/components/chat/intro'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import type { HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { notifyError } from '@/store/notifications'
 import { $avatarEditorOpen, closeAvatarEditor } from '@/store/avatar'
+import { notifyError } from '@/store/notifications'
 
 type ThreadLoadingState = 'response' | 'session'
 

--- a/apps/desktop/src/components/assistant-ui/thread/index.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/index.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useMemo, useRef, useState } from 'react'
+import { useStore } from '@nanostores/react'
 
 import { AssistantMessage } from '@/components/assistant-ui/thread/assistant-message'
 import { ThreadMessageList } from '@/components/assistant-ui/thread/list'
@@ -8,11 +9,13 @@ import { ThreadTimeline } from '@/components/assistant-ui/thread/timeline'
 import { type RestoreMessageTarget } from '@/components/assistant-ui/thread/types'
 import { UserEditComposer } from '@/components/assistant-ui/thread/user-edit-composer'
 import { UserMessage } from '@/components/assistant-ui/thread/user-message'
+import { AvatarEditorDialog } from '@/components/chat/avatar-editor-dialog'
 import { Intro, type IntroProps } from '@/components/chat/intro'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import type { HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { notifyError } from '@/store/notifications'
+import { $avatarEditorOpen, closeAvatarEditor } from '@/store/avatar'
 
 type ThreadLoadingState = 'response' | 'session'
 
@@ -56,6 +59,8 @@ export const Thread = memo(function Thread({
   const [restoreConfirmTarget, setRestoreConfirmTarget] = useState<
     (RestoreMessageTarget & { messageId: string }) | null
   >(null)
+
+  const avatarEditorOpen = useStore($avatarEditorOpen)
 
   const closeRestoreConfirm = useCallback(() => setRestoreConfirmTarget(null), [])
 
@@ -165,6 +170,7 @@ export const Thread = memo(function Thread({
         open={Boolean(restoreConfirmTarget)}
         title={copy.restoreTitle}
       />
+      <AvatarEditorDialog onClose={closeAvatarEditor} open={avatarEditorOpen} />
     </div>
   )
 })

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -1,4 +1,5 @@
 import { ActionBarPrimitive, BranchPickerPrimitive, MessagePrimitive, useAuiState } from '@assistant-ui/react'
+import { useStore } from '@nanostores/react'
 import { type FC, type ReactNode, useCallback, useRef, useState } from 'react'
 
 import { DirectiveContent } from '@/components/assistant-ui/directive-text'
@@ -7,12 +8,14 @@ import { ReactionBadge, ReactionPicker } from '@/components/assistant-ui/thread/
 import { type RestoreMessageTarget } from '@/components/assistant-ui/thread/types'
 import { useMessageReactions } from '@/components/assistant-ui/thread/use-message-reactions'
 import { UserMessageText } from '@/components/assistant-ui/thread/user-message-text'
+import { MessageAvatar } from '@/components/chat/message-avatar'
 import { Codicon } from '@/components/ui/codicon'
 import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { StopFilled } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { $avatarNames, DEFAULT_NAMES, getAvatarName } from '@/store/avatar'
 import { notifyThreadEditOpen } from '@/store/thread-scroll'
 import { isWatchWindow } from '@/store/windows'
 
@@ -215,6 +218,8 @@ export const UserMessage: FC<{
 
   useResizeObserver(measureClamp, clampInnerRef)
 
+  const userName = useStore($avatarNames).user || DEFAULT_NAMES.user
+
   // Injected background-process notification, not a human prompt — render the
   // compact system-style notice (after all hooks above have run).
   if (PROCESS_NOTIFICATION_RE.test(messageText.trim())) {
@@ -262,8 +267,13 @@ export const UserMessage: FC<{
 
   return (
     <MessagePrimitive.Root asChild>
-      <StickyHumanMessageContainer
-        attachments={
+      <div className="message-row message-row-user flex w-full min-w-0 items-end justify-end gap-2" data-slot="message-row">
+        <div className="flex min-w-0 flex-1 flex-col items-end">
+          <span className="message-name-label mb-0.5 mr-1 text-[0.6875rem] leading-4 text-(--ui-text-tertiary) select-none">
+            {userName}
+          </span>
+          <StickyHumanMessageContainer
+            attachments={
           // Attachments live BELOW the sticky bubble in normal flow, so they
           // scroll away behind the pinned bubble instead of riding along with
           // it. Image refs render as thumbnails, file refs as chips; no border.
@@ -433,6 +443,9 @@ export const UserMessage: FC<{
           </div>
         </ActionBarPrimitive.Root>
       </StickyHumanMessageContainer>
+        </div>
+        <MessageAvatar clickToEdit role="user" />
+      </div>
     </MessagePrimitive.Root>
   )
 }

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -268,7 +268,7 @@ export const UserMessage: FC<{
   return (
     <MessagePrimitive.Root asChild>
       <div className="message-row message-row-user flex w-full min-w-0 items-end justify-end gap-2" data-slot="message-row">
-        <div className="flex min-w-0 flex-1 flex-col items-end">
+        <div className="flex min-w-0 max-w-[75%] flex-col items-end">
           <span className="message-name-label mb-0.5 mr-1 text-[0.6875rem] leading-4 text-(--ui-text-tertiary) select-none">
             {userName}
           </span>

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -15,7 +15,7 @@ import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { StopFilled } from '@/lib/icons'
 import { cn } from '@/lib/utils'
-import { $avatarNames, DEFAULT_NAMES, getAvatarName } from '@/store/avatar'
+import { $avatarNames, DEFAULT_NAMES } from '@/store/avatar'
 import { notifyThreadEditOpen } from '@/store/thread-scroll'
 import { isWatchWindow } from '@/store/windows'
 
@@ -268,7 +268,7 @@ export const UserMessage: FC<{
   return (
     <MessagePrimitive.Root asChild>
       <div className="message-row message-row-user flex w-full min-w-0 items-end justify-end gap-2" data-slot="message-row">
-        <div className="flex min-w-0 max-w-[75%] flex-col items-end">
+        <div className="flex min-w-0 flex-1 flex-col items-end">
           <span className="message-name-label mb-0.5 mr-1 text-[0.6875rem] leading-4 text-(--ui-text-tertiary) select-none">
             {userName}
           </span>

--- a/apps/desktop/src/components/chat/avatar-editor-dialog.tsx
+++ b/apps/desktop/src/components/chat/avatar-editor-dialog.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { type FC, useState } from 'react'
+import { type FC, useCallback, useMemo, useState } from 'react'
 
 import { MessageAvatar } from '@/components/chat/message-avatar'
 import { Button } from '@/components/ui/button'
@@ -12,12 +12,12 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { useI18n } from '@/i18n/context'
 import {
   $avatarImages,
   $avatarNames,
   type AvatarRole,
   DEFAULT_NAMES,
-  getAvatarName,
   setAvatarImage,
   setAvatarName
 } from '@/store/avatar'
@@ -32,17 +32,55 @@ interface AvatarEditorDialogProps {
 }
 
 // ---------------------------------------------------------------------------
+// Locale-aware copy
+// ---------------------------------------------------------------------------
+
+const COPY: Record<string, {
+  title: string
+  description: string
+  youLabel: string
+  hermesLabel: string
+  placeholder: string
+}> = {
+  zh: {
+    title: '编辑头像',
+    description: '自定义每个参与者的名称和头像。',
+    youLabel: '你（用户）',
+    hermesLabel: 'Hermes（助手）',
+    placeholder: '输入名称'
+  },
+  'zh-hant': {
+    title: '編輯頭像',
+    description: '自訂每個參與者的名稱和頭像。',
+    youLabel: '你（使用者）',
+    hermesLabel: 'Hermes（助手）',
+    placeholder: '輸入名稱'
+  },
+  ja: {
+    title: 'アバターを編集',
+    description: '各参加者の表示名とアバターをカスタマイズします。',
+    youLabel: 'あなた（ユーザー）',
+    hermesLabel: 'Hermes（アシスタント）',
+    placeholder: '名前を入力'
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Single participant row
 // ---------------------------------------------------------------------------
 
 interface ParticipantRowProps {
-  role: AvatarRole
   label: string
+  placeholder: string
+  role: AvatarRole
+  onNameChange: (name: string) => void
+  savedName: string
 }
 
-const ParticipantRow: FC<ParticipantRowProps> = ({ label, role }) => {
+const ParticipantRow: FC<ParticipantRowProps> = ({ label, onNameChange, placeholder, role, savedName }) => {
   const names = useStore($avatarNames)
   const images = useStore($avatarImages)
+  const { t } = useI18n()
   const [localName, setLocalName] = useState(names[role])
   const hasImage = Boolean(images[role])
 
@@ -60,27 +98,22 @@ const ParticipantRow: FC<ParticipantRowProps> = ({ label, role }) => {
         <div className="flex items-center gap-2">
           <Input
             className="h-8 text-[length:var(--conversation-text-font-size)]"
-            onChange={event => setLocalName(event.target.value)}
+            onChange={event => {
+              setLocalName(event.target.value)
+              onNameChange(event.target.value)
+            }}
             onKeyDown={event => {
               if (event.key === 'Enter') {
-                setAvatarName(role, localName)
+                const trimmed = event.currentTarget.value.trim()
+                setAvatarName(role, trimmed || savedName)
               }
             }}
-            onBlur={() => {
-              const trimmed = localName.trim()
-
-              if (trimmed && trimmed !== names[role]) {
-                setAvatarName(role, trimmed)
-              } else if (!trimmed) {
-                setLocalName(names[role] || DEFAULT_NAMES[role])
-              }
-            }}
-            placeholder={DEFAULT_NAMES[role]}
+            placeholder={placeholder || DEFAULT_NAMES[role]}
             value={localName}
           />
           {hasImage && (
             <Button
-              aria-label="Remove avatar image"
+              aria-label={t.common.remove}
               onClick={() => setAvatarImage(role, '')}
               size="icon-sm"
               variant="ghost"
@@ -98,24 +131,77 @@ const ParticipantRow: FC<ParticipantRowProps> = ({ label, role }) => {
 // Dialog
 // ---------------------------------------------------------------------------
 
-export const AvatarEditorDialog: FC<AvatarEditorDialogProps> = ({ onClose, open }) => (
-  <Dialog onOpenChange={onClose} open={open}>
-    <DialogContent className="max-w-sm">
-      <DialogHeader>
-        <DialogTitle>Edit chat avatars</DialogTitle>
-        <DialogDescription>Customise the display name and avatar for each participant.</DialogDescription>
-      </DialogHeader>
+export const AvatarEditorDialog: FC<AvatarEditorDialogProps> = ({ onClose, open }) => {
+  const { t, locale } = useI18n()
+  const copy = COPY[locale] || {
+    title: 'Edit chat avatars',
+    description: 'Customise the display name and avatar for each participant.',
+    youLabel: 'You (user)',
+    hermesLabel: 'Hermes (assistant)',
+    placeholder: 'Enter name'
+  }
+  const names = useStore($avatarNames)
 
-      <div className="space-y-4 py-2">
-        <ParticipantRow label="You (user)" role="user" />
-        <ParticipantRow label="Hermes (assistant)" role="assistant" />
-      </div>
+  // Track pending edits so Done can save all changes at once
+  const [pendingNames, setPendingNames] = useState<Partial<Record<AvatarRole, string>>>({})
 
-      <DialogFooter>
-        <Button onClick={onClose} variant="secondary">
-          Done
-        </Button>
-      </DialogFooter>
-    </DialogContent>
-  </Dialog>
-)
+  const handleNameChange = useCallback((role: AvatarRole, name: string) => {
+    setPendingNames(prev => ({ ...prev, [role]: name }))
+  }, [])
+
+  const handleDone = useCallback(() => {
+    // Flush pending name changes to the store
+    for (const role of ['user', 'assistant'] as AvatarRole[]) {
+      const pending = pendingNames[role]
+      if (pending !== undefined) {
+        const trimmed = pending.trim()
+        setAvatarName(role, trimmed || names[role] || DEFAULT_NAMES[role])
+      }
+    }
+    onClose()
+  }, [onClose, pendingNames, names])
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        // User clicked ✖️ — save pending changes then close
+        handleDone()
+      }
+    },
+    [handleDone]
+  )
+
+  return (
+    <Dialog onOpenChange={handleOpenChange} open={open}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{copy.title}</DialogTitle>
+          <DialogDescription>{copy.description}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <ParticipantRow
+            label={copy.youLabel}
+            onNameChange={name => handleNameChange('user', name)}
+            placeholder={copy.placeholder}
+            role="user"
+            savedName={names.user || DEFAULT_NAMES.user}
+          />
+          <ParticipantRow
+            label={copy.hermesLabel}
+            onNameChange={name => handleNameChange('assistant', name)}
+            placeholder={copy.placeholder}
+            role="assistant"
+            savedName={names.assistant || DEFAULT_NAMES.assistant}
+          />
+        </div>
+
+        <DialogFooter>
+          <Button onClick={handleDone} variant="secondary">
+            {t.common.done}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/components/chat/avatar-editor-dialog.tsx
+++ b/apps/desktop/src/components/chat/avatar-editor-dialog.tsx
@@ -1,0 +1,121 @@
+import { useStore } from '@nanostores/react'
+import { type FC, useState } from 'react'
+
+import { MessageAvatar } from '@/components/chat/message-avatar'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import {
+  $avatarImages,
+  $avatarNames,
+  type AvatarRole,
+  DEFAULT_NAMES,
+  getAvatarName,
+  setAvatarImage,
+  setAvatarName
+} from '@/store/avatar'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface AvatarEditorDialogProps {
+  open: boolean
+  onClose: () => void
+}
+
+// ---------------------------------------------------------------------------
+// Single participant row
+// ---------------------------------------------------------------------------
+
+interface ParticipantRowProps {
+  role: AvatarRole
+  label: string
+}
+
+const ParticipantRow: FC<ParticipantRowProps> = ({ label, role }) => {
+  const names = useStore($avatarNames)
+  const images = useStore($avatarImages)
+  const [localName, setLocalName] = useState(names[role])
+  const hasImage = Boolean(images[role])
+
+  return (
+    <div className="flex items-center gap-3">
+      <MessageAvatar
+        editable
+        onImageChange={setAvatarImage}
+        role={role}
+      />
+      <div className="min-w-0 flex-1 space-y-1">
+        <label className="text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+          {label}
+        </label>
+        <div className="flex items-center gap-2">
+          <Input
+            className="h-8 text-[length:var(--conversation-text-font-size)]"
+            onChange={event => setLocalName(event.target.value)}
+            onKeyDown={event => {
+              if (event.key === 'Enter') {
+                setAvatarName(role, localName)
+              }
+            }}
+            onBlur={() => {
+              const trimmed = localName.trim()
+
+              if (trimmed && trimmed !== names[role]) {
+                setAvatarName(role, trimmed)
+              } else if (!trimmed) {
+                setLocalName(names[role] || DEFAULT_NAMES[role])
+              }
+            }}
+            placeholder={DEFAULT_NAMES[role]}
+            value={localName}
+          />
+          {hasImage && (
+            <Button
+              aria-label="Remove avatar image"
+              onClick={() => setAvatarImage(role, '')}
+              size="icon-sm"
+              variant="ghost"
+            >
+              ✕
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Dialog
+// ---------------------------------------------------------------------------
+
+export const AvatarEditorDialog: FC<AvatarEditorDialogProps> = ({ onClose, open }) => (
+  <Dialog onOpenChange={onClose} open={open}>
+    <DialogContent className="max-w-sm">
+      <DialogHeader>
+        <DialogTitle>Edit chat avatars</DialogTitle>
+        <DialogDescription>Customise the display name and avatar for each participant.</DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-4 py-2">
+        <ParticipantRow label="You (user)" role="user" />
+        <ParticipantRow label="Hermes (assistant)" role="assistant" />
+      </div>
+
+      <DialogFooter>
+        <Button onClick={onClose} variant="secondary">
+          Done
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+)

--- a/apps/desktop/src/components/chat/avatar-editor-dialog.tsx
+++ b/apps/desktop/src/components/chat/avatar-editor-dialog.tsx
@@ -161,23 +161,26 @@ export const AvatarEditorDialog: FC<AvatarEditorDialogProps> = ({ onClose, open 
     onClose()
   }, [onClose, pendingNames, names])
 
-  const handleOpenChange = useCallback(
-    (nextOpen: boolean) => {
-      if (!nextOpen) {
-        // User clicked ✖️ — save pending changes then close
-        handleDone()
-      }
-    },
-    [handleDone]
-  )
+  const handleClose = useCallback(() => {
+    setPendingNames({})
+    onClose()
+  }, [onClose])
 
   return (
-    <Dialog onOpenChange={handleOpenChange} open={open}>
-      <DialogContent className="max-w-sm">
+    <Dialog onOpenChange={nextOpen => { if (!nextOpen) onClose(); }} open={open}>
+      <DialogContent className="max-w-sm" showCloseButton={false}>
         <DialogHeader>
           <DialogTitle>{copy.title}</DialogTitle>
           <DialogDescription>{copy.description}</DialogDescription>
         </DialogHeader>
+        <button
+          aria-label={t.common.close}
+          className="absolute right-2.5 top-2.5 z-20 flex size-6 items-center justify-center rounded-md text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-foreground"
+          onClick={handleClose}
+          type="button"
+        >
+          ✕
+        </button>
 
         <div className="space-y-4 py-2">
           <ParticipantRow

--- a/apps/desktop/src/components/chat/avatar-editor-dialog.tsx
+++ b/apps/desktop/src/components/chat/avatar-editor-dialog.tsx
@@ -113,11 +113,13 @@ export const AvatarEditorDialog: FC<AvatarEditorDialogProps> = ({ onClose, open 
     // Flush pending name changes to the store
     for (const role of ['user', 'assistant'] as AvatarRole[]) {
       const pending = pendingNames[role]
+
       if (pending !== undefined) {
         const trimmed = pending.trim()
         setAvatarName(role, trimmed || names[role] || DEFAULT_NAMES[role])
       }
     }
+
     onClose()
   }, [onClose, pendingNames, names])
 
@@ -127,7 +129,7 @@ export const AvatarEditorDialog: FC<AvatarEditorDialogProps> = ({ onClose, open 
   }, [onClose])
 
   return (
-    <Dialog onOpenChange={nextOpen => { if (!nextOpen) onClose(); }} open={open}>
+    <Dialog onOpenChange={nextOpen => { if (!nextOpen) { onClose() } }} open={open}>
       <DialogContent className="max-w-sm" showCloseButton={false}>
         <DialogHeader>
           <DialogTitle>{ae.title}</DialogTitle>

--- a/apps/desktop/src/components/chat/avatar-editor-dialog.tsx
+++ b/apps/desktop/src/components/chat/avatar-editor-dialog.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { type FC, useCallback, useMemo, useState } from 'react'
+import { type FC, useCallback, useState } from 'react'
 
 import { MessageAvatar } from '@/components/chat/message-avatar'
 import { Button } from '@/components/ui/button'
@@ -29,40 +29,6 @@ import {
 interface AvatarEditorDialogProps {
   open: boolean
   onClose: () => void
-}
-
-// ---------------------------------------------------------------------------
-// Locale-aware copy
-// ---------------------------------------------------------------------------
-
-const COPY: Record<string, {
-  title: string
-  description: string
-  youLabel: string
-  hermesLabel: string
-  placeholder: string
-}> = {
-  zh: {
-    title: '编辑头像',
-    description: '自定义每个参与者的名称和头像。',
-    youLabel: '你（用户）',
-    hermesLabel: 'Hermes（助手）',
-    placeholder: '输入名称'
-  },
-  'zh-hant': {
-    title: '編輯頭像',
-    description: '自訂每個參與者的名稱和頭像。',
-    youLabel: '你（使用者）',
-    hermesLabel: 'Hermes（助手）',
-    placeholder: '輸入名稱'
-  },
-  ja: {
-    title: 'アバターを編集',
-    description: '各参加者の表示名とアバターをカスタマイズします。',
-    youLabel: 'あなた（ユーザー）',
-    hermesLabel: 'Hermes（アシスタント）',
-    placeholder: '名前を入力'
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -132,14 +98,8 @@ const ParticipantRow: FC<ParticipantRowProps> = ({ label, onNameChange, placehol
 // ---------------------------------------------------------------------------
 
 export const AvatarEditorDialog: FC<AvatarEditorDialogProps> = ({ onClose, open }) => {
-  const { t, locale } = useI18n()
-  const copy = COPY[locale] || {
-    title: 'Edit chat avatars',
-    description: 'Customise the display name and avatar for each participant.',
-    youLabel: 'You (user)',
-    hermesLabel: 'Hermes (assistant)',
-    placeholder: 'Enter name'
-  }
+  const { t } = useI18n()
+  const ae = t.assistant.avatarEditor
   const names = useStore($avatarNames)
 
   // Track pending edits so Done can save all changes at once
@@ -170,8 +130,8 @@ export const AvatarEditorDialog: FC<AvatarEditorDialogProps> = ({ onClose, open 
     <Dialog onOpenChange={nextOpen => { if (!nextOpen) onClose(); }} open={open}>
       <DialogContent className="max-w-sm" showCloseButton={false}>
         <DialogHeader>
-          <DialogTitle>{copy.title}</DialogTitle>
-          <DialogDescription>{copy.description}</DialogDescription>
+          <DialogTitle>{ae.title}</DialogTitle>
+          <DialogDescription>{ae.description}</DialogDescription>
         </DialogHeader>
         <button
           aria-label={t.common.close}
@@ -184,16 +144,16 @@ export const AvatarEditorDialog: FC<AvatarEditorDialogProps> = ({ onClose, open 
 
         <div className="space-y-4 py-2">
           <ParticipantRow
-            label={copy.youLabel}
+            label={ae.youLabel}
             onNameChange={name => handleNameChange('user', name)}
-            placeholder={copy.placeholder}
+            placeholder={ae.placeholder}
             role="user"
             savedName={names.user || DEFAULT_NAMES.user}
           />
           <ParticipantRow
-            label={copy.hermesLabel}
+            label={ae.hermesLabel}
             onNameChange={name => handleNameChange('assistant', name)}
-            placeholder={copy.placeholder}
+            placeholder={ae.placeholder}
             role="assistant"
             savedName={names.assistant || DEFAULT_NAMES.assistant}
           />

--- a/apps/desktop/src/components/chat/message-avatar.tsx
+++ b/apps/desktop/src/components/chat/message-avatar.tsx
@@ -1,0 +1,147 @@
+import { useStore } from '@nanostores/react'
+import { type FC, useCallback, useRef } from 'react'
+
+import { $avatarImages, $avatarNames, DEFAULT_NAMES, openAvatarEditor, type AvatarRole } from '@/store/avatar'
+import { cn } from '@/lib/utils'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const AVATAR_SIZE = 28 // px — matches the design system's control size
+
+const FALLBACK_COLORS: Record<AvatarRole, { bg: string; fg: string }> = {
+  assistant: { bg: '#00796B', fg: '#FFFFFF' },
+  user: { bg: '#5C6BC0', fg: '#FFFFFF' }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map(w => w[0].toUpperCase())
+    .join('')
+}
+
+function acceptImageFiles(event: React.ChangeEvent<HTMLInputElement>, onDataUrl: (url: string) => void) {
+  const file = event.target.files?.[0]
+
+  if (!file) {
+    return
+  }
+
+  const reader = new FileReader()
+
+  reader.onload = () => {
+    if (typeof reader.result === 'string') {
+      onDataUrl(reader.result)
+    }
+  }
+
+  reader.readAsDataURL(file)
+  // allow re-upload of the same file
+  event.target.value = ''
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface MessageAvatarProps {
+  role: AvatarRole
+  /** When true, clicking opens the native file picker (used in editor dialog). */
+  editable?: boolean
+  /** When true, clicking opens the avatar editor dialog. */
+  clickToEdit?: boolean
+  onImageChange?: (role: AvatarRole, dataUrl: string) => void
+}
+
+export const MessageAvatar: FC<MessageAvatarProps> = ({ clickToEdit = false, editable = false, onImageChange, role }) => {
+  const images = useStore($avatarImages)
+  const avatarNames = useStore($avatarNames)
+  const name = avatarNames[role] || DEFAULT_NAMES[role]
+  const imageSrc = images[role]
+  const colors = FALLBACK_COLORS[role]
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const handleFileChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      acceptImageFiles(event, url => onImageChange?.(role, url))
+    },
+    [onImageChange, role]
+  )
+
+  const avatar = imageSrc ? (
+    <img
+      alt={name}
+      className="size-full rounded-full object-cover"
+      data-slot="message-avatar-image"
+      src={imageSrc}
+    />
+  ) : (
+    <span
+      className="flex size-full select-none items-center justify-center rounded-full text-[0.6875rem] font-semibold leading-none"
+      data-slot="message-avatar-fallback"
+      style={{ backgroundColor: colors.bg, color: colors.fg }}
+    >
+      {initials(name)}
+    </span>
+  )
+
+  if (!editable) {
+    if (clickToEdit) {
+      return (
+        <button
+          aria-label={`${name} — click to edit avatar`}
+          className={cn('message-avatar shrink-0 cursor-pointer transition-opacity hover:opacity-85', !imageSrc && 'avatar-fallback-ring')}
+          data-slot="message-avatar"
+          onClick={() => openAvatarEditor()}
+          style={{ width: AVATAR_SIZE, height: AVATAR_SIZE }}
+          title="Click to edit avatar"
+          type="button"
+        >
+          {avatar}
+        </button>
+      )
+    }
+
+    return (
+      <div
+        aria-label={name}
+        className={cn('message-avatar shrink-0', !imageSrc && 'avatar-fallback-ring')}
+        data-slot="message-avatar"
+        role="img"
+        style={{ width: AVATAR_SIZE, height: AVATAR_SIZE }}
+      >
+        {avatar}
+      </div>
+    )
+  }
+
+  return (
+    <button
+      aria-label={`${name} — click to change avatar`}
+      className="message-avatar message-avatar-editable shrink-0 cursor-pointer transition-opacity hover:opacity-80"
+      data-slot="message-avatar"
+      onClick={() => inputRef.current?.click()}
+      style={{ width: AVATAR_SIZE, height: AVATAR_SIZE }}
+      title="Click to change avatar"
+      type="button"
+    >
+      {avatar}
+      <input
+        accept="image/png,image/jpeg,image/webp,image/gif,image/svg+xml"
+        aria-hidden="true"
+        className="hidden"
+        onChange={handleFileChange}
+        ref={inputRef}
+        type="file"
+      />
+    </button>
+  )
+}

--- a/apps/desktop/src/components/chat/message-avatar.tsx
+++ b/apps/desktop/src/components/chat/message-avatar.tsx
@@ -8,7 +8,7 @@ import { cn } from '@/lib/utils'
 // Constants
 // ---------------------------------------------------------------------------
 
-const AVATAR_SIZE = 28 // px — matches the design system's control size
+const AVATAR_SIZE = 48 // px — large enough for facial detail, small enough not to dominate
 
 const FALLBACK_COLORS: Record<AvatarRole, { bg: string; fg: string }> = {
   assistant: { bg: '#00796B', fg: '#FFFFFF' },

--- a/apps/desktop/src/components/chat/message-avatar.tsx
+++ b/apps/desktop/src/components/chat/message-avatar.tsx
@@ -28,6 +28,50 @@ function initials(name: string): string {
     .join('')
 }
 
+function resizeImageToDataUrl(file: File, maxSize: number, onDataUrl: (url: string) => void) {
+  const img = new Image()
+  const url = URL.createObjectURL(file)
+
+  img.onload = () => {
+    URL.revokeObjectURL(url)
+
+    let { width, height } = img
+    if (width > maxSize || height > maxSize) {
+      const ratio = Math.min(maxSize / width, maxSize / height)
+      width = Math.round(width * ratio)
+      height = Math.round(height * ratio)
+    }
+
+    const canvas = document.createElement('canvas')
+    canvas.width = width
+    canvas.height = height
+    const ctx = canvas.getContext('2d')
+    if (!ctx) {
+      return
+    }
+
+    ctx.drawImage(img, 0, 0, width, height)
+    canvas.toBlob(
+      blob => {
+        if (!blob) {
+          return
+        }
+        const reader = new FileReader()
+        reader.onload = () => {
+          if (typeof reader.result === 'string') {
+            onDataUrl(reader.result)
+          }
+        }
+        reader.readAsDataURL(blob)
+      },
+      'image/jpeg',
+      0.85
+    )
+  }
+
+  img.src = url
+}
+
 function acceptImageFiles(event: React.ChangeEvent<HTMLInputElement>, onDataUrl: (url: string) => void) {
   const file = event.target.files?.[0]
 
@@ -35,15 +79,32 @@ function acceptImageFiles(event: React.ChangeEvent<HTMLInputElement>, onDataUrl:
     return
   }
 
-  const reader = new FileReader()
-
-  reader.onload = () => {
-    if (typeof reader.result === 'string') {
-      onDataUrl(reader.result)
-    }
+  // Reject non-image files
+  if (!file.type.startsWith('image/')) {
+    return
   }
 
-  reader.readAsDataURL(file)
+  // Reject files larger than 10 MB (before any resize)
+  const MAX_FILE_SIZE = 10 * 1024 * 1024
+  if (file.size > MAX_FILE_SIZE) {
+    return
+  }
+
+  // If under 1 MB, use directly; otherwise downscale to max 128x128 px
+  const DIRECT_THRESHOLD = 1 * 1024 * 1024
+
+  if (file.size <= DIRECT_THRESHOLD) {
+    const reader = new FileReader()
+    reader.onload = () => {
+      if (typeof reader.result === 'string') {
+        onDataUrl(reader.result)
+      }
+    }
+    reader.readAsDataURL(file)
+  } else {
+    resizeImageToDataUrl(file, 128, onDataUrl)
+  }
+
   // allow re-upload of the same file
   event.target.value = ''
 }

--- a/apps/desktop/src/components/chat/message-avatar.tsx
+++ b/apps/desktop/src/components/chat/message-avatar.tsx
@@ -1,8 +1,8 @@
 import { useStore } from '@nanostores/react'
 import { type FC, useCallback, useRef } from 'react'
 
-import { $avatarImages, $avatarNames, DEFAULT_NAMES, openAvatarEditor, type AvatarRole } from '@/store/avatar'
 import { cn } from '@/lib/utils'
+import { $avatarImages, $avatarNames, type AvatarRole, DEFAULT_NAMES, openAvatarEditor } from '@/store/avatar'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -36,6 +36,7 @@ function resizeImageToDataUrl(file: File, maxSize: number, onDataUrl: (url: stri
     URL.revokeObjectURL(url)
 
     let { width, height } = img
+
     if (width > maxSize || height > maxSize) {
       const ratio = Math.min(maxSize / width, maxSize / height)
       width = Math.round(width * ratio)
@@ -46,6 +47,7 @@ function resizeImageToDataUrl(file: File, maxSize: number, onDataUrl: (url: stri
     canvas.width = width
     canvas.height = height
     const ctx = canvas.getContext('2d')
+
     if (!ctx) {
       return
     }
@@ -56,12 +58,15 @@ function resizeImageToDataUrl(file: File, maxSize: number, onDataUrl: (url: stri
         if (!blob) {
           return
         }
+
         const reader = new FileReader()
+
         reader.onload = () => {
           if (typeof reader.result === 'string') {
             onDataUrl(reader.result)
           }
         }
+
         reader.readAsDataURL(blob)
       },
       'image/jpeg',
@@ -86,6 +91,7 @@ function acceptImageFiles(event: React.ChangeEvent<HTMLInputElement>, onDataUrl:
 
   // Reject files larger than 10 MB (before any resize)
   const MAX_FILE_SIZE = 10 * 1024 * 1024
+
   if (file.size > MAX_FILE_SIZE) {
     return
   }
@@ -95,11 +101,13 @@ function acceptImageFiles(event: React.ChangeEvent<HTMLInputElement>, onDataUrl:
 
   if (file.size <= DIRECT_THRESHOLD) {
     const reader = new FileReader()
+
     reader.onload = () => {
       if (typeof reader.result === 'string') {
         onDataUrl(reader.result)
       }
     }
+
     reader.readAsDataURL(file)
   } else {
     resizeImageToDataUrl(file, 128, onDataUrl)

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2304,6 +2304,13 @@ export const ar = defineLocale({
       sendEdited: 'إرسال التعديل',
       attachingFile: 'جار إرفاق الملف'
     },
+    avatarEditor: {
+      title: 'تعديل الصور الرمزية',
+      description: 'تخصيص أسماء وصور المشاركين.',
+      youLabel: 'أنت (مستخدم)',
+      hermesLabel: 'Hermes (مساعد)',
+      placeholder: 'أدخل الاسم'
+    },
     approval: {
       gatewayDisconnected: 'البوابة غير متصلة',
       sendFailed: 'فشل الإرسال',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2843,6 +2843,13 @@ export const en: Translations = {
         web_search: { done: 'Searched web', pending: 'Searching web', pendingAction: 'Searching' },
         write_file: { done: 'Edited file', pending: 'Editing file', pendingAction: 'Editing' }
       }
+    },
+    avatarEditor: {
+      title: 'Edit Avatars',
+      description: 'Customize participant names and avatars.',
+      youLabel: 'You (User)',
+      hermesLabel: 'Hermes (Assistant)',
+      placeholder: 'Enter name'
     }
   },
 

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2686,6 +2686,13 @@ export const ja = defineLocale({
         web_search: { done: 'Web を検索しました', pending: 'Web を検索中', pendingAction: '検索中' },
         write_file: { done: 'ファイルを編集しました', pending: 'ファイルを編集中', pendingAction: '編集中' }
       }
+    },
+    avatarEditor: {
+      title: 'アバターを編集',
+      description: '各参加者の表示名とアバターをカスタマイズします。',
+      youLabel: 'あなた（ユーザー）',
+      hermesLabel: 'Hermes（アシスタント）',
+      placeholder: '名前を入力'
     }
   },
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2404,6 +2404,13 @@ export interface Translations {
       }
       titles: Record<ToolTitleKey, ToolTitleCopy>
     }
+    avatarEditor: {
+      title: string
+      description: string
+      youLabel: string
+      hermesLabel: string
+      placeholder: string
+    }
   }
 
   prompts: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2576,6 +2576,13 @@ export const zhHant = defineLocale({
         web_search: { done: '已搜尋網頁', pending: '正在搜尋網頁', pendingAction: '正在搜尋' },
         write_file: { done: '已編輯檔案', pending: '正在編輯檔案', pendingAction: '正在編輯' }
       }
+    },
+    avatarEditor: {
+      title: '編輯頭像',
+      description: '自訂每個參與者的名稱和頭像。',
+      youLabel: '你（使用者）',
+      hermesLabel: 'Hermes（助手）',
+      placeholder: '輸入名稱'
     }
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3006,6 +3006,13 @@ export const zh: Translations = {
         web_search: { done: '已搜索网页', pending: '正在搜索网页', pendingAction: '正在搜索' },
         write_file: { done: '已编辑文件', pending: '正在编辑文件', pendingAction: '正在编辑' }
       }
+    },
+    avatarEditor: {
+      title: '编辑头像',
+      description: '自定义每个参与者的名称和头像。',
+      youLabel: '你（用户）',
+      hermesLabel: 'Hermes（助手）',
+      placeholder: '输入名称'
     }
   },
 

--- a/apps/desktop/src/store/avatar.ts
+++ b/apps/desktop/src/store/avatar.ts
@@ -1,0 +1,100 @@
+/**
+ * Avatar profile store — persisted to localStorage.
+ *
+ * Each participant (user / assistant) has a display name + optional
+ * image data URL.  Names default to "You" / "Hermes".
+ */
+
+import { atom } from 'nanostores'
+
+import { persistString, persistStringRecord, storedString, storedStringRecord } from '@/lib/storage'
+
+// ---------------------------------------------------------------------------
+// Keys
+// ---------------------------------------------------------------------------
+
+const IMAGE_KEY = 'hermes.desktop.avatarImages.v1'
+const NAME_KEY = 'hermes.desktop.avatarNames.v1'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AvatarRole = 'user' | 'assistant'
+
+export const DEFAULT_NAMES: Record<AvatarRole, string> = {
+  assistant: 'Hermes',
+  user: 'You'
+}
+
+// ---------------------------------------------------------------------------
+// Image store  (Record<AvatarRole, dataURL | empty>)
+// ---------------------------------------------------------------------------
+
+function loadImages(): Record<AvatarRole, string> {
+  const raw = storedStringRecord(IMAGE_KEY)
+  const images: Record<string, string> = { assistant: '', user: '' }
+
+  if (raw.assistant) images.assistant = raw.assistant
+  if (raw.user) images.user = raw.user
+
+  return images
+}
+
+export const $avatarImages = atom<Record<AvatarRole, string>>(loadImages())
+
+$avatarImages.subscribe(images => persistStringRecord(IMAGE_KEY, images))
+
+export function setAvatarImage(role: AvatarRole, dataUrl: string): void {
+  const next = { ...$avatarImages.get(), [role]: dataUrl }
+
+  $avatarImages.set(next)
+}
+
+// ---------------------------------------------------------------------------
+// Name store  (Record<AvatarRole, string>)
+// ---------------------------------------------------------------------------
+
+function loadNames(): Record<AvatarRole, string> {
+  const raw = storedStringRecord(NAME_KEY)
+  const names = { ...DEFAULT_NAMES }
+
+  if (raw.assistant) names.assistant = raw.assistant
+  if (raw.user) names.user = raw.user
+
+  return names
+}
+
+export const $avatarNames = atom<Record<AvatarRole, string>>(loadNames())
+
+$avatarNames.subscribe(names => persistStringRecord(NAME_KEY, names))
+
+export function setAvatarName(role: AvatarRole, name: string): void {
+  const trimmed = name.trim()
+  const fallback = DEFAULT_NAMES[role]
+
+  // Empty → fall back to default, but still persist explicit empties as empty
+  // so the store knows it was intentionally cleared.
+  const next = { ...$avatarNames.get(), [role]: trimmed || fallback }
+
+  $avatarNames.set(next)
+}
+
+/** Resolved name: returns the custom name or the default. */
+export function getAvatarName(role: AvatarRole): string {
+  return $avatarNames.get()[role] || DEFAULT_NAMES[role]
+}
+
+// ---------------------------------------------------------------------------
+// Editor dialog open state
+// ---------------------------------------------------------------------------
+
+export const $avatarEditorOpen = atom<boolean>(false)
+
+export function openAvatarEditor(): void {
+  $avatarEditorOpen.set(true)
+}
+
+export function closeAvatarEditor(): void {
+  $avatarEditorOpen.set(false)
+}

--- a/apps/desktop/src/store/avatar.ts
+++ b/apps/desktop/src/store/avatar.ts
@@ -73,8 +73,7 @@ export function setAvatarName(role: AvatarRole, name: string): void {
   const trimmed = name.trim()
   const fallback = DEFAULT_NAMES[role]
 
-  // Empty → fall back to default, but still persist explicit empties as empty
-  // so the store knows it was intentionally cleared.
+  // Empty trims to the fallback default name.
   const next = { ...$avatarNames.get(), [role]: trimmed || fallback }
 
   $avatarNames.set(next)

--- a/apps/desktop/src/store/avatar.ts
+++ b/apps/desktop/src/store/avatar.ts
@@ -7,7 +7,7 @@
 
 import { atom } from 'nanostores'
 
-import { persistString, persistStringRecord, storedString, storedStringRecord } from '@/lib/storage'
+import { persistStringRecord, storedStringRecord } from '@/lib/storage'
 
 // ---------------------------------------------------------------------------
 // Keys
@@ -35,8 +35,13 @@ function loadImages(): Record<AvatarRole, string> {
   const raw = storedStringRecord(IMAGE_KEY)
   const images: Record<string, string> = { assistant: '', user: '' }
 
-  if (raw.assistant) images.assistant = raw.assistant
-  if (raw.user) images.user = raw.user
+  if (raw.assistant) {
+    images.assistant = raw.assistant
+  }
+
+  if (raw.user) {
+    images.user = raw.user
+  }
 
   return images
 }
@@ -59,8 +64,13 @@ function loadNames(): Record<AvatarRole, string> {
   const raw = storedStringRecord(NAME_KEY)
   const names = { ...DEFAULT_NAMES }
 
-  if (raw.assistant) names.assistant = raw.assistant
-  if (raw.user) names.user = raw.user
+  if (raw.assistant) {
+    names.assistant = raw.assistant
+  }
+
+  if (raw.user) {
+    names.user = raw.user
+  }
 
   return names
 }

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2229,3 +2229,38 @@ button[data-slot='aui_msg-reactions'] svg {
     opacity: 0.4;
   }
 }
+
+/* ------------------------------------------------------------------ */
+/*  Message avatars                                                   */
+/* ------------------------------------------------------------------ */
+
+.message-avatar {
+  border-radius: 9999px;
+  overflow: hidden;
+}
+
+.avatar-fallback-ring {
+  box-shadow: 0 0 0 1px var(--ui-stroke-tertiary, rgba(255, 255, 255, 0.1));
+}
+
+.message-avatar-editable:focus-visible {
+  outline: 2px solid var(--dt-midground, var(--dt-primary));
+  outline-offset: 2px;
+}
+
+/* Fade the name label in on hover — subtle, not distracting. */
+[data-slot="message-row"] .message-name-label {
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+[data-slot="message-row"]:hover .message-name-label,
+[data-slot="message-row"]:focus-within .message-name-label {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .message-name-label {
+    transition: none;
+  }
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2237,6 +2237,8 @@ button[data-slot='aui_msg-reactions'] svg {
 .message-avatar {
   border-radius: 9999px;
   overflow: hidden;
+  position: relative;
+  z-index: 50;
 }
 
 .avatar-fallback-ring {


### PR DESCRIPTION
## Summary
Add circular avatar icons to chat messages in the desktop app, with left-right alignment (assistant left, user right), hover name labels, and an editor dialog for customizing name and image.

## Motivation
The current desktop chat UI lacks visual distinction between user and assistant messages. Adding avatars makes the conversation easier to scan, matching the UX conventions of WeChat, Feishu, Slack, etc.

## Changes (7 files, +445/-11)

### New
- `store/avatar.ts` — nanostore atoms + localStorage persistence via `persistStringRecord`
- `components/chat/message-avatar.tsx` — circular avatar (image, initials fallback, click-to-edit)
- `components/chat/avatar-editor-dialog.tsx` — name + image editor dialog

### Modified
- `thread/user-message.tsx` — wrap user message in `flex justify-end` row with avatar on right
- `thread/assistant-message.tsx` — wrap assistant message in `flex justify-start` row with avatar on left
- `thread/index.tsx` — render `AvatarEditorDialog` at Thread root
- `styles.css` — avatar circle, name label hover animation, `prefers-reduced-motion` support

## Design
- **Data layer**: nanostore atoms (`$avatarNames`, `$avatarImages`, `$avatarEditorOpen`) follow project conventions (`$` prefix, `persistStringRecord`)
- **Component tree**: Thread → AvatarEditorDialog (global dialog) + MessageAvatar (per message)
- **CSS**: scoped via `[data-slot="message-row"]`, no conflicting selectors
- **Accessibility**: `prefers-reduced-motion` disables name-label transition

## Testing
- Visual verification via static HTML preview page
- Manual testing on Windows Electron desktop
- Code reviewed by OpenCode CLI
- All existing desktop build/tests pass