### PR TITLE
fix: scope private URL policy per multiplexed profile

### DIFF
--- a/tests/tools/test_browser_ssrf_local.py
+++ b/tests/tools/test_browser_ssrf_local.py
@@ -368,3 +368,33 @@ class TestAllowPrivateUrlsConfig:
         )
 
         assert browser_tool._allow_private_urls() is False
+
+    def test_profile_scoped_config_does_not_reuse_another_profiles_opt_out(
+        self, tmp_path
+    ):
+        """The browser's independent guard must follow the active profile."""
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        allowed_home = tmp_path / "allowed"
+        blocked_home = tmp_path / "blocked"
+        allowed_home.mkdir()
+        blocked_home.mkdir()
+        (allowed_home / "config.yaml").write_text(
+            "browser:\n  allow_private_urls: true\n", encoding="utf-8"
+        )
+        (blocked_home / "config.yaml").write_text(
+            "browser:\n  allow_private_urls: false\n", encoding="utf-8"
+        )
+
+        def under_profile(home):
+            token = set_hermes_home_override(home)
+            try:
+                return browser_tool._allow_private_urls()
+            finally:
+                reset_hermes_home_override(token)
+
+        assert under_profile(allowed_home) is True
+        assert under_profile(blocked_home) is False

--- a/tests/tools/test_browser_ssrf_local.py
+++ b/tests/tools/test_browser_ssrf_local.py
@@ -369,8 +369,13 @@ class TestAllowPrivateUrlsConfig:
 
         assert browser_tool._allow_private_urls() is False
 
