### PR TITLE
feat(api): bind Runs clarification responses

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -18,6 +18,7 @@ Exposes an HTTP server with endpoints:
 - GET  /v1/runs/{run_id}           — retrieve current run status
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
 - POST /v1/runs/{run_id}/approval — resolve a pending run approval
+- POST /v1/runs/{run_id}/clarification — answer an exact pending clarification
 - POST /v1/runs/{run_id}/stop       — interrupt a running agent
 - GET  /health                     — health check
 - GET  /health/detailed            — rich status for cross-container dashboard probing
@@ -67,6 +68,13 @@ _PROFILE_REJECTED = object()
 _api_request_profile: ContextVar[Optional[str]] = ContextVar(
     "api_server_request_profile", default=None
 )
+
+_RUN_CLARIFY_PROMPT_VERSION = 1
+_RUN_CLARIFY_MAX_QUESTION_CHARS = 2000
+_RUN_CLARIFY_MAX_CHOICE_CHARS = 500
+_RUN_CLARIFY_MAX_RESPONSE_CHARS = 2000
+_RUN_CLARIFY_REQUEST_ID_RE = re.compile(r"^clarify_[0-9a-f]{32}$")
+
 
 def _approval_event_choices(*, smart_denied: bool, allow_permanent: bool) -> list[str]:
     if smart_denied:
@@ -989,6 +997,9 @@ class APIServerAdapter(BasePlatformAdapter):
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
+        # Clarify requests use the same per-run isolation rule as approvals,
+        # but remain a separate primitive and response endpoint.
+        self._run_clarify_sessions: Dict[str, str] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
         self._session_db_lock: Optional[asyncio.Lock] = None  # Single-flight for lazy init
         # Concurrency cap shared across all agent-serving endpoints
@@ -1069,7 +1080,12 @@ class APIServerAdapter(BasePlatformAdapter):
         active_api_runs = sum(
             1
             for status in self._run_statuses.values()
-            if status.get("status") in {"queued", "running", "waiting_for_approval"}
+            if status.get("status") in {
+                "queued",
+                "running",
+                "waiting_for_approval",
+                "waiting_for_clarification",
+            }
         )
         process_depth = 0
         active_delegations = 0
@@ -1515,6 +1531,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/v1/runs/{run_id}", self._handle_get_run),
             ("GET", "/v1/runs/{run_id}/events", self._handle_run_events),
             ("POST", "/v1/runs/{run_id}/approval", self._handle_run_approval),
+            ("POST", "/v1/runs/{run_id}/clarification", self._handle_run_clarification),
             ("POST", "/v1/runs/{run_id}/stop", self._handle_stop_run),
         ]
         if _CRON_AVAILABLE:
@@ -1754,6 +1771,8 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        clarify_callback=None,
+        enable_clarify: bool = False,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -1774,6 +1793,11 @@ class APIServerAdapter(BasePlatformAdapter):
         routing).  When set — and no session ``/model`` override exists for
         this session — its model/provider/api_key/base_url override the
         global defaults for this agent instance only.
