### PR TITLE
feat(api): add exact stoppable session continuation

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -12,6 +12,7 @@ Exposes an HTTP server with endpoints:
 - POST /api/sessions               — create an empty Hermes session
 - GET/PATCH/DELETE /api/sessions/{session_id} — read/update/delete a session
 - GET  /api/sessions/{session_id}/messages — read session message history
+- GET  /v1/sessions/{session_id}/continuation — issue an exact Runs continuation descriptor
 - POST /api/sessions/{session_id}/fork — branch a session using SessionDB lineage
 - POST /api/sessions/{session_id}/chat[/stream] — chat with a persisted session
 - POST /v1/runs                    — start a run, returns run_id immediately (202)
@@ -156,6 +157,29 @@ MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 RESPONSES_AUTO_TRUNCATION_HISTORY_LIMIT = 100
 _COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
+RUN_SESSION_CONTINUATION_VERSION = 1
+RUN_SESSION_CONTINUATION_REVISION_RE = re.compile(r"sessionrev_[0-9a-f]{64}")
+
+
+def _run_session_continuation_revision(
+    session_id: str,
+    conversation_history: List[Dict[str, Any]],
+    message_ids: List[int],
+) -> str:
+    """Hash the exact normalized history used for a continued Runs turn."""
+    canonical = json.dumps(
+        {
+            "version": RUN_SESSION_CONTINUATION_VERSION,
+            "session_id": session_id,
+            "message_ids": message_ids,
+            "conversation_history": conversation_history,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return f"sessionrev_{hashlib.sha256(canonical).hexdigest()}"
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -1381,6 +1405,12 @@ class APIServerAdapter(BasePlatformAdapter):
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
+        # Exact Runs continuations are single-writer per resolved session tip.
+        # Values are the run IDs that own the in-process claim until their
+        # executor-backed work has fully exited.
+        self._active_continuation_sessions: Dict[
+            tuple[Optional[str], str], str
+        ] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
         # Last-known-good resolved model per session (keyed by gateway_session_key
         # ONLY — never session_id, which rotates/is ephemeral for one-off API
@@ -1950,6 +1980,11 @@ class APIServerAdapter(BasePlatformAdapter):
             ("PATCH", "/api/sessions/{session_id}", self._handle_patch_session),
             ("DELETE", "/api/sessions/{session_id}", self._handle_delete_session),
             ("GET", "/api/sessions/{session_id}/messages", self._handle_session_messages),
+            (
+                "GET",
+                "/v1/sessions/{session_id}/continuation",
+                self._handle_session_continuation,
+            ),
             ("POST", "/api/sessions/{session_id}/fork", self._handle_fork_session),
             ("POST", "/api/sessions/{session_id}/chat", self._handle_session_chat),
             ("POST", "/api/sessions/{session_id}/chat/stream", self._handle_session_chat_stream),
@@ -3008,6 +3043,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_chat_streaming": True,
                 "session_fork": True,
                 "session_model_lock": True,
+                "run_session_continuation": True,
+                "run_session_continuation_version": RUN_SESSION_CONTINUATION_VERSION,
+                "run_session_continuation_exact_revision": True,
+                "run_session_continuation_stoppable": True,
                 "admin_config_rw": False,
                 "jobs_admin": False,
                 "memory_write_api": False,
@@ -3038,6 +3077,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_update": {"method": "PATCH", "path": "/api/sessions/{session_id}"},
                 "session_delete": {"method": "DELETE", "path": "/api/sessions/{session_id}"},
                 "session_messages": {"method": "GET", "path": "/api/sessions/{session_id}/messages"},
+                "session_continuation": {
+                    "method": "GET",
+                    "path": "/v1/sessions/{session_id}/continuation",
+                },
                 "session_fork": {"method": "POST", "path": "/api/sessions/{session_id}/fork"},
                 "session_chat": {"method": "POST", "path": "/api/sessions/{session_id}/chat"},
                 "session_chat_stream": {"method": "POST", "path": "/api/sessions/{session_id}/chat/stream"},
@@ -3414,6 +3457,93 @@ class APIServerAdapter(BasePlatformAdapter):
             "object": "list",
             "session_id": resolved_id,
             "data": [self._message_response(m) for m in messages],
+        })
+
+    async def _handle_session_continuation(
+        self, request: "web.Request"
+    ) -> "web.Response":
+        """Issue a revision-bound descriptor for one stoppable Runs turn."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        session_id = request.match_info["session_id"]
+        db = await self._ensure_session_db_async()
+        if db is None:
+            return web.json_response(
+                _openai_error(
+                    "Session database unavailable",
+                    code="session_db_unavailable",
+                ),
+                status=503,
+            )
+        try:
+            snapshot = await asyncio.to_thread(
+                db.get_continuation_snapshot,
+                session_id,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to create continuation descriptor for session %s",
+                session_id,
+            )
+            return web.json_response(
+                _openai_error(
+                    "Session continuation is temporarily unavailable",
+                    code="session_continuation_unavailable",
+                ),
+                status=503,
+            )
+        if snapshot is None:
+            return web.json_response(
+                _openai_error(
+                    "Session not found",
+                    code="session_not_found",
+                ),
+                status=404,
+            )
+
+        resolved_id, conversation_history, message_ids = snapshot
+        from gateway.session import _is_path_unsafe
+
+        if (
+            not isinstance(resolved_id, str)
+            or not resolved_id
+            or len(resolved_id) > self._MAX_SESSION_HEADER_LEN
+            or re.search(r"[\r\n\x00]", resolved_id)
+            or _is_path_unsafe(resolved_id)
+        ):
+            return web.json_response(
+                _openai_error(
+                    "Session cannot be represented by a continuation descriptor",
+                    code="session_continuation_unavailable",
+                ),
+                status=409,
+            )
+        try:
+            revision = _run_session_continuation_revision(
+                resolved_id,
+                conversation_history,
+                message_ids,
+            )
+        except (TypeError, ValueError):
+            logger.exception(
+                "Session %s could not be normalized for continuation",
+                resolved_id,
+            )
+            return web.json_response(
+                _openai_error(
+                    "Session continuation is unavailable for this history",
+                    code="session_continuation_unavailable",
+                ),
+                status=409,
+            )
+
+        return web.json_response({
+            "object": "hermes.session.continuation",
+            "version": RUN_SESSION_CONTINUATION_VERSION,
+            "session_id": resolved_id,
+            "revision": revision,
         })
 
     async def _handle_fork_session(self, request: "web.Request") -> "web.Response":
@@ -6270,6 +6400,11 @@ class APIServerAdapter(BasePlatformAdapter):
             body = await request.json()
         except Exception:
             return web.json_response(_openai_error("Invalid JSON"), status=400)
+        if not isinstance(body, dict):
+            return web.json_response(
+                _openai_error("Request body must be a JSON object"),
+                status=400,
+            )
 
         raw_input = body.get("input")
         if not raw_input:
@@ -6282,11 +6417,170 @@ class APIServerAdapter(BasePlatformAdapter):
         instructions = body.get("instructions")
         previous_response_id = body.get("previous_response_id")
 
+        continued_session_id: Optional[str] = None
+        continued_history: Optional[List[Dict[str, Any]]] = None
+        continuation_claim_id: Optional[str] = None
+        continuation_claim_key: Optional[tuple[Optional[str], str]] = None
+        raw_continuation = body.get("continuation")
+        if raw_continuation is not None:
+            if not isinstance(raw_continuation, dict):
+                return web.json_response(
+                    _openai_error(
+                        "'continuation' must be an object",
+                        code="invalid_session_continuation",
+                    ),
+                    status=400,
+                )
+            expected_fields = {"version", "session_id", "revision"}
+            if set(raw_continuation) != expected_fields:
+                return web.json_response(
+                    _openai_error(
+                        "'continuation' must contain exactly version, session_id, and revision",
+                        code="invalid_session_continuation",
+                    ),
+                    status=400,
+                )
+            if any(
+                field in body
+                for field in (
+                    "session_id",
+                    "conversation_history",
+                    "previous_response_id",
+                )
+            ) or (isinstance(raw_input, list) and len(raw_input) > 1):
+                return web.json_response(
+                    _openai_error(
+                        "Continuation cannot be combined with session_id or client-supplied history",
+                        code="ambiguous_session_continuation",
+                    ),
+                    status=400,
+                )
+
+            continuation_version = raw_continuation.get("version")
+            continuation_session_id = raw_continuation.get("session_id")
+            continuation_revision = raw_continuation.get("revision")
+            from gateway.session import _is_path_unsafe
+
+            if (
+                not isinstance(continuation_version, int)
+                or isinstance(continuation_version, bool)
+                or continuation_version != RUN_SESSION_CONTINUATION_VERSION
+                or not isinstance(continuation_session_id, str)
+                or not continuation_session_id
+                or len(continuation_session_id) > self._MAX_SESSION_HEADER_LEN
+                or re.search(r"[\r\n\x00]", continuation_session_id)
+                or _is_path_unsafe(continuation_session_id)
+                or not isinstance(continuation_revision, str)
+                or RUN_SESSION_CONTINUATION_REVISION_RE.fullmatch(
+                    continuation_revision
+                )
+                is None
+            ):
+                return web.json_response(
+                    _openai_error(
+                        "Invalid session continuation descriptor",
+                        code="invalid_session_continuation",
+                    ),
+                    status=400,
+                )
+
+            db = await self._ensure_session_db_async()
+            if db is None:
+                return web.json_response(
+                    _openai_error(
+                        "Session database unavailable",
+                        code="session_db_unavailable",
+                    ),
+                    status=503,
+                )
+            continuation_claim_key = (
+                _api_request_profile.get(),
+                continuation_session_id,
+            )
+            if continuation_claim_key in self._active_continuation_sessions:
+                return web.json_response(
+                    _openai_error(
+                        "Session continuation already has an active run",
+                        code="session_continuation_active",
+                    ),
+                    status=409,
+                )
+            continuation_claim_id = f"checking_{uuid.uuid4().hex}"
+            self._active_continuation_sessions[
+                continuation_claim_key
+            ] = continuation_claim_id
+            try:
+                try:
+                    snapshot = await asyncio.to_thread(
+                        db.get_continuation_snapshot,
+                        continuation_session_id,
+                    )
+                except Exception:
+                    logger.exception("Failed to verify a Runs continuation descriptor")
+                    return web.json_response(
+                        _openai_error(
+                            "Session continuation is temporarily unavailable",
+                            code="session_continuation_unavailable",
+                        ),
+                        status=503,
+                    )
+                if snapshot is None:
+                    return web.json_response(
+                        _openai_error(
+                            "Session continuation is no longer current",
+                            code="session_continuation_changed",
+                        ),
+                        status=409,
+                    )
+                resolved_id, snapshot_history, snapshot_message_ids = snapshot
+                try:
+                    current_revision = _run_session_continuation_revision(
+                        resolved_id,
+                        snapshot_history,
+                        snapshot_message_ids,
+                    )
+                except (TypeError, ValueError):
+                    return web.json_response(
+                        _openai_error(
+                            "Session continuation is unavailable for this history",
+                            code="session_continuation_unavailable",
+                        ),
+                        status=409,
+                    )
+                if (
+                    resolved_id != continuation_session_id
+                    or not hmac.compare_digest(
+                        current_revision,
+                        continuation_revision,
+                    )
+                ):
+                    return web.json_response(
+                        _openai_error(
+                            "Session continuation is no longer current",
+                            code="session_continuation_changed",
+                        ),
+                        status=409,
+                    )
+                continued_session_id = resolved_id
+                continued_history = snapshot_history
+            finally:
+                if (
+                    continued_session_id is None
+                    and self._active_continuation_sessions.get(
+                        continuation_claim_key
+                    )
+                    == continuation_claim_id
+                ):
+                    self._active_continuation_sessions.pop(
+                        continuation_claim_key,
+                        None,
+                    )
+
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
-        conversation_history: List[Dict[str, str]] = []
+        conversation_history: List[Dict[str, Any]] = list(continued_history or [])
         raw_history = body.get("conversation_history")
-        if raw_history:
+        if continued_history is None and raw_history:
             if not isinstance(raw_history, list):
                 return web.json_response(
                     _openai_error("'conversation_history' must be an array of message objects"),
@@ -6303,7 +6597,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
         stored_session_id = None
-        if not conversation_history and previous_response_id:
+        if continued_history is None and not conversation_history and previous_response_id:
             stored = self._response_store.get(previous_response_id)
             if stored:
                 conversation_history = list(stored.get("conversation_history", []))
@@ -6314,7 +6608,12 @@ class APIServerAdapter(BasePlatformAdapter):
         # When input is a multi-message array, extract all but the last
         # message as conversation history (the last becomes user_message).
         # Only fires when no explicit history was provided.
-        if not conversation_history and isinstance(raw_input, list) and len(raw_input) > 1:
+        if (
+            continued_history is None
+            and not conversation_history
+            and isinstance(raw_input, list)
+            and len(raw_input) > 1
+        ):
             for msg in raw_input[:-1]:
                 if isinstance(msg, dict) and msg.get("role") and msg.get("content"):
                     content = msg["content"]
@@ -6340,7 +6639,26 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response(_openai_error(selection_error), status=400)
 
         run_id = f"run_{uuid.uuid4().hex}"
-        session_id = session_id or run_id
+        session_id = (
+            continued_session_id
+            or session_id
+            or run_id
+        )
+        if continued_session_id is not None:
+            # The verification reservation remains owned, and no await occurs
+            # while it is transferred to the newly allocated run ID.
+            if (
+                self._active_continuation_sessions.get(continuation_claim_key)
+                != continuation_claim_id
+            ):
+                return web.json_response(
+                    _openai_error(
+                        "Session continuation claim was lost",
+                        code="session_continuation_changed",
+                    ),
+                    status=409,
+                )
+            self._active_continuation_sessions[continuation_claim_key] = run_id
         # Approval queues gate host-side tool execution and must be isolated
         # per API run.  Client-provided session IDs and memory session keys are
         # conversation/memory scopes, not authorization namespaces: multiple
@@ -6384,6 +6702,11 @@ class APIServerAdapter(BasePlatformAdapter):
             created_at=created_at,
             session_id=session_id,
             model=body.get("model", self._model_name),
+            **(
+                {"continuation_version": RUN_SESSION_CONTINUATION_VERSION}
+                if continued_session_id is not None
+                else {}
+            ),
         )
 
         # Background task outlives the HTTP response (and thus the middleware
@@ -6639,6 +6962,17 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
+                if (
+                    continued_session_id is not None
+                    and self._active_continuation_sessions.get(
+                        continuation_claim_key
+                    )
+                    == run_id
+                ):
+                    self._active_continuation_sessions.pop(
+                        continuation_claim_key,
+                        None,
+                    )
                 self._stopping_run_ids.discard(run_id)
 
         self._activate_admitted_request()

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3043,7 +3043,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_chat_streaming": True,
                 "session_fork": True,
                 "session_model_lock": True,
-                "run_session_continuation": True,
+                "run_session_continuation": bool(self._api_key),
                 "run_session_continuation_version": RUN_SESSION_CONTINUATION_VERSION,
                 "run_session_continuation_exact_revision": True,
                 "run_session_continuation_stoppable": True,
@@ -3466,6 +3466,14 @@ class APIServerAdapter(BasePlatformAdapter):
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
+        if not self._api_key:
+            return web.json_response(
+                _openai_error(
+                    "Session continuation requires API key authentication",
+                    code="session_continuation_auth_required",
+                ),
+                status=403,
+            )
 
         session_id = request.match_info["session_id"]
         db = await self._ensure_session_db_async()
@@ -6423,6 +6431,17 @@ class APIServerAdapter(BasePlatformAdapter):
         continuation_claim_key: Optional[tuple[Optional[str], str]] = None
         raw_continuation = body.get("continuation")
         if raw_continuation is not None:
+            auth_err = self._check_auth(request)
+            if auth_err:
+                return auth_err
+            if not self._api_key:
+                return web.json_response(
+                    _openai_error(
+                        "Session continuation requires API key authentication",
+                        code="session_continuation_auth_required",
+                    ),
+                    status=403,
+                )
             if not isinstance(raw_continuation, dict):
                 return web.json_response(
                     _openai_error(
@@ -6625,7 +6644,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         )
                     conversation_history.append({"role": msg["role"], "content": str(content)})
 
-        session_id = body.get("session_id") or stored_session_id
+        session_id = continued_session_id or body.get("session_id") or stored_session_id
         route = self._resolve_route(body.get("model"))
         agent_overrides = _request_agent_overrides(body, virtual_model=self._model_name)
         selection_error = self._request_route_conflict_error(
@@ -6636,14 +6655,21 @@ class APIServerAdapter(BasePlatformAdapter):
             route=route,
         )
         if selection_error:
+            if (
+                continued_session_id is not None
+                and self._active_continuation_sessions.get(
+                    continuation_claim_key
+                )
+                == continuation_claim_id
+            ):
+                self._active_continuation_sessions.pop(
+                    continuation_claim_key,
+                    None,
+                )
             return web.json_response(_openai_error(selection_error), status=400)
 
         run_id = f"run_{uuid.uuid4().hex}"
-        session_id = (
-            continued_session_id
-            or session_id
-            or run_id
-        )
+        session_id = session_id or run_id
         if continued_session_id is not None:
             # The verification reservation remains owned, and no await occurs
             # while it is transferred to the newly allocated run ID.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5494,36 +5494,40 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Returns the latest continuation tip, or the input id when no
         continuation exists.
         """
