### PR TITLE
fix(desktop): fall back from stale boot session

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
@@ -1,0 +1,116 @@
+import { cleanup, render, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  getRememberedSessionId,
+  setRememberedRoute,
+  setRememberedSessionId,
+  setSessions
+} from '@/store/session'
+
+import { NEW_CHAT_ROUTE, sessionRoute } from '../../routes'
+
+import { useDesktopIntegrations } from './use-desktop-integrations'
+
+vi.mock('@/app/chat/close-tab', () => ({
+  closeActiveTab: vi.fn()
+}))
+
+vi.mock('@/app/chat/composer/focus', () => ({
+  requestComposerFocus: vi.fn(),
+  requestComposerInsert: vi.fn()
+}))
+
+vi.mock('@/store/native-notifications', () => ({
+  respondToApprovalAction: vi.fn()
+}))
+
+vi.mock('@/store/session-sync', () => ({
+  onSessionsChanged: vi.fn(() => undefined)
+}))
+
+vi.mock('@/store/updates', () => ({
+  openUpdatesWindow: vi.fn(),
+  startUpdatePoller: vi.fn(),
+  stopUpdatePoller: vi.fn()
+}))
+
+vi.mock('@/store/windows', () => ({
+  isSecondaryWindow: vi.fn(() => false)
+}))
+
+function makeSession(id: string, isActive = false): { _lineage_root_id?: null | string; id: string; is_active: boolean } {
+  return { id, is_active: isActive, _lineage_root_id: null }
+}
+
+interface HarnessProps {
+  locationPathname: string
+  navigate: (to: string, options?: { replace?: boolean }) => void
+  refreshSessions: () => Promise<unknown> | unknown
+}
+
+function Harness(props: HarnessProps): ReactNode {
+  useDesktopIntegrations({
+    chatOpen: true,
+    hasPreview: false,
+    locationPathname: props.locationPathname,
+    navigate: props.navigate,
+    refreshSessions: props.refreshSessions,
+    resumeExhaustedSessionId: null,
+    routedSessionId: null,
+    runtimeIdByStoredSessionId: { current: new Map() }
+  })
+
+  return null
+}
+
+describe('useDesktopIntegrations', () => {
+  afterEach(() => {
+    cleanup()
+    setRememberedRoute(null)
+    setRememberedSessionId(null)
+    setSessions([] as any)
+    vi.restoreAllMocks()
+  })
+
+  it('falls back to the most recent live session when the remembered session id is stale on cold boot', async () => {
+    setRememberedRoute(null)
+    setRememberedSessionId('dead-session')
+
+    const navigate = vi.fn()
+
+    const refreshSessions = vi.fn(async () => {
+      setSessions([makeSession('live-session', true), makeSession('older-session', false)] as any)
+    })
+
+    render(<Harness locationPathname={NEW_CHAT_ROUTE} navigate={navigate} refreshSessions={refreshSessions} />)
+
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith(sessionRoute('live-session'), { replace: true })
+    })
+
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+    expect(getRememberedSessionId()).toBe('live-session')
+  })
+
+  it('lands on new chat when the remembered session and backend session list are both empty', async () => {
+    setRememberedRoute(null)
+    setRememberedSessionId('dead-session')
+
+    const navigate = vi.fn()
+
+    const refreshSessions = vi.fn(async () => {
+      setSessions([] as any)
+    })
+
+    render(<Harness locationPathname={NEW_CHAT_ROUTE} navigate={navigate} refreshSessions={refreshSessions} />)
+
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith(NEW_CHAT_ROUTE, { replace: true })
+    })
+
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+    expect(getRememberedSessionId()).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -3,13 +3,19 @@ import { useEffect, useRef } from 'react'
 import { closeActiveTab } from '@/app/chat/close-tab'
 import { storedSessionIdForNotification } from '@/lib/session-ids'
 import { respondToApprovalAction } from '@/store/native-notifications'
-import { getRememberedRoute, getRememberedSessionId, setRememberedRoute, setRememberedSessionId } from '@/store/session'
+import {
+  $sessions,
+  getRememberedRoute,
+  getRememberedSessionId,
+  setRememberedRoute,
+  setRememberedSessionId
+} from '@/store/session'
 import { onSessionsChanged } from '@/store/session-sync'
 import { openUpdatesWindow, startUpdatePoller, stopUpdatePoller } from '@/store/updates'
 import { isSecondaryWindow } from '@/store/windows'
 
 import { requestComposerFocus, requestComposerInsert } from '../../chat/composer/focus'