+
+        ``enable_clarify`` is reserved for the Runs lifecycle, whose typed,
+        request-bound HTTP response route can safely satisfy the callback.
+        Other API surfaces remain headless even when their configured toolset
+        would otherwise include ``clarify``.
         """
         from run_agent import AIAgent
         from gateway.run import (
@@ -1847,7 +1871,10 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         user_config = _load_gateway_config()
-        enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        enabled_toolsets = set(_get_platform_tools(user_config, "api_server"))
+        if enable_clarify:
+            enabled_toolsets.add("clarify")
+        enabled_toolsets = sorted(enabled_toolsets)
 
         max_iterations = _current_max_iterations()
 
@@ -1869,6 +1896,7 @@ class APIServerAdapter(BasePlatformAdapter):
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,
             tool_complete_callback=tool_complete_callback,
+            clarify_callback=clarify_callback,
             session_db=self._ensure_session_db(),
             fallback_model=fallback_model,
             reasoning_config=reasoning_config,
@@ -2029,8 +2057,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_events_sse": True,
                 "run_stop": True,
                 "run_approval_response": True,
+                "run_clarification_response": True,
+                "run_clarification_request_binding": True,
+                "run_clarification_prompt_version": _RUN_CLARIFY_PROMPT_VERSION,
                 "tool_progress_events": True,
                 "approval_events": True,
+                "clarification_events": True,
                 "session_resources": True,
                 "session_chat": True,
                 "session_chat_streaming": True,
@@ -2055,6 +2087,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
                 "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
                 "run_approval": {"method": "POST", "path": "/v1/runs/{run_id}/approval"},
+                "run_clarification": {
+                    "method": "POST",
+                    "path": "/v1/runs/{run_id}/clarification",
+                },
                 "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
                 "skills": {"method": "GET", "path": "/v1/skills"},
                 "toolsets": {"method": "GET", "path": "/v1/toolsets"},
@@ -4854,6 +4890,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # concurrent runs can intentionally share them, and resolving an
         # approval for one run must not unblock another run's dangerous command.
         approval_session_key = run_id
+        clarify_session_key = run_id
         ephemeral_system_prompt = instructions
         loop = asyncio.get_running_loop()
         q: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue()
@@ -4861,6 +4898,7 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_streams[run_id] = q
         self._run_streams_created[run_id] = created_at
         self._run_approval_sessions[run_id] = approval_session_key
+        self._run_clarify_sessions[run_id] = clarify_session_key
 
         event_cb = self._make_run_event_callback(run_id, loop)
 
@@ -4914,6 +4952,78 @@ class APIServerAdapter(BasePlatformAdapter):
                         last_event="run.cancelled",
                     )
                     return
+                def _clarify_callback(question: str, choices) -> str:
+                    from tools import clarify_gateway
+
+                    safe_question = str(
+                        redact_sensitive_text(str(question or ""), force=True) or ""
+                    )[:_RUN_CLARIFY_MAX_QUESTION_CHARS]
+                    safe_choices = None
+                    if choices:
+                        safe_choices = [
+                            str(redact_sensitive_text(str(choice), force=True) or "")[
+                                :_RUN_CLARIFY_MAX_CHOICE_CHARS
+                            ]
+                            for choice in list(choices)[:4]
+                        ]
+                    request_id = f"clarify_{uuid.uuid4().hex}"
+                    clarify_gateway.register(
+                        clarify_id=request_id,
+                        session_key=clarify_session_key,
+                        question=safe_question,
+                        choices=safe_choices,
+                    )
+                    prompt: Dict[str, Any] = {
+                        "version": _RUN_CLARIFY_PROMPT_VERSION,
+                        "type": "choice" if safe_choices else "text",
+                        "question": safe_question,
+                    }
+                    if safe_choices:
+                        prompt["choices"] = [
+                            {"id": f"choice-{index}", "label": label}
+                            for index, label in enumerate(safe_choices, start=1)
+                        ]
+
+                    def _publish_clarify() -> None:
+                        if (
+                            run_id in self._stopping_run_ids
+                            or clarify_gateway.get_pending_by_id(
+                                request_id,
+                                session_key=clarify_session_key,
+                            )
+                            is None
+                        ):
+                            return
+                        if self._run_streams.get(run_id) is not q:
+                            clarify_gateway.clear_session(clarify_session_key)
+                            return
+                        self._set_run_status(
+                            run_id,
+                            "waiting_for_clarification",
+                            last_event="clarify.request",
+                        )
+                        _put_event_if_active({
+                            "event": "clarify.request",
+                            "run_id": run_id,
+                            "request_id": request_id,
+                            "timestamp": time.time(),
+                            "prompt": prompt,
+                        })
+
+                    try:
+                        loop.call_soon_threadsafe(_publish_clarify)
+                    except RuntimeError:
+                        clarify_gateway.clear_session(clarify_session_key)
+                        return "[clarify prompt could not be delivered]"
+                    timeout = clarify_gateway.get_clarify_timeout()
+                    response = clarify_gateway.wait_for_response(
+                        request_id,
+                        timeout=float(timeout),
+                    )
+                    if not response:
+                        return f"[user did not respond within {int(timeout / 60)}m]"
+                    return response
+
                 with self._profile_scope(request_profile):
                     agent = self._create_agent(
                         ephemeral_system_prompt=ephemeral_system_prompt,
@@ -4922,6 +5032,8 @@ class APIServerAdapter(BasePlatformAdapter):
                         tool_progress_callback=event_cb,
                         gateway_session_key=gateway_session_key,
                         route=route,
+                        clarify_callback=_clarify_callback,
+                        enable_clarify=True,
                     )
                 self._active_run_agents[run_id] = agent
 
@@ -5099,6 +5211,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
+                try:
+                    from tools.clarify_gateway import clear_session
+
+                    clear_session(clarify_session_key)
+                except Exception:
+                    pass
+                self._run_clarify_sessions.pop(run_id, None)
                 self._stopping_run_ids.discard(run_id)
 
         self._activate_admitted_request()
@@ -5275,6 +5394,150 @@ class APIServerAdapter(BasePlatformAdapter):
             "resolved": resolved,
         })
 
+    async def _handle_run_clarification(self, request: "web.Request") -> "web.Response":
+        """Answer one exact, run-bound clarification request."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        run_id = request.match_info["run_id"]
+        if run_id not in self._run_statuses:
+            return web.json_response(
+                _openai_error(f"Run not found: {run_id}", code="run_not_found"),
+                status=404,
+            )
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(_openai_error("Invalid JSON"), status=400)
+        if not isinstance(body, dict):
+            return web.json_response(_openai_error("JSON body must be an object"), status=400)
+
+        request_id = body.get("request_id")
+        if not isinstance(request_id, str) or not _RUN_CLARIFY_REQUEST_ID_RE.fullmatch(request_id):
+            return web.json_response(
+                _openai_error(
+                    "Invalid clarification request_id",
+                    code="invalid_clarification_request_id",
+                ),
+                status=400,
+            )
+        response = body.get("response")
+        if not isinstance(response, dict):
+            return web.json_response(
+                _openai_error(
+                    "Clarification response must be an object",
+                    code="invalid_clarification_response",
+                ),
+                status=400,
+            )
+
+        clarify_session_key = self._run_clarify_sessions.get(run_id)
+        if not clarify_session_key:
+            return web.json_response(
+                _openai_error(
+                    f"Run has no active clarification session: {run_id}",
+                    code="clarification_not_active",
+                ),
+                status=409,
+            )
+        from tools import clarify_gateway
+
+        pending = clarify_gateway.get_pending_by_id(
+            request_id,
+            session_key=clarify_session_key,
+        )
+        if pending is None:
+            return web.json_response(
+                _openai_error(
+                    "Clarification is stale, unknown, resolved, or belongs to another run",
+                    code="clarification_not_pending",
+                ),
+                status=409,
+            )
+
+        response_type = response.get("type")
+        if response_type == "choice":
+            choice_id = response.get("choice_id")
+            choices = pending.get("choices") or []
+            match = re.fullmatch(r"choice-([1-4])", str(choice_id or ""))
+            index = int(match.group(1)) - 1 if match else -1
+            if index < 0 or index >= len(choices):
+                return web.json_response(
+                    _openai_error(
+                        "Invalid clarification choice_id",
+                        code="invalid_clarification_choice",
+                    ),
+                    status=400,
+                )
+            answer = str(choices[index])
+            response_summary: Dict[str, Any] = {
+                "type": "choice",
+                "choice_id": choice_id,
+            }
+        elif response_type == "text":
+            text = response.get("text")
+            if not isinstance(text, str) or not text.strip():
+                return web.json_response(
+                    _openai_error(
+                        "Clarification text must be a non-empty string",
+                        code="invalid_clarification_text",
+                    ),
+                    status=400,
+                )
+            if len(text) > _RUN_CLARIFY_MAX_RESPONSE_CHARS:
+                return web.json_response(
+                    _openai_error(
+                        f"Clarification text exceeds {_RUN_CLARIFY_MAX_RESPONSE_CHARS} characters",
+                        code="clarification_text_too_long",
+                    ),
+                    status=400,
+                )
+            answer = text.strip()
+            response_summary = {"type": "text"}
+        else:
+            return web.json_response(
+                _openai_error(
+                    "Clarification response type must be 'choice' or 'text'",
+                    code="invalid_clarification_response_type",
+                ),
+                status=400,
+            )
+
+        if not clarify_gateway.resolve_gateway_clarify(
+            request_id,
+            answer,
+            session_key=clarify_session_key,
+        ):
+            return web.json_response(
+                _openai_error(
+                    "Clarification is no longer pending",
+                    code="clarification_not_pending",
+                ),
+                status=409,
+            )
+
+        self._set_run_status(run_id, "running", last_event="clarify.responded")
+        q = self._run_streams.get(run_id)
+        event = {
+            "event": "clarify.responded",
+            "run_id": run_id,
+            "request_id": request_id,
+            "timestamp": time.time(),
+            **response_summary,
+        }
+        if q is not None:
+            try:
+                q.put_nowait(event)
+            except Exception:
+                pass
+        return web.json_response({
+            "object": "hermes.run.clarification_response",
+            "run_id": run_id,
+            "request_id": request_id,
+            **response_summary,
+        })
+
     async def _handle_stop_run(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs/{run_id}/stop — interrupt a running agent."""
         auth_err = self._check_auth(request)
@@ -5294,6 +5557,15 @@ class APIServerAdapter(BasePlatformAdapter):
         if agent is not None:
             try:
                 agent.interrupt("Stop requested via API")
+            except Exception:
+                pass
+
+        clarify_session_key = self._run_clarify_sessions.get(run_id)
+        if clarify_session_key:
+            try:
+                from tools.clarify_gateway import clear_session
+
+                clear_session(clarify_session_key)
             except Exception:
                 pass
 
@@ -5336,6 +5608,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
+                clarify_session_key = self._run_clarify_sessions.pop(run_id, None)
+                if clarify_session_key:
+                    try:
+                        from tools.clarify_gateway import clear_session
+
+                        clear_session(clarify_session_key)
+                    except Exception:
+                        pass
                 self._stopping_run_ids.discard(run_id)
 
         stale_statuses = [

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -986,8 +986,16 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["chat_completions"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
+            assert data["features"]["run_clarification_response"] is True
+            assert data["features"]["run_clarification_request_binding"] is True
+            assert data["features"]["run_clarification_prompt_version"] == 1
+            assert data["features"]["clarification_events"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
+            assert data["endpoints"]["run_clarification"] == {
+                "method": "POST",
+                "path": "/v1/runs/{run_id}/clarification",
+            }
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}
             assert data["endpoints"]["toolsets"] == {"method": "GET", "path": "/v1/toolsets"}
 

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -25,6 +25,7 @@ from gateway.platforms.api_server import (
     security_headers_middleware,
 )
 from tools import approval as approval_mod
+from tools import clarify_gateway as clarify_mod
 
 
 # ---------------------------------------------------------------------------
@@ -69,6 +70,10 @@ def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
     app.router.add_get("/v1/runs/{run_id}/events", adapter._handle_run_events)
     app.router.add_post("/v1/runs/{run_id}/approval", adapter._handle_run_approval)
+    app.router.add_post(
+        "/v1/runs/{run_id}/clarification",
+        adapter._handle_run_clarification,
+    )
     app.router.add_post("/v1/runs/{run_id}/stop", adapter._handle_stop_run)
     return app
 
@@ -377,6 +382,167 @@ class TestRunEvents:
         )
 
     @pytest.mark.asyncio
+    async def test_clarification_event_waits_for_exact_choice_response(self, adapter):
+        app = _create_runs_app(adapter)
+        callback_result = {}
+
+        def make_agent(**kwargs):
+            mock_agent = MagicMock()
+
+            def run_conversation(**_run_kwargs):
+                callback_result["answer"] = kwargs["clarify_callback"](
+                    "Pick a color OPENAI_API_KEY=sk-secret-12345678901234567890",
+                    ["Red", "Blue"],
+                )
+                return {"final_response": callback_result["answer"]}
+
+            mock_agent.run_conversation.side_effect = run_conversation
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            return mock_agent
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", side_effect=make_agent) as create:
+                started = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await started.json())["run_id"]
+                event = await asyncio.wait_for(adapter._run_streams[run_id].get(), timeout=3)
+
+                assert event["event"] == "clarify.request"
+                assert event["run_id"] == run_id
+                assert event["request_id"].startswith("clarify_")
+                assert event["prompt"] == {
+                    "version": 1,
+                    "type": "choice",
+                    "question": "Pick a color OPENAI_API_KEY=***",
+                    "choices": [
+                        {"id": "choice-1", "label": "Red"},
+                        {"id": "choice-2", "label": "Blue"},
+                    ],
+                }
+                assert create.call_args.kwargs["enable_clarify"] is True
+
+                response = await cli.post(
+                    f"/v1/runs/{run_id}/clarification",
+                    json={
+                        "request_id": event["request_id"],
+                        "response": {"type": "choice", "choice_id": "choice-2"},
+                    },
+                )
+                assert response.status == 200
+                payload = await response.json()
+                assert payload["request_id"] == event["request_id"]
+                assert payload["choice_id"] == "choice-2"
+
+                for _ in range(40):
+                    status = adapter._run_statuses[run_id]
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert callback_result["answer"] == "Blue"
+                assert status["status"] == "completed"
+                assert run_id not in adapter._run_clarify_sessions
+
+    @pytest.mark.asyncio
+    async def test_clarification_is_bound_to_run_and_single_use(self, adapter):
+        app = _create_runs_app(adapter)
+        first_run = "run_first"
+        second_run = "run_second"
+        request_id = "clarify_" + "a" * 32
+        for run_id in (first_run, second_run):
+            adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
+            adapter._run_clarify_sessions[run_id] = run_id
+        clarify_mod.register(request_id, second_run, "Question?", ["One", "Two"])
+
+        async with TestClient(TestServer(app)) as cli:
+            cross_run = await cli.post(
+                f"/v1/runs/{first_run}/clarification",
+                json={
+                    "request_id": request_id,
+                    "response": {"type": "choice", "choice_id": "choice-1"},
+                },
+            )
+            assert cross_run.status == 409
+
+            exact = await cli.post(
+                f"/v1/runs/{second_run}/clarification",
+                json={
+                    "request_id": request_id,
+                    "response": {"type": "choice", "choice_id": "choice-2"},
+                },
+            )
+            assert exact.status == 200
+            assert clarify_mod.wait_for_response(request_id, timeout=0.1) == "Two"
+
+            duplicate = await cli.post(
+                f"/v1/runs/{second_run}/clarification",
+                json={
+                    "request_id": request_id,
+                    "response": {"type": "choice", "choice_id": "choice-2"},
+                },
+            )
+            assert duplicate.status == 409
+
+    @pytest.mark.asyncio
+    async def test_clarification_rejects_malformed_and_oversized_text(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_validation"
+        request_id = "clarify_" + "b" * 32
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
+        adapter._run_clarify_sessions[run_id] = run_id
+        clarify_mod.register(request_id, run_id, "Question?", None)
+
+        async with TestClient(TestServer(app)) as cli:
+            malformed = await cli.post(
+                f"/v1/runs/{run_id}/clarification",
+                json={"request_id": "../not-safe", "response": {"type": "text", "text": "ok"}},
+            )
+            assert malformed.status == 400
+
+            too_long = await cli.post(
+                f"/v1/runs/{run_id}/clarification",
+                json={
+                    "request_id": request_id,
+                    "response": {"type": "text", "text": "x" * 2001},
+                },
+            )
+            assert too_long.status == 400
+            assert clarify_mod.get_pending_by_id(request_id, session_key=run_id) is not None
+
+            accepted = await cli.post(
+                f"/v1/runs/{run_id}/clarification",
+                json={
+                    "request_id": request_id,
+                    "response": {"type": "text", "text": "A bounded answer"},
+                },
+            )
+            assert accepted.status == 200
+            assert clarify_mod.wait_for_response(request_id, timeout=0.1) == "A bounded answer"
+
+    @pytest.mark.asyncio
+    async def test_clarification_requires_api_auth(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        run_id = "run_auth"
+        request_id = "clarify_" + "c" * 32
+        auth_adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
+        auth_adapter._run_clarify_sessions[run_id] = run_id
+        clarify_mod.register(request_id, run_id, "Question?", None)
+
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                f"/v1/runs/{run_id}/clarification",
+                json={
+                    "request_id": request_id,
+                    "response": {"type": "text", "text": "answer"},
+                },
+            )
+            assert response.status == 401
+            assert clarify_mod.get_pending_by_id(request_id, session_key=run_id) is not None
+
+        clarify_mod.clear_session(run_id)
+
+    @pytest.mark.asyncio
     async def test_approval_resolve_all_is_scoped_to_target_run(self, auth_adapter):
         """Same client session_id must not let one run approve another run's queue."""
         app = _create_runs_app(auth_adapter)
@@ -603,6 +769,52 @@ class TestRunLifecycleSweep:
 
 
 class TestStopRun:
+    @pytest.mark.asyncio
+    async def test_stop_releases_pending_clarification(self, adapter):
+        app = _create_runs_app(adapter)
+
+        def make_agent(**kwargs):
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.side_effect = lambda **_run_kwargs: {
+                "final_response": kwargs["clarify_callback"](
+                    "Q" * 2500,
+                    ["X" * 600, "Y" * 600, "Z" * 600, "W" * 600, "extra"],
+                )
+            }
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            return mock_agent
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", side_effect=make_agent):
+                started = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await started.json())["run_id"]
+                event = await asyncio.wait_for(
+                    adapter._run_streams[run_id].get(), timeout=3
+                )
+                assert event["event"] == "clarify.request"
+                assert len(event["prompt"]["question"]) == 2000
+                assert len(event["prompt"]["choices"]) == 4
+                assert all(
+                    len(choice["label"]) == 500
+                    for choice in event["prompt"]["choices"]
+                )
+
+                stopped = await cli.post(f"/v1/runs/{run_id}/stop")
+                assert stopped.status == 200
+                assert clarify_mod.get_pending_by_id(
+                    event["request_id"], session_key=run_id
+                ) is None
+
+                for _ in range(40):
+                    if run_id not in adapter._active_run_tasks:
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert adapter._run_statuses[run_id]["status"] == "cancelled"
+                assert run_id not in adapter._run_clarify_sessions
+
     @pytest.mark.asyncio
     async def test_stop_before_agent_creation_prevents_run_start(self, adapter):
         """A stop accepted while queued must prevent agent construction."""

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -176,3 +176,31 @@ class TestApiServerAdapterToolset:
             call_kwargs = mock_agent_cls.call_args
             toolsets = call_kwargs.kwargs.get("enabled_toolsets")
             assert sorted(toolsets) == ["terminal", "web"]