+        with self._lock:
+            return self._get_compression_tip_locked(session_id)
+
+    def _get_compression_tip_locked(self, session_id: str) -> Optional[str]:
+        """Resolve a compression tip while ``self._lock`` is already held."""
         current = session_id
         seen = {current} if current else set()
         # Bound the walk defensively — compression chains this deep are
         # pathological and shouldn't happen in practice. 100 = plenty.
         for _ in range(100):
-            with self._lock:
-                cursor = self._conn.execute(
-                    f"""
-                    SELECT child.id
-                    FROM sessions parent
-                    JOIN sessions child ON child.parent_session_id = parent.id
-                    WHERE parent.id = ?
-                      AND parent.end_reason = 'compression'
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
-                      AND COALESCE(child.source, '') != 'tool'
-                    ORDER BY
-                      CASE
-                        WHEN child.end_reason = 'compression' THEN 0
-                        WHEN child.ended_at IS NULL THEN 1
-                        ELSE 2
-                      END,
-                      {_sql_session_last_active("child")} DESC,
-                      child.started_at DESC,
-                      child.id DESC
-                    LIMIT 1
-                    """,
-                    (current,),
-                )
-                row = cursor.fetchone()
+            cursor = self._conn.execute(
+                f"""
+                SELECT child.id
+                FROM sessions parent
+                JOIN sessions child ON child.parent_session_id = parent.id
+                WHERE parent.id = ?
+                  AND parent.end_reason = 'compression'
+                  AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
+                  AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
+                  AND COALESCE(child.source, '') != 'tool'
+                ORDER BY
+                  CASE
+                    WHEN child.end_reason = 'compression' THEN 0
+                    WHEN child.ended_at IS NULL THEN 1
+                    ELSE 2
+                  END,
+                  {_sql_session_last_active("child")} DESC,
+                  child.started_at DESC,
+                  child.id DESC
+                LIMIT 1
+                """,
+                (current,),
+            )
+            row = cursor.fetchone()
             if row is None:
                 return current
             child_id = row["id"]
