### PR TITLE
fix(approval): bind interactive responses to exact requests

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -10195,7 +10195,11 @@ ipcMain.handle('hermes:notify', (_event, payload) => {
   // kind+session can arrive here twice. Collapse it at this single choke point.
   // Return true (not false): a notification for the event IS being shown by the
   // first caller, so the settings "send test" success probe stays honest.
-  if (isDuplicateNotification(`${payload?.kind ?? ''}:${payload?.sessionId ?? ''}`)) {
+  if (
+    isDuplicateNotification(
+      `${payload?.kind ?? ''}:${payload?.sessionId ?? ''}:${payload?.requestId ?? ''}`
+    )
+  ) {
     return true
   }
 
@@ -10229,7 +10233,11 @@ ipcMain.handle('hermes:notify', (_event, payload) => {
     const action = actions[index]
 
     if (action?.id) {
-      mainWindow.webContents.send('hermes:notification-action', { sessionId: payload?.sessionId, actionId: action.id })
+      mainWindow.webContents.send('hermes:notification-action', {
+        sessionId: payload?.sessionId,
+        requestId: payload?.requestId,
+        actionId: action.id
+      })
     }
   })
   notification.show()

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -144,8 +144,8 @@ export function useDesktopIntegrations({
   }, [navigate, runtimeIdByStoredSessionId])
 
   useEffect(() => {
-    const unsubscribe = window.hermesDesktop?.onNotificationAction?.(({ actionId, sessionId }) => {
-      void respondToApprovalAction(sessionId ?? null, actionId)
+    const unsubscribe = window.hermesDesktop?.onNotificationAction?.(({ actionId, requestId, sessionId }) => {
+      void respondToApprovalAction(sessionId ?? null, actionId, requestId)
     })
 
     return () => unsubscribe?.()

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -893,6 +893,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         // surfaces once the user focuses that chat.
         const command = typeof payload?.command === 'string' ? payload.command : ''
         const description = typeof payload?.description === 'string' ? payload.description : 'dangerous command'
+        const requestId = typeof payload?.request_id === 'string' ? payload.request_id : undefined
 
         setApprovalRequest({
           // false only when a tirith warning forbids it; backend omits the field otherwise.
@@ -902,6 +903,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             : undefined,
           command,
           description,
+          requestId,
           sessionId: sessionId ?? null,
           smartDenied: payload?.smart_denied === true
         })
@@ -917,6 +919,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           ],
           body: command || description,
           kind: 'approval',
+          requestId,
           sessionId,
           title: translateNow('notifications.native.approvalTitle')
         })

--- a/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
@@ -33,7 +33,7 @@ function part(toolName: string): ToolPart {
 function setRequest(
   command = 'rm -rf /tmp/x',
   allowPermanent?: boolean,
-  extra: { choices?: string[]; smartDenied?: boolean } = {}
+  extra: { choices?: string[]; requestId?: string; smartDenied?: boolean } = {}
 ) {
   $activeSessionId.set('sess-1')
   setApprovalRequest({ allowPermanent, command, description: 'dangerous command', sessionId: 'sess-1', ...extra })
@@ -77,15 +77,46 @@ describe('PendingToolApproval', () => {
 
   it('sends approval.respond {choice: "once"} and clears the request on Run', async () => {
     const request = mockGateway()
-    setRequest()
+    setRequest('rm -rf /tmp/x', undefined, { requestId: 'approval-second' })
     render(<PendingToolApproval part={part('terminal')} />)
 
     fireEvent.click(screen.getByRole('button', { name: /Run/ }))
 
     await waitFor(() => {
-      expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'once', session_id: 'sess-1' })
+      expect(request).toHaveBeenCalledWith('approval.respond', {
+        choice: 'once',
+        request_id: 'approval-second',
+        session_id: 'sess-1'
+      })
     })
     expect($approvalRequest.get()).toBeNull()
+  })
+
+  it('does not clear a newer approval that arrives while the response is in flight', async () => {
+    let finish: ((value: { resolved: boolean }) => void) | undefined
+
+    const request = vi.fn().mockImplementation(
+      () =>
+        new Promise<{ resolved: boolean }>(resolve => {
+          finish = resolve
+        })
+    )
+
+    $gateway.set({ request } as unknown as HermesGateway)
+    setRequest('first command', undefined, { requestId: 'approval-first' })
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Run/ }))
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(1))
+    setApprovalRequest({
+      command: 'second command',
+      description: 'newer approval',
+      requestId: 'approval-second',
+      sessionId: 'sess-1'
+    })
+    finish?.({ resolved: true })
+
+    await waitFor(() => expect($approvalRequest.get()?.requestId).toBe('approval-second'))
   })
 
   it('reveals the full command inline when the Command toggle is clicked', () => {

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -144,16 +144,17 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
       try {
         await gateway.request<{ resolved?: boolean }>('approval.respond', {
           choice,
+          ...(request.requestId ? { request_id: request.requestId } : {}),
           session_id: request.sessionId ?? undefined
         })
         triggerHaptic(choice === 'deny' ? 'cancel' : 'submit')
-        clearApprovalRequest(request.sessionId)
+        clearApprovalRequest(request.sessionId, request.requestId)
       } catch (error) {
         notifyError(error, copy.sendFailed)
         setSubmitting(null)
       }
     },
-    [busy, copy.gatewayDisconnected, copy.sendFailed, gateway, request.sessionId]
+    [busy, copy.gatewayDisconnected, copy.sendFailed, gateway, request.requestId, request.sessionId]
   )
 
   // ⌘/Ctrl+Enter → Run, Esc → Reject.

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -249,7 +249,9 @@ declare global {
       signalDeepLinkReady?: () => Promise<{ ok: boolean }>
       onWindowStateChanged?: (callback: (payload: HermesWindowState) => void) => () => void
       onFocusSession?: (callback: (sessionId: string) => void) => () => void
-      onNotificationAction?: (callback: (payload: { actionId: string; sessionId?: string }) => void) => () => void
+      onNotificationAction?: (
+        callback: (payload: { actionId: string; requestId?: string; sessionId?: string }) => void
+      ) => () => void
       onPreviewFileChanged: (callback: (payload: HermesPreviewFileChanged) => void) => () => void
       onBackendExit: (callback: (payload: BackendExit) => void) => () => void
       // Soft gateway-mode apply: primary backend was torn down without a window
@@ -758,6 +760,7 @@ export interface HermesNotification {
   body?: string
   silent?: boolean
   kind?: string
+  requestId?: string
   sessionId?: string
   actions?: { id: string; text: string }[]
 }

--- a/apps/desktop/src/store/native-notifications.test.ts
+++ b/apps/desktop/src/store/native-notifications.test.ts
@@ -134,9 +134,21 @@ describe('dispatchNativeNotification preferences', () => {
 
   it('forwards kind and sessionId to the bridge', () => {
     setActiveSessionId('abc')
-    dispatchNativeNotification({ body: 'hi', kind: 'turnError', sessionId: 'abc', title: 'boom' })
+    dispatchNativeNotification({
+      body: 'hi',
+      kind: 'turnError',
+      requestId: 'approval-one',
+      sessionId: 'abc',
+      title: 'boom'
+    })
     expect(notify).toHaveBeenCalledWith(
-      expect.objectContaining({ body: 'hi', kind: 'turnError', sessionId: 'abc', title: 'boom' })
+      expect.objectContaining({
+        body: 'hi',
+        kind: 'turnError',
+        requestId: 'approval-one',
+        sessionId: 'abc',
+        title: 'boom'
+      })
     )
   })
 })
@@ -210,17 +222,45 @@ describe('respondToApprovalAction', () => {
 
   it('approves via approval.respond {choice: "once"} and clears the prompt', async () => {
     setActiveSessionId('bg')
-    setApprovalRequest({ command: 'rm -rf /', description: 'dangerous', sessionId: 'bg' })
+    setApprovalRequest({
+      command: 'rm -rf /',
+      description: 'dangerous',
+      requestId: 'approval-second',
+      sessionId: 'bg'
+    })
 
-    await respondToApprovalAction('bg', 'approve')
+    await respondToApprovalAction('bg', 'approve', 'approval-second')
 
-    expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'once', session_id: 'bg' })
+    expect(request).toHaveBeenCalledWith('approval.respond', {
+      choice: 'once',
+      request_id: 'approval-second',
+      session_id: 'bg'
+    })
     expect($approvalRequest.get()).toBeNull()
   })
 
   it('rejects via approval.respond {choice: "deny"}', async () => {
     await respondToApprovalAction('bg', 'reject')
     expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'deny', session_id: 'bg' })
+  })
+
+  it('uses the notification request ID and does not clear a newer prompt', async () => {
+    setActiveSessionId('bg')
+    setApprovalRequest({
+      command: 'second command',
+      description: 'newer approval',
+      requestId: 'approval-second',
+      sessionId: 'bg'
+    })
+
+    await respondToApprovalAction('bg', 'approve', 'approval-first')
+
+    expect(request).toHaveBeenCalledWith('approval.respond', {
+      choice: 'once',
+      request_id: 'approval-first',
+      session_id: 'bg'
+    })
+    expect($approvalRequest.get()?.requestId).toBe('approval-second')
   })
 
   it('ignores unknown action ids', async () => {

--- a/apps/desktop/src/store/native-notifications.ts
+++ b/apps/desktop/src/store/native-notifications.ts
@@ -143,6 +143,7 @@ export interface NativeNotificationInput {
   kind: NativeNotificationKind
   title: string
   body?: string
+  requestId?: string
   sessionId?: null | string
   /**
    * Not tied to a chat session (e.g. pet generation). Fires whenever the user
@@ -169,7 +170,12 @@ export function dispatchNativeNotification(input: NativeNotificationInput): void
     return
   }
 
-  if (throttled(`${input.kind}:${input.sessionId ?? (input.global ? 'global' : '')}`, Date.now())) {
+  if (
+    throttled(
+      `${input.kind}:${input.sessionId ?? (input.global ? 'global' : '')}:${input.requestId ?? ''}`,
+      Date.now()
+    )
+  ) {
     return
   }
 
@@ -177,15 +183,21 @@ export function dispatchNativeNotification(input: NativeNotificationInput): void
     actions: input.actions,
     body: input.body,
     kind: input.kind,
+    requestId: input.requestId,
     sessionId: input.sessionId ?? undefined,
     silent: input.silent,
     title: input.title
   })
 }
 
-// Resolve a pending approval from a notification button, mirroring the in-app
-// Run/Reject bar. Keyed by session id — a background approval has no local guard.
-export async function respondToApprovalAction(sessionId: null | string, actionId: string): Promise<void> {
+// Resolve the exact approval represented by this notification. The request ID
+// is captured when the notification is created; looking up the current
+// per-session prompt here could authorize a newer command than the one shown.
+export async function respondToApprovalAction(
+  sessionId: null | string,
+  actionId: string,
+  requestId?: string
+): Promise<void> {
   const choice = actionId === 'approve' ? 'once' : actionId === 'reject' ? 'deny' : null
 
   if (!choice) {
@@ -199,8 +211,12 @@ export async function respondToApprovalAction(sessionId: null | string, actionId
   }
 
   try {
-    await gateway.request('approval.respond', { choice, session_id: sessionId ?? undefined })
-    clearApprovalRequest(sessionId)
+    await gateway.request('approval.respond', {
+      choice,
+      ...(requestId ? { request_id: requestId } : {}),
+      session_id: sessionId ?? undefined
+    })
+    clearApprovalRequest(sessionId, requestId)
   } catch {
     // Leave the prompt parked so the user can still resolve it in-app.
   }

--- a/apps/desktop/src/store/prompts.test.ts
+++ b/apps/desktop/src/store/prompts.test.ts
@@ -30,11 +30,17 @@ afterEach(() => {
 
 describe('approval prompt store', () => {
   it('holds the active session-keyed approval request', () => {
-    setApprovalRequest({ command: 'rm -rf /tmp/x', description: 'recursive delete', sessionId: 's1' })
+    setApprovalRequest({
+      command: 'rm -rf /tmp/x',
+      description: 'recursive delete',
+      requestId: 'approval-one',
+      sessionId: 's1'
+    })
 
     expect($approvalRequest.get()).toEqual({
       command: 'rm -rf /tmp/x',
       description: 'recursive delete',
+      requestId: 'approval-one',
       sessionId: 's1'
     })
   })

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -67,15 +67,16 @@ function keyedPromptStore<T extends KeyedPrompt>(): PromptStore<T> {
   }
 }
 
-// Approval is session-keyed on the backend (one in-flight approval per session,
-// resolved via approval.respond {choice, session_id}). It carries no request_id,
-// unlike sudo/secret which are _block()-style request/response.
+// Approval prompts remain parked per session in the UI, while requestId binds
+// each response to the exact backend queue entry that produced the prompt.
+// It is optional so newer clients remain compatible with older gateways.
 export interface ApprovalRequest extends KeyedPrompt {
   // false when the backend won't honor a permanent allow (tirith warning) → hide "Always allow".
   allowPermanent?: boolean
   choices?: string[]
   command: string
   description: string
+  requestId?: string
   smartDenied?: boolean
 }
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -52,6 +52,7 @@ import os
 import re
 import sqlite3
 import sys
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -72,6 +73,80 @@ def _approval_event_choices(*, smart_denied: bool, allow_permanent: bool) -> lis
     if smart_denied:
         return ["once", "deny"]
     return ["once", "session", "always", "deny"] if allow_permanent else ["once", "session", "deny"]
+
+
+_APPROVAL_PREVIEW_COPY = {
+    "terminal_command": (
+        "Terminal command approval",
+        "Hermes stopped a terminal command that matched a protected action.",
+    ),
+    "code_execution": (
+        "Code execution approval",
+        "Hermes stopped generated code that can change files or start processes.",
+    ),
+    "tool_policy": (
+        "Tool policy approval",
+        "A Hermes policy stopped a tool action for explicit approval.",
+    ),
+    "external_consent": (
+        "External consent request",
+        "An external tool requested explicit consent through Hermes.",
+    ),
+    "security_scan": (
+        "Security review approval",
+        "A Hermes security check stopped an action for explicit approval.",
+    ),
+    "protected_action": (
+        "Protected action approval",
+        "Hermes stopped an action that requires explicit approval.",
+    ),
+}
+
+
+def _safe_approval_preview(approval_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Build a bounded preview without echoing approval payload text."""
+    raw_keys = approval_data.get("pattern_keys")
+    if not isinstance(raw_keys, (list, tuple)):
+        raw_keys = [approval_data.get("pattern_key")]
+    keys = {
+        value
+        for value in raw_keys[:32]
+        if isinstance(value, str) and 0 < len(value) <= 160
+    }
+
+    try:
+        from tools.approval import DANGEROUS_PATTERNS
+
+        safe_reason_labels = {
+            description
+            for _, description in DANGEROUS_PATTERNS
+            if isinstance(description, str)
+        }
+    except Exception:
+        safe_reason_labels = set()
+
+    risk_labels = sorted(keys & safe_reason_labels)[:4]
+    if "execute_code" in keys:
+        category = "code_execution"
+    elif "mcp_elicitation" in keys:
+        category = "external_consent"
+    elif risk_labels:
+        category = "terminal_command"
+    elif any(key.startswith("plugin_rule:") for key in keys):
+        category = "tool_policy"
+    elif any(key.startswith("tirith:") for key in keys):
+        category = "security_scan"
+    else:
+        category = "protected_action"
+
+    title, summary = _APPROVAL_PREVIEW_COPY[category]
+    return {
+        "version": 1,
+        "category": category,
+        "title": title,
+        "summary": summary,
+        "risk_labels": risk_labels,
+    }
 
 
 try:
@@ -1252,6 +1327,10 @@ class APIServerAdapter(BasePlatformAdapter):
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
+        # Run callbacks can arrive from multiple threads. Keep every status
+        # read/modify/write sequence on one re-entrant lock so an older
+        # response or progress event cannot overwrite a newer approval wait.
+        self._run_status_lock = threading.RLock()
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
         # Last-known-good resolved model per session (keyed by gateway_session_key
         # ONLY — never session_id, which rotates/is ephemeral for one-off API
@@ -2871,6 +2950,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_events_sse": True,
                 "run_stop": True,
                 "run_approval_response": True,
+                "run_approval_request_binding": True,
+                "run_approval_structured_preview": True,
+                "run_approval_preview_version": 1,
                 "tool_progress_events": True,
                 "approval_events": True,
                 "session_resources": True,
@@ -5974,27 +6056,53 @@ class APIServerAdapter(BasePlatformAdapter):
 
     def _set_run_status(self, run_id: str, status: str, **fields: Any) -> Dict[str, Any]:
         """Update pollable run status without exposing private agent objects."""
-        now = time.time()
-        current = self._run_statuses.get(run_id, {})
-        current.update({
-            "object": "hermes.run",
-            "run_id": run_id,
-            "status": status,
-            "updated_at": now,
-        })
-        current.setdefault("created_at", fields.pop("created_at", now))
-        current.update(fields)
-        self._run_statuses[run_id] = current
-        return current
+        with self._run_status_lock:
+            now = time.time()
+            current = self._run_statuses.get(run_id, {})
+            current.update({
+                "object": "hermes.run",
+                "run_id": run_id,
+                "status": status,
+                "updated_at": now,
+            })
+            current.setdefault("created_at", fields.pop("created_at", now))
+            current.update(fields)
+            self._run_statuses[run_id] = current
+            return current
+
+    def _mark_run_waiting_for_approval(self, run_id: str) -> Dict[str, Any]:
+        with self._run_status_lock:
+            return self._set_run_status(
+                run_id,
+                "waiting_for_approval",
+                last_event="approval.request",
+            )
+
+    def _refresh_run_status_after_approval(
+        self,
+        run_id: str,
+        approval_session_key: str,
+    ) -> str:
+        from tools.approval import has_blocking_approval
+
+        with self._run_status_lock:
+            status = (
+                "waiting_for_approval"
+                if has_blocking_approval(approval_session_key)
+                else "running"
+            )
+            self._set_run_status(run_id, status, last_event="approval.responded")
+            return status
 
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
         def _push(event: Dict[str, Any]) -> None:
-            self._set_run_status(
-                run_id,
-                self._run_statuses.get(run_id, {}).get("status", "running"),
-                last_event=event.get("event"),
-            )
+            with self._run_status_lock:
+                self._set_run_status(
+                    run_id,
+                    self._run_statuses.get(run_id, {}).get("status", "running"),
+                    last_event=event.get("event"),
+                )
             q = self._run_streams.get(run_id)
             if q is None:
                 return
@@ -6249,6 +6357,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
                 def _approval_notify(approval_data: Dict[str, Any]) -> None:
                     event = dict(approval_data or {})
+                    event["preview"] = _safe_approval_preview(event)
                     # Redact credentials from the command before it enters the
                     # SSE/API event stream — same egress bug as #48456, second
                     # transport: API/desktop clients would otherwise receive the
@@ -6266,11 +6375,7 @@ class APIServerAdapter(BasePlatformAdapter):
                             allow_permanent=event.get("allow_permanent") is not False,
                         ),
                     })
-                    self._set_run_status(
-                        run_id,
-                        "waiting_for_approval",
-                        last_event="approval.request",
-                    )
+                    self._mark_run_waiting_for_approval(run_id)
                     try:
                         loop.call_soon_threadsafe(q.put_nowait, event)
                     except Exception:
@@ -6562,6 +6667,8 @@ class APIServerAdapter(BasePlatformAdapter):
             body = await request.json()
         except Exception:
             return web.json_response(_openai_error("Invalid JSON"), status=400)
+        if not isinstance(body, dict):
+            return web.json_response(_openai_error("Invalid JSON object"), status=400)
 
         raw_choice = str(body.get("choice", "")).strip().lower()
         aliases = {"approve": "once", "approved": "once", "allow": "once"}
@@ -6575,6 +6682,19 @@ class APIServerAdapter(BasePlatformAdapter):
                 ),
                 status=400,
             )
+
+        request_id = body.get("request_id") if "request_id" in body else None
+        if request_id is not None:
+            from tools.approval import is_valid_approval_request_id
+
+            if not is_valid_approval_request_id(request_id):
+                return web.json_response(
+                    _openai_error(
+                        "Invalid approval request_id",
+                        code="invalid_approval_request_id",
+                    ),
+                    status=400,
+                )
 
         approval_session_key = self._run_approval_sessions.get(run_id)
         if not approval_session_key:
@@ -6590,47 +6710,74 @@ class APIServerAdapter(BasePlatformAdapter):
             _coerce_request_bool(body.get("all"), default=False)
             or _coerce_request_bool(body.get("resolve_all"), default=False)
         )
+        if request_id is not None and resolve_all:
+            return web.json_response(
+                _openai_error(
+                    "Exact approval request binding cannot be combined with resolve_all",
+                    code="invalid_approval_scope",
+                ),
+                status=400,
+            )
         try:
             from tools.approval import resolve_gateway_approval
 
+            resolve_kwargs = {"resolve_all": resolve_all}
+            if request_id is not None:
+                resolve_kwargs["request_id"] = request_id
             resolved = resolve_gateway_approval(
                 approval_session_key,
                 choice,
-                resolve_all=resolve_all,
+                **resolve_kwargs,
             )
         except Exception as exc:
             logger.exception("[api_server] approval resolution failed for run %s", run_id)
             return web.json_response(_openai_error(str(exc)), status=500)
 
         if resolved <= 0:
+            error_code = (
+                "approval_request_not_pending"
+                if request_id is not None
+                else "approval_not_pending"
+            )
+            message = (
+                f"Run has no pending approval matching request_id: {run_id}"
+                if request_id is not None
+                else f"Run has no pending approval: {run_id}"
+            )
             return web.json_response(
                 _openai_error(
-                    f"Run has no pending approval: {run_id}",
-                    code="approval_not_pending",
+                    message,
+                    code=error_code,
                 ),
                 status=409,
             )
 
-        self._set_run_status(run_id, "running", last_event="approval.responded")
+        self._refresh_run_status_after_approval(run_id, approval_session_key)
         q = self._run_streams.get(run_id)
         if q is not None:
             try:
-                q.put_nowait({
+                responded_event = {
                     "event": "approval.responded",
                     "run_id": run_id,
                     "timestamp": time.time(),
                     "choice": choice,
                     "resolved": resolved,
-                })
+                }
+                if request_id is not None:
+                    responded_event["request_id"] = request_id
+                q.put_nowait(responded_event)
             except Exception:
                 pass
 
-        return web.json_response({
+        response_data = {
             "object": "hermes.run.approval_response",
             "run_id": run_id,
             "choice": choice,
             "resolved": resolved,
-        })
+        }
+        if request_id is not None:
+            response_data["request_id"] = request_id
+        return web.json_response(response_data)
 
     async def _handle_stop_run(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs/{run_id}/stop — interrupt a running agent."""

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -261,6 +261,7 @@ class QQAdapter(BasePlatformAdapter):
         # box; callers can override with set_interaction_callback(None) or
         # register a custom handler.
         self._interaction_callback = self._default_interaction_dispatch
+        self._exec_approval_state: Dict[str, Any] = {}
 
     # ------------------------------------------------------------------
     # Properties
@@ -1139,9 +1140,17 @@ class QQAdapter(BasePlatformAdapter):
 
         approval = parse_approval_button_data(button_data)
         if approval is not None:
-            session_key, decision = approval
+            approval_id, decision = approval
+            state = self._exec_approval_state.get(approval_id)
+            if isinstance(state, dict):
+                session_key = str(state.get("session_key") or "")
+                request_id = str(state.get("request_id") or "")
+            else:
+                # Pre-binding buttons carried the session key directly.
+                session_key = str(state or approval_id)
+                request_id = ""
             choice = self._APPROVAL_BUTTON_TO_CHOICE.get(decision)
-            if choice is None:
+            if choice is None or not session_key:
                 logger.warning(
                     "[%s] Unknown approval decision %r (session=%s)",
                     self._log_tag, decision, session_key,
@@ -1158,7 +1167,16 @@ class QQAdapter(BasePlatformAdapter):
                 # Import lazily to keep the adapter importable in tests that
                 # don't exercise the approval subsystem.
                 from tools.approval import resolve_gateway_approval
-                count = resolve_gateway_approval(session_key, choice)
+                if request_id:
+                    count = resolve_gateway_approval(
+                        session_key,
+                        choice,
+                        request_id=request_id,
+                    )
+                else:
+                    count = resolve_gateway_approval(session_key, choice)
+                if count:
+                    self._exec_approval_state.pop(approval_id, None)
                 logger.info(
                     "[%s] Button resolved %d approval(s) for session %s "
                     "(choice=%s, operator=%s)",
@@ -2689,7 +2707,14 @@ class QQAdapter(BasePlatformAdapter):
         :func:`tools.approval.resolve_gateway_approval` — dispatched by the
         adapter's interaction callback (:meth:`_default_interaction_dispatch`).
         """
-        del metadata  # QQ doesn't have thread_id / DM targeting overrides.
+        request_id = str((metadata or {}).get("approval_request_id") or "")
+        approval_id = request_id or uuid.uuid4().hex
+        self._exec_approval_state[approval_id] = {
+            "session_key": session_key,
+            "request_id": request_id,
+        }
+        while len(self._exec_approval_state) > DEDUP_MAX_SIZE:
+            self._exec_approval_state.pop(next(iter(self._exec_approval_state)))
         del allow_session  # QQ's 3-button keyboard has no session tier (once/always/deny).
         if smart_denied:
             description += " Owner override applies to this one operation only."
@@ -2700,16 +2725,19 @@ class QQAdapter(BasePlatformAdapter):
         msg_id = self._last_msg_id.get(chat_id)
 
         req = ApprovalRequest(
-            session_key=session_key,
+            session_key=approval_id,
             title="Execute this command?",
             description=description,
             command_preview=command,
             timeout_sec=self._APPROVAL_TIMEOUT_SECONDS,
             allow_permanent=allow_permanent and not smart_denied,
         )
-        return await self.send_approval_request(
+        result = await self.send_approval_request(
             chat_id, req, reply_to=msg_id,
         )
+        if not result.success:
+            self._exec_approval_state.pop(approval_id, None)
+        return result
 
     _APPROVAL_TIMEOUT_SECONDS = 300  # matches gateway's default gateway_timeout
 

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -327,12 +327,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # fallback path, same as after a gateway restart).
         #   _clarify_state:        clarify_id → session_key (resolves via
         #                          tools.clarify_gateway.resolve_gateway_clarify)
-        #   _exec_approval_state:  approval_id → session_key (resolves via
-        #                          tools.approval.resolve_gateway_approval)
+        #   _exec_approval_state:  request_id → pending approval metadata
         #   _slash_confirm_state:  confirm_id → session_key (resolves via
         #                          tools.slash_confirm.resolve)
         self._clarify_state: "OrderedDict[str, str]" = OrderedDict()
-        self._exec_approval_state: "OrderedDict[str, str]" = OrderedDict()
+        self._exec_approval_state: "OrderedDict[str, Any]" = OrderedDict()
         self._slash_confirm_state: "OrderedDict[str, str]" = OrderedDict()
 
         # Runtime
@@ -352,7 +351,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         return f"{GRAPH_API_BASE}/{self._api_version}/{self._phone_number_id}/{path}"
 
     @staticmethod
-    def _bounded_put(cache: "OrderedDict[str, str]", key: str, value: str) -> None:
+    def _bounded_put(cache: "OrderedDict[str, Any]", key: str, value: Any) -> None:
         """Insert into a FIFO-capped OrderedDict, evicting oldest entries."""
         cache[key] = value
         while len(cache) > INTERACTIVE_STATE_CACHE_SIZE:
@@ -861,7 +860,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             + ("\n\nSmart DENY: owner override applies to this one operation only." if smart_denied else "")
         )
 
-        approval_id = uuid.uuid4().hex[:12]
+        request_id = str((metadata or {}).get("approval_request_id") or "")
+        approval_id = request_id or uuid.uuid4().hex
         reply_to = (metadata or {}).get("reply_to_message_id") if metadata else None
 
         interactive = {
@@ -883,7 +883,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
         result = await self._post_interactive(chat_id, interactive, reply_to=reply_to)
         if result.success:
-            self._bounded_put(self._exec_approval_state, approval_id, session_key)
+            self._bounded_put(
+                self._exec_approval_state,
+                approval_id,
+                {"session_key": session_key, "request_id": request_id},
+            )
         return result
 
     async def send_slash_confirm(
@@ -1785,8 +1789,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if len(parts) != 3:
                 return False
             _, approval_id, choice = parts
-            session_key = self._exec_approval_state.pop(approval_id, None)
-            if not session_key:
+            state = self._exec_approval_state.pop(approval_id, None)
+            if not state:
                 logger.info(
                     "[whatsapp_cloud] approval tap with no matching state "
                     "(approval_id=%s) — likely stale; falling back to text",
@@ -1794,7 +1798,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 )
                 return False
             if choice not in ("approve", "deny"):
-                self._exec_approval_state[approval_id] = session_key
+                self._exec_approval_state[approval_id] = state
                 return False
             try:
                 from tools.approval import resolve_gateway_approval
@@ -1803,7 +1807,20 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     "[whatsapp_cloud] approval resolver unavailable"
                 )
                 return False
-            count = resolve_gateway_approval(session_key, choice)
+            if isinstance(state, dict):
+                session_key = state["session_key"]
+                request_id = state.get("request_id")
+                if request_id:
+                    count = resolve_gateway_approval(
+                        session_key,
+                        choice,
+                        request_id=request_id,
+                    )
+                else:
+                    count = resolve_gateway_approval(session_key, choice)
+            else:
+                session_key = state
+                count = resolve_gateway_approval(session_key, choice)
             if not count:
                 logger.info(
                     "[whatsapp_cloud] approval resolver reported no waiter "

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -322,8 +322,9 @@ class RelayAdapter(BasePlatformAdapter):
         self._stamp_slack_session_thread(event)
         # Phase 3: a structured prompt answer resolves its waiting primitive
         # (approval/confirm/clarify) and is CONSUMED — it must not also
-        # dispatch as a chat message. Unknown/expired prompt ids fall through
-        # (the command-shaped text then behaves like a typed reply).
+        # dispatch as a chat message. Unknown/expired prompt ids are consumed
+        # too: their command-shaped fallback text must never reach FIFO
+        # approval handling and affect a different pending request.
         if await self._consume_prompt_response(event):
             return
         await self._localize_inbound_media(event)
@@ -1714,9 +1715,14 @@ class RelayAdapter(BasePlatformAdapter):
                 "\n\n**Smart DENY:** owner override applies to this one operation only."
             )
 
+        request_id = str((metadata or {}).get("approval_request_id") or "")
         prompt_id = self._mint_prompt(
             "exec_approval",
-            {"session_key": session_key, "chat_id": str(chat_id)},
+            {
+                "session_key": session_key,
+                "chat_id": str(chat_id),
+                "request_id": request_id,
+            },
         )
         result = await self._send_prompt(
             chat_id,
@@ -1829,12 +1835,9 @@ class RelayAdapter(BasePlatformAdapter):
     async def _consume_prompt_response(self, event) -> bool:
         """Route an inbound prompt_response to its waiting primitive.
 
-        Returns True when the event was a prompt answer (consumed — do NOT
-        dispatch it as a chat message), False otherwise. Unknown/expired
-        prompt ids fall through to normal dispatch: the command-shaped text
-        ("/once", "/deny", …) then behaves like a typed reply, which the
-        approval/confirm text lanes already understand — the same stale-tap
-        degradation the native adapters implement with an "expired" edit.
+        Returns True when the event was a structured prompt answer (consumed —
+        do NOT dispatch it as a chat message), False for ordinary messages.
+        Unknown, malformed, and expired structured responses fail closed.
         """
         pr = getattr(event, "prompt_response", None)
         if not isinstance(pr, dict):
@@ -1842,20 +1845,32 @@ class RelayAdapter(BasePlatformAdapter):
         prompt_id = str(pr.get("prompt_id") or "")
         option_id = str(pr.get("option_id") or "")
         if not prompt_id or not option_id:
-            return False
+            logger.info("relay received malformed structured prompt_response")
+            return True
         state = self._pop_prompt(prompt_id)
         if state is None:
             logger.info(
                 "relay prompt_response for unknown/expired prompt %s (option=%s) — "
-                "falling through to text dispatch",
+                "consuming without text fallback",
                 prompt_id,
                 option_id,
             )
-            return False
+            chat_id = str(getattr(event.source, "chat_id", ""))
+            if chat_id:
+                try:
+                    await self.send(
+                        chat_id,
+                        "⌛ That prompt has already expired or was resolved.",
+                        metadata=self._prompt_reply_metadata(event),
+                    )
+                except Exception:
+                    logger.debug("relay expired-prompt notice failed", exc_info=True)
+            return True
 
         kind = state.get("kind")
         chat_id = str(state.get("chat_id") or getattr(event.source, "chat_id", ""))
         session_key = str(state.get("session_key") or "")
+        request_id = str(state.get("request_id") or "")
         try:
             if kind == "exec_approval":
                 from tools.approval import resolve_gateway_approval
@@ -1865,7 +1880,14 @@ class RelayAdapter(BasePlatformAdapter):
                     if option_id in {"once", "session", "always", "deny"}
                     else "deny"
                 )
-                count = resolve_gateway_approval(session_key, choice)
+                if request_id:
+                    count = resolve_gateway_approval(
+                        session_key,
+                        choice,
+                        request_id=request_id,
+                    )
+                else:
+                    count = resolve_gateway_approval(session_key, choice)
                 label = {
                     "once": "✅ Approved once",
                     "session": "✅ Approved for session",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4815,6 +4815,10 @@ class TurnRunner:
 
             cmd = approval_data.get("command", "")
             desc = approval_data.get("description", "dangerous command")
+            approval_metadata = dict(ctx._status_thread_metadata or {})
+            request_id = approval_data.get("request_id")
+            if request_id:
+                approval_metadata["approval_request_id"] = request_id
 
             # Redact credentials from the command before displaying it in
             # the approval prompt — Tirith's findings are already redacted,
@@ -4835,7 +4839,7 @@ class TurnRunner:
                             command=cmd,
                             session_key=_approval_session_key,
                             description=desc,
-                            metadata=ctx._status_thread_metadata,
+                            metadata=approval_metadata or None,
                             allow_permanent=approval_data.get("allow_permanent", True),
                             allow_session=approval_data.get("allow_session", True),
                             smart_denied=approval_data.get("smart_denied", False),

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6804,6 +6804,7 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
+            request_id = str((metadata or {}).get("approval_request_id") or "")
             # Resolve channel — use thread_id from metadata if present
             target_id = chat_id
             if metadata and metadata.get("thread_id"):
@@ -6862,6 +6863,7 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             view = ExecApprovalView(
                 session_key=session_key,
+                request_id=request_id,
                 allowed_user_ids=self._allowed_user_ids,
                 allowed_role_ids=self._allowed_role_ids,
                 require_admin=require_admin,
@@ -8134,9 +8136,11 @@ def _define_discord_view_classes() -> None:
             allow_permanent: bool = True,
             allow_session: bool = True,
             smart_denied: bool = False,
+            request_id: str = "",
         ):
             super().__init__(timeout=_read_discord_prompt_timeout())
             self.session_key = session_key
+            self.request_id = request_id
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
             # Opt-in admin gate for exec approval (default off → user-scope,
@@ -8210,7 +8214,14 @@ def _define_discord_view_classes() -> None:
             # must not claim "Approved" — the command was already denied.
             try:
                 from tools.approval import resolve_gateway_approval
-                count = resolve_gateway_approval(self.session_key, choice)
+                if self.request_id:
+                    count = resolve_gateway_approval(
+                        self.session_key,
+                        choice,
+                        request_id=self.request_id,
+                    )
+                else:
+                    count = resolve_gateway_approval(self.session_key, choice)
                 logger.info(
                     "Discord button resolved %d approval(s) for session %s (choice=%s, user=%s)",
                     count, self.session_key, choice, interaction.user.display_name,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1502,8 +1502,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._media_batch_state = FeishuBatchState()
         self._pending_media_batches = self._media_batch_state.events
         self._pending_media_batch_tasks = self._media_batch_state.tasks
-        # Exec approval button state (approval_id → {session_key, message_id, chat_id})
-        self._approval_state: Dict[int, Dict[str, str]] = {}
+        # Exec approval button state (request_id → pending approval metadata)
+        self._approval_state: Dict[str, Dict[str, str]] = {}
         self._approval_counter = itertools.count(1)
         # Update prompt button state (prompt_id → {session_key, message_id, chat_id})
         self._update_prompt_state: Dict[int, Dict[str, str]] = {}
@@ -2024,7 +2024,8 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
-            approval_id = next(self._approval_counter)
+            request_id = str((metadata or {}).get("approval_request_id") or "")
+            approval_id = request_id or uuid.uuid4().hex
 
             def _btn(label: str, action_name: str, btn_type: str = "default") -> dict:
                 return {
@@ -2071,6 +2072,7 @@ class FeishuAdapter(BasePlatformAdapter):
             if result.success:
                 self._approval_state[approval_id] = {
                     "session_key": session_key,
+                    "request_id": request_id,
                     "message_id": result.message_id or "",
                     "chat_id": chat_id,
                 }
@@ -2873,7 +2875,15 @@ class FeishuAdapter(BasePlatformAdapter):
             return
         try:
             from tools.approval import resolve_gateway_approval
-            count = resolve_gateway_approval(state["session_key"], choice)
+            request_id = state.get("request_id")
+            if request_id:
+                count = resolve_gateway_approval(
+                    state["session_key"],
+                    choice,
+                    request_id=request_id,
+                )
+            else:
+                count = resolve_gateway_approval(state["session_key"], choice)
             logger.info(
                 "Feishu button resolved %d approval(s) for session %s (choice=%s, user=%s)",
                 count, state["session_key"], choice, user_name,

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -448,11 +448,13 @@ class _MatrixApprovalPrompt:
         session_key: str,
         chat_id: str,
         message_id: str,
+        request_id: str = "",
         resolved: bool = False,
         requester_user_id: str | None = None,
         expires_at: float | None = None,
     ):
         self.session_key = session_key
+        self.request_id = request_id
         self.chat_id = chat_id
         self.message_id = message_id
         self.resolved = resolved
@@ -2247,6 +2249,7 @@ class MatrixAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         requester_user_id = str((metadata or {}).get("requester_user_id") or "") or None
+        request_id = str((metadata or {}).get("approval_request_id") or "")
         scope_choices = ""
         if smart_denied:
             scope_choices = "Smart DENY: owner override applies to this one operation only.\n"
@@ -2275,14 +2278,12 @@ class MatrixAdapter(BasePlatformAdapter):
 
         prompt = _MatrixApprovalPrompt(
             session_key=session_key,
+            request_id=request_id,
             chat_id=chat_id,
             message_id=result.message_id,
             requester_user_id=requester_user_id,
             expires_at=time.monotonic() + max(self._approval_timeout_seconds, 0),
         )
-        old_event = self._approval_prompt_by_session.get(session_key)
-        if old_event:
-            self._approval_prompts_by_event.pop(old_event, None)
         self._approval_prompts_by_event[result.message_id] = prompt
         self._approval_prompt_by_session[session_key] = result.message_id
 
@@ -3610,11 +3611,19 @@ class MatrixAdapter(BasePlatformAdapter):
                 try:
                     from tools.approval import resolve_gateway_approval
 
-                    count = resolve_gateway_approval(prompt.session_key, choice)
+                    if prompt.request_id:
+                        count = resolve_gateway_approval(
+                            prompt.session_key,
+                            choice,
+                            request_id=prompt.request_id,
+                        )
+                    else:
+                        count = resolve_gateway_approval(prompt.session_key, choice)
                     if count:
                         prompt.resolved = True
                         self._approval_prompts_by_event.pop(reacts_to, None)
-                        self._approval_prompt_by_session.pop(prompt.session_key, None)
+                        if self._approval_prompt_by_session.get(prompt.session_key) == reacts_to:
+                            self._approval_prompt_by_session.pop(prompt.session_key, None)
                         logger.info(
                             "Matrix reaction resolved %d approval(s) for session %s "
                             "(choice=%s, user=%s)",
@@ -3763,7 +3772,8 @@ class MatrixAdapter(BasePlatformAdapter):
     ) -> None:
         prompt.resolved = True
         self._approval_prompts_by_event.pop(target_event_id, None)
-        self._approval_prompt_by_session.pop(prompt.session_key, None)
+        if self._approval_prompt_by_session.get(prompt.session_key) == target_event_id:
+            self._approval_prompt_by_session.pop(prompt.session_key, None)
         await self._redact_bot_approval_reactions(room_id, prompt)
         await self._send_invalid_reaction_feedback(
             room_id,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -951,6 +951,7 @@ class SlackAdapter(BasePlatformAdapter):
         # be workspace-scoped markers (team_id, ts) in multi-workspace mode.
         self._approval_resolved: Dict[Any, bool] = {}
         self._APPROVAL_RESOLVED_MAX = 1000
+        self._approval_request_state: Dict[str, str] = {}
         # Same guard for clarify prompts (interactive multiple-choice
         # buttons); mirrors _approval_resolved.
         self._clarify_resolved: Dict[Any, bool] = {}
@@ -6365,6 +6366,8 @@ class SlackAdapter(BasePlatformAdapter):
             chat_id, team_id=self._metadata_team_id(metadata)
         )
         try:
+            request_id = str((metadata or {}).get("approval_request_id") or "")
+            button_value = request_id or session_key
             thread_ts = self._resolve_thread_ts(None, metadata)
 
             # Slack hard-caps a section block's text at 3000 chars; an
@@ -6387,7 +6390,7 @@ class SlackAdapter(BasePlatformAdapter):
                     "text": {"type": "plain_text", "text": "Allow Once"},
                     "style": "primary",
                     "action_id": "hermes_approve_once",
-                    "value": session_key,
+                    "value": button_value,
                 },
             ]
             if not smart_denied and allow_session:
@@ -6395,21 +6398,21 @@ class SlackAdapter(BasePlatformAdapter):
                     "type": "button",
                     "text": {"type": "plain_text", "text": "Allow Session"},
                     "action_id": "hermes_approve_session",
-                    "value": session_key,
+                    "value": button_value,
                 })
                 if allow_permanent:
                     actions.append({
                         "type": "button",
                         "text": {"type": "plain_text", "text": "Always Allow"},
                         "action_id": "hermes_approve_always",
-                        "value": session_key,
+                        "value": button_value,
                     })
             actions.append({
                 "type": "button",
                 "text": {"type": "plain_text", "text": "Deny"},
                 "style": "danger",
                 "action_id": "hermes_deny",
-                "value": session_key,
+                "value": button_value,
             })
             blocks = [
                 {
@@ -6439,6 +6442,12 @@ class SlackAdapter(BasePlatformAdapter):
                 self._approval_resolved[
                     self._workspace_message_marker(team_id, msg_ts)
                 ] = False
+                if request_id:
+                    self._approval_request_state[request_id] = session_key
+                    while len(self._approval_request_state) > self._APPROVAL_RESOLVED_MAX:
+                        self._approval_request_state.pop(
+                            next(iter(self._approval_request_state))
+                        )
                 self._trim_oldest_dict_entries(
                     self._approval_resolved, self._APPROVAL_RESOLVED_MAX
                 )
@@ -6848,7 +6857,7 @@ class SlackAdapter(BasePlatformAdapter):
 
         team_id = self._event_team_id({}, body)
         action_id = action.get("action_id", "")
-        session_key = action.get("value", "")
+        request_id = action.get("value", "")
         message = body.get("message", {})
         msg_ts = message.get("ts", "")
         channel_id = body.get("channel", {}).get("id", "")
@@ -6901,13 +6910,25 @@ class SlackAdapter(BasePlatformAdapter):
         if self._approval_resolved.pop(approval_key, True):
             return
 
+        session_key = self._approval_request_state.pop(request_id, "")
+        exact_request = bool(session_key)
+        if not session_key:
+            session_key = request_id
+
         # Resolve the approval FIRST — this unblocks the agent thread. Render
         # after, so a click that lands past the approval timeout (count == 0)
         # shows "expired" instead of falsely claiming the command was approved.
         try:
             from tools.approval import resolve_gateway_approval
 
-            count = resolve_gateway_approval(session_key, choice)
+            if exact_request:
+                count = resolve_gateway_approval(
+                    session_key,
+                    choice,
+                    request_id=request_id,
+                )
+            else:
+                count = resolve_gateway_approval(session_key, choice)
             logger.info(
                 "Slack button resolved %d approval(s) for session %s (choice=%s, user=%s)",
                 count,

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -1014,6 +1014,7 @@ class TeamsAdapter(BasePlatformAdapter):
         data = action.data or {}
         hermes_action = data.get("hermes_action", "")
         session_key = data.get("session_key", "")
+        request_id = data.get("request_id", "")
 
         if not hermes_action or not session_key:
             return InvokeResponse(
@@ -1074,7 +1075,21 @@ class TeamsAdapter(BasePlatformAdapter):
                 ),
             )
 
-        resolve_gateway_approval(session_key, choice)
+        if request_id:
+            resolved = resolve_gateway_approval(
+                session_key,
+                choice,
+                request_id=request_id,
+            )
+        else:
+            resolved = resolve_gateway_approval(session_key, choice)
+        if not resolved:
+            return InvokeResponse(
+                status=200,
+                body=AdaptiveCardActionMessageResponse(
+                    value="Approval already resolved or expired."
+                ),
+            )
 
         label_map = {
             "once": "✅ Allowed (once)",
@@ -1115,9 +1130,11 @@ class TeamsAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Teams app not initialized")
 
         cmd_preview = command[:2000] + "..." if len(command) > 2000 else command
+        request_id = str((metadata or {}).get("approval_request_id") or "")
         # Truncated for button data payload — just enough to reconstruct the card body.
         btn_data_base = {
             "session_key": session_key,
+            "request_id": request_id,
             "cmd": command[:200] + "..." if len(command) > 200 else command,
             "desc": description,
         }

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -18,6 +18,7 @@ import html as _html
 import re
 import threading
 import time
+import uuid
 from contextvars import ContextVar
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
@@ -827,8 +828,8 @@ class TelegramAdapter(BasePlatformAdapter):
         # Interactive model picker state per chat
         self._model_picker_state: Dict[str, dict] = {}
         self._choice_picker_state: Dict[str, dict] = {}
-        # Approval button state: message_id → session_key
-        self._approval_state: Dict[int, str] = {}
+        # Approval button state: request_id → pending approval metadata
+        self._approval_state: Dict[str, Any] = {}
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
         # and any other slash-confirm prompts; see GatewayRunner._request_slash_confirm).
         self._slash_confirm_state: Dict[str, str] = {}
@@ -5350,13 +5351,8 @@ class TelegramAdapter(BasePlatformAdapter):
             # Resolve thread context for thread replies
             thread_id = self._metadata_thread_id(metadata)
 
-            # We'll use the message_id as part of callback_data to look up session_key
-            # Send a placeholder first, then update — or use a counter.
-            # Simpler: use a monotonic counter to generate short IDs.
-            import itertools
-            if not hasattr(self, "_approval_counter"):
-                self._approval_counter = itertools.count(1)
-            approval_id = next(self._approval_counter)
+            request_id = str((metadata or {}).get("approval_request_id") or "")
+            approval_id = request_id or uuid.uuid4().hex
 
             buttons = [
                 InlineKeyboardButton("✅ Allow Once", callback_data=f"ea:once:{approval_id}")
@@ -5396,8 +5392,10 @@ class TelegramAdapter(BasePlatformAdapter):
 
             msg = await self._send_message_with_thread_fallback(**kwargs)
 
-            # Store session_key keyed by approval_id for the callback handler
-            self._approval_state[approval_id] = session_key
+            self._approval_state[approval_id] = {
+                "session_key": session_key,
+                "request_id": request_id,
+            }
 
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -6242,9 +6240,8 @@ class TelegramAdapter(BasePlatformAdapter):
             parts = data.split(":", 2)
             if len(parts) == 3:
                 choice = parts[1]  # once, session, always, deny
-                try:
-                    approval_id = int(parts[2])
-                except (ValueError, IndexError):
+                request_id = parts[2]
+                if not request_id:
                     await query.answer(text="Invalid approval data.")
                     return
 
@@ -6260,8 +6257,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     await query.answer(text="⛔ You are not authorized to approve commands.")
                     return
 
-                session_key = self._approval_state.pop(approval_id, None)
-                if not session_key:
+                state = self._approval_state.get(request_id)
+                if state is None and request_id.isdigit():
+                    state = self._approval_state.get(int(request_id))
+                if not state:
                     await query.answer(text="This approval has already been resolved.")
                     return
 
@@ -6275,7 +6274,20 @@ class TelegramAdapter(BasePlatformAdapter):
                 # regression follow-up: 60s waits made stale taps common).
                 try:
                     from tools.approval import resolve_gateway_approval
-                    count = resolve_gateway_approval(session_key, choice)
+                    if isinstance(state, dict):
+                        session_key = state["session_key"]
+                        exact_request_id = state.get("request_id")
+                        if exact_request_id:
+                            count = resolve_gateway_approval(
+                                session_key,
+                                choice,
+                                request_id=exact_request_id,
+                            )
+                        else:
+                            count = resolve_gateway_approval(session_key, choice)
+                    else:
+                        session_key = state
+                        count = resolve_gateway_approval(session_key, choice)
                     logger.info(
                         "Telegram button resolved %d approval(s) for session %s (choice=%s, user=%s)",
                         count, session_key, choice, user_display,
@@ -6283,6 +6295,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 except Exception as exc:
                     logger.error("Failed to resolve gateway approval from Telegram button: %s", exc)
                     count = 0
+                finally:
+                    self._approval_state.pop(request_id, None)
+                    if request_id.isdigit():
+                        self._approval_state.pop(int(request_id), None)
 
                 if count:
                     # Map choice to human-readable label

--- a/reviews/2026-07-30-approval-request-binding.md
+++ b/reviews/2026-07-30-approval-request-binding.md
@@ -1,0 +1,388 @@
+# Feature Slice Review: Bind displayed approvals to exact queued requests
+
+Status: In progress  
+Slice: `approval-request-binding`  
+Date: `2026-07-30`  
+Review log: `reviews/2026-07-30-approval-request-binding.md`
+
+## Slice contract
+
+### Goal
+
+Every interactive approval surface resolves the precise queued request shown to
+the user, while typed approval commands and clients that omit a request ID keep
+their existing FIFO behavior.
+
+### In scope
+
+- Give each queued gateway approval a validated, stable request ID and include
+  it in the notification payload.
+- Resolve an exact pending entry by request ID without disturbing sibling
+  entries.
+- Port request binding and the existing authorization seam through the current
+  native messaging adapters.
+- Carry request binding through the Relay prompt state and response path.
+- Carry request binding through the TUI/Desktop approval event and response
+  protocol without changing the rendered controls.
+- Expose exact request binding through the Runs API, including stale-ID
+  rejection, capability flags, pending-status handling, and a fixed,
+  server-owned structured preview.
+- Preserve redaction, adapter-local authorization, and legacy FIFO behavior.
+- Update the relevant API and TUI protocol documentation.
+
+### Out of scope
+
+- Changing approval choices or approval policy.
+- Redesigning approval controls or adding user-facing copy.
+- Removing or changing the typed `/approve` and `/deny` FIFO contract.
+- Unrelated current-main refactors, host-specific test repairs, or CI changes.
+- Closing or modifying PR #6105.
+
+### Acceptance criteria
+
+| ID | Observable criterion | Evidence | Status |
+| --- | --- | --- | --- |
+| AC-1 | Selecting the second of two pending approvals resolves only the second and leaves the first pending. | Queue-core and live-transport regression tests. | Pass |
+| AC-2 | An unknown, invalid, or stale request ID resolves nothing and fails closed at public protocol boundaries. | Core, Relay, TUI gateway, and Runs API negative-path tests. | Pass |
+| AC-3 | Exact request selection cannot be combined with `all` or `resolve_all`. | Runs API and TUI gateway validation tests. | Pass |
+| AC-4 | Native adapters, Relay, TUI, Desktop, and the Runs API round-trip the displayed request ID. | Adapter, protocol, and client behavior tests. | Pass |
+| AC-5 | Clients and typed commands that omit a request ID retain FIFO behavior. | Existing FIFO regression tests plus compatibility tests. | Pass |
+| AC-6 | A run remains `waiting_for_approval` while another request is pending. | Mounted Runs API two-request integration test. | Pass |
+| AC-7 | Existing authorization and command-redaction behavior does not regress. | Authorization and redaction suites. | Pass |
+| AC-8 | Structured Runs API previews contain only fixed Hermes-owned categories and allowlisted labels. | Preview allowlist and secret/path exclusion tests. | Pass |
+
+### Constraints and recovery
+
+- Safety: Resolve only the selected entry; stale identities fail closed;
+  authorization remains ahead of resolution; preview fields never echo command,
+  plugin, credential, or private-path text.
+- Compatibility: No-ID clients and typed commands retain FIFO semantics. New
+  clients send a request ID; new backends accept both modes.
+- Rendered behavior: Existing approval controls, choices, layout, and copy stay
+  unchanged. Only protocol state gains the request ID.
+- Rollback or recovery: No data migration or persisted schema is introduced.
+  The slice can be reverted as code and documentation commits.
+- Documentation targets:
+  `website/docs/developer-guide/programmatic-integration.md`,
+  `website/docs/user-guide/features/api-server.md`, and `ui-tui/README.md`.
+- Version-control strategy: Work from
+  `codex/http-approval-request-binding-rewrite` based on
+  `upstream/main@8defb9fd6`; preserve mr.Shu's authorship for the
+  contributor-derived commit; publish to the existing PR branch only after the
+  final publication gate.
+
+### Scope discussion and approval
+
+- Recommendation and rationale: Close the complete displayed-request bug class,
+  including the reviewer-requested Relay path and the equivalent current-main
+  TUI/Desktop path, while preserving the existing Runs API extension.
+- Alternatives considered: Relay-only would be smaller but leave TUI/Desktop
+  with the same FIFO substitution risk; dropping the structured Runs API
+  preview would discard an already-reviewed safety boundary.
+- User decisions: Approved the proposed slice, review-log path, and
+  version-control strategy.
+- Approved at: 2026-07-30, user response: "yes I approve. lets do it".
+
+## Test strategy
+
+| Acceptance criterion | Pre-implementation gap | Planned test or evidence | What it proves | Limitations |
+| --- | --- | --- | --- | --- |
+| AC-1 | Core, Relay, and TUI/Desktop currently resolve by session FIFO. | Two-entry queue tests at core, Relay, TUI gateway, and mounted Runs API layers. | The selected second request is the only entry signalled and the first remains pending. | Native service SDKs remain mocked at the network edge. |
+| AC-2 | Public handlers accept no exact selector today. | Invalid-format, unknown, expired, and double-response tests. | Bad or stale identities cannot fall back to another pending action. | Does not simulate every real network retry ordering. |
+| AC-3 | `all` currently has no request-ID interaction to validate. | Protocol tests for request ID plus `all`/`resolve_all`. | Exact and bulk scopes cannot be mixed ambiguously. | Limited to public protocol boundaries where bulk scope exists. |
+| AC-4 | Events and client state omit the approval request ID. | Native adapter payload tests, Relay state test, TUI event/type/response tests, Desktop store/component/notification tests, Runs API SSE test. | The ID survives every displayed approval round trip. | No visual screenshot is needed because layout/copy do not change. |
+| AC-5 | Existing FIFO behavior is intentional compatibility. | Existing FIFO tests plus explicit no-ID API/TUI tests. | Legacy callers and typed commands retain their contract. | Does not guarantee behavior of unknown third-party clients beyond the documented protocol. |
+| AC-6 | Runs API always marks a successful response `running`. | Mounted API test with two live pending entries. | Status accurately reports that another approval still blocks the run. | Exercises the server boundary without launching a real model provider. |
+| AC-7 | The port crosses several authorization and redaction seams. | Existing authorization/redaction suites plus exact-ID assertions after authorization. | Request binding cannot bypass actor checks or leak unredacted commands. | External platform authorization APIs remain represented by established test doubles. |
+| AC-8 | Existing API events expose redacted but still free-form fields. | Structured-preview category, allowlist, truncation, credential/path, and plugin-text tests. | The advertised preview is bounded and server-owned. | Legacy free-form event fields remain for compatibility; clients must use the advertised preview capability. |
+
+### Baseline results
+
+| Command or action | Environment | Result | Notes |
+| --- | --- | --- | --- |
+| Source and call-path inspection | macOS worktree at `upstream/main@1fd7548b4` | Fail (gap reproduced) | Core, Runs API, Relay, and TUI gateway all resolve displayed approvals without a request selector. |
+| GitHub review inspection | PR #68080 | Pass | One actionable top-level reviewer cluster; no inline review threads; branch conflicts; no checks reported. |
+| `HERMES_PYTHON=/Users/hazeion/projects/hermes-agent/.venv/bin/python HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/gateway/test_approve_deny_commands.py tests/gateway/relay/test_relay_interactive.py tests/gateway/test_api_server_runs.py tests/gateway/test_tui_approval_redaction.py` | macOS, sandboxed workspace | Environment-limited | 27 passed; 12 mounted Runs API tests failed because the sandbox rejected loopback socket binding with `PermissionError: [Errno 1]`. |
+| `HERMES_PYTHON=/Users/hazeion/projects/hermes-agent/.venv/bin/python HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/gateway/test_api_server_runs.py` | macOS, host execution | Pass | 16 passed; confirms the sandbox-only socket failures are not a current-main regression. |
+| New exact-request core and Relay regression tests | macOS, sandboxed workspace | Expected fail | Three tests failed on pristine current-main behavior: the core rejected the new `request_id` argument/import, and Relay resolved the older FIFO entry instead of the displayed second request. |
+
+### Test discussion and approval
+
+- User questions and decisions: Approved the proposed focused, safety,
+  compatibility, full-suite, and documentation checks.
+- Accepted coverage gaps:
+  - Platform network APIs remain behind the repository's established test
+    doubles.
+  - No screenshot comparison is required because approval controls, layout,
+    and wording do not change.
+  - Third-party legacy clients are represented by documented no-ID protocol
+    compatibility tests rather than tested individually.
+- Approved at: 2026-07-30, user response: "yes".
+
+## Implementation record
+
+### Changes
+
+- The approval queue now assigns a validated request ID to every entry and can
+  resolve one exact entry without disturbing its siblings. Typed commands and
+  callers that omit the ID retain FIFO behavior.
+- Gateway notifications carry the request ID through Relay and the current
+  native messaging adapters. Each adapter keeps its existing authorization
+  gate ahead of resolution, uses an ID short enough for Telegram callback data,
+  and fails closed when a displayed request has expired.
+- The Runs API and TUI/Desktop JSON-RPC protocols accept an optional request
+  ID, reject ambiguous exact-plus-bulk requests, and return a stale-request
+  error without falling back to FIFO.
+- Runs API approval events advertise request-binding and structured-preview
+  capabilities. The preview is fixed server-owned data with allowlisted risk
+  labels; it does not echo commands, paths, plugin text, or credentials.
+- TUI and Desktop client state round-trip the request ID without changing
+  approval controls, choices, layout, or copy.
+- Desktop native notifications capture the immutable request ID in the
+  notification action itself. Late Desktop and TUI responses clear client
+  state only when the completed response still matches the visible request.
+- Relay consumes malformed, unknown, expired, and replayed structured
+  responses without falling back to typed FIFO denial. Matrix retains each
+  same-session event-to-request mapping until that event is resolved or
+  expires.
+- Runs API status transitions share one re-entrant lock. An older approval
+  response or tool-progress callback cannot overwrite a newer
+  `waiting_for_approval` transition.
+- Regression coverage now exercises exact second-request selection, stale and
+  invalid IDs, legacy no-ID FIFO behavior, authorization order, redaction,
+  sibling-pending run state, structured-response replay, late client
+  completions, same-session Matrix prompts, and transport-specific request
+  propagation.
+
+### Deviations and decisions
+
+- The request-ID grammar is deliberately limited to 48 transport-safe
+  characters because Telegram's 64-byte callback-data limit is the tightest
+  native transport in scope.
+- The existing adapter-local authorization checks were preserved. The stale
+  PR's removed global base-adapter authorization seam was not restored because
+  current main has explicit platform-specific authorization behavior.
+- The branch was refreshed from `upstream/main@1fd7548b4` to
+  `upstream/main@8defb9fd6` after implementation. The two intervening upstream
+  commits changed only
+  `apps/desktop/src/app/chat/composer/status-stack/index.tsx`, outside this
+  slice, and the uncommitted rewrite applied without conflict.
+- TUI and Desktop still render one approval prompt per session, as they did
+  before this slice. Exact binding prevents a visible prompt from resolving
+  the wrong queue entry or clearing a newer prompt, but an older sibling is not
+  automatically resurfaced. A true multi-prompt UI remains a separate product
+  change.
+
+## Verification
+
+### Focused checks
+
+| Command or action | Environment | Exit/result | Pass/fail/skip counts | Notes or artifacts |
+| --- | --- | --- | --- | --- |
+| Core queue and Relay request-binding suites | macOS worktree | Pass | 25 passed | Includes exact second-entry selection, stale-ID no-op, unique IDs, Relay state binding, and legacy no-ID FIFO. |
+| TUI gateway exact-request cases | macOS worktree | Pass | 2 passed | Exact selection, stale failure, exact-plus-bulk rejection, and compatibility behavior were also covered by the later full gateway file. |
+| Native adapter approval, authorization, and redaction suite | macOS host execution | Pass | 227 passed | Thirteen QQ, WhatsApp, Slack, Telegram, Feishu, Teams, Discord, and Matrix files. |
+| Runs API, queue-command, Relay, and Matrix suites | macOS host execution | Pass | 142 passed | Includes mounted two-pending-request behavior, safe preview, capability flags, stale IDs, legacy FIFO, replay consumption, same-session Matrix bindings, and serialized response/progress status races. |
+| Desktop focused post-review suites | Node/Vitest on macOS | Pass | 35 passed | Exact component response, immutable native-notification action binding, late completion, and newer-prompt preservation. |
+| TUI focused post-review suites | Node/Vitest on macOS | Pass | 98 passed | Event propagation plus exact guarded clearing for matching, stale, and legacy prompts. |
+| TUI and Desktop type checks | Node/TypeScript on macOS | Pass | 2 commands passed | No TypeScript errors. |
+| TUI lint | Node/ESLint on macOS | Pass | 0 errors | Clean. |
+| Desktop lint | Node/ESLint on macOS | Pass with warnings | 0 errors, 74 warnings | Warnings are pre-existing; no new lint errors. |
+| Desktop full UI suite | Node/Vitest on macOS host execution | Pass | 3,994 passed, 2 skipped | 428 files passed and 1 skipped. Sequential host rerun avoided the timing failures seen under concurrent load. |
+| TUI full UI suite | Node/Vitest on macOS host execution | Pass | 1,439 passed, 1 skipped | 134 files passed. Sequential host rerun avoided sandbox watcher exhaustion. |
+| `git diff --check` | macOS worktree | Pass | 0 whitespace errors | Run repeatedly after implementation. |
+| `scripts/run_tests.sh tests/tools/test_approval.py` | macOS worktree | Mixed, unrelated baseline issue | 89 passed, 1 failed | Existing untouched test assumes mocked `/tmp` remains canonical on macOS; implementation diff does not touch dangerous-command detection or this test. |
+
+### Full suite
+
+| Command or action | Environment | Exit/result | Pass/fail/skip counts | Notes |
+| --- | --- | --- | --- | --- |
+| `HERMES_PYTHON=/Users/hazeion/projects/hermes-agent/.venv/bin/python HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh` | macOS host execution, 16 workers | Mixed | 22,813 passed, 24 failed across 16 files | All changed feature suites passed. The failures are in untouched shutdown/systemd, provider, update, monitoring, service, macOS temp-path, computer-use, file/performance, execution-flag, Modal, audio, and transcription tests. Heavy parallelism also triggered platform-specific and timing failures. Exact failing files are retained below for audit. |
+
+Full-run failing files:
+
+- `tests/gateway/test_shutdown_forensics.py`
+- `tests/gateway/test_systemd_notify.py`
+- `tests/hermes_cli/test_runtime_provider_resolution.py`
+- `tests/hermes_cli/test_gateway_service.py`
+- `tests/hermes_cli/test_update_eol_churn.py`
+- `tests/monitoring/test_otlp_exporter.py`
+- `tests/hermes_cli/test_service_manager.py`
+- `tests/tools/test_approval.py`
+- `tests/tools/test_computer_use.py`
+- `tests/tools/test_file_sync_perf.py`
+- `tests/tools/test_file_tools.py`
+- `tests/tools/test_execution_flag_detection.py`
+- `tests/tools/test_modal_snapshot_isolation.py`
+- `tests/tools/test_tts_command_providers.py`
+- `tests/tools/test_transcription_tools.py`
+- `tests/tools/test_voice_mode.py`
+
+No failing test file is modified by this branch. The one failure in the
+approval subsystem was rerun separately and remained confined to an untouched
+dangerous-`rm` macOS path assertion; all 89 sibling tests passed.
+
+### Rendered or manual behavior
+
+- Not applicable unless implementation changes rendered output.
+
+## Adversarial review
+
+### Round 1
+
+Two independent, read-only reviewers examined the implementation and tests:
+
+- Security/reliability reviewer: changes requested.
+  - Desktop native notification actions looked up mutable session state instead
+    of carrying the request ID captured when the notification was created.
+  - Replayed or expired Relay structured responses could fall through to a
+    typed FIFO `/deny`.
+  - Late Desktop/TUI exact-response completions could clear a newer prompt.
+  - An older Runs API response could race with a newer approval notification
+    and overwrite `waiting_for_approval` with `running`.
+- Compatibility/integration reviewer: changes requested.
+  - Confirmed the Desktop native-action and late-completion issues.
+  - Found that a second same-session Matrix prompt removed the first event's
+    request mapping, making the still-visible older reaction inert.
+
+All five findings were accepted. The implementation now carries immutable
+Desktop action IDs, consumes invalid structured Relay responses without FIFO
+fallback, guards client clearing by exact ID, serializes Runs API status
+transitions, and preserves independent Matrix event bindings. Dedicated
+regressions were added for every finding.
+
+### Round 2
+
+The same two reviewers re-examined the corrected slice on
+`upstream/main@8defb9fd6`:
+
+- Compatibility/integration reviewer: approved. All eight acceptance criteria
+  passed, all round-one findings were resolved, and no new P0-P2 issue was
+  found.
+- Security/reliability reviewer: changes requested. The reviewer found one
+  additional P2 status race: a tool-progress callback could snapshot
+  `running`, then overwrite a newer `waiting_for_approval` transition because
+  that read/modify/write path did not share the approval status lock.
+
+The P2 was accepted. All run-status writes now use a shared
+`threading.RLock`, and the tool-progress callback holds it across the current
+status lookup and update. A deterministic barrier regression reproduces the
+old interleaving and verifies that the newer approval wait wins. The complete
+affected Python set passes with 142 tests.
+
+### Round 3
+
+Both reviewers approved the final slice on `upstream/main@8defb9fd6`:
+
+- Security/reliability reviewer: approved with no remaining P0-P2 findings.
+  The reviewer confirmed the shared `RLock`, queue-sampling critical section,
+  tool-progress critical section, lock ordering, and deterministic regression.
+- Compatibility/integration reviewer: approved with no P0-P2 findings. The
+  reviewer confirmed that re-entrancy is intentional, no deadlock path was
+  introduced, and AC-1 through AC-8 still pass.
+
+Independent reviewer reruns included 14 focused Runs race, Relay, and Matrix
+tests plus a clean `git diff --check`.
+
+## Documentation updates
+
+- Roadmap: No repository roadmap exists.
+- Changelog: No repository changelog exists.
+- Architecture/operator docs: Updated Runs API developer and user guides plus
+  the TUI protocol README with capability detection, request-ID round trips,
+  stale-ID behavior, safe preview fields, and legacy FIFO compatibility.
+- Project/session notes: This review log is the slice record.
+- Documentation verification: Diff and link/path inspection complete; no
+  generated documentation build is configured for these Markdown-only edits.
+
+## Publication gate
+
+- Proposed files: 48 total, split into two commits.
+  - Contributor-authored core/native commit:
+    `tools/approval.py`, `gateway/run.py`,
+    `gateway/platforms/qqbot/adapter.py`,
+    `gateway/platforms/whatsapp_cloud.py`,
+    `plugins/platforms/discord/adapter.py`,
+    `plugins/platforms/feishu/adapter.py`,
+    `plugins/platforms/matrix/adapter.py`,
+    `plugins/platforms/slack/adapter.py`,
+    `plugins/platforms/teams/adapter.py`,
+    `plugins/platforms/telegram/adapter.py`,
+    `tests/gateway/test_approve_deny_commands.py`,
+    `tests/gateway/test_discord_component_auth.py`,
+    `tests/gateway/test_feishu_approval_buttons.py`,
+    `tests/gateway/test_matrix_exec_approval.py`,
+    `tests/gateway/test_qqbot.py`,
+    `tests/gateway/test_slack_approval_buttons.py`,
+    `tests/gateway/test_teams.py`,
+    `tests/gateway/test_telegram_approval_buttons.py`, and
+    `tests/gateway/test_whatsapp_cloud.py`.
+  - Current-main Relay/API/client/docs commit:
+    `gateway/platforms/api_server.py`, `gateway/relay/adapter.py`,
+    `tests/gateway/relay/test_relay_interactive.py`,
+    `tests/gateway/test_api_server.py`,
+    `tests/gateway/test_api_server_runs.py`,
+    `tests/test_tui_gateway_server.py`,
+    `tui_gateway/methods_prompt.py`,
+    `apps/desktop/electron/main.ts`,
+    `apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts`,
+    `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts`,
+    `apps/desktop/src/components/assistant-ui/tool/approval.test.tsx`,
+    `apps/desktop/src/components/assistant-ui/tool/approval.tsx`,
+    `apps/desktop/src/global.d.ts`,
+    `apps/desktop/src/store/native-notifications.test.ts`,
+    `apps/desktop/src/store/native-notifications.ts`,
+    `apps/desktop/src/store/prompts.test.ts`,
+    `apps/desktop/src/store/prompts.ts`, `ui-tui/README.md`,
+    `ui-tui/src/__tests__/createGatewayEventHandler.test.ts`,
+    `ui-tui/src/__tests__/overlayStore.test.ts`,
+    `ui-tui/src/app/createGatewayEventHandler.ts`,
+    `ui-tui/src/app/overlayStore.ts`,
+    `ui-tui/src/app/useInputHandlers.ts`,
+    `ui-tui/src/app/useMainApp.ts`, `ui-tui/src/gatewayTypes.ts`,
+    `ui-tui/src/types.ts`,
+    `website/docs/developer-guide/programmatic-integration.md`,
+    `website/docs/user-guide/features/api-server.md`, and
+    `reviews/2026-07-30-approval-request-binding.md`.
+- Branch and base:
+  `codex/http-approval-request-binding-rewrite` on
+  `upstream/main@8defb9fd6`.
+- Commit messages:
+  - `fix(approval): bind interactive approvals to exact requests`, authored by
+    `mr.Shu <mr@shu.io>` and committed by the current maintainer.
+  - `fix(approval): complete request binding across current clients`.
+- PR title: `fix(approval): bind interactive responses to exact requests`.
+- PR summary: Exact request IDs now round-trip through every current
+  interactive transport. Stale IDs fail closed, no-ID callers retain FIFO, and
+  Runs clients get a bounded structured preview plus capability flags.
+- Unresolved risks:
+  - TUI/Desktop remain single-prompt surfaces and do not automatically
+    resurface an older sibling.
+  - Legacy no-ID overlaps remain intentionally FIFO.
+  - Real platform networks are covered through established test doubles.
+  - The broad Python run retains 24 failures in 16 untouched files; all changed
+    feature suites pass.
+- User authorization and scope: Approved the exact 48-file publication packet,
+  both commit identities and messages, the humanized PR description and
+  reviewer response, and the force-with-lease update on 2026-07-30.
+- Commit hash:
+  - Contributor-authored commit:
+    `611475bcab9c57b9ef594903c52a46eb7f92c557`.
+  - Current-client integration commit: this review log is included in that
+    commit; its hash is reported in the publication outcome.
+- Ready PR URL: Existing PR #68080 will be updated only after approval.
+
+## Outcome review
+
+- Classification: Approved by both independent reviewers; ready for the
+  publication approval gate.
+- Acceptance criteria summary: AC-1 through AC-8 pass in implementation tests
+  and both final reviewer verdicts.
+- Potential bugs or untested paths: Real platform networks remain represented
+  by established test doubles. TUI/Desktop intentionally remain single-prompt
+  surfaces and do not automatically resurface an older sibling.
+- Remaining reviewer dissent: None.
+- Compatibility/migration/rollback concerns: No migration planned; legacy FIFO
+  compatibility is tested and remains an acceptance criterion.
+- User decision: Approved publication and the existing PR rewrite.
+- Next slice authorized: No.

--- a/tests/gateway/relay/test_relay_interactive.py
+++ b/tests/gateway/relay/test_relay_interactive.py
@@ -8,8 +8,8 @@ Covers:
     triggers run.py's text fallback);
   - the pending-prompt registry: mint → consume-once → expiry;
   - _consume_prompt_response routes answers to the approval / slash-confirm /
-    clarify resolvers and CONSUMES the event; unknown/expired ids fall
-    through to normal dispatch;
+    clarify resolvers and CONSUMES the event; unknown/expired structured ids
+    fail closed without falling through to typed FIFO commands;
   - the Discord type-3 hp1 decode (structured prompt_response replacing the
     bare-custom_id stub; foreign custom_ids keep the legacy text shape);
   - on_processing_start/complete drive react ops (👀 → ✅/❌), op-gated and
@@ -87,7 +87,11 @@ def _event(
 async def test_exec_approval_renders_full_option_set():
     adapter, stub = _adapter()
     result = await adapter.send_exec_approval(
-        "c1", "rm -rf /tmp/x", "sess:1", description="deletes files"
+        "c1",
+        "rm -rf /tmp/x",
+        "sess:1",
+        description="deletes files",
+        metadata={"approval_request_id": "req-relay"},
     )
     assert result.success is True
     assert result.message_id == "pm1"
@@ -103,6 +107,103 @@ async def test_exec_approval_renders_full_option_set():
     state = adapter._pending_prompts[action["prompt_id"]]
     assert state["kind"] == "exec_approval"
     assert state["session_key"] == "sess:1"
+    assert state["request_id"] == "req-relay"
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_response_resolves_the_displayed_pending_request():
+    """Relay must not let a later prompt resolve the oldest queue entry."""
+    from tools.approval import _ApprovalEntry, _gateway_queues
+
+    adapter, stub = _adapter()
+    session_key = "sess:relay-targeted"
+    first = _ApprovalEntry({"command": "first", "request_id": "req-first"})
+    second = _ApprovalEntry({"command": "second", "request_id": "req-second"})
+    _gateway_queues[session_key] = [first, second]
+
+    try:
+        result = await adapter.send_exec_approval(
+            "c1",
+            "second",
+            session_key,
+            metadata={"approval_request_id": "req-second"},
+        )
+        assert result.success is True
+        prompt_id = stub.sent[-1]["prompt_id"]
+
+        consumed = await adapter._consume_prompt_response(
+            _event({"prompt_id": prompt_id, "option_id": "deny"})
+        )
+
+        assert consumed is True
+        assert not first.event.is_set()
+        assert second.event.is_set()
+        assert second.result == "deny"
+        assert _gateway_queues[session_key] == [first]
+    finally:
+        _gateway_queues.pop(session_key, None)
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_stale_request_does_not_fall_back_to_fifo():
+    from tools.approval import _ApprovalEntry, _gateway_queues
+
+    adapter, stub = _adapter()
+    session_key = "sess:relay-stale"
+    pending = _ApprovalEntry({"command": "live", "request_id": "req-live"})
+    _gateway_queues[session_key] = [pending]
+
+    try:
+        result = await adapter.send_exec_approval(
+            "c1",
+            "stale",
+            session_key,
+            metadata={"approval_request_id": "req-stale"},
+        )
+        prompt_id = stub.sent[-1]["prompt_id"]
+
+        consumed = await adapter._consume_prompt_response(
+            _event({"prompt_id": prompt_id, "option_id": "once"})
+        )
+
+        assert consumed is True
+        assert not pending.event.is_set()
+        assert _gateway_queues[session_key] == [pending]
+    finally:
+        _gateway_queues.pop(session_key, None)
+
+
+@pytest.mark.asyncio
+async def test_replayed_prompt_response_is_consumed_without_resolving_sibling():
+    from tools.approval import _ApprovalEntry, _gateway_queues
+
+    adapter, stub = _adapter()
+    session_key = "sess:relay-replay"
+    target = _ApprovalEntry({"command": "target", "request_id": "req-target"})
+    sibling = _ApprovalEntry({"command": "sibling", "request_id": "req-sibling"})
+    _gateway_queues[session_key] = [target, sibling]
+
+    try:
+        await adapter.send_exec_approval(
+            "c1",
+            "target",
+            session_key,
+            metadata={"approval_request_id": "req-target"},
+        )
+        prompt_id = stub.sent[-1]["prompt_id"]
+        event = _event({"prompt_id": prompt_id, "option_id": "deny"})
+
+        assert await adapter._consume_prompt_response(event) is True
+        assert target.event.is_set()
+        assert not sibling.event.is_set()
+
+        # The consumed prompt ID is now stale. Its command-shaped event text
+        # must not fall through to typed /deny and resolve the sibling.
+        assert await adapter._consume_prompt_response(event) is True
+        assert not sibling.event.is_set()
+        assert _gateway_queues[session_key] == [sibling]
+    finally:
+        _gateway_queues.pop(session_key, None)
 
 
 @pytest.mark.asyncio
@@ -255,5 +356,3 @@ async def test_processing_lifecycle_reacts_eyes_then_check():
         ("✅", False),
     ]
     assert all(r["message_id"] == "m42" and r["chat_id"] == "ch1" for r in reacts)
-
-

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -641,6 +641,9 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["chat_completions"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
+            assert data["features"]["run_approval_request_binding"] is True
+            assert data["features"]["run_approval_structured_preview"] is True
+            assert data["features"]["run_approval_preview_version"] == 1
             assert data["features"]["model_options"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
@@ -2616,5 +2619,4 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
-
 

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -21,6 +21,7 @@ from gateway.config import PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
     _approval_event_choices,
+    _safe_approval_preview,
     cors_middleware,
     security_headers_middleware,
 )
@@ -48,6 +49,25 @@ def test_approval_event_choices_follow_backend_capabilities(
         smart_denied=smart_denied,
         allow_permanent=allow_permanent,
     ) == expected
+
+
+def test_safe_approval_preview_uses_fixed_copy_and_allowlisted_risk_labels():
+    preview = _safe_approval_preview(
+        {
+            "command": "rm -rf /tmp/private-token-value",
+            "description": "private-token-value",
+            "pattern_keys": ["recursive delete", "private-token-value"],
+        }
+    )
+
+    assert preview == {
+        "version": 1,
+        "category": "terminal_command",
+        "title": "Terminal command approval",
+        "summary": "Hermes stopped a terminal command that matched a protected action.",
+        "risk_labels": ["recursive delete"],
+    }
+    assert "private-token-value" not in repr(preview)
 
 
 def _make_adapter(api_key: str = "") -> APIServerAdapter:
@@ -401,6 +421,167 @@ class TestRunEvents:
                     approval_mod._gateway_queues.pop(victim_run, None)
                 victim_interrupted.set()
                 attacker_interrupted.set()
+
+    @pytest.mark.asyncio
+    async def test_approval_response_targets_exact_pending_request(self, adapter):
+        """Answering the second prompt must leave the first prompt pending."""
+        run_id = "run_exact_approval"
+        first = approval_mod._ApprovalEntry(
+            {
+                "command": "rm -rf /tmp/first",
+                "description": "first approval",
+                "request_id": "approval-first",
+            }
+        )
+        second = approval_mod._ApprovalEntry(
+            {
+                "command": "rm -rf /tmp/second",
+                "description": "second approval",
+                "request_id": "approval-second",
+            }
+        )
+        adapter._set_run_status(run_id, "waiting_for_approval")
+        adapter._run_approval_sessions[run_id] = run_id
+        adapter._run_streams[run_id] = asyncio.Queue()
+        with approval_mod._lock:
+            approval_mod._gateway_queues[run_id] = [first, second]
+
+        app = _create_runs_app(adapter)
+        try:
+            async with TestClient(TestServer(app)) as cli:
+                exact = await cli.post(
+                    f"/v1/runs/{run_id}/approval",
+                    json={"choice": "once", "request_id": "approval-second"},
+                )
+                exact_data = await exact.json()
+
+                assert exact.status == 200
+                assert exact_data["request_id"] == "approval-second"
+                assert exact_data["resolved"] == 1
+                assert second.result == "once"
+                assert second.event.is_set()
+                assert first.result is None
+                assert not first.event.is_set()
+                assert adapter._run_statuses[run_id]["status"] == "waiting_for_approval"
+                with approval_mod._lock:
+                    assert approval_mod._gateway_queues[run_id] == [first]
+
+                responded_event = adapter._run_streams[run_id].get_nowait()
+                assert responded_event["request_id"] == "approval-second"
+
+                stale = await cli.post(
+                    f"/v1/runs/{run_id}/approval",
+                    json={"choice": "deny", "request_id": "approval-second"},
+                )
+                stale_data = await stale.json()
+                assert stale.status == 409
+                assert stale_data["error"]["code"] == "approval_request_not_pending"
+                assert first.result is None
+
+                invalid_scope = await cli.post(
+                    f"/v1/runs/{run_id}/approval",
+                    json={
+                        "choice": "deny",
+                        "request_id": "approval-first",
+                        "resolve_all": True,
+                    },
+                )
+                assert invalid_scope.status == 400
+                assert (await invalid_scope.json())["error"]["code"] == "invalid_approval_scope"
+                assert first.result is None
+
+                legacy = await cli.post(
+                    f"/v1/runs/{run_id}/approval",
+                    json={"choice": "deny"},
+                )
+                assert legacy.status == 200
+                assert first.result == "deny"
+                assert first.event.is_set()
+                assert adapter._run_statuses[run_id]["status"] == "running"
+        finally:
+            with approval_mod._lock:
+                approval_mod._gateway_queues.pop(run_id, None)
+            adapter._run_approval_sessions.pop(run_id, None)
+            adapter._run_streams.pop(run_id, None)
+            adapter._run_statuses.pop(run_id, None)
+
+    def test_new_approval_notification_wins_status_race(self, adapter, monkeypatch):
+        """A newer wait must remain visible after an older response refresh."""
+        run_id = "run_approval_status_race"
+        entered_queue_sample = threading.Event()
+        release_queue_sample = threading.Event()
+
+        def no_pending_yet(_session_key):
+            entered_queue_sample.set()
+            assert release_queue_sample.wait(timeout=3)
+            return False
+
+        monkeypatch.setattr(approval_mod, "has_blocking_approval", no_pending_yet)
+        refresh = threading.Thread(
+            target=adapter._refresh_run_status_after_approval,
+            args=(run_id, run_id),
+        )
+        refresh.start()
+        assert entered_queue_sample.wait(timeout=3)
+
+        newer_wait = threading.Thread(
+            target=adapter._mark_run_waiting_for_approval,
+            args=(run_id,),
+        )
+        newer_wait.start()
+        release_queue_sample.set()
+        refresh.join(timeout=3)
+        newer_wait.join(timeout=3)
+
+        assert not refresh.is_alive()
+        assert not newer_wait.is_alive()
+        assert adapter._run_statuses[run_id]["status"] == "waiting_for_approval"
+        assert adapter._run_statuses[run_id]["last_event"] == "approval.request"
+        adapter._run_statuses.pop(run_id, None)
+
+    def test_new_approval_notification_wins_tool_progress_status_race(
+        self,
+        adapter,
+        monkeypatch,
+    ):
+        """An older progress callback must not overwrite a newer approval wait."""
+        run_id = "run_approval_progress_status_race"
+        entered_progress_write = threading.Event()
+        release_progress_write = threading.Event()
+        original_set_status = adapter._set_run_status
+
+        def blocking_set_status(run_id_arg, status, **fields):
+            if fields.get("last_event") == "tool.started":
+                entered_progress_write.set()
+                assert release_progress_write.wait(timeout=3)
+            return original_set_status(run_id_arg, status, **fields)
+
+        adapter._set_run_status(run_id, "running")
+        monkeypatch.setattr(adapter, "_set_run_status", blocking_set_status)
+        progress_callback = adapter._make_run_event_callback(run_id, MagicMock())
+
+        progress = threading.Thread(
+            target=progress_callback,
+            args=("tool.started",),
+            kwargs={"tool_name": "terminal"},
+        )
+        progress.start()
+        assert entered_progress_write.wait(timeout=3)
+
+        newer_wait = threading.Thread(
+            target=adapter._mark_run_waiting_for_approval,
+            args=(run_id,),
+        )
+        newer_wait.start()
+        release_progress_write.set()
+        progress.join(timeout=3)
+        newer_wait.join(timeout=3)
+
+        assert not progress.is_alive()
+        assert not newer_wait.is_alive()
+        assert adapter._run_statuses[run_id]["status"] == "waiting_for_approval"
+        assert adapter._run_statuses[run_id]["last_event"] == "approval.request"
+        adapter._run_statuses.pop(run_id, None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -156,6 +156,64 @@ class TestBlockingGatewayApproval:
         assert not e2.event.is_set()
         assert len(_gateway_queues[session_key]) == 1
 
+    def test_resolve_specific_request_id_leaves_older_entry_pending(self):
+        """A displayed approval must resolve its own queue entry, not FIFO."""
+        from tools.approval import (
+            _ApprovalEntry,
+            _gateway_queues,
+            pending_approval_count,
+            resolve_gateway_approval,
+        )
+
+        session_key = "test-targeted"
+        first = _ApprovalEntry({"command": "first", "request_id": "req-first"})
+        second = _ApprovalEntry({"command": "second", "request_id": "req-second"})
+        _gateway_queues[session_key] = [first, second]
+
+        count = resolve_gateway_approval(
+            session_key,
+            "deny",
+            request_id="req-second",
+        )
+
+        assert count == 1
+        assert not first.event.is_set()
+        assert second.event.is_set()
+        assert second.result == "deny"
+        assert pending_approval_count(session_key) == 1
+
+    def test_unknown_request_id_fails_closed(self):
+        from tools.approval import (
+            _ApprovalEntry,
+            _gateway_queues,
+            resolve_gateway_approval,
+        )
+
+        session_key = "test-stale-target"
+        pending = _ApprovalEntry({"command": "pending", "request_id": "req-live"})
+        _gateway_queues[session_key] = [pending]
+
+        count = resolve_gateway_approval(
+            session_key,
+            "once",
+            request_id="req-stale",
+        )
+
+        assert count == 0
+        assert not pending.event.is_set()
+        assert _gateway_queues[session_key] == [pending]
+
+    def test_invalid_supplied_request_id_is_replaced_with_transport_safe_id(self):
+        from tools.approval import _ApprovalEntry, is_valid_approval_request_id
+
+        entry = _ApprovalEntry(
+            {"command": "pending", "request_id": "bad:id with spaces"}
+        )
+
+        assert entry.request_id != "bad:id with spaces"
+        assert entry.data["request_id"] == entry.request_id
+        assert is_valid_approval_request_id(entry.request_id)
+
 
 # ------------------------------------------------------------------
 # /approve command
@@ -375,7 +433,7 @@ class TestBlockingApprovalE2E:
         from tools.approval import (
             register_gateway_notify, unregister_gateway_notify,
             resolve_gateway_approval, check_all_command_guards,
-            _gateway_queues,
+            _gateway_queues, is_valid_approval_request_id,
         )
 
         session_key = "e2e-parallel"
@@ -415,6 +473,9 @@ class TestBlockingApprovalE2E:
 
         assert len(notified) == 3
         assert len(_gateway_queues.get(session_key, [])) == 3
+        request_ids = [item.get("request_id") for item in notified]
+        assert all(is_valid_approval_request_id(value) for value in request_ids)
+        assert len(set(request_ids)) == 3
 
         # Approve all at once
         count = resolve_gateway_approval(session_key, "session", resolve_all=True)

--- a/tests/gateway/test_discord_component_auth.py
+++ b/tests/gateway/test_discord_component_auth.py
@@ -13,6 +13,7 @@ handling, and fail-closed behavior so the parity cannot regress.
 """
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -111,6 +112,32 @@ def test_exec_approval_view_accepts_role_allowlist():
     assert view._check_auth(_interaction(99999, role_ids=[42])) is True
     # Neither user nor role match: reject
     assert view._check_auth(_interaction(99999, role_ids=[7])) is False
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_view_resolves_exact_request_id():
+    view = ExecApprovalView(
+        session_key="sess-1",
+        request_id="approval-second",
+        allowed_user_ids={"11111"},
+    )
+    interaction = SimpleNamespace(
+        message=SimpleNamespace(embeds=[]),
+        response=SimpleNamespace(
+            edit_message=AsyncMock(),
+            send_message=AsyncMock(),
+        ),
+        user=SimpleNamespace(display_name="Owner", id=11111, roles=[]),
+    )
+
+    with patch("tools.approval.resolve_gateway_approval", return_value=1) as resolve:
+        await view._resolve(interaction, "once", object(), "Approved once")
+
+    resolve.assert_called_once_with(
+        "sess-1",
+        "once",
+        request_id="approval-second",
+    )
 
 
 def test_slash_confirm_view_accepts_role_allowlist():
@@ -277,4 +304,3 @@ def test_other_views_not_admin_gated():
         session_key="s", confirm_id="c", allowed_user_ids={"11111"}
     )
     assert sc._check_auth(_interaction(11111)) is True
-

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -144,14 +144,42 @@ class TestFeishuExecApproval:
                 chat_id="oc_12345",
                 command="echo test",
                 session_key="my-session-key",
+                metadata={"approval_request_id": "approval-feishu"},
             )
 
         assert len(adapter._approval_state) == 1
-        approval_id = list(adapter._approval_state.keys())[0]
+        approval_id = "approval-feishu"
         state = adapter._approval_state[approval_id]
         assert state["session_key"] == "my-session-key"
+        assert state["request_id"] == "approval-feishu"
         assert state["message_id"] == "msg_002"
         assert state["chat_id"] == "oc_12345"
+
+    @pytest.mark.asyncio
+    async def test_resolves_exact_approval_request(self):
+        adapter = _make_adapter()
+        adapter._allowed_group_users = {"ou_owner"}
+        adapter._approval_state["approval-second"] = {
+            "session_key": "session-key",
+            "request_id": "approval-second",
+            "message_id": "msg-002",
+            "chat_id": "oc_12345",
+        }
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as resolve:
+            await adapter._resolve_approval(
+                "approval-second",
+                "once",
+                "Owner",
+                open_id="ou_owner",
+                chat_id="oc_12345",
+            )
+
+        resolve.assert_called_once_with(
+            "session-key",
+            "once",
+            request_id="approval-second",
+        )
 
 
 # ===========================================================================
@@ -445,5 +473,4 @@ class TestResolveUpdatePrompt:
 
         assert (tmp_path / ".hermes" / ".update_response").read_text() == "y"
         assert 1 not in adapter._update_prompt_state
-
 

--- a/tests/gateway/test_matrix_exec_approval.py
+++ b/tests/gateway/test_matrix_exec_approval.py
@@ -4,9 +4,49 @@ import pytest
 from unittest.mock import AsyncMock, patch
 
 from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
 
 
 class TestMatrixExecApprovalReactions:
+
+    @pytest.mark.asyncio
+    async def test_two_same_session_prompts_remain_bound_to_their_events(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@liizfq:liizfq.top")
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = MatrixAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="tok",
+                extra={"homeserver": "https://matrix.example.org"},
+            )
+        )
+        adapter._client = object()
+        adapter.send = AsyncMock(
+            side_effect=[
+                SendResult(success=True, message_id="$first"),
+                SendResult(success=True, message_id="$second"),
+            ]
+        )
+        adapter._send_reaction = AsyncMock(return_value=None)
+
+        await adapter.send_exec_approval(
+            "!room:example.org",
+            "first",
+            "sess-1",
+            metadata={"approval_request_id": "approval-first"},
+        )
+        await adapter.send_exec_approval(
+            "!room:example.org",
+            "second",
+            "sess-1",
+            metadata={"approval_request_id": "approval-second"},
+        )
+
+        assert set(adapter._approval_prompts_by_event) == {"$first", "$second"}
+        assert adapter._approval_prompts_by_event["$first"].request_id == "approval-first"
+        assert adapter._approval_prompts_by_event["$second"].request_id == "approval-second"
+        assert adapter._approval_prompt_by_session["sess-1"] == "$second"
 
 
     @pytest.mark.asyncio
@@ -18,7 +58,10 @@ class TestMatrixExecApprovalReactions:
         # Resolve user_id so _is_self_sender doesn't defensively drop all traffic (#15763).
         adapter._user_id = "@bot:example.org"
         adapter._approval_prompts_by_event["$target"] = _MatrixApprovalPrompt(
-            session_key="sess-1", chat_id="!room:example.org", message_id="$target"
+            session_key="sess-1",
+            chat_id="!room:example.org",
+            message_id="$target",
+            request_id="approval-second",
         )
         adapter._approval_prompt_by_session["sess-1"] = "$target"
 
@@ -33,6 +76,10 @@ class TestMatrixExecApprovalReactions:
         with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
             await adapter._on_reaction(event)
 
-        mock_resolve.assert_called_once_with("sess-1", "once")
+        mock_resolve.assert_called_once_with(
+            "sess-1",
+            "once",
+            request_id="approval-second",
+        )
         assert "$target" not in adapter._approval_prompts_by_event
         assert "sess-1" not in adapter._approval_prompt_by_session

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -853,11 +853,15 @@ class TestDefaultInteractionDispatch:
     async def test_approval_click_once_maps_to_once(self):
         """'allow-once' button → resolve_gateway_approval(session, 'once')."""
         adapter = self._make_adapter()
+        adapter._exec_approval_state["approval-second"] = {
+            "request_id": "approval-second",
+            "session_key": "agent:main:qqbot:c2c:u-42",
+        }
 
         resolve_calls = []
 
-        def fake_resolve(session_key, choice, resolve_all=False):
-            resolve_calls.append((session_key, choice, resolve_all))
+        def fake_resolve(session_key, choice, resolve_all=False, request_id=None):
+            resolve_calls.append((session_key, choice, resolve_all, request_id))
             return 1
 
         # Patch the *module-level* function that _default_interaction_dispatch
@@ -871,13 +875,20 @@ class TestDefaultInteractionDispatch:
                 "id": "i",
                 "chat_type": 2,
                 "user_openid": "u-42",
-                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:c2c:u-42:allow-once"}},
+                "data": {"resolved": {"button_data": "approve:approval-second:allow-once"}},
             })
             await adapter._default_interaction_dispatch(event)
         finally:
             tools.approval.resolve_gateway_approval = orig
 
-        assert resolve_calls == [("agent:main:qqbot:c2c:u-42", "once", False)]
+        assert resolve_calls == [
+            (
+                "agent:main:qqbot:c2c:u-42",
+                "once",
+                False,
+                "approval-second",
+            )
+        ]
 
 
     @pytest.mark.asyncio
@@ -956,14 +967,41 @@ class TestSendExecApproval:
             command="rm -rf /tmp/demo",
             session_key="sess:abc",
             description="delete temp dir",
+            metadata={"approval_request_id": "approval-qq"},
         )
         assert result.success
         assert len(calls) == 1
         req = calls[0]["req"]
-        assert req.session_key == "sess:abc"
+        assert req.session_key == "approval-qq"
+        assert adapter._exec_approval_state["approval-qq"] == {
+            "request_id": "approval-qq",
+            "session_key": "sess:abc",
+        }
         assert req.command_preview == "rm -rf /tmp/demo"
         assert req.description == "delete temp dir"
         assert calls[0]["reply_to"] == "inbound-42"
+
+    @pytest.mark.asyncio
+    async def test_without_request_metadata_marks_fifo_fallback(self):
+        adapter = self._make_adapter()
+        captured = {}
+
+        async def fake_send_approval(chat_id, req, reply_to=None):
+            from gateway.platforms.base import SendResult
+            captured["approval_id"] = req.session_key
+            return SendResult(success=True, message_id="m-1")
+
+        adapter.send_approval_request = fake_send_approval  # type: ignore[assignment]
+        await adapter.send_exec_approval(
+            chat_id="user-1",
+            command="rm -rf /tmp/demo",
+            session_key="sess:abc",
+        )
+
+        assert adapter._exec_approval_state[captured["approval_id"]] == {
+            "request_id": "",
+            "session_key": "sess:abc",
+        }
 
 
 class TestSendUpdatePrompt:
@@ -1221,4 +1259,3 @@ class TestReadEventsClosedWsGuard:
         adapter._ws = SimpleNamespace(closed=True)
         with pytest.raises(RuntimeError):
             asyncio.run(adapter._read_events())
-

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -95,6 +95,7 @@ class TestSlackExecApproval:
             command="rm -rf /important",
             session_key="agent:main:slack:group:C1:1111",
             description="dangerous deletion",
+            metadata={"approval_request_id": "approval-slack"},
         )
 
         assert result.success is True
@@ -117,9 +118,12 @@ class TestSlackExecApproval:
         assert "hermes_approve_session" in action_ids
         assert "hermes_approve_always" in action_ids
         assert "hermes_deny" in action_ids
-        # Each button carries the session key as value
+        # Each button carries the exact approval request ID, not only the session.
         for e in elements:
-            assert e["value"] == "agent:main:slack:group:C1:1111"
+            assert e["value"] == "approval-slack"
+        assert adapter._approval_request_state["approval-slack"] == (
+            "agent:main:slack:group:C1:1111"
+        )
 
     @pytest.mark.asyncio
     async def test_smart_deny_owner_override_hides_persistent_buttons(self):
@@ -137,6 +141,7 @@ class TestSlackExecApproval:
         assert [element["action_id"] for element in elements] == [
             "hermes_approve_once", "hermes_deny",
         ]
+        assert {element["value"] for element in elements} == {"s"}
         assert "one operation" in kwargs["blocks"][0]["text"]["text"].lower()
 
 
@@ -178,6 +183,31 @@ class TestSlackApprovalAction:
         update_kwargs = mock_client.chat_update.call_args[1]
         section_text = update_kwargs["blocks"][0]["text"]["text"]
         assert len(section_text) <= 3000
+
+    @pytest.mark.asyncio
+    async def test_resolves_the_exact_approval_request(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        adapter._approval_resolved["1.2"] = False
+        adapter._approval_request_state["approval-second"] = "session-key"
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1.2", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "alice", "id": "U_ALICE"},
+        }
+        action = {"action_id": "hermes_approve_once", "value": "approval-second"}
+        adapter._team_clients["T1"].chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        resolve.assert_called_once_with(
+            "session-key",
+            "once",
+            request_id="approval-second",
+        )
 
     @pytest.mark.asyncio
     async def test_global_allowlist_blocks_unauthorized_click(self, monkeypatch):
@@ -840,4 +870,3 @@ class TestSlackReactionAuthorizationGate:
         assert "U_RANDO" in runner.auth_checked
         assert runner.handled == []
         adapter.handle_message.assert_not_called()
-

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -4,7 +4,7 @@ import json
 import sys
 import types
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -259,6 +259,71 @@ class TestTeamsAdapterInit:
             _make_config(client_id="id", client_secret="secret", tenant_id="tenant", port="abc")
         )
         assert adapter._port == 3978
+
+
+class TestTeamsApprovalBinding:
+    @pytest.mark.asyncio
+    async def test_card_action_resolves_exact_request_id(self, monkeypatch):
+        adapter = TeamsAdapter(
+            _make_config(client_id="id", client_secret="secret", tenant_id="tenant")
+        )
+        monkeypatch.setenv("TEAMS_ALLOW_ALL_USERS", "true")
+        ctx = SimpleNamespace(
+            activity=SimpleNamespace(
+                from_=SimpleNamespace(id="owner"),
+                value=SimpleNamespace(
+                    action=SimpleNamespace(
+                        data={
+                            "hermes_action": "approve_once",
+                            "request_id": "approval-second",
+                            "session_key": "session-key",
+                        }
+                    )
+                ),
+            )
+        )
+
+        with (
+            patch("tools.approval.has_blocking_approval", return_value=True),
+            patch("tools.approval.resolve_gateway_approval", return_value=1) as resolve,
+        ):
+            response = await adapter._on_card_action(ctx)
+
+        assert response.status == 200
+        resolve.assert_called_once_with(
+            "session-key",
+            "once",
+            request_id="approval-second",
+        )
+
+    @pytest.mark.asyncio
+    async def test_legacy_card_action_keeps_fifo_resolution(self, monkeypatch):
+        adapter = TeamsAdapter(
+            _make_config(client_id="id", client_secret="secret", tenant_id="tenant")
+        )
+        monkeypatch.setenv("TEAMS_ALLOW_ALL_USERS", "true")
+        ctx = SimpleNamespace(
+            activity=SimpleNamespace(
+                from_=SimpleNamespace(id="owner"),
+                value=SimpleNamespace(
+                    action=SimpleNamespace(
+                        data={
+                            "hermes_action": "deny",
+                            "session_key": "session-key",
+                        }
+                    )
+                ),
+            )
+        )
+
+        with (
+            patch("tools.approval.has_blocking_approval", return_value=True),
+            patch("tools.approval.resolve_gateway_approval", return_value=1) as resolve,
+        ):
+            response = await adapter._on_card_action(ctx)
+
+        assert response.status == 200
+        resolve.assert_called_once_with("session-key", "deny")
 
 
 # ---------------------------------------------------------------------------
@@ -712,5 +777,3 @@ class TestTeamsMediaAttachments:
         result = await adapter.send_document("19:abc@thread.v2", str(doc))
         assert result.success
         adapter._app.send.assert_awaited_once()
-
-

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -93,6 +93,7 @@ class TestTelegramExecApproval:
             command="rm -rf /important",
             session_key="agent:main:telegram:group:12345:99",
             description="dangerous deletion",
+            metadata={"approval_request_id": "approval-telegram"},
         )
 
         assert result.success is True
@@ -104,6 +105,10 @@ class TestTelegramExecApproval:
         assert "rm -rf /important" in kwargs["text"]
         assert "dangerous deletion" in kwargs["text"]
         assert kwargs["reply_markup"] is not None  # InlineKeyboardMarkup
+        assert adapter._approval_state["approval-telegram"] == {
+            "request_id": "approval-telegram",
+            "session_key": "agent:main:telegram:group:12345:99",
+        }
 
 
     @pytest.mark.asyncio
@@ -215,12 +220,15 @@ class TestTelegramApprovalCallback:
         rest of a long-running turn after a button click.
         """
         adapter = _make_adapter()
-        adapter._approval_state[5] = "agent:main:telegram:group:12345:99"
+        adapter._approval_state["approval-second"] = {
+            "request_id": "approval-second",
+            "session_key": "agent:main:telegram:group:12345:99",
+        }
         adapter.pause_typing_for_chat("12345")
         assert "12345" in adapter._typing_paused
 
         query = AsyncMock()
-        query.data = "ea:once:5"
+        query.data = "ea:once:approval-second"
         query.message = MagicMock()
         query.message.chat_id = 12345
         query.from_user = MagicMock()
@@ -234,9 +242,14 @@ class TestTelegramApprovalCallback:
         context = MagicMock()
 
         with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
-            with patch("tools.approval.resolve_gateway_approval", return_value=1):
+            with patch("tools.approval.resolve_gateway_approval", return_value=1) as resolve:
                 await adapter._handle_callback_query(update, context)
 
+        resolve.assert_called_once_with(
+            "agent:main:telegram:group:12345:99",
+            "once",
+            request_id="approval-second",
+        )
         assert "12345" not in adapter._typing_paused
 
 
@@ -359,4 +372,3 @@ class TestTelegramApprovalCallback:
         assert runner.last_source is not None
         assert runner.last_source.platform == Platform.TELEGRAM
         assert runner.last_source.user_id == "222"
-

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -979,6 +979,7 @@ class TestSendExecApprovalButtons:
             command="rm -rf /tmp/foo",
             session_key="sess-app-1",
             description="cleanup script",
+            metadata={"approval_request_id": "approval-whatsapp"},
         )
 
         assert result.success
@@ -997,7 +998,10 @@ class TestSendExecApprovalButtons:
         body = payload["interactive"]["body"]["text"]
         assert "rm -rf /tmp/foo" in body
         assert "cleanup script" in body
-        assert adapter._exec_approval_state[approval_id] == "sess-app-1"
+        assert adapter._exec_approval_state[approval_id] == {
+            "request_id": "approval-whatsapp",
+            "session_key": "sess-app-1",
+        }
 
 
 class TestSendSlashConfirmButtons:
@@ -1098,7 +1102,10 @@ class TestDispatchInteractiveReplyApproval:
     @pytest.mark.asyncio
     async def test_approve_tap_calls_resolver_and_confirms(self, monkeypatch):
         adapter = _make_adapter()
-        adapter._exec_approval_state["app1"] = "sess-app-1"
+        adapter._exec_approval_state["app1"] = {
+            "request_id": "app1",
+            "session_key": "sess-app-1",
+        }
         adapter._http_client = MagicMock()
         adapter._http_client.post = AsyncMock(
             return_value=_mock_httpx_response(200, {"messages": [{"id": "x"}]})
@@ -1107,7 +1114,9 @@ class TestDispatchInteractiveReplyApproval:
         calls = []
         monkeypatch.setattr(
             "tools.approval.resolve_gateway_approval",
-            lambda session_key, choice: calls.append((session_key, choice)) or 1,
+            lambda session_key, choice, **kwargs: calls.append(
+                (session_key, choice, kwargs)
+            ) or 1,
         )
 
         raw = {
@@ -1121,7 +1130,9 @@ class TestDispatchInteractiveReplyApproval:
         handled = await adapter._dispatch_interactive_reply(raw, {})
 
         assert handled is True
-        assert calls == [("sess-app-1", "approve")]
+        assert calls == [
+            ("sess-app-1", "approve", {"request_id": "app1"})
+        ]
         assert "app1" not in adapter._exec_approval_state
         confirm_payload = adapter._http_client.post.call_args.kwargs["json"]
         assert confirm_payload["type"] == "text"
@@ -1399,4 +1410,3 @@ class TestReplyContextResolution:
         assert event.reply_to_message_id is None
         assert event.reply_to_text is None
         assert event.reply_to_is_own_message is False
-

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -14,6 +14,7 @@ import pytest
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from hermes_cli.active_sessions import active_session_registry_snapshot
 from hermes_cli.browser_connect import ChromeDebugLaunch
+from tools import approval as approval_mod
 from tui_gateway import server
 
 
@@ -9616,6 +9617,100 @@ def test_respond_unpacks_sid_tuple_correctly():
     finally:
         server._pending.pop("rid-x", None)
         server._answers.pop("rid-x", None)
+
+
+def test_approval_respond_targets_exact_request_and_preserves_fifo_fallback():
+    """TUI/Desktop responses must not approve a sibling parallel request."""
+    sid = "approval-rpc"
+    session_key = "approval-rpc-key"
+    first = approval_mod._ApprovalEntry(
+        {
+            "command": "rm -rf /tmp/first",
+            "description": "first approval",
+            "request_id": "approval-first",
+        }
+    )
+    second = approval_mod._ApprovalEntry(
+        {
+            "command": "rm -rf /tmp/second",
+            "description": "second approval",
+            "request_id": "approval-second",
+        }
+    )
+    server._sessions[sid] = _session(session_key=session_key)
+    with approval_mod._lock:
+        approval_mod._gateway_queues[session_key] = [first, second]
+
+    try:
+        exact = server.handle_request(
+            {
+                "id": "approval-1",
+                "method": "approval.respond",
+                "params": {
+                    "choice": "once",
+                    "request_id": "approval-second",
+                    "session_id": sid,
+                },
+            }
+        )
+
+        assert exact["result"]["resolved"] == 1
+        assert second.result == "once"
+        assert second.event.is_set()
+        assert first.result is None
+        assert not first.event.is_set()
+        with approval_mod._lock:
+            assert approval_mod._gateway_queues[session_key] == [first]
+
+        stale = server.handle_request(
+            {
+                "id": "approval-2",
+                "method": "approval.respond",
+                "params": {
+                    "choice": "deny",
+                    "request_id": "approval-second",
+                    "session_id": sid,
+                },
+            }
+        )
+        assert stale["error"]["code"] == 4009
+        assert first.result is None
+
+        legacy = server.handle_request(
+            {
+                "id": "approval-3",
+                "method": "approval.respond",
+                "params": {"choice": "deny", "session_id": sid},
+            }
+        )
+        assert legacy["result"]["resolved"] == 1
+        assert first.result == "deny"
+        assert first.event.is_set()
+    finally:
+        server._sessions.pop(sid, None)
+        with approval_mod._lock:
+            approval_mod._gateway_queues.pop(session_key, None)
+
+
+def test_approval_respond_rejects_exact_request_with_all():
+    sid = "approval-rpc-invalid"
+    server._sessions[sid] = _session(session_key="approval-rpc-invalid-key")
+    try:
+        response = server.handle_request(
+            {
+                "id": "approval-invalid",
+                "method": "approval.respond",
+                "params": {
+                    "all": True,
+                    "choice": "deny",
+                    "request_id": "approval-one",
+                    "session_id": sid,
+                },
+            }
+        )
+        assert response["error"]["code"] == 4004
+    finally:
+        server._sessions.pop(sid, None)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -21,6 +21,7 @@ import tempfile
 import threading
 import time
 import unicodedata
+import uuid
 from typing import Optional
 from hermes_cli.config import cfg_get
 
@@ -2152,13 +2153,33 @@ def _denial_breaker_addendum(session_key: str) -> str:
 # resolves every pending approval in the session.
 
 
+# Keep IDs short enough for the tightest native transport. Telegram callback
+# data is capped at 64 bytes and adds an ``ea:<choice>:`` prefix.
+_APPROVAL_REQUEST_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,47}")
+
+
+def is_valid_approval_request_id(value: object) -> bool:
+    """Return whether *value* is safe for approval transports and APIs."""
+    return (
+        isinstance(value, str)
+        and _APPROVAL_REQUEST_ID_RE.fullmatch(value) is not None
+    )
+
+
 class _ApprovalEntry:
     """One pending dangerous-command approval inside a gateway session."""
-    __slots__ = ("event", "data", "result", "reason")
+    __slots__ = ("event", "data", "request_id", "result", "reason")
 
     def __init__(self, data: dict):
+        self.data = dict(data or {})
+        candidate = self.data.get("request_id")
+        self.request_id = (
+            candidate
+            if is_valid_approval_request_id(candidate)
+            else uuid.uuid4().hex
+        )
+        self.data["request_id"] = self.request_id
         self.event = threading.Event()
-        self.data = data          # command, description, pattern_keys, …
         self.result: Optional[str] = None  # "once"|"session"|"always"|"deny"
         # Optional free-text reason supplied with an explicit deny
         # (``/deny <reason>``) so the agent can adapt instead of only
@@ -2197,13 +2218,14 @@ def unregister_gateway_notify(session_key: str) -> None:
 
 def resolve_gateway_approval(session_key: str, choice: str,
                              resolve_all: bool = False,
-                             reason: Optional[str] = None) -> int:
+                             reason: Optional[str] = None,
+                             request_id: Optional[str] = None) -> int:
     """Called by the gateway's /approve or /deny handler to unblock
     waiting agent thread(s).
 
     When *resolve_all* is True every pending approval in the session is
     resolved at once (``/approve all``).  Otherwise only the oldest one
-    is resolved (FIFO).
+    is resolved (FIFO), unless *request_id* targets one exact entry.
 
     *reason* is an optional free-text explanation attached to an explicit
     deny (``/deny <reason>``).  It is relayed back to the agent in the
@@ -2218,6 +2240,14 @@ def resolve_gateway_approval(session_key: str, choice: str,
         if resolve_all:
             targets = list(queue)
             queue.clear()
+        elif request_id:
+            targets = []
+            for index, entry in enumerate(queue):
+                if entry.request_id == request_id:
+                    targets = [queue.pop(index)]
+                    break
+            if not targets:
+                return 0
         else:
             targets = [queue.pop(0)]
         if not queue:
@@ -2235,6 +2265,12 @@ def has_blocking_approval(session_key: str) -> bool:
     """Check if a session has one or more blocking gateway approvals waiting."""
     with _lock:
         return bool(_gateway_queues.get(session_key))
+
+
+def pending_approval_count(session_key: str) -> int:
+    """Return the number of pending approval entries for a session."""
+    with _lock:
+        return len(_gateway_queues.get(session_key, ()))
 
 
 def submit_pending(session_key: str, approval: dict):
@@ -3293,7 +3329,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
 
     # Notify the user (bridges sync agent thread → async gateway)
     try:
-        notify_cb(approval_data)
+        notify_cb(entry.data)
     except Exception as exc:
         logger.warning("Gateway approval notify failed: %s", exc)
         _drop_entry()

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -867,18 +867,31 @@ def _(rid, params: dict) -> dict:
     if err:
         return err
     try:
-        from tools.approval import resolve_gateway_approval
-
-        return _ok(
-            rid,
-            {
-                "resolved": resolve_gateway_approval(
-                    session["session_key"],
-                    params.get("choice", "deny"),
-                    resolve_all=params.get("all", False),
-                )
-            },
+        from tools.approval import (
+            is_valid_approval_request_id,
+            resolve_gateway_approval,
         )
+
+        request_id = params.get("request_id") if "request_id" in params else None
+        resolve_all = bool(params.get("all", False))
+        if request_id is not None and not is_valid_approval_request_id(request_id):
+            return _err(rid, 4004, "invalid approval request_id")
+        if request_id is not None and resolve_all:
+            return _err(
+                rid,
+                4004,
+                "exact approval request binding cannot be combined with all",
+            )
+
+        resolved = resolve_gateway_approval(
+            session["session_key"],
+            params.get("choice", "deny"),
+            resolve_all=resolve_all,
+            request_id=request_id,
+        )
+        if request_id is not None and resolved == 0:
+            return _err(rid, 4009, "approval request is no longer pending")
+        return _ok(rid, {"resolved": resolved})
     except Exception as e:
         return _err(rid, 5004, str(e))
 

--- a/ui-tui/README.md
+++ b/ui-tui/README.md
@@ -219,6 +219,12 @@ The Python gateway can pause the main loop and request structured input:
 
 These are stateful UI branches in `app.tsx`, not separate screens.
 
+`approval.request` carries a stable `request_id` on current gateways. The
+client returns it as `approval.respond { choice, request_id, session_id }`, so
+the selected prompt resolves its exact queue entry when multiple tools are
+waiting at once. If an older gateway omits the ID, the client omits it too and
+the gateway retains its legacy FIFO behavior.
+
 ## Commands
 
 The following commands are handled directly by the TUI client. Unrecognized commands fall through to the Python gateway via `slash.exec` and `command.dispatch`.
@@ -285,7 +291,7 @@ Primary event types the client handles today:
 | `tool.progress`            | `{ name, preview }`                                                         |
 | `tool.complete`            | `{ tool_id, name, error?, summary?, duration_s?, inline_diff?, todos? }`    |
 | `clarify.request`          | `{ question, choices?, request_id }`                                        |
-| `approval.request`         | `{ command, description, allow_permanent? }`                                |
+| `approval.request`         | `{ command, description, request_id?, allow_permanent? }`                   |
 | `sudo.request`             | `{ request_id }`                                                            |
 | `sudo.expire`              | `{ request_id }` clears a timed-out sudo prompt                             |
 | `secret.request`           | `{ prompt, env_var, request_id }`                                           |

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -1179,12 +1179,17 @@ describe('createGatewayEventHandler', () => {
         choices: ['once', 'deny'],
         command: 'rm -rf /tmp/x',
         description: 'smart deny override',
+        request_id: 'approval-second',
         smart_denied: true
       },
       type: 'approval.request'
     } as any)
 
-    expect(getOverlayState().approval).toMatchObject({ choices: ['once', 'deny'], smartDenied: true })
+    expect(getOverlayState().approval).toMatchObject({
+      choices: ['once', 'deny'],
+      requestId: 'approval-second',
+      smartDenied: true
+    })
   })
 
   it('still surfaces terminal turn failures as errors', () => {

--- a/ui-tui/src/__tests__/overlayStore.test.ts
+++ b/ui-tui/src/__tests__/overlayStore.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { clearApprovalIfCurrent, getOverlayState, patchOverlayState, resetOverlayState } from '../app/overlayStore.js'
+
+afterEach(() => resetOverlayState())
+
+describe('approval overlay completion', () => {
+  it('does not clear a newer approval after an older response completes', () => {
+    patchOverlayState({
+      approval: {
+        command: 'second command',
+        description: 'newer approval',
+        requestId: 'approval-second'
+      }
+    })
+
+    expect(clearApprovalIfCurrent('approval-first')).toBe(false)
+    expect(getOverlayState().approval?.requestId).toBe('approval-second')
+  })
+
+  it('clears only the matching approval, including legacy no-ID prompts', () => {
+    patchOverlayState({
+      approval: {
+        command: 'first command',
+        description: 'approval',
+        requestId: 'approval-first'
+      }
+    })
+    expect(clearApprovalIfCurrent('approval-first')).toBe(true)
+    expect(getOverlayState().approval).toBeNull()
+
+    patchOverlayState({
+      approval: {
+        command: 'legacy command',
+        description: 'legacy approval'
+      }
+    })
+    expect(clearApprovalIfCurrent()).toBe(true)
+    expect(getOverlayState().approval).toBeNull()
+  })
+})

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1177,6 +1177,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
             choices: ev.payload.choices,
             command: String(ev.payload.command ?? ''),
             description,
+            requestId: ev.payload.request_id,
             smartDenied: ev.payload.smart_denied === true
           }
         })

--- a/ui-tui/src/app/overlayStore.ts
+++ b/ui-tui/src/app/overlayStore.ts
@@ -70,6 +70,23 @@ export const getOverlayState = () => $overlayState.get()
 export const patchOverlayState = (next: Partial<OverlayState> | ((state: OverlayState) => OverlayState)) =>
   $overlayState.set(typeof next === 'function' ? next($overlayState.get()) : { ...$overlayState.get(), ...next })
 
+/** Clear only the approval that produced a completed response. */
+export const clearApprovalIfCurrent = (requestId?: string): boolean => {
+  let cleared = false
+
+  patchOverlayState(state => {
+    if (!state.approval || state.approval.requestId !== requestId) {
+      return state
+    }
+
+    cleared = true
+
+    return { ...state, approval: null }
+  })
+
+  return cleared
+}
+
 /** Full reset — used by session/turn teardown and tests. */
 export const resetOverlayState = () => $overlayState.set(buildOverlayState())
 

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -25,7 +25,7 @@ import {
   type InputHandlerResult,
   type OverlayState
 } from './interfaces.js'
-import { $isBlocked, $overlayState, patchOverlayState } from './overlayStore.js'
+import { $isBlocked, $overlayState, clearApprovalIfCurrent, patchOverlayState } from './overlayStore.js'
 import { turnController } from './turnController.js'
 import { patchTurnState } from './turnStore.js'
 import { getUiState } from './uiStore.js'
@@ -178,9 +178,19 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
     }
 
     if (overlay.approval) {
+      const requestId = overlay.approval.requestId
+
       return gateway
-        .rpc<ApprovalRespondResponse>('approval.respond', { choice: 'deny', session_id: getUiState().sid })
-        .then(r => r && (patchOverlayState({ approval: null }), patchTurnState({ outcome: 'denied' })))
+        .rpc<ApprovalRespondResponse>('approval.respond', {
+          choice: 'deny',
+          ...(requestId ? { request_id: requestId } : {}),
+          session_id: getUiState().sid
+        })
+        .then(r => {
+          if (r && clearApprovalIfCurrent(requestId)) {
+            patchTurnState({ outcome: 'denied' })
+          }
+        })
     }
 
     if (overlay.sudo || overlay.secret) {

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -47,7 +47,7 @@ import { createSlashHandler } from './createSlashHandler.js'
 import { planGatewayRecovery } from './gatewayRecovery.js'
 import { getInputSelection } from './inputSelectionStore.js'
 import { type GatewayRpc, type TranscriptRow } from './interfaces.js'
-import { $overlayState, patchOverlayState } from './overlayStore.js'
+import { $overlayState, clearApprovalIfCurrent, patchOverlayState } from './overlayStore.js'
 import { $goodVibesTick } from './petFlashStore.js'
 import { scrollWithSelectionBy } from './scroll.js'
 import { turnController } from './turnController.js'
@@ -949,13 +949,27 @@ export function useMainApp(gw: GatewayClient) {
   )
 
   const answerApproval = useCallback(
-    (choice: string) =>
-      respondWith('approval.respond', { choice, session_id: ui.sid }, () => {
-        patchOverlayState({ approval: null })
-        patchTurnState({ outcome: choice === 'deny' ? 'denied' : `approved (${choice})` })
-        patchUiState({ status: 'running…' })
-      }),
-    [respondWith, ui.sid]
+    (choice: string) => {
+      const requestId = overlay.approval?.requestId
+
+      return respondWith(
+        'approval.respond',
+        {
+          choice,
+          ...(requestId ? { request_id: requestId } : {}),
+          session_id: ui.sid
+        },
+        () => {
+          if (!clearApprovalIfCurrent(requestId)) {
+            return
+          }
+
+          patchTurnState({ outcome: choice === 'deny' ? 'denied' : `approved (${choice})` })
+          patchUiState({ status: 'running…' })
+        }
+      )
+    },
+    [overlay.approval?.requestId, respondWith, ui.sid]
   )
 
   const answerSudo = useCallback(

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -703,6 +703,7 @@ export type GatewayEvent =
         choices?: string[]
         command: string
         description: string
+        request_id?: string
         smart_denied?: boolean
       }
       session_id?: string

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -95,6 +95,7 @@ export interface ApprovalReq {
   choices?: string[]
   command: string
   description: string
+  requestId?: string
   smartDenied?: boolean
 }
 

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -58,7 +58,7 @@ terminal.resize         clipboard.paste         image.attach
 
 ### Events streamed back
 
-`message.delta`, `message.complete`, `tool.start`, `tool.progress`, `tool.complete`, `approval.request`, `clarify.request`, `sudo.request`, `sudo.expire`, `secret.request`, `secret.expire`, `gateway.ready`, plus session lifecycle and error events. Expiry events carry the original `{ request_id }`; external hosts should clear only the matching pending prompt.
+`message.delta`, `message.complete`, `tool.start`, `tool.progress`, `tool.complete`, `approval.request`, `clarify.request`, `sudo.request`, `sudo.expire`, `secret.request`, `secret.expire`, `gateway.ready`, plus session lifecycle and error events. Approval events carry a stable `request_id`; send it back with `approval.respond` so parallel approvals cannot be answered out of order. Older gateways may omit the field, in which case omitting it from the response retains the legacy FIFO behavior. Expiry events carry the original `{ request_id }`; external hosts should clear only the matching pending prompt.
 
 ### Pi-style RPC mapping
 
@@ -99,6 +99,13 @@ GET  /v1/models                  Lists hermes-agent
 GET  /api/model/options          Provider-aware picker inventory
 GET  /health, /health/detailed
 ```
+
+An `approval.request` run event includes a stable `request_id` and a fixed,
+server-owned `preview`. Send that ID back to
+`POST /v1/runs/{id}/approval` with the selected `choice`. Clients can
+feature-detect this contract through
+`features.run_approval_request_binding` and
+`features.run_approval_structured_preview`.
 
 Setup, headers (`X-Hermes-Session-Id`, `X-Hermes-Session-Key`), and frontend wiring: [API Server](../user-guide/features/api-server).
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -250,7 +250,10 @@ Returns a machine-readable description of the API server's stable surface for ex
     "run_submission": true,
     "run_status": true,
     "run_events_sse": true,
-    "run_stop": true
+    "run_stop": true,
+    "run_approval_request_binding": true,
+    "run_approval_structured_preview": true,
+    "run_approval_preview_version": 1
   }
 }
 ```
@@ -401,7 +404,51 @@ running.
 
 ### POST /v1/runs/\{run_id\}/approval
 
-Resolve a pending approval for a run that is waiting on a human decision (for example, a tool call gated behind an approval policy). The body carries the approval decision; the run resumes once the decision is recorded. This endpoint is advertised in `/v1/capabilities` as the `run_approval` feature so external UIs can detect support before surfacing an approval prompt.
+Resolve a pending approval for a run that is waiting on a human decision (for example, a tool call gated behind an approval policy).
+
+Each `approval.request` SSE event includes a stable `request_id`, the available
+`choices`, and a fixed `preview` object:
+
+```json
+{
+  "event": "approval.request",
+  "request_id": "9a06e485e35d41f2a6896c146d63a53a",
+  "choices": ["once", "session", "always", "deny"],
+  "preview": {
+    "version": 1,
+    "category": "terminal_command",
+    "title": "Terminal command approval",
+    "summary": "Hermes stopped a terminal command that matched a protected action.",
+    "risk_labels": ["recursive delete"]
+  }
+}
+```
+
+The preview uses Hermes-owned text and allowlisted risk labels, so clients do
+not need to build UI copy from raw command or plugin text. Existing redacted
+event fields remain available for compatibility.
+
+Send the displayed request ID back with the decision:
+
+```json
+{
+  "choice": "once",
+  "request_id": "9a06e485e35d41f2a6896c146d63a53a"
+}
+```
+
+Hermes resolves only that queue entry. A stale or unknown ID returns `409`
+without resolving another pending request, and the run remains
+`waiting_for_approval` while sibling approvals are still pending. Do not
+combine `request_id` with `all` or `resolve_all`.
+
+Clients that support older Hermes versions may omit `request_id`; this keeps
+the legacy FIFO behavior. Do not retry a failed exact response without its ID,
+because that would target a different pending request.
+
+The endpoint and binding contract are advertised in `/v1/capabilities` through
+`run_approval_response`, `run_approval_request_binding`,
+`run_approval_structured_preview`, and `run_approval_preview_version`.
 
 ## Jobs API (background scheduled work)
 


### PR DESCRIPTION
## Why this is needed

Hermes can have more than one approval waiting in the same session. Until now, an interactive button identified the session but not the approval that created the button. The backend then resolved the oldest item in the queue.

That creates a bad mismatch: a button showing command B could approve or deny command A simply because command A was queued first.

## What this changes

Every queued approval now gets a stable, transport-safe `request_id`. Relay, the native messaging adapters, the Runs API, TUI, and Desktop carry that ID with the prompt and send it back with the response. The resolver uses it to select the exact pending entry.

Unknown or stale IDs resolve nothing. Typed `/approve` and `/deny` commands still use FIFO, and older clients that omit `request_id` keep the same behavior they have today.

Relay now stores `approval_request_id` in its prompt state and passes it to `resolve_gateway_approval(..., request_id=...)`. The regression test starts with two pending approvals, responds to the second Relay prompt, and verifies that the first request stays pending.

Desktop notifications keep the request ID that was present when the notification was created. A late Desktop or TUI response only clears local state if the completed request still matches the prompt on screen. Matrix keeps separate event mappings when the same session has more than one prompt.

The Runs API advertises request-binding and structured-preview capabilities. The preview comes from fixed server-owned categories and allowlisted risk labels, rather than free-form command or plugin text. Exact request selection cannot be combined with bulk resolution. Run status updates share one lock so an older response or tool-progress callback cannot hide a newer approval wait.

Malformed, expired, or replayed structured Relay responses are consumed without falling through to typed FIFO handling.

## Compatibility

This does not change approval choices, policy, controls, or user-facing copy. Clients that send `request_id` get exact selection and stale-request rejection. Clients that do not send it remain FIFO.

## Credit

This is a current-main rewrite of the exact approval-binding work from #6105. The first commit keeps `mr.Shu <mr@shu.io>` as its author. The commit hash changed because the patch had to be adapted to current platform authorization and transport code.

## Validation

- 227 native adapter approval, authorization, and redaction tests passed
- 142 affected API, approval-core, Relay, and Matrix tests passed
- Desktop full suite: 3,994 passed and 2 skipped
- TUI full suite: 1,439 passed and 1 skipped
- Type checks and lint completed with no errors
- Two independent adversarial reviews approved all eight acceptance criteria

The broad Python run completed with 22,813 passing tests and 24 failures across 16 untouched files. All changed feature suites pass. The committed review log contains the full verification history and the exact failure list.