### PR TITLE
PLY-324: Scaffold Fluxer plugin skeleton

### DIFF
--- a/plugins/platforms/fluxer/__init__.py
+++ b/plugins/platforms/fluxer/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/fluxer/adapter.py
+++ b/plugins/platforms/fluxer/adapter.py
@@ -1,0 +1,220 @@
+"""
+Fluxer platform adapter stub.
+
+Fluxer is an open-source Discord alternative (https://github.com/fluxer).
+This adapter provides the skeleton for connecting Hermes to a Fluxer
+instance via WebSocket gateway (real-time) and REST API (cron/standalone).
+
+Environment variables:
+    FLUXER_BOT_TOKEN          Bot authentication token
+    FLUXER_API_URL            Base URL of the Fluxer API (e.g. https://fluxer.example.com)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+# ---------------------------------------------------------------------------
+# Ensure Hermes core is importable when loaded as a bundled plugin
+# ---------------------------------------------------------------------------
+_HERMES_ROOT = Path(__file__).resolve().parents[3]
+if str(_HERMES_ROOT) not in sys.path:
+    sys.path.insert(0, str(_HERMES_ROOT))
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---- Optional dependency guards -------------------------------------------
+
+try:
+    import websockets  # noqa: F401
+
+    WEBSOCKETS_AVAILABLE = True
+except ImportError:
+    WEBSOCKETS_AVAILABLE = False
+    websockets = None  # type: ignore[assignment]
+
+try:
+    import httpx  # noqa: F401
+
+    HTTPX_AVAILABLE = True
+except ImportError:
+    HTTPX_AVAILABLE = False
+    httpx = None  # type: ignore[assignment]
+
+# ---- Class stubs ----------------------------------------------------------
+
+
+class FluxerGatewayClient:
+    """Manages a WebSocket connection to the Fluxer gateway.
+
+    Responsible for:
+    - Establishing and maintaining the WebSocket connection
+    - Receiving real-time events (messages, presence, etc.)
+    - Heartbeat / keep-alive handling
+    - Reconnection with exponential backoff
+    """
+
+    def __init__(self, token: str, api_url: str) -> None:
+        self.token = token
+        self.api_url = api_url.rstrip("/")
+        self._connected = False
+
+    async def connect(self) -> bool:
+        """Open the WebSocket connection and authenticate."""
+        raise NotImplementedError  # pragma: no cover
+
+    async def disconnect(self) -> None:
+        """Close the WebSocket connection gracefully."""
+        raise NotImplementedError  # pragma: no cover
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+
+class FluxerRESTClient:
+    """HTTP client for the Fluxer REST API.
+
+    Used for out-of-process operations such as:
+    - Sending messages from cron jobs (standalone sender)
+    - Channel / guild metadata queries
+    - File uploads
+    """
+
+    def __init__(self, token: str, api_url: str) -> None:
+        self.token = token
+        self.api_url = api_url.rstrip("/")
+
+    async def send_message(
+        self, channel_id: str, content: str, **kwargs: Any
+    ) -> Dict[str, Any]:
+        """Post a message to a Fluxer channel via REST."""
+        raise NotImplementedError  # pragma: no cover
+
+
+class FluxerAdapter(BasePlatformAdapter):
+    """Platform adapter for the Fluxer messaging platform.
+
+    Integrates Hermes with a Fluxer instance through a WebSocket gateway
+    (real-time messaging) and REST API (standalone / cron delivery).
+    """
+
+    supports_code_blocks: bool = True
+    supports_async_delivery: bool = True
+    splits_long_messages: bool = True
+    typed_command_prefix: str = "/"
+
+    def __init__(self, config: PlatformConfig) -> None:
+        super().__init__(config)
+        self._token: str = os.environ.get("FLUXER_BOT_TOKEN", "")
+        self._api_url: str = os.environ.get(
+            "FLUXER_API_URL", "http://localhost:8090"
+        )
+        self._gateway: Optional[FluxerGatewayClient] = None
+        self._rest: Optional[FluxerRESTClient] = None
+
+    # ---- BasePlatformAdapter abstract methods -----------------------------
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """Connect to the Fluxer instance.
+
+        Initialises the gateway client and opens the WebSocket connection.
+        On reconnect (is_reconnect=True), applies backoff / state recovery.
+        """
+        self._gateway = FluxerGatewayClient(self._token, self._api_url)
+        self._rest = FluxerRESTClient(self._token, self._api_url)
+        connected = await self._gateway.connect()
+        if connected:
+            logger.info(
+                "Fluxer adapter %s to %s",
+                "reconnected" if is_reconnect else "connected",
+                self._api_url,
+            )
+        return connected
+
+    async def disconnect(self) -> None:
+        """Disconnect from the Fluxer instance."""
+        if self._gateway is not None:
+            await self._gateway.disconnect()
+            self._gateway = None
+
+    async def send(
+        self,
+        message: str,
+        channel_id: str,
+        message_type: MessageType = MessageType.TEXT,
+        event: Optional[MessageEvent] = None,
+        **kwargs: Any,
+    ) -> SendResult:
+        """Send a message to a Fluxer channel.
+
+        Attempts gateway (WebSocket) delivery first; falls back to REST
+        if the gateway is not connected.
+        """
+        raise NotImplementedError  # pragma: no cover
+
+    async def send_media(
+        self,
+        file_path: str,
+        channel_id: str,
+        caption: Optional[str] = None,
+        **kwargs: Any,
+    ) -> SendResult:
+        """Upload and send a media file to a Fluxer channel."""
+        raise NotImplementedError  # pragma: no cover
+
+    def is_alive(self) -> bool:
+        """Return whether the adapter is currently connected."""
+        return self._gateway is not None and self._gateway.is_connected
+
+    def get_me(self) -> Optional[Dict[str, Any]]:
+        """Return the bot user's identity metadata, or None if unknown."""
+        return None  # pragma: no cover
+
+
+# ---- Requirements check ---------------------------------------------------
+
+
+def check_fluxer_requirements() -> bool:
+    """Return True when all required dependencies are available.
+
+    Must be silent (no WARNING-level logging) since it is called
+    frequently during config loading.
+    """
+    return WEBSOCKETS_AVAILABLE and HTTPX_AVAILABLE
+
+
+def _is_connected(config: PlatformConfig) -> bool:
+    """Return whether the Fluxer adapter appears configured and connected."""
+    token = os.environ.get("FLUXER_BOT_TOKEN", "")
+    api_url = os.environ.get("FLUXER_API_URL", "")
+    return bool(token) and bool(api_url)
+
+
+# ---- Plugin entry point ---------------------------------------------------
+
+
+def register(ctx) -> None:
+    """Plugin entry point — called by the Hermes plugin system."""
+    ctx.register_platform(
+        name="fluxer",
+        label="Fluxer",
+        adapter_factory=lambda cfg: FluxerAdapter(cfg),
+        check_fn=check_fluxer_requirements,
+        is_connected=_is_connected,
+        required_env=["FLUXER_BOT_TOKEN", "FLUXER_API_URL"],
+        install_hint="pip install 'hermes-agent[fluxer]'",
+        emoji="💬",
+    )

