### PR TITLE
fix(secret-sources): ship the conformance kit so plugin authors can import it

### DIFF
--- a/agent/secret_sources/registry.py
+++ b/agent/secret_sources/registry.py
@@ -186,10 +186,21 @@ def _ensure_builtin_sources() -> None:
                        exc_info=True)
 
 
-def _reset_registry_for_tests() -> None:
+def reset_registry_for_testing() -> None:
+    """Clear all registered sources and reset the built-in-load latch.
+
+    Test-support seam: the conformance kit and the internal suite use this to
+    start from an empty registry (then register just the source under test).
+    It is not part of the SecretSource protocol; the frozen
+    ``SECRET_SOURCE_API_VERSION`` contract is unchanged.
+    """
     global _BUILTINS_LOADED
     _SOURCES.clear()
     _BUILTINS_LOADED = False
+
+
+# Back-compat alias for the internal suite's existing call sites.
+_reset_registry_for_tests = reset_registry_for_testing
 
 
 # ---------------------------------------------------------------------------

--- a/agent/secret_sources/testing/__init__.py
+++ b/agent/secret_sources/testing/__init__.py
@@ -1,0 +1,16 @@
+"""Shipped test-support for secret-source backends.
+
+The conformance kit lives here, not under ``tests/``, so it ships in the
+wheel: an external secret-source plugin is a standalone repo that depends on
+an installed ``hermes-agent`` and validates itself against the contract with
+``from agent.secret_sources.testing import SecretSourceConformance``. See the
+plugin guide (``developer-guide/secret-source-plugin.md``).
+
+Importing this package pulls in ``pytest`` (the kit is built on it); that is a
+dev-time dependency, which any plugin author running the kit already has.
+Nothing on the Hermes runtime import path imports this package.
+"""
+
+from agent.secret_sources.testing.conformance import SecretSourceConformance
+
+__all__ = ["SecretSourceConformance"]

--- a/agent/secret_sources/testing/conformance.py
+++ b/agent/secret_sources/testing/conformance.py
@@ -5,7 +5,7 @@ itself against the contract by subclassing :class:`SecretSourceConformance`
 and providing a ``source`` fixture (plus optional per-source config
 fixtures).  Example::
 
-    from tests.secret_sources.conformance import SecretSourceConformance
+    from agent.secret_sources.testing import SecretSourceConformance
 
     class TestMySourceConformance(SecretSourceConformance):
         @pytest.fixture
@@ -30,9 +30,9 @@ from agent.secret_sources.base import (
     SecretSource,
 )
 from agent.secret_sources.registry import (
-    _reset_registry_for_tests,
     apply_all,
     register_source,
+    reset_registry_for_testing,
 )
 
 
@@ -106,7 +106,7 @@ class SecretSourceConformance:
     def test_registers_and_applies_via_orchestrator(self, source, tmp_path,
                                                     monkeypatch):
         """The source must survive a full apply_all() pass without breaking it."""
