### PR TITLE
fix(desktop): avoid rich status during local startup

### DIFF
--- a/apps/desktop/electron/backend-readiness.test.ts
+++ b/apps/desktop/electron/backend-readiness.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  completeLocalBackendHandshake,
+  createHermesReadinessProbe,
+  shouldFallbackFromReadyEndpoint
+} from './backend-readiness'
+
+test('local backend readiness uses the lightweight endpoint', async () => {
+  const paths: string[] = []
+
+  const probe = createHermesReadinessProbe({
+    preferReadyEndpoint: true,
+    request: async path => {
+      paths.push(path)
+    }
+  })
+
+  await probe()
+
+  assert.deepEqual(paths, ['/api/ready'])
+})
+
+test('remote readiness keeps the public status contract', async () => {
+  const paths: string[] = []
+
+  const probe = createHermesReadinessProbe({
+    preferReadyEndpoint: false,
+    request: async path => {
+      paths.push(path)
+    }
+  })
+
+  await probe()
+
+  assert.deepEqual(paths, ['/api/status'])
+})
+
+test('an older backend falls back from a missing ready endpoint and remembers the fallback', async () => {
+  const paths: string[] = []
+
+  const probe = createHermesReadinessProbe({
+    preferReadyEndpoint: true,
+    request: async path => {
+      paths.push(path)
+
+      if (path === '/api/ready') {
+        throw new Error('404: {"detail":"Not Found"}')
+      }
+    }
+  })
+
+  await probe()
+  await probe()
+
+  assert.deepEqual(paths, ['/api/ready', '/api/status', '/api/status'])
+})
+
+test('an old local runtime with token drift falls back to public status exactly once', async () => {
+  const paths: string[] = []
+
+  const probe = createHermesReadinessProbe({
+    preferReadyEndpoint: true,
+    request: async path => {
+      paths.push(path)
+
+      if (path === '/api/ready') {
+        throw new Error('401: {"detail":"Unauthorized"}')
+      }
+    }
+  })
+
+  await probe()
+  await probe()
+
+  assert.deepEqual(paths, ['/api/ready', '/api/status', '/api/status'])
+})
+
+test('an older SPA fallback response is treated as a missing ready endpoint', () => {
+  assert.equal(
+    shouldFallbackFromReadyEndpoint(
+      new Error(
+        'Expected JSON from http://127.0.0.1:9119/api/ready but got HTML (status 200). ' +
+          'The endpoint is likely missing on the Hermes backend.'
+      )
+    ),
+    true
+  )
+})
+
+test('local handshake adopts the served token only after readiness succeeds', async () => {
+  const sequence: string[] = []
+
+  const token = await completeLocalBackendHandshake({
+    waitForReady: async () => {
+      sequence.push('ready-via-public-status-fallback')
+    },
+    markReady: () => {
+      sequence.push('mark-ready')
+    },
+    adoptServedToken: async () => {
+      sequence.push('adopt-served-token')
+
+      return 'served-token'
+    }
+  })
+
+  assert.equal(token, 'served-token')
+  assert.deepEqual(sequence, ['ready-via-public-status-fallback', 'mark-ready', 'adopt-served-token'])
+})
+
+test('transient ready failures retry ready instead of silently switching contracts', async () => {
+  const paths: string[] = []
+
+  const probe = createHermesReadinessProbe({
+    preferReadyEndpoint: true,
+    request: async path => {
+      paths.push(path)
+      throw new Error('503: starting')
+    }
+  })
+
+  await assert.rejects(probe(), /503: starting/)
+  await assert.rejects(probe(), /503: starting/)
+
+  assert.deepEqual(paths, ['/api/ready', '/api/ready'])
+})

