### PR TITLE
fix(agent): run pre_verify on every candidate final answer

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5564,11 +5564,13 @@ def run_conversation(
                     final_response = None
                     continue
 
-                # User verification-loop gate: when the agent edited code this
-                # turn, let a registered `pre_verify` hook (plugin/shell) keep it
-                # going one more turn. The shipped guidance is folded into the
-                # evidence-based verify-on-stop nudge above, so this path has no
-                # default continuation cost.
+                # User stop-loop gate: let a registered ``pre_verify`` hook
+                # (plugin/shell) inspect every candidate final answer and keep
+                # the same turn going. ``changed_paths`` remains available for
+                # code-verification policies, but is deliberately not an
+                # invocation precondition: recovery policies also need to steer
+                # browser/search/communication work before an incomplete answer
+                # escapes to the user.
                 _verify_nudge2 = None
                 _edited = sorted(getattr(agent, "_turn_file_mutation_paths", set()) or [])
                 _attempt = getattr(agent, "_pre_verify_nudges", 0)
@@ -5576,7 +5578,7 @@ def run_conversation(
                     from agent.verify_hooks import max_verify_nudges
                     from hermes_cli.plugins import get_pre_verify_continue_message, has_hook
 
-                    if _edited and has_hook("pre_verify") and _attempt < max_verify_nudges():
+                    if has_hook("pre_verify") and _attempt < max_verify_nudges():
                         # Posture is fixed for the session — resolve once + cache.
                         coding = getattr(agent, "_resolved_is_coding", None)
                         if coding is None:

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -146,7 +146,7 @@ _DEFAULT_PAYLOADS = {
         "coding": True,
         "attempt": 0,
         "final_response": "All done — the change is applied.",
-        "changed_paths": ["src/app.tsx"],
+        "changed_paths": [],
     },
     "on_session_start": {"session_id": "test-session"},
     "on_session_end": {"session_id": "test-session"},

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -143,9 +143,9 @@ VALID_HOOKS: Set[str] = {
     "transform_llm_output",
     "pre_llm_call",
     "post_llm_call",
-    # Verification-loop gate. Fired once per turn when the agent has edited code
-    # and is about to verify/finish (after the verify-on-stop guard). A callback
-    # may keep the agent going — run a check, defer it, tidy the diff — instead
+    # Candidate-final-answer gate. Fired whenever the agent is about to finish
+    # (after the code-specific verify-on-stop guard). A callback may keep the
+    # same turn going — recover work, gather evidence, run a check, tidy a diff — instead
     # of stopping by returning:
     #   {"action": "continue", "message": "<follow-up instruction>"}
     # The Claude-Code Stop shape {"decision": "block", "reason": "..."} (block
@@ -2288,8 +2288,9 @@ def get_pre_verify_continue_message(
 ) -> Optional[str]:
     """Check user ``pre_verify`` hooks for a directive to keep the agent going.
 
-    Fired once per turn when the agent edited code and is about to verify/finish.
-    A hook keeps the turn going (run a check, defer it, tidy the diff) by
+    Fired for every candidate final answer. A hook keeps the same turn going
+    (recover a failed tool path, gather missing evidence, run a check, tidy the
+    diff) by
     returning::
 
         {"action": "continue", "message": "<follow-up for the model>"}
@@ -2299,9 +2300,9 @@ def get_pre_verify_continue_message(
     non-empty message wins; any other return lets the turn finish. Mirrors
     :func:`get_pre_tool_call_block_message` — the call site stays a one-liner.
 
-    ``coding`` / ``attempt`` let a hook scope itself (``if not coding`` …) and
-    self-throttle (``if attempt`` …), the same way a ``pre_tool_call`` hook
-    scopes on ``tool_name``.
+    ``coding`` / ``changed_paths`` let code-specific hooks scope themselves,
+    while ``attempt`` lets every hook self-throttle. ``changed_paths`` is empty
+    for turns without file edits.
     """
     hook_results = invoke_hook(
         "pre_verify",

--- a/tests/run_agent/test_verification_continuation_budget.py
+++ b/tests/run_agent/test_verification_continuation_budget.py
@@ -80,9 +80,14 @@ def test_verify_on_stop_preserves_composed_report_at_budget_limit(agent, monkeyp
     assert not result["messages"][1].get("_verification_stop_synthetic")
 
 
-def test_pre_verify_preserves_composed_report_at_budget_limit(agent, monkeypatch):
+@pytest.mark.parametrize("changed_paths", [set(), {"changed.py"}])
+def test_pre_verify_preserves_composed_report_at_budget_limit(
+    agent,
+    monkeypatch,
+    changed_paths,
+):
     def model_call(_api_kwargs):
-        agent._turn_file_mutation_paths = {"changed.py"}
+        agent._turn_file_mutation_paths = changed_paths
         return _response()
 
     agent._interruptible_api_call = model_call
@@ -103,6 +108,33 @@ def test_pre_verify_preserves_composed_report_at_budget_limit(agent, monkeypatch
     _assert_pending_response_survives(agent, result)
     # The assistant response persists (it is real, unflagged content).
     assert not result["messages"][1].get("_pre_verify_synthetic")
+
+
+def test_pre_verify_receives_empty_changed_paths_for_non_edit_turn(agent, monkeypatch):
+    agent.max_iterations = 2
+    agent.iteration_budget.max_total = 2
+    answers = iter([_response("I cannot complete this."), _response("Recovered result")])
+    agent._interruptible_api_call = lambda _kwargs: next(answers)
+    seen: list[dict] = []
+
+    def steer(**kwargs):
+        seen.append(kwargs)
+        if kwargs["attempt"] == 0:
+            return "recover inside the same turn"
+        return None
+
+    monkeypatch.setenv("HERMES_VERIFY_ON_STOP", "0")
+    with (
+        patch("hermes_cli.plugins.has_hook", side_effect=lambda name: name == "pre_verify"),
+        patch("hermes_cli.plugins.get_pre_verify_continue_message", side_effect=steer),
+        patch("agent.verify_hooks.max_verify_nudges", return_value=2),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("finish the browser task")
+
+    assert result["final_response"] == "Recovered result"
+    assert [call["attempt"] for call in seen] == [0, 1]
+    assert all(call["changed_paths"] == [] for call in seen)
 
 
 def test_intermediate_ack_uses_summary_instead_of_premature_text(agent, monkeypatch):

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -655,7 +655,7 @@ def register(ctx):
 
 ### `pre_verify`
 
-Fires **once per turn when the agent edited code**, just before it finishes (after the built-in verify-on-stop guard). This is a user/plugin policy gate: a callback can keep the agent going — run a check, defer it, tidy the diff — instead of letting it stop.
+Fires for **every candidate final answer**, just before the agent finishes (after the built-in code verify-on-stop guard). This is a user/plugin policy gate: a callback can keep the same turn going — recover an incomplete tool path, gather missing evidence, run a check, defer it, or tidy a diff — instead of letting it stop.
 
 Hermes' shipped verification guidance is not a default `pre_verify` hook. It is appended to the evidence-based verify-on-stop nudge when edited code lacks fresh verification evidence, so it does not create a second default continuation path. Set `agent.verify_guidance: false` to keep that built-in evidence nudge terse.
 
@@ -674,11 +674,11 @@ def my_callback(session_id: str, platform: str, model: str, coding: bool,
 | `coding` | `bool` | Whether the turn is in the coding posture (in a code workspace) — scope your hook on this |
 | `attempt` | `int` | How many times this turn has already been nudged (0 on the first) — self-throttle on this |
 | `final_response` | `str` | The answer the agent is about to deliver |
-| `changed_paths` | `list` | Files the agent edited this turn (sorted, always non-empty here) |
+| `changed_paths` | `list` | Files the agent edited this turn (sorted; empty when no files changed) |
 
-Scope a hook to the coding context by checking `coding` and make it one-shot with `attempt` (shell hooks read both from `.extra`), the same way a `pre_tool_call` hook scopes on `tool_name` — so you can register several `pre_verify` hooks, each firing only where it should.
+Scope code-specific hooks with `coding` and/or `changed_paths`, and make them one-shot with `attempt` (shell hooks read these from `.extra`), the same way a `pre_tool_call` hook scopes on `tool_name`. Broader recovery hooks can inspect `final_response` even when `changed_paths` is empty.
 
-**Fires:** In `agent/conversation_loop.py`, at the point the agent would accept a final answer, immediately after the verify-on-stop check — but only when the agent edited code this turn and at least one `pre_verify` hook is registered.
+**Fires:** In `agent/conversation_loop.py`, at the point the agent would accept a final answer, immediately after the code-specific verify-on-stop check, whenever at least one `pre_verify` hook is registered.
 
 **Return value — keep the agent going:**
 


### PR DESCRIPTION
## Summary
- invoke registered `pre_verify` hooks for every candidate final answer, not only turns with file edits
- keep `changed_paths` as an empty/non-empty payload so code-specific hooks can still scope themselves
- add regression coverage for non-edit browser-style turns and continuation-budget fallback
- update hook docs and CLI sample payload

## Why
`pre_verify` is the host's bounded same-turn stop gate, but its file-edit precondition made non-coding recovery policies impossible. A browser/search/communication plugin could detect a premature "cannot do this / you do X" answer, yet its callback was never invoked. This change removes only the invocation precondition; code-specific policies can continue checking `coding` or `changed_paths`.

## Verification
- `uv run --with pytest --with python-dotenv pytest -q tests/run_agent/test_verification_continuation_budget.py tests/hermes_cli/test_plugins.py tests/hermes_cli/test_hooks_cli.py` (136 passed)
- `python3 -m py_compile agent/conversation_loop.py hermes_cli/plugins.py hermes_cli/hooks.py`
- `git diff --check`

Companion Bob policy PR: https://github.com/trac3r00/bob/pull/411
