### PR TITLE
fix(moonshot): inject required:[] on object schemas to fix kimi HTTP 400 (#66835)

### DIFF
--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -15,6 +15,9 @@ and MoonshotAI/kimi-cli#1595:
 2. When ``anyOf`` is used, ``type`` must be on the ``anyOf`` children, not
    the parent.  Presence of both causes "type should be defined in anyOf
    items instead of the parent schema".
+3. Every object schema must carry a ``required`` array, even an empty one.
+   Standard JSON Schema allows omitting it; Moonshot 400s with
+   "required must be an array".
 
 The ``#/definitions/...`` → ``#/$defs/...`` rewrite for draft-07 refs is
 handled separately in ``tools/mcp_tool._normalize_mcp_input_schema`` so it
@@ -130,7 +133,30 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
             else:
                 repaired.pop("enum")
 
+    # Rule 4: object schemas must carry a `required` array, even when empty.
+    if repaired.get("type") == "object":
+        repaired = _ensure_required_array(repaired)
+
     return repaired
+
+
+def _ensure_required_array(node: Dict[str, Any]) -> Dict[str, Any]:
+    """Guarantee an object schema carries a ``required`` array (Moonshot rule).
+
+    Standard JSON Schema lets you omit ``required`` when nothing is required;
+    Moonshot 400s on that ("required must be an array").  Ensure the key is a
+    list.  When ``properties`` is known, prune ``required`` entries that don't
+    name a real property — defensive against dangling names, which Moonshot
+    also rejects.  Mutates and returns ``node``.
+    """
+    props = node.get("properties")
+    req = node.get("required")
+    if isinstance(req, list):
+        if isinstance(props, dict):
+            node["required"] = [r for r in req if r in props]
+    else:
+        node["required"] = []
+    return node
 
 
 def _fill_missing_type(node: Dict[str, Any]) -> Dict[str, Any]:
@@ -174,17 +200,18 @@ def sanitize_moonshot_tool_parameters(parameters: Any) -> Dict[str, Any]:
     applied.  Input is not mutated.
     """
     if not isinstance(parameters, dict):
-        return {"type": "object", "properties": {}}
+        return {"type": "object", "properties": {}, "required": []}
 
     repaired = _repair_schema(copy.deepcopy(parameters), is_schema=True)
     if not isinstance(repaired, dict):
-        return {"type": "object", "properties": {}}
+        return {"type": "object", "properties": {}, "required": []}
 
     # Top-level must be an object schema
     if repaired.get("type") != "object":
         repaired["type"] = "object"
     if "properties" not in repaired:
         repaired["properties"] = {}
+    _ensure_required_array(repaired)
 
     return repaired
 

--- a/tests/agent/test_moonshot_schema.py
+++ b/tests/agent/test_moonshot_schema.py
@@ -188,9 +188,10 @@ class TestTopLevelGuarantees:
     """The returned top-level schema is always a well-formed object."""
 
     def test_non_dict_input_returns_empty_object(self):
-        assert sanitize_moonshot_tool_parameters(None) == {"type": "object", "properties": {}}
-        assert sanitize_moonshot_tool_parameters("garbage") == {"type": "object", "properties": {}}
-        assert sanitize_moonshot_tool_parameters([]) == {"type": "object", "properties": {}}
+        empty = {"type": "object", "properties": {}, "required": []}
+        assert sanitize_moonshot_tool_parameters(None) == empty
+        assert sanitize_moonshot_tool_parameters("garbage") == empty
+        assert sanitize_moonshot_tool_parameters([]) == empty
 
     def test_non_object_top_level_coerced(self):
         params = {"type": "string"}
@@ -210,6 +211,66 @@ class TestTopLevelGuarantees:
         sanitize_moonshot_tool_parameters(params)
         assert params["type"] == snapshot["type"]
         assert "type" not in params["properties"]["q"]
+
+
+class TestRequiredArray:
+    """Rule 4: every object schema must carry a ``required`` array (#66835)."""
+
+    def test_empty_object_gets_empty_required(self):
+        out = sanitize_moonshot_tool_parameters({"type": "object", "properties": {}})
+        assert out["required"] == []
+
+    def test_object_with_only_optional_props_gets_empty_required(self):
+        params = {
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["required"] == []
+
+    def test_existing_required_preserved(self):
+        params = {
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": ["q"],
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["required"] == ["q"]
+
+    def test_dangling_required_pruned(self):
+        params = {
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": ["q", "ghost"],
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["required"] == ["q"]
+
+    def test_non_list_required_replaced(self):
+        params = {
+            "type": "object",
+            "properties": {},
+            "required": "q",  # invalid: string, not array
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["required"] == []
+
+    def test_nested_object_property_gets_required(self):
+        params = {
+            "type": "object",
+            "properties": {
+                "filter": {"type": "object", "properties": {}},
+            },
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["properties"]["filter"]["required"] == []
+        assert out["required"] == []
+
+    def test_coerced_top_level_gets_required(self):
+        # A non-object top level is forced to object and must gain required.
+        out = sanitize_moonshot_tool_parameters({"type": "string"})
+        assert out["type"] == "object"
+        assert out["required"] == []
 
 
 class TestToolListSanitizer:
@@ -239,8 +300,10 @@ class TestToolListSanitizer:
         ]
         out = sanitize_moonshot_tools(tools)
         assert out[0]["function"]["parameters"]["properties"]["q"]["type"] == "string"
-        # Second tool already clean — should be structurally equivalent
-        assert out[1]["function"]["parameters"] == {"type": "object", "properties": {}}
+        # Second tool: empty object gains the required-array Moonshot demands
+        assert out[1]["function"]["parameters"] == {
+            "type": "object", "properties": {}, "required": []
+        }
 
     def test_empty_list_is_passthrough(self):
         assert sanitize_moonshot_tools([]) == []

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -747,6 +747,28 @@ class TestChatCompletionsKimi:
         )
         assert kw["tools"][0]["function"]["parameters"]["properties"]["q"]["type"] == "string"
 
+    def test_moonshot_outgoing_schema_carries_required_array(self, transport):
+        """Moonshot 400s on object schemas without an explicit `required` array
+        (#66835). Assert the wire-level tool schema — what actually leaves the
+        transport — carries `required: []` on a zero-required-param tool."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "browser_snapshot",
+                    "description": "Snapshot",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+        ]
+        kw = transport.build_kwargs(
+            model="moonshotai/kimi-k3",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["tools"][0]["function"]["parameters"]["required"] == []
+
     def test_non_moonshot_tools_are_not_mutated(self, transport):
         """Other models don't go through the Moonshot sanitizer."""
         original_params = {


### PR DESCRIPTION
## Summary
Kimi/Moonshot tool calls no longer 400 on tools with zero required parameters — every object schema leaving the Moonshot sanitizer now carries an explicit `required` array.

Salvages #66855 by @PRATHAMESH75 onto current main (authorship preserved). Root cause: Moonshot's "flavored" JSON Schema validator rejects object schemas that omit `required` ("required must be an array"), which standard JSON Schema permits. `agent/moonshot_schema.py` repaired missing `type`, `anyOf` parents, and enum nulls, but never injected `required: []` — so 20 builtin tools (browser_snapshot, delegate_task, session_search, read_terminal, ...) plus most MCP tools failed live on kimi-k2.6/k3.

Closes #66835. Supersedes #66852 (same fix, earlier submission by @Ahmett101 — credited; that variant left the fallback returns and object+anyOf shapes uncovered).

## Changes
- `agent/moonshot_schema.py`: Rule 4 via `_ensure_required_array()` — injected in `_repair_schema` (recursive, covers nested objects), both non-dict fallback returns, and after top-level object coercion; prunes dangling `required` entries not present in `properties`
- `tests/agent/test_moonshot_schema.py`: new `TestRequiredArray` class (7 tests) + updated fallback expectations
- `tests/agent/transports/test_chat_completions.py`: wire-level regression — outgoing tool schema at `build_kwargs` carries `required: []` (our follow-up)

## Validation
| | Before | After |
|---|---|---|
| Zero-required-param tool on kimi-k3 | HTTP 400 | schema carries `required: []` |
| E2E sweep of all 79 builtin tool schemas | 20 object nodes missing `required` | 0 violations, 20 tools emitting `required: []` |
| Targeted tests | — | both files green via scripts/run_tests.sh |

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa30900/3yiyRxt42zJT8sfhmbR7X_KZLoaJEx.png)
