### PR TITLE
fix(memory): activate holographic HRR setup

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -80,7 +80,10 @@ def _prompt(label: str, default: str | None = None, secret: bool = False) -> str
 def _install_dependencies(provider_name: str) -> None:
     """Install pip dependencies declared in plugin.yaml."""
     import subprocess
-    from plugins.memory import find_provider_dir
+    from plugins.memory import (
+        find_provider_dir,
+        memory_provider_dependency_satisfied,
+    )
 
     plugin_dir = find_provider_dir(provider_name)
     if not plugin_dir:
@@ -100,22 +103,10 @@ def _install_dependencies(provider_name: str) -> None:
     if not pip_deps:
         return
 
-    # pip name → import name mapping for packages where they differ
-    _IMPORT_NAMES = {
-        "honcho-ai": "honcho",
-        "mem0ai": "mem0",
-        "hindsight-client": "hindsight_client",
-        "hindsight-all": "hindsight",
-    }
-
     # Check which packages are missing
-    missing = []
-    for dep in pip_deps:
-        import_name = _IMPORT_NAMES.get(dep, dep.replace("-", "_").split("[")[0])
-        try:
-            __import__(import_name)
-        except ImportError:
-            missing.append(dep)
+    missing = [
+        dep for dep in pip_deps if not memory_provider_dependency_satisfied(dep)
+    ]
 
     if not missing:
         return

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5167,32 +5167,10 @@ def _memory_provider_setup_info(name: str) -> Dict[str, Any]:
     return setup
 
 
-_MEMORY_PROVIDER_IMPORT_NAMES = {
-    "honcho-ai": "honcho",
-    "mem0ai": "mem0",
-    "hindsight-client": "hindsight_client",
-    "hindsight-all": "hindsight",
-}
-
-
-def _memory_provider_dependency_package(dep: str) -> str:
-    return re.split(r"[\[<>=!~;]", dep, maxsplit=1)[0].strip()
-
-
-def _memory_provider_import_name(dep: str) -> str:
-    package = _memory_provider_dependency_package(dep)
-    return _MEMORY_PROVIDER_IMPORT_NAMES.get(package, package.replace("-", "_"))
-
-
 def _dependency_importable(dep: str) -> bool:
-    import_name = _memory_provider_import_name(dep)
-    if not import_name:
-        return False
-    try:
-        __import__(import_name)
-        return True
-    except ImportError:
-        return False
+    from plugins.memory import memory_provider_dependency_satisfied
+
+    return memory_provider_dependency_satisfied(dep)
 
 
 def _trim_setup_output(value: Optional[str], limit: int = 4000) -> str:

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -34,6 +34,13 @@ logger = logging.getLogger(__name__)
 
 _MEMORY_PLUGINS_DIR = Path(__file__).parent
 
+_DEPENDENCY_IMPORT_NAMES = {
+    "honcho-ai": "honcho",
+    "mem0ai": "mem0",
+    "hindsight-client": "hindsight_client",
+    "hindsight-all": "hindsight",
+}
+
 # Synthetic parent package for user-installed providers, so they don't
 # collide with bundled providers in sys.modules.
 _USER_NAMESPACE = "_hermes_user_memory"
@@ -137,6 +144,43 @@ def find_provider_dir(name: str) -> Optional[Path]:
         if user.is_dir() and _is_memory_provider_dir(user):
             return user
     return None
+
+
+def memory_provider_dependency_satisfied(spec: str) -> bool:
+    """Return whether a manifest dependency is importable at a valid version."""
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+        from packaging.requirements import Requirement
+        from packaging.utils import canonicalize_name
+    except ImportError:
+        return False
+    try:
+        requirement = Requirement(spec)
+    except Exception:
+        return False
+
+    if requirement.marker is not None and not requirement.marker.evaluate():
+        return True
+
+    canonical_package = canonicalize_name(requirement.name)
+    import_name = _DEPENDENCY_IMPORT_NAMES.get(
+        canonical_package, canonical_package.replace("-", "_")
+    )
+    try:
+        __import__(import_name)
+    except ImportError:
+        return False
+
+    if not requirement.specifier:
+        return True
+    try:
+        return requirement.specifier.contains(
+            version(requirement.name), prereleases=True
+        )
+    except PackageNotFoundError:
+        return False
+    except Exception:
+        return False
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/memory/holographic/README.md
+++ b/plugins/memory/holographic/README.md
@@ -4,7 +4,8 @@ Local SQLite fact store with FTS5 search, trust scoring, entity resolution, and 
 
 ## Requirements
 
