### PR TITLE
fix(agent): price reasoning tokens in estimate_usage_cost (#68081)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -553,6 +553,13 @@ def estimate_usage_cost(
     for tokens, rate, rate_above, note in (
         (usage.input_tokens, entry.input_cost_per_million, entry.input_cost_per_million_above, ()),
         (usage.output_tokens, entry.output_cost_per_million, entry.output_cost_per_million_above, ()),
+        # Reasoning tokens are billed by providers as completion tokens (confirmed
+        # against OpenRouter per-call billing, #68081). normalize_usage captures them
+        # as a separate additive bucket disjoint from output_tokens, so without this
+        # they were silently dropped from cost and reasoning-model spend undercounted.
+        # Priced at the output rate so above-tier context rates apply to them too; a
+        # missing output rate with reasoning tokens present reports unknown, not $0.
+        (usage.reasoning_tokens, entry.output_cost_per_million, entry.output_cost_per_million_above, ()),
         (usage.cache_read_tokens, entry.cache_read_cost_per_million, entry.cache_read_cost_per_million_above,
          ("cache-read pricing unavailable for route",)),
         (usage.cache_write_tokens, entry.cache_write_cost_per_million, None,

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1324,7 +1324,7 @@ def estimate_usage_cost(
 
     if usage.input_tokens and entry.input_cost_per_million is None:
         return CostResult(amount_usd=None, status="unknown", source=entry.source, label="n/a")
-    if usage.output_tokens and entry.output_cost_per_million is None:
+    if (usage.output_tokens or usage.reasoning_tokens) and entry.output_cost_per_million is None:
         return CostResult(amount_usd=None, status="unknown", source=entry.source, label="n/a")
     if usage.cache_read_tokens:
         if entry.cache_read_cost_per_million is None:
@@ -1349,6 +1349,12 @@ def estimate_usage_cost(
         amount += Decimal(usage.input_tokens) * entry.input_cost_per_million / _ONE_MILLION
     if entry.output_cost_per_million is not None:
         amount += Decimal(usage.output_tokens) * entry.output_cost_per_million / _ONE_MILLION
+        # Reasoning tokens are billed by providers as completion tokens (confirmed
+        # against OpenRouter's per-call billing, #68081). normalize_usage captures
+        # them as a separate additive bucket — disjoint from output_tokens, the
+        # same convention used everywhere else in session accounting — so they
+        # were silently dropped from cost and undercounted reasoning-model spend.
+        amount += Decimal(usage.reasoning_tokens) * entry.output_cost_per_million / _ONE_MILLION
     if entry.cache_read_cost_per_million is not None:
         amount += Decimal(usage.cache_read_tokens) * entry.cache_read_cost_per_million / _ONE_MILLION
     if entry.cache_write_cost_per_million is not None:

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -80,6 +80,78 @@ def test_normalize_usage_openai_reads_top_level_anthropic_cache_fields():
 
 
 
+def _openrouter_flat_pricing(monkeypatch):
+    """Pin an OpenRouter route to $1/M prompt, $5/M completion (no cache rates)."""
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_model_metadata",
+        lambda: {
+            "deepseek/deepseek-v4-pro": {
+                "pricing": {
+                    "prompt": "0.000001",
+                    "completion": "0.000005",
+                }
+            }
+        },
+    )
+
+
+def test_estimate_usage_cost_prices_reasoning_tokens_at_output_rate(monkeypatch):
+    """Reasoning tokens are billed as completion tokens and must be priced at the
+    output rate, not silently dropped (#68081)."""
+    _openrouter_flat_pricing(monkeypatch)
+
+    result = estimate_usage_cost(
+        "deepseek/deepseek-v4-pro",
+        CanonicalUsage(input_tokens=1000, output_tokens=1000, reasoning_tokens=5000),
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert result.status == "estimated"
+    # (1000 × $1/M) + (1000 × $5/M) + (5000 reasoning × $5/M) = $0.031
+    assert float(result.amount_usd) == 0.031
+
+
+def test_estimate_usage_cost_reasoning_only_marks_unknown_without_output_rate(monkeypatch):
+    """A reasoning-only response must not be priced at $0 when the route has no
+    output rate — it should report unknown, mirroring the output-token guard."""
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_model_metadata",
+        lambda: {"some/model": {"pricing": {"prompt": "0.000001"}}},
+    )
+
+    result = estimate_usage_cost(
+        "some/model",
+        CanonicalUsage(reasoning_tokens=5000),
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert result.status == "unknown"
+
+
+def test_custom_endpoint_models_api_pricing_is_supported(monkeypatch):
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda base_url, api_key=None: {
+            "zai-org/GLM-5-TEE": {
+                "pricing": {
+                    "prompt": "0.0000005",
+                    "completion": "0.000002",
+                }
+            }
+        },
+    )
+
+    entry = get_pricing_entry(
+        "zai-org/GLM-5-TEE",
+        provider="custom",
+        base_url="https://llm.chutes.ai/v1",
+        api_key="test-key",
+    )
+
+    assert float(entry.input_cost_per_million) == 0.5
+    assert float(entry.output_cost_per_million) == 2.0
 
 
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -78,6 +78,78 @@ def test_normalize_usage_openai_reads_top_level_anthropic_cache_fields():
 
 
 
+def _openrouter_flat_pricing(monkeypatch):
+    """Pin an OpenRouter route to $1/M prompt, $5/M completion (no cache rates)."""
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_model_metadata",
+        lambda: {
+            "deepseek/deepseek-v4-pro": {
+                "pricing": {
+                    "prompt": "0.000001",
+                    "completion": "0.000005",
+                }
+            }
+        },
+    )
+
+
+def test_estimate_usage_cost_prices_reasoning_tokens_at_output_rate(monkeypatch):
+    """Reasoning tokens are billed as completion tokens and must be priced at the
+    output rate, not silently dropped (#68081)."""
+    _openrouter_flat_pricing(monkeypatch)
+
+    result = estimate_usage_cost(
+        "deepseek/deepseek-v4-pro",
+        CanonicalUsage(input_tokens=1000, output_tokens=1000, reasoning_tokens=5000),
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert result.status == "estimated"
+    # (1000 × $1/M) + (1000 × $5/M) + (5000 reasoning × $5/M) = $0.031
+    assert float(result.amount_usd) == 0.031
+
+
+def test_estimate_usage_cost_reasoning_only_marks_unknown_without_output_rate(monkeypatch):
+    """A reasoning-only response must not be priced at $0 when the route has no
+    output rate — it should report unknown, mirroring the output-token guard."""
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_model_metadata",
+        lambda: {"some/model": {"pricing": {"prompt": "0.000001"}}},
+    )
+
+    result = estimate_usage_cost(
+        "some/model",
+        CanonicalUsage(reasoning_tokens=5000),
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert result.status == "unknown"
+
+
+def test_custom_endpoint_models_api_pricing_is_supported(monkeypatch):
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda base_url, api_key=None: {
+            "zai-org/GLM-5-TEE": {
+                "pricing": {
+                    "prompt": "0.0000005",
+                    "completion": "0.000002",
+                }
+            }
+        },
+    )
+
+    entry = get_pricing_entry(
+        "zai-org/GLM-5-TEE",
+        provider="custom",
+        base_url="https://llm.chutes.ai/v1",
+        api_key="test-key",
+    )
+
+    assert float(entry.input_cost_per_million) == 0.5
+    assert float(entry.output_cost_per_million) == 2.0
 
 
 


### PR DESCRIPTION
## What does this PR do?

`estimate_usage_cost()` in `agent/usage_pricing.py` priced input, output, and cache tokens but never `usage.reasoning_tokens`, so cost was systematically **undercounted for every reasoning model** — in proportion to how much hidden reasoning it does per call.

`normalize_usage()` already extracts `reasoning_tokens` (its own comment notes they "dominate output spend on models like deepseek-v4-flash") into a **separate additive bucket**, disjoint from `output_tokens` and consistent with how the rest of session accounting sums tokens (e.g. `hermes_cli/main.py`'s resume total is `input + output + cache + reasoning`, and the web_server aggregations SUM `reasoning_tokens` as its own column). The pricing function was the lone outlier that dropped it.

Providers bill reasoning tokens as completion tokens, so the fix prices them at the same `output_cost_per_million` rate. The reporter confirmed the gap byte-for-byte against OpenRouter's Activity log on `deepseek/deepseek-v4-pro` (`default_effort: high`): visible-token cost undercounted real billed cost by 1.6–2.3x per call, and ~55–75% at the project level, while a non-reasoning Haiku profile reconciled to within ~11% using the same method.

This also fixes `cost_details` for anyone using the Langfuse observability plugin, whose `_usage_and_cost()` calls the same function.

## Related Issue

Fixes #68081

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/usage_pricing.py`: in `estimate_usage_cost()`, price `usage.reasoning_tokens` at `entry.output_cost_per_million` alongside output tokens. Also extend the missing-output-rate guard so a reasoning-only response reports `unknown` instead of a false `$0`.
- `tests/agent/test_usage_pricing.py`: add `test_estimate_usage_cost_prices_reasoning_tokens_at_output_rate` (the issue's exact repro: 1000 in / 1000 out / 5000 reasoning at $1/M · $5/M → $0.031, previously $0.006) and `test_estimate_usage_cost_reasoning_only_marks_unknown_without_output_rate`.

## How to Test

```
scripts/run_tests.sh tests/agent/test_usage_pricing.py
```

Result: `33 tests passed, 0 failed`. The two new tests fail against the unpatched function (reasoning cost dropped) and pass with the fix.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected tests and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comments) — comment added at the pricing site explaining the disjoint-bucket rationale; no user-facing docs affected
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact — N/A (pure arithmetic, platform-independent)
- [x] Tool descriptions/schemas — N/A (no tool behavior change)

## Screenshots / Logs

From the issue's debug report, reasoning tokens are captured but never surfaced in cost:
```
API call #2: model=deepseek/deepseek-v4-pro provider=openrouter in=22276 out=165 ... cache=3712/22276 (17%)
```
Predicted (visible tokens only): $0.00823 vs real (OpenRouter): $0.0137 — the gap is the unpriced reasoning tokens this PR now includes.
