### PR TITLE
fix(usage): normalize Anthropic extra-usage units

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -797,8 +797,17 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
         monthly_limit = extra.get("monthly_limit")
         currency = extra.get("currency") or "USD"
         if isinstance(used_credits, (int, float)) and isinstance(monthly_limit, (int, float)):
+            decimal_places = extra.get("decimal_places", 2)
+            if (
+                isinstance(decimal_places, bool)
+                or not isinstance(decimal_places, int)
+                or not 0 <= decimal_places <= 6
+            ):
+                decimal_places = 2
+            scale = 10 ** decimal_places
             details.append(
-                f"Extra usage: {used_credits:.2f} / {monthly_limit:.2f} {currency}"
+                f"Extra usage: {used_credits / scale:.{decimal_places}f} / "
+                f"{monthly_limit / scale:.{decimal_places}f} {currency}"
             )
     return AccountUsageSnapshot(
         provider="anthropic",

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -1,11 +1,16 @@
 from datetime import datetime, timezone
 
+import pytest
+
 from agent.account_usage import (
     AccountUsageSnapshot,
     AccountUsageWindow,
     fetch_account_usage,
     render_account_usage_lines,
 )
+
+
+_OMIT_DECIMAL_PLACES = object()
 
 
 class _Response:
@@ -93,6 +98,63 @@ def test_fetch_account_usage_codex(monkeypatch):
     assert snapshot.windows[0].used_percent == 15.0
     assert snapshot.windows[0].reset_at == datetime.fromtimestamp(1_900_000_000, tz=timezone.utc)
     assert "Credits balance: $12.50" in snapshot.details
+
+
+@pytest.mark.parametrize(
+    ("decimal_places", "expected"),
+    (
+        pytest.param(
+            _OMIT_DECIMAL_PLACES,
+            "Extra usage: 12.34 / 50.00 USD",
+            id="missing-falls-back-to-two",
+        ),
+        pytest.param(
+            True, "Extra usage: 12.34 / 50.00 USD", id="true-falls-back-to-two"
+        ),
+        pytest.param(
+            False, "Extra usage: 12.34 / 50.00 USD", id="false-falls-back-to-two"
+        ),
+        pytest.param(
+            "2", "Extra usage: 12.34 / 50.00 USD", id="string-falls-back-to-two"
+        ),
+        pytest.param(
+            -1, "Extra usage: 12.34 / 50.00 USD", id="negative-falls-back-to-two"
+        ),
+        pytest.param(
+            7, "Extra usage: 12.34 / 50.00 USD", id="too-large-falls-back-to-two"
+        ),
+        pytest.param(0, "Extra usage: 1234 / 5000 USD", id="zero-decimal-units"),
+        pytest.param(2, "Extra usage: 12.34 / 50.00 USD", id="two-decimal-units"),
+        pytest.param(4, "Extra usage: 0.1234 / 0.5000 USD", id="four-decimal-units"),
+    ),
+)
+def test_fetch_account_usage_anthropic_normalizes_extra_usage_minor_units(
+    monkeypatch,
+    decimal_places,
+    expected,
+):
+    extra_usage = {
+        "is_enabled": True,
+        "monthly_limit": 5_000,
+        "used_credits": 1_234.0,
+        "utilization": 24.68,
+        "currency": "USD",
+    }
+    if decimal_places is not _OMIT_DECIMAL_PLACES:
+        extra_usage["decimal_places"] = decimal_places
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_anthropic_token",
+        lambda: "sk-ant-oat-test",
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client({"extra_usage": extra_usage}),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert snapshot.details == (expected,)
 
 
 def test_render_account_usage_lines_includes_reset_and_provider():


### PR DESCRIPTION
## Current-head update — 2026-08-23

This PR has been rebased onto the live `NousResearch/main` at `f293e7206b4d` and remains a single commit. Current head: `57c08fd2d14`.

The latest exact-head validation and the distinction from the open canonical Anthropic-limit reconciliation work are in the most recent PR comment. The older validation references below describe the pre-rebase head and should be read as historical context only.

## What does this PR do?

Normalizes Anthropic `extra_usage.used_credits` and `monthly_limit` from the API's minor units before rendering them. The API includes `decimal_places`; the current renderer prints the raw values as major currency units, so a two-decimal response is displayed 100× too high.

The renderer now uses `decimal_places` for both scaling and precision. Missing or malformed precision falls back to two decimal places, matching the existing USD default.

## Related Work

No exact duplicate was found for this display bug.

- Related provider-quota context: #59425.
- Broader `/quota` aggregation in #34461 treats this formatting correction as orthogonal.
- Same-file open work to watch: #60115, #58228, and #54467. If one lands first, the account-usage fixtures will need reconciliation; #54467 currently expects unscaled `extra_usage` values when `decimal_places` is absent.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/account_usage.py`: scale Anthropic extra-usage values by `10 ** decimal_places` and format them at the advertised precision.
- `tests/test_account_usage.py`: add a synthetic regression for the minor-unit response shape.

## Evidence and Reproduction

A read-only live contract check confirmed that Anthropic's `extra_usage` response provides numeric `used_credits` and `monthly_limit`, a currency code, `decimal_places: 2`, and a utilization ratio consistent with those two numeric values. Public evidence is limited to that sanitized contract; authorization material, account identifiers, and account-specific amounts are omitted.

Deterministic synthetic reproduction:

```text
before={"detail": "Extra usage: 1234.00 / 5000.00 USD"}
after={"detail": "Extra usage: 12.34 / 50.00 USD"}
```

## How to Test

```text
HERMES_HOME=<isolated-home> scripts/run_tests.sh \
  tests/test_account_usage.py \
  tests/gateway/test_usage_command.py \
  tests/agent/test_account_usage.py \
  tests/agent/test_nous_credits_gauge.py \
  tests/agent/test_nous_credits_snapshot.py \
  tests/agent/test_credits_view.py \
  tests/agent/test_credits_fixture_snapshot.py
# 74 passed

ruff check agent/account_usage.py tests/test_account_usage.py
# passed

ty check agent/account_usage.py tests/test_account_usage.py
# passed

python -m py_compile agent/account_usage.py tests/test_account_usage.py
# passed

python scripts/check-windows-footguns.py --all
# passed (784 files)

git diff --check
# passed
```

The same focused suite also reports 74 passed after a synthetic merge onto current `main`. Hosted exact-head CI reports all required checks passing.

A full `HERMES_HOME=<isolated-home> scripts/run_tests.sh` local run found six environment-specific failures. The same six failures reproduced on an untouched detached checkout of the base commit: one Copilot ACP HOME assertion, three TUI/voice-environment failures, and two web-server cross-filesystem hard-link failures.

## Not in Scope

- New account-usage providers or quota aggregation.
- Authentication, OAuth refresh, or endpoint changes.
- Support for Anthropic's alternate/newer `spend` payload shape.
- Changes to the existing `/usage` presentation beyond correcting these amounts.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — six environment-specific failures reproduce on the untouched base as noted above; hosted exact-head CI is green
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora Linux 44; sanitized live contract check plus deterministic mocked transport

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no public contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