-None — uses SQLite (always available). NumPy optional for HRR algebra.
+SQLite is always available. The setup wizard installs NumPy for HRR algebra;
+without NumPy the provider falls back to FTS5 and token-overlap retrieval.
 
 ## Setup
 
@@ -14,6 +15,7 @@ hermes memory setup    # select "holographic"
 
 Or manually:
 ```bash
+uv pip install --python "$(command -v python)" numpy==2.4.3  # enables HRR algebra
 hermes config set memory.provider holographic
 ```
 

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -27,6 +27,7 @@ from tools.registry import tool_error
 from .store import MemoryStore
 from .retrieval import FactRetriever
 from hermes_cli.config import cfg_get
+from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -235,7 +236,7 @@ class HolographicMemoryProvider(MemoryProvider):
         return tool_error(f"Unknown tool: {tool_name}")
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
-        if not self._config.get("auto_extract", False):
+        if not is_truthy_value(self._config.get("auto_extract"), default=False):
             return
         if not self._store or not messages:
             return

--- a/plugins/memory/holographic/plugin.yaml
+++ b/plugins/memory/holographic/plugin.yaml
@@ -1,5 +1,7 @@
 name: holographic
 version: 0.1.0
 description: "Holographic memory — local SQLite fact store with FTS5 search, trust scoring, and HRR-based compositional retrieval."
+pip_dependencies:
+  - numpy==2.4.3
 hooks:
   - on_session_end

--- a/tests/hermes_cli/test_memory_setup_provider_arg.py
+++ b/tests/hermes_cli/test_memory_setup_provider_arg.py
@@ -103,3 +103,28 @@ class TestInstallDependenciesRunner:
         calls, py = self._run_with_missing_dep(tmp_path, lambda b: None, behavior)
         assert any("ensurepip" in c for c in calls)
         assert calls[-1][:4] == [py, "-m", "pip", "install"]
+
+    def test_versioned_dependency_uses_shared_satisfaction_check(self, tmp_path):
+        (tmp_path / "plugin.yaml").write_text(
+            "pip_dependencies:\n  - numpy==2.4.3\n", encoding="utf-8"
+        )
+
+        with patch("plugins.memory.find_provider_dir", return_value=tmp_path), \
+             patch("plugins.memory.memory_provider_dependency_satisfied", return_value=True) as satisfied, \
+             patch("hermes_cli.tools_config._pip_install") as pip_install:
+            memory_setup._install_dependencies("holographic")
+
+        satisfied.assert_called_once_with("numpy==2.4.3")
+        pip_install.assert_not_called()
+
+    def test_installed_package_at_wrong_version_is_reinstalled(self, tmp_path):
+        (tmp_path / "plugin.yaml").write_text(
+            "pip_dependencies:\n  - numpy==0.0.0\n", encoding="utf-8"
+        )
+
+        result = SimpleNamespace(returncode=0, stdout="", stderr="")
+        with patch("plugins.memory.find_provider_dir", return_value=tmp_path), \
+             patch("hermes_cli.tools_config._pip_install", return_value=result) as pip_install:
+            memory_setup._install_dependencies("holographic")
+
+        pip_install.assert_called_once_with(["--quiet", "numpy==0.0.0"], timeout=120)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -603,6 +603,16 @@ class TestWebServerEndpoints:
         assert config_resp.status_code == 200
         assert config_resp.json()["setup"]["external_dependencies"] == byterover_setup["external_dependencies"]
 
+    def test_memory_provider_dependency_check_honors_version_specifier(self):
+        from importlib.metadata import version
+
+        import hermes_cli.web_server as web_server
+
+        installed = version("httpx")
+        assert web_server._dependency_importable(f"httpx=={installed}") is True
+        assert web_server._dependency_importable(f"HTTPX=={installed}") is True
+        assert web_server._dependency_importable("httpx==0.0.0") is False
+
     def test_memory_status_reports_honcho_needs_config_after_dependency_setup(self, monkeypatch, tmp_path):
         # Pin HOME so a developer's real ~/.honcho config can't flip the status.
         monkeypatch.setenv("HOME", str(tmp_path))

