### PR TITLE
fix(discord): treat a rejected bot token as non-retryable

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1237,6 +1237,17 @@ class DiscordAdapter(BasePlatformAdapter):
             await self._cancel_bot_task()
             self._release_platform_lock()
             return False
+        except discord.LoginFailure as e:
+            # Discord rejected the token. Retrying cannot fix that, and the
+            # generic handler below would leave the failure retryable, so the
+            # supervisor re-attempts on the reconnect backoff indefinitely --
+            # each attempt another failed identify that Discord penalizes.
+            logger.error("[%s] Discord rejected the bot token: %s", self.name, e)
+            self._set_fatal_error("discord_auth_failed", str(e), retryable=False)
+            # Same zombie-client hazard as the timeout branch (see below).
+            await self._cancel_bot_task()
+            self._release_platform_lock()
+            return False
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to connect to Discord: %s", self.name, e, exc_info=True)
             # Same zombie-client hazard as the timeout branch: the background

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -124,6 +124,10 @@ def _ensure_discord_mock() -> None:
     discord_mod.Thread = type("Thread", (), {})
     discord_mod.ForumChannel = type("ForumChannel", (), {})
     discord_mod.Interaction = object
+    # A real subclass, not Exception itself: connect() catches LoginFailure
+    # ahead of a generic `except Exception`, and aliasing the two would make
+    # that generic handler unreachable under test.
+    discord_mod.LoginFailure = type("LoginFailure", (Exception,), {})
     discord_mod.Message = type("Message", (), {})
 
     # Embed: accept the kwargs production code / tests use

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -332,6 +332,76 @@ async def test_connect_releases_token_lock_on_timeout(monkeypatch):
     assert adapter._platform_lock_identity is None
 
 
+async def _connect_raising(monkeypatch, exc, token="test-token"):
+    """Drive connect() to failure with *exc* raised from the ready wait."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token=token))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    released = []
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: released.append((scope, identity)))
+
+    intents = SimpleNamespace(message_content=False, dm_messages=False, guild_messages=False, members=False, voice_states=False)
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+    monkeypatch.setattr(
+        discord_platform.commands,
+        "Bot",
+        lambda **kwargs: FakeBot(
+            intents=kwargs["intents"],
+            proxy=kwargs.get("proxy"),
+            allowed_mentions=kwargs.get("allowed_mentions"),
+        ),
+    )
+
+    async def fake_wait_for_ready(ready_event, bot_task, timeout):
+        raise exc
+
+    monkeypatch.setattr(
+        discord_platform, "_wait_for_ready_or_bot_exit", fake_wait_for_ready
+    )
+
+    ok = await adapter.connect()
+    return adapter, ok, released
+
+
+@pytest.mark.asyncio
+async def test_connect_marks_login_failure_non_retryable(monkeypatch):
+    """A rejected token cannot start working on a retry.
+
+    Left retryable, the supervisor re-attempts on the reconnect backoff
+    forever, and every attempt is another failed identify against Discord.
+    """
+    import discord
+
+    adapter, ok, released = await _connect_raising(
+        monkeypatch,
+        discord.LoginFailure("Improper token has been passed."),
+        token="bad-token",
+    )
+
+    assert ok is False
+    assert adapter.fatal_error_code == "discord_auth_failed"
+    assert adapter.fatal_error_retryable is False
+    assert released == [("discord-bot-token", "bad-token")]
+    assert adapter._platform_lock_identity is None
+
+
+@pytest.mark.asyncio
+async def test_connect_generic_failure_stays_retryable(monkeypatch):
+    """The LoginFailure branch must not shadow the generic handler.
+
+    A transient fault (DNS, proxy, network blip) still has to be retryable, so
+    it must not be recorded as an auth failure.
+    """
+    adapter, ok, released = await _connect_raising(
+        monkeypatch, RuntimeError("proxy connect failed"),
+    )
+
+    assert ok is False
+    assert adapter.fatal_error_code != "discord_auth_failed"
+    assert adapter.fatal_error_retryable is True
+    assert released == [("discord-bot-token", "test-token")]
+
+
 @pytest.mark.asyncio
 async def test_connect_timeout_cancels_bot_task(monkeypatch):
     """Regression: connect() timeout must cancel _bot_task so the zombie


### PR DESCRIPTION
## The bug

`DiscordAdapter.connect()` has no handler for `discord.LoginFailure`, so a rejected token falls through to the generic `except Exception` at the end of the method. That branch logs and returns `False` but never calls `_set_fatal_error`, so `_fatal_error_retryable` keeps its constructor default of `True` (`gateway/platforms/base.py:2449`).

`GatewayRunner` reads that flag and queues the platform for background reconnection when it's true. The result: an auth rejection is retried on the reconnect backoff (30s, 60s, 120s, … capped at 5 min) forever. Retrying cannot fix it — the token is wrong — and every attempt is another failed identify, which Discord penalizes.

Rotating or revoking a bot token is enough to trigger this.

## The fix

Catch `LoginFailure` ahead of the generic handler and record it with `retryable=False`, so the runner drops the platform and renders a clear disabled state instead of looping.

The handler is deliberately **specific, not broad**, so the generic `except Exception` below stays reachable — transient faults (DNS, proxy, network blips) must remain retryable. There's a regression test pinning exactly that.

## Test-stub note

The shared gateway conftest gains a `LoginFailure` stub. It's a distinct `Exception` subclass rather than an alias of `Exception`, because aliasing the two would make the generic handler unreachable under test and quietly void the second test below. This mirrors how the same file already stubs PTB's error hierarchy.

## Tests

- `test_connect_marks_login_failure_non_retryable` — asserts `fatal_error_code == "discord_auth_failed"`, `fatal_error_retryable is False`, and that the token lock is still released. Verified to fail when the new handler is removed.
- `test_connect_generic_failure_stays_retryable` — a `RuntimeError` from the same path must stay retryable and must not be recorded as an auth failure. This is the guard against the new handler shadowing the existing one.

`tests/gateway/test_discord_connect.py` passes; the wider `tests/gateway` run shows no regressions against the upstream baseline.