### PR TITLE
fix(tui): persist session workspace metadata

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2435,7 +2435,7 @@ class SessionDB:
     def update_session_cwd(
         self, session_id: str, cwd: str, git_branch: str = None, git_repo_root: str = None
     ) -> None:
-        """Persist the session working directory when a frontend knows it.
+        """Persist the session working directory and matching git metadata.
 
         ``git_branch`` records the git branch checked out in ``cwd`` at the time
         the session started/resumed. The sidebar groups main-checkout sessions
@@ -2444,31 +2444,82 @@ class SessionDB:
         misattribute past sessions).
 
         ``git_repo_root`` records the git repo this cwd belongs to — the
-        authoritative project key. Resolving it here, at the lowest level, means
-        every surface reads the same membership instead of re-probing git in the
-        GUI over a partial page. Each field is only written when non-empty so a
-        probe failure never clobbers a previously-captured value.
+        authoritative project key. When the cwd changes, absent metadata clears
+        both old values so a non-git directory cannot inherit the previous
+        repository. When the cwd is unchanged, absent metadata preserves values
+        from an earlier successful probe. The CASE expressions and cwd update
+        execute as one SQL UPDATE to avoid a read-then-write race.
         """
         if not session_id or not cwd:
             return
 
-        branch = (git_branch or "").strip()
-        repo_root = (git_repo_root or "").strip()
+        branch = (git_branch or "").strip() or None
+        repo_root = (git_repo_root or "").strip() or None
 
+        # SQLite evaluates each SET expression against the row being updated,
+        # allowing the CASE predicates to distinguish a cwd change atomically.
         sets = ["cwd = ?"]
         params: List[Any] = [cwd]
-        if branch:
-            sets.append("git_branch = ?")
-            params.append(branch)
-        if repo_root:
-            sets.append("git_repo_root = ?")
-            params.append(repo_root)
+        sets.append(
+            "git_branch = CASE WHEN cwd = ? AND ? IS NULL THEN git_branch ELSE ? END"
+        )
+        params.extend((cwd, branch, branch))
+        sets.append(
+            "git_repo_root = CASE WHEN cwd = ? AND ? IS NULL THEN git_repo_root ELSE ? END"
+        )
+        params.extend((cwd, repo_root, repo_root))
         params.append(session_id)
 
         def _do(conn):
             conn.execute(f"UPDATE sessions SET {', '.join(sets)} WHERE id = ?", params)
 
         self._execute_write(_do)
+
+    def update_session_git_meta_if_cwd_matches(
+        self,
+        session_id: str,
+        expected_cwd: str,
+        git_branch: str = None,
+        git_repo_root: str = None,
+    ) -> bool:
+        """Persist non-empty git metadata only for the current session cwd.
+
+        The id and cwd predicate are evaluated in the same UPDATE as the
+        metadata write, so a stale asynchronous probe cannot overwrite a newer
+        cwd or its git metadata.  The cwd column is intentionally never part of
+        this update.
+        """
+        if not session_id or not expected_cwd:
+            return False
+
+        branch = (git_branch or "").strip()
+        repo_root = (git_repo_root or "").strip()
+        if not (branch or repo_root):
+            return False
+
+        sets = []
+        params: List[Any] = []
+        if branch:
+            sets.append("git_branch = ?")
+            params.append(branch)
+        if repo_root:
+            sets.append("git_repo_root = ?")
+            params.append(repo_root)
+        params.extend((session_id, expected_cwd))
+
+        def _do(conn):
+            cursor = conn.execute(
+                f"UPDATE sessions SET {', '.join(sets)} "
+                "WHERE id = ? AND cwd = ?",
+                params,
+            )
+            return cursor.rowcount
+
+        try:
+            rows = self._execute_write(_do)
+            return bool(rows)
+        except Exception:
+            return False
 
     def backfill_repo_roots(self, cwd_to_root: Dict[str, str]) -> None:
         """Persist resolved git repo roots for cwds that don't have one yet.

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -162,12 +162,82 @@ class TestSessionLifecycle:
 
         assert db.get_session("s1")["git_repo_root"] == "/work/repo"
 
