### PR TITLE
fix(kanban): add operator override for the active-PR respawn guard (#67249)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -276,6 +276,35 @@ def _resolve_rate_limit_cooldown_seconds() -> int:
     return DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS
 
 
+def _resolve_pr_guard_window_seconds() -> int:
+    """Return the active-PR respawn-guard window in seconds.
+
+    Reads ``HERMES_KANBAN_PR_GUARD_WINDOW_SECONDS`` from the environment;
+    falls back to ``_RESPAWN_GUARD_PR_WINDOW`` when absent, empty,
+    non-integer, or negative. A value of 0 disables the guard — useful for
+    operators whose deployment never opens PRs (or who are hitting the
+    false-positive class below) and who therefore want the card to respawn
+    immediately rather than being parked for a full day (#67249).
+
+    The sibling rate-limit guard already has an equivalent override
+    (``_resolve_rate_limit_cooldown_seconds`` / the
+    ``HERMES_KANBAN_RATE_LIMIT_COOLDOWN_SECONDS`` env var). This one mirrors
+    that so both respawn guards are operator-tunable without patching the
+    installed file. The default window stays 24h.
+    """
+    raw = os.environ.get(
+        "HERMES_KANBAN_PR_GUARD_WINDOW_SECONDS", ""
+    ).strip()
+    if raw:
+        try:
+            parsed = int(raw)
+        except ValueError:
+            parsed = -1
+        if parsed >= 0:
+            return parsed
+    return _RESPAWN_GUARD_PR_WINDOW
+
+
 # Worker-context caps so build_worker_context() stays bounded on
 # pathological boards (retry-heavy tasks, comment storms, giant
 # summaries). Values chosen to fit a typical 100k-char LLM prompt with
@@ -7368,13 +7397,18 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
-    pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
-    for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
-        (task_id, pr_cutoff),
-    ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+    pr_window = _resolve_pr_guard_window_seconds()
+    if pr_window <= 0:
+        # Guard disabled via HERMES_KANBAN_PR_GUARD_WINDOW_SECONDS=0.
+        pass
+    else:
+        pr_cutoff = now - pr_window
+        for c in conn.execute(
+            "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+            (task_id, pr_cutoff),
+        ).fetchall():
+            if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+                return "active_pr"
 
     return None
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1944,6 +1944,67 @@ def test_respawn_guard_old_pr_comment_not_guarded(kanban_home):
     assert reason is None
 
 
+def test_respawn_guard_pr_window_env_override_zero_disables_guard(kanban_home, monkeypatch):
+    """HERMES_KANBAN_PR_GUARD_WINDOW_SECONDS=0 disables the active-PR guard.
+
+    Mirrors the rate-limit sibling (``HERMES_KANBAN_RATE_LIMIT_COOLDOWN_SECONDS``);
+    an operator whose deployment never opens PRs must be able to tune/disable
+    the 24h park without patching the installed file (#67249).
+    """
+    monkeypatch.setenv("HERMES_KANBAN_PR_GUARD_WINDOW_SECONDS", "0")
+    assert kb._resolve_pr_guard_window_seconds() == 0
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="pr-override", assignee="alice")
+        kb.add_comment(
+            conn, t, "worker",
+            "PR created: https://github.com/totemx-AI/subsidysmart/pull/42",
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
+
+
+def test_respawn_guard_pr_window_env_override_custom(kanban_home, monkeypatch):
+    """The env override shrinks the effective PR-guard window."""
+    monkeypatch.setenv("HERMES_KANBAN_PR_GUARD_WINDOW_SECONDS", "60")
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="pr-custom", assignee="alice")
+        # A comment just inside the default 24h window but outside the 60s
+        # override must no longer trip the guard.
+        recent_ts = int(time.time()) - 120
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, 'worker', "
+            "'https://github.com/totemx-AI/subsidysmart/pull/7', ?)",
+            (t, recent_ts),
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
+
+
+def test_respawn_guard_pr_window_env_override_invalid_falls_back(kanban_home, monkeypatch):
+    """A non-integer override falls back to the built-in 24h default."""
+    monkeypatch.setenv("HERMES_KANBAN_PR_GUARD_WINDOW_SECONDS", "not-a-number")
+    assert kb._resolve_pr_guard_window_seconds() == kb._RESPAWN_GUARD_PR_WINDOW
+
+
+def test_respawn_guard_pr_url_regex_still_matches_evidence(kanban_home):
+    """The PR-guard regex still trips on a real PR-creation comment.
+
+    The guard's text-match semantics are unchanged by the operator override;
+    this test pins that an actual PR URL in a comment still parks the card
+    within the default 24h window (regression guard so a future tidy-up
+    can't silently weaken the duplicate-PR protection).
+    """
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="pr-evidence", assignee="alice")
+        kb.add_comment(
+            conn, t, "worker",
+            "PR created: https://github.com/totemx-AI/subsidysmart/pull/42",
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason == "active_pr"
+
+
 def test_dispatch_respawn_guard_defers_auth_error_without_auto_block(
     kanban_home, all_assignees_spawnable
 ):


### PR DESCRIPTION
## Summary

Fixes #67249.

`check_respawn_guard()` parks a kanban card for a hard-coded 24h whenever any
task comment contains a GitHub PR URL (`_RESPAWN_GUARD_PR_WINDOW = 86400`).
The intent — don't re-spawn a worker that would open a duplicate PR — is
sound. But there was **no operator override**, unlike the sibling rate-limit
guard which already reads `HERMES_KANBAN_RATE_LIMIT_COOLDOWN_SECONDS`.

That left two rough edges (from #67249):

1. No supported way to tune or disable the window. An operator whose
   deployment never opens PRs (or who is hitting the false-positive class
   where ingested web/changelog/handoff text merely *cites* a PR) can only
   have the card parked for a full day, or patch the installed file.
2. The window was a bare module constant.

## Fix

Mirror the sibling override exactly:

- Add `_resolve_pr_guard_window_seconds()` reading
  `HERMES_KANBAN_PR_GUARD_WINDOW_SECONDS`. Falls back to the 24h default when
  absent, empty, non-integer, or negative. A value of `0` **disables** the
  guard so the card respawns immediately.
- Wire it into `check_respawn_guard()`; short-circuit the PR scan when the
  resolved window `<= 0`.

The default behavior is unchanged (24h window, same regex match). Only the
operator-knob and the `=0` disable path are new.

## Scope note

The issue also floated narrowing the PR-URL regex so it only matches
PR-*creation* evidence rather than any cited PR link. I deliberately did
**not** do that: distinguishing "this task opened a PR" from "a PR URL was
cited in pasted text" by regex alone is unreliable and risks false negatives
that would let genuinely duplicate PRs slip through. The operator override is
the safe, requested fix; regex tightening is left for a maintainer decision.

## Test

`tests/hermes_cli/test_kanban_db.py`, all new, patterned on the existing
`test_respawn_guard_*` suite:

- `test_respawn_guard_pr_window_env_override_zero_disables_guard` — `=0` makes
  a fresh PR comment not trip the guard.
- `test_respawn_guard_pr_window_env_override_custom` — a 60s window excludes a
  120s-old comment.
- `test_respawn_guard_pr_window_env_override_invalid_falls_back` — a
  non-integer value falls back to 24h.
- `test_respawn_guard_pr_url_regex_still_matches_evidence` — regression guard
  that the existing PR-evidence match is unchanged.

Verified: full file **234/234 pass** via `scripts/run_tests.sh
tests/hermes_cli/test_kanban_db.py`.