@@ -6992,6 +6996,49 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 current = child_id
 
             return best if best is not None else session_id
+
+    def get_continuation_snapshot(
+        self, session_id: str
+    ) -> Optional[Tuple[str, List[Dict[str, Any]], List[int]]]:
+        """Return one atomic, model-fed snapshot for exact HTTP continuation.
+
+        The resolved compression tip and its active conversation rows are read
+        while holding the same SessionDB lock. Callers can therefore bind a
+        revision to the exact history they will pass to the agent instead of
+        resolving a tip and loading its messages in two raceable reads.
+
+        Returns ``None`` when the requested session does not exist. The
+        returned conversation is alternation-repaired in memory, matching the
+        live resume path without changing durable transcript rows. Message row
+        IDs are returned separately so a delete-and-recreate with identical
+        prose still changes the continuation revision.
+        """
+        if not session_id:
+            return None
+
+        with self._lock:
+            exists = self._conn.execute(
+                "SELECT 1 FROM sessions WHERE id = ? LIMIT 1",
+                (session_id,),
+            ).fetchone()
+            if exists is None:
+                return None
+
+            resolved_id = self._get_compression_tip_locked(session_id) or session_id
+            rows = self._conn.execute(
+                f"SELECT id, {self._CONVERSATION_ROW_COLUMNS} "
+                "FROM messages WHERE session_id = ? AND active = 1 ORDER BY id",
+                (resolved_id,),
+            ).fetchall()
+            message_ids = [int(row["id"]) for row in rows]
+
+        history = self._rows_to_conversation(
+            rows,
+            session_id=resolved_id,
+            include_ancestors=False,
+            repair_alternation=True,
+        )
+        return resolved_id, history, message_ids
 
     def get_messages_as_conversation(
         self,

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -21,9 +21,11 @@ from gateway.config import PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
     _approval_event_choices,
+    _run_session_continuation_revision,
     cors_middleware,
     security_headers_middleware,
 )
