### PR TITLE
fix(voice): reconcile NeuTTS backbone/codec GPU device strings

### DIFF
--- a/tools/neutts_synth.py
+++ b/tools/neutts_synth.py
@@ -59,6 +59,12 @@ def main():
     parser.add_argument("--device", default="cpu", help="Device (cpu/cuda/mps)")
     args = parser.parse_args()
 
+    # llama_cpp (backbone) offloads to GPU only for the literal string "gpu";
+    # torch (codec) only accepts "cuda". A single --device value can't satisfy
+    # both — "cuda" silently no-ops on the backbone, leaving it on CPU.
+    backbone_device = "gpu" if args.device == "cuda" else args.device
+    codec_device = args.device
+
     # Validate inputs
     ref_audio = Path(args.ref_audio).expanduser()
     ref_text_path = Path(args.ref_text).expanduser()
@@ -80,9 +86,9 @@ def main():
 
     tts = NeuTTS(
         backbone_repo=args.model,
-        backbone_device=args.device,
+        backbone_device=backbone_device,
         codec_repo="neuphonic/neucodec",
-        codec_device=args.device,
+        codec_device=codec_device,
     )
     ref_codes = tts.encode_reference(str(ref_audio))
     wav = tts.infer(args.text, ref_codes, ref_text)


### PR DESCRIPTION
## Problem
`tools/neutts_synth.py` passes the single `--device` value straight through to both the GGUF backbone loader (`llama_cpp`) and the codec (`torch`). The two libraries don't agree on vocabulary for GPU:

- `llama_cpp`'s GGUF loader only sets `n_gpu_layers=-1` when the device string is the literal `"gpu"` (see `neutts/neutts.py::_load_backbone`) — `"cuda"` silently falls through to `n_gpu_layers=0`, i.e. CPU.
- `torch`'s codec (`.to(device)`) only accepts `"cuda"` — `"gpu"` raises `RuntimeError`.

Since `config.yaml`'s documented setting is `tts.neutts.device: cuda` (matches torch convention, and is what the codec needs), the backbone was silently running on CPU with GPU configured and no error/warning.

## Fix
Map `cuda -> gpu` for the backbone only; leave the codec on the torch-native string the user configured.

## Verification
Manual timing on an RTX 5070 Ti Laptop GPU with `neuphonic/neutts-air-q4-gguf`, same input text, `device: cuda`:

| | before | after |
|---|---|---|
| wall time | 24.9s | 13.1s |
| backbone load line | `Loading backbone ... on cuda` (n_gpu_layers=0) | `Loading backbone ... on gpu` (n_gpu_layers=-1) |

Also ran the adjacent TTS test suites (no dedicated unit tests exist for this subprocess helper — it isn't imported/mocked anywhere):
```
scripts/run_tests.sh tests/tools/test_tts_command_providers.py tests/agent/test_tts_registry.py tests/tools/test_tts_plugin_dispatch.py
=== Summary: 3 files, 134 tests passed, 0 failed ===
```

Remaining ~13s is model *load* time (confirmed constant regardless of text length), inherent to the current per-call subprocess architecture — out of scope for this fix.