### PR TITLE
fix(windows): bind c-h eagerly for backspace in PS7+Windows Terminal

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13162,6 +13162,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         from prompt_toolkit.keys import Keys as _IgnoreKeys
 
+        # Backspace fix for Windows Terminal + PowerShell-hosted prompt_toolkit.
+        # In that setup the DEL byte (0x7f) decodes to Keys.ControlH but the
+        # default ControlH->backward-delete-char binding does not fire, so
+        # Backspace appears dead in the Hermes CLI prompt while working
+        # everywhere else. Binding c-h explicitly on Hermes' own KeyBindings
+        # (which take precedence over prompt_toolkit defaults) restores it.
+        # Guarded to only delete when there is an editable buffer with text
+        # before the cursor, so it never swallows a real Ctrl+H chord in a
+        # read-only/empty context. See keystroke_diagnostic.py output showing
+        # c-h data='\x7f'.
+        @kb.add('c-h')
+        def handle_backspace_control_h(event):
+            buf = event.current_buffer
+            if buf is None:
+                return
+            buf.delete_before_cursor(count=event.arg)
+
         @kb.add(_IgnoreKeys.Ignore, eager=True)
         def handle_ignored_terminal_sequence(event):
             """Consume parser-level ignored terminal sequences before self-insert.

--- a/cli.py
+++ b/cli.py
@@ -13163,16 +13163,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         from prompt_toolkit.keys import Keys as _IgnoreKeys
 
         # Backspace fix for Windows Terminal + PowerShell-hosted prompt_toolkit.
-        # In that setup the DEL byte (0x7f) decodes to Keys.ControlH but the
-        # default ControlH->backward-delete-char binding does not fire, so
-        # Backspace appears dead in the Hermes CLI prompt while working
-        # everywhere else. Binding c-h explicitly on Hermes' own KeyBindings
-        # (which take precedence over prompt_toolkit defaults) restores it.
-        # Guarded to only delete when there is an editable buffer with text
-        # before the cursor, so it never swallows a real Ctrl+H chord in a
-        # read-only/empty context. See keystroke_diagnostic.py output showing
-        # c-h data='\x7f'.
-        @kb.add('c-h')
+        # prompt_toolkit's basic_bindings registers a no-op stub @handle("c-h")
+        # (line 12) BEFORE the real backward-delete-char handler (line 117).
+        # Since Keys.Backspace == Keys.ControlH, "backspace" and "c-h" are the
+        # same key — the stub swallows the keystroke before the delete handler
+        # can fire. Hermes' own KeyBindings take precedence over basic_bindings
+        # in the merge order, so this explicit binding (with eager=True to
+        # guarantee it fires first) restores backspace. Confirmed via
+        # keystroke_diagnostic.py: c-h data='\x7f'.
+        @kb.add('c-h', eager=True)
         def handle_backspace_control_h(event):
             buf = event.current_buffer
             if buf is None:


### PR DESCRIPTION
## Summary

Backspace is dead in the Hermes CLI prompt when running on **Windows Terminal hosting PowerShell 7**. The key works everywhere else (PS7 PSReadLine, notepad, browser, keyboardtester.com) — only the Hermes `prompt_toolkit` prompt is affected.

## Root Cause

`prompt_toolkit`'s `basic_bindings` registers a **no-op stub** `@handle("c-h")` at line ~12 — BEFORE the real `backward-delete-char` handler at line ~117 (which binds `"backspace"`). Since `Keys.Backspace == Keys.ControlH` (they are the same enum value in prompt_toolkit), `"backspace"` and `"c-h"` resolve to the **same key**. When multiple handlers bind the same key, the first one wins — the stub swallows the keystroke before the delete handler can fire.

On Windows Terminal + PS7, the DEL byte (`0x7f`) decodes to `Keys.ControlH`, but the default `ControlH -> backward-delete-char` binding never fires because the stub intercepts it.

## Diagnosis

Confirmed using the built-in diagnostic:

```
venv\Scripts\python.exe scripts\keystroke_diagnostic.py
```

Output when pressing Backspace:
```
key=<Keys.ControlH: 'c-h'> data='\x7f'
```

The terminal is sending the correct byte (`0x7f` DEL) — prompt_toolkit is classifying it as `c-h`, and the no-op stub eats it.

## Fix

Bind `c-h` with `eager=True` on Hermes' own `KeyBindings` object (`kb`), which takes precedence over `basic_bindings` in the merge order. The `eager=True` is critical — without it, the no-op stub can still fire first and swallow the key.

```python
kb = KeyBindings()

@kb.add('c-h', eager=True)
def handle_backspace_control_h(event):
    buf = event.current_buffer
    if buf is None:
        return
    buf.delete_before_cursor(count=event.arg)
```

This is surgical — 16 lines added, zero existing code modified, no changes to the shell, terminal, or PS7 profile. Applies globally to every text-entry context (normal input, clarify freetext, sudo/secret prompts).

## Test Plan

- [x] Ran `keystroke_diagnostic.py` — confirmed `c-h` / `0x7f` before fix
- [x] Applied fix, restarted Hermes CLI, Backspace now works in the prompt
- [x] `cli.py` syntax compiles (`ast.parse` OK)
- [ ] Existing prompt_toolkit keybinding tests pass (CI)

## Environment

- Windows 11 (10.0.26200), PowerShell 7.6.3, Windows Terminal
- `display.interface: cli` (prompt_toolkit, not Ink TUI)
- Hermes installed via git clone at `$HERMES_HOME/hermes-agent`