### PR TITLE
fix(computer-use): forward drag button and modifiers

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -213,6 +213,43 @@ class TestSafetyGuards:
             parsed = json.loads(handle_computer_use({"action": "key", "keys": keys}))
             assert "error" not in parsed, keys
 
+    @pytest.mark.parametrize(
+        "modifiers",
+        (
+            "shift,ctrl",
+            ["shift", "q"],
+            ["shift", 1],
+        ),
+    )
+    def test_invalid_pointer_modifiers_rejected_before_backend(self, modifiers, noop_backend):
+        from tools.computer_use.tool import handle_computer_use
+
+        out = handle_computer_use({
+            "action": "drag",
+            "from_coordinate": [10, 20],
+            "to_coordinate": [30, 40],
+            "modifiers": modifiers,
+        })
+
+        parsed = json.loads(out)
+        assert "error" in parsed
+        assert not any(call[0] == "drag" for call in noop_backend.calls)
+
+    def test_pointer_modifiers_are_normalized_before_backend(self, noop_backend):
+        from tools.computer_use.tool import handle_computer_use
+
+        out = handle_computer_use({
+            "action": "drag",
+            "from_coordinate": [10, 20],
+            "to_coordinate": [30, 40],
+            "modifiers": [" SHIFT ", "ALT"],
+        })
+
+        parsed = json.loads(out)
+        assert "error" not in parsed
+        drag_kw = next(call[1] for call in noop_backend.calls if call[0] == "drag")
+        assert drag_kw["modifiers"] == ["shift", "alt"]
+
     def test_type_with_empty_string_is_allowed(self, noop_backend):
         from tools.computer_use.tool import handle_computer_use
         out = handle_computer_use({"action": "type", "text": ""})
@@ -1456,7 +1493,7 @@ class TestCuaCliFallbackResolution:
         ]
 
 
-class TestClickButtonPassthrough:
+class TestPointerButtonPassthrough:
     """Surface 5 (NousResearch/hermes-agent#47072) — `middle_click` must
     actually reach cua-driver as a middle button, not silently degrade to
     left. Pre-fix, the backend's `click()` chose the tool by name
@@ -1465,7 +1502,8 @@ class TestClickButtonPassthrough:
     cua-driver. Post-fix, the backend always passes a normalised
     `button: "left"|"right"|"middle"` to cua-driver's `click` tool
     (trycua/cua#1961 click.button enum), and rejects unknown buttons
-    instead of silently mapping them.
+    instead of silently mapping them. Drag tests inspect the final MCP payload
+    to enforce the same lossless button and modifier mapping.
     """
 
     def _backend_with_active_target(self):
@@ -1508,6 +1546,45 @@ class TestClickButtonPassthrough:
             "not silently mapped to left (the original Surface 5 bug)."
         )
 
+
+
+    def test_coordinate_drag_preserves_button_and_modifiers(self):
+        backend = self._backend_with_active_target()
+        res = backend.drag(
+            from_xy=(10, 20),
+            to_xy=(30, 40),
+            button="right",
+            modifiers=["shift", "ctrl"],
+        )
+        assert res.ok
+        name, args = backend._session.call_tool.call_args.args
+        assert name == "drag"
+        assert args["button"] == "right"
+        assert args["modifier"] == ["shift", "ctrl"]
+
+    def test_element_drag_preserves_middle_button(self):
+        backend = self._backend_with_active_target()
+        res = backend.drag(from_element=5, to_element=7, button="middle")
+        assert res.ok
+        name, args = backend._session.call_tool.call_args.args
+        assert name == "drag"
+        assert args["button"] == "middle"
+        assert "modifier" not in args
+
+    def test_default_drag_keeps_legacy_payload_shape(self):
+        backend = self._backend_with_active_target()
+        res = backend.drag(from_xy=(10, 20), to_xy=(30, 40))
+        assert res.ok
+        _, args = backend._session.call_tool.call_args.args
+        assert "button" not in args
+        assert "modifier" not in args
+
+    def test_unknown_drag_button_rejected_no_tool_call(self):
+        backend = self._backend_with_active_target()
+        res = backend.drag(from_xy=(10, 20), to_xy=(30, 40), button="bogus")
+        assert not res.ok
+        assert "expected" in res.message.lower()
+        backend._session.call_tool.assert_not_called()
 
     def test_coordinate_drag_and_scroll_keep_the_captured_window(self):
         backend = self._backend_with_active_target()

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -214,6 +214,43 @@ class TestSafetyGuards:
             parsed = json.loads(handle_computer_use({"action": "key", "keys": keys}))
             assert "error" not in parsed, keys
 