--- a/tests/plugins/memory/test_holographic_provider_config.py
+++ b/tests/plugins/memory/test_holographic_provider_config.py
@@ -1,0 +1,64 @@
+"""Behavior tests for Holographic memory provider configuration."""
+
+from pathlib import Path
+
+import yaml
+
+from plugins.memory.holographic import HolographicMemoryProvider
+
+
+def test_auto_extract_string_false_disables_session_end_extraction(tmp_path):
+    provider = HolographicMemoryProvider(
+        config={
+            "db_path": str(tmp_path / "memory_store.db"),
+            "auto_extract": "false",
+        }
+    )
+    provider.initialize("session-1")
+
+    try:
+        provider.on_session_end(
+            [{"role": "user", "content": "I prefer concise answers in every conversation."}]
+        )
+
+        store = provider._store
+        assert store is not None
+        assert store.list_facts() == []
+    finally:
+        provider.shutdown()
+
+
+def test_auto_extract_string_true_enables_session_end_extraction(tmp_path):
+    provider = HolographicMemoryProvider(
+        config={
+            "db_path": str(tmp_path / "memory_store.db"),
+            "auto_extract": "true",
+        }
+    )
+    provider.initialize("session-1")
+
+    try:
+        provider.on_session_end(
+            [{"role": "user", "content": "I prefer concise answers in every conversation."}]
+        )
+
+        store = provider._store
+        assert store is not None
+        assert [fact["content"] for fact in store.list_facts()] == [
+            "I prefer concise answers in every conversation."
+        ]
+    finally:
+        provider.shutdown()
+
+
+def test_plugin_declares_numpy_for_hrr_algebra():
+    plugin_path = (
+        Path(__file__).resolve().parents[3]
+        / "plugins"
+        / "memory"
+        / "holographic"
+        / "plugin.yaml"
+    )
+    metadata = yaml.safe_load(plugin_path.read_text(encoding="utf-8"))
+
+    assert "numpy==2.4.3" in metadata.get("pip_dependencies", [])

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -446,8 +446,8 @@ Local SQLite fact store with FTS5 full-text search, trust scoring, and HRR (Holo
 
 | | |
 |---|---|
-| **Best for** | Local-only memory with advanced retrieval, no external dependencies |
-| **Requires** | Nothing (SQLite is always available). NumPy optional for HRR algebra. |
+| **Best for** | Local-only memory with advanced retrieval and no external service |
+| **Requires** | SQLite (always available). Setup installs NumPy for HRR algebra. |
 | **Data storage** | Local SQLite |
 | **Cost** | Free |
 
@@ -457,6 +457,7 @@ Local SQLite fact store with FTS5 full-text search, trust scoring, and HRR (Holo
 ```bash
 hermes memory setup    # select "holographic"
 # Or manually:
+uv pip install --python "$(command -v python)" numpy==2.4.3  # enables HRR algebra
 hermes config set memory.provider holographic
 ```
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
@@ -376,8 +376,8 @@ echo "HINDSIGHT_API_KEY=your-key" >> ~/.hermes/.env
 
 | | |
 |---|---|
-| **适合场景** | 无外部依赖的纯本地高级检索记忆 |
-| **依赖** | 无（SQLite 始终可用）。NumPy 可选，用于 HRR 代数。 |
+| **适合场景** | 无外部服务的纯本地高级检索记忆 |
+| **依赖** | SQLite（始终可用）。安装向导会安装 NumPy 以启用 HRR 代数。 |
 | **数据存储** | 本地 SQLite |
 | **费用** | 免费 |
 
@@ -387,6 +387,7 @@ echo "HINDSIGHT_API_KEY=your-key" >> ~/.hermes/.env
 ```bash
 hermes memory setup    # 选择 "holographic"
 # 或手动配置：
+uv pip install --python "$(command -v python)" numpy==2.4.3  # 启用 HRR 代数
 hermes config set memory.provider holographic
 ```
 


### PR DESCRIPTION
## Summary
- parse string-valued Holographic `auto_extract` flags safely
- install pinned NumPy through memory-provider setup so HRR is active
- verify declared dependency versions consistently in CLI and dashboard paths

## Verification
- `scripts/run_tests.sh` targeted suite: 532 passed
- Ruff: all changed Python files passed
- live smoke test: NumPy 2.4.3, HRR vector 8192 bytes, search returned the stored fact

No historical sessions are backfilled.