### PR TITLE
fix(skills_sync): merge owner-write into mode instead of clamping to 0o700 (#67496)

### DIFF
--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -2,6 +2,7 @@
 
 import shutil
 import json
+import sys
 import pytest
 from pathlib import Path
 from unittest.mock import patch
@@ -270,6 +271,70 @@ class TestRmtreeWritableScopeGuard:
 
         assert skills.exists()
         assert not sub.exists()
+
+
+class TestRmtreeWritablePreservesParentMode:
+    """``_rmtree_writable``'s error handler must ADD owner-write to a
+    directory's mode, not REPLACE it with ``0o700`` (#67496).
+
+    The handler chmods ``os.path.dirname(fpath)`` to make a read-only entry
+    removable (Nix/deb/rpm sources — #34860, #34972). When the failing entry
+    is a direct child of the skills root, that parent *is* the skills root.
+    The previous ``os.chmod(target, stat.S_IRWXU)`` assignment discarded the
+    group/other bits, clamping the root to ``0o700`` on every ``hermes
+    update`` and breaking traversal for every non-owner role on a
+    group-shared install. The handler must instead OR owner-rwx into the
+    existing mode so shared permissions survive.
+    """
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"), reason="POSIX permission semantics"
+    )
+    def test_parent_group_other_bits_survive_rmtree(self, tmp_path):
+        import os
+        import stat
+
+        from tools.skills_sync import _rmtree_writable
+
+        if os.geteuid() == 0:
+            pytest.skip("root bypasses permission checks; _on_error never fires")
+
+        skills = tmp_path / "skills"
+        skills.mkdir()
+        # A skill directory directly under the root, with a file inside it.
+        skill = skills / "youtube-content"
+        skill.mkdir()
+        (skill / "SKILL.md").write_text("# skill")
+
+        # Group-shared install with group traversal + a non-writable root.
+        # Removing the file inside ``skill`` succeeds (owner can write to
+        # ``skill``), but ``os.rmdir(skill)`` then fails because it needs
+        # write permission on the *parent* (the 0o550 root). rmtree falls
+        # into ``_on_error`` with ``fpath == skill`` (a direct child of the
+        # root), whose ``dirname`` is the root itself — exactly the path that
+        # clamped the root in #67496. 0o550 = r-xr-x--- (owner has NO write,
+        # group keeps r-x).
+        os.chmod(skills, 0o550)
+        captured_mode = None
+        try:
+            with patch("tools.skills_sync.SKILLS_DIR", skills):
+                _rmtree_writable(skill)
+            # Capture the root's mode BEFORE any cleanup restores it.
+            captured_mode = stat.S_IMODE(os.stat(skills).st_mode)
+        finally:
+            # Ensure pytest can clean up regardless of outcome.
+            os.chmod(skills, 0o755)
+
+        assert not skill.exists()  # the tree was actually removed
+        assert captured_mode is not None
+        mode = captured_mode
+        # Owner-write was added to make removal possible, but the group
+        # traversal bits that existed before MUST survive — the root must not
+        # collapse to 0o700.
+        assert mode & stat.S_IRGRP, f"group-read stripped: {oct(mode)}"
+        assert mode & stat.S_IXGRP, f"group-exec stripped: {oct(mode)}"
+        # Regression assertion: the root is NOT clamped to 0o700 (#67496).
+        assert mode != 0o700, "skills root was clamped to 0o700 (#67496 regression)"
 
 
 class TestExternalDirsIndexing:

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -759,9 +759,20 @@ def _rmtree_writable(path: Path) -> None:
     def _on_error(func, fpath, exc_info):
         # Unlinking a child requires the parent dir to be writable, so chmod
         # the parent as well as the failing path, then retry.
+        #
+        # ADD owner rwx to the existing mode rather than REPLACING it with
+        # ``0o700``. ``os.chmod(target, stat.S_IRWXU)`` is an assignment that
+        # discards all group/other bits; because this handler also chmods
+        # ``os.path.dirname(fpath)``, a failure on a direct child of the
+        # skills root clamps the *root itself* to ``0o700``, permanently
+        # stripping the group/other permissions a shared install relies on —
+        # and it re-clamps on every ``hermes update`` (#67496). Merging the
+        # owner-write bits in keeps the entry removable (the stated intent —
+        # #34860, #34972) without touching anyone else's access.
         for target in (os.path.dirname(fpath), fpath):
             try:
-                os.chmod(target, stat.S_IRWXU)
+                current = os.stat(target).st_mode
+                os.chmod(target, current | stat.S_IRWXU)
             except OSError:
                 pass
         func(fpath)


### PR DESCRIPTION
## Summary

Fixes #67496.

`tools/skills_sync.py::_rmtree_writable()`'s `_on_error` handler called
`os.chmod(target, stat.S_IRWXU)`, which **replaces** a directory's mode with
`0o700` instead of **adding** owner-write to the existing mode. Because the
handler also chmods `os.path.dirname(fpath)`, a removal failure on a direct
child of the skills root clamps the **skills root itself** to `0o700`,
permanently stripping the group/other bits a group-shared install depends on.

It re-clamps on **every** `hermes update`, so a manual `chmod` is not a durable
fix. On any group-shared install every non-owner role then dies with
`PermissionError` while *building its system prompt* (traversing the skills
dir), before any tool runs — presenting as an unrelated workload failure.

## Root cause

```python
def _on_error(func, fpath, exc_info):
    for target in (os.path.dirname(fpath), fpath):
        try:
            os.chmod(target, stat.S_IRWXU)   # <-- assignment, discards group/other
        except OSError:
            pass
    func(fpath)
```

The docstring's stated intent is only to make read-only entries *writable
enough to remove* (Nix/deb/rpm `r-xr-xr-x` sources, #34860 / #34972). But
`os.chmod(target, stat.S_IRWXU)` is an assignment, not a merge. The existing
`#48200` scope guard protects the root from **deletion**, but this chmod
reaches `dirname(fpath)`, which *is* the skills root when `fpath` is a direct
child of it.

## Fix

Merge owner-rwx into the existing mode instead of overwriting it:

```python
current = os.stat(target).st_mode
os.chmod(target, current | stat.S_IRWXU)
```

The entry stays removable (the handler's whole purpose) without discarding
anyone else's access. Minimal, one-line behavioral change.

## Test

Adds `TestRmtreeWritablePreservesParentMode` which reproduces the clamp: a
skills root at `0o550` (owner has no write, group keeps `r-x`) with a file
inside a direct-child skill dir forces `os.rmdir(child)` to fail → `_on_error`
fires on the child → its `dirname` is the root. The test captures the root's
mode immediately after removal and asserts the group traversal bits survive and
the root is not collapsed to `0o700`.

Verified RED → GREEN:
- On old code the test fails: `AssertionError: group-read stripped: 0o700`.
- With the fix it passes.
- Full file: **70/70 pass** via `scripts/run_tests.sh tests/tools/test_skills_sync.py`.

The test is skipped on Windows (POSIX permission semantics) and when running as
root (root bypasses the permission check, so `_on_error` never fires).
