### PR TITLE
chore: map contributor ruslanvasylev for #68056 salvage

### DIFF
--- a/contributors/emails/ruslan.vasylev.vfx@gmail.com
+++ b/contributors/emails/ruslan.vasylev.vfx@gmail.com
@@ -1,0 +1,1 @@
+ruslanvasylev


### PR DESCRIPTION
## Summary
Maps `ruslan.vasylev.vfx@gmail.com` → @ruslanvasylev for the contributor audit. Their co-authored work shipped via #68056 (read-aloud + transcription timeout salvage of #39286); this mapping surfaced during the v0.19.0 release audit re-run.

## Changes
- `contributors/emails/ruslan.vasylev.vfx@gmail.com`: new mapping file

## Infographic

![contributor mapping](https://v3b.fal.media/files/b/0aa30aeb/pDir6JuIvVQ1ZBNf1WV-A_f6yzs7GM.png)
