### PR TITLE
feat(hindsight): add invalidate tool — SDK path with HTTP fallback

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -127,8 +127,9 @@ Available in `hybrid` and `tools` memory modes:
 | Tool | Description |
 |------|-------------|
 | `hindsight_retain` | Store information with auto entity extraction; supports optional per-call `tags` |
-| `hindsight_recall` | Multi-strategy search (semantic + entity graph) |
+| `hindsight_recall` | Multi-strategy search (semantic + entity graph); supports optional `types` param |
 | `hindsight_reflect` | Cross-memory synthesis (LLM-powered) |
+| `hindsight_invalidate` | Soft-delete or restore memories (world/experience only) |
 
 ## Environment Variables
 

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -76,15 +76,14 @@ Config file: `~/.hermes/hindsight/config.json`
 | `recall_tags` | — | Tags to filter when searching memories |
 | `recall_tags_match` | `any` | Tag matching mode: `any` / `all` / `any_strict` / `all_strict` |
 | `recall_types` | `observation` | Fact types surfaced by recall (both auto-recall and the `hindsight_recall` tool). Comma-separated string or JSON list. **Default narrowed to `observation` only** (see "Behavior change" below). Set to `observation,world,experience` to also include raw facts. |
-| `auto_recall` | `true` | Automatically recall memories before each turn |
 
 > **Behavior change — `recall_types` defaults to `observation` only.**
 >
 > Previously recall returned all three fact types. It now returns only observations.
 >
-> Per [Hindsight's docs](https://hindsight.vectorize.io/developer/observations), observations are the **consolidated** knowledge layer Hindsight builds on top of raw facts: deduplicated beliefs grounded in evidence, refined as new facts arrive, with proof counts and freshness signals. Raw `world` / `experience` facts are the individual supporting evidence that feeds them. For per-turn context injection, observations are denser per token and avoid feeding the model multiple raw facts that one observation already summarizes.
+> Per [Hindsight's docs](https://hindsight.vectorize.io/developer/observations), observations are the **consolidated** knowledge layer Hindsight builds on top of raw facts: deduplicated beliefs grounded in evidence, refined as new facts arrive, with proof counts and freshness signals. Raw `world` / `experience` facts are the individual supporting evidence that feeds them. For per-turn context injection, observations are denser per token and avoid feeding the model multiple raw facts that one observation already summarizes. The `hindsight_recall` tool accepts an optional per-call `types` parameter to override the default for a single invocation.
 >
-> Restore the broad recall with `"recall_types": "observation,world,experience"` (string or JSON list) in `~/.hermes/hindsight/config.json`. This applies to **both** auto-recall and the `hindsight_recall` tool — both read the same `recall_types` setting (the tool schema has no per-call `types` argument), so narrowing the default narrows both paths.
+> Restore the broad recall with `"recall_types": "observation,world,experience"` (string or JSON list) in `~/.hermes/hindsight/config.json`. Or override per-call via the tool's `types` parameter (e.g. `["world", "experience"]`).
 
 ### Retain
 
@@ -129,7 +128,7 @@ Available in `hybrid` and `tools` memory modes:
 | `hindsight_retain` | Store information with auto entity extraction; supports optional per-call `tags` |
 | `hindsight_recall` | Multi-strategy search (semantic + entity graph); supports optional `types` param |
 | `hindsight_reflect` | Cross-memory synthesis (LLM-powered) |
-| `hindsight_invalidate` | Soft-delete or restore memories (world/experience only) |
+| `hindsight_invalidate` | Soft-delete or restore memories (world/experience only). Two modes: mutation (invalidate/restore by ID) and discovery (search for previously-invalidated memories by query). Use query mode to find IDs, then mutation mode to restore. |
 
 ## Environment Variables
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -341,6 +341,39 @@ REFLECT_SCHEMA = {
     },
 }
 
+INVALIDATE_SCHEMA = {
+    "name": "hindsight_invalidate",
+    "description": (
+        "Invalidate (soft-delete) or restore a stored memory. "
+        "Invalidated memories are excluded from recall, consolidation, "
+        "and graph maintenance, but kept for audit — fully reversible. "
+        "Only world/experience facts can be invalidated; observations are derived.\n\n"
+        "WORKFLOW: first use hindsight_recall to find the memory_id "
+        "(each result includes an id=... prefix), confirm it is the "
+        "target, then call this tool. "
+        "Pass restore=true to revert a previous invalidation."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {
+                "type": "string",
+                "description": "Memory ID from hindsight_recall results (e.g. '5e79c849-f3b6')."
+            },
+            "reason": {
+                "type": "string",
+                "description": "Why this memory is being invalidated (for audit trail)."
+            },
+            "restore": {
+                "type": "boolean",
+                "default": False,
+                "description": "Set true to RESTORE a previously invalidated memory to valid."
+            },
+        },
+        "required": ["memory_id"],
+    },
+}
+
 
 # ---------------------------------------------------------------------------
 # Config
@@ -1698,7 +1731,7 @@ class HindsightMemoryProvider(MemoryProvider):
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         if self._memory_mode == "context":
             return []
