### PR TITLE
feat(kanban): add atomic pre-claim disposition hook

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -85,7 +85,7 @@ import threading
 import logging
 import time
 from contextvars import ContextVar, Token
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
@@ -4100,6 +4100,8 @@ def complete_task(
     metadata: Optional[dict] = None,
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
+    expected_status: Optional[str] = None,
+    event_evidence: Optional[dict] = None,
 ) -> bool:
     """Transition ``running|ready -> done`` and record ``result``.
 
@@ -4162,41 +4164,31 @@ def complete_task(
         conn, task_id, metadata, summary=summary, result=result,
     )
     with write_txn(conn):
-        if expected_run_id is None:
-            cur = conn.execute(
-                """
-                UPDATE tasks
-                   SET status       = 'done',
-                       result       = ?,
-                       completed_at = ?,
-                       claim_lock   = NULL,
-                       claim_expires= NULL,
-                       worker_pid   = NULL,
-                       block_kind   = NULL,
-                       block_recurrences = 0
-                 WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
-                """,
-                (result, now, task_id),
-            )
-        else:
-            cur = conn.execute(
-                """
-                UPDATE tasks
-                   SET status       = 'done',
-                       result       = ?,
-                       completed_at = ?,
-                       claim_lock   = NULL,
-                       claim_expires= NULL,
-                       worker_pid   = NULL,
-                       block_kind   = NULL,
-                       block_recurrences = 0
-                 WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
-                   AND current_run_id = ?
-                """,
-                (result, now, task_id, int(expected_run_id)),
-            )
+        status_clause = (
+            "status = ?" if expected_status is not None
+            else "status IN ('running', 'ready', 'blocked')"
+        )
+        run_clause = "" if expected_run_id is None else " AND current_run_id = ?"
+        params: list[Any] = [result, now, task_id]
+        if expected_status is not None:
+            params.append(expected_status)
+        if expected_run_id is not None:
+            params.append(int(expected_run_id))
+        cur = conn.execute(
+            f"""
+            UPDATE tasks
+               SET status       = 'done',
+                   result       = ?,
+                   completed_at = ?,
+                   claim_lock   = NULL,
+                   claim_expires= NULL,
+                   worker_pid   = NULL,
+                   block_kind   = NULL,
+                   block_recurrences = 0
+             WHERE id = ? AND {status_clause}{run_clause}
+            """,
+            params,
+        )
         if cur.rowcount != 1:
             return False
         if isinstance(metadata, dict):
@@ -4254,6 +4246,8 @@ def complete_task(
                 ]
                 if cleaned_artifacts:
                     completed_payload["artifacts"] = cleaned_artifacts
+        if event_evidence is not None:
+            completed_payload["evidence"] = event_evidence
         _append_event(
             conn, task_id, "completed",
             completed_payload,
@@ -4880,6 +4874,7 @@ def block_task(
     reason: Optional[str] = None,
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    expected_status: Optional[str] = None,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
 
@@ -4914,6 +4909,19 @@ def block_task(
         )
     routed_to = "blocked"
     recurrences = 0
+    status_predicate = (
+        "status = ?" if expected_status is not None
+        else "status IN ('running', 'ready')"
+    )
+    run_predicate = "" if expected_run_id is None else " AND current_run_id = ?"
+
+    def _cas_params(*values: Any) -> tuple[Any, ...]:
+        return (
+            tuple(values)
+            + ((expected_status,) if expected_status is not None else ())
+            + ((int(expected_run_id),) if expected_run_id is not None else ())
+        )
+
     with write_txn(conn):
         cur_row = conn.execute(
             "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
@@ -4935,7 +4943,7 @@ def block_task(
         # a dependency-wait as something to "unblock".
         if kind == "dependency":
             cur = conn.execute(
-                """
+                f"""
                 UPDATE tasks
                    SET status        = 'todo',
                        claim_lock    = NULL,
@@ -4943,10 +4951,9 @@ def block_task(
                        worker_pid    = NULL,
                        block_kind    = ?
                  WHERE id = ?
-                   AND status IN ('running', 'ready')
-                """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
-                (kind, task_id) if expected_run_id is None
-                else (kind, task_id, int(expected_run_id)),
+                   AND {status_predicate}{run_predicate}
+                """,
+                _cas_params(kind, task_id),
             )
             if cur.rowcount != 1:
                 return False
@@ -4988,7 +4995,7 @@ def block_task(
             # Loop detected — stop letting the unblocker spin this task. Route
             # to triage for a human-in-the-loop decision instead of blocked.
             cur = conn.execute(
-                """
+                f"""
                 UPDATE tasks
                    SET status        = 'triage',
                        claim_lock    = NULL,
@@ -4997,10 +5004,9 @@ def block_task(
                        block_kind    = ?,
                        block_recurrences = ?
                  WHERE id = ?
-                   AND status IN ('running', 'ready')
-                """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
-                (kind, recurrences, task_id) if expected_run_id is None
-                else (kind, recurrences, task_id, int(expected_run_id)),
+                   AND {status_predicate}{run_predicate}
+                """,
+                _cas_params(kind, recurrences, task_id),
             )
             if cur.rowcount != 1:
                 return False
@@ -5025,37 +5031,19 @@ def block_task(
             )
             routed_to = "triage"
         else:
-            if expected_run_id is None:
-                cur = conn.execute(
-                    """
-                    UPDATE tasks
-                       SET status        = 'blocked',
-                           claim_lock    = NULL,
-                           claim_expires = NULL,
-                           worker_pid    = NULL,
-                           block_kind    = ?,
-                           block_recurrences = ?
-                     WHERE id = ?
-                       AND status IN ('running', 'ready')
-                    """,
-                    (kind, recurrences, task_id),
-                )
-            else:
-                cur = conn.execute(
-                    """
-                    UPDATE tasks
-                       SET status        = 'blocked',
-                           claim_lock    = NULL,
-                           claim_expires = NULL,
-                           worker_pid    = NULL,
-                           block_kind    = ?,
-                           block_recurrences = ?
-                     WHERE id = ?
-                       AND status IN ('running', 'ready')
-                       AND current_run_id = ?
-                    """,
-                    (kind, recurrences, task_id, int(expected_run_id)),
-                )
+            cur = conn.execute(
+                f"""
+                UPDATE tasks
+                   SET status        = 'blocked',
+                       claim_lock    = NULL,
+                       claim_expires = NULL,
+                       worker_pid    = NULL,
+                       block_kind    = ?,
+                       block_recurrences = ?
+                 WHERE id = ? AND {status_predicate}{run_predicate}
+                """,
+                _cas_params(kind, recurrences, task_id),
+            )
             if cur.rowcount != 1:
                 return False
             run_id = _end_run(
@@ -6057,6 +6045,10 @@ class DispatchResult:
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
     """Task ids auto-blocked by the spawn-failure circuit breaker."""
+    pre_claim_dispositions: list[tuple[str, str]] = field(default_factory=list)
+    """Pre-claim policy outcomes as ``(task_id, action)`` pairs."""
+    pre_claim_errors: list[tuple[str, str]] = field(default_factory=list)
+    """Fail-closed pre-claim faults as ``(task_id, error)`` pairs."""
     timed_out: list[str] = field(default_factory=list)
     """Task ids whose workers exceeded ``max_runtime_seconds``."""
     stale: list[str] = field(default_factory=list)
@@ -6079,6 +6071,152 @@ class DispatchResult:
     DB writes this tick — the lock holder is making progress on the same
     board. This is the steady-state signal that a single-writer guard is
     actively preventing two dispatchers from racing on ``kanban.db``."""
