### PR TITLE
feat: support bounded inline images in runs

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -40,6 +40,8 @@ Requires:
 """
 
 import asyncio
+import base64
+import binascii
 import errno
 import hashlib
 import hmac
@@ -129,6 +131,24 @@ MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 RESPONSES_AUTO_TRUNCATION_HISTORY_LIMIT = 100
 _COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
+
+# ``/v1/runs`` is the controllable, pollable agent lifecycle intended for
+# remote control planes. Its image input is deliberately narrower than the
+# chat/responses surface: callers can send a small, inline image they already
+# possess, but cannot cause the Hermes host to fetch a URL or inspect a local
+# path. The values are advertised through ``/v1/capabilities``.
+RUN_INLINE_IMAGE_MAX_COUNT = 4
+RUN_INLINE_IMAGE_MAX_BYTES = 5 * 1024 * 1024
+RUN_INLINE_IMAGE_MIME_TYPES = frozenset({
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+})
+_RUN_INLINE_IMAGE_DATA_URL_RE = re.compile(
+    r"^data:(image/(?:png|jpeg|gif|webp));base64,([A-Za-z0-9+/]+={0,2})$",
+    re.IGNORECASE,
+)
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -588,6 +608,82 @@ def _normalize_multimodal_content(content: Any) -> Any:
         return "\n".join(p["text"] for p in normalized_parts if p.get("text"))
 
     return normalized_parts
+
+
+def _normalize_run_input(raw_input: Any) -> Any:
+    """Normalize a bounded, path-free Runs message.
+
+    Plain string input retains the original Runs contract. A structured Runs
+    input uses the same OpenAI content-part shape as chat/responses, but image
+    references are intentionally restricted to validated inline data URLs.
+    This avoids turning an authenticated remote control endpoint into an SSRF
+    fetcher or a local-file transport while preserving the exact Runs status,
+    event, approval, and stop lifecycle.
+
+    Raises ``ValueError`` with an ``error_code:message`` value suitable for an
+    OpenAI-style client error. Validation completes before a run ID, stream,
+    or agent is allocated.
+    """
+    if isinstance(raw_input, str):
+        return raw_input
+    if not isinstance(raw_input, list) or not raw_input:
+        raise ValueError("invalid_run_input:No user message found in input")
+
+    # Accept direct content parts (the compact form suited to Runs) as well as
+    # the existing Responses-style list of message objects. Earlier messages
+    # continue through the established conversation-history path below.
+    if all(isinstance(item, dict) and "type" in item for item in raw_input):
+        content = raw_input
+    else:
+        last = raw_input[-1]
+        if not isinstance(last, dict) or "content" not in last:
+            raise ValueError("invalid_run_input:No user message found in input")
+        content = last.get("content")
+
+    normalized = _normalize_multimodal_content(content)
+    if not normalized:
+        raise ValueError("invalid_run_input:No user message found in input")
+    if isinstance(normalized, str):
+        return normalized
+
+    image_count = 0
+    text_length = 0
+    for part in normalized:
+        if part.get("type") == "text":
+            text_length += len(str(part.get("text") or ""))
+            continue
+        if part.get("type") != "image_url":
+            raise ValueError("invalid_run_input:Runs input contains an unsupported content part")
+        image_count += 1
+        if image_count > RUN_INLINE_IMAGE_MAX_COUNT:
+            raise ValueError(
+                f"run_image_limit:Runs accepts at most {RUN_INLINE_IMAGE_MAX_COUNT} inline images"
+            )
+        image_ref = part.get("image_url")
+        url_value = image_ref.get("url") if isinstance(image_ref, dict) else None
+        match = _RUN_INLINE_IMAGE_DATA_URL_RE.fullmatch(str(url_value or ""))
+        if not match:
+            raise ValueError(
+                "run_image_data_url_required:Runs images must use an inline data:image/...;base64 URL"
+            )
+        mime_type = match.group(1).lower()
+        if mime_type not in RUN_INLINE_IMAGE_MIME_TYPES:
+            raise ValueError("run_image_mime_unsupported:Runs image MIME type is unsupported")
+        encoded = match.group(2)
+        # Reject oversized input before decoding, then check decoded bytes so
+        # the advertised limit is exact even for padded base64 input.
+        if len(encoded) > ((RUN_INLINE_IMAGE_MAX_BYTES + 2) // 3) * 4:
+            raise ValueError("run_image_too_large:Runs inline image exceeds the size limit")
+        try:
+            decoded = base64.b64decode(encoded, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise ValueError("invalid_image_url:Runs image data URL has invalid base64") from exc
+        if not decoded or len(decoded) > RUN_INLINE_IMAGE_MAX_BYTES:
+            raise ValueError("run_image_too_large:Runs inline image exceeds the size limit")
+
+    if text_length > MAX_NORMALIZED_TEXT_LENGTH:
+        raise ValueError("run_text_too_large:Runs inline input has too much text")
+    return normalized
 
 
 def _content_has_visible_payload(content: Any) -> bool:
@@ -2870,6 +2966,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_status": True,
                 "run_events_sse": True,
                 "run_stop": True,
+                "run_inline_images": True,
+                "run_inline_images_version": 1,
+                "run_inline_images_data_urls_only": True,
+                "run_inline_images_max_count": RUN_INLINE_IMAGE_MAX_COUNT,
+                "run_inline_images_max_bytes": RUN_INLINE_IMAGE_MAX_BYTES,
                 "run_approval_response": True,
                 "tool_progress_events": True,
                 "approval_events": True,
@@ -2897,6 +2998,16 @@ class APIServerAdapter(BasePlatformAdapter):
                 "chat_completions": {"method": "POST", "path": "/v1/chat/completions"},
                 "responses": {"method": "POST", "path": "/v1/responses"},
                 "runs": {"method": "POST", "path": "/v1/runs"},
+                "run_inline_images": {
+                    "method": "POST",
+                    "path": "/v1/runs",
+                    "version": 1,
+                    "input": "OpenAI content parts: input_text and input_image",
+                    "image_transport": "data_url_only",
+                    "mime_types": sorted(RUN_INLINE_IMAGE_MIME_TYPES),
+                    "max_count": RUN_INLINE_IMAGE_MAX_COUNT,
+                    "max_bytes_per_image": RUN_INLINE_IMAGE_MAX_BYTES,
+                },
                 "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
                 "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
                 "run_approval": {"method": "POST", "path": "/v1/runs/{run_id}/approval"},
@@ -6100,12 +6211,16 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response(_openai_error("Invalid JSON"), status=400)
 
         raw_input = body.get("input")
-        if not raw_input:
+        if raw_input is None or raw_input == "" or raw_input == []:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
-
-        user_message = raw_input if isinstance(raw_input, str) else (raw_input[-1].get("content", "") if isinstance(raw_input, list) else "")
-        if not user_message:
-            return web.json_response(_openai_error("No user message found in input"), status=400)
+        try:
+            user_message = _normalize_run_input(raw_input)
+        except ValueError as exc:
+            code, _, message = str(exc).partition(":")
+            return web.json_response(
+                _openai_error(message or "The Runs input is invalid", code=code or "invalid_run_input"),
+                status=400,
+            )
 
         instructions = body.get("instructions")
         previous_response_id = body.get("previous_response_id")

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -661,6 +661,11 @@ def _normalize_run_input(raw_input: Any) -> Any:
             )
         image_ref = part.get("image_url")
         url_value = image_ref.get("url") if isinstance(image_ref, dict) else None
+        detail = image_ref.get("detail") if isinstance(image_ref, dict) else None
+        if detail not in (None, "low", "high", "auto"):
+            raise ValueError(
+                "run_image_detail_unsupported:Runs image detail must be low, high, or auto"
+            )
         match = _RUN_INLINE_IMAGE_DATA_URL_RE.fullmatch(str(url_value or ""))
         if not match:
             raise ValueError(

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -139,6 +139,7 @@ _COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
 # path. The values are advertised through ``/v1/capabilities``.
 RUN_INLINE_IMAGE_MAX_COUNT = 4
 RUN_INLINE_IMAGE_MAX_BYTES = 5 * 1024 * 1024
+RUN_INLINE_IMAGE_REQUEST_MAX_BYTES = 32 * 1024 * 1024
 RUN_INLINE_IMAGE_MIME_TYPES = frozenset({
     "image/png",
     "image/jpeg",
@@ -149,6 +150,7 @@ _RUN_INLINE_IMAGE_DATA_URL_RE = re.compile(
     r"^data:(image/(?:png|jpeg|gif|webp));base64,([A-Za-z0-9+/]+={0,2})$",
     re.IGNORECASE,
 )
+_RUN_SUBMISSION_PATH_RE = re.compile(r"^(?:/p/[^/]+)?/v1/runs$")
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -1086,12 +1088,25 @@ def _reserve_pending_api_work(adapter):
 if AIOHTTP_AVAILABLE:
     @web.middleware
     async def body_limit_middleware(request, handler):
-        """Reject overly large request bodies early based on Content-Length."""
+        """Apply the default body cap, with a fixed larger budget for Runs images."""
+        max_request_bytes = MAX_REQUEST_BYTES
+        if (
+            request.method == "POST"
+            and _RUN_SUBMISSION_PATH_RE.fullmatch(request.path)
+        ):
+            # Four 5 MiB images expand to about 28 MiB when base64 encoded.
+            # Clone only this fixed route so aiohttp's read-time cap matches
+            # the advertised Runs contract without widening any other API
+            # surface. The handler still validates count, decoded size, MIME,
+            # and transport before allocating a run.
+            max_request_bytes = RUN_INLINE_IMAGE_REQUEST_MAX_BYTES
+            request = request.clone(client_max_size=max_request_bytes)
+
         if request.method in {"POST", "PUT", "PATCH"}:
             cl = request.headers.get("Content-Length")
             if cl is not None:
                 try:
-                    if int(cl) > MAX_REQUEST_BYTES:
+                    if int(cl) > max_request_bytes:
                         return web.json_response(_openai_error("Request body too large.", code="body_too_large"), status=413)
                 except ValueError:
                     return web.json_response(_openai_error("Invalid Content-Length header.", code="invalid_content_length"), status=400)
@@ -2976,6 +2991,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_inline_images_data_urls_only": True,
                 "run_inline_images_max_count": RUN_INLINE_IMAGE_MAX_COUNT,
                 "run_inline_images_max_bytes": RUN_INLINE_IMAGE_MAX_BYTES,
+                "run_inline_images_max_request_bytes": (
+                    RUN_INLINE_IMAGE_REQUEST_MAX_BYTES
+                ),
                 "run_approval_response": True,
                 "tool_progress_events": True,
                 "approval_events": True,
@@ -3012,6 +3030,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "mime_types": sorted(RUN_INLINE_IMAGE_MIME_TYPES),
                     "max_count": RUN_INLINE_IMAGE_MAX_COUNT,
                     "max_bytes_per_image": RUN_INLINE_IMAGE_MAX_BYTES,
+                    "max_request_bytes": RUN_INLINE_IMAGE_REQUEST_MAX_BYTES,
                 },
                 "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
                 "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
@@ -6868,6 +6887,37 @@ class APIServerAdapter(BasePlatformAdapter):
             return False
         return True
 
+    def _build_http_application(self) -> "web.Application":
+        """Build the exact aiohttp application used by the live API server."""
+        mws = [
+            mw
+            for mw in (
+                self._make_profile_prefix_middleware(),
+                cors_middleware,
+                body_limit_middleware,
+                security_headers_middleware,
+            )
+            if mw is not None
+        ]
+        app = web.Application(
+            middlewares=mws,
+            client_max_size=MAX_REQUEST_BYTES,
+        )
+        # Native routes + multiplex /p/<profile>/… mirrors. Same handlers;
+        # the profile-prefix middleware validates the prefix and scopes
+        # config/credentials to that profile when multiplexing is on.
+        for method, path, handler in self._http_route_table():
+            app.router.add_route(method, path, handler)
+            app.router.add_route(method, f"/p/{{profile}}{path}", handler)
+        # Store the adapter after native routes are registered. Local
+        # Hermes-Relay bootstrap shims use this key as a feature-detection
+        # hook; registering native routes first lets those shims no-op instead
+        # of shadowing the upstream session-control handlers.
+        app["api_server_adapter"] = self
+        if self.gateway_runner is not None:
+            app["gateway_runner"] = self.gateway_runner
+        return app
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Start the aiohttp web server."""
         if not AIOHTTP_AVAILABLE:
@@ -6898,31 +6948,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return False
 
         try:
-            mws = [
-                mw
-                for mw in (
-                    self._make_profile_prefix_middleware(),
-                    cors_middleware,
-                    body_limit_middleware,
-                    security_headers_middleware,
-                )
-                if mw is not None
-            ]
-            self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
-            assert self._app is not None
-            # Native routes + multiplex /p/<profile>/… mirrors. Same handlers;
-            # the profile-prefix middleware validates the prefix and scopes
-            # config/credentials to that profile when multiplexing is on.
-            for method, path, handler in self._http_route_table():
-                self._app.router.add_route(method, path, handler)
-                self._app.router.add_route(method, f"/p/{{profile}}{path}", handler)
-            # Store the adapter after native routes are registered. Local Hermes-Relay
-            # bootstrap shims use this key as a feature-detection hook; registering
-            # native routes first lets those shims no-op instead of shadowing the
-            # upstream session-control handlers.
-            self._app["api_server_adapter"] = self
-            if self.gateway_runner is not None:
-                self._app["gateway_runner"] = self.gateway_runner
+            self._app = self._build_http_application()
 
             # Start background sweep to clean up orphaned (unconsumed) run streams
             sweep_task = asyncio.create_task(self._sweep_orphaned_runs())

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -642,9 +642,25 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
             assert data["features"]["model_options"] is True