+from hermes_state import SessionDB
 from tools import approval as approval_mod
 
 
@@ -104,6 +106,21 @@ def _make_slow_agent(**kwargs):
     return mock_agent, ready, interrupted
 
 
+def _continuation_descriptor(db: SessionDB, session_id: str) -> dict:
+    snapshot = db.get_continuation_snapshot(session_id)
+    assert snapshot is not None
+    resolved_id, history, message_ids = snapshot
+    return {
+        "version": 1,
+        "session_id": resolved_id,
+        "revision": _run_session_continuation_revision(
+            resolved_id,
+            history,
+            message_ids,
+        ),
+    }
+
+
 @pytest.fixture
 def adapter():
     return _make_adapter()
@@ -144,6 +161,350 @@ class TestStartRun:
                 assert status["run_id"] == data["run_id"]
                 assert status["status"] in {"queued", "running", "completed"}
                 assert status["object"] == "hermes.run"
+
+
+class TestExactSessionContinuation:
+    @pytest.mark.asyncio
+    async def test_verified_continuation_loads_history_into_stoppable_run(
+        self,
+        adapter,
+        tmp_path,
+    ):
+        db = SessionDB(tmp_path / "continuation.db")
+        adapter._session_db = db
+        try:
+            session_id = db.create_session("continued-session", "api_server")
+            db.append_message(session_id, "user", "earlier question")
+            db.append_message(session_id, "assistant", "earlier answer")
+            descriptor = _continuation_descriptor(db, session_id)
+
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "continued"}
+            mock_agent.session_prompt_tokens = 3
+            mock_agent.session_completion_tokens = 2
+            mock_agent.session_total_tokens = 5
+
+            app = _create_runs_app(adapter)
+            with patch.object(adapter, "_create_agent", return_value=mock_agent):
+                async with TestClient(TestServer(app)) as cli:
+                    resp = await cli.post(
+                        "/v1/runs",
+                        json={"input": "next step", "continuation": descriptor},
+                    )
+                    assert resp.status == 202, await resp.text()
+                    run_id = (await resp.json())["run_id"]
+
+                    for _ in range(40):
+                        status_resp = await cli.get(f"/v1/runs/{run_id}")
+                        status = await status_resp.json()
+                        if status["status"] == "completed":
+                            break
+                        await asyncio.sleep(0.025)
+
+            assert status["status"] == "completed"
+            assert status["session_id"] == session_id
+            assert status["continuation_version"] == 1
+            assert status["output"] == "continued"
+            call = mock_agent.run_conversation.call_args.kwargs
+            assert call["task_id"] == session_id
+            assert call["user_message"] == "next step"
+            assert [
+                (message["role"], message["content"])
+                for message in call["conversation_history"]
+            ] == [
+                ("user", "earlier question"),
+                ("assistant", "earlier answer"),
+            ]
+            assert adapter._active_continuation_sessions == {}
+        finally:
+            db.close()
+
+    @pytest.mark.asyncio
+    async def test_changed_revision_fails_before_run_allocation(self, adapter, tmp_path):
+        db = SessionDB(tmp_path / "changed.db")
+        adapter._session_db = db
+        try:
+            session_id = db.create_session("changed-session", "api_server")
+            db.append_message(session_id, "user", "original")
+            descriptor = _continuation_descriptor(db, session_id)
+            db.append_message(session_id, "assistant", "new state")
+
+            app = _create_runs_app(adapter)
+            with patch.object(adapter, "_create_agent") as create_agent:
+                async with TestClient(TestServer(app)) as cli:
+                    resp = await cli.post(
+                        "/v1/runs",
+                        json={"input": "continue", "continuation": descriptor},
+                    )
+                    payload = await resp.json()
+
+            assert resp.status == 409
+            assert payload["error"]["code"] == "session_continuation_changed"
+            assert "original" not in str(payload)
+            assert "new state" not in str(payload)
+            create_agent.assert_not_called()
+            assert adapter._run_streams == {}
+            assert adapter._run_statuses == {}
+            assert adapter._active_continuation_sessions == {}
+        finally:
+            db.close()
+
+    @pytest.mark.asyncio
+    async def test_cross_session_revision_fails_closed(self, adapter, tmp_path):
+        db = SessionDB(tmp_path / "cross-session.db")
+        adapter._session_db = db
+        try:
+            first_id = db.create_session("first-session", "api_server")
+            second_id = db.create_session("second-session", "api_server")
+            db.append_message(first_id, "user", "first history")
+            db.append_message(second_id, "user", "second history")
+            descriptor = _continuation_descriptor(db, first_id)
+            descriptor["session_id"] = second_id
+
+            app = _create_runs_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "continue", "continuation": descriptor},
+                )
+                payload = await resp.json()
+
+            assert resp.status == 409
+            assert payload["error"]["code"] == "session_continuation_changed"
+            assert adapter._run_statuses == {}
+        finally:
+            db.close()
+
+    @pytest.mark.asyncio
+    async def test_compression_rotation_makes_tip_descriptor_stale(
+        self,
+        adapter,
+        tmp_path,
+    ):
+        db = SessionDB(tmp_path / "compressed.db")
+        adapter._session_db = db
+        try:
+            tip_id = db.create_session("old-tip", "api_server")
+            db.append_message(tip_id, "user", "old tip history")
+            descriptor = _continuation_descriptor(db, tip_id)
+            db.end_session(tip_id, "compression")
+            new_tip = db.create_session(
+                "new-tip",
+                "api_server",
+                parent_session_id=tip_id,
+            )
+            db.append_message(new_tip, "user", "new tip history")
+
+            app = _create_runs_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "continue", "continuation": descriptor},
+                )
+                payload = await resp.json()
+
+            assert resp.status == 409
+            assert payload["error"]["code"] == "session_continuation_changed"
+            assert adapter._run_statuses == {}
+        finally:
+            db.close()
+
+    @pytest.mark.asyncio
+    async def test_continuation_rejects_ambiguous_or_malformed_input(
+        self,
+        adapter,
+        tmp_path,
+    ):
+        db = SessionDB(tmp_path / "invalid.db")
+        adapter._session_db = db
+        try:
+            session_id = db.create_session("invalid-session", "api_server")
+            db.append_message(session_id, "user", "history")
+            descriptor = _continuation_descriptor(db, session_id)
+            cases = [
+                ({"input": "continue", "continuation": "invalid"}, 400),
+                (
+                    {
+                        "input": "continue",
+                        "continuation": {**descriptor, "extra": True},
+                    },
+                    400,
+                ),
+                (
+                    {
+                        "input": "continue",
+                        "session_id": session_id,
+                        "continuation": descriptor,
+                    },
+                    400,
+                ),
+                (
+                    {
+                        "input": "continue",
+                        "conversation_history": [],
+                        "continuation": descriptor,
+                    },
+                    400,
+                ),
+                (
+                    {
+                        "input": [
+                            {"role": "user", "content": "old"},
+                            {"role": "user", "content": "new"},
+                        ],
+                        "continuation": descriptor,
+                    },
+                    400,
+                ),
+                (
+                    {
+                        "input": "continue",
+                        "continuation": {**descriptor, "version": True},
+                    },
+                    400,
+                ),
+                (
+                    {
+                        "input": "continue",
+                        "continuation": {**descriptor, "revision": "sessionrev_bad"},
+                    },
+                    400,
+                ),
+            ]
+
+            app = _create_runs_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                for body, expected_status in cases:
+                    resp = await cli.post("/v1/runs", json=body)
+                    assert resp.status == expected_status, await resp.text()
+
+            assert adapter._run_statuses == {}
+            assert adapter._run_streams == {}
+            assert adapter._active_continuation_sessions == {}
+        finally:
+            db.close()
+
+    @pytest.mark.asyncio
+    async def test_only_one_continuation_run_can_own_a_session_and_stop_releases_it(
+        self,
+        adapter,
+        tmp_path,
+    ):
+        db = SessionDB(tmp_path / "active.db")
+        adapter._session_db = db
+        try:
+            session_id = db.create_session("active-session", "api_server")
+            db.append_message(session_id, "user", "history")
+            descriptor = _continuation_descriptor(db, session_id)
+            slow_agent, ready, interrupted = _make_slow_agent()
+
+            app = _create_runs_app(adapter)
+            with patch.object(adapter, "_create_agent", return_value=slow_agent):
+                async with TestClient(TestServer(app)) as cli:
+                    first = await cli.post(
+                        "/v1/runs",
+                        json={"input": "first", "continuation": descriptor},
+                    )
+                    assert first.status == 202, await first.text()
+                    first_id = (await first.json())["run_id"]
+                    assert await asyncio.to_thread(ready.wait, 2)
+
+                    second = await cli.post(
+                        "/v1/runs",
+                        json={"input": "second", "continuation": descriptor},
+                    )
+                    second_payload = await second.json()
+                    assert second.status == 409
+                    assert (
+                        second_payload["error"]["code"]
+                        == "session_continuation_active"
+                    )
+
+                    stopped = await cli.post(f"/v1/runs/{first_id}/stop")
+                    assert stopped.status == 200
+                    assert interrupted.wait(timeout=2)
+                    for _ in range(40):
+                        if not adapter._active_continuation_sessions:
+                            break
+                        await asyncio.sleep(0.025)
+
+            assert adapter._active_continuation_sessions == {}
+            assert len(adapter._run_statuses) == 1
+            assert adapter._run_statuses[first_id]["status"] == "cancelled"
+        finally:
+            db.close()
+
+    @pytest.mark.asyncio
+    async def test_verification_reservation_closes_concurrent_snapshot_race(
+        self,
+        adapter,
+        tmp_path,
+    ):
+        db = SessionDB(tmp_path / "verification-race.db")
+        try:
+            session_id = db.create_session("verification-race", "api_server")
+            db.append_message(session_id, "user", "history")
+            descriptor = _continuation_descriptor(db, session_id)
+            snapshot_started = threading.Event()
+            release_snapshot = threading.Event()
+
+            class BlockingSnapshotDB:
+                calls = 0
+
+                def get_continuation_snapshot(self, requested_id):
+                    self.calls += 1
+                    snapshot_started.set()
+                    release_snapshot.wait(timeout=5)
+                    return db.get_continuation_snapshot(requested_id)
+
+            blocking_db = BlockingSnapshotDB()
+            adapter._session_db = blocking_db
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "done"}
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+
+            app = _create_runs_app(adapter)
+            with patch.object(adapter, "_create_agent", return_value=mock_agent):
+                async with TestClient(TestServer(app)) as cli:
+                    first_task = asyncio.create_task(
+                        cli.post(
+                            "/v1/runs",
+                            json={"input": "first", "continuation": descriptor},
+                        )
+                    )
+                    assert await asyncio.to_thread(snapshot_started.wait, 2)
+
+                    second = await cli.post(
+                        "/v1/runs",
+                        json={"input": "second", "continuation": descriptor},
+                    )
+                    second_payload = await second.json()
+                    assert second.status == 409
+                    assert (
+                        second_payload["error"]["code"]
+                        == "session_continuation_active"
+                    )
+                    assert blocking_db.calls == 1
+
+                    release_snapshot.set()
+                    first = await first_task
+                    assert first.status == 202, await first.text()
+                    for _ in range(40):
+                        if not adapter._active_continuation_sessions:
+                            break
+                        await asyncio.sleep(0.025)
+
+            assert adapter._active_continuation_sessions == {}
+            assert len(adapter._run_statuses) == 1
+        finally:
+            if "release_snapshot" in locals():
+                release_snapshot.set()
+            db.close()
+
+
+class TestStartRunValidation:
 
     @pytest.mark.asyncio
     async def test_start_binds_chat_id_for_delegation_wake_target(self, adapter):

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -164,6 +164,16 @@ class TestStartRun:
 
 
 class TestExactSessionContinuation:
