### PR TITLE
fix(api-server): make request body limit configurable

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -164,6 +164,17 @@ def _coerce_request_bool(value: Any, default: bool = False) -> bool:
     return default
 
 
+def _coerce_positive_int(value: Any, default: int) -> int:
+    """Parse a positive integer, falling back for malformed or unsafe values."""
+    if isinstance(value, (bool, float)):
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return parsed if parsed > 0 else default
+
+
 def _normalize_chat_content(
     content: Any, *, _max_depth: int = 10, _depth: int = 0,
 ) -> str:
@@ -751,11 +762,13 @@ if AIOHTTP_AVAILABLE:
     @web.middleware
     async def body_limit_middleware(request, handler):
         """Reject overly large request bodies early based on Content-Length."""
+        adapter = request.app.get("api_server_adapter")
+        max_request_bytes = getattr(adapter, "_max_request_bytes", MAX_REQUEST_BYTES)
         if request.method in {"POST", "PUT", "PATCH"}:
             cl = request.headers.get("Content-Length")
             if cl is not None:
                 try:
-                    if int(cl) > MAX_REQUEST_BYTES:
+                    if int(cl) > max_request_bytes:
                         return web.json_response(_openai_error("Request body too large.", code="body_too_large"), status=413)
                 except ValueError:
                     return web.json_response(_openai_error("Invalid Content-Length header.", code="invalid_content_length"), status=400)
@@ -945,6 +958,13 @@ class APIServerAdapter(BasePlatformAdapter):
         if raw_port is None:
             raw_port = os.getenv("API_SERVER_PORT", str(DEFAULT_PORT))
         self._port: int = _coerce_port(raw_port, DEFAULT_PORT)
+        self._max_request_bytes: int = _coerce_positive_int(
+            extra.get(
+                "max_request_bytes",
+                os.getenv("API_SERVER_MAX_REQUEST_BYTES", str(MAX_REQUEST_BYTES)),
+            ),
+            MAX_REQUEST_BYTES,
+        )
         self._api_key: str = extra.get("key", os.getenv("API_SERVER_KEY", ""))
         self._cors_origins: tuple[str, ...] = self._parse_cors_origins(
             extra.get("cors_origins", os.getenv("API_SERVER_CORS_ORIGINS", "")),
@@ -5400,7 +5420,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
                 if mw is not None
             ]
-            self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
+            self._app = web.Application(
+                middlewares=mws,
+                client_max_size=self._max_request_bytes,
+            )
             assert self._app is not None
             # Native routes + multiplex /p/<profile>/… mirrors. Same handlers;
             # the profile-prefix middleware validates the prefix and scopes

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4582,6 +4582,14 @@ OPTIONAL_ENV_VARS = {
         "category": "messaging",
         "advanced": True,
     },
+    "API_SERVER_MAX_REQUEST_BYTES": {
+        "description": "Maximum API server request-body size in bytes (default: 10000000). Increase for trusted local frontends that inline large images or documents.",
+        "prompt": "API server maximum request bytes",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+        "advanced": True,
+    },
     "API_SERVER_HOST": {
         "description": "Host/bind address for the API server (default: 127.0.0.1). API_SERVER_KEY is still required even on loopback binds.",
         "prompt": "API server host",

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -31,6 +31,7 @@ from gateway.platforms.api_server import (
     _IdempotencyCache,
     _derive_chat_session_id,
     _redact_api_error_text,
+    body_limit_middleware,
     check_api_server_requirements,
     cors_middleware,
     security_headers_middleware,
@@ -330,6 +331,34 @@ class TestAdapterInit:
         adapter = APIServerAdapter(config)
         assert adapter._port == 8642
 
+    def test_max_request_bytes_from_env(self, monkeypatch):
+        monkeypatch.setenv("API_SERVER_MAX_REQUEST_BYTES", "25000000")
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        assert adapter._max_request_bytes == 25_000_000
+
+    @pytest.mark.parametrize("value", ["not-a-number", "0", "-1"])
+    def test_invalid_max_request_bytes_falls_back_to_default(self, monkeypatch, value):
+        monkeypatch.setenv("API_SERVER_MAX_REQUEST_BYTES", value)
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        assert adapter._max_request_bytes == 10_000_000
+
+    @pytest.mark.parametrize(
+        "value",
+        [True, False, 1.5, float("inf"), float("-inf"), float("nan")],
+    )
+    def test_invalid_extra_max_request_bytes_falls_back_to_default(self, value):
+        adapter = APIServerAdapter(
+            PlatformConfig(enabled=True, extra={"max_request_bytes": value})
+        )
+        assert adapter._max_request_bytes == 10_000_000
+
+    def test_extra_max_request_bytes_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("API_SERVER_MAX_REQUEST_BYTES", "25000000")
+        adapter = APIServerAdapter(
+            PlatformConfig(enabled=True, extra={"max_request_bytes": 15_000_000})
+        )
+        assert adapter._max_request_bytes == 15_000_000
+
     def test_create_agent_forwards_runtime_config(self, monkeypatch):
         captured = {}
 
@@ -489,6 +518,50 @@ class TestAdapterInit:
 
         assert isinstance(agent, FakeAgent)
         assert captured["model"] == "primary/model"
+
+
+class TestBodyLimit:
+    @pytest.mark.asyncio
+    async def test_rejects_content_length_above_adapter_limit(self):
+        adapter = APIServerAdapter(
+            PlatformConfig(enabled=True, extra={"max_request_bytes": 64})
+        )
+
+        async def handler(_request):
+            return web.Response(text="ok")
+
+        app = web.Application(middlewares=[body_limit_middleware], client_max_size=1024)
+        app["api_server_adapter"] = adapter
+        app.router.add_post("/", handler)
+
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post("/", data=b"x" * 65)
+            response_status = response.status
+            response_data = await response.json()
+
+        assert response_status == 413
+        assert response_data["error"]["code"] == "body_too_large"
+
+    @pytest.mark.asyncio
+    async def test_connect_applies_adapter_limit_to_aiohttp(self):
+        adapter = APIServerAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "host": "127.0.0.1",
+                    "port": 0,
+                    "key": "sk-test-1234567890",
+                    "max_request_bytes": 64,
+                },
+            )
+        )
+
+        try:
+            assert await adapter.connect() is True
+            assert adapter._app is not None
+            assert adapter._app._client_max_size == 64
+        finally:
+            await adapter.disconnect()
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -479,6 +479,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `API_SERVER_KEY` | Bearer token for API server authentication. Required whenever the API server is enabled. |
 | `API_SERVER_CORS_ORIGINS` | Comma-separated browser origins allowed to call the API server directly (for example `http://localhost:3000,http://127.0.0.1:3000`). Default: disabled. |
 | `API_SERVER_PORT` | Port for the API server (default: `8642`) |
