### PR TITLE
feat(desktop): two-finger swipe on sidebar to cycle profiles

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -25,6 +25,7 @@ import { TipKeybindLabel } from '@/components/ui/tooltip'
 import { useContributions } from '@/contrib/react/use-contributions'
 import { searchSessions, type SessionInfo, type SessionSearchResult } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { useSidebarSwipe } from './use-sidebar-swipe'
 import { comboTokens } from '@/lib/keybinds/combo'
 import { profileColor } from '@/lib/profile-color'
 import { sessionMatchesSearch } from '@/lib/session-search'
@@ -340,6 +341,10 @@ export function ChatSidebar({
   const [messagingVisible, setMessagingVisible] = useState<Record<string, number>>({})
   const searchInputRef = useRef<HTMLInputElement>(null)
   const trimmedQuery = searchQuery.trim()
+
+  // Two-finger horizontal swipe on the sidebar → cycle profiles.
+  const sidebarRef = useRef<HTMLDivElement>(null)
+  useSidebarSwipe(sidebarRef)
 
   // Hotkey (session.focusSearch) → focus the field once it's mounted.
   useEffect(() => {
@@ -1095,6 +1100,7 @@ export function ChatSidebar({
       collapsible="none"
     >
       <SidebarContent className="gap-0 overflow-hidden bg-transparent px-2.5">
+        <div ref={sidebarRef} className="flex min-h-0 flex-1 flex-col">
         <SidebarGroup className="shrink-0 p-0 pb-2 pt-[calc(var(--titlebar-height)+0.375rem)]">
           <SidebarGroupContent>
             <SidebarMenu className="gap-px">
@@ -1480,6 +1486,7 @@ export function ChatSidebar({
 
         <div className="shrink-0 px-0.5 pb-1 pt-0.5">
           <ProfileRail />
+        </div>
         </div>
       </SidebarContent>
       <ProjectDialog />

--- a/apps/desktop/src/app/chat/sidebar/use-sidebar-swipe.ts
+++ b/apps/desktop/src/app/chat/sidebar/use-sidebar-swipe.ts
@@ -1,0 +1,90 @@
+// Two-finger horizontal swipe detection for the sidebar.
+//
+// On macOS, a two-finger horizontal swipe on a trackpad produces native
+// `wheel` events with a non‑zero `deltaX` and typically zero `deltaY`.
+// This hook discriminates deliberate swipes from ordinary vertical scrolling
+// and calls the profile‑cycle callback.
+//
+// Electron exposes no dedicated swipe‑gesture DOM event — the only reliable
+// signal is the wheel‑event delta, which is what every browser-based swipe
+// surface on macOS uses (see also: lib/trackpad-gestures).
+
+import { useCallback, useEffect, useRef, type RefObject } from 'react'
+
+import { cycleProfile } from '@/store/profile'
+
+/**
+ * Minimum accumulated horizontal delta (in pixels or equivalent) to treat as a
+ * deliberate swipe.
+ */
+const SWIPE_THRESHOLD_PX = 20
+
+/**
+ * Cooldown (ms) between consecutive profile cycles.
+ */
+const COOLDOWN_MS = 400
+
+/** Assumed line-height in pixels when deltaMode is DOM_DELTA_LINE. */
+const LINE_HEIGHT_PX = 20
+
+/**
+ * Resolve a wheel delta to equivalent pixels regardless of deltaMode.
+ */
+function resolveDeltaX(event: WheelEvent): number {
+  switch (event.deltaMode) {
+    case WheelEvent.DOM_DELTA_LINE:
+      return event.deltaX * LINE_HEIGHT_PX
+    case WheelEvent.DOM_DELTA_PAGE:
+      return event.deltaX * window.innerWidth
+    default:
+      return event.deltaX
+  }
+}
+
+/**
+ * Subscribe to a container element and fire `cycleProfile` on two‑finger
+ * horizontal swipes.
+ */
+export function useSidebarSwipe(containerRef: RefObject<HTMLElement | null>): void {
+  const lastCycleAt = useRef(0)
+
+  const handleWheel = useCallback((event: WheelEvent) => {
+    const dx = resolveDeltaX(event)
+    const dy = event.deltaY
+
+    // Ignore predominantly vertical movement
+    if (dy !== 0 && Math.abs(dx / dy) < 1.2) {
+      return
+    }
+
+    // Need enough horizontal movement
+    const absDx = Math.abs(dx)
+    if (absDx < SWIPE_THRESHOLD_PX) {
+      return
+    }
+
+    // Cooldown
+    const now = Date.now()
+    if (now - lastCycleAt.current < COOLDOWN_MS) {
+      event.preventDefault()
+      return
+    }
+
+    lastCycleAt.current = now
+    event.preventDefault()
+    event.stopPropagation()
+    cycleProfile(dx > 0 ? 1 : -1)
+  }, [])
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+
+    // Use capture phase to catch events before child scrollers consume them
+    el.addEventListener('wheel', handleWheel, { passive: false, capture: true })
+
+    return () => {
+      el.removeEventListener('wheel', handleWheel)
+    }
+  }, [containerRef, handleWheel])
+}


### PR DESCRIPTION

feat(desktop): two-finger swipe on sidebar to cycle profiles

Two-finger swipe on the sidebar content area to cycle through profiles.
Uses the existing `cycleProfile(1 | -1)` from `store/profile.ts` —
swipe right → next profile, left → previous.

Added `useSidebarSwipe` hook with:
- Native wheel event listener with capture phase (catches events before
  child scrollers)
- Proper `deltaMode` handling (lines/pages → pixels) for macOS trackpad
- 400ms cooldown to prevent rapid cycling
- Uses existing `cycleProfile(1 | -1)` from `store/profile.ts`

**2 files changed, 97 insertions:**
- `apps/desktop/src/app/chat/sidebar/use-sidebar-swipe.ts` — new hook (90 lines)
- `apps/desktop/src/app/chat/sidebar/index.tsx` — import + ref + wrapper (7 lines)