+    @pytest.fixture(autouse=True)
+    def _configured_key_for_continuation_logic(self, adapter):
+        """Exercise continuation state logic with its required key configured.
+
+        The HTTP bearer gate itself has dedicated coverage below; these tests
+        focus on descriptor binding, races, and lifecycle behavior.
+        """
+        adapter._api_key = "sk-secret"
+        adapter._check_auth = lambda _request: None
+
     @pytest.mark.asyncio
     async def test_verified_continuation_loads_history_into_stoppable_run(
         self,
@@ -215,6 +225,126 @@ class TestExactSessionContinuation:
                 ("user", "earlier question"),
                 ("assistant", "earlier answer"),
             ]
+            assert adapter._active_continuation_sessions == {}
+        finally:
+            db.close()
+
+    @pytest.mark.asyncio
+    async def test_continuation_submission_refuses_an_unkeyed_api_server(
+        self, tmp_path
+    ):
+        adapter = _make_adapter()
+        db = SessionDB(tmp_path / "unkeyed-continuation.db")
+        adapter._session_db = db
+        try:
+            session_id = db.create_session("private-session", "api_server")
+            db.append_message(session_id, "user", "private history")
+            descriptor = _continuation_descriptor(db, session_id)
+            app = _create_runs_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post(
+                    "/v1/runs",
+                    json={"input": "continue", "continuation": descriptor},
+                )
+                payload = await response.json()
+
+            assert response.status == 403
+            assert payload["error"]["code"] == "session_continuation_auth_required"
+            assert "private" not in str(payload)
+            assert adapter._run_statuses == {}
+        finally:
+            db.close()
+
+    @pytest.mark.asyncio
+    async def test_continuation_requires_configured_bearer_before_allocation(
+        self,
+        tmp_path,
+    ):
+        adapter = _make_adapter(api_key="sk-secret")
+        db = SessionDB(tmp_path / "authenticated-continuation.db")
+        adapter._session_db = db
+        try:
+            session_id = db.create_session("private-session", "api_server")
+            db.append_message(session_id, "user", "private history")
+            descriptor = _continuation_descriptor(db, session_id)
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {
+                "final_response": "continued"
+            }
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+
+            app = _create_runs_app(adapter)
+            with patch.object(
+                adapter,
+                "_create_agent",
+                return_value=mock_agent,
+            ) as create_agent:
+                async with TestClient(TestServer(app)) as cli:
+                    unauthorized = await cli.post(
+                        "/v1/runs",
+                        json={"input": "continue", "continuation": descriptor},
+                    )
+                    unauthorized_payload = await unauthorized.json()
+
+                    assert unauthorized.status == 401
+                    assert (
+                        unauthorized_payload["error"]["code"]
+                        == "gateway_auth_failed"
+                    )
+                    create_agent.assert_not_called()
+                    assert adapter._run_statuses == {}
+                    assert adapter._run_streams == {}
+                    assert adapter._active_run_tasks == {}
+                    assert adapter._active_continuation_sessions == {}
+
+                    authorized = await cli.post(
+                        "/v1/runs",
+                        json={"input": "continue", "continuation": descriptor},
+                        headers={"Authorization": "Bearer sk-secret"},
+                    )
+                    assert authorized.status == 202, await authorized.text()
+
+            create_agent.assert_called_once()
+        finally:
+            db.close()
+
+    @pytest.mark.asyncio
+    async def test_route_conflict_releases_verified_continuation_claim(
+        self,
+        adapter,
+        tmp_path,
+    ):
+        db = SessionDB(tmp_path / "route-conflict-continuation.db")
+        adapter._session_db = db
+        adapter._model_routes = {
+            "locked-route": {
+                "model": "route/model",
+                "provider": "openrouter",
+            }
+        }
+        try:
+            session_id = db.create_session("route-session", "api_server")
+            db.append_message(session_id, "user", "private history")
+            descriptor = _continuation_descriptor(db, session_id)
+            app = _create_runs_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": "continue",
+                        "continuation": descriptor,
+                        "model": "locked-route",
+                        "provider": "anthropic",
+                    },
+                )
+                payload = await response.json()
+
+            assert response.status == 400
+            assert payload["error"]["type"] == "invalid_request_error"
+            assert adapter._run_statuses == {}
+            assert adapter._run_streams == {}
             assert adapter._active_continuation_sessions == {}
         finally:
             db.close()

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -1,5 +1,6 @@
 """Focused tests for API server session-control endpoints."""
 