+    @pytest.mark.parametrize(
+        "modifiers",
+        (
+            "shift,ctrl",
+            ["shift", "q"],
+            ["shift", 1],
+        ),
+    )
+    def test_invalid_pointer_modifiers_rejected_before_backend(self, modifiers, noop_backend):
+        from tools.computer_use.tool import handle_computer_use
+
+        out = handle_computer_use({
+            "action": "drag",
+            "from_coordinate": [10, 20],
+            "to_coordinate": [30, 40],
+            "modifiers": modifiers,
+        })
+
+        parsed = json.loads(out)
+        assert "error" in parsed
+        assert not any(call[0] == "drag" for call in noop_backend.calls)
+
+    def test_pointer_modifiers_are_normalized_before_backend(self, noop_backend):
+        from tools.computer_use.tool import handle_computer_use
+
+        out = handle_computer_use({
+            "action": "drag",
+            "from_coordinate": [10, 20],
+            "to_coordinate": [30, 40],
+            "modifiers": [" SHIFT ", "ALT"],
+        })
+
+        parsed = json.loads(out)
+        assert "error" not in parsed
+        drag_kw = next(call[1] for call in noop_backend.calls if call[0] == "drag")
+        assert drag_kw["modifiers"] == ["shift", "alt"]
+
     def test_type_with_empty_string_is_allowed(self, noop_backend):
         from tools.computer_use.tool import handle_computer_use
         out = handle_computer_use({"action": "type", "text": ""})
@@ -1671,7 +1708,7 @@ class TestCuaCliFallbackResolution:
         ]
 
 
-class TestClickButtonPassthrough:
+class TestPointerButtonPassthrough:
     """Surface 5 (NousResearch/hermes-agent#47072) — `middle_click` must
     actually reach cua-driver as a middle button, not silently degrade to
     left. Pre-fix, the backend's `click()` chose the tool by name
@@ -1680,7 +1717,8 @@ class TestClickButtonPassthrough:
     cua-driver. Post-fix, the backend always passes a normalised
     `button: "left"|"right"|"middle"` to cua-driver's `click` tool
     (trycua/cua#1961 click.button enum), and rejects unknown buttons
-    instead of silently mapping them.
+    instead of silently mapping them. Drag tests inspect the final MCP payload
+    to enforce the same lossless button and modifier mapping.
     """
 
     def _backend_with_active_target(self):
@@ -1723,6 +1761,45 @@ class TestClickButtonPassthrough:
             "not silently mapped to left (the original Surface 5 bug)."
         )
 
