### PR TITLE
feat(state): add config.yaml flag to disable trigram FTS index

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -601,6 +601,17 @@ memory:
 # When a reset triggers, the agent gets one turn to save important memories and
 # skills before the context is wiped. Persistent memory carries across sessions.
 #
+# state.db (session/message store) tuning.
+state:
+  # The trigram FTS5 index powers CJK and substring/fuzzy message search, but it
+  # over-indexes every 3-character window and can grow to be the largest object
+  # in state.db (multiple GB on long-lived gateways). Set true to skip it:
+  # normal word/token search still works at full quality via the standard FTS
+  # index; only CJK/substring queries fall back to LIKE. Default false preserves
+  # current behavior. When set true on an already-bloated database the trigram
+  # index is dropped on next start; run VACUUM to return the freed pages to the OS.
+  disable_fts_trigram: false
+
 session_reset:
   mode: both           # "both", "idle", "daily", or "none"
   idle_minutes: 1440   # Inactivity timeout in minutes (default: 1440 = 24 hours)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -17,6 +17,7 @@ Key design decisions:
 import asyncio
 import json
 import logging
+import os
 import random
 import re
 import sqlite3
@@ -27,7 +28,7 @@ from pathlib import Path
 
 from agent.memory_manager import sanitize_context
 from agent.message_sanitization import _sanitize_surrogates
-from hermes_constants import get_hermes_home
+from hermes_constants import get_config_path, get_hermes_home
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
 logger = logging.getLogger(__name__)
@@ -196,14 +197,57 @@ _last_init_error_lock = threading.Lock()
 _wal_fallback_warned_paths: set[str] = set()
 _wal_fallback_warned_lock = threading.Lock()
 
