### PR TITLE
test: fix Windows portability in bitwarden secret-source tests

### DIFF
--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -94,7 +94,11 @@ def test_platform_asset_name(system, machine, libc_text, expected):
 def _make_fake_zip(binary_bytes: bytes) -> bytes:
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
-        zf.writestr("bws", binary_bytes)
+        # Mirror the real release archive: the Windows zip
+        # (bws-x86_64-pc-windows-msvc-*.zip) ships bws.exe, while every
+        # other platform ships a bare bws. Use the same platform switch
+        # install_bws() uses so the mock member matches what it looks for.
+        zf.writestr(bw._platform_binary_name(), binary_bytes)
     return buf.getvalue()
 
 
@@ -157,8 +161,10 @@ def test_install_bws_happy_path(hermes_home, monkeypatch):
     path = bw.install_bws()
     assert path.exists()
     assert path.read_bytes() == fake_binary
-    # Executable bit set
-    assert path.stat().st_mode & stat.S_IXUSR
+    # Executable bit set. POSIX-only: Windows os.chmod only toggles the
+    # read-only bit, so S_IXUSR is never reported there.
+    if os.name != "nt":
+        assert path.stat().st_mode & stat.S_IXUSR
 
 
 
@@ -370,8 +376,11 @@ def test_encrypted_cache_writes_without_plaintext(monkeypatch, tmp_path):
     assert not bw._disk_cache_path(home).exists()
     cache_path = bw._encrypted_disk_cache_path(home)
     assert cache_path.exists()
-    mode = stat.S_IMODE(os.stat(cache_path).st_mode)
-    assert mode == 0o600, f"expected 0o600, got 0o{mode:o}"
+    # POSIX-only: on Windows os.chmod only toggles the read-only bit, so a
+    # writable file always reports 0o666 and an exact 0o600 check cannot hold.
+    if os.name != "nt":
+        mode = stat.S_IMODE(os.stat(cache_path).st_mode)
+        assert mode == 0o600, f"expected 0o600, got 0o{mode:o}"
     text = cache_path.read_text()
     assert "secret-value" not in text
     assert "0.t" not in text


### PR DESCRIPTION
## What

Two tests in `tests/test_bitwarden_secrets.py` fail on Windows for reasons that have nothing to do with the code under test. Both encode Linux-only assumptions in the *test*, not bugs in the secret source. This makes the file pass on Windows with no change to any `agent/secret_sources/` module.

Scope: one file, +14/-5, test only. No source change, no behaviour change on Linux or macOS.

**Rebased onto current main and rebuilt.** The original version of this PR gated a mode assertion in `test_disk_cache_written_after_first_fetch`, which no longer exists after the test prune. The equivalent assertion now lives in the encrypted-cache test, so the fix moved with it. That also clears the merge conflict.

## The two failures

**1. `test_install_bws_happy_path` builds a mock archive with the wrong member name.**

`_make_fake_zip()` hardcoded the member as `"bws"`, but `install_bws()` looks it up through `_platform_binary_name()`, which correctly returns `bws.exe` on Windows. That matches the real release archive: `bws-x86_64-pc-windows-msvc-*.zip` ships `bws.exe`, every other platform ships a bare `bws`. So on Windows the extractor raises, because the member it expects is not in the mock.

The source is right, the mock was Linux shaped. The fix builds the member with the same platform switch the code uses:

```python
zf.writestr(bw._platform_binary_name(), binary_bytes)
```

The same test then asserts `st_mode & stat.S_IXUSR`. On Windows `os.chmod` only toggles the read-only bit, so the executable bit is never reported there, and the assertion cannot hold no matter what the code does. It is gated to POSIX rather than weakened.

**2. `test_encrypted_cache_writes_without_plaintext` asserts an exact 0600 mode.**

```python
mode = stat.S_IMODE(os.stat(cache_path).st_mode)
assert mode == 0o600, f"expected 0o600, got 0o{mode:o}"
```

The writer does the correct POSIX thing (`os.chmod(tmp, 0o600)` in `agent/secret_sources/bitwarden.py`). On Windows a writable file always reports `0o666`, so an exact `0o600` check can never pass there. The guarantee is meaningful on POSIX, since the secret cache must be owner-only, so instead of relaxing it the assertion is gated to where it applies, using the same `os.name != "nt"` idiom the suite already uses elsewhere. The rest of the test, including the checks that no plaintext secret is written, still runs everywhere.

## Why test only is the right call

Neither change touches the secret source. `_platform_binary_name()` already returns the correct name for the real archive, and the cache writer already sets the tightest mode the OS supports. The failures were the tests assuming a Linux filesystem, so the fix belongs in the tests.

## Test evidence

Windows 11, Python 3.13, cherry-picked onto current main:

```
# before: 2 failed, 16 passed
#   test_install_bws_happy_path                   -> member bws.exe not found in archive
#   test_encrypted_cache_writes_without_plaintext -> AssertionError: expected 0o600, got 0o666
# after:
18 passed
```

Green ubuntu run for this head: https://github.com/cryptoyasenka/hermes-agent/actions/runs/31055703166

`ruff check` clean. Linux and macOS keep the exact-mode and executable-bit assertions unchanged.
