### PR TITLE
fix(desktop): refresh repo status on session switch with unchanged cwd

### DIFF
--- a/apps/desktop/src/store/coding-status.test.ts
+++ b/apps/desktop/src/store/coding-status.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { HermesRepoStatus } from '@/global'
 
 import { $repoStatus, $repoStatusLoading, refreshRepoStatus } from './coding-status'
-import { $currentCwd } from './session'
+import { $currentCwd, $selectedStoredSessionId } from './session'
 
 const sampleStatus: HermesRepoStatus = {
   branch: 'feature/login',
@@ -30,6 +30,7 @@ describe('refreshRepoStatus', () => {
     vi.useFakeTimers()
     $repoStatus.set(null)
     $currentCwd.set('')
+    $selectedStoredSessionId.set(null)
     delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
   })
 
@@ -116,5 +117,28 @@ describe('refreshRepoStatus', () => {
     expect(maxActive).toBe(1)
     expect($repoStatus.get()).toEqual(sampleStatus)
     expect($repoStatusLoading.get()).toBe(false)
+  })
+
+  it('refreshes when the stored session id changes even if the cwd is unchanged', async () => {
+    const probe = vi.fn(async () => sampleStatus)
+    stubProbe(probe)
+
+    $currentCwd.set('/repo')
+    $selectedStoredSessionId.set('session-a')
+    // The cwd subscription fires on the set above; drain the debounced refresh.
+    vi.advanceTimersByTime(200)
+    await vi.runAllTicks()
+
+    probe.mockClear()
+
+    // Switch to a different session in the SAME repo dir. The cwd atom value is
+    // identical, so its subscription would not re-fire — but the stored-session
+    // id did change, which must still trigger a probe so the branch label
+    // tracks the new session's checked-out branch.
+    $selectedStoredSessionId.set('session-b')
+    vi.advanceTimersByTime(200)
+    await vi.runAllTicks()
+
+    expect(probe).toHaveBeenCalledWith('/repo')
   })
 })

--- a/apps/desktop/src/store/coding-status.ts
+++ b/apps/desktop/src/store/coding-status.ts
@@ -4,7 +4,7 @@ import type { HermesGitWorktree, HermesRepoStatus } from '@/global'
 import { desktopGit } from '@/lib/desktop-git'
 
 import { $worktreeRefreshToken } from './projects'
-import { $busy, $currentCwd } from './session'
+import { $busy, $currentCwd, $selectedStoredSessionId } from './session'
 import { $workspaceChangeTick } from './workspace-events'
 
 // Live working-tree status for the active session's cwd — the data backbone of
@@ -171,6 +171,13 @@ function scheduleRepoStatusRefresh(cwd?: null | string): void {
 
 // The active session's cwd changed (session switch / new chat) → re-probe.
 $currentCwd.subscribe(cwd => scheduleRepoStatusRefresh(cwd))
+
+// Switching sessions can land on the same cwd but a different checked-out
+// branch (the agent ran `git checkout` in another session's terminal). The cwd
+// subscription above won't fire when the path is identical, so the branch label
+// would stay stale until a window focus or turn-settle triggers a refresh.
+// Treat the stored-session id as a structural edge in its own right.
+$selectedStoredSessionId.subscribe(() => scheduleRepoStatusRefresh())
 
 // A worktree add/remove (desktop op, or the agent's out-of-band git in a settled
 // turn / a window refocus — both already bump this token) → re-probe.


### PR DESCRIPTION
## What does this PR do?

Fixes a stale git branch label in the desktop app's composer coding rail.

The branch label in `coding-row.tsx` reads from `$repoStatus`, which is populated by a live `git status --porcelain=v2 --branch` IPC probe. The probe refreshes on five structural edges in `coding-status.ts`: `$currentCwd` change, `$worktreeRefreshToken`, `$workspaceChangeTick`, busy→idle, and window focus.

**The bug:** when switching between two sessions that share the same cwd (same repo directory, different checked-out branch — e.g. the agent ran `git checkout` in another session's terminal), `$currentCwd` is set to an identical string value. Nanostores skips the notification on identical values, so `$repoStatus` is **not** refreshed and the branch label keeps showing the previous session's branch (e.g. "main"). The user sees stale branch text until a window focus or turn-settle happens to fire a refresh — matching the reported symptom: "clicking away and back fixes it."

**The fix:** subscribe to `$selectedStoredSessionId` in `coding-status.ts` alongside the existing `$currentCwd` subscription. A session switch is a structural edge where the working tree may be on a different branch, even when the cwd path hasn't changed. The debounced `scheduleRepoStatusRefresh` re-probes git and the branch label tracks the new session's checkout immediately on switch.

## Related Issue

Fixes #68146

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/coding-status.ts` — added `$selectedStoredSessionId` subscription that triggers `scheduleRepoStatusRefresh()` on session switch, so the repo status probe fires even when the cwd is identical to the previous session's
- `apps/desktop/src/store/coding-status.test.ts` — added test verifying the probe fires when `$selectedStoredSessionId` changes without a cwd change; reset `$selectedStoredSessionId` in `beforeEach` for isolation

## How to Test

1. Open two sessions in the same repo directory but on different branches (e.g. session A on `main`, session B on `feature` — switch via terminal `git checkout` in one session)
2. Switch from session A → session B
3. Before the fix: the composer's branch label stays on "main" until you click away from the window and back
4. After the fix: the branch label updates to "feature" immediately on switch

**Unit test:**

```bash
cd apps/desktop && npx vitest run --environment jsdom src/store/coding-status.test.ts
```

```
✓  ui  src/store/coding-status.test.ts (7 tests) 10ms
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

`tsc --noEmit` passes with zero errors in the changed files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS (Linux)

### Documentation & Housekeeping

- [x] N/A — no config keys, tool schemas, or architecture changes