--- a/apps/desktop/electron/backend-readiness.ts
+++ b/apps/desktop/electron/backend-readiness.ts
@@ -1,0 +1,65 @@
+/**
+ * Selects the cheapest readiness contract supported by a Hermes backend.
+ *
+ * Local Desktop children started by a current runtime expose `/api/ready`, a
+ * narrow authenticated event-loop probe. Older runtimes do not, so the probe
+ * falls back once to the existing rich `/api/status` contract and remembers
+ * that capability decision for subsequent retries. The fallback also covers a
+ * 401 from an old local runtime: legacy backends may regenerate the spawn
+ * token, and Desktop can only adopt the served token after public readiness
+ * succeeds. Remote connections retain `/api/status`: they use its
+ * public/auth-aware contract and update on a separate release clock.
+ */
+
+export type HermesReadinessPath = '/api/ready' | '/api/status'
+
+export interface HermesReadinessProbeOptions {
+  preferReadyEndpoint: boolean
+  request: (path: HermesReadinessPath) => Promise<unknown>
+}
+
+export interface CompleteLocalBackendHandshakeOptions {
+  waitForReady: () => Promise<unknown>
+  markReady: () => void
+  adoptServedToken: () => Promise<string>
+}
+
+export function shouldFallbackFromReadyEndpoint(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return (
+    /^(?:401|404)(?:\s|:)/.test(message) ||
+    message.includes('The endpoint is likely missing on the Hermes backend.')
+  )
+}
+
+export function createHermesReadinessProbe({
+  preferReadyEndpoint,
+  request
+}: HermesReadinessProbeOptions): () => Promise<void> {
+  let path: HermesReadinessPath = preferReadyEndpoint ? '/api/ready' : '/api/status'
+
+  return async () => {
+    try {
+      await request(path)
+    } catch (error) {
+      if (path !== '/api/ready' || !shouldFallbackFromReadyEndpoint(error)) {
+        throw error
+      }
+
+      path = '/api/status'
+      await request(path)
+    }
+  }
+}
+
+export async function completeLocalBackendHandshake({
+  waitForReady,
+  markReady,
+  adoptServedToken
+}: CompleteLocalBackendHandshakeOptions): Promise<string> {
+  await waitForReady()
+  markReady()
+
+  return adoptServedToken()
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -35,6 +35,7 @@ import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, normalizeHermesHomeRoot } from './backend-env'
 import { canImportHermesCli, shouldTrustHermesOverride, verifyHermesCli } from './backend-probes'
+import { completeLocalBackendHandshake, createHermesReadinessProbe } from './backend-readiness'
 import { waitForDashboardPortAnnouncement } from './backend-ready'
 import { shouldLatchBackendStartFailure } from './backend-start-failure'
 import { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } from './bootstrap-platform'
@@ -4634,7 +4635,17 @@ function closePreviewWatchers() {
   }
 }
 
