### PR TITLE
fix(teams): preserve discovered channel thread targets

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -714,6 +714,21 @@ def _maybe_mirror_cron_delivery(
         return
     try:
         from gateway.mirror import mirror_to_session
+        from tools.send_message_tool import _target_identity
+
+        # Teams persists inbound thread sessions with the composite chat id,
+        # while outbound routing uses a split chat/thread pair.  Mirroring is
+        # already origin-scoped, so use the origin's exact stored shape when
+        # both representations identify the same lane.
+        origin = _resolve_origin(job)
+        if origin and _target_identity(
+            origin.get("platform", ""),
+            origin.get("chat_id", ""),
+            origin.get("thread_id"),
+        ) == _target_identity(platform_name, chat_id, thread_id):
+            platform_name = origin["platform"]
+            chat_id = origin["chat_id"]
+            thread_id = origin.get("thread_id")
 
         # Mirror as a USER turn with a labelled prefix, NOT an assistant turn.
         # The brief is not the agent speaking; an assistant-role mirror lands as
@@ -1296,12 +1311,18 @@ def _resolve_delivery_targets(job: dict) -> List[dict]:
     for raw in raw_parts:
         parts.extend(_expand_routing_tokens(raw))
 
+    from tools.send_message_tool import _target_identity
+
     seen = set()
     targets = []
     for part in parts:
         target = _resolve_single_delivery_target(job, part)
         if target:
-            key = (target["platform"].lower(), str(target["chat_id"]), target.get("thread_id"))
+            key = _target_identity(
+                target["platform"],
+                target["chat_id"],
+                target.get("thread_id"),
+            )
             if key not in seen:
                 seen.add(key)
                 targets.append(target)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -662,16 +662,22 @@ def _target_matches_origin(origin: dict, platform_name: str, chat_id: str,
     """
     if not origin:
         return False
-    if str(origin.get("platform", "")).lower() != str(platform_name).lower():
+    from tools.send_message_tool import _target_identity
+
+    origin_identity = _target_identity(
+        origin.get("platform", ""),
+        origin.get("chat_id", ""),
+        origin.get("thread_id"),
+    )
+    target_identity = _target_identity(platform_name, chat_id, thread_id)
+    if origin_identity[:2] != target_identity[:2]:
         return False
-    if str(origin.get("chat_id", "")) != str(chat_id):
-        return False
-    # thread_id must match when the origin pins one (topic-scoped chats); a
-    # target that lost the thread_id is not the same conversation lane.
-    origin_thread = origin.get("thread_id")
-    if origin_thread is not None and str(origin_thread) != str(thread_id or ""):
-        return False
-    return True
+    # Preserve the historical one-way rule: an origin pinned to a thread must
+    # match that lane, while a root origin may still mirror a threaded target.
+    return (
+        origin_identity[2] is None
+        or origin_identity[2] == target_identity[2]
+    )
 
 
 def _maybe_mirror_cron_delivery(

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -478,6 +478,26 @@ _ALLOWED_TEAMS_SERVICE_HOSTS = frozenset({
 # value cannot path-traverse out of ``/v3/conversations/<id>/activities``.
 import re as _re_teams
 _TEAMS_CONV_ID_RE = _re_teams.compile(r"^[A-Za-z0-9:@\-_.]+$")
+_TEAMS_MESSAGE_ID_MARKER = ";messageid="
+
+
+def _split_teams_conversation_target(chat_id: str) -> tuple[str, Optional[str]]:
+    """Split a validated Teams thread artifact from a conversation ID.
+
+    Teams session discovery can persist channel IDs as
+    ``<conversation>;messageid=<activity>``.  Bot Framework proactive-send
+    replies require both portions.  Only split when each independently
+    satisfies the existing conservative ID guard; malformed values must
+    continue to fail validation in ``_standalone_send``.
+    """
+    conversation_id, marker, message_id = chat_id.rpartition(_TEAMS_MESSAGE_ID_MARKER)
+    if (
+        marker
+        and _TEAMS_CONV_ID_RE.fullmatch(conversation_id)
+        and _TEAMS_CONV_ID_RE.fullmatch(message_id)
+    ):
+        return conversation_id, message_id
+    return chat_id, None
 
 
 def _validate_teams_service_url(raw: str) -> Optional[str]:
@@ -559,12 +579,19 @@ async def _standalone_send(
     # the URL path.
     if not chat_id:
         return {"error": "Teams standalone send: chat_id (conversation ID) is required"}
-    if not _TEAMS_CONV_ID_RE.match(chat_id):
+    chat_id, discovered_thread_id = _split_teams_conversation_target(chat_id)
+    if not _TEAMS_CONV_ID_RE.fullmatch(chat_id):
         return {"error": "Teams standalone send: chat_id contains characters outside the Bot Framework conversation ID set"}
-    if not _TEAMS_CONV_ID_RE.match(tenant_id):
+    explicit_thread_id = str(thread_id).strip() if thread_id is not None else None
+    effective_thread_id = explicit_thread_id or discovered_thread_id
+    if effective_thread_id and not _TEAMS_CONV_ID_RE.fullmatch(effective_thread_id):
+        return {"error": "Teams standalone send: thread_id contains characters outside the Bot Framework activity ID set"}
+    if not _TEAMS_CONV_ID_RE.fullmatch(tenant_id):
         return {"error": "Teams standalone send: TEAMS_TENANT_ID contains characters outside the expected set"}
 
     token_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+    if effective_thread_id:
+        chat_id = f"{chat_id}{_TEAMS_MESSAGE_ID_MARKER}{effective_thread_id}"
     activities_url = f"{service_url}v3/conversations/{chat_id}/activities"
 
     if not AIOHTTP_AVAILABLE:
@@ -1169,16 +1196,27 @@ class TeamsAdapter(BasePlatformAdapter):
         if not self._app:
             return SendResult(success=False, error="Teams app not initialized")
 
+        metadata_thread_id = (metadata or {}).get("thread_id")
+        effective_reply_to = reply_to if reply_to is not None else metadata_thread_id
+        effective_reply_to = str(effective_reply_to).strip() if effective_reply_to is not None else None
+        if effective_reply_to == "0":
+            effective_reply_to = None
+        if effective_reply_to and not _TEAMS_CONV_ID_RE.fullmatch(effective_reply_to):
+            return SendResult(success=False, error="Invalid Teams thread activity ID")
+        metadata_thread_requested = reply_to is None and bool(effective_reply_to)
+
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted)
         last_message_id = None
 
         for chunk in chunks:
             try:
-                if reply_to and reply_to.isdigit() and reply_to != "0":
+                if effective_reply_to:
                     try:
-                        result = await self._app.reply(chat_id, reply_to, chunk)
+                        result = await self._app.reply(chat_id, effective_reply_to, chunk)
                     except Exception as reply_err:
+                        if metadata_thread_requested:
+                            raise
                         # Group chats 400 on threaded sends; the Teams SDK
                         # doesn't expose typed HTTP errors, so fall back on
                         # any exception and log for diagnostics.

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -1248,6 +1248,8 @@ class TeamsAdapter(BasePlatformAdapter):
         default_mime: str,
         caption: Optional[str] = None,
         media_label: str = "media",
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send any media file/URL as a Teams attachment.
 
@@ -1280,11 +1282,51 @@ class TeamsAdapter(BasePlatformAdapter):
             if caption:
                 activity = activity.add_text(caption)
 
-            conv_ref = self._conv_refs.get(chat_id)
-            if conv_ref:
-                result = await self._app.activity_sender.send(activity, conv_ref)
+            metadata_thread_id = (metadata or {}).get("thread_id")
+            effective_reply_to = (
+                reply_to if reply_to is not None else metadata_thread_id
+            )
+            effective_reply_to = (
+                str(effective_reply_to).strip()
+                if effective_reply_to is not None
+                else None
+            )
+            if effective_reply_to == "0":
+                effective_reply_to = None
+            if (
+                effective_reply_to
+                and not _TEAMS_CONV_ID_RE.fullmatch(effective_reply_to)
+            ):
+                return SendResult(
+                    success=False,
+                    error="Invalid Teams thread activity ID",
+                )
+            metadata_thread_requested = (
+                reply_to is None and bool(effective_reply_to)
+            )
+
+            async def _send_flat():
+                conv_ref = self._conv_refs.get(chat_id)
+                if conv_ref:
+                    return await self._app.activity_sender.send(
+                        activity,
+                        conv_ref,
+                    )
+                return await self._app.send(chat_id, activity)
+
+            if effective_reply_to:
+                try:
+                    result = await self._app.reply(
+                        chat_id,
+                        effective_reply_to,
+                        activity,
+                    )
+                except Exception:
+                    if metadata_thread_requested:
+                        raise
+                    result = await _send_flat()
             else:
-                result = await self._app.send(chat_id, activity)
+                result = await _send_flat()
 
             return SendResult(success=True, message_id=getattr(result, "id", None))
         except Exception as e:
@@ -1305,6 +1347,8 @@ class TeamsAdapter(BasePlatformAdapter):
             default_mime="image/png",
             caption=caption,
             media_label="image",
+            reply_to=reply_to,
+            metadata=metadata,
         )
 
     async def send_image_file(
@@ -1313,6 +1357,7 @@ class TeamsAdapter(BasePlatformAdapter):
         image_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         return await self.send_image(
@@ -1320,6 +1365,7 @@ class TeamsAdapter(BasePlatformAdapter):
             image_url=image_path,
             caption=caption,
             reply_to=reply_to,
+            metadata=metadata,
         )
 
     async def send_video(
@@ -1337,6 +1383,8 @@ class TeamsAdapter(BasePlatformAdapter):
             default_mime="video/mp4",
             caption=caption,
             media_label="video",
+            reply_to=reply_to,
+            metadata=metadata,
         )
 
     async def send_voice(
@@ -1354,6 +1402,8 @@ class TeamsAdapter(BasePlatformAdapter):
             default_mime="audio/mpeg",
             caption=caption,
             media_label="voice",
+            reply_to=reply_to,
+            metadata=metadata,
         )
 
     async def send_document(
@@ -1372,6 +1422,8 @@ class TeamsAdapter(BasePlatformAdapter):
             default_mime="application/octet-stream",
             caption=caption,
             media_label="document",
+            reply_to=reply_to,
+            metadata=metadata,
         )
 
     async def get_chat_info(self, chat_id: str) -> dict:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets
+from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets, _target_matches_origin
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
@@ -104,6 +104,68 @@ class TestResolveOrigin:
         """
         job = {"origin": non_dict_origin}
         assert _resolve_origin(job) is None
+
+
+class TestTargetMatchesOrigin:
+    def test_teams_composite_origin_matches_split_delivery_target(self):
+        origin = {
+            "platform": "teams",
+            "chat_id": (
+                "19:channel@thread.tacv2;messageid=1780267076971"
+            ),
+            "thread_id": None,
+        }
+
+        assert _target_matches_origin(
+            origin,
+            "teams",
+            "19:channel@thread.tacv2",
+            "1780267076971",
+        )
+
+    def test_teams_split_origin_matches_composite_delivery_target(self):
+        origin = {
+            "platform": "teams",
+            "chat_id": "19:channel@thread.tacv2",
+            "thread_id": "1780267076971",
+        }
+
+        assert _target_matches_origin(
+            origin,
+            "teams",
+            "19:channel@thread.tacv2;messageid=1780267076971",
+            None,
+        )
+
+    def test_teams_different_thread_is_not_the_origin(self):
+        origin = {
+            "platform": "teams",
+            "chat_id": (
+                "19:channel@thread.tacv2;messageid=1780267076971"
+            ),
+            "thread_id": None,
+        }
+
+        assert not _target_matches_origin(
+            origin,
+            "teams",
+            "19:channel@thread.tacv2",
+            "different-root",
+        )
+
+    def test_unpinned_origin_preserves_root_match_semantics(self):
+        origin = {
+            "platform": "telegram",
+            "chat_id": "-1001",
+            "thread_id": None,
+        }
+
+        assert _target_matches_origin(
+            origin,
+            "telegram",
+            "-1001",
+            "42",
+        )
 
 
 class TestResolveDeliveryTarget:
@@ -1899,5 +1961,3 @@ class TestSetCronSessionTitle:
         out = _set_cron_session_title(db, "sess-1", "Nightly Synthesis")
         assert out == "Nightly Synthesis #2"
         db.get_next_title_in_lineage.assert_called_once_with("Nightly Synthesis")
-
-

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -305,6 +305,29 @@ class TestRoutingIntents:
         assert "signal" not in platforms
         assert "matrix" not in platforms
 
+    def test_teams_origin_and_split_target_are_deduplicated(self):
+        from cron.scheduler import _resolve_delivery_targets
+
+        composite = "19:channel@thread.tacv2;messageid=1780267076971"
+        targets = _resolve_delivery_targets(
+            {
+                "deliver": f"origin,teams:{composite}",
+                "origin": {
+                    "platform": "teams",
+                    "chat_id": composite,
+                    "thread_id": None,
+                },
+            }
+        )
+
+        assert targets == [
+            {
+                "platform": "teams",
+                "chat_id": composite,
+                "thread_id": None,
+            }
+        ]
+
 
 class TestDeliverResultWrapping:
     """Verify that cron deliveries are wrapped with header/footer and no longer mirrored."""
@@ -1653,6 +1676,31 @@ class TestCronDeliveryMirror:
         # boundary) still distinguishes it from a genuine user message.
         assert args[2].startswith("[Cron delivery: Morning Brief]")
         assert "Market movers today" in args[2]
+
+    def test_teams_mirror_uses_persisted_composite_origin(self):
+        from cron.scheduler import _maybe_mirror_cron_delivery
+
+        composite = "19:channel@thread.tacv2;messageid=1780267076971"
+        job = {
+            "id": "j1",
+            "origin": {
+                "platform": "teams",
+                "chat_id": composite,
+                "thread_id": None,
+            },
+        }
+        with patch("gateway.mirror.mirror_to_session", return_value=True) as mirror:
+            _maybe_mirror_cron_delivery(
+                job,
+                "teams",
+                "19:channel@thread.tacv2",
+                "Daily brief",
+                thread_id="1780267076971",
+                enabled=True,
+            )
+
+        assert mirror.call_args.args[:2] == ("teams", composite)
+        assert mirror.call_args.kwargs["thread_id"] is None
 
 
     def test_delivery_mirrors_clean_content_not_wrapped(self):

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -951,7 +951,60 @@ class TestTeamsMediaAttachments:
         adapter._app = MagicMock()
         adapter._app.id = "bot-id"
         adapter._app.send = AsyncMock(return_value=MagicMock(id="msg-001"))
+        adapter._app.reply = AsyncMock(return_value=MagicMock(id="reply-001"))
         return adapter
+
+    @pytest.mark.asyncio
+    async def test_send_image_uses_cron_thread_metadata(self):
+        adapter = self._make_adapter()
+
+        result = await adapter.send_image(
+            "19:abc@thread.v2",
+            "https://example.invalid/image.png",
+            metadata={"thread_id": "1780267076971"},
+        )
+
+        assert result.success
+        adapter._app.reply.assert_awaited_once()
+        assert adapter._app.reply.await_args.args[:2] == (
+            "19:abc@thread.v2",
+            "1780267076971",
+        )
+        adapter._app.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_all_media_methods_forward_thread_metadata(self, tmp_path):
+        adapter = self._make_adapter()
+        metadata = {"thread_id": "1780267076971"}
+        media = tmp_path / "media.bin"
+        media.write_bytes(b"media")
+
+        await adapter.send_image_file(
+            "19:abc@thread.v2",
+            str(media),
+            metadata=metadata,
+        )
+        await adapter.send_video(
+            "19:abc@thread.v2",
+            str(media),
+            metadata=metadata,
+        )
+        await adapter.send_voice(
+            "19:abc@thread.v2",
+            str(media),
+            metadata=metadata,
+        )
+        await adapter.send_document(
+            "19:abc@thread.v2",
+            str(media),
+            metadata=metadata,
+        )
+
+        assert adapter._app.reply.await_count == 4
+        assert {
+            call.args[1] for call in adapter._app.reply.await_args_list
+        } == {"1780267076971"}
+        adapter._app.send.assert_not_awaited()
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -350,6 +350,73 @@ class TestTeamsSend:
         assert result.message_id == "msg-123"
         mock_app.send.assert_awaited_once_with("conv-id", "Hello")
 
+    @pytest.mark.anyio
+    async def test_send_uses_metadata_thread_id(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        mock_result = MagicMock()
+        mock_result.id = "msg-123"
+        mock_app = MagicMock()
+        mock_app.reply = AsyncMock(return_value=mock_result)
+        mock_app.send = AsyncMock()
+        adapter._app = mock_app
+
+        result = await adapter.send(
+            "19:channel@thread.tacv2",
+            "Hello thread",
+            metadata={"thread_id": "1780267076971"},
+        )
+
+        assert result.success is True
+        assert result.message_id == "msg-123"
+        mock_app.reply.assert_awaited_once_with(
+            "19:channel@thread.tacv2",
+            "1780267076971",
+            "Hello thread",
+        )
+        mock_app.send.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_send_rejects_invalid_metadata_thread_id(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        mock_app = MagicMock()
+        mock_app.reply = AsyncMock()
+        mock_app.send = AsyncMock()
+        adapter._app = mock_app
+
+        result = await adapter.send(
+            "19:channel@thread.tacv2",
+            "Hello thread",
+            metadata={"thread_id": "../activities"},
+        )
+
+        assert result.success is False
+        assert "thread activity ID" in result.error
+        mock_app.reply.assert_not_awaited()
+        mock_app.send.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_send_metadata_thread_failure_does_not_fall_back_to_top_level(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        mock_app = MagicMock()
+        mock_app.reply = AsyncMock(side_effect=Exception("thread unavailable"))
+        mock_app.send = AsyncMock()
+        adapter._app = mock_app
+
+        result = await adapter.send(
+            "19:channel@thread.tacv2",
+            "Hello thread",
+            metadata={"thread_id": "1780267076971"},
+        )
+
+        assert result.success is False
+        assert "thread unavailable" in result.error
+        mock_app.send.assert_not_awaited()
 
 def _make_summary_payload():
     return TeamsMeetingSummaryPayload(
@@ -653,6 +720,109 @@ class TestTeamsStandaloneSend:
         assert activity_kwargs["json"]["text"] == "hello cron"
         assert activity_kwargs["json"]["type"] == "message"
 
+    @pytest.mark.asyncio
+    async def test_standalone_send_preserves_discovered_thread_target(self, monkeypatch):
+        monkeypatch.setenv("TEAMS_CLIENT_ID", "client-id")
+        monkeypatch.setenv("TEAMS_CLIENT_SECRET", "secret")
+        monkeypatch.setenv("TEAMS_TENANT_ID", "tenant")
+        monkeypatch.delenv("TEAMS_SERVICE_URL", raising=False)
+
+        token_resp = _FakeAiohttpResponse(200, {"access_token": "the-token"})
+        activity_resp = _FakeAiohttpResponse(200, {"id": "msg-99"})
+        session = _FakeAiohttpSession([token_resp, activity_resp])
+        _install_fake_aiohttp(monkeypatch, session)
+
+        result = await _teams_mod._standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            "19:channel@thread.tacv2;messageid=1780267076971",
+            "hello channel",
+        )
+
+        assert result == {"success": True, "message_id": "msg-99"}
+        activity_url, _activity_kwargs = session.calls[1]
+        assert (
+            "/v3/conversations/19:channel@thread.tacv2;messageid=1780267076971/activities"
+            in activity_url
+        )
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_uses_explicit_thread_id(self, monkeypatch):
+        monkeypatch.setenv("TEAMS_CLIENT_ID", "client-id")
+        monkeypatch.setenv("TEAMS_CLIENT_SECRET", "secret")
+        monkeypatch.setenv("TEAMS_TENANT_ID", "tenant")
+        monkeypatch.delenv("TEAMS_SERVICE_URL", raising=False)
+
+        token_resp = _FakeAiohttpResponse(200, {"access_token": "the-token"})
+        activity_resp = _FakeAiohttpResponse(200, {"id": "msg-99"})
+        session = _FakeAiohttpSession([token_resp, activity_resp])
+        _install_fake_aiohttp(monkeypatch, session)
+
+        result = await _teams_mod._standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            "19:channel@thread.tacv2",
+            "hello thread",
+            thread_id="1780267076971",
+        )
+
+        assert result == {"success": True, "message_id": "msg-99"}
+        activity_url, _activity_kwargs = session.calls[1]
+        assert activity_url.endswith(
+            "/v3/conversations/19:channel@thread.tacv2;messageid=1780267076971/activities"
+        )
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_explicit_thread_overrides_discovered_thread(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("TEAMS_CLIENT_ID", "client-id")
+        monkeypatch.setenv("TEAMS_CLIENT_SECRET", "secret")
+        monkeypatch.setenv("TEAMS_TENANT_ID", "tenant")
+        monkeypatch.delenv("TEAMS_SERVICE_URL", raising=False)
+
+        token_resp = _FakeAiohttpResponse(200, {"access_token": "the-token"})
+        activity_resp = _FakeAiohttpResponse(200, {"id": "msg-99"})
+        session = _FakeAiohttpSession([token_resp, activity_resp])
+        _install_fake_aiohttp(monkeypatch, session)
+
+        result = await _teams_mod._standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            "19:channel@thread.tacv2;messageid=discovered-root",
+            "hello thread",
+            thread_id="explicit-root",
+        )
+
+        assert result == {"success": True, "message_id": "msg-99"}
+        activity_url, _activity_kwargs = session.calls[1]
+        assert activity_url.endswith(
+            "/v3/conversations/19:channel@thread.tacv2;messageid=explicit-root/activities"
+        )
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_empty_thread_uses_discovered_thread(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("TEAMS_CLIENT_ID", "client-id")
+        monkeypatch.setenv("TEAMS_CLIENT_SECRET", "secret")
+        monkeypatch.setenv("TEAMS_TENANT_ID", "tenant")
+        monkeypatch.delenv("TEAMS_SERVICE_URL", raising=False)
+
+        token_resp = _FakeAiohttpResponse(200, {"access_token": "the-token"})
+        activity_resp = _FakeAiohttpResponse(200, {"id": "msg-99"})
+        session = _FakeAiohttpSession([token_resp, activity_resp])
+        _install_fake_aiohttp(monkeypatch, session)
+
+        result = await _teams_mod._standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            "19:channel@thread.tacv2;messageid=discovered-root",
+            "hello thread",
+            thread_id="",
+        )
+
+        assert result == {"success": True, "message_id": "msg-99"}
+        activity_url, _activity_kwargs = session.calls[1]
+        assert activity_url.endswith(
+            "/v3/conversations/19:channel@thread.tacv2;messageid=discovered-root/activities"
+        )
 
     @pytest.mark.asyncio
     async def test_standalone_send_propagates_token_failure(self, monkeypatch):
@@ -677,6 +847,95 @@ class TestTeamsStandaloneSend:
         assert "error" in result
         assert "401" in result["error"]
         assert "token" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "chat_id",
+        [
+            "19:channel@thread.tacv2;messageid=",
+            "19:channel@thread.tacv2;messageid=../activities",
+            "19:channel@thread.tacv2;messageid=123;messageid=456",
+        ],
+    )
+    async def test_standalone_send_rejects_malformed_discovery_suffix(self, monkeypatch, chat_id):
+        monkeypatch.setenv("TEAMS_CLIENT_ID", "client-id")
+        monkeypatch.setenv("TEAMS_CLIENT_SECRET", "secret")
+        monkeypatch.setenv("TEAMS_TENANT_ID", "tenant")
+        monkeypatch.delenv("TEAMS_SERVICE_URL", raising=False)
+
+        session = _FakeAiohttpSession([])
+        _install_fake_aiohttp(monkeypatch, session)
+
+        result = await _teams_mod._standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            chat_id,
+            "hi",
+        )
+
+        assert "error" in result
+        assert "Bot Framework conversation ID" in result["error"]
+        assert len(session.calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_rejects_invalid_explicit_thread_id(self, monkeypatch):
+        monkeypatch.setenv("TEAMS_CLIENT_ID", "client-id")
+        monkeypatch.setenv("TEAMS_CLIENT_SECRET", "secret")
+        monkeypatch.setenv("TEAMS_TENANT_ID", "tenant")
+        monkeypatch.delenv("TEAMS_SERVICE_URL", raising=False)
+
+        session = _FakeAiohttpSession([])
+        _install_fake_aiohttp(monkeypatch, session)
+
+        result = await _teams_mod._standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            "19:channel@thread.tacv2",
+            "hi",
+            thread_id="../activities",
+        )
+
+        assert "error" in result
+        assert "thread_id" in result["error"]
+        assert len(session.calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_rejects_chat_id_with_trailing_newline(self, monkeypatch):
+        monkeypatch.setenv("TEAMS_CLIENT_ID", "client-id")
+        monkeypatch.setenv("TEAMS_CLIENT_SECRET", "secret")
+        monkeypatch.setenv("TEAMS_TENANT_ID", "tenant")
+        monkeypatch.delenv("TEAMS_SERVICE_URL", raising=False)
+
+        session = _FakeAiohttpSession([])
+        _install_fake_aiohttp(monkeypatch, session)
+
+        result = await _teams_mod._standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            "19:channel@thread.tacv2\n",
+            "hi",
+        )
+
+        assert "error" in result
+        assert "conversation ID" in result["error"]
+        assert len(session.calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_rejects_tenant_id_with_trailing_newline(self, monkeypatch):
+        monkeypatch.setenv("TEAMS_CLIENT_ID", "client-id")
+        monkeypatch.setenv("TEAMS_CLIENT_SECRET", "secret")
+        monkeypatch.setenv("TEAMS_TENANT_ID", "tenant\n")
+        monkeypatch.delenv("TEAMS_SERVICE_URL", raising=False)
+
+        session = _FakeAiohttpSession([])
+        _install_fake_aiohttp(monkeypatch, session)
+
+        result = await _teams_mod._standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            "19:channel@thread.tacv2",
+            "hi",
+        )
+
+        assert "error" in result
+        assert "TEAMS_TENANT_ID" in result["error"]
+        assert len(session.calls) == 0
 
 
 class TestTeamsMediaAttachments:
@@ -712,5 +971,3 @@ class TestTeamsMediaAttachments:
         result = await adapter.send_document("19:abc@thread.v2", str(doc))
         assert result.success
         adapter._app.send.assert_awaited_once()
-
-

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -10,7 +10,11 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 from gateway.config import Platform
-from tools.send_message_tool import _parse_target_ref, send_message_tool
+from tools.send_message_tool import (
+    _maybe_skip_cron_duplicate_send,
+    _parse_target_ref,
+    send_message_tool,
+)
 
 
 def _run_async_immediately(coro):
@@ -73,6 +77,47 @@ def test_teams_malformed_thread_targets_are_not_explicit() -> None:
         )[2]
         is False
     )
