### PR TITLE
feat(slack): add secure custom message hook

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -340,18 +340,39 @@ class GatewayAuthorizationMixin:
         return False
 
     def _pairing_store_for(self, source: "SessionSource"):
-        """Pick the per-profile PairingStore for a source, falling back to global.
+        """Pick the per-profile PairingStore for a source.
 
         In a multiplexing gateway, each profile owns its own pairing whitelist
-        so isolation is preserved. When the source has no profile (single-
-        profile gateway, or a path that hasn't stamped profile yet) or the
-        profile isn't registered, fall back to ``self.pairing_store`` (the
-        global default) so existing behavior is preserved.
+        so isolation is preserved.
+
+        Under multiplexing a source carrying a profile MUST be answered from
+        that profile's store or not at all. Returning the default store for an
+        unregistered profile would let the default profile's pairing grants
+        authorize another profile's traffic — the store may be missing because
+        it failed to initialize, or because the profile is stale/unknown, and
+        neither is a reason to widen access. Returning ``None`` denies the
+        pairing grant specifically; the caller still evaluates the remaining
+        (profile-independent) authorization rules.
+
+        Without multiplexing an unset profile unambiguously means the one
+        active profile, so the global ``self.pairing_store`` is the correct and
+        only store — behavior there is unchanged.
         """
+        from gateway.run import logger
+
         per_profile = getattr(self, "pairing_stores", None) or {}
         profile = getattr(source, "profile", None)
         if profile and profile in per_profile:
             return per_profile[profile]
+        if profile and getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            logger.warning(
+                "No PairingStore registered for profile %r (%s/%s); denying the "
+                "pairing grant instead of consulting the default profile",
+                profile,
+                getattr(getattr(source, "platform", None), "value", "?"),
+                getattr(source, "chat_id", "?"),
+            )
+            return None
         return getattr(self, "pairing_store", None)
 
     def _is_user_authorized(self, source: SessionSource) -> bool:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2744,6 +2744,16 @@ class BasePlatformAdapter(ABC):
     # routing is platform-generic instead of Discord-only.
     gateway_runner = None  # type: ignore[assignment]  # set by gateway/run.py
 
+    # The gateway profile this adapter instance speaks for, injected by
+    # ``gateway/run.py`` at the same seam that installs the message handler.
+    # Under ``gateway.multiplex_profiles`` one process runs a separate adapter
+    # per profile, and ordinary inbound events get ``source.profile`` stamped by
+    # the per-profile message-handler wrapper in run.py. Any path that acts on a
+    # message *before* that wrapper — a platform's pre-dispatch command seam,
+    # say — sees an unstamped source and would otherwise be served by the
+    # default profile. ``apply_owner_profile`` is the generic recovery.
+    owner_profile: Optional[str] = None  # type: ignore[assignment]  # set by gateway/run.py
+
     def __init__(self, config: PlatformConfig, platform: Platform):
         self.config = config
         self.platform = platform
@@ -3288,6 +3298,80 @@ class BasePlatformAdapter(ABC):
         an optional response string.
         """
         self._message_handler = handler
+
+    def set_owner_profile(self, profile_name: Optional[str]) -> None:
+        """Record which gateway profile owns this adapter instance.
+
+        ``gateway/run.py`` calls this for every adapter it creates — the active
+        profile's as well as each secondary profile's — so "which profile does
+        this adapter speak for" is answerable directly, instead of only
+        implicitly via the message-handler closure that stamps
+        ``source.profile`` on the way to ``_handle_message``.
+        """
+        name = (profile_name or "").strip()
+        self.owner_profile = name or None  # type: ignore[assignment]
+
+    def _owning_gateway_runner(self) -> Any:
+        """Return the ``GatewayRunner`` driving this adapter, or ``None``.
+
+        ``gateway_runner`` is the reference run.py injects and the one
+        ``build_source`` already uses for profile routing; the
+        ``_message_handler`` bound-method owner is the older path some adapters
+        were wired through. Prefer the former so callers resolve the *same*
+        runner that stamped ``source.profile``.
+        """
+        runner = getattr(self, "gateway_runner", None)
+        if runner is not None:
+            return runner
+        return getattr(getattr(self, "_message_handler", None), "__self__", None)
+
+    def apply_owner_profile(self, source: Any) -> bool:
+        """Stamp this adapter's owning profile onto a pre-dispatch ``source``.
+
+        Returns whether ``source`` ends up carrying a *determinate* profile
+        identity. Precedence, highest first:
+
+          1. An explicit ``gateway.profile_routes`` match. ``build_source``
+             already stamped ``source.profile`` from it, and routing always
+             wins — this never overwrites a set profile.
+          2. This adapter's owning profile, for events that never reached the
+             per-profile message-handler wrapper in ``gateway/run.py``.
+
+        On a single-profile gateway there is nothing to disambiguate: an unset
+        profile unambiguously means the one active profile. Returns True
+        *without* stamping, so session keying stays byte-identical to before.
+
+        Under multiplexing an adapter with no recorded owner is ambiguous — it
+        could speak for any served profile — and this returns False. Callers on
+        security-sensitive paths (authorization, runtime scope) must fail closed
+        on False rather than let the default profile's policy and HERMES_HOME
+        serve another profile's traffic.
+        """
+        if source is None:
+            return False
+        if getattr(source, "profile", None):
+            return True
+
+        runner = self._owning_gateway_runner()
+        if not getattr(getattr(runner, "config", None), "multiplex_profiles", False):
+            return True
+
+        owner = (getattr(self, "owner_profile", None) or "").strip()
+        if not owner:
+            logger.warning(
+                "%s adapter has no owning profile under multiplexing; "
+                "cannot resolve the profile for %s/%s",
+                getattr(self, "platform", "?"),
+                getattr(source, "platform", "?"),
+                getattr(source, "chat_id", "?"),
+            )
+            return False
+        try:
+            source.profile = owner
+        except Exception:
+            logger.warning("could not stamp owning profile on source", exc_info=True)
+            return False
+        return True
 
     def set_topic_recovery_fn(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1774,6 +1774,17 @@ class SecondaryPortBindingConfigError(MultiplexConfigError):
     """A secondary profile conflicts with the multiplexer's shared listener."""
 
 
+class ProfileNotServedError(RuntimeError):
+    """An inbound source names a profile this gateway does not serve.
+
+    Raised per-message (not at startup) by ``_require_served_profile_home`` for
+    a stale route, a renamed/deleted profile, or any stamped profile outside the
+    served set. Callers must refuse the message: the alternative — the lenient
+    global-HERMES_HOME fallback — would serve that traffic under the
+    multiplexer's own config, skills and credentials.
+    """
+
+
 @_contextmanager
 def _profile_runtime_scope(profile_home: "Path"):
     """Scope config/skills/memory AND credentials to a profile for one turn.
@@ -5851,7 +5862,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         from gateway.pairing import PairingStore
         self.pairing_store = PairingStore()
         self.pairing_stores: Dict[str, "PairingStore"] = {}
-        
+        # Profiles whose PairingStore failed to initialize. Kept separate from
+        # "never registered" so ``_pairing_store_for`` can tell an init failure
+        # (fail closed, never fall back to the default profile's whitelist)
+        # from a single-profile gateway that legitimately has no per-profile
+        # map at all.
+        self._pairing_store_failed: set = set()
+
         # Event hook system
         from gateway.hooks import HookRegistry
         self.hooks = HookRegistry()
@@ -10564,7 +10581,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         enabled_platform_count = 0
         startup_nonretryable_errors: list[str] = []
         startup_retryable_errors: list[str] = []
-        
+
+        # Adapters built here serve the profile this process runs as. Secondary
+        # profiles get theirs from _start_one_profile_adapters.
+        active_profile = self._active_profile_name()
+
+        # Under multiplexing, register the active profile's PairingStore before
+        # any adapter connects — the first adapter to come up is live (and can
+        # be authorized against) before the rest of startup finishes.
+        if getattr(self.config, "multiplex_profiles", False):
+            self._ensure_pairing_store(active_profile)
+
         # Initialize and connect each configured platform
         _multiplex_on = bool(getattr(self.config, "multiplex_profiles", False))
         _multiplex_skipped_platforms: list[Platform] = []
@@ -10608,6 +10635,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             
             # Set up message + fatal error handlers
             adapter.set_message_handler(self._handle_message)
+            self._stamp_adapter_owner_profile(adapter, active_profile)
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
@@ -11597,14 +11625,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     break
                 await asyncio.sleep(1)
 
-    def _active_profile_name(self) -> str:
-        """Return the profile name this gateway represents."""
-        try:
-            from hermes_cli.profiles import get_active_profile_name
-            return get_active_profile_name() or "default"
-        except Exception:
-            return "default"
-
     # ── Kanban board watchers ───────────────────────────────────────────
     # The kanban notifier/dispatcher watcher loops + their helpers live in
     # GatewayKanbanWatchersMixin (gateway/kanban_watchers.py). They use only
@@ -11709,6 +11729,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         continue
 
                     adapter.set_message_handler(self._handle_message)
+                    self._stamp_adapter_owner_profile(
+                        adapter, self._active_profile_name()
+                    )
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
@@ -12472,6 +12495,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if profile_name == active:
                 continue  # handled by the primary startup loop
             try:
+                # Register the pairing store BEFORE connecting this profile's
+                # adapters. Socket-mode transports (Slack) are live the moment
+                # connect() returns — and a pre-dispatch command seam authorizes
+                # ahead of the startup restore queue — so a store registered
+                # after the connect loop leaves a window where a correctly
+                # stamped secondary source finds no per-profile store.
+                self._ensure_pairing_store(profile_name)
                 connected += await self._start_one_profile_adapters(
                     profile_name, profile_home, claimed
                 )
@@ -12492,24 +12522,125 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Record served profiles in runtime status for `hermes status`.
         try:
             from gateway.status import write_runtime_status
-            from gateway.pairing import PairingStore
             served = [active] + sorted(self._profile_adapters.keys())
-            # Per-profile PairingStores so authz_mixin can route pairing
-            # checks to the right whitelist. The active profile gets a store
-            # at its HERMES_HOME; additional served profiles resolve from
-            # their own profile homes. See gateway.pairing.PairingStore.
+            # Safety net only: every profile above already registered its store
+            # before connecting. This re-runs for any profile whose adapters all
+            # failed to connect (so the loop above skipped it) and keeps the
+            # served list and the store map in agreement.
             for name in served:
-                if name and name not in self.pairing_stores:
-                    self.pairing_stores[name] = (
-                        self.pairing_store
-                        if name == active
-                        else PairingStore(profile=name)
-                    )
+                self._ensure_pairing_store(name)
             write_runtime_status(served_profiles=served)
         except Exception:
             logger.debug("could not record served_profiles", exc_info=True)
 
         return connected
+
+    def _ensure_pairing_store(self, profile_name: Optional[str]) -> bool:
+        """Register a profile's PairingStore, returning whether one is usable.
+
+        Idempotent — an already-registered profile short-circuits. On failure
+        the profile is recorded in ``_pairing_store_failed`` so
+        ``_pairing_store_for`` denies rather than silently consulting the
+        default profile's whitelist: a store we could not open must never
+        degrade into another profile's pairing grants.
+        """
+        name = (profile_name or "").strip()
+        if not name:
+            return False
+        # getattr-default throughout: bare ``object.__new__(GatewayRunner)``
+        # instances (used by tests and by partially-constructed runners) never
+        # ran __init__, and bookkeeping must not mask the store registration.
+        failed = getattr(self, "_pairing_store_failed", None)
+        if failed is None:
+            failed = set()
+            self._pairing_store_failed = failed
+        stores = getattr(self, "pairing_stores", None)
+        if stores is None:
+            stores = {}
+            self.pairing_stores = stores
+        if name in stores:
+            return True
+        # The "default" profile IS ``~/.hermes`` — there is no
+        # ``profiles/default/`` subtree. ``PairingStore(profile="default")``
+        # would create and read an empty directory *beside* the real one, so
+        # codes issued here would never be visible to ``hermes pairing
+        # approve`` or to the dashboard (both of which use the legacy global
+        # path), and an approval made there would never be seen here. Alias the
+        # global store so every default-profile reader and writer shares one
+        # set of files.
+        if name == "default":
+            legacy = getattr(self, "pairing_store", None)
+            if legacy is None:
+                failed.add(name)
+                logger.error(
+                    "No global PairingStore to alias for the default profile; "
+                    "pairing grants are denied until it is fixed"
+                )
+                return False
+            stores[name] = legacy
+            failed.discard(name)
+            return True
+        try:
+            from gateway.pairing import PairingStore
+
+            stores[name] = PairingStore(profile=name)
+        except Exception:
+            failed.add(name)
+            logger.error(
+                "Could not initialize PairingStore for profile '%s'; pairing "
+                "grants are denied for that profile until it is fixed",
+                name, exc_info=True,
+            )
+            return False
+        failed.discard(name)
+        return True
+
+    def _multiplex_served_profiles(self) -> set:
+        """Names of every profile this process actually serves.
+
+        The active profile plus each secondary profile that got adapters from
+        ``_start_secondary_profile_adapters``. Used to reject a stamped profile
+        that this gateway does not serve — a stale route, a renamed profile, or
+        a source stamped by something other than our own startup wiring.
+        """
+        served = set(getattr(self, "_profile_adapters", None) or {})
+        active = self._active_profile_name()
+        if active:
+            served.add(active)
+        return {name for name in served if name}
+
+    def _require_served_profile_home(self, source: SessionSource) -> "Path":
+        """Resolve a source's profile home, refusing unknown/stale profiles.
+
+        Same answer as ``_resolve_profile_home_for_source`` for every valid
+        source — route precedence and adapter ownership are untouched. The
+        difference is the failure mode under multiplexing: a nonempty explicit
+        or stamped profile that this gateway does not serve, or that no longer
+        exists on disk, raises instead of falling back to the global
+        HERMES_HOME. Entering the global home would run another profile's
+        traffic against the multiplexer's own config, skills and credentials.
+
+        Callers on authorization and runtime-entry paths use this; the plain
+        resolver keeps its lenient fallback for non-multiplex callers.
+        """
+        if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            name = (getattr(source, "profile", None) or "").strip()
+            if not name:
+                name = (self._profile_name_for_source(source) or "").strip()
+            if name:
+                served = self._multiplex_served_profiles()
+                if name not in served:
+                    raise ProfileNotServedError(
+                        f"profile {name!r} is not served by this gateway "
+                        f"(served: {sorted(served) or 'none'})"
+                    )
+                from hermes_cli.profiles import profile_exists
+
+                if not profile_exists(name):
+                    raise ProfileNotServedError(
+                        f"profile {name!r} no longer exists on disk"
+                    )
+        return self._resolve_profile_home_for_source(source)
 
     async def _start_one_profile_adapters(
         self, profile_name: str, profile_home: "Path", claimed: Dict[tuple, str]
@@ -12648,7 +12779,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         platform: Platform,
     ) -> None:
         """Install the profile-scoped handlers shared by startup and reconnect."""
+        # Stamp every inbound event from this adapter with its profile so the
+        # agent turn (and session key) resolve to the right home.
         adapter.set_message_handler(self._make_profile_message_handler(profile_name))
+        # The handler above only stamps events that reach it. Record the
+        # ownership explicitly too, so a platform seam that acts on a message
+        # *before* dispatch (and therefore never runs that wrapper) can still
+        # resolve this profile instead of defaulting.
+        self._stamp_adapter_owner_profile(adapter, profile_name)
         adapter.set_fatal_error_handler(
             self._make_profile_fatal_error_handler(profile_name, platform)
         )
@@ -12829,6 +12967,44 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         # Reconnect is scoped to the profile's own config and secret mapping;
         # never rebuild a secondary adapter with the default profile's credentials.
+
+    def _active_profile_name(self) -> Optional[str]:
+        """Name of the profile this gateway process itself runs as.
+
+        Adapters built by the primary startup and reconnect loops speak for this
+        profile; ``_start_one_profile_adapters`` stamps its own name instead.
+        Returns None when the profile system is unavailable — ownership then
+        stays unset, and pre-dispatch callers under multiplexing fail closed
+        rather than guess.
+        """
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+            return get_active_profile_name() or "default"
+        except Exception:
+            logger.debug("could not resolve active profile name", exc_info=True)
+            return None
+
+    @staticmethod
+    def _stamp_adapter_owner_profile(adapter: Any, profile_name: Optional[str]) -> None:
+        """Record the owning profile on an adapter.
+
+        Every real adapter inherits ``set_owner_profile`` from
+        ``BasePlatformAdapter``; the attribute fallback covers minimal stand-ins
+        that implement only the handler-installation surface. A failure here is
+        never fatal — it leaves ownership unset, which makes pre-dispatch seams
+        fail closed instead of serving traffic under the wrong profile.
+        """
+        try:
+            setter = getattr(adapter, "set_owner_profile", None)
+            if callable(setter):
+                setter(profile_name)
+            else:
+                adapter.owner_profile = (profile_name or "").strip() or None
+        except Exception:
+            logger.warning(
+                "could not record owning profile %r on %s adapter",
+                profile_name, getattr(adapter, "platform", "?"), exc_info=True,
+            )
 
     def _make_profile_message_handler(self, profile_name: str):
         """Return a message handler that stamps source.profile then delegates.
@@ -15415,7 +15591,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     ) -> Optional[str]:
         """Run inbound preprocessing under the routed profile when multiplexed."""
         if getattr(getattr(self, "config", None), "multiplex_profiles", False):