+
+
+    def test_coordinate_drag_preserves_button_and_modifiers(self):
+        backend = self._backend_with_active_target()
+        res = backend.drag(
+            from_xy=(10, 20),
+            to_xy=(30, 40),
+            button="right",
+            modifiers=["shift", "ctrl"],
+        )
+        assert res.ok
+        name, args = backend._session.call_tool.call_args.args
+        assert name == "drag"
+        assert args["button"] == "right"
+        assert args["modifier"] == ["shift", "ctrl"]
+
+    def test_element_drag_preserves_middle_button(self):
+        backend = self._backend_with_active_target()
+        res = backend.drag(from_element=5, to_element=7, button="middle")
+        assert res.ok
+        name, args = backend._session.call_tool.call_args.args
+        assert name == "drag"
+        assert args["button"] == "middle"
+        assert "modifier" not in args
+
+    def test_default_drag_keeps_legacy_payload_shape(self):
+        backend = self._backend_with_active_target()
+        res = backend.drag(from_xy=(10, 20), to_xy=(30, 40))
+        assert res.ok
+        _, args = backend._session.call_tool.call_args.args
+        assert "button" not in args
+        assert "modifier" not in args
+
+    def test_unknown_drag_button_rejected_no_tool_call(self):
+        backend = self._backend_with_active_target()
+        res = backend.drag(from_xy=(10, 20), to_xy=(30, 40), button="bogus")
+        assert not res.ok
+        assert "expected" in res.message.lower()
+        backend._session.call_tool.assert_not_called()
 
     def test_coordinate_drag_and_scroll_keep_the_captured_window(self):
         backend = self._backend_with_active_target()

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -2714,6 +2714,10 @@ class CuaDriverBackend(ComputerUseBackend):
         if pid is None:
             return ActionResult(ok=False, action="drag",
                                 message="No active window — call capture() first.")
+        button_norm = (button or "left").lower()
+        if button_norm not in {"left", "right", "middle"}:
+            return ActionResult(ok=False, action="drag",
+                                message=f"unknown button {button!r} — expected left, right, middle.")
         args: Dict[str, Any] = {"pid": pid}
         if from_element is not None and to_element is not None:
             if self._active_window_id is None:
@@ -2732,6 +2736,13 @@ class CuaDriverBackend(ComputerUseBackend):
         else:
             return ActionResult(ok=False, action="drag",
                                 message="drag requires from_element/to_element or from_coordinate/to_coordinate.")
+        # Preserve the legacy default payload for older cua-driver builds while
+        # forwarding options that would otherwise silently degrade to a plain
+        # left-button drag.
+        if button_norm != "left":
+            args["button"] = button_norm
+        if modifiers:
+            args["modifier"] = modifiers
         return self._run_input_action("drag", args, delivery_mode, bring_to_front)
 
     def scroll(

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -3364,6 +3364,10 @@ class CuaDriverBackend(ComputerUseBackend):
         if pid is None:
             return ActionResult(ok=False, action="drag",
                                 message="No active window — call capture() first.")
+        button_norm = (button or "left").lower()
+        if button_norm not in {"left", "right", "middle"}:
+            return ActionResult(ok=False, action="drag",
+                                message=f"unknown button {button!r} — expected left, right, middle.")
         args: Dict[str, Any] = {"pid": pid}
         if from_element is not None and to_element is not None:
             if self._active_window_id is None:
@@ -3382,6 +3386,13 @@ class CuaDriverBackend(ComputerUseBackend):
         else:
             return ActionResult(ok=False, action="drag",
                                 message="drag requires from_element/to_element or from_coordinate/to_coordinate.")
+        # Preserve the legacy default payload for older cua-driver builds while
+        # forwarding options that would otherwise silently degrade to a plain
+        # left-button drag.
+        if button_norm != "left":
+            args["button"] = button_norm
+        if modifiers:
+            args["modifier"] = modifiers
         return self._run_input_action("drag", args, delivery_mode, bring_to_front)
 
     def scroll(

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -113,6 +113,15 @@ _KEY_ALIASES = {
     "windows": "win", "super": "win", "meta": "win",
 }
 
+_POINTER_ACTIONS_WITH_MODIFIERS = frozenset({
+    "click", "double_click", "right_click", "middle_click", "drag",
+})
+_ALLOWED_POINTER_MODIFIERS = frozenset({
+    "cmd", "shift", "option", "alt", "ctrl", "fn", "win", "windows", "super", "meta",
+})
+
+
+
 
 def _canon_key_combo(keys: str) -> frozenset:
     # Split on both "+" and "-": the cua-driver backend's _parse_key_combo
@@ -150,6 +159,27 @@ def _input_target_mismatch(backend, requested_app: str) -> Optional[str]:
     if wanted in current or current in wanted:
         return None
     return getattr(backend, "_last_app", None)
+
+def _normalize_pointer_modifiers(raw: Any) -> List[str]:
+    """Validate held pointer modifiers at the runtime boundary.
+
+    Tool schemas are advisory for some providers and direct callers, so do
+    not rely on the schema's array/enum constraints before forwarding values
+    to cua-driver.
+    """
+    if not isinstance(raw, list):
+        raise ValueError("modifiers must be a list of strings")
+
+    normalized: List[str] = []
+    for modifier in raw:
+        if not isinstance(modifier, str):
+            raise ValueError("modifiers must be a list of strings")
+        value = modifier.strip().lower()
+        if value not in _ALLOWED_POINTER_MODIFIERS:
+            expected = ", ".join(sorted(_ALLOWED_POINTER_MODIFIERS))
+            raise ValueError(f"unknown modifier {modifier!r} — expected one of {expected}")
+        normalized.append(value)
+    return normalized
 
 
 # Dangerous text patterns for the `type` action. Same list as #4562.
@@ -581,6 +611,13 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
             "error": "bring_to_front requires delivery_mode='foreground'",
             "code": "bring_to_front_requires_foreground",
         })