-        return [RETAIN_SCHEMA, RECALL_SCHEMA, REFLECT_SCHEMA]
+        return [RETAIN_SCHEMA, RECALL_SCHEMA, REFLECT_SCHEMA, INVALIDATE_SCHEMA]
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
         if tool_name == "hindsight_retain":
@@ -1747,7 +1780,12 @@ class HindsightMemoryProvider(MemoryProvider):
                 logger.debug("Tool hindsight_recall: %d results", num_results)
                 if not resp.results:
                     return json.dumps({"result": "No relevant memories found."})
-                lines = [f"{i}. {r.text}" for i, r in enumerate(resp.results, 1)]
+                lines = []
+                for i, r in enumerate(resp.results, 1):
+                    sid = r.id[:12] if r.id else "?"
+                    state = getattr(r, "state", None)
+                    flag = " [INVALIDATED]" if state == "invalidated" else ""
+                    lines.append(f"{i}. id={sid} {r.text}{flag}")
                 return json.dumps({"result": "\n".join(lines)})
             except Exception as e:
                 logger.warning("hindsight_recall failed: %s", e, exc_info=True)
@@ -1771,7 +1809,88 @@ class HindsightMemoryProvider(MemoryProvider):
                 logger.warning("hindsight_reflect failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to reflect: {e}")
 
+        elif tool_name == "hindsight_invalidate":
+            memory_id = args.get("memory_id", "")
+            if not memory_id:
+                return tool_error("Missing required parameter: memory_id")
+            state = "valid" if args.get("restore", False) else "invalidated"
+            reason = args.get("reason", "")
+
+            try:
+                UpdateMemoryRequest = _try_import_update_memory_request()
+                if UpdateMemoryRequest is not None:
+                    # —— SDK >= 0.8.4 path ——
+                    req = UpdateMemoryRequest(state=state)
+                    if reason:
+                        req.reason = reason
+                    self._run_hindsight_operation(
+                        lambda client: client.memory.update_memory(
+                            bank_id=self._bank_id,
+                            memory_id=memory_id,
+                            update_memory_request=req,
+                        )
+                    )
+                else:
+                    # —— HTTP fallback (SDK < 0.8.4) ——
+                    self._http_patch_memory(memory_id, state, reason=reason or None)
+
+                action = "restored" if state == "valid" else "invalidated"
+                return json.dumps({"result": f"Memory {memory_id[:12]}... {action}."})
+            except Exception as e:
+                logger.warning("hindsight_invalidate failed: %s", e, exc_info=True)
+                return tool_error(f"Failed to curate memory: {e}")
+
         return tool_error(f"Unknown tool: {tool_name}")
