### PR TITLE
fix(desktop): stop statusbar neighbors jittering as timers count

### DIFF
--- a/apps/desktop/src/lib/statusbar.test.tsx
+++ b/apps/desktop/src/lib/statusbar.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { formatDuration, LiveDuration } from './statusbar'
+
+describe('formatDuration', () => {
+  it('formats sub-hour durations as m:ss', () => {
+    expect(formatDuration(0)).toBe('0:00')
+    expect(formatDuration(59_000)).toBe('0:59')
+    expect(formatDuration(61_000)).toBe('1:01')
+  })
+
+  it('formats hour-plus durations as h:mm:ss', () => {
+    expect(formatDuration(3_600_000)).toBe('1:00:00')
+    expect(formatDuration(3_661_000)).toBe('1:01:01')
+  })
+
+  it('clamps negative elapsed to zero', () => {
+    expect(formatDuration(-5_000)).toBe('0:00')
+  })
+})
+
+describe('LiveDuration', () => {
+  it('renders nothing without a start timestamp', () => {
+    const { container } = render(<LiveDuration since={null} />)
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders the elapsed time with fixed-width digits so neighbors do not shift', () => {
+    vi.useFakeTimers()
+
+    try {
+      const now = Date.now()
+      render(<LiveDuration since={now - 71_000} />)
+
+      const el = screen.getByText('1:11')
+      // tabular-nums keeps every digit the same width; without it the
+      // statusbar row to the left of the session timer jitters each second.
+      expect(el.classList.contains('tabular-nums')).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/apps/desktop/src/lib/statusbar.tsx
+++ b/apps/desktop/src/lib/statusbar.tsx
@@ -72,5 +72,7 @@ export function LiveDuration({ since }: { since: number | null | undefined }) {
     return () => window.clearInterval(timer)
   }, [since])
 
-  return since ? formatDuration(now - since) : null
+  // `tabular-nums` keeps every digit the same width so the counting timer
+  // doesn't change width each second and shove its statusbar neighbors around.
+  return since ? <span className="tabular-nums">{formatDuration(now - since)}</span> : null
 }


### PR DESCRIPTION
## Symptom

In the desktop statusbar, the items to the left of the session timer shift horizontally every second as the timer counts.

## Root cause

`LiveDuration` (`apps/desktop/src/lib/statusbar.ts`) — used by both the `session-timer` and `running-timer` statusbar items — rendered its digits in the proportional UI font. Digits have different widths there (`1` is narrower than `0`/`4`), so each tick changed the rendered text width, and the flex row re-flowed, shoving the neighboring items around. The chat activity timer (`activity-timer-text.tsx`) already guards against exactly this with `tabular-nums`; the statusbar timer didn't.

## Fix

- `LiveDuration` now wraps the formatted duration in `<span className="tabular-nums">`, so every digit occupies the same width and the row stays fixed while the timer counts. Fixes both the session timer and the running-turn timer, since they share the component.
- Renamed `statusbar.ts` → `statusbar.tsx` (the component now returns JSX). The `@/lib/statusbar` import specifier is unchanged; `use-statusbar-items.tsx` was the only importer.
- Added `src/lib/statusbar.test.tsx` covering `formatDuration` and asserting the rendered timer carries `tabular-nums`.

Note: width still grows once at natural digit-count boundaries (`9:59` → `10:00`) — the per-second jitter is what's eliminated.

## Verification

- `npx tsc --noEmit` clean
- `npx vitest run src/lib/statusbar.test.tsx` — 5/5 passing
- `npx eslint` clean on both files
