### PR TITLE
fix: close Hindsight clients on agent eviction

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -281,6 +281,33 @@ def _run_sync(coro, timeout: float = _DEFAULT_TIMEOUT):
     return future.result(timeout=timeout)
 
 
+def _close_async_client_from_finalizer(coro) -> None:
+    """Best-effort close for a client whose provider lost its owner."""
+    loop = _loop
+    if loop is None or not loop.is_running():
+        try:
+            coro.close()
+        except Exception:
+            pass
+        return
+    try:
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+    except Exception:
+        try:
+            coro.close()
+        except Exception:
+            pass
+        return
+    # A finalizer normally runs outside the shared loop thread. If it does
+    # not, waiting here would deadlock; the scheduled close is sufficient.
+    if threading.current_thread() is _loop_thread:
+        return
+    try:
+        future.result(timeout=2.0)
+    except Exception:
+        # The future retains the coroutine if the bounded wait expires, so
+        # the close can still finish without blocking object finalization.
+        pass
 # ---------------------------------------------------------------------------
 # Backward-compatible alias — instances use self._run_sync() instead.
 # ---------------------------------------------------------------------------
@@ -712,6 +739,38 @@ class HindsightMemoryProvider(MemoryProvider):
         self._bank_mission = ""
         self._bank_retain_mission: str | None = None
         self._bank_id_template = ""
+
+    def __del__(self):
+        """Close a client if provider ownership is lost unexpectedly.
+
+        Normal lifecycle paths call ``shutdown()``. This finalizer is a
+        bounded safety net for temporary/helper agents that can be collected
+        without reaching a gateway session-boundary callback; otherwise the
+        Hindsight aiohttp session survives until interpreter shutdown.
+        """
+        try:
+            client = getattr(self, "_client", None)
+            if client is None:
+                return
+            self._client = None
+            if self._mode == "local_embedded":
+                inner_client = getattr(client, "_client", None)
+                aclose = getattr(inner_client, "aclose", None)
+                if callable(aclose):
+                    _close_async_client_from_finalizer(aclose())
+                    try:
+                        client._client = None
+                    except Exception:
+                        pass
+                close = getattr(client, "close", None)
+                if callable(close):
+                    close()
+            else:
+                aclose = getattr(client, "aclose", None)
+                if callable(aclose):
+                    _close_async_client_from_finalizer(aclose())
+        except Exception:
+            pass
 
     @property
     def name(self) -> str:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3572,12 +3572,13 @@ class AIAgent:
           - process_registry entries for task_id (user's bg shells)
           - terminal sandbox for task_id (cwd, env, shell state)
           - browser daemon for task_id (open tabs, cookies)
-          - memory provider (has its own lifecycle; keeps running)
 
         We DO close:
           - OpenAI/httpx client pool (big chunk of held memory + sockets;
             the rebuilt agent gets a fresh client anyway)
           - Active child subagents (per-turn artefacts; safe to drop)
+          - Memory-provider clients (durable state is in the backend; a rebuilt
+            agent creates a fresh provider for the same session)
 
         Safe to call multiple times.  Distinct from close() — which is the
         hard teardown for actual session boundaries (/new, /reset, session
@@ -3597,6 +3598,19 @@ class AIAgent:
                         child.close()
                     except Exception:
                         pass
+        except Exception:
+            pass
+
+        # A soft-evicted agent is removed from the cache and will not be able
+        # to own its memory provider again. Keep the durable session state,
+        # but close the provider's network client so an aiohttp/httpx pool is
+        # not orphaned until interpreter shutdown. Do not call
+        # on_session_end(): cache eviction is not a session boundary, and a
+        # resumed agent must not observe a false end-of-session transition.
+        try:
+            memory_manager = getattr(self, "_memory_manager", None)
+            if memory_manager is not None:
+                memory_manager.shutdown_all()
         except Exception:
             pass
 

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -1463,6 +1463,24 @@ class TestAgentCacheIdleResume:
         # Post-release: client reference is dropped (memory freed).
         assert agent.client is None
 
+    def test_release_clients_closes_memory_provider_without_ending_session(self):
+        """Soft eviction must close provider clients without a false boundary."""
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            model="anthropic/claude-sonnet-4", api_key="test",
+            base_url="https://openrouter.ai/api/v1", provider="openrouter",
+            max_iterations=5, quiet_mode=True,
+            skip_context_files=True, skip_memory=True,
+        )
+        memory_manager = MagicMock()
+        agent._memory_manager = memory_manager
+
+        agent.release_clients()
+
+        memory_manager.shutdown_all.assert_called_once_with()
+        memory_manager.on_session_end.assert_not_called()
+
     def test_close_vs_release_full_teardown_difference(self, monkeypatch):
         """close() tears down task state; release_clients() does not.
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1791,6 +1791,21 @@ class TestSharedEventLoopLifecycle:
         mock_client.aclose.assert_called_once()
         assert provider._client is None
 
+    def test_finalizer_closes_orphaned_client(self, provider_with_config):
+        """Provider collection must not leave an aiohttp client behind."""
+        from plugins.memory import hindsight as hindsight_mod
+
+        async def _noop():
+            return 1
+
+        assert hindsight_mod._run_sync(_noop()) == 1
+        provider = provider_with_config()
+        mock_client = provider._client
+
+        provider.__del__()
+
+        mock_client.aclose.assert_awaited_once()
+        assert provider._client is None
 
 class TestShutdown:
     def test_local_embedded_shutdown_closes_inner_async_client_on_shared_loop(self, provider):


### PR DESCRIPTION
## Summary

- close external memory-provider clients when a cached agent is soft-evicted
- add a bounded Hindsight finalizer for orphaned aiohttp clients
- add lifecycle regression coverage for cache eviction and provider cleanup

## Root cause

Hindsight owns aiohttp sessions per agent. Cache eviction released the agent's other clients but left the Hindsight provider client alive, allowing sockets to accumulate until macOS's low process file-descriptor limit affected Telegram.

## Validation

- `pytest -q tests/gateway/test_agent_cache.py` — 81 passed
- `pytest -q tests/plugins/memory/test_hindsight_provider.py` — 117 passed
- `python -m py_compile plugins/memory/hindsight/__init__.py run_agent.py`
- `git diff --check`
- live Benjamus startup verification before promotion: Telegram and Discord connected, Hindsight healthy, file descriptors 76–77, `CLOSE_WAIT=0`

## Scope boundary

This PR is published from the Benjamus-specific repair branch. Merge and deployment remain pending upstream review. The live Benjamus service was not restarted as part of publication; its already-certified runtime was left intact.