### PR TITLE
fix(gateway): read Slack thread-context messages whose text lives in blocks/attachments (#68138)

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4390,6 +4390,21 @@ class SlackAdapter(BasePlatformAdapter):
 
                 msg_text = msg.get("text", "").strip()
                 if not msg_text:
+                    # Alerting integrations (Grafana, etc.) and older webhook
+                    # bots carry their content in Block Kit blocks or legacy
+                    # attachments with an empty plain-text field. Fall back the
+                    # same way the main message handler does so these messages
+                    # aren't dropped from thread context.
+                    msg_text = _extract_text_from_slack_blocks(
+                        msg.get("blocks", [])
+                    ).strip()
+                if not msg_text:
+                    for att in msg.get("attachments", []):
+                        att_text = (att.get("text", "") or att.get("fallback", "")).strip()
+                        if att_text:
+                            msg_text = att_text
+                            break
+                if not msg_text:
                     continue
 
                 # Strip bot mentions from context messages

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -4995,3 +4995,76 @@ class TestThreadContextUnverifiedTagging:
         # Renders successfully without trust tag (exception → unknown trust).
         assert "U_X: hello" in content
         assert "[unverified]" not in content
+
+    @pytest.mark.asyncio
+    async def test_thread_context_reads_block_only_alert(self, adapter):
+        """Alerting integrations (Grafana, etc.) post messages whose content
+        lives in Block Kit ``blocks`` with an empty plain ``text`` field. The
+        thread-context loop must fall back to block extraction instead of
+        dropping the message, so the agent can see what it is replying under."""
+        adapter._thread_context_cache.clear()
+        adapter._app.client.conversations_replies = self._make_replies([
+            {
+                "ts": "100.0",
+                "user": "",
+                "username": "Grafana",
+                "bot_id": "B_GRAFANA",
+                "text": "",
+                "blocks": [
+                    {
+                        "type": "rich_text",
+                        "elements": [
+                            {
+                                "type": "rich_text_section",
+                                "elements": [
+                                    {"type": "text", "text": "FIRING: High CPU on prod-db"}
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+            {"ts": "101.0", "user": "U_BOB", "text": "on it"},
+        ])
+
+        with patch.object(
+            adapter, "_resolve_user_name",
+            new=AsyncMock(side_effect=lambda uid, **_: uid),
+        ):
+            content = await adapter._fetch_thread_context(
+                channel_id="C1", thread_ts="100.0", current_ts="999.0",
+            )
+
+        assert "FIRING: High CPU on prod-db" in content
+        assert "U_BOB: on it" in content
+
+    @pytest.mark.asyncio
+    async def test_thread_context_reads_attachment_only_message(self, adapter):
+        """Legacy webhook bots carry content in ``attachments`` (text/fallback)
+        with an empty ``text``. The thread-context loop must fall back to the
+        attachment text rather than skipping the message."""
+        adapter._thread_context_cache.clear()
+        adapter._app.client.conversations_replies = self._make_replies([
+            {
+                "ts": "100.0",
+                "user": "",
+                "username": "LegacyBot",
+                "bot_id": "B_LEGACY",
+                "text": "",
+                "attachments": [
+                    {"text": "Disk usage at 95% on web-01", "fallback": "disk alert"}
+                ],
+            },
+            {"ts": "101.0", "user": "U_BOB", "text": "acking"},
+        ])
+
+        with patch.object(
+            adapter, "_resolve_user_name",
+            new=AsyncMock(side_effect=lambda uid, **_: uid),
+        ):
+            content = await adapter._fetch_thread_context(
+                channel_id="C1", thread_ts="100.0", current_ts="999.0",
+            )
+
+        assert "Disk usage at 95% on web-01" in content
+        assert "U_BOB: acking" in content


### PR DESCRIPTION
## What does this PR do?

When the agent is @mentioned inside a Slack thread, `_fetch_thread_context`
builds context from prior messages but read only `msg["text"]`, skipping any
message with an empty plain-text field. Messages posted by alerting
integrations (Grafana, etc.) and older webhook bots carry their content in
Block Kit **blocks** or legacy **attachments** with an empty `text`, so they
were dropped entirely. The agent then answers something like "I don't see any
incident description in this thread" while replying literally under the alert.

The **main** message handler already falls back to
`_extract_text_from_slack_blocks(...)` and attachment text/fallback; the
thread-context path never got the same treatment. This PR applies the same
fallback there.

## Related Issue

Fixes #68138

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/slack/adapter.py` — in the `_fetch_thread_context` loop,
  when `msg["text"]` is empty, fall back to
  `_extract_text_from_slack_blocks(msg.get("blocks", []))`, then to attachment
  `text`/`fallback`, before skipping the message.
- `tests/gateway/test_slack.py` — added two regression tests under
  `TestThreadContextUnverifiedTagging`: a block-only Grafana-style alert and an
  attachment-only legacy-bot message are now both surfaced in thread context.

## How to Test

```
scripts/run_tests.sh tests/gateway/test_slack.py -k ThreadContext -q
```

Both new tests (`test_thread_context_reads_block_only_alert`,
`test_thread_context_reads_attachment_only_message`) pass along with the
existing thread-context suite (14 passed). Preflight (windows-footguns, ruff,
affected tests) is green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected tests and they pass (`scripts/run_tests.sh tests/gateway/test_slack.py -k ThreadContext -q`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (pure Python, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Credits

Root cause independently confirmed by @alloevil in the issue thread, who
pinpointed the exact `adapter.py` lines and the inconsistency with the main
handler's `_extract_text_from_slack_blocks` fallback.
