### PR TITLE
fix(browser): reap daemon on command timeout to prevent orphaned Chromium trees

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2503,6 +2503,30 @@ def _run_browser_command(
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait()
+            # Reap orphaned daemon + Chromium tree spawned by agent-browser.
+            # proc.kill() only terminates the CLI client; the background daemon
+            # (which holds Chromium via AGENT_BROWSER_SOCKET_DIR) survives as
+            # an unowned process.  Use the PID file that agent-browser writes
+            # into the socket directory.  Two passes with a short sleep give
+            # the daemon time to write the file if it was mid-startup.
+            session_name = session_info.get("session_name", "")
+            if session_name and os.name != "nt":
+                from tools.process_registry import ProcessRegistry
+                for _pass in range(2):
+                    _pid_file = os.path.join(task_socket_dir, f"{session_name}.pid")
+                    if os.path.isfile(_pid_file):
+                        try:
+                            _daemon_pid = int(Path(_pid_file).read_text(encoding="utf-8").strip())
+                            ProcessRegistry._terminate_host_pid(_daemon_pid)
+                            logger.warning(
+                                "Reaped orphaned browser daemon PID %s after timeout "
+                                "(task=%s, socket_dir=%s)",
+                                _daemon_pid, task_id, task_socket_dir,
+                            )
+                        except (ProcessLookupError, ValueError, PermissionError, OSError):
+                            pass
+                        break
+                    time.sleep(1)
             stdout, stderr = _read_command_output_files(stdout_path, stderr_path)
             _unlink_command_output_files(stdout_path, stderr_path)
             if stderr and stderr.strip():


### PR DESCRIPTION
## Root Cause

When a browser command (`open`, `snapshot`, etc.) times out in `_run_browser_command`, the `TimeoutExpired` handler calls `proc.kill()` which only terminates the **CLI client process** (`agent-browser` npm binary). However, that CLI spawns a **background daemon** that manages the actual Chromium instance. The daemon receives its socket directory via the `AGENT_BROWSER_SOCKET_DIR` environment variable (inherited from the CLI client's env), **not via argv** — so nothing about the daemon is discoverable from the killed process's command line.

The daemon + full Chromium tree (~150–250 MB RSS) survives as an unowned process inside the gateway's cgroup.

## Why Existing Cleanup Doesn't Help

The orphan reaper (`_reap_orphaned_browser_sessions`) only runs:
1. On process start (once)
2. During `atexit` cleanup

A long-lived `gateway run` process **never re-triggers it**, so orphans accumulate across retries within one gateway lifetime. The reaper's ownership check also treats sessions whose `owner_pid` is alive as in-use — and the owner (the gateway itself) *is* alive.

## Real-World Impact

On a 1 GB LXC host running hermes-agent 0.18.0 with Telegram gateway:
- Two `browser_navigate` timeout episodes in one day (cold daemon start > 120s on a small host)
- Two orphaned Chromium trees leaked → host RAM exhausted → global swap thrash → sshd unresponsive for ~1 hour → kernel OOM killer tore down the service

## Fix

After killing the timed-out CLI client, check the socket directory for the daemon's PID file (`{session_name}.pid`, written by agent-browser's daemon startup) and terminate the daemon process tree using `ProcessRegistry._terminate_host_pid` (the same helper used by `_cleanup_single_browser_session` and `_reap_orphaned_browser_sessions`).

Two passes with a 1-second sleep give the daemon time to write the PID file if it was mid-startup when the timeout fired.

## Changes

- **`tools/browser_tool.py`**: Added daemon reaping logic in `_run_browser_command`'s `TimeoutExpired` handler (~20 lines added)

## Edge Cases Considered

- **Daemon not yet started / no PID file**: Two-pass sweep with 1s sleep handles the race where timeout fires before daemon writes its PID
- **Windows**: Skipped (`os.name != "nt"`) — Windows process management differs significantly; `/proc` env scanning is Linux-only
- **Cloud/CDP mode**: The daemon reaping only applies to local mode sessions that have a `session_name` and `task_socket_dir`
- **PID reuse**: `ProcessRegistry._terminate_host_pid` performs a tree kill; the PID file is written by agent-browser's own daemon startup, so reuse risk is minimal
