### PR TITLE
fix(desktop): preserve fenced loopback URLs

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
@@ -173,6 +173,29 @@ describe('preprocessMarkdown', () => {
     )
   })
 
+  it('preserves fenced loopback URLs so preview cleanup cannot erase them', () => {
+    const input = '```text\nhttp://127.0.0.1:8318/v1/responses\n```'
+
+    expect(preprocessMarkdown(input)).toBe(input)
+  })
+
+  it('preserves fenced loopback URLs with authority-level queries', () => {
+    const input = '```text\nhttp://localhost:8318?health=1\n```'
+
+    expect(preprocessMarkdown(input)).toBe(input)
+  })
+
+  it('preserves a multi-URL fence when any line targets loopback', () => {
+    const input = [
+      '```text',
+      'https://example.com/docs',
+      'http://127.0.0.1:8318/v1/responses',
+      '```'
+    ].join('\n')
+
+    expect(preprocessMarkdown(input)).toBe(input)
+  })
+
   it('does not swallow trailing emphasis asterisks into an autolinked url', () => {
     const input = '**PR opened: https://github.com/NousResearch/hermes-agent/pull/12345**'
 

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -23,6 +23,7 @@ const CUSTOM_DISPLAY_MATH_LINE_RE = /^([ \t]*(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \
 const RAW_URL_RE = /https?:\/\/[^\s<>"'`*]+[^\s<>"'`*.,;:!?]/g
 const LOCAL_PREVIEW_URL_RE = /(^|\s)https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?\/?[^\s<>"'`]*/gi
 const LOCAL_PREVIEW_ONLY_RE = /^https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?\/?$/i
+const LOOPBACK_URL_RE = /^https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?(?:[/?#]|$)/i
 const URL_ONLY_LINE_RE = /^\s*https?:\/\/\S+\s*$/i
 const CITATION_MARKER_RE = /(?<=[\p{L}\p{N})\].,!?:;"'”’])\[(?:\d+(?:\s*,\s*\d+)*)\](?!\()/gu
 
@@ -410,7 +411,12 @@ function normalizeFenceBlocks(text: string): string {
       continue
     }
 
-    if (closeIndex !== -1 && isUrlOnlyBlock(bodyLines)) {
+    // Public URL-only fences become compact clickable links. Keep loopback
+    // URLs fenced, though: normalizeVisibleProse intentionally strips local
+    // preview-server URLs, so demoting one here would erase an explicitly
+    // requested CLI/API endpoint from the answer.
+    const hasLoopbackUrl = bodyLines.some(line => LOOPBACK_URL_RE.test(line.trim()))
+    if (closeIndex !== -1 && isUrlOnlyBlock(bodyLines) && !hasLoopbackUrl) {
       extend(out, bodyLines)
       index = closeIndex + 1
 


### PR DESCRIPTION
## Summary

- keep fenced loopback URLs intact during Desktop Markdown preprocessing
- continue converting public URL-only fences into compact links
- cover loopback paths, authority-level query URLs, and mixed multi-URL fences

## Problem

`normalizeFenceBlocks()` demotes URL-only fences into visible prose. A later preview-cleanup pass intentionally removes loopback preview URLs from prose, so an explicitly fenced local endpoint such as:

```text
http://127.0.0.1:8318/v1/responses
```

could disappear from the rendered answer entirely.

The preservation check applies to every URL line in the fence and recognizes paths, query strings, and fragments after the loopback authority, avoiding order-dependent behavior in multi-URL blocks.

## Test plan

- `npm --prefix apps/desktop test -- --run src/components/assistant-ui/markdown-text.test.ts` — 38 passed
- `npm --prefix apps/desktop run typecheck` — passed
- adversarial review after edge-case fixes — no P0–P3 findings
