### PR TITLE
fix(feishu): keep msg_type=post consistent across chunks of long markdown replies

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1910,11 +1910,21 @@ class FeishuAdapter(BasePlatformAdapter):
 
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+        # When chunking splits a long markdown response, an individual chunk
+        # can end up as plain prose that doesn't match the per-chunk hint
+        # regex — so it would be sent as ``msg_type=text`` and the user would
+        # see literal ``**bold``/``## heading``/code fences in the Feishu
+        # client while other chunks render correctly. Lock the markdown
+        # decision at the whole-message level so every chunk consistently
+        # uses ``post``. See #26841.
+        prefer_post = bool(_MARKDOWN_HINT_RE.search(formatted))
         last_response = None
 
         try:
             for chunk in chunks:
-                msg_type, payload = self._build_outbound_payload(chunk)
+                msg_type, payload = self._build_outbound_payload(
+                    chunk, prefer_post=prefer_post,
+                )
                 try:
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
@@ -4545,14 +4555,21 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound payload construction and send pipeline
     # =========================================================================
 
-    def _build_outbound_payload(self, content: str) -> tuple[str, str]:
+    def _build_outbound_payload(
+        self, content: str, *, prefer_post: bool = False,
+    ) -> tuple[str, str]:
         # Empirically (issue #52786), current Feishu clients render markdown
         # tables inside ``post``-type ``md`` elements natively. The previous
         # table-downgrade branch forced any table-containing message to
         # ``text``, which left Feishu readers seeing the raw pipe-and-dash
         # source instead of a rendered table. Trust the common markdown path
         # for table content too.
-        if _MARKDOWN_HINT_RE.search(content):
+        #
+        # ``prefer_post`` lets ``send`` treat the chunk as part of a larger
+        # markdown document: when a long markdown reply is split at
+        # MAX_MESSAGE_LENGTH, the per-chunk regex would otherwise
+        # mis-classify a plain-prose chunk as ``text``. See #26841.
+        if prefer_post or _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2708,6 +2708,110 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_uses_post_for_every_chunk_of_multi_chunk_markdown(self):
+        """Regression for #26841: when a long Markdown message is split
+        across multiple chunks, every chunk must go out as
+        ``msg_type=post`` — including chunk 1.  The bug was that the
+        first chunk often had only plain prose (the per-chunk regex
+        didn't match) and was sent as ``text``, so users saw literal
+        ``**bold``/``## heading``/code fences while later chunks
+        rendered correctly.
+        """
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = []
+
+        class _MessageAPI:
+            def create(self, request):
+                captured.append(request)
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(
+                        message_id=f"om_chunk_{len(captured)}",
+                    ),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        # Force a deterministic split so the test doesn't depend on the
+        # exact 8000-char limit.  Chunk 1 is plain prose; chunk 2 has
+        # the markdown markers.  Without the fix, chunk 1 went out as
+        # ``msg_type=text``.
+        first_chunk = "Here is a short intro that has no markdown markers at all."
+        second_chunk = "## Heading\nAnd then some **bold** text."
+
+        with patch.object(
+            adapter, "truncate_message", return_value=[first_chunk, second_chunk],
+        ), patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content=first_chunk + "\n" + second_chunk,
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(len(captured), 2)
+        msg_types = [r.request_body.msg_type for r in captured]
+        self.assertEqual(msg_types, ["post", "post"])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_plain_text_message_not_upgraded_by_prefer_post(self):
+        """A message with no markdown at all must still go out as plain
+        ``msg_type=text`` — the whole-message ``prefer_post`` decision
+        only flips on when the formatted message matches the hint regex.
+        """
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = []
+
+        class _MessageAPI:
+            def create(self, request):
+                captured.append(request)
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(
+                        message_id=f"om_chunk_{len(captured)}",
+                    ),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="just a plain sentence",
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(len(captured), 1)
+        self.assertEqual(captured[0].request_body.msg_type, "text")
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_uses_post_for_inline_markdown(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter


### PR DESCRIPTION
## Summary

Every chunk of a long Feishu markdown reply now goes out with a consistent `msg_type` — the markdown/post decision is made once for the whole message instead of per chunk.

Root cause (#26841, #29471): `send()` splits replies at `MAX_MESSAGE_LENGTH` (8000 chars) and classified each chunk independently. Chunk 1 of a long markdown reply is often plain prose, so it went out as `msg_type=text` (raw `**bold**` / `## heading` markers) while later chunks rendered as `post`.

Salvage of PR #26848 (@xxxigm) — transplanted onto the current plugin adapter path (`plugins/platforms/feishu/adapter.py`; the original targeted the since-removed `gateway/platforms/feishu.py`), exactly as the sweeper review on that PR recommended.

**Stacked on #68121** (table→post fix). One deliberate divergence from the original PR: its per-chunk table exemption (tables stay `text` even under `prefer_post`) is dropped, because with #68121 tables route through `post` and the exemption would reintroduce the raw-table downgrade.

## Changes

- `plugins/platforms/feishu/adapter.py`: `send()` computes `prefer_post = bool(_MARKDOWN_HINT_RE.search(formatted))` once before chunking; `_build_outbound_payload()` gains a keyword-only `prefer_post` flag
- `tests/gateway/test_feishu.py`: 2 regression tests — multi-chunk markdown sends every chunk as `post` (was `["text", "post"]`); plain-text messages are not upgraded by `prefer_post`

## Validation

| Scenario | Before | After |
|---|---|---|
| Long markdown reply, prose-only chunk 1 | chunk 1 `text`, chunk 2 `post` | both `post` |
| Plain-text message | `text` | `text` (unchanged) |

- `scripts/run_tests.sh tests/gateway/test_feishu.py tests/gateway/test_feishu_table_markdown.py` → 217 passed, 0 failed

Resolves #26841 and #29471.

## Infographic

![feishu-chunk-consistency](https://v3b.fal.media/files/b/0aa306e3/w_p4UohlILjcn0R_qmB_s_tnYZekh2.png)