+
+
+def _normalize_pre_claim_decisions(results: list[Any]) -> dict[str, Any]:
+    """Validate hook returns and combine them into one fail-closed decision."""
+    normalized: list[dict[str, Any]] = []
+    schemas = {
+        "allow": ({"action"}, {"action"}),
+        "defer": ({"action"}, {"action", "reason"}),
+        "block": ({"action", "reason", "kind"}, {"action", "reason", "kind"}),
+        "complete": (
+            {"action", "summary", "evidence"},
+            {"action", "summary", "evidence"},
+        ),
+    }
+    for raw in results:
+        if not isinstance(raw, dict) or not isinstance(raw.get("action"), str):
+            raise ValueError("pre-claim callback must return a decision dict")
+        action = raw["action"].strip().lower()
+        if action not in schemas:
+            raise ValueError(f"unknown pre-claim action: {raw['action']!r}")
+        required, allowed = schemas[action]
+        keys = set(raw)
+        if not required.issubset(keys) or not keys.issubset(allowed):
+            raise ValueError(f"invalid fields for pre-claim action {action!r}")
+        decision = dict(raw)
+        decision["action"] = action
+        for key in ("reason", "summary"):
+            if key in decision:
+                value = decision[key]
+                if not isinstance(value, str) or not value.strip():
+                    raise ValueError(f"pre-claim {action} requires nonblank {key}")
+                decision[key] = value.strip()
+        if action == "block" and decision["kind"] not in VALID_BLOCK_KINDS:
+            raise ValueError("pre-claim block has invalid kind")
+        if action == "complete":
+            evidence = decision["evidence"]
+            if not isinstance(evidence, dict) or not evidence:
+                raise ValueError("pre-claim complete requires non-empty evidence")
+            try:
+                json.dumps(evidence)
+            except (TypeError, ValueError) as exc:
+                raise ValueError("pre-claim complete evidence must be JSON-serializable") from exc
+        normalized.append(decision)
+
+    non_allow = [decision for decision in normalized if decision["action"] != "allow"]
+    if not non_allow:
+        return {"action": "allow"}
+    if any(decision != non_allow[0] for decision in non_allow[1:]):
+        raise ValueError("conflicting non-allow pre-claim decisions")
+    return non_allow[0]
+
+
+def _evaluate_pre_claim(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    assignee: str,
+    source_status: str,
+    board: Optional[str],
+    dry_run: bool,
+    failure_limit: int,
+    result: DispatchResult,
+) -> bool:
+    """Run and apply the shared ready/review gate; return True to skip claim."""
+    task = get_task(conn, task_id)
+    if task is None or task.status != source_status:
+        return True
+    try:
+        from hermes_cli.plugins import invoke_hook_strict
+
+        hook_results = invoke_hook_strict(
+            "kanban_task_pre_claim",
+            task_id=task_id,
+            board=board or get_current_board(),
+            assignee=assignee,
+            source_status=source_status,
+            task=asdict(task),
+            dry_run=dry_run,
+        )
+        decision = _normalize_pre_claim_decisions(hook_results)
+    except Exception as exc:
+        error = str(exc) or type(exc).__name__
+        result.pre_claim_errors.append((task_id, error))
+        if not dry_run and _record_task_failure(
+            conn,
+            task_id,
+            error,
+            outcome="kanban_pre_claim_error",
+            failure_limit=failure_limit,
+            expected_status=source_status,
+            synthesize_run=True,
+            event_kind="kanban_pre_claim_error",
+            event_payload_extra={"source_status": source_status},
+        ):
+            result.auto_blocked.append(task_id)
+        return True
+
+    action = decision["action"]
+    if action == "allow":
+        if hook_results:
+            result.pre_claim_dispositions.append((task_id, action))
+        return False
+    if dry_run:
+        result.pre_claim_dispositions.append((task_id, action))
+        return True
+
+    # The callback ran outside a SQLite transaction and may have changed the
+    # task through another connection. Never overwrite that newer state.
+    current = get_task(conn, task_id)
+    if current is None or current.status != source_status:
+        return True
+    if action == "defer":
+        with write_txn(conn):
+            cur = conn.execute(
+                "UPDATE tasks SET status=status WHERE id=? AND status=?",
+                (task_id, source_status),
+            )
+            applied = cur.rowcount == 1
+            if applied:
+                _append_event(
+                    conn,
+                    task_id,
+                    "kanban_pre_claim_deferred",
+                    {"reason": decision.get("reason"), "source_status": source_status},
+                )
+    elif action == "block":
+        applied = block_task(
+            conn,
+            task_id,
+            reason=decision["reason"],
+            kind=decision["kind"],
+            expected_status=source_status,
+        )
+    else:
+        evidence = decision["evidence"]
+        applied = complete_task(
+            conn,
+            task_id,
+            summary=decision["summary"],
+            metadata={"evidence": evidence},
+            expected_status=source_status,
+            event_evidence=evidence,
+        )
+    if applied:
+        result.pre_claim_dispositions.append((task_id, action))
+    return True
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -7030,6 +7168,9 @@ def _record_task_failure(
     release_claim: bool = False,
     end_run: bool = False,
     event_payload_extra: Optional[dict] = None,
+    expected_status: Optional[str] = None,
+    synthesize_run: bool = False,
+    event_kind: Optional[str] = None,
 ) -> bool:
     """Record a non-success outcome (spawn_failed / crashed / timed_out)
     and maybe trip the circuit breaker.
@@ -7054,6 +7195,10 @@ def _record_task_failure(
       run with the appropriate outcome. This just increments the
       counter; if the breaker trips, the task is re-transitioned
       ``ready → blocked`` and a ``gave_up`` event is emitted.
+
+    * ``expected_status=..., synthesize_run=True`` — pre-claim gate path.
+      The counter update is status-CAS guarded and every fault gets a closed
+      synthetic run plus ``event_kind`` audit event without creating a claim.
 
     ``event_payload_extra`` merges into the ``gave_up`` event payload
     when the breaker trips, so callers can include outcome-specific
@@ -7086,6 +7231,8 @@ def _record_task_failure(
             return False
         failures = int(row["consecutive_failures"]) + 1
         cur_status = row["status"]
+        if expected_status is not None and cur_status != expected_status:
+            return False
 
         # Per-task override wins over both caller-supplied and default
         # thresholds. None (the common case) falls through.
@@ -7101,7 +7248,16 @@ def _record_task_failure(
 
         if force_trip or failures >= effective_limit:
             # Trip the breaker.
-            if release_claim:
+            if expected_status is not None:
+                cur = conn.execute(
+                    "UPDATE tasks SET status = 'blocked', "
+                    "consecutive_failures = ?, last_failure_error = ? "
+                    "WHERE id = ? AND status = ?",
+                    (failures, error[:500], task_id, expected_status),
+                )
+                if cur.rowcount != 1:
+                    return False
+            elif release_claim:
                 # Spawn path: still running, also clear claim state.
                 conn.execute(
                     "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
@@ -7120,8 +7276,25 @@ def _record_task_failure(
                     "WHERE id = ? AND status IN ('ready', 'running')",
                     (failures, error[:500], task_id),
                 )
+            payload = {
+                "failures": failures,
+                "effective_limit": effective_limit,
+                "limit_source": limit_source,
+                "error": error[:500],
+                "trigger_outcome": outcome,
+            }
+            if event_payload_extra:
+                payload.update(event_payload_extra)
             run_id = None
-            if end_run:
+            if synthesize_run:
+                run_id = _synthesize_ended_run(
+                    conn, task_id, outcome=outcome, error=error[:500],
+                    metadata=payload,
+                )
+                _append_event(
+                    conn, task_id, event_kind or outcome, payload, run_id=run_id,
+                )
+            elif end_run:
                 # Only the spawn path has an open run to close.
                 run_id = _end_run(
                     conn, task_id,
@@ -7134,22 +7307,21 @@ def _record_task_failure(
                         "limit_source": limit_source,
                     },
                 )
-            payload = {
-                "failures": failures,
-                "effective_limit": effective_limit,
-                "limit_source": limit_source,
-                "error": error[:500],
-                "trigger_outcome": outcome,
-            }
-            if event_payload_extra:
-                payload.update(event_payload_extra)
             _append_event(
                 conn, task_id, "gave_up", payload, run_id=run_id,
             )
             blocked = True
         else:
             # Below threshold.
-            if release_claim:
+            if expected_status is not None:
+                cur = conn.execute(
+                    "UPDATE tasks SET consecutive_failures = ?, "
+                    "last_failure_error = ? WHERE id = ? AND status = ?",
+                    (failures, error[:500], task_id, expected_status),
+                )
+                if cur.rowcount != 1:
+                    return False
+            elif release_claim:
                 # Spawn path: transition running → ready + clear claim.
                 conn.execute(
                     "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
@@ -7166,7 +7338,24 @@ def _record_task_failure(
                     "last_failure_error = ? WHERE id = ?",
                     (failures, error[:500], task_id),
                 )
-            if end_run:
+            if synthesize_run:
+                payload = {
+                    "error": error[:500],
+                    "failures": failures,
+                    "effective_limit": effective_limit,
+                    "limit_source": limit_source,
+                    "trigger_outcome": outcome,
+                }
+                if event_payload_extra:
+                    payload.update(event_payload_extra)
+                run_id = _synthesize_ended_run(
+                    conn, task_id, outcome=outcome, error=error[:500],
+                    metadata=payload,
+                )
+                _append_event(
+                    conn, task_id, event_kind or outcome, payload, run_id=run_id,
+                )
+            elif end_run:
                 # Spawn path: close the open run with outcome.
                 run_id = _end_run(
                     conn, task_id,
@@ -7748,6 +7937,17 @@ def _dispatch_once_locked(
                         {"reason": guard_reason},
                     )
             continue
+        if _evaluate_pre_claim(
+            conn,
+            row["id"],
+            assignee=row_assignee,
+            source_status="ready",
+            board=board,
+            dry_run=dry_run,
+            failure_limit=failure_limit,
+            result=result,
+        ):
+            continue
         if dry_run:
             result.spawned.append((row["id"], row_assignee, ""))
             # Increment per-profile counter even in dry_run so the cap
@@ -7847,6 +8047,17 @@ def _dispatch_once_locked(
             profile_exists = None  # type: ignore[assignment]
         if profile_exists is not None and not profile_exists(row["assignee"]):
             result.skipped_nonspawnable.append(row["id"])
+            continue
+        if _evaluate_pre_claim(
+            conn,
+            row["id"],
+            assignee=row["assignee"],
+            source_status="review",
+            board=board,
+            dry_run=dry_run,
+            failure_limit=failure_limit,
+            result=result,
+        ):
             continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -44,7 +44,7 @@ import threading
 import types
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Set, Union
 
 from hermes_constants import get_hermes_home
 from utils import env_var_enabled, fast_safe_load
@@ -212,8 +212,9 @@ VALID_HOOKS: Set[str] = {
     "kanban_task_claimed",
     "kanban_task_completed",
     "kanban_task_blocked",
-    # Exceptional synchronous dispatcher policy hook. Unlike lifecycle
-    # observers, callback failures must propagate so dispatch fails closed.
+    # Behavior-changing, synchronous, dispatcher-process-only policy hook.
+    # Unlike lifecycle observers, callback failures must propagate so dispatch
+    # fails closed.
     "kanban_task_pre_claim",
 }
 
@@ -278,6 +279,19 @@ def _get_enabled_plugins() -> Optional[set]:
 # ---------------------------------------------------------------------------
 
 _VALID_PLUGIN_KINDS: Set[str] = {"standalone", "backend", "exclusive", "platform", "model-provider"}
+
+
+@dataclass
+class PreClaimDisposition:
+    decision: Literal["allow", "defer", "block", "complete"]
+    reason: Optional[str] = None
+    block_kind: Optional[str] = None
+    summary: Optional[str] = None
+    evidence: dict = field(default_factory=dict)
+    plugin_id: str = ""
+
+    def __post_init__(self) -> "PreClaimDisposition":
+        return self
 
 
 @dataclass

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -212,6 +212,9 @@ VALID_HOOKS: Set[str] = {
     "kanban_task_claimed",
     "kanban_task_completed",
     "kanban_task_blocked",
+    # Exceptional synchronous dispatcher policy hook. Unlike lifecycle
+    # observers, callback failures must propagate so dispatch fails closed.
+    "kanban_task_pre_claim",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"
@@ -1926,6 +1929,17 @@ class PluginManager:
                 )
         return results
 
+    def invoke_hook_strict(self, hook_name: str, **kwargs: Any) -> List[Any]:
+        """Call callbacks without swallowing exceptions.
+
+        Reserved for behavior-changing gates whose caller must fail closed.
+        Observer hooks continue to use :meth:`invoke_hook`.
+        """
+        results: List[Any] = []
+        for callback in self._hooks.get(hook_name, []):
+            results.append(callback(**kwargs))
+        return results
+
     def has_hook(self, hook_name: str) -> bool:
         """Return True when at least one callback is registered for a hook."""
         return bool(self._hooks.get(hook_name))
@@ -2052,6 +2066,11 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     Returns a list of non-``None`` return values from plugin callbacks.
     """
     return get_plugin_manager().invoke_hook(hook_name, **kwargs)