-            with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
+            with _profile_runtime_scope(self._require_served_profile_home(source)):
                 return await self._prepare_inbound_message_text(
                     event=event,
                     source=source,
@@ -17414,7 +17590,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         thread.
         """
         if getattr(getattr(self, "config", None), "multiplex_profiles", False):
-            with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
+            with _profile_runtime_scope(self._require_served_profile_home(source)):
                 return self._format_session_info()
         return self._format_session_info()
 
@@ -22999,7 +23175,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 message_type=message_type,
             )
 
-        profile_home = self._resolve_profile_home_for_source(source)
+        profile_home = self._require_served_profile_home(source)
         with _profile_runtime_scope(profile_home):
             return await self._run_agent_inner(
                 message, context_prompt, history, source, session_id,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1391,7 +1391,8 @@ class SlackAdapter(BasePlatformAdapter):
                 self._start_socket_mode_handler()
             except Exception as exc:  # pragma: no cover - defensive logging
                 logger.error(
-                    "[Slack] Socket Mode reconnect failed: %s", exc, exc_info=True
+                    "[Slack] Socket Mode reconnect failed: %s",
+                    _sanitized_slack_error(exc),
                 )
 
     async def _socket_watchdog_loop(self) -> None:
@@ -2316,7 +2317,9 @@ class SlackAdapter(BasePlatformAdapter):
             return True
 
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[Slack] Connection failed: %s", e, exc_info=True)
+            logger.error(
+                "[Slack] Connection failed: %s", _sanitized_slack_error(e)
+            )
             return False
         finally:
             if lock_acquired and not self._running:
@@ -3930,7 +3933,11 @@ class SlackAdapter(BasePlatformAdapter):
                 or user_id
             )
         except Exception as e:
-            logger.debug("[Slack] users.info failed for %s: %s", user_id, e)
+            logger.debug(
+                "[Slack] users.info failed for %s: %s",
+                user_id,
+                _sanitized_slack_error(e),
+            )
             name = user_id
 
         self._user_name_cache[cache_key] = name
@@ -5989,7 +5996,7 @@ class SlackAdapter(BasePlatformAdapter):
         classification_text = classification_text.strip()
         try:
             custom_token = self._classify_custom_message(classification_text, event)
-        except Exception:
+        except Exception as exc:
             # Fail closed by CONSUMING the message, not by demoting it to
             # ordinary chat. The classifier is the only thing that knows
             # whether this was a command; if it failed we cannot know either,
@@ -5998,7 +6005,10 @@ class SlackAdapter(BasePlatformAdapter):
             # never meant to run. No reply — an error here would fire on every
             # message a broken classifier touches. No message text in the log:
             # it may carry user content.
-            logger.exception("[Slack] custom message classifier failed - dropping event")
+            logger.error(
+                "[Slack] custom message classifier failed - dropping event: %s",
+                _sanitized_slack_error(exc),
+            )
             return
 
         # Authorize the caller *before* the token buys anything. A classified
@@ -6656,21 +6666,25 @@ class SlackAdapter(BasePlatformAdapter):
                 # profile owns the process.
                 with self._profile_runtime_scope_for(source):
                     handled = await self._on_custom_message(custom_ctx)
-            except Exception:
+            except Exception as exc:
                 # Fail closed. A classified message is a side-effecting
                 # command; falling through would hand a half-run command to
                 # the LLM to improvise. Report and consume it instead.
                 # No command text in the log — it may carry user content.
-                logger.exception("[Slack] custom message hook failed")
+                logger.error(
+                    "[Slack] custom message hook failed: %s",
+                    _sanitized_slack_error(exc),
+                )
                 try:
                     await self.send(
                         channel_id,
                         "⚠️ That command failed. Please try again.",
                         metadata=custom_ctx.reply_metadata,
                     )
-                except Exception:
-                    logger.exception(
-                        "[Slack] failed to report custom message hook error"
+                except Exception as report_exc:
+                    logger.error(
+                        "[Slack] failed to report custom message hook error: %s",
+                        _sanitized_slack_error(report_exc),
                     )
                 return
             if handled:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -283,6 +283,59 @@ class _ThreadContextCache:
     messages: List[Dict[str, Any]] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class SlackCustomMessageContext:
+    """Context passed to :meth:`SlackAdapter._on_custom_message`.
+
+    Public (no leading underscore) because out-of-tree adapter subclasses
+    depend on it; see ``SlackAdapter.CUSTOM_MESSAGE_HOOK_VERSION`` for the
+    compatibility marker.
+    """
+
+    # Normalized, mention-stripped text of *this* message only.  Deliberately
+    # NOT the string handed to the agent: entering a thread cold prepends the
+    # fetched transcript to that one, and a command parser reading it would
+    # take someone else's earlier message as its arguments.
+    text: str
+    # Whatever :meth:`SlackAdapter._classify_custom_message` returned for this
+    # message.  Opaque to core — never inspected, only round-tripped — so a
+    # subclass can pass a parsed command object and skip re-parsing here.
+    classification: Any
+    event: Dict[str, Any]  # Raw Slack message event
+    source: Any  # MessageSource built for this message
+    client: Any  # Workspace-specific AsyncWebClient
+    channel_id: str
+    user_id: str
+    team_id: str
+    ts: str  # This message's timestamp
+    thread_ts: Optional[str]  # Session thread key; may equal ``ts``
+    is_dm: bool
+    is_mentioned: bool
+    message_type: Any  # MessageType resolved for this message
+
+    @property
+    def reply_metadata(self) -> Dict[str, str]:
+        """``send()`` metadata that replies on the invoking surface.
+
+        Always carries ``slack_team_id`` when known: :meth:`SlackAdapter.send`
+        resolves the outbound workspace client from it, and without it falls
+        back to a process-wide ``channel_id → team_id`` map. Two workspaces the
+        bot is installed in can hold the *same* channel ID (and that map is
+        last-writer-wins across concurrent events), so an untagged reply can
+        post into the wrong workspace.
+
+        A synthetic ``thread_ts == ts`` marks a top-level channel message;
+        passing it through would open a reply thread instead of posting flat,
+        so only a real thread key becomes ``thread_id``.
+        """
+        metadata: Dict[str, str] = {}
+        if self.team_id:
+            metadata["slack_team_id"] = self.team_id
+        if self.thread_ts and self.thread_ts != self.ts:
+            metadata["thread_id"] = self.thread_ts
+        return metadata
+
+
 def check_slack_requirements() -> bool:
     """Check if Slack dependencies are available.
 
@@ -852,6 +905,49 @@ def _is_slack_voice_clip(file_obj: Dict[str, Any]) -> bool:
     return name.startswith("audio_message")
 
 
+# Slack API error codes are a fixed lowercase-slug vocabulary
+# (``channel_not_found``, ``invalid_auth``, ``ratelimited``, …). Anything that
+# does not match this shape is treated as untrusted text and dropped rather
+# than logged.
+_SLACK_ERROR_CODE_RE = re.compile(r"^[a-z0-9_]{1,64}$")
+
+# Returned to callers for every send failure. Deliberately constant: the
+# SendResult error can be rendered into a channel or a log line downstream, so
+# it must not vary with — and therefore cannot leak — the underlying exception.
+SEND_FAILED_ERROR = "Slack send failed"
+
+
+def _sanitized_slack_error(exc: BaseException) -> str:
+    """Describe a Slack SDK / network exception without leaking its contents.
+
+    ``SlackApiError.__str__`` embeds the entire ``SlackResponse`` — which
+    carries the request context, including the bot token that was used — and
+    aiohttp's errors can embed the full request URL, which for ``response_url``
+    delivery is itself a credential. Neither may reach a log line or a
+    ``SendResult.error``.
+
+    Returns the exception's type name, plus Slack's own stable error code when
+    the response carries one that matches the known slug shape. Both are fixed
+    vocabularies safe to log and to alert on; the raw exception, its args, and
+    its traceback are all discarded.
+    """
+    label = type(exc).__name__
+    response = getattr(exc, "response", None)
+    raw = None
+    if isinstance(response, dict):
+        raw = response.get("error")
+    elif response is not None:
+        # SlackResponse supports __getitem__; fall back to an attribute for
+        # other SDK shapes. Both are best-effort — a failure just means no code.
+        try:
+            raw = response["error"]
+        except Exception:
+            raw = getattr(response, "error", None)
+    if isinstance(raw, str) and _SLACK_ERROR_CODE_RE.match(raw):
+        return f"{label}({raw})"
+    return label
+
+
 class SlackAdapter(BasePlatformAdapter):
     """
     Slack bot adapter using Socket Mode.
@@ -879,6 +975,12 @@ class SlackAdapter(BasePlatformAdapter):
     # "!" to "/" for known commands (see _handle_slack_message), so "!" is
     # the prefix that works everywhere — instruction text must show it.
     typed_command_prefix = "!"
+
+    # Contract version for the two-stage custom-message subclass seam
+    # (``_classify_custom_message`` + ``_on_custom_message``).  Bump when
+    # either hook's signature or SlackCustomMessageContext's fields change so
+    # out-of-tree plugin subclasses can detect an incompatible core.
+    CUSTOM_MESSAGE_HOOK_VERSION = 1
 
     # Slack has both halves the ``in_channel`` continuable-cron surface needs:
     # a flat-reply outbound gate (``reply_in_thread: false`` → ``_resolve_thread_ts``
@@ -1585,9 +1687,11 @@ class SlackAdapter(BasePlatformAdapter):
                             )
             return SendResult(success=True, message_id=None)
         except Exception as e:
+            # The response_url is itself a bearer credential and aiohttp errors
+            # embed the request URL, so log only the sanitized type/code.
             logger.warning(
                 "[Slack] response_url POST failed: %s",
-                e,
+                _sanitized_slack_error(e),
             )
             return SendResult(success=False, error=str(e))
 
@@ -2596,12 +2700,10 @@ class SlackAdapter(BasePlatformAdapter):
 
         except Exception as e:  # pragma: no cover - defensive logging
             # Clear the assistant status even when the failure happened
-            # BEFORE thread_ts was resolved (formatting, slash-context, DM
-            # resolution): stop_typing falls back to metadata / the uniquely
-            # tracked status for this channel, so a failed turn cannot leave
-            # "is thinking..." visible (#24117).
+            # before thread_ts was resolved. Never log the raw exception or
+            # traceback: SlackApiError can contain request credentials.
             await self._clear_thread_status_quietly(chat_id, metadata)
-            logger.error("[Slack] Send error: %s", e, exc_info=True)
+            logger.error("[Slack] Send error: %s", _sanitized_slack_error(e))
             _retryable = self._is_retryable_upload_error(e)
             _retry_after = None
             if _retryable:
@@ -2615,7 +2717,7 @@ class SlackAdapter(BasePlatformAdapter):
                         pass
             return SendResult(
                 success=False,
-                error=str(e),
+                error=SEND_FAILED_ERROR,
                 retryable=_retryable,
                 retry_after=_retry_after,
             )
@@ -2660,9 +2762,11 @@ class SlackAdapter(BasePlatformAdapter):
                 message_id=result.get("message_ts") or result.get("ts"),
                 raw_response=result,
             )
-        except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[Slack] Ephemeral send error: %s", e, exc_info=True)
-            return SendResult(success=False, error=str(e))
+        except Exception as e:
+            logger.error(
+                "[Slack] Ephemeral send error: %s", _sanitized_slack_error(e)
+            )
+            return SendResult(success=False, error=SEND_FAILED_ERROR)
 
     async def send_or_update_status(
         self,
@@ -2769,7 +2873,7 @@ class SlackAdapter(BasePlatformAdapter):
             if finalize:
                 await self._clear_thread_status_quietly(chat_id, metadata)
             return SendResult(success=True, message_id=message_id)
-        except Exception as e:  # pragma: no cover - defensive logging
+        except Exception as e:
             if finalize:
                 await self._clear_thread_status_quietly(chat_id, metadata)
             aiohttp_module = globals().get("aiohttp")
@@ -2813,10 +2917,9 @@ class SlackAdapter(BasePlatformAdapter):
                 "[Slack] Failed to edit message %s in channel %s: %s",
                 message_id,
                 chat_id,
-                e,
-                exc_info=True,
+                _sanitized_slack_error(e),
             )
-            return SendResult(success=False, error=str(e))
+            return SendResult(success=False, error=SEND_FAILED_ERROR)
 
     async def delete_message(self, chat_id: str, message_id: str) -> bool:
         """Delete a Slack message previously sent by this bot.
@@ -2941,7 +3044,10 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception as e:
             # Silently ignore — may lack assistant:write scope or not be
             # in an assistant-enabled context. Falls back to reactions.
-            logger.debug("[Slack] assistant.threads.setStatus failed: %s", e)
+            logger.debug(
+                "[Slack] assistant.threads.setStatus failed: %s",
+                _sanitized_slack_error(e),
+            )
 
     async def stop_typing(self, chat_id: str, metadata=None) -> None:
         """Clear the assistant thread status indicator."""
@@ -3020,7 +3126,10 @@ class SlackAdapter(BasePlatformAdapter):
                 status="",
             )
         except Exception as e:
