### PR TITLE
fix(desktop): load disk plugins from local Hermes home

### DIFF
--- a/apps/desktop/electron/desktop-plugin-home.test.ts
+++ b/apps/desktop/electron/desktop-plugin-home.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { desktopPluginHome } from './desktop-plugin-home'
+
+describe('desktopPluginHome', () => {
+  const root = '/Users/test/.hermes'
+
+  it('uses the selected local profile home', () => {
+    expect(desktopPluginHome(root, 'work')).toBe('/Users/test/.hermes/profiles/work')
+  })
+
+  it('keeps the default profile at the local root', () => {
+    expect(desktopPluginHome(root, 'default')).toBe(root)
+  })
+
+  it('honors the sticky profile when Desktop has no explicit selection', () => {
+    expect(desktopPluginHome(root, null, () => 'personal\n')).toBe('/Users/test/.hermes/profiles/personal')
+  })
+
+  it('fails closed to the default home for an invalid sticky profile', () => {
+    expect(desktopPluginHome(root, null, () => '../other')).toBe(root)
+  })
+})

--- a/apps/desktop/electron/desktop-plugin-home.ts
+++ b/apps/desktop/electron/desktop-plugin-home.ts
@@ -1,0 +1,22 @@
+import path from 'node:path'
+
+const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+
+/** Resolve the trusted desktop-machine plugin home without consulting a remote gateway. */
+export function desktopPluginHome(root: string, selectedProfile: null | string, readStickyProfile?: () => string): string {
+  let profile = selectedProfile
+
+  if (!profile && readStickyProfile) {
+    try {
+      profile = readStickyProfile().trim()
+    } catch {
+      profile = null
+    }
+  }
+
+  if (!profile || profile === 'default' || !PROFILE_NAME_RE.test(profile)) {
+    return root
+  }
+
+  return path.join(root, 'profiles', profile)
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -66,6 +66,7 @@ import {
   shouldRemoveAppBundle,
   uninstallArgsForMode
 } from './desktop-uninstall'
+import { desktopPluginHome } from './desktop-plugin-home'
 import { installEmbedReferer } from './embed-referer'
 import { readDirForIpc } from './fs-read-dir'
 import { probeGatewayWebSocket } from './gateway-ws-probe'
@@ -8677,6 +8678,14 @@ ipcMain.handle('hermes:openExternal', (_event, url) => {
     throw new Error('Invalid external URL')
   }
 })
