### PR TITLE
fix(url_safety): don't leak multiplexed profiles' allow_private_urls toggle (#68197)

### DIFF
--- a/tests/tools/test_browser_ssrf_local.py
+++ b/tests/tools/test_browser_ssrf_local.py
@@ -368,3 +368,60 @@ class TestAllowPrivateUrlsConfig:
         )
 
         assert browser_tool._allow_private_urls() is False
+
+
+class TestMultiplexedProfileAllowPrivateUrls:
+    """#68197: browser_tool's toggle must follow the active profile too."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_cache(self):
+        browser_tool._allow_private_urls_resolved = False
+        browser_tool._cached_allow_private_urls = None
+        yield
+        browser_tool._allow_private_urls_resolved = False
+        browser_tool._cached_allow_private_urls = None
+
+    def _make_profile(self, tmp_path, name, allow: bool) -> str:
+        home = tmp_path / name
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "browser:\n  allow_private_urls: %s\n" % ("true" if allow else "false"),
+            encoding="utf-8",
+        )
+        return str(home)
+
+    def test_profiles_do_not_leak_toggle(self, tmp_path):
+        from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+
+        home_a = self._make_profile(tmp_path, "A", True)
+        home_b = self._make_profile(tmp_path, "B", False)
+
+        tok_a = set_hermes_home_override(home_a)
+        try:
+            assert browser_tool._allow_private_urls() is True
+        finally:
+            reset_hermes_home_override(tok_a)
+
+        tok_b = set_hermes_home_override(home_b)
+        try:
+            assert browser_tool._allow_private_urls() is False
+        finally:
+            reset_hermes_home_override(tok_b)
+
+    def test_reverse_order_also_isolated(self, tmp_path):
+        from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+
+        home_a = self._make_profile(tmp_path, "A", True)
+        home_b = self._make_profile(tmp_path, "B", False)
+
+        tok_b = set_hermes_home_override(home_b)
+        try:
+            assert browser_tool._allow_private_urls() is False
+        finally:
+            reset_hermes_home_override(tok_b)
+
+        tok_a = set_hermes_home_override(home_a)
+        try:
+            assert browser_tool._allow_private_urls() is True
+        finally:
+            reset_hermes_home_override(tok_a)

--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -713,3 +713,59 @@ class TestRedirectTargetFromResponse:
     def test_no_location_no_next_request_returns_none(self):
         resp = _FakeResponse(is_redirect=True)
         assert redirect_target_from_response(resp) is None
+
+
+class TestMultiplexedProfileAllowPrivateUrls:
+    """#68197: multiplexed profiles must not leak each other's toggle.
+
+    With ``gateway.multiplex_profiles: true`` several profiles run in
+    one process, each scoped via a context-local ``HERMES_HOME``
+    override. The process-wide cache must be bypassed for the active
+    profile so profile B's ``allow_private_urls`` is not overwritten by
+    the value resolved for profile A.
+    """
+
+    def _make_profile(self, tmp_path, name, allow: bool) -> str:
+        home = tmp_path / name
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "security:\n  allow_private_urls: %s\n" % ("true" if allow else "false"),
+            encoding="utf-8",
+        )
+        return str(home)
+
+    def test_profiles_do_not_leak_toggle(self, tmp_path):
+        from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+
+        home_a = self._make_profile(tmp_path, "A", True)
+        home_b = self._make_profile(tmp_path, "B", False)
+
+        tok_a = set_hermes_home_override(home_a)
+        try:
+            assert _global_allow_private_urls() is True
+        finally:
+            reset_hermes_home_override(tok_a)
+
+        tok_b = set_hermes_home_override(home_b)
+        try:
+            assert _global_allow_private_urls() is False
+        finally:
+            reset_hermes_home_override(tok_b)
+
+    def test_reverse_order_also_isolated(self, tmp_path):
+        from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+
+        home_a = self._make_profile(tmp_path, "A", True)
+        home_b = self._make_profile(tmp_path, "B", False)
+
+        tok_b = set_hermes_home_override(home_b)
+        try:
+            assert _global_allow_private_urls() is False
+        finally:
+            reset_hermes_home_override(tok_b)
+
+        tok_a = set_hermes_home_override(home_a)
+        try:
+            assert _global_allow_private_urls() is True
+        finally:
+            reset_hermes_home_override(tok_a)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1386,26 +1386,43 @@ def _last_session_key(task_id: str) -> str:
 def _allow_private_urls() -> bool:
     """Return whether the browser is allowed to navigate to private/internal addresses.
 