-            logger.debug("[Slack] assistant.threads.setStatus clear failed: %s", e)
+            logger.debug(
+                "[Slack] assistant.threads.setStatus clear failed: %s",
+                _sanitized_slack_error(e),
+            )
 
     def _dm_top_level_threads_as_sessions(self) -> bool:
         """Whether top-level Slack DMs get per-message session threads.
@@ -3995,8 +4104,13 @@ class SlackAdapter(BasePlatformAdapter):
             self._user_name_cache[cache_key] = name
             return is_bot
         except Exception as e:
-            logger.debug("[Slack] users.info bot check failed for %s: %s", user_id, e)
+            logger.debug(
+                "[Slack] users.info bot check failed for %s: %s",
+                user_id,
+                _sanitized_slack_error(e),
+            )
             self._user_is_bot_cache[cache_key] = False
+            self._user_name_cache.setdefault(cache_key, user_id)
             return False
 
     async def send_image_file(
@@ -4550,6 +4664,227 @@ class SlackAdapter(BasePlatformAdapter):
         if isinstance(raw, str):
             return raw.strip().lower() not in {"0", "false", "no", "off"}
         return bool(raw)
+
+    def _gateway_runner(self) -> Any:
+        """Return the GatewayRunner driving this adapter, or ``None``.
+
+        ``gateway_runner`` is the reference run.py installs and the one
+        :meth:`build_source` already uses for profile routing; the
+        ``_message_handler`` bound-method owner is the older path some call
+        sites were wired through. Prefer the former so the seam resolves the
+        *same* runner that stamped ``source.profile``.
+        """
+        return self._owning_gateway_runner()
+
+    def _build_message_source(
+        self,
+        *,
+        channel_id: str,
+        is_dm: bool,
+        user_id: str,
+        thread_ts: Optional[str],
+        team_id: Any,
+        event: dict,
+        channel_name: Optional[str] = None,
+        user_name: Optional[str] = None,
+    ) -> Any:
+        """Build the SessionSource for an inbound Slack message.
+
+        Single source of truth for how a message event maps onto a
+        ``SessionSource``, so the authorization gate and the dispatched event
+        can never drift onto different chat types, thread keys, team scopes,
+        bot flags or routed profiles. ``user_name`` is the one field that
+        arrives late (it needs a users.info round-trip we don't make before
+        authorizing) and it is cosmetic — no authorization rule reads it.
+
+        ``build_source`` resolves ``source.profile`` from ``profile_routes``
+        only. A per-profile adapter with no matching route would come back
+        profile-less, because the wrapper in ``gateway/run.py`` that stamps
+        ownership runs on dispatch — and a classified custom message is handled
+        *before* dispatch, so it never gets there. ``apply_owner_profile`` fills
+        that gap from the adapter's recorded owner (routes still win), which is
+        what keeps authorization and runtime scope on the owning profile.
+        """
+        source = self.build_source(
+            chat_id=channel_id,
+            chat_name=channel_name or channel_id,
+            chat_type="dm" if is_dm else "group",
+            user_id=user_id,
+            user_name=user_name,
+            thread_id=thread_ts,
+            scope_id=str(team_id) if team_id else None,
+            # Slack Workflow Builder / app posts arrive as
+            # subtype=bot_message with user=None; flag them so the
+            # gateway SLACK_ALLOW_BOTS bypass can authorize them
+            # (they carry no user_id to match against the allowlist).
+            is_bot=bool(event.get("bot_id")) or event.get("subtype") == "bot_message",
+        )
+        self.apply_owner_profile(source)
+        return source
+
+    def _is_message_source_authorized(self, source: Any) -> bool:
+        """Authorize an inbound message source under the gateway's own policy.
+
+        Delegates to ``GatewayRunner._is_user_authorized`` — the identical
+        check ordinary messages get from ``handle_message`` — passing the real
+        routed source. That matters beyond tidiness: the runner selects the
+        per-profile pairing store from ``source.profile``, so authorizing a
+        profile-less stand-in would consult the *default* profile's pairing
+        grants for a channel routed to a secondary profile.
+
+        Falls back to the env-only allowlist only when no runner is attached.
+        Once a runner owns authorization, an exception must fail closed rather
+        than silently replacing profile-aware policy with the default env gate.
+
+        Indeterminate ownership is refused outright: under multiplexing, judging
+        a profile-less source would silently apply the *default* profile's
+        policy to another profile's channel. Failing the command closed is the
+        only safe answer when we cannot tell whose policy applies.
+        """
+        if not self.apply_owner_profile(source):
+            logger.error(
+                "[Slack] Refusing custom message in %s: cannot determine the "
+                "owning profile under multiplexing",
+                getattr(source, "chat_id", "?"),
+            )
+            return False
+        auth_fn = getattr(self._gateway_runner(), "_is_user_authorized", None)
+        if callable(auth_fn):
+            try:
+                return bool(auth_fn(source))
+            except Exception:
+                logger.warning(
+                    "[Slack] Custom-message authorization failed closed",
+                    exc_info=True,
+                )
+                return False
+        return self._is_env_allowlisted_user(getattr(source, "user_id", "") or "")
+
+    def _profile_runtime_scope_for(self, source: Any) -> Any:
+        """Context manager entering the routed profile's runtime scope.
+
+        Mirrors ``GatewayRunner._run_agent``: gated on
+        ``gateway.multiplex_profiles``, resolving the home through the runner's
+        own ``_resolve_profile_home_for_source`` so HERMES_HOME (config, skills,
+        memory) and the credential scope match what an ordinary agent turn for
+        this source would see. A no-op on single-profile gateways.
+
+        Needed because a handled custom message *replaces* the agent turn —
+        it never reaches ``handle_message``, so it would otherwise run under
+        whichever profile happens to own the process.
+        """
+        from contextlib import nullcontext
+
+        runner = self._gateway_runner()
+        if not getattr(getattr(runner, "config", None), "multiplex_profiles", False):
+            return nullcontext()
+        if not self.apply_owner_profile(source):
+            # Multiplexing with no determinate owner: running the command would
+            # execute it against whichever profile's HERMES_HOME owns the
+            # process. Raise so the caller consumes the message instead.
+            raise RuntimeError(
+                "cannot determine the owning profile for a custom Slack message"
+            )
+        try:
+            from gateway.run import _profile_runtime_scope
+
+            # ``_require_served_profile_home`` over the plain resolver: the
+            # resolver falls back to the global HERMES_HOME for a profile this
+            # gateway does not serve, which would run the command under the
+            # multiplexer's own config and credentials. The validating variant
+            # raises instead, and the caller consumes the message.
+            resolve = getattr(runner, "_require_served_profile_home", None)
+            if not callable(resolve):
+                resolve = runner._resolve_profile_home_for_source
+            return _profile_runtime_scope(resolve(source))
+        except Exception:
+            logger.warning(
+                "[Slack] Could not enter routed profile scope; custom message will fail closed",
+                exc_info=True,
+            )
+            raise
+
+    def _classify_custom_message(self, text: str, event: dict) -> Any:
+        """Stage 1 of the custom-message seam: label a message, don't run it.
+
+        Subclasses (out-of-tree ``SlackAdapter`` plugins) may override this to
+        recognise their own Slack thread commands — plain ``!`` messages that
+        work inside threads, where Slack rejects native slash commands.
+        Return any truthy-or-not opaque token (a string, an enum, a parsed
+        command object) to claim the message, or ``None`` to decline.
+
+        ``text`` is the *raw* message text with our own ``<@bot>`` mention
+        removed and nothing else done to it — no ``!``→``/`` rewrite, no block
+        or attachment text appended — so the leading ``!`` the user actually
+        typed is still visible.
+
+        Contract, and the reason this is split from :meth:`_on_custom_message`:
+
+        * **Sync and side-effect-free.**  It runs on every inbound message,
+          including ones that are about to be dropped.  Do not send, mutate
+          state, or do I/O here — parse and return.
+        * **It runs before mention gating and before user authorization**, so
+          that a bare top-level ``!log`` is recognisable at all.  Classifying
+          is deliberately the one stage that precedes auth; nothing a token
+          buys takes effect until the caller has been authorized.  A returned
+          token then waives *only* the mention/session gate
+          (``require_mention`` / ``strict_mention`` / bot-thread /
+          active-session).  It never waives user authorization, the
+          ``allowed_channels`` whitelist, the bot/self-message filters, dedup,
+          or the subtype filter.
+        * **Classifying is not authorizing.**  Returning a token only means
+          "this looks like my command".  Core immediately authorizes the
+          caller's real routed source via :meth:`_is_message_source_authorized`
+          — the same ``GatewayRunner._is_user_authorized`` policy every
+          ordinary message is judged by — and silently drops the message if it
+          fails, so an unauthorized user can reach this method but can never
+          reach :meth:`_on_custom_message` or the mention bypass.
+        * **Raising drops the message.**  This is the only stage that can tell
+          a command from ordinary chat, so if it fails core cannot know either.
+          It logs (without the text) and consumes the event rather than
+          demoting a possibly side-effecting command to an agent prompt.  Keep
+          this method total — return ``None`` for anything unrecognised.
+
+        The base implementation classifies nothing, so core behavior is
+        unchanged unless a subclass overrides it.
+        """
+        return None
+
+    async def _on_custom_message(self, ctx: "SlackCustomMessageContext") -> bool:
+        """Stage 2 of the custom-message seam: execute a classified message.
+
+        Only called when :meth:`_classify_custom_message` returned a token,
+        which ``ctx.classification`` carries through unchanged — so a subclass
+        parses once and executes without reimplementing
+        :meth:`_handle_slack_message`.
+
+        Runs after user authorization (checked explicitly by core once
+        :meth:`_classify_custom_message` claims the message, since this hook
+        fires before the gateway's own auth would), after channel/mention
+        gating and text normalization, but *before* typing reactions, session
+        creation and any LLM dispatch.  Return ``True`` to mark the message fully handled; it is
+        then never forwarded to the agent.  Return ``False`` to fall through to
+        normal handling — that is how an alias like ``!explain`` can be
+        recognised here yet still be answered by the agent.  ``ctx`` carries
+        everything needed to reply (see :class:`SlackCustomMessageContext`);
+        use ``self.send()`` with ``ctx.reply_metadata``, or ``ctx.client``.
+
+        Because a handled command *replaces* the agent turn, this runs inside
+        the routed profile's runtime scope on a multiplexed gateway (see
+        :meth:`_profile_runtime_scope_for`): ``get_hermes_home()`` and
+        ``get_secret`` resolve against the profile that owns this channel, not
+        whichever profile owns the process.
+
+        If this raises, core **fails closed**: it logs, posts a generic error
+        on the invoking surface, and consumes the message.  A classified
+        message is a side-effecting command, so falling through to the LLM
+        after a failure would ask the agent to improvise a command it was
+        never meant to run.
+
+        The base implementation is a no-op, and is unreachable unless a
+        subclass also overrides :meth:`_classify_custom_message`.
+        """
+        return False
 
     async def _set_assistant_thread_title(
         self,
@@ -5347,6 +5682,11 @@ class SlackAdapter(BasePlatformAdapter):
 
         original_text = event.get("text", "")
 
+        # Snapshot the text exactly as typed, before the !→/ rewrite below.
+        # The classification seam matches on the leading "!" the user actually
+        # sent, which the rewrite would otherwise erase for known commands.
+        raw_text = original_text
+
         # Slack blocks native slash commands inside threads ("/queue is not
         # supported in threads. Sorry!").  As a workaround, recognise a
         # leading ``!`` as an alternate command prefix and rewrite it to
@@ -5636,6 +5976,64 @@ class SlackAdapter(BasePlatformAdapter):
                     return
                 if allow_bots == "mentions" and not is_mentioned:
                     return
+        # Stage 1 of the custom-message seam (see CUSTOM_MESSAGE_HOOK_VERSION).
+        # Sync and side-effect-free by contract: it only labels the message so
+        # the mention gate below can let a custom command through. Classifying
+        # is the one stage allowed to run before user auth — the token is not
+        # honoured until the authorization check right after this.
+        # Runs on the raw pre-rewrite text minus our own mention, so a subclass
+        # sees the leading "!" as typed in both "!log" and "<@bot> !log".
+        classification_text = raw_text
+        if bot_uid:
+            classification_text = classification_text.replace(f"<@{bot_uid}>", "")
+        classification_text = classification_text.strip()
+        try:
+            custom_token = self._classify_custom_message(classification_text, event)
+        except Exception:
+            # Fail closed by CONSUMING the message, not by demoting it to
+            # ordinary chat. The classifier is the only thing that knows
+            # whether this was a command; if it failed we cannot know either,
+            # and forwarding a possibly-side-effecting command ("!log delete
+            # everything") to the agent asks it to improvise a command it was
+            # never meant to run. No reply — an error here would fire on every
+            # message a broken classifier touches. No message text in the log:
+            # it may carry user content.
+            logger.exception("[Slack] custom message classifier failed - dropping event")
+            return
+
+        # Authorize the caller *before* the token buys anything. A classified
+        # message skips both remaining user-auth gates: the mention bypass
+        # below, and — because _on_custom_message runs ahead of
+        # handle_message — the gateway's own _is_user_authorized. So the seam
+        # has to run that exact check itself, and only for classified
+        # messages; everything else still gets it from the gateway, once.
+        #
+        # Judged on the REAL source, built by the same helper the dispatched
+        # event uses: chat type, thread key, team scope, bot flag and the
+        # routed profile all feed authorization, and the profile in particular
+        # selects which pairing store the runner consults — a profile-less
+        # stand-in would check the default profile's grants for a channel
+        # routed to a secondary one. Only user_name is missing here; it needs a
+        # users.info call we won't spend on an unauthorized caller, and no
+        # authorization rule reads it.
+        #
+        # Dropped silently: an error reply would confirm the command exists.
+        if custom_token is not None and not self._is_message_source_authorized(
+            self._build_message_source(
+                channel_id=channel_id,
+                is_dm=is_dm,
+                user_id=user_id,
+                thread_ts=thread_ts,
+                team_id=team_id,
+                event=event,
+            )
+        ):
+            logger.warning(
+                "[Slack] Unauthorized custom message from %s in %s - ignoring",
+                user_id,
+                channel_id,
+            )
+            return
 
         if not is_one_to_one_dm and bot_uid:
             # Check allowed channels — if set, only respond in these channels (whitelist)
@@ -5663,8 +6061,11 @@ class SlackAdapter(BasePlatformAdapter):
                 )
                 return
 
-            if force_process:
-                pass  # Explicit internal routing path (reaction trigger).
+            if force_process or custom_token is not None:
+                # Explicit reaction routing and classified custom commands may
+                # bypass mention/session gating only after the channel and
+                # routed-authorization checks above.
+                pass
             elif (
                 channel_id not in self._slack_require_mention_channels()
                 and (
@@ -5752,6 +6153,10 @@ class SlackAdapter(BasePlatformAdapter):
                 and not self._slack_thread_require_mention()
             ):
                 self._register_mentioned_thread(thread_ts, team_id=team_id)
+
+        # Keep the current turn available to the custom hook independently of
+        # any recovered thread context that is later sent to the agent.
+        current_message_text = text
 
         # Thread context rules:
         # - First message in a thread session (cold start): hydrate full
@@ -6189,7 +6594,19 @@ class SlackAdapter(BasePlatformAdapter):
         # Slack's AI Agent Messages tab shows visible app threads; title the
         # first DM thread turn from the user's prompt when Slack AI APIs are
         # available. This is best-effort and configurable via config.yaml.
-        if is_dm and thread_ts and msg_type != MessageType.COMMAND:
+        # ``thread_ts == ts``: only the thread ROOT names the thread — a later
+        # reply would rename an already-titled thread (including one the user
+        # named explicitly). ``custom_token is None``: a classified command is
+        # not a conversation topic, and unlike native slash commands it keeps
+        # its "!" (the /-rewrite only fires for known gateway commands), so
+        # ``!log`` / ``!name?`` would otherwise become the thread's title.
+        if (
+            is_dm
+            and thread_ts
+            and thread_ts == ts
+            and custom_token is None
+            and msg_type != MessageType.COMMAND
+        ):
             await self._set_assistant_thread_title(
                 channel_id,
                 thread_ts,
@@ -6197,21 +6614,67 @@ class SlackAdapter(BasePlatformAdapter):
                 team_id=team_id,
             )
 
-        # Build source
-        source = self.build_source(
-            chat_id=channel_id,
-            chat_name=channel_name,
-            chat_type="dm" if is_dm else "group",
+        # Build the exact source shape used by the authorization gate above,
+        # adding only the resolved cosmetic channel/user names for dispatch.
+        source = self._build_message_source(
+            channel_id=channel_id,
+            channel_name=channel_name,
+            is_dm=is_dm,
             user_id=user_id,
+            thread_ts=thread_ts,
+            team_id=team_id,
+            event=event,
             user_name=user_name,
-            thread_id=thread_ts,
-            scope_id=str(team_id) if team_id else None,
-            # Slack Workflow Builder / app posts arrive as
-            # subtype=bot_message with user=None; flag them so the
-            # gateway SLACK_ALLOW_BOTS bypass can authorize them
-            # (they carry no user_id to match against the allowlist).
-            is_bot=bool(event.get("bot_id")) or event.get("subtype") == "bot_message",
         )
+
+        # Stage 2 of the custom-message seam (see CUSTOM_MESSAGE_HOOK_VERSION).
+        # Only classified messages get here, and only once gating and
+        # normalization are done but before typing reactions, session creation
+        # and LLM dispatch — so a plugin can fully own the message.
+        if custom_token is not None:
+            custom_ctx = SlackCustomMessageContext(
+                # This message only — never the fetched thread transcript.
+                text=current_message_text,
+                classification=custom_token,
+                event=event,
+                source=source,
+                client=self._get_client(channel_id, team_id),
+                channel_id=channel_id,
+                user_id=user_id,
+                team_id=str(team_id) if team_id else "",
+                ts=ts,
+                thread_ts=thread_ts,
+                is_dm=is_dm,
+                is_mentioned=is_mentioned,
+                message_type=msg_type,
+            )
+            try:
+                # A handled command replaces the agent turn outright, so it has
+                # to run under the same routed-profile runtime scope that turn
+                # would have had — otherwise a secondary profile's command
+                # resolves config/skills/memory/credentials from whichever
+                # profile owns the process.
+                with self._profile_runtime_scope_for(source):
+                    handled = await self._on_custom_message(custom_ctx)
+            except Exception:
+                # Fail closed. A classified message is a side-effecting
+                # command; falling through would hand a half-run command to
+                # the LLM to improvise. Report and consume it instead.
+                # No command text in the log — it may carry user content.
+                logger.exception("[Slack] custom message hook failed")
+                try:
+                    await self.send(
+                        channel_id,
+                        "⚠️ That command failed. Please try again.",
+                        metadata=custom_ctx.reply_metadata,
+                    )
+                except Exception:
+                    logger.exception(
+                        "[Slack] failed to report custom message hook error"
+                    )
+                return
+            if handled:
+                return
 
         # Per-channel ephemeral prompt
         from gateway.platforms.base import (
@@ -6445,8 +6908,10 @@ class SlackAdapter(BasePlatformAdapter):
 
             return SendResult(success=True, message_id=msg_ts, raw_response=result)
         except Exception as e:
-            logger.error("[Slack] send_exec_approval failed: %s", e, exc_info=True)
-            return SendResult(success=False, error=str(e))
+            logger.error(
+                "[Slack] send_exec_approval failed: %s", _sanitized_slack_error(e)
+            )
+            return SendResult(success=False, error=SEND_FAILED_ERROR)
 
     async def send_slash_confirm(
         self,
@@ -6526,8 +6991,40 @@ class SlackAdapter(BasePlatformAdapter):
                 success=True, message_id=result.get("ts", ""), raw_response=result
             )
         except Exception as e:
-            logger.error("[Slack] send_slash_confirm failed: %s", e, exc_info=True)
-            return SendResult(success=False, error=str(e))
+            logger.error(
+                "[Slack] send_slash_confirm failed: %s", _sanitized_slack_error(e)
+            )
+            return SendResult(success=False, error=SEND_FAILED_ERROR)
+
+    def _build_interactive_source(
+        self,
+        user_id: str,
+        *,
+        channel_id: str = "",
+        user_name: Optional[str] = None,
+        team_id: str = "",
+    ) -> Any:
+        """Build the routed ``SessionSource`` a Slack interactive payload speaks for.
+
+        Goes through ``build_source`` rather than constructing a
+        ``SessionSource`` directly so an interactive click resolves its profile
+        from ``gateway.profile_routes`` exactly like the message in the same
+        channel would. Without that, the routed profile is never even a
+        candidate and the caller cannot tell whose policy applies.
+
+        A button click carries no thread identity we need for authorization —
+        ``thread_id`` is deliberately left unset, mirroring the pre-existing
+        stand-in source this replaces.
+        """
+        chat_id = str(channel_id or user_id)
+        return self.build_source(
+            chat_id=chat_id,
+            chat_name=chat_id,
+            chat_type="dm" if str(channel_id or "").startswith("D") else "group",
+            user_id=user_id,
+            user_name=str(user_name).strip() if user_name else None,
+            scope_id=str(team_id) if team_id else None,
+        )
 
     async def send_clarify(
         self,
@@ -6642,32 +7139,97 @@ class SlackAdapter(BasePlatformAdapter):
         user_name: Optional[str] = None,
         team_id: str = "",
     ) -> bool:
-        """Return whether a Slack interactive caller may perform gated actions."""
+        """Return whether a Slack interactive caller may perform gated actions.
+
+        Button clicks never reach ``handle_message``, so this is the *only*
+        authorization gate a dangerous-command approval or a slash confirmation
+        passes through. It must therefore land on the same policy an ordinary
+        message gets: ``GatewayRunner._is_user_authorized`` on a properly routed
+        source, from which the runner selects the per-profile pairing store.
+
+        Resolving the runner through :meth:`_gateway_runner` — not the
+        ``_message_handler`` bound-method owner — is what makes that hold under
+        multiplexing. A secondary profile's handler is a *closure*, so it has no
+        ``__self__``; the old lookup found no runner and quietly degraded every
+        secondary profile's buttons to the process-global env allowlist. That is
+        a strictly different (and typically wider) policy than the one guarding
+        that same profile's messages, and it is decided by env vars belonging to
+        whichever profile happens to own the process.
+
+        Fails closed instead of falling back whenever ownership is knowable: a
+        runner that raises, or an adapter that cannot name its owning profile
+        under multiplexing, must not hand the decision to the env allowlist.
+        The env path survives only for the single-profile, no-runner case, where
+        an unset profile unambiguously means the one active profile.
+        """
         normalized_user_id = str(user_id or "").strip()
         if not normalized_user_id:
             return False
 
-        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
-        auth_fn = getattr(runner, "_is_user_authorized", None)
+        try:
+            source = self._build_interactive_source(
+                normalized_user_id,
+                channel_id=channel_id,
+                user_name=user_name,
+                team_id=team_id,
+            )
+        except Exception:
+            logger.warning(
+                "[Slack] Could not build the routed source for an interactive "
+                "click by %s — failing closed",
+                normalized_user_id,
+                exc_info=True,
+            )
+            return False
+
+        # Same precedence as inbound messages: an explicit route wins, else the
+        # adapter's recorded owner. False means multiplexing with no
+        # determinate owner — judging the click would apply the default
+        # profile's policy to another profile's channel.
+        if not self.apply_owner_profile(source):
+            logger.error(
+                "[Slack] Refusing interactive click in %s: cannot determine the "
+                "owning profile under multiplexing",
+                str(channel_id or "?"),
+            )
+            return False
+
+        auth_fn = getattr(self._gateway_runner(), "_is_user_authorized", None)
         if callable(auth_fn):
             try:
-                from gateway.session import SessionSource
-
-                source = SessionSource(
-                    platform=Platform.SLACK,
-                    chat_id=str(channel_id or normalized_user_id),
-                    chat_type="dm" if str(channel_id or "").startswith("D") else "group",
-                    user_id=normalized_user_id,
-                    user_name=str(user_name).strip() if user_name else None,
-                    scope_id=str(team_id) if team_id else None,
-                )
                 return bool(auth_fn(source))
             except Exception:
-                logger.debug(
-                    "[Slack] Falling back to env-only interactive auth for user %s",
+                logger.warning(
+                    "[Slack] Interactive authorization failed closed for user %s",
                     normalized_user_id,
                     exc_info=True,
                 )
+                return False
+
+        if getattr(source, "profile", None):
+            # A profile owner is stamped but no runner owns authorization. The
+            # env allowlist describes the process-global profile, not this one,
+            # so consulting it would answer a question about the wrong profile.
+            logger.error(
+                "[Slack] No gateway runner for an interactive click routed to "
+                "profile %r — refusing rather than applying the global env allowlist",
+                getattr(source, "profile", None),
+            )
+            return False
+
+        return self._is_env_allowlisted_user(normalized_user_id)
+
+    @staticmethod
+    def _is_env_allowlisted_user(user_id: str) -> bool:
+        """Env-only allowlist check — the fallback when no runner is reachable.
+
+        Shared by :meth:`_is_interactive_user_authorized` and
+        :meth:`_is_message_source_authorized` so the degraded path is identical
+        for buttons and for messages.
+        """
+        normalized_user_id = str(user_id or "").strip()
+        if not normalized_user_id:
+            return False
 
         if os.getenv("SLACK_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
             return True
@@ -6792,27 +7354,19 @@ class SlackAdapter(BasePlatformAdapter):
                 blocks=sanitize_blocks(updated_blocks),
             )
         except Exception as e:
-            logger.warning("[Slack] Failed to update slash-confirm message: %s", e)
+            logger.warning(
+                "[Slack] Failed to update slash-confirm message: %s",
+                _sanitized_slack_error(e),
+            )
 
-        # Resolve via the module-level primitive and post any follow-up.
+        # Resolve via the module-level primitive.
+        result_text = None
         try:
             from tools import slash_confirm as _slash_confirm_mod
 
             result_text = await _slash_confirm_mod.resolve(
                 session_key, confirm_id, choice
             )
-            if result_text:
-                post_kwargs: Dict[str, Any] = {
-                    "channel": channel_id,
-                    "text": result_text,
-                }
-                # Inherit the thread so the reply stays in the same place.
-                thread_ts = message.get("thread_ts") or msg_ts
-                if thread_ts:
-                    post_kwargs["thread_ts"] = thread_ts
-                await self._get_client(
-                    channel_id, team_id=team_id or None
-                ).chat_postMessage(**post_kwargs)
             logger.info(
                 "Slack button resolved slash-confirm for session %s (choice=%s, user=%s)",
                 session_key,
@@ -6825,6 +7379,31 @@ class SlackAdapter(BasePlatformAdapter):
                 exc,
                 exc_info=True,
             )
+
+        # The follow-up post gets its own guard. Sharing the resolve's ``except``
+        # meant a Slack API failure here was logged raw with a traceback — and a
+        # SlackApiError stringifies to the whole request context, bot token
+        # included. It also conflated two unrelated outcomes: by this point the
+        # confirmation is already recorded and the agent thread already
+        # unblocked, so a failed post is cosmetic, not a failed resolve.
+        if result_text:
+            try:
+                post_kwargs: Dict[str, Any] = {
+                    "channel": channel_id,
+                    "text": result_text,
+                }
+                # Inherit the thread so the reply stays in the same place.
+                thread_ts = message.get("thread_ts") or msg_ts
+                if thread_ts:
+                    post_kwargs["thread_ts"] = thread_ts
+                await self._get_client(
+                    channel_id, team_id=team_id or None
+                ).chat_postMessage(**post_kwargs)
+            except Exception as e:
+                logger.warning(
+                    "[Slack] Failed to post slash-confirm follow-up: %s",
+                    _sanitized_slack_error(e),
+                )
 
     async def _handle_feedback_action(self, ack, body, action) -> None:
         """Ack Slack AI feedback button clicks and log the choice."""
@@ -6971,7 +7550,10 @@ class SlackAdapter(BasePlatformAdapter):
                 blocks=sanitize_blocks(updated_blocks),
             )
         except Exception as e:
-            logger.warning("[Slack] Failed to update approval message: %s", e)
+            logger.warning(
+                "[Slack] Failed to update approval message: %s",
+                _sanitized_slack_error(e),
+            )
 
         # (approval already resolved above; state consumed by atomic pop)
 
@@ -7320,7 +7902,10 @@ class SlackAdapter(BasePlatformAdapter):
             return content
 
         except Exception as e:
-            logger.warning("[Slack] Failed to fetch thread context: %s", e)
+            logger.warning(
+                "[Slack] Failed to fetch thread context: %s",
+                _sanitized_slack_error(e),
+            )
             return ""
 
     async def _format_thread_context(
@@ -7531,7 +8116,10 @@ class SlackAdapter(BasePlatformAdapter):
                 text = text.replace(f"<@{bot_uid}>", "").strip()
             return text
         except Exception as exc:  # pragma: no cover - defensive
-            logger.debug("[Slack] Failed to fetch thread parent text: %s", exc)
+            logger.debug(
+                "[Slack] Failed to fetch thread parent text: %s",
+                _sanitized_slack_error(exc),
+            )
             return ""
 
     async def _collect_thread_root_images(

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1694,7 +1694,7 @@ class SlackAdapter(BasePlatformAdapter):
                 "[Slack] response_url POST failed: %s",
                 _sanitized_slack_error(e),
             )
-            return SendResult(success=False, error=str(e))
+            return SendResult(success=False, error=SEND_FAILED_ERROR)
 
     async def _post_ephemeral_fallback(
         self,
@@ -1744,7 +1744,11 @@ class SlackAdapter(BasePlatformAdapter):
                     )
             return SendResult(success=True, message_id=None)
         except Exception as e:
-            return SendResult(success=False, error=str(e))
+            logger.warning(
+                "[Slack] chat.postEphemeral failed: %s",
+                _sanitized_slack_error(e),
+            )
+            return SendResult(success=False, error=SEND_FAILED_ERROR)
 
     def _warn_if_missing_group_dm_scopes(self, auth_response, team_name: str) -> None:
         """Nudge existing installs to reinstall when group-DM scopes are absent.
@@ -4758,7 +4762,11 @@ class SlackAdapter(BasePlatformAdapter):
         auth_fn = getattr(self._gateway_runner(), "_is_user_authorized", None)
         if callable(auth_fn):
             try:
-                return bool(auth_fn(source))
+                # Multiplexed allowlists live in the routed profile's secret
+                # scope. Authorizing outside it makes get_secret() fall back to
+                # the process-default profile and can admit the wrong user.
+                with self._profile_runtime_scope_for(source):
+                    return bool(auth_fn(source))
             except Exception:
                 logger.warning(
                     "[Slack] Custom-message authorization failed closed",
@@ -4776,9 +4784,9 @@ class SlackAdapter(BasePlatformAdapter):
         memory) and the credential scope match what an ordinary agent turn for
         this source would see. A no-op on single-profile gateways.
 