+
+// Disk plugins execute with full renderer authority, so they must always come
+// from the trusted desktop machine rather than a remote gateway's filesystem.
+ipcMain.handle('hermes:hermes-home:local', () =>
+  desktopPluginHome(HERMES_HOME, readActiveDesktopProfile(), () =>
+    fs.readFileSync(path.join(HERMES_HOME, 'active_profile'), 'utf8')
+  )
+)
 
 ipcMain.handle('hermes:openPreviewInBrowser', async (_event, url) => {
   if (!(await openPreviewInBrowser(url))) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -57,6 +57,7 @@ import {
   tokenPreview
 } from './connection-config'
 import { adoptServedDashboardToken } from './dashboard-token'
+import { desktopPluginHome } from './desktop-plugin-home'
 import {
   buildPosixCleanupScript,
   buildWindowsCleanupScript,
@@ -66,7 +67,6 @@ import {
   shouldRemoveAppBundle,
   uninstallArgsForMode
 } from './desktop-uninstall'
-import { desktopPluginHome } from './desktop-plugin-home'
 import { installEmbedReferer } from './embed-referer'
 import { readDirForIpc } from './fs-read-dir'
 import { probeGatewayWebSocket } from './gateway-ws-probe'

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -36,6 +36,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     }
   },
   getBootProgress: () => ipcRenderer.invoke('hermes:boot-progress:get'),
+  getLocalHermesHome: () => ipcRenderer.invoke('hermes:hermes-home:local'),
   getConnectionConfig: profile => ipcRenderer.invoke('hermes:connection-config:get', profile),
   saveConnectionConfig: payload => ipcRenderer.invoke('hermes:connection-config:save', payload),
   applyConnectionConfig: payload => ipcRenderer.invoke('hermes:connection-config:apply', payload),

--- a/apps/desktop/src/contrib/runtime-loader.local.test.ts
+++ b/apps/desktop/src/contrib/runtime-loader.local.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getLocalHermesHome: vi.fn(),
+  loadText: vi.fn(),
+  readDir: vi.fn(),
+  stopWatch: vi.fn(),
+  watch: vi.fn()
+}))
+
+vi.mock('@/sdk/runtime', () => ({
+  installPluginSdk: vi.fn(),
+  sdkImportMap: () => ({})
+}))
+
+vi.mock('@/store/notifications', () => ({ notifyError: vi.fn() }))
+vi.mock('./plugin', () => ({ createPluginContext: vi.fn() }))
+vi.mock('./plugins-store', () => ({
+  dropPlugin: vi.fn(),
+  pluginActive: vi.fn(() => true),
+  publishPlugin: vi.fn()
+}))
+
+import { discoverRuntimePlugins } from './runtime-loader'
+
+describe('runtime disk plugins', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getLocalHermesHome.mockResolvedValue('/Users/test/.hermes')
+    mocks.readDir.mockResolvedValue({
+      entries: [{ isDirectory: true, name: 'example', path: '/Users/test/.hermes/desktop-plugins/example' }],
+      path: '/Users/test/.hermes/desktop-plugins'
+    })
+    mocks.loadText
+      .mockResolvedValueOnce({ path: '/Users/test/.hermes/desktop-plugins/example/plugin.js', text: 'plugin' })
+      .mockRejectedValueOnce(new Error('stop before evaluation'))
+    mocks.watch.mockResolvedValue({ id: 'watch-1', url: 'file:///plugin.js' })
+
+    vi.stubGlobal('window', {
+      hermesDesktop: {
+        getLocalHermesHome: mocks.getLocalHermesHome,
+        onPreviewFileChanged: vi.fn(),
+        readDir: mocks.readDir,
+        readFileText: mocks.loadText,
+        stopPreviewFileWatch: mocks.stopWatch,
+        watchPreviewFile: mocks.watch
+      }
+    })
+  })
+
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('discovers trusted plugins from the desktop machine home', async () => {
+    await discoverRuntimePlugins()
+
+    expect(mocks.getLocalHermesHome).toHaveBeenCalledOnce()
+    expect(mocks.readDir).toHaveBeenCalledWith('/Users/test/.hermes/desktop-plugins')
+    expect(mocks.loadText).toHaveBeenCalledWith('/Users/test/.hermes/desktop-plugins/example/plugin.js')
+  })
+})

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -27,7 +27,6 @@
  * trust seam.
  */
 
-import { getStatus } from '@/hermes'
 import { installPluginSdk, sdkImportMap } from '@/sdk/runtime'
 import { notifyError } from '@/store/notifications'
 
@@ -246,8 +245,8 @@ async function scanDiskPlugins(): Promise<void> {
   scanning = true
 
   try {
-    const { hermes_home } = await getStatus()
-    const { entries } = await desktop.readDir(`${hermes_home}/desktop-plugins`)
+    const hermesHome = await desktop.getLocalHermesHome()
+    const { entries } = await desktop.readDir(`${hermesHome}/desktop-plugins`)
     const seen = new Set<string>()
 
     for (const dir of entries.filter(e => e.isDirectory)) {

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -48,6 +48,8 @@ declare global {
         onControl: (callback: (payload: PetOverlayControl) => void) => () => void
       }
       getBootProgress: () => Promise<DesktopBootProgress>
+      /** Local desktop-machine Hermes home, independent of the active gateway. */
+      getLocalHermesHome: () => Promise<string>
       getConnectionConfig: (profile?: null | string) => Promise<DesktopConnectionConfig>
       saveConnectionConfig: (payload: DesktopConnectionConfigInput) => Promise<DesktopConnectionConfig>
       applyConnectionConfig: (payload: DesktopConnectionConfigInput) => Promise<DesktopConnectionConfig>


### PR DESCRIPTION
## Summary

- load desktop disk plugins from the desktop machine's local Hermes home instead of the active gateway's reported home
- preserve local profile scoping, including the sticky profile fallback
- add focused coverage for remote-gateway discovery and local profile path resolution

## Why

When Desktop connects to a remote gateway, `getStatus().hermes_home` refers to the remote machine. The runtime loader then passes that remote path to Electron's local filesystem bridge, so local disk plugins disappear. Because disk plugins execute with full renderer authority, reading plugin source from the trusted desktop machine also preserves the intended security boundary.

Fixes #68267.

## Verification

- `npm run typecheck` (from `apps/desktop`)
- `vitest run --project ui --project electron`
  - 256 test files passed
  - 2,174 tests passed, 2 skipped
- `git diff --check`

The focused tests were written before the implementation and reproduced the missing local-home behavior.
