### PR TITLE
fix(mcp): collapse multi-type `type` arrays in MCP tool input schemas

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -433,6 +433,60 @@ class TestSchemaConversion:
 
         assert schema["type"] == "object"
 
+    def test_multitype_array_is_collapsed_to_anyof(self):
+        """A multi-type ``type`` array must become an ``anyOf`` of single-type schemas.
+
+        Anthropic's tool ``input_schema`` validator rejects an array-valued ``type``
+        with "JSON schema is invalid. It must match JSON Schema draft 2020-12", 400ing
+        every Claude-backed provider. This is not hypothetical: GitHub's hosted MCP ships
+        ``issue_write`` with ``issue_fields[].value`` typed exactly this way. Before this
+        fix the array survived ingestion untouched (``_strip_nullable_union`` only handles
+        the ``[X, "null"]`` two-element case), and the tool 400d on first use.
+        """
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {
+                "value": {"type": ["string", "number", "boolean"]},
+            },
+        })
+
+        value = schema["properties"]["value"]
+        assert "type" not in value or not isinstance(value["type"], list)
+        assert value["anyOf"] == [
+            {"type": "string"},
+            {"type": "number"},
+            {"type": "boolean"},
+        ]
+
+    def test_nested_multitype_array_under_array_items_is_collapsed(self):
+        """The real GitHub ``issue_write`` shape: the array type is nested two levels deep
+        under ``properties.<field>.items.properties.<sub>``. The sanitizer must recurse."""
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {
+                "issue_fields": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "value": {"type": ["string", "number", "boolean"]},
+                        },
+                    },
+                },
+            },
+        })
+
+        value = schema["properties"]["issue_fields"]["items"]["properties"]["value"]
+        assert value["anyOf"] == [
+            {"type": "string"},
+            {"type": "number"},
+            {"type": "boolean"},
+        ]
+
     def test_required_pruned_when_property_missing(self):
         """Gemini 400s on required names that don't exist in properties."""
         from tools.mcp_tool import _normalize_mcp_input_schema

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4728,6 +4728,19 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
     normalized = _rewrite_local_refs(schema)
     normalized = _strip_nullable_union(normalized)
     normalized = _repair_object_shape(normalized)
+    # Collapse multi-type ``type`` arrays (e.g. ``["string", "number", "boolean"]``)
+    # into an ``anyOf`` of single-type schemas. ``_strip_nullable_union`` above only
+    # handles the two-element ``[X, "null"]`` case; a genuine multi-type array survives
+    # it untouched, and Anthropic's tool ``input_schema`` validator rejects any array
+    # ``type`` with "JSON schema is invalid. It must match JSON Schema draft 2020-12"
+    # (observed via GitHub's hosted MCP: the ``issue_write`` tool declares
+    # ``issue_fields[].value`` as ``type: ["string", "number", "boolean"]``, which 400s
+    # on every Claude-backed provider). ``_sanitize_node`` is the same routine
+    # ``sanitize_tool_schemas`` applies to non-MCP tools, so this makes MCP ingestion
+    # share that behaviour instead of diverging from it.
+    from tools.schema_sanitizer import _sanitize_node
+
+    normalized = _sanitize_node(normalized, path="<mcp>")
 
     # Ensure top-level is a well-formed object schema
     if not isinstance(normalized, dict):


### PR DESCRIPTION
## Summary

`_normalize_mcp_input_schema` runs `_strip_nullable_union` (which only handles the two-element `[X, "null"]` case) but never the **multi-type array** form, e.g. `type: ["string", "number", "boolean"]`. That form is valid JSON Schema, but **Anthropic's tool `input_schema` validator rejects any array-valued `type`** with *"JSON schema is invalid. It must match JSON Schema draft 2020-12"*, which 400s every Claude-backed provider (direct, Amazon Bedrock, Google Vertex, Azure).

## This is not hypothetical

GitHub's hosted MCP (`https://api.githubcopilot.com/mcp/`) ships the `issue_write` tool with `issue_fields[].value` typed exactly this way:

```json
"value": { "type": ["string", "number", "boolean"], "description": "Value to set..." }
```

nested two levels deep under `properties.issue_fields.items.properties.value`. With the GitHub MCP configured, the **first turn that offers the full tool list to a Claude model** fails with:

```
tools.<N>.custom.input_schema: JSON schema is invalid. It must match JSON Schema draft 2020-12
```

and the tool is unusable. Because the tool list is sent on every request, this effectively takes tool-use down for that turn.

## The fix

Route MCP ingestion through `_sanitize_node` — the same routine `sanitize_tool_schemas` already applies to non-MCP tools — so MCP schemas share that behaviour instead of diverging from it. `_sanitize_node` collapses a multi-type array into an `anyOf` of single-type schemas, **preserving every branch** (no data lost), and is a no-op for already-well-formed schemas.

The one-line pipeline addition sits after the existing steps:

```python
normalized = _rewrite_local_refs(schema)
normalized = _strip_nullable_union(normalized)
normalized = _repair_object_shape(normalized)
normalized = _sanitize_node(normalized, path="<mcp>")   # new
```

## Tests

Two tests added to `tests/tools/test_mcp_tool.py`:
- the flat case (`type: [...]` directly on a property);
- the real nested GitHub `issue_write` shape (array under `items.properties`).

Both **fail before this change** (`KeyError` — the array survives ingestion and no `anyOf` is produced) and **pass after**. The full file is green:

```
tests/tools/test_mcp_tool.py ....... 216 passed
```

Verified against the live GitHub Copilot MCP tool list (47 tools): `issue_write` is the only one carrying a multi-type array, and all 47 retain a valid object-typed top-level schema after the fix.