### PR TITLE
fix(doctor): accept runtime model provider plugins

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -882,6 +882,26 @@ def run_doctor(args):
                 if name:
                     known_providers.add("custom:" + name.lower().replace(" ", "-"))
 
+            # Runtime model-provider plugins have their own lazy registry. Doctor
+            # must consult the same registry before rejecting a configured id;
+            # otherwise a loaded user plugin can appear in the printed known
+            # list while still being marked unknown by the static catalogs.
+            plugin_provider_ids: set[str] = set()
+            try:
+                from providers import list_providers as _list_plugin_providers
+                for profile in _list_plugin_providers():
+                    profile_name = str(getattr(profile, "name", "") or "").strip().lower()
+                    if profile_name:
+                        plugin_provider_ids.add(profile_name)
+                    plugin_provider_ids.update(
+                        str(alias).strip().lower()
+                        for alias in (getattr(profile, "aliases", ()) or ())
+                        if str(alias).strip()
+                    )
+            except Exception:
+                pass
+            known_providers.update(plugin_provider_ids)
+
             valid_provider_ids = set(known_providers)
             provider_ids_to_accept = {provider} if provider else set()
             if _normalize_catalog_provider is not None:
@@ -907,7 +927,7 @@ def run_doctor(args):
             if (
                 provider
                 and _resolve_provider_full is not None
-                and provider not in {"auto", "custom"}
+                and provider not in ({"auto", "custom"} | plugin_provider_ids)
             ):
                 provider_def = _resolve_provider_full(provider, user_providers, custom_providers)
                 catalog_provider = provider_def.id if provider_def is not None else None

--- a/tests/test_doctor_plugin_provider.py
+++ b/tests/test_doctor_plugin_provider.py
@@ -1,0 +1,12 @@
+import inspect
+
+import hermes_cli.doctor as doctor
+
+
+def test_doctor_accepts_runtime_model_provider_plugin():
+    """Doctor must not reject providers resolved by the runtime plugin registry."""
+    source = inspect.getsource(doctor.run_doctor)
+
+    assert "from providers import list_providers as _list_plugin_providers" in source
+    assert "known_providers.update(plugin_provider_ids)" in source
+    assert 'provider not in ({"auto", "custom"} | plugin_provider_ids)' in source


### PR DESCRIPTION
## Summary
- include the lazy runtime model-provider plugin registry in Doctor provider validation
- avoid forcing runtime plugin ids through the static models.dev resolver
- add a regression assertion for the validation contract

## Bug
A working user model-provider plugin can be loaded and used for real inference while `hermes doctor` reports it as unknown. With the OmniRoute user plugin, Doctor even prints `omniroute` in the known list while rejecting it. This is tracked in #58759.

## Root cause
Runtime inference discovers profiles through `providers.list_providers()`, including `$HERMES_HOME/plugins/model-providers/*`. Doctor only checked the auth/models.dev/user-config catalogs and then required `resolve_provider_full()`, which does not own runtime plugins.

## Verification
- new regression test passes in the Hermes venv
- `python -m compileall hermes_cli/doctor.py` passes
- disposable live validation with the existing OmniRoute user plugin removes the false Doctor error
- real Hermes inference remains healthy (`HERMES_UPDATE_OK`)

Addresses the third-party plugin variant of #58759.