### PR TITLE
fix(moonshot): flatten top-level anyOf/oneOf so the sanitizer can't emit a type+union 400

### DIFF
--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -18,6 +18,10 @@ and MoonshotAI/kimi-cli#1595:
 3. Every object schema must carry a ``required`` array, even an empty one.
    Standard JSON Schema allows omitting it; Moonshot 400s with
    "required must be an array".
+4. A tool's top-level ``parameters`` must be a plain object schema — a
+   top-level ``anyOf``/``oneOf`` union is flattened into one object (Rule 2
+   forbids a ``type`` alongside a union, so the forced object coercion would
+   otherwise emit the very ``type``+union 400 this module prevents).
 
 The ``#/definitions/...`` → ``#/$defs/...`` rewrite for draft-07 refs is
 handled separately in ``tools/mcp_tool._normalize_mcp_input_schema`` so it
@@ -159,6 +163,46 @@ def _ensure_required_array(node: Dict[str, Any]) -> Dict[str, Any]:
     return node
 
 
+def _flatten_top_level_union(node: Dict[str, Any]) -> Dict[str, Any]:
+    """Collapse a top-level ``anyOf``/``oneOf`` into a single object schema.
+
+    Moonshot requires a tool's ``parameters`` to be a plain object schema, and
+    (Rule 2) rejects ``type`` sitting alongside a union at all. But the
+    top-level coercion in :func:`sanitize_moonshot_tool_parameters` forces
+    ``type: object`` unconditionally, so a tool whose parameters are expressed
+    as a union — ``{"anyOf": [{object A}, {object B}]}`` — comes out as
+    ``{"anyOf": [...], "type": "object", ...}``, exactly the ``type``+union
+    combination Rule 2 says Moonshot 400s on. The sanitizer, whose whole job is
+    to prevent those 400s, would then hand Moonshot a schema it is guaranteed
+    to reject, and every call to that tool fails.
+
+    A union cannot be preserved at the top level (Moonshot has no object-union
+    form there), so merge the branches' ``properties`` into one object with all
+    of them optional — the branches are alternatives, so nothing is universally
+    required. The tool stays callable instead of being rejected outright.
+    Nested unions are untouched: Rule 2 keeps ``type`` off their parent, so only
+    the forced-object top level needs this.
+    """
+    merged_props: Dict[str, Any] = {}
+    for union_key in ("anyOf", "oneOf"):
+        branches = node.get(union_key)
+        if not isinstance(branches, list):
+            continue
+        for branch in branches:
+            if isinstance(branch, dict) and isinstance(branch.get("properties"), dict):
+                for pname, pschema in branch["properties"].items():
+                    merged_props.setdefault(pname, pschema)
+        node.pop(union_key, None)
+    existing_props = node.get("properties")
+    if isinstance(existing_props, dict):
+        for pname, pschema in existing_props.items():
+            merged_props.setdefault(pname, pschema)
+    node["properties"] = merged_props
+    node["type"] = "object"
+    node["required"] = []
+    return node
+
+
 def _fill_missing_type(node: Dict[str, Any]) -> Dict[str, Any]:
     """Infer a reasonable ``type`` if this schema node has none."""
     node_type = node.get("type")
@@ -205,6 +249,13 @@ def sanitize_moonshot_tool_parameters(parameters: Any) -> Dict[str, Any]:
     repaired = _repair_schema(copy.deepcopy(parameters), is_schema=True)
     if not isinstance(repaired, dict):
         return {"type": "object", "properties": {}, "required": []}
+
+    # A top-level union has no valid Moonshot object form and cannot carry a
+    # parent ``type`` (Rule 2). Flatten it to one object BEFORE the object
+    # coercion below, otherwise that coercion produces the ``type``+union combo
+    # Moonshot rejects — the exact 400 this sanitizer exists to prevent.
+    if "anyOf" in repaired or "oneOf" in repaired:
+        repaired = _flatten_top_level_union(repaired)
 
     # Top-level must be an object schema
     if repaired.get("type") != "object":

--- a/tests/agent/test_moonshot_schema.py
+++ b/tests/agent/test_moonshot_schema.py
@@ -213,6 +213,77 @@ class TestTopLevelGuarantees:
         assert "type" not in params["properties"]["q"]
 
 
