### PR TITLE
fix: suppress reasoning display in quiet single-query mode

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15972,9 +15972,11 @@ def main(
                         cli.agent.suppress_status_output = True
                         # Suppress streaming display callbacks so stdout stays
                         # machine-readable (no styled "Hermes" box, no tool-gen
-                        # status lines).  The response is printed once below.
+                        # status lines, no reasoning box).  The response is
+                        # printed once below.
                         cli.agent.stream_delta_callback = None
                         cli.agent.tool_gen_callback = None
+                        cli.agent.reasoning_callback = None
                         try:
                             result = cli.agent.run_conversation(
                                 user_message=effective_query,


### PR DESCRIPTION
## Problem

The -Q quiet single-query path suppresses stream_delta_callback and tool_gen_callback to keep stdout machine-readable, but missed reasoning_callback. When display.show_reasoning is on (the default), the reasoning box leaks into stdout before the final response, corrupting output for automation wrappers and third-party integrations using --source tool.

## Fix

Add cli.agent.reasoning_callback = None alongside the two existing callback suppressions. One line, mirrors the existing pattern.

## Verification

Before: hermes chat -Q --source tool -q 'Reply with exactly: PING_OK' prints the reasoning box then PING_OK. After: prints only PING_OK.