-        Needed because a handled custom message *replaces* the agent turn —
-        it never reaches ``handle_message``, so it would otherwise run under
-        whichever profile happens to own the process.
+        Needed for pre-dispatch operations such as custom-message authorization,
+        custom handlers, and interactive authorization. None reaches the normal
+        agent-turn scope before consulting profile-owned credentials or state.
         """
         from contextlib import nullcontext
 
@@ -4790,7 +4798,7 @@ class SlackAdapter(BasePlatformAdapter):
             # execute it against whichever profile's HERMES_HOME owns the
             # process. Raise so the caller consumes the message instead.
             raise RuntimeError(
-                "cannot determine the owning profile for a custom Slack message"
+                "cannot determine the owning profile for this Slack operation"
             )
         try:
             from gateway.run import _profile_runtime_scope
@@ -4806,7 +4814,7 @@ class SlackAdapter(BasePlatformAdapter):
             return _profile_runtime_scope(resolve(source))
         except Exception:
             logger.warning(
-                "[Slack] Could not enter routed profile scope; custom message will fail closed",
+                "[Slack] Could not enter routed profile scope; operation will fail closed",
                 exc_info=True,
             )
             raise
@@ -4827,14 +4835,16 @@ class SlackAdapter(BasePlatformAdapter):
 
         Contract, and the reason this is split from :meth:`_on_custom_message`:
 
-        * **Sync and side-effect-free.**  It runs on every inbound message,
-          including ones that are about to be dropped.  Do not send, mutate
+        * **Sync and side-effect-free.**  It may run on messages that the
+          routed authorization or mention gate will drop.  Do not send, mutate
           state, or do I/O here — parse and return.
-        * **It runs before mention gating and before user authorization**, so
-          that a bare top-level ``!log`` is recognisable at all.  Classifying
-          is deliberately the one stage that precedes auth; nothing a token
-          buys takes effect until the caller has been authorized.  A returned
-          token then waives *only* the mention/session gate
+        * **It runs before mention gating and before this seam's routed
+          authorization**, so that a bare top-level ``!log`` is recognisable at
+          all. Adapter-wide guards may already reject bot/self messages,
+          duplicates, ignored channels, or unauthorized media senders before
+          this method is reached. Nothing a token buys takes effect until the
+          routed caller has been authorized. A returned token then waives
+          *only* the mention/session gate
           (``require_mention`` / ``strict_mention`` / bot-thread /
           active-session).  It never waives user authorization, the
           ``allowed_channels`` whitelist, the bot/self-message filters, dedup,
@@ -5867,14 +5877,25 @@ class SlackAdapter(BasePlatformAdapter):
         _runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
         _auth_fn = getattr(_runner, "_is_user_authorized", None)
         if user_id and callable(_auth_fn):
-            _source = self.build_source(
-                chat_id=channel_id,
-                chat_name="",
-                chat_type="dm" if is_dm else "group",
+            _source = self._build_message_source(
+                channel_id=channel_id,
+                is_dm=is_dm,
                 user_id=user_id,
-                user_name="",
+                thread_ts=event.get("thread_ts") or assistant_meta.get("thread_ts"),
+                team_id=team_id,
+                event=event,
             )
-            if not _auth_fn(_source):
+            try:
+                with self._profile_runtime_scope_for(_source):
+                    early_authorized = bool(_auth_fn(_source))
+            except Exception:
+                logger.warning(
+                    "[Slack] Early authorization failed closed for user %s in channel %s",
+                    user_id,
+                    channel_id,
+                )
+                return
+            if not early_authorized:
                 logger.warning(
                     "[Slack] Early reject of unauthorized user %s in channel %s",
                     user_id,
@@ -5986,8 +6007,8 @@ class SlackAdapter(BasePlatformAdapter):
         # Stage 1 of the custom-message seam (see CUSTOM_MESSAGE_HOOK_VERSION).
         # Sync and side-effect-free by contract: it only labels the message so
         # the mention gate below can let a custom command through. Classifying
-        # is the one stage allowed to run before user auth — the token is not
-        # honoured until the authorization check right after this.
+        # does not authorize anything — the token is not honoured until the
+        # routed authorization check right after this.
         # Runs on the raw pre-rewrite text minus our own mention, so a subclass
         # sees the leading "!" as typed in both "!log" and "<@bot> !log".
         classification_text = raw_text
@@ -7017,6 +7038,7 @@ class SlackAdapter(BasePlatformAdapter):
         channel_id: str = "",
         user_name: Optional[str] = None,
         team_id: str = "",
+        thread_id: str = "",
     ) -> Any:
         """Build the routed ``SessionSource`` a Slack interactive payload speaks for.
 
@@ -7026,9 +7048,9 @@ class SlackAdapter(BasePlatformAdapter):
         channel would. Without that, the routed profile is never even a
         candidate and the caller cannot tell whose policy applies.
 
-        A button click carries no thread identity we need for authorization —
-        ``thread_id`` is deliberately left unset, mirroring the pre-existing
-        stand-in source this replaces.
+        Slack includes ``message.thread_ts`` for buttons posted inside a thread.
+        Preserve it so a thread-specific profile route authorizes the click
+        under the same profile that rendered the button.
         """
         chat_id = str(channel_id or user_id)
         return self.build_source(
@@ -7037,6 +7059,7 @@ class SlackAdapter(BasePlatformAdapter):
             chat_type="dm" if str(channel_id or "").startswith("D") else "group",
             user_id=user_id,
             user_name=str(user_name).strip() if user_name else None,
+            thread_id=str(thread_id) if thread_id else None,
             scope_id=str(team_id) if team_id else None,
         )
 
@@ -7152,6 +7175,7 @@ class SlackAdapter(BasePlatformAdapter):
         channel_id: str = "",
         user_name: Optional[str] = None,
         team_id: str = "",
+        thread_id: str = "",
     ) -> bool:
         """Return whether a Slack interactive caller may perform gated actions.
 
@@ -7186,6 +7210,7 @@ class SlackAdapter(BasePlatformAdapter):
                 channel_id=channel_id,
                 user_name=user_name,
                 team_id=team_id,
