### PR TITLE
fix(bootstrap): reject truncated install-script downloads via Content-Length (#68163)

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/install_script.rs
+++ b/apps/bootstrap-installer/src-tauri/src/install_script.rs
@@ -313,6 +313,25 @@ fn upgrade_cached_script(kind: ScriptKind, cached: &Path, emit_log: &impl Fn(&st
     }
 }
 
+/// Rejects a download whose body is shorter (or longer) than the advertised
+/// `Content-Length`. Only enforced when the length is known — a decompressed
+/// response reports `None` and is passed through unchecked. See #68163.
+fn verify_download_length(
+    filename: &str,
+    url: &str,
+    content_length: Option<u64>,
+    body_len: usize,
+) -> Result<()> {
+    if let Some(expected) = content_length {
+        if body_len as u64 != expected {
+            return Err(anyhow!(
+                "Truncated download of {filename}: got {body_len} bytes, expected {expected} (Content-Length) from {url}"
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Downloads to `dest_path` via reqwest with rustls. Atomically renames
 /// `dest_path.tmp` → `dest_path` so partial writes don't poison the cache.
 ///
@@ -363,10 +382,25 @@ async fn download(kind: ScriptKind, commit_or_ref: &str, dest_path: &Path) -> Re
         ));
     }
 
+    // Capture the advertised length before the body is consumed. reqwest
+    // returns `None` when the response was transparently decompressed (the
+    // decoded length no longer matches the header), in which case the guard
+    // below is skipped — we only assert equality when the length is known.
+    let content_length = response.content_length();
+
     let bytes = response
         .bytes()
         .await
         .with_context(|| format!("reading body of {url}"))?;
+
+    // A truncated body that still returns HTTP 200 must never be promoted into
+    // the cache: it would fail every subsequent `install.ps1 -Manifest` run
+    // with parser errors and, for immutable pins, be trusted forever (#68163).
+    // Validate the raw download length against Content-Length before BOM prep
+    // changes the size, so a short read errors out and the atomic rename never
+    // happens.
+    verify_download_length(kind.filename(), &url, content_length, bytes.len())?;
+
     let bytes = prepare_cached_script_bytes(kind, &bytes);
 
     let mut file = tokio::fs::File::create(&tmp_path)
@@ -498,5 +532,27 @@ mod tests {
         assert_eq!(std::fs::read(&cached).unwrap(), b"#!/bin/bash\n");
 
         std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn verify_download_length_accepts_matching_length() {
+        assert!(verify_download_length("install.ps1", "http://x", Some(42), 42).is_ok());
+    }
+
+    #[test]
+    fn verify_download_length_rejects_truncated_body() {
+        // The #68163 failure mode: HTTP 200 with a body ~5 KB short of the
+        // advertised length. It must error so the atomic rename never fires.
+        let err = verify_download_length("install.ps1", "http://x", Some(184266), 179412)
+            .expect_err("truncated body must be rejected");
+        let msg = format!("{err}");
+        assert!(msg.contains("179412"), "error names the received length: {msg}");
+        assert!(msg.contains("184266"), "error names the expected length: {msg}");
+    }
+
+    #[test]
+    fn verify_download_length_skips_when_length_unknown() {
+        // Decompressed responses report `None`; the guard must pass through.
+        assert!(verify_download_length("install.ps1", "http://x", None, 1).is_ok());
     }
 }


### PR DESCRIPTION
Fixes #68163

## Problem

`install_script.rs::download()` reads `response.bytes()` and atomically renames it into `bootstrap-cache/` with **no length validation**. A body that returns HTTP 200 but is truncated (the reported case: cached `install-main.ps1` was 179,412 bytes vs. 184,266 fresh) gets promoted as authoritative, so every subsequent `install.ps1 -Manifest` fails identically with PowerShell parser errors — and a typical Windows user can't recover without manually deleting the cache dir.

## What already covers part of this

The issue's **branch-pin "corrupt forever"** complaint (point #3) was already fixed upstream in #67193 / `73b3a8afe`: mutable branch pins now `Fetch { stale_ok: true }` and re-download on every run, only falling back to a stale cache when the network fails. That change does **not** guard the cache *write* itself, though — a truncated body is still promoted for both mutable and immutable pins, and immutable SHA pins reuse a poisoned cache forever.

## Fix

Implements the issue's suggested fix #1 (integrity validation on cache write):

- Capture `response.content_length()` **before** consuming the body.
- Compare it against the **raw** download length (before BOM prep changes the size) in a small pure helper, `verify_download_length`.
- On mismatch → error, so the atomic rename never fires and the poison is never cached; the next run re-downloads.
- Only enforced when the length is known. reqwest reports `None` for transparently decompressed responses, so there are no false positives.

Scoped to the cache-write integrity gap only — no changes to the resolve/refresh flow, which #67193 already handles. Parse-validation on read (suggested fix #2) is intentionally left out as a separate, more invasive concern.

## Tests

Adds three unit tests for `verify_download_length` (matching length → Ok; truncated body → Err naming both lengths; unknown length → Ok). Existing tests unchanged.

> Note: `cargo` was unavailable in the authoring environment, so the Rust crate could not be compiled/tested locally — CI is the verification path. The change is a self-contained pure helper using idioms already present in the crate (`anyhow!` with captured identifiers, `reqwest::Response::content_length`). The expected arm64-fork-Docker CI failure is unrelated.