+
+    if action in _POINTER_ACTIONS_WITH_MODIFIERS and "modifiers" in args:
+        try:
+            modifiers = _normalize_pointer_modifiers(args["modifiers"])
+        except ValueError as exc:
+            return json.dumps({"error": str(exc)})
+        args = {**args, "modifiers": modifiers}
 
     # Approval gate (destructive actions only). A durable config grant is
     # already the user's authorization, so it stands in for the prompt.

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -113,6 +113,15 @@ _KEY_ALIASES = {
     "windows": "win", "super": "win", "meta": "win",
 }
 
+_POINTER_ACTIONS_WITH_MODIFIERS = frozenset({
+    "click", "double_click", "right_click", "middle_click", "drag",
+})
+_ALLOWED_POINTER_MODIFIERS = frozenset({
+    "cmd", "shift", "option", "alt", "ctrl", "fn", "win", "windows", "super", "meta",
+})
+
+
+
 
 def _canon_key_combo(keys: str) -> frozenset:
     # Split on both "+" and "-": the cua-driver backend's _parse_key_combo
@@ -122,6 +131,29 @@ def _canon_key_combo(keys: str) -> frozenset:
     parts = [p.strip().lower() for p in re.split(r"\s*[+\-]\s*", keys) if p.strip()]
     parts = [_KEY_ALIASES.get(p, p) for p in parts]
     return frozenset(parts)
+
+
+def _normalize_pointer_modifiers(raw: Any) -> List[str]:
+    """Validate held pointer modifiers at the runtime boundary.
+
+    Tool schemas are advisory for some providers and direct callers, so do
+    not rely on the schema's array/enum constraints before forwarding values
+    to cua-driver.
+    """
+    if not isinstance(raw, list):
+        raise ValueError("modifiers must be a list of strings")
+
+    normalized: List[str] = []
+    for modifier in raw:
+        if not isinstance(modifier, str):
+            raise ValueError("modifiers must be a list of strings")
+        value = modifier.strip().lower()
+        if value not in _ALLOWED_POINTER_MODIFIERS:
+            expected = ", ".join(sorted(_ALLOWED_POINTER_MODIFIERS))
+            raise ValueError(f"unknown modifier {modifier!r} — expected one of {expected}")
+        normalized.append(value)
+    return normalized
+
 
 
 # Dangerous text patterns for the `type` action. Same list as #4562.
@@ -475,6 +507,13 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
             "error": "bring_to_front requires delivery_mode='foreground'",
             "code": "bring_to_front_requires_foreground",
         })
