### PR TITLE
feat(api): add authenticated profile inventory

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7,6 +7,7 @@ Exposes an HTTP server with endpoints:
 - GET  /v1/responses/{response_id} — Retrieve a stored response
 - DELETE /v1/responses/{response_id} — Delete a stored response
 - GET  /v1/models                  — lists hermes-agent and any configured model_routes aliases
+- GET  /v1/profiles                — default-listener profile inventory
 - GET  /v1/capabilities            — machine-readable API capabilities for external UIs
 - GET  /api/sessions               — list client-visible Hermes sessions
 - POST /api/sessions               — create an empty Hermes session
@@ -127,6 +128,9 @@ MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversation
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
+PROFILE_INVENTORY_VERSION = 1
+MAX_PROFILE_INVENTORY_SIZE = 1_000
+PROFILE_INVENTORY_ID_RE = re.compile(r"[a-z0-9][a-z0-9_-]{0,63}")
 RESPONSES_AUTO_TRUNCATION_HISTORY_LIMIT = 100
 _COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
 
@@ -1811,6 +1815,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/health/detailed", self._handle_health_detailed),
             ("GET", "/v1/health", self._handle_health),
             ("GET", "/v1/models", self._handle_models),
+            ("GET", "/v1/profiles", self._handle_profiles),
             ("GET", "/api/model/options", self._handle_model_options),
             ("GET", "/v1/capabilities", self._handle_capabilities),
             ("GET", "/v1/skills", self._handle_skills),
@@ -2795,6 +2800,126 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return web.json_response({"object": "list", "data": models})
 
+    async def _profile_inventory_request_profile(self) -> str:
+        """Return the profile that owns inventory authority for this request.
+
+        A multiplex prefix is authoritative when present. For an unprefixed
+        request, resolve the process profile off the event loop so a standalone
+        named-profile listener cannot be mistaken for the default listener.
+        """
+        routed_profile = _api_request_profile.get()
+        if routed_profile:
+            return routed_profile
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+
+            return str(await asyncio.to_thread(get_active_profile_name) or "")
+        except Exception as exc:
+            logger.warning(
+                "Failed to resolve API-server profile inventory authority: %s",
+                type(exc).__name__,
+            )
+            return ""
+
+    async def _handle_profiles(self, request: "web.Request") -> "web.Response":
+        """GET /v1/profiles — return a bounded, secret-free global roster.
+
+        Complete inventory is a control-plane capability owned by the default
+        listener. A named profile's valid API key authenticates that profile,
+        but intentionally does not grant a global roster response.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        if not self._api_key:
+            return web.json_response(
+                _openai_error(
+                    "Profile inventory requires API key authentication",
+                    code="profile_inventory_auth_required",
+                ),
+                status=403,
+            )
+
+        request_profile = await self._profile_inventory_request_profile()
+        if request_profile != "default":
+            return web.json_response(
+                _openai_error(
+                    "Profile inventory requires the default listener",
+                    code="profile_inventory_default_authority_required",
+                ),
+                status=403,
+            )
+
+        def _load_snapshot() -> tuple[str, List[tuple]]:
+            from hermes_cli.profiles import (
+                get_active_profile_name,
+                profiles_to_serve,
+            )
+
+            active = get_active_profile_name() or "default"
+            return active, profiles_to_serve(multiplex=True)
+
+        try:
+            active_profile, raw_profiles = await asyncio.to_thread(_load_snapshot)
+            if len(raw_profiles) > MAX_PROFILE_INVENTORY_SIZE:
+                return web.json_response(
+                    _openai_error(
+                        "Profile inventory is too large to return safely",
+                        code="profile_inventory_too_large",
+                    ),
+                    status=409,
+                )
+
+            profile_ids: List[str] = []
+            seen: set[str] = set()
+            for raw_name, _profile_home in raw_profiles:
+                if not isinstance(raw_name, str):
+                    raise ValueError("non-string profile identifier")
+                profile_id = raw_name
+                if PROFILE_INVENTORY_ID_RE.fullmatch(profile_id) is None:
+                    raise ValueError("invalid profile identifier")
+                if profile_id in seen:
+                    raise ValueError("duplicate profile identifier")
+                seen.add(profile_id)
+                profile_ids.append(profile_id)
+
+            if "default" not in seen:
+                raise ValueError("default profile missing")
+            if active_profile != "default":
+                raise ValueError("listener profile changed during inventory")
+
+            runner = getattr(self, "gateway_runner", None)
+            config = getattr(runner, "config", None)
+            multiplex = bool(getattr(config, "multiplex_profiles", False))
+            served_ids = set(profile_ids) if multiplex else {"default"}
+        except Exception:
+            logger.exception("GET /v1/profiles failed")
+            return web.json_response(
+                _openai_error(
+                    "Profile inventory is temporarily unavailable",
+                    err_type="server_error",
+                    code="profile_inventory_unavailable",
+                ),
+                status=503,
+            )
+
+        return web.json_response({
+            "object": "list",
+            "version": PROFILE_INVENTORY_VERSION,
+            "complete": True,
+            "active_profile": active_profile,
+            "data": [
+                {
+                    "id": profile_id,
+                    "object": "hermes.profile",
+                    "is_default": profile_id == "default",
+                    "is_active": profile_id == active_profile,
+                    "served": profile_id in served_ids,
+                }
+                for profile_id in profile_ids
+            ],
+        })
+
     async def _handle_model_options(self, request: "web.Request") -> "web.Response":
         """GET /api/model/options — return Hermes provider/model inventory.
 
