### PR TITLE
fix(desktop): resume listening after voice reply

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
@@ -1,0 +1,101 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { recorderCancel, recorderStart, recorderStop } = vi.hoisted(() => ({
+  recorderCancel: vi.fn(),
+  recorderStart: vi.fn(),
+  recorderStop: vi.fn()
+}))
+
+let onSilence: (() => void) | undefined
+
+vi.mock('./use-mic-recorder', () => ({
+  useMicRecorder: () => ({
+    handle: {
+      cancel: recorderCancel,
+      start: vi.fn(async (options: { onSilence?: () => void }) => {
+        onSilence = options.onSilence
+        recorderStart()
+      }),
+      stop: recorderStop
+    },
+    level: 0
+  })
+}))
+
+vi.mock('@/lib/voice-playback', () => ({
+  playSpeechText: vi.fn(async () => undefined),
+  stopVoicePlayback: vi.fn()
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      notifications: {
+        voice: {
+          configureSpeechToText: 'configure STT',
+          couldNotStartSession: 'could not start',
+          microphoneFailed: 'microphone failed',
+          playbackFailed: 'playback failed',
+          transcriptionFailed: 'transcription failed',
+          unavailable: 'unavailable'
+        }
+      }
+    }
+  })
+}))
+
+const { useVoiceConversation } = await import('./use-voice-conversation')
+
+describe('useVoiceConversation', () => {
+  beforeEach(() => {
+    onSilence = undefined
+    recorderStart.mockClear()
+    recorderStop.mockReset()
+    recorderCancel.mockClear()
+  })
+
+  it('automatically resumes listening after the final spoken response', async () => {
+    let response: { id: string; pending: boolean; text: string } | null = null
+    const pendingResponse = () => response
+    const consumePendingResponse = vi.fn()
+    const onSubmit = vi.fn(async () => undefined)
+    const onTranscribeAudio = vi.fn(async () => 'hello')
+
+    recorderStop.mockResolvedValue({
+      audio: new Blob(['voice'], { type: 'audio/webm' }),
+      durationMs: 500,
+      heardSpeech: true
+    })
+
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useVoiceConversation({
+          busy: false,
+          consumePendingResponse,
+          enabled,
+          onSubmit,
+          onTranscribeAudio,
+          pendingResponse
+        }),
+      { initialProps: { enabled: false } }
+    )
+
+    rerender({ enabled: true })
+    await waitFor(() => expect(recorderStart).toHaveBeenCalledTimes(1))
+
+    response = { id: 'assistant-1', pending: false, text: 'Hello there.' }
+    await act(async () => {
+      onSilence?.()
+    })
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('hello'))
+    await waitFor(() => expect(consumePendingResponse).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(recorderStart).toHaveBeenCalledTimes(2))
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -359,7 +359,16 @@ export function useVoiceConversation({
           consumePendingResponse()
           resetSpeechBuffer()
           pendingStartRef.current = true
-          setStatus('idle')
+
+          // The final spoken chunk already leaves us idle. Setting idle again
+          // is a React no-op, so the effect would not rerun to restart the mic.
+          // Resume directly when possible; otherwise transition to idle and let
+          // the next effect pass start listening.
+          if (status === 'idle') {
+            void startListening()
+          } else {
+            setStatus('idle')
+          }
 
           return
         }


### PR DESCRIPTION
## Summary
- restart the Desktop microphone immediately after the final spoken response when the conversation is already idle
- preserve the existing idle-transition path for non-idle states
- add a regression test covering a complete listen → transcribe → reply → speak → listen cycle

## Root cause
After the final TTS chunk, `speak()` already sets the conversation status to `idle`. The response-completion branch then set `idle` again and only toggled `pendingStartRef`. React correctly treated the repeated state value as a no-op, so the driving effect did not rerun and the microphone remained stopped until another UI state change (for example mute/unmute).

## Verification
- regression test fails on current `main`: expected microphone start count 2, received 1
- `npx vitest run --project ui src/app/chat/composer/hooks/use-voice-conversation.test.tsx`
- `npm run typecheck`
- `npx eslint src/app/chat/composer/hooks/use-voice-conversation.ts src/app/chat/composer/hooks/use-voice-conversation.test.tsx`