### PR TITLE
fix: reap idle LSP clients

### DIFF
--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -167,8 +167,13 @@ class LSPService:
         self._idle_timeout = idle_timeout
 
         self._loop = _BackgroundLoop()
-        if self._enabled:
-            self._loop.start()
+
+        # Idle reaper task (runs on the background loop).  Long-running
+        # gateway/CLI processes can touch many worktrees over time; without a
+        # periodic sweep, language servers for no-longer-used workspaces remain
+        # alive until Python exit.  Keep the task best-effort and disabled when
+        # the service itself is disabled.
+        self._idle_reaper_task: Optional[asyncio.Task] = None
 
         # Per-(server_id, workspace_root) state
         self._clients: Dict[Tuple[str, str], LSPClient] = {}
@@ -176,6 +181,13 @@ class LSPService:
         self._spawning: Dict[Tuple[str, str], asyncio.Future] = {}
         self._last_used: Dict[Tuple[str, str], float] = {}
         self._state_lock = threading.Lock()
+
+        if self._enabled:
+            self._loop.start()
+            try:
+                self._loop.run(self._start_idle_reaper_async(), timeout=2.0)
+            except Exception as e:  # noqa: BLE001
+                logger.debug("LSP idle reaper start failed: %s", e)
 
         # Delta baseline: file path → snapshot of diagnostics taken
         # immediately before a write.  ``get_diagnostics_sync`` filters
@@ -226,6 +238,11 @@ class LSPService:
                 if isinstance(init, dict):
                     init_overrides[name] = init
 
+        try:
+            idle_timeout = float(lsp_cfg.get("idle_timeout", DEFAULT_IDLE_TIMEOUT))
+        except (TypeError, ValueError):
+            idle_timeout = DEFAULT_IDLE_TIMEOUT
+
         return cls(
             enabled=enabled,
             wait_mode=wait_mode,
@@ -235,6 +252,7 @@ class LSPService:
             env_overrides=env_overrides,
             init_overrides=init_overrides,
             disabled_servers=disabled,
+            idle_timeout=idle_timeout,
         )
 
     # ------------------------------------------------------------------
@@ -442,9 +460,67 @@ class LSPService:
         self._loop.stop()
         clear_cache()
 
+    def reap_idle_clients(self) -> int:
+        """Synchronously shut down clients idle longer than ``idle_timeout``.
+
+        Intended for tests, CLI/status hooks, and explicit maintenance.  The
+        service also starts a periodic background reaper so long-running gateway
+        processes do not need another LSP request before stale clients are
+        collected.
+        """
+        if not self._enabled:
+            return 0
+        try:
+            return int(self._loop.run(self._reap_idle_clients_async(), timeout=10.0) or 0)
+        except Exception as e:  # noqa: BLE001
+            logger.debug("LSP idle reap error: %s", e)
+            return 0
+
     # ------------------------------------------------------------------
     # async internals
     # ------------------------------------------------------------------
+
+    async def _start_idle_reaper_async(self) -> None:
+        if self._idle_reaper_task is None or self._idle_reaper_task.done():
+            self._idle_reaper_task = asyncio.create_task(
+                self._idle_reaper_loop(),
+                name="hermes-lsp-idle-reaper",
+            )
+
+    async def _idle_reaper_loop(self) -> None:
+        interval = min(60.0, max(0.05, self._idle_timeout / 2.0))
+        try:
+            while True:
+                await asyncio.sleep(interval)
+                await self._reap_idle_clients_async()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # noqa: BLE001
+            logger.debug("LSP idle reaper stopped after error: %s", e)
+
+    async def _reap_idle_clients_async(self, *, now: Optional[float] = None) -> int:
+        if self._idle_timeout <= 0:
+            return 0
+        cutoff = (time.time() if now is None else now) - self._idle_timeout
+        stale: List[Tuple[Tuple[str, str], LSPClient]] = []
+        with self._state_lock:
+            for key, client in list(self._clients.items()):
+                last_used = self._last_used.get(key, 0.0)
+                if last_used <= cutoff:
+                    stale.append((key, client))
+                    self._clients.pop(key, None)
+                    self._last_used.pop(key, None)
+        if not stale:
+            return 0
+        results = await asyncio.gather(
+            *(client.shutdown() for _, client in stale),
+            return_exceptions=True,
+        )
+        for (key, _client), result in zip(stale, results):
+            if isinstance(result, Exception):
+                logger.debug("LSP idle shutdown failed for %s: %s", key, result)
+        logger.info("Reaped %d idle LSP client(s)", len(stale))
+        return len(stale)
 
     async def _snapshot_async(self, file_path: str) -> List[Dict[str, Any]]:
         client = await self._get_or_spawn(file_path)
@@ -567,6 +643,16 @@ class LSPService:
                 self._spawning.pop(key, None)
 
     async def _shutdown_async(self) -> None:
+        idle_task = self._idle_reaper_task
+        self._idle_reaper_task = None
+        if idle_task is not None:
+            idle_task.cancel()
+            try:
+                await idle_task
+            except asyncio.CancelledError:
+                pass
+            except Exception as e:  # noqa: BLE001
+                logger.debug("LSP idle reaper shutdown error: %s", e)
         with self._state_lock:
             clients = list(self._clients.values())
             self._clients.clear()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9169,6 +9169,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _phase_elapsed(),
             )
 