+    @pytest.mark.parametrize(
+        "profile_order",
+        [("allowed", "blocked"), ("blocked", "allowed")],
+        ids=["allowed-then-blocked", "blocked-then-allowed"],
+    )
     def test_profile_scoped_config_does_not_reuse_another_profiles_opt_out(
-        self, tmp_path
+        self, tmp_path, profile_order
     ):
         """The browser's independent guard must follow the active profile."""
         from hermes_constants import (
@@ -396,5 +401,7 @@ class TestAllowPrivateUrlsConfig:
             finally:
                 reset_hermes_home_override(token)
 
-        assert under_profile(allowed_home) is True
-        assert under_profile(blocked_home) is False
+        homes = {"allowed": allowed_home, "blocked": blocked_home}
+        expected = {"allowed": True, "blocked": False}
+        for profile in profile_order:
+            assert under_profile(homes[profile]) is expected[profile]

--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -400,8 +400,13 @@ class TestGlobalAllowPrivateUrls:
         monkeypatch.setenv("HERMES_ALLOW_PRIVATE_URLS", "false")
         assert _global_allow_private_urls() is True
 
+    @pytest.mark.parametrize(
+        "profile_order",
+        [("allowed", "blocked"), ("blocked", "allowed")],
+        ids=["allowed-then-blocked", "blocked-then-allowed"],
+    )
     def test_profile_scoped_config_does_not_reuse_another_profiles_opt_out(
-        self, tmp_path, monkeypatch
+        self, tmp_path, monkeypatch, profile_order
     ):
         """Multiplexed profiles must resolve their own private-URL policy."""
         from hermes_constants import (
@@ -433,8 +438,10 @@ class TestGlobalAllowPrivateUrls:
             finally:
                 reset_hermes_home_override(token)
 
-        assert under_profile(allowed_home) is True
-        assert under_profile(blocked_home) is False
+        homes = {"allowed": allowed_home, "blocked": blocked_home}
+        expected = {"allowed": True, "blocked": False}
+        for profile in profile_order:
+            assert under_profile(homes[profile]) is expected[profile]
 
 
 class TestAllowPrivateUrlsIntegration:

--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -400,6 +400,42 @@ class TestGlobalAllowPrivateUrls:
         monkeypatch.setenv("HERMES_ALLOW_PRIVATE_URLS", "false")
         assert _global_allow_private_urls() is True
 
+    def test_profile_scoped_config_does_not_reuse_another_profiles_opt_out(
+        self, tmp_path, monkeypatch
+    ):
+        """Multiplexed profiles must resolve their own private-URL policy."""
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        monkeypatch.delenv("HERMES_ALLOW_PRIVATE_URLS", raising=False)
+        allowed_home = tmp_path / "allowed"
+        blocked_home = tmp_path / "blocked"
+        allowed_home.mkdir()
+        blocked_home.mkdir()
+        (allowed_home / "config.yaml").write_text(
+            "security:\n  allow_private_urls: true\n", encoding="utf-8"
+        )
+        (blocked_home / "config.yaml").write_text(
+            "security:\n  allow_private_urls: false\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            lambda *_args, **_kwargs: [(2, 1, 6, "", ("10.0.0.8", 0))],
+        )
+
+        def under_profile(home):
+            token = set_hermes_home_override(home)
+            try:
+                return is_safe_url("http://profile-private.test/resource")
+            finally:
+                reset_hermes_home_override(token)
+
+        assert under_profile(allowed_home) is True
+        assert under_profile(blocked_home) is False
+
 
 class TestAllowPrivateUrlsIntegration:
     """Integration tests: is_safe_url respects the global toggle."""

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -66,7 +66,11 @@ from typing import Dict, Any, Optional, List, Tuple, Union
 from pathlib import Path
 from agent.auxiliary_client import call_llm
 from agent.redact import redact_cdp_url
-from hermes_constants import agent_browser_runnable, get_hermes_home
+from hermes_constants import (
+    agent_browser_runnable,
+    get_hermes_home,
+    get_hermes_home_override,
+)
 from utils import env_int, is_truthy_value
 from hermes_cli.config import DEFAULT_CONFIG, cfg_get
 from hermes_cli._subprocess_compat import windows_hide_flags
@@ -1386,26 +1390,39 @@ def _last_session_key(task_id: str) -> str:
 def _allow_private_urls() -> bool:
     """Return whether the browser is allowed to navigate to private/internal addresses.
 
-    Reads ``config["browser"]["allow_private_urls"]`` once and caches the result
-    for the process lifetime.  Defaults to ``False`` (SSRF protection active).
+    Reads ``config["browser"]["allow_private_urls"]``. Single-profile calls
+    cache the result for the process lifetime; multiplexed profile turns resolve
+    their context-local config on each call. Defaults to ``False`` (SSRF
+    protection active).
     """
     global _cached_allow_private_urls, _allow_private_urls_resolved
+
+    # The profile multiplexer scopes config with a ContextVar while sharing
+    # this module. Never reuse another profile's private-network opt-out.
+    if get_hermes_home_override() is not None:
+        return _resolve_allow_private_urls()
+
     if _allow_private_urls_resolved:
         return _cached_allow_private_urls
 
     _allow_private_urls_resolved = True
-    _cached_allow_private_urls = False  # safe default
+    _cached_allow_private_urls = _resolve_allow_private_urls()
+    return _cached_allow_private_urls
+
+
+def _resolve_allow_private_urls() -> bool:
+    """Read the browser private-URL toggle from the active config scope."""
     try:
         from hermes_cli.config import read_raw_config
         cfg = read_raw_config()
         browser_cfg = cfg.get("browser", {})
         if isinstance(browser_cfg, dict):
-            _cached_allow_private_urls = is_truthy_value(
+            return is_truthy_value(
                 browser_cfg.get("allow_private_urls"), default=False
             )
     except Exception as e:
         logger.debug("Could not read allow_private_urls from config: %s", e)
-    return _cached_allow_private_urls
+    return False
 
 
 def _socket_safe_tmpdir() -> str:

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -32,6 +32,7 @@ import re
 from typing import Any, Optional
 from urllib.parse import parse_qsl, quote, unquote, urljoin, urlparse, urlsplit, urlunsplit
 
+from hermes_constants import get_hermes_home_override
 from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
@@ -205,23 +206,36 @@ def _global_allow_private_urls() -> bool:
     2. ``security.allow_private_urls`` in config.yaml
     3. ``browser.allow_private_urls`` in config.yaml  (legacy / backward compat)
 
-    Result is cached for the process lifetime.
+    The single-profile result is cached for the process lifetime. Multiplexed
+    profile turns bypass that process-global cache because their config root is
+    context-local; ``read_raw_config()`` already provides path/mtime caching.
     """
     global _allow_private_resolved, _cached_allow_private
+
+    # A multiplex gateway serves several independently configured profiles in
+    # one process. Reusing the first profile's opt-out here would let it disable
+    # private-network blocking for every later profile in that process.
+    if get_hermes_home_override() is not None:
+        return _resolve_allow_private_urls()
+
     if _allow_private_resolved:
         return _cached_allow_private
 
     _allow_private_resolved = True
-    _cached_allow_private = False  # safe default
+    _cached_allow_private = _resolve_allow_private_urls()
+    return _cached_allow_private
+
+
+def _resolve_allow_private_urls() -> bool:
+    """Resolve the effective private-URL toggle from the active config scope."""
 
     # 1. Env var override (highest priority)
     env_val = os.getenv("HERMES_ALLOW_PRIVATE_URLS", "").strip().lower()
     if env_val in {"true", "1", "yes"}:
-        _cached_allow_private = True
-        return _cached_allow_private
+        return True
     if env_val in {"false", "0", "no"}:
         # Explicit false — don't fall through to config
-        return _cached_allow_private
+        return False
 
     # 2. Config file
     try:
@@ -232,20 +246,18 @@ def _global_allow_private_urls() -> bool:
         if isinstance(sec, dict) and is_truthy_value(
             sec.get("allow_private_urls"), default=False
         ):
-            _cached_allow_private = True
-            return _cached_allow_private
+            return True
         # browser.allow_private_urls (legacy fallback)
         browser = cfg.get("browser", {})
         if isinstance(browser, dict) and is_truthy_value(
             browser.get("allow_private_urls"), default=False
         ):
-            _cached_allow_private = True
-            return _cached_allow_private
+            return True
     except Exception:
         # Config unavailable (e.g. tests, early import) — keep default
         pass
 
-    return _cached_allow_private
+    return False
 
 
 def _reset_allow_private_cache() -> None:


### PR DESCRIPTION
## What does this PR do?

Prevents multiplexed gateway profiles from reusing the first profile's `allow_private_urls` value.

The active profile home is context-local, but the URL-safety and browser helpers stored this setting in process-global module caches. This change resolves the active profile's setting whenever a profile-home override is present, while preserving the existing process-lifetime cache for ordinary single-profile execution. The underlying `read_raw_config()` path/signature cache still avoids unnecessary file parsing.

## Related Issue

Fixes #68197

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/url_safety.py`
  - Resolve the effective private-URL policy from the active profile scope.
  - Retain the existing cache for unscoped, single-profile calls.
- `tools/browser_tool.py`
  - Apply the same profile-aware behavior to the browser's independent guard.
- `tests/tools/test_url_safety.py`
  - Add a two-profile regression that verifies opposite policies remain isolated.
- `tests/tools/test_browser_ssrf_local.py`
  - Add matching regression coverage for the browser helper.

## How to Test

1. Create two temporary profile homes with opposite `allow_private_urls` values.
2. Enter each profile with `set_hermes_home_override()` and call the relevant helper.
3. Verify the allowed profile returns `True` and the blocked profile returns `False`.
4. Run the related test group:
   ```bash
   python -m pytest tests/tools/test_url_safety.py tests/tools/test_browser_ssrf_local.py tests/tools/test_browser_console_ssrf.py tests/tools/test_browser_eval_ssrf.py tests/tools/test_browser_get_images_ssrf.py tests/tools/test_browser_snapshot_ssrf.py tests/tools/test_browser_hybrid_routing.py tests/tools/test_browser_hardening.py
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
Focused regressions: 2 passed, 159 deselected
Related URL/browser suite: 255 passed
Ruff: All checks passed!
```