### PR TITLE
feat(hindsight): add invalidate tool — HTTP-only, max compatibility

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -341,6 +341,39 @@ REFLECT_SCHEMA = {
     },
 }
 
+INVALIDATE_SCHEMA = {
+    "name": "hindsight_invalidate",
+    "description": (
+        "Invalidate (soft-delete) or restore a stored memory. "
+        "Invalidated memories are excluded from recall, consolidation, "
+        "and graph maintenance, but kept for audit — fully reversible. "
+        "Only world/experience facts can be invalidated; observations are derived.\n\n"
+        "WORKFLOW: first use hindsight_recall to find the memory_id "
+        "(each result includes an id=... prefix), confirm it is the "
+        "target, then call this tool. "
+        "Pass restore=true to revert a previous invalidation."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {
+                "type": "string",
+                "description": "Memory ID from hindsight_recall results (e.g. '5e79c849-f3b6')."
+            },
+            "reason": {
+                "type": "string",
+                "description": "Why this memory is being invalidated (for audit trail)."
+            },
+            "restore": {
+                "type": "boolean",
+                "default": False,
+                "description": "Set true to RESTORE a previously invalidated memory to valid."
+            },
+        },
+        "required": ["memory_id"],
+    },
+}
+
 
 # ---------------------------------------------------------------------------
 # Config
@@ -1698,7 +1731,7 @@ class HindsightMemoryProvider(MemoryProvider):
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         if self._memory_mode == "context":
             return []
-        return [RETAIN_SCHEMA, RECALL_SCHEMA, REFLECT_SCHEMA]
+        return [RETAIN_SCHEMA, RECALL_SCHEMA, REFLECT_SCHEMA, INVALIDATE_SCHEMA]
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
         if tool_name == "hindsight_retain":
@@ -1747,7 +1780,12 @@ class HindsightMemoryProvider(MemoryProvider):
                 logger.debug("Tool hindsight_recall: %d results", num_results)
                 if not resp.results:
                     return json.dumps({"result": "No relevant memories found."})
-                lines = [f"{i}. {r.text}" for i, r in enumerate(resp.results, 1)]
+                lines = []
+                for i, r in enumerate(resp.results, 1):
+                    sid = r.id[:12] if r.id else "?"
+                    state = getattr(r, "state", None)
+                    flag = " [INVALIDATED]" if state == "invalidated" else ""
+                    lines.append(f"{i}. id={sid} {r.text}{flag}")
                 return json.dumps({"result": "\n".join(lines)})
             except Exception as e:
                 logger.warning("hindsight_recall failed: %s", e, exc_info=True)
@@ -1771,7 +1809,58 @@ class HindsightMemoryProvider(MemoryProvider):
                 logger.warning("hindsight_reflect failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to reflect: {e}")
 
+        elif tool_name == "hindsight_invalidate":
+            memory_id = args.get("memory_id", "")
+            if not memory_id:
+                return tool_error("Missing required parameter: memory_id")
+            state = "valid" if args.get("restore", False) else "invalidated"
+            reason = args.get("reason", "")
+
+            try:
+                self._http_patch_memory(memory_id, state, reason=reason or None)
+                action = "restored" if state == "valid" else "invalidated"
+                return json.dumps({"result": f"Memory {memory_id[:12]}... {action}."})
+            except Exception as e:
+                logger.warning("hindsight_invalidate failed: %s", e, exc_info=True)
+                return tool_error(f"Failed to curate memory: {e}")
+
         return tool_error(f"Unknown tool: {tool_name}")
+
+    def _http_patch_memory(self, memory_id: str, state: str, *,
+                           reason: str | None = None):
+        """PATCH /v1/default/banks/{bank_id}/memories/{memory_id}.
+
+        Direct HTTP call to the Hindsight server's memory curation endpoint.
+        Uses urllib (already imported in this module for /version checks).
+        Works with any hindsight-client SDK version — no SDK upgrade required.
+
+        Raises RuntimeError on HTTP errors.
+        """
+        import urllib.error       # noqa: PLC0415
+        import urllib.request     # noqa: PLC0415
+
+        url = (
+            f"{self._api_url.rstrip('/')}"
+            f"/v1/default/banks/{self._bank_id}/memories/{memory_id}"
+        )
+        body = {"state": state}
+        if reason:
+            body["reason"] = reason
+        data = json.dumps(body).encode("utf-8")
+
+        req = urllib.request.Request(
+            url, data=data, method="PATCH",
+            headers={"Content-Type": "application/json"},
+        )
+        if self._api_key:
+            req.add_header("Authorization", f"Bearer {self._api_key}")
+
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+                resp.read()  # consume — 200 returns empty body
+        except urllib.error.HTTPError as e:
+            body = e.read().decode(errors="replace")
+            raise RuntimeError(f"HTTP {e.code}: {body[:300]}") from None
 
     def on_session_switch(
         self,


### PR DESCRIPTION
## Summary

Add a `hindsight_invalidate` tool to the Hindsight memory plugin, allowing agents to soft-delete (and restore) stale or incorrect memories. Uses a direct HTTP `PATCH` call to the Hindsight server — zero new dependencies, works with any `hindsight-client` version including the currently pinned 0.6.1.

## Background

Hindsight v0.8.2+ provides [Reversible Memory Curation](https://hindsight.vectorize.io/developer/api/memories) via `PATCH /v1/default/banks/{bank_id}/memories/{memory_id}`. Invalidated memories are excluded from recall, consolidation, and graph maintenance but kept for audit — fully reversible.

The current plugin has no tool for this. When an agent receives stale recall results (e.g. an old server address after a migration), it has no way to clean up the bad data.

## What this PR does

**1. Enhanced `hindsight_recall` output** — each result now includes an `id=...` prefix and `[INVALIDATED]` flag, so the agent can identify and reference specific memories:

```
Before:  1. Hindsight currently runs on exo-service (100.66.238.97:8888)
After:   1. id=5e79c849-f3b6 Hindsight currently runs on exo-service (100.66.238.97:8888)
```

**2. New `hindsight_invalidate` tool:**

| Param | Type | Description |
|-------|------|-------------|
| `memory_id` | string | Memory ID from recall results |
| `reason` | string | Why this memory is being invalidated (optional, for audit trail) |
| `restore` | boolean | Set true to RESTORE a previously invalidated memory (default false) |

**3. Direct HTTP implementation** — uses `urllib.request` (already imported in the same file at line 184 for `/version` checks) to call `PATCH /v1/default/banks/{bank_id}/memories/{memory_id}`. No SDK upgrade needed. Handles `Authorization: Bearer` header when `api_key` is configured, just like the existing `/version` check.

## Why HTTP-only (not the SDK's `update_memory`)

A separate PR ([feat/hindsight-invalidate-sdk-path](https://github.com/NousResearch/hermes-agent/compare/main...kumaxs:hermes-agent:feat/hindsight-invalidate-sdk-path)) implements the same tool with SDK auto-detection + HTTP fallback. This PR takes the simpler path:

- The PATCH endpoint needs exactly two fields (`state` + `reason`) — the SDK's `UpdateMemoryRequest` model adds type-checking overhead with no practical benefit for such a trivial payload
- The plugin already uses `urllib` for `/version` checks — the code pattern is proven
- Zero dependency risk: no import guard, no reliance on auto-generated SDK internals that may change between versions
- Fewer lines, simpler code path, easier to review

If maintainers prefer the SDK integration path, please review the [alternate PR](https://github.com/NousResearch/hermes-agent/compare/main...kumaxs:hermes-agent:feat/hindsight-invalidate-sdk-path) instead.

## Intended workflow

```
→ hindsight_recall("server address")
   1. id=5e79c849-f3b6 Hindsight currently runs on exo-service (100.66.238.97:8888)
   2. id=baee4d5b-84bd Hindsight v0.8.4 running on NAS (100.113.18.29:8888)

→ agent notices #1 contradicts current config

→ hindsight_invalidate(memory_id="5e79c849-f3b6", reason="migrated to NAS z425-5997")
   "Memory 5e79c849-f3b6... invalidated."

→ subsequent recalls no longer return #1
```

Errors from the Hindsight API (e.g. trying to invalidate an observation-type fact, or an invalid memory_id) are surfaced directly to the agent.

## Related

- Hindsight API: `PATCH /memories/{id}` (available since v0.8.2)
- [PR #62536](https://github.com/NousResearch/hermes-agent/pull/62536) — bumps `hindsight-client` to 0.8.4 (this PR does not depend on it)
- Hindsight MCP server already exposes `invalidate_memory` as a tool — this PR brings the same capability to the native Hermes plugin
