### PR TITLE
feat(cli): add --sandbox flag for terminal-jail PID namespace isolation

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -240,6 +240,13 @@ def build_top_level_parser():
     )
     _inherited_flag(
         parser,
+        "--sandbox",
+        action="store_true",
+        default=False,
+        help="Enable terminal sandboxing (PID namespace isolation via the terminal-jail plugin). Sets HERMES_TERMINAL_JAIL_ENABLED=true; see also terminal.jail_enabled in config.yaml",
+    )
+    _inherited_flag(
+        parser,
         "--tui",
         action="store_true",
         default=False,
@@ -418,6 +425,13 @@ def build_top_level_parser():
         action="store_true",
         default=argparse.SUPPRESS,
         help="Troubleshooting mode: disable ALL customizations — user config, AGENTS.md/memory injection, plugins, and MCP servers (implies --ignore-user-config and --ignore-rules). Use to isolate whether a problem comes from your setup or from Hermes itself.",
+    )
+    _inherited_flag(
+        chat_parser,
+        "--sandbox",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Enable terminal sandboxing (PID namespace isolation via the terminal-jail plugin). Sets HERMES_TERMINAL_JAIL_ENABLED=true; see also terminal.jail_enabled in config.yaml",
     )
     chat_parser.add_argument(
         "--source",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1291,6 +1291,11 @@ DEFAULT_CONFIG = {
         # Enabled by default for non-local backends (SSH); local is always opt-in
         # via TERMINAL_LOCAL_PERSISTENT env var.
         "persistent_shell": True,
+        # Opt-in terminal sandboxing via the terminal-jail plugin (Linux PID
+        # namespace isolation through `unshare`).  Bridged to
+        # HERMES_TERMINAL_JAIL_ENABLED.  `hermes chat --sandbox` force-enables
+        # it for a single run regardless of this setting.
+        "jail_enabled": False,
     },
 
     "web": {
@@ -7230,6 +7235,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
     "sandbox_dir": "TERMINAL_SANDBOX_DIR",
     "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
+    "jail_enabled": "HERMES_TERMINAL_JAIL_ENABLED",
 }
 
 
@@ -7285,6 +7291,15 @@ def apply_terminal_config_to_env(
                 continue
             if isinstance(value, str):
                 value = os.path.expanduser(value)
+        if cfg_key == "jail_enabled":
+            # Opt-in only: export "true" when enabled, never export a falsy
+            # value — the terminal-jail plugin treats the var's absence as
+            # its own default, and presence-based checks must not see a
+            # "False" string.  `hermes chat --sandbox` sets the env var
+            # directly and always wins over config.
+            if not value:
+                continue
+            value = "true"
         if should_override or env_var not in target:
             target[env_var] = _terminal_env_value(value)
     return target

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2415,6 +2415,7 @@ def cmd_chat(args):
     use_tui = _resolve_use_tui(args)
 
     _apply_safe_mode(args)
+    _apply_sandbox(args)
 
     # Resolve --continue into --resume with the latest session or by name
     continue_val = getattr(args, "continue_last", None)
@@ -12987,6 +12988,7 @@ def _prepare_agent_startup(args) -> None:
     if getattr(args, "yolo", False):
         os.environ["HERMES_YOLO_MODE"] = "1"
     _apply_safe_mode(args)
+    _apply_sandbox(args)
 
     _sub_attr, _sub_set = _AGENT_SUBCOMMANDS.get(args.command, (None, None))
     if not (
@@ -13061,6 +13063,19 @@ def _apply_safe_mode(args) -> None:
     os.environ["HERMES_IGNORE_RULES"] = "1"
 
 
+def _apply_sandbox(args) -> None:
+    """Bridge --sandbox to the terminal-jail plugin's env var.
+
+    The plugin reads HERMES_TERMINAL_JAIL_ENABLED (default "true" upstream);
+    the CLI flag is an explicit opt-in that force-enables it for this process
+    and any children (TUI, gateway workers).  Persistent enablement lives in
+    config.yaml as terminal.jail_enabled (bridged via TERMINAL_CONFIG_ENV_MAP).
+    """
+    if not getattr(args, "sandbox", False):
+        return
+    os.environ["HERMES_TERMINAL_JAIL_ENABLED"] = "true"
+
+
 def _set_chat_arg_defaults(args) -> None:
     for attr, default in [
         ("query", None),
@@ -13071,6 +13086,7 @@ def _set_chat_arg_defaults(args) -> None:
         ("resume", None),
         ("continue_last", None),
         ("worktree", False),
+        ("sandbox", False),
     ]:
         if not hasattr(args, attr):
             setattr(args, attr, default)

--- a/tests/hermes_cli/test_sandbox_flag.py
+++ b/tests/hermes_cli/test_sandbox_flag.py
@@ -1,0 +1,136 @@
+"""Tests for `hermes chat --sandbox` → HERMES_TERMINAL_JAIL_ENABLED bridge."""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+import pytest
+
+
+_VAR = "HERMES_TERMINAL_JAIL_ENABLED"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv(_VAR, raising=False)
+    yield
+    os.environ.pop(_VAR, None)
+
+
+def test_apply_sandbox_sets_env_when_flag_true():
+    import hermes_cli.main as main_mod
+
+    args = types.SimpleNamespace(sandbox=True)
+    main_mod._apply_sandbox(args)
+
+    assert os.environ[_VAR] == "true"
+
+
+def test_apply_sandbox_noop_when_flag_false():
+    import hermes_cli.main as main_mod
+
+    args = types.SimpleNamespace(sandbox=False)
+    main_mod._apply_sandbox(args)
+
+    assert _VAR not in os.environ
+
+
+def test_apply_sandbox_noop_when_attr_missing():
+    """SimpleNamespace-based callers (e.g. Termux fast paths, tests) may not
+    define `sandbox` at all — must not raise."""
+    import hermes_cli.main as main_mod
+
+    args = types.SimpleNamespace()
+    main_mod._apply_sandbox(args)
+
+    assert _VAR not in os.environ
+
+
+def test_chat_parser_accepts_sandbox_flag():
+    from hermes_cli._parser import build_top_level_parser
+
+    parser, _subparsers, _chat_parser = build_top_level_parser()
+    args = parser.parse_args(["chat", "--sandbox"])
+
+    assert args.sandbox is True
+
+
+def test_chat_parser_sandbox_absent_leaves_default():
+    from hermes_cli._parser import build_top_level_parser
+
+    parser, _subparsers, _chat_parser = build_top_level_parser()
+    args = parser.parse_args(["chat"])
+
+    # chat subparser uses argparse.SUPPRESS for inherited flags — attribute
+    # falls back to the top-level parser's default (False).
+    assert getattr(args, "sandbox", False) is False
+
+
+def test_top_level_sandbox_propagates_to_chat_subcommand():
+    """`hermes --sandbox chat -q ...` must not drop the flag (parent→subparser
+    propagation, same contract as --yolo/--safe-mode)."""
+    from hermes_cli._parser import build_top_level_parser
+
+    parser, _subparsers, _chat_parser = build_top_level_parser()
+    args = parser.parse_args(["--sandbox", "chat"])
+
+    assert args.sandbox is True
+
+
+def test_prepare_agent_startup_applies_sandbox_before_plugin_discovery(monkeypatch):
+    import hermes_cli.main as main_mod
+
+    args = types.SimpleNamespace(command="chat", sandbox=True, tui=False)
+    plugins = types.ModuleType("hermes_cli.plugins")
+
+    def discover_plugins() -> None:
+        assert os.environ[_VAR] == "true"
+
+    setattr(plugins, "discover_plugins", discover_plugins)
+    monkeypatch.setitem(sys.modules, "hermes_cli.plugins", plugins)
+    monkeypatch.setattr(main_mod, "_should_background_mcp_startup", lambda _args: False)
+    monkeypatch.setattr(main_mod, "_command_has_dedicated_mcp_startup", lambda _args: True)
+
+    main_mod._prepare_agent_startup(args)
+
+    assert os.environ[_VAR] == "true"
+
+
+def test_sandbox_flag_inherited_on_relaunch():
+    """--sandbox must survive self-relaunch (sessions browse, setup wizard)."""
+    from hermes_cli.relaunch import _extract_inherited_flags
+
+    assert "--sandbox" in _extract_inherited_flags(["chat", "--sandbox", "-q", "hi"])
+    assert "--sandbox" in _extract_inherited_flags(["--sandbox", "chat"])
+
+
+def test_config_bridge_exports_true_only_when_enabled(monkeypatch, tmp_path):
+    """terminal.jail_enabled: true → HERMES_TERMINAL_JAIL_ENABLED=true.
+    False/absent → env var untouched (plugin default applies)."""
+    from hermes_cli import config as config_mod
+
+    cfg = {"terminal": {"jail_enabled": True}}
+    env: dict[str, str] = {}
+    monkeypatch.setattr(config_mod, "read_raw_config", lambda: {"terminal": {}})
+    config_mod.apply_terminal_config_to_env(env=env, config=cfg, override=True)
+    assert env[_VAR] == "true"
+
+    env2: dict[str, str] = {}
+    cfg_off = {"terminal": {"jail_enabled": False}}
+    config_mod.apply_terminal_config_to_env(env=env2, config=cfg_off, override=True)
+    assert _VAR not in env2
+
+
+def test_config_bridge_does_not_clobber_cli_flag(monkeypatch):
+    """--sandbox sets the env var directly; the config bridge with
+    jail_enabled absent/false must not unset it."""
+    from hermes_cli import config as config_mod
+
+    env: dict[str, str] = {_VAR: "true"}  # as --sandbox would set
+    monkeypatch.setattr(config_mod, "read_raw_config", lambda: {})
+    config_mod.apply_terminal_config_to_env(
+        env=env, config={"terminal": {"jail_enabled": False}}, override=False
+    )
+    assert env[_VAR] == "true"


### PR DESCRIPTION
## Summary

Adds a `--sandbox` CLI flag (`hermes chat --sandbox`) that enables PID namespace isolation for terminal commands via the terminal-jail plugin.

## What it does

- Sets `HERMES_TERMINAL_JAIL_ENABLED=true` when `--sandbox` is passed
- Follows the `_apply_safe_mode` pattern: flag on both top-level and chat parsers
- Inherited across self-relaunch
- Applied in both `_prepare_agent_startup` (before plugin discovery) and `cmd_chat`
- Adds `terminal.jail_enabled` config key for persistent opt-in, bridged through `TERMINAL_CONFIG_ENV_MAP`
- Bridge only exports env var when enabled (never falsy) so presence-based checks stay intact
- CLI flag always wins over config

## Files changed

- `hermes_cli/_parser.py`: +14 lines (CLI flags)
- `hermes_cli/config.py`: +15 lines (config key + env bridge)
- `hermes_cli/main.py`: +16 lines (`_apply_sandbox()` bridge function)
- `tests/hermes_cli/test_sandbox_flag.py`: +136 lines (10 tests)

## Related

- terminal-jail plugin: PID namespace sandbox for terminal commands
- Blocked by: HOOK-GAP (terminal-jail v0.1.0 provides observability-only without this flag)
- Addresses T4.8 / HOOK-GAP-01 from the terminal-jail project