### PR TITLE
fix(desktop): keep empty composer from collapsing

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -189,7 +189,8 @@ export function useComposerDraft({
     draftRef.current = ''
 
     if (editorRef.current) {
-      editorRef.current.replaceChildren()
+      renderComposerContents(editorRef.current, '')
+      placeCaretEnd(editorRef.current)
     }
   }, [setComposerText])
 

--- a/apps/desktop/src/app/chat/composer/inline-refs.ts
+++ b/apps/desktop/src/app/chat/composer/inline-refs.ts
@@ -125,9 +125,14 @@ function buildRefFragment(
 
 export function insertInlineRefsIntoEditor(editor: HTMLDivElement, refs: readonly InlineRefInput[]) {
   const parsed = refs.map(parseInlineRef).filter((ref): ref is NonNullable<typeof ref> => ref !== null)
+  const hasEmptySentinel = editor.childNodes.length === 1 && editor.firstChild?.nodeName === 'BR'
 
   if (!parsed.length) {
     return null
+  }
+
+  if (hasEmptySentinel) {
+    editor.replaceChildren()
   }
 
   editor.focus({ preventScroll: true })
@@ -135,7 +140,7 @@ export function insertInlineRefsIntoEditor(editor: HTMLDivElement, refs: readonl
   const selection = window.getSelection()
 
   const range =
-    selection?.rangeCount && editor.contains(selection.getRangeAt(0).commonAncestorContainer)
+    !hasEmptySentinel && selection?.rangeCount && editor.contains(selection.getRangeAt(0).commonAncestorContainer)
       ? selection.getRangeAt(0)
       : null
 

--- a/apps/desktop/src/app/chat/composer/rich-editor.test.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.test.ts
@@ -34,6 +34,17 @@ describe('renderComposerContents', () => {
     expect(editor.textContent).toContain('<b>raw</b>')
     expect(composerPlainText(editor)).toBe('@file:`<img src=x onerror=alert(1)>` <b>raw</b>')
   })
+
+  it('keeps a caret br sentinel for the empty composer', () => {
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+
+    renderComposerContents(editor, '')
+
+    expect(editor.childNodes.length).toBe(1)
+    expect(editor.firstChild?.nodeName).toBe('BR')
+    expect(composerPlainText(editor)).toBe('')
+  })
 })
 
 describe('normalizeComposerEditorDom', () => {
@@ -58,6 +69,18 @@ describe('normalizeComposerEditorDom', () => {
     expect(composerPlainText(editor)).toBe('@file:`src/foo.ts`')
     expect(editor.querySelector('br')).toBeNull()
   })
+
+  it('keeps a lone caret br sentinel but still treats it as empty text', () => {
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+
+    renderComposerContents(editor, '')
+    normalizeComposerEditorDom(editor)
+
+    expect(editor.childNodes.length).toBe(1)
+    expect(editor.firstChild?.nodeName).toBe('BR')
+    expect(composerPlainText(editor)).toBe('')
+  })
 })
 
 describe('insertInlineRefsIntoEditor', () => {
@@ -68,6 +91,17 @@ describe('insertInlineRefsIntoEditor', () => {
     insertInlineRefsIntoEditor(editor, ['@file:`src/foo.ts`'])
 
     expect(editor.querySelector(':scope > div')).toBeNull()
+    expect(composerPlainText(editor)).toBe('@file:`src/foo.ts` ')
+  })
+
+  it('replaces the empty caret br sentinel before inserting refs', () => {
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+    renderComposerContents(editor, '')
+
+    insertInlineRefsIntoEditor(editor, ['@file:`src/foo.ts`'])
+
+    expect(editor.firstChild?.nodeName).not.toBe('BR')
     expect(composerPlainText(editor)).toBe('@file:`src/foo.ts` ')
   })
 })
@@ -105,6 +139,21 @@ describe('insertPlainTextAtCaret', () => {
     insertPlainTextAtCaret(editor, 'cd')
 
     expect(composerPlainText(editor)).toBe('abcdef')
+
+    editor.remove()
+  })
+
+  it('drops the empty sentinel before pasting into a cleared composer', () => {
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+    renderComposerContents(editor, '')
+    document.body.append(editor)
+    caretIn(editor)
+
+    insertPlainTextAtCaret(editor, 'hello')
+
+    expect(editor.firstChild?.nodeName).not.toBe('BR')
+    expect(composerPlainText(editor)).toBe('hello')
 
     editor.remove()
   })

--- a/apps/desktop/src/app/chat/composer/rich-editor.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.ts
@@ -130,6 +130,10 @@ export function appendComposerContents(target: DocumentFragment | HTMLElement, t
 export function renderComposerContents(target: HTMLElement, text: string) {
   target.replaceChildren()
   appendComposerContents(target, text)
+
+  if (!target.childNodes.length) {
+    target.append(document.createElement('br'))
+  }
 }
 
 /** Caret range when the selection lives inside `editor`; else null. */
@@ -148,6 +152,10 @@ function composerSelectionRange(editor: HTMLElement) {
  *  instead of `execCommand('insertText')` — Chromium's editing pipeline is
  *  ~O(n²) on large multiline blobs. */
 export function insertPlainTextAtCaret(editor: HTMLElement, text: string) {
+  if (editor.childNodes.length === 1 && editor.firstChild?.nodeName === 'BR') {
+    editor.replaceChildren()
+  }
+
   const hit = composerSelectionRange(editor)
   const fragment = document.createDocumentFragment()
 
@@ -276,6 +284,10 @@ export function composerPlainText(node: Node): string {
     return el.dataset.refText
   }
 
+  if (el.dataset.slot === RICH_INPUT_SLOT && el.childNodes.length === 1 && el.firstChild?.nodeName === 'BR') {
+    return ''
+  }
+
   if (el.tagName === 'BR') {
     return '\n'
   }
@@ -350,6 +362,10 @@ export function normalizeComposerEditorDom(editor: HTMLElement) {
   const last = editor.lastChild
 
   if (last?.nodeName === 'BR') {
+    if (editor.childNodes.length === 1) {
+      return
+    }
+
     let prev: ChildNode | null = last.previousSibling
 
     while (prev?.nodeType === Node.TEXT_NODE && !(prev.textContent || '').trim()) {
@@ -359,5 +375,9 @@ export function normalizeComposerEditorDom(editor: HTMLElement) {
     if (!prev || (prev as HTMLElement).dataset?.refText) {
       editor.removeChild(last)
     }
+  }
+
+  if (!editor.childNodes.length) {
+    editor.append(document.createElement('br'))
   }
 }

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1173,8 +1173,17 @@ text-* variant utilities. */ .btn-arc {
   font-size: 0.8125rem;
 }
 
-[data-slot='composer-rich-input']:empty::before {
+[data-slot='composer-rich-input']:empty::before,
+[data-slot='composer-rich-input']:has(> br:only-child)::before {
   color: var(--ui-text-tertiary) !important;
+}
+
+[data-slot='composer-rich-input']:has(> br:only-child) {
+  min-height: var(--composer-input-min-height);
+}
+
+[data-slot='composer-rich-input'] > br:only-child {
+  display: block;
 }
 
 /* ── Composer fill — ONE var painted by the surface AND anything docked to it


### PR DESCRIPTION
## Summary

Keep the Desktop composer from visually collapsing when empty by preserving a caret BR sentinel, treating that sentinel as empty plain text, and removing it before programmatic insertions.

## What changed

- renderComposerContents() now leaves a lone BR in an empty composer.
- composerPlainText() treats that lone sentinel as empty.
- normalizeComposerEditorDom() preserves the sentinel for the empty state but still strips phantom line breaks after chips.
- clearDraft() renders the empty sentinel instead of leaving the editor blank.
- Inline ref insertion and plain-text insertion both remove the sentinel before inserting, so empty-draft paste/ref actions stay newline-free.
- CSS keeps the placeholder visible in the empty-sentinel state.
- Regression tests cover empty render, empty normalization, ref insertion into an empty composer, and paste into an empty composer.

## Verification

- npm run test:ui -- src/app/chat/composer/rich-editor.test.ts
- npm run typecheck
- npm run lint
- npm run build
- npm run test
- git diff --check

## Review

Independent Codex review completed; follow-up issues in the insertion paths were fixed and re-reviewed cleanly.

Closes #68134
Closes #68095
