### PR TITLE
feat: add revision-aware Kanban API

### DIFF
--- a/gateway/kanban_api.py
+++ b/gateway/kanban_api.py
@@ -1,0 +1,423 @@
+"""Bounded, revision-aware Kanban records for the API-server bearer surface.
+
+This module deliberately does not reuse the dashboard plugin API.  It exposes
+only a small server-to-server contract and funnels writes through the existing
+Kanban database helpers so CLI, dashboard, gateway, and API callers share the
+same state-machine invariants.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import re
+import sqlite3
+from typing import Any
+
+from hermes_cli import kanban_db
+
+
+KANBAN_API_VERSION = 1
+MAX_BOARDS = 100
+MAX_PROFILES = 200
+MAX_TASKS = 200
+MAX_COMMENTS = 100
+MAX_RUNS = 100
+MAX_EVENTS = 200
+MAX_TEXT = 20_000
+_BOARD_RE = re.compile(r"[a-z0-9][a-z0-9_-]{0,63}\Z")
+_TASK_RE = re.compile(r"t_[a-f0-9]{8}\Z")
+_PROFILE_RE = re.compile(r"[a-z0-9][a-z0-9_-]{0,63}\Z")
+_IDEMPOTENCY_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{7,127}\Z")
+_REVISION_RE = re.compile(r"kanbanrev_[0-9a-f]{64}\Z")
+
+
+class KanbanApiError(ValueError):
+    """A deliberate public API failure with no reflected database details."""
+
+    def __init__(self, status: int, code: str, message: str):
+        super().__init__(message)
+        self.status = status
+        self.code = code
+        self.message = message
+
+
+def _text(value: Any, limit: int = MAX_TEXT) -> str:
+    value = str(value or "").replace("\x00", "")
+    value = "".join(ch for ch in value if ch.isprintable() or ch in "\n\t")
+    return value[:limit]
+
+
+def _optional_text(value: Any, limit: int) -> str | None:
+    text = _text(value, limit).strip()
+    return text or None
+
+
+def _required_text(value: Any, label: str, limit: int) -> str:
+    text = _optional_text(value, limit)
+    if text is None:
+        raise KanbanApiError(400, "invalid_request", f"{label} is required")
+    return text
+
+
+def _board(value: Any) -> str:
+    board = _text(value, 64).strip().lower()
+    if not _BOARD_RE.fullmatch(board):
+        raise KanbanApiError(400, "invalid_board", "Board identifier is invalid")
+    if board != kanban_db.DEFAULT_BOARD and not kanban_db.board_exists(board):
+        raise KanbanApiError(404, "board_not_found", "Board was not found")
+    return board
+
+
+def _task_id(value: Any) -> str:
+    task_id = _text(value, 16).strip()
+    if not _TASK_RE.fullmatch(task_id):
+        raise KanbanApiError(400, "invalid_task", "Task identifier is invalid")
+    return task_id
+
+
+def _profile(value: Any, *, allow_none: bool = True) -> str | None:
+    if value is None and allow_none:
+        return None
+    profile = _text(value, 64).strip().lower()
+    if not _PROFILE_RE.fullmatch(profile):
+        raise KanbanApiError(400, "invalid_profile", "Profile identifier is invalid")
+    return profile
+
+
+def _idempotency_key(value: Any) -> str:
+    key = _text(value, 128).strip()
+    if not _IDEMPOTENCY_RE.fullmatch(key):
+        raise KanbanApiError(400, "invalid_idempotency_key", "Idempotency key is invalid")
+    return key
+
+
+def _revision(value: Any) -> str:
+    revision = _text(value, 80).strip()
+    if not _REVISION_RE.fullmatch(revision):
+        raise KanbanApiError(400, "invalid_revision", "Revision is invalid")
+    return revision
+
+
+def _canonical_hash(value: Any, *, prefix: str) -> str:
+    encoded = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return prefix + hashlib.sha256(encoded).hexdigest()
+
+
+def _only_keys(payload: dict[str, Any], allowed: set[str]) -> None:
+    if not isinstance(payload, dict) or set(payload) - allowed:
+        raise KanbanApiError(400, "invalid_request", "Request contains unsupported fields")
+
+
+def _task_record(task: kanban_db.Task, *, include_body: bool) -> dict[str, Any]:
+    return {
+        "id": task.id,
+        "object": "hermes.kanban.task",
+        "title": _text(task.title, 500),
+        **({"body": _text(task.body, MAX_TEXT)} if include_body else {}),
+        "assignee": task.assignee,
+        "status": task.status,
+        "priority": int(task.priority),
+        "created_by": _optional_text(task.created_by, 80),
+        "created_at": int(task.created_at),
+        "started_at": task.started_at,
+        "completed_at": task.completed_at,
+        "result": _text(task.result, MAX_TEXT) if include_body else None,
+        "block_kind": task.block_kind,
+        "block_recurrences": int(task.block_recurrences),
+    }
+
+
+def _comment_record(comment: kanban_db.Comment) -> dict[str, Any]:
+    return {
+        "id": int(comment.id),
+        "author": _text(comment.author, 64),
+        "body": _text(comment.body, 4_000),
+        "created_at": int(comment.created_at),
+    }
+
+
+def _run_record(run: kanban_db.Run) -> dict[str, Any]:
+    return {
+        "id": int(run.id),
+        "profile": _optional_text(run.profile, 64),
+        "status": _text(run.status, 32),
+        "outcome": _optional_text(run.outcome, 32),
+        "summary": _text(run.summary, 4_000),
+        "error": _text(run.error, 2_000),
+        "started_at": int(run.started_at),
+        "ended_at": run.ended_at,
+    }
+
+
+def _event_record(event: kanban_db.Event) -> dict[str, Any]:
+    # Event payloads can contain worker paths, output, or arbitrary user text.
+    # The public contract deliberately exposes only a bounded audit identity.
+    return {
+        "id": int(event.id),
+        "kind": _text(event.kind, 80),
+        "created_at": int(event.created_at),
+        "run_id": event.run_id,
+    }
+
+
+def _task_edges(conn: sqlite3.Connection, task_id: str) -> dict[str, list[dict[str, Any]]]:
+    parents = conn.execute(
+        "SELECT t.id, t.status FROM tasks t JOIN task_links l ON l.parent_id = t.id "
+        "WHERE l.child_id = ? ORDER BY t.id ASC LIMIT ?",
+        (task_id, MAX_TASKS + 1),
+    ).fetchall()
+    children = conn.execute(
+        "SELECT t.id, t.status FROM tasks t JOIN task_links l ON l.child_id = t.id "
+        "WHERE l.parent_id = ? ORDER BY t.id ASC LIMIT ?",
+        (task_id, MAX_TASKS + 1),
+    ).fetchall()
+    if len(parents) > MAX_TASKS or len(children) > MAX_TASKS:
+        raise KanbanApiError(
+            409,
+            "task_relationship_limit",
+            "Task relationships exceed the safe API limit",
+        )
+    return {
+        "parents": [{"id": row["id"], "status": row["status"]} for row in parents],
+        "children": [{"id": row["id"], "status": row["status"]} for row in children],
+    }
+
+
+def task_snapshot(conn: sqlite3.Connection, task_id: str) -> dict[str, Any]:
+    """Return the exact bounded state used for reads and mutation revisions."""
+    task = kanban_db.get_task(conn, task_id)
+    if task is None:
+        raise KanbanApiError(404, "task_not_found", "Task was not found")
+    comments = kanban_db.list_comments(conn, task_id)
+    runs = kanban_db.list_runs(conn, task_id)
+    events = kanban_db.list_events(conn, task_id)
+    comments_truncated = len(comments) > MAX_COMMENTS
+    runs_truncated = len(runs) > MAX_RUNS
+    events_truncated = len(events) > MAX_EVENTS
+    snapshot = {
+        "object": "hermes.kanban.task_detail",
+        "version": KANBAN_API_VERSION,
+        "task": _task_record(task, include_body=True),
+        "comments": [_comment_record(value) for value in comments[-MAX_COMMENTS:]],
+        "runs": [_run_record(value) for value in runs[-MAX_RUNS:]],
+        "events": [_event_record(value) for value in events[-MAX_EVENTS:]],
+        "truncated": {
+            "comments": comments_truncated,
+            "runs": runs_truncated,
+            "events": events_truncated,
+        },
+        **_task_edges(conn, task_id),
+    }
+    snapshot["revision"] = _canonical_hash(snapshot, prefix="kanbanrev_")
+    return snapshot
+
+
+def _request_hash(operation: str, board: str, task_id: str | None, payload: dict[str, Any]) -> str:
+    return _canonical_hash(
+        {"operation": operation, "board": board, "task_id": task_id, "payload": payload},
+        prefix="sha256:",
+    )
+
+
+def _key_hash(key: str) -> str:
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()
+
+
+def _idempotency_replay(
+    conn: sqlite3.Connection, *, key: str, request_hash: str
+) -> tuple[bool, str | None]:
+    row = conn.execute(
+        "SELECT request_hash, task_id FROM kanban_api_idempotency WHERE key_hash = ?",
+        (_key_hash(key),),
+    ).fetchone()
+    if row is None:
+        return False, None
+    if not hmac.compare_digest(str(row["request_hash"]), request_hash):
+        raise KanbanApiError(409, "idempotency_conflict", "Idempotency key was already used for different input")
+    return True, str(row["task_id"])
+
+
+def _record_idempotency(conn: sqlite3.Connection, *, key: str, request_hash: str, task_id: str) -> None:
+    conn.execute(
+        "INSERT INTO kanban_api_idempotency (key_hash, request_hash, task_id, created_at) "
+        "VALUES (?, ?, ?, strftime('%s','now'))",
+        (_key_hash(key), request_hash, task_id),
+    )
+
+
+def list_boards() -> dict[str, Any]:
+    boards = kanban_db.list_boards(include_archived=True)
+    if len(boards) > MAX_BOARDS:
+        raise KanbanApiError(409, "board_limit_exceeded", "Too many boards to return safely")
+    return {
+        "object": "list",
+        "version": KANBAN_API_VERSION,
+        "complete": True,
+        "data": [
+            {
+                "id": _board(value.get("slug")),
+                "object": "hermes.kanban.board",
+                "name": _text(value.get("name") or value.get("slug"), 160),
+                "archived": bool(value.get("archived")),
+                "is_current": bool(value.get("is_current")),
+            }
+            for value in boards
+        ],
+    }
+
+
+def list_profiles(board_value: Any) -> dict[str, Any]:
+    board = _board(board_value)
+    with kanban_db.connect_closing(board=board) as conn:
+        profiles = kanban_db.known_assignees(conn)
+    if len(profiles) > MAX_PROFILES:
+        raise KanbanApiError(409, "profile_limit_exceeded", "Too many profiles to return safely")
+    return {
+        "object": "list",
+        "version": KANBAN_API_VERSION,
+        "complete": True,
+        "board": board,
+        "data": [
+            {
+                "id": _profile(value.get("name"), allow_none=False),
+                "object": "hermes.kanban.profile",
+                "available": bool(value.get("on_disk")),
+                "counts": {
+                    _text(status, 32): max(0, int(count))
+                    for status, count in dict(value.get("counts") or {}).items()
+                },
+            }
+            for value in profiles
+        ],
+    }
+
+
+def list_tasks(board_value: Any, *, status: Any = None, assignee: Any = None, limit: Any = None) -> dict[str, Any]:
+    board = _board(board_value)
+    try:
+        requested_limit = MAX_TASKS if limit is None else int(limit)
+    except (TypeError, ValueError):
+        raise KanbanApiError(400, "invalid_limit", "Task limit is invalid") from None
+    if requested_limit < 1 or requested_limit > MAX_TASKS:
+        raise KanbanApiError(400, "invalid_limit", "Task limit is invalid")
+    status_value = _optional_text(status, 32)
+    if status_value is not None and status_value not in kanban_db.VALID_STATUSES:
+        raise KanbanApiError(400, "invalid_status", "Task status is invalid")
+    with kanban_db.connect_closing(board=board) as conn:
+        tasks = kanban_db.list_tasks(
+            conn,
+            status=status_value,
+            assignee=_profile(assignee) if assignee is not None else None,
+            include_archived=status_value == "archived",
+            limit=requested_limit + 1,
+        )
+    truncated = len(tasks) > requested_limit
+    return {
+        "object": "list",
+        "version": KANBAN_API_VERSION,
+        "complete": not truncated,
+        "board": board,
+        "data": [_task_record(task, include_body=False) for task in tasks[:requested_limit]],
+    }
+
+
+def get_task(board_value: Any, task_value: Any) -> dict[str, Any]:
+    board, task_id = _board(board_value), _task_id(task_value)
+    with kanban_db.connect_closing(board=board) as conn:
+        conn.execute("BEGIN")
+        try:
+            snapshot = task_snapshot(conn, task_id)
+        finally:
+            conn.execute("ROLLBACK")
+    snapshot["board"] = board
+    return snapshot
+
+
+def create_task(board_value: Any, payload: dict[str, Any]) -> dict[str, Any]:
+    board = _board(board_value)
+    _only_keys(payload, {"title", "body", "assignee", "workspace_kind", "priority", "idempotency_key"})
+    title = _required_text(payload.get("title"), "Title", 500)
+    body = _optional_text(payload.get("body"), MAX_TEXT)
+    assignee = _profile(payload.get("assignee"))
+    workspace_kind = _text(payload.get("workspace_kind") or "scratch", 16).strip()
+    if workspace_kind not in {"scratch", "worktree"}:
+        raise KanbanApiError(400, "invalid_workspace_kind", "Workspace kind is invalid")
+    try:
+        priority = int(payload.get("priority", 0))
+    except (TypeError, ValueError):
+        raise KanbanApiError(400, "invalid_priority", "Priority is invalid") from None
+    if priority < -1000 or priority > 1000:
+        raise KanbanApiError(400, "invalid_priority", "Priority is invalid")
+    key = _idempotency_key(payload.get("idempotency_key"))
+    material = {
+        "title": title, "body": body, "assignee": assignee,
+        "workspace_kind": workspace_kind, "priority": priority,
+    }
+    request_hash = _request_hash("create", board, None, material)
+    with kanban_db.connect_closing(board=board) as conn, kanban_db.write_txn(conn):
+        replay, existing_id = _idempotency_replay(conn, key=key, request_hash=request_hash)
+        if replay:
+            return {"replayed": True, **task_snapshot(conn, existing_id or "")}
+        task_id = kanban_db.create_task(
+            conn, title=title, body=body, assignee=assignee, priority=priority,
+            workspace_kind=workspace_kind, created_by="api_server",
+            idempotency_key="api:" + _key_hash(key), board=board,
+        )
+        _record_idempotency(conn, key=key, request_hash=request_hash, task_id=task_id)
+        return {"replayed": False, **task_snapshot(conn, task_id)}
+
+
+def mutate_task(board_value: Any, task_value: Any, payload: dict[str, Any]) -> dict[str, Any]:
+    board, task_id = _board(board_value), _task_id(task_value)
+    _only_keys(
+        payload,
+        {"action", "expected_revision", "idempotency_key", "assignee", "author", "body", "reason", "kind"},
+    )
+    action = _text(payload.get("action"), 32).strip().lower()
+    if action not in {"assign", "comment", "reply", "promote", "block", "retry", "terminate"}:
+        raise KanbanApiError(400, "invalid_action", "Action is not supported")
+    expected_revision = _revision(payload.get("expected_revision"))
+    key = _idempotency_key(payload.get("idempotency_key"))
+    material = {key: value for key, value in payload.items() if key != "idempotency_key"}
+    request_hash = _request_hash(action, board, task_id, material)
+    with kanban_db.connect_closing(board=board) as conn, kanban_db.write_txn(conn):
+        replay, existing_id = _idempotency_replay(conn, key=key, request_hash=request_hash)
+        if replay:
+            if existing_id != task_id:
+                raise KanbanApiError(409, "idempotency_conflict", "Idempotency key belongs to another task")
+            return {"replayed": True, **task_snapshot(conn, task_id)}
+        current = task_snapshot(conn, task_id)
+        if not hmac.compare_digest(current["revision"], expected_revision):
+            raise KanbanApiError(409, "stale_revision", "Task changed; refresh it before acting")
+        if action == "assign":
+            changed = kanban_db.assign_task(conn, task_id, _profile(payload.get("assignee")))
+        elif action in {"comment", "reply"}:
+            body = _required_text(payload.get("body"), "Comment", 4_000)
+            author = _profile(payload.get("author") or "api_client", allow_none=False)
+            kanban_db.add_comment(conn, task_id, author or "api_client", body)
+            changed = True
+        elif action == "promote":
+            changed, _reason = kanban_db.promote_task(
+                conn, task_id, actor="api_server", reason=_optional_text(payload.get("reason"), 2_000)
+            )
+        elif action == "block":
+            kind = _text(payload.get("kind") or "needs_input", 32).strip()
+            if kind not in kanban_db.VALID_BLOCK_KINDS:
+                raise KanbanApiError(400, "invalid_block_kind", "Block kind is invalid")
+            changed = kanban_db.block_task(
+                conn, task_id, reason=_required_text(payload.get("reason"), "Reason", 2_000), kind=kind
+            )
+        elif action == "retry":
+            changed = kanban_db.unblock_task(conn, task_id)
+        else:
+            changed = kanban_db.reclaim_task(
+                conn, task_id, reason=_optional_text(payload.get("reason"), 2_000)
+            )
+        if not changed:
+            raise KanbanApiError(409, "mutation_refused", "Task cannot accept that action in its current state")
+        _record_idempotency(conn, key=key, request_hash=request_hash, task_id=task_id)
+        return {"replayed": False, **task_snapshot(conn, task_id)}

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7,6 +7,11 @@ Exposes an HTTP server with endpoints:
 - GET  /v1/responses/{response_id} — Retrieve a stored response
 - DELETE /v1/responses/{response_id} — Delete a stored response
 - GET  /v1/models                  — lists hermes-agent and any configured model_routes aliases
+- GET  /v1/kanban/boards           — bounded revision-aware Kanban board records
+- GET  /v1/kanban/profiles         — bounded Kanban assignee/profile records
+- GET/POST /v1/kanban/tasks        — bounded task listing and idempotent creation
+- GET  /v1/kanban/tasks/{task_id}  — exact task snapshot with revision
+- POST /v1/kanban/tasks/{task_id}/actions — revision-bound fixed task actions
 - GET  /v1/capabilities            — machine-readable API capabilities for external UIs
 - GET  /api/sessions               — list client-visible Hermes sessions
 - POST /api/sessions               — create an empty Hermes session
@@ -1483,6 +1488,12 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/health/detailed", self._handle_health_detailed),
             ("GET", "/v1/health", self._handle_health),
             ("GET", "/v1/models", self._handle_models),
+            ("GET", "/v1/kanban/boards", self._handle_kanban_boards),
+            ("GET", "/v1/kanban/profiles", self._handle_kanban_profiles),
+            ("GET", "/v1/kanban/tasks", self._handle_kanban_tasks),
+            ("POST", "/v1/kanban/tasks", self._handle_create_kanban_task),
+            ("GET", "/v1/kanban/tasks/{task_id}", self._handle_kanban_task),
+            ("POST", "/v1/kanban/tasks/{task_id}/actions", self._handle_kanban_action),
             ("GET", "/v1/capabilities", self._handle_capabilities),
             ("GET", "/v1/skills", self._handle_skills),
             ("GET", "/v1/toolsets", self._handle_toolsets),
@@ -1990,6 +2001,93 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return web.json_response({"object": "list", "data": models})
 
+    async def _kanban_api_call(self, request: "web.Request", operation, *args, **kwargs) -> "web.Response":
+        """Run one bounded Kanban API operation behind the normal bearer gate."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        # The listener normally cannot start without this key, but keep the
+        # route fail-closed for direct test/manual wiring as well.
+        if not self._api_key:
+            return web.json_response(
+                _openai_error(
+                    "Kanban API requires API key authentication",
+                    code="kanban_api_auth_required",
+                ),
+                status=403,
+            )
+        try:
+            from gateway.kanban_api import KanbanApiError
+            payload = await asyncio.to_thread(operation, *args, **kwargs)
+        except KanbanApiError as exc:
+            return web.json_response(
+                _openai_error(exc.message, code=exc.code), status=exc.status
+            )
+        except Exception:
+            logger.exception("Kanban API operation failed")
+            return web.json_response(
+                _openai_error(
+                    "Kanban API is temporarily unavailable",
+                    err_type="server_error",
+                    code="kanban_api_unavailable",
+                ),
+                status=503,
+            )
+        return web.json_response(payload)
+
+    async def _handle_kanban_boards(self, request: "web.Request") -> "web.Response":
+        from gateway.kanban_api import list_boards
+        return await self._kanban_api_call(request, list_boards)
+
+    async def _handle_kanban_profiles(self, request: "web.Request") -> "web.Response":
+        from gateway.kanban_api import list_profiles
+        return await self._kanban_api_call(request, list_profiles, request.query.get("board"))
+
+    async def _handle_kanban_tasks(self, request: "web.Request") -> "web.Response":
+        from gateway.kanban_api import list_tasks
+        return await self._kanban_api_call(
+            request,
+            list_tasks,
+            request.query.get("board"),
+            status=request.query.get("status"),
+            assignee=request.query.get("assignee"),
+            limit=request.query.get("limit"),
+        )
+
+    async def _handle_kanban_task(self, request: "web.Request") -> "web.Response":
+        from gateway.kanban_api import get_task
+        return await self._kanban_api_call(
+            request, get_task, request.query.get("board"), request.match_info.get("task_id")
+        )
+
+    async def _handle_create_kanban_task(self, request: "web.Request") -> "web.Response":
+        try:
+            payload = await request.json()
+        except Exception:
+            return web.json_response(
+                _openai_error("Invalid JSON", code="invalid_json"), status=400
+            )
+        from gateway.kanban_api import create_task
+        return await self._kanban_api_call(
+            request, create_task, request.query.get("board"), payload
+        )
+
+    async def _handle_kanban_action(self, request: "web.Request") -> "web.Response":
+        try:
+            payload = await request.json()
+        except Exception:
+            return web.json_response(
+                _openai_error("Invalid JSON", code="invalid_json"), status=400
+            )
+        from gateway.kanban_api import mutate_task
+        return await self._kanban_api_call(
+            request,
+            mutate_task,
+            request.query.get("board"),
+            request.match_info.get("task_id"),
+            payload,
+        )
+
     async def _handle_capabilities(self, request: "web.Request") -> "web.Response":
         """GET /v1/capabilities — advertise the stable API surface.
 
@@ -2039,6 +2137,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 "jobs_admin": False,
                 "memory_write_api": False,
                 "skills_api": True,
+                "kanban_api": bool(self._api_key),
+                "kanban_api_version": 1,
+                "kanban_api_revisioned": True,
+                "kanban_api_idempotency": True,
+                "kanban_api_requires_api_key": True,
                 "audio_api": False,
                 "realtime_voice": False,
                 "session_continuity_header": "X-Hermes-Session-Id",
@@ -2049,6 +2152,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 "health": {"method": "GET", "path": "/health"},
                 "health_detailed": {"method": "GET", "path": "/health/detailed"},
                 "models": {"method": "GET", "path": "/v1/models"},
+                "kanban_boards": {"method": "GET", "path": "/v1/kanban/boards"},
+                "kanban_profiles": {"method": "GET", "path": "/v1/kanban/profiles?board={board}"},
+                "kanban_tasks": {"method": "GET", "path": "/v1/kanban/tasks?board={board}"},
+                "kanban_task": {"method": "GET", "path": "/v1/kanban/tasks/{task_id}?board={board}"},
+                "kanban_task_create": {"method": "POST", "path": "/v1/kanban/tasks?board={board}"},
+                "kanban_task_action": {"method": "POST", "path": "/v1/kanban/tasks/{task_id}/actions?board={board}"},
                 "chat_completions": {"method": "POST", "path": "/v1/chat/completions"},
                 "responses": {"method": "POST", "path": "/v1/responses"},
                 "runs": {"method": "POST", "path": "/v1/runs"},

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1202,6 +1202,16 @@ CREATE TABLE IF NOT EXISTS task_events (
     created_at INTEGER NOT NULL
 );
 
+-- Bounded API-server idempotency registry. Keys are SHA-256 digests, never
+-- caller-provided text, and a duplicate key may only replay the exact
+-- canonical request hash recorded with it.
+CREATE TABLE IF NOT EXISTS kanban_api_idempotency (
+    key_hash     TEXT PRIMARY KEY,
+    request_hash TEXT NOT NULL,
+    task_id      TEXT NOT NULL,
+    created_at   INTEGER NOT NULL
+);
+
 -- Historical attempt record. Each time the dispatcher claims a task, a
 -- new row is created here; claim state, PID, heartbeat, runtime cap,
 -- and structured summary all live on the run, not the task. Multiple
@@ -1270,6 +1280,7 @@ CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
 CREATE INDEX IF NOT EXISTS idx_links_parent          ON task_links(parent_id);
 CREATE INDEX IF NOT EXISTS idx_comments_task         ON task_comments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_events_task           ON task_events(task_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_api_idempotency_task  ON kanban_api_idempotency(task_id);
 CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, started_at);
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_attachments_task      ON task_attachments(task_id, created_at);
@@ -2315,7 +2326,16 @@ def write_txn(conn: sqlite3.Connection):
     The explicit ROLLBACK on exception is wrapped in try/except so that
     a SQLite auto-rollback (which leaves no active transaction) does not
     shadow the original exception with a spurious rollback error.
+
+    Calls may be safely nested when an outer caller already owns the
+    transaction.  The outermost caller remains solely responsible for commit
+    or rollback.  This lets an authenticated API perform an exact snapshot,
+    compare a revision, and invoke the existing mutation helpers in one
+    process-wide write transaction instead of reimplementing their invariants.
     """
