### PR TITLE
fix(gateway): route TUI skill secret prompts to the owning session (#68261)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -16174,3 +16174,75 @@ def test_prompt_submit_releases_old_history_before_heap_trim(monkeypatch):
         assert cleanup_order == ["trim", "reset_home"]
     finally:
         server._sessions.pop("sid_trim", None)
+
+
+def test_secret_capture_routes_to_owning_session_not_last_wired(monkeypatch):
+    """A skill credential prompt must reach the session that started the skill
+    setup flow, even when a newer session wired its callbacks afterwards.
+
+    Regression for #68261: ``set_secret_capture_callback`` stores one
+    process-global callback, so wiring session B replaced the closure session A
+    installed, and A's ``secret.request`` was emitted with B's sid. The prompt
+    is now routed by the per-turn ``HERMES_UI_SESSION_ID`` contextvar (bound at
+    turn start via ``_set_session_context``) rather than the last-wired ``sid``.
+    """
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from tools import skills_tool
+
+    routed: list = []
+    monkeypatch.setattr(
+        server,
+        "_block",
+        lambda event, sid, payload, timeout=300: routed.append((event, sid)) or "",
+    )
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+
+    prev_cb = skills_tool._secret_capture_callback
+    tokens = None
+    try:
+        server._wire_callbacks("session-A")
+        server._wire_callbacks("session-B")  # clobbers the process-global callback
+
+        # Session A's turn is running: its ui session id is bound for this context.
+        tokens = set_session_vars(ui_session_id="session-A")
+
+        skills_tool._capture_required_environment_variables(
+            "demo-skill",
+            [{"name": "API_KEY", "prompt": "Enter API key"}],
+        )
+    finally:
+        if tokens is not None:
+            clear_session_vars(tokens)
+        skills_tool.set_secret_capture_callback(prev_cb)
+
+    assert routed == [("secret.request", "session-A")]
+
+
+def test_secret_capture_falls_back_to_wired_sid_without_session_context(monkeypatch):
+    """With no session context engaged (single-session / CLI), the callback
+    still routes to the sid it was wired with — the fallback path of #68261."""
+    from tools import skills_tool
+
+    routed: list = []
+    monkeypatch.setattr(
+        server,
+        "_block",
+        lambda event, sid, payload, timeout=300: routed.append((event, sid)) or "",
+    )
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.setattr(
+        "gateway.session_context.get_session_env",
+        lambda name, default="": default,
+    )
+
+    prev_cb = skills_tool._secret_capture_callback
+    try:
+        server._wire_callbacks("only-session")
+        skills_tool._capture_required_environment_variables(
+            "demo-skill",
+            [{"name": "API_KEY", "prompt": "Enter API key"}],
+        )
+    finally:
+        skills_tool.set_secret_capture_callback(prev_cb)
+
+    assert routed == [("secret.request", "only-session")]

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -22279,3 +22279,75 @@ def test_workspace_move_rehomes_running_session(monkeypatch, tmp_path):
     assert captured["row_update"] == (target, str(new_cwd))
     assert live["cwd"] == str(new_cwd)
     assert live.get("explicit_cwd") is True
+
+
+def test_secret_capture_routes_to_owning_session_not_last_wired(monkeypatch):
+    """A skill credential prompt must reach the session that started the skill
+    setup flow, even when a newer session wired its callbacks afterwards.
+
+    Regression for #68261: ``set_secret_capture_callback`` stores one
+    process-global callback, so wiring session B replaced the closure session A
+    installed, and A's ``secret.request`` was emitted with B's sid. The prompt
+    is now routed by the per-turn ``HERMES_UI_SESSION_ID`` contextvar (bound at
+    turn start via ``_set_session_context``) rather than the last-wired ``sid``.
+    """
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from tools import skills_tool
+
+    routed: list = []
+    monkeypatch.setattr(
+        server,
+        "_block",
+        lambda event, sid, payload, timeout=300: routed.append((event, sid)) or "",
+    )
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+
+    prev_cb = skills_tool._secret_capture_callback
+    tokens = None
+    try:
+        server._wire_callbacks("session-A")
+        server._wire_callbacks("session-B")  # clobbers the process-global callback
+
+        # Session A's turn is running: its ui session id is bound for this context.
+        tokens = set_session_vars(ui_session_id="session-A")
+
+        skills_tool._capture_required_environment_variables(
+            "demo-skill",
+            [{"name": "API_KEY", "prompt": "Enter API key"}],
+        )
+    finally:
+        if tokens is not None:
+            clear_session_vars(tokens)
+        skills_tool.set_secret_capture_callback(prev_cb)
+
+    assert routed == [("secret.request", "session-A")]
+
+
+def test_secret_capture_falls_back_to_wired_sid_without_session_context(monkeypatch):
+    """With no session context engaged (single-session / CLI), the callback
+    still routes to the sid it was wired with — the fallback path of #68261."""
+    from tools import skills_tool
+
+    routed: list = []
+    monkeypatch.setattr(
+        server,
+        "_block",
+        lambda event, sid, payload, timeout=300: routed.append((event, sid)) or "",
+    )
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.setattr(
+        "gateway.session_context.get_session_env",
+        lambda name, default="": default,
+    )
+
+    prev_cb = skills_tool._secret_capture_callback
+    try:
+        server._wire_callbacks("only-session")
+        skills_tool._capture_required_environment_variables(
+            "demo-skill",
+            [{"name": "API_KEY", "prompt": "Enter API key"}],
+        )
+    finally:
+        skills_tool.set_secret_capture_callback(prev_cb)
+
+    assert routed == [("secret.request", "only-session")]

--- a/tui_gateway/agent_callbacks.py
+++ b/tui_gateway/agent_callbacks.py
@@ -158,8 +158,17 @@ def _wire_callbacks(sid: str):
     from tools.project_tools import set_project_workspace_callback
 
     def secret_cb(env_var, prompt, metadata=None):
+        # set_secret_capture_callback stores ONE process-global callback, so the
+        # most-recently-wired session's `sid` would otherwise own every prompt.
+        # When several sessions share this gateway process, route to the session
+        # whose turn is actually running by reading the per-turn contextvar
+        # (bound via _set_session_context(ui_session_id=...) at turn start);
+        # fall back to the wired `sid` when no session context is engaged.
+        from gateway.session_context import get_session_env
+
+        target_sid = get_session_env("HERMES_UI_SESSION_ID") or sid
         pl = {"prompt": prompt, "env_var": env_var, **({"metadata": metadata} if metadata else {})}
-        val = _block("secret.request", sid, pl)
+        val = _block("secret.request", target_sid, pl)
         if not val:
             return {"success": True, "stored_as": env_var, "validated": False, "skipped": True, "message": "skipped"}
         from hermes_cli.config import save_env_value_secure

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5750,10 +5750,19 @@ def _wire_callbacks(sid: str):
     set_project_workspace_callback(_apply_project_workspace)
 
     def secret_cb(env_var, prompt, metadata=None):
+        # set_secret_capture_callback stores ONE process-global callback, so the
+        # most-recently-wired session's `sid` would otherwise own every prompt.
+        # When several sessions share this gateway process, route to the session
+        # whose turn is actually running by reading the per-turn contextvar
+        # (bound via _set_session_context(ui_session_id=...) at turn start);
+        # fall back to the wired `sid` when no session context is engaged.
+        from gateway.session_context import get_session_env
+
+        target_sid = get_session_env("HERMES_UI_SESSION_ID") or sid
         pl = {"prompt": prompt, "env_var": env_var}
         if metadata:
             pl["metadata"] = metadata
-        val = _block("secret.request", sid, pl)
+        val = _block("secret.request", target_sid, pl)
         if not val:
             return {
                 "success": True,


### PR DESCRIPTION
## What does this PR do?

Fixes a cross-session routing bug where a TUI/Desktop skill credential prompt
could be delivered to the **wrong** session when several sessions share one
gateway process.

`tools/skills_tool.set_secret_capture_callback()` stores **one process-global**
callback. `tui_gateway.server._wire_callbacks(sid)` installs a closure bound to
its `sid`, so whichever session was wired *last* owned every subsequent
`secret.request`. A prompt started by session A could then be emitted with
session B's id — surfacing the credential prompt in B, and continuing the wrong
session's skill-setup flow when the value was submitted.

The turn thread already binds the owning session's id into the
`HERMES_UI_SESSION_ID` contextvar at turn start (`_set_session_context(...,
ui_session_id=sid)`), and `skills_tool` already reads session context via
`get_session_env`. So the fix resolves the target session **at emit time** from
that per-turn contextvar, falling back to the wired `sid` when no session
context is engaged (single-session / CLI). This matches the codebase's existing
concurrency-safe session-routing pattern in `gateway/session_context.py` and the
issue's recommendation to carry the owning session context.

Scope note: the sudo-password callback is thread-local and re-wired per turn, so
it is already session-safe — only secret capture used a module global, so only
it needed this change. One logical change.

## Related Issue

Fixes #68261

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` — `_wire_callbacks.secret_cb` now resolves the target
  session from `get_session_env("HERMES_UI_SESSION_ID")` (falling back to the
  wired `sid`) before calling `_block("secret.request", target_sid, ...)`.
- `tests/test_tui_gateway_server.py` — two regression tests:
  - `test_secret_capture_routes_to_owning_session_not_last_wired` — wires
    session A then B (clobbering the global), binds A's ui-session context,
    drives the real `_capture_required_environment_variables` flow, and asserts
    the `secret.request` is emitted to **A**.
  - `test_secret_capture_falls_back_to_wired_sid_without_session_context` —
    with no session context engaged, the prompt still routes to the wired sid.

## How to Test

```
scripts/run_tests.sh tests/test_tui_gateway_server.py -k "secret_capture_routes or secret_capture_falls_back"
```

Result: `2 passed`. Full `tests/test_tui_gateway_server.py` (~373 tests) also
passes via the preflight. On `upstream/main` (without the `server.py` change)
the first test fails — the prompt is emitted to `session-B` — confirming the
regression is real and the fix closes it.

Tested on macOS.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected suite (`scripts/run_tests.sh tests/test_tui_gateway_server.py`) and it passes
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no doc surface; behavior-only fix)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (contextvar routing, platform-agnostic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schema change)