+
+
+def invoke_hook_strict(hook_name: str, **kwargs: Any) -> List[Any]:
+    """Invoke a behavior-changing hook and surface callback exceptions."""
+    return get_plugin_manager().invoke_hook_strict(hook_name, **kwargs)
 
 
 def invoke_middleware(kind: str, **kwargs: Any) -> List[Any]:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -37,6 +37,7 @@ import asyncio
 import importlib.metadata
 import importlib.util
 import inspect
+import json
 import logging
 import os
 import sys
@@ -280,6 +281,29 @@ def _get_enabled_plugins() -> Optional[set]:
 
 _VALID_PLUGIN_KINDS: Set[str] = {"standalone", "backend", "exclusive", "platform", "model-provider"}
 
+#: Public allowlist for ``PreClaimDisposition.block_kind``.
+BLOCK_KINDS: frozenset[str] = frozenset({
+    "policy_violation",
+    "dependency_unsatisfied",
+    "quota_exceeded",
+    "auth_required",
+    "unsupported",
+})
+
+
+class PreClaimHookError(Exception):
+    """Raised when a plugin returns an invalid pre-claim disposition."""
+
+    plugin_id: str
+    rule: str
+
+    def __init__(self, plugin_id: str, rule: str) -> None:
+        self.plugin_id = plugin_id
+        self.rule = rule
+        super().__init__(
+            f"Plugin {plugin_id!r} violated pre-claim disposition rule: {rule}"
+        )
+
 
 @dataclass
 class PreClaimDisposition:
@@ -290,8 +314,57 @@ class PreClaimDisposition:
     evidence: dict = field(default_factory=dict)
     plugin_id: str = ""
 
