### PR TITLE
fix(slack): echo prompt slash inputs publicly

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -858,6 +858,90 @@ class SlackAdapter(BasePlatformAdapter):
         # Non-fatal — the user saw the initial ack already.
         return SendResult(success=True, message_id=None)
 
+    def _slash_public_echo_text(
+        self,
+        slash_name: str,
+        routed_text: str,
+        user_id: str,
+    ) -> str:
+        """Return a public mirror for prompt-bearing Slack slash inputs.
+
+        Slack slash invocations are otherwise only visible to the user who ran
+        them. Mirror natural-language prompt payloads into the channel so the
+        human request is visible, while keeping operational commands private.
+        """
+        prompt_text = ""
+        label = "asked Hermes"
+        slash_key = slash_name.lower().lstrip("/")
+
+        if (
+            slash_key in {"hermes", ""}
+            and routed_text
+            and not routed_text.startswith("/")
+        ):
+            prompt_text = routed_text.strip()
+        elif routed_text.startswith("/"):
+            try:
+                from hermes_cli.commands import resolve_command
+
+                command_token, _, args = routed_text[1:].partition(" ")
+                cmd = resolve_command(command_token)
+                canonical = cmd.name if cmd else command_token.lower()
+                if canonical in {"background", "queue", "steer", "moa"}:
+                    prompt_text = args.strip()
+                    label = {
+                        "background": "started a background request",
+                        "queue": "queued a request",
+                        "steer": "steered Hermes",
+                        "moa": "asked Hermes",
+                    }.get(canonical, label)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug(
+                    "[Slack] Could not classify slash input for public echo: %s",
+                    exc,
+                )
+
+        if not prompt_text:
+            return ""
+
+        prompt_text = self.format_message(prompt_text)
+        actor = f"<@{user_id}>" if user_id else "A user"
+        return f"*{actor} {label}:*\n{prompt_text}"
+
+    async def _echo_slash_input_publicly(
+        self,
+        command: dict,
+        *,
+        routed_text: str,
+        slash_name: str,
+        user_id: str,
+        channel_id: str,
+        team_id: str,
+    ) -> None:
+        """Best-effort public Slack mirror for hidden slash prompt inputs."""
+        echo_text = self._slash_public_echo_text(
+            slash_name=slash_name,
+            routed_text=routed_text,
+            user_id=user_id,
+        )
+        if not echo_text or not channel_id:
+            return
+
+        kwargs: Dict[str, Any] = {
+            "channel": channel_id,
+            "text": echo_text,
+            "mrkdwn": True,
+        }
+        thread_ts = command.get("thread_ts")
+        if thread_ts:
+            kwargs["thread_ts"] = thread_ts
+        try:
+            await self._get_client(
+                channel_id, team_id=team_id
+            ).chat_postMessage(**kwargs)
+        except Exception as exc:  # pragma: no cover - best-effort visibility
+            logger.warning("[Slack] Failed to echo slash input publicly: %s", exc)
+
     def _warn_if_missing_group_dm_scopes(self, auth_response, team_name: str) -> None:
         """Nudge existing installs to reinstall when group-DM scopes are absent.
 
@@ -4572,6 +4656,15 @@ class SlackAdapter(BasePlatformAdapter):
             ),
             source=source,
             raw_message=command,
+        )
+
+        await self._echo_slash_input_publicly(
+            command,
+            routed_text=text,
+            slash_name=slash_name,
+            user_id=user_id,
+            channel_id=channel_id,
+            team_id=team_id,
         )
 
         # Stash the Slack response_url so the first reply for this

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -4719,6 +4719,7 @@ class TestSlashEphemeralAck:
     @pytest.mark.asyncio
     async def test_freeform_hermes_question_does_not_stash_context(self, adapter):
         """Free-form /hermes <question> must NOT route agent reply ephemeral."""
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "echo-ts"})
         command = {
             "command": "/hermes",
             "text": "what's the weather",
@@ -4735,6 +4736,89 @@ class TestSlashEphemeralAck:
         assert event.text == "what's the weather"
         # Context must NOT be stashed — agent reply should be public
         assert len(adapter._slash_command_contexts) == 0
+
+    @pytest.mark.asyncio
+    async def test_freeform_hermes_question_echoes_public_input(self, adapter):
+        """Free-form /hermes prompts are hidden by Slack, so mirror them publicly."""
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "echo-ts"})
+        command = {
+            "command": "/hermes",
+            "text": "summarize the launch plan",
+            "user_id": "U_FREE",
+            "channel_id": "C_FREE",
+            "team_id": "T_FREE",
+            "response_url": "https://hooks.slack.com/commands/T1/4/free",
+        }
+
+        await adapter._handle_slash_command(command)
+
+        adapter._app.client.chat_postMessage.assert_awaited_once()
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert kwargs["channel"] == "C_FREE"
+        assert kwargs["mrkdwn"] is True
+        assert "<@U_FREE> asked Hermes" in kwargs["text"]
+        assert "summarize the launch plan" in kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_freeform_hermes_command_like_request_echoes_public_input(self, adapter):
+        """Command-like natural language under /hermes still needs visibility."""
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "echo-ts"})
+        command = {
+            "command": "/hermes",
+            "text": "list plugins",
+            "user_id": "U_FREE",
+            "channel_id": "C_FREE",
+            "team_id": "T_FREE",
+            "response_url": "https://hooks.slack.com/commands/T1/4/free",
+        }
+
+        await adapter._handle_slash_command(command)
+
+        adapter._app.client.chat_postMessage.assert_awaited_once()
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert kwargs["channel"] == "C_FREE"
+        assert "<@U_FREE> asked Hermes" in kwargs["text"]
+        assert "list plugins" in kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_prompt_bearing_native_slash_echoes_public_input(self, adapter):
+        """Native prompt slash commands such as /q also need a visible request."""
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "echo-ts"})
+        command = {
+            "command": "/q",
+            "text": "follow up with risks",
+            "user_id": "U_Q",
+            "channel_id": "C_Q",
+            "team_id": "T_Q",
+            "response_url": "https://hooks.slack.com/commands/T1/2/q",
+        }
+
+        await adapter._handle_slash_command(command)
+
+        adapter._app.client.chat_postMessage.assert_awaited_once()
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert kwargs["channel"] == "C_Q"
+        assert "<@U_Q> queued a request" in kwargs["text"]
+        assert "follow up with risks" in kwargs["text"]
+        assert ("C_Q", "U_Q") in adapter._slash_command_contexts
+
+    @pytest.mark.asyncio
+    async def test_operational_native_slash_does_not_echo_public_input(self, adapter):
+        """Control-plane commands stay private instead of creating channel noise."""
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "echo-ts"})
+        command = {
+            "command": "/stop",
+            "text": "",
+            "user_id": "U_STOP",
+            "channel_id": "C_STOP",
+            "team_id": "T_STOP",
+            "response_url": "https://hooks.slack.com/commands/T1/5/stop",
+        }
+
+        await adapter._handle_slash_command(command)
+
+        adapter._app.client.chat_postMessage.assert_not_awaited()
+        assert ("C_STOP", "U_STOP") in adapter._slash_command_contexts
 
     @pytest.mark.asyncio
     async def test_concurrent_users_same_channel_isolates_contexts(self, adapter):


### PR DESCRIPTION
## Summary

Slack slash invocations are only visible to the user who ran them, which hid prompt-like requests such as `/hermes list plugins` from the channel. This PR mirrors prompt-bearing slash inputs into the channel before dispatching the request, while leaving operational commands private.

## Root Cause

The Slack adapter routed `/hermes <text>` free-form requests correctly, but the original slash invocation remained Slack-private. As a result, Hermes responses appeared without the visible user request that caused them.

## Changes

- Add a best-effort public echo path for prompt-bearing Slack slash inputs.
- Echo free-form `/hermes <prompt>` requests, including command-like natural language such as `list plugins`.
- Echo prompt-bearing native slash commands such as `/q <prompt>` with command-specific labels.
- Keep operational commands such as `/stop` private.
- Add regression coverage for public echo behavior and slash context preservation.

## Validation

- `git diff --check -- plugins/platforms/slack/adapter.py tests/gateway/test_slack.py`
- `venv/bin/python -B -m py_compile plugins/platforms/slack/adapter.py tests/gateway/test_slack.py`
- Live Slack validation confirmed `/hermes list plugins` now echoes publicly before the agent response.

Note: `venv/bin/python -m pytest tests/gateway/test_slack.py::TestSlashEphemeralAck -q` could not run in this local venv because `pytest-asyncio` is not installed; all failures were pytest async-plugin collection/runtime errors.