### PR TITLE
fix(desktop): authenticate primary-profile session slices via OAuth session

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8302,11 +8302,14 @@ async function fetchProfilesSessionSlice(searchParams, remoteProfiles) {
     }
 
     const primary = await ensureBackend(null)
+    const sliceUrl = `${primary.baseUrl}/api/profiles/sessions?${searchParams}`
+    const sliceOpts = { method: 'GET', timeoutMs: DEFAULT_FETCH_TIMEOUT_MS }
 
-    return fetchJson(`${primary.baseUrl}/api/profiles/sessions?${searchParams}`, primary.token, {
-      method: 'GET',
-      timeoutMs: DEFAULT_FETCH_TIMEOUT_MS
-    }).catch(() => ({ sessions: [], total: 0, profile_totals: {} }))
+    // OAuth-mode primaries have no static token (cookie-authed via the
+    // partition) — plain fetchJson would 401 and the catch below would
+    // silently blank this profile's slice (see requestJsonForProfile).
+    return (primary.authMode === 'oauth' ? fetchJsonViaOauthSession(sliceUrl, sliceOpts) : fetchJson(sliceUrl, primary.token, sliceOpts))
+      .catch(() => ({ sessions: [], total: 0, profile_totals: {} }))
   }
 
   return mergeRemoteProfileSessions(searchParams, remoteProfiles)
@@ -8322,11 +8325,14 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
   const order = searchParams.get('order') === 'created' ? 'started_at' : 'last_active'
 
   const primary = await ensureBackend(null)
+  const baseUrl = `${primary.baseUrl}/api/profiles/sessions?${searchParams}`
+  const baseOpts = { method: 'GET', timeoutMs: DEFAULT_FETCH_TIMEOUT_MS }
 
-  const base = (await fetchJson(`${primary.baseUrl}/api/profiles/sessions?${searchParams}`, primary.token, {
-    method: 'GET',
-    timeoutMs: DEFAULT_FETCH_TIMEOUT_MS
-  }).catch(() => ({ sessions: [], total: 0, profile_totals: {} }))) as any
+  // Same OAuth caveat as fetchProfilesSessionSlice: token is null for OAuth
+  // primaries, so route through the cookie-bound session or the base
+  // aggregate 401s and silently contributes zero rows.
+  const base = (await (primary.authMode === 'oauth' ? fetchJsonViaOauthSession(baseUrl, baseOpts) : fetchJson(baseUrl, primary.token, baseOpts))
+    .catch(() => ({ sessions: [], total: 0, profile_totals: {} }))) as any
 
   // Over-fetch each remote from offset 0 (limit+offset rows) so the merged window
   // is correct for this page — mirrors the primary's per-profile over-fetch.


### PR DESCRIPTION
## Bug Description

In remote OAuth mode with per-profile overrides, the desktop sidebar shows every profile's sessions **except the default/primary profile's** — that list renders empty (only the live in-progress session appears, since it comes from the WS, not the list fetch). Chat in the default tab works fine; only the session list is blank.

## Root Cause

OAuth-mode backend connections carry `token: null` by design — REST is meant to be cookie-authed through the Electron session partition via `fetchJsonViaOauthSession` (see `buildRemoteConnection`: "No static token in OAuth mode; REST is cookie-authed via the partition").

Two remote-splice helpers in `apps/desktop/electron/main.ts` missed that contract and called plain `fetchJson(url, primary.token)` for the primary profile's session-list slices:

1. `fetchProfilesSessionSlice` — the local-primary (non-override) branch
2. `mergeRemoteProfileSessions` — the base aggregate for `profile=all`

Every sidebar refresh for the primary profile therefore got a `401 no_cookie`, which the `.catch(() => ({ sessions: [], total: 0, profile_totals: {} }))` silently swallowed — a permanently empty list with no error surfaced. Per-profile-override tabs worked because they route through `requestJsonForProfile`, which is already auth-mode-aware.

## Fix

Route both helpers through `fetchJsonViaOauthSession` when the primary connection is OAuth-mode, matching the existing `requestJsonForProfile` pattern (`conn.authMode === 'oauth' ? fetchJsonViaOauthSession(...) : fetchJson(...)`).

Audited every `fetchJson` call site in `main.ts` — the two `/api/status` probes hit a public endpoint, and `hermes:api` / `requestJsonForProfile` were already guarded. These were the only two broken paths.

## How to Verify

1. Configure the desktop app in remote mode with `authMode: "oauth"` (primary) plus at least one per-profile remote override in `connection.json`
2. Open the app, sign in via OAuth
3. Before fix: default profile tab shows an empty session list; other profile tabs populate
4. After fix: default profile tab populates with the full session list

## Test Plan

- [x] Existing tests still pass (469 electron vitest tests, 46 files)
- [x] `npm run typecheck` clean
- [x] Manual verification of the fix — live remote OAuth setup: primary profile list (800+ sessions) now populates; regression confirmed gone after deploying the patched build

## Risk Assessment

**Low** — the change only alters the auth transport for two GET fetches (cookie session instead of a null bearer token) and preserves the existing silent-degradation catch behavior for genuinely dead backends. Token/local-mode connections take the identical code path as before.
