### PR TITLE
perf(discord): stream voice PCM to ffmpeg instead of a temp file

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -711,34 +711,32 @@ class VoiceReceiver:
     @staticmethod
     def pcm_to_wav(pcm_data: bytes, output_path: str,
                    src_rate: int = 48000, src_channels: int = 2):
-        """Convert raw PCM to 16kHz mono WAV via ffmpeg."""
-        with tempfile.NamedTemporaryFile(suffix=".pcm", delete=False) as f:
-            f.write(pcm_data)
-            pcm_path = f.name
-        try:
-            from hermes_cli._subprocess_compat import windows_hide_flags
+        """Convert raw PCM to 16kHz mono WAV via ffmpeg.
 
-            subprocess.run(
-                [
-                    "ffmpeg", "-y", "-loglevel", "error",
-                    "-f", "s16le",
-                    "-ar", str(src_rate),
-                    "-ac", str(src_channels),
-                    "-i", pcm_path,
-                    "-ar", "16000",
-                    "-ac", "1",
-                    output_path,
-                ],
-                check=True,
-                timeout=10,
-                stdin=subprocess.DEVNULL,
-                creationflags=windows_hide_flags(),
-            )
-        finally:
-            try:
-                os.unlink(pcm_path)
-            except OSError:
-                pass
+        The PCM is fed straight to ffmpeg's stdin, which avoids staging it in a
+        temp file on every utterance. The WAV is still written to *output_path*
+        rather than captured from stdout: ffmpeg cannot seek on a pipe, so a
+        piped WAV carries placeholder (0xFFFFFFFF) RIFF/data sizes that make
+        strict readers misreport the length.
+        """
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
+        subprocess.run(
+            [
+                "ffmpeg", "-y", "-loglevel", "error",
+                "-f", "s16le",
+                "-ar", str(src_rate),
+                "-ac", str(src_channels),
+                "-i", "pipe:0",
+                "-ar", "16000",
+                "-ac", "1",
+                output_path,
+            ],
+            input=pcm_data,
+            check=True,
+            timeout=10,
+            creationflags=windows_hide_flags(),
+        )
 
 
 def _read_dm_role_auth_guild() -> Optional[int]:

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -2974,3 +2974,54 @@ class TestShouldAutoTtsForChat:
         fn, adapter = self._make_adapter(default=False, enabled={"chat1"})
         assert fn(adapter, "chat1") is True
         assert fn(adapter, "chat2") is False
+
+
+class TestPcmToWav:
+    """pcm_to_wav streams PCM through ffmpeg's stdin, not a temp file."""
+
+    def test_pcm_is_piped_to_stdin_not_staged_on_disk(self, tmp_path):
+        from plugins.platforms.discord.adapter import VoiceReceiver
+
+        out = tmp_path / "out.wav"
+        with patch("plugins.platforms.discord.adapter.subprocess.run") as run:
+            VoiceReceiver.pcm_to_wav(b"\x00\x01" * 16, str(out))
+
+        args, kwargs = run.call_args
+        cmd = args[0]
+        assert kwargs["input"] == b"\x00\x01" * 16, "PCM must be fed via stdin"
+        assert "pipe:0" in cmd, "ffmpeg must read the PCM from stdin"
+        assert cmd[-1] == str(out), (
+            "the WAV must be written to the real path; ffmpeg cannot seek on a "
+            "pipe, so a piped WAV gets placeholder RIFF/data sizes"
+        )
+        assert not any(str(a).endswith(".pcm") for a in cmd), (
+            "no temp .pcm file should be staged"
+        )
+
+    @pytest.mark.skipif(
+        __import__("shutil").which("ffmpeg") is None, reason="ffmpeg not installed",
+    )
+    def test_output_wav_header_reports_true_length(self, tmp_path):
+        """A piped-stdout WAV reports 0xFFFFFFFF sizes; the written file must not."""
+        import math
+        import struct
+        import wave
+
+        from plugins.platforms.discord.adapter import VoiceReceiver
+
+        frames = 48000  # 1s @ 48kHz stereo
+        pcm = b"".join(
+            struct.pack("<hh", v, v)
+            for v in (
+                int(20000 * math.sin(2 * math.pi * 440 * i / 48000))
+                for i in range(frames)
+            )
+        )
+        out = tmp_path / "out.wav"
+        VoiceReceiver.pcm_to_wav(pcm, str(out))
+
+        with wave.open(str(out)) as w:
+            assert w.getnchannels() == 1
+            assert w.getframerate() == 16000
+            # 48kHz -> 16kHz is a 3x decimation of a 1s clip.
+            assert w.getnframes() == 16000


### PR DESCRIPTION
## What

`VoiceReceiver.pcm_to_wav` staged every captured utterance in a `NamedTemporaryFile` purely to give ffmpeg an input path, then unlinked it. This pipes the PCM to ffmpeg's stdin instead.

Per voice utterance that removes one file created, written, read back and deleted — on a path that runs for every spoken message (`adapter.py` calls it via `asyncio.to_thread` on each utterance). The `try/finally` cleanup goes away with it, so the function gets shorter as well as faster.

## Why the WAV still goes to a file, not stdout

The obvious next step — capture the WAV from stdout too — is a trap, and worth recording here.

ffmpeg cannot seek on a pipe, so it cannot go back and patch the RIFF/`data` chunk sizes after writing. A WAV produced with `-f wav pipe:1` carries placeholder `0xFFFFFFFF` sizes. Measured on a 1s 48kHz stereo clip:

| output | RIFF size field | `data` size field | `wave.getnframes()` |
|---|---|---|---|
| `pipe:1` | 4294967295 | 4294967295 | **2147483647** |
| `output_path` | 32070 (correct) | 32000 (correct) | **16000** (correct) |

Any reader that trusts the header — which is the whole point of writing a WAV rather than raw PCM for STT — misjudges the length. So the input is piped and the output keeps its real, seekable path.

## Tests

- `test_pcm_is_piped_to_stdin_not_staged_on_disk` — asserts the PCM goes over `input=`, that `pipe:0` is used, that the final arg is the real output path, and that no `.pcm` temp file appears in the command.
- `test_output_wav_header_reports_true_length` — skipped when ffmpeg isn't installed; converts a real 1s tone and asserts the header reports 16000 frames rather than the piped-stdout placeholder.

Full `tests/gateway/test_voice_command.py` + `test_discord_voice_mixer.py`: 208 passed.