-async function waitForHermes(baseUrl, token, signal?) {
+async function waitForHermes(
+  baseUrl,
+  token,
+  { preferReadyEndpoint = false, signal }: { preferReadyEndpoint?: boolean; signal?: AbortSignal } = {}
+) {
+
+  const probe = createHermesReadinessProbe({
+    preferReadyEndpoint,
+    request: path => fetchJson(`${baseUrl}${path}`, token)
+  })
+
   const deadline = Date.now() + 45_000
   let lastError = null
 
@@ -4646,7 +4657,7 @@ async function waitForHermes(baseUrl, token, signal?) {
     }
 
     try {
-      await fetchJson(`${baseUrl}/api/status`, token)
+      await probe()
 
       return
     } catch (error) {
@@ -6909,7 +6920,7 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
       forward: (localPort, remotePort) => ssh.forward(localPort, remotePort),
       cancelForward: (localPort, remotePort) => ssh.cancelForward(localPort, remotePort),
       pickLocalPort,
-      waitForHermes: (baseUrl, token) => waitForHermes(baseUrl, token, lease.signal),
+      waitForHermes: (baseUrl, token) => waitForHermes(baseUrl, token, { signal: lease.signal }),
       probeReuseProof: sshProbeReuseProof,
       adoptServedToken: adoptServedDashboardToken,
       rememberLog: sshRememberLog,
@@ -7670,13 +7681,18 @@ async function spawnPoolBackend(profile, entry) {
   entry.port = port
 
   const baseUrl = `http://127.0.0.1:${port}`
-  await Promise.race([waitForHermes(baseUrl, token), startFailed])
-  ready = true
 
-  const authToken = await adoptServedDashboardToken(baseUrl, token, {
-    childAlive: () => child.exitCode === null && !child.killed,
-    label: `Hermes backend for profile "${profile}"`,
-    rememberLog
+  const authToken = await completeLocalBackendHandshake({
+    waitForReady: () => Promise.race([waitForHermes(baseUrl, token, { preferReadyEndpoint: true }), startFailed]),
+    markReady: () => {
+      ready = true
+    },
+    adoptServedToken: () =>
+      adoptServedDashboardToken(baseUrl, token, {
+        childAlive: () => child.exitCode === null && !child.killed,
+        label: `Hermes backend for profile "${profile}"`,
+        rememberLog
+      })
   })
 
   entry.token = authToken
@@ -7978,13 +7994,19 @@ async function startHermes() {
 
     const baseUrl = `http://127.0.0.1:${port}`
     await advanceBootProgress('backend.wait', 'Waiting for Hermes backend to become ready', 90)
-    await Promise.race([waitForHermes(baseUrl, token), backendStartFailed])
-    backendReady = true
-    backendStartFailure = null
 
-    const authToken = await adoptServedDashboardToken(baseUrl, token, {
-      childAlive: () => hermesProcess.exitCode === null && !hermesProcess.killed,
-      rememberLog
+    const authToken = await completeLocalBackendHandshake({
+      waitForReady: () =>
+        Promise.race([waitForHermes(baseUrl, token, { preferReadyEndpoint: true }), backendStartFailed]),
+      markReady: () => {
+        backendReady = true
+        backendStartFailure = null
+      },
+      adoptServedToken: () =>
+        adoptServedDashboardToken(baseUrl, token, {
+          childAlive: () => hermesProcess.exitCode === null && !hermesProcess.killed,
+          rememberLog
+        })
     })
 
     updateBootProgress({

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2985,6 +2985,18 @@ async def get_ssh_ownership(request: Request):
     return {"ok": True, "sshOwnerNonce": _SSH_OWNER_NONCE, "protocolVersion": 1}
 
 
+@app.get("/api/ready")
+async def get_ready():
+    """Authenticated, side-effect-free readiness probe for local Desktop.
+
+    ``/api/status`` remains the rich public operational snapshot. Desktop only
+    needs proof that the freshly spawned server can service requests, so this
+    endpoint deliberately avoids gateway/plugin discovery, session reads, and
+    host topology collection on the startup-critical path.
+    """
+    return {"ready": True, "version": __version__}
+
+
 @app.get("/api/status")
 async def get_status(profile: Optional[str] = None):
     status_scope = None

--- a/tests/hermes_cli/test_web_server_readiness_endpoint.py
+++ b/tests/hermes_cli/test_web_server_readiness_endpoint.py
@@ -1,0 +1,55 @@
+"""Regression coverage for the lightweight Desktop readiness handshake."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hermes_cli import web_server
+from hermes_cli.dashboard_auth.public_paths import PUBLIC_API_PATHS
+
+
+@pytest.fixture
+def loopback_client():
+    previous_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.auth_required = False
+
+    with TestClient(web_server.app, base_url="http://127.0.0.1:9119") as client:
+        yield client
+
+    web_server.app.state.auth_required = previous_required
+
+
+def test_ready_endpoint_is_authenticated_and_minimal(loopback_client):
+    assert "/api/ready" not in PUBLIC_API_PATHS
+    assert loopback_client.get("/api/ready").status_code == 401
+
+    response = loopback_client.get(
+        "/api/ready",
+        headers={web_server._SESSION_HEADER_NAME: web_server._SESSION_TOKEN},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "ready": True,
+        "version": web_server.__version__,
+    }
+
+
+def test_ready_endpoint_skips_expensive_status_work(loopback_client, monkeypatch):
+    def unexpected(*_args, **_kwargs):
+        raise AssertionError("readiness must not execute rich /api/status work")
+
+    monkeypatch.setattr(web_server, "check_config_version", unexpected)
+    monkeypatch.setattr(web_server, "get_running_pid_cached", unexpected)
+    monkeypatch.setattr(web_server, "_status_active_sessions", unexpected)
+    monkeypatch.setattr(web_server, "_resolve_restart_drain_timeout", unexpected)
+    monkeypatch.setattr(web_server, "_collect_profile_gateway_topology", unexpected)
+
+    response = loopback_client.get(
+        "/api/ready",
+        headers={web_server._SESSION_HEADER_NAME: web_server._SESSION_TOKEN},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["ready"] is True


### PR DESCRIPTION
## What does this PR do?

Speeds up local Hermes Desktop startup by separating **readiness** from the existing rich operational status snapshot.

After the spawned backend binds its socket, Desktop currently waits for `/api/status`. That endpoint intentionally resolves gateway/plugin configuration, session state, profile topology, and host status. None of that work is needed to prove that the new local server can accept requests.

This PR adds a minimal, authenticated `/api/ready` event-loop probe and uses it only for local Desktop children. It does **not** remove or defer any feature:

- `/api/status` keeps its existing response, behavior, and public liveness contract;
- remote Desktop connections keep using `/api/status`;
- profile-pool local children use `/api/ready` too;
- newer Desktop builds fall back once to `/api/status` when an older runtime lacks `/api/ready` or regenerated its spawn token, then retain the existing served-token adoption;
- transient readiness failures continue retrying `/api/ready` instead of silently changing contracts.

Four isolated backend launches using a real non-secret multi-profile config shape:

| First request after port announcement | Median |
|---|---:|
| authenticated `/api/ready` | **78.3 ms** |
| rich `/api/status` | **2116.1 ms** |

That removes about **2.1 seconds** from this installation's startup-critical handshake while preserving the status work for consumers that actually request it.

## Related Issue

Fixes #68170

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add the authenticated, side-effect-free `/api/ready` route in `hermes_cli/web_server.py`.
- Add a dependency-free readiness selector in `apps/desktop/electron/backend-readiness.ts`.
- Use the lightweight probe for primary and profile-pool local children while preserving `/api/status` for remote connections.
- Persist a one-time fallback to `/api/status` for old local runtimes that lack `/api/ready` or reject the pre-adoption spawn token.
- Add behavioral tests for auth, minimal endpoint work, local/remote selection, old-runtime/token-drift fallback, readiness/mark/adoption ordering, SPA fallback, and transient failures.

## How to Test

1. Start `hermes serve --host 127.0.0.1 --port 0` with `HERMES_DASHBOARD_SESSION_TOKEN` set.
2. Verify unauthenticated `GET /api/ready` returns `401`, while the session-token request returns `{"ready": true, "version": "..."}`.
3. Start current Desktop against the current runtime and verify local startup probes `/api/ready`; start it against an older runtime and verify the probe falls back to `/api/status` once.

Executed locally on CachyOS Linux. After the current-main rebase, commit `c716c16aa1d2b34e09e2525e25736caa5f598999` was verified with:

```text
env -u PYTHONPATH -u VIRTUAL_ENV .venv/bin/python -m pytest tests/hermes_cli/test_web_server_readiness_endpoint.py -q
# 2 passed

env -u PYTHONPATH -u VIRTUAL_ENV .venv/bin/ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server_readiness_endpoint.py
# All checks passed

NODE_ENV=test npm --workspace apps/desktop exec -- vitest run electron/backend-readiness.test.ts --environment node
# 1 file passed; 7 tests passed

NODE_ENV=test npm --workspace apps/desktop run typecheck
NODE_ENV=test npm --workspace apps/desktop exec -- eslint electron/main.ts electron/backend-readiness.ts electron/backend-readiness.test.ts
NODE_ENV=production npm --workspace apps/desktop run build
# all passed

git diff --check origin/main...HEAD
# passed
```

A prior broader-suite run recorded unrelated baseline failures that were reproduced unchanged on clean `origin/main`:

- `tests/hermes_cli/test_web_server.py::TestNewEndpoints::test_profiles_create_creates_wrapper_alias_when_safe` (9168 other `tests/hermes_cli` tests pass);
- locale-sensitive `fallback-model.test.ts` formatting;
- two existing `billing/index.test.tsx` failures (2166 other Desktop tests pass).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: CachyOS Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; internal Desktop handshake is documented in code
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-neutral HTTP and TypeScript path; Electron tests cover platform helpers
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No visual behavior changes. Benchmark output from four fresh backend processes:

```json
{"run":1,"spawn_to_port_ms":695.6,"ready_ms":76.5,"status_ms":2135.5}
{"run":2,"spawn_to_port_ms":665.4,"ready_ms":80.1,"status_ms":2162.0}
{"run":3,"spawn_to_port_ms":614.9,"ready_ms":60.1,"status_ms":2096.6}
{"run":4,"spawn_to_port_ms":634.8,"ready_ms":88.8,"status_ms":2018.4}
{"median_ready_ms":78.3,"median_status_ms":2116.1}
```
