### PR TITLE
fix(prompt-caching): inject cache breakpoints after message normalization

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1002,19 +1002,6 @@ def run_conversation(
             for idx, pfm in enumerate(agent.prefill_messages):
                 api_messages.insert(sys_offset + idx, pfm.copy())
 
-        # Apply Anthropic prompt caching for Claude models on native
-        # Anthropic, OpenRouter, and third-party Anthropic-compatible
-        # gateways. Auto-detected: if ``_use_prompt_caching`` is set,
-        # inject cache_control breakpoints (system + last 3 messages)
-        # to reduce input token costs by ~75% on multi-turn
-        # conversations.
-        if agent._use_prompt_caching:
-            api_messages = apply_anthropic_cache_control(
-                api_messages,
-                cache_ttl=agent._cache_ttl,
-                native_anthropic=agent._use_native_cache_layout,
-            )
-
         # Safety net: strip orphaned tool results / add stubs for missing
         # results before sending to the API.  Runs unconditionally — not
         # gated on context_compressor — so orphans from session loading or
@@ -1072,6 +1059,33 @@ def run_conversation(
         # lone surrogates (U+D800-U+DFFF) that crash json.dumps() inside
         # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
         _sanitize_messages_surrogates(api_messages)
+
+        # Apply Anthropic prompt caching for Claude models on native
+        # Anthropic, OpenRouter, and third-party Anthropic-compatible
+        # gateways. Auto-detected: if ``_use_prompt_caching`` is set,
+        # inject cache_control breakpoints (system + last 3 messages)
+        # to reduce input token costs by ~75% on multi-turn
+        # conversations.
+        #
+        # Runs LAST, after every message mutation above. Marking earlier
+        # defeats the prefix stability the mutations exist to create:
+        # ``_apply_cache_marker`` rewrites ``content`` from a plain string
+        # into a ``[{"type": "text", ...}]`` block, so the marked messages
+        # no longer match the ``isinstance(content, str)`` test in the
+        # whitespace-normalization pass and silently keep their raw
+        # leading/trailing whitespace. A tool result ending in "\n" is
+        # therefore sent unstripped while it sits in the last-3 window and
+        # stripped once it rolls out of it — the same message, different
+        # bytes on consecutive turns, which breaks the prefix match at
+        # exactly the point the breakpoints were meant to protect. Marking
+        # last also keeps breakpoints off messages that the orphan sweep or
+        # the thinking-only drop is about to remove or merge away.
+        if agent._use_prompt_caching:
+            api_messages = apply_anthropic_cache_control(
+                api_messages,
+                cache_ttl=agent._cache_ttl,
+                native_anthropic=agent._use_native_cache_layout,
+            )
 
         # One image-stripped message estimate feeds both figures. Was: a
         # str(msg) char walk (re-serialized base64 every call) + a second

--- a/tests/agent/test_prompt_caching.py
+++ b/tests/agent/test_prompt_caching.py
@@ -223,3 +223,59 @@ class TestApplyAnthropicCacheControl:
         assert isinstance(result[1]["content"], list)
         assert result[1]["content"][0]["cache_control"] == {"type": "ephemeral"}
         assert "cache_control" not in result[1]
+
+
+class TestNormalizationOrdering:
+    """The conversation loop normalizes message text for prefix stability and
+    injects cache breakpoints. Marking must happen AFTER normalization.
+
+    ``_apply_cache_marker`` rewrites a plain-string ``content`` into a
+    ``[{"type": "text", ...}]`` block. The loop's whitespace pass is guarded
+    on ``isinstance(content, str)``, so anything marked first is skipped by
+    it — and a message is only marked while it sits in the last-3 window.
+    The same message would then be sent raw on one turn and stripped on the
+    next, breaking the prefix match the breakpoints exist to protect.
+    """
+
+    def test_marking_a_string_hides_it_from_string_normalization(self):
+        """The mechanism: marking changes content out of ``str`` shape."""
+        msgs = [{"role": "user", "content": "hello  \n"}]
+        marked = apply_anthropic_cache_control(msgs, native_anthropic=False)
+        assert not isinstance(marked[0]["content"], str)
+        # Raw whitespace survives, now unreachable by an isinstance(str) pass.
+        assert marked[0]["content"][0]["text"] == "hello  \n"
+
+    def test_normalized_then_marked_matches_the_unmarked_wire_text(self):
+        """Normalize-then-mark keeps a message byte-identical across the
+        turn where it rolls out of the cache window."""
+        raw = "file1\nfile2\n"  # trailing newline: every shell tool result
+
+        # Turn N+1, message has left the window: plain string, normalized.
+        out_of_window = raw.strip()
+
+        # Turn N, message is in the window: normalized first, then marked.
+        marked = apply_anthropic_cache_control(
+            [{"role": "tool", "content": raw.strip(), "tool_call_id": "t1"}],
+            native_anthropic=False,
+        )
+        in_window = marked[0]["content"][0]["text"]
+
+        assert in_window == out_of_window
+
+    def test_cache_marking_runs_after_every_message_mutation(self):
+        """Ordering invariant, locked against regression."""
+        import inspect
+
+        from agent import conversation_loop
+
+        src = inspect.getsource(conversation_loop)
+        mark = src.index("apply_anthropic_cache_control(\n")
+        for earlier in (
+            'am["content"].strip()',              # whitespace normalization
+            "_sanitize_api_messages(api_messages)",       # orphan sweep
+            "_drop_thinking_only_and_merge_users(",       # drop / merge
+            "_sanitize_messages_surrogates(api_messages)",
+        ):
+            assert src.index(earlier) < mark, (
+                f"{earlier!r} must run before cache breakpoints are injected"
+            )


### PR DESCRIPTION
## What

The conversation loop normalizes message text immediately before the API call
so the request prefix is byte-identical across turns. Its own comment states
why: *"Ensures bit-perfect prefixes across turns, which enables KV cache reuse
on local inference servers (llama.cpp, vLLM, Ollama) and improves cache hit
rates for cloud providers."*

Cache breakpoints were injected **before** that pass, which defeats it.

`_apply_cache_marker` rewrites a plain-string `content` into a
`[{"type": "text", ...}]` block. The normalization pass is guarded on
`isinstance(content, str)`, so every message that was just marked is silently
skipped by it and keeps its raw leading/trailing whitespace. A message is only
marked while it sits in the last-3 window, so the same message changes shape
between turns:

```
turn N     in the window   -> marked, text "file1\nfile2\n"   (not stripped)
turn N+1   rolled out      -> plain,  text "file1\nfile2"     (stripped)
```

Verified against the real decorator:

```
in window  -> content type: list   strip runs? False   text: 'file1\nfile2\n'
out window -> content type: str    strip runs? True    text: 'file1\nfile2'
SAME message, bytes differ across turns: True
```

The prefix stops matching at that position — which is *inside* the span the
breakpoints were placed to protect — so the reusable prefix collapses back
toward the system breakpoint on every turn. Tool results carry a trailing
newline almost by default (any shell command output), so this is the common
case, not an edge case.

## Fix

Move the injection below every message mutation.

Besides fixing the whitespace divergence, this stops breakpoints from being
spent on messages the orphan sweep or the thinking-only drop is about to
remove or merge away — a marker on a dropped message is a wasted breakpoint
out of the four available.

Nothing between the old and new call sites reads `cache_control` (checked in
`_sanitize_api_messages` and `_drop_thinking_only_and_merge_users`), and the
mutators now see the plain-string shapes they were written against.

## Tests

`tests/agent/test_prompt_caching.py` — new `TestNormalizationOrdering` (26
passed in the file):

- marking a string moves content out of `str` shape, hiding it from the
  normalization pass (the mechanism)
- normalize-then-mark keeps a message byte-identical across the turn where it
  leaves the cache window
- ordering invariant locked against regression: marking must follow the
  whitespace pass, the orphan sweep, the thinking-only drop, and the surrogate
  strip

The ordering test fails on `main` with an assertion error and passes with the
fix.

Regression: `test_prompt_caching.py`, `test_moa_aggregator_cache_control.py`,
`test_anthropic_adapter.py`, `test_anthropic_thinking_block_order.py`,
`test_anthropic_kwargs_sanitize.py`, `test_verification_stop_caching.py` —
218 passed, 1 skipped. Plus every `tests/agent/` file touching the
conversation loop: 585 passed, with the same 2 pre-existing failures
(`test_codex_app_server_persist`, `test_memory_async_sync`) reproduced
identically on a clean `main`.