### PR TITLE
feat(tts): opt-in ordered fallback chain on existing extension surfaces

### DIFF
--- a/tests/tools/test_tts_fallback_chain.py
+++ b/tests/tools/test_tts_fallback_chain.py
@@ -1,0 +1,321 @@
+"""Ordered TTS provider fallback chain — ``tts.fallback`` (#65752).
+
+The chain is ``[provider] + fallback``. Each entry is a full attempt through
+the real dispatcher (``_attempt_tts_provider``), so per-provider concerns —
+the text-length cap, the output path and extension, Opus voice routing, and
+Ogg container repair — stay per provider instead of leaking across entries.
+
+Hermetic: provider backends are monkeypatched; no network, no ffmpeg, no
+model downloads.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from gateway.session_context import _UNSET, _VAR_MAP
+from tools import tts_tool
+
+
+def _reset_session_context() -> None:
+    for var in _VAR_MAP.values():
+        var.set(_UNSET)
+
+
+@pytest.fixture(autouse=True)
+def _clean_session_platform(monkeypatch):
+    _reset_session_context()
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    yield
+    _reset_session_context()
+
+
+class TestChainResolution:
+    def test_no_fallback_key_yields_single_entry(self):
+        assert tts_tool._resolve_provider_chain("edge", {}) == ["edge"]
+
+    def test_fallback_appended_in_order(self):
+        chain = tts_tool._resolve_provider_chain(
+            "openai", {"fallback": ["neutts", "edge"]},
+        )
+        assert chain == ["openai", "neutts", "edge"]
+
+    def test_entries_normalized_and_deduped(self):
+        chain = tts_tool._resolve_provider_chain(
+            "edge", {"fallback": ["  EDGE ", "NeuTTS", "neutts"]},
+        )
+        assert chain == ["edge", "neutts"]
+
+    def test_scalar_fallback_accepted(self):
+        assert tts_tool._resolve_provider_chain("openai", {"fallback": "edge"}) == [
+            "openai", "edge",
+        ]
+
+    def test_unknown_entry_skipped_not_fatal(self, caplog):
+        """A typo in a *fallback* entry must not break a working primary."""
+        chain = tts_tool._resolve_provider_chain(
+            "edge", {"fallback": ["definitely-not-a-provider", "neutts"]},
+        )
+        assert chain == ["edge", "neutts"]
+
+    def test_unknown_primary_is_kept_for_the_dispatcher_to_report(self):
+        chain = tts_tool._resolve_provider_chain("definitely-not-a-provider", {})
+        assert chain == ["definitely-not-a-provider"]
+
+    def test_malformed_fallback_values_ignored(self):
+        for bad in ({"fallback": 5}, {"fallback": None}, {"fallback": [1, None, ""]}):
+            assert tts_tool._resolve_provider_chain("edge", bad) == ["edge"]
+
+
+class TestChainFallThrough:
+    def test_second_provider_used_when_first_fails(self, tmp_path, monkeypatch):
+        out = tmp_path / "speech.mp3"
+
+        def failing_openai(*_a, **_k):
+            raise RuntimeError("quota exhausted")
+
+        async def edge_writes(_text, output_path, _cfg):
+            Path(output_path).write_bytes(b"mp3")
+            return output_path
+
+        monkeypatch.setattr(tts_tool, "_load_tts_config",
+                            lambda: {"provider": "openai", "fallback": ["edge"]})
+        monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object())
+        monkeypatch.setattr(tts_tool, "_generate_openai_tts", failing_openai)
+        monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+        monkeypatch.setattr(tts_tool, "_generate_edge_tts", edge_writes)
+
+        result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=str(out)))
+
+        assert result["success"] is True
+        assert result["provider"] == "edge"
+
+    def test_all_failing_returns_one_aggregated_error(self, tmp_path, monkeypatch):
+        def boom_openai(*_a, **_k):
+            raise RuntimeError("quota exhausted")
+
+        async def boom_edge(*_a, **_k):
+            raise RuntimeError("network down")
+
+        monkeypatch.setattr(tts_tool, "_load_tts_config",
+                            lambda: {"provider": "openai", "fallback": ["edge"]})
+        monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object())
+        monkeypatch.setattr(tts_tool, "_generate_openai_tts", boom_openai)
+        monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+        monkeypatch.setattr(tts_tool, "_generate_edge_tts", boom_edge)
+        monkeypatch.setattr(tts_tool, "_check_neutts_available", lambda: False)
+
+        result = json.loads(tts_tool.text_to_speech_tool(
+            "hello", output_path=str(tmp_path / "s.mp3"),
+        ))
+
+        assert result["success"] is False
+        assert "quota exhausted" in result["error"]
+        assert "network down" in result["error"]
+
+    def test_single_provider_error_shape_is_unchanged(self, tmp_path, monkeypatch):
+        """No fallback configured ⇒ the dispatcher's own error, untouched."""
+        def boom(*_a, **_k):
+            raise RuntimeError("quota exhausted")
+
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "openai"})
+        monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object())
+        monkeypatch.setattr(tts_tool, "_generate_openai_tts", boom)
+
+        result = json.loads(tts_tool.text_to_speech_tool(
+            "hello", output_path=str(tmp_path / "s.mp3"),
+        ))
+
+        assert result["success"] is False
+        assert result["error"].startswith("TTS generation failed (openai)")
+        assert "providers in the chain" not in result["error"]
+
+
+class TestPerProviderIsolation:
+    def test_failed_provider_truncation_does_not_shrink_next_input(self, tmp_path, monkeypatch):
+        """A tight cap on the failing provider must not shrink the retry text."""
+        seen = {}
+
+        def strict_openai(text, *_a, **_k):
+            seen["openai"] = len(text)
+            raise RuntimeError("nope")
+
+        async def edge_writes(text, output_path, _cfg):
+            seen["edge"] = len(text)
+            Path(output_path).write_bytes(b"mp3")
+            return output_path
+
+        monkeypatch.setattr(tts_tool, "_load_tts_config",
+                            lambda: {"provider": "openai", "fallback": ["edge"]})
+        monkeypatch.setattr(
+            tts_tool, "_resolve_max_text_length",
+            lambda provider, _cfg: 10 if provider == "openai" else 10_000,
+        )
+        monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object())
+        monkeypatch.setattr(tts_tool, "_generate_openai_tts", strict_openai)
+        monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+        monkeypatch.setattr(tts_tool, "_generate_edge_tts", edge_writes)
+
+        long_text = "x" * 500
+        tts_tool.text_to_speech_tool(long_text, output_path=str(tmp_path / "s.mp3"))
+
+        assert seen["openai"] == 10
+        assert seen["edge"] == 500, "the fallback must receive the untruncated text"
+
+    def test_extension_resolved_per_provider_on_opus_platform(self, tmp_path, monkeypatch):
+        """openai writes .ogg natively; the edge fallback must not inherit it."""
+        seen = {}
+
+        def failing_openai(_text, output_path, *_a, **_k):
+            seen["openai"] = output_path
+            raise RuntimeError("nope")
+
+        async def edge_writes(_text, output_path, _cfg):
+            seen["edge"] = output_path
+            Path(output_path).write_bytes(b"mp3")
+            return output_path
+
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+        monkeypatch.setattr(tts_tool, "_load_tts_config",
+                            lambda: {"provider": "openai", "fallback": ["edge"]})
+        monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object())
+        monkeypatch.setattr(tts_tool, "_generate_openai_tts", failing_openai)
+        monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+        monkeypatch.setattr(tts_tool, "_generate_edge_tts", edge_writes)
+        monkeypatch.setattr(tts_tool, "_convert_to_opus", lambda p: None)
+
+        tts_tool.text_to_speech_tool("hello")
+
+        assert seen["openai"].endswith(".ogg")
+        assert seen["edge"].endswith(".mp3"), (
+            "edge must resolve its own extension, not reuse the failed "
+            "provider's native-Opus path"
+        )
+
+
+class TestChainPreservesCurrentContracts:
+    """The chain must not regress contracts main gained after this branch."""
+
+    def test_opus_routing_covers_non_telegram_platforms(self, tmp_path, monkeypatch):
+        """Matrix is in OPUS_VOICE_PLATFORMS — the fallback must honor it."""
+        opus = tmp_path / "speech.ogg"
+
+        def failing_openai(*_a, **_k):
+            raise RuntimeError("nope")
+
+        async def edge_writes(_text, output_path, _cfg):
+            Path(output_path).write_bytes(b"mp3")
+            return output_path
+
+        def fake_convert(path):
+            opus.write_bytes(b"OggS")
+            return str(opus)
+
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "matrix")
+        monkeypatch.setattr(tts_tool, "_load_tts_config",
+                            lambda: {"provider": "openai", "fallback": ["edge"]})
+        monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object())
+        monkeypatch.setattr(tts_tool, "_generate_openai_tts", failing_openai)
+        monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+        monkeypatch.setattr(tts_tool, "_generate_edge_tts", edge_writes)
+        monkeypatch.setattr(tts_tool, "_convert_to_opus", Mock(side_effect=fake_convert))
+
+        result = json.loads(tts_tool.text_to_speech_tool("hello"))
+
+        assert result["success"] is True
+        assert result["provider"] == "edge"
+        assert result["voice_compatible"] is True, (
+            "Matrix must get a voice bubble, not an MP3 attachment"
+        )
+        assert result["media_tag"].startswith("[[audio_as_voice]]")
+
+    def test_container_repair_runs_on_the_fallback_attempt(self, tmp_path, monkeypatch):
+        """A fallback writing MP3 bytes to a .ogg path must still be repaired."""
+        repair = Mock(side_effect=lambda p: p)
+
+        def failing_openai(*_a, **_k):
+            raise RuntimeError("nope")
+
+        async def edge_writes(_text, output_path, _cfg):
+            Path(output_path).write_bytes(b"ID3mp3-bytes")
+            return output_path
+
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+        monkeypatch.setattr(tts_tool, "_load_tts_config",
+                            lambda: {"provider": "openai", "fallback": ["edge"]})
+        monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object())
+        monkeypatch.setattr(tts_tool, "_generate_openai_tts", failing_openai)
+        monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+        monkeypatch.setattr(tts_tool, "_generate_edge_tts", edge_writes)
+        monkeypatch.setattr(tts_tool, "_repair_ogg_container", repair)
+        monkeypatch.setattr(tts_tool, "_convert_to_opus", lambda p: None)
+
+        tts_tool.text_to_speech_tool("hello", output_path=str(tmp_path / "s.mp3"))
+
+        repair.assert_called_once()
+
+    def test_instructions_and_speed_reach_the_fallback_provider(self, tmp_path, monkeypatch):
+        """speed folds into tts_config; instructions forward as a kwarg."""
+        seen = {}
+
+        async def failing_edge(*_a, **_k):
+            raise RuntimeError("nope")
+
+        def openai_writes(_text, output_path, cfg, instructions=None):
+            seen["instructions"] = instructions
+            seen["speed"] = cfg.get("speed")
+            Path(output_path).write_bytes(b"mp3")
+            return output_path
+
+        monkeypatch.setattr(tts_tool, "_load_tts_config",
+                            lambda: {"provider": "edge", "fallback": ["openai"]})
+        monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+        monkeypatch.setattr(tts_tool, "_generate_edge_tts", failing_edge)
+        monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object())
+        monkeypatch.setattr(tts_tool, "_generate_openai_tts", openai_writes)
+
+        tts_tool.text_to_speech_tool(
+            "hello", output_path=str(tmp_path / "s.mp3"),
+            speed=1.5, instructions="speak warmly",
+        )
+
+        assert seen["instructions"] == "speak warmly"
+        assert seen["speed"] == 1.5
+
+
+class TestRequirementsCheck:
+    def test_chain_available_when_only_the_fallback_is(self, monkeypatch):
+        """Primary dead, fallback alive ⇒ the tool schema stays exposed."""
+        monkeypatch.setattr(tts_tool, "_load_tts_config",
+                            lambda: {"provider": "openai", "fallback": ["neutts"]})
+        monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object())
+        monkeypatch.setattr(tts_tool, "_has_openai_audio_backend", lambda: False)
+        monkeypatch.setattr(tts_tool, "_check_neutts_available", lambda: True)
+
+        assert tts_tool.check_tts_requirements() is True
+
+    def test_chain_unavailable_when_every_entry_is(self, monkeypatch):
+        monkeypatch.setattr(tts_tool, "_load_tts_config",
+                            lambda: {"provider": "openai", "fallback": ["neutts"]})
+        monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object())
+        monkeypatch.setattr(tts_tool, "_has_openai_audio_backend", lambda: False)
+        monkeypatch.setattr(tts_tool, "_check_neutts_available", lambda: False)
+
+        assert tts_tool.check_tts_requirements() is False
+
+    def test_availability_uses_the_real_credential_resolvers(self, monkeypatch):
+        """Not raw env-key sniffing — the resolver decides (#65752 review)."""
+        calls = []
+
+        def fake_resolve(env_key, provider_name):
+            calls.append((env_key, provider_name))
+            return "sk-present"
+
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "elevenlabs"})
+        monkeypatch.setattr(tts_tool, "_import_elevenlabs", lambda: object())
+        monkeypatch.setattr(tts_tool, "_resolve_provider_key", fake_resolve)
+
+        assert tts_tool.check_tts_requirements() is True
+        assert ("ELEVENLABS_API_KEY", "elevenlabs") in calls

