### PR TITLE
fix(memory): hold _file_lock around learning-graph memory writes

### DIFF
--- a/agent/learning_mutations.py
+++ b/agent/learning_mutations.py
@@ -191,10 +191,18 @@ def _edit_memory(node_id: str, content: str) -> dict[str, Any]:
 
 def _write_memory(path: Path, chunks: list[str]) -> None:
     """Atomic temp-file + rename via the memory tool, so a concurrent reader
-    never sees a half-written file (and the §-join stays single-sourced)."""
+    never sees a half-written file (and the §-join stays single-sourced).
+
+    The write is held under ``MemoryStore._file_lock`` so a dashboard- or
+    learning-graph-initiated mutation cannot interleave with a concurrent agent
+    read-modify-write on the same memory file. Every other read-modify-write
+    caller in ``MemoryStore`` already acquires this lock; ``_write_file`` itself
+    does not, so this path must hold it explicitly."""
     from tools.memory_tool import MemoryStore
 
-    MemoryStore._write_file(path, [c.strip() for c in chunks if c.strip()])
+    cleaned = [c.strip() for c in chunks if c.strip()]
+    with MemoryStore._file_lock(path):
+        MemoryStore._write_file(path, cleaned)
 
 
 def _clear_skill_cache() -> None:


### PR DESCRIPTION
# PR: Hold `_file_lock` around learning-graph memory writes

**Branch:** `fix/memory-write-lock` → `NousResearch/hermes-agent:main`
**Type:** Bug fix (concurrency)

## Summary

`agent/learning_mutations._write_memory()` delegated to
`MemoryStore._write_file()` **without acquiring `_file_lock`**, unlike every
other read-modify-write path in `MemoryStore` (the `_path_for` writers at
`tools/memory_tool.py:347/402/463/523` all wrap the lock).

`_write_file()` is atomic (temp-file + `os.replace`), so a reader never sees a
half-written file — but atomicity is not mutual exclusion. Two writers can still
race: a dashboard/learning-graph-initiated memory edit (`edit_node` /
`delete_node` → `_write_memory`) can interleave with a concurrent agent
read-modify-write on the **same memory file**, and the last atomic rename wins —
silently dropping the other update (lost-update / write-skew).

## Fix

Wrap the write in the existing `MemoryStore._file_lock(path)` context manager so
both paths serialize on the same `.lock` file. `_write_file()` does not acquire
the lock itself (the other callers wrap it externally), so there is no
re-entrant deadlock.

```python
def _write_memory(path: Path, chunks: list[str]) -> None:
    from tools.memory_tool import MemoryStore
    cleaned = [c.strip() for c in chunks if c.strip()]
    with MemoryStore._file_lock(path):
        MemoryStore._write_file(path, cleaned)
```

## Verification

- `python -m py_compile` clean.
- Concurrency smoke test: 4 threads × 50 writes each on one memory file →
  no errors, no interleaving/corruption, single clean final state, no deadlock.

## Notes for maintainers

Two lower-severity items were found in the same review and are **not** in this PR
(kept minimal, one concern per PR):
- `_file_lock` never `unlink`s its `.lock` file — cosmetic; `flock` is fd-based
  so a lingering lock file is harmless.
- The memory drift detector preserves evidence (`.bak`) but has no auto-recovery
  path; one bad write disables memory curation until manual intervention, and the
  drift error is tool-output only (no guaranteed user-visible alert). Worth a
  separate discussion.

## Push instructions (owner action)

This local clone's `origin` is `NousResearch/hermes-agent` (not owned by us), so
opening the PR needs a fork:

```
gh repo fork NousResearch/hermes-agent --clone=false
git push <your-fork-remote> fix/memory-write-lock
gh pr create --repo NousResearch/hermes-agent --head <your-user>:fix/memory-write-lock
```