+            # The process-global LSP service is independent from the tool
+            # subprocess registry.  Explicitly stop it during gateway teardown
+            # so long-running gateway restarts do not leave pyright/gopls/
+            # typescript-language-server children around until atexit.
+            try:
+                from agent.lsp import shutdown_service as _shutdown_lsp_service
+                _shutdown_lsp_service()
+            except Exception as _e:
+                logger.debug("LSP shutdown_service error: %s", _e)
+            logger.info(
+                "Shutdown phase: LSP service cleanup done at +%.2fs",
+                _phase_elapsed(),
+            )
+
             # Reap the process-global auxiliary-client cache once at the very
             # end of teardown.  Per-turn cleanup runs in _cleanup_agent_resources
             # for each active agent, but clients bound to worker-thread loops

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3295,11 +3295,17 @@ DEFAULT_CONFIG = {
         "wait_timeout": 5.0,
 
         # How to handle missing server binaries.
-        # ``"auto"`` — try to install via npm/go/pip into
+        # ``auto`` — try to install via npm/go/pip into
         #              ``<HERMES_HOME>/lsp/bin/`` on first use.
-        # ``"manual"`` — only use binaries already on PATH.
-        # ``"off"`` — alias for ``manual``.
+        # ``manual`` — only use binaries already on PATH.
+        # ``off`` — alias for ``manual``.
         "install_strategy": "auto",
+
+        # Idle language-server processes are shut down automatically after
+        # this many seconds with no file activity.  This prevents long-running
+        # gateway processes from accumulating stale pyright/gopls/tsserver
+        # children as agents move across worktrees.
+        "idle_timeout": 600.0,
 
         # Per-server overrides.  Each key is a server_id from the
         # registry (``pyright``, ``typescript``, ``gopls``,

--- a/tests/agent/lsp/test_service.py
+++ b/tests/agent/lsp/test_service.py
@@ -8,6 +8,7 @@ on.
 from __future__ import annotations
 
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -172,5 +173,70 @@ def test_service_status_includes_clients(mock_pyright):
         info = svc.get_status()
         assert info["enabled"] is True
         assert any(c["server_id"] == "pyright" for c in info["clients"])
+    finally:
+        svc.shutdown()
+
+
+class _FakeIdleClient:
+    def __init__(self, server_id: str = "pyright", workspace_root: str = "/tmp/repo"):
+        self.server_id = server_id
+        self.workspace_root = workspace_root
+        self.state = "running"
+        self.is_running = True
+        self.shutdown_calls = 0
+
+    async def shutdown(self):
+        self.shutdown_calls += 1
+        self.is_running = False
+        self.state = "stopped"
+
+
+def test_service_reap_idle_clients_shuts_down_stale_lsp_clients():
+    svc = LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=3.0,
+        install_strategy="manual",
+        idle_timeout=0.1,
+    )
+    client = _FakeIdleClient()
+    key = (client.server_id, client.workspace_root)
+    try:
+        with svc._state_lock:
+            svc._clients[key] = client  # pyright: ignore[reportArgumentType]
+            svc._last_used[key] = time.time() - 5.0
+
+        assert svc.reap_idle_clients() == 1
+        assert client.shutdown_calls == 1
+        assert key not in svc._clients
+        assert key not in svc._last_used
+    finally:
+        svc.shutdown()
+
+
+def test_service_idle_reaper_runs_without_new_lsp_requests():
+    svc = LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=3.0,
+        install_strategy="manual",
+        idle_timeout=0.05,
+    )
+    client = _FakeIdleClient()
+    key = (client.server_id, client.workspace_root)
+    try:
+        with svc._state_lock:
+            svc._clients[key] = client  # pyright: ignore[reportArgumentType]
+            svc._last_used[key] = time.time() - 5.0
+
+        deadline = time.time() + 2.0
+        while time.time() < deadline:
+            if client.shutdown_calls:
+                break
+            time.sleep(0.02)
+
+        assert client.shutdown_calls == 1
+        assert key not in svc._clients
+        assert key not in svc._last_used
     finally:
         svc.shutdown()

--- a/tests/gateway/test_shutdown_cache_cleanup.py
+++ b/tests/gateway/test_shutdown_cache_cleanup.py
@@ -12,7 +12,7 @@ The fix adds an explicit sweep of ``_agent_cache`` after
 import asyncio
 import threading
 from collections import OrderedDict
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -162,6 +162,16 @@ class TestCachedAgentCleanupOnShutdown:
         await gw_mod.GatewayRunner.stop(gw)  # Should not raise
 
         assert len(gw._agent_cache) == 0
+
+    @pytest.mark.asyncio
+    async def test_lsp_service_shut_down_on_gateway_stop(self):
+        """Gateway stop explicitly tears down the process-global LSP service."""
+        gw = _FakeGateway()
+
+        with patch("agent.lsp.shutdown_service") as shutdown_service:
+            await gw_mod.GatewayRunner.stop(gw)  # pyright: ignore[reportArgumentType]
+
+        shutdown_service.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_multiple_cached_agents_all_cleaned(self):


### PR DESCRIPTION
## Summary
- add a periodic LSP idle reaper so stale `(server_id, workspace_root)` clients are shut down after `lsp.idle_timeout`
- add `lsp.idle_timeout` config with a 600s default
- explicitly shut down the process-global LSP service during gateway teardown
- cover explicit idle reap, background reap, and gateway shutdown cleanup with regression tests

## Test Plan
- `pytest tests/agent/lsp/test_service.py::test_service_reap_idle_clients_shuts_down_stale_lsp_clients tests/agent/lsp/test_service.py::test_service_idle_reaper_runs_without_new_lsp_requests tests/gateway/test_shutdown_cache_cleanup.py::TestCachedAgentCleanupOnShutdown::test_lsp_service_shut_down_on_gateway_stop -q`
- `pytest tests/agent/lsp/test_service.py tests/agent/lsp/test_lifecycle.py tests/gateway/test_shutdown_cache_cleanup.py -q`
- `pytest tests/agent/lsp -q`