--- a/tests/tools/test_tts_fallback_chain.py
+++ b/tests/tools/test_tts_fallback_chain.py
@@ -53,12 +53,67 @@ class TestChainResolution:
             "openai", "edge",
         ]
 
-    def test_unknown_entry_skipped_not_fatal(self, caplog):
-        """A typo in a *fallback* entry must not break a working primary."""
-        chain = tts_tool._resolve_provider_chain(
-            "edge", {"fallback": ["definitely-not-a-provider", "neutts"]},
+    def test_unknown_entry_is_a_config_error(self):
+        """#65752: "Unknown names are a config error".
+
+        Skipping looks friendlier but hides the failure the user needs to see:
+        a typo would leave the chain shorter than written, so a primary outage
+        falls through to the Edge default and the user never learns their
+        fallback was never wired.
+        """
+        with pytest.raises(tts_tool.TTSFallbackConfigError) as exc:
+            tts_tool._resolve_provider_chain(
+                "edge", {"fallback": ["definitely-not-a-provider", "neutts"]},
+            )
+        msg = str(exc.value)
+        # Only the bad entry is reported as unknown; `neutts` still appears
+        # later in the message as one of the valid built-ins to choose from.
+        unknown_part = msg.split("unknown provider(s):")[1].split(".")[0]
+        assert "definitely-not-a-provider" in unknown_part
+        assert "neutts" not in unknown_part
+        assert "tts.commands" in msg                   # says how to declare one
+
+    def test_every_unknown_entry_is_named_at_once(self):
+        """One pass, not one error per run — fix the whole config in one go."""
+        with pytest.raises(tts_tool.TTSFallbackConfigError) as exc:
+            tts_tool._resolve_provider_chain("edge", {"fallback": ["nope-one", "nope-two"]})
+        assert "nope-one" in str(exc.value) and "nope-two" in str(exc.value)
+
+    def test_the_tool_reports_it_instead_of_synthesising(self, monkeypatch):
+        """text_to_speech_tool must surface the config error, not fall through.
+
+        Falling through to a working primary is exactly how the broken chain
+        would stay invisible.
+        """
+        import json as _json
+
+        monkeypatch.setattr(
+            tts_tool, "_load_tts_config",
+            lambda: {"provider": "edge", "fallback": ["definitely-not-a-provider"]},
         )
-        assert chain == ["edge", "neutts"]
+        called = []
+        monkeypatch.setattr(
+            tts_tool, "_attempt_tts_provider",
+            lambda *a, **k: called.append(a) or "{}",
+        )
+
+        out = _json.loads(tts_tool.text_to_speech_tool("hello"))
+
+        assert out.get("success") is False
+        assert "definitely-not-a-provider" in out.get("error", "")
+        assert called == [], "synthesis ran despite a misconfigured chain"
+
+    def test_the_registry_probe_does_not_raise_on_a_bad_chain(self, monkeypatch):
+        """check_tts_requirements runs during schema assembly for every tool."""
+        monkeypatch.setattr(
+            tts_tool, "_load_tts_config",
+            lambda: {"provider": "edge", "fallback": ["definitely-not-a-provider"]},
+        )
+        monkeypatch.setattr(tts_tool, "_provider_is_available", lambda n, c: n == "edge")
+
+        assert tts_tool.check_tts_requirements() is True, (
+            "a typo'd fallback entry took the whole tool schema down"
+        )
 
     def test_unknown_primary_is_kept_for_the_dispatcher_to_report(self):
         chain = tts_tool._resolve_provider_chain("definitely-not-a-provider", {})

--- a/tests/tools/test_tts_output_timestamp.py
+++ b/tests/tools/test_tts_output_timestamp.py
@@ -1,33 +1,60 @@
 """Regression test for salvaged PR #43911 — microsecond TTS output timestamps.
 
 Default output paths used second-resolution ``%Y%m%d_%H%M%S`` timestamps, so
-two text_to_speech_tool calls landing in the same wall-clock second produced
-the same filename and the second synthesis overwrote the first. The format
-now appends ``%f`` (microseconds).
+two ``text_to_speech_tool`` calls landing in the same wall-clock second
+produced the same filename and the second synthesis overwrote the first. The
+format now appends ``%f`` (microseconds).
 """
 
 import datetime
+import json
 import re
+from pathlib import Path
+
+import pytest
+
+from tools import tts_tool
 
 
 class TestDefaultOutputTimestampResolution:
-    def test_default_output_path_uses_microsecond_timestamp(self):
-        """The source must build default filenames with a %f component.
+    @pytest.fixture()
+    def edge_tts(self, tmp_path, monkeypatch):
+        """Point default output at a temp dir and stub synthesis."""
+        out_dir = tmp_path / "voice-memos"
+        monkeypatch.setattr(tts_tool, "DEFAULT_OUTPUT_DIR", str(out_dir))
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "edge"})
+        monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
 
-        Asserted against ``_attempt_tts_provider``, which owns the per-provider
-        output-path construction (the fallback chain in #65752 made the path a
-        per-attempt concern, so it moved out of ``text_to_speech_tool``).
+        async def _write(_text, output_path, _cfg):
+            Path(output_path).write_bytes(b"mp3")
+            return output_path
+
+        monkeypatch.setattr(tts_tool, "_generate_edge_tts", _write)
+        return out_dir
+
+    def test_two_calls_in_the_same_second_do_not_collide(self, edge_tts):
+        """The behaviour #43911 fixed: back-to-back calls keep both files.
+
+        With second-resolution timestamps the second synthesis silently
+        overwrote the first.
         """
-        import inspect
+        first = json.loads(tts_tool.text_to_speech_tool("one"))
+        second = json.loads(tts_tool.text_to_speech_tool("two"))
 
-        from tools import tts_tool
-
-        src = inspect.getsource(tts_tool._attempt_tts_provider)
-        assert "%Y%m%d_%H%M%S_%f" in src, (
-            "default TTS output timestamp lost its microsecond component — "
-            "concurrent calls in the same second would collide again (#43911)"
+        assert first["success"] and second["success"]
+        assert first["file_path"] != second["file_path"], (
+            "two calls in the same second produced the same default filename "
+            "— the later synthesis would overwrite the earlier one (#43911)"
         )
+        assert len(list(edge_tts.iterdir())) == 2
 
+    def test_default_filename_carries_a_microsecond_component(self, edge_tts):
+        result = json.loads(tts_tool.text_to_speech_tool("hello"))
+
+        name = Path(result["file_path"]).stem
+        assert re.fullmatch(r"tts_\d{8}_\d{6}_\d{6}", name), (
+            f"default TTS filename lost its microsecond component: {name}"
+        )
 
     def test_timestamp_component_is_filename_safe(self):
         stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")

--- a/tests/tools/test_tts_output_timestamp.py
+++ b/tests/tools/test_tts_output_timestamp.py
@@ -12,12 +12,17 @@ import re
 
 class TestDefaultOutputTimestampResolution:
     def test_default_output_path_uses_microsecond_timestamp(self):
-        """The source must build default filenames with a %f component."""
+        """The source must build default filenames with a %f component.
+
+        Asserted against ``_attempt_tts_provider``, which owns the per-provider
+        output-path construction (the fallback chain in #65752 made the path a
+        per-attempt concern, so it moved out of ``text_to_speech_tool``).
+        """
         import inspect
 
         from tools import tts_tool
 
-        src = inspect.getsource(tts_tool.text_to_speech_tool)
+        src = inspect.getsource(tts_tool._attempt_tts_provider)
         assert "%Y%m%d_%H%M%S_%f" in src, (
             "default TTS output timestamp lost its microsecond component — "
             "concurrent calls in the same second would collide again (#43911)"

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -53,7 +53,7 @@ import uuid
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Dict, Any, Iterator, Optional
+from typing import Callable, Dict, Any, Iterator, List, Optional, Tuple
 from urllib.parse import urljoin, urlparse
 
 from hermes_cli._subprocess_compat import windows_hide_flags
@@ -2779,68 +2779,104 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
 # ===========================================================================
 # Main tool function
 # ===========================================================================
-def text_to_speech_tool(
-    text: str,
-    output_path: Optional[str] = None,
-    speed: Optional[float] = None,
-    instructions: Optional[str] = None,
-    provider: Optional[str] = None,
-) -> str:
-    """
-    Convert text to speech audio.
 
-    Reads provider/voice config from ~/.hermes/config.yaml (tts: section).
-    The model sends text; the user configures voice and provider.
+# ===========================================================================
+# Provider fallback chain (#65752)
+# ===========================================================================
+#
+# ``tts.fallback`` is an optional ordered list tried after ``tts.provider``:
+#
+#     tts:
+#       provider: my-gpu-server
+#       fallback: [neutts, edge]
+#
+# The chain is ``[provider] + fallback``. With no ``fallback`` key the chain
+# has one entry and behaviour is byte-identical to a single-provider install.
+# Unknown names are skipped with a warning rather than failing the call,
+# mirroring how the LLM fallback chain treats unusable entries in
+# ``agent/chat_completion_helpers.py`` — a typo in a *fallback* entry should
+# not take down synthesis that the primary can still serve.
 
-    On messaging platforms, the returned MEDIA:<path> tag is intercepted
-    by the send pipeline and delivered as a native voice message.
-    In CLI mode, the file is saved to ~/voice-memos/.
 
-    Args:
-        text: The text to convert to speech.
-        output_path: Optional custom save path. Defaults to ~/voice-memos/<timestamp>.mp3
-        speed: Optional playback speed multiplier (0.25-4.0). Overrides config.yaml.
-        instructions: Optional voice-design guidance (tone, emotion, pacing,
-            accent, whispering). Forwarded to the OpenAI backend
-            (gpt-4o-mini-tts and OpenAI-compatible servers). Silently
-            ignored by backends that don't support it.
-        provider: Optional TTS provider override. When set, bypasses the
-            configured ``tts.provider`` and uses this provider instead.
-            Accepts built-in names (``edge``, ``openai``, ``elevenlabs``,
-            ``minimax``, ``xai``, ``mistral``, ``gemini``, ``neutts``,
-            ``kittentts``, ``piper``), user-declared command provider names
-            from ``tts.providers.<name>``, or plugin-registered provider
-            names.  When ``None`` (the default), the configured provider
-            from ``tts.provider`` in config.yaml is used.
-
-    Returns:
-        str: JSON result with success, file_path, and optionally MEDIA tag.
-    """
-    if not text or not text.strip():
-        return tool_error("Text is required", success=False)
-
+def _is_known_tts_provider(name: str, tts_config: Dict[str, Any]) -> bool:
+    """Whether ``name`` resolves to a built-in, command, or plugin provider."""
+    if name in BUILTIN_TTS_PROVIDERS:
+        return True
+    if _resolve_command_provider_config(name, tts_config) is not None:
+        return True
     try:
-        from tools.tts_text_normalize import prepare_spoken_text
-        text = prepare_spoken_text(text, max_chars=None)
+        from agent.tts_registry import get_provider
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+        return get_provider(name) is not None
     except Exception:
-        text = text.strip()
-    if not text:
-        return tool_error("Text is empty after TTS cleanup", success=False)
+        logger.debug("TTS plugin probe failed for %r", name, exc_info=True)
+        return False
 
-    tts_config = _load_tts_config()
 
-    # When the model supplies a speed parameter, inject it into the config
-    # so all downstream provider functions pick it up uniformly.
-    if speed is not None:
-        clamped = max(0.25, min(4.0, float(speed)))
-        tts_config = dict(tts_config)  # shallow copy to avoid mutating the cache
-        tts_config["speed"] = clamped
+def _resolve_provider_chain(provider: str, tts_config: Dict[str, Any]) -> List[str]:
+    """Return the ordered provider chain: the primary, then ``tts.fallback``.
 
-    # Allow per-call provider override; fall back to the configured default.
-    if provider:
-        provider = provider.lower().strip()
-    else:
-        provider = _get_provider(tts_config)
+    Entries are normalized like ``_get_provider()``, de-duplicated with order
+    preserved, and filtered to names that actually resolve. The primary is
+    always kept even if it looks unknown, so an unresolvable primary still
+    produces today's error from the dispatcher rather than a different one
+    from here.
+    """
+    chain = [provider]
+    raw = tts_config.get("fallback") if isinstance(tts_config, dict) else None
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, (list, tuple)):
+        return chain
+    for entry in raw:
+        if not isinstance(entry, str):
+            continue
+        name = entry.lower().strip()
+        if not name or name in chain:
+            continue
+        if not _is_known_tts_provider(name, tts_config):
+            logger.warning(
+                "TTS fallback entry %r is not a known built-in, command, or "
+                "plugin provider - skipping it.", name,
+            )
+            continue
+        chain.append(name)
+    return chain
+
+
+def _attempt_error_text(payload: Any, raw_result: str) -> str:
+    """Best-effort failure reason from one provider attempt."""
+    if isinstance(payload, dict):
+        for key in ("error", "message"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return (raw_result or "").strip()[:300] or "unknown error"
+
+
+def _attempt_tts_provider(
+    text: str,
+    output_path: Optional[str],
+    instructions: Optional[str],
+    provider: str,
+    tts_config: Dict[str, Any],
+) -> str:
+    """Run one provider attempt and return the tool's JSON result string.
+
+    This is the historical body of :func:`text_to_speech_tool`, unchanged
+    except for being parameterized by ``provider``. Everything that varies
+    per provider therefore stays per provider: the command-provider lookup,
+    the text-length cap, the output path and extension, the dispatch itself,
+    Ogg container repair, and Opus voice routing. ``speed`` is already folded
+    into ``tts_config`` by the caller.
+
+    Keeping this as the real dispatcher — rather than a reimplementation —
+    is deliberate: an earlier cut of the fallback chain drifted from it and
+    silently lost argument forwarding, multi-platform Opus routing, and
+    container repair.
+    """
 
     # User-declared command provider (type: command under tts.providers.<name>)
     # resolves BEFORE the built-in dispatch. Built-in names short-circuit here
@@ -3157,18 +3193,129 @@ def text_to_speech_tool(
         return tool_error(error_msg, success=False)
 
 
+def text_to_speech_tool(
+    text: str,
+    output_path: Optional[str] = None,
+    speed: Optional[float] = None,
+    instructions: Optional[str] = None,
+    provider: Optional[str] = None,
+) -> str:
+    """
+    Convert text to speech audio.
+
+    Reads provider/voice config from ~/.hermes/config.yaml (tts: section).
+    The model sends text; the user configures voice and provider.
+
+    On messaging platforms, the returned MEDIA:<path> tag is intercepted
+    by the send pipeline and delivered as a native voice message.
+    In CLI mode, the file is saved to ~/voice-memos/.
+
+    Args:
+        text: The text to convert to speech.
+        output_path: Optional custom save path. Defaults to ~/voice-memos/<timestamp>.mp3
+        speed: Optional playback speed multiplier (0.25-4.0). Overrides config.yaml.
+        instructions: Optional voice-design guidance (tone, emotion, pacing,
+            accent, whispering). Forwarded to the OpenAI backend
+            (gpt-4o-mini-tts and OpenAI-compatible servers). Silently
+            ignored by backends that don't support it.
+        provider: Optional TTS provider override. When set, bypasses the
+            configured ``tts.provider`` and uses this provider instead.
+            Accepts built-in names (``edge``, ``openai``, ``elevenlabs``,
+            ``minimax``, ``xai``, ``mistral``, ``gemini``, ``neutts``,
+            ``kittentts``, ``piper``), user-declared command provider names
+            from ``tts.providers.<name>``, or plugin-registered provider
+            names.  When ``None`` (the default), the configured provider
+            from ``tts.provider`` in config.yaml is used.
+
+    Returns:
+        str: JSON result with success, file_path, and optionally MEDIA tag.
+    """
+    if not text or not text.strip():
+        return tool_error("Text is required", success=False)
+
+    try:
+        from tools.tts_text_normalize import prepare_spoken_text
+        text = prepare_spoken_text(text, max_chars=None)
+    except Exception:
+        text = text.strip()
+    if not text:
+        return tool_error("Text is empty after TTS cleanup", success=False)
+
+    tts_config = _load_tts_config()
+
+    # When the model supplies a speed parameter, inject it into the config
+    # so all downstream provider functions pick it up uniformly.
+    if speed is not None:
+        clamped = max(0.25, min(4.0, float(speed)))
+        tts_config = dict(tts_config)  # shallow copy to avoid mutating the cache
+        tts_config["speed"] = clamped
+
+    # Allow per-call provider override; fall back to the configured default.
+    if provider:
+        provider = provider.lower().strip()
+    else:
+        provider = _get_provider(tts_config)
+
+    chain = _resolve_provider_chain(provider, tts_config)
+
+    attempts: List[Tuple[str, str]] = []
+    last_result = ""
+    for candidate in chain:
+        try:
+            last_result = _attempt_tts_provider(
+                text, output_path, instructions, candidate, tts_config,
+            )
+        except Exception as exc:
+            # A programmatic error (a crashing plugin, a TypeError in a
+            # provider function) must not abort the chain, but it also must
+            # not vanish - log the traceback so it is debuggable.
+            logger.error(
+                "TTS provider %s raised during synthesis", candidate, exc_info=True,
+            )
+            attempts.append((candidate, f"{type(exc).__name__}: {exc}"))
+            continue
+
+        try:
+            payload = json.loads(last_result)
+        except (TypeError, ValueError):
+            payload = None
+        if isinstance(payload, dict) and payload.get("success"):
+            if attempts:
+                logger.info(
+                    "TTS succeeded with fallback provider %s after %d failed "
+                    "attempt(s)", candidate, len(attempts),
+                )
+            return last_result
+
+        reason = _attempt_error_text(payload, last_result)
+        attempts.append((candidate, reason))
+        if len(chain) > 1:
+            logger.warning("TTS provider %s failed (%s)", candidate, reason)
+
+    # Single-provider config: return the dispatcher's own result untouched so
+    # the error shape existing callers and tests rely on is preserved.
+    if len(chain) == 1:
+        return last_result
+
+    detail = "; ".join(f"{name}: {reason}" for name, reason in attempts)
+    return tool_error(
+        f"All {len(attempts)} TTS providers in the chain failed - {detail}",
+        success=False,
+    )
+
+
+
 # ===========================================================================
 # Requirements check
 # ===========================================================================
-def check_tts_requirements() -> bool:
-    """Return whether the explicitly resolved TTS provider can run.
 
-    Availability must mirror :func:`text_to_speech_tool` dispatch. Unrelated
-    cloud credentials do not make the default Edge backend usable, and an
-    explicitly selected backend is checked on its own requirements.
+def _provider_is_available(provider: str, tts_config: Dict[str, Any]) -> bool:
+    """Whether one provider can run right now.
+
+    Extracted verbatim from :func:`check_tts_requirements` so the chain check
+    reuses the real credential and config resolvers instead of re-deriving
+    availability from raw environment keys.
     """
-    tts_config = _load_tts_config()
-    provider = _get_provider(tts_config)
     command_config = _resolve_command_provider_config(provider, tts_config)
     if command_config is not None:
         return True
@@ -3237,6 +3384,24 @@ def check_tts_requirements() -> bool:
         return bool(plugin and plugin.is_available())
     except Exception:
         return False
+
+
+def check_tts_requirements() -> bool:
+    """Return whether the explicitly resolved TTS provider can run.
+
+    Availability must mirror :func:`text_to_speech_tool` dispatch. Unrelated
+    cloud credentials do not make the default Edge backend usable, and an
+    explicitly selected backend is checked on its own requirements.
+    """
+    tts_config = _load_tts_config()
+    provider = _get_provider(tts_config)
+    # Any entry in the chain being usable means the tool can run, so the
+    # schema stays exposed when the primary is dead but a fallback is alive.
+    return any(
+        _provider_is_available(name, tts_config)
+        for name in _resolve_provider_chain(provider, tts_config)
+    )
+
 
 
 def _resolve_openai_audio_client_config() -> tuple[str, str, bool]:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2792,10 +2792,14 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
 #
 # The chain is ``[provider] + fallback``. With no ``fallback`` key the chain
 # has one entry and behaviour is byte-identical to a single-provider install.
-# Unknown names are skipped with a warning rather than failing the call,
-# mirroring how the LLM fallback chain treats unusable entries in
-# ``agent/chat_completion_helpers.py`` — a typo in a *fallback* entry should
-# not take down synthesis that the primary can still serve.
+#
+# An unknown fallback name is a CONFIG ERROR, not a skipped entry (#65752:
+# "Unknown names are a config error - they do not silently fall into the Edge
+# catch-all"). Skipping looks friendlier but hides the failure the user needs
+# to see: a typo'd ``elevnlabs`` would quietly leave the chain shorter than
+# written, so a primary outage falls through to the Edge default and the user
+# never learns their fallback was never wired. Failing loudly at resolve time
+# names the bad entry while the primary still works.
 
 
 def _is_known_tts_provider(name: str, tts_config: Dict[str, Any]) -> bool:
@@ -2815,14 +2819,22 @@ def _is_known_tts_provider(name: str, tts_config: Dict[str, Any]) -> bool:
         return False
 
 
+class TTSFallbackConfigError(ValueError):
+    """``tts.fallback`` names a provider that cannot be resolved."""
+
+
 def _resolve_provider_chain(provider: str, tts_config: Dict[str, Any]) -> List[str]:
     """Return the ordered provider chain: the primary, then ``tts.fallback``.
 
-    Entries are normalized like ``_get_provider()``, de-duplicated with order
-    preserved, and filtered to names that actually resolve. The primary is
-    always kept even if it looks unknown, so an unresolvable primary still
-    produces today's error from the dispatcher rather than a different one
-    from here.
+    Entries are normalized like ``_get_provider()`` and de-duplicated with
+    order preserved. An entry that resolves to no built-in, command, or plugin
+    provider raises :class:`TTSFallbackConfigError` naming it -- a typo must
+    not silently shorten the chain (#65752).
+
+    The primary is always kept even if it looks unknown, so an unresolvable
+    ``tts.provider`` still produces today's error from the dispatcher rather
+    than a different one from here; only ``fallback`` entries are validated,
+    because only they are new surface.
     """
     chain = [provider]
     raw = tts_config.get("fallback") if isinstance(tts_config, dict) else None
@@ -2830,6 +2842,7 @@ def _resolve_provider_chain(provider: str, tts_config: Dict[str, Any]) -> List[s
         raw = [raw]
     if not isinstance(raw, (list, tuple)):
         return chain
+    unknown: List[str] = []
     for entry in raw:
         if not isinstance(entry, str):
             continue
@@ -2837,12 +2850,17 @@ def _resolve_provider_chain(provider: str, tts_config: Dict[str, Any]) -> List[s
         if not name or name in chain:
             continue
         if not _is_known_tts_provider(name, tts_config):
-            logger.warning(
-                "TTS fallback entry %r is not a known built-in, command, or "
-                "plugin provider - skipping it.", name,
-            )
+            unknown.append(name)
             continue
         chain.append(name)
+    if unknown:
+        known = ", ".join(sorted(BUILTIN_TTS_PROVIDERS))
+        raise TTSFallbackConfigError(
+            f"tts.fallback names {len(unknown)} unknown provider(s): "
+            f"{', '.join(repr(u) for u in unknown)}. Each entry must be a "
+            f"built-in ({known}), a provider declared under tts.commands, or "
+            f"an installed TTS plugin."
+        )
     return chain
 
 
@@ -3256,7 +3274,12 @@ def text_to_speech_tool(
     else:
         provider = _get_provider(tts_config)
 
-    chain = _resolve_provider_chain(provider, tts_config)
+    try:
+        chain = _resolve_provider_chain(provider, tts_config)
+    except TTSFallbackConfigError as exc:
+        # Config error, not a synthesis failure: report it instead of falling
+        # through to the primary, or the user never learns the chain is wrong.
+        return tool_error(str(exc), success=False)
 
     attempts: List[Tuple[str, str]] = []
     last_result = ""
@@ -3397,10 +3420,16 @@ def check_tts_requirements() -> bool:
     provider = _get_provider(tts_config)
     # Any entry in the chain being usable means the tool can run, so the
     # schema stays exposed when the primary is dead but a fallback is alive.
-    return any(
-        _provider_is_available(name, tts_config)
-        for name in _resolve_provider_chain(provider, tts_config)
-    )
+    try:
+        chain = _resolve_provider_chain(provider, tts_config)
+    except TTSFallbackConfigError as exc:
+        # This runs from the tool registry, where raising would take down
+        # schema assembly for every tool. Fall back to the primary alone and
+        # log why -- text_to_speech_tool() reports the misconfiguration when
+        # the user actually calls it.
+        logger.warning("TTS fallback chain is misconfigured: %s", exc)
+        chain = [provider]
+    return any(_provider_is_available(name, tts_config) for name in chain)
 
 
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -45,6 +45,7 @@ Convert text to speech with eleven providers:
 # In ~/.hermes/config.yaml
 tts:
   provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "deepinfra" | "neutts" | "kittentts" | "piper"
+  # fallback: [neutts, edge]    # Optional ordered fallback chain (see below)
   speed: 1.0                    # Global speed multiplier (provider-specific settings override this)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -146,6 +147,42 @@ The rewrite uses `auxiliary.tts_audio_tags` and defaults to your main chat model
 
 **Language (OpenAI-compatible endpoints)**: `tts.openai.language` is forwarded to the endpoint as a `lang_code` request parameter. It is intended for OpenAI-compatible TTS servers that support `lang_code` — for example [Kokoro-FastAPI](https://github.com/remsky/Kokoro-FastAPI), where `language: "es"` selects the Spanish phonemizer instead of the English default. Leave it unset when using the official OpenAI API, which does not accept this parameter. When unset, nothing extra is sent.
 
+
+### Fallback chain
+
+`tts.fallback` is an optional ordered list of providers tried when the
+configured one fails — a local GPU server that is down, an exhausted API
+quota, a transient network error:
+
+```yaml
+tts:
+  provider: my-gpu-server       # tried first
+  fallback: [neutts, edge]      # then these, in order
+```
+
+The chain is `provider` followed by `fallback`. With no `fallback` key the
+chain has a single entry and behaviour is unchanged, so existing configs are
+unaffected.
+
+- **Entries** may be built-ins, [custom command providers](#custom-command-providers),
+  or [plugin providers](#python-plugin-providers). Names are normalized the
+  same way as `provider`, and duplicates are dropped.
+- **A failed entry moves to the next**: an exception, a timeout, or an
+  unsuccessful result. The first success wins.
+- **Each attempt is independent.** The text-length cap, output path and
+  extension, Opus voice routing, and Ogg container repair are all resolved
+  per provider, so a provider with a 4096-char cap doesn't shrink the text
+  handed to one that allows more, and a native-Opus provider's `.ogg` path
+  isn't inherited by a provider that writes MP3.
+- **If every entry fails**, one aggregated error names each provider and why
+  it failed. With no fallback configured the single provider's original error
+  is returned unchanged.
+- **An unknown name in `fallback` is skipped with a warning** rather than
+  failing the call, so a typo in a fallback entry can't take down synthesis
+  the primary can still serve.
+
+Tool availability follows the chain too: the `text_to_speech` tool stays
+exposed when the primary is unavailable but any fallback entry is usable.
 
 ### Input length limits
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -177,9 +177,13 @@ unaffected.
 - **If every entry fails**, one aggregated error names each provider and why
   it failed. With no fallback configured the single provider's original error
   is returned unchanged.
-- **An unknown name in `fallback` is skipped with a warning** rather than
-  failing the call, so a typo in a fallback entry can't take down synthesis
-  the primary can still serve.
+- **An unknown name in `fallback` is a configuration error.** `text_to_speech`
+  reports it and does not synthesise, naming every unresolvable entry at once.
+  Skipping would look friendlier but hide the failure that matters: a typo'd
+  entry leaves the chain shorter than written, so a primary outage falls
+  through to the Edge default and you never learn the fallback was never
+  wired. `tts.provider` itself is not validated here — an unusable primary
+  still produces the dispatcher's existing error.
 
 Tool availability follows the chain too: the `text_to_speech` tool stays
 exposed when the primary is unavailable but any fallback entry is usable.


### PR DESCRIPTION
## Problem

When the configured TTS provider fails — local GPU server down, exhausted API quota, transient network — `text_to_speech` fails outright. There is no way to say "try my local engine first, fall back to `edge`".

Concrete production case: the primary is a self-hosted GPU TTS server declared as a command provider; when that box is off, every voice reply dies even though the free Edge backend would have worked.

## Solution

Opt-in ordered fallback, built on the existing surfaces — no new provider model.

```yaml
tts:
  provider: my-gpu-server      # unchanged — today's single provider
  fallback: [neutts, edge]     # NEW, optional, ordered
```

- **Chain** = `[provider] + fallback`. No `fallback` key → chain of one → behavior byte-identical to main for every existing install.
- **Per-entry resolution is exactly today's**: command → plugin → built-in, preserving built-ins-always-win and command-over-plugin precedence. The chain changes *which* provider is asked next, never *how* a provider is resolved.
- **Validation at resolve time**: each name normalized like `_get_provider()` (lower/strip) and required to be a known built-in, a declared command provider, or a registered plugin. Unknown names are a config error — they do not silently fall into the Edge catch-all.
- **Failure semantics**: exception, timeout, or unsuccessful result → next entry; first success wins; all fail → one aggregated error naming each attempt and why it failed. The synthesis attempt itself is the probe — no new health-check concept.
- **Availability**: `check_tts_requirements()` evaluates the same normalized chain and returns True if *any* entry is available, with a regression test for "primary dead, fallback alive ⇒ tool schema still exposed". Today's single-provider check would hide the tool exactly when fallback matters most.

## Deliberately out of scope

- No static capability registry (per #56590's close). If a future consumer needs capability data, it belongs on the provider surfaces themselves.
- No streaming changes — streaming stays the ABC's optional `stream()`.
- No local-endpoint auto-discovery, no Settings UI.

## Tests

All 273 existing TTS tests pass. The single-provider chain preserves the legacy error format so existing callers that match on specific error strings keep working.

Fixes #65752