+import re
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -45,6 +46,10 @@ def _create_session_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_patch("/api/sessions/{session_id}", adapter._handle_patch_session)
     app.router.add_delete("/api/sessions/{session_id}", adapter._handle_delete_session)
     app.router.add_get("/api/sessions/{session_id}/messages", adapter._handle_session_messages)
+    app.router.add_get(
+        "/v1/sessions/{session_id}/continuation",
+        adapter._handle_session_continuation,
+    )
     app.router.add_post("/api/sessions/{session_id}/fork", adapter._handle_fork_session)
     app.router.add_post("/api/sessions/{session_id}/chat", adapter._handle_session_chat)
     app.router.add_post("/api/sessions/{session_id}/chat/stream", adapter._handle_session_chat_stream)
@@ -64,6 +69,10 @@ async def test_capabilities_advertises_session_control_surface(adapter):
     assert features["session_chat"] is True
     assert features["session_chat_streaming"] is True
     assert features["session_fork"] is True
+    assert features["run_session_continuation"] is True
+    assert features["run_session_continuation_version"] == 1
+    assert features["run_session_continuation_exact_revision"] is True
+    assert features["run_session_continuation_stoppable"] is True
     assert features["admin_config_rw"] is False
     assert features["memory_write_api"] is False
     assert features["skills_api"] is True
