### PR TITLE
fix: pass explicit basename to send_document to prevent silent delivery failure

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1302,6 +1302,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                             "Telegram caption-fallback send failed for missing media: %s",
                             _sanitize_error_text(_cap_err),
                         )
+                        warnings.append(_sanitize_error_text(_cap_err))
                 continue
 
             ext = os.path.splitext(media_path)[1].lower()
@@ -1342,7 +1343,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                             )
                         else:
                             last_msg = await bot.send_document(
-                                chat_id=int_chat_id, document=f, **media_kwargs
+                                chat_id=int_chat_id, document=f, filename=os.path.basename(media_path), **media_kwargs
                             )
                     except Exception as media_err:
                         if _is_telegram_thread_not_found(media_err) and media_kwargs.get("message_thread_id"):
@@ -1373,7 +1374,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                                 )
                             else:
                                 last_msg = await bot.send_document(
-                                    chat_id=int_chat_id, document=f, **media_kwargs
+                                    chat_id=int_chat_id, document=f, filename=os.path.basename(media_path), **media_kwargs
                                 )
                         elif media_kwargs.get("parse_mode") and (
                             "parse" in str(media_err).lower()
@@ -1402,9 +1403,17 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                                 last_msg = await bot.send_video(
                                     chat_id=int_chat_id, video=f, **media_kwargs
                                 )
+                            elif ext in _VOICE_EXTS and is_voice:
+                                last_msg = await bot.send_voice(
+                                    chat_id=int_chat_id, voice=f, **media_kwargs
+                                )
+                            elif ext in _TELEGRAM_SEND_AUDIO_EXTS:
+                                last_msg = await bot.send_audio(
+                                    chat_id=int_chat_id, audio=f, **media_kwargs
+                                )
                             else:
                                 last_msg = await bot.send_document(
-                                    chat_id=int_chat_id, document=f, **media_kwargs
+                                    chat_id=int_chat_id, document=f, filename=os.path.basename(media_path), **media_kwargs
                                 )
                         else:
                             raise


### PR DESCRIPTION
- **fix(write_file): detect cwd-shaped relative paths missing leading slash**
- **fix(write_file): coerce cwd-shaped relative paths in _resolve_path_for_task**
- **fix(write_file): structural cwd-shape detection instead of allowlist**
- **fix(telegram): pass explicit basename to send_document to prevent silent delivery failure**