-    def __post_init__(self) -> "PreClaimDisposition":
-        return self
+    def __post_init__(self) -> None:
+        def fail(rule: str) -> None:
+            raise PreClaimHookError(self.plugin_id, rule)
+
+        if self.decision not in ("allow", "defer", "block", "complete"):
+            fail("decision must be one of: allow, defer, block, complete")
+        if not isinstance(self.evidence, dict):
+            fail("evidence must be a dict")
+        try:
+            json.dumps(self.evidence)
+        except (TypeError, ValueError) as exc:
+            raise PreClaimHookError(
+                self.plugin_id, "evidence must be JSON-serializable"
+            ) from exc
+
+        for name, value in (("reason", self.reason), ("summary", self.summary)):
+            if value is not None and not isinstance(value, str):
+                fail(f"{name} must be a str or None")
+
+        if self.decision == "allow":
+            if self.reason is not None:
+                fail("allow requires reason to be None")
+            if self.block_kind is not None:
+                fail("allow requires block_kind to be None")
+            if self.summary is not None:
+                fail("allow requires summary to be None")
+            if self.evidence:
+                fail("allow requires evidence to be empty")
+            return
+
+        if self.decision == "defer":
+            if self.block_kind is not None:
+                fail("defer requires block_kind to be None")
+            return
+
+        if self.decision == "block":
+            if not isinstance(self.reason, str) or not self.reason.strip():
+                fail("block requires reason to be a nonblank str")
+            if (
+                not isinstance(self.block_kind, str)
+                or self.block_kind not in BLOCK_KINDS
+            ):
+                fail(f"block_kind must be one of: {', '.join(sorted(BLOCK_KINDS))}")
+            return
+
+        if self.block_kind is not None:
+            fail("complete requires block_kind to be None")
+        if not isinstance(self.summary, str) or not self.summary.strip():
+            fail("complete requires summary to be a nonblank str")
+        if not self.evidence:
+            fail("complete requires evidence to be a non-empty dict")
 
 
 @dataclass

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -43,7 +43,8 @@ import os
 import sys
 import threading
 import types
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
+from functools import wraps
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Literal, Optional, Set, Union
 
@@ -222,6 +223,7 @@ VALID_HOOKS: Set[str] = {
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"
 
 _NS_PARENT = "hermes_plugins"
+_REGISTERED_PLUGIN_ID_ATTR = "__hermes_registered_plugin_id__"
 
 
 def _env_enabled(name: str) -> bool:
@@ -1259,7 +1261,21 @@ class PluginContext:
                 hook_name,
                 ", ".join(sorted(VALID_HOOKS)),
             )
-        self._manager._hooks.setdefault(hook_name, []).append(callback)
+
+        registered_callback = callback
+        if hook_name == "kanban_task_pre_claim":
+
+            @wraps(callback)
+            def pre_claim_callback(*args: Any, **kwargs: Any) -> Any:
+                return callback(*args, **kwargs)
+
+            setattr(
+                pre_claim_callback,
+                _REGISTERED_PLUGIN_ID_ATTR,
+                self.manifest.key or self.manifest.name,
+            )
+            registered_callback = pre_claim_callback
+        self._manager._hooks.setdefault(hook_name, []).append(registered_callback)
         logger.debug("Plugin %s registered hook: %s", self.manifest.name, hook_name)
 
     # -- middleware registration -------------------------------------------
@@ -2158,6 +2174,66 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
 def invoke_hook_strict(hook_name: str, **kwargs: Any) -> List[Any]:
     """Invoke a behavior-changing hook and surface callback exceptions."""
     return get_plugin_manager().invoke_hook_strict(hook_name, **kwargs)
+
+
+def aggregate_hooks(
+    hook_name: str, **kwargs: Any
+) -> Union[List[Any], PreClaimDisposition]:
+    """Invoke hooks using the policy dedicated to each hook kind.
+
+    ``kanban_task_pre_claim`` is a synchronous dispatcher-process policy
+    hook. Every registered callback is invoked in registration order with
+    exactly the caller-supplied task-snapshot keyword arguments; callbacks
+    are never given a database connection or workspace handle. With no
+    callbacks, or with only ``None``/``allow`` responses, the result is
+    ``PreClaimDisposition(decision="allow")``. Otherwise the highest-ranked
+    disposition wins according to ``block > complete > defer > allow``, with
+    registration order breaking equal-rank ties.
+
+    All other hooks retain the observer behavior of :func:`invoke_hook`:
+    callback failures are isolated and non-``None`` results are returned as
+    a list.
+    """
+    if hook_name != "kanban_task_pre_claim":
+        return invoke_hook(hook_name, **kwargs)
+
+    ranks = {"allow": 0, "defer": 1, "complete": 2, "block": 3}
+    best = PreClaimDisposition(decision="allow")
+    best_rank = ranks[best.decision]
+    callbacks = get_plugin_manager()._hooks.get(hook_name, [])
+
+    for callback in callbacks:
+        registered_plugin_id = getattr(callback, _REGISTERED_PLUGIN_ID_ATTR, "")
+        try:
+            response = callback(**kwargs)
+        except PreClaimHookError as exc:
+            if registered_plugin_id:
+                raise PreClaimHookError(registered_plugin_id, exc.rule) from exc
+            raise
+
+        if response is None:
+            continue
+        if not isinstance(response, PreClaimDisposition):
+            raise PreClaimHookError(
+                registered_plugin_id or "<unknown>",
+                "callback must return PreClaimDisposition or None",
+            )
+        try:
+            response = replace(
+                response,
+                plugin_id=registered_plugin_id or response.plugin_id,
+            )
+        except PreClaimHookError as exc:
+            if registered_plugin_id and exc.plugin_id != registered_plugin_id:
+                raise PreClaimHookError(registered_plugin_id, exc.rule) from exc
+            raise
+
+        response_rank = ranks[response.decision]
+        if response_rank > best_rank:
+            best = response
+            best_rank = response_rank
+
+    return best
 
 
 def invoke_middleware(kind: str, **kwargs: Any) -> List[Any]:

--- a/tests/hermes_cli/test_kanban_pre_claim_hook.py
+++ b/tests/hermes_cli/test_kanban_pre_claim_hook.py
@@ -1,0 +1,372 @@
+"""Behavior contract for the synchronous kanban pre-claim plugin hook."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import fields
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.plugins import VALID_HOOKS, get_plugin_manager
+
+
+@pytest.fixture
+def board(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = kb.kanban_db_path(board="default")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db(board="default")
+    with kb.connect(board="default") as conn:
+        yield conn, tmp_path
+
+
+@pytest.fixture
+def pre_claim_hooks():
+    manager = get_plugin_manager()
+    saved = {name: list(callbacks) for name, callbacks in manager._hooks.items()}
+    manager._hooks["kanban_task_pre_claim"] = []
+    try:
+        yield manager._hooks["kanban_task_pre_claim"]
+    finally:
+        manager._hooks = saved
+
+
+def _task(conn, root: Path, *, status="ready", max_retries=None):
+    workspace = root / "workspace"
+    workspace.mkdir(exist_ok=True)
+    task_id = kb.create_task(
+        conn,
+        title=f"{status} task",
+        assignee="worker",
+        workspace_kind="dir",
+        workspace_path=str(workspace),
+        max_retries=max_retries,
+    )
+    if status != "ready":
+        conn.execute("UPDATE tasks SET status=? WHERE id=?", (status, task_id))
+        conn.commit()
+    return task_id
+
+
+def _events(conn, task_id, kind):
+    return [event for event in kb.list_events(conn, task_id) if event.kind == kind]
+
+
+def _runs(conn, task_id):
+    return [
+        dict(row)
+        for row in conn.execute(
+            "SELECT * FROM task_runs WHERE task_id=? ORDER BY id", (task_id,)
+        )
+    ]
+
+
+def test_hook_is_registered_and_no_hook_preserves_spawn(
+    board, pre_claim_hooks, all_assignees_spawnable
+):
+    conn, root = board
+    assert "kanban_task_pre_claim" in VALID_HOOKS
+    task_id = _task(conn, root)
+    calls = []
+
+    result = kb.dispatch_once(
+        conn, spawn_fn=lambda task, workspace: calls.append(task.id) or None
+    )
+
+    assert calls == [task_id]
+    assert result.spawned[0][0] == task_id
+    assert result.pre_claim_dispositions == []
+    assert result.pre_claim_errors == []
+
+
+@pytest.mark.parametrize(
+    ("decision", "expected_status", "event_kind"),
+    [
+        (
+            {"action": "defer", "reason": "maintenance"},
+            "ready",
+            "kanban_pre_claim_deferred",
+        ),
+        (
+            {"action": "block", "reason": "needs token", "kind": "needs_input"},
+            "blocked",
+            "blocked",
+        ),
+        (
+            {
+                "action": "complete",
+                "summary": "already shipped",
+                "evidence": {"pr": 42},
+            },
+            "done",
+            "completed",
+        ),
+    ],
+)
+def test_non_allow_actions_skip_workspace_and_spawn_and_persist_disposition(
+    board,
+    pre_claim_hooks,
+    all_assignees_spawnable,
+    monkeypatch,
+    decision,
+    expected_status,
+    event_kind,
+):
+    conn, root = board
+    task_id = _task(conn, root)
+    conn.execute(
+        "UPDATE tasks SET workspace_kind='worktree', workspace_path=? WHERE id=?",
+        (str(root / "does-not-exist"), task_id),
+    )
+    conn.commit()
+    pre_claim_hooks.append(lambda **kwargs: decision)
+    monkeypatch.setattr(
+        kb,
+        "_resolve_worktree_workspace",
+        lambda *args, **kwargs: pytest.fail("workspace resolver must not run"),
+    )
+    spawn = lambda *args, **kwargs: pytest.fail("spawn must not run")
+
+    result = kb.dispatch_once(conn, spawn_fn=spawn)
+    task = kb.get_task(conn, task_id)
+
+    assert task.status == expected_status
+    assert task.consecutive_failures == 0
+    assert result.pre_claim_dispositions == [(task_id, decision["action"])]
+    assert _events(conn, task_id, event_kind)
+    assert not _events(conn, task_id, "spawn_failed")
+
+    if decision["action"] == "block":
+        assert task.block_kind == "needs_input"
+        assert _runs(conn, task_id)[-1]["summary"] == "needs token"
+    if decision["action"] == "complete":
+        run = _runs(conn, task_id)[-1]
+        assert run["summary"] == "already shipped"
+        assert json.loads(run["metadata"]) == {"evidence": {"pr": 42}}
+        payload = _events(conn, task_id, "completed")[-1].payload
+        assert payload["evidence"] == {"pr": 42}
+
+
+def test_allow_receives_stable_snapshot_and_spawns(
+    board, pre_claim_hooks, all_assignees_spawnable
+):
+    conn, root = board
+    task_id = _task(conn, root)
+    original = kb.get_task(conn, task_id)
+    captured = {}
+    pre_claim_hooks.append(
+        lambda **kwargs: captured.update(kwargs) or {"action": "allow"}
+    )
+
+    result = kb.dispatch_once(conn, board="default", spawn_fn=lambda *_: None)
+
+    assert result.spawned[0][0] == task_id
+    assert result.pre_claim_dispositions == [(task_id, "allow")]
+    assert captured.keys() == {
+        "task_id",
+        "board",
+        "assignee",
+        "source_status",
+        "task",
+        "dry_run",
+    }
+    assert captured["task_id"] == task_id
+    assert captured["board"] == "default"
+    assert captured["source_status"] == "ready"
+    assert captured["dry_run"] is False
+    assert captured["task"] == {
+        field.name: getattr(original, field.name) for field in fields(kb.Task)
+    }
+
+
+def test_dry_run_allow_reports_decision_and_existing_would_spawn(
+    board, pre_claim_hooks, all_assignees_spawnable
+):
+    conn, root = board
+    task_id = _task(conn, root)
+    pre_claim_hooks.append(lambda **_: {"action": "allow"})
+
+    result = kb.dispatch_once(conn, dry_run=True)
+
+    assert result.pre_claim_dispositions == [(task_id, "allow")]
+    assert result.spawned == [(task_id, "worker", "")]
+    assert kb.get_task(conn, task_id).status == "ready"
+
+
+@pytest.mark.parametrize(
+    "callbacks",
+    [
+        [lambda **_: None],
+        [lambda **_: {"action": "wat"}],
+        [lambda **_: {"action": "allow", "reason": "extra"}],
+        [lambda **_: {"action": "defer", "reason": ""}],
+        [lambda **_: {"action": "block", "reason": "x", "kind": "unknown"}],
+        [lambda **_: {"action": "complete", "summary": "x", "evidence": {}}],
+        [lambda **_: {"action": "complete", "summary": "x", "evidence": {"bad": {1}}}],
+        [lambda **_: "allow"],
+        [
+            lambda **_: {"action": "defer"},
+            lambda **_: {"action": "block", "reason": "x", "kind": "capability"},
+        ],
+    ],
+)
+def test_malformed_or_conflicting_results_fail_closed(
+    board, pre_claim_hooks, all_assignees_spawnable, callbacks
+):
+    conn, root = board
+    task_id = _task(conn, root)
+    pre_claim_hooks.extend(callbacks)
+
+    result = kb.dispatch_once(
+        conn, spawn_fn=lambda *_: pytest.fail("must not spawn"), failure_limit=5
+    )
+
+    task = kb.get_task(conn, task_id)
+    assert task.status == "ready"
+    assert task.consecutive_failures == 1
+    assert result.pre_claim_errors and result.pre_claim_errors[0][0] == task_id
+    assert _runs(conn, task_id)[-1]["outcome"] == "kanban_pre_claim_error"
+    assert _events(conn, task_id, "kanban_pre_claim_error")
+    assert not _events(conn, task_id, "spawn_failed")
+
+
+def test_callback_exception_uses_failure_breaker_and_is_bounded(
+    board, pre_claim_hooks, all_assignees_spawnable
+):
+    conn, root = board
+    task_id = _task(conn, root, max_retries=2)
+
+    def raising(**_):
+        raise RuntimeError("policy unavailable")
+
+    pre_claim_hooks.append(raising)
+    first = kb.dispatch_once(
+        conn, spawn_fn=lambda *_: pytest.fail("must not spawn"), failure_limit=9
+    )
+    second = kb.dispatch_once(
+        conn, spawn_fn=lambda *_: pytest.fail("must not spawn"), failure_limit=9
+    )
+    third = kb.dispatch_once(
+        conn, spawn_fn=lambda *_: pytest.fail("must not spawn"), failure_limit=9
+    )
+
+    assert first.pre_claim_errors == [(task_id, "policy unavailable")]
+    assert task_id in second.auto_blocked
+    assert kb.get_task(conn, task_id).status == "blocked"
+    assert third.pre_claim_errors == []
+    assert len(_runs(conn, task_id)) == 2
+    assert not _events(conn, task_id, "spawn_failed")
+
+
+@pytest.mark.parametrize(
+    "decision",
+    [
+        {"action": "defer", "reason": "later"},
+        {"action": "block", "reason": "human", "kind": "needs_input"},
+        {"action": "complete", "summary": "done", "evidence": {"check": True}},
+    ],
+)
+def test_dry_run_reports_without_any_mutation_or_side_effect(
+    board, pre_claim_hooks, all_assignees_spawnable, monkeypatch, decision
+):
+    conn, root = board
+    task_id = _task(conn, root)
+    before_events = len(kb.list_events(conn, task_id))
+    pre_claim_hooks.append(
+        lambda **kwargs: decision if kwargs["dry_run"] is True else pytest.fail()
+    )
+    monkeypatch.setattr(
+        kb,
+        "resolve_workspace",
+        lambda *args, **kwargs: pytest.fail("resolver must not run"),
+    )
+
+    result = kb.dispatch_once(
+        conn, dry_run=True, spawn_fn=lambda *_: pytest.fail("spawn must not run")
+    )
+
+    task = kb.get_task(conn, task_id)
+    assert task.status == "ready"
+    assert task.consecutive_failures == 0
+    assert len(kb.list_events(conn, task_id)) == before_events
+    assert _runs(conn, task_id) == []
+    assert result.pre_claim_dispositions == [(task_id, decision["action"])]
+
+
+@pytest.mark.parametrize("source_status", ["ready", "review"])
+@pytest.mark.parametrize("action", ["defer", "block", "complete"])
+def test_ready_and_review_have_identical_non_allow_contract(
+    board, pre_claim_hooks, all_assignees_spawnable, source_status, action
+):
+    conn, root = board
+    task_id = _task(conn, root, status=source_status)
+    decisions = {
+        "defer": {"action": "defer"},
+        "block": {"action": "block", "reason": "policy", "kind": "capability"},
+        "complete": {
+            "action": "complete",
+            "summary": "verified",
+            "evidence": {"ok": 1},
+        },
+    }
+    seen = []
+    pre_claim_hooks.append(
+        lambda **kwargs: seen.append(kwargs["source_status"]) or decisions[action]
+    )
+
+    first = kb.dispatch_once(conn, spawn_fn=lambda *_: pytest.fail("must not spawn"))
+    second = kb.dispatch_once(conn, spawn_fn=lambda *_: pytest.fail("must not spawn"))
+
+    assert seen[0] == source_status
+    assert first.pre_claim_dispositions == [(task_id, action)]
+    if action == "defer":
+        assert second.pre_claim_dispositions == [(task_id, action)]
+        repeated = kb.get_task(conn, task_id)
+        assert repeated is not None and repeated.status == source_status
+    else:
+        assert second.pre_claim_dispositions == []
+
+
+def test_non_allow_cas_does_not_overwrite_hook_status_change(
+    board, pre_claim_hooks, all_assignees_spawnable
+):
+    conn, root = board
+    task_id = _task(conn, root)
+
+    def race(**_):
+        with kb.connect(board="default") as other:
+            other.execute("UPDATE tasks SET status='todo' WHERE id=?", (task_id,))
+            other.commit()
+        return {"action": "block", "reason": "stale", "kind": "capability"}
+
+    pre_claim_hooks.append(race)
+    result = kb.dispatch_once(conn, spawn_fn=lambda *_: pytest.fail("must not spawn"))
+
+    assert kb.get_task(conn, task_id).status == "todo"
+    assert result.pre_claim_dispositions == []
+    assert not _events(conn, task_id, "blocked")
+
+
+def test_hook_runs_while_board_dispatch_lock_is_held(
+    board, pre_claim_hooks, all_assignees_spawnable
+):
+    conn, root = board
+    task_id = _task(conn, root)
+    nested = []
+
+    def inspect_lock(**_):
+        with kb.connect(board="default") as other:
+            nested.append(kb.dispatch_once(other).skipped_locked)
+        return {"action": "defer"}
+
+    pre_claim_hooks.append(inspect_lock)
+    kb.dispatch_once(conn)
+
+    assert nested == [True]
+    assert kb.get_task(conn, task_id).status == "ready"

--- a/tests/hermes_cli/test_plugins_preclaim.py
+++ b/tests/hermes_cli/test_plugins_preclaim.py
@@ -1,0 +1,300 @@
+"""Tests for typed plugin aggregation at the kanban pre-claim boundary."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+import hermes_cli.plugins as plugins
+from hermes_cli.plugins import (
+    BLOCK_KINDS,
+    PluginContext,
+    PluginManager,
+    PluginManifest,
+    PreClaimDisposition,
+    PreClaimHookError,
+    aggregate_hooks,
+)
+
+
+PLUGIN_ID = "test/preclaim-policy"
+
+
+@pytest.fixture
+def manager(monkeypatch):
+    instance = PluginManager()
+    monkeypatch.setattr(plugins, "_plugin_manager", instance)
+    return instance
+
+
+def _register_pre_claim(manager, plugin_id, callback):
+    PluginContext(PluginManifest(name=plugin_id, key=plugin_id), manager).register_hook(
+        "kanban_task_pre_claim", callback
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"decision": "allow"},
+        {"decision": "defer"},
+        {"decision": "defer", "reason": "try later"},
+        *[
+            {
+                "decision": "block",
+                "reason": "policy denied the claim",
+                "block_kind": block_kind,
+            }
+            for block_kind in sorted(BLOCK_KINDS)
+        ],
+        {
+            "decision": "complete",
+            "summary": "work already verified",
+            "evidence": {"checks": ["unit", "lint"]},
+        },
+    ],
+)
+def test_pre_claim_disposition_accepts_every_valid_decision_path(kwargs):
+    disposition = PreClaimDisposition(plugin_id=PLUGIN_ID, **kwargs)
+
+    assert disposition.decision == kwargs["decision"]
+    assert disposition.plugin_id == PLUGIN_ID
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"decision": "unknown"},
+        {"decision": "defer", "evidence": []},
+        {"decision": "defer", "reason": 7},
+        {"decision": "defer", "summary": 7},
+        {"decision": "allow", "reason": "extra"},
+        {"decision": "allow", "block_kind": "unsupported"},
+        {"decision": "allow", "summary": "extra"},
+        {"decision": "allow", "evidence": {"extra": True}},
+        {"decision": "defer", "block_kind": "unsupported"},
+        {"decision": "block", "block_kind": "unsupported"},
+        {"decision": "block", "reason": "", "block_kind": "unsupported"},
+        {"decision": "block", "reason": "   ", "block_kind": "unsupported"},
+        {"decision": "block", "reason": "denied"},
+        {
+            "decision": "block",
+            "reason": "denied",
+            "block_kind": "not-a-supported-kind",
+        },
+        {
+            "decision": "complete",
+            "block_kind": "unsupported",
+            "summary": "done",
+            "evidence": {"proof": True},
+        },
+        {"decision": "complete", "evidence": {"proof": True}},
+        {"decision": "complete", "summary": "", "evidence": {"proof": True}},
+        {"decision": "complete", "summary": "   ", "evidence": {"proof": True}},
+        {"decision": "complete", "summary": "done", "evidence": {}},
+    ],
+)
+def test_pre_claim_disposition_rejects_decision_specific_invalid_matrix(kwargs):
+    with pytest.raises(PreClaimHookError) as exc_info:
+        PreClaimDisposition(plugin_id=PLUGIN_ID, **kwargs)
+
+    assert PLUGIN_ID in str(exc_info.value)
+
+
+def test_pre_claim_disposition_rejects_non_json_serializable_evidence():
+    with pytest.raises(PreClaimHookError) as exc_info:
+        PreClaimDisposition(
+            decision="complete",
+            summary="done",
+            evidence={"unsupported": {1, 2}},
+            plugin_id=PLUGIN_ID,
+        )
+
+    assert PLUGIN_ID in str(exc_info.value)
+
+
+def test_pre_claim_disposition_rejects_block_kind_outside_public_allowlist():
+    outside_kind = "outside-the-allowlist"
+    assert outside_kind not in BLOCK_KINDS
+
+    with pytest.raises(PreClaimHookError) as exc_info:
+        PreClaimDisposition(
+            decision="block",
+            reason="denied",
+            block_kind=outside_kind,
+            plugin_id=PLUGIN_ID,
+        )
+
+    assert PLUGIN_ID in str(exc_info.value)
+
+
+def test_aggregate_pre_claim_without_callbacks_defaults_to_allow(manager):
+    result = aggregate_hooks("kanban_task_pre_claim", task={"id": "t1"})
+
+    assert result == PreClaimDisposition(decision="allow")
+
+
+def test_aggregate_pre_claim_invokes_all_callbacks_synchronously_with_exact_kwargs(
+    manager,
+):
+    caller_thread = threading.get_ident()
+    snapshot = {
+        "task_id": "t1",
+        "board": "default",
+        "assignee": "worker",
+        "source_status": "ready",
+        "task": {"id": "t1", "title": "safe snapshot"},
+        "dry_run": False,
+    }
+    calls = []
+
+    def observe_first(**kwargs):
+        calls.append(("first", threading.get_ident(), kwargs))
+
+    def observe_second(**kwargs):
+        calls.append(("second", threading.get_ident(), kwargs))
+        return PreClaimDisposition(decision="defer", reason="later")
+
+    manager._hooks["kanban_task_pre_claim"] = [observe_first, observe_second]
+
+    result = aggregate_hooks("kanban_task_pre_claim", **snapshot)
+
+    assert result.decision == "defer"
+    assert calls == [
+        ("first", caller_thread, snapshot),
+        ("second", caller_thread, snapshot),
+    ]
+
+
+def test_aggregate_pre_claim_treats_none_as_allow(manager):
+    manager._hooks["kanban_task_pre_claim"] = [lambda **_: None]
+
+    assert aggregate_hooks("kanban_task_pre_claim").decision == "allow"
+
+
+@pytest.mark.parametrize(
+    ("order", "expected_plugin_id"),
+    [
+        (("allow", "defer"), "defer-plugin"),
+        (("defer", "allow"), "defer-plugin"),
+        (("defer", "complete"), "complete-plugin"),
+        (("complete", "defer"), "complete-plugin"),
+        (("complete", "block"), "block-plugin"),
+        (("block", "complete"), "block-plugin"),
+    ],
+)
+def test_aggregate_pre_claim_uses_decision_priority_not_registration_order(
+    manager, order, expected_plugin_id
+):
+    returned = {
+        "allow": PreClaimDisposition(decision="allow", plugin_id="allow-plugin"),
+        "defer": PreClaimDisposition(
+            decision="defer", reason="later", plugin_id="defer-plugin"
+        ),
+        "complete": PreClaimDisposition(
+            decision="complete",
+            summary="already done",
+            evidence={"proof": True},
+            plugin_id="complete-plugin",
+        ),
+        "block": PreClaimDisposition(
+            decision="block",
+            reason="denied",
+            block_kind="policy_violation",
+            plugin_id="block-plugin",
+        ),
+    }
+    calls = []
+    for decision in order:
+        value = returned[decision]
+        _register_pre_claim(
+            manager,
+            value.plugin_id,
+            lambda value=value: calls.append(value.decision) or value,
+        )
+
+    result = aggregate_hooks("kanban_task_pre_claim")
+
+    assert calls == list(order)
+    assert isinstance(result, PreClaimDisposition)
+    assert result.plugin_id == expected_plugin_id
+
+
+def test_aggregate_pre_claim_keeps_registration_order_for_equal_rank(manager):
+    first = PreClaimDisposition(decision="defer", reason="first", plugin_id="first")
+    second = PreClaimDisposition(decision="defer", reason="second", plugin_id="second")
+    manager._hooks["kanban_task_pre_claim"] = [
+        lambda: first,
+        lambda: second,
+    ]
+
+    result = aggregate_hooks("kanban_task_pre_claim")
+
+    assert result.reason == "first"
+    assert result.plugin_id == "first"
+
+
+@pytest.mark.parametrize("invalid_response", ["allow", {"decision": "allow"}, 1])
+def test_aggregate_pre_claim_rejects_invalid_type_with_registered_plugin_id(
+    manager, invalid_response
+):
+    manifest = PluginManifest(name="display-name", key=PLUGIN_ID)
+    context = PluginContext(manifest, manager)
+    context.register_hook("kanban_task_pre_claim", lambda **_: invalid_response)
+
+    with pytest.raises(PreClaimHookError) as exc_info:
+        aggregate_hooks("kanban_task_pre_claim", task={"id": "t1"})
+
+    assert PLUGIN_ID in str(exc_info.value)
+
+
+def test_aggregate_pre_claim_does_not_trust_plugin_id_on_invalid_response(manager):
+    class InvalidResponse:
+        plugin_id = "spoofed-plugin"
+
+    manifest = PluginManifest(name="display-name", key=PLUGIN_ID)
+    PluginContext(manifest, manager).register_hook(
+        "kanban_task_pre_claim", lambda **_: InvalidResponse()
+    )
+
+    with pytest.raises(PreClaimHookError) as exc_info:
+        aggregate_hooks("kanban_task_pre_claim")
+
+    assert PLUGIN_ID in str(exc_info.value)
+    assert "spoofed-plugin" not in str(exc_info.value)
+
+
+def test_aggregate_pre_claim_revalidates_mutated_disposition_with_registered_id(
+    manager,
+):
+    invalid = PreClaimDisposition(decision="allow", plugin_id=PLUGIN_ID)
+    invalid.reason = "added after validation"
+    PluginContext(
+        PluginManifest(name="display-name", key=PLUGIN_ID), manager
+    ).register_hook("kanban_task_pre_claim", lambda **_: invalid)
+
+    with pytest.raises(PreClaimHookError) as exc_info:
+        aggregate_hooks("kanban_task_pre_claim")
+
+    assert PLUGIN_ID in str(exc_info.value)
+
+
+def test_aggregate_hooks_preserves_observer_list_semantics(manager):
+    calls = []
+
+    def first(**kwargs):
+        calls.append(kwargs)
+        return "first-result"
+
+    manager._hooks["post_tool_call"] = [first, lambda **_: None]
+
+    result = aggregate_hooks("post_tool_call", tool_name="terminal")
+
+    assert result == ["first-result"]
+    assert calls == [
+        {
+            "tool_name": "terminal",
+            "telemetry_schema_version": "hermes.observer.v1",
+        }
+    ]

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -610,16 +610,46 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 | `kanban_task_claimed` | A kanban task is claimed (dispatcher process, before the worker spawns) | `task_id: str, board: str \| None, assignee: str \| None, run_id: int \| None, profile_name: str` | ignored |
 | `kanban_task_completed` | A kanban task completes (worker process) | `task_id, board, assignee, run_id, profile_name, summary: str \| None` | ignored |
 | `kanban_task_blocked` | A kanban task is blocked (worker process) | `task_id, board, assignee, run_id, profile_name, reason: str \| None` | ignored |