+            assert data["features"]["run_inline_images"] is True
+            assert data["features"]["run_inline_images_version"] == 1
+            assert data["features"]["run_inline_images_data_urls_only"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
-            assert data["endpoints"]["model_options"] == {"method": "GET", "path": "/api/model/options"}
+            assert data["endpoints"]["model_options"] == {
+                "method": "GET",
+                "path": "/api/model/options",
+            }
+            assert data["endpoints"]["run_inline_images"] == {
+                "method": "POST",
+                "path": "/v1/runs",
+                "version": 1,
+                "input": "OpenAI content parts: input_text and input_image",
+                "image_transport": "data_url_only",
+                "mime_types": ["image/gif", "image/jpeg", "image/png", "image/webp"],
+                "max_count": 4,
+                "max_bytes_per_image": 5 * 1024 * 1024,
+            }
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}
             assert data["endpoints"]["toolsets"] == {"method": "GET", "path": "/v1/toolsets"}
 
@@ -2616,5 +2632,4 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
-
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -30,6 +30,9 @@ from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
     ResponseStore,
+    RUN_INLINE_IMAGE_MAX_BYTES,
+    RUN_INLINE_IMAGE_MAX_COUNT,
+    RUN_INLINE_IMAGE_REQUEST_MAX_BYTES,
     _IdempotencyCache,
     _derive_chat_session_id,
     _hermes_version,