+
+
+def test_cron_duplicate_matches_composite_teams_origin() -> None:
+    with patch(
+        "tools.send_message_tool._get_cron_auto_delivery_target",
+        return_value={
+            "platform": "teams",
+            "chat_id": (
+                "19:channel@thread.tacv2;messageid=1780267076971"
+            ),
+            "thread_id": None,
+        },
+    ):
+        result = _maybe_skip_cron_duplicate_send(
+            "teams",
+            "19:channel@thread.tacv2",
+            "1780267076971",
+        )
+
+    assert result is not None
+    assert result["reason"] == "cron_auto_delivery_duplicate_target"
+
+
+def test_cron_duplicate_rejects_different_teams_thread() -> None:
+    with patch(
+        "tools.send_message_tool._get_cron_auto_delivery_target",
+        return_value={
+            "platform": "teams",
+            "chat_id": (
+                "19:channel@thread.tacv2;messageid=1780267076971"
+            ),
+            "thread_id": None,
+        },
+    ):
+        result = _maybe_skip_cron_duplicate_send(
+            "teams",
+            "19:channel@thread.tacv2",
+            "different-root",
+        )
+
+    assert result is None
 
 
 def test_send_message_routes_discovered_teams_thread_target() -> None:

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -29,6 +29,124 @@ def test_e164_target_still_requires_phone_platform() -> None:
     assert _parse_target_ref("matrix", "+15551234567")[2] is False
 
 