-    Reads ``config["browser"]["allow_private_urls"]`` once and caches the result
-    for the process lifetime.  Defaults to ``False`` (SSRF protection active).
+    Reads ``config["browser"]["allow_private_urls"]`` (for the *currently
+    active* profile) and caches the result for the process lifetime
+    **unless** a profile-home override is active. Multiplexed profiles
+    share one process but each profile is scoped via a context-local
+    ``HERMES_HOME`` override; a process-wide cache would leak one
+    profile's toggle into another (#68197). When an override is active
+    we re-read the active profile's config instead of returning the
+    cached value. Defaults to ``False`` (SSRF protection active).
     """
+    from hermes_constants import get_hermes_home_override
+    if get_hermes_home_override():
+        return _read_allow_private_urls()
+
     global _cached_allow_private_urls, _allow_private_urls_resolved
     if _allow_private_urls_resolved:
         return _cached_allow_private_urls
 
     _allow_private_urls_resolved = True
-    _cached_allow_private_urls = False  # safe default
+    _cached_allow_private_urls = _read_allow_private_urls()
+    return _cached_allow_private_urls
+
+
+def _read_allow_private_urls() -> bool:
+    """Resolve ``browser.allow_private_urls`` from the active profile's config."""
     try:
         from hermes_cli.config import read_raw_config
         cfg = read_raw_config()
         browser_cfg = cfg.get("browser", {})
         if isinstance(browser_cfg, dict):
