### PR TITLE
fix(desktop): title-case only Sol/Terra/Luna GPT codenames

### DIFF
--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -13,6 +13,12 @@ describe('model-status-label', () => {
     expect(displayModelName('openai/gpt-5.5-fast')).toBe('GPT-5.5')
     expect(displayModelName('deepseek/deepseek-v4-pro-thinking')).toBe('Deepseek V4 Pro')
     expect(displayModelName('openai/gpt-5.5')).toBe('GPT-5.5')
+    expect(displayModelName('openai/gpt-5.6-sol')).toBe('GPT-5.6-Sol')
+    expect(displayModelName('openai/gpt-5.6-terra')).toBe('GPT-5.6-Terra')
+    expect(displayModelName('openai/gpt-5.6-luna')).toBe('GPT-5.6-Luna')
+    expect(displayModelName('openai/gpt-5.6-sol-pro')).toBe('GPT-5.6-Sol-pro')
+    expect(displayModelName('openai/gpt-4o-mini')).toBe('GPT-4o-mini')
+    expect(displayModelName('openai/gpt-5.5-pro')).toBe('GPT-5.5-pro')
   })
 
   it('strips trailing date-pin snapshots from the display name', () => {

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -63,7 +63,14 @@ function prettifyBase(base: string): string {
   }
 
   if (/^gpt-/i.test(base)) {
-    return base.replace(/^gpt-/i, 'GPT-')
+    // Keep the GPT-id shape (`GPT-5.6`) but title-case only the known
+    // codename segments sol/terra/luna, leaving mini/pro/oss/chat/etc alone.
+    return base
+      .replace(/^gpt-/i, 'GPT-')
+      .replace(
+        /-(sol|terra|luna)(?=-|$)/gi,
+        (_, seg: string) => `-${seg.charAt(0).toUpperCase()}${seg.slice(1).toLowerCase()}`
+      )
   }
 
   if (/^gemini-/i.test(base)) {


### PR DESCRIPTION
## Summary
- Title-case GPT display-name hyphen segments only for exact `sol` / `terra` / `luna` codenames (case-insensitive).
- Leave other alphabetic GPT suffixes alone (`mini`, `pro`, `oss`, `chat`, etc.).
- Add regression coverage for Sol/Terra/Luna and unchanged `gpt-4o-mini` / `gpt-5.5-pro`.

## Test plan
- [x] `npx vitest run src/lib/model-status-label.test.ts --environment jsdom` (apps/desktop)
- [x] `npm run typecheck` (apps/desktop)
- [x] `npx prettier --check src/lib/model-status-label.ts src/lib/model-status-label.test.ts`