### PR TITLE
fix(cli): wait for background MCP discovery before building the one-shot agent (#68137)

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -395,6 +395,21 @@ def _run_agent(
     if toolsets_list is None and use_config_toolsets:
         toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
 
+    # CLI startup kicks MCP discovery onto a background thread for the one-shot
+    # command (see hermes_cli.main._should_background_mcp_startup). AIAgent
+    # snapshots the tool registry at construction, so — exactly like the
+    # interactive path (cli_agent_setup_mixin) — we must wait for that discovery
+    # to finish first; otherwise slow stdio MCP servers are silently dropped and
+    # the model runs without their tools. The wait is a no-op when no discovery
+    # is in flight and is bounded by ``mcp_discovery_timeout`` so a dead server
+    # can't hang the one-shot.
+    try:
+        from hermes_cli.mcp_startup import wait_for_mcp_discovery
+
+        wait_for_mcp_discovery()
+    except Exception:
+        logging.debug("oneshot MCP discovery wait failed", exc_info=True)
+
     session_db = _create_session_db_for_oneshot()
     # The try spans agent construction (not just ``chat``) so the SQLite store
     # opened above is always closed — including when ``AIAgent(...)`` itself

--- a/tests/hermes_cli/test_oneshot_mcp_wait.py
+++ b/tests/hermes_cli/test_oneshot_mcp_wait.py
@@ -1,0 +1,83 @@
+"""Regression: one-shot (`hermes -z`) must wait for background MCP discovery
+before building the agent, so slow stdio MCP servers aren't silently dropped.
+
+See the issue: CLI startup kicks MCP discovery onto the ``cli-mcp-discovery``
+background thread for the one-shot command, but ``_run_agent`` used to build
+``AIAgent`` (which snapshots the tool registry) without joining that thread —
+so tools from slow servers never reached the model. The fix mirrors the
+interactive path by calling ``wait_for_mcp_discovery()`` first.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from hermes_cli import oneshot
+
+
+def _run_agent_with_stubs(calls):
+    """Invoke oneshot._run_agent with every collaborator stubbed, recording the
+    order in which discovery-wait and agent construction happen in ``calls``."""
+
+    def _record_wait():
+        calls.append("wait")
+
+    def _make_agent(*_args, **_kwargs):
+        calls.append("agent")
+        agent = MagicMock()
+        agent.run_conversation.return_value = {"final_response": "ok"}
+        return agent
+
+    runtime = {
+        "api_key": "k",
+        "base_url": "https://example.test",
+        "provider": "openrouter",
+        "api_mode": "openai",
+        "credential_pool": None,
+    }
+
+    with patch("hermes_cli.config.load_config", return_value={}), \
+        patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=runtime), \
+        patch("hermes_cli.tools_config._get_platform_tools", return_value=set()), \
+        patch("hermes_cli.oneshot.get_fallback_chain", return_value=[]), \
+        patch("hermes_cli.oneshot._create_session_db_for_oneshot", return_value=None), \
+        patch("hermes_cli.mcp_startup.wait_for_mcp_discovery", side_effect=_record_wait), \
+        patch("run_agent.AIAgent", side_effect=_make_agent):
+        return oneshot._run_agent("say hi", model="openrouter/some-model")
+
+
+class TestOneshotWaitsForMcpDiscovery:
+    def test_waits_before_building_agent(self):
+        calls: list[str] = []
+        response, result = _run_agent_with_stubs(calls)
+
+        assert response == "ok"
+        assert result == {"final_response": "ok"}
+        # The wait must happen, and it must happen BEFORE the agent snapshots
+        # the tool registry — otherwise slow MCP servers are dropped.
+        assert "wait" in calls, "wait_for_mcp_discovery was never called"
+        assert calls.index("wait") < calls.index("agent")
+
+    def test_wait_failure_does_not_break_oneshot(self):
+        """A failure while waiting must not abort the one-shot run."""
+        def _boom():
+            raise RuntimeError("discovery join blew up")
+
+        runtime = {
+            "api_key": "k",
+            "base_url": "https://example.test",
+            "provider": "openrouter",
+            "api_mode": "openai",
+            "credential_pool": None,
+        }
+        agent = MagicMock()
+        agent.run_conversation.return_value = {"final_response": "ok"}
+
+        with patch("hermes_cli.config.load_config", return_value={}), \
+            patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=runtime), \
+            patch("hermes_cli.tools_config._get_platform_tools", return_value=set()), \
+            patch("hermes_cli.oneshot.get_fallback_chain", return_value=[]), \
+            patch("hermes_cli.oneshot._create_session_db_for_oneshot", return_value=None), \
+            patch("hermes_cli.mcp_startup.wait_for_mcp_discovery", side_effect=_boom), \
+            patch("run_agent.AIAgent", return_value=agent):
+            response, _ = oneshot._run_agent("say hi", model="openrouter/some-model")
+
+        assert response == "ok"


### PR DESCRIPTION
## What does this PR do?

`hermes -z` (one-shot) snapshots the tool registry **before** background MCP
discovery finishes. CLI startup kicks MCP discovery onto the
`cli-mcp-discovery` background thread for the one-shot command
(`_should_background_mcp_startup`), but `hermes_cli/oneshot.py:_run_agent`
built `AIAgent` — which snapshots the tool registry at construction — without
ever joining that thread.

Fast servers (a compiled binary like `mcp-grafana`) usually make it in; slower
stdio servers (a Python-based MCP that takes several seconds to import/boot)
are **silently dropped** — the agent runs without their tools, with no error
anywhere. Since the model never sees the tools, it sometimes refuses the task
and sometimes fabricates a plausible answer as if it had called the tool.

The interactive path already waits (`cli_agent_setup_mixin` calls
`wait_for_mcp_discovery()`); the one-shot path just never got the same
treatment. This PR adds that wait before constructing the agent.

## Related Issue

Fixes #68137

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/oneshot.py` — in `_run_agent`, call
  `wait_for_mcp_discovery()` before building `AIAgent`. The wait is a no-op
  when no discovery thread is in flight and is bounded by
  `mcp_discovery_timeout`, so a dead server can't hang the one-shot; failures
  are swallowed (debug-logged) so they never abort the run.
- `tests/hermes_cli/test_oneshot_mcp_wait.py` — new regression tests: the wait
  is invoked **before** the agent is constructed, and a wait that raises does
  not break the one-shot run.

## How to Test

```
scripts/run_tests.sh tests/hermes_cli/test_oneshot_mcp_wait.py -q
```

Both tests pass. Verified the ordering test genuinely fails without the
source change (stashed the fix → `test_waits_before_building_agent` fails).
Preflight (windows-footguns, ruff, affected tests) is green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected tests and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (pure Python, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Notes

The issue also flags a related quirk: under `-p <profile>`, `load_config()`
resolves the **profile** config, so a globally-set `mcp_discovery_timeout` may
not be honored by profile runs. That is a separate config-resolution concern
and is intentionally left out of this focused fix.
