### PR TITLE
fix(profile): 5 UX gaps in profile switching and gateway resilience

### DIFF
--- a/contributors/emails/webtecnica.dev@users.noreply.github.com
+++ b/contributors/emails/webtecnica.dev@users.noreply.github.com
@@ -1,0 +1,2 @@
+webtecnica
+# PR #68243 fix(profile): 5 UX gaps in profile switching and gateway resilience

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2001,6 +2001,19 @@ def _own_policy_open_startup_violation(config) -> Optional[str]:
     return None
 
 
+def _disable_open_policy_platform(config, platform_value: str) -> None:
+    """Disable a platform adapter that failed its open-policy check.
+
+    Sets ``enabled=False`` on the platform config so the gateway skips
+    its adapter initialisation below.  This is a runtime-only mutation
+    — the on-disk config is never written to.
+    """
+    for platform, platform_config in getattr(config, "platforms", {}).items():
+        if platform.value == platform_value:
+            platform_config.enabled = False
+            return
+
+
 # Sentinel placed into _running_agents immediately when a session starts
 # processing, *before* any await.  Prevents a second message for the same
 # session from bypassing the "already running" guard during the async gap
@@ -7496,19 +7509,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if platform.value == platform_value:
                     allow_all_env = open_env[2]
                     break
-            logger.error(
-                "Refusing to start: %s has dm_policy/group_policy set to 'open' "
-                "but neither GATEWAY_ALLOW_ALL_USERS nor %s is enabled.",
+            logger.warning(
+                "✗ %s has dm_policy/group_policy set to 'open' "
+                "but neither GATEWAY_ALLOW_ALL_USERS nor %s is enabled. "
+                "Skipping this platform — it will be unavailable until "
+                "the allow-all flag is configured.",
                 platform_value,
                 allow_all_env or "a platform allow-all flag",
             )
-            try:
-                from gateway.status import write_runtime_status
-                write_runtime_status(gateway_state="startup_failed", exit_reason=reason)
-            except Exception:
-                pass
-            self._request_clean_exit(reason)
-            return True
+            # Remove the offending platform config so we skip its adapter
+            # initialization below, rather than killing the entire gateway.
+            # One misconfigured platform should not take down all others.
+            # See the PR description for context
+            _disable_open_policy_platform(self.config, platform_value)
         
         # Discover Python plugins before shell hooks so plugin block
         # decisions take precedence in tie cases.  The CLI startup path

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -587,9 +587,21 @@ def _apply_profile_override() -> None:
     # `hermes profile use` and the gateway should honour that choice.
     # See issue #22502.
     hermes_home_env = os.environ.get("HERMES_HOME", "")
+    hermes_profile_env = os.environ.get("HERMES_PROFILE", "").strip()
     if profile_name is None and hermes_home_env:
         if Path(hermes_home_env).parent.name == "profiles":
             return
+
+    # 1.6 No explicit flag or profile-path HERMES_HOME — check HERMES_PROFILE
+    # env var (systemd override.conf, Docker Compose, etc.).  This gives
+    # sysadmins a clean way to pin the gateway to a profile without needing
+    # the active_profile file or --profile flag.  See the PR description for context
+    if profile_name is None and hermes_profile_env:
+        import re as _profile_re
+
+        if _profile_re.match(r"^[a-z0-9][a-z0-9_-]{0,63}$", hermes_profile_env):
+            profile_name = hermes_profile_env
+            consume = 0  # not in argv, nothing to strip
 
     # 2. If no flag, check active_profile in the hermes root.
     #
@@ -11649,6 +11661,33 @@ def _coalesce_session_name_args(argv: list) -> list:
     return result
 
 
+def _try_add_root_skills_external_dir(profile_dir: Path) -> None:
+    """Add the root skills directory to the profile's skills.external_dirs.
+
+    Profiles use distinct skills/ directories; without this, skills
+    installed at the root level (e.g. delegation, subagent-dispatch)
+    are invisible to the new profile.
+    """
+    config_path = profile_dir / "config.yaml"
+    if not config_path.exists():
+        return
+    try:
+        import yaml
+        from hermes_constants import get_default_hermes_root
+
+        raw = config_path.read_text()
+        config = yaml.safe_load(raw) or {}
+        skills_cfg = config.setdefault("skills", {})
+        external = skills_cfg.setdefault("external_dirs", [])
+        root_skills = str(get_default_hermes_root() / "skills")
+
+        if root_skills not in external:
+            external.append(root_skills)
+            config_path.write_text(yaml.dump(config, default_flow_style=False))
+    except Exception:
+        pass  # best-effort — the profile still works without it
+
+
 def cmd_profile(args):
     """Profile management — create, delete, list, switch, alias."""
     from hermes_cli.profiles import (
@@ -11735,11 +11774,29 @@ def cmd_profile(args):
     elif action == "use":
         name = args.profile_name
         try:
+            old_name = get_active_profile_name()
             set_active_profile(name)
             if name == "default":
                 print("Switched to: default (~/.hermes)")
             else:
                 print(f"Switched to: {name}")
+            # Warn about per-profile data when switching away from default
+            # to a named profile.  Several data stores (webhook subscriptions,
+            # user-installed plugins, PR watch state) are scoped to
+            # HERMES_HOME and don't follow the profile switch.  See the PR description for context
+            if old_name != name and old_name != "custom":
+                print()
+                print(
+                    "  ⚠  Per-profile data does not follow the switch."
+                )
+                print(
+                    "     Webhook subscriptions, user plugins, and"
+                )
+                print(
+                    "     PR watch state live under the previous profile."
+                )
+                print(f"     Run:  hermes profile migrate {old_name} {name}")
+                print()
         except (ValueError, FileNotFoundError) as e:
             print(f"Error: {e}")
             sys.exit(1)
@@ -11809,6 +11866,29 @@ def cmd_profile(args):
                             name
                         )
                     )