--- a/plugins/platforms/fluxer/plugin.yaml
+++ b/plugins/platforms/fluxer/plugin.yaml
@@ -1,0 +1,31 @@
+name: fluxer-platform
+label: Fluxer
+kind: platform
+version: 1.0.0
+description: >
+  Fluxer gateway adapter for Hermes Agent.
+  Connects to a Fluxer instance via WebSocket gateway (real-time messages)
+  and REST API (cron/standalone delivery). Fluxer is an open-source Discord
+  alternative that supports guilds, channels, threads, and voice.
+author: Hermes
+requires_env:
+  - name: FLUXER_BOT_TOKEN
+    description: "Fluxer bot authentication token"
+    prompt: "Fluxer bot token"
+    password: true
+  - name: FLUXER_API_URL
+    description: "Base URL of the Fluxer API (e.g. https://fluxer.example.com)"
+    prompt: "Fluxer API URL"
+    password: false
+optional_env:
+  - name: FLUXER_HOME_CHANNEL
+    description: "Default channel ID for cron / notification delivery"
+    prompt: "Home channel ID"
+    password: false
+  - name: FLUXER_HOME_CHANNEL_NAME
+    description: "Display name for the Fluxer home channel"
+    prompt: "Home channel display name"
+    password: false
+pip_dependencies:
+  - websockets>=14.0
+  - httpx>=0.27.0