+| `kanban_task_pre_claim` | Eligible ready/review candidate, under the board dispatch lock and before claim/workspace/spawn (dispatcher process only) | `task_id, board, assignee, source_status, task: dict, dry_run: bool` | strict `allow` / `defer` / `block` / `complete` decision |
 
-Most hooks are fire-and-forget observers — their return values are ignored. The exception is `pre_llm_call`, which can inject context into the conversation.
+Most hooks are fire-and-forget observers — their return values are ignored and
+callback errors are logged and skipped. Behavior-changing hooks have explicit
+contracts; `pre_llm_call` can inject context, while
+`kanban_task_pre_claim` is the exceptional synchronous dispatcher policy gate.
 
-All callbacks should accept `**kwargs` for forward compatibility. If a hook callback crashes, it's logged and skipped. Other hooks and the agent continue normally.
+All callbacks should accept `**kwargs` for forward compatibility. Observer
+callback failures do not affect the agent. A `kanban_task_pre_claim` failure is
+instead surfaced to the dispatcher, recorded as `kanban_pre_claim_error`, and
+fails that candidate closed through the normal kanban failure breaker.
 
 The kanban lifecycle hooks fire **after** the board DB change commits, so a callback always sees durable state and can never hold the SQLite write lock. Because kanban workers run as separate `hermes -p <profile> chat -q` subprocesses, `kanban_task_claimed` fires in the **dispatcher** process while `kanban_task_completed` / `kanban_task_blocked` fire in the **worker** process — hook in the dispatcher to observe every transition centrally, or in the worker for per-task in-session context.
 