+| `API_SERVER_MAX_REQUEST_BYTES` | Maximum API request-body size in bytes (default: `10000000`). Raise this only for trusted clients that inline large images or documents; the limit still bounds memory use. |
 | `API_SERVER_HOST` | Host/bind address for the API server (default: `127.0.0.1`). `API_SERVER_KEY` is still required on loopback; use a narrow `API_SERVER_CORS_ORIGINS` allowlist for browser access. |
 | `API_SERVER_MODEL_NAME` | Model name advertised on `/v1/models`. Defaults to the profile name (or `hermes-agent` for the default profile). Useful for multi-user setups where frontends like Open WebUI need distinct model names per connection. |
 | `GATEWAY_PROXY_URL` | URL of a remote Hermes API server to forward messages to ([proxy mode](/user-guide/messaging/matrix#proxy-mode-e2ee-on-macos)). When set, the gateway handles platform I/O only — all agent work is delegated to the remote server. Also configurable via `gateway.proxy_url` in `config.yaml`. |

--- a/website/docs/user-guide/messaging/open-webui.md
+++ b/website/docs/user-guide/messaging/open-webui.md
@@ -195,6 +195,7 @@ With streaming enabled (the default), you'll see brief inline indicators as tool
 |----------|---------|-------------|
 | `API_SERVER_ENABLED` | `false` | Enable the API server |
 | `API_SERVER_PORT` | `8642` | HTTP server port |
+| `API_SERVER_MAX_REQUEST_BYTES` | `10000000` | Maximum request body in bytes. Increase for trusted local Open WebUI deployments that inline large images. |
 | `API_SERVER_HOST` | `127.0.0.1` | Bind address |
 | `API_SERVER_KEY` | _(required)_ | Bearer token for auth. Match `OPENAI_API_KEY`. |
 
@@ -230,6 +231,12 @@ Make sure your `OPENAI_API_KEY` in Open WebUI matches the `API_SERVER_KEY` in He
 :::warning
 Open WebUI persists OpenAI-compatible connection settings in its own database after first launch. If you accidentally saved a wrong key in the Admin UI, fixing the environment variables alone is not enough — update or delete the saved connection in **Admin Settings → Connections**, or reset the Open WebUI data directory / database.
 :::
+
+### "Request body too large" errors
+
+Open WebUI may inline attached images as Base64 data URLs in the completion request. Base64 adds about 33% overhead, so a large image can exceed Hermes's default 10 MB request limit even when separately uploaded PDFs are small.
+
+Prefer configuring Open WebUI's image-compression width and height so oversized screenshots are resized before they are sent. For trusted deployments that intentionally need larger inline payloads, set `API_SERVER_MAX_REQUEST_BYTES` to a positive byte count and restart the Hermes gateway. Keep the limit bounded: the API server may hold the request body in memory while parsing it.
 
 ## Multi-User Setup with Profiles
 


### PR DESCRIPTION
## Summary

- add `API_SERVER_MAX_REQUEST_BYTES` with a bounded 10,000,000-byte default
- support `platforms.api_server.extra.max_request_bytes` with config-over-environment precedence
- apply the resolved limit to both early `Content-Length` rejection and aiohttp `client_max_size`
- reject malformed, non-positive, boolean, fractional, and non-finite values without crashing startup
- document Open WebUI Base64 image overhead and recommend image compression before raising the limit

## Motivation

OpenAI-compatible frontends can inline attached images as Base64 data URLs. Base64 adds about 33% overhead, so a valid image plus conversation payload can exceed the existing hard-coded 10 MB request limit. Keeping 10 MB as the default preserves the current memory-safety boundary while allowing trusted deployments to raise it intentionally.

## Verification

- `tests/gateway/test_api_server.py`: **219 passed**
- related API-server suites: **152 passed**
- targeted request-limit coverage: **13 passed**
- Ruff: passed
- independent pre-commit review: passed with no security concerns, logic errors, or suggestions

The implementation was rebased onto current `main` and preserves the newer profile-prefix middleware, chunked-body 413 handling, and native route registration behavior.