+
+    @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
+    def test_runs_can_enable_clarify_without_changing_api_server_default(self):
+        from gateway.platforms.api_server import APIServerAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = APIServerAdapter(PlatformConfig())
+        with patch("gateway.run._resolve_runtime_agent_kwargs") as mock_kwargs, \
+             patch("gateway.run._resolve_gateway_model", return_value="test/model"), \
+             patch("gateway.run._load_gateway_config", return_value={}), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_kwargs.return_value = {
+                "api_key": "test-key",
+                "base_url": None,
+                "provider": None,
+                "api_mode": None,
+                "command": None,
+                "args": [],
+            }
+            callback = MagicMock()
+            adapter._create_agent(
+                clarify_callback=callback,
+                enable_clarify=True,
+            )
+
+        call_kwargs = mock_agent_cls.call_args.kwargs
+        assert "clarify" in call_kwargs["enabled_toolsets"]
+        assert call_kwargs["clarify_callback"] is callback

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -124,6 +124,31 @@ class TestClarifyPrimitive:
 
         assert cm.resolve_gateway_clarify("nope", "anything") is False
 
+    def test_exact_resolution_is_session_bound_and_single_use(self):
+        from tools import clarify_gateway as cm
+
+        entry = cm.register("id-bound", "owner", "Q?", ["A"])
+        assert cm.get_pending_by_id("id-bound", session_key="other") is None
+        assert cm.resolve_gateway_clarify(
+            "id-bound", "A", session_key="other"
+        ) is False
+        assert not entry.event.is_set()
+
+        snapshot = cm.get_pending_by_id("id-bound", session_key="owner")
+        assert snapshot == {
+            "clarify_id": "id-bound",
+            "session_key": "owner",
+            "question": "Q?",
+            "choices": ["A"],
+        }
+        assert cm.resolve_gateway_clarify(
+            "id-bound", "A", session_key="owner"
+        ) is True
+        assert cm.resolve_gateway_clarify(
+            "id-bound", "A", session_key="owner"
+        ) is False
+        assert cm.get_pending_by_id("id-bound", session_key="owner") is None
+
     def test_resolve_after_wait_completes_is_noop(self):
         """A late resolve on a finished entry doesn't blow up."""
         from tools import clarify_gateway as cm

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -147,18 +147,48 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
 # Public API — gateway / adapter side
 # =========================================================================
 
