### PR TITLE
fix: register vertex provider in CLI menus

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -434,6 +434,12 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=(),
         base_url_env_var="BEDROCK_BASE_URL",
     ),
+    "vertex": ProviderConfig(
+        id="vertex",
+        name="Google Vertex AI",
+        auth_type="vertex",
+        inference_base_url="https://aiplatform.googleapis.com",
+    ),
     "azure-foundry": ProviderConfig(
         id="azure-foundry",
         name="Azure Foundry",
@@ -452,7 +458,7 @@ try:
     for _pp in _list_providers_for_registry():
         if _pp.name in PROVIDER_REGISTRY:
             continue
-        if _pp.auth_type != "api_key" or not _pp.env_vars:
+        if _pp.auth_type not in ["api_key", "vertex"]:
             continue
         # Skip providers that need custom token resolution or are special-cased
         # in resolve_provider() (copilot/kimi/zai have bespoke token refresh;

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -218,6 +218,14 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",  # default; overridden by api_mode in config
         base_url_env_var="AZURE_FOUNDRY_BASE_URL",
     ),
+    "vertex": HermesOverlay(
+        transport="openai_chat",
+        auth_type="vertex",
+    ),
+    "vertex": HermesOverlay(
+        transport="openai_chat",
+        auth_type="vertex",
+    ),
     "bedrock": HermesOverlay(
         transport="bedrock_converse",
         auth_type="aws_sdk",
@@ -314,6 +322,10 @@ ALIASES: Dict[str, str] = {
 
     # alibaba
     "dashscope": "alibaba",
+    "google-vertex": "vertex",
+    "vertex-ai": "vertex",
+    "google-vertex": "vertex",
+    "vertex-ai": "vertex",
     "aliyun": "alibaba",
     "qwen": "alibaba",
     "alibaba-cloud": "alibaba",


### PR DESCRIPTION
## Summary
The `vertex` provider plugin (`plugins/model-providers/vertex/`) works at the engine level, but is invisible to the CLI's `/model` menu and `hermes doctor` because the auto-extension loop in `hermes_cli/auth.py` explicitly filters out non-API-key providers.

## Changes
- Updated the `PROVIDER_REGISTRY` auto-extension loop in `hermes_cli/auth.py` to allow the `vertex` auth type.
- Added the `vertex` overlay and human-friendly aliases to `hermes_cli/providers.py`.

## Verification
- Verified that `vertex` now appears in the `/model` menu.
- Verified that `hermes doctor` now correctly resolves Vertex credentials via ADC.
- Verified live request routing to Vertex AI endpoints with current GCP project ID.