### PR TITLE
fix(discord): add debug log when ignore-no-mention silently drops a message

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1316,6 +1316,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 free_channels = self._discord_free_response_channels()
                 channel_keys = self._discord_channel_keys(message, parent_id)
                 if "*" not in free_channels and not (channel_keys & free_channels):
+                    logger.debug(
+                        "[%s] Ignoring non-mention message in non-free-response channel (keys=%s, free_channels=%s)",
+                        self.name, channel_keys, free_channels,
+                    )
                     return False, False
 
         return True, role_authorized

--- a/tests/gateway/test_discord_ignore_no_mention_drop_log.py
+++ b/tests/gateway/test_discord_ignore_no_mention_drop_log.py
@@ -1,0 +1,67 @@
+"""Regression test for PR #68253: ignore-no-mention drops must be visible.
+
+``DiscordAdapter._discord_message_admission`` silently dropped messages that
+mention a human (but not the bot) in a non-free-response channel under
+``DISCORD_IGNORE_NO_MENTION=true`` (the default) with zero log output,
+making channel responsiveness impossible to diagnose. The fix adds a DEBUG
+diagnostic at the drop site.
+
+This test pins the behavior contract: the message is still rejected
+``(False, False)``, and the drop is now observable via caplog at DEBUG level.
+"""
+
+import logging
+from types import SimpleNamespace
+
+import discord  # Shared mock installed by tests/gateway/conftest.py
+
+from gateway.config import PlatformConfig
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+DROPPED_DIAGNOSTIC = "Ignoring non-mention message in non-free-response channel"
+
+
+def _make_adapter() -> DiscordAdapter:
+    return DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+
+def test_discord_ignore_no_mention_drop_logs_debug_and_rejects(monkeypatch, caplog):
+    """A non-free-response channel drop still rejects, and now logs at DEBUG."""
+    adapter = _make_adapter()
+    # Admission compares against the client's own user; give it a distinct bot.
+    adapter._client = SimpleNamespace(user=SimpleNamespace(id=777))
+
+    # Default DISCORD_IGNORE_NO_MENTION=true; no free-response channels.
+    monkeypatch.delenv("DISCORD_IGNORE_NO_MENTION", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    # Let the author through the allowlist so the run reaches the mention gate.
+    monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "true")
+
+    message = SimpleNamespace(
+        id="msg-ignore-no-mention-regression",
+        author=SimpleNamespace(id=42, bot=False),
+        type=discord.MessageType.default,
+        channel=SimpleNamespace(id=999, name="general", parent_id=None),
+        guild=SimpleNamespace(id=1, name="test-guild"),
+        # Mentions a human, NOT the bot and NOT another bot: this is exactly
+        # the path the ignore-no-mention gate drops in non-free channels.
+        mentions=[SimpleNamespace(id=43, bot=False)],
+        content="<@43> hello there",
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        admitted, role_authorized = adapter._discord_message_admission(
+            message, claim=False,
+        )
+
+    # Rejection result is preserved.
+    assert admitted is False
+    assert role_authorized is False
+
+    # The drop is now observable: one DEBUG record naming the channel gate.
+    drop_records = [
+        record for record in caplog.records
+        if DROPPED_DIAGNOSTIC in record.getMessage()
+    ]
+    assert len(drop_records) == 1
+    assert drop_records[0].levelno == logging.DEBUG


### PR DESCRIPTION
## Problem

`DISCORD_IGNORE_NO_MENTION` defaults to `true`, and when it drops a message, there is **zero log output**. The message arrives via `on_message`, passes through `_discord_message_admission`, and disappears at the free-response-channel check with no trace.

This cost 30+ minutes debugging a v0.19 multiplex routing setup where messages were correctly arriving at the gateway but being silently discarded. Through the REST API we could see the messages existed — but the gateway inbound log had nothing. We chased Discord permissions, bot intents, and even kicked/re-invited the bot before finding the silent filter in the adapter source.

## Root Cause

In `_discord_message_admission` (`adapter.py` L1316-1319):

```python
if ignore_no_mention and not raw_self_mention and not other_bots_mentioned:
    free_channels = self._discord_free_response_channels()
    channel_keys = self._discord_channel_keys(message, parent_id)
    if "*" not in free_channels and not (channel_keys & free_channels):
        return False, False  # silently dropped
```

Every other admission rejection path has logging. This one doesn't.

## Fix

One `logger.debug` before the return:

```python
if "*" not in free_channels and not (channel_keys & free_channels):
    logger.debug(
        "[%s] Ignoring non-mention message in non-free-response channel "
        "(keys=%s, free_channels=%s)",
        self.name, channel_keys, free_channels,
    )
    return False, False
```

Log level is **DEBUG** — zero overhead in production. The channel keys and free-response set are included so the operator can immediately diagnose the issue without reading source code.

## Why DEBUG and not INFO/WARNING?

This is a normal, intentional operational path. Many deployments deliberately use `DISCORD_IGNORE_NO_MENTION` with explicit free-response allowlists. Logging at INFO/WARNING would be noise for correct configurations. DEBUG makes it searchable when troubleshooting without polluting normal logs.

## Tested

Hit this in production during a v0.19 multiplex routing setup on a single-guild Discord server. The fix would have turned a 30-minute debugging session into a 30-second `grep`.