### PR TITLE
fix(memory_manager): sanitize_context handles multimodal list content

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -161,23 +161,36 @@ _INTERNAL_NOTE_RE = re.compile(
 )
 
 
-def sanitize_context(text) -> str:
+def sanitize_context(text: Any) -> str:
     """Strip fence tags, injected context blocks, and system notes from provider output.
 
-    Accepts string OR list (multimodal message content) - lists are flattened
-    via _summarize_user_message_for_log before regex sanitization. Without
-    this guard, multimodal messages reach the regex as a list and crash with
-    ``expected string or bytes-like object, got 'list'``.
+    Accepts string OR list (multimodal message content) — lists are flattened
+    via ``_summarize_user_message_for_log`` before regex sanitization.
+
+    Without this guard, multimodal messages reach the regex as a list and crash
+    with ``expected string or bytes-like object, got 'list'``. PR #44738
+    normalizes content at the external-memory sync boundary, so this code path
+    is normally not reached for that case; this function is the last line of
+    defense if a caller forgets the boundary normalization.
     """
     if not isinstance(text, str):
         # Lazy import to avoid circular: memory_manager is imported widely.
         try:
             from agent.codex_responses_adapter import _summarize_user_message_for_log
             text = _summarize_user_message_for_log(text, sep="\n")
-        except Exception:
+        except ImportError:
+            logger.warning("sanitize_context: _summarize_user_message_for_log unavailable; using str() fallback")
             try:
                 text = str(text)
             except Exception:
+                logger.warning("sanitize_context: str() coercion failed; returning empty string")
+                return ""
+        except Exception:
+            logger.warning("sanitize_context: flatten helper raised; using str() fallback", exc_info=True)
+            try:
+                text = str(text)
+            except Exception:
+                logger.warning("sanitize_context: str() coercion failed; returning empty string")
                 return ""
     text = _INTERNAL_CONTEXT_RE.sub('', text)
     text = _INTERNAL_NOTE_RE.sub('', text)

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -161,8 +161,24 @@ _INTERNAL_NOTE_RE = re.compile(
 )
 
 
-def sanitize_context(text: str) -> str:
-    """Strip fence tags, injected context blocks, and system notes from provider output."""
+def sanitize_context(text) -> str:
+    """Strip fence tags, injected context blocks, and system notes from provider output.
+
+    Accepts string OR list (multimodal message content) - lists are flattened
+    via _summarize_user_message_for_log before regex sanitization. Without
+    this guard, multimodal messages reach the regex as a list and crash with
+    ``expected string or bytes-like object, got 'list'``.
+    """
+    if not isinstance(text, str):
+        # Lazy import to avoid circular: memory_manager is imported widely.
+        try:
+            from agent.codex_responses_adapter import _summarize_user_message_for_log
+            text = _summarize_user_message_for_log(text, sep="\n")
+        except Exception:
+            try:
+                text = str(text)
+            except Exception:
+                return ""
     text = _INTERNAL_CONTEXT_RE.sub('', text)
     text = _INTERNAL_NOTE_RE.sub('', text)
     text = _FENCE_TAG_RE.sub('', text)

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1646,3 +1646,77 @@ class TestMemoryInjectionRejectsMalformedSchema:
         names = {t["function"]["name"] for t in agent.tools}
         assert names == {"good_tool"}
         assert agent.valid_tool_names == {"good_tool"}
+
+
+
+# ---------------------------------------------------------------------------
+# sanitize_context regression tests (PR #68072)
+#
+# Regression: prior to this fix, sanitize_context assumed str input and crashed
+# with "expected string or bytes-like object, got 'list'" when callers passed
+# multimodal message content (a list of typed parts). PR #44738 normalizes
+# content at the external-memory sync boundary; this test ensures the
+# defensive guard inside sanitize_context() still does its job if a caller
+# forgets the boundary normalization.
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeContextMultimodalList:
+    def test_string_passthrough(self):
+        from agent.memory_manager import sanitize_context
+        # Plain string with a known-bad pattern should still be stripped.
+        assert sanitize_context("<memory-context>x</memory-context>hello") == "hello"
+
+    def test_empty_string(self):
+        from agent.memory_manager import sanitize_context
+        assert sanitize_context("") == ""
+
+    def test_none_returns_empty(self):
+        from agent.memory_manager import sanitize_context
+        # None is not a str, so the guard path runs. Must not raise.
+        assert sanitize_context(None) == ""
+
+    def test_list_of_text_parts(self):
+        from agent.memory_manager import sanitize_context
+        content = [
+            {"type": "text", "text": "hello "},
+            {"type": "text", "text": "world"},
+        ]
+        # Lists should be flattened, never crash. Whitespace-separated join.
+        result = sanitize_context(content)
+        assert "hello" in result
+        assert "world" in result
+
+    def test_list_with_fence_tags(self):
+        from agent.memory_manager import sanitize_context
+        # The fence-tag strip must work AFTER list flattening.
+        content = [
+            {"type": "text", "text": "<memory-context>leak</memory-context>safe"},
+        ]
+        result = sanitize_context(content)
+        assert "leak" not in result
+        assert "safe" in result
+
+    def test_list_with_image_part(self):
+        from agent.memory_manager import sanitize_context
+        # Image parts should not crash; they may become a marker or be skipped.
+        content = [
+            {"type": "text", "text": "see image"},
+            {"type": "image_url", "image_url": {"url": "data:..."}},
+        ]
+        result = sanitize_context(content)
+        assert "see image" in result
+
+    def test_scalar_fallback(self):
+        from agent.memory_manager import sanitize_context
+        # A scalar (int / bool / float) should coerce via str() and not crash.
+        assert "42" in sanitize_context(42)
+        assert "True" in sanitize_context(True)
+
+    def test_does_not_call_re_sub_on_list(self):
+        # Direct guard: feeding a list directly must not raise TypeError.
+        from agent.memory_manager import sanitize_context
+        try:
+            sanitize_context([{"type": "text", "text": "ok"}])
+        except TypeError as e:
+            pytest.fail(f"sanitize_context raised TypeError on list input: {e}")


### PR DESCRIPTION
## Bug

`sanitize_context(text)` in `agent/memory_manager.py` does `text = re.sub(...)` which expects a string.

When called with multimodal content (a list of typed parts, e.g. `[{type: text, text: ...}, {type: image_url, ...}]`), it raises:

```
TypeError: expected string or bytes-like object, got 'list'
```

This bug kills long-running QA workers after ~89 API calls when the memory provider passes back multimodal content. The model itself is fine — the error is in the post-call handler.

## Fix

Detect non-string input and flatten via `_summarize_user_message_for_log` before regex sanitization. The test class `TestFlattenMessageContent` already exists — the implementation just wasn't using it.

```python
def sanitize_context(text) -> str:
    if not isinstance(text, str):
        from agent.codex_responses_adapter import _summarize_user_message_for_log
        text = _summarize_user_message_for_log(text, sep="\n")
    text = _INTERNAL_CONTEXT_RE.sub('', text)
    text = _INTERNAL_NOTE_RE.sub('', text)
    text = _FENCE_TAG_RE.sub('', text)
    return text
```

## Tests

All 10 tests in `TestFlattenMessageContent` pass.

## Repro

Run a long-running agent with multimodal content + memory provider enabled. After ~89 API calls the worker dies with the exact error above.

## Reported by

@matiasgonzalocalvo (mgcstudios user)