+
+            # Auto-activate the profile if it's the first non-default profile.
+            # Without this, the user creates a profile but the gateway keeps
+            # running under the default profile — a silent no-op that looks
+            # like the profile wasn't created at all. See the PR description for context
+            if not (clone_config or clone_all):
+                current_active = get_active_profile_name()
+                profiles = list_profiles()
+                non_default = [p for p in profiles if not p.is_default]
+                if current_active == "default" and len(non_default) == 1:
+                    set_active_profile(name)
+                    print(
+                        f"✔ Profile '{name}' set as active "
+                        "(first non-default profile)"
+                    )
+
+            # Auto-populate skills.external_dirs so the new profile inherits
+            # skills installed at the root level (delegation, subagent-dispatch,
+            # my-prs-status, etc.). Without this, each profile has its own
+            # isolated skills/ directory and skills from the root are invisible.
+            # See the PR description for context
+            if not (clone_config or clone_all):
+                _try_add_root_skills_external_dir(profile_dir)
 
             # Create wrapper alias
             if not no_alias:

--- a/tests/gateway/test_own_policy_startup_gate.py
+++ b/tests/gateway/test_own_policy_startup_gate.py
@@ -30,8 +30,12 @@ async def test_unrelated_allow_all_does_not_bypass_yuanbao_open_gate(
     ok = await runner.start()
 
     assert ok is True
-    assert runner.should_exit_cleanly is True
-    assert "yuanbao" in (runner.exit_reason or "").lower()
+    # The PR changed this from _request_clean_exit() to
+    # _disable_open_policy_platform() — the gateway continues running,
+    # skipping the misconfigured platform instead of killing the entire
+    # gateway process.
+    assert runner.should_exit_cleanly is False
+    assert runner.config.platforms[Platform.YUANBAO].enabled is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Five independent but related fixes addressing UX gaps discovered during real-world profile switching on a production gateway instance. Each fix is scoped to a single concern and backed by existing test suites (155 profile tests + 54 gateway tests pass).

---

### 1. Auto-activate first non-default profile on create

`hermes profile create <name>` now runs `set_active_profile(name)` when the new profile is the first (and only) non-default profile.

**Before:** Create a profile, configure it with API keys and model, restart the gateway — and the gateway keeps using the default profile. No error. No warning. The `active_profile` file doesn't exist. The user's configuration is completely invisible.

**After:** First non-default profile is automatically activated with an explicit message: `✔ Profile 'webtecnica' set as active (first non-default profile)`.

### 2. Support HERMES_PROFILE env var as profile override

New step 1.6 in `_apply_profile_override()`: when no `--profile` flag is given and `HERMES_HOME` points to the default root (not a profile subdirectory), read the `HERMES_PROFILE` environment variable before falling back to the `active_profile` file.

This gives sysadmins a clean way to pin a systemd or Docker gateway to a specific profile:

```ini
[Service]
Environment=HERMES_PROFILE=webtecnica
```

**Before:** Systemd units that inherit `HERMES_HOME=/root/.hermes` from the default service template must either pass `--profile <name>` in `ExecStart` (breaking automated deployment tools that write the unit), or depend on a human having run `hermes profile use <name>` at some earlier point. Neither is reliable.

**After:** Set `HERMES_PROFILE=<name>` in the systemd override and restart — the gateway activates the profile immediately.

### 3. Auto-populate skills.external_dirs on profile creation

New profiles now get `skills.external_dirs: [/path/to/root/skills]` automatically written into their `config.yaml` on creation.

Introduces `_try_add_root_skills_external_dir()` helper.

**Before:** Each profile has its own isolated `skills/` directory. Skills installed at the Hermes root (e.g. `delegation`, `subagent-dispatch`, `my-prs-status`, `workflow`, `hermes`) are invisible to the profile. Users discover this only when the bot stops delegating tasks or monitoring PRs.

**After:** Root-level skills are inherited automatically. The external_dirs mechanism already existed and is tested — it was simply never populated.

### 4. Warn on profile switch about per-profile data

`hermes profile use <name>` now prints a warning when switching away from the default profile:

```
  ⚠  Per-profile data does not follow the switch.
     Webhook subscriptions, user plugins, and
     PR watch state live under the previous profile.
     Run:  hermes profile migrate default webtecnica
```

**Before:** Silent data fragmentation. Webhook subscriptions, user plugins, PR watch state, and cost snapshots are all resolved from `HERMES_HOME`, which changes with the profile. Users who don't know this lose access to actively-running webhooks and automated PR monitoring.

**After:** The warning appears every time you switch, pointing to the (forthcoming) migration command.

### 5. Graceful degradation on misconfigured platform adapters

When a platform adapter has `dm_policy/group_policy` set to `'open'` without the corresponding allow-all env var, the gateway previously called `_request_clean_exit()` — killing the entire gateway process and all other connected platforms over one misconfigured adapter.

Introduces `_disable_open_policy_platform()` runtime-only helper.

**Before:**
```
ERROR Refusing to start: whatsapp has dm_policy/group_policy set to 'open'...
```
Gateway exits with code 1. Systemd restarts it. Same error repeats. Infinite restart loop.

**After:**
```
WARNING  ✗ whatsapp has dm_policy/group_policy set to 'open'...
         Skipping this platform — it will be unavailable until
         the allow-all flag is configured.
```
All other platforms (Telegram, Discord, etc.) continue working normally.

## How tested

- `tests/hermes_cli/test_profiles.py` — 155/155 passed
- `tests/hermes_cli/test_apply_profile_override.py` — 12/12 passed
- `tests/gateway/test_profile_resolution.py` — 54/54 passed
- Python syntax check: `py_compile` passed on both modified files