-import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, sessionRoute } from '../../routes'
+import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, routeSessionId, sessionRoute } from '../../routes'
 
 interface DesktopIntegrationsParams {
   chatOpen: boolean
@@ -20,6 +26,20 @@ interface DesktopIntegrationsParams {
   resumeExhaustedSessionId: null | string
   routedSessionId: null | string
   runtimeIdByStoredSessionId: { readonly current: Map<string, string> }
+}
+
+type RestorableSession = {
+  _lineage_root_id?: null | string
+  id: string
+  is_active?: boolean | null
+}
+
+function sessionExists(sessionId: string, sessions: readonly RestorableSession[]): boolean {
+  return sessions.some(session => session.id === sessionId || session._lineage_root_id === sessionId)
+}
+
+function pickFallbackSession(sessions: readonly RestorableSession[]): RestorableSession | null {
+  return sessions.find(session => session.is_active) ?? sessions[0] ?? null
 }
 
 /**
@@ -75,7 +95,9 @@ export function useDesktopIntegrations({
 
   // Restore once on cold start — only when the renderer booted at the default
   // route (a hidden-then-shown window keeps its own route). Prefer the full
-  // remembered route (covers pages); fall back to the last session id.
+  // remembered route (covers pages); fall back to the last session id. If the
+  // pinned session is stale, re-home to the engine's most recent live session
+  // instead of booting into an error screen for a chat the user never chose.
   useEffect(() => {
     if (restoredRef.current || locationPathname !== NEW_CHAT_ROUTE) {
       restoredRef.current = true
@@ -84,10 +106,50 @@ export function useDesktopIntegrations({
     }
 
     restoredRef.current = true
+
+    const restoreSession = async (sessionId: string, routeToUse?: string) => {
+      try {
+        await refreshSessions()
+      } catch {
+        setRememberedSessionId(null)
+        navigate(NEW_CHAT_ROUTE, { replace: true })
+
+        return
+      }
+
+      const sessions = $sessions.get() as RestorableSession[]
+
+      if (sessionExists(sessionId, sessions)) {
+        navigate(routeToUse ?? sessionRoute(sessionId), { replace: true })
+
+        return
+      }
+
+      const fallback = pickFallbackSession(sessions)
+
+      if (fallback) {
+        setRememberedSessionId(fallback.id)
+        navigate(sessionRoute(fallback.id), { replace: true })
+
+        return
+      }
+
+      setRememberedSessionId(null)
+      navigate(NEW_CHAT_ROUTE, { replace: true })
+    }
+
     const route = getRememberedRoute()
 
     if (route && route !== NEW_CHAT_ROUTE && !isOverlayView(appViewForPath(route))) {
-      navigate(route, { replace: true })
+      const rememberedSessionId = routeSessionId(route)
+
+      if (!rememberedSessionId) {
+        navigate(route, { replace: true })
+
+        return
+      }
+
+      void restoreSession(rememberedSessionId, route)
 
       return
     }
@@ -95,9 +157,9 @@ export function useDesktopIntegrations({
     const last = getRememberedSessionId()
 
     if (last) {
-      navigate(sessionRoute(last), { replace: true })
+      void restoreSession(last)
     }
-  }, [locationPathname, navigate])
+  }, [locationPathname, navigate, refreshSessions])
 
   useEffect(() => {
     if (resumeExhaustedSessionId && getRememberedSessionId() === resumeExhaustedSessionId) {


### PR DESCRIPTION
## Summary\n- Validate remembered desktop sessions on cold boot before restoring them.\n- Fall back to the most recent live session, or new chat when nothing is available.\n- Add coverage for stale boot-session recovery.\n\n## Verification\n- npm exec vitest -- run src/app/contrib/hooks/use-desktop-integrations.test.tsx\n- npm run typecheck\n- npx eslint src/app/contrib/hooks/use-desktop-integrations.ts src/app/contrib/hooks/use-desktop-integrations.test.tsx\n- npm run build\n- npm test\n\nFixes #60541