### PR TITLE
fix(desktop): close update reentry race during handoff quit-dwell

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2754,6 +2754,16 @@ async function handOffWindowsBootstrapRecovery(reason) {
     return false
   }
 
+  // Reuse the applyUpdates() in-flight guard: if an update handoff is already
+  // running (or in the 2.5s quit-dwell window before app.quit() fires),
+  // spawning another hermes-setup.exe here would race the first one for the
+  // venv shim and reproduce the self-locking loop this function exists to
+  // heal. Bail out and let the in-flight update finish.
+  if (updateInFlight) {
+    rememberLog(`[recovery] deferred: another update is already in flight`)
+    return false
+  }
+
   const updater = resolveUpdaterBinary()
 
   if (!updater) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2330,6 +2330,16 @@ async function readCommitLog(cwd, branch) {
 
 let updateInFlight = false
 
+// Timestamp (ms since epoch) of the last applyUpdates() invocation. Used to
+// detect retry loops: if applyUpdates is called again within APPLY_MIN_GAP_MS
+// of the previous call, it's almost certainly a reentry bug or an external
+// relauncher (VBS/launchd/login item) racing the quit-dwell. Bail out
+// instead of spawning another updater - the previous one is either still
+// running or just failed, and another immediate attempt will almost always
+// hit the same venv shim file lock the previous attempt created.
+const APPLY_MIN_GAP_MS = 30_000
+let lastApplyAt = 0
+
 // Set to true when the desktop is about to quit so a detached swap/install/
 // uninstall script can take over. On macOS, app.quit() closes windows but
 // window-all-closed deliberately keeps the process alive (standard Electron
@@ -2573,6 +2583,25 @@ async function applyUpdates(opts = {}) {
     throw new Error('An update is already in progress.')
   }
 
+  // Loop guard: if we were called within APPLY_MIN_GAP_MS of the previous
+  // call, the previous attempt either is still running (and holding the venv
+  // shim) or just failed moments ago. Spawning another updater in this
+  // window causes the self-locking shim race - the new hermes-setup.exe
+  // can't read the shim because the previous instance's file handle hasn't
+  // been released yet. Bail out and let the caller surface a retry-later
+  // message instead of compounding the loop.
+  const now = Date.now()
+  if (lastApplyAt > 0 && now - lastApplyAt < APPLY_MIN_GAP_MS) {
+    const waitMs = APPLY_MIN_GAP_MS - (now - lastApplyAt)
+    rememberLog(`[updates] apply throttled: ${waitMs}ms since last attempt; deferring to avoid shim self-lock`)
+    return {
+      ok: false,
+      error: 'throttled',
+      message: `An update was just attempted ${Math.round((now - lastApplyAt) / 1000)}s ago. Please wait ${Math.round(waitMs / 1000)}s before retrying.`
+    }
+  }
+
+  lastApplyAt = now
   updateInFlight = true
 
   try {
@@ -2695,6 +2724,14 @@ async function applyUpdates(opts = {}) {
     // appears), THEN quit to release the venv shim. The updater rebuilds and
     // relaunches us when it's done. (#50419 — a 600ms quit looked like a crash
     // and lured users into the #50238 relaunch loop.)
+    //
+    // IMPORTANT: do NOT reset `updateInFlight` in the `finally` block when
+    // we've handed off to the updater. The process is about to quit (2.5s
+    // dwell), but until app.quit() actually fires, any reentry into
+    // applyUpdates() would race the still-pending quit and spawn another
+    // updater that self-locks the venv shim. We deliberately leave
+    // `updateInFlight = true` on the handed-off path so the loop guard holds
+    // during the dwell window; the process exit clears it for the next boot.
     isQuittingForHandoff = true
     setTimeout(() => {
       app.quit()
@@ -2702,7 +2739,13 @@ async function applyUpdates(opts = {}) {
 
     return { ok: true, handedOff: true, updater }
   } finally {
-    updateInFlight = false
+    // Only clear the in-flight flag on the NON-handed-off paths (early
+    // returns above for missing updater / lock failure / errors). When we
+    // did hand off, the flag must stay set so the dwell window is protected
+    // against reentry. The process will exit shortly and reset state.
+    if (!isQuittingForHandoff) {
+      updateInFlight = false
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Consolidates the update reentry race fix from #61899 with an additional guard for `handOffWindowsBootstrapRecovery`. Maintainer asked me to consolidate overlapping fixes in #68110 triage comment.

## Background

`applyUpdates()` in `apps/desktop/electron/main.ts` has a reentry race during the 2.5s handoff quit-dwell:

1. `finally { updateInFlight = false }` resets the guard immediately on `return`
2. `setTimeout(() => app.quit(), UPDATE_HANDOFF_DWELL_MS)` waits 2.5s before quitting
3. During that window `updateInFlight === false` while the venv shim is still held by the spawned `hermes-setup.exe`
4. Any re-triggered `applyUpdates()` (IPC retry, recovery handoff, etc.) spawns another `hermes-setup.exe --update`, which fails with `Cannot open shim file for read` because the shim is locked
5. desktop exits, the VBS relauncher (or the OS) restarts desktop, which triggers apply again — infinite loop

Observed in the wild on Windows: 18+ different `hermes-setup.exe` PIDs in `desktop.log` within seconds, each failing with the same shim-lock error.

## Relationship to #61899

#61899 fixes the same root cause but has two issues raised in its review (https://github.com/NousResearch/hermes-agent/pull/61899#pullrequestreview):

1. **Blocking issue #1 (lock-abort regression)**: #61899 replaces `finally` with `catch`, so `updateInFlight` is never reset on the `!lock.unlocked` early-return path. After one aborted update, every subsequent `applyUpdates()` call hits the `updateInFlight` guard and throws — for the rest of the process lifetime.
2. **`windowsHide: false → true` is now redundant**: #66040 (landed 2026-07-16) extracted `spawnUpdaterProcess` which automatically adds `windowsHide: true` via `hiddenWindowsChildOptions`. The two spawn sites in `applyUpdates` and `handOffWindowsBootstrapRecovery` already go through `spawnUpdaterProcess`, so #61899's `windowsHide` diff is a no-op on current main.
3. **`handOffWindowsBootstrapRecovery` guard missing**: #61899 adds an `updateInFlight` guard to `handOffWindowsBootstrapRecovery` but doesn't cover the case where `applyUpdates` is in the 2.5s dwell window.

## This PR

### Fix 1: Conditional `updateInFlight` reset (addresses #61899 blocking issue #1)

Replace the blanket `finally { updateInFlight = false }` with:

```ts
} finally {
  if (!isQuittingForHandoff) {
    updateInFlight = false
  }
}
```

On the handed-off (success) path, `isQuittingForHandoff === true` so the guard stays set through the 2.5s quit-dwell — the bug is fixed. On every other path (lock-abort, no updater, manual-command, error thrown), `isQuittingForHandoff === false` so the guard is reset normally — the lock-abort regression from #61899 is avoided.

### Fix 2: 30s reentry throttle (defense in depth)

Even if `updateInFlight` is correctly maintained, a fast double-click on "Update now" or an aggressive IPC retry loop can still spawn two updaters within the 2.5s window before the first one takes the lock. Add a 30-second `lastApplyAt` timestamp gate at the top of `applyUpdates()`:

```ts
const APPLY_MIN_GAP_MS = 30_000
let lastApplyAt = 0
// ... at entry, after updateInFlight check:
if (lastApplyAt > 0 && Date.now() - lastApplyAt < APPLY_MIN_GAP_MS) {
  return { ok: false, error: 'throttled', message: '...' }
}
lastApplyAt = Date.now()
```

30s is well below human double-click latency but well above the 2.5s dwell, so it cleanly breaks the auto-retry loop without affecting UX.

### Fix 3: Guard `handOffWindowsBootstrapRecovery` against in-flight updates

`handOffWindowsBootstrapRecovery()` spawns `hermes-setup.exe` independently of `applyUpdates()`. If `applyUpdates()` is still in its 2.5s quit-dwell window (`updateInFlight === true`, `app.quit()` pending), a concurrent recovery hand-off would race the in-flight updater for the venv shim and reproduce the self-locking loop this function exists to heal.

Reuse the `applyUpdates()` `updateInFlight` guard: bail out when an update is already in flight and let it finish. The recovery path will run on the next desktop launch if the bootstrap is still broken.

## What this PR does NOT do

- Does **not** change `windowsHide` — #66040 already covers it via `spawnUpdaterProcess`.
- Does **not** add a guard inside `handOffWindowsBootstrapRecovery`'s own spawn path beyond the entry check — the function's failure cleanup is unchanged.
- Does **not** update `windows-child-options.test.ts` — no behavior change there.

## Test plan

- [ ] `tsx --test electron/updater-process.test.ts` — existing tests cover `spawnUpdaterProcess` behavior (unaffected)
- [ ] `tsx --test electron/windows-child-options.test.ts` — existing tests cover `hiddenWindowsChildOptions` (unaffected)
- [ ] Manual: trigger an update on Windows, verify only one `hermes-setup.exe` is spawned during the 2.5s dwell
- [ ] Manual: trigger an update, immediately trigger another within 30s, verify the second is rejected as `throttled`
- [ ] Manual: trigger an update, then trigger `handOffWindowsBootstrapRecovery` during the dwell, verify the recovery is deferred

## Closes

Closes #61899 (consolidated). Addresses the race described in #61898.