@@ -645,6 +648,10 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["run_inline_images"] is True
             assert data["features"]["run_inline_images_version"] == 1
             assert data["features"]["run_inline_images_data_urls_only"] is True
+            assert (
+                data["features"]["run_inline_images_max_request_bytes"]
+                == RUN_INLINE_IMAGE_REQUEST_MAX_BYTES
+            )
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
             assert data["endpoints"]["model_options"] == {
@@ -658,8 +665,9 @@ class TestCapabilitiesEndpoint:
                 "input": "OpenAI content parts: input_text and input_image",
                 "image_transport": "data_url_only",
                 "mime_types": ["image/gif", "image/jpeg", "image/png", "image/webp"],
-                "max_count": 4,
-                "max_bytes_per_image": 5 * 1024 * 1024,
+                "max_count": RUN_INLINE_IMAGE_MAX_COUNT,
+                "max_bytes_per_image": RUN_INLINE_IMAGE_MAX_BYTES,
+                "max_request_bytes": RUN_INLINE_IMAGE_REQUEST_MAX_BYTES,
             }
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}
             assert data["endpoints"]["toolsets"] == {"method": "GET", "path": "/v1/toolsets"}
@@ -2632,4 +2640,3 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
-

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -9,6 +9,8 @@ Covers:
 """
 
 import asyncio
+import base64
+import json
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -20,7 +22,10 @@ from aiohttp.test_utils import TestClient, TestServer
 from gateway.config import PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
+    MAX_REQUEST_BYTES,
     RUN_INLINE_IMAGE_MAX_COUNT,
+    RUN_INLINE_IMAGE_MAX_BYTES,
+    RUN_INLINE_IMAGE_REQUEST_MAX_BYTES,
     _approval_event_choices,
     cors_middleware,
     security_headers_middleware,
@@ -290,6 +295,128 @@ class TestStartRun:
         _, kwargs = mock_agent.run_conversation.call_args
         assert kwargs["user_message"] == expected_message
         assert adapter._run_statuses[run_id]["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_production_app_accepts_largest_advertised_inline_image_input(
+        self, adapter
+    ):
+        encoded_image = base64.b64encode(
+            b"\0" * RUN_INLINE_IMAGE_MAX_BYTES
+        ).decode("ascii")
+        payload = {
+            "input": [
+                {
+                    "type": "input_image",
+                    "image_url": f"data:image/png;base64,{encoded_image}",
+                }
+                for _ in range(RUN_INLINE_IMAGE_MAX_COUNT)
+            ]
+        }
+        request_body = json.dumps(payload, separators=(",", ":")).encode()
+        assert MAX_REQUEST_BYTES < len(request_body)
+        assert len(request_body) <= RUN_INLINE_IMAGE_REQUEST_MAX_BYTES
+
+        app = adapter._build_http_application()
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {
+                    "final_response": "All images received."
+                }
+                mock_agent.session_prompt_tokens = 1
+                mock_agent.session_completion_tokens = 1
+                mock_agent.session_total_tokens = 2
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    data=request_body,
+                    headers={"Content-Type": "application/json"},
+                )
+                assert resp.status == 202, await resp.text()
+                run_id = (await resp.json())["run_id"]
+                for _ in range(20):
+                    await asyncio.sleep(0)
+                    if adapter._run_statuses[run_id]["status"] == "completed":
+                        break
+
+        assert mock_create.call_count == 1
+        assert adapter._run_statuses[run_id]["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_production_app_rejects_first_oversize_inline_image(
+        self, adapter
+    ):
+        encoded_image = base64.b64encode(
+            b"\0" * (RUN_INLINE_IMAGE_MAX_BYTES + 1)
+        ).decode("ascii")
+        payload = {
+            "input": [{
+                "type": "input_image",
+                "image_url": f"data:image/png;base64,{encoded_image}",
+            }]
+        }
+
+        app = adapter._build_http_application()
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/runs", json=payload)
+            body = await resp.json()
+
+        assert resp.status == 400
+        assert body["error"]["code"] == "run_image_too_large"
+        assert adapter._run_streams == {}
+        assert adapter._run_statuses == {}
+
+    @pytest.mark.asyncio
+    async def test_production_app_rejects_first_byte_over_runs_request_budget(
+        self, adapter
+    ):
+        prefix = b'{"input":"hello","padding":"'
+        suffix = b'"}'
+        padding = b"x" * (
+            RUN_INLINE_IMAGE_REQUEST_MAX_BYTES + 1 - len(prefix) - len(suffix)
+        )
+        request_body = prefix + padding + suffix
+        assert len(request_body) == RUN_INLINE_IMAGE_REQUEST_MAX_BYTES + 1
+
+        app = adapter._build_http_application()
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                resp = await cli.post(
+                    "/v1/runs",
+                    data=request_body,
+                    headers={"Content-Type": "application/json"},
+                )
+                body = await resp.json()
+
+        assert resp.status == 413
+        assert body["error"]["code"] == "body_too_large"
+        mock_create.assert_not_called()
+        assert adapter._run_streams == {}
+        assert adapter._run_statuses == {}
+
+    @pytest.mark.asyncio
+    async def test_production_app_keeps_default_budget_for_other_routes(
+        self, adapter
+    ):
+        prefix = b'{"model":"hermes-agent","messages":[{"role":"user","content":"'
+        suffix = b'"}]}'
+        padding = b"x" * (MAX_REQUEST_BYTES + 1 - len(prefix) - len(suffix))
+        request_body = prefix + padding + suffix
+        assert len(request_body) == MAX_REQUEST_BYTES + 1
+        assert len(request_body) < RUN_INLINE_IMAGE_REQUEST_MAX_BYTES
+
+        app = adapter._build_http_application()
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                data=request_body,
+                headers={"Content-Type": "application/json"},
+            )
+            body = await resp.json()
+
+        assert resp.status == 413
+        assert body["error"]["code"] == "body_too_large"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -330,6 +330,26 @@ class TestStartRun:
         assert adapter._run_streams == {}
         assert adapter._run_statuses == {}
 
+    @pytest.mark.asyncio
+    async def test_start_rejects_unbounded_image_detail_before_allocating_run(self, adapter):
+        app = _create_runs_app(adapter)
+        payload = {
+            "input": [{
+                "type": "input_image",
+                "image_url": {
+                    "url": "data:image/png;base64,AAAA",
+                    "detail": "operator supplied unrestricted detail text",
+                },
+            }]
+        }
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/runs", json=payload)
+            body = await resp.json()
+        assert resp.status == 400
+        assert body["error"]["code"] == "run_image_detail_unsupported"
+        assert adapter._run_streams == {}
+        assert adapter._run_statuses == {}
+
 
 # ---------------------------------------------------------------------------
 # GET /v1/runs/{run_id} — poll run status

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -20,6 +20,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from gateway.config import PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
+    RUN_INLINE_IMAGE_MAX_COUNT,
     _approval_event_choices,
     cors_middleware,
     security_headers_middleware,
@@ -257,6 +258,77 @@ class TestStartRun:
         assert kwargs["requested_model"] == "MiniMax-M3"
         assert kwargs["requested_provider"] == "minimax"
         assert kwargs["model_options"] == model_options
+
+    @pytest.mark.asyncio
+    async def test_start_accepts_bounded_inline_images_through_runs_lifecycle(self, adapter):
+        app = _create_runs_app(adapter)
+        image_input = [
+            {"type": "input_text", "text": "Describe this image."},
+            {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+        ]
+        expected_message = [
+            {"type": "text", "text": "Describe this image."},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ]
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "A tiny image."}
+                mock_agent.session_prompt_tokens = 1
+                mock_agent.session_completion_tokens = 1
+                mock_agent.session_total_tokens = 2
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": image_input})
+                assert resp.status == 202, await resp.text()
+                run_id = (await resp.json())["run_id"]
+                for _ in range(20):
+                    await asyncio.sleep(0)
+                    if adapter._run_statuses[run_id]["status"] == "completed":
+                        break
+
+        _, kwargs = mock_agent.run_conversation.call_args
+        assert kwargs["user_message"] == expected_message
+        assert adapter._run_statuses[run_id]["status"] == "completed"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("image_url", "expected_code"),
+        [
+            ("https://private.example/image.png", "run_image_data_url_required"),
+            ("data:image/svg+xml;base64,PHN2Zy8+", "run_image_data_url_required"),
+            ("data:image/png;base64,not base64", "run_image_data_url_required"),
+        ],
+    )
+    async def test_start_rejects_nonprivate_or_invalid_inline_image_inputs(
+        self, adapter, image_url, expected_code
+    ):
+        app = _create_runs_app(adapter)
+        payload = {"input": [{"type": "input_image", "image_url": image_url}]}
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/runs", json=payload)
+            body = await resp.json()
+        assert resp.status == 400
+        assert body["error"]["code"] == expected_code
+        assert adapter._run_streams == {}
+        assert adapter._run_statuses == {}
+
+    @pytest.mark.asyncio
+    async def test_start_rejects_too_many_inline_images_before_allocating_run(self, adapter):
+        app = _create_runs_app(adapter)
+        payload = {
+            "input": [
+                {"type": "input_image", "image_url": "data:image/png;base64,AAAA"}
+                for _ in range(RUN_INLINE_IMAGE_MAX_COUNT + 1)
+            ]
+        }
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/runs", json=payload)
+            body = await resp.json()
+        assert resp.status == 400
+        assert body["error"]["code"] == "run_image_limit"
+        assert adapter._run_streams == {}
+        assert adapter._run_statuses == {}
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -365,13 +365,15 @@ OpenAI-style content-part array:
 }
 ```
 
-Runs accepts up to four inline PNG, JPEG, GIF, or WebP images, each up to 5
-MiB. It deliberately accepts only `data:image/...;base64` values—no web URLs,
-file uploads, or local paths—so this controllable endpoint cannot fetch a
-private network URL or inspect the Hermes host. The same Run keeps its usual
-status, events, approval, and stop controls. Discover the exact version and
-limits through `features.run_inline_images` and `endpoints.run_inline_images`
-in `/v1/capabilities` before sending images.
+Runs accept up to four inline PNG, JPEG, GIF, or WebP images, each up to 5
+MiB. The route has a 32 MiB request budget so all four images remain reachable
+after base64 and JSON expansion; the default 10 MB budget remains in force for
+other API routes. Runs deliberately accept only `data:image/...;base64`
+values—no web URLs, file uploads, or local paths—so this controllable endpoint
+cannot fetch a private network URL or inspect the Hermes host. The same Run
+keeps its usual status, events, approval, and stop controls. Discover the exact
+version and limits through `features.run_inline_images` and
+`endpoints.run_inline_images` in `/v1/capabilities` before sending images.
 
 ### GET /v1/runs/\{run_id\}
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -353,6 +353,26 @@ Create a new agent run. Returns a `run_id` that can be used to subscribe to prog
 
 Runs accept a simple `input` string and optional `session_id`, `instructions`, `conversation_history`, or `previous_response_id`. When `session_id` is provided, Hermes surfaces it in the run status so external UIs can correlate runs with their own conversation IDs.
 
+When a controllable run needs an image, `input` may instead be a compact
+OpenAI-style content-part array:
+
+```json
+{
+  "input": [
+    {"type": "input_text", "text": "Describe this screenshot."},
+    {"type": "input_image", "image_url": "data:image/png;base64,..."}
+  ]
+}
+```
+
+Runs accepts up to four inline PNG, JPEG, GIF, or WebP images, each up to 5
+MiB. It deliberately accepts only `data:image/...;base64` values—no web URLs,
+file uploads, or local paths—so this controllable endpoint cannot fetch a
+private network URL or inspect the Hermes host. The same Run keeps its usual
+status, events, approval, and stop controls. Discover the exact version and
+limits through `features.run_inline_images` and `endpoints.run_inline_images`
+in `/v1/capabilities` before sending images.
+
 ### GET /v1/runs/\{run_id\}
 
 Poll the current run state. This is useful for dashboards that need status without holding an SSE connection open, or for UIs that reconnect after navigation.


### PR DESCRIPTION
## Summary

`POST /v1/runs` now accepts OpenAI-style `input_text` and `input_image` content parts. Image requests use the same run lifecycle as text requests, so callers still get a run ID, status polling, SSE events, approval handling, and stop controls.

Runs accept up to four inline PNG, JPEG, GIF, or WebP images, each up to 5 MiB. Images must be `data:image/...;base64` values. The handler rejects HTTP(S) URLs, file uploads, local paths, unsupported media, malformed data, and oversized images before creating a run.

The Runs route has a 32 MiB body limit so four 5 MiB images fit after base64 and JSON expansion. Other API routes keep the existing 10,000,000-byte limit. `/v1/capabilities` reports the image limits and request budget.

## Why

Before this change, `/v1/runs` treated list input as message objects and read the final object's `content` field. A compact array of `input_text` and `input_image` parts therefore could not reach the agent.

This lets dashboards and other control planes send screenshots through the controllable Runs API instead of falling back to a separate chat path. It does not add URL fetching or local file access.

## Verification

- `scripts/run_tests.sh tests/gateway/test_api_server_runs.py tests/gateway/test_session_api.py tests/gateway/test_api_server.py -q`: 130 passed
- `uvx --from ruff==0.15.10 ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py tests/gateway/test_api_server_runs.py`: passed
- `python -m py_compile gateway/platforms/api_server.py`: passed
- `git diff --check`: passed

The HTTP tests send four maximum-size images through the production application. They also confirm that a 5 MiB + 1 byte image and a 32 MiB + 1 byte Runs body are rejected, while other routes still reject at 10,000,001 bytes.

The documentation site build was not run because this worktree does not contain `website/node_modules`.