+    def test_update_session_cwd_clears_stale_git_metadata_when_cwd_changes(self, db):
+        db.create_session(session_id="s1", source="cli", cwd="/work/repo-a")
+        db.update_session_cwd(
+            "s1", "/work/repo-a", git_branch="feature-a", git_repo_root="/work/repo-a"
+        )
+
+        db.update_session_cwd("s1", "/work/not-a-repo")
+
+        session = db.get_session("s1")
+        assert session["cwd"] == "/work/not-a-repo"
+        assert session["git_branch"] is None
+        assert session["git_repo_root"] is None
+
+    def test_update_session_cwd_installs_new_git_metadata_when_cwd_changes(self, db):
+        db.create_session(session_id="s1", source="cli", cwd="/work/repo-a")
+        db.update_session_cwd(
+            "s1", "/work/repo-a", git_branch="feature-a", git_repo_root="/work/repo-a"
+        )
+
+        db.update_session_cwd(
+            "s1",
+            "/work/repo-b/src",
+            git_branch="feature-b",
+            git_repo_root="/work/repo-b",
+        )
+
+        session = db.get_session("s1")
+        assert session["cwd"] == "/work/repo-b/src"
+        assert session["git_branch"] == "feature-b"
+        assert session["git_repo_root"] == "/work/repo-b"
+
+    def test_update_session_cwd_same_cwd_without_git_metadata_preserves_values(self, db):
+        db.create_session(session_id="s1", source="cli", cwd="/work/repo-a")
+        db.update_session_cwd(
+            "s1", "/work/repo-a", git_branch="feature-a", git_repo_root="/work/repo-a"
+        )
+
+        db.update_session_cwd("s1", "/work/repo-a")
+
+        session = db.get_session("s1")
+        assert session["cwd"] == "/work/repo-a"
+        assert session["git_branch"] == "feature-a"
+        assert session["git_repo_root"] == "/work/repo-a"
+
     def test_update_session_cwd_empty_repo_root_does_not_clobber(self, db):
         db.create_session(session_id="s1", source="cli")
         db.update_session_cwd("s1", "/work/repo", git_repo_root="/work/repo")
         db.update_session_cwd("s1", "/work/repo", git_repo_root="")
 
         assert db.get_session("s1")["git_repo_root"] == "/work/repo"
+
+    def test_update_session_git_meta_if_cwd_matches_updates_metadata(self, db):
+        db.create_session(session_id="s1", source="cli", cwd="/work/repo")
+
+        updated = db.update_session_git_meta_if_cwd_matches(
+            "s1", "/work/repo", git_branch="feature", git_repo_root="/work"
+        )
+
+        assert updated is True
+        session = db.get_session("s1")
+        assert session["cwd"] == "/work/repo"
+        assert session["git_branch"] == "feature"
+        assert session["git_repo_root"] == "/work"
+
+    def test_update_session_git_meta_if_cwd_matches_rejects_mismatch(self, db):
+        db.create_session(session_id="s1", source="cli", cwd="/work/new")
+
+        updated = db.update_session_git_meta_if_cwd_matches(
+            "s1", "/work/old", git_branch="stale", git_repo_root="/old"
+        )
+
+        assert updated is False
+        session = db.get_session("s1")
+        assert session["cwd"] == "/work/new"
+        assert session["git_branch"] is None
+        assert session["git_repo_root"] is None
 
     def test_distinct_session_cwds_aggregates_history(self, db):
         db.create_session("s1", "cli", cwd="/repo")

