### PR TITLE
test: isolate the default session database path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -371,6 +371,16 @@ def _hermetic_environment(tmp_path, monkeypatch):
     (fake_hermes_home / "skills").mkdir()
     monkeypatch.setenv("HERMES_HOME", str(fake_hermes_home))
 
+    # hermes_state is commonly imported during collection, before this fixture
+    # runs. Its DEFAULT_DB_PATH is therefore a snapshot of the developer's real
+    # profile even though HERMES_HOME is isolated above. SessionDB() consults
+    # that module global when no explicit path is supplied, so patch the snapshot
+    # as part of the same isolation boundary. Without this, model-switch tests
+    # have written fixture sessions such as ``session-key`` into live state.db.
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", fake_hermes_home / "state.db")
+
     # 4. Deterministic locale / timezone / hashseed. CI runs in UTC with
     #    C.UTF-8 locale; local dev often doesn't. Pin everything.
     monkeypatch.setenv("TZ", "UTC")

--- a/tests/test_hermetic_environment.py
+++ b/tests/test_hermetic_environment.py
@@ -1,0 +1,15 @@
+"""Regression coverage for the test suite's process-state isolation."""
+
+import os
+from pathlib import Path
+
+import hermes_state
+
+
+def test_session_db_default_is_scoped_to_per_test_hermes_home():
+    """Collection-time imports must not retain the developer's live DB path."""
+    expected = Path(os.environ["HERMES_HOME"]) / "state.db"
+
+    # Do not construct SessionDB here: if this isolation regresses, construction
+    # would open and initialize the developer's live database before failing.
+    assert hermes_state.DEFAULT_DB_PATH == expected


### PR DESCRIPTION
## Summary

- patch `hermes_state.DEFAULT_DB_PATH` inside the suite-wide hermetic fixture
- prevent collection-time imports from retaining the developer's live profile database path
- add a regression test that verifies the default path without constructing a database

## Problem

`hermes_state` is commonly imported during test collection, before the autouse hermetic fixture sets a temporary `HERMES_HOME`. Its module-level `DEFAULT_DB_PATH` can therefore retain the developer's real `state.db` path.

Tests that later call `SessionDB()` without an explicit path can then initialize or write fixture sessions into live user state despite the temporary environment. The fixture now patches the already-imported module global and lets `monkeypatch` restore it after each test.

The regression assertion compares the path directly rather than constructing `SessionDB`; if isolation regresses, the test itself cannot open the live database before failing.

## Test plan

- `./scripts/run_tests.sh tests/test_hermetic_environment.py tests/hermes_cli/test_model_switch_custom_providers.py -q` — 52 passed
- adversarial review of fixture order, teardown, process isolation, and live-state safety — no P0–P3 findings