--- a/tests/plugins/test_fluxer_plugin.py
+++ b/tests/plugins/test_fluxer_plugin.py
@@ -1,0 +1,152 @@
+"""Tests for the bundled fluxer platform plugin."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_DIR = REPO_ROOT / "plugins" / "platforms" / "fluxer"
+
+
+def test_plugin_yaml_exists_and_has_required_fields():
+    """Verify plugin.yaml has correct metadata and env var declarations."""
+    yaml_path = PLUGIN_DIR / "plugin.yaml"
+    assert yaml_path.exists(), f"Missing {yaml_path}"
+
+    data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+
+    assert data["name"] == "fluxer-platform"
+    assert data["label"] == "Fluxer"
+    assert data["kind"] == "platform"
+    assert data["version"] == "1.0.0"
+
+    # Required env vars
+    env_names = {env["name"] for env in data.get("requires_env", [])}
+    assert "FLUXER_BOT_TOKEN" in env_names
+    assert "FLUXER_API_URL" in env_names
+
+    # Optional env vars
+    opt_env_names = {env["name"] for env in data.get("optional_env", [])}
+    assert "FLUXER_HOME_CHANNEL" in opt_env_names
+
+    # Dependencies listed
+    assert "pip_dependencies" in data
+
+
+def test_init_exports_register():
+    """__init__.py imports and re-exports register from adapter."""
+    from plugins.platforms.fluxer import register
+
+    assert callable(register)
+
+
+def test_register_calls_register_platform():
+    """register() calls ctx.register_platform() with the right shape."""
+    from plugins.platforms.fluxer.adapter import register
+
+    calls = []
+
+    class FakeCtx:
+        def register_platform(self, *args, **kwargs):
+            calls.append(("register_platform", kwargs))
+
+    ctx = FakeCtx()
+    register(ctx)
+
+    assert len(calls) == 1
+    _, kwargs = calls[0]
+    assert kwargs["name"] == "fluxer"
+    assert kwargs["label"] == "Fluxer"
+    assert callable(kwargs["adapter_factory"])
+    assert callable(kwargs["check_fn"])
+    assert callable(kwargs["is_connected"])
+    assert "FLUXER_BOT_TOKEN" in kwargs.get("required_env", [])
+
+
+def test_adapter_stub_classes_exist():
+    """All three stub classes exist and have expected signatures."""
+    from plugins.platforms.fluxer.adapter import (
+        FluxerAdapter,
+        FluxerGatewayClient,
+        FluxerRESTClient,
+    )
+
+    # FluxerGatewayClient
+    assert hasattr(FluxerGatewayClient, "__init__")
+    assert hasattr(FluxerGatewayClient, "connect")
+    assert hasattr(FluxerGatewayClient, "disconnect")
+    assert hasattr(FluxerGatewayClient, "is_connected")
+
+    # FluxerRESTClient
+    assert hasattr(FluxerRESTClient, "__init__")
+    assert hasattr(FluxerRESTClient, "send_message")
+
+    # FluxerAdapter
+    assert issubclass(FluxerAdapter, object)  # would need BasePlatformAdapter import
+    assert hasattr(FluxerAdapter, "__init__")
+    assert hasattr(FluxerAdapter, "connect")
+    assert hasattr(FluxerAdapter, "disconnect")
+    assert hasattr(FluxerAdapter, "send")
+    assert hasattr(FluxerAdapter, "send_media")
+    assert hasattr(FluxerAdapter, "is_alive")
+    assert hasattr(FluxerAdapter, "get_me")
+
+
+def test_check_fluxer_requirements_returns_bool():
+    """check_fn returns a boolean without error."""
+    from plugins.platforms.fluxer.adapter import check_fluxer_requirements
+
+    result = check_fluxer_requirements()
+    assert isinstance(result, bool)
+
+
+def test_is_connected_checks_env_vars(monkeypatch):
+    """_is_connected returns False when env vars are missing."""
+    from plugins.platforms.fluxer.adapter import _is_connected
+    from gateway.config import PlatformConfig
+
+    monkeypatch.delenv("FLUXER_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("FLUXER_API_URL", raising=False)
+
+    config = PlatformConfig()
+    assert _is_connected(config) is False
+
+
+def test_is_connected_returns_true_when_env_set(monkeypatch):
+    """_is_connected returns True when required env vars are set."""
+    from plugins.platforms.fluxer.adapter import _is_connected
+    from gateway.config import PlatformConfig
+
+    monkeypatch.setenv("FLUXER_BOT_TOKEN", "test-token")
+    monkeypatch.setenv("FLUXER_API_URL", "https://fluxer.example.com")
+
+    config = PlatformConfig()
+    assert _is_connected(config) is True
+
+
+def _reset_bundled_cache(monkeypatch):
+    """Reset the module-level bundled plugin names cache."""
+    import gateway.config as cfg
+
+    monkeypatch.setattr(cfg, "_Platform__bundled_plugin_names", None)
+
+
+def test_discoverable_as_bundled_plugin(monkeypatch):
+    """Plugin is discoverable by Platform._scan_bundled_plugin_platforms()."""
+    from gateway.config import Platform
+
+    _reset_bundled_cache(monkeypatch)
+    names = Platform._scan_bundled_plugin_platforms()
+    assert "fluxer" in names
+
+
+def test_platform_enum_accepts_fluxer(monkeypatch):
+    """Platform('fluxer') creates a dynamic member without error."""
+    from gateway.config import Platform
+
+    _reset_bundled_cache(monkeypatch)
+    p = Platform("fluxer")
+    assert p.value == "fluxer"


### PR DESCRIPTION
## Changes

Created the Fluxer platform plugin structure at `plugins/platforms/fluxer/` following the existing Discord/Matrix plugin pattern:

- **`__init__.py`** — Imports and re-exports `register` from adapter module
- **`plugin.yaml`** — Metadata (name: fluxer-platform, label: Fluxer, version 1.0.0), required env vars (`FLUXER_BOT_TOKEN`, `FLUXER_API_URL`), optional env vars (`FLUXER_HOME_CHANNEL`, `FLUXER_HOME_CHANNEL_NAME`), and pip dependencies (`websockets>=14.0`, `httpx>=0.27.0`)
- **`adapter.py`** — Stub classes:
  - `FluxerGatewayClient` — WebSocket gateway connection management
  - `FluxerRESTClient` — REST API client for standalone/cron operations
  - `FluxerAdapter` — Extends `BasePlatformAdapter` with stub methods for connect/disconnect/send/send_media
- **Plugin registration** — `register()` calls `ctx.register_platform()` with factory, check_fn, is_connected, required_env, install_hint
- **Tests** — `tests/plugins/test_fluxer_plugin.py` with 9 tests covering YAML validation, import, register() contract, class stubs, check_fn, is_connected, bundled plugin discovery, and Platform enum acceptance

Plugin is auto-discovered by `Platform._scan_bundled_plugin_platforms()` since `plugins/platforms/fluxer/` contains `__init__.py` and `plugin.yaml`.

## Testing

\`\`\`
$ python -m pytest tests/plugins/test_fluxer_plugin.py -v
9 passed in 5.32s

$ python -m pytest tests/gateway/test_platform_registry.py -v
50 passed (no regressions)
\`\`\`

## Notes

- All three stub classes use `raise NotImplementedError` with `# pragma: no cover` — this is a skeleton meant to be filled by PLY-325 (REST client) and PLY-326 (WebSocket gateway)
- Assumption: Fluxer API follows the typical WebSocket gateway + REST API pattern (like Discord)
- Required env vars declared in plugin.yaml: FLUXER_BOT_TOKEN, FLUXER_API_URL

Fixes PLY-324