@@ -2843,6 +2968,11 @@ class APIServerAdapter(BasePlatformAdapter):
         if auth_err:
             return auth_err
 
+        inventory_profile = await self._profile_inventory_request_profile()
+        profile_inventory_available = bool(
+            self._api_key and inventory_profile == "default"
+        )
+
         return web.json_response({
             "object": "hermes.api_server.capabilities",
             "platform": "hermes-agent",
@@ -2883,6 +3013,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 "jobs_admin": False,
                 "memory_write_api": False,
                 "skills_api": True,
+                "profile_inventory": profile_inventory_available,
+                "profile_inventory_version": PROFILE_INVENTORY_VERSION,
+                "profile_inventory_complete": profile_inventory_available,
+                "profile_inventory_scope": "default_listener",
+                "profile_inventory_requires_api_key": True,
                 "audio_api": False,
                 "realtime_voice": False,
                 "session_continuity_header": "X-Hermes-Session-Id",
@@ -2893,6 +3028,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "health": {"method": "GET", "path": "/health"},
                 "health_detailed": {"method": "GET", "path": "/health/detailed"},
                 "models": {"method": "GET", "path": "/v1/models"},
+                "profiles": {"method": "GET", "path": "/v1/profiles"},
                 "model_options": {"method": "GET", "path": "/api/model/options"},
                 "chat_completions": {"method": "POST", "path": "/v1/chat/completions"},
                 "responses": {"method": "POST", "path": "/v1/responses"},

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -617,6 +617,202 @@ class TestModelsEndpoint:
 
 
 # ---------------------------------------------------------------------------
+# /v1/profiles endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestProfilesEndpoint:
+    @staticmethod
+    def _app(adapter: APIServerAdapter) -> web.Application:
+        app = web.Application()
+        app.router.add_get("/v1/profiles", adapter._handle_profiles)
+        return app
+
+    @pytest.mark.asyncio
+    async def test_requires_configured_api_key_before_inventory(self, adapter):
+        with patch(
+            "hermes_cli.profiles.profiles_to_serve",
+            side_effect=AssertionError("inventory must not run"),
+        ):
+            async with TestClient(TestServer(self._app(adapter))) as client:
+                response = await client.get("/v1/profiles")
+                data = await response.json()
+
+        assert response.status == 403
+        assert data["error"]["code"] == (
+            "profile_inventory_auth_required"
+        )
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_bearer_before_inventory(self, auth_adapter):
+        with patch(
+            "hermes_cli.profiles.profiles_to_serve",
+            side_effect=AssertionError("inventory must not run"),
+        ):
+            async with TestClient(TestServer(self._app(auth_adapter))) as client:
+                response = await client.get(
+                    "/v1/profiles",
+                    headers={"Authorization": "Bearer wrong"},
+                )
+
+        assert response.status == 401
+
+    @pytest.mark.asyncio
+    async def test_named_profile_authority_rejected_before_inventory(
+        self,
+        auth_adapter,
+    ):
+        from gateway.platforms.api_server import _api_request_profile
+
+        request = MagicMock()
+        with patch.object(
+            auth_adapter,
+            "_check_auth",
+            return_value=None,
+        ), patch(
+            "hermes_cli.profiles.profiles_to_serve",
+            side_effect=AssertionError("inventory must not run"),
+        ):
+            token = _api_request_profile.set("builder")
+            try:
+                response = await auth_adapter._handle_profiles(request)
+            finally:
+                _api_request_profile.reset(token)
+
+        assert response.status == 403
+        assert json.loads(response.body)["error"]["code"] == (
+            "profile_inventory_default_authority_required"
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_complete_allowlisted_inventory(self, auth_adapter):
+        auth_adapter.gateway_runner = MagicMock()
+        auth_adapter.gateway_runner.config.multiplex_profiles = False
+        private_path = "/Users/operator/.hermes/profiles/builder"
+
+        with patch(
+            "hermes_cli.profiles.get_active_profile_name",
+            return_value="default",
+        ), patch(
+            "hermes_cli.profiles.profiles_to_serve",
+            return_value=[
+                ("default", "/private/default"),
+                ("builder", private_path),
+            ],
+        ):
+            async with TestClient(TestServer(self._app(auth_adapter))) as client:
+                response = await client.get(
+                    "/v1/profiles",
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                data = await response.json()
+
+        assert response.status == 200
+        assert data["object"] == "list"
+        assert data["version"] == 1
+        assert data["complete"] is True
+        assert data["active_profile"] == "default"
+        assert data["data"] == [
+            {
+                "id": "default",
+                "object": "hermes.profile",
+                "is_default": True,
+                "is_active": True,
+                "served": True,
+            },
+            {
+                "id": "builder",
+                "object": "hermes.profile",
+                "is_default": False,
+                "is_active": False,
+                "served": False,
+            },
+        ]
+        assert set(data) == {
+            "object",
+            "version",
+            "complete",
+            "active_profile",
+            "data",
+        }
+        serialized = json.dumps(data)
+        for forbidden in (
+            private_path,
+            "description",
+            "provider",
+            "model",
+            "alias",
+            "distribution",
+            "skill",
+            "env",
+            "credential",
+        ):
+            assert forbidden not in serialized
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "rows",
+        [
+            [("default", "/private/default"), ("default", "/private/duplicate")],
+            [("default", "/private/default"), ("../escape", "/private/escape")],
+            [("default", "/private/default"), (123, "/private/non-string")],
+            [("default", "/private/default"), (" builder", "/private/leading-space")],
+            [("default", "/private/default"), ("builder ", "/private/trailing-space")],
+            [("builder", "/private/builder")],
+        ],
+    )
+    async def test_invalid_inventory_fails_closed_without_reflection(
+        self,
+        auth_adapter,
+        rows,
+    ):
+        private_marker = "/private/"
+        with patch(
+            "hermes_cli.profiles.get_active_profile_name",
+            return_value="default",
+        ), patch(
+            "hermes_cli.profiles.profiles_to_serve",
+            return_value=rows,
+        ):
+            async with TestClient(TestServer(self._app(auth_adapter))) as client:
+                response = await client.get(
+                    "/v1/profiles",
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                body = await response.text()
+
+        assert response.status == 503
+        assert json.loads(body)["error"]["code"] == "profile_inventory_unavailable"
+        assert private_marker not in body
+
+    @pytest.mark.asyncio
+    async def test_oversized_inventory_fails_closed(self, auth_adapter):
+        rows = [("default", "/private/default")]
+        rows.extend(
+            (f"profile-{index}", f"/private/{index}")
+            for index in range(1_000)
+        )
+        with patch(
+            "hermes_cli.profiles.get_active_profile_name",
+            return_value="default",
+        ), patch(
+            "hermes_cli.profiles.profiles_to_serve",
+            return_value=rows,
+        ):
+            async with TestClient(TestServer(self._app(auth_adapter))) as client:
+                response = await client.get(
+                    "/v1/profiles",
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                data = await response.json()
+
+        assert response.status == 409
+        assert data["error"]["code"] == (
+            "profile_inventory_too_large"
+        )
+
+
+# ---------------------------------------------------------------------------
 # /v1/capabilities endpoint
 # ---------------------------------------------------------------------------
 
@@ -2616,5 +2812,3 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
-
-

--- a/tests/gateway/test_api_server_multiplex_secret_scope.py
+++ b/tests/gateway/test_api_server_multiplex_secret_scope.py
@@ -9,15 +9,18 @@ now enters the DEFAULT profile's runtime scope when multiplex is active and
 no profile was requested.
 
 Adapted from PR #61283 by @giggling-ginger (originally targeting a
-pre-``_profile_scope`` helper); no live gateway or network.
+pre-``_profile_scope`` helper). Tests use an in-process aiohttp server and no
+external gateway or network.
 """
 
 from __future__ import annotations
 
 import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
 
 from agent import secret_scope as ss
-from gateway.config import PlatformConfig
+from gateway.config import GatewayConfig, PlatformConfig
 from gateway.platforms.api_server import APIServerAdapter
 
 
@@ -159,3 +162,202 @@ async def test_profile_middleware_binds_auth_before_handler(
         assert (await accepted.json())["profile"] == "worker"
 
 
+def _profile_inventory_app(adapter: APIServerAdapter) -> web.Application:
+    """Mount the real inventory/capability route entries like connect()."""
+    app = web.Application(
+        middlewares=[adapter._make_profile_prefix_middleware()]
+    )
+    selected = {
+        "/v1/profiles",
+        "/v1/capabilities",
+    }
+    mounted = set()
+    for method, path, handler in adapter._http_route_table():
+        if path not in selected:
+            continue
+        app.router.add_route(method, path, handler)
+        app.router.add_route(method, f"/p/{{profile}}{path}", handler)
+        mounted.add(path)
+    assert mounted == selected
+    return app
+
+
+@pytest.mark.asyncio
+async def test_profile_inventory_requires_default_listener_authority(
+    tmp_path,
+    monkeypatch,
+):
+    from hermes_cli import profiles
+
+    default_home = tmp_path / ".hermes"
+    profiles_root = default_home / "profiles"
+    worker_home = profiles_root / "worker"
+    worker_home.mkdir(parents=True)
+    default_key = "d" * 32
+    worker_key = "w" * 32
+    (worker_home / ".env").write_text(
+        f"API_SERVER_KEY={worker_key}\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.setattr(
+        profiles,
+        "_get_default_hermes_home",
+        lambda: default_home,
+    )
+    monkeypatch.setattr(
+        profiles,
+        "_get_profiles_root",
+        lambda: profiles_root,
+    )
+    profiles_to_serve_calls = 0
+    real_profiles_to_serve = profiles.profiles_to_serve
+
+    def tracked_profiles_to_serve(*, multiplex):
+        nonlocal profiles_to_serve_calls
+        profiles_to_serve_calls += 1
+        return real_profiles_to_serve(multiplex=multiplex)
+
+    monkeypatch.setattr(
+        profiles,
+        "profiles_to_serve",
+        tracked_profiles_to_serve,
+    )
+
+    adapter = APIServerAdapter(
+        PlatformConfig(enabled=True, extra={"key": default_key})
+    )
+    adapter.gateway_runner = type(
+        "_Runner",
+        (),
+        {"config": GatewayConfig(multiplex_profiles=True)},
+    )()
+    ss.set_multiplex_active(True)
+
+    async with TestClient(
+        TestServer(_profile_inventory_app(adapter))
+    ) as client:
+        default_response = await client.get(
+            "/v1/profiles",
+            headers={"Authorization": f"Bearer {default_key}"},
+        )
+        assert default_response.status == 200
+        default_inventory = await default_response.json()
+        assert [
+            item["id"] for item in default_inventory["data"]
+        ] == ["default", "worker"]
+        assert [
+            item["served"] for item in default_inventory["data"]
+        ] == [True, True]
+
+        default_alias = await client.get(
+            "/p/default/v1/profiles",
+            headers={"Authorization": f"Bearer {default_key}"},
+        )
+        assert default_alias.status == 200
+
+        named_with_default_key = await client.get(
+            "/p/worker/v1/profiles",
+            headers={"Authorization": f"Bearer {default_key}"},
+        )
+        assert named_with_default_key.status == 401
+
+        default_with_named_key = await client.get(
+            "/v1/profiles",
+            headers={"Authorization": f"Bearer {worker_key}"},
+        )
+        assert default_with_named_key.status == 401
+
+        calls_before_named_request = profiles_to_serve_calls
+        named_response = await client.get(
+            "/p/worker/v1/profiles",
+            headers={"Authorization": f"Bearer {worker_key}"},
+        )
+        calls_after_named_route_resolution = profiles_to_serve_calls
+        assert named_response.status == 403
+        named_body = await named_response.json()
+        assert named_body["error"]["code"] == (
+            "profile_inventory_default_authority_required"
+        )
+        assert "data" not in named_body
+        assert "active_profile" not in named_body
+        # A prefixed route performs the existing middleware membership scan.
+        # The endpoint must not perform a second, handler-owned global roster
+        # load after authenticating a named-profile key.
+        assert (
+            calls_after_named_route_resolution - calls_before_named_request
+        ) == 1
+
+        default_capabilities = await client.get(
+            "/v1/capabilities",
+            headers={"Authorization": f"Bearer {default_key}"},
+        )
+        assert default_capabilities.status == 200
+        default_features = (await default_capabilities.json())["features"]
+        assert default_features["profile_inventory"] is True
+        assert default_features["profile_inventory_version"] == 1
+        assert default_features["profile_inventory_complete"] is True
+        assert default_features["profile_inventory_scope"] == "default_listener"
+        assert default_features["profile_inventory_requires_api_key"] is True
+
+        named_capabilities = await client.get(
+            "/p/worker/v1/capabilities",
+            headers={"Authorization": f"Bearer {worker_key}"},
+        )
+        assert named_capabilities.status == 200
+        named_features = (await named_capabilities.json())["features"]
+        assert named_features["profile_inventory"] is False
+        assert named_features["profile_inventory_complete"] is False
+        assert named_features["profile_inventory_scope"] == "default_listener"
+
+
+@pytest.mark.asyncio
+async def test_standalone_named_listener_cannot_enumerate_global_profiles(
+    tmp_path,
+    monkeypatch,
+):
+    from hermes_cli import profiles
+
+    default_home = tmp_path / ".hermes"
+    profiles_root = default_home / "profiles"
+    worker_home = profiles_root / "worker"
+    worker_home.mkdir(parents=True)
+    worker_key = "w" * 32
+
+    monkeypatch.setenv("HERMES_HOME", str(worker_home))
+    monkeypatch.setattr(
+        profiles,
+        "_get_default_hermes_home",
+        lambda: default_home,
+    )
+    monkeypatch.setattr(
+        profiles,
+        "_get_profiles_root",
+        lambda: profiles_root,
+    )
+    adapter = APIServerAdapter(
+        PlatformConfig(enabled=True, extra={"key": worker_key})
+    )
+    ss.set_multiplex_active(False)
+
+    async with TestClient(
+        TestServer(_profile_inventory_app(adapter))
+    ) as client:
+        response = await client.get(
+            "/v1/profiles",
+            headers={"Authorization": f"Bearer {worker_key}"},
+        )
+        assert response.status == 403
+        assert (await response.json())["error"]["code"] == (
+            "profile_inventory_default_authority_required"
+        )
+
+        capabilities = await client.get(
+            "/v1/capabilities",
+            headers={"Authorization": f"Bearer {worker_key}"},
+        )
+        assert capabilities.status == 200
+        assert (await capabilities.json())["features"][
+            "profile_inventory"
+        ] is False

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -96,11 +96,14 @@ POST /v1/runs/{id}/approval      Resolve a pending approval
 POST /v1/runs/{id}/stop          Interrupt the run
 GET  /v1/capabilities            Machine-readable feature flags
 GET  /v1/models                  Lists hermes-agent
+GET  /v1/profiles                Default-listener profile inventory
 GET  /api/model/options          Provider-aware picker inventory
 GET  /health, /health/detailed
 ```
 
 Setup, headers (`X-Hermes-Session-Id`, `X-Hermes-Session-Key`), and frontend wiring: [API Server](../user-guide/features/api-server).
+The API Server guide also defines the profile-inventory response fields,
+default-listener authority boundary, and stable error codes.
 
 ### Model catalog surfaces
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -202,6 +202,71 @@ Lists the agent as an available model. The advertised model name defaults to the
 enumerate every authenticated provider/model combination Hermes can route to,
 and it does not do pricing or capability enrichment.
 
+### GET /v1/profiles
+
+Returns a complete, bounded roster of Hermes profile identities for
+control-plane clients. The response includes only each profile's canonical ID
+and whether it is the default, active, or currently served profile. It never
+includes filesystem paths, credentials, provider/model configuration,
+descriptions, aliases, skills, or environment data.
+
+Global roster retrieval is intentionally restricted to the **default
+listener** and its `API_SERVER_KEY`:
+
+- Unprefixed `/v1/profiles` and `/p/default/v1/profiles` can return the global
+  roster when authenticated with the default listener's key.
+- When `gateway.multiplex_profiles` is enabled,
+  `/p/<named-profile>/v1/profiles` authenticates with that profile's own key
+  but returns `403`; the endpoint does not return sibling profile IDs. When
+  multiplexing is disabled, Hermes preserves the existing API-server behavior
+  of treating a prefixed path as the unprefixed listener route.
+- An API server started directly under a named profile also returns `403` for
+  the unprefixed inventory route.
+
+Example response:
+
+```json
+{
+  "object": "list",
+  "version": 1,
+  "complete": true,
+  "active_profile": "default",
+  "data": [
+    {
+      "id": "default",
+      "object": "hermes.profile",
+      "is_default": true,
+      "is_active": true,
+      "served": true
+    },
+    {
+      "id": "builder",
+      "object": "hermes.profile",
+      "is_default": false,
+      "is_active": false,
+      "served": true
+    }
+  ]
+}
+```
+
+Endpoint-owned errors use the standard API error envelope. Prefixed routing can
+also reject a request before it reaches the endpoint:
+
+| Status | Code | Meaning |
+| --- | --- | --- |
+| `401` | `gateway_auth_failed` | The bearer key is missing, invalid, or belongs to another routed profile. |
+| `404` | None | The existing multiplex router does not recognize the requested profile prefix. |
+| `403` | `profile_inventory_auth_required` | No API-server key is configured; this only applies to unsupported manual wiring and tests because normal startup requires a key. |
+| `403` | `profile_inventory_default_authority_required` | The request authenticated as a named profile, which cannot read the global roster. |
+| `409` | `profile_inventory_too_large` | The roster exceeds the bounded response limit. |
+| `503` | `profile_inventory_unavailable` | Hermes could not validate a complete, consistent snapshot. |
+
+The endpoint is advertised by `/v1/capabilities` through
+`profile_inventory`, `profile_inventory_version`, and
+`profile_inventory_scope`. Clients should require
+`profile_inventory: true` before requesting the roster.
+
 ### GET /api/model/options
 
 Hermes-aware clients can request the same curated provider/model inventory used
@@ -530,6 +595,10 @@ to the routed profile**:
 - Unprefixed routes and `/p/default/...` keep using the default profile's key.
 - A named profile with no `API_SERVER_KEY` of its own fails closed — its
   prefix is unreachable until you set one.
+- While multiplex routing is enabled, global `GET /v1/profiles` inventory is a
+  deliberate exception to mirrored route equivalence: only the default
+  listener has inventory authority. A correctly authenticated named-profile
+  route returns `403` without returning sibling profile IDs.
 
 :::warning Breaking change (July 2026)
 Before this fix, a valid default-profile key was accepted on any


### PR DESCRIPTION
## Purpose

Hermes supports isolated profiles, but external control planes do not have a supported way to list their canonical IDs. Clients would otherwise need to inspect profile directories or depend on private Python internals.

This PR adds an authenticated, read-only `GET /v1/profiles` endpoint with a small, versioned response contract.

## Authorization boundary

The complete roster is available only through the default listener using its own `API_SERVER_KEY`.

When multiplex routing is enabled, a named profile's key can authenticate its routed request, but `GET /v1/profiles` returns `403` instead of exposing the global roster. An API server started directly under a named profile follows the same rule.

I chose default-listener-only access instead of returning a one-item inventory to named profiles. The endpoint exists for complete control-plane discovery, while `/v1/models` already identifies the current named profile. A second inventory scope would add response and capability semantics without helping the global discovery use case.

## Response and failure behavior

Successful responses contain only:

- the canonical profile ID
- whether the profile is default
- whether it is active
- whether the current gateway serves it

The endpoint does not return paths, credentials, descriptions, aliases, provider or model configuration, skills, distribution metadata, or environment state.

The handler validates the snapshot before returning it. Invalid identifiers, duplicates, missing default state, inconsistent listener state, and inventories larger than 1,000 entries fail closed. Profile scanning runs outside the aiohttp event loop.

`GET /v1/capabilities` now reports whether profile inventory is available for the current request scope, along with its version, completeness, authority scope, and authentication requirement.

## Review changes

This version was rebuilt on current `main` and addresses the profile-isolation concern raised in review:

- bearer authentication runs before the endpoint constructs the global snapshot
- named-profile routes return a stable authority error
- distinct default and named keys are exercised through the real multiplex route table
- cross-profile keys return `401`
- named-profile inventory responses contain no roster data
- a standalone named listener cannot enumerate the global roster
- the mounted test distinguishes the existing prefix-routing lookup from the handler-owned roster load

The existing multiplex router still resolves profile prefixes before endpoint handlers and returns `404` for unknown prefixes. This PR preserves that shared routing behavior instead of introducing an endpoint-specific authentication path.

## Verification

- 111 focused and adjacent API-server and multiplex tests passed
- Python compilation, Ruff, `git diff --check`, and the Windows-footgun scan passed
- documentation diagram lint passed across 383 files
- Docusaurus builds passed for English and zh-Hans; existing unrelated zh-Hans link warnings remain

The repository-wide run completed with 22,713 passing tests. Its reproducible failures were confined to 16 untouched platform, timing, and optional-dependency test files. A clean checkout of the same upstream commit reproduced the exact same 39 serial failures.