### PR TITLE
fix(gateway): emit settled state after stale interrupt

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -150,6 +150,60 @@ def test_handoff_fail_marks_only_inflight_rows(monkeypatch):
         server._sessions.pop(sid, None)
 
 
+def test_interrupt_stale_running_emits_settle(monkeypatch):
+    """A stale running flag must settle the client's busy state after Stop."""
+
+    class FakeAgent:
+        model = "m"
+        provider = "p"
+
+        def interrupt(self):
+            pass
+
+    events: list[tuple[str, str, dict | None]] = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, session_id, payload=None: events.append(
+            (event, session_id, payload)
+        ),
+    )
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda agent, session=None: {
+            "running": bool((session or {}).get("running"))
+        },
+    )
+
+    sid = "rt-stale-interrupt"
+    dead_thread = threading.Thread(target=lambda: None)
+    dead_thread.start()
+    dead_thread.join()
+
+    session = {
+        "session_key": "stored-stale",
+        "history_lock": threading.RLock(),
+        "agent": FakeAgent(),
+        "running": True,
+        "_run_thread": dead_thread,
+        "inflight_turn": {"text": "hi"},
+    }
+    server._sessions[sid] = session
+    try:
+        monkeypatch.setattr(server, "_sess", lambda params, rid: (session, None))
+        response = server._methods["session.interrupt"](
+            "r1", {"session_id": sid}
+        )
+
+        assert response["result"] == {"status": "interrupted"}
+        assert session["running"] is False
+        assert session["inflight_turn"] is None
+        assert events == [("session.info", sid, {"running": False})]
+    finally:
+        server._sessions.pop(sid, None)
+
+
 def test_dashboard_process_isolation_config_defaults_without_default_merge(monkeypatch):
     """tui_gateway.server::_load_cfg is raw YAML, so defaults live at read site."""
     monkeypatch.setattr(server, "_load_cfg", lambda: {})

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9103,11 +9103,20 @@ def _(rid, params: dict) -> dict:
     with session["history_lock"]:
         session["_turn_cancel_requested"] = True
         session["queued_prompt"] = None
+    stale_cleared = False
     if not run_thread_alive:
         with session["history_lock"]:
             if session.get("running"):
                 session["running"] = False
                 _clear_inflight_turn(session)
+                stale_cleared = True
+    # A stale-flag recovery clears `running` server-side but the run loop's
+    # `finally` (which normally re-emits session.info) never ran — so without an
+    # explicit emit here the client's busy flag stays stuck true forever: the
+    # composer wedges on Stop and the queued-prompt auto-drain, gated on
+    # !isBusy, never fires. Push the settled state to the client now.
+    if stale_cleared:
+        _emit_session_info_for_session(str(params.get("session_id") or ""), session)
 
     # Stop = stop the TURN (cooperative interrupt above also kills the in-flight
     # foreground subprocess). Background processes the agent started (dev servers,


### PR DESCRIPTION
## Summary

- emit a settled `session.info` event when `session.interrupt` repairs a stale `running=true` flag
- keep the existing live-thread interrupt path unchanged
- add regression coverage for the dead-thread recovery branch

## Problem

When a turn thread dies before its normal `finally` path, the session can remain marked as running. `session.interrupt` already detects and clears that stale server-side flag, but it did not notify connected clients.

The Desktop/TUI client could therefore remain busy indefinitely after Stop even though the backend had recovered. This also prevented client work gated on `running=false`, such as queued-prompt draining, from continuing.

The new event is emitted only when this handler actually clears the stale flag, so the normal live-thread teardown remains the sole owner of its existing settle event.

## Test plan

- `./scripts/run_tests.sh tests/test_tui_gateway_server.py -q` — 382 passed
- adversarial review of locking, races, duplicate emits, and event ownership — no P0–P3 findings
