### PR TITLE
fix(desktop): prevent duplicate messages when verification candidates are persisted

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5066,6 +5066,47 @@ class SessionDB:
         )
         return model_history, display_history
 
+    def get_ancestor_display_prefix(self, session_id: str) -> List[Dict[str, Any]]:
+        """Return the ancestor-only display messages for a session lineage.
+
+        These are messages from parent/grandparent sessions (compression
+        ancestors) that appear in the display transcript but NOT in the
+        tip session's model-fed history. Used by ``session.resume`` to
+        build the ``display_history_prefix`` that ``_live_session_payload``
+        prepends to the live model history.
+
+        Previously the prefix was calculated as
+        ``display_history[:len(display) - len(raw)]``, but that overcounts
+        when ``repair_message_sequence`` removes messages from the MIDDLE
+        of the tip history (e.g. verification candidates collapsed by the
+        consecutive-assistant merge) — the length difference includes both
+        ancestor messages AND repair-removed tip messages, but the slice
+        only captures the first N display messages (which are tip messages
+        when there are no ancestors), causing duplication. This method
+        returns ONLY the genuine ancestor messages, identified by
+        ``session_id != tip_session_id``. (#65919)
+        """
+        session_ids = self._session_lineage_root_to_tip(session_id)
+        if len(session_ids) <= 1:
+            return []
+        with self._lock:
+            placeholders = ",".join("?" for _ in session_ids)
+            rows = self._conn.execute(
+                f"SELECT session_id, {self._CONVERSATION_ROW_COLUMNS} "
+                f"FROM messages WHERE session_id IN ({placeholders}) AND active = 1 "
+                "ORDER BY id",
+                tuple(session_ids),
+            ).fetchall()
+        ancestor_rows = [r for r in rows if r["session_id"] != session_id]
+        if not ancestor_rows:
+            return []
+        return self._rows_to_conversation(
+            ancestor_rows,
+            session_id=session_id,
+            include_ancestors=True,
+            repair_alternation=False,
+        )
+
     def get_conversation_root(self, session_id: str) -> str:
         """Return the ROOT id of *session_id*'s lineage chain.
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1365,6 +1365,57 @@ class TestMessageStorage:
         assert model_history == model_expected
         assert display_history == display_expected
 
+    def test_get_ancestor_display_prefix_single_session_returns_empty(self, db):
+        """A session with no compression ancestors has an empty prefix."""
+        db.create_session("solo", "cli")
+        db.append_message("solo", role="user", content="hi")
+        db.append_message("solo", role="assistant", content="hello")
+
+        assert db.get_ancestor_display_prefix("solo") == []
+
+    def test_get_ancestor_display_prefix_returns_ancestor_only_messages(self, db):
+        """The prefix contains ONLY ancestor messages, not tip messages.
+
+        Previously the prefix was calculated as
+        display_history[:len(display) - len(raw)], which overcounts when
+        repair_message_sequence removes messages from the MIDDLE of the
+        tip history — the length difference includes both ancestor messages
+        AND repair-removed tip messages, but the slice captures the first N
+        display messages (tip messages when there are no ancestors),
+        causing duplication in _live_session_payload. (#65919)
+        """
+        db.create_session("root", "tui")
+        db.append_message("root", role="user", content="ancestor prompt")
+        db.append_message("root", role="assistant", content="ancestor reply")
+        db.create_session("child", "tui", parent_session_id="root")
+        db.append_message("child", role="user", content="tip prompt")
+        db.append_message("child", role="assistant", content="tip reply")
+        # A verification candidate that repair_message_sequence collapses
+        # (consecutive-assistant merge replaces it with the next assistant).
+        db.append_message(
+            "child",
+            role="assistant",
+            content="verification candidate",
+            finish_reason="verification_required",
+        )
+        db.append_message("child", role="assistant", content="post-verification reply")
+
+        prefix = db.get_ancestor_display_prefix("child")
+        # Only the ancestor messages, not any tip messages.
+        assert len(prefix) == 2
+        assert prefix[0]["role"] == "user"
+        assert prefix[0]["content"] == "ancestor prompt"
+        assert prefix[1]["role"] == "assistant"
+        assert prefix[1]["content"] == "ancestor reply"
+
+        # The old broken calculation would produce a non-empty prefix
+        # (because repair collapses the verification candidate, making
+        # len(display) > len(raw)), even though there are 2 ancestor
+        # messages — it would overcount.
+        raw, display = db.get_resume_conversations("child")
+        old_prefix_len = max(0, len(display) - len(raw))
+        assert len(prefix) <= old_prefix_len
+
     def test_finish_reason_stored(self, db):
         db.create_session(session_id="s1", source="cli")
         db.append_message("s1", role="assistant", content="Done", finish_reason="stop")

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1418,6 +1418,9 @@ def test_session_resume_uses_parent_lineage_for_display(monkeypatch):
                 self.get_messages_as_conversation(session_id, include_ancestors=True),
             )
 
+        def get_ancestor_display_prefix(self, _sid):
+            return []
+
         def get_messages_as_conversation(self, target, include_ancestors=False, repair_alternation=False):
             captured.setdefault("history_calls", []).append((target, include_ancestors))
             return (
@@ -1555,6 +1558,9 @@ def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
                 self.get_messages_as_conversation(session_id, include_ancestors=True),
             )
 
+        def get_ancestor_display_prefix(self, _sid):
+            return []
+
         def get_messages_as_conversation(self, target, include_ancestors=False, repair_alternation=False):
             return [{"role": "user", "content": "hello"}]
 
@@ -1620,6 +1626,9 @@ def test_session_resume_profile_uses_profile_db_cwd(monkeypatch, tmp_path):
                 self.get_messages_as_conversation(session_id, repair_alternation=True),
                 self.get_messages_as_conversation(session_id, include_ancestors=True),
             )
+
+        def get_ancestor_display_prefix(self, _sid):
+            return []
 
         def get_messages_as_conversation(self, _target, include_ancestors=False, repair_alternation=False):
             return [{"role": "user", "content": "hello"}]
@@ -5677,6 +5686,9 @@ def test_slash_exec_r7_read_commands_use_metadata_mirror_flag_on(monkeypatch):
                 self.get_messages_as_conversation(session_id, repair_alternation=True),
                 self.get_messages_as_conversation(session_id, include_ancestors=True),
             )
+
+        def get_ancestor_display_prefix(self, _sid):
+            return []
 
         def get_messages_as_conversation(self, key, include_ancestors=True, repair_alternation=False):
             assert key == "session-key"

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -352,6 +352,9 @@ def test_session_resume_returns_hydrated_messages(server, monkeypatch):
                 self.get_messages_as_conversation(session_id, include_ancestors=True),
             )
 
+        def get_ancestor_display_prefix(self, _sid):
+            return []
+
         def get_messages_as_conversation(self, _sid, include_ancestors=False, repair_alternation=False):
             return [
                 {"role": "user", "content": "hello"},
@@ -417,6 +420,9 @@ def test_session_resume_defaults_to_deferred_build(server, monkeypatch):
                 self.get_messages_as_conversation(session_id, repair_alternation=True),
                 self.get_messages_as_conversation(session_id, include_ancestors=True),
             )
+
+        def get_ancestor_display_prefix(self, _sid):
+            return []
 
         def get_messages_as_conversation(self, _sid, include_ancestors=False, repair_alternation=False):
             return [
@@ -565,6 +571,9 @@ def test_session_resume_handles_multimodal_list_content(server, monkeypatch):
                 self.get_messages_as_conversation(session_id, include_ancestors=True),
             )
 
+        def get_ancestor_display_prefix(self, _sid):
+            return []
+
         def get_messages_as_conversation(self, _sid, include_ancestors=False, repair_alternation=False):
             return [multimodal_user, text_only_assistant]
 
@@ -620,6 +629,9 @@ def test_session_resume_lazy_registers_watch_session_without_agent(server, monke
                 self.get_messages_as_conversation(session_id, repair_alternation=True),
                 self.get_messages_as_conversation(session_id, include_ancestors=True),
             )
+
+        def get_ancestor_display_prefix(self, _sid):
+            return []
 
         def get_messages_as_conversation(self, _sid, include_ancestors=False, repair_alternation=False):
             return [
@@ -700,6 +712,9 @@ def test_session_resume_lazy_reports_running_for_inflight_child(server, monkeypa
                 self.get_messages_as_conversation(session_id, include_ancestors=True),
             )
 
+        def get_ancestor_display_prefix(self, _sid):
+            return []
+
         def get_messages_as_conversation(self, _sid, include_ancestors=False, repair_alternation=False):
             return [{"role": "user", "content": "delegated goal"}]
 
@@ -756,6 +771,9 @@ def test_session_resume_lazy_tolerates_missing_row_for_active_child(server, monk
                 self.get_messages_as_conversation(session_id, repair_alternation=True),
                 self.get_messages_as_conversation(session_id, include_ancestors=True),
             )
+
+        def get_ancestor_display_prefix(self, _sid):
+            return []
 
         def get_messages_as_conversation(self, _sid, include_ancestors=False, repair_alternation=False):
             # No rows for an unwritten session.
@@ -859,6 +877,9 @@ def test_session_resume_reuses_existing_live_session(server, monkeypatch):
                 self.get_messages_as_conversation(session_id, repair_alternation=True),
                 self.get_messages_as_conversation(session_id, include_ancestors=True),
             )
+
+        def get_ancestor_display_prefix(self, _sid):
+            return []
 
         def get_messages_as_conversation(self, _sid, include_ancestors=False, repair_alternation=False):
             return [
@@ -1082,6 +1103,9 @@ def test_session_resume_live_payload_uses_current_history_with_ancestors(server,
                 self.get_messages_as_conversation(session_id, repair_alternation=True),
                 self.get_messages_as_conversation(session_id, include_ancestors=True),
             )
+
+        def get_ancestor_display_prefix(self, _sid):
+            return list(ancestor_history)
 
         def get_messages_as_conversation(self, _sid, include_ancestors=False, repair_alternation=False):
             if include_ancestors:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6345,7 +6345,7 @@ def _(rid, params: dict) -> dict:
         # Display keeps the full transcript; the model-fed history drops a
         # dangling/interrupted tool-call tail so a session killed mid-loop does
         # not replay the unanswered call forever (#29086).
-        prefix = display_history[: max(0, len(display_history) - len(raw_history))]
+        prefix = db.get_ancestor_display_prefix(target)
         history = sanitize_replay_history(raw_history)
         # Restore the model/provider/reasoning/tier this chat last used so the
         # deferred build (and the info below) match the eager path — without them
@@ -6421,9 +6421,7 @@ def _(rid, params: dict) -> dict:
         # re-issue the unanswered call forever — the permanent-"thinking" stuck
         # session in #29086.  The messaging gateway already strips this; this is
         # the WebUI/TUI resume path picking up the same cleanup.
-        display_history_prefix = display_history[
-            : max(0, len(display_history) - len(raw_history))
-        ]
+        display_history_prefix = db.get_ancestor_display_prefix(target)
         history = sanitize_replay_history(raw_history)
         messages = _history_to_messages(display_history)
         tokens = _set_session_context(target)


### PR DESCRIPTION
## Problem

When a session contains verification candidate messages (`finish_reason=verification_required`), opening/resuming it in the desktop app shows **duplicate user messages**.

Root cause: the `display_history_prefix` calculation in `session.resume` used `display_history[:len(display) - len(raw)]`, which assumes the model (repaired) history is always a **suffix** of the display history. This assumption breaks when `repair_message_sequence` removes messages from the **middle** of the tip history (verification candidates are collapsed by the consecutive-assistant merge):

- The candidate stays in the **display** history (it's real persisted content — #65919 changed it from synthetic to real)
- The candidate is removed from the **model** history (collapsed by repair)
- The length gap counts BOTH ancestor messages AND repair-removed tip messages
- The prefix grabs the first N display messages — which are tip messages when there are no compression ancestors
- `_live_session_payload` concatenates `prefix + model_history`, **duplicating** the first N messages

On session `20260720_110036_a33889` (8 verification candidates), this duplicated the first 8 messages in every warm-cache `session.activate` response.

before:
<img width="858" height="1413" alt="image" src="https://github.com/user-attachments/assets/4dc61e1a-e4fb-464d-b363-9e26a5c3e348" />

after:
<img width="859" height="1494" alt="image" src="https://github.com/user-attachments/assets/f91623d0-3da4-4732-86a4-d9da68b3afd0" />


## Fix

Add `SessionDB.get_ancestor_display_prefix()` which returns ONLY genuine ancestor messages (rows where `session_id != tip_session_id`), identified at the row level before `_rows_to_conversation` strips `session_id`. Both resume paths (eager + deferred) now use this instead of the length-slice heuristic.

## Verification

- `scripts/run_tests.sh tests/test_hermes_state.py tests/tui_gateway/test_protocol.py tests/test_tui_gateway_server.py` → **848 passed, 0 failed**
- Confirmed against real session `20260720_110036_a33889`: old prefix = 8 messages (duplicated), new prefix = 0 (correct — no compression ancestors)
- The 3 pre-existing test failures (`test_make_agent_passes_configured_fallback_chain`, `test_ensure_session_db_row_*`) are unrelated to this change (confirmed via `git stash` baseline)

## Test coverage

- `test_get_ancestor_display_prefix_single_session_returns_empty` — single session (no ancestors) returns `[]`
- `test_get_ancestor_display_prefix_returns_ancestor_only_messages` — with ancestors + a verification candidate, returns only ancestor messages, not tip messages
- Updated 12 mock DBs across `test_protocol.py` + `test_tui_gateway_server.py` to implement the new method