### PR TITLE
fix(desktop): keep contentEditable composer from collapsing when empty

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -734,8 +734,12 @@ export function ChatBar({
         autoCapitalize="off"
         autoCorrect="off"
         className={cn(
-          'min-h-(--composer-input-min-height) max-h-(--composer-input-max-height) cursor-text overflow-y-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere] bg-transparent pb-1 pr-1 pt-1 leading-normal text-foreground outline-none disabled:cursor-not-allowed',
+          // Literal min-h backs the CSS var: Chromium can still collapse an empty
+          // contentEditable when the var path races with DOM normalize (#68095).
+          'min-h-[1.625rem] min-h-(--composer-input-min-height) max-h-(--composer-input-max-height) cursor-text overflow-y-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere] bg-transparent pb-1 pr-1 pt-1 leading-normal text-foreground outline-none disabled:cursor-not-allowed',
+          // Lone caret <br> is our empty-editor seed — still show the placeholder.
           'empty:before:content-[attr(data-placeholder)] empty:before:text-muted-foreground/60',
+          '[&:has(>br:only-child)]:before:content-[attr(data-placeholder)] [&:has(>br:only-child)]:before:text-muted-foreground/60',
           '**:data-ref-text:cursor-default',
           stacked && 'pl-3',
           stacked ? 'w-full' : 'min-w-(--composer-input-inline-min-width) flex-1'

--- a/apps/desktop/src/app/chat/composer/rich-editor.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.ts
@@ -130,6 +130,16 @@ export function appendComposerContents(target: DocumentFragment | HTMLElement, t
 export function renderComposerContents(target: HTMLElement, text: string) {
   target.replaceChildren()
   appendComposerContents(target, text)
+  ensureComposerCaretBreak(target)
+}
+
+/** Empty contentEditable with zero children collapses to near-zero height in
+ *  Chromium even when CSS min-height is set. Keep a caret <br> so the box
+ *  retains a line box; `composerPlainText` treats that lone break as empty. */
+function ensureComposerCaretBreak(editor: HTMLElement) {
+  if (editor.childNodes.length === 0) {
+    editor.append(document.createElement('br'))
+  }
 }
 
 /** Caret range when the selection lives inside `editor`; else null. */
@@ -280,6 +290,16 @@ export function composerPlainText(node: Node): string {
     return '\n'
   }
 
+  // Chromium keeps a lone caret <br> in an empty contentEditable. That is not a
+  // real newline — treat the composer root as empty so draft/isEmpty stay honest.
+  if (el.dataset.slot === RICH_INPUT_SLOT) {
+    const kids = el.childNodes
+
+    if (kids.length === 0 || (kids.length === 1 && kids[0]?.nodeName === 'BR')) {
+      return ''
+    }
+  }
+
   const text = Array.from(node.childNodes).map(composerPlainText).join('')
   const block = el.tagName === 'DIV' || el.tagName === 'P'
 
@@ -360,4 +380,8 @@ export function normalizeComposerEditorDom(editor: HTMLElement) {
       editor.removeChild(last)
     }
   }
+
+  // Phantom-break cleanup above can leave zero children (e.g. sole caret <br>).
+  // Re-seed a caret break so Chromium does not visually collapse the input.
+  ensureComposerCaretBreak(editor)
 }


### PR DESCRIPTION
## Summary
- Fixes #68095: Desktop composer can visually collapse to a tiny height while typing (paste still works).
- Root cause: `normalizeComposerEditorDom` can leave the contentEditable with zero children; Chromium then collapses the line box even with CSS `min-height`.
- Keep a caret `<br>` after normalize/empty render, treat that lone break as empty in `composerPlainText`, harden min-height + placeholder CSS for the caret-br empty state.

## Test plan
- [x] `cd apps/desktop && npm run test:ui -- src/app/chat/composer/rich-editor.test.ts`
- [ ] Manual: open Desktop, type character-by-character in the composer → input height stays normal
- [ ] Manual: clear the composer → placeholder still shows
- [ ] Manual: paste still works