+def test_teams_discovered_thread_target_is_explicit() -> None:
+    chat_id, thread_id, is_explicit = _parse_target_ref(
+        "teams",
+        "19:channel@thread.tacv2;messageid=1780267076971",
+    )
+
+    assert chat_id == "19:channel@thread.tacv2"
+    assert thread_id == "1780267076971"
+    assert is_explicit is True
+
+
+def test_teams_friendly_name_still_uses_directory_resolution() -> None:
+    assert _parse_target_ref("teams", "general")[2] is False
+
+
+def test_teams_plain_native_targets_are_explicit() -> None:
+    assert _parse_target_ref("teams", "19:channel@thread.tacv2") == (
+        "19:channel@thread.tacv2",
+        None,
+        True,
+    )
+    assert _parse_target_ref("teams", "a:personal-conversation") == (
+        "a:personal-conversation",
+        None,
+        True,
+    )
+
+
+def test_teams_malformed_thread_targets_are_not_explicit() -> None:
+    assert _parse_target_ref("teams", "19:channel@thread.tacv2;messageid=")[2] is False
+    assert (
+        _parse_target_ref(
+            "teams",
+            "19:channel@thread.tacv2;messageid=../activities",
+        )[2]
+        is False
+    )
+    assert (
+        _parse_target_ref(
+            "teams",
+            "19:channel@thread.tacv2;messageid=123;messageid=456",
+        )[2]
+        is False
+    )
+
+
+def test_send_message_routes_discovered_teams_thread_target() -> None:
+    teams_platform = Platform("teams")
+    teams_cfg = SimpleNamespace(enabled=True, token=None, extra={})
+    config = SimpleNamespace(
+        platforms={teams_platform: teams_cfg},
+        get_home_channel=lambda _platform: None,
+    )
+
+    with patch("gateway.config.load_gateway_config", return_value=config), \
+         patch("tools.interrupt.is_interrupted", return_value=False), \
+         patch("gateway.channel_directory.resolve_channel_name", side_effect=AssertionError("native Teams target should not use directory resolution")), \
+         patch("model_tools._run_async", side_effect=_run_async_immediately), \
+         patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+         patch("gateway.mirror.mirror_to_session", return_value=True):
+        result = json.loads(
+            send_message_tool(
+                {
+                    "action": "send",
+                    "target": "teams:19:channel@thread.tacv2;messageid=1780267076971",
+                    "message": "hello thread",
+                }
+            )
+        )
+
+    assert result["success"] is True
+    send_mock.assert_awaited_once_with(
+        teams_platform,
+        teams_cfg,
+        "19:channel@thread.tacv2",
+        "hello thread",
+        thread_id="1780267076971",
+        media_files=[],
+        force_document=False,
+    )
+
+
+def test_send_message_routes_directory_resolved_teams_thread_target() -> None:
+    teams_platform = Platform("teams")
+    teams_cfg = SimpleNamespace(enabled=True, token=None, extra={})
+    config = SimpleNamespace(
+        platforms={teams_platform: teams_cfg},
+        get_home_channel=lambda _platform: None,
+    )
+
+    with patch("gateway.config.load_gateway_config", return_value=config), \
+         patch("tools.interrupt.is_interrupted", return_value=False), \
+         patch("gateway.channel_directory.resolve_channel_name", return_value="19:channel@thread.tacv2;messageid=1780267076971"), \
+         patch("model_tools._run_async", side_effect=_run_async_immediately), \
+         patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+         patch("gateway.mirror.mirror_to_session", return_value=True):
+        result = json.loads(
+            send_message_tool(
+                {
+                    "action": "send",
+                    "target": "teams:general",
+                    "message": "hello thread",
+                }
+            )
+        )
+
+    assert result["success"] is True
+    send_mock.assert_awaited_once_with(
+        teams_platform,
+        teams_cfg,
+        "19:channel@thread.tacv2",
+        "hello thread",
+        thread_id="1780267076971",
+        media_files=[],
+        force_document=False,
+    )
+
+
 def test_send_message_routes_whatsapp_group_jid_without_home_fallback() -> None:
     whatsapp_cfg = SimpleNamespace(enabled=True, token=None, extra={"api_url": "http://bridge"})
     config = SimpleNamespace(
@@ -63,4 +181,3 @@ def test_send_message_routes_whatsapp_group_jid_without_home_fallback() -> None:
         media_files=[],
         force_document=False,
     )
