### PR TITLE
fix(memory): read non-secret provider config from config.yaml for OpenViking and RetainDB (#68209)

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -930,12 +930,30 @@ def _resolve_connection_settings(provider_config: Optional[dict] = None) -> dict
     user_env = _env_value("OPENVIKING_USER")
     agent_env = _env_value("OPENVIKING_AGENT")
 
+    # Non-secret fields fall back to config.yaml (e.g. the Dashboard writes
+    # ``memory.openviking.endpoint`` there) before the built-in default, so the
+    # full chain is env -> ovcli -> config.yaml -> default. The secret api_key is
+    # sourced from the environment (synced from .env), never from config.yaml.
     return {
-        "endpoint": _first_nonempty(endpoint_env, ovcli_values.get("endpoint"), default=_DEFAULT_ENDPOINT),
+        "endpoint": _first_nonempty(
+            endpoint_env,
+            ovcli_values.get("endpoint"),
+            _clean_config_value(provider_config.get("endpoint")),
+            default=_DEFAULT_ENDPOINT,
+        ),
         "api_key": api_key_env if api_key_env is not None else ovcli_values.get("api_key", ""),
-        "account": account_env if account_env is not None else ovcli_values.get("account", ""),
-        "user": user_env if user_env is not None else ovcli_values.get("user", ""),
-        "agent": _first_nonempty(agent_env, ovcli_values.get("agent"), default=_DEFAULT_AGENT),
+        "account": account_env if account_env is not None else _first_nonempty(
+            ovcli_values.get("account"), _clean_config_value(provider_config.get("account"))
+        ),
+        "user": user_env if user_env is not None else _first_nonempty(
+            ovcli_values.get("user"), _clean_config_value(provider_config.get("user"))
+        ),
+        "agent": _first_nonempty(
+            agent_env,
+            ovcli_values.get("agent"),
+            _clean_config_value(provider_config.get("agent")),
+            default=_DEFAULT_AGENT,
+        ),
     }
 
 
@@ -1929,6 +1947,10 @@ class OpenVikingMemoryProvider(MemoryProvider):
         if os.environ.get("OPENVIKING_ENDPOINT"):
             return True
         provider_config = _load_hermes_openviking_config()
+        # A non-secret endpoint saved to config.yaml (e.g. via the Dashboard)
+        # counts as configured even without an env var or ovcli config.
+        if _clean_config_value(provider_config.get("endpoint")):
+            return True
         if not provider_config.get("use_ovcli_config"):
             return False
         try:

--- a/plugins/memory/retaindb/__init__.py
+++ b/plugins/memory/retaindb/__init__.py
@@ -44,6 +44,29 @@ _DEFAULT_BASE_URL = "https://api.retaindb.com"
 _ASYNC_SHUTDOWN = object()
 
 
+def _load_retaindb_config() -> Dict[str, Any]:
+    """Return the ``memory.retaindb`` block from config.yaml (empty on any error).
+
+    Non-secret fields (``base_url``, ``project``) are persisted here by the
+    Dashboard; the runtime must read them back when the matching env var is
+    unset. The secret ``api_key`` continues to come from the environment.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        memory_config = config.get("memory", {}) if isinstance(config, dict) else {}
+        provider_config = memory_config.get("retaindb", {}) if isinstance(memory_config, dict) else {}
+        return dict(provider_config) if isinstance(provider_config, dict) else {}
+    except Exception:
+        return {}
+
+
+def _config_str(value: Any) -> str:
+    """Return a stripped string for a config value, else ``""``."""
+    return value.strip() if isinstance(value, str) else ""
+
+
 # ---------------------------------------------------------------------------
 # Tool schemas
 # ---------------------------------------------------------------------------
@@ -489,12 +512,21 @@ class RetainDBMemoryProvider(MemoryProvider):
     # ── Lifecycle ──────────────────────────────────────────────────────────
 
     def initialize(self, session_id: str, **kwargs) -> None:
+        # Non-secret fields fall back to config.yaml (written by the Dashboard)
+        # when the env var is unset: env -> config.yaml -> default. The API key
+        # stays a scoped-credential read via get_secret (never raw os.environ).
+        provider_config = _load_retaindb_config()
         api_key = get_secret("RETAINDB_API_KEY", "") or ""
-        base_url = re.sub(r"/+$", "", os.environ.get("RETAINDB_BASE_URL", _DEFAULT_BASE_URL))
+        base_url_raw = (
+            os.environ.get("RETAINDB_BASE_URL")
+            or _config_str(provider_config.get("base_url"))
+            or _DEFAULT_BASE_URL
+        )
+        base_url = re.sub(r"/+$", "", base_url_raw)
 
-        # Project resolution: RETAINDB_PROJECT > hermes-<profile> > "default"
+        # Project resolution: RETAINDB_PROJECT > config.yaml project > hermes-<profile> > "default"
         # If unset, the API auto-creates and uses the "default" project — no config required.
-        explicit = os.environ.get("RETAINDB_PROJECT")
+        explicit = os.environ.get("RETAINDB_PROJECT") or _config_str(provider_config.get("project"))
         if explicit:
             project = explicit
         else:

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -993,3 +993,354 @@ def test_prefetch_sends_contract_safe_memory_context_payload(monkeypatch):
     assert "target_uri" not in payload
 
 
+def test_prefetch_uses_session_search_when_session_id_available(monkeypatch):
+    provider = _make_prefetch_provider()
+
+    captured_calls = []
+
+    class StubClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        def post(self, path, payload=None, **kwargs):
+            captured_calls.append((path, payload))
+            return {
+                "result": {
+                    "memories": [
+                        {
+                            "uri": "viking://user/peers/hermes/memories/events/mem_1.md",
+                            "score": 0.9,
+                            "abstract": "session-aware memory",
+                        },
+                    ],
+                    "resources": [],
+                    "skills": [],
+                }
+            }
+
+    monkeypatch.setattr(openviking_module, "_VikingClient", StubClient)
+
+    result = provider.prefetch("anything", session_id="sid-123")
+
+    assert captured_calls == [
+        (
+            "/api/v1/search/search",
+            {
+                "query": "anything",
+                "limit": 24,
+                "score_threshold": 0,
+                "context_type": "memory",
+                "session_id": "sid-123",
+            },
+        )
+    ]
+    payload = captured_calls[0][1]
+    assert "top_k" not in payload
+    assert "mode" not in payload
+    assert "target_uri" not in payload
+    assert "session-aware memory" in result
+
+
+def test_prefetch_falls_back_to_find_when_session_search_fails(monkeypatch):
+    provider = _make_prefetch_provider()
+
+    captured_calls = []
+
+    class StubClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        def post(self, path, payload=None, **kwargs):
+            captured_calls.append((path, payload))
+            if path == "/api/v1/search/search":
+                raise RuntimeError("session unavailable")
+            return {
+                "result": {
+                    "memories": [
+                        {
+                            "uri": "viking://user/peers/hermes/memories/events/mem_2.md",
+                            "score": 0.8,
+                            "abstract": "non-session fallback",
+                        },
+                    ],
+                    "resources": [],
+                    "skills": [],
+                }
+            }
+
+    monkeypatch.setattr(openviking_module, "_VikingClient", StubClient)
+
+    result = provider.prefetch("anything", session_id="sid-123")
+
+    assert captured_calls == [
+        (
+            "/api/v1/search/search",
+            {
+                "query": "anything",
+                "limit": 24,
+                "score_threshold": 0,
+                "context_type": "memory",
+                "session_id": "sid-123",
+            },
+        ),
+        (
+            "/api/v1/search/find",
+            {
+                "query": "anything",
+                "limit": 24,
+                "score_threshold": 0,
+                "context_type": "memory",
+            },
+        ),
+    ]
+    for _path, payload in captured_calls:
+        assert "top_k" not in payload
+        assert "mode" not in payload
+        assert "target_uri" not in payload
+    assert "non-session fallback" in result
+
+
+def test_prefetch_budget_exhaustion_skips_find_fallback_log(caplog):
+    class StubClient:
+        def post(self, path, payload=None, **kwargs):
+            raise AssertionError("local budget exhaustion should not issue HTTP calls")
+
+    with caplog.at_level("DEBUG", logger=openviking_module.__name__):
+        with pytest.raises(TimeoutError):
+            OpenVikingMemoryProvider._post_prefetch_search(
+                StubClient(),
+                "anything",
+                "sid-123",
+                limit=24,
+                context_type="memory",
+                deadline=time.monotonic() - 1.0,
+                request_timeout=4.0,
+            )
+
+    assert "falling back to search/find" not in caplog.text
+
+
+def test_prefetch_reads_l2_content_and_ignores_skills_by_default(monkeypatch):
+    provider = _make_prefetch_provider()
+
+    captured_reads = []
+
+    class StubClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        def post(self, path, payload=None, **kwargs):
+            return {
+                "result": {
+                    "memories": [
+                        {
+                            "uri": "viking://user/peers/hermes/memories/events/mem_3.md",
+                            "score": 0.9,
+                            "level": 2,
+                            "category": "events",
+                            "abstract": "short abstract",
+                        },
+                    ],
+                    "resources": [],
+                    "skills": [
+                        {
+                            "uri": "viking://user/skills/release-triage",
+                            "score": 0.7,
+                            "abstract": "skill context",
+                        },
+                    ],
+                }
+            }
+
+        def get(self, path, params=None, **kwargs):
+            captured_reads.append((path, params or {}))
+            return {"result": {"content": "full memory content\nwith useful context"}}
+
+    monkeypatch.setattr(openviking_module, "_VikingClient", StubClient)
+
+    context = provider.prefetch("anything")
+
+    assert captured_reads == [
+        (
+            "/api/v1/content/read",
+            {"uri": "viking://user/peers/hermes/memories/events/mem_3.md"},
+        )
+    ]
+    assert "full memory content" in context
+    assert "short abstract" not in context
+    assert "skill context" not in context
+
+
+def test_prefetch_reads_empty_abstract_content_within_budget(monkeypatch):
+    provider = _make_prefetch_provider()
+
+    captured_reads = []
+
+    class StubClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        def post(self, path, payload=None, **kwargs):
+            return {
+                "result": {
+                    "memories": [
+                        {
+                            "uri": "viking://user/peers/hermes/memories/one.md",
+                            "score": 0.9,
+                            "abstract": "",
+                        },
+                    ],
+                    "resources": [],
+                    "skills": [],
+                }
+            }
+
+        def get(self, path, params=None, **kwargs):
+            captured_reads.append((path, params or {}))
+            uri = (params or {}).get("uri", "")
+            return {"result": f"content for {uri}"}
+
+    monkeypatch.setattr(openviking_module, "_VikingClient", StubClient)
+
+    context = provider.prefetch("anything")
+
+    assert [params["uri"] for _path, params in captured_reads] == [
+        "viking://user/peers/hermes/memories/one.md",
+    ]
+    assert (
+        "content for viking://user/peers/hermes/memories/one.md"
+        in context
+    )
+
+
+def test_prefetch_caps_full_content_reads(monkeypatch):
+    provider = _make_prefetch_provider()
+
+    captured_reads = []
+
+    class StubClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        def post(self, path, payload=None, **kwargs):
+            return {
+                "result": {
+                    "memories": [
+                        {
+                            "uri": f"viking://user/peers/hermes/memories/events/mem_{idx}.md",
+                            "score": 0.9 - (idx * 0.01),
+                            "level": 2,
+                            "category": "events",
+                            "abstract": f"short abstract {idx}",
+                        }
+                        for idx in range(6)
+                    ],
+                    "resources": [],
+                    "skills": [],
+                }
+            }
+
+        def get(self, path, params=None, **kwargs):
+            captured_reads.append((path, params or {}))
+            uri = (params or {}).get("uri", "")
+            return {"result": {"content": f"full content for {uri}"}}
+
+    monkeypatch.setattr(openviking_module, "_VikingClient", StubClient)
+
+    context = provider.prefetch("anything")
+
+    assert len(captured_reads) == 2
+    assert "full content for viking://user/peers/hermes/memories/events/mem_0.md" in context
+    assert "full content for viking://user/peers/hermes/memories/events/mem_1.md" in context
+    assert "short abstract 2" in context
+
+
+def test_prefetch_uses_bounded_http_timeouts(monkeypatch):
+    provider = _make_prefetch_provider()
+
+    captured_post_kwargs = []
+    captured_get_kwargs = []
+
+    class StubClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        def post(self, path, payload=None, **kwargs):
+            captured_post_kwargs.append(kwargs)
+            return {
+                "result": {
+                    "memories": [
+                        {
+                            "uri": "viking://user/peers/hermes/memories/events/mem_timeout.md",
+                            "score": 0.9,
+                            "level": 2,
+                            "category": "events",
+                            "abstract": "short abstract",
+                        },
+                    ],
+                    "resources": [],
+                    "skills": [],
+                }
+            }
+
+        def get(self, path, params=None, **kwargs):
+            captured_get_kwargs.append(kwargs)
+            return {"result": {"content": "full memory content"}}
+
+    monkeypatch.setattr(openviking_module, "_VikingClient", StubClient)
+
+    provider.prefetch("anything", session_id="sid-123")
+
+    assert 0 < captured_post_kwargs[0]["timeout"] < openviking_module._TIMEOUT
+    assert 0 < captured_get_kwargs[0]["timeout"] < openviking_module._TIMEOUT
+
+
+def test_resolve_connection_settings_reads_config_yaml_non_secret_fields(monkeypatch):
+    """#68209: non-secret fields saved to config.yaml feed the resolution chain."""
+    _clear_openviking_env(monkeypatch)
+    provider_config = {
+        "endpoint": "http://saved.local:1933",
+        "account": "cfg-account",
+        "user": "cfg-user",
+        "agent": "cfg-agent",
+    }
+
+    settings = openviking_module._resolve_connection_settings(provider_config)
+
+    assert settings["endpoint"] == "http://saved.local:1933"
+    assert settings["account"] == "cfg-account"
+    assert settings["user"] == "cfg-user"
+    assert settings["agent"] == "cfg-agent"
+
+
+def test_env_overrides_config_yaml_non_secret_fields(monkeypatch):
+    """env still wins over config.yaml (env -> ovcli -> config.yaml -> default)."""
+    _clear_openviking_env(monkeypatch)
+    monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://env.local")
+    monkeypatch.setenv("OPENVIKING_AGENT", "env-agent")
+
+    settings = openviking_module._resolve_connection_settings(
+        {"endpoint": "http://saved.local", "agent": "cfg-agent"}
+    )
+
+    assert settings["endpoint"] == "http://env.local"
+    assert settings["agent"] == "env-agent"
+
+
+def test_is_available_true_for_config_yaml_endpoint(monkeypatch):
+    """#68209: a config.yaml endpoint (no env, no ovcli) counts as available."""
+    _clear_openviking_env(monkeypatch)
+    monkeypatch.setattr(
+        openviking_module,
+        "_load_hermes_openviking_config",
+        lambda: {"endpoint": "http://saved.local:1933"},
+    )
+    assert OpenVikingMemoryProvider().is_available() is True
+
+
+def test_is_available_false_without_any_endpoint(monkeypatch):
+    _clear_openviking_env(monkeypatch)
+    monkeypatch.setattr(
+        openviking_module, "_load_hermes_openviking_config", lambda: {}
+    )
+    assert OpenVikingMemoryProvider().is_available() is False

--- a/tests/plugins/memory/test_retaindb_provider.py
+++ b/tests/plugins/memory/test_retaindb_provider.py
@@ -38,3 +38,69 @@ def test_upload_file_allows_regular_file(tmp_path):
     provider._client.upload_file.assert_called_once()
     assert provider._client.upload_file.call_args.args[0] == note.read_bytes()
     assert result["file"]["id"] == "file-1"
+
+
+def _capture_initialized_client(monkeypatch, tmp_path):
+    """Patch _Client/_WriteQueue/get_hermes_home; return a dict capturing args."""
+    import hermes_constants
+
+    import plugins.memory.retaindb as retaindb_module
+
+    captured: dict = {}
+
+    class _FakeClient:
+        def __init__(self, api_key, base_url, project):
+            captured["api_key"] = api_key
+            captured["base_url"] = base_url
+            captured["project"] = project
+            self.project = project
+
+    monkeypatch.setattr(retaindb_module, "_Client", _FakeClient)
+    monkeypatch.setattr(retaindb_module, "_WriteQueue", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    return retaindb_module, captured
+
+
+def test_initialize_reads_base_url_and_project_from_config_yaml(tmp_path, monkeypatch):
+    """#68209: non-secret base_url/project come from config.yaml when env is unset."""
+    for var in ("RETAINDB_API_KEY", "RETAINDB_BASE_URL", "RETAINDB_PROJECT"):
+        monkeypatch.delenv(var, raising=False)
+    retaindb_module, captured = _capture_initialized_client(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        retaindb_module,
+        "_load_retaindb_config",
+        lambda: {"base_url": "https://retaindb.example.com/", "project": "cfg-project"},
+    )
+
+    RetainDBMemoryProvider().initialize("sess-1")
+
+    assert captured["base_url"] == "https://retaindb.example.com"  # trailing slash stripped
+    assert captured["project"] == "cfg-project"
+
+
+def test_initialize_env_overrides_config_yaml(tmp_path, monkeypatch):
+    for var in ("RETAINDB_API_KEY", "RETAINDB_PROJECT"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("RETAINDB_BASE_URL", "https://env.example.com")
+    retaindb_module, captured = _capture_initialized_client(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        retaindb_module,
+        "_load_retaindb_config",
+        lambda: {"base_url": "https://cfg.example.com", "project": "cfg-project"},
+    )
+
+    RetainDBMemoryProvider().initialize("sess-1")
+
+    assert captured["base_url"] == "https://env.example.com"
+
+
+def test_initialize_falls_back_to_default_base_url(tmp_path, monkeypatch):
+    for var in ("RETAINDB_API_KEY", "RETAINDB_BASE_URL", "RETAINDB_PROJECT"):
+        monkeypatch.delenv(var, raising=False)
+    retaindb_module, captured = _capture_initialized_client(monkeypatch, tmp_path)
+    monkeypatch.setattr(retaindb_module, "_load_retaindb_config", lambda: {})
+
+    RetainDBMemoryProvider().initialize("sess-1")
+
+    assert captured["base_url"] == retaindb_module._DEFAULT_BASE_URL
+    assert captured["project"] == "default"


### PR DESCRIPTION
## What does this PR do?

Two in-tree memory providers ignore the non-secret configuration the Dashboard writes to `config.yaml`, so they can't be enabled through the UI. The root cause is on the **reading** side — secrets already reach the runtime via `save_env_value()`'s `os.environ` sync; the non-secret fields (endpoint, base_url, project) are saved to `config.yaml` but never read back.

- **OpenViking** — `is_available()` only checked `OPENVIKING_ENDPOINT` and `use_ovcli_config`, so an `endpoint` saved to `memory.openviking.endpoint` reported `needs_config`. `_resolve_connection_settings()` likewise never folded `config.yaml`'s non-secret fields into its resolution chain, so even past an availability check the runtime would fall back to the default endpoint.
- **RetainDB** — `initialize()` read `base_url`/`project` from `os.environ` only, ignoring the values the Dashboard persists to `memory.retaindb.*`.

Both now resolve non-secret fields as **env → (ovcli →) config.yaml → default**; secrets continue to come from the environment only. Scoped deliberately to these two reading bugs — the issue's broader "shared config interface for all 8 providers" refactor is intentionally left out.

## Related Issue

Fixes #68209

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/openviking/__init__.py`
  - `is_available()` now returns `True` when a non-secret `endpoint` is present in `config.yaml` (not just env/ovcli).
  - `_resolve_connection_settings()` folds `config.yaml`'s non-secret fields (`endpoint`, `account`, `user`, `agent`) into the chain before the built-in default; the secret `api_key` is unchanged (env-sourced).
- `plugins/memory/retaindb/__init__.py`
  - Added `_load_retaindb_config()` (reads the `memory.retaindb` block, empty on error) and a small `_config_str()` helper.
  - `initialize()` falls back to `config.yaml` for `base_url` and `project` when the env var is unset.
- `tests/plugins/memory/test_openviking_provider.py`, `tests/plugins/memory/test_retaindb_provider.py`
  - Regression tests: config.yaml values are read back, env still overrides config.yaml, and the default fallback is preserved.

## How to Test

```bash
scripts/run_tests.sh tests/plugins/memory/test_openviking_provider.py tests/plugins/memory/test_retaindb_provider.py
```
Result: `144 tests passed, 0 failed`. The new tests fail against `upstream/main` (OpenViking `is_available()` returns `False` for a config.yaml-only endpoint; RetainDB's `initialize()` never consults `config.yaml`) and pass with this change.

Manual: set `memory.openviking.endpoint` (or `memory.retaindb.base_url`/`project`) in `config.yaml` with no matching env var — OpenViking now reports available, and RetainDB connects to the configured base URL/project instead of the defaults.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected test files and all tests pass (144 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstrings updated inline; behavior documented in code comments)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new keys; reads existing `memory.<provider>.*`)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure config-reading logic, no platform-specific paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
