### PR TITLE
fix(agent): strip gateway-only timestamp/message_id keys before LLM call

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2633,6 +2633,16 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
 
 
 
+# Keys the gateway splats onto message dicts purely for local
+# transcript/session-store bookkeeping (``gateway/run.py``). They are not part
+# of the OpenAI-compatible chat schema and ride along on session resume/history
+# reload, so strict providers (e.g. GLM-5.2) reject them with HTTP 400 "Extra
+# inputs are not permitted, field: 'messages[N].timestamp'" (#68077). ``message_id``
+# has no meaning in the API schema and this codebase's tool dedup is keyed on
+# ``tool_call_id``, not ``message_id``, so dropping both here is safe.
+_GATEWAY_ONLY_MESSAGE_KEYS = frozenset({"timestamp", "message_id"})
+
+
 def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Fix orphaned tool_call / tool_result pairs before every LLM call.
 
@@ -2828,6 +2838,27 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             "Pre-call sanitizer: removed %d duplicate tool_call_id reference(s)",
             removed_dupes,
         )
+
+    # --- Strip gateway-only bookkeeping keys (timestamp/message_id) ---
+    # These are attached to message dicts for local transcript/session-store
+    # bookkeeping and are not valid OpenAI-compatible schema fields; strict
+    # providers 400 on them (#68077). Rebuild new dicts rather than editing in
+    # place so persisted session/transcript objects (and prompt-cache
+    # byte-stability) stay intact.
+    stripped = 0
+    cleaned: List[Dict[str, Any]] = []
+    for msg in messages:
+        if isinstance(msg, dict) and _GATEWAY_ONLY_MESSAGE_KEYS.intersection(msg):
+            msg = {k: v for k, v in msg.items() if k not in _GATEWAY_ONLY_MESSAGE_KEYS}
+            stripped += 1
+        cleaned.append(msg)
+    if stripped:
+        messages = cleaned
+        _ra().logger.debug(
+            "Pre-call sanitizer: stripped gateway-only keys from %d message(s)",
+            stripped,
+        )
+
     return messages
 
 

--- a/tests/run_agent/test_session_meta_filtering.py
+++ b/tests/run_agent/test_session_meta_filtering.py
@@ -64,6 +64,63 @@ class TestSanitizeApiMessagesRoleFilter:
 
 
 # ---------------------------------------------------------------------------
+# Layer 1b — _sanitize_api_messages strips gateway-only bookkeeping keys
+# (issue #68077 — strict OpenAI-compatible providers, e.g. GLM-5.2, reject
+# unknown per-message fields like ``timestamp``/``message_id`` with HTTP 400
+# "Extra inputs are not permitted". The gateway splats these onto message
+# dicts for local transcript/session bookkeeping and they ride along on
+# session resume/history reload.)
+# ---------------------------------------------------------------------------
+
+class TestSanitizeApiMessagesGatewayKeyStrip:
+
+    def test_strips_timestamp_key(self):
+        msgs = [
+            {"role": "user", "content": "hello", "timestamp": 1784553211.368},
+            {"role": "assistant", "content": "hi", "timestamp": 1784553212.0},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert all("timestamp" not in m for m in out)
+        # content/role preserved
+        assert [m["role"] for m in out] == ["user", "assistant"]
+        assert out[0]["content"] == "hello"
+
+    def test_strips_message_id_key(self):
+        msgs = [
+            {"role": "user", "content": "hello", "message_id": "m-123", "timestamp": 1.0},
+            {"role": "assistant", "content": "hi"},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert all("message_id" not in m and "timestamp" not in m for m in out)
+
+    def test_does_not_mutate_input_dicts(self):
+        """Non-mutating — persisted session/transcript objects stay intact."""
+        original = {"role": "user", "content": "hello", "timestamp": 1784553211.368}
+        AIAgent._sanitize_api_messages([original])
+        assert original["timestamp"] == 1784553211.368
+
+    def test_preserves_schema_valid_keys(self):
+        msgs = [
+            {"role": "user", "content": "hello", "timestamp": 1.0},
+            {
+                "role": "assistant",
+                "content": "",
+                "timestamp": 2.0,
+                "tool_calls": [{"id": "c1", "function": {"name": "t", "arguments": "{}"}}],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "ok", "timestamp": 3.0, "name": "t"},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert all("timestamp" not in m for m in out)
+        # tool_calls and tool_call_id (real schema keys) survive
+        assistant = next(m for m in out if m["role"] == "assistant")
+        assert assistant["tool_calls"][0]["id"] == "c1"
+        tool = next(m for m in out if m["role"] == "tool")
+        assert tool["tool_call_id"] == "c1"
+        assert tool["name"] == "t"
+
+
+# ---------------------------------------------------------------------------
 # Layer 2 — CLI session-restore filters session_meta before loading
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

`sanitize_api_messages()` in `agent/agent_runtime_helpers.py` is documented as the final pre-API chokepoint, but it never removed the `timestamp` and `message_id` keys the gateway attaches to message dicts for local transcript and session bookkeeping. This change strips those two keys from every message right before the sanitizer returns.

## Why

`gateway/run.py` puts `timestamp` (and `message_id` on the first user turn) directly onto message dicts so the session store and transcript can track them. On session resume and history reload those dicts get reused as-is inside `api_messages`, so the extra keys travel all the way to the provider. Strict OpenAI-compatible providers reject unknown per-message fields with an HTTP 400:

```
HTTP 400: Extra inputs are not permitted, field: 'messages[N].timestamp'
```

This was reported against a GLM-5.2 backend in #68077. Lenient providers such as Kimi silently ignore the fields, which is why the same sessions ran for weeks without surfacing it. The sanitizer already normalizes this exact class of pre-API problems (orphaned tool calls, empty `tool_calls` arrays, duplicate `tool_call_id`s), so dropping non-schema keys belongs in the same place.

The keys are safe to drop here. `message_id` has no meaning in the chat schema, and tool-call deduplication in this codebase is keyed on `tool_call_id`, not `message_id`. The strip rebuilds new dicts instead of editing in place, so the persisted session objects and prompt-cache byte stability are left untouched.

## How to test

```
python -m pytest tests/run_agent/test_session_meta_filtering.py
```

New coverage lives in `TestSanitizeApiMessagesGatewayKeyStrip`: it verifies that `timestamp` and `message_id` are removed, that the input dicts are not mutated, and that real schema keys (`tool_calls`, `tool_call_id`, `name`) survive. The existing sanitizer suites (`test_message_sequence_repair.py`, `test_agent_guardrails.py`, and the sanitize cases in `test_run_agent.py`) still pass.

Tested on Windows 11 with Python 3.13.

Closes #68077