-def resolve_gateway_clarify(clarify_id: str, response: str) -> bool:
-    """Unblock the agent thread waiting on ``clarify_id``.
+def get_pending_by_id(
+    clarify_id: str,
+    *,
+    session_key: Optional[str] = None,
+) -> Optional[Dict[str, object]]:
+    """Return a snapshot of an unresolved clarify request.
 
-    Returns True if an entry was found and resolved, False otherwise
-    (already resolved, expired, or never existed).
+    ``session_key`` lets transports bind an opaque request identifier to the
+    run/session that owns it without exposing the mutable queue entry.
     """
     with _lock:
         entry = _entries.get(clarify_id)
-        if entry is None:
+        if (
+            entry is None
+            or entry.event.is_set()
+            or (session_key is not None and entry.session_key != session_key)
+        ):
+            return None
+        return entry.signature()
+
+
+def resolve_gateway_clarify(
+    clarify_id: str,
+    response: str,
+    *,
+    session_key: Optional[str] = None,
+) -> bool:
+    """Unblock the agent thread waiting on ``clarify_id``.
+
+    Returns True if an entry was found and resolved, False otherwise
+    (wrong session, already resolved, expired, or never existed).
+    """
+    with _lock:
+        entry = _entries.get(clarify_id)
+        if (
+            entry is None
+            or entry.event.is_set()
+            or (session_key is not None and entry.session_key != session_key)
+        ):
             return False
-    entry.response = str(response) if response is not None else ""
-    entry.event.set()
+        entry.response = str(response) if response is not None else ""
+        entry.event.set()
     return True
 
 

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -92,6 +92,7 @@ POST /v1/runs                    Start a run, returns run_id (202)
 GET  /v1/runs/{id}               Run status
 GET  /v1/runs/{id}/events        SSE stream of lifecycle events
 POST /v1/runs/{id}/approval      Resolve a pending approval
+POST /v1/runs/{id}/clarification Answer an exact pending clarification
 POST /v1/runs/{id}/stop          Interrupt the run
 GET  /v1/capabilities            Machine-readable feature flags
 GET  /v1/models                  Lists hermes-agent

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -293,6 +293,43 @@ running.
 
 Resolve a pending approval for a run that is waiting on a human decision (for example, a tool call gated behind an approval policy). The body carries the approval decision; the run resumes once the decision is recorded. This endpoint is advertised in `/v1/capabilities` as the `run_approval` feature so external UIs can detect support before surfacing an approval prompt.
 
+### POST /v1/runs/\{run_id\}/clarification
+
+When the agent needs a missing detail, the event stream emits a bounded,
+secret-redacted `clarify.request` with a stable `request_id` and a versioned
+prompt. Choice prompts use server-issued IDs:
+
+```json
+{
+  "event": "clarify.request",
+  "run_id": "run_abc123",
+  "request_id": "clarify_0123456789abcdef0123456789abcdef",
+  "prompt": {
+    "version": 1,
+    "type": "choice",
+    "question": "Which environment should I use?",
+    "choices": [
+      {"id": "choice-1", "label": "Staging"},
+      {"id": "choice-2", "label": "Production"}
+    ]
+  }
+}
+```
+
+Answer that exact request with a choice ID:
+
+```json
+{
+  "request_id": "clarify_0123456789abcdef0123456789abcdef",
+  "response": {"type": "choice", "choice_id": "choice-1"}
+}
+```
+
+For an open question, send
+`{"type": "text", "text": "your answer"}`. Unknown, stale, already answered,
+or cross-run request IDs fail closed. Check `run_clarification_response` and
+`run_clarification_request_binding` in `/v1/capabilities` before showing this UI.
+
 ## Jobs API (background scheduled work)
 
 The server exposes a lightweight jobs CRUD surface for managing scheduled / background agent runs from a remote client. All endpoints are gated behind the same bearer auth.


### PR DESCRIPTION
## Summary

- enable `clarify` only for the stoppable `/v1/runs` lifecycle
- emit a bounded, secret-redacted, versioned `clarify.request` with a stable request ID and server-issued choice IDs
- add an authenticated, typed response route that rejects stale, resolved, malformed, and cross-run requests
- release pending clarification waits on stop and cleanup without changing Chat Completions, Responses, or messaging behavior
- advertise and document the capability

## Safety contract

Responses bind to the exact run session and still-pending request. Resolution is atomic and single-use. Choice labels and questions are redacted and bounded before HTTP egress; free-text responses are bounded and never echoed in response events.

## Verification

- focused API/core/messaging compatibility suite: `472 passed`, `0 failed`
- Ruff, Python compile, diff check, and Windows-footgun checks: passed
- full canonical suite: `43,605 passed`, `26 failed` across 2,113 files
- the 26 failures exactly match the previously reproduced pristine-main 12-file macOS/Python 3.13 set: credential fixtures, `/tmp` vs `/private/tmp`, Linux/systemd assumptions, host command availability, and process timing
- two unrelated large-suite/performance tests failed once and passed on retry; the Matrix file passed all 251 tests but exited non-zero

## Compatibility

The shared clarification resolver keeps existing callers compatible. Chat Completions and Responses stay headless; only Runs receives the callback and toolset overlay.