+                thread_id=thread_id,
             )
         except Exception:
             logger.warning(
@@ -7211,7 +7236,8 @@ class SlackAdapter(BasePlatformAdapter):
         auth_fn = getattr(self._gateway_runner(), "_is_user_authorized", None)
         if callable(auth_fn):
             try:
-                return bool(auth_fn(source))
+                with self._profile_runtime_scope_for(source):
+                    return bool(auth_fn(source))
             except Exception:
                 logger.warning(
                     "[Slack] Interactive authorization failed closed for user %s",
@@ -7284,6 +7310,9 @@ class SlackAdapter(BasePlatformAdapter):
         value = action.get("value", "")
         message = body.get("message", {})
         msg_ts = message.get("ts", "")
+        thread_id = message.get("thread_ts") or body.get("container", {}).get(
+            "thread_ts", ""
+        )
         channel_id = body.get("channel", {}).get("id", "")
         user_name = body.get("user", {}).get("name", "unknown")
         user_id = body.get("user", {}).get("id", "")
@@ -7292,6 +7321,7 @@ class SlackAdapter(BasePlatformAdapter):
             channel_id=channel_id,
             user_name=user_name,
             team_id=team_id,
+            thread_id=thread_id,
         ):
             logger.warning(
                 "[Slack] Unauthorized slash-confirm click by %s (%s) - ignoring",
@@ -7444,6 +7474,9 @@ class SlackAdapter(BasePlatformAdapter):
         session_key = action.get("value", "")
         message = body.get("message", {})
         msg_ts = message.get("ts", "")
+        thread_id = message.get("thread_ts") or body.get("container", {}).get(
+            "thread_ts", ""
+        )
         channel_id = body.get("channel", {}).get("id", "")
         user_name = body.get("user", {}).get("name", "unknown")
         user_id = body.get("user", {}).get("id", "")
@@ -7453,6 +7486,7 @@ class SlackAdapter(BasePlatformAdapter):
             channel_id=channel_id,
             user_name=user_name,
             team_id=team_id,
+            thread_id=thread_id,
         ):
             logger.warning(
                 "[Slack] Unauthorized approval click by %s (%s) - ignoring",
@@ -7607,14 +7641,20 @@ class SlackAdapter(BasePlatformAdapter):
         value = action.get("value", "")
         message = body.get("message", {})
         msg_ts = message.get("ts", "")
+        thread_id = message.get("thread_ts") or body.get("container", {}).get(
+            "thread_ts", ""
+        )
         channel_id = body.get("channel", {}).get("id", "")
         user_name = body.get("user", {}).get("name", "unknown")
         user_id = body.get("user", {}).get("id", "")
+        team_id = self._event_team_id({}, body)
 
         if not self._is_interactive_user_authorized(
             user_id,
             channel_id=channel_id,
             user_name=user_name,
+            team_id=team_id,
+            thread_id=thread_id,
         ):
             logger.warning(
                 "[Slack] Unauthorized clarify click by %s (%s) - ignoring",

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -96,6 +96,95 @@ class TestProfileMessageHandler:
         assert seen["profile"] == "coder"
 
 
+class TestAdapterOwnerProfile:
+    """Per-profile adapters carry their owning profile explicitly.
+
+    The message-handler wrapper above only stamps events that reach dispatch.
+    A platform seam that handles a message *before* dispatch (Slack's custom
+    command hook) never runs it, so it resolves the profile from ownership
+    instead — which only works if startup actually records it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_secondary_profile_adapter_records_its_owner(self, monkeypatch):
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        class _Adapter:
+            platform = Platform.TELEGRAM
+            owner_profile = None
+
+            def set_message_handler(self, handler):
+                pass
+
+            def set_owner_profile(self, profile_name):
+                self.owner_profile = profile_name
+
+            def set_fatal_error_handler(self, handler):
+                pass
+
+            def set_session_store(self, store):
+                pass
+
+            def set_busy_session_handler(self, handler):
+                pass
+
+            def set_topic_recovery_fn(self, handler):
+                pass
+
+            def set_authorization_check(self, handler):
+                pass
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+        runner.session_store = object()
+        runner._handle_adapter_fatal_error = object()
+        runner._handle_active_session_busy_message = object()
+        runner._recover_telegram_topic_thread_id = object()
+        runner._busy_text_mode = "queue"
+        runner._make_adapter_auth_check = lambda platform, profile_name=None: object()
+
+        reviewer_cfg = GatewayConfig(multiplex_profiles=True)
+        reviewer_cfg.platforms = {
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="reviewer-token"),
+        }
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: reviewer_cfg)
+
+        adapter = _Adapter()
+
+        async def _connect(a, platform):
+            return True
+
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: adapter)
+        monkeypatch.setattr(runner, "_connect_adapter_with_timeout", _connect)
+
+        await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
+
+        assert adapter.owner_profile == "reviewer"
+
+    def test_stamping_tolerates_adapters_without_the_setter(self):
+        """A minimal stand-in still ends up owned, via plain attribute set."""
+
+        class _Bare:
+            platform = "telegram"
+
+        adapter = _Bare()
+        GatewayRunner._stamp_adapter_owner_profile(adapter, "reviewer")
+
+        assert adapter.owner_profile == "reviewer"
+
+    def test_blank_owner_normalizes_to_none(self):
+        """Empty/whitespace names must not read as a real profile downstream."""
+
+        class _Bare:
+            platform = "telegram"
+
+        adapter = _Bare()
+        GatewayRunner._stamp_adapter_owner_profile(adapter, "   ")
+
+        assert adapter.owner_profile is None
+
+
 class _SecondaryRecoveryAdapter:
     platform = Platform.DISCORD
 

--- a/tests/gateway/test_multiplex_pairing_startup.py
+++ b/tests/gateway/test_multiplex_pairing_startup.py
@@ -1,0 +1,526 @@
+"""Per-profile PairingStore availability at startup, and fail-closed lookup.
+
+Two defects are pinned here, both about the window between "an adapter is live"
+and "this gateway knows which pairing whitelist that adapter's profile uses":
+
+1. ``_start_secondary_profile_adapters`` registered every profile's PairingStore
+   only *after* the connect loop finished. Slack Socket Mode is accepting events
+   the moment ``connect()`` returns, and the Slack custom-message seam authorizes
+   ahead of the startup restore queue — so a correctly stamped secondary source
+   could reach ``_is_user_authorized`` while ``pairing_stores`` was still empty.
+
+2. ``_pairing_store_for`` then fell back to ``self.pairing_store`` — the DEFAULT
+   profile's whitelist. That turns a startup race (or a failed store init, or a
+   stale profile) into a cross-profile authorization grant.
+
+These drive the REAL ``GatewayRunner`` methods and the REAL
+``GatewayAuthorizationMixin._is_user_authorized`` against real ``PairingStore``
+instances on disk, not a fake runner.
+"""
+
+import asyncio
+import re
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import gateway.pairing
+from gateway.config import Platform
+from gateway.pairing import MAX_PENDING_PER_PLATFORM, PairingStore
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _bare_runner(multiplex: bool = True):
+    """A GatewayRunner with only the state the methods under test touch."""
+    runner = object.__new__(GatewayRunner)
+    runner.config = MagicMock(multiplex_profiles=multiplex)
+    runner.adapters = {}
+    runner._profile_adapters = {}
+    runner.pairing_stores = {}
+    runner._pairing_store_failed = set()
+    runner.pairing_store = PairingStore()
+    return runner
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    # ``PAIRING_DIR`` is resolved at *import* time from the real HERMES_HOME, and
+    # a profile-less ``PairingStore()`` — the global/default store these tests
+    # now exercise directly — reads it instead of the env var. Without this the
+    # suite reads and writes the developer's own ~/.hermes pairing files.
+    monkeypatch.setattr(
+        gateway.pairing, "PAIRING_DIR", home / "platforms" / "pairing"
+    )
+    return home
+
+
+class TestStoreRegisteredBeforeConnect:
+    """The store must exist before that profile's adapters go live."""
+
+    def test_store_registered_before_profile_adapters_connect(self, hermes_home):
+        """Observed at connect time, not after the loop.
+
+        ``_start_one_profile_adapters`` stands in for the real connect; it
+        records what ``pairing_stores`` looked like at the instant this
+        profile's adapters would have started accepting traffic. Pre-fix that
+        snapshot was empty for every profile.
+        """
+        runner = _bare_runner()
+        seen_at_connect = {}
+
+        async def _record_then_connect(profile_name, profile_home, claimed):
+            seen_at_connect[profile_name] = set(runner.pairing_stores)
+            runner._profile_adapters[profile_name] = {}
+            return 1
+
+        runner._start_one_profile_adapters = _record_then_connect
+        runner._adapter_credential_fingerprint = lambda adapter: None
+
+        with patch("hermes_cli.profiles.profiles_to_serve", return_value=[
+            ("coder", hermes_home / "profiles" / "coder"),
+            ("ops", hermes_home / "profiles" / "ops"),
+        ]), patch("hermes_cli.profiles.get_active_profile_name", return_value="default"):
+            asyncio.run(runner._start_secondary_profile_adapters())
+
+        assert "coder" in seen_at_connect["coder"], (
+            "coder's PairingStore was still unregistered when its adapters "
+            "connected — the startup race is back"
+        )
+        assert "ops" in seen_at_connect["ops"], (
+            "ops's PairingStore was still unregistered when its adapters connected"
+        )
+
+    def test_store_registered_even_when_connect_fails(self, hermes_home):
+        """A profile whose adapters all fail still gets its store.
+
+        The safety-net pass after the loop covers it, so a later retry-connect
+        cannot find the profile served but store-less.
+        """
+        runner = _bare_runner()
+
+        async def _boom(profile_name, profile_home, claimed):
+            raise RuntimeError("connect failed")
+
+        runner._start_one_profile_adapters = _boom
+        runner._adapter_credential_fingerprint = lambda adapter: None
+
+        with patch("hermes_cli.profiles.profiles_to_serve", return_value=[
+            ("coder", hermes_home / "profiles" / "coder"),
+        ]), patch("hermes_cli.profiles.get_active_profile_name", return_value="default"):
+            asyncio.run(runner._start_secondary_profile_adapters())
+
+        assert "coder" in runner.pairing_stores
+        assert "default" in runner.pairing_stores
+
+    def test_ensure_pairing_store_is_idempotent(self, hermes_home):
+        """Re-registering must not replace a live store instance."""
+        runner = _bare_runner()
+
+        assert runner._ensure_pairing_store("coder") is True
+        first = runner.pairing_stores["coder"]
+        assert runner._ensure_pairing_store("coder") is True
+        assert runner.pairing_stores["coder"] is first
+
+    def test_blank_profile_name_is_not_registered(self, hermes_home):
+        """An empty/whitespace profile is not a profile — never register one."""
+        runner = _bare_runner()
+
+        assert runner._ensure_pairing_store("") is False
+        assert runner._ensure_pairing_store("   ") is False
+        assert runner._ensure_pairing_store(None) is False
+        assert runner.pairing_stores == {}
+
+
+class TestStoreInitFailure:
+    """A store that fails to open must deny, never degrade to the default."""
+
+    def test_init_failure_records_profile_and_denies(self, hermes_home):
+        runner = _bare_runner()
+
+        with patch("gateway.pairing.PairingStore", side_effect=OSError("disk on fire")):
+            assert runner._ensure_pairing_store("coder") is False
+
+        assert "coder" not in runner.pairing_stores
+        assert "coder" in runner._pairing_store_failed
+
+        # The authorization seam must NOT hand back the default store.
+        source = SessionSource(platform=Platform.SLACK, chat_id="C1", profile="coder")
+        assert runner._pairing_store_for(source) is None, (
+            "a profile whose store failed to init fell back to the default "
+            "profile's pairing whitelist"
+        )
+
+    def test_recovery_after_transient_failure(self, hermes_home):
+        """Once the store opens, the profile is no longer marked failed."""
+        runner = _bare_runner()
+
+        with patch("gateway.pairing.PairingStore", side_effect=OSError("transient")):
+            runner._ensure_pairing_store("coder")
+        assert "coder" in runner._pairing_store_failed
+
+        assert runner._ensure_pairing_store("coder") is True
+        assert "coder" not in runner._pairing_store_failed
+        source = SessionSource(platform=Platform.SLACK, chat_id="C1", profile="coder")
+        assert runner._pairing_store_for(source) is runner.pairing_stores["coder"]
+
+
+class TestPairingStoreForFailsClosed:
+    """``_pairing_store_for`` selection rules, on the real mixin method."""
+
+    def test_missing_store_under_multiplex_returns_none(self, hermes_home):
+        runner = _bare_runner(multiplex=True)
+        source = SessionSource(platform=Platform.SLACK, chat_id="C1", profile="ghost")
+
+        assert runner._pairing_store_for(source) is None
+
+    def test_registered_profile_gets_its_own_store(self, hermes_home):
+        runner = _bare_runner(multiplex=True)
+        runner._ensure_pairing_store("coder")
+        runner._ensure_pairing_store("ops")
+
+        coder = SessionSource(platform=Platform.SLACK, chat_id="C1", profile="coder")
+        ops = SessionSource(platform=Platform.SLACK, chat_id="C1", profile="ops")
+
+        assert runner._pairing_store_for(coder) is runner.pairing_stores["coder"]
+        assert runner._pairing_store_for(ops) is runner.pairing_stores["ops"]
+        assert runner.pairing_stores["coder"] is not runner.pairing_stores["ops"]
+
+    def test_unstamped_source_under_multiplex_uses_default(self, hermes_home):
+        """No profile at all is a different case from an unserved profile.
+
+        An unstamped source has not asserted any profile identity, so the
+        default store stays correct; the fail-closed rule targets sources that
+        DO name a profile we cannot serve.
+        """
+        runner = _bare_runner(multiplex=True)
+        source = SessionSource(platform=Platform.SLACK, chat_id="C1")
+
+        assert runner._pairing_store_for(source) is runner.pairing_store
+
+    def test_single_profile_gateway_unchanged(self, hermes_home):
+        """Without multiplexing the global store answers everything."""
+        runner = _bare_runner(multiplex=False)
+        source = SessionSource(platform=Platform.SLACK, chat_id="C1", profile="anything")
+
+        assert runner._pairing_store_for(source) is runner.pairing_store
+
+
+class TestAuthorizationIntegration:
+    """End-to-end through the real ``_is_user_authorized``."""
+
+    @pytest.fixture(autouse=True)
+    def _no_env_allowlists(self, monkeypatch):
+        # Strip every allowlist so the pairing grant is the only thing that can
+        # authorize — otherwise these tests could pass for the wrong reason.
+        for var in (
+            "GATEWAY_ALLOW_ALL_USERS", "GATEWAY_ALLOWED_USERS",
+            "SLACK_ALLOWED_USERS", "SLACK_ALLOW_ALL_USERS",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+    def _runner_with_default_grant(self, user_id="U_PAIRED"):
+        runner = _bare_runner(multiplex=True)
+        runner._ensure_pairing_store("default")
+        runner.pairing_stores["default"]._approve_user("slack", user_id)
+        return runner
+
+    def test_default_grant_does_not_authorize_unregistered_profile(self, hermes_home):
+        """The core cross-profile leak.
+
+        ``U_PAIRED`` is paired on the DEFAULT profile only. A source stamped for
+        a secondary profile with no registered store must not inherit that
+        grant — pre-fix, ``_pairing_store_for`` returned the default store and
+        ``is_approved`` said yes.
+        """
+        runner = self._runner_with_default_grant()
+        source = SessionSource(
+            platform=Platform.SLACK, chat_id="C1",
+            user_id="U_PAIRED", chat_type="dm", profile="coder",
+        )
+
+        assert runner._is_user_authorized(source) is False, (
+            "a default-profile pairing grant authorized a secondary profile's "
+            "traffic — cross-profile pairing leak"
+        )
+
+    def test_default_grant_still_authorizes_default_profile(self, hermes_home):
+        """The fail-closed rule must not break the legitimate case."""
+        runner = self._runner_with_default_grant()
+        source = SessionSource(
+            platform=Platform.SLACK, chat_id="C1",
+            user_id="U_PAIRED", chat_type="dm", profile="default",
+        )
+
+        assert runner._is_user_authorized(source) is True
+
+    def test_grant_is_isolated_to_its_own_profile(self, hermes_home):
+        """A secondary profile's own grant authorizes only that profile."""
+        runner = _bare_runner(multiplex=True)
+        runner._ensure_pairing_store("default")
+        runner._ensure_pairing_store("coder")
+        runner.pairing_stores["coder"]._approve_user("slack", "U_CODER")
+
+        def _source(profile):
+            return SessionSource(
+                platform=Platform.SLACK, chat_id="C1",
+                user_id="U_CODER", chat_type="dm", profile=profile,
+            )
+
+        assert runner._is_user_authorized(_source("coder")) is True
+        assert runner._is_user_authorized(_source("default")) is False
+
+    def test_startup_race_window_denies(self, hermes_home):
+        """A stamped source arriving before its store exists is denied.
+
+        This is the shape of the original race: the adapter is live, the store
+        is not yet registered. Denying is correct; inheriting the default
+        profile's whitelist is the bug.
+        """
+        runner = self._runner_with_default_grant()
+        # 'coder' is served but its store has not been registered yet.
+        runner._profile_adapters["coder"] = {}
+        source = SessionSource(
+            platform=Platform.SLACK, chat_id="C1",
+            user_id="U_PAIRED", chat_type="dm", profile="coder",
+        )
+
+        assert runner._is_user_authorized(source) is False
+
+
+class TestDefaultProfileStoreAliasesGlobal:
+    """``default`` must resolve to the legacy global store, not a new subtree.
+
+    The "default" profile IS ``~/.hermes`` — there is no ``profiles/default/``
+    directory. ``PairingStore(profile="default")`` therefore opens a *different*
+    directory from the one ``hermes pairing approve`` and the dashboard write,
+    so a code issued under the default profile could never be approved.
+    """
+
+    def test_default_store_is_the_global_store(self, hermes_home):
+        runner = _bare_runner()
+
+        assert runner._ensure_pairing_store("default") is True
+        assert runner.pairing_stores["default"] is runner.pairing_store, (
+            "the default profile got its own PairingStore instead of the "
+            "legacy global one the CLI and dashboard use"
+        )
+
+    def test_default_store_uses_the_legacy_directory(self, hermes_home):
+        """Pin the directory, not just object identity."""
+        runner = _bare_runner()
+        runner._ensure_pairing_store("default")
+
+        assert runner.pairing_stores["default"].profile is None
+        assert "profiles/default" not in str(runner.pairing_stores["default"]._dir)
+
+    def test_code_issued_for_default_is_visible_to_the_cli_store(self, hermes_home):
+        """Round-trip: generated on the runner, read back on a fresh global store.
+
+        A separate ``PairingStore()`` is exactly what ``hermes pairing approve``
+        constructs, so this proves the CLI can see the code.
+        """
+        runner = _bare_runner()
+        runner._ensure_pairing_store("default")
+        source = SessionSource(
+            platform=Platform.SLACK, chat_id="D1",
+            user_id="U_NEW", chat_type="dm", profile="default",
+        )
+
+        code = runner._pairing_store_for(source).generate_code(
+            "slack", "U_NEW", "newcomer"
+        )
+        assert code
+
+        # A bare ``PairingStore()`` is exactly what the CLI constructs. Codes are
+        # stored salted+hashed, so its own verification is the only honest way
+        # to ask "can this store approve that code".
+        cli_view = PairingStore()
+        approved = cli_view.approve_code("slack", code)
+        assert approved and approved.get("user_id") == "U_NEW", (
+            "a default-profile pairing code was invisible to the CLI's global store"
+        )
+
+    def test_secondary_profile_still_gets_its_own_store(self, hermes_home):
+        """The aliasing is default-only — secondaries stay isolated."""
+        runner = _bare_runner()
+        runner._ensure_pairing_store("default")
+        runner._ensure_pairing_store("coder")
+
+        assert runner.pairing_stores["coder"] is not runner.pairing_store
+        assert runner.pairing_stores["coder"].profile == "coder"
+
+
+class TestPairingCodeGenerationUsesTheAuthStore:
+    """Generation and rate-limiting must hit the store auth reads.
+
+    ``_handle_message`` wrote ``self.pairing_store`` (the global one) while
+    ``_is_user_authorized`` read ``_pairing_store_for(source)``. For a secondary
+    profile those are different files: the code landed in the default profile's
+    pending list, so approving it never granted access, and the rate-limit
+    counter was written where nobody looked.
+
+    These drive the REAL ``GatewayRunner._handle_message`` pairing branch.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_env_allowlists(self, monkeypatch):
+        for var in (
+            "GATEWAY_ALLOW_ALL_USERS", "GATEWAY_ALLOWED_USERS",
+            "SLACK_ALLOWED_USERS", "SLACK_ALLOW_ALL_USERS",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+    def _runner_for_dm(self, multiplex=True):
+        runner = _bare_runner(multiplex=multiplex)
+        runner._startup_restore_in_progress = False
+        runner._scale_to_zero_note_real_inbound = lambda: None
+        runner._get_unauthorized_dm_behavior = lambda platform, profile=None: "pair"
+        runner.sent = []
+
+        adapter = MagicMock()
+
+        async def _send(chat_id, text, *a, **kw):
+            runner.sent.append(text)
+
+        adapter.send = _send
+        runner._adapter_for_source = lambda source: adapter
+        return runner
+
+    @staticmethod
+    def _dm_event(profile):
+        from gateway.platforms.base import MessageEvent
+
+        return MessageEvent(
+            text="hello?",
+            source=SessionSource(
+                platform=Platform.SLACK, chat_id="D1",
+                user_id="U_NEW", user_name="newcomer",
+                chat_type="dm", profile=profile,
+            ),
+        )
+
+    @staticmethod
+    def _issued_code(runner):
+        """Pull the code out of the pairing message the user was sent."""
+        assert runner.sent, "no pairing message was sent"
+        match = re.search(r"pairing code: `([^`]+)`", runner.sent[0])
+        assert match, f"unexpected pairing message: {runner.sent[0]!r}"
+        return match.group(1)
+
+    @staticmethod
+    def _can_approve(store, code, user_id="U_NEW"):
+        """Whether ``code`` is redeemable in ``store``.
+
+        Pending codes are stored salted+hashed, so there is no field to compare
+        — asking the store to verify it is the only honest check, and it is also
+        the exact operation ``hermes pairing approve`` performs. A miss returns
+        None without mutating anything, so this is safe on the negative side.
+        """
+        entry = store.approve_code("slack", code)
+        return bool(entry) and entry.get("user_id") == user_id
+
+    def test_secondary_code_lands_in_that_profiles_store(self, hermes_home):
+        """The core defect: written to default, read from 'coder'."""
+        runner = self._runner_for_dm()
+        runner._ensure_pairing_store("default")
+        runner._ensure_pairing_store("coder")
+
+        asyncio.run(runner._handle_message(self._dm_event("coder")))
+        code = self._issued_code(runner)
+
+        # Negative side first — a miss does not mutate, so order is free.
+        assert not self._can_approve(runner.pairing_store, code), (
+            "the code was written to the default profile's store"
+        )
+        assert self._can_approve(runner.pairing_stores["coder"], code), (
+            "the code was not written to the profile's own store"
+        )
+
+    def test_secondary_code_approves_and_then_authorizes(self, hermes_home):
+        """End-to-end: the issued code actually grants access to that profile.
+
+        Pre-fix this was the user-visible symptom — approving the code the bot
+        handed out did nothing, because the approval and the check were looking
+        at different files.
+        """
+        runner = self._runner_for_dm()
+        runner._ensure_pairing_store("coder")
+
+        asyncio.run(runner._handle_message(self._dm_event("coder")))
+        code = self._issued_code(runner)
+
+        assert self._can_approve(runner.pairing_stores["coder"], code)
+
+        source = SessionSource(
+            platform=Platform.SLACK, chat_id="D1",
+            user_id="U_NEW", chat_type="dm", profile="coder",
+        )
+        assert runner._is_user_authorized(source) is True
+
+    def test_default_profile_path_is_unchanged(self, hermes_home):
+        """The legacy global path must behave exactly as before."""
+        runner = self._runner_for_dm()
+        runner._ensure_pairing_store("default")
+
+        asyncio.run(runner._handle_message(self._dm_event("default")))
+        code = self._issued_code(runner)
+
+        assert self._can_approve(PairingStore(), code), (
+            "the default profile stopped writing the legacy global store the "
+            "CLI and dashboard read"
+        )
+
+    def test_unstamped_source_on_single_profile_gateway_unchanged(self, hermes_home):
+        """No multiplexing, no profile: still the global store."""
+        runner = self._runner_for_dm(multiplex=False)
+
+        asyncio.run(runner._handle_message(self._dm_event(None)))
+        code = self._issued_code(runner)
+
+        assert self._can_approve(runner.pairing_store, code)
+
+    def test_no_store_for_profile_issues_no_code(self, hermes_home):
+        """Fail closed: an unserved/failed profile gets no pairing code.
+
+        There is no file an approval could land in, so a code would be a dead
+        end — and handing one out under multiplexing would imply a grant path
+        that does not exist.
+        """
+        runner = self._runner_for_dm()
+        runner._ensure_pairing_store("default")
+        # 'ghost' has no registered store.
+
+        asyncio.run(runner._handle_message(self._dm_event("ghost")))
+
+        assert runner.sent == [], "a pairing code was offered with no store to hold it"
+        default_pending = runner.pairing_store._load_json(
+            runner.pairing_store._pending_path("slack")
+        )
+        assert not default_pending, (
+            "an unserved profile's pairing code was written to the default store"
+        )
+
+    def test_rate_limit_is_recorded_in_the_profiles_own_store(self, hermes_home):
+        """The rate limit must count where the next request will read it."""
+        runner = self._runner_for_dm()
+        runner._ensure_pairing_store("coder")
+        store = runner.pairing_stores["coder"]
+
+        # Exhaust the per-platform pending budget so generate_code returns None
+        # and the rejection branch records the rate limit.
+        for i in range(MAX_PENDING_PER_PLATFORM):
+            store.generate_code("slack", f"U_OTHER{i}", "filler")
+
+        asyncio.run(runner._handle_message(self._dm_event("coder")))
+
+        assert runner.sent and "Too many pairing requests" in runner.sent[0]
+        assert store._is_rate_limited("slack", "U_NEW") is True, (
+            "the rate limit was recorded somewhere the next request won't read"
+        )
+        assert runner.pairing_store._is_rate_limited("slack", "U_NEW") is False, (
+            "the rate limit was written to the default profile's store"
+        )

--- a/tests/gateway/test_multiplex_pairing_stores.py
+++ b/tests/gateway/test_multiplex_pairing_stores.py
@@ -15,6 +15,7 @@ the per-profile stores actually materialize.
 import asyncio
 from unittest.mock import MagicMock, patch
 
+from gateway.pairing import PairingStore
 from gateway.run import GatewayRunner
 
 
@@ -23,7 +24,10 @@ def _bare_runner(multiplex: bool = True):
     runner.config = MagicMock(multiplex_profiles=multiplex)
     runner.adapters = {}
     runner._profile_adapters = {}
-    runner.pairing_store = MagicMock()
+    # Real GatewayRunner.__init__ always creates the legacy/global store.
+    # The default multiplex profile intentionally aliases it so the CLI,
+    # dashboard, pairing generation, and authorization all share one path.
+    runner.pairing_store = PairingStore()
     runner.pairing_stores = {}
     return runner
 

--- a/tests/gateway/test_profile_served_validation.py
+++ b/tests/gateway/test_profile_served_validation.py
@@ -1,0 +1,168 @@
+"""``_require_served_profile_home`` — refusing unknown/stale profiles.
+
+``_resolve_profile_home_for_source`` is deliberately lenient: an explicit
+profile that does not exist logs a warning and falls back to the global
+HERMES_HOME. That is survivable on a single-profile gateway, where the global
+home IS the only profile's home.
+
+Under multiplexing it is not. A stale ``profile_routes`` entry, a renamed or
+deleted profile, or a source stamped by anything other than our own startup
+wiring would be served under the MULTIPLEXER's config, skills, memory and
+credentials. ``_require_served_profile_home`` is the validating wrapper used on
+the authorization and runtime-entry paths; it raises ``ProfileNotServedError``
+where the plain resolver would silently fall back.
+
+These tests drive the REAL resolver underneath the real wrapper — nothing about
+resolution itself is mocked out, so route precedence and owner-stamp behavior
+are exercised as they ship.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.profile_routing import ProfileRoute
+from gateway.run import GatewayRunner, ProfileNotServedError
+from gateway.session import SessionSource
+
+
+def _runner(multiplex=True, served=(), routes=(), active="default"):
+    """Runner with the REAL resolver + wrapper bound, serving ``served``."""
+    runner = object.__new__(GatewayRunner)
+    runner.config = MagicMock(multiplex_profiles=multiplex, profile_routes=list(routes))
+    runner._profile_adapters = {name: {} for name in served if name != active}
+    runner._active_profile_name = lambda: active
+    return runner
+
+
+def _source(profile=None, chat_id="C1", platform=Platform.SLACK, **kw):
+    return SessionSource(platform=platform, chat_id=chat_id, profile=profile, **kw)
+
+
+class TestUnknownProfileRefused:
+    def test_unserved_profile_raises(self, tmp_path, monkeypatch):
+        """A stamped profile this gateway does not serve must not resolve."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        runner = _runner(served=["default", "coder"])
+
+        with pytest.raises(ProfileNotServedError) as exc:
+            runner._require_served_profile_home(_source(profile="ghost"))
+
+        assert "ghost" in str(exc.value)
+
+    def test_unserved_profile_does_not_reach_global_home(self, tmp_path, monkeypatch):
+        """Contrast with the lenient resolver, on the identical source.
+
+        The plain resolver returns the global HERMES_HOME — that IS the defect.
+        The wrapper must not.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        runner = _runner(served=["default"])
+        source = _source(profile="ghost")
+
+        # The lenient path still behaves as documented...
+        assert runner._resolve_profile_home_for_source(source) == Path(str(tmp_path))
+        # ...but the validating path refuses instead of entering it.
+        with pytest.raises(ProfileNotServedError):
+            runner._require_served_profile_home(source)
+
+    def test_served_but_deleted_profile_raises(self, tmp_path, monkeypatch):
+        """A profile that is served but no longer on disk is stale."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        runner = _runner(served=["default", "coder"])
+
+        with patch("hermes_cli.profiles.profile_exists", return_value=False):
+            with pytest.raises(ProfileNotServedError) as exc:
+                runner._require_served_profile_home(_source(profile="coder"))
+
+        assert "no longer exists" in str(exc.value)
+
+    def test_stale_route_target_raises(self, tmp_path, monkeypatch):
+        """A route pointing at an unserved profile is refused too.
+
+        The profile arrives via routing rather than a stamp, but it is just as
+        explicit — and just as unserveable.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        route = ProfileRoute(name="r", platform="slack", chat_id="C1", profile="retired")
+        runner = _runner(served=["default"], routes=[route])
+
+        with pytest.raises(ProfileNotServedError) as exc:
+            runner._require_served_profile_home(_source(chat_id="C1"))
+
+        assert "retired" in str(exc.value)
+
+
+class TestValidProfilesUnaffected:
+    """The wrapper must be a pass-through for everything legitimate."""
+
+    def test_served_profile_resolves_to_its_own_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        runner = _runner(served=["default", "coder"])
+
+        with patch("hermes_cli.profiles.profile_exists", return_value=True):
+            home = runner._require_served_profile_home(_source(profile="coder"))
+            # Identical to what the plain resolver would have returned — the
+            # wrapper only changes the failure mode, never a valid answer.
+            lenient = runner._resolve_profile_home_for_source(_source(profile="coder"))
+
+        assert home == lenient
+        assert "coder" in str(home)
+
+    def test_active_profile_is_always_served(self, tmp_path, monkeypatch):
+        """The multiplexer's own profile needs no adapter-map entry."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        runner = _runner(served=[], active="default")
+
+        with patch("hermes_cli.profiles.profile_exists", return_value=True):
+            assert runner._require_served_profile_home(_source(profile="default"))
+
+    def test_route_precedence_preserved(self, tmp_path, monkeypatch):
+        """An explicit stamp still wins over a matching route.
+
+        Same precedence the plain resolver documents — validating must not
+        reorder resolution, only reject unserveable answers.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        route = ProfileRoute(name="r", platform="slack", chat_id="C1", profile="routed")
+        runner = _runner(served=["default", "routed", "stamped"], routes=[route])
+
+        with patch("hermes_cli.profiles.profile_exists", return_value=True):
+            home = runner._require_served_profile_home(
+                _source(profile="stamped", chat_id="C1")
+            )
+
+        assert "stamped" in str(home)
+        assert "routed" not in str(home)
+
+    def test_valid_route_resolves_when_served(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        route = ProfileRoute(name="r", platform="slack", chat_id="C1", profile="routed")
+        runner = _runner(served=["default", "routed"], routes=[route])
+
+        with patch("hermes_cli.profiles.profile_exists", return_value=True):
+            home = runner._require_served_profile_home(_source(chat_id="C1"))
+
+        assert "routed" in str(home)
+
+    def test_unstamped_unrouted_source_uses_active(self, tmp_path, monkeypatch):
+        """No profile asserted → active profile, no validation, no raise."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        runner = _runner(served=["default"])
+
+        with patch("hermes_cli.profiles.profile_exists", return_value=True):
+            assert runner._require_served_profile_home(_source()) is not None
+
+
+class TestNonMultiplexUnchanged:
+    """Single-profile gateways keep the lenient fallback."""
+
+    def test_unknown_profile_falls_back_without_multiplexing(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        runner = _runner(multiplex=False, served=["default"])
+
+        home = runner._require_served_profile_home(_source(profile="ghost"))
+
+        assert home == Path(str(tmp_path))

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1499,7 +1499,9 @@ class _FakeRunner:
     the one policy every inbound message is judged by).
     """
 
-    def __init__(self, *, multiplex=False, routes=None, homes=None, authorized=True):
+    def __init__(
+        self, *, multiplex=False, routes=None, homes=None, authorized: object = True
+    ):
         self.config = SimpleNamespace(multiplex_profiles=multiplex)
         self._routes = routes or {}
         self._homes = homes or {}
@@ -1876,6 +1878,38 @@ class TestCustomMessageHook:
         a.send.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_custom_command_auth_runs_inside_routed_secret_scope(
+        self, tmp_path, monkeypatch
+    ):
+        """Secondary-profile allowlists must not fall back to process secrets."""
+        from agent.secret_scope import get_secret
+
+        secondary = tmp_path / "secondary"
+        secondary.mkdir()
+        (secondary / ".env").write_text("GATEWAY_ALLOWED_USERS=U_USER\n")
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "U_DEFAULT")
+        observed = []
+
+        def authorized(source):
+            observed.append(get_secret("GATEWAY_ALLOWED_USERS"))
+            return observed[-1] == source.user_id
+
+        runner = _FakeRunner(
+            multiplex=True,
+            routes={"C_SECONDARY": "secondary"},
+            homes={"secondary": secondary},
+        )
+        runner.authorized = authorized
+        a = self._make_adapter(handled=True, runner=runner)
+
+        await a._handle_slack_message(
+            self._make_event("!log", channel_type="channel", channel="C_SECONDARY")
+        )
+
+        assert observed == ["U_USER"]
+        assert len(a.hook_calls) == 1
+
+    @pytest.mark.asyncio
     async def test_hook_runs_inside_the_routed_profile_runtime_scope(self, tmp_path):
         """The hook resolves config/skills/memory against its own profile home.
 
@@ -1917,8 +1951,10 @@ class TestCustomMessageHook:
 
         assert a.hook_calls == []
         handle_mock.assert_not_called()
-        send_mock.assert_awaited_once()
-        assert send_mock.await_args.kwargs["metadata"] == {}
+        # Authorization could not be evaluated under the owning profile, so do
+        # not reveal command handling to a caller whose identity is still
+        # untrusted.
+        send_mock.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_hook_scope_is_released_after_the_hook_returns(self, tmp_path):
@@ -5711,6 +5747,67 @@ class TestSendErrorSanitization:
         assert self.TOKEN not in blob
         assert self.TOKEN not in (result.error or "")
         assert "RuntimeError" in blob, "the exception type should still be logged"
+
+    def test_response_url_failure_does_not_escape_through_send_result(self, caplog):
+        """aiohttp exceptions can contain the credential-bearing response_url."""
+        adapter = self._adapter()
+
+        token = self.TOKEN
+
+        class _RaisingSession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def post(self, *args, **kwargs):
+                raise RuntimeError(f"request failed at {args[0]} {token}")
+
+        with (
+            patch.object(
+                _slack_mod.aiohttp,
+                "ClientSession",
+                return_value=_RaisingSession(),
+            ),
+            caplog.at_level(logging.DEBUG),
+        ):
+            result = asyncio.run(
+                adapter._send_slash_ephemeral(
+                    {"response_url": f"https://hooks.slack.com/actions/{self.TOKEN}"},
+                    "hello",
+                )
+            )
+
+        blob = "\n".join(r.getMessage() for r in caplog.records)
+        assert result.success is False
+        assert self.TOKEN not in (result.error or "")
+        assert self.TOKEN not in blob
+        assert "RuntimeError" in blob
+
+    def test_post_ephemeral_failure_does_not_escape_through_send_result(self, caplog):
+        """The Web API fallback also returns and logs only sanitized errors."""
+        adapter = self._adapter()
+        client = AsyncMock()
+        client.chat_postEphemeral = AsyncMock(
+            side_effect=RuntimeError(f"Slack request carried {self.TOKEN}")
+        )
+        adapter._get_client = MagicMock(return_value=client)
+
+        with caplog.at_level(logging.DEBUG):
+            result = asyncio.run(
+                adapter._post_ephemeral_fallback(
+                    "C1",
+                    {"user_id": "U1"},
+                    "hello",
+                )
+            )
+
+        blob = "\n".join(r.getMessage() for r in caplog.records)
+        assert result.success is False
+        assert self.TOKEN not in (result.error or "")
+        assert self.TOKEN not in blob
+        assert "RuntimeError" in blob
 
     def test_junk_error_code_is_dropped(self, caplog):
         """Only the known slug shape is trusted; anything else is dropped."""

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2330,6 +2330,39 @@ class TestCustomMessageHook:
 
         assert "hunter2" not in caplog.text
 
+    @pytest.mark.asyncio
+    async def test_classifier_slack_error_does_not_log_token(self, caplog):
+        """Classifier failures may originate from Slack SDK calls in plugins."""
+        token = "xoxb-CLASSIFIER-SUPERSECRET"
+        a = self._make_adapter()
+        a._classify_custom_message = MagicMock(
+            side_effect=_TokenBearingSlackApiError(token)
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            await a._handle_slack_message(self._make_event("!log"))
+
+        assert token not in caplog.text
+        assert "CLASSIFIER-SUPERSECRET" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_hook_and_error_reply_failures_do_not_log_tokens(self, caplog):
+        """Both the plugin hook and its best-effort error reply stay sanitized."""
+        hook_token = "xoxb-HOOK-SUPERSECRET"
+        reply_token = "xoxb-REPLY-SUPERSECRET"
+        a = self._make_adapter(handled=True)
+        a._on_custom_message = AsyncMock(
+            side_effect=_TokenBearingSlackApiError(hook_token)
+        )
+        a.send = AsyncMock(side_effect=_TokenBearingSlackApiError(reply_token))
+
+        with caplog.at_level(logging.DEBUG):
+            await a._handle_slack_message(self._make_event("!log"))
+
+        assert hook_token not in caplog.text
+        assert reply_token not in caplog.text
+        assert "SUPERSECRET" not in caplog.text
+
     # -- context text purity ------------------------------------------------
 
     @pytest.mark.asyncio
@@ -2378,8 +2411,9 @@ class TestCustomMessageHook:
         )
 
         msg_event = a.handle_message.call_args[0][0]
-        assert msg_event.text.startswith("[Thread context]")
-        assert msg_event.text.endswith("!find blog toc")
+        assert msg_event.text == "!find blog toc"
+        assert msg_event.channel_context.startswith("[Thread context]")
+        assert "U_OTHER: earlier" in msg_event.channel_context
 
     # -- assistant thread titles -------------------------------------------
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -12,11 +12,12 @@ import asyncio
 import contextlib
 import importlib
 from importlib.machinery import PathFinder
+import logging
 import os
 import socket
 import sys
 import time
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch, call
 
 import pytest
@@ -1480,6 +1481,967 @@ class TestBangPrefixCommands:
         msg_event = adapter.handle_message.await_args.args[0]
         assert msg_event.source.chat_type == "group"
         assert msg_event.source.chat_id == "C123"
+
+
+# ---------------------------------------------------------------------------
+# TestCustomMessageHook
+# ---------------------------------------------------------------------------
+
+
+class _FakeRunner:
+    """Minimal ``GatewayRunner`` stand-in for the members the seam reaches for.
+
+    The Slack custom-message seam runs ahead of ``handle_message``, so it has
+    to consult the runner directly for two things ordinary messages get for
+    free: profile routing (``_profile_name_for_source``, called by
+    ``build_source``; ``_resolve_profile_home_for_source``, used to enter the
+    routed profile's runtime scope) and authorization (``_is_user_authorized``,
+    the one policy every inbound message is judged by).
+    """
+
+    def __init__(self, *, multiplex=False, routes=None, homes=None, authorized=True):
+        self.config = SimpleNamespace(multiplex_profiles=multiplex)
+        self._routes = routes or {}
+        self._homes = homes or {}
+        self.authorized = authorized
+        #: Every source ``_is_user_authorized`` was asked about, in order.
+        self.auth_sources = []
+
+    def _profile_name_for_source(self, source):
+        if not self.config.multiplex_profiles:
+            return None
+        return self._routes.get(source.chat_id)
+
+    def _resolve_profile_home_for_source(self, source):
+        name = source.profile or self._profile_name_for_source(source) or "default"
+        return self._homes[name]
+
+    def _is_user_authorized(self, source):
+        self.auth_sources.append(source)
+        if callable(self.authorized):
+            return self.authorized(source)
+        return self.authorized
+
+
+class _HookAdapter(SlackAdapter):
+    """Stand-in for an out-of-tree ``SlackAdapter`` subclass plugin.
+
+    Real deployment-specific thread commands live in out-of-tree plugins; core
+    only guarantees the two-stage seam: a sync classifier that labels the
+    message, and an async hook that executes it.
+    """
+
+    #: Bare tokens this fake plugin claims, mapped to opaque classification
+    #: values.  ``!queue`` is deliberately a *known gateway command* so the
+    #: "hook declines → normal bang/slash handling" path can be asserted.
+    COMMANDS = {"!log": "log", "!find": "find", "!queue": "queue-alias"}
+
+    def __init__(self, config, handled=True, boom=False, classify_boom=False):
+        super().__init__(config)
+        self._hook_handled = handled
+        self._hook_boom = boom
+        self._classify_boom = classify_boom
+        self.classify_calls = []
+        self.hook_calls = []
+        #: ``get_hermes_home()`` as observed from inside the hook, per call.
+        self.hook_homes = []
+
+    def _classify_custom_message(self, text, event):
+        self.classify_calls.append(text)
+        if self._classify_boom:
+            raise RuntimeError("plugin classifier exploded")
+        first = text.split(maxsplit=1)[0] if text.split() else ""
+        return self.COMMANDS.get(first)
+
+    async def _on_custom_message(self, ctx):
+        from hermes_constants import get_hermes_home
+
+        self.hook_calls.append(ctx)
+        self.hook_homes.append(get_hermes_home())
+        if self._hook_boom:
+            raise RuntimeError("plugin hook exploded")
+        return self._hook_handled
+
+
+class TestCustomMessageHook:
+    """Two-stage seam for plugin subclasses.
+
+    ``_classify_custom_message`` is sync, side-effect-free, and runs *before*
+    mention gating so a bare top-level ``!log`` is recognised at all.  A
+    classification token waives only mention/session gating — never
+    channel/user authorization, bot filters, dedup or subtype filters.
+    ``_on_custom_message`` then executes, but only for classified messages.
+    """
+
+    def _make_adapter(self, runner=None, **kwargs):
+        config = PlatformConfig(enabled=True, token="xoxb-fake-token")
+        a = _HookAdapter(config, **kwargs)
+        a._app = MagicMock()
+        a._app.client = AsyncMock()
+        a._bot_user_id = "U_BOT"
+        a._running = True
+        a.handle_message = AsyncMock()
+        a.send = AsyncMock()
+        a._resolve_user_name = AsyncMock(return_value="Test User")
+        a._fetch_thread_context = AsyncMock(return_value="")
+        a._fetch_thread_parent_text = AsyncMock(return_value="")
+        # Channel messages: mention required, non-strict — the realistic
+        # deployment where the regression bit.
+        a._slack_require_mention = MagicMock(return_value=True)
+        a._slack_strict_mention = MagicMock(return_value=False)
+        # Custom commands execute before the gateway's own user authorization,
+        # so the seam authorizes the routed source itself against the same
+        # runner policy. Default to an authorizing runner; auth tests flip it.
+        a.gateway_runner = _FakeRunner() if runner is None else runner
+        return a
+
+    def _make_profile_adapter(self, profile, runner, **kwargs):
+        """An adapter wired the way ``gateway/run.py`` wires a per-profile one.
+
+        Two things happen at that seam: ownership is recorded
+        (``set_owner_profile``) and the message handler is wrapped so it stamps
+        ``source.profile`` before delegating. The wrapper is reproduced here as
+        a ``handle_message`` side effect because that is precisely the point —
+        it fires on *dispatch* only, so a classified custom message (handled
+        before dispatch) never reaches it and must recover the profile from
+        ownership instead.
+        """
+        a = self._make_adapter(runner=runner, **kwargs)
+        a.set_owner_profile(profile)
+
+        async def _stamp_on_dispatch(event):
+            source = getattr(event, "source", None)
+            if source is not None and not source.profile:
+                source.profile = profile
+
+        a.handle_message = AsyncMock(side_effect=_stamp_on_dispatch)
+        return a
+
+    def _make_event(self, text, channel_type="im", channel="D123", **extra):
+        evt = {
+            "text": text,
+            "user": "U_USER",
+            "channel": channel,
+            "channel_type": channel_type,
+            "ts": "1234567890.000001",
+        }
+        evt.update(extra)
+        return evt
+
+    def test_hook_version_marker_is_exposed(self):
+        """Plugins pin against an explicit contract version."""
+        assert SlackAdapter.CUSTOM_MESSAGE_HOOK_VERSION == 1
+
+    # -- stage 1: classification -------------------------------------------
+
+    def test_default_classifier_returns_none(self, adapter):
+        """Base adapter classifies nothing, so nothing ever bypasses gating."""
+        assert adapter._classify_custom_message("!log today", {}) is None
+        assert adapter._classify_custom_message("", {}) is None
+
+    @pytest.mark.asyncio
+    async def test_classifier_sees_raw_bang_text_and_is_called_once(self):
+        """Classifier runs on the pre-rewrite text, exactly once, no side effects.
+
+        ``!queue`` is a known gateway command that the adapter rewrites to
+        ``/queue``; the classifier must still see the ``!`` the user typed.
+        """
+        a = self._make_adapter(handled=True)
+
+        await a._handle_slack_message(
+            self._make_event("!queue", channel_type="channel", channel="C123")
+        )
+
+        assert a.classify_calls == ["!queue"]
+        # Classification alone must not send or dispatch anything.
+        a.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_classified_bare_command_bypasses_mention_gating(self):
+        """THE regression: authorized ``!log`` works top-level, no @mention."""
+        a = self._make_adapter(handled=True)
+
+        await a._handle_slack_message(
+            self._make_event("!log", channel_type="channel", channel="C123")
+        )
+
+        assert len(a.hook_calls) == 1
+        assert a.hook_calls[0].classification == "log"
+        a.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_classified_command_bypasses_strict_mention_gating(self):
+        """strict_mention is mention gating too — same bypass applies."""
+        a = self._make_adapter(handled=True)
+        a._slack_strict_mention = MagicMock(return_value=True)
+
+        await a._handle_slack_message(
+            self._make_event("!log", channel_type="channel", channel="C123")
+        )
+
+        assert len(a.hook_calls) == 1
+        a.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unclassified_bare_text_is_still_ignored_without_mention(self):
+        """No token → mention gating stands, message dropped, hook never runs."""
+        a = self._make_adapter(handled=True)
+
+        await a._handle_slack_message(
+            self._make_event("hello there", channel_type="channel", channel="C123")
+        )
+
+        assert a.hook_calls == []
+        a.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_classification_does_not_bypass_allowed_channel_check(self):
+        """A token waives mention gating only — never channel authorization."""
+        a = self._make_adapter(handled=True)
+        a._slack_allowed_channels = MagicMock(return_value={"C_ALLOWED"})
+
+        await a._handle_slack_message(
+            self._make_event("!log", channel_type="channel", channel="C_DENIED")
+        )
+
+        assert a.hook_calls == []
+        a.handle_message.assert_not_called()
+        a.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_classification_does_not_bypass_user_authorization(self):
+        """THE hole: the seam runs before the gateway ever checks the user.
+
+        ``_on_custom_message`` executes ahead of ``handle_message``, so the
+        runner's ``_is_user_authorized`` (``SLACK_ALLOWED_USERS`` and friends)
+        never sees a classified command. The seam must therefore authorize the
+        caller itself, and drop unauthorized ones silently — no hook, no agent
+        dispatch, and no reply that would confirm the command exists.
+        """
+        a = self._make_adapter(handled=True, runner=_FakeRunner(authorized=False))
+
+        await a._handle_slack_message(
+            self._make_event("!log", channel_type="channel", channel="C123")
+        )
+
+        assert a.hook_calls == []
+        a.handle_message.assert_not_called()
+        a.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_authorization_exception_fails_closed(self):
+        """A broken profile policy must not fall back to a broader env gate."""
+        def explode(_source):
+            raise RuntimeError("pairing store unavailable")
+
+        runner = _FakeRunner()
+        runner.authorized = explode  # type: ignore[assignment]
+        a = self._make_adapter(handled=True, runner=runner)
+        env_auth = MagicMock(return_value=True)
+        a._is_env_allowlisted_user = env_auth  # type: ignore[method-assign]
+
+        await a._handle_slack_message(
+            self._make_event("!log", channel_type="channel", channel="C123")
+        )
+
+        assert a.hook_calls == []
+        a.handle_message.assert_not_called()
+        a.send.assert_not_called()
+        env_auth.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_custom_command_is_dropped_in_dm(self):
+        """DMs skip mention gating entirely, so they need the same check."""
+        a = self._make_adapter(handled=True, runner=_FakeRunner(authorized=False))
+
+        await a._handle_slack_message(self._make_event("!log"))
+
+        assert a.hook_calls == []
+        a.handle_message.assert_not_called()
+        a.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_custom_command_auth_judges_the_real_routed_source(self):
+        """Auth runs on the *actual* source, not a stripped-down stand-in.
+
+        ``_is_user_authorized`` reads chat type, thread, team scope, bot flag
+        and profile off the source — a synthetic source missing any of them is
+        judged under the wrong policy (wrong pairing store, wrong group rules).
+        """
+        runner = _FakeRunner()
+        a = self._make_adapter(handled=True, runner=runner)
+
+        await a._handle_slack_message(
+            self._make_event(
+                "!log",
+                channel_type="channel",
+                channel="C123",
+                team="T_TEAM",
+                thread_ts="1111111111.000001",
+            )
+        )
+
+        assert len(runner.auth_sources) == 1
+        src = runner.auth_sources[0]
+        assert src.platform == Platform.SLACK
+        assert src.chat_id == "C123"
+        assert src.chat_type == "group"
+        assert src.user_id == "U_USER"
+        assert src.thread_id == "1111111111.000001"
+        assert src.scope_id == "T_TEAM"
+        assert src.is_bot is False
+        assert len(a.hook_calls) == 1
+        # And it is the very same source the hook then receives.
+        assert a.hook_calls[0].source.chat_id == src.chat_id
+        assert a.hook_calls[0].source.thread_id == src.thread_id
+        assert a.hook_calls[0].source.profile == src.profile
+
+    @pytest.mark.asyncio
+    async def test_dm_custom_command_auth_uses_dm_chat_type(self):
+        """A DM must be judged as a DM — group policy would be the wrong gate."""
+        runner = _FakeRunner()
+        a = self._make_adapter(handled=True, runner=runner)
+
+        await a._handle_slack_message(self._make_event("!log"))
+
+        assert len(runner.auth_sources) == 1
+        assert runner.auth_sources[0].chat_type == "dm"
+        assert runner.auth_sources[0].chat_id == "D123"
+
+    @pytest.mark.asyncio
+    async def test_unclassified_message_keeps_normal_gateway_auth(self):
+        """No token → no seam-level auth; the gateway path stays the only check.
+
+        Authorization is duplicated only for messages that skip
+        ``handle_message``. Everything else must reach the gateway with its
+        auth flow intact, even when the seam's own check would say no.
+        """
+        a = self._make_adapter(handled=True, runner=_FakeRunner(authorized=False))
+
+        await a._handle_slack_message(self._make_event("hello there"))
+
+        assert a.gateway_runner.auth_sources == []
+        a.handle_message.assert_awaited_once()
+
+    # -- multiplex: profile-aware authorization and runtime scope -----------
+
+    @pytest.mark.asyncio
+    async def test_custom_command_auth_carries_the_routed_profile(self, tmp_path):
+        """Routing stamps ``source.profile``; auth must see it.
+
+        ``_is_user_authorized`` picks the per-profile pairing store off
+        ``source.profile``. Authorizing a profile-less source silently consults
+        the *default* profile's pairing state for a secondary profile's channel.
+        """
+        runner = _FakeRunner(
+            multiplex=True,
+            routes={"C_SECONDARY": "secondary"},
+            homes={"secondary": tmp_path / "secondary", "default": tmp_path / "default"},
+        )
+        a = self._make_adapter(handled=True, runner=runner)
+
+        await a._handle_slack_message(
+            self._make_event("!log", channel_type="channel", channel="C_SECONDARY")
+        )
+
+        assert len(runner.auth_sources) == 1
+        assert runner.auth_sources[0].profile == "secondary"
+        assert len(a.hook_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_default_profile_pairing_does_not_authorize_routed_profile(
+        self, tmp_path
+    ):
+        """Paired on the default profile ≠ paired on the routed one.
+
+        The runner here approves only profile-less (default) sources — exactly
+        what a default-profile pairing grant looks like. A command in a channel
+        routed to ``secondary`` must be dropped, not admitted on the default
+        profile's grant.
+        """
+        runner = _FakeRunner(
+            multiplex=True,
+            routes={"C_SECONDARY": "secondary"},
+            homes={"secondary": tmp_path / "secondary", "default": tmp_path / "default"},
+            authorized=lambda source: source.profile is None,
+        )
+        a = self._make_adapter(handled=True, runner=runner)
+
+        await a._handle_slack_message(
+            self._make_event("!log", channel_type="channel", channel="C_SECONDARY")
+        )
+
+        assert a.hook_calls == []
+        a.handle_message.assert_not_called()
+        a.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_hook_runs_inside_the_routed_profile_runtime_scope(self, tmp_path):
+        """The hook resolves config/skills/memory against its own profile home.
+
+        ``_on_custom_message`` replaces the agent turn for a classified command,
+        so it must run in the same ``_profile_runtime_scope`` the gateway would
+        have entered — otherwise a secondary profile's command reads the
+        default profile's HERMES_HOME.
+        """
+        secondary = tmp_path / "secondary"
+        secondary.mkdir()
+        runner = _FakeRunner(
+            multiplex=True,
+            routes={"C_SECONDARY": "secondary"},
+            homes={"secondary": secondary, "default": tmp_path / "default"},
+        )
+        a = self._make_adapter(handled=True, runner=runner)
+
+        await a._handle_slack_message(
+            self._make_event("!log", channel_type="channel", channel="C_SECONDARY")
+        )
+
+        assert a.hook_homes == [secondary]
+
+    @pytest.mark.asyncio
+    async def test_profile_scope_resolution_failure_consumes_command(self, tmp_path):
+        """Never execute a routed command under the process-default profile."""
+        runner = _FakeRunner(
+            multiplex=True,
+            routes={"C_SECONDARY": "secondary"},
+            homes={},
+        )
+        a = self._make_adapter(handled=True, runner=runner)
+        handle_mock = getattr(a, "handle_message")
+        send_mock = getattr(a, "send")
+
+        await a._handle_slack_message(
+            self._make_event("!log", channel_type="channel", channel="C_SECONDARY")
+        )
+
+        assert a.hook_calls == []
+        handle_mock.assert_not_called()
+        send_mock.assert_awaited_once()
+        assert send_mock.await_args.kwargs["metadata"] == {}
+
+    @pytest.mark.asyncio
+    async def test_hook_scope_is_released_after_the_hook_returns(self, tmp_path):
+        """The profile override is per-turn — it must not leak into the process."""
+        from hermes_constants import get_hermes_home
+
+        secondary = tmp_path / "secondary"
+        secondary.mkdir()
+        runner = _FakeRunner(
+            multiplex=True,
+            routes={"C_SECONDARY": "secondary"},
+            homes={"secondary": secondary, "default": tmp_path / "default"},
+        )
+        a = self._make_adapter(handled=True, runner=runner)
+        before = get_hermes_home()
+
+        await a._handle_slack_message(
+            self._make_event("!log", channel_type="channel", channel="C_SECONDARY")
+        )
+
+        assert get_hermes_home() == before
+
+    @pytest.mark.asyncio
+    async def test_single_profile_gateway_does_not_enter_profile_scope(self):
+        """Multiplexing off → transparent pass-through, exactly like the runner."""
+        from hermes_constants import get_hermes_home
+
+        a = self._make_adapter(handled=True)
+
+        await a._handle_slack_message(
+            self._make_event("!log", channel_type="channel", channel="C123")
+        )
+
+        assert a.hook_homes == [get_hermes_home()]
+
+    # -- multiplex: per-profile adapter ownership ---------------------------
+
+    @pytest.mark.asyncio
+    async def test_owning_profile_serves_command_without_any_route(self, tmp_path):
+        """THE regression: a per-profile adapter, no ``profile_routes`` at all.
+
+        Production only stamps ``source.profile`` in the per-profile
+        message-handler wrapper, which runs on dispatch. A classified command is
+        handled *before* dispatch, so without adapter ownership the source comes
+        back profile-less and the secondary profile's command is authorized
+        against — and executed under — the default profile.
+        """
+        secondary = tmp_path / "secondary"
+        secondary.mkdir()
+        runner = _FakeRunner(
+            multiplex=True,
+            routes={},  # no profile_routes configured — ownership is all we have
+            homes={"secondary": secondary, "default": tmp_path / "default"},
+        )
+        a = self._make_profile_adapter("secondary", runner, handled=True)
+
+        await a._handle_slack_message(
+            self._make_event("!log", channel_type="channel", channel="C_ANY")
+        )
+
+        assert len(runner.auth_sources) == 1
+        assert runner.auth_sources[0].profile == "secondary"
+        assert a.hook_homes == [secondary]
+        # The dispatch wrapper never ran — the command replaced the agent turn.
+        a.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_explicit_route_outranks_adapter_ownership(self, tmp_path):
+        """``profile_routes`` keeps precedence; ownership only fills a gap."""
+        routed = tmp_path / "routed"
+        routed.mkdir()
+        runner = _FakeRunner(
+            multiplex=True,
+            routes={"C_ROUTED": "routed"},
+            homes={
+                "routed": routed,
+                "secondary": tmp_path / "secondary",
+                "default": tmp_path / "default",
+            },
+        )
+        # Adapter is owned by "secondary", but the channel routes to "routed".
+        a = self._make_profile_adapter("secondary", runner, handled=True)
+
+        await a._handle_slack_message(
+            self._make_event("!log", channel_type="channel", channel="C_ROUTED")
+        )
+
+        assert len(runner.auth_sources) == 1
+        assert runner.auth_sources[0].profile == "routed"
+        assert a.hook_homes == [routed]
+
+    @pytest.mark.asyncio
+    async def test_ordinary_message_ownership_matches_the_dispatch_wrapper(
+        self, tmp_path
+    ):
+        """Stamping ownership early agrees with what the wrapper would do.
+
+        The same helper builds the source for ordinary messages, so this pins
+        that filling the profile in early is not a behaviour change: the
+        dispatched event carries the owning profile either way.
+        """
+        runner = _FakeRunner(
+            multiplex=True,
+            routes={},
+            homes={"secondary": tmp_path / "secondary", "default": tmp_path / "default"},
+        )
+        a = self._make_profile_adapter("secondary", runner, handled=True)
+
+        await a._handle_slack_message(
+            self._make_event("<@U_BOT> how do I export a report", channel_type="channel")
+        )
+
+        a.handle_message.assert_awaited_once()
+        assert a.handle_message.call_args[0][0].source.profile == "secondary"
+
+    @pytest.mark.asyncio
+    async def test_unowned_adapter_under_multiplex_fails_closed(self, tmp_path):
+        """Ambiguous ownership must never fall back to the default profile.
+
+        Multiplexing is on, no route matches, and the adapter carries no owner —
+        so there is no way to tell whose policy or HERMES_HOME applies. The
+        command is dropped before authorization is even consulted.
+        """
+        runner = _FakeRunner(
+            multiplex=True,
+            routes={},
+            homes={"default": tmp_path / "default"},
+        )
+        a = self._make_adapter(handled=True, runner=runner)  # no owner recorded
+
+        await a._handle_slack_message(
+            self._make_event("!log", channel_type="channel", channel="C_ANY")
+        )
+
+        assert a.hook_calls == []
+        assert runner.auth_sources == []
+        a.handle_message.assert_not_called()
+        a.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_single_profile_adapter_needs_no_ownership(self):
+        """Multiplexing off: an unset profile is unambiguous, nothing changes."""
+        from hermes_constants import get_hermes_home
+
+        runner = _FakeRunner(multiplex=False)
+        a = self._make_adapter(handled=True, runner=runner)  # no owner recorded
+
+        await a._handle_slack_message(
+            self._make_event("!log", channel_type="channel", channel="C123")
+        )
+
+        assert len(a.hook_calls) == 1
+        assert len(runner.auth_sources) == 1
+        assert runner.auth_sources[0].profile is None
+        assert a.hook_homes == [get_hermes_home()]
+
+    @pytest.mark.asyncio
+    async def test_classification_does_not_bypass_bot_message_filter(self):
+        """Bot/self filters run before classification and still win."""
+        a = self._make_adapter(handled=True)
+
+        await a._handle_slack_message(
+            self._make_event(
+                "!log",
+                channel_type="channel",
+                channel="C123",
+                bot_id="B_OTHER",
+                subtype="bot_message",
+            )
+        )
+
+        assert a.classify_calls == []
+        assert a.hook_calls == []
+
+    @pytest.mark.asyncio
+    async def test_classification_does_not_bypass_dedup(self):
+        """A redelivered event is dropped before the classifier runs."""
+        a = self._make_adapter(handled=True)
+        evt = self._make_event("!log", channel_type="channel", channel="C123")
+
+        await a._handle_slack_message(evt)
+        await a._handle_slack_message(dict(evt))
+
+        assert len(a.hook_calls) == 1
+        assert len(a.classify_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_classification_does_not_bypass_subtype_filter(self):
+        """Edits/deletions never reach the seam."""
+        a = self._make_adapter(handled=True)
+
+        await a._handle_slack_message(
+            self._make_event(
+                "!log",
+                channel_type="channel",
+                channel="C123",
+                subtype="message_changed",
+            )
+        )
+
+        assert a.classify_calls == []
+        assert a.hook_calls == []
+
+    # -- stage 2: execution -------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_execution_hook_not_invoked_without_classification(self):
+        """Unclassified messages go straight to the agent, hook untouched."""
+        a = self._make_adapter(handled=True)
+
+        await a._handle_slack_message(self._make_event("just a message"))
+
+        assert a.hook_calls == []
+        a.handle_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_hook_receives_token_and_normalized_context(self):
+        """Hook gets the opaque token plus normalized text and reply context."""
+        a = self._make_adapter(handled=True)
+
+        await a._handle_slack_message(
+            self._make_event(
+                "<@U_BOT> !find blog toc",
+                channel_type="channel",
+                channel="C123",
+                thread_ts="1111111111.000001",
+                team="T_TEAM",
+            )
+        )
+
+        ctx = a.hook_calls[0]
+        assert ctx.classification == "find"
+        # Mention stripped, not the raw event text.
+        assert ctx.text == "!find blog toc"
+        assert ctx.channel_id == "C123"
+        assert ctx.user_id == "U_USER"
+        assert ctx.team_id == "T_TEAM"
+        assert ctx.thread_ts == "1111111111.000001"
+        assert ctx.ts == "1234567890.000001"
+        assert ctx.is_mentioned is True
+        assert ctx.is_dm is False
+        # Enough context to reply without reimplementing _handle_slack_message.
+        assert ctx.event["channel"] == "C123"
+        assert ctx.source.chat_id == "C123"
+        assert ctx.source.thread_id == "1111111111.000001"
+        assert ctx.client is a._app.client
+        # Workspace-scoped: without slack_team_id, send() resolves the client
+        # from a channel-id map that two workspaces can collide in.
+        assert ctx.reply_metadata == {
+            "slack_team_id": "T_TEAM",
+            "thread_id": "1111111111.000001",
+        }
+
+    @pytest.mark.asyncio
+    async def test_reply_metadata_carries_team_for_top_level_messages(self):
+        """No thread key, but still a workspace — the team must survive."""
+        a = self._make_adapter(handled=True)
+
+        await a._handle_slack_message(
+            self._make_event(
+                "!log", channel_type="channel", channel="C123", team="T_TEAM"
+            )
+        )
+
+        assert a.hook_calls[0].reply_metadata == {"slack_team_id": "T_TEAM"}
+
+    # -- cross-workspace reply safety --------------------------------------
+
+    def _make_multi_workspace_adapter(self, **kwargs):
+        """Two workspaces that share a channel ID — the collision case."""
+        a = self._make_adapter(**kwargs)
+        a._team_clients = {"T_A": AsyncMock(), "T_B": AsyncMock()}
+        for client in a._team_clients.values():
+            client.chat_postMessage.return_value = {}
+        # A stale channel→team mapping from workspace A. This is the trap:
+        # _get_client falls back to it whenever metadata carries no team.
+        a._channel_team = {"C_SHARED": "T_A"}
+        return a
+
+    @pytest.mark.asyncio
+    async def test_reply_metadata_selects_the_invoking_workspace_client(self):
+        """Same channel ID in two workspaces must not cross-post."""
+        a = self._make_multi_workspace_adapter(handled=True)
+
+        await a._handle_slack_message(
+            self._make_event(
+                "!log", channel_type="channel", channel="C_SHARED", team="T_B"
+            )
+        )
+
+        ctx = a.hook_calls[0]
+        assert ctx.reply_metadata["slack_team_id"] == "T_B"
+        resolved = a._get_client(
+            ctx.channel_id, team_id=a._metadata_team_id(ctx.reply_metadata)
+        )
+        assert resolved is a._team_clients["T_B"]
+        assert resolved is not a._team_clients["T_A"]
+
+    @pytest.mark.asyncio
+    async def test_hook_error_reply_posts_to_the_invoking_workspace(self):
+        """The generic failure notice must land in the workspace that asked."""
+        a = self._make_multi_workspace_adapter(boom=True)
+        # Real send(): prove the client selection end to end, not just metadata.
+        del a.send
+
+        await a._handle_slack_message(
+            self._make_event(
+                "!log", channel_type="channel", channel="C_SHARED", team="T_B"
+            )
+        )
+
+        a.handle_message.assert_not_called()
+        a._team_clients["T_B"].chat_postMessage.assert_awaited_once()
+        a._team_clients["T_A"].chat_postMessage.assert_not_awaited()
+        a._app.client.chat_postMessage.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_hook_returning_false_falls_through_to_bang_handling(self):
+        """Agent-routed aliases: declining resumes normal bang/slash handling."""
+        a = self._make_adapter(handled=False)
+
+        await a._handle_slack_message(
+            self._make_event("!queue", channel_type="channel", channel="C123")
+        )
+
+        assert len(a.hook_calls) == 1
+        a.handle_message.assert_awaited_once()
+        msg_event = a.handle_message.call_args[0][0]
+        # The !→/ rewrite still applied downstream of the declined hook.
+        assert msg_event.text.startswith("/queue")
+        assert msg_event.message_type == MessageType.COMMAND
+
+    @pytest.mark.asyncio
+    async def test_hook_exception_is_consumed_with_error_reply(self):
+        """Fail closed: a broken command never falls into the LLM."""
+        a = self._make_adapter(boom=True)
+
+        await a._handle_slack_message(
+            self._make_event("!log", channel_type="channel", channel="C123")
+        )
+
+        a.handle_message.assert_not_called()
+        a.send.assert_awaited_once()
+        chat_id, content = a.send.call_args[0][:2]
+        assert chat_id == "C123"
+        assert content  # generic, user-visible error
+        # Top-level channel message → flat reply, no synthetic thread.
+        assert a.send.call_args.kwargs["metadata"] == {}
+
+    @pytest.mark.asyncio
+    async def test_hook_exception_in_thread_replies_in_thread(self):
+        """The error lands on the invoking surface."""
+        a = self._make_adapter(boom=True)
+
+        await a._handle_slack_message(
+            self._make_event(
+                "!log",
+                channel_type="channel",
+                channel="C123",
+                thread_ts="1111111111.000001",
+            )
+        )
+
+        a.handle_message.assert_not_called()
+        assert a.send.call_args.kwargs["metadata"] == {
+            "thread_id": "1111111111.000001"
+        }
+
+    # -- classifier failure -------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_classifier_exception_consumes_the_message_in_channel(self):
+        """A broken classifier must not hand the raw text to the agent.
+
+        The classifier is the only thing that knows whether this was a command.
+        If it fails, treating the message as ordinary chat forwards a
+        side-effecting command (``!log delete everything``) to the LLM to
+        improvise. Fail closed: consume it.
+        """
+        a = self._make_adapter(classify_boom=True)
+
+        await a._handle_slack_message(
+            self._make_event("!log", channel_type="channel", channel="C123")
+        )
+
+        assert a.classify_calls == ["!log"]
+        assert a.hook_calls == []
+        a.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_classifier_exception_consumes_the_message_in_dm(self):
+        """DMs have no mention gate to fall back on — same fail-closed rule."""
+        a = self._make_adapter(classify_boom=True)
+
+        await a._handle_slack_message(self._make_event("hello there"))
+
+        assert a.hook_calls == []
+        a.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_classifier_exception_does_not_log_message_text(self, caplog):
+        """Log the failure, never the payload — it may carry user content."""
+        a = self._make_adapter(classify_boom=True)
+
+        with caplog.at_level("DEBUG"):
+            await a._handle_slack_message(
+                self._make_event("!log my private passphrase hunter2")
+            )
+
+        assert "hunter2" not in caplog.text
+
+    # -- context text purity ------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_ctx_text_excludes_fetched_thread_history(self):
+        """``ctx.text`` is what the user just typed, not the thread transcript.
+
+        Entering a thread cold prepends fetched history to ``text`` for the
+        LLM's benefit. A command parser reading that prefixed string would
+        parse someone else's earlier message as its arguments.
+        """
+        a = self._make_adapter(handled=True)
+        a._has_active_session_for_thread = MagicMock(return_value=False)
+        a._fetch_thread_context = AsyncMock(
+            return_value="[Thread context]\nU_OTHER: !log fake earlier entry\n\n"
+        )
+
+        await a._handle_slack_message(
+            self._make_event(
+                "<@U_BOT> !find blog toc",
+                channel_type="channel",
+                channel="C123",
+                thread_ts="1111111111.000001",
+            )
+        )
+
+        ctx = a.hook_calls[0]
+        assert ctx.text == "!find blog toc"
+        assert "fake earlier entry" not in ctx.text
+
+    @pytest.mark.asyncio
+    async def test_thread_history_still_reaches_the_llm_on_fallthrough(self):
+        """Purity applies to ``ctx.text`` only — the agent still gets context."""
+        a = self._make_adapter(handled=False)
+        a._has_active_session_for_thread = MagicMock(return_value=False)
+        a._fetch_thread_context = AsyncMock(
+            return_value="[Thread context]\nU_OTHER: earlier\n\n"
+        )
+
+        await a._handle_slack_message(
+            self._make_event(
+                "<@U_BOT> !find blog toc",
+                channel_type="channel",
+                channel="C123",
+                thread_ts="1111111111.000001",
+            )
+        )
+
+        msg_event = a.handle_message.call_args[0][0]
+        assert msg_event.text.startswith("[Thread context]")
+        assert msg_event.text.endswith("!find blog toc")
+
+    # -- assistant thread titles -------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_classified_command_does_not_title_the_assistant_thread(self):
+        """A command is not a conversation topic.
+
+        Auto-titling reads the first DM turn's text. ``!log`` and ``!name?``
+        are not known gateway commands, so they never get the ``/`` rewrite
+        that the title path skips — without an explicit guard the thread ends
+        up titled with the command the user typed.
+        """
+        a = self._make_adapter(handled=True)
+        a._app.client.assistant_threads_setTitle = AsyncMock()
+        a.config.extra["assistant_thread_titles"] = True
+
+        await a._handle_slack_message(self._make_event("!log"))
+
+        assert len(a.hook_calls) == 1
+        a._app.client.assistant_threads_setTitle.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unclassified_dm_still_titles_the_assistant_thread(self):
+        """The guard is scoped to commands — ordinary DMs keep auto-titling."""
+        a = self._make_adapter(handled=True)
+        a._app.client.assistant_threads_setTitle = AsyncMock()
+        a.config.extra["assistant_thread_titles"] = True
+
+        await a._handle_slack_message(self._make_event("how do I export a report"))
+
+        a._app.client.assistant_threads_setTitle.assert_awaited_once()
+
+    # -- base adapter regression net ---------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_default_seam_does_not_swallow_normal_messages(self, adapter):
+        """Base adapter is a no-op — unchanged public behavior."""
+        # ``_app.client`` is a bare AsyncMock, so ``users_info`` would return
+        # another AsyncMock and the ``result.get(...)`` inside
+        # ``_resolve_user_name`` would build a coroutine nobody awaits. Give the
+        # concrete lookup a real response dict so it runs to completion.
+        adapter._app.client.users_info = AsyncMock(
+            return_value={"user": {"profile": {"display_name": "Test User"}}}
+        )
+
+        await adapter._handle_slack_message(self._make_event("just a message"))
+
+        adapter.handle_message.assert_awaited_once()
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "just a message"
+
+    @pytest.mark.asyncio
+    async def test_default_seam_still_ignores_unmentioned_channel_bang(self, adapter):
+        """Without a classifier, ``!log`` in a channel stays gated as before."""
+        adapter._slack_require_mention = MagicMock(return_value=True)
+        adapter._slack_strict_mention = MagicMock(return_value=False)
+
+        await adapter._handle_slack_message(
+            self._make_event("!log", channel_type="channel", channel="C123")
+        )
+
+        adapter.handle_message.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -3007,6 +3969,52 @@ class TestAssistantThreadLifecycle:
         msg_event = assistant_adapter.handle_message.call_args[0][0]
         assert msg_event.metadata["slack_team_id"] == "T_TEAM"
 
+    @pytest.mark.asyncio
+    async def test_existing_dm_reply_does_not_reset_title_after_restart(
+        self, assistant_adapter
+    ):
+        """A fresh adapter must not auto-title an already-existing DM thread."""
+        assistant_adapter._app.client.users_info = AsyncMock(
+            return_value={"user": {"profile": {"display_name": "Tyler"}}}
+        )
+        assistant_adapter._app.client.reactions_add = AsyncMock()
+        assistant_adapter._app.client.reactions_remove = AsyncMock()
+        assistant_adapter._app.client.assistant_threads_setTitle = AsyncMock()
+
+        await assistant_adapter._handle_slack_message(
+            {
+                "text": "This reply must not replace an explicit !name title",
+                "channel": "D123",
+                "channel_type": "im",
+                "ts": "171.222",
+                "thread_ts": "171.111",
+                "team": "T_TEAM",
+                "user": "U_USER",
+            }
+        )
+
+        assistant_adapter._app.client.assistant_threads_setTitle.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dm_message_title_can_be_disabled(self, assistant_adapter):
+        assistant_adapter.config.extra["assistant_thread_titles"] = False
+        assistant_adapter._app.client.users_info = AsyncMock(return_value={"user": {}})
+        assistant_adapter._app.client.reactions_add = AsyncMock()
+        assistant_adapter._app.client.reactions_remove = AsyncMock()
+        assistant_adapter._app.client.assistant_threads_setTitle = AsyncMock()
+        event = {
+            "text": "title me",
+            "channel": "D123",
+            "channel_type": "im",
+            "ts": "171.111",
+            "team": "T_TEAM",
+            "user": "U_USER",
+        }
+
+        await assistant_adapter._handle_slack_message(event)
+
+        assistant_adapter._app.client.assistant_threads_setTitle.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # TestUserNameResolution
@@ -4527,3 +5535,236 @@ class TestSlackUserAgent:
         elsewhere in the codebase for platform-partner attribution."""
         assert _slack_mod._HERMES_SLACK_USER_AGENT_PREFIX.startswith("HermesAgent/")
 
+# ---------------------------------------------------------------------------
+# TestSendErrorSanitization
+# ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+
+
+class _TokenBearingSlackApiError(Exception):
+    """Stand-in for ``slack_sdk.errors.SlackApiError``.
+
+    The real one renders its whole ``SlackResponse`` — including the request's
+    ``token`` — through ``__str__``, and carries the same response object on
+    ``.response``. Both leak paths are reproduced here so the test pins the
+    contract rather than the SDK version installed in CI.
+    """
+
+    def __init__(self, token, code="channel_not_found"):
+        self.response = {
+            "ok": False,
+            "error": code,
+            "req_args": {"token": token, "channel": "C1"},
+        }
+        super().__init__(
+            f"The request to the Slack API failed. "
+            f"(url: https://slack.com/api/chat.postMessage) "
+            f"The server responded with: {self.response}"
+        )
+
+
+class TestSendErrorSanitization:
+    """Host contract: a send failure must not leak credentials.
+
+    ``send()`` is inherited unmodified by every out-of-tree ``SlackAdapter``
+    subclass, so whatever it logs and returns is part of the surface those
+    plugins inherit. It used to log the raw exception with ``exc_info=True``
+    and return ``str(e)`` — for a ``SlackApiError`` that is the bot token, in
+    the log file and in a ``SendResult.error`` that callers may render into a
+    channel.
+
+    These drive the REAL inherited ``send`` on a plugin subclass.
+    """
+
+    TOKEN = "xoxb-9876543210-SUPERSECRET-do-not-log"
+
+    def _adapter(self):
+        """A plugin subclass with the real inherited ``send``."""
+        adapter = _HookAdapter(PlatformConfig(enabled=True, token=self.TOKEN))
+        adapter._app = MagicMock()
+        adapter._app.client = AsyncMock()
+        adapter.stop_typing = AsyncMock()
+        # No pending slash context — exercise the chat_postMessage path.
+        adapter._pop_slash_context = MagicMock(return_value=None)
+        assert type(adapter).send is SlackAdapter.send, (
+            "test must exercise the inherited send, not an override"
+        )
+        return adapter
+
+    def _fail_with(self, adapter, exc):
+        adapter._app.client.chat_postMessage = AsyncMock(side_effect=exc)
+        adapter._get_client = MagicMock(return_value=adapter._app.client)
+
+    def test_token_absent_from_returned_error(self, caplog):
+        adapter = self._adapter()
+        self._fail_with(adapter, _TokenBearingSlackApiError(self.TOKEN))
+
+        with caplog.at_level(logging.DEBUG):
+            result = asyncio.run(adapter.send("C1", "hello"))
+
+        assert result.success is False
+        assert self.TOKEN not in (result.error or ""), (
+            "bot token leaked into SendResult.error"
+        )
+        assert "SUPERSECRET" not in (result.error or "")
+
+    def test_token_absent_from_logs(self, caplog):
+        adapter = self._adapter()
+        self._fail_with(adapter, _TokenBearingSlackApiError(self.TOKEN))
+
+        with caplog.at_level(logging.DEBUG):
+            asyncio.run(adapter.send("C1", "hello"))
+
+        blob = "\n".join(
+            [r.getMessage() for r in caplog.records]
+            + [str(r.exc_info) for r in caplog.records if r.exc_info]
+        )
+        assert self.TOKEN not in blob, "bot token leaked into the log record"
+        assert "SUPERSECRET" not in blob
+
+    def test_no_traceback_or_request_context_logged(self, caplog):
+        """No ``exc_info``: traceback frames carry the request kwargs."""
+        adapter = self._adapter()
+        self._fail_with(adapter, _TokenBearingSlackApiError(self.TOKEN))
+
+        with caplog.at_level(logging.DEBUG):
+            asyncio.run(adapter.send("C1", "hello"))
+
+        send_errors = [r for r in caplog.records if "Send error" in r.getMessage()]
+        assert send_errors, "the send failure was not logged at all"
+        for record in send_errors:
+            assert record.exc_info is None, "raw traceback attached to the log record"
+            assert "req_args" not in record.getMessage()
+            assert "slack.com/api" not in record.getMessage()
+
+    def test_stable_slack_error_code_is_kept(self, caplog):
+        """Sanitized ≠ useless: the stable error slug still reaches the log."""
+        adapter = self._adapter()
+        self._fail_with(adapter, _TokenBearingSlackApiError(self.TOKEN, code="ratelimited"))
+
+        with caplog.at_level(logging.DEBUG):
+            asyncio.run(adapter.send("C1", "hello"))
+
+        blob = "\n".join(r.getMessage() for r in caplog.records)
+        assert "ratelimited" in blob
+        assert "_TokenBearingSlackApiError" in blob
+
+    def test_returned_error_is_stable_across_failures(self):
+        """The returned text must not vary with the underlying exception."""
+        first = self._adapter()
+        self._fail_with(first, _TokenBearingSlackApiError(self.TOKEN, code="ratelimited"))
+        second = self._adapter()
+        self._fail_with(second, RuntimeError(f"boom {self.TOKEN}"))
+
+        r1 = asyncio.run(first.send("C1", "hello"))
+        r2 = asyncio.run(second.send("C1", "hello"))
+
+        assert r1.error == r2.error, (
+            "SendResult.error varies with the exception — it can still be used "
+            "as an oracle for its contents"
+        )
+        assert self.TOKEN not in (r2.error or "")
+
+    def test_plain_exception_text_is_not_echoed(self, caplog):
+        """A non-SDK exception's message is untrusted text too."""
+        adapter = self._adapter()
+        self._fail_with(adapter, RuntimeError(f"connection to {self.TOKEN} refused"))
+
+        with caplog.at_level(logging.DEBUG):
+            result = asyncio.run(adapter.send("C1", "hello"))
+
+        blob = "\n".join(r.getMessage() for r in caplog.records)
+        assert self.TOKEN not in blob
+        assert self.TOKEN not in (result.error or "")
+        assert "RuntimeError" in blob, "the exception type should still be logged"
+
+    def test_junk_error_code_is_dropped(self, caplog):
+        """Only the known slug shape is trusted; anything else is dropped."""
+        adapter = self._adapter()
+        exc = _TokenBearingSlackApiError(self.TOKEN)
+        exc.response["error"] = f"not a slug: {self.TOKEN}"
+        self._fail_with(adapter, exc)
+
+        with caplog.at_level(logging.DEBUG):
+            asyncio.run(adapter.send("C1", "hello"))
+
+        blob = "\n".join(r.getMessage() for r in caplog.records)
+        assert self.TOKEN not in blob, (
+            "an attacker-shaped error field was echoed into the log"
+        )
+
+    def test_typing_indicator_still_cleared_on_failure(self):
+        """Sanitizing must not disturb the existing cleanup behavior."""
+        adapter = self._adapter()
+        self._fail_with(adapter, _TokenBearingSlackApiError(self.TOKEN))
+
+        asyncio.run(adapter.send("C1", "hello", reply_to="100.0"))
+
+        adapter.stop_typing.assert_awaited()
+
+    def test_threaded_send_and_real_status_cleanup_do_not_leak(self, caplog):
+        """A second Slack failure during cleanup cannot bypass send sanitization."""
+        adapter = self._adapter()
+        adapter.stop_typing = SlackAdapter.stop_typing.__get__(adapter, type(adapter))
+        assert adapter._app is not None
+        client = adapter._app.client
+        client.chat_postMessage = AsyncMock(
+            side_effect=_TokenBearingSlackApiError(self.TOKEN)
+        )
+        client.assistant_threads_setStatus = AsyncMock(
+            side_effect=_TokenBearingSlackApiError(self.TOKEN)
+        )
+        adapter._get_client = MagicMock(return_value=client)
+
+        with caplog.at_level(logging.DEBUG):
+            result = asyncio.run(
+                adapter.send(
+                    "C1",
+                    "hello",
+                    metadata={"thread_id": "100.0", "slack_team_id": "T1"},
+                )
+            )
+
+        blob = "\n".join(
+            [r.getMessage() for r in caplog.records]
+            + [str(r.exc_info) for r in caplog.records if r.exc_info]
+        )
+        assert result.success is False
+        assert self.TOKEN not in blob
+        assert self.TOKEN not in (result.error or "")
+        client.chat_postMessage.assert_awaited_once()
+        client.assistant_threads_setStatus.assert_awaited_once()
+
+    def test_pre_hook_slack_reads_do_not_log_credentials(self, caplog):
+        """User and cold-thread lookups sanitize SDK exceptions before hooks run."""
+        adapter = self._adapter()
+        assert adapter._app is not None
+        client = adapter._app.client
+        client.users_info = AsyncMock(
+            side_effect=_TokenBearingSlackApiError(self.TOKEN)
+        )
+        client.conversations_replies = AsyncMock(
+            side_effect=_TokenBearingSlackApiError(self.TOKEN)
+        )
+        adapter._get_client = MagicMock(return_value=client)
+
+        async def exercise():
+            assert await adapter._resolve_user_name(
+                "U1", chat_id="C1", team_id="T1"
+            ) == "U1"
+            assert await adapter._fetch_thread_context(
+                "C1", "100.0", "101.0", team_id="T1"
+            ) == ""
+            assert await adapter._fetch_thread_parent_text(
+                "C1", "100.0", team_id="T1"
+            ) == ""
+
+        with caplog.at_level(logging.DEBUG):
+            asyncio.run(exercise())
+
+        blob = "\n".join(
+            [r.getMessage() for r in caplog.records]
+            + [str(r.exc_info) for r in caplog.records if r.exc_info]
+        )
+        assert self.TOKEN not in blob
+        assert "_TokenBearingSlackApiError" in blob

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -3,6 +3,8 @@
 import asyncio
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -62,6 +64,9 @@ class _AuthRunner:
     def __init__(self, auth_fn=None):
         self._auth_fn = auth_fn or (lambda _source: True)
         self.seen_sources = []
+        self.config = SimpleNamespace(multiplex_profiles=False)
+        self.profile_name_fn: Callable[[Any], Any] = lambda _source: None
+        self.profile_home_fn: Callable[[Any], Any] = lambda _source: None
 
     async def handle(self, event):
         return None
@@ -69,6 +74,12 @@ class _AuthRunner:
     def _is_user_authorized(self, source):
         self.seen_sources.append(source)
         return self._auth_fn(source)
+
+    def _profile_name_for_source(self, source):
+        return self.profile_name_fn(source)
+
+    def _require_served_profile_home(self, source):
+        return self.profile_home_fn(source)
 
 
 def _attach_auth_runner(adapter, auth_fn=None):
@@ -205,6 +216,30 @@ class TestSlackApprovalAction:
         ack.assert_called_once()
         mock_resolve.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_click_auth_preserves_workspace_and_thread_scope(self):
+        adapter = _make_adapter()
+        adapter._is_interactive_user_authorized = MagicMock(return_value=False)
+
+        await adapter._handle_approval_action(
+            AsyncMock(),
+            {
+                "team": {"id": "T_SECONDARY"},
+                "message": {"ts": "222.001", "thread_ts": "111.000", "blocks": []},
+                "channel": {"id": "C_SHARED"},
+                "user": {"name": "operator", "id": "U_OK"},
+            },
+            {"action_id": "hermes_approve_once", "value": "session-key"},
+        )
+
+        adapter._is_interactive_user_authorized.assert_called_once_with(
+            "U_OK",
+            channel_id="C_SHARED",
+            user_name="operator",
+            team_id="T_SECONDARY",
+            thread_id="111.000",
+        )
+
 
 class TestSlackInteractiveAuth:
     def test_delegates_to_gateway_runner_auth(self):
@@ -226,6 +261,55 @@ class TestSlackInteractiveAuth:
         assert runner.seen_sources[0].platform == Platform.SLACK
         assert runner.seen_sources[0].chat_id == "C1"
         assert runner.seen_sources[0].chat_type == "group"
+
+    def test_thread_route_outranks_channel_route(self):
+        adapter = _make_adapter()
+        runner = _attach_auth_runner(adapter)
+        runner.profile_name_fn = lambda source: (
+            "thread-profile" if source.thread_id == "111.000" else "channel-profile"
+        )
+        adapter.gateway_runner = runner  # type: ignore[assignment]
+
+        assert adapter._is_interactive_user_authorized(
+            "U_OK",
+            channel_id="C1",
+            team_id="T1",
+            thread_id="111.000",
+        ) is True
+
+        assert runner.seen_sources[-1].thread_id == "111.000"
+        assert runner.seen_sources[-1].profile == "thread-profile"
+
+    def test_authorizes_inside_routed_profile_secret_scope(
+        self, tmp_path, monkeypatch
+    ):
+        from agent.secret_scope import get_secret
+
+        secondary = tmp_path / "secondary"
+        secondary.mkdir()
+        (secondary / ".env").write_text("GATEWAY_ALLOWED_USERS=U_SECONDARY\n")
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "U_DEFAULT")
+
+        adapter = _make_adapter()
+        runner = _attach_auth_runner(adapter)
+        runner.config = SimpleNamespace(multiplex_profiles=True)
+        runner.profile_name_fn = lambda _source: "secondary"
+        runner.profile_home_fn = lambda _source: secondary
+        runner._auth_fn = lambda source: (
+            get_secret("GATEWAY_ALLOWED_USERS") == source.user_id
+        )
+        adapter.gateway_runner = runner  # type: ignore[assignment]
+
+        assert adapter._is_interactive_user_authorized(
+            "U_SECONDARY",
+            channel_id="C1",
+            team_id="T1",
+        ) is True
+        assert adapter._is_interactive_user_authorized(
+            "U_DEFAULT",
+            channel_id="C1",
+            team_id="T1",
+        ) is False
 
 
 class TestSlackSlashConfirmAction:

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -1070,6 +1070,107 @@ def register(ctx):
 
 ---
 
+### Slack custom-message adapter subclass seam
+
+Slack exposes a versioned, two-stage subclass seam for out-of-tree plugins that need to own typed messages such as thread-safe `!` commands. It runs inside the Slack adapter because classification must happen before Slack's mention gate; it is **not** registered with `ctx.register_hook()`.
+
+:::note Why not `pre_gateway_dispatch`?
+`pre_gateway_dispatch` runs after platform gating, so it cannot make a bare command such as `!log` reachable in a mention-gated channel. The Slack seam can waive the mention/session gate for a classified message, but never waives authorization or channel policy.
+:::
+
+The compatibility marker is `SlackAdapter.CUSTOM_MESSAGE_HOOK_VERSION`. A plugin should check it before replacing the bundled adapter factory and fail closed on unsupported versions.
+
+#### Stage 1: classify synchronously
+
+Override `_classify_custom_message(text, event)` and return an opaque token to claim the message, or `None` to decline it.
+
+- The method is synchronous and runs on every message that reaches the custom seam, including classified messages later rejected by routed authorization. Adapter-wide bot/self, deduplication, ignored-channel, and media-safety authorization guards may reject an event before the seam.
+- It must be pure and side-effect-free: do not send messages, mutate state, perform I/O, or authorize users here. Parse and return only.
+- `text` is this message's text with the bot's own mention removed and surrounding whitespace trimmed. It has not received the `!` to `/` rewrite, block/attachment enrichment, or fetched thread history.
+- Classification runs before mention gating and before the seam's routed authorization. A token bypasses only mention/session gating; core still enforces bot/self filters, deduplication, subtype checks, `allowed_channels`, and routed user authorization.
+- If the classifier raises, core consumes the event rather than forwarding a possibly side-effecting command to the agent. Return `None` for all unrecognized input.
+
+#### Stage 2: handle asynchronously
+
+Override `async _on_custom_message(ctx)` to execute a classified message. Core calls it only after routed authorization and normal Slack policy checks, and under the owning profile's runtime scope on multiplexed gateways.
+
+- `ctx.classification` is the exact token returned by the classifier.
+- Return `True` when the plugin fully handled the message. Core consumes it before session creation or LLM dispatch.
+- Return `False` to continue normal handling. Use this only deliberately—for example, a recognized alias that should still reach the agent.
+- If the handler raises, core sends a generic failure reply and consumes the message. It never falls through to the LLM after a partial command failure.
+- `ctx.client` is the `AsyncWebClient` for the message's Slack workspace.
+- Prefer `self.send(ctx.channel_id, ..., metadata=ctx.reply_metadata)`. When known, `reply_metadata` carries `slack_team_id` so multi-workspace replies use the correct client, and adds `thread_id` only for a real thread reply. Do not reconstruct these fields from process-global state.
+
+#### External subclass example
+
+A user plugin can replace only the bundled Slack adapter factory while inheriting the bundled setup, YAML bridge, standalone sender, and connectivity checks:
+
+```text
+~/.hermes/plugins/platforms/slack/
+├── plugin.yaml
+└── __init__.py
+```
+
+```yaml title="plugin.yaml"
+name: my-slack-platform
+kind: platform
+version: "1.0.0"
+description: Adds a thread-safe !ping command to Slack
+```
+
+```python title="__init__.py"
+from plugins.platforms.slack.adapter import (
+    SlackAdapter,
+    SlackCustomMessageContext,
+    register as register_bundled_slack,
+)
+
+SUPPORTED_HOOK_VERSIONS = {1}
+
+
+class MySlackAdapter(SlackAdapter):
+    def _classify_custom_message(self, text: str, event: dict):
+        command, separator, argument = text.partition(" ")
+        if command != "!ping":
+            return None
+        # Parsing only: no I/O, state mutation, or authorization here.
+        return argument if separator else ""
+
+    async def _on_custom_message(
+        self, ctx: SlackCustomMessageContext
+    ) -> bool:
+        suffix = f" {ctx.classification}" if ctx.classification else ""
+        result = await self.send(
+            ctx.channel_id,
+            f"pong{suffix}",
+            metadata=ctx.reply_metadata,
+        )
+        if not result.success:
+            # Raising fails closed; the command never falls through to the LLM.
+            raise RuntimeError("Slack reply failed")
+        return True
+
+
+def register(ctx):
+    version = getattr(SlackAdapter, "CUSTOM_MESSAGE_HOOK_VERSION", None)
+    if version not in SUPPORTED_HOOK_VERSIONS:
+        raise RuntimeError(f"Unsupported Slack custom-message hook: {version!r}")
+
+    # Register all bundled Slack behavior, then replace only its factory.
+    register_bundled_slack(ctx)
+
+    from gateway.platform_registry import platform_registry
+
+    entry = platform_registry.get("slack")
+    if entry is None:
+        raise RuntimeError("Bundled Slack platform did not register")
+    entry.adapter_factory = MySlackAdapter
+```
+
+Enable the plugin by adding `my-slack-platform` to `plugins.enabled`, then restart the gateway. The bundled and user manifests keep distinct discovery keys; the user plugin explicitly initializes the canonical `slack` platform entry with `register_bundled_slack(ctx)` and replaces only its `adapter_factory`. This preserves the bundled checks, CLI commands, config metadata, and all behavior the subclass does not override.
+
+---
+
 ### `pre_approval_request`
 
 Fires before an approval decision is requested. It covers prompted surfaces—interactive CLI, Ink TUI, gateway platforms, and ACP clients—and `approvals.mode=smart` decisions made without a human prompt (`surface="smart"`). In smart mode, the hook runs before the auxiliary LLM is called.


### PR DESCRIPTION
## Summary

- add a versioned, two-stage Slack custom-message extension seam for real out-of-tree platform plugins
- classify before mention gating, but execute only after routed authorization, workspace resolution, and profile runtime isolation
- stamp adapter ownership for multiplex profiles and make pairing/profile resolution fail closed instead of falling back to the default profile
- sanitize Slack SDK failures across command, approval, status, and thread-context paths

## Why

Slack thread commands are plain messages rather than native slash commands. A standalone user plugin needs to claim those messages before mention gating without copying the bundled Slack adapter or bypassing gateway authorization. The hook is generic and versioned; all deployment-specific command behavior remains outside this repository.

## Security properties

- routed `SessionSource` authorization
- owner-profile runtime scope for pre-dispatch messages and interactive approvals
- workspace-specific Slack clients and reply metadata
- fail-closed missing/unknown profiles and pairing stores
- original current-message text preserved before thread context is fetched
- token-bearing Slack exceptions are not returned or logged

## Verification

- `tests/gateway/test_slack.py`: 302 passed
- multiplex/pairing/profile focused suite: 71 passed
- security-focused Slack subset with `RuntimeWarning` as errors: 57 passed
- `compileall`: passed
- `git diff --check`: passed

The full Slack file still reports 42 pre-existing `AsyncMock` RuntimeWarnings outside the focused hook/security subset.