--- a/tests/tui_gateway/test_session_metadata.py
+++ b/tests/tui_gateway/test_session_metadata.py
@@ -1,0 +1,471 @@
+from __future__ import annotations
+
+import threading
+import types
+
+import pytest
+
+from hermes_state import SessionDB
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from tui_gateway import server
+from tui_gateway.transport import TeeTransport
+
+
+class _WebSocketTransport:
+    def write(self, _obj: dict) -> bool:
+        return True
+
+    def close(self) -> None:
+        return None
+
+
+@pytest.fixture()
+def gateway_db(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    token = set_hermes_home_override(home)
+    db = SessionDB(db_path=home / "state.db")
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test/model")
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *_args, **_kwargs: None)
+    for session in list(server._sessions.values()):
+        server._teardown_session(session)
+    server._sessions.clear()
+    try:
+        yield db
+    finally:
+        for session in list(server._sessions.values()):
+            server._teardown_session(session)
+        server._sessions.clear()
+        db.close()
+        reset_hermes_home_override(token)
+
+
+def test_stdio_session_persists_launch_cwd_on_first_prompt(gateway_db, monkeypatch, tmp_path):
+    launch_cwd = tmp_path / "launch"
+    launch_cwd.mkdir()
+    monkeypatch.chdir(launch_cwd)
+    monkeypatch.delenv("HERMES_CWD", raising=False)
+    monkeypatch.setattr(server, "current_transport", lambda: server._stdio_transport)
+
+    response = server._methods["session.create"]("create", {})
+    sid = response["result"]["session_id"]
+    session_key = response["result"]["stored_session_id"]
+
+    assert gateway_db.get_session(session_key) is None
+
+    server._ensure_session_db_row(server._sessions[sid])
+
+    row = gateway_db.get_session(session_key)
+    assert row is not None
+    assert row["cwd"] == str(launch_cwd)
+
+
+def test_stdio_session_uses_hermes_cwd_over_configured_terminal_cwd(
+    gateway_db, monkeypatch, tmp_path
+):
+    configured_cwd = tmp_path / "configured"
+    launch_cwd = tmp_path / "launch"
+    configured_cwd.mkdir()
+    launch_cwd.mkdir()
+    monkeypatch.chdir(launch_cwd)
+    monkeypatch.setenv("HERMES_CWD", str(launch_cwd))
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"terminal": {"cwd": str(configured_cwd)}},
+    )
+    monkeypatch.setattr(server, "current_transport", lambda: server._stdio_transport)
+
+    response = server._methods["session.create"]("create", {})
+    sid = response["result"]["session_id"]
+    session_key = response["result"]["stored_session_id"]
+
+    assert response["result"]["info"]["cwd"] == str(launch_cwd)
+
+    server._ensure_session_db_row(server._sessions[sid])
+
+    row = gateway_db.get_session(session_key)
+    assert row is not None
+    assert row["cwd"] == str(launch_cwd)
+
+
+def test_tee_wrapped_stdio_session_uses_hermes_cwd_over_configured_terminal_cwd(
+    gateway_db, monkeypatch, tmp_path
+):
+    configured_cwd = tmp_path / "configured"
+    launch_cwd = tmp_path / "launch"
+    configured_cwd.mkdir()
+    launch_cwd.mkdir()
+    monkeypatch.chdir(configured_cwd)
+    monkeypatch.setenv("HERMES_CWD", str(launch_cwd))
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"terminal": {"cwd": str(configured_cwd)}},
+    )
+    tee = TeeTransport(server._stdio_transport, _WebSocketTransport())
+    monkeypatch.setattr(server, "current_transport", lambda: tee)
+
+    response = server._methods["session.create"]("create-tee", {})
+    sid = response["result"]["session_id"]
+    session_key = response["result"]["stored_session_id"]
+
+    assert response["result"]["info"]["cwd"] == str(launch_cwd)
+
+    server._ensure_session_db_row(server._sessions[sid])
+
+    row = gateway_db.get_session(session_key)
+    assert row is not None
+    assert row["cwd"] == str(launch_cwd)
+
+
+def test_websocket_session_without_cwd_stays_unbound_but_explicit_cwd_persists(
+    gateway_db, monkeypatch, tmp_path
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    transport = _WebSocketTransport()
+    monkeypatch.setattr(server, "current_transport", lambda: transport)
+
+    unbound = server._methods["session.create"]("create-unbound", {})
+    unbound_sid = unbound["result"]["session_id"]
+    unbound_key = unbound["result"]["stored_session_id"]
+    server._ensure_session_db_row(server._sessions[unbound_sid])
+
+    explicit = server._methods["session.create"](
+        "create-explicit", {"cwd": str(workspace)}
+    )
+    explicit_sid = explicit["result"]["session_id"]
+    explicit_key = explicit["result"]["stored_session_id"]
+    server._ensure_session_db_row(server._sessions[explicit_sid])
+
+    assert gateway_db.get_session(unbound_key)["cwd"] is None
+    assert gateway_db.get_session(explicit_key)["cwd"] == str(workspace)
+
+
+def test_lazy_row_git_enrichment_runs_after_row_creation(gateway_db, monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setattr(server, "current_transport", lambda: server._stdio_transport)
+
+    started = threading.Event()
+    completed = threading.Event()
+    session_key = ""
+
+    original_update = gateway_db.update_session_git_meta_if_cwd_matches
+
+    def update_and_signal(*args, **kwargs):
+        result = original_update(*args, **kwargs)
+        completed.set()
+        return result
+
+    monkeypatch.setattr(
+        gateway_db,
+        "update_session_git_meta_if_cwd_matches",
+        update_and_signal,
+    )
+
+    def branch(_cwd):
+        if session_key:
+            assert gateway_db.get_session(session_key) is not None
+            started.set()
+        return "task-02"
+
+    monkeypatch.setattr(server, "_git_branch_for_cwd", branch)
+    monkeypatch.setattr(server, "_git_common_repo_root_for_cwd", lambda _cwd: str(repo))
+
+    response = server._methods["session.create"]("create", {"cwd": str(repo)})
+    sid = response["result"]["session_id"]
+    session_key = response["result"]["stored_session_id"]
+
+    server._ensure_session_db_row(server._sessions[sid])
+
+    assert started.wait(timeout=2)
+    assert completed.wait(timeout=2)
+    row = gateway_db.get_session(session_key)
+    assert row is not None
+    assert row["cwd"] == str(repo)
+    assert row["git_branch"] == "task-02"
+    assert row["git_repo_root"] == str(repo)
+
+
+def test_async_git_enrichment_rejects_stale_cwd_after_session_move(
+    gateway_db, monkeypatch, tmp_path
+):
+    cwd_a = tmp_path / "a"
+    cwd_b = tmp_path / "b"
+    cwd_a.mkdir()
+    cwd_b.mkdir()
+    monkeypatch.setattr(server, "current_transport", lambda: server._stdio_transport)
+
+    a_started = threading.Event()
+    release_a = threading.Event()
+    a_update_attempted = threading.Event()
+    b_update_completed = threading.Event()
+
+    def branch(cwd):
+        if cwd == str(cwd_a):
+            a_started.set()
+            assert release_a.wait(timeout=2)
+            return "branch-a"
+        assert cwd == str(cwd_b)
+        return "branch-b"
+
+    monkeypatch.setattr(server, "_git_branch_for_cwd", branch)
+    monkeypatch.setattr(
+        server,
+        "_git_common_repo_root_for_cwd",
+        lambda cwd: str(tmp_path / cwd.split("/")[-1]),
+    )
+
+    original_update = gateway_db.update_session_git_meta_if_cwd_matches
+
+    def update_and_signal(session_key, cwd, *args, **kwargs):
+        result = original_update(session_key, cwd, *args, **kwargs)
+        if cwd == str(cwd_a):
+            a_update_attempted.set()
+        elif cwd == str(cwd_b):
+            b_update_completed.set()
+        return result
+
+    monkeypatch.setattr(
+        gateway_db,
+        "update_session_git_meta_if_cwd_matches",
+        update_and_signal,
+    )
+
+    response = server._methods["session.create"]("create", {"cwd": str(cwd_a)})
+    sid = response["result"]["session_id"]
+    session_key = response["result"]["stored_session_id"]
+    session = server._sessions[sid]
+
+    server._ensure_session_db_row(session)
+    assert a_started.wait(timeout=2)
+
+    try:
+        server._set_session_cwd(session, str(cwd_b))
+        assert b_update_completed.wait(timeout=2)
+        row = gateway_db.get_session(session_key)
+        assert row["cwd"] == str(cwd_b)
+        assert row["git_branch"] == "branch-b"
+        assert row["git_repo_root"] == str(cwd_b)
+
+        release_a.set()
+        assert a_update_attempted.wait(timeout=2)
+        row = gateway_db.get_session(session_key)
+        assert row["cwd"] == str(cwd_b)
+        assert row["git_branch"] == "branch-b"
+        assert row["git_repo_root"] == str(cwd_b)
+    finally:
+        release_a.set()
+
+
+def test_resume_preserves_stored_cwd(gateway_db, monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    session_key = "resume-cwd"
+    gateway_db.create_session(session_key, source="cli", cwd=str(workspace))
+    gateway_db.append_message(session_key, "user", "hello")
+    monkeypatch.setattr(server, "current_transport", lambda: server._stdio_transport)
+
+    response = server._methods["session.resume"](
+        "resume", {"session_id": session_key}
+    )
+
+    sid = response["result"]["session_id"]
+    assert server._sessions[sid]["cwd"] == str(workspace)
+    assert response["result"]["info"]["cwd"] == str(workspace)
+
+
+def test_session_cwd_set_lazy_response_does_not_probe_git_synchronously(
+    gateway_db, monkeypatch, tmp_path
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    transport = _WebSocketTransport()
+    monkeypatch.setattr(server, "current_transport", lambda: transport)
+
+    created = server._methods["session.create"]("create", {})
+    sid = created["result"]["session_id"]
+    session_key = created["result"]["stored_session_id"]
+    server._ensure_session_db_row(server._sessions[sid])
+
+    rpc_thread = threading.get_ident()
+    probe_started = threading.Event()
+    enrichment_completed = threading.Event()
+
+    def branch(cwd):
+        assert threading.get_ident() != rpc_thread
+        assert cwd == str(repo)
+        probe_started.set()
+        return "task-02"
+
+    def root(cwd):
+        assert threading.get_ident() != rpc_thread
+        assert cwd == str(repo)
+        return str(repo)
+
+    monkeypatch.setattr(server, "_git_branch_for_cwd", branch)
+    monkeypatch.setattr(server, "_git_common_repo_root_for_cwd", root)
+    original_update = gateway_db.update_session_git_meta_if_cwd_matches
+
+    def update_and_signal(*args, **kwargs):
+        result = original_update(*args, **kwargs)
+        enrichment_completed.set()
+        return result
+
+    monkeypatch.setattr(
+        gateway_db,
+        "update_session_git_meta_if_cwd_matches",
+        update_and_signal,
+    )
+
+    response = server._methods["session.cwd.set"](
+        "set-cwd", {"session_id": sid, "cwd": str(repo)}
+    )
+
+    assert response["result"]["cwd"] == str(repo)
+    assert response["result"]["branch"] is None
+    assert probe_started.wait(timeout=2)
+    assert enrichment_completed.wait(timeout=2)
+    row = gateway_db.get_session(session_key)
+    assert row["cwd"] == str(repo)
+    assert row["git_branch"] == "task-02"
+    assert row["git_repo_root"] == str(repo)
+
+
+def test_session_cwd_set_initialized_agent_does_not_probe_git_on_rpc_thread(
+    gateway_db, monkeypatch, tmp_path
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    transport = _WebSocketTransport()
+    monkeypatch.setattr(server, "current_transport", lambda: transport)
+
+    created = server._methods["session.create"]("create", {})
+    sid = created["result"]["session_id"]
+    session_key = created["result"]["stored_session_id"]
+    session = server._sessions[sid]
+    server._ensure_session_db_row(session)
+    session["agent"] = types.SimpleNamespace(
+        model="test/model", provider="test", tools=[], reasoning_config={}
+    )
+
+    rpc_thread = threading.get_ident()
+    probe_started = threading.Event()
+    enrichment_completed = threading.Event()
+
+    def branch(cwd):
+        assert threading.get_ident() != rpc_thread
+        assert cwd == str(repo)
+        probe_started.set()
+        return "task-02"
+
+    def root(cwd):
+        assert threading.get_ident() != rpc_thread
+        assert cwd == str(repo)
+        return str(repo)
+
+    monkeypatch.setattr(server, "_git_branch_for_cwd", branch)
+    monkeypatch.setattr(server, "_git_common_repo_root_for_cwd", root)
+    original_update = gateway_db.update_session_git_meta_if_cwd_matches
+
+    def update_and_signal(*args, **kwargs):
+        result = original_update(*args, **kwargs)
+        enrichment_completed.set()
+        return result
+
+    monkeypatch.setattr(
+        gateway_db,
+        "update_session_git_meta_if_cwd_matches",
+        update_and_signal,
+    )
+
+    response = server._methods["session.cwd.set"](
+        "set-cwd", {"session_id": sid, "cwd": str(repo)}
+    )
+
+    assert response["result"]["cwd"] == str(repo)
+    assert response["result"]["branch"] is None
+    assert probe_started.wait(timeout=2)
+    assert enrichment_completed.wait(timeout=2)
+    row = gateway_db.get_session(session_key)
+    assert row["git_branch"] == "task-02"
+    assert row["git_repo_root"] == str(repo)
+
+
+def _run_project_workspace_callback_test(
+    gateway_db, monkeypatch, tmp_path, *, initialized_agent
+):
+    workspace = tmp_path / ("agent-workspace" if initialized_agent else "lazy-workspace")
+    workspace.mkdir()
+    transport = _WebSocketTransport()
+    monkeypatch.setattr(server, "current_transport", lambda: transport)
+
+    created = server._methods["session.create"]("create", {})
+    sid = created["result"]["session_id"]
+    session_key = created["result"]["stored_session_id"]
+    session = server._sessions[sid]
+    server._ensure_session_db_row(session)
+    if initialized_agent:
+        session["agent"] = types.SimpleNamespace(
+            model="test/model", provider="test", tools=[], reasoning_config={}
+        )
+
+    rpc_thread = threading.get_ident()
+    probe_started = threading.Event()
+    enrichment_completed = threading.Event()
+    emitted = []
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+
+    def branch(cwd):
+        assert threading.get_ident() != rpc_thread
+        assert cwd == str(workspace)
+        probe_started.set()
+        return "project-branch"
+
+    def root(cwd):
+        assert threading.get_ident() != rpc_thread
+        assert cwd == str(workspace)
+        return str(workspace)
+
+    monkeypatch.setattr(server, "_git_branch_for_cwd", branch)
+    monkeypatch.setattr(server, "_git_common_repo_root_for_cwd", root)
+    original_update = gateway_db.update_session_git_meta_if_cwd_matches
+
+    def update_and_signal(*args, **kwargs):
+        result = original_update(*args, **kwargs)
+        enrichment_completed.set()
+        return result
+
+    monkeypatch.setattr(
+        gateway_db,
+        "update_session_git_meta_if_cwd_matches",
+        update_and_signal,
+    )
+
+    server._apply_project_workspace(session_key, str(workspace))
+
+    assert emitted
+    info = emitted[-1][2]
+    assert info["cwd"] == str(workspace)
+    assert info["branch"] is None
+    assert probe_started.wait(timeout=2)
+    assert enrichment_completed.wait(timeout=2)
+
+
+def test_project_workspace_callback_initialized_agent_does_not_probe_git_synchronously(
+    gateway_db, monkeypatch, tmp_path
+):
+    _run_project_workspace_callback_test(
+        gateway_db, monkeypatch, tmp_path, initialized_agent=True
+    )
+
+
+def test_project_workspace_callback_lazy_session_does_not_probe_git_synchronously(
+    gateway_db, monkeypatch, tmp_path
+):
+    _run_project_workspace_callback_test(
+        gateway_db, monkeypatch, tmp_path, initialized_agent=False
+    )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -30,6 +30,7 @@ from agent.replay_cleanup import sanitize_replay_history
 from tui_gateway import git_probe
 from tui_gateway.transport import (
     StdioTransport,
+    TeeTransport,
     Transport,
     bind_transport,
     current_transport,
@@ -1731,6 +1732,42 @@ def _normalize_completion_path(path_part: str) -> str:
     return expanded
 
 
+def _is_stdio_transport(transport: Transport | None) -> bool:
+    """Return whether *transport* ultimately writes to the stdio sink.
+
+    The sidecar publisher wraps the real stdio transport in ``TeeTransport``.
+    Unwrap only that known wrapper (including nested wrappers) and require the
+    primary to be an actual ``StdioTransport``; WebSocket transports must never
+    inherit stdio launch-cwd semantics.
+    """
+    seen: set[int] = set()
+    while isinstance(transport, TeeTransport):
+        marker = id(transport)
+        if marker in seen:
+            return False
+        seen.add(marker)
+        transport = getattr(transport, "_primary", None)
+    return isinstance(transport, StdioTransport)
+
+
+def _stdio_launch_cwd() -> str:
+    """Resolve the real cwd of a stdio TUI launch.
+
+    The TUI launcher passes its validated launch directory as ``HERMES_CWD``.
+    That process-local value must win over a profile's configured
+    ``terminal.cwd``: the latter is a terminal backend setting, while stdio's
+    cwd is the workspace the current Ink process was actually launched in.
+    """
+    raw = os.environ.get("HERMES_CWD") or os.getcwd()
+    try:
+        resolved = os.path.abspath(os.path.expanduser(str(raw)))
+        if os.path.isdir(resolved):
+            return resolved
+    except Exception:
+        pass
+    return os.path.abspath(os.getcwd())
+
+
 def _completion_cwd(params: dict | None = None) -> str:
     params = params or {}
     raw = (
@@ -1870,7 +1907,10 @@ def _display_session_cwd(session: dict | None) -> str:
 
     healed = _heal_dead_cwd(cwd)
     if healed and healed != cwd and session is not None:
-        session["cwd"] = healed
+        with _sessions_lock:
+            session["cwd"] = healed
+            session["git_branch"] = None
+            session["git_repo_root"] = None
         try:
             with _session_db(session) as db:
                 if db is not None:
@@ -1903,6 +1943,19 @@ def _register_session_cwd(session: dict | None) -> None:
         pass
 
 
+def _session_cwd_should_persist(session: dict) -> bool:
+    """Return whether this session's effective cwd is durable metadata.
+
+    Desktop/WebSocket sessions intentionally remain unbound when the client did
+    not choose a folder.  The stdio Ink client has a real launch workspace,
+    however, so its completion cwd is meaningful even without an RPC ``cwd``.
+    """
+    if session.get("explicit_cwd"):
+        return True
+    transport = session.get("transport")
+    return _is_stdio_transport(transport)
+
+
 def _ensure_session_db_row(session: dict) -> None:
     """Idempotently persist the session's DB row on first real activity.
 
@@ -1911,12 +1964,9 @@ def _ensure_session_db_row(session: dict) -> None:
     Uses INSERT OR IGNORE under the hood, so re-calls (and the AIAgent's own
     lazy create) are no-ops.
 
-    Only an *explicitly chosen* workspace is persisted as the session's cwd.
-    The agent still runs in the auto-detected directory (session["cwd"]), but
-    we don't stamp that onto the row — otherwise every session the user never
-    picked a folder for gets grouped under whatever directory the desktop
-    happened to launch in (e.g. "desktop"). Leaving it null groups them under
-    "No workspace", which is the desired default.
+    Desktop/WebSocket sessions only persist an explicitly chosen workspace. The
+    stdio Ink client is different: its launch directory is the user's workspace
+    even when no ``cwd`` RPC parameter was sent.
     """
     key = session.get("session_key")
     if not key:
@@ -1997,6 +2047,7 @@ def _ensure_session_db_row(session: dict) -> None:
     parent_session_id = session.get("parent_session_id") or None
     if parent_session_id:
         model_config["_branched_from"] = parent_session_id
+    persisted_cwd = _session_cwd(session) if _session_cwd_should_persist(session) else None
     try:
         db.create_session(
             key,
@@ -2004,10 +2055,13 @@ def _ensure_session_db_row(session: dict) -> None:
             model=row_model,
             model_config=model_config or None,
             parent_session_id=parent_session_id,
-            cwd=_session_cwd(session) if session.get("explicit_cwd") else None,
+            cwd=persisted_cwd,
         )
     except Exception:
         logger.debug("failed to persist desktop session row", exc_info=True)
+    else:
+        if persisted_cwd:
+            _persist_session_git_meta(session, persisted_cwd)
     finally:
         if close_db:
             try:
@@ -2081,10 +2135,10 @@ def _persist_session_git_meta(session: dict, cwd: str) -> None:
     or on an unreachable mount. Run them on a short-lived daemon thread instead
     and persist via the same profile-aware db the caller writes ``cwd`` to.
 
-    Best-effort: ``cwd`` itself is persisted synchronously by the caller, so a
-    probe failure just leaves these enrichment columns unset (the project tree
-    falls back to its live resolver / lazy backfill). Daemon, so a mid-flight
-    probe never delays gateway shutdown.
+    The database update is a compare-and-set on ``session_key`` + captured cwd.
+    Only after that succeeds do we update the live in-memory cache, and only when
+    the same live session still points at the captured cwd. This prevents a late
+    probe for cwd A from repopulating metadata after the session moved to cwd B.
     """
     session_key = session.get("session_key", "")
     if not session_key or not cwd:
@@ -2092,6 +2146,7 @@ def _persist_session_git_meta(session: dict, cwd: str) -> None:
     # Snapshot the routing fields now; the live session dict may be gone by the
     # time the thread runs. `_session_db` reopens the profile-correct db inside.
     db_session = {"session_key": session_key, "profile_home": session.get("profile_home")}
+    live_session = session
 
     def _run() -> None:
         try:
@@ -2100,8 +2155,22 @@ def _persist_session_git_meta(session: dict, cwd: str) -> None:
             if not (branch or root):
                 return
             with _session_db(db_session) as db:
-                if db is not None:
-                    db.update_session_cwd(session_key, cwd, branch, root)
+                if db is None:
+                    return
+                updated = db.update_session_git_meta_if_cwd_matches(
+                    session_key, cwd, branch, root
+                )
+            if not updated:
+                return
+            # Keep the cache coherent with the CAS-protected row. The lock also
+            # serializes this check with cwd-changing paths below.
+            with _sessions_lock:
+                if live_session.get("cwd") != cwd:
+                    return
+                if not any(candidate is live_session for candidate in _sessions.values()):
+                    return
+                live_session["git_branch"] = (branch or "").strip() or None
+                live_session["git_repo_root"] = (root or "").strip() or None
         except Exception:
             logger.debug("failed to persist session git metadata", exc_info=True)
 
@@ -2115,7 +2184,12 @@ def _set_session_cwd(session: dict, cwd: str) -> str:
     resolved = os.path.abspath(os.path.expanduser(cwd))
     if not os.path.isdir(resolved):
         raise ValueError(f"working directory does not exist: {cwd}")
-    session["cwd"] = resolved
+    with _sessions_lock:
+        session["cwd"] = resolved
+        # A cwd move invalidates metadata captured for the previous workspace;
+        # the new cwd's async enrichment may repopulate it later.
+        session["git_branch"] = None
+        session["git_repo_root"] = None
     # An explicit user choice — persist it as the workspace (and let a later
     # lazy row creation persist it too, not the launch-dir fallback).
     session["explicit_cwd"] = True
@@ -3799,7 +3873,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "tools": dict(mirror.get("tools") or {}) if isinstance(mirror.get("tools"), dict) else {},
         "skills": dict(mirror.get("skills") or {}) if isinstance(mirror.get("skills"), dict) else {},
         "cwd": cwd,
-        "branch": _git_branch_for_cwd(cwd),
+        "branch": (session or {}).get("git_branch"),
         "project": _project_info_for_cwd(cwd),
         "personality": str(personality or ""),
         "running": bool((session or {}).get("running")),
@@ -4386,7 +4460,10 @@ def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:
     if not os.path.isdir(resolved):
         return
 
-    session["cwd"] = resolved
+    with _sessions_lock:
+        session["cwd"] = resolved
+        session["git_branch"] = None
+        session["git_repo_root"] = None
     session["explicit_cwd"] = True
     _register_session_cwd(session)
 
@@ -4406,7 +4483,7 @@ def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:
             if agent is not None
             else {
                 "cwd": resolved,
-                "branch": _git_branch_for_cwd(resolved),
+                "branch": None,
                 "project": _project_info_for_cwd(resolved),
                 "lazy": True,
             }
@@ -5148,6 +5225,8 @@ def _init_session(
             "attached_images": [],
             "image_counter": 0,
             "cwd": cwd or _completion_cwd(),
+            "git_branch": None,
+            "git_repo_root": None,
             "cols": cols,
             "slash_worker": None,
             "show_reasoning": _load_show_reasoning(),
@@ -5170,6 +5249,8 @@ def _init_session(
             with _sessions_lock:
                 if sid in _sessions:
                     _sessions[sid]["cwd"] = row["cwd"]
+                    _sessions[sid]["git_branch"] = row.get("git_branch")
+                    _sessions[sid]["git_repo_root"] = row.get("git_repo_root")
         else:
             try:
                 _cwd = _sessions[sid]["cwd"]
@@ -5746,7 +5827,12 @@ def _(rid, params: dict) -> dict:
         explicit_cwd = bool(raw_cwd) and os.path.isdir(os.path.abspath(os.path.expanduser(raw_cwd)))
     except Exception:
         explicit_cwd = False
-    resolved_cwd = _completion_cwd(params)
+    resolved_cwd = (
+        _stdio_launch_cwd()
+        if not raw_cwd
+        and _is_stdio_transport(current_transport() or _stdio_transport)
+        else _completion_cwd(params)
+    )
     source = _resolve_session_source(str(params.get("source") or "").strip() or None)
     _enable_gateway_prompts()
 
@@ -5868,7 +5954,9 @@ def _(rid, params: dict) -> dict:
                 "tools": {},
                 "skills": {},
                 "cwd": _sessions[sid]["cwd"],
-                "branch": _git_branch_for_cwd(_sessions[sid]["cwd"]),
+                # Git enrichment is deliberately asynchronous; probing here
+                # would block session.create and race with cwd changes.
+                "branch": None,
                 "project": _project_info_for_cwd(_sessions[sid]["cwd"]),
                 "lazy": True,
                 "desktop_contract": DESKTOP_BACKEND_CONTRACT,
@@ -6010,12 +6098,14 @@ def _(rid, params: dict) -> dict:
         return _ok(rid, {"verification": {"status": "unknown", "evidence": None}})
 
 
-def _lazy_resume_info(cwd: str, *, model: str = "", provider: str = "") -> dict:
+def _lazy_resume_info(
+    cwd: str, *, model: str = "", provider: str = "", branch: str | None = None
+) -> dict:
     """session.info for a not-yet-built session (the shape session.create
     returns). tools/skills land later when the deferred build emits session.info."""
     info = {
         "cwd": cwd,
-        "branch": _git_branch_for_cwd(cwd),
+        "branch": branch,
         "project": _project_info_for_cwd(cwd),
         "model": model or _resolve_model(),
         "tools": {},
@@ -6043,6 +6133,8 @@ def _deferred_session_record(
     lazy: bool = False,
     model_override=None,
     resume_runtime_overrides: dict | None = None,
+    git_branch: str | None = None,
+    git_repo_root: str | None = None,
 ) -> dict:
     """A live-session record whose AIAgent is built later (lazy watch / cold
     resume) — _init_session's shape minus the agent."""
@@ -6058,6 +6150,8 @@ def _deferred_session_record(
         "created_at": now,
         "cwd": cwd,
         "display_history_prefix": display_history_prefix or [],
+        "git_branch": git_branch,
+        "git_repo_root": git_repo_root,
         "edit_snapshots": {},
         "explicit_cwd": False,
         "history": history,
@@ -6247,6 +6341,8 @@ def _(rid, params: dict) -> dict:
             close_on_disconnect=is_truthy_value(params.get("close_on_disconnect", False)),
             profile_home=profile_home,
             lazy=True,
+            git_branch=found.get("git_branch"),
+            git_repo_root=found.get("git_repo_root"),
         )
         if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
             return _ok(rid, _reuse_live_payload(*live))
@@ -6261,7 +6357,9 @@ def _(rid, params: dict) -> dict:
                 "resumed": target,
                 "message_count": len(messages),
                 "messages": messages,
-                "info": _lazy_resume_info(cwd),
+                "info": _lazy_resume_info(
+                    cwd, branch=found.get("git_branch")
+                ),
                 "inflight": None,
                 "running": child_running,
                 "session_key": target,
@@ -6329,6 +6427,8 @@ def _(rid, params: dict) -> dict:
             profile_home=profile_home,
             model_override=overrides.get("model_override"),
             resume_runtime_overrides=overrides or None,
+            git_branch=found.get("git_branch"),
+            git_repo_root=found.get("git_repo_root"),
         )
         if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
             return _ok(rid, _reuse_live_payload(*live))
@@ -6348,6 +6448,7 @@ def _(rid, params: dict) -> dict:
                     cwd,
                     model=model_override.get("model") or "",
                     provider=overrides.get("provider_override") or "",
+                    branch=found.get("git_branch"),
                 ),
                 "inflight": None,
                 "running": False,
@@ -6510,7 +6611,9 @@ def _(rid, params: dict) -> dict:
     agent = session.get("agent")
     info = _session_info(agent, session) if agent is not None else {
         "cwd": cwd,
-        "branch": _git_branch_for_cwd(cwd),
+        # Git enrichment is deliberately asynchronous; probing here would
+        # block session.cwd.set and race with cwd changes.
+        "branch": None,
         "project": _project_info_for_cwd(cwd),
         "lazy": True,
     }


### PR DESCRIPTION
## Summary

- persist the actual TUI/gateway session cwd together with Git repository root and branch metadata
- preserve stdio launch cwd through direct, nested, and cyclic `TeeTransport` wrappers without applying stdio semantics to WebSocket transports
- perform Git enrichment asynchronously and update metadata only when the session cwd still matches
- atomically clear stale Git metadata when cwd changes while preserving metadata on same-cwd updates
- remove direct and indirect synchronous Git probes from `session.create`, `session.cwd.set`, and project-workspace response paths
- keep profile-aware state DB routing and resume behavior

## Verification

- canonical `tests/tui_gateway`: **395 passed**
- targeted SessionDB/gateway/metadata suites: **481 passed**
- nested/cyclic TeeTransport, stdio/WebSocket precedence, stale CAS/cache, profile routing, and nonblocking RPC adversarial probes: **passed**
- `py_compile`: **passed**
- `git diff --check`: **passed**
- isolated dev-Orca end-to-end test confirmed the persisted cwd, Git root, and branch
- independent final review: **approved**

## Notes

- existing diagnostic handling for an already-deleted local cwd may still perform a synchronous Git recovery probe; validated session creation/cwd/project-workspace paths do not reach it.