-            _cached_allow_private_urls = is_truthy_value(
-                browser_cfg.get("allow_private_urls"), default=False
+            return bool(
+                is_truthy_value(
+                    browser_cfg.get("allow_private_urls"), default=False
+                )
             )
     except Exception as e:
         logger.debug("Could not read allow_private_urls from config: %s", e)
-    return _cached_allow_private_urls
+    return False
 
 
 def _socket_safe_tmpdir() -> str:

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -197,31 +197,21 @@ _allow_private_resolved = False
 _cached_allow_private: bool = False
 
 
-def _global_allow_private_urls() -> bool:
-    """Return True when the user has opted out of private-IP blocking.
+def _read_allow_private_urls() -> bool:
+    """Resolve ``security.allow_private_urls`` / ``browser.allow_private_urls``.
 
-    Checks (in priority order):
-    1. ``HERMES_ALLOW_PRIVATE_URLS`` env var  (``true``/``1``/``yes``)
-    2. ``security.allow_private_urls`` in config.yaml
-    3. ``browser.allow_private_urls`` in config.yaml  (legacy / backward compat)
-
-    Result is cached for the process lifetime.
+    Checks (priority order): env var, ``security.allow_private_urls``,
+    then the legacy ``browser.allow_private_urls`` fallback. Defaults to
+    ``False`` (SSRF protection active). Reads the config for the
+    *currently active* profile via ``read_raw_config()``.
     """
-    global _allow_private_resolved, _cached_allow_private
-    if _allow_private_resolved:
-        return _cached_allow_private
-
-    _allow_private_resolved = True
-    _cached_allow_private = False  # safe default
-
     # 1. Env var override (highest priority)
     env_val = os.getenv("HERMES_ALLOW_PRIVATE_URLS", "").strip().lower()
     if env_val in {"true", "1", "yes"}:
-        _cached_allow_private = True
-        return _cached_allow_private
+        return True
     if env_val in {"false", "0", "no"}:
         # Explicit false — don't fall through to config
-        return _cached_allow_private
+        return False
 
     # 2. Config file
     try:
@@ -232,19 +222,45 @@ def _global_allow_private_urls() -> bool:
         if isinstance(sec, dict) and is_truthy_value(
             sec.get("allow_private_urls"), default=False
         ):
-            _cached_allow_private = True
-            return _cached_allow_private
+            return True
         # browser.allow_private_urls (legacy fallback)
         browser = cfg.get("browser", {})
         if isinstance(browser, dict) and is_truthy_value(
             browser.get("allow_private_urls"), default=False
         ):
-            _cached_allow_private = True
-            return _cached_allow_private
+            return True
     except Exception:
         # Config unavailable (e.g. tests, early import) — keep default
         pass
 
+    return False
+
+
+def _global_allow_private_urls() -> bool:
+    """Return True when the user has opted out of private-IP blocking.
+
+    Resolution priority:
+    1. ``HERMES_ALLOW_PRIVATE_URLS`` env var (``true``/``1``/``yes``)
+    2. ``security.allow_private_urls`` in config.yaml
+    3. ``browser.allow_private_urls`` in config.yaml (legacy / backward compat)
+
+    The result is cached for the process lifetime **unless** a profile-home
+    override is active. Multiplexed profiles share one process but each
+    profile is scoped via a context-local ``HERMES_HOME`` override; a
+    process-wide cache would leak one profile's toggle into another (#68197).
+    When an override is active we re-read the active profile's config
+    instead of returning the cached value.
+    """
+    from hermes_constants import get_hermes_home_override
+    if get_hermes_home_override():
+        return _read_allow_private_urls()
+
+    global _allow_private_resolved, _cached_allow_private
+    if _allow_private_resolved:
+        return _cached_allow_private
+
+    _allow_private_resolved = True
+    _cached_allow_private = _read_allow_private_urls()
     return _cached_allow_private
 
 


### PR DESCRIPTION
## Summary

Fixes #68197.

With `gateway.multiplex_profiles: true`, several profiles run in one
process, each scoped via a context-local `HERMES_HOME` override
(`hermes_constants.set_hermes_home_override`). But two helpers cached
their `allow_private_urls` resolution in **process-wide** module
globals:

- `tools/url_safety.py::_global_allow_private_urls()`
- `tools/browser_tool.py::_allow_private_urls()`

So profile A's value (e.g. `true`) leaked into profile B (`false`):
a deterministic two-profile test produced `True, True` instead of the
expected `True, False`. The reverse order leaked the opposite way.

## Fix

- Extracted `_read_allow_private_urls()` (resolves the toggle from the
  currently-active profile's `read_raw_config()`) in both modules.
- `_global_allow_private_urls()` / `_allow_private_urls()` keep the
  process cache for ordinary single-profile use, but **bypass the cache
  when a profile-home override is active** (detected via
  `get_hermes_home_override()`), reading the active profile's config
  instead. This is exactly the multiplexed-profile case, and
  `read_raw_config()` already caches by config path + signature so the
  extra reads are not expensive.

No behavior change for single-profile (non-override) callers: the cache
path is unchanged.

## Verification

- New tests (2 per module): `TestMultiplexedProfileAllowPrivateUrls`
  in `test_url_safety.py` and `test_browser_ssrf_local.py`, each with a
  forward and reverse profile-order case asserting the toggles follow
  A/B independently.
- RED→GREEN: the 4 new tests fail against `upstream/main` (process cache
  leaks A into B) and pass with the fix.
- Full `tests/tools/test_url_safety.py` (94) + `tests/tools/test_browser_ssrf_local.py` (69) suites: 163 passed, 0 failed — existing
  toggle tests still green.