@@ -73,6 +82,128 @@ async def test_capabilities_advertises_session_control_surface(adapter):
         "method": "POST",
         "path": "/api/sessions/{session_id}/chat/stream",
     }
+    assert data["endpoints"]["session_continuation"] == {
+        "method": "GET",
+        "path": "/v1/sessions/{session_id}/continuation",
+    }
+
+
+@pytest.mark.asyncio
+async def test_continuation_descriptor_binds_resolved_tip_and_exact_history(
+    auth_adapter,
+    session_db,
+):
+    source_id = session_db.create_session("source-session", "api_server")
+    session_db.append_message(source_id, "user", "private ancestor")
+    session_db.end_session(source_id, "compression")
+    tip_id = session_db.create_session(
+        "tip-session",
+        "api_server",
+        parent_session_id=source_id,
+    )
+    session_db.append_message(tip_id, "user", "private current question")
+    session_db.append_message(tip_id, "assistant", "private current answer")
+
+    app = _create_session_app(auth_adapter)
+    async with TestClient(TestServer(app)) as cli:
+        unauthenticated = await cli.get(
+            f"/v1/sessions/{source_id}/continuation"
+        )
+        first = await cli.get(
+            f"/v1/sessions/{source_id}/continuation",
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        second = await cli.get(
+            f"/v1/sessions/{tip_id}/continuation",
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        first_payload = await first.json()
+        second_payload = await second.json()
+
+    assert unauthenticated.status == 401
+    assert first.status == 200
+    assert first_payload == second_payload
+    assert set(first_payload) == {"object", "version", "session_id", "revision"}
+    assert first_payload["object"] == "hermes.session.continuation"
+    assert first_payload["version"] == 1
+    assert first_payload["session_id"] == tip_id
+    assert re.fullmatch(r"sessionrev_[0-9a-f]{64}", first_payload["revision"])
+    assert "private" not in str(first_payload)
+
+
+@pytest.mark.asyncio
+async def test_continuation_descriptor_revision_changes_with_model_history(
+    auth_adapter,
+    session_db,
+):
+    session_id = session_db.create_session("revision-session", "api_server")
+    session_db.append_message(session_id, "user", "first")
+    app = _create_session_app(auth_adapter)
+    headers = {"Authorization": "Bearer sk-test"}
+
+    async with TestClient(TestServer(app)) as cli:
+        first = await cli.get(
+            f"/v1/sessions/{session_id}/continuation",
+            headers=headers,
+        )
+        first_payload = await first.json()
+        session_db.append_message(session_id, "assistant", "changed")
+        second = await cli.get(
+            f"/v1/sessions/{session_id}/continuation",
+            headers=headers,
+        )
+        second_payload = await second.json()
+
+    assert first.status == 200
+    assert second.status == 200
+    assert first_payload["session_id"] == second_payload["session_id"]
+    assert first_payload["revision"] != second_payload["revision"]
+
+
+@pytest.mark.asyncio
+async def test_continuation_revision_binds_message_identity_not_only_text(
+    auth_adapter,
+    session_db,
+):
+    session_id = session_db.create_session("identity-session", "api_server")
+    session_db.append_message(session_id, "user", "same text")
+    app = _create_session_app(auth_adapter)
+    headers = {"Authorization": "Bearer sk-test"}
+
+    async with TestClient(TestServer(app)) as cli:
+        first = await cli.get(
+            f"/v1/sessions/{session_id}/continuation",
+            headers=headers,
+        )
+        first_payload = await first.json()
+        session_db.replace_messages(session_id, [])
+        session_db.append_message(session_id, "user", "same text")
+        second = await cli.get(
+            f"/v1/sessions/{session_id}/continuation",
+            headers=headers,
+        )
+        second_payload = await second.json()
+
+    assert first.status == 200
+    assert second.status == 200
+    assert first_payload["revision"] != second_payload["revision"]
+
+
+@pytest.mark.asyncio
+async def test_continuation_descriptor_unknown_session_is_content_free(
+    auth_adapter,
+):
+    app = _create_session_app(auth_adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get(
+            "/v1/sessions/missing-session/continuation",
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        payload = await resp.json()
+
+    assert resp.status == 404
+    assert payload["error"]["code"] == "session_not_found"
+    assert "missing-session" not in str(payload)
 
 
 @pytest.mark.asyncio
@@ -606,5 +737,4 @@ async def test_require_model_lock_hard_fails_when_global_default_would_be_used(a
             body = await resp.json()
             assert body["error"]["code"] in {"model_lock_unavailable", "invalid_model_lock", "missing_model"}
     mock_run.assert_not_called()
-
 

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -69,7 +69,7 @@ async def test_capabilities_advertises_session_control_surface(adapter):
     assert features["session_chat"] is True
     assert features["session_chat_streaming"] is True
     assert features["session_fork"] is True
-    assert features["run_session_continuation"] is True
+    assert features["run_session_continuation"] is False
     assert features["run_session_continuation_version"] == 1
     assert features["run_session_continuation_exact_revision"] is True
     assert features["run_session_continuation_stoppable"] is True
@@ -86,6 +86,20 @@ async def test_capabilities_advertises_session_control_surface(adapter):
         "method": "GET",
         "path": "/v1/sessions/{session_id}/continuation",
     }
+
+
+@pytest.mark.asyncio
+async def test_continuation_refuses_an_unkeyed_api_server(adapter, session_db):
+    session_id = session_db.create_session("private-session", "api_server")
+    session_db.append_message(session_id, "user", "private history")
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.get(f"/v1/sessions/{session_id}/continuation")
+        payload = await response.json()
+
+    assert response.status == 403
+    assert payload["error"]["code"] == "session_continuation_auth_required"
+    assert "private" not in str(payload)
 
 
 @pytest.mark.asyncio
@@ -737,4 +751,3 @@ async def test_require_model_lock_hard_fails_when_global_default_would_be_used(a
             body = await resp.json()
             assert body["error"]["code"] in {"model_lock_unavailable", "invalid_model_lock", "missing_model"}
     mock_run.assert_not_called()
-

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -90,6 +90,7 @@ Endpoints:
 POST /v1/chat/completions        OpenAI Chat Completions (streaming via SSE)
 POST /v1/responses               OpenAI Responses API (stateful)
 POST /v1/runs                    Start a run, returns run_id (202)
+GET  /v1/sessions/{id}/continuation Issue an exact Runs continuation descriptor
 GET  /v1/runs/{id}               Run status
 GET  /v1/runs/{id}/events        SSE stream of lifecycle events
 POST /v1/runs/{id}/approval      Resolve a pending approval

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -250,7 +250,11 @@ Returns a machine-readable description of the API server's stable surface for ex
     "run_submission": true,
     "run_status": true,
     "run_events_sse": true,
-    "run_stop": true
+    "run_stop": true,
+    "run_session_continuation": true,
+    "run_session_continuation_version": 1,
+    "run_session_continuation_exact_revision": true,
+    "run_session_continuation_stoppable": true
   }
 }
 ```
@@ -351,7 +355,48 @@ Create a new agent run. Returns a `run_id` that can be used to subscribe to prog
 }
 ```
 
-Runs accept a simple `input` string and optional `session_id`, `instructions`, `conversation_history`, or `previous_response_id`. When `session_id` is provided, Hermes surfaces it in the run status so external UIs can correlate runs with their own conversation IDs.
+Runs accept a simple `input` string and optional `session_id`, `instructions`, `conversation_history`, or `previous_response_id`. When `session_id` is provided, Hermes surfaces it in the run status so external UIs can correlate runs with their own conversation IDs. That field alone does not load persisted history; use the exact continuation contract below when continuing a Hermes session.
+
+### Continue an exact session through Runs
+
+First request a descriptor for the selected session:
+
+```text
+GET /v1/sessions/{session_id}/continuation
+```
+
+Hermes resolves a compression root to its current tip and returns a content-free
+descriptor bound to that tip and the exact active message identities/history:
+
+```json
+{
+  "object": "hermes.session.continuation",
+  "version": 1,
+  "session_id": "resolved-session-tip",
+  "revision": "sessionrev_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+}
+```
+
+Pass that object unchanged in the next Runs request:
+
+```json
+{
+  "input": "Continue with the next step",
+  "continuation": {
+    "version": 1,
+    "session_id": "resolved-session-tip",
+    "revision": "sessionrev_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  }
+}
+```
+
+Hermes recalculates the binding before allocating the run. A changed message,
+replaced message identity, newer compression tip, malformed descriptor, or
+second active continuation fails closed. Do not combine `continuation` with
+`session_id`, `conversation_history`, `previous_response_id`, or a multi-message
+input. Once accepted, the turn uses the normal Runs status, events, approval,
+and stop endpoints. Descriptors are authenticated binding data, not bearer
+credentials or durable leases.
 
 ### GET /v1/runs/\{run_id\}
 
@@ -451,6 +496,7 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 | `PATCH` | `/api/sessions/{id}` | Update title or `end_reason` |
 | `DELETE` | `/api/sessions/{id}` | Delete a session |
 | `GET` | `/api/sessions/{id}/messages` | Message history for a session |
+| `GET` | `/v1/sessions/{id}/continuation` | Issue an exact revision descriptor for a stoppable Runs continuation |
 | `POST` | `/api/sessions/{id}/fork` | Branch the session via `SessionDB` lineage (matches CLI `/branch` semantics) |
 | `POST` | `/api/sessions/{id}/chat` | Run one synchronous agent turn |
 | `POST` | `/api/sessions/{id}/chat/stream` | SSE wrapper over a single turn — emits `assistant.delta`, `tool.started`, `tool.completed`, `run.completed` events |


### PR DESCRIPTION
## Summary

- add an authenticated `GET /v1/sessions/{session_id}/continuation` descriptor endpoint
- bind descriptors to the resolved compression tip, active message row identities, and normalized model-fed history
- accept the exact descriptor in `POST /v1/runs` while preserving Runs status, events, approval/clarification, cancellation, and stop behavior
- reject stale, cross-session, malformed, ambiguous, and concurrently active continuations before allocating a run
- advertise the versioned capability and document the distinction from correlation-only `session_id`

## Safety

- the descriptor contains no transcript content or secret
- verification is profile-scoped and single-writer per continued session
- existing new-run and correlation-only behavior remains unchanged

## Verification

- `56 passed` — changed session/Runs modules after rebase onto current `main`
- `416 passed` — complete API-server surface
- `669 passed` — expanded API/session/storage surface
- Python compile, Ruff, and `git diff --check` passed
- docs diagram lint passed across 365 files
- Docusaurus build passed for English and zh-Hans (existing unrelated link warnings remain)

The canonical full-suite attempt was stopped at 43% after an unrelated Chromium fixture left a browser subprocess alive for over 30 minutes. The affected continuation surface was rerun cleanly afterward.