+class TestTopLevelUnionFlattened:
+    """A top-level ``anyOf``/``oneOf`` must not survive the object coercion.
+
+    Moonshot requires ``parameters`` to be a plain object and (Rule 2) rejects
+    ``type`` sitting next to a union. The unconditional top-level
+    ``type: object`` coercion would otherwise emit ``{anyOf/oneOf, type:
+    object}`` — the exact ``type``+union combination Moonshot 400s on — so a
+    tool expressed as a union of object variants would be rejected on every
+    call. The union is flattened to one object with the branch properties
+    merged (all optional).
+    """
+
+    def _assert_no_top_level_union(self, out):
+        assert out["type"] == "object"
+        assert "anyOf" not in out
+        assert "oneOf" not in out
+        # required must be a list (Rule 3) and empty (alternatives → nothing
+        # universally required).
+        assert out["required"] == []
+
+    def test_top_level_anyof_of_objects_is_flattened(self):
+        out = sanitize_moonshot_tool_parameters(
+            {
+                "anyOf": [
+                    {"type": "object", "properties": {"a": {"type": "string"}}},
+                    {"type": "object", "properties": {"b": {"type": "integer"}}},
+                ]
+            }
+        )
+        self._assert_no_top_level_union(out)
+        assert set(out["properties"]) == {"a", "b"}
+        assert out["properties"]["a"]["type"] == "string"
+        assert out["properties"]["b"]["type"] == "integer"
+
+    def test_top_level_oneof_of_objects_is_flattened(self):
+        out = sanitize_moonshot_tool_parameters(
+            {
+                "oneOf": [
+                    {"type": "object", "properties": {"x": {"type": "string"}}},
+                    {"type": "object", "properties": {"y": {"type": "number"}}},
+                ]
+            }
+        )
+        self._assert_no_top_level_union(out)
+        assert set(out["properties"]) == {"x", "y"}
+
+    def test_top_level_union_merges_with_sibling_properties(self):
+        out = sanitize_moonshot_tool_parameters(
+            {
+                "type": "object",
+                "properties": {"base": {"type": "string"}},
+                "anyOf": [
+                    {"type": "object", "properties": {"a": {"type": "string"}}},
+                ],
+            }
+        )
+        self._assert_no_top_level_union(out)
+        assert set(out["properties"]) == {"base", "a"}
+
+    def test_normal_object_is_untouched_by_the_flatten_path(self):
+        out = sanitize_moonshot_tool_parameters(
+            {
+                "type": "object",
+                "properties": {"p": {"type": "string"}},
+                "required": ["p"],
+            }
+        )
+        assert out["required"] == ["p"]
+        assert set(out["properties"]) == {"p"}
+
+
 class TestRequiredArray:
     """Rule 4: every object schema must carry a ``required`` array (#66835)."""
 


### PR DESCRIPTION
## What

The Moonshot tool-schema sanitizer exists to keep Hermes tool schemas inside
Moonshot's flavored-JSON-Schema subset. Its own documented Rule 2:

> when `anyOf` is used, `type` must be on the anyOf children, not the parent —
> *"type should be defined in anyOf items instead of the parent schema"* (HTTP 400).

But `sanitize_moonshot_tool_parameters` ends by forcing the top level to be an
object **unconditionally**:

```python
if repaired.get("type") != "object":
    repaired["type"] = "object"
```

So a tool whose `parameters` are a union of object variants —
`{"anyOf": [{obj A}, {obj B}]}` — comes out as `{"anyOf": [...], "type": "object", ...}`:
exactly the `type`+union combo Rule 2 says Moonshot 400s on. The sanitizer,
whose whole job is to prevent those 400s, hands Moonshot a schema it is
guaranteed to reject → **every call to that tool fails on Kimi**. `oneOf` is
worse: Rule 2's collapse only inspects `anyOf`, so a top-level `oneOf` keeps
its parent `type` and hits the same wall.

Reproduced against the real sanitizer:

```
S({"anyOf":[{objA},{objB}]}) -> {"anyOf":[...], "type":"object", ...}
has BOTH type:object AND anyOf (the documented 400): True   # anyOf AND oneOf
```

## Fix

A union has no object form at the top level, so it can't be preserved. Flatten
it into one object, merging the branches' `properties` as optional (branches are
alternatives → nothing universally required). The tool stays callable instead of
being rejected. Runs only at the forced-object top level — nested unions keep
going through the existing Rule 2 path untouched.

## Tests

`tests/agent/test_moonshot_schema.py` — new `TestTopLevelUnionFlattened`:
top-level `anyOf`/`oneOf` of objects flattened (no surviving union, merged
properties, empty `required`), union merges with sibling top-level properties,
normal object untouched. The 3 union cases fail on `main` with the surviving
`{anyOf/oneOf, type:object}`; the control passes. Full moonshot + kimi transport
suites: **195 passed**.