-

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -88,7 +88,7 @@ def test_send_message_routes_discovered_teams_thread_target() -> None:
          patch("gateway.channel_directory.resolve_channel_name", side_effect=AssertionError("native Teams target should not use directory resolution")), \
          patch("model_tools._run_async", side_effect=_run_async_immediately), \
          patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
-         patch("gateway.mirror.mirror_to_session", return_value=True):
+         patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
         result = json.loads(
             send_message_tool(
                 {
@@ -109,6 +109,14 @@ def test_send_message_routes_discovered_teams_thread_target() -> None:
         media_files=[],
         force_document=False,
     )
+    mirror_mock.assert_called_once_with(
+        "teams",
+        "19:channel@thread.tacv2;messageid=1780267076971",
+        "hello thread",
+        source_label="cli",
+        thread_id=None,
+        user_id=None,
+    )
 
 
 def test_send_message_routes_directory_resolved_teams_thread_target() -> None:
@@ -124,7 +132,7 @@ def test_send_message_routes_directory_resolved_teams_thread_target() -> None:
          patch("gateway.channel_directory.resolve_channel_name", return_value="19:channel@thread.tacv2;messageid=1780267076971"), \
          patch("model_tools._run_async", side_effect=_run_async_immediately), \
          patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
-         patch("gateway.mirror.mirror_to_session", return_value=True):
+         patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
         result = json.loads(
             send_message_tool(
                 {
@@ -144,6 +152,14 @@ def test_send_message_routes_directory_resolved_teams_thread_target() -> None:
         thread_id="1780267076971",
         media_files=[],
         force_document=False,
+    )
+    mirror_mock.assert_called_once_with(
+        "teams",
+        "19:channel@thread.tacv2;messageid=1780267076971",
+        "hello thread",
+        source_label="cli",
+        thread_id=None,
+        user_id=None,
     )
 
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -52,6 +52,13 @@ _WHATSAPP_JID_RE = re.compile(
     r"^\s*[\w-]+@(?:g\.us|s\.whatsapp\.net|lid|broadcast|newsletter)\s*$",
     re.IGNORECASE,
 )
+# Teams-native conversation IDs use an ``a:`` or ``19:`` prefix. Channel
+# discovery appends the root activity as ``;messageid=<id>``; parse that
+# suffix here so copied/directory-resolved targets reach the adapter instead
+# of being mistaken for human-friendly channel names.
+_TEAMS_TARGET_RE = re.compile(
+    r"^\s*((?:a|19):[A-Za-z0-9:@\-_.]+)(?:;messageid=([A-Za-z0-9:@\-_.]+))?\s*$"
+)
 # Email addresses — a valid email like "user@domain.com" should be treated as
 # an explicit target for the email platform, not fall through to channel-name
 # resolution which has no way to resolve a raw address.
@@ -591,6 +598,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         # through to the _PHONE_PLATFORMS handler below.
         if _WHATSAPP_JID_RE.fullmatch(target_ref):
             return target_ref.strip(), None, True
+    if platform_name == "teams":
+        match = _TEAMS_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), match.group(2), True
     stripped_target = target_ref.strip()
     if platform_name == "signal" and stripped_target.startswith("group:"):
         group_id = stripped_target[len("group:"):].strip()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -641,6 +641,30 @@ def _parse_target_ref(platform_name: str, target_ref: str):
     return None, None, False
 
 
+def _target_identity(
+    platform_name: str,
+    chat_id: str,
+    thread_id: str | None,
+) -> tuple[str, str, str | None]:
+    """Return a canonical identity for routing-equivalence comparisons.
+
+    Teams persists an inbound channel-thread origin as one composite
+    ``chat_id`` while outbound parsing uses a split chat/thread pair.  Treat
+    those two representations as the same lane without changing the values
+    passed to the adapter or the session-mirroring lookup.
+    """
+    platform = str(platform_name).lower()
+    chat = str(chat_id)
+    thread = None if thread_id is None else str(thread_id)
+    if platform == "teams":
+        match = _TEAMS_TARGET_RE.fullmatch(chat)
+        if match and match.group(2):
+            composite_thread = match.group(2)
+            if thread is None or thread == composite_thread:
+                return platform, match.group(1), composite_thread
+    return platform, chat, thread
+
+
 def _describe_media_for_mirror(media_files):
     """Return a human-readable mirror summary when a message only contains media."""
     if not media_files:
@@ -681,10 +705,14 @@ def _maybe_skip_cron_duplicate_send(platform_name: str, chat_id: str, thread_id:
     if not auto_target:
         return None
 
-    same_target = (
-        auto_target["platform"] == platform_name
-        and str(auto_target["chat_id"]) == str(chat_id)
-        and auto_target.get("thread_id") == thread_id
+    same_target = _target_identity(
+        auto_target["platform"],
+        auto_target["chat_id"],
+        auto_target.get("thread_id"),
+    ) == _target_identity(
+        platform_name,
+        chat_id,
+        thread_id,
     )
     if not same_target:
         return None

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -523,7 +523,9 @@ def _handle_send(args):
             try:
                 from gateway.mirror import mirror_to_session
                 from gateway.session_context import get_session_env
-                source_label = get_session_env("HERMES_SESSION_PLATFORM", "cli")
+                source_label = (
+                    get_session_env("HERMES_SESSION_PLATFORM", "") or "cli"
+                )
                 user_id = get_session_env("HERMES_SESSION_USER_ID", "") or None
                 if mirror_to_session(
                     platform_name,

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -398,6 +398,16 @@ def _handle_send(args):
                 f"Try using a numeric channel ID instead."
             )
 
+    # Teams persists inbound channel-thread origins using Bot Framework's
+    # composite ``<conversation>;messageid=<activity>`` value.  Sending needs
+    # the split conversation/thread pair, but mirroring must use the persisted
+    # composite origin or it cannot find the receiving gateway session.
+    mirror_chat_id = None
+    mirror_thread_id = thread_id
+    if platform_name == "teams" and chat_id and thread_id:
+        mirror_chat_id = f"{chat_id};messageid={thread_id}"
+        mirror_thread_id = None
+
     from tools.interrupt import is_interrupted
     if is_interrupted():
         return tool_error("Interrupted")
@@ -517,10 +527,10 @@ def _handle_send(args):
                 user_id = get_session_env("HERMES_SESSION_USER_ID", "") or None
                 if mirror_to_session(
                     platform_name,
-                    chat_id,
+                    mirror_chat_id or chat_id,
                     mirror_text,
                     source_label=source_label,
-                    thread_id=thread_id,
+                    thread_id=mirror_thread_id,
                     user_id=user_id,
                 ):
                     result["mirrored"] = True


### PR DESCRIPTION
## Summary

Teams channel discovery persists threaded targets as `<conversation>;messageid=<root-activity>`. This PR preserves that native identity end to end instead of treating it as a friendly channel name or rejecting the semicolon during delivery.

- parse and validate Teams-native `19:` / `a:` targets before directory fallback
- preserve the root activity ID through live-gateway and standalone text delivery
- canonicalize composite and split Teams identities for cron target deduplication and origin mirroring
- mirror successful cron delivery through the origin session's exact persisted composite key
- route cron media attachments through the same thread using the SDK's supported `App.reply(conversation_id, message_id, activity)` path
- fail closed on malformed identifiers or threaded proactive-send failures instead of posting to the top-level channel

Closes #68088.

## Validation

- 115 affected Teams, send-message, cron, and channel-directory tests passed
- Ruff passed on all changed Python files
- `git diff --check` passed
- fork CI passed on exact head `ce29a7581050dd3ce5c4bd17d8ebaffb8b817e22`
- fresh Codex review on that exact head: no major issues
- all fork review threads resolved