+
+    if action in _POINTER_ACTIONS_WITH_MODIFIERS and "modifiers" in args:
+        try:
+            modifiers = _normalize_pointer_modifiers(args["modifiers"])
+        except ValueError as exc:
+            return json.dumps({"error": str(exc)})
+        args = {**args, "modifiers": modifiers}
 
     # Approval gate (destructive actions only).
     if action in _DESTRUCTIVE_ACTIONS:


### PR DESCRIPTION
## Current-head update — 2026-08-23

This PR has been rebased onto the live `NousResearch/main` at `f293e7206b4d`, with the current CUA/MCP safety behavior preserved through the conflict resolution. It remains a single commit. Current head: `67a4db4e995c`.

The latest exact-head validation and the upstream CUA/MCP context are in the most recent PR comment. The older validation references below describe the pre-rebase head and should be read as historical context only.

## What does this PR do?

Preserves non-default drag buttons and modifier keys at the final `CuaDriverBackend` transport boundary. The public schema and dispatcher already accept and pass these options, but `CuaDriverBackend.drag()` omitted both fields, so a requested right/middle/modifier drag silently reached cua-driver as a plain left-button drag.

It also enforces the existing modifier schema at the shared tool boundary for click and drag actions. Direct tool-handler/provider calls that bypass schema enforcement now reject string-vs-list misuse, unknown items, and non-string members before approval or backend dispatch. Valid modifier names are normalized for case and surrounding whitespace.

The default left-button payload remains unchanged for compatibility with older cua-driver builds. Unknown buttons fail before transport, matching the existing click path.

## Related Issue and Contract Work

- Follow-up to #47072 (Surface 5: lossless action mapping).
- `trycua/cua#2329` has merged and establishes the current cross-platform driver contract.
- `trycua/cua#1961` has merged and remains the earlier `click.button` transport precedent.
- #67807 changes both production files but does not implement this drag-button/modifier fix; this PR remains an independent focused delta and will be rebased if #67807 lands first.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/computer_use/cua_backend.py`: validate drag buttons and forward non-default `button` plus nonempty `modifier` values.
- `tools/computer_use/tool.py`: normalize and allowlist click/drag modifiers before approval and backend dispatch.
- `tests/tools/test_computer_use.py`: cover coordinate and element drags, default-payload compatibility, invalid-button refusal, malformed modifier payloads, backend non-dispatch, and normalization.

## How to Test

Current-main transport reproduction with a mocked cua-driver session:

```text
before={"button": null, "modifier": null, "ok": true, "tool": "drag"}
after={"button": "right", "modifier": ["shift", "ctrl"], "ok": true, "tool": "drag"}
```

The installed `cua-driver 0.10.0` contract was checked with `cua-driver describe drag`; it advertises `button: left|right|middle`, `modifier: array`, and a default left button.

Validation on the current rebased head:

```text
HERMES_HOME=<isolated-home> scripts/run_tests.sh \
  tests/tools/test_computer_use.py \
  tests/tools/test_computer_use_vision_routing.py \
  tests/tools/test_computer_use_null_pid_windows.py \
  tests/tools/test_computer_use_delivery_ladder.py \
  tests/tools/test_computer_use_capture_routing.py
# 297 passed

ruff check tools/computer_use/tool.py \
  tools/computer_use/cua_backend.py \
  tests/tools/test_computer_use.py
# passed

python -m py_compile tools/computer_use/tool.py \
  tools/computer_use/cua_backend.py \
  tests/tools/test_computer_use.py
# passed

python scripts/check-windows-footguns.py --all
# current-main baseline reports one unrelated finding in scripts/tool_search_livetest2.py;
# no PR-added Windows-footgun findings

git diff --check
# passed
```

## Not in Scope

- Foreground-delivery or run-scoped backend lifecycle changes from #67807.
- Driver capability negotiation or changes to the public `computer_use` schema.
- Scroll-modifier transport; the current Cua backend does not forward that field.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused computer-use paths pass; repository CI is the full gate
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora Linux 44; transport boundary with mocked session; live cua-driver 0.10.0 schema

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no public contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; runtime validation now enforces the existing schema