### PR TITLE
fix(desktop): navigate to selected session from pages

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -72,7 +72,14 @@ import { PetGenerateOverlay } from '../pet-generate/pet-generate-overlay'
 import { FileActionDialogs } from '../right-sidebar/file-actions'
 import { RemoteFolderPicker } from '../right-sidebar/files/remote-picker'
 import { PersistentTerminal } from '../right-sidebar/terminal/persistent'
-import { CRON_ROUTE, routeSessionId, sessionRoute, SETTINGS_ROUTE, syncWorkspaceIsPage } from '../routes'
+import {
+  $workspaceIsPage,
+  CRON_ROUTE,
+  routeSessionId,
+  sessionRoute,
+  SETTINGS_ROUTE,
+  syncWorkspaceIsPage
+} from '../routes'
 import { SessionPickerOverlay } from '../session-picker-overlay'
 import { SessionSwitcher } from '../session-switcher'
 import { useBackgroundQueueDrain } from '../session/hooks/use-background-queue-drain'
@@ -755,7 +762,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     // Already on screen (open tile, or the main session)? Jump to its tab;
     // otherwise load it into main.
     onResumeSession: sessionId => {
-      if (!focusOpenSession(sessionId)) {
+      if (!focusOpenSession(sessionId, $workspaceIsPage.get())) {
         navigate(sessionRoute(sessionId))
       }
     },

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { group, split } from '@/components/pane-shell/tree/model'
 import type { SessionTile } from '@/store/session-states'
-import { orderTilesByTree, selectionHomesToWorkspace } from '@/store/session-states'
+import { mainSessionIsOnScreen, orderTilesByTree, selectionHomesToWorkspace } from '@/store/session-states'
 
 const tile = (storedSessionId: string): SessionTile => ({ storedSessionId })
 const tilePane = (id: string) => `session-tile:${id}`
@@ -29,6 +29,17 @@ describe('orderTilesByTree', () => {
     const tree = group(['workspace', tilePane('b')])
 
     expect(orderTilesByTree(tree, [tile('a'), tile('b'), tile('c')])).toEqual([tile('b'), tile('a'), tile('c')])
+  })
+})
+
+describe('mainSessionIsOnScreen', () => {
+  it('requires navigation when a full-page utility view covers the selected main session', () => {
+    expect(mainSessionIsOnScreen('selected', 'selected', true)).toBe(false)
+  })
+
+  it('recognizes the selected main session while the chat route is visible', () => {
+    expect(mainSessionIsOnScreen('selected', 'selected', false)).toBe(true)
+    expect(mainSessionIsOnScreen('other', 'selected', false)).toBe(false)
   })
 })
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -540,12 +540,23 @@ export function openSessionTile(
   }
 }
 
+/** Whether the selected primary session is actually visible in the workspace.
+ * A full-page route can cover the workspace while leaving the prior selection
+ * intact; in that state a sidebar click must navigate back to the chat route. */
+export function mainSessionIsOnScreen(
+  storedSessionId: string,
+  selectedStoredSessionId: null | string,
+  workspaceIsPage: boolean
+): boolean {
+  return storedSessionId === selectedStoredSessionId && !workspaceIsPage
+}
+
 /** If a session is already ON SCREEN — an open tile OR the one loaded in main —
  *  front its tab (and focus its zone) and return true. A sidebar click on an
  *  already-open chat JUMPS to its tab instead of reloading it; `false` means the
  *  caller must load it into main. Covers the two dead clicks: an open tile, and
  *  the main session while focus sits on a tile (route unchanged → no reload). */
-export function focusOpenSession(storedSessionId: string): boolean {
+export function focusOpenSession(storedSessionId: string, workspaceIsPage = false): boolean {
   if ($sessionTiles.get().some(t => t.storedSessionId === storedSessionId)) {
     const paneId = `${TILE_PANE_PREFIX}${storedSessionId}`
     revealTreePane(paneId) // un-dismiss + adopt + front in its group
@@ -561,7 +572,9 @@ export function focusOpenSession(storedSessionId: string): boolean {
 
   // Already the main session: front the workspace tab and drop tile focus so
   // the readouts + sidebar highlight come home (a no-op when main is focused).
-  if (storedSessionId === $selectedStoredSessionId.get()) {
+  // A full-page utility route can leave this selection intact while covering
+  // the chat; return false there so the caller navigates back to its route.
+  if (mainSessionIsOnScreen(storedSessionId, $selectedStoredSessionId.get(), workspaceIsPage)) {
     revealTreePane('workspace')
     noteActiveTreeGroup(null)
 


### PR DESCRIPTION
## What does this PR do?

Fixes a dead sidebar click in Hermes Desktop when the selected primary session is covered by a full-page route such as Capabilities, Messaging, or Artifacts.

`focusOpenSession()` previously treated the selected primary session as already on screen solely because its stored ID still matched `$selectedStoredSessionId`. Full-page routes preserve that selection while replacing the workspace contents, so the handler returned early and never navigated back to the session route.

The fix makes that short-circuit conditional on the workspace chat actually being visible. Open session tiles retain their existing focus behavior.

## Related Issue

No existing issue found after searching open/closed issues and PRs for the symptom.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Pass the authoritative `$workspaceIsPage` state into `focusOpenSession()` from the sidebar resume handler.
- Add `mainSessionIsOnScreen()` so the visibility decision is explicit and testable.
- Add regression coverage for a selected primary session hidden by a full-page utility route.

## How to Test

1. Open an existing desktop session.
2. Navigate to Capabilities, Messaging, or Artifacts.
3. Click the same selected session in the sidebar.
4. Verify the desktop navigates back to that chat instead of doing nothing.
5. Verify clicking an already-open session tile still fronts that tile.

Automated verification:

- `npx vitest run --project ui src/store/session-states.test.ts`
- `NODE_OPTIONS=--no-experimental-webstorage npm run test:ui` — 207 files passed, 1,699 tests passed, 1 skipped
- `npm run typecheck`
- `npx eslint src/store/session-states.ts src/store/session-states.test.ts src/app/contrib/wiring.tsx`
- `npm run build`

The `NODE_OPTIONS` flag is needed locally because Node 26's experimental global web storage shadows jsdom unless disabled.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] Desktop UI test suite passes (Python `pytest` is N/A for this renderer-only change)
- [x] I've added tests for my changes
- [x] I've tested on macOS 26.5.2 (Apple Silicon)

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] `cli-config.yaml.example` update — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A
- [x] Cross-platform impact considered: renderer-only route/state logic with no platform-specific behavior
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

Before: while a full-page utility view is open, clicking the currently selected session row leaves the page unchanged.

After: the same click navigates to `sessionRoute(sessionId)`; the regression test proves a covered primary session is not classified as on screen.
