### PR TITLE
fix(kanban): let review-required self-park not deadlock dependency children (#67963)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3390,6 +3390,51 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     return bool(row) and row["kind"] == "blocked"
 
 
+def _parent_gates_children(conn: sqlite3.Connection, parent_id: str) -> bool:
+    """Whether ``parent_id`` should hold back its dependency children.
+
+    A parent *gates* (delays promotion of) its children unless it has
+    reached a terminal state or is merely self-parked awaiting review:
+
+    * ``done`` / ``archived`` → does **not** gate (normal completion).
+    * ``blocked`` with a ``review-required:`` reason → does **not** gate.
+      This is a transient worker self-park (the common pattern where a
+      worker parks via ``kanban_block(reason="review-required: ...")`` and
+      then spawns the follow-up review task as a dependency child). Treating
+      it like a hard failure would deadlock the child in ``todo`` forever
+      (#67963).
+    * any other state (``running``, ``ready``, ``todo``, ``blocked`` for a
+      genuine external blocker, ``failed``, …) → gates.
+
+    Reads the most-recent ``blocked`` event's ``reason`` to recognise the
+    ``review-required:`` park; returns False for non-blocked parents.
+    """
+    row = conn.execute(
+        "SELECT status FROM tasks WHERE id = ?", (parent_id,)
+    ).fetchone()
+    if not row:
+        # Unknown parent — fail safe and gate (don't silently promote).
+        return True
+    status = row["status"]
+    if status in ("done", "archived"):
+        return False
+    if status != "blocked":
+        # running/ready/todo/failed/etc. — still in progress or terminal-fail.
+        return True
+    # status == "blocked": only the review-required self-park is non-gating.
+    ev = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'blocked' "
+        "ORDER BY id DESC LIMIT 1",
+        (parent_id,),
+    ).fetchone()
+    if ev and (json.loads(ev["payload"] or "{}").get("reason") or "").startswith(
+        "review-required:"
+    ):
+        return False
+    return True
+
+
 def recompute_ready(
     conn: sqlite3.Connection, failure_limit: int = None,
 ) -> int:
@@ -3439,12 +3484,12 @@ def recompute_ready(
                 # this predicate back).
                 continue
             parents = conn.execute(
-                "SELECT t.status FROM tasks t "
+                "SELECT t.id, t.status FROM tasks t "
                 "JOIN task_links l ON l.parent_id = t.id "
                 "WHERE l.child_id = ?",
                 (task_id,),
             ).fetchall()
-            if all(p["status"] in ("done", "archived") for p in parents):
+            if all(not _parent_gates_children(conn, p["id"]) for p in parents):
                 if cur_status == "blocked":
                     # Don't auto-recover tasks that have hit the
                     # circuit-breaker failure limit.  Without this
@@ -3498,19 +3543,32 @@ def claim_task(
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
         # Structural invariant: never transition ready -> running while any
-        # parent is not yet 'done'. This is the single enforcement point
-        # regardless of which writer (create_task, link_tasks, unblock_task,
-        # release_stale_claims, manual SQL) set status='ready'. If a racy
-        # writer promoted a task with undone parents, demote it back to
-        # 'todo' here — recompute_ready will re-promote when the parents
-        # actually finish. See RCA at
-        # kanban/boards/cookai/workspaces/t_a6acd07d/root-cause.md.
+        # parent is still a genuine blocker. A `done`/`archived` parent, or a
+        # parent merely self-parked with `review-required:` (a transient wait,
+        # not a hard failure — see _parent_gates_children / #67963), does not
+        # hold the child back, so it is excluded from the "undone" check.
         undone = conn.execute(
             "SELECT 1 FROM task_links l "
             "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
+            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') "
+            "LIMIT 1",
             (task_id,),
         ).fetchone()
+        if undone:
+            # A non-done parent exists; only demote if at least one of
+            # those parents actually gates the child (a genuinely-blocked
+            # parent, not a `review-required:` self-park — see
+            # _parent_gates_children / #67963).
+            non_terminal = conn.execute(
+                "SELECT p.id FROM task_links l "
+                "JOIN tasks p ON p.id = l.parent_id "
+                "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived')",
+                (task_id,),
+            ).fetchall()
+            if non_terminal and not any(
+                _parent_gates_children(conn, row["id"]) for row in non_terminal
+            ):
+                undone = None
         if undone:
             conn.execute(
                 "UPDATE tasks SET status = 'todo' "

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -323,10 +323,10 @@ def test_recompute_ready_cascades_through_chain(kanban_home):
         kb.complete_task(conn, b)
         assert kb.get_task(conn, c).status == "ready"
 
-
 def test_recompute_ready_promotes_blocked_with_done_parents(kanban_home):
     """blocked tasks with all parents done should be promoted to ready,
-    unless the circuit-breaker failure limit has been reached."""
+    unless the circuit-breaker failure limit has been reached.
+    """
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent", assignee="a")
         child = kb.create_task(
@@ -351,6 +351,84 @@ def test_recompute_ready_promotes_blocked_with_done_parents(kanban_home):
         assert task.status == "ready"
         assert task.consecutive_failures == 0
         assert task.last_failure_error is None
+
+
+def test_recompute_ready_promotes_child_of_review_required_parent(kanban_home):
+    """#67963: a parent self-parked via a `review-required:` block (a
+    transient wait, not a hard failure) must NOT deadlock its dependency
+    children. The child should promote to ready even though the parent
+    is still `blocked`.
+    """
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="a")
+        child = kb.create_task(
+            conn, title="child", assignee="a", parents=[parent],
+        )
+        # Worker self-parks the parent awaiting review (common pattern:
+        # then spawns the follow-up review child as a dependency).
+        assert kb.block_task(
+            conn, parent, reason="review-required: awaiting human review",
+            kind="needs_input",
+        )
+        assert kb.get_task(conn, parent).status == "blocked"
+        # Child starts in todo and must be promoted despite the parent
+        # still being blocked.
+        assert kb.get_task(conn, child).status == "todo"
+        promoted = kb.recompute_ready(conn)
+        assert promoted == 1
+        assert kb.get_task(conn, child).status == "ready"
+
+
+def test_recompute_ready_still_gates_on_hard_blocked_parent(kanban_home):
+    """A parent with a genuine external block (e.g. `needs_input` without
+    the `review-required:` prefix) must still gate its children — only the
+    review-required self-park is non-gating (#67963).
+    """
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="a")
+        child = kb.create_task(
+            conn, title="child", assignee="a", parents=[parent],
+        )
+        assert kb.block_task(
+            conn, parent, reason="waiting on customer", kind="needs_input",
+        )
+        assert kb.get_task(conn, parent).status == "blocked"
+        promoted = kb.recompute_ready(conn)
+        assert promoted == 0
+        assert kb.get_task(conn, child).status == "todo"
+
+
+def test_parent_gates_children_predicate(kanban_home):
+    """Unit cases for _parent_gates_children: done/archived and a
+    review-required park do NOT gate; genuine blocks and in-progress
+    states DO gate (#67963).
+    """
+    with kb.connect() as conn:
+        done = kb.create_task(conn, title="done")
+        kb.complete_task(conn, done)
+        archived = kb.create_task(conn, title="arch")
+        kb.complete_task(conn, archived)
+        # move archived to archived
+        conn.execute("UPDATE tasks SET status='archived' WHERE id=?", (archived,))
+        review_park = kb.create_task(conn, title="rp")
+        kb.block_task(
+            conn, review_park,
+            reason="review-required: pending", kind="transient",
+        )
+        hard_block = kb.create_task(conn, title="hb")
+        kb.block_task(
+            conn, hard_block, reason="waiting on customer", kind="needs_input",
+        )
+        running = kb.create_task(conn, title="run")
+        kb.claim_task(conn, running)
+
+        assert kb._parent_gates_children(conn, done) is False
+        assert kb._parent_gates_children(conn, archived) is False
+        assert kb._parent_gates_children(conn, review_park) is False
+        assert kb._parent_gates_children(conn, hard_block) is True
+        assert kb._parent_gates_children(conn, running) is True
+        # Unknown parent fails safe (gates).
+        assert kb._parent_gates_children(conn, "does_not_exist") is True
 
 
 def test_recompute_ready_fan_in_waits_for_all_parents(kanban_home):


### PR DESCRIPTION
## Summary

Fixes #67963.

A kanban parent that self-parks via `kanban_block(reason="review-required: ...")`
stays in `blocked`, but `recompute_ready` and `claim_task`'s structural
invariant treated *any* non-`done`/`archived` parent as a hard gate. So the
follow-up review task created as a dependency child sat in `todo` forever
until a human ran `hermes kanban unlink` — a silent deadlock hit repeatedly
in production fleets.

## Fix

- Added `_parent_gates_children(conn, parent_id)`:
  - `done` / `archived` → does **not** gate (normal completion).
  - `blocked` whose most-recent `blocked` event payload reason starts with
    `review-required:` → does **not** gate (transient self-park, not a hard
    failure).
  - any other state (`running`, `ready`, `todo`, a genuine `needs_input`
    block, unknown parent) → gates (fail-safe).
- `recompute_ready` promotes a child when **no** parent gates it (preserves
  the empty-parent-list behavior — `all()` over `[]` is `True`).
- `claim_task`'s invariant no longer demotes a `ready` child whose only
  non-terminal parent is a `review-required:` park.

Hard external blocks (e.g. `needs_input` without the `review-required:`
prefix) still gate children — only the self-park is non-gating.

## Verification

- New tests: `test_recompute_ready_promotes_child_of_review_required_parent`
  (the deadlock case now promotes), `test_recompute_ready_still_gates_on_hard_blocked_parent`
  (genuine block still gates), `test_parent_gates_children_predicate`
  (unit cases incl. fail-safe unknown parent), plus the existing done-parent
  promotion test preserved.
- RED→GREEN: the new tests fail against `upstream/main`; pass with the fix.
- Full `tests/hermes_cli/test_kanban_db.py` suite: the 3 circuit-breaker
  recovery tests (`recovers_below_limit`, `honours_dispatcher_failure_limit`,
  `per_task_max_retries_overrides_dispatcher`) and `delete_task_cascades_links`
  pass with the change (they are unrelated to this edit).

## Notes

The block reason lives in the `task_events.payload` JSON column, not a `reason`
column — the helper reads `json.loads(payload).get("reason")`.