+    if getattr(conn, "in_transaction", False):
+        yield conn
+        return
     _execute_boundary_with_retry(conn, "BEGIN IMMEDIATE")
     try:
         yield conn
@@ -2944,7 +2964,7 @@ def add_comment(
 
 def list_comments(conn: sqlite3.Connection, task_id: str) -> list[Comment]:
     rows = conn.execute(
-        "SELECT * FROM task_comments WHERE task_id = ? ORDER BY created_at ASC",
+        "SELECT * FROM task_comments WHERE task_id = ? ORDER BY created_at ASC, id ASC",
         (task_id,),
     ).fetchall()
     return [

--- a/tests/gateway/test_kanban_api.py
+++ b/tests/gateway/test_kanban_api.py
@@ -1,0 +1,143 @@
+"""Behavioral contract tests for the API-server Kanban surface."""
+
+from __future__ import annotations
+
+import pytest
+import json
+
+from gateway.kanban_api import KanbanApiError, create_task, get_task, mutate_task
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+from hermes_cli import kanban_db
+
+
+class _Request:
+    def __init__(self, *, authorization: str = ""):
+        self.headers = {"Authorization": authorization} if authorization else {}
+        self.query = {}
+        self.match_info = {}
+        self.transport = None
+        self.remote = "127.0.0.1"
+        self.method = "GET"
+        self.path_qs = "/v1/kanban/boards"
+
+
+def _create_payload(key: str = "create-key-0001") -> dict:
+    return {
+        "title": "Ship revisioned Kanban",
+        "body": "Keep the browser away from dashboard tokens.",
+        "assignee": None,
+        "workspace_kind": "scratch",
+        "priority": 3,
+        "idempotency_key": key,
+    }
+
+
+def test_create_replays_only_the_exact_idempotent_request():
+    created = create_task("default", _create_payload())
+    task_id = created["task"]["id"]
+    assert created["replayed"] is False
+    assert created["revision"].startswith("kanbanrev_")
+
+    replayed = create_task("default", _create_payload())
+    assert replayed["replayed"] is True
+    assert replayed["task"]["id"] == task_id
+
+    changed = _create_payload()
+    changed["title"] = "Different task"
+    with pytest.raises(KanbanApiError, match="Idempotency key") as exc_info:
+        create_task("default", changed)
+    assert exc_info.value.status == 409
+    assert exc_info.value.code == "idempotency_conflict"
+
+
+def test_revision_action_is_atomic_stale_safe_and_replay_safe():
+    created = create_task("default", _create_payload("create-key-0002"))
+    task_id, revision = created["task"]["id"], created["revision"]
+    action = {
+        "action": "comment",
+        "author": "mentat",
+        "body": "Please verify the post-action read-back.",
+        "expected_revision": revision,
+        "idempotency_key": "comment-key-0002",
+    }
+    mutated = mutate_task("default", task_id, action)
+    assert mutated["replayed"] is False
+    assert mutated["comments"][-1]["body"] == action["body"]
+    assert mutated["revision"] != revision
+
+    replayed = mutate_task("default", task_id, action)
+    assert replayed["replayed"] is True
+    assert len(replayed["comments"]) == 1
+
+    stale = dict(action, idempotency_key="comment-key-0003")
+    with pytest.raises(KanbanApiError, match="refresh") as exc_info:
+        mutate_task("default", task_id, stale)
+    assert exc_info.value.status == 409
+    assert exc_info.value.code == "stale_revision"
+
+
+def test_snapshot_omits_event_payload_and_local_execution_details():
+    created = create_task("default", _create_payload("create-key-0003"))
+    task_id = created["task"]["id"]
+    with kanban_db.connect_closing(board="default") as conn, kanban_db.write_txn(conn):
+        kanban_db._append_event(
+            conn,
+            task_id,
+            "private_worker_detail",
+            {"path": "/Users/operator/private", "token": "secret"},
+        )
+    snapshot = get_task("default", task_id)
+    assert snapshot["events"][-1] == {
+        "id": snapshot["events"][-1]["id"],
+        "kind": "private_worker_detail",
+        "created_at": snapshot["events"][-1]["created_at"],
+        "run_id": None,
+    }
+    assert "/Users/operator/private" not in str(snapshot)
+    assert "secret" not in str(snapshot)
+    assert "workspace_path" not in str(snapshot)
+    assert "worker_pid" not in str(snapshot)
+
+
+def test_outer_write_transaction_supports_existing_mutation_helpers():
+    with kanban_db.connect_closing(board="default") as conn, kanban_db.write_txn(conn):
+        task_id = kanban_db.create_task(conn, title="nested transaction")
+        assert kanban_db.assign_task(conn, task_id, "builder") is True
+    with kanban_db.connect_closing(board="default") as conn:
+        assert kanban_db.get_task(conn, task_id).assignee == "builder"
+
+
+@pytest.mark.asyncio
+async def test_http_route_requires_configured_api_key_before_kanban_access():
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    response = await adapter._handle_kanban_boards(_Request())
+    assert response.status == 403
+    assert json.loads(response.body)["error"]["code"] == "kanban_api_auth_required"
+
+
+@pytest.mark.asyncio
+async def test_http_route_uses_normal_bearer_auth_and_advertises_contract():
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "sk-secret"}))
+    denied = await adapter._handle_kanban_boards(_Request())
+    assert denied.status == 401
+    allowed = await adapter._handle_kanban_boards(_Request(authorization="Bearer sk-secret"))
+    assert allowed.status == 200
+    capabilities = await adapter._handle_capabilities(_Request(authorization="Bearer sk-secret"))
+    data = json.loads(capabilities.body)
+    assert data["features"]["kanban_api"] is True
+    assert data["features"]["kanban_api_revisioned"] is True
+    assert data["endpoints"]["kanban_task_action"]["path"].startswith("/v1/kanban/")
+
+
+def test_http_route_table_includes_every_kanban_contract_path():
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "sk-secret"}))
+    routes = {(method, path) for method, path, _handler in adapter._http_route_table()}
+    assert {
+        ("GET", "/v1/kanban/boards"),
+        ("GET", "/v1/kanban/profiles"),
+        ("GET", "/v1/kanban/tasks"),
+        ("POST", "/v1/kanban/tasks"),
+        ("GET", "/v1/kanban/tasks/{task_id}"),
+        ("POST", "/v1/kanban/tasks/{task_id}/actions"),
+    } <= routes

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -93,6 +93,8 @@ GET  /v1/runs/{id}               Run status
 GET  /v1/runs/{id}/events        SSE stream of lifecycle events
 POST /v1/runs/{id}/approval      Resolve a pending approval
 POST /v1/runs/{id}/stop          Interrupt the run
