### PR TITLE
fix(tui): treat backslash and drive paths as @file navigation (supersedes #15532)

### DIFF
--- a/tests/gateway/test_complete_path_at_filter.py
+++ b/tests/gateway/test_complete_path_at_filter.py
@@ -120,6 +120,67 @@ def test_fuzzy_at_finds_file_without_directory_prefix(tmp_path, monkeypatch):
     assert row[2] == "ui-tui/src/components"
 
 
+def test_fuzzy_skipped_when_path_has_backslashes(tmp_path, monkeypatch):
+    r"""A Windows-style `\` separator is navigation intent, not fuzzy search.
+
+    The routing guard runs on the raw query before path normalization, so a
+    backslash query must be recognised as navigation *and* normalized to `/`
+    before listing — otherwise it either fuzzes the whole repo or lists
+    nothing.
+    """
+    monkeypatch.chdir(tmp_path)
+    _nested_fixture(tmp_path)
+
+    texts = [t for t, _, _ in _items(r"@file:ui-tui\src\components\app")]
+
+    # Directory-listing mode normalizes `\`→`/` and lists direct children of
+    # the named dir — not the nested `useCompletion.ts` a fuzzy walk surfaces.
+    assert "@file:ui-tui/src/components/appChrome.tsx" in texts, texts
+    assert "@file:ui-tui/src/components/appLayout.tsx" in texts, texts
+    assert not any("useCompletion.ts" in t for t in texts), texts
+
+
+def test_fuzzy_skipped_when_path_has_drive_letter(tmp_path, monkeypatch):
+    """A `C:`-style drive prefix is navigation intent, not fuzzy search."""
+    monkeypatch.chdir(tmp_path)
+    _nested_fixture(tmp_path)
+
+    texts = [t for t, _, _ in _items("@file:C:nonexistent")]
+
+    # `C:nonexistent` carries no `/` or `\`, so the drive-letter clause in
+    # `_is_path_navigation` (`path_part[1] == ":"`) is the *sole* condition that
+    # routes it to navigation — distinct from the backslash form already covered
+    # by test_fuzzy_skipped_when_path_has_backslashes. With no separator there is
+    # nothing to normalize, and `C:nonexistent` matches no dir on the test host,
+    # so the listing branch yields nothing.  End-to-end, it must NOT fall into
+    # repo-wide fuzzy (which would leak useCompletion.ts).  Note: for this input
+    # the fuzzy path would also drop useCompletion.ts (its `:` matches no
+    # basename), so this assertion alone can't distinguish the branches — the
+    # unit test below pins the drive-letter clause so its removal fails loudly.
+    assert not any("useCompletion.ts" in t for t in texts), texts
+
+
+def test_is_path_navigation_drive_letter_branch():
+    r"""Unit guard for the drive-letter clause in `_is_path_navigation`.
+
+    The integration test above routes a `C:`-prefixed query through the
+    navigation branch, but a `C:` drive prefix can never be told apart from
+    fuzzy by output alone (a bare `C:name` resolves to no real dir on POSIX,
+    and adding a separator would trip the `/` branch instead). Pin the clause
+    directly so deleting it — or the `/` and `\` clauses — fails a test.
+    """
+    # Drive prefix with no separator: only the drive-letter clause can match.
+    assert server._is_path_navigation("C:nonexistent")
+    assert server._is_path_navigation("d:foo")
+    # The `/` and `\` clauses stay covered here too.
+    assert server._is_path_navigation("ui-tui/src")
+    assert server._is_path_navigation(r"ui-tui\src")
+    # A bare basename carries no navigation intent.
+    assert not server._is_path_navigation("appChrome")
+    # A `:` that is not in the drive position is not a drive prefix.
+    assert not server._is_path_navigation("ab:cd")
+
+
 def test_fuzzy_paths_relative_to_cwd_inside_subdir(tmp_path, monkeypatch):
     """When the gateway runs from a subdirectory of a git repo, fuzzy
     completion paths must resolve under that cwd — not under the repo root.

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -92,13 +92,14 @@ def _(rid, params: dict) -> dict:
         # name with no path separator — `@appChrome` surfaces every file
         # whose basename matches, regardless of directory depth. Matches what
         # editors like Cursor / VS Code do for Cmd-P. Path-ish queries (with
-        # `/`, `./`, `~/`, `/abs`) fall through to the directory-listing
-        # path so explicit navigation intent is preserved.
+        # `/`, `\`, `./`, `~/`, `/abs`, or a `C:\` drive prefix) fall through
+        # to the directory-listing path so explicit navigation intent is
+        # preserved.
         if (
             is_context
             and path_part
             and len(path_part.strip()) >= 2
-            and "/" not in path_part
+            and not _is_path_navigation(path_part)
             and prefix_tag != "folder"
         ):
             ranked: list[tuple[tuple[int, int], str, str, bool]] = []

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2096,7 +2096,30 @@ def _normalize_completion_path(path_part: str) -> str:
             and normalized[0].isalpha()
         ):
             return f"/mnt/{normalized[0].lower()}/{normalized[3:]}"
+        # A POSIX host still receives Windows-style queries from remote/SSH
+        # sessions, so fold `\` to `/` here too — otherwise the navigation
+        # branch's os.path.dirname/basename can't split the path and lists
+        # nothing.  On a real Windows host os.path handles `\` natively, so
+        # the nt path is left untouched.
+        return normalized
     return expanded
+
+
+def _is_path_navigation(path_part: str) -> bool:
+    """True when the query carries explicit navigation intent — a POSIX ``/``,
+    a Windows ``\\``, or a ``C:``-style drive prefix — so it should fall through
+    to directory listing rather than repo-wide fuzzy basename search.
+
+    The fuzzy-vs-navigation decision runs on the RAW query, before
+    ``_normalize_completion_path`` converts ``\\`` and drive letters, so the
+    guard must recognise those forms itself or a Windows path like
+    ``ui-tui\\src\\components\\app`` gets misrouted into fuzzy search.
+    """
+    return (
+        "/" in path_part
+        or "\\" in path_part
+        or (len(path_part) >= 2 and path_part[0].isalpha() and path_part[1] == ":")
+    )
 
 
 def _completion_cwd(params: dict | None = None) -> str:


### PR DESCRIPTION
## What does this PR do?

Fixes `@file:` / `@folder:` completion in the TUI gateway for Windows-style paths. The `complete.path` handler routes between repo-wide fuzzy basename search and directory-listing navigation off the RAW query, and only checked for a forward slash. A query like `@file:ui-tui\src\components\app` (backslash separators, no `/`) was misrouted into fuzzy search instead of listing that directory, so Windows / remote-SSH users got wrong (or empty) completions.

Two coupled halves — both are required, and this is why they ship together:

1. **Routing guard** (`tui_gateway/server.py`): the fuzzy-vs-navigation decision runs on the raw query, *before* `_normalize_completion_path` folds separators, so it must recognise navigation intent on the raw string itself. New `_is_path_navigation(path_part)` returns True for a `/`, a `\`, or a `C:`-style drive prefix; the guard now gates on `not _is_path_navigation(path_part)` instead of `"/" not in path_part`.

2. **Normalization** (`tui_gateway/server.py`): `_normalize_completion_path` only returned the backslash-folded form for *drive-letter* paths — a relative `ui-tui\src\...` query came back unchanged, so even once routed to navigation the branch's `os.path.dirname`/`basename` couldn't split it and listed nothing. It now folds `\`→`/` for all POSIX-host queries. The real Windows `os.name == "nt"` path is untouched (os.path splits `\` natively there).

## Related Issue

Supersedes #15532 (same bug; abandoned, `CONFLICTING`, zero human review). That PR's diff pairs the identical guard change with an output-side `os.sep`→`/` normalization that has since landed on main — but it did **not** fold `\` on the input side, so its `test_fuzzy_skipped_when_path_has_backslashes` asserts a listing that never materializes on a POSIX CI host and cannot go green. This PR ships the version that actually passes CI: guard + input-side normalization, with a regression test that fails if *either* half is reverted.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: add `_is_path_navigation` helper; gate the fuzzy-search branch on it instead of a bare `"/" not in path_part`; fold `\`→`/` for POSIX-host queries in `_normalize_completion_path`.
- `tests/gateway/test_complete_path_at_filter.py`: add `test_fuzzy_skipped_when_path_has_backslashes` and `test_fuzzy_skipped_when_path_has_drive_letter`.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_complete_path_at_filter.py -v` → 17 passed.
2. Regression guard (verified): reverting **only** the guard change, or **only** the normalization change, turns `test_fuzzy_skipped_when_path_has_backslashes` red; with both applied it is green. So each half is load-bearing.
3. Manually: `@file:ui-tui\src\components\app` now lists `appChrome.tsx` / `appLayout.tsx` (directory navigation) rather than fuzzing `useCompletion.ts` from elsewhere in the tree.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the focused suite (`tests/gateway/test_complete_path_at_filter.py`, plus `tests/tui_gateway/test_protocol.py`) and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (POSIX host; the `os.name == "nt"` branch is unchanged)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings + the routing comment) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — the fix is specifically for Windows-style paths; the native Windows code path is left untouched
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A