### PR TITLE
fix(dashboard): accept HERMES_DASHBOARD_PUBLIC_URL hostname in Host-header validation

### DIFF
--- a/contributors/emails/webtecnica.dev@users.noreply.github.com
+++ b/contributors/emails/webtecnica.dev@users.noreply.github.com
@@ -1,0 +1,1 @@
+webtecnica

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -397,6 +397,27 @@ _LOOPBACK_HOST_VALUES: frozenset = frozenset({
 })
 
 
+def _resolve_allowed_hosts() -> frozenset:
+    """Return hostnames from ``dashboard.public_url`` /
+    ``HERMES_DASHBOARD_PUBLIC_URL`` as a frozenset.
+
+    Used by ``_is_accepted_host`` to accept the declared public hostname
+    through a loopback-bound dashboard behind a reverse proxy (the most
+    common self-host deploy pattern).
+    """
+    try:
+        from hermes_cli.dashboard_auth.prefix import resolve_public_url
+        url = resolve_public_url()
+        if url:
+            parsed = urllib.parse.urlparse(url)
+            hostname = parsed.hostname
+            if hostname:
+                return frozenset({hostname.lower()})
+    except Exception:
+        pass
+    return frozenset()
+
+
 def should_require_auth(host: str, allow_public: bool = False) -> bool:
     """Return True iff the dashboard auth gate must be active.
 
@@ -419,7 +440,8 @@ def should_require_auth(host: str, allow_public: bool = False) -> bool:
     return host not in _LOOPBACK_HOST_VALUES
 
 
-def _is_accepted_host(host_header: str, bound_host: str) -> bool:
+def _is_accepted_host(host_header: str, bound_host: str,
+                      extra_hosts: frozenset = frozenset()) -> bool:
     """True if the Host header targets the interface we bound to.
 
     Accepts:
@@ -427,6 +449,9 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     - Loopback aliases when bound to loopback
     - Any host when bound to 0.0.0.0 (explicit opt-in to non-loopback,
       no protection possible at this layer)
+    - ``extra_hosts`` hostnames (e.g. ``dashboard.public_url``) when
+      bound to loopback — lets a reverse-proxy on the same machine
+      forward a public hostname through 127.0.0.1.
     """
     if not host_header:
         return False
@@ -438,7 +463,7 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     #   127.0.0.1:9119
     h = host_header.strip()
     if h.startswith("["):
-        # IPv6 bracketed — port (if any) follows "]:"
+        # IPv6 bracketed — port (if any) follows "]:""
         close = h.find("]")
         if close != -1:
             host_only = h[1:close]  # strip brackets
@@ -454,10 +479,15 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     if bound_host in {"0.0.0.0", "::"}:
         return True
 
-    # Loopback bind: accept the loopback names
+    # Loopback bind: accept the loopback names plus any extra hosts
+    # declared via dashboard.public_url / HERMES_DASHBOARD_PUBLIC_URL.
     bound_lc = bound_host.lower()
     if bound_lc in _LOOPBACK_HOST_VALUES:
-        return host_only in _LOOPBACK_HOST_VALUES
+        if host_only in _LOOPBACK_HOST_VALUES:
+            return True
+        if extra_hosts and host_only in extra_hosts:
+            return True
+        return False
 
     # Explicit non-loopback bind: require exact host match
     return host_only == bound_lc
@@ -480,7 +510,8 @@ async def host_header_middleware(request: Request, call_next):
     bound_host = getattr(app.state, "bound_host", None)
     if bound_host:
         host_header = request.headers.get("host", "")
-        if not _is_accepted_host(host_header, bound_host):
+        extra_hosts = getattr(app.state, "allowed_hosts", frozenset())
+        if not _is_accepted_host(host_header, bound_host, extra_hosts=extra_hosts):
             return JSONResponse(
                 status_code=400,
                 content={
@@ -19270,6 +19301,7 @@ def start_server(
     # Record the bound host so host_header_middleware can validate incoming
     # Host headers against it. Defends against DNS rebinding (GHSA-ppp5-vxwm-4cf7).
     app.state.bound_host = host
+    app.state.allowed_hosts = _resolve_allowed_hosts()
 
     # ── Start uvicorn with direct Server API ─────────────────────────
     # We use uvicorn.Server directly (not uvicorn.run) so we can split


### PR DESCRIPTION
## Summary

When the dashboard is bound to a loopback address (127.0.0.1) behind a reverse proxy (Nginx, Caddy, Traefik, etc.), the Host-header middleware rejects all proxied requests because the public hostname doesn't match any loopback alias (`localhost`, `127.0.0.1`, `::1`).

## Root Cause

`_is_accepted_host()` only accepts loopback hostnames when bound to loopback. There is no mechanism to declare additional accepted hostnames.

## Fix

Three changes in `hermes_cli/web_server.py`:

1. **`_resolve_allowed_hosts()`** — new helper that extracts the hostname from `dashboard.public_url` / `HERMES_DASHBOARD_PUBLIC_URL` env var
2. **`_is_accepted_host()`** — new optional `extra_hosts` param; when bound to loopback and the Host header isn't a loopback alias, also checks against the extra set
3. **`start_server()`** — stores `app.state.allowed_hosts` at startup so the middleware can use it

The public URL is an operator-declared config value, never extracted from request headers — so the DNS-rebinding protection (GHSA-ppp5-vxwm-4cf7) is fully preserved.

## Security

- Loopback-only behaviour is **unchanged** when `HERMES_DASHBOARD_PUBLIC_URL` / `dashboard.public_url` is unset (the default)
- Only the operator-declared value is trusted — no header-based host override
- The existing enforcement for non-loopback binds (auth gate requiring OAuth or password) is untouched

## Testing

- `http://127.0.0.1:9119/` → 200 (direct, unchanged)
- `https://public.example.com/` (via Nginx → 127.0.0.1:9119) → **200** (was 400 before the fix)
- `https://evil-attacker.com/` → 400 (rejected, DNS-rebinding still blocked)