### PR TITLE
fix(schema): preserve dependentRequired property names

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -189,6 +189,26 @@ def test_required_all_missing_is_dropped():
     assert "required" not in out[0]["function"]["parameters"]
 
 
+def test_dependent_required_property_names_are_preserved():
+    schema = {
+        "type": "object",
+        "properties": {
+            "organization": {"type": "string"},
+            "project": {"type": "string"},
+            "repository": {"type": "string"},
+        },
+        "dependentRequired": {
+            "project": ["organization"],
+            "repository": ["organization", "project"],
+        },
+    }
+    tools = [_tool("code_history", copy.deepcopy(schema))]
+
+    out = sanitize_tool_schemas(tools)
+
+    assert out[0]["function"]["parameters"] == schema
+
+
 def test_well_formed_schema_unchanged():
     schema = {
         "type": "object",

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -323,11 +323,12 @@ def _sanitize_node(node: Any, path: str) -> Any:
                 _sanitize_node(item, f"{path}.{key}[{i}]")
                 for i, item in enumerate(value)
             ]
-        elif key in {"required", "enum", "examples"}:
+        elif key in {"required", "enum", "examples", "dependentRequired"}:
             # Schema "sibling" keywords whose values are NOT schemas:
             #  - ``required``: list of property-name strings
             #  - ``enum``: list of literal values (any JSON type)
             #  - ``examples``: list of example values (any JSON type)
+            #  - ``dependentRequired``: property-name -> required-name strings
             # Recursing into these with _sanitize_node() would mis-interpret
             # literal strings like "path" as bare-string schemas and replace
             # them with {"type": "object"} dicts. Pass through unchanged.


### PR DESCRIPTION
## Summary
- preserve JSON Schema dependentRequired maps during tool schema sanitization
- prevent dependency property-name strings from being rewritten as empty object schemas
- add regression coverage based on an MCP schema that triggered provider HTTP 400 responses

## Test plan
- python -m pytest tests/tools/test_schema_sanitizer.py -q
- Hermes one-shot session with the affected MCP server enabled