+`kanban_task_pre_claim` is not a lifecycle observer. It runs synchronously in
+the dispatcher under the board-scoped dispatch lock, after ordinary candidate
+guards but before claim and workspace resolution. It receives a plain
+`dataclasses.asdict(Task)` snapshot and never a SQLite connection. Return only
+one of these exact schemas (unknown fields are errors):
+
+```python
+{"action": "allow"}
+{"action": "defer"}  # may include a nonblank reason
+{"action": "block", "reason": "...", "kind": "capability"}
+{"action": "complete", "summary": "...", "evidence": {"verified": True}}
+```
+
+`block.kind` must be one of the canonical kanban block kinds. Multiple
+non-allow callbacks must return exactly the same normalized decision;
+otherwise dispatch fails closed. Dry runs pass `dry_run=True`, report the
+decision, and perform no disposition, failure, workspace, or spawn side
+effects.
+
 ### `pre_llm_call` context injection
 
-This is the only hook whose return value matters. When a `pre_llm_call` callback returns a dict with a `"context"` key (or a plain string), Hermes injects that text into the **current turn's user message**. This is the mechanism for memory plugins, RAG integrations, guardrails, and any plugin that needs to provide the model with additional context.
+This is the hook whose return value injects conversation context. When a
+`pre_llm_call` callback returns a dict with a `"context"` key (or a plain
+string), Hermes injects that text into the **current turn's user message**.
+This is the mechanism for memory plugins, RAG integrations, guardrails, and
+any plugin that needs to provide the model with additional context.
 
 #### Return format
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -14,7 +14,10 @@ Hermes has three hook systems that run custom code at key lifecycle points:
 | **[Plugin hooks](#plugin-hooks)** | `ctx.register_hook()` in a [plugin](/user-guide/features/plugins) | CLI + Gateway | Tool interception, metrics, guardrails |
 | **[Shell hooks](#shell-hooks)** | `hooks:` block in `~/.hermes/config.yaml` pointing at shell scripts | CLI + Gateway | Drop-in scripts for blocking, auto-formatting, context injection |
 
-All three systems are non-blocking — errors in any hook are caught and logged, never crashing the agent.
+Gateway hooks, shell hooks, and ordinary plugin observer hooks are
+best-effort: errors are caught and logged. The exceptional
+`kanban_task_pre_claim` plugin hook is a synchronous policy gate; its errors
+fail the candidate closed without crashing the dispatcher.
 
 ## Gateway Event Hooks
 
@@ -370,8 +373,11 @@ def register(ctx):
 **General rules for all hooks:**
 
 - Callbacks receive **keyword arguments**. Always accept `**kwargs` for forward compatibility — new parameters may be added in future versions without breaking your plugin.
-- If a callback **crashes**, it's logged and skipped. Other hooks and the agent continue normally. A misbehaving plugin can never break the agent.
-- Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call. All other hooks are fire-and-forget observers.
+- Observer callback crashes are logged and skipped. The synchronous
+  [`kanban_task_pre_claim`](#kanban_task_pre_claim) gate instead surfaces
+  callback errors to the dispatcher so it can fail the candidate closed.
+- Several policy/transform hooks have documented return contracts. Hooks whose
+  return value is listed as `ignored` remain fire-and-forget observers.
 - Observer callbacks receive `telemetry_schema_version` automatically. When present, `turn_id`, `api_request_id`, `task_id`, `session_id`, and `api_call_count` are separate correlation fields. Treat `api_request_id` as an opaque identifier; do not parse its string format.
 
 ### Quick reference
@@ -395,6 +401,45 @@ def register(ctx):
 | [`transform_tool_result`](#transform_tool_result) | After any tool returns, before the result is handed back to the model | `str` to replace the result, `None` to leave unchanged |
 | [`transform_terminal_output`](#transform_terminal_output) | Inside the `terminal` tool, before truncation/ANSI-strip/redact | `str` to replace the raw output, `None` to leave unchanged |
 | [`transform_llm_output`](#transform_llm_output) | After the tool-calling loop completes, before the final response is delivered | `str` to replace the response text, `None`/empty to leave unchanged |
+| [`kanban_task_pre_claim`](#kanban_task_pre_claim) | Dispatcher has an eligible ready/review candidate, before claim or workspace resolution | `allow`, `defer`, `block`, or `complete` decision dict |
+
+---
+
+### `kanban_task_pre_claim`
+
+This is the exceptional behavior-changing, synchronous plugin hook. It runs
+only in the **dispatcher process**, under the board-scoped dispatch lock,
+after a ready or review task passes normal eligibility checks and before the
+task is claimed, its workspace is resolved, or a worker is spawned.
+
+```python
+def gate(task_id, board, assignee, source_status, task, dry_run, **kwargs):
+    if maintenance_window():
+        return {"action": "defer", "reason": "maintenance window"}
+    return {"action": "allow"}
+
+def register(ctx):
+    ctx.register_hook("kanban_task_pre_claim", gate)
+```
+
+Callbacks receive a plain dataclass snapshot in `task`; no SQLite connection
+is exposed. Return exactly one of these strict shapes (extra fields are
+rejected):
+
+```python
+{"action": "allow"}
+{"action": "defer"}  # optional nonblank "reason"
+{"action": "block", "reason": "...", "kind": "needs_input"}
+{"action": "complete", "summary": "...", "evidence": {"check": "..."}}
+```
+
+Block `kind` must be `dependency`, `needs_input`, `capability`, or `transient`.
+Malformed, conflicting, or raising callbacks fail closed and feed the normal
+kanban consecutive-failure breaker. Dry runs invoke the hook with
+`dry_run=True` and report the decision without mutating task/run/event state or
+resolving a workspace. Keep callbacks fast: synchronous execution deliberately
+holds the dispatch lock so two dispatcher processes cannot race the policy and
+claim.
 
 ---
 
@@ -510,7 +555,8 @@ def register(ctx):
 
 ### `pre_llm_call`
 
-Fires **once per turn**, before the tool-calling loop begins. This is the **only hook whose return value is used** — it can inject context into the current turn's user message.
+Fires **once per turn**, before the tool-calling loop begins. This is the hook
+whose return value injects context into the current turn's user message.
 
 **Callback signature:**
 


### PR DESCRIPTION
## Summary

- add a strict synchronous `kanban_task_pre_claim` policy hook before claim, workspace resolution, and worker spawn
- apply `allow`, `defer`, `block`, and `complete` consistently to ready and review candidates with CAS-safe canonical transitions
- record structured dispositions and bounded fail-closed hook errors without producing `spawn_failed`
- document the exceptional behavior-changing hook contract

Kanban: `t_03462a83`

## What Done Looks Like

- no-hook dispatch preserves existing spawn behavior
- non-allow dispositions skip stale-worktree resolution and spawning
- complete persists summary and structured evidence; block persists reason and kind
- malformed, raising, and conflicting callbacks are auditable and bounded by the existing failure breaker
- dry-run, repeat ticks, ready/review parity, status CAS, and dispatch-lock serialization have behavior tests

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_pre_claim_hook.py tests/hermes_cli/test_kanban_lifecycle_hooks.py tests/hermes_cli/test_kanban_db.py` — 263 passed
- `scripts/run_tests.sh tests/hermes_cli/test_kanban*.py` — 751 passed across the relevant suite; `test_kanban_notify.py` had the same 11 pre-existing failures on clean `origin/main` because this worker environment lacks `pytest-asyncio`
- `ruff check --fix` and `ruff check` on the touched Python files — passed
- static added-line security scan — no findings
- Lane-D CodeRabbit pre-flight — advisory timeout after 120 seconds (not reported as a pass)
