### PR TITLE
feat(desktop): add opt-in assistant bubble color (closes #67290)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -91,7 +91,7 @@ export const AssistantMessage: FC<{
 
   return (
     <MessagePrimitive.Root
-      className="group flex w-full min-w-0 max-w-full flex-col gap-0 self-start overflow-hidden"
+      className="group flex w-full min-w-0 max-w-full flex-col gap-0 self-start overflow-hidden bg-(--dt-assistant-bubble)"
       data-role="assistant"
       data-slot="aui_assistant-message-root"
       data-streaming={isRunning ? 'true' : undefined}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -310,6 +310,7 @@
     --dt-sidebar-border: var(--ui-stroke-secondary);
     --dt-user-bubble: var(--ui-chat-bubble-background);
     --dt-user-bubble-border: var(--ui-stroke-tertiary);
+    --dt-assistant-bubble: ; /* unset by default; assistant bubble opt-in surface */
 
     --dt-font-sans:
       'Segoe WPC', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif,

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -220,6 +220,7 @@ function applyTheme(theme: DesktopTheme, mode: 'light' | 'dark') {
     '--dt-destructive-foreground': c.destructiveForeground,
     '--dt-sidebar-border': c.sidebarBorder ?? c.border,
     '--dt-user-bubble-border': c.userBubbleBorder ?? c.border,
+    '--dt-assistant-bubble': c.assistantBubble ?? '',
     '--dt-font-sans': typo.fontSans,
     '--dt-font-mono': typo.fontMono,
     '--noise-opacity-mul': isDark ? 'calc(0.04 / 0.21)' : 'calc(0.34 / 0.21)'

--- a/apps/desktop/src/themes/types.ts
+++ b/apps/desktop/src/themes/types.ts
@@ -45,6 +45,13 @@ export interface DesktopThemeColors {
   sidebarBorder?: string
   userBubble?: string
   userBubbleBorder?: string
+  /**
+   * Optional assistant-message bubble background. When unset, the assistant
+   * bubble renders with no surface (current default behavior). Set per-theme or
+   * via user theme overrides to give the assistant a distinct bubble. Opt-in:
+   * existing users see no change until a value is provided.
+   */
+  assistantBubble?: string
 }
 
 export interface DesktopThemeTypography {

--- a/examples/desktop-plugins/elise-red/plugin.js
+++ b/examples/desktop-plugins/elise-red/plugin.js
@@ -1,0 +1,110 @@
+// Elise Red — example assistant-bubble theme for Hermes Desktop
+//
+// This is a worked TEMPLATE showing how to give the assistant message its own
+// surface color using the opt-in `assistantBubble` theme color (added by PR for
+// issue #67290). Drop this file at:
+//
+//   $HERMES_HOME/desktop-plugins/elise-red/plugin.js
+//
+// (folder name must equal the plugin id). The app hot-reloads it within seconds;
+// toggle in Settings -> Plugins. No app rebuild needed.
+//
+// REQUIRES the upstream change that adds `--dt-assistant-bubble` and wires it into
+// the assistant message root. Without that build, this theme still applies (it is a
+// valid DesktopTheme) but the assistant bubble stays unset.
+//
+// To make your OWN color: change DRAGON_RED (and the dark-mode surface) below.
+//
+// Disk plugin: plain ESM, no build step. Only @hermes/plugin-sdk / react /
+// react/jsx-runtime may be imported. A theme contribution needs no JSX, just a data object.
+
+import { THEMES_AREA } from '@hermes/plugin-sdk'
+
+const NOUS_BLUE = '#0053FD'
+const PSYCHE_WARM = '#FFE6CB'
+const nousTint = (pct) => `color-mix(in srgb, ${NOUS_BLUE} ${pct}%, #FFFFFF)`
+const nousTintTransparent = (pct) => `color-mix(in srgb, ${NOUS_BLUE} ${pct}%, transparent)`
+
+// === CHANGE THIS to make the assistant bubble your color =========================
+const DRAGON_RED = '#C8102E' // light-mode assistant bubble surface
+const DRAGON_RED_DARK = '#3A0E18' // dark-mode assistant bubble surface (deeper reads better)
+// =================================================================================
+
+// Nous palette (mirrors the built-in "Nous" theme) + the assistant bubble color.
+const eliseRedTheme = {
+  name: 'elise-red',
+  label: 'Elise Red',
+  description: 'Nous palette with a dragon-red assistant bubble',
+  colors: {
+    background: '#F8FAFF',
+    foreground: '#17171A',
+    card: '#FFFFFF',
+    cardForeground: '#17171A',
+    muted: nousTint(5),
+    mutedForeground: '#666678',
+    popover: '#FFFFFF',
+    popoverForeground: '#17171A',
+    primary: NOUS_BLUE,
+    primaryForeground: '#FCFCFC',
+    secondary: nousTint(7),
+    secondaryForeground: '#242432',
+    accent: nousTint(10),
+    accentForeground: '#202030',
+    border: nousTintTransparent(22),
+    input: nousTintTransparent(30),
+    ring: NOUS_BLUE,
+    midground: NOUS_BLUE,
+    composerRing: NOUS_BLUE,
+    destructive: '#C72E4D',
+    destructiveForeground: '#FFFFFF',
+    sidebarBackground: '#F3F7FF',
+    sidebarBorder: nousTintTransparent(18),
+    userBubble: nousTint(6),
+    userBubbleBorder: nousTintTransparent(24),
+    // The only addition: give the assistant its own surface.
+    assistantBubble: DRAGON_RED
+  },
+  darkColors: {
+    background: '#0D2F86',
+    foreground: PSYCHE_WARM,
+    card: '#12378F',
+    cardForeground: PSYCHE_WARM,
+    muted: '#183F9A',
+    mutedForeground: '#B5C7F3',
+    popover: '#123A96',
+    popoverForeground: PSYCHE_WARM,
+    primary: PSYCHE_WARM,
+    primaryForeground: '#0D2F86',
+    secondary: '#1B45A4',
+    secondaryForeground: '#E0E8FF',
+    accent: '#1540B1',
+    accentForeground: '#F0F4FF',
+    border: '#3158AD',
+    input: '#0B2566',
+    ring: PSYCHE_WARM,
+    midground: NOUS_BLUE,
+    composerRing: PSYCHE_WARM,
+    destructive: '#C0473A',
+    destructiveForeground: '#FEF2F2',
+    sidebarBackground: '#09286F',
+    sidebarBorder: '#234A9C',
+    userBubble: '#143B91',
+    userBubbleBorder: '#3A63BD',
+    // Dark mode: a deep red surface reads better than bright red.
+    assistantBubble: DRAGON_RED_DARK
+  },
+  typography: {
+    fontSans:
+      '"Segoe WPC", "Segoe UI", -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif',
+    fontMono:
+      '"Cascadia Code", "JetBrains Mono", "SF Mono", ui-monospace, Menlo, Monaco, Consolas, monospace'
+  }
+}
+
+export default {
+  id: 'elise-red',
+  name: 'Elise Red Theme',
+  register(ctx) {
+    ctx.register({ id: 'theme', area: THEMES_AREA, data: eliseRedTheme })
+  }
+}


### PR DESCRIPTION
## Summary
Adds an **opt-in** `assistantBubble` color to the desktop theme system, giving the assistant message its own surface (e.g. a distinct brand color). Closes #67290.

- `apps/desktop/src/themes/types.ts`: new optional `assistantBubble?: string` on `DesktopThemeColors`.
- `apps/desktop/src/themes/context.tsx`: `applyTheme` writes `--dt-assistant-bubble: c.assistantBubble ?? ''`.
- `apps/desktop/src/styles.css`: declares `--dt-assistant-bubble: ;` (empty default).
- `apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx`: assistant root gets `bg-(--dt-assistant-bubble)`.

## Why opt-in (Option A from the issue)
The variable defaults to empty, so `bg-(--dt-assistant-bubble)` resolves to no background — **identical to current default behavior**. Existing users see zero change unless a theme or override sets `assistantBubble`. This is the mergeable first cut the issue contributor preferred.

## Worked example: "Elise Red" theme plugin
This PR is self-demonstrating. `examples/desktop-plugins/elise-red/plugin.js` is a ready-to-use `THEMES_AREA` plugin that turns the assistant bubble dragon red (`#C8102E` light / `#3A0E18` dark) with **no app rebuild**:

1. Copy `examples/desktop-plugins/elise-red/plugin.js` to `$HERMES_HOME/desktop-plugins/elise-red/plugin.js`
   (folder name must equal the plugin id `elise-red`).
2. The app hot-reloads it within seconds; enable in Settings -> Plugins.
3. Change the `DRAGON_RED` constant at the top of the file to make the assistant your own color.

The plugin requires this PR's `--dt-assistant-bubble` wiring to be built into the app; without it, the theme applies but the assistant bubble stays unset.

## Verification
- `npm run build` in `apps/desktop` passes (exit 0, postbuild assert OK). Compiled `dist/assets/index-*.css` contains both `--dt-assistant-bubble: ;` and the rule `.bg-\(--dt-assistant-bubble\){background-color:var(--dt-assistant-bubble)}`.
- The example plugin's effect was visually confirmed by the reporter on a running desktop build (assistant bubble renders dragon red).
- Alternative (no source change): the assistant bubble can also be colored by patching the app's compiled CSS directly (hardcode a `[data-role="assistant"]` background rule), which is how the dragon-red was first observed; the plugin path above is the supported, update-safe route.

## Test plan
- [ ] Default theme: assistant bubble unchanged (no surface).
- [ ] Apply the "Elise Red" plugin: assistant bubble shows dragon red; user bubble unaffected.

🤖 Generated with [Hermes Agent](https://github.com/NousResearch/hermes-agent)