### PR TITLE
fix(telegram): pass filename=basename to bot.send_document to fix silent delivery failure on long paths

### DIFF
--- a/tests/tools/test_telegram_send_message_caption.py
+++ b/tests/tools/test_telegram_send_message_caption.py
@@ -139,3 +139,115 @@ def test_multi_file_keeps_separate_text(monkeypatch: pytest.MonkeyPatch) -> None
     finally:
         os.unlink(img)
         os.unlink(img2)
+
+
+def test_document_send_uses_basename_not_full_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """send_document receives filename=os.path.basename(media_path), not the full host path."""
+    from tools.send_message_tool import _send_telegram
+
+    _no_proxy(monkeypatch)
+    bot = _make_bot()
+    _install_telegram_mock(monkeypatch, MagicMock(return_value=bot))
+
+    # Create a temp file with a long path that would exceed Telegram's filename limit
+    # if the full path were used as the multipart filename.
+    with tempfile.TemporaryDirectory(prefix="very_long_directory_name_that_exceeds_limits_") as tmpdir:
+        long_filename = "A" * 50 + ".pdf"  # 50+ char basename
+        media_path = os.path.join(tmpdir, long_filename)
+        with open(media_path, "wb") as f:
+            f.write(b"dummy content")
+
+        try:
+            res = asyncio.run(
+                _send_telegram("tok", "123", "Here is the doc", media_files=[(media_path, False)])
+            )
+            assert res["success"] is True
+            # send_document should be called with filename=basename only
+            bot.send_document.assert_awaited_once()
+            call_kwargs = bot.send_document.await_args.kwargs
+            assert "filename" in call_kwargs
+            assert call_kwargs["filename"] == long_filename
+            assert call_kwargs["filename"] != media_path  # full path NOT leaked
+        finally:
+            pass  # temp dir auto-cleans
+
+
+def test_document_retry_thread_not_found_uses_basename(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retry path (thread not found) also passes filename=basename."""
+    from tools.send_message_tool import _send_telegram, _is_telegram_thread_not_found
+
+    _no_proxy(monkeypatch)
+    bot = _make_bot()
+    _install_telegram_mock(monkeypatch, MagicMock(return_value=bot))
+
+    # Make first send_document raise "thread not found", second succeed
+    call_count = {"n": 0}
+
+    async def failing_then_ok(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # Simulate "thread not found" error
+            raise Exception("Bad Request: thread not found")
+        return SimpleNamespace(message_id=99)
+
+    bot.send_document = AsyncMock(side_effect=failing_then_ok)
+
+    with tempfile.TemporaryDirectory(prefix="long_path_") as tmpdir:
+        fname = "B" * 60 + ".docx"
+        media_path = os.path.join(tmpdir, fname)
+        with open(media_path, "wb") as f:
+            f.write(b"x")
+
+        try:
+            res = asyncio.run(
+                _send_telegram("tok", "123", "caption", media_files=[(media_path, False)], thread_id="123")
+            )
+            assert res["success"] is True
+            # Two calls: first fails, second succeeds (retry without thread_id)
+            assert bot.send_document.await_count == 2
+            # Both calls should have filename=basename
+            for call in bot.send_document.await_args_list:
+                assert call.kwargs.get("filename") == fname
+                assert call.kwargs.get("filename") != media_path
+        finally:
+            pass
+
+
+def test_document_retry_caption_parse_failure_uses_basename(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retry path (caption parse failure) also passes filename=basename."""
+    from tools.send_message_tool import _send_telegram
+
+    _no_proxy(monkeypatch)
+    bot = _make_bot()
+    _install_telegram_mock(monkeypatch, MagicMock(return_value=bot))
+
+    # First call fails with "can't parse entities" (caption parse error), second succeeds
+    call_count = {"n": 0}
+
+    async def failing_then_ok(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise Exception("Bad Request: can't parse entities: Character '$' is reserved")
+        return SimpleNamespace(message_id=99)
+
+    bot.send_document = AsyncMock(side_effect=failing_then_ok)
+
+    with tempfile.TemporaryDirectory(prefix="long_path_") as tmpdir:
+        fname = "C" * 55 + ".txt"
+        media_path = os.path.join(tmpdir, fname)
+        with open(media_path, "wb") as f:
+            f.write(b"x")
+
+        try:
+            res = asyncio.run(
+                _send_telegram("tok", "123", "Price: $100", media_files=[(media_path, False)])
+            )
+            assert res["success"] is True
+            # Two calls: first fails, second succeeds (retry with parse_mode=None)
+            assert bot.send_document.await_count == 2
+            # Both calls should have filename=basename
+            for call in bot.send_document.await_args_list:
+                assert call.kwargs.get("filename") == fname
+                assert call.kwargs.get("filename") != media_path
+        finally:
+            pass

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1342,7 +1342,10 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                             )
                         else:
                             last_msg = await bot.send_document(
-                                chat_id=int_chat_id, document=f, **media_kwargs
+                                chat_id=int_chat_id,
+                                document=f,
+                                filename=os.path.basename(media_path),
+                                **media_kwargs,
                             )
                     except Exception as media_err:
                         if _is_telegram_thread_not_found(media_err) and media_kwargs.get("message_thread_id"):
@@ -1373,7 +1376,10 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                                 )
                             else:
                                 last_msg = await bot.send_document(
-                                    chat_id=int_chat_id, document=f, **media_kwargs
+                                    chat_id=int_chat_id,
+                                    document=f,
+                                    filename=os.path.basename(media_path),
+                                    **media_kwargs,
                                 )
                         elif media_kwargs.get("parse_mode") and (
                             "parse" in str(media_err).lower()
@@ -1404,7 +1410,10 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                                 )
                             else:
                                 last_msg = await bot.send_document(
-                                    chat_id=int_chat_id, document=f, **media_kwargs
+                                    chat_id=int_chat_id,
+                                    document=f,
+                                    filename=os.path.basename(media_path),
+                                    **media_kwargs,
                                 )
                         else:
                             raise


### PR DESCRIPTION
When delivering files via MEDIA:<path> on Telegram, long filenames failed silently because python-telegram-bot derives the multipart filename from f.name (the full host path) when no explicit filename is provided. Telegram servers reject long paths in Content-Disposition with no error surfaced, so the agent believes the file was delivered while the user never receives it.

This adds filename=os.path.basename(media_path) at all three bot.send_document call sites in _send_telegram (initial send, thread-not-found retry, and caption-parse retry). The adapter-level TelegramAdapter.send_document already passed display_name correctly.

Fixes #67552.

**Tests:** Added three tests covering the initial send and both retry paths verifying filename=basename is passed and full path is not leaked.

**Verification:** All 7 tests in test_telegram_send_message_caption.py pass, including the 3 new tests.