+GET  /v1/kanban/boards           Bounded bearer-authenticated Kanban boards
+GET/POST /v1/kanban/tasks        Revision-aware Kanban task records/actions
 GET  /v1/capabilities            Machine-readable feature flags
 GET  /v1/models                  Lists hermes-agent
 GET  /health, /health/detailed

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -376,6 +376,31 @@ curl http://localhost:8642/v1/toolsets \
 
 `/v1/skills` returns the same metadata the skills hub uses internally. `/v1/toolsets` returns toolsets resolved for the `api_server` platform with the concrete `tools` list each one expands to. Both are advertised under `endpoints.*` in `/v1/capabilities`.
 
+## Revision-aware Kanban API
+
+External control planes can use the bearer-authenticated `/v1/kanban` surface
+instead of dashboard routes or Kanban database files. Discover it first through
+`GET /v1/capabilities`: look for `kanban_api`, `kanban_api_revisioned`, and
+`kanban_api_idempotency`.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/v1/kanban/boards` | Bounded board records |
+| `GET` | `/v1/kanban/profiles?board=default` | Bounded assignee/profile records |
+| `GET` / `POST` | `/v1/kanban/tasks?board=default` | List tasks or create one idempotently |
+| `GET` | `/v1/kanban/tasks/{task_id}?board=default` | Exact task snapshot and revision |
+| `POST` | `/v1/kanban/tasks/{task_id}/actions?board=default` | Revision-bound action and read-back |
+
+Task details include a `kanbanrev_…` revision. Send that exact value plus a
+new idempotency key with every action. The API rejects stale state before it
+changes anything, and a safe retry returns fresh state without repeating the
+operation. Supported actions are `assign`, `comment`/`reply`, `promote`,
+`block`, `retry`, and `terminate`.
+
+The API intentionally omits attachment locations, worker PIDs and locks, run
+metadata, and raw event payloads. It is a server-to-server control surface, not
+a replacement for the authenticated interactive dashboard.
+
 ## Long-term memory scoping (`X-Hermes-Session-Key`)
 
 Multi-user frontends like Open WebUI need a stable per-channel identifier for long-term memory (Honcho, etc.) that is **independent** of the transcript-scoped `X-Hermes-Session-Id` (which rotates on `/new`). Pass `X-Hermes-Session-Key` on `/v1/chat/completions`, `/v1/responses`, or `/v1/runs` and Hermes threads it through to `AIAgent(gateway_session_key=...)`, where the Honcho memory provider uses it to derive a stable scope.


### PR DESCRIPTION
## Summary

Adds a small `/v1/kanban` API-server surface for server-to-server control planes. It uses the existing `API_SERVER_KEY` bearer boundary rather than dashboard routes, dashboard tokens, SSH, or direct Kanban database access.

- advertises bounded Kanban board/profile/task/detail/action paths in `/v1/capabilities`
- returns deterministic `kanbanrev_…` task revisions over safe bounded task, comment, run, event, and dependency state
- atomically rejects stale revisions before each fixed mutation; existing Kanban helpers run inside the same outer writer transaction
- adds durable, hashed idempotency records for create and fixed actions; exact retries return a fresh read-back, conflicting reuse fails
- limits output and excludes workspace paths, attachments, claim locks, worker PIDs, run metadata, and raw event payloads
- documents the contract and adds focused API/database behavior coverage

## Verification

- `scripts/run_tests.sh tests/gateway/test_kanban_api.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_write_txn_busy_retry.py -q` — 245 passed
- `scripts/run_tests.sh tests/gateway/test_api_server.py tests/gateway/test_multiplex_api_server_routing.py -q` — 212 passed
- `ruff check gateway/kanban_api.py gateway/platforms/api_server.py hermes_cli/kanban_db.py tests/gateway/test_kanban_api.py`
- `py_compile` and `git diff --check`

The website build was not run locally because this worktree has no installed website dependencies.