-_FTS_TRIGGERS = (
+_FTS_BASE_TRIGGERS = (
     "messages_fts_insert",
     "messages_fts_delete",
     "messages_fts_update",
+)
+_FTS_TRIGRAM_TRIGGERS = (
     "messages_fts_trigram_insert",
     "messages_fts_trigram_delete",
     "messages_fts_trigram_update",
 )
+# Full set kept for backward compatibility; the boot-time repair check picks the
+# active subset (base only when the trigram index is disabled) so a disabled
+# trigram does not look like "triggers missing" and force a rebuild every boot.
+_FTS_TRIGGERS = _FTS_BASE_TRIGGERS + _FTS_TRIGRAM_TRIGGERS
+
+
+def _fts_trigram_disabled() -> bool:
+    """Whether the trigram FTS5 index is disabled by user configuration.
+
+    The user-facing switch is ``state.disable_fts_trigram`` in ``config.yaml``
+    (behavioral flags live in config.yaml per AGENTS.md, not in ``.env``). The
+    ``HERMES_DISABLE_FTS_TRIGRAM`` environment variable is honored only as an
+    internal bridge (tests, managed deploys); it is not the documented switch.
+
+    Default is ``False`` — trigram stays on for existing users unless they opt
+    out. Fail-open: any read/parse error leaves trigram enabled.
+    """
+    env = os.environ.get("HERMES_DISABLE_FTS_TRIGRAM")
+    if env is not None:
+        return env.strip().lower() in ("1", "true", "yes", "on")
+    try:
+        from utils import fast_safe_load
+
+        config_path = get_config_path()
+        if config_path.exists():
+            with open(config_path, "r", encoding="utf-8") as f:
+                cfg = fast_safe_load(f) or {}
+            # Managed scope: an administrator can pin state.* too. Overlay via
+            # the shared helper (fail-open) since this reads config.yaml directly.
+            try:
+                from hermes_cli import managed_scope
+
+                cfg = managed_scope.apply_managed_overlay(cfg)
+            except Exception:
+                pass
+            state_cfg = cfg.get("state", {})
+            if isinstance(state_cfg, dict):
+                return bool(state_cfg.get("disable_fts_trigram", False))
+    except Exception:
+        pass
+    return False
 
 
 def _set_last_init_error(msg: Optional[str]) -> None:
@@ -1037,6 +1081,10 @@ class SessionDB:
         self._fts_runtime_rebuild_attempted = False
         self._fts_enabled = False
         self._trigram_available = False
+        # User opt-out (config.yaml: state.disable_fts_trigram). When set, the
+        # trigram index is never created/maintained and an existing one is
+        # dropped, so state.db stops carrying the ~GB CJK/substring index.
+        self._trigram_disabled = _fts_trigram_disabled()
         self._fts_unavailable_warned = False
         self._conn = None
         try:
@@ -1187,14 +1235,29 @@ class SessionDB:
                 pass
 
     @staticmethod
-    def _fts_trigger_count(cursor: sqlite3.Cursor) -> int:
-        placeholders = ",".join("?" for _ in _FTS_TRIGGERS)
+    def _fts_trigger_count(
+        cursor: sqlite3.Cursor, expected: Tuple[str, ...] = _FTS_TRIGGERS
+    ) -> int:
+        placeholders = ",".join("?" for _ in expected)
         row = cursor.execute(
             f"SELECT COUNT(*) FROM sqlite_master "
             f"WHERE type = 'trigger' AND name IN ({placeholders})",
-            _FTS_TRIGGERS,
+            expected,
         ).fetchone()
         return int(row[0] if not isinstance(row, sqlite3.Row) else row[0])
+
+    @staticmethod
+    def _drop_fts_trigram(cursor: sqlite3.Cursor) -> None:
+        """Remove the trigram index and its sync triggers.
+
+        Called when ``state.disable_fts_trigram`` is set so an already-bloated
+        state.db stops maintaining the ~GB CJK/substring index. The freed pages
+        go to the freelist immediately and return to the OS on the next VACUUM;
+        the index is fully rebuildable from ``messages`` if re-enabled later.
+        """
+        for trigger in _FTS_TRIGRAM_TRIGGERS:
+            cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+        cursor.execute("DROP TABLE IF EXISTS messages_fts_trigram")
 
     @staticmethod
     def _rebuild_fts_indexes(
@@ -1699,18 +1762,24 @@ class SessionDB:
                                 "COALESCE(tool_calls, '') "
                                 "FROM messages"
                             )
-                        trigram_ok = self._ensure_fts_schema(
-                            cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
-                        )
-                        if trigram_ok:
-                            cursor.execute(
-                                "INSERT INTO messages_fts_trigram(rowid, content) "
-                                "SELECT id, "
-                                "COALESCE(content, '') || ' ' || "
-                                "COALESCE(tool_name, '') || ' ' || "
-                                "COALESCE(tool_calls, '') "
-                                "FROM messages"
+                        if self._trigram_disabled:
+                            # Opted out: drop any existing trigram index instead
+                            # of recreating/backfilling it during migration.
+                            self._drop_fts_trigram(cursor)
+                            trigram_ok = False
+                        else:
+                            trigram_ok = self._ensure_fts_schema(
+                                cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
                             )
+                            if trigram_ok:
+                                cursor.execute(
+                                    "INSERT INTO messages_fts_trigram(rowid, content) "
+                                    "SELECT id, "
+                                    "COALESCE(content, '') || ' ' || "
+                                    "COALESCE(tool_name, '') || ' ' || "
+                                    "COALESCE(tool_calls, '') "
+                                    "FROM messages"
+                                )
                         if not base_fts_ok:
                             fts_migrations_complete = False
                         # Track trigram availability for CJK LIKE fallback.
@@ -1913,22 +1982,34 @@ class SessionDB:
         if fts5_available:
             # FTS5 setup. Run the DDL even when the virtual table exists so
             # CREATE TRIGGER IF NOT EXISTS repairs trigger-only degradation from
-            # an earlier no-FTS5 runtime.
-            triggers_need_repair = self._fts_trigger_count(cursor) < len(_FTS_TRIGGERS)
+            # an earlier no-FTS5 runtime. When the trigram index is disabled we
+            # only expect the base triggers, so a missing trigram trigger set is
+            # not mistaken for degradation (which would rebuild FTS every boot).
+            expected_triggers = (
+                _FTS_BASE_TRIGGERS if self._trigram_disabled else _FTS_TRIGGERS
+            )
+            triggers_need_repair = (
+                self._fts_trigger_count(cursor, expected_triggers)
+                < len(expected_triggers)
+            )
             self._fts_enabled = self._ensure_fts_schema(cursor, "messages_fts", FTS_SQL)
 
             # Trigram FTS5 for CJK/substring search. This is optional relative
             # to the main FTS table; if it cannot be created, CJK search falls
-            # back to LIKE.
+            # back to LIKE. When disabled via config, drop any existing trigram
+            # index so an already-bloated state.db reclaims the space.
             if self._fts_enabled:
-                trigram_enabled = self._ensure_fts_schema(
-                    cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
-                )
-                self._trigram_available = trigram_enabled
+                if self._trigram_disabled:
+                    self._drop_fts_trigram(cursor)
+                    self._trigram_available = False
+                else:
+                    self._trigram_available = self._ensure_fts_schema(
+                        cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
+                    )
                 if triggers_need_repair:
                     self._rebuild_fts_indexes(
                         cursor,
-                        include_trigram=trigram_enabled,
+                        include_trigram=self._trigram_available,
                     )
 
         self._conn.commit()
@@ -7498,8 +7579,8 @@ class SessionDB:
         index internally, then VACUUM returns the freed pages to the OS.
 
         Skips any FTS table that does not exist (e.g. the trigram index when
-        disabled via ``HERMES_DISABLE_FTS_TRIGRAM`` or not yet created), so
-        it is safe to call unconditionally.
+        disabled via ``config.yaml: state.disable_fts_trigram`` or not yet
+        created), so it is safe to call unconditionally.
 
         Returns the number of FTS indexes that were optimized.
         """

--- a/tests/test_hermes_state_trigram_disable.py
+++ b/tests/test_hermes_state_trigram_disable.py
@@ -1,0 +1,147 @@
+"""Tests for the `state.disable_fts_trigram` config flag (issue #55233).
+
+Covers: fresh DBs skip the trigram index when disabled, no boot rebuild loop,
+default behavior is unchanged, an existing trigram index is dropped on opt-out,
+and the config.yaml read path itself works.
+"""
+
+import sqlite3
+
+import pytest
+
+import hermes_state
+from hermes_state import (
+    _FTS_BASE_TRIGGERS,
+    _FTS_TRIGRAM_TRIGGERS,
+    SessionDB,
+)
+
+
+def _table_exists(db_path, name):
+    con = sqlite3.connect(db_path)
+    try:
+        row = con.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+        ).fetchone()
+        return row is not None
+    finally:
+        con.close()
+
+
+def _trigger_names(db_path):
+    con = sqlite3.connect(db_path)
+    try:
+        return {
+            r[0]
+            for r in con.execute(
+                "SELECT name FROM sqlite_master WHERE type='trigger'"
+            ).fetchall()
+        }
+    finally:
+        con.close()
+
+
+def test_disabled_fresh_db_skips_trigram(tmp_path, monkeypatch):
+    monkeypatch.setattr(hermes_state, "_fts_trigram_disabled", lambda: True)
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+
+    assert db._trigram_disabled is True
+    assert db._trigram_available is False
+    # Trigram table + its 3 triggers must be absent...
+    assert not _table_exists(db_path, "messages_fts_trigram")
+    assert _trigram_names_absent(db_path)
+    # ...but base FTS + its triggers must be present and functional.
+    assert _table_exists(db_path, "messages_fts")
+    assert set(_FTS_BASE_TRIGGERS).issubset(_trigger_names(db_path))
+
+    # Word search via messages_fts still works.
+    db.create_session("s1", source="cli")
+    db.append_message("s1", role="user", content="hello trigram world")
+    results = db.search_messages("trigram")
+    assert any("trigram" in (r.get("snippet") or "") for r in results)
+
+
+def _trigram_names_absent(db_path):
+    names = _trigger_names(db_path)
+    return not set(_FTS_TRIGRAM_TRIGGERS) & names
+
+
+def test_disabled_no_boot_rebuild_loop(tmp_path, monkeypatch):
+    """A disabled trigram must NOT make the 2nd open think triggers are missing
+    (which would rebuild the whole FTS on every boot)."""
+    monkeypatch.setattr(hermes_state, "_fts_trigram_disabled", lambda: True)
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path=db_path)
+
+    con = sqlite3.connect(db_path)
+    try:
+        cur = con.cursor()
+        # With trigram disabled we only expect the base triggers, and they are
+        # all present -> no repair needed.
+        assert SessionDB._fts_trigger_count(cur, _FTS_BASE_TRIGGERS) == len(
+            _FTS_BASE_TRIGGERS
+        )
+    finally:
+        con.close()
+
+    # Second open must construct cleanly (no exception, trigram still absent).
+    db2 = SessionDB(db_path=db_path)
+    assert db2._trigram_available is False
+    assert not _table_exists(db_path, "messages_fts_trigram")
+
+
+def test_default_keeps_trigram(tmp_path, monkeypatch):
+    monkeypatch.setattr(hermes_state, "_fts_trigram_disabled", lambda: False)
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+
+    assert db._trigram_disabled is False
+    # Default preserves current behavior: trigram present (unless the SQLite
+    # build lacks the tokenizer, in which case _trigram_available is False but
+    # that is orthogonal to this flag).
+    if db._trigram_available:
+        assert _table_exists(db_path, "messages_fts_trigram")
+        assert set(_FTS_TRIGRAM_TRIGGERS).issubset(_trigger_names(db_path))
+
+
+def test_existing_trigram_dropped_on_optout(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    # First build WITH trigram (default).
+    monkeypatch.setattr(hermes_state, "_fts_trigram_disabled", lambda: False)
+    seeded = SessionDB(db_path=db_path)
+    if not seeded._trigram_available:
+        pytest.skip("SQLite build lacks the trigram tokenizer")
+    assert _table_exists(db_path, "messages_fts_trigram")
+
+    # Reopen WITH the flag on -> trigram table + triggers must be dropped.
+    monkeypatch.setattr(hermes_state, "_fts_trigram_disabled", lambda: True)
+    reopened = SessionDB(db_path=db_path)
+    assert reopened._trigram_available is False
+    assert not _table_exists(db_path, "messages_fts_trigram")
+    assert _trigram_names_absent(db_path)
+
+
+def test_config_yaml_read_path(tmp_path, monkeypatch):
+    """The real config.yaml read path (not just the monkeypatch) resolves the
+    flag from `state.disable_fts_trigram`."""
+    monkeypatch.delenv("HERMES_DISABLE_FTS_TRIGRAM", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    (tmp_path / "config.yaml").write_text("state:\n  disable_fts_trigram: true\n")
+    assert hermes_state._fts_trigram_disabled() is True
+
+    (tmp_path / "config.yaml").write_text("state:\n  disable_fts_trigram: false\n")
+    assert hermes_state._fts_trigram_disabled() is False
+
+    (tmp_path / "config.yaml").write_text("other: {}\n")
+    assert hermes_state._fts_trigram_disabled() is False
+
+
+def test_env_bridge_overrides(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("state:\n  disable_fts_trigram: false\n")
+    monkeypatch.setenv("HERMES_DISABLE_FTS_TRIGRAM", "1")
+    assert hermes_state._fts_trigram_disabled() is True
+    monkeypatch.setenv("HERMES_DISABLE_FTS_TRIGRAM", "off")
+    assert hermes_state._fts_trigram_disabled() is False


### PR DESCRIPTION
## Summary

Closes #55233. Adds an opt-in `config.yaml` switch — **`state.disable_fts_trigram`** (default `false`) — to skip the `messages_fts_trigram` FTS5 index. That index over-indexes every 3-character window and becomes the largest object in `state.db` (multiple GB on long-lived gateways) purely to serve CJK/substring search many deployments never use.

Default is unchanged behavior; existing users see no difference unless they opt in.

## Addressing the prior reviews

This supersedes the closed #27770 / #42190 and folds in the reviewer feedback from the closed #57761:

- **Config, not env (AGENTS.md).** The user-facing knob is `config.yaml: state.disable_fts_trigram`, read via the same `fast_safe_load` + managed-scope-overlay pattern as `_read_logging_config()`. `HERMES_DISABLE_FTS_TRIGRAM` is retained **only** as an internal bridge (tests/managed deploys), not a documented switch — so `.env` stays credentials-only.
- **No boot rebuild loop.** `_fts_trigger_count()` / the startup repair check now expect the **base-only** trigger set when trigram is disabled. Previously a disabled index looked like "triggers missing" and forced a full FTS rebuild on every boot (the regression flagged on #57761). Covered by `test_disabled_no_boot_rebuild_loop`.

## Behavior when enabled

- Startup **and** the legacy migration path skip creating `messages_fts_trigram` and its triggers.
- An already-present trigram index + triggers are **dropped** (`_drop_fts_trigram`), so a bloated `state.db` reclaims the space — pages return to the OS on the next `VACUUM`. Fully rebuildable from `messages` if re-enabled.
- Standard word/token search is unaffected (`messages_fts`); only CJK/substring queries fall back to `LIKE`.
- Also removes the misleading `optimize_fts()` docstring that referenced an unimplemented `HERMES_DISABLE_FTS_TRIGRAM` switch.

## Tests

New `tests/test_hermes_state_trigram_disable.py` (6 cases): fresh-DB skip, no boot-rebuild loop, default keeps trigram, existing index dropped on opt-out, `config.yaml` read path (true/false/absent), env-bridge override. Existing `tests/test_hermes_state.py`: **382 passed, no regressions**.

## Reclaiming space on an already-bloated database

```yaml
# config.yaml
state:
  disable_fts_trigram: true
```
Restart the gateway (drops the index), then `sqlite3 state.db "VACUUM;"` to return the freed pages to the OS.