-        _reset_registry_for_tests()
+        reset_registry_for_testing()
         # Prevent the bundled sources from interfering.
         monkeypatch.setattr(
             "agent.secret_sources.registry._ensure_builtin_sources", lambda: None
@@ -120,4 +120,4 @@ class SecretSourceConformance:
             names = [sr.name for sr in report.sources]
             assert source.name in names
         finally:
-            _reset_registry_for_tests()
+            reset_registry_for_testing()

--- a/tests/secret_sources/test_conformance_kit_ships.py
+++ b/tests/secret_sources/test_conformance_kit_ships.py
@@ -1,0 +1,36 @@
+"""The SecretSource conformance kit must ship in the installed wheel.
+
+The plugin guide (``developer-guide/secret-source-plugin.md``) tells external
+secret-source authors to keep their backend in a standalone repo and validate
+it against the conformance kit, calling green conformance "the review bar."
+That contract is only real if the kit is importable from an *installed*
+hermes-agent: a standalone plugin repo has ``pip install hermes-agent``, not
+the hermes-agent ``tests/`` tree, which ``[tool.setuptools.packages.find]``
+does not ship.
+
+These guard against the kit regressing back under an unshipped package.
+"""
+
+from __future__ import annotations
+
+
+def test_conformance_kit_importable_from_shipped_package():
+    # Before the fix the kit lived at ``tests.secret_sources.conformance`` and
+    # ``tests`` is not in ``[tool.setuptools.packages.find].include``, so the
+    # documented import raised ``ModuleNotFoundError`` after install.
+    from agent.secret_sources.testing import SecretSourceConformance
+
+    assert SecretSourceConformance.__name__ == "SecretSourceConformance"
+
+
+def test_conformance_kit_lives_under_shipped_agent_package():
+    """The kit's package must be one setuptools ships (``agent.*``), not ``tests``."""
+    import agent.secret_sources.testing.conformance as kit
+
+    top_level = kit.__name__.split(".", 1)[0]
+    assert top_level == "agent", (
+        f"conformance kit is under {top_level!r}; it must live under a shipped "
+        "top-level package (agent.*), not the unshipped tests/ tree, or the "
+        "documented `from agent.secret_sources.testing import ...` breaks "
+        "after install"
+    )

--- a/tests/secret_sources/test_secret_source_registry.py
+++ b/tests/secret_sources/test_secret_source_registry.py
@@ -30,7 +30,7 @@ from agent.secret_sources.base import (  # noqa: E402
 )
 from agent.secret_sources import registry as reg  # noqa: E402
 from agent.secret_sources.bitwarden import BitwardenSource  # noqa: E402
-from tests.secret_sources.conformance import SecretSourceConformance  # noqa: E402
+from agent.secret_sources.testing import SecretSourceConformance  # noqa: E402
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_packaging_build_guard.py
+++ b/tests/test_packaging_build_guard.py
@@ -70,3 +70,52 @@ def test_artifact_build_allows_explicit_nix_package_build_marker(kind, artifact_
 
     assert result.returncode == 0, result.stderr
     assert list(tmp_path.glob(artifact_glob))
+
+
+def test_built_wheel_ships_importable_secret_source_conformance_kit(tmp_path):
+    """The conformance kit has to import from the artifact, not just the checkout.
+
+    website/docs/developer-guide/secret-source-plugin.md sends external
+    secret-source authors to `from agent.secret_sources.testing import
+    SecretSourceConformance` against an installed hermes-agent, and calls green
+    conformance the review bar. A checkout-only import test cannot see that
+    contract break: it stays green even if [tool.setuptools.packages.find] later
+    stops shipping the package, because tests/ runs with the source tree on
+    sys.path. So exercise the import against the wheel this module already
+    builds, with the checkout kept off sys.path.
+    """
+    result = _build_artifact("wheel", tmp_path, nix_build=True)
+    assert result.returncode == 0, result.stderr
+
+    wheels = list(tmp_path.glob("hermes_agent-*.whl"))
+    assert len(wheels) == 1, wheels
+    wheel = wheels[0]
+
+    env = os.environ.copy()
+    # A wheel is a zip, so zipimport can import straight out of it: the assertion
+    # then covers the artifact itself rather than an unpacked copy of it.
+    env["PYTHONPATH"] = str(wheel)
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from agent.secret_sources.testing import SecretSourceConformance\n"
+            "import agent.secret_sources.testing as kit\n"
+            "print(SecretSourceConformance.__name__)\n"
+            "print(kit.__file__)\n",
+        ],
+        # Not PROJECT_ROOT: the checkout must not be able to satisfy the import,
+        # otherwise this asserts nothing about what setuptools shipped.
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert probe.returncode == 0, probe.stderr
+    name, module_path = probe.stdout.splitlines()
+    assert name == "SecretSourceConformance"
+    assert Path(module_path).is_relative_to(wheel), (
+        f"kit imported from {module_path}, not from the built wheel at {wheel}"
+    )

--- a/website/docs/developer-guide/secret-source-plugin.md
+++ b/website/docs/developer-guide/secret-source-plugin.md
@@ -144,11 +144,11 @@ Multi-source precedence, conflict warnings, and `(from My Vault)` provenance lab
 
 ## Validate with the conformance kit
 
-Subclass the kit from the Hermes repo (`tests/secret_sources/conformance.py`) in your plugin's tests:
+The conformance kit ships with `hermes-agent`. Subclass it in your plugin's tests:
 
 ```python
 import pytest
-from tests.secret_sources.conformance import SecretSourceConformance
+from agent.secret_sources.testing import SecretSourceConformance
 
 class TestMyVaultConformance(SecretSourceConformance):
     @pytest.fixture


### PR DESCRIPTION
## What and why

I hit this while building an external secret-source backend by following `website/docs/developer-guide/secret-source-plugin.md`. That guide tells external authors to keep the backend in a standalone repo and validate it against the conformance kit, and calls green conformance "the review bar" for a contract-compliant backend.

From a standalone plugin repo I have `pip install hermes-agent`, not the hermes-agent `tests/` tree. But the kit lived at `tests/secret_sources/conformance.py`, and `tests` is not in `[tool.setuptools.packages.find].include`, so the documented import

```python
from tests.secret_sources.conformance import SecretSourceConformance
```

raises `ModuleNotFoundError` from an installed `hermes-agent`. The kit also imported the private `registry._reset_registry_for_tests`. So the review bar the guide mandates is unreachable from the exact setup the guide prescribes.

## The fix

Move the kit to `agent/secret_sources/testing/`, which already ships via the `agent.*` entry in `packages.find.include`, so there is no `pyproject.toml` change. Concretely:

- `agent/secret_sources/testing/conformance.py` -- the kit, relocated (git tracks it as a rename).
- `agent/secret_sources/testing/__init__.py` -- re-exports `SecretSourceConformance`.
- `agent/secret_sources/registry.py` -- add a public `reset_registry_for_testing()` seam; keep `_reset_registry_for_tests = reset_registry_for_testing` as a back-compat alias so the existing internal suite is untouched. The shipped kit imports the public name.
- Update the one internal importer (`tests/secret_sources/test_secret_source_registry.py`) and the guide's two import lines.

No change to the `SecretSource` protocol or `SECRET_SOURCE_API_VERSION`, and no behavioral change to any secret source. This is packaging plus one public alias.

### Why a `testing/` subpackage

It keeps the pytest-importing test-support in one place, the way `numpy.testing` does, and signals intent to reviewers. Nothing on the runtime import path pulls it in: `agent/secret_sources/__init__.py` imports only from `base`, so shipping `testing/` never drags `pytest` into a runtime path. `pytest` is a dev-dependency that any author running the kit already has.

## Tests

Two layers, because a checkout-level test and an artifact-level test fail on different things.

`tests/secret_sources/test_conformance_kit_ships.py` asserts the kit imports from the shipped `agent.*` package and resolves under `agent`, not under the unshipped `tests/` tree. It runs with the source tree on `sys.path`, so it pins the import contract but stays green even if packaging later stops shipping the kit.

`tests/test_packaging_build_guard.py` closes that hole, on the release surface that already owns it: that module drives the real PEP 517 hooks, so the artifact check belongs there rather than in a new file. The added test builds the wheel and imports `SecretSourceConformance` straight out of the `.whl` through zipimport, from a `cwd` outside the checkout with `PYTHONPATH` set to the artifact, then asserts the imported module path lives inside that wheel. No new CI step, no new dependency, no unpacking, and it is one more wheel build in a module that already builds two.

It bites: adding `exclude = ["agent.secret_sources.testing", "agent.secret_sources.testing.*"]` to `[tool.setuptools.packages.find]` turns the new test red with `ModuleNotFoundError: No module named 'agent.secret_sources.testing'` while both checkout tests stay green.

Verified on Windows 11, Python 3.13, cherry-picked onto current main:

```
44 passed             # tests/secret_sources/
5 passed              # tests/test_packaging_build_guard.py
3 passed              # the new artifact test plus the two checkout tests
1 failed, 2 passed    # those same three with the packaging exclude applied, the ModuleNotFoundError above
```

Green ubuntu run for this head: https://github.com/cryptoyasenka/hermes-agent/actions/runs/31261128483 (`tests/test_packaging_build_guard.py` 5 passed there, `tests/secret_sources/` green).

`ruff check` clean.