+
+    @staticmethod
+    def _try_import_update_memory_request():
+        """Return UpdateMemoryRequest class, or None if SDK < 0.8.x.
+
+        Uses a lazy import guard so the plugin continues to work with
+        hindsight-client 0.6.1 — the caller falls back to an HTTP PATCH.
+        """
+        try:
+            from hindsight_client_api.models.update_memory_request import (  # noqa: PLC0415
+                UpdateMemoryRequest,
+            )
+            return UpdateMemoryRequest
+        except ImportError:
+            return None
+
+    def _http_patch_memory(self, memory_id: str, state: str, *,
+                           reason: str | None = None):
+        """PATCH /v1/default/banks/{bank_id}/memories/{memory_id}.
+
+        Direct HTTP fallback for SDK versions that don't expose
+        MemoryApi.update_memory (available from 0.8.x onward).
+
+        Raises RuntimeError on HTTP errors.
+        """
+        import urllib.error       # noqa: PLC0415
+        import urllib.request     # noqa: PLC0415
+
+        url = (
+            f"{self._api_url.rstrip('/')}"
+            f"/v1/default/banks/{self._bank_id}/memories/{memory_id}"
+        )
+        body = {"state": state}
+        if reason:
+            body["reason"] = reason
+        data = json.dumps(body).encode("utf-8")
+
+        req = urllib.request.Request(
+            url, data=data, method="PATCH",
+            headers={"Content-Type": "application/json"},
+        )
+        if self._api_key:
+            req.add_header("Authorization", f"Bearer {self._api_key}")
+
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+                resp.read()  # consume — 200 returns empty body
+        except urllib.error.HTTPError as e:
+            body = e.read().decode(errors="replace")
+            raise RuntimeError(f"HTTP {e.code}: {body[:300]}") from None
 
     def on_session_switch(
         self,

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -540,6 +540,25 @@ def _normalize_observation_scopes(value: Any) -> Any:
     return None
 
 
+def _coerce_bool(value):
+    """Parse a bool-like value safely, handling None/bool/string.
+
+    Used instead of truthiness checks so that string "false" / "0"
+    is recognized as False rather than acting as a truthy string.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        v = value.strip().lower()
+        if v in {"true", "1", "yes", "on"}:
+            return True
+        if v in {"false", "0", "no", "off"}:
+            return False
+    return None
+
+
 def _utc_timestamp() -> str:
     """Return current UTC timestamp in ISO-8601 with milliseconds and Z suffix."""
     return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
@@ -1514,14 +1533,16 @@ class HindsightMemoryProvider(MemoryProvider):
                 f"# Hindsight Memory\n"
                 f"Active (tools mode). Bank: {self._bank_id}, budget: {self._budget}.\n"
                 f"Use hindsight_recall to search, hindsight_reflect for synthesis, "
-                f"hindsight_retain to store facts."
+                f"hindsight_retain to store facts, "
+                f"hindsight_invalidate to curate memories."
             )
         return (
             f"# Hindsight Memory\n"
             f"Active. Bank: {self._bank_id}, budget: {self._budget}.\n"
             f"Relevant memories are automatically injected into context. "
             f"Use hindsight_recall to search, hindsight_reflect for synthesis, "
-            f"hindsight_retain to store facts."
+            f"hindsight_retain to store facts, "
+            f"hindsight_invalidate to curate memories."
         )
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
@@ -1816,9 +1837,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 for i, r in enumerate(resp.results, 1):
                     sid = getattr(r, "id", None)
                     sid_str = sid if sid else "?"
-                    state = getattr(r, "state", None)
-                    flag = " [INVALIDATED]" if state == "invalidated" else ""
-                    lines.append(f"{i}. id={sid_str} {r.text}{flag}")
+                    lines.append(f"{i}. id={sid_str} {r.text}")
                 return json.dumps({"result": "\n".join(lines)})
             except Exception as e:
                 logger.warning("hindsight_recall failed: %s", e, exc_info=True)
@@ -1859,7 +1878,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     lines = []
                     for r in results:
                         sid = r.get("id", "?")
-                        text = r.get("content", "") or r.get("text", "")
+                        text = r.get("text", "")
                         lines.append(f"id={sid} {text}")
                     return json.dumps({
                         "result": "\n".join(lines),
@@ -1874,7 +1893,8 @@ class HindsightMemoryProvider(MemoryProvider):
             # —— Mutation mode ——
             if not memory_id:
                 return tool_error("Provide query to search or memory_id to mutate")
-            state = "valid" if args.get("restore", False) else "invalidated"
+            restore_bool = _coerce_bool(args.get("restore", False))
+            state = "valid" if restore_bool else "invalidated"
             reason = args.get("reason", "")
 
             try:
@@ -1929,10 +1949,12 @@ class HindsightMemoryProvider(MemoryProvider):
         """
         import urllib.error       # noqa: PLC0415
         import urllib.request     # noqa: PLC0415
+        import urllib.parse       # noqa: PLC0415
 
+        encoded_id = urllib.parse.quote(memory_id, safe="")
         url = (
-            f"{self._api_url.rstrip('/')}"
-            f"/v1/default/banks/{self._bank_id}/memories/{memory_id}"
+            f"{self._probe_url().rstrip('/')}"
+            f"/v1/default/banks/{self._bank_id}/memories/{encoded_id}"
         )
         body = {"state": state}
         if reason:
@@ -1947,51 +1969,55 @@ class HindsightMemoryProvider(MemoryProvider):
             req.add_header("Authorization", f"Bearer {self._api_key}")
 
         try:
-            with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+            with urllib.request.urlopen(req, timeout=self._timeout) as resp:  # noqa: S310
                 resp.read()  # consume — 200 returns empty body
         except urllib.error.HTTPError as e:
             body = e.read().decode(errors="replace")
             raise RuntimeError(f"HTTP {e.code}: {body[:300]}") from None
 
     def _http_list_invalidated(self, query: str):
-        """GET /v1/default/banks/{bank_id}/memories?state=invalidated.
+        """GET /v1/default/banks/{bank_id}/memories/list?q=<query>&state=invalidated&limit=50.
 
-        Retrieves invalidated memories and filters by substring match
-        against *query* on content/text fields. Returns a list of
-        ``{id, content, text}`` dicts, or empty when nothing matches.
+        Uses server-side full-text search via ``q=`` param. Returns a list of
+        ``{id, text}`` dicts parsed from the ``items`` key, or empty when
+        nothing matches. Surfaces truncation when ``total > len(items)``.
         """
         import urllib.error
         import urllib.request
+        import urllib.parse
 
+        encoded_query = urllib.parse.quote(query, safe="")
         url = (
-            f"{self._api_url.rstrip('/')}"
-            f"/v1/default/banks/{self._bank_id}/memories"
-            f"?state=invalidated&limit=50"
+            f"{self._probe_url().rstrip('/')}"
+            f"/v1/default/banks/{self._bank_id}/memories/list"
+            f"?q={encoded_query}&state=invalidated&limit=50"
         )
         req = urllib.request.Request(url, headers={})
         if self._api_key:
             req.add_header("Authorization", f"Bearer {self._api_key}")
 
         try:
-            with urllib.request.urlopen(req, timeout=30) as resp:
+            with urllib.request.urlopen(req, timeout=self._timeout) as resp:
                 body = json.loads(resp.read().decode("utf-8"))
         except urllib.error.HTTPError as e:
             body_raw = e.read().decode(errors="replace")
             raise RuntimeError(f"HTTP {e.code}: {body_raw[:300]}") from None
 
-        items = body if isinstance(body, list) else body.get("memories", [])
-        query_lower = query.lower()
+        items = body.get("items", [])
+        total = body.get("total", 0)
         matched = []
         for m in items:
             if not isinstance(m, dict):
                 continue
-            content = (m.get("content") or m.get("text") or "").lower()
-            if query_lower in content:
-                matched.append({
-                    "id": m.get("id", "?"),
-                    "content": m.get("content", ""),
-                    "text": m.get("text", ""),
-                })
+            matched.append({
+                "id": m.get("id", "?"),
+                "text": m.get("text", ""),
+            })
+        if total > len(items):
+            logger.warning(
+                "hindsight_invalidate query returned %d of %d total matches; results truncated",
+                len(items), total,
+            )
         return matched
 
     def on_session_switch(

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -315,12 +315,30 @@ RECALL_SCHEMA = {
     "name": "hindsight_recall",
     "description": (
         "Search long-term memory. Returns memories ranked by relevance using "
-        "semantic search, keyword matching, entity graph traversal, and reranking."
+        "semantic search, keyword matching, entity graph traversal, and reranking.\n\n"
+        "Each result includes an id=... prefix so the target can be passed to "
+        "hindsight_invalidate. Use the optional `types` parameter to recall "
+        "world/experience facts (curatable) instead of the default observations.\n\n"
+        "FACT TYPES: observation (consolidated summaries), world (external "
+        "knowledge), experience (agent's own actions). Only world/experience "
+        "facts can be invalidated."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "query": {"type": "string", "description": "What to search for."},
+            "types": {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": ["world", "experience", "observation"],
+                },
+                "description": (
+                    "Fact types to recall. Overrides the configured default "
+                    "for this single call. Use ['world','experience'] when "
+                    "looking for facts to invalidate. Omit to use defaults."
+                ),
+            },
         },
         "required": ["query"],
     },
@@ -358,7 +376,7 @@ INVALIDATE_SCHEMA = {
         "properties": {
             "memory_id": {
                 "type": "string",
-                "description": "Memory ID from hindsight_recall results (e.g. '5e79c849-f3b6')."
+                "description": "Full memory ID from hindsight_recall results (e.g. from 'id=5e79c849-f3b6-4a1e-b789-123456789abc' output)."
             },
             "reason": {
                 "type": "string",
@@ -1771,8 +1789,12 @@ class HindsightMemoryProvider(MemoryProvider):
                 if self._recall_tags:
                     recall_kwargs["tags"] = self._recall_tags
                     recall_kwargs["tags_match"] = self._recall_tags_match
-                if self._recall_types:
-                    recall_kwargs["types"] = self._recall_types
+                # Agent-provided `types` param overrides the configured default
+                # for this single call. Omit → fall back to self._recall_types.
+                caller_types = args.get("types")
+                effective_types = caller_types if caller_types else self._recall_types
+                if effective_types:
+                    recall_kwargs["types"] = effective_types
                 logger.debug("Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
                              self._bank_id, len(query), self._budget)
                 resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
@@ -1782,10 +1804,11 @@ class HindsightMemoryProvider(MemoryProvider):
                     return json.dumps({"result": "No relevant memories found."})
                 lines = []
                 for i, r in enumerate(resp.results, 1):
-                    sid = r.id[:12] if r.id else "?"
+                    sid = getattr(r, "id", None)
+                    sid_str = sid if sid else "?"
                     state = getattr(r, "state", None)
                     flag = " [INVALIDATED]" if state == "invalidated" else ""
-                    lines.append(f"{i}. id={sid} {r.text}{flag}")
+                    lines.append(f"{i}. id={sid_str} {r.text}{flag}")
                 return json.dumps({"result": "\n".join(lines)})
             except Exception as e:
                 logger.warning("hindsight_recall failed: %s", e, exc_info=True)
@@ -1817,7 +1840,7 @@ class HindsightMemoryProvider(MemoryProvider):
             reason = args.get("reason", "")
 
             try:
-                UpdateMemoryRequest = _try_import_update_memory_request()
+                UpdateMemoryRequest = self._try_import_update_memory_request()
                 if UpdateMemoryRequest is not None:
                     # —— SDK >= 0.8.4 path ——
                     req = UpdateMemoryRequest(state=state)
@@ -1835,7 +1858,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     self._http_patch_memory(memory_id, state, reason=reason or None)
 
                 action = "restored" if state == "valid" else "invalidated"
-                return json.dumps({"result": f"Memory {memory_id[:12]}... {action}."})
+                return json.dumps({"result": f"Memory {memory_id} {action}."})
             except Exception as e:
                 logger.warning("hindsight_invalidate failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to curate memory: {e}")

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -362,21 +362,32 @@ REFLECT_SCHEMA = {
 INVALIDATE_SCHEMA = {
     "name": "hindsight_invalidate",
     "description": (
-        "Invalidate (soft-delete) or restore a stored memory. "
+        "Invalidate (soft-delete) or restore a stored memory, or search for "
+        "invalidated memories to restore. "
         "Invalidated memories are excluded from recall, consolidation, "
         "and graph maintenance, but kept for audit — fully reversible. "
         "Only world/experience facts can be invalidated; observations are derived.\n\n"
-        "WORKFLOW: first use hindsight_recall to find the memory_id "
-        "(each result includes an id=... prefix), confirm it is the "
-        "target, then call this tool. "
-        "Pass restore=true to revert a previous invalidation."
+        "TWO MODES (one of memory_id or query is required):\n"
+        "1. Mutation: provide memory_id to invalidate or restore a specific memory.\n"
+        "2. Discovery: provide query to search for previously-invalidated memories.\n\n"
+        "WORKFLOW: use query mode to find invalidated memories and their IDs, "
+        "then call again with memory_id + restore=true to restore."
     ),
     "parameters": {
         "type": "object",
         "properties": {
+            "query": {
+                "type": "string",
+                "description": (
+                    "Search term to find invalidated (soft-deleted) memories for "
+                    "potential restore. Returns matching memories with their full IDs. "
+                    "Use this when you need to find and restore a previously-invalidated "
+                    "memory but don't know its ID. Mutually exclusive with memory_id."
+                ),
+            },
             "memory_id": {
                 "type": "string",
-                "description": "Full memory ID from hindsight_recall results (e.g. from 'id=5e79c849-f3b6-4a1e-b789-123456789abc' output)."
+                "description": "Full memory ID from hindsight_recall or query results. Required for mutation mode."
             },
             "reason": {
                 "type": "string",
@@ -388,7 +399,6 @@ INVALIDATE_SCHEMA = {
                 "description": "Set true to RESTORE a previously invalidated memory to valid."
             },
         },
-        "required": ["memory_id"],
     },
 }
 
@@ -1834,8 +1844,36 @@ class HindsightMemoryProvider(MemoryProvider):
 
         elif tool_name == "hindsight_invalidate":
             memory_id = args.get("memory_id", "")
+            query = args.get("query", "")
+
+            # —— Discovery mode: search for invalidated memories ——
+            if query:
+                if memory_id:
+                    return tool_error("Provide query or memory_id, not both")
+                try:
+                    results = self._http_list_invalidated(query)
+                    if not results:
+                        return json.dumps({
+                            "result": "No invalidated memories match that query."
+                        })
+                    lines = []
+                    for r in results:
+                        sid = r.get("id", "?")
+                        text = r.get("content", "") or r.get("text", "")
+                        lines.append(f"id={sid} {text}")
+                    return json.dumps({
+                        "result": "\n".join(lines),
+                        "ids": [r.get("id") for r in results],
+                    })
+                except Exception as e:
+                    logger.warning(
+                        "hindsight_invalidate query failed: %s", e, exc_info=True,
+                    )
+                    return tool_error(f"Failed to search invalidated memories: {e}")
+
+            # —— Mutation mode ——
             if not memory_id:
-                return tool_error("Missing required parameter: memory_id")
+                return tool_error("Provide query to search or memory_id to mutate")
             state = "valid" if args.get("restore", False) else "invalidated"
             reason = args.get("reason", "")
 
@@ -1914,6 +1952,47 @@ class HindsightMemoryProvider(MemoryProvider):
         except urllib.error.HTTPError as e:
             body = e.read().decode(errors="replace")
             raise RuntimeError(f"HTTP {e.code}: {body[:300]}") from None
+
+    def _http_list_invalidated(self, query: str):
+        """GET /v1/default/banks/{bank_id}/memories?state=invalidated.
+
+        Retrieves invalidated memories and filters by substring match
+        against *query* on content/text fields. Returns a list of
+        ``{id, content, text}`` dicts, or empty when nothing matches.
+        """
+        import urllib.error
+        import urllib.request
+
+        url = (
+            f"{self._api_url.rstrip('/')}"
+            f"/v1/default/banks/{self._bank_id}/memories"
+            f"?state=invalidated&limit=50"
+        )
+        req = urllib.request.Request(url, headers={})
+        if self._api_key:
+            req.add_header("Authorization", f"Bearer {self._api_key}")
+
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                body = json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            body_raw = e.read().decode(errors="replace")
+            raise RuntimeError(f"HTTP {e.code}: {body_raw[:300]}") from None
+
+        items = body if isinstance(body, list) else body.get("memories", [])
+        query_lower = query.lower()
+        matched = []
+        for m in items:
+            if not isinstance(m, dict):
+                continue
+            content = (m.get("content") or m.get("text") or "").lower()
+            if query_lower in content:
+                matched.append({
+                    "id": m.get("id", "?"),
+                    "content": m.get("content", ""),
+                    "text": m.get("text", ""),
+                })
+        return matched
 
     def on_session_switch(
         self,

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -70,8 +70,8 @@ def _make_mock_client():
     client.arecall = AsyncMock(
         return_value=SimpleNamespace(
             results=[
-                SimpleNamespace(id="5e79c849-f3b6-4a1e-b789-123456789abc", text="Memory 1", state="valid"),
-                SimpleNamespace(id="baee4d5b-84bd-4c3e-9f12-abcdef123456", text="Memory 2", state="valid"),
+                SimpleNamespace(id="5e79c849-f3b6-4a1e-b789-123456789abc", text="Memory 1"),
+                SimpleNamespace(id="baee4d5b-84bd-4c3e-9f12-abcdef123456", text="Memory 2"),
             ]
         )
     )
@@ -714,17 +714,6 @@ class TestToolHandlers:
         call_kwargs = provider._client.arecall.call_args.kwargs
         assert call_kwargs["types"] == ["observation"]
 
-    def test_recall_invalidated_flag(self, provider, monkeypatch):
-        """Results with state=invalidated show [INVALIDATED] flag."""
-        mock_resp = SimpleNamespace(results=[
-            SimpleNamespace(id="abc-def-123", text="Old address", state="invalidated"),
-        ])
-        provider._client.arecall = AsyncMock(return_value=mock_resp)
-        result = json.loads(provider.handle_tool_call(
-            "hindsight_recall", {"query": "address"}
-        ))
-        assert "[INVALIDATED]" in result["result"]
-
     def test_recall_missing_id(self, provider, monkeypatch):
         """Results without an id attribute show '?' gracefully."""
         mock_resp = SimpleNamespace(results=[
@@ -869,7 +858,7 @@ class TestToolHandlers:
         monkeypatch.setattr(
             provider, "_http_list_invalidated",
             MagicMock(return_value=[
-                {"id": "abc-123", "content": "old server address"},
+                {"id": "abc-123", "text": "old server address"},
                 {"id": "def-456", "text": "deprecated config"},
             ]),
         )
@@ -911,6 +900,75 @@ class TestToolHandlers:
         ))
         assert "error" in result
         assert "422" in result["error"]
+
+
+class TestHttpHelpersWire:
+    """Wire-level tests for _http_list_invalidated and _http_patch_memory."""
+
+    @pytest.fixture()
+    def _http_server(self):
+        """Start a local ThreadingHTTPServer recording requests."""
+        import json as _json
+        from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+        from threading import Thread
+
+        captured = {"path": "", "method": "", "body": b""}
+
+        class _Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                captured["path"] = self.path
+                captured["method"] = "GET"
+                resp = _json.dumps({
+                    "items": [
+                        {"id": "abc-123", "text": "old server address"},
+                    ],
+                    "total": 1, "limit": 50, "offset": 0,
+                }).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(resp)))
+                self.end_headers()
+                self.wfile.write(resp)
+
+            def do_PATCH(self):
+                captured["path"] = self.path
+                captured["method"] = "PATCH"
+                length = int(self.headers.get("Content-Length", 0))
+                captured["body"] = self.rfile.read(length)
+                self.send_response(200)
+                self.end_headers()
+
+            def log_message(self, *args):
+                pass
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        port = server.server_address[1]
+        thread = Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        yield f"http://127.0.0.1:{port}", captured
+        server.shutdown()
+
+    def test_list_invalidated_endpoint(self, provider, _http_server):
+        """_http_list_invalidated hits the correct endpoint with q= and state=."""
+        base_url, captured = _http_server
+        provider._api_url = base_url
+        provider._timeout = 5
+        result = provider._http_list_invalidated("server")
+        assert result == [{"id": "abc-123", "text": "old server address"}]
+        assert "/memories/list" in captured["path"]
+        assert "q=server" in captured["path"]
+        assert "state=invalidated" in captured["path"]
+        assert captured["method"] == "GET"
+
+    def test_patch_memory_quotes_id(self, provider, _http_server):
+        """_http_patch_memory URL-encodes the memory_id in the path."""
+        base_url, captured = _http_server
+        provider._api_url = base_url
+        provider._timeout = 5
+        provider._http_patch_memory("abc#frag?x=1", "invalidated")
+        assert captured["method"] == "PATCH"
+        assert "abc%23frag%3Fx%3D1" in captured["path"]
+        assert "#" not in captured["path"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -70,8 +70,8 @@ def _make_mock_client():
     client.arecall = AsyncMock(
         return_value=SimpleNamespace(
             results=[
-                SimpleNamespace(text="Memory 1"),
-                SimpleNamespace(text="Memory 2"),
+                SimpleNamespace(id="5e79c849-f3b6-4a1e-b789-123456789abc", text="Memory 1", state="valid"),
+                SimpleNamespace(id="baee4d5b-84bd-4c3e-9f12-abcdef123456", text="Memory 2", state="valid"),
             ]
         )
     )
@@ -275,11 +275,11 @@ class TestSchemas:
         assert REFLECT_SCHEMA["name"] == "hindsight_reflect"
         assert "query" in REFLECT_SCHEMA["parameters"]["properties"]
 
-    def test_get_tool_schemas_returns_three(self, provider):
+    def test_get_tool_schemas_returns_four(self, provider):
         schemas = provider.get_tool_schemas()
-        assert len(schemas) == 3
+        assert len(schemas) == 4
         names = {s["name"] for s in schemas}
-        assert names == {"hindsight_retain", "hindsight_recall", "hindsight_reflect"}
+        assert names == {"hindsight_retain", "hindsight_recall", "hindsight_reflect", "hindsight_invalidate"}
 
     def test_context_mode_returns_no_tools(self, provider_with_config):
         p = provider_with_config(memory_mode="context")
@@ -695,6 +695,46 @@ class TestToolHandlers:
         ))
         assert "Memory 1" in result["result"]
         assert "Memory 2" in result["result"]
+        assert "id=5e79c849-f3b6-4a1e-b789-123456789abc" in result["result"]
+
+    def test_recall_with_types_override(self, provider):
+        """Agent-provided types param overrides the default recall_types."""
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "test", "types": ["world", "experience"]}
+        ))
+        call_kwargs = provider._client.arecall.call_args.kwargs
+        assert call_kwargs["types"] == ["world", "experience"]
+        assert "Memory 1" in result["result"]
+
+    def test_recall_without_types_uses_default(self, provider):
+        """When types is omitted, default observation filter applies."""
+        provider.handle_tool_call(
+            "hindsight_recall", {"query": "test"}
+        )
+        call_kwargs = provider._client.arecall.call_args.kwargs
+        assert call_kwargs["types"] == ["observation"]
+
+    def test_recall_invalidated_flag(self, provider, monkeypatch):
+        """Results with state=invalidated show [INVALIDATED] flag."""
+        mock_resp = SimpleNamespace(results=[
+            SimpleNamespace(id="abc-def-123", text="Old address", state="invalidated"),
+        ])
+        provider._client.arecall = AsyncMock(return_value=mock_resp)
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "address"}
+        ))
+        assert "[INVALIDATED]" in result["result"]
+
+    def test_recall_missing_id(self, provider, monkeypatch):
+        """Results without an id attribute show '?' gracefully."""
+        mock_resp = SimpleNamespace(results=[
+            SimpleNamespace(text="No ID memory"),
+        ])
+        provider._client.arecall = AsyncMock(return_value=mock_resp)
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "test"}
+        ))
+        assert "id=?" in result["result"]
 
     def test_recall_passes_max_tokens(self, provider_with_config):
         p = provider_with_config(recall_max_tokens=2048)
@@ -778,10 +818,65 @@ class TestToolHandlers:
             "hindsight_recall", {"query": "test"}
         ))
 
-        assert result["result"] == "1. Recovered memory"
+        assert result["result"] == "1. id=? Recovered memory"
         assert provider._client is second_client
         first_client.arecall.assert_called_once()
         second_client.arecall.assert_called_once()
+    def test_invalidate_success(self, provider, monkeypatch):
+        """Invalidate via SDK path successfully."""
+        mock_req_class = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr(provider, "_try_import_update_memory_request", lambda: mock_req_class)
+        monkeypatch.setattr(provider, "_run_hindsight_operation", MagicMock())
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_invalidate",
+            {"memory_id": "abc-123-def", "reason": "stale info"},
+        ))
+        assert provider._run_hindsight_operation.called
+        assert "invalidated" in result["result"]
+        assert "abc-123-def" in result["result"]
+
+    def test_invalidate_restore(self, provider, monkeypatch):
+        """Restore=true sets state=valid."""
+        mock_req_class = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr(provider, "_try_import_update_memory_request", lambda: mock_req_class)
+        monkeypatch.setattr(provider, "_run_hindsight_operation", MagicMock())
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_invalidate",
+            {"memory_id": "abc-123", "restore": True},
+        ))
+        assert "restored" in result["result"]
+
+    def test_invalidate_http_fallback(self, provider, monkeypatch):
+        """When SDK < 0.8.4, HTTP fallback is used."""
+        monkeypatch.setattr(provider, "_try_import_update_memory_request", lambda: None)
+        monkeypatch.setattr(provider, "_http_patch_memory", MagicMock())
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_invalidate",
+            {"memory_id": "abc-123-def"},
+        ))
+        assert provider._http_patch_memory.called
+        assert "invalidated" in result["result"]
+
+    def test_invalidate_missing_id(self, provider):
+        """Missing memory_id returns error."""
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_invalidate", {}
+        ))
+        assert "error" in result
+
+    def test_invalidate_error_handling(self, provider, monkeypatch):
+        """API errors are surfaced."""
+        monkeypatch.setattr(provider, "_try_import_update_memory_request", lambda: None)
+        monkeypatch.setattr(
+            provider, "_http_patch_memory",
+            MagicMock(side_effect=RuntimeError("HTTP 422: observation type cannot be invalidated")),
+        )
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_invalidate",
+            {"memory_id": "obs-123"},
+        ))
+        assert "error" in result
+        assert "422" in result["error"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -857,10 +857,44 @@ class TestToolHandlers:
         assert provider._http_patch_memory.called
         assert "invalidated" in result["result"]
 
-    def test_invalidate_missing_id(self, provider):
-        """Missing memory_id returns error."""
+    def test_invalidate_missing_params(self, provider):
+        """Neither query nor memory_id returns error."""
         result = json.loads(provider.handle_tool_call(
             "hindsight_invalidate", {}
+        ))
+        assert "error" in result
+
+    def test_invalidate_query_mode(self, provider, monkeypatch):
+        """Query mode searches invalidated memories."""
+        monkeypatch.setattr(
+            provider, "_http_list_invalidated",
+            MagicMock(return_value=[
+                {"id": "abc-123", "content": "old server address"},
+                {"id": "def-456", "text": "deprecated config"},
+            ]),
+        )
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_invalidate", {"query": "server"}
+        ))
+        assert "abc-123" in result["result"]
+        assert "old server address" in result["result"]
+        assert result["ids"] == ["abc-123", "def-456"]
+
+    def test_invalidate_query_no_results(self, provider, monkeypatch):
+        """Query mode with no matches returns empty message."""
+        monkeypatch.setattr(
+            provider, "_http_list_invalidated", MagicMock(return_value=[])
+        )
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_invalidate", {"query": "nonexistent"}
+        ))
+        assert "No invalidated memories" in result["result"]
+
+    def test_invalidate_query_and_id_mutually_exclusive(self, provider):
+        """Providing both query and memory_id returns error."""
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_invalidate",
+            {"query": "test", "memory_id": "abc-123"}
         ))
         assert "error" in result
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -404,7 +404,7 @@ Long-term memory with knowledge graph, entity resolution, and multi-strategy ret
 | **Data storage** | Hindsight Cloud or local embedded PostgreSQL |
 | **Cost** | Hindsight pricing (cloud) or free (local) |
 
-**Tools:** `hindsight_retain` (store with entity extraction), `hindsight_recall` (multi-strategy search), `hindsight_reflect` (cross-memory synthesis)
+**Tools:** `hindsight_retain` (store with entity extraction), `hindsight_recall` (multi-strategy search, supports optional `types` param), `hindsight_reflect` (cross-memory synthesis), `hindsight_invalidate` (soft-delete/restore memories)
 
 **Setup:**
 ```bash


### PR DESCRIPTION
## Summary

Add a `hindsight_invalidate` tool to the Hindsight memory plugin, allowing agents to soft-delete (and restore) stale or incorrect memories. Uses the SDK's `MemoryApi.update_memory()` when available (`hindsight-client >= 0.8.4`), with an automatic HTTP fallback for older SDK versions.

## Background

Hindsight v0.8.2+ provides [Reversible Memory Curation](https://hindsight.vectorize.io/developer/api/memories) via `PATCH /v1/default/banks/{bank_id}/memories/{memory_id}`. Invalidated memories are excluded from recall, consolidation, and graph maintenance but kept for audit — fully reversible.

The current plugin has no tool for this. When an agent receives stale recall results (e.g. an old server address after a migration), it has no way to clean up the bad data.

## What this PR does

**1. Enhanced `hindsight_recall` output** — each result now includes an `id=...` prefix and `[INVALIDATED]` flag, so the agent can identify and reference specific memories:

```
Before:  1. Hindsight currently runs on exo-service (100.66.238.97:8888)
After:   1. id=5e79c849-f3b6 Hindsight currently runs on exo-service (100.66.238.97:8888)
```

**2. New `hindsight_invalidate` tool:**

| Param | Type | Description |
|-------|------|-------------|
| `memory_id` | string | Memory ID from recall results |
| `reason` | string | Why this memory is being invalidated (optional, for audit trail) |
| `restore` | boolean | Set true to RESTORE a previously invalidated memory (default false) |

**3. Two implementation paths — auto-selected at runtime:**

- **SDK path** (`client.memory.update_memory()`): used when `hindsight-client >= 0.8.4` is installed. Uses the generated `UpdateMemoryRequest` model with full type safety.
- **HTTP fallback** (`PATCH` via `urllib`): used when SDK < 0.8.4. The plugin already uses `urllib` for `/version` checks (line 184).

The auto-detection is done via a lazy import guard — try importing `UpdateMemoryRequest`, fall back to HTTP if the class isn't available.

## Intended workflow

```
→ hindsight_recall("server address")
   1. id=5e79c849-f3b6 Hindsight currently runs on exo-service (100.66.238.97:8888)
   2. id=baee4d5b-84bd Hindsight v0.8.4 running on NAS (100.113.18.29:8888)

→ agent notices #1 contradicts current config

→ hindsight_invalidate(memory_id="5e79c849-f3b6", reason="migrated to NAS z425-5997")
   "Memory 5e79c849-f3b6... invalidated."

→ subsequent recalls no longer return #1
```

Errors from the Hindsight API (e.g. trying to invalidate an observation-type fact, or an invalid memory_id) are surfaced directly to the agent.

## Related

- Hindsight API: `PATCH /memories/{id}` (available since v0.8.2)
- [PR #62536](https://github.com/NousResearch/hermes-agent/pull/62536) — bumps `hindsight-client` to 0.8.4 (this PR works both with and without that upgrade)
- Hindsight MCP server already exposes `invalidate_memory` as a tool — this PR brings the same capability to the native Hermes plugin

## Notes for maintainers

- **SDK upgrade consideration**: This PR is designed to work whether or not #62536 is merged. If the SDK is bumped to 0.8.4, the SDK path is used. If not, the HTTP fallback handles it silently.
- The `pyright` diagnostic on `import hindsight_client_api.models.update_memory_request` is expected — the import is guarded by `try/except ImportError`.
