### PR TITLE
fix(cron): don't re-fire a job that already ran for its missed slot

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2072,6 +2072,33 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                                 rj["next_run_at"] = new_next
                                 needs_save = True
                                 break
+
+                        # Guard against re-firing a job that already completed
+                        # the slot we're about to credit it for. next_run_at is
+                        # normally advanced past this slot before/on completion
+                        # (advance_next_run + mark_job_run), but if the gateway
+                        # crashes in the narrow window between a run finishing
+                        # and that advance persisting, next_run_at can still
+                        # show the just-completed slot as "missed" here and
+                        # cause a duplicate fire. Mirrors the one-shot guard in
+                        # _recoverable_oneshot_run_at (`if last_run_at: return
+                        # None`), generalized to cron/interval by comparing
+                        # timestamps instead of mere presence.
+                        last_run_at = job.get("last_run_at")
+                        if last_run_at:
+                            try:
+                                last_run_dt = _ensure_aware(datetime.fromisoformat(last_run_at))
+                            except Exception:
+                                last_run_dt = None
+                            if last_run_dt and last_run_dt >= next_run_dt:
+                                logger.info(
+                                    "Job '%s': already ran for the missed slot (%s) "
+                                    "at %s — skipping duplicate fire",
+                                    job.get("name", job.get("id", "?")),
+                                    next_run,
+                                    last_run_at,
+                                )
+                                continue
                         # Fall through to due.append(job) — execute once now
 
                 # One-shot dispatch-limit guard (issue #38758): a finite one-shot


### PR DESCRIPTION
## Summary
- `_get_due_jobs_locked()`'s missed-schedule catch-up branch fast-forwards `next_run_at` but never checked `last_run_at` before re-firing, unlike the one-shot path (`_recoverable_oneshot_run_at`, which explicitly refuses to re-arm once `last_run_at` is set).
- If the gateway restarts/crashes in the window between a run completing and its `next_run_at` advance persisting, the stale timestamp survives and looks "missed" again on the next tick — duplicating the delivery even though the job already ran.
- Adds a `last_run_at >= next_run_dt` guard in that branch, generalizing the existing one-shot `last_run_at` check to cron/interval jobs.

## Observed in production
A weekly cron job ("Weekly Portfolio Brief", `0 8 * * 1`) ran successfully at 08:00, then re-fired at 20:01 the same day after a gateway restart, duplicating a Discord post. Scheduler log:
```
Job 'Weekly Portfolio Brief' missed its scheduled time (2026-07-20T08:00:00+08:00, grace=7200s). Running now; next run provisionally set to: 2026-07-27T08:00:00+08:00
```

## Test plan
- [x] `pytest tests/cron/test_scheduler.py tests/cron/test_cron_no_agent.py` — 240 passed, no regressions
- [x] Verified the guard mirrors `_recoverable_oneshot_run_at`'s existing pattern rather than introducing new dedup logic