### PR TITLE
fix(browser): tree-kill orphaned agent-browser daemon on command timeout (#68139)

### DIFF
--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -537,3 +537,76 @@ class TestEmergencyCleanupRunsReaper:
         assert reaper_called, (
             "Reaper must run on exit even with no active sessions"
         )
+
+
+class TestKillBrowserDaemonOnTimeout:
+    """Issue #68139: the agent-browser daemon (Chromium cold-start) spawned by a
+    command that times out must be tree-killed, not orphaned inside the gateway.
+    """
+
+    def _make_socket_dir(self, tmpdir, session_name, pid=None):
+        import tools.browser_tool as bt
+        d = tmpdir / f"agent-browser-{session_name}"
+        d.mkdir()
+        if pid is not None:
+            (d / f"{session_name}.pid").write_text(str(pid))
+        return d
+
+    def test_daemon_reaped_when_verified(self, fake_tmpdir):
+        import tools.browser_tool as bt
+
+        session_name = "h_timeout1234"
+        d = self._make_socket_dir(fake_tmpdir, session_name, pid=12345)
+
+        kill_calls = []
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon",
+                   return_value=True), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda pid: kill_calls.append(pid)):
+            reaped = bt._kill_browser_daemon_on_timeout(str(d), session_name)
+
+        assert reaped is True
+        assert kill_calls == [12345]
+
+    def test_dead_daemon_not_reaped(self, fake_tmpdir):
+        import tools.browser_tool as bt
+
+        session_name = "h_timeoutdead1"
+        d = self._make_socket_dir(fake_tmpdir, session_name, pid=999999999)
+
+        with patch("gateway.status._pid_exists", return_value=False), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=AssertionError("should not terminate dead PID")):
+            reaped = bt._kill_browser_daemon_on_timeout(str(d), session_name)
+
+        assert reaped is False
+
+    def test_unverified_daemon_not_reaped(self, fake_tmpdir):
+        """A daemon that fails the reap-verification check must be left alone
+        (issue #14073 spoof defense) even on command timeout."""
+        import tools.browser_tool as bt
+
+        session_name = "h_timeoutspoof"
+        d = self._make_socket_dir(fake_tmpdir, session_name, pid=12345)
+
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon",
+                   return_value=False), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=AssertionError("should not terminate unverified PID")):
+            reaped = bt._kill_browser_daemon_on_timeout(str(d), session_name)
+
+        assert reaped is False
+
+    def test_missing_pid_file_is_noop(self, fake_tmpdir):
+        import tools.browser_tool as bt
+
+        session_name = "h_timeoutnopid"
+        d = self._make_socket_dir(fake_tmpdir, session_name)  # no .pid file
+
+        with patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=AssertionError("should not terminate without pid")):
+            reaped = bt._kill_browser_daemon_on_timeout(str(d), session_name)
+
+        assert reaped is False

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1158,6 +1158,11 @@ def _run_chrome_fallback_command(
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait()
+            # Mirror the daemon reaping done in _run_browser_command: the CLI
+            # client is gone but the detached agent-browser daemon (Chromium
+            # cold-start) survives proc.kill() and leaks inside the gateway
+            # (issue #68139).  Tree-kill the daemon via the verified path.
+            _kill_browser_daemon_on_timeout(task_socket_dir, tmp_session)
             return {"success": False, "error": f"Chrome fallback '{cmd}' timed out"}
         try:
             with open(stdout_path, "r", encoding="utf-8") as f:
@@ -1667,6 +1672,58 @@ def _verify_reapable_browser_daemon(daemon_pid: int, socket_dir: str,
         return False
 
     return True
+
+
+def _kill_browser_daemon_on_timeout(task_socket_dir: str,
+                                    session_name: str) -> bool:
+    """Best-effort tree-kill of the agent-browser daemon left behind on timeout.
+
+    When a ``browser_*`` CLI command hits ``subprocess.TimeoutExpired`` we only
+    ``proc.kill()`` the *CLI client* process (see ``_run_browser_command`` and
+    ``_run_chrome_fallback_command``).  agent-browser spawns a detached daemon
+    grandchild (which cold-starts Chromium) whose socket dir is passed via the
+    ``AGENT_BROWSER_SOCKET_DIR`` env var — never via argv — so that daemon keeps
+    running and is never reaped by the startup-only orphan reaper inside a
+    long-lived gateway.  The daemon + full Chromium tree (~150-250 MB) is then
+    orphaned inside the gateway's cgroup until the host OOMs.
+
+    Terminate the orphaned daemon here using the *same* verified-termination
+    path the orphan reaper uses, so we never signal a process that isn't
+    genuinely ours (issue #14073 spoof defense).  Returns True if a daemon was
+    reaped.
+    """
+    pid_file = os.path.join(task_socket_dir, f"{session_name}.pid")
+    if not os.path.isfile(pid_file):
+        # No daemon PID file — nothing to reap.
+        return False
+    try:
+        daemon_pid = int(Path(pid_file).read_text(encoding="utf-8").strip())
+    except (ValueError, OSError):
+        return False
+
+    from gateway.status import _pid_exists
+    if not _pid_exists(daemon_pid):
+        return False
+
+    if not _verify_reapable_browser_daemon(daemon_pid, task_socket_dir, session_name):
+        logger.warning(
+            "browser daemon PID %d failed reap verification on command "
+            "timeout; leaving it for the next orphan sweep (session %s)",
+            daemon_pid, session_name)
+        return False
+
+    try:
+        from tools.process_registry import ProcessRegistry
+        ProcessRegistry._terminate_host_pid(daemon_pid)
+        logger.info(
+            "Reaped browser daemon PID %d after command timeout (session %s)",
+            daemon_pid, session_name)
+        return True
+    except (ProcessLookupError, PermissionError, OSError) as exc:
+        logger.warning(
+            "Could not reap browser daemon PID %d on command timeout: %s",
+            daemon_pid, exc)
+        return False
 
 
 def _reap_orphaned_browser_sessions():
@@ -2503,6 +2560,16 @@ def _run_browser_command(
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait()
+            # The CLI client is dead, but agent-browser spawned a detached
+            # daemon grandchild (Chromium cold-start) whose socket dir is passed
+            # via AGENT_BROWSER_SOCKET_DIR, not argv.  That daemon is NOT killed
+            # by proc.kill() and the startup-only orphan reaper never reaps it
+            # inside a long-lived gateway — it orphans ~150-250 MB of Chromium
+            # per timeout (issue #68139).  Tree-kill the daemon too, using the
+            # same verified-termination path as the orphan reaper.
+            session_name = session_info.get("session_name")
+            if session_name:
+                _kill_browser_daemon_on_timeout(task_socket_dir, session_name)
             stdout, stderr = _read_command_output_files(stdout_path, stderr_path)
             _unlink_command_output_files(stdout_path, stderr_path)
             if stderr and stderr.strip():


### PR DESCRIPTION
## Summary

Fixes #68139.

When an `agent-browser` CLI command hits its `subprocess.TimeoutExpired`, the
handler only killed the **CLI client** process (`proc.kill()`). agent-browser
spawns a detached daemon grandchild (which cold-starts Chromium) whose socket
dir is passed via the `AGENT_BROWSER_SOCKET_DIR` env var — never via argv — so
that daemon survives `proc.kill()` and is **never** reaped by the
startup-only orphan reaper inside a long-lived `gateway run`. Each timeout
orphans ~150–250 MB of Chromium inside the gateway's cgroup until the host OOMs.

## Fix

Added `_kill_browser_daemon_on_timeout(task_socket_dir, session_name)` in
`tools/browser_tool.py`, which mirrors the **verified** termination path the
orphan reaper already uses:

1. read `<session>.pid` from the socket dir,
2. confirm the PID is alive (`gateway.status._pid_exists`),
3. `_verify_reapable_browser_daemon()` — identity + binding check so we never
   signal a process that isn't genuinely ours (issue #14073 spoof defense),
4. `ProcessRegistry._terminate_host_pid()` to tree-kill the daemon + Chromium
   children.

It is now called on the `TimeoutExpired` branch of both `_run_browser_command`
and the Chrome-fallback `_run_tmp` runner. The spoof-defense verification means
a daemon that fails the check is left for a later orphan sweep rather than
killed blindly.

## Tests

`tests/tools/test_browser_orphan_reaper.py::TestKillBrowserDaemonOnTimeout` (4
cases): reaps a verified live daemon, leaves a dead PID alone, leaves an
unverified (spoofed) daemon alone, and no-ops when the `.pid` file is missing.
Full reaper file: 30/30 pass.

## Verification

- RED→GREEN: the 4 new tests fail against unmodified `upstream/main` (function
  undefined) and pass after the fix.
- No change to the startup reaper or normal close path.
