### PR TITLE
feat(matrix): add dynamic task room names

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2843,6 +2843,10 @@ class BasePlatformAdapter(ABC):
         # cadence picks up changes, so updating this dict costs no extra
         # platform API calls. Cleared when the typing loop winds down.
         self._status_text: Dict[str, str] = {}
+        # Optional gateway-owned probe for session-scoped background work.
+        # Adapters may use it for a runtime status surface, but the registry
+        # ownership and lifecycle remain in the gateway/tools layers.
+        self._session_background_work_probe: Optional[Callable[[str], bool]] = None
 
     @property
     def message_len_fn(self) -> Callable[[str], int]:
@@ -4906,6 +4910,35 @@ class BasePlatformAdapter(ABC):
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Hook called when background processing begins."""
 
+    def set_session_background_work_probe(
+        self, probe: Optional[Callable[[str], bool]],
+    ) -> None:
+        """Install the gateway's exact-session background-work probe."""
+        self._session_background_work_probe = probe if callable(probe) else None
+
+    def has_session_background_work(self, session_key: str) -> bool:
+        """Return whether Hermes still owns background work for *session_key*."""
+        if not session_key:
+            return False
+        probe = self._session_background_work_probe
+        if probe is None:
+            runner = getattr(self, "gateway_runner", None)
+            probe = getattr(runner, "has_owned_background_work_for_session", None)
+        if not callable(probe):
+            return False
+        try:
+            return bool(probe(session_key))
+        except Exception:
+            logger.debug("[%s] background-work probe failed", self.name, exc_info=True)
+            return False
+
+    async def on_session_background_work_changed(
+        self,
+        source: SessionSource,
+        session_key: str,
+    ) -> None:
+        """Hook after a session-owned background unit reaches a terminal state."""
+
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Hook called when background processing completes.
 
@@ -5808,6 +5841,10 @@ class BasePlatformAdapter(ABC):
             )
         
         try:
+            # Lifecycle hooks need the exact already-resolved key rather than
+            # reconstructing it from a source (which can lose multiplex
+            # profile routing or a thread discriminator).
+            setattr(event, "_gateway_session_key", session_key)
             await self._run_processing_hook("on_processing_start", event)
 
             # Call the handler (this can take a while with tool calls)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -75,6 +75,10 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 # wall deadlines plus readiness; other platforms retain the 30s isolation bound.
 _TELEGRAM_CONNECT_TIMEOUT_SECS_DEFAULT = 180.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
+# Completion events are published just before their durable record transitions
+# out of ``finalizing``.  This only needs to cover that immediate handoff; a
+# missing private signal must never stall the gateway watcher.
+_ASYNC_DELEGATION_FINALIZATION_WAIT_TIMEOUT_SECS = 0.25
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 _GATEWAY_HYGIENE_PLATFORM = "gateway_hygiene"
@@ -6542,6 +6546,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             profile=_profile,
         )
 
+    def has_owned_background_work_for_session(self, session_key: str) -> bool:
+        """Return whether Hermes owns active background work for one exact key.
+
+        ``process_registry.has_active_for_session`` deliberately includes every
+        running process owned by the session, including long-lived daemons.
+        That is its established gateway-session ownership contract; dynamic
+        room status must report the same work rather than guessing which
+        commands a user is still awaiting.
+        """
+        if not session_key:
+            return False
+        try:
+            from tools.process_registry import process_registry
+            if process_registry.has_active_for_session(session_key):
+                return True
+        except Exception:
+            logger.debug("Background-process activity probe failed", exc_info=True)
+        try:
+            from tools.async_delegation import has_active_for_session
+            return has_active_for_session(session_key)
+        except Exception:
+            logger.debug("Async-delegation activity probe failed", exc_info=True)
+            return False
+
+    def _wire_adapter_background_work_probe(self, adapter: BasePlatformAdapter) -> None:
+        """Give an adapter the runner-owned exact-session activity predicate."""
+        install = getattr(adapter, "set_session_background_work_probe", None)
+        if callable(install):
+            install(self.has_owned_background_work_for_session)
+
     def _telegram_topic_mode_enabled(self, source: SessionSource) -> bool:
         """Return whether Telegram DM topic mode is active for this chat."""
         if source.platform != Platform.TELEGRAM or source.chat_type != "dm":
@@ -10818,6 +10852,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_message_handler(self._primary_message_handler())
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
+            self._wire_adapter_background_work_probe(adapter)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
             _set_reaction = getattr(adapter, "set_reaction_handler", None)
             if callable(_set_reaction):
@@ -11919,6 +11954,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter.set_message_handler(self._primary_message_handler())
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
+                    self._wire_adapter_background_work_probe(adapter)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
                     _set_reaction = getattr(adapter, "set_reaction_handler", None)
                     if callable(_set_reaction):
@@ -12861,6 +12897,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._make_profile_fatal_error_handler(profile_name, platform)
         )
         adapter.set_session_store(self.session_store)
+        self._wire_adapter_background_work_probe(adapter)
         adapter.set_busy_session_handler(self._handle_active_session_busy_message)
         _set_reaction = getattr(adapter, "set_reaction_handler", None)
         if callable(_set_reaction):
@@ -13970,6 +14007,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Otherwise control/session commands like /new or /help get silently
         # consumed as update answers instead of being dispatched normally.
         _quick_key = self._session_key_for_source(source)
+        # BasePlatformAdapter stamps a provisional key before it enters the
+        # runner.  This is the first runner-owned resolution and may include
+        # multiplex profile routing, so replace that fallback before any
+        # runner lifecycle or command path can observe the event.
+        setattr(event, "_gateway_session_key", _quick_key)
         _up_state = self._peek_session_state(_quick_key)
         if _up_state is not None and _up_state.persistent.update_prompt_pending:
             raw = (event.text or "").strip()
@@ -15750,6 +15792,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         session_entry = await self.async_session_store.get_or_create_session(source)
         session_key = session_entry.session_key
+        # SessionStore is the final authority (including source rewrites such
+        # as Telegram topic recovery). Keep lifecycle consumers on this exact
+        # same key that tools inherit through the session context.
+        setattr(event, "_gateway_session_key", session_key)
         pinned_session_id = str(
             (getattr(event, "metadata", None) or {}).get("gateway_session_id") or ""
         ).strip()
@@ -21605,6 +21651,63 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_name=str(evt.get("user_name") or "").strip() or None,
         )
 
+    async def _refresh_session_background_work(self, evt: dict) -> None:
+        """Notify the owning adapter that one background unit finalized.
+
+        This deliberately follows the persisted event session key and source
+        resolution used for completion delivery.  It is a generic adapter
+        lifecycle seam: adapters decide whether they expose a status surface;
+        gateway core never imports a platform implementation.
+        """
+        session_key = str(evt.get("session_key") or "").strip()
+        if not session_key:
+            return
+        source = self._build_process_event_source(evt)
+        if source is None:
+            return
+        adapter = self._adapter_for_source(source)
+        hook = getattr(adapter, "on_session_background_work_changed", None)
+        if not callable(hook):
+            return
+        try:
+            result = hook(source, session_key)
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            logger.debug(
+                "Background-work lifecycle refresh failed for session %s",
+                session_key,
+                exc_info=True,
+            )
+
+    async def _await_async_delegation_finalization(self, evt: dict) -> None:
+        """Bound the publish-before-terminal handoff for a live completion.
+
+        Async delegation intentionally persists and queues a completion while
+        its record is still ``finalizing``.  The private Event exists only on
+        that in-process queue item; restored durable events are already past
+        this handoff. Waiting happens off-loop, and the producer guarantees
+        that it signals from a ``finally`` block immediately after publishing.
+        A missing or corrupted signal times out and fails open to the status
+        refresh instead of wedging the watcher.
+        """
+        completion_signal = evt.get("_finalization_complete")
+        wait = getattr(completion_signal, "wait", None)
+        is_set = getattr(completion_signal, "is_set", None)
+        if not callable(wait) or (callable(is_set) and is_set()):
+            return
+        finalized = await asyncio.to_thread(
+            wait,
+            _ASYNC_DELEGATION_FINALIZATION_WAIT_TIMEOUT_SECS,
+        )
+        if not finalized:
+            logger.warning(
+                "Async delegation finalization signal timed out after %.2fs "
+                "for %s; refreshing background status fail-open",
+                _ASYNC_DELEGATION_FINALIZATION_WAIT_TIMEOUT_SECS,
+                evt.get("delegation_id", "unknown"),
+            )
+
     async def _inject_watch_notification(
         self, synth_text: str, evt: dict,
     ) -> Optional[bool]:
@@ -21978,17 +22081,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 for evt in requeue:
                     _pr.completion_queue.put(evt)
                 for evt in async_events:
-                    self._enrich_async_delegation_routing(evt)
-                    synth_text = _format_gateway_process_notification(evt)
-                    if not synth_text:
-                        continue
                     try:
-                        delivered = await self._deliver_completion_notification(synth_text, evt)
-                        if delivered is False:
-                            _pr.completion_queue.put(evt)
+                        self._enrich_async_delegation_routing(evt)
+                        synth_text = _format_gateway_process_notification(evt)
+                        if synth_text:
+                            delivered = await self._deliver_completion_notification(synth_text, evt)
+                            if delivered is False:
+                                _pr.completion_queue.put(evt)
                     except Exception as e:
                         _pr.completion_queue.put(evt)
                         logger.error("Async delegation injection error: %s", e)
+                    finally:
+                        # Completion delivery may be text-only, skipped, or
+                        # retryable.  The worker is terminal either way, so
+                        # refresh runtime-owned adapter state independently.
+                        await self._await_async_delegation_finalization(evt)
+                        await self._refresh_session_background_work(evt)
             except Exception as e:
                 logger.debug("Async delegation watcher error: %s", e)
             await asyncio.sleep(interval)
@@ -22032,6 +22140,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if session is None or session.exited:
                     break
             logger.debug("Process watcher ended (silent): %s", session_id)
+            await self._refresh_session_background_work({
+                "session_key": session_key,
+                "platform": platform_name,
+                "chat_type": watcher.get("chat_type", ""),
+                "chat_id": chat_id,
+                "thread_id": thread_id,
+                "user_id": user_id,
+                "user_name": user_name,
+            })
             return
 
         last_output_len = 0
@@ -22182,6 +22299,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         logger.error("Watcher delivery error: %s", e)
 
         logger.debug("Process watcher ended: %s", session_id)
+        await self._refresh_session_background_work({
+            "session_key": session_key,
+            "platform": platform_name,
+            "chat_type": watcher.get("chat_type", ""),
+            "chat_id": chat_id,
+            "thread_id": thread_id,
+            "user_id": user_id,
+            "user_name": user_name,
+        })
 
     _MAX_INTERRUPT_DEPTH = 3  # Cap recursive interrupt handling (#816)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19276,6 +19276,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return
         if str(getattr(current_entry, "session_id", "")) != str(session_id):
             return
+        session_db = getattr(self, "_session_db", None)
+        if session_db is None:
+            return
+        try:
+            current_title = await session_db.get_session_title(session_id)
+        except Exception:
+            logger.debug(
+                "Could not validate current title before adapter title propagation",
+                exc_info=True,
+            )
+            return
+        if current_title != title:
+            return
         adapter = self._adapter_for_source(source)
         if adapter is None:
             return

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5532,11 +5532,13 @@ class TurnRunner:
                         effective_session_id,
                         title,
                     )
+                elif self._runner._adapter_supports_semantic_base_refresh(ctx.source):
+                    maybe_auto_title_kwargs["title_callback"] = lambda title: self._runner._schedule_adapter_semantic_base_refresh(
+                        ctx.source, effective_session_id
+                    )
                 elif self._runner._adapter_supports_session_title_propagation(ctx.source):
                     maybe_auto_title_kwargs["title_callback"] = lambda title: self._runner._schedule_adapter_session_title_propagation(
-                        ctx.source,
-                        effective_session_id,
-                        title,
+                        ctx.source, effective_session_id, title
                     )
                 maybe_auto_title(
                     getattr(self._runner._session_db, "_db", self._runner._session_db),
@@ -15860,7 +15862,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         context = build_session_context(source, self.config, session_entry)
         
         # Set session context variables for tools (task-local, concurrency-safe)
-        _session_env_tokens = self._set_session_env(context)
+        _session_env_tokens = self._set_session_env(context, run_generation)
         
         # Read privacy.redact_pii from config (re-read per message)
         _redact_pii = False
@@ -18171,6 +18173,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_initiated=True,
             background_processes=_bg_procs,
         )
+        if not mgr.is_active() and source is not None:
+            self._schedule_adapter_semantic_base_refresh(source, sid)
         msg = decision.get("message") or ""
 
         # Defer the status line until after the adapter has delivered the
@@ -19265,6 +19269,277 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return callable(
             inspect.getattr_static(adapter, "on_session_title_changed", None)
         )
+
+    def _adapter_supports_semantic_base_refresh(self, source: SessionSource) -> bool:
+        adapter = self._adapter_for_source(source)
+        if adapter is None or not callable(
+            inspect.getattr_static(adapter, "on_session_semantic_base_changed", None)
+        ):
+            return False
+        capability = inspect.getattr_static(
+            adapter, "supports_session_semantic_base_refresh", None
+        )
+        if callable(capability):
+            try:
+                return bool(adapter.supports_session_semantic_base_refresh(source))
+            except Exception:
+                logger.debug("Adapter semantic-base capability check failed", exc_info=True)
+                return False
+        return True
+
+    def _make_current_chat_rename_callback(
+        self,
+        source: SessionSource,
+        session_key: str,
+        session_id: str,
+        run_generation: Optional[int],
+    ):
+        """Bind a synchronous tool callback to one live gateway turn."""
+        if not self._adapter_supports_semantic_base_refresh(source):
+            return None
+        try:
+            copied_source = dataclasses.replace(source)
+        except Exception:
+            copied_source = source
+
+        def _rename(title: str) -> dict:
+            loop = getattr(self, "_gateway_loop", None)
+            if loop is None or loop.is_closed() or not loop.is_running():
+                return {
+                    "success": False,
+                    "error": "The gateway event loop is not available; the current chat was not renamed.",
+                }
+            generation = self._reserve_adapter_title_generation(session_id)
+            future = safe_schedule_threadsafe(
+                self._rename_current_gateway_chat(
+                    copied_source,
+                    session_key,
+                    session_id,
+                    run_generation,
+                    title,
+                    generation,
+                ),
+                loop,
+                logger=logger,
+                log_message="Current gateway chat rename failed to schedule",
+            )
+            if future is None:
+                self._release_adapter_title_generation(session_id)
+                return {
+                    "success": False,
+                    "error": "The current gateway chat rename could not be scheduled.",
+                }
+            try:
+                return future.result()
+            except Exception as exc:
+                logger.debug("Current gateway chat rename failed", exc_info=True)
+                return {
+                    "success": False,
+                    "error": f"Current gateway chat rename failed: {exc}",
+                }
+            finally:
+                self._release_adapter_title_generation(session_id)
+
+        return _rename
+
+    async def _rename_current_gateway_chat(
+        self,
+        source: SessionSource,
+        session_key: str,
+        session_id: str,
+        run_generation: Optional[int],
+        title: str,
+        generation: int,
+    ) -> dict:
+        """Persist and apply a current-chat semantic title on the gateway loop."""
+        title = str(title or "").strip()
+        if not title:
+            return {"success": False, "error": "A non-empty title is required."}
+        key = str(session_id)
+        with self._adapter_title_state_lock:
+            apply_lock = self._adapter_title_apply_locks.setdefault(key, asyncio.Lock())
+        async with apply_lock:
+            def _generation_is_current() -> bool:
+                with self._adapter_title_state_lock:
+                    return self._adapter_title_generations.get(key) == generation
+
+            async def _resolve_current_source() -> Optional[SessionSource]:
+                if not _generation_is_current():
+                    return None
+                if run_generation is not None and not self._is_session_run_current(
+                    session_key, run_generation
+                ):
+                    return None
+                try:
+                    current_source = self._get_cached_session_source(session_key) or source
+                    if self._session_key_for_source(current_source) != session_key:
+                        return None
+                    entry = await self.async_session_store.get_or_create_session(
+                        current_source
+                    )
+                except Exception:
+                    return None
+                if str(getattr(entry, "session_id", "")) != key:
+                    return None
+                return current_source
+
+            current_source = await _resolve_current_source()
+            if current_source is None:
+                return {
+                    "success": False,
+                    "error": "The originating gateway session is no longer current; no rename was applied.",
+                }
+            adapter = self._adapter_for_source(current_source)
+            hook = getattr(adapter, "on_session_semantic_base_changed", None)
+            if not callable(hook) or self._session_db is None:
+                return {
+                    "success": False,
+                    "error": "The current gateway platform does not support chat renaming.",
+                }
+
+            # Authoritative revalidation immediately before persistence.
+            current_source = await _resolve_current_source()
+            if current_source is None:
+                return {
+                    "success": False,
+                    "error": "The originating gateway session changed before persistence; no rename was applied.",
+                }
+            try:
+                persisted = await self._session_db.set_session_title(key, title)
+            except Exception as exc:
+                return {"success": False, "error": f"Session title persistence failed: {exc}"}
+            if not persisted:
+                return {"success": False, "error": "The current session no longer exists."}
+
+            # An active goal remains the visible semantic base.  The explicit
+            # title is still persisted as the fallback used once that goal is
+            # paused or completed.
+            base = title
+            try:
+                from hermes_cli.goals import GoalManager
+                manager = GoalManager(session_id=key)
+                if manager.is_active() and manager.state is not None:
+                    base = manager.state.goal
+            except Exception:
+                logger.debug("Could not resolve active goal during chat rename", exc_info=True)
+
+            # Revalidate again immediately before the live adapter update.
+            current_source = await _resolve_current_source()
+            if current_source is None:
+                return {
+                    "success": False,
+                    "error": "The originating gateway session changed after title persistence; live chat rename was not applied.",
+                }
+            try:
+                # Re-resolve the adapter as well: multiplex profile routing can
+                # replace the live adapter while an older turn is still alive.
+                adapter = self._adapter_for_source(current_source)
+                hook = getattr(adapter, "on_session_semantic_base_changed", None)
+                if not callable(hook):
+                    return {
+                        "success": False,
+                        "error": "The current gateway platform no longer supports chat renaming.",
+                    }
+                applied = hook(current_source, base)
+                if inspect.isawaitable(applied):
+                    applied = await applied
+            except Exception as exc:
+                return {"success": False, "error": f"Live chat rename failed: {exc}"}
+            if not applied:
+                return {
+                    "success": False,
+                    "error": "The platform declined the live chat rename; the session title was persisted.",
+                }
+            if not _generation_is_current():
+                return {
+                    "success": False,
+                    "error": "This rename was superseded by a newer rename request.",
+                }
+            return {"success": True, "title": title, "visible_base": base}
+
+    async def _refresh_adapter_semantic_base(
+        self,
+        source: SessionSource,
+        session_id: str,
+        generation: int,
+    ) -> None:
+        """Resolve goal > title > adapter recovery and apply it race-safely."""
+        key = str(session_id)
+        try:
+            current_entry = await self.async_session_store.get_or_create_session(source)
+            if str(getattr(current_entry, "session_id", "")) != key:
+                return
+            with self._adapter_title_state_lock:
+                apply_lock = self._adapter_title_apply_locks.setdefault(key, asyncio.Lock())
+            async with apply_lock:
+                with self._adapter_title_state_lock:
+                    if self._adapter_title_generations.get(key) != generation:
+                        return
+                current_entry = await self.async_session_store.get_or_create_session(source)
+                if str(getattr(current_entry, "session_id", "")) != key:
+                    return
+                base = None
+                try:
+                    from hermes_cli.goals import GoalManager
+                    mgr = GoalManager(session_id=key)
+                    if mgr.is_active() and mgr.state is not None:
+                        base = mgr.state.goal
+                except Exception:
+                    logger.debug("Could not resolve active goal for semantic base", exc_info=True)
+                if not base and self._session_db is not None:
+                    try:
+                        base = await self._session_db.get_session_title(key)
+                    except Exception:
+                        logger.debug("Could not resolve session title for semantic base", exc_info=True)
+                with self._adapter_title_state_lock:
+                    if self._adapter_title_generations.get(key) != generation:
+                        return
+                adapter = self._adapter_for_source(source)
+                hook = getattr(adapter, "on_session_semantic_base_changed", None)
+                if callable(hook):
+                    result = hook(source, base)
+                    if inspect.isawaitable(result):
+                        await result
+        except Exception:
+            logger.debug("Adapter semantic-base refresh failed", exc_info=True)
+
+    def _schedule_adapter_semantic_base_refresh(
+        self, source: SessionSource, session_id: str
+    ) -> None:
+        """Schedule a fresh persisted semantic-base resolution on gateway loop."""
+        if not self._adapter_supports_semantic_base_refresh(source):
+            return
+        gateway_loop = getattr(self, "_gateway_loop", None)
+        if gateway_loop is not None and gateway_loop.is_running() and not gateway_loop.is_closed():
+            loop = gateway_loop
+        else:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+        if loop is None or loop.is_closed():
+            return
+        generation = self._reserve_adapter_title_generation(session_id)
+        try:
+            copied_source = dataclasses.replace(source)
+        except Exception:
+            copied_source = source
+        future = safe_schedule_threadsafe(
+            self._refresh_adapter_semantic_base(copied_source, session_id, generation),
+            loop, logger=logger,
+            log_message="Adapter semantic-base refresh failed to schedule",
+        )
+        if future is None:
+            self._release_adapter_title_generation(session_id)
+            return
+        def _done(fut) -> None:
+            try:
+                fut.result()
+            except Exception:
+                logger.debug("Adapter semantic-base refresh failed", exc_info=True)
+            finally:
+                self._release_adapter_title_generation(session_id)
+        future.add_done_callback(_done)
 
     def _ensure_adapter_title_state(self) -> None:
         """Lazily initialize title ordering state for partial test runners."""
@@ -20747,7 +21022,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return delivered
 
-    def _set_session_env(self, context: SessionContext) -> list:
+    def _set_session_env(
+        self, context: SessionContext, run_generation: Optional[int] = None
+    ) -> list:
         """Set session context variables for the current async task.
 
         Uses ``contextvars`` instead of ``os.environ`` so that concurrent
@@ -20781,6 +21058,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
             async_delivery=_async_delivery,
+            current_chat_rename_callback=self._make_current_chat_rename_callback(
+                context.source,
+                context.session_key,
+                context.session_id,
+                run_generation,
+            ),
         )
 
     def _clear_session_env(self, tokens: list) -> None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19307,7 +19307,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         title: str,
         generation: Optional[int] = None,
     ) -> None:
-        """Best-effort title propagation through an adapter's optional hook."""
+        """Best-effort title propagation through an adapter's optional hook.
+
+        Production callers must enter through
+        ``_schedule_adapter_session_title_propagation`` so all per-session
+        apply locks are created and acquired on the canonical gateway loop.
+        Direct awaits are reserved for partial runners/tests without a live
+        gateway loop.
+        """
         if not title or not self._adapter_supports_session_title_propagation(source):
             return
         owns_generation = generation is None
@@ -19385,10 +19392,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Schedule an optional adapter title hook from any caller thread."""
         if not title or not self._adapter_supports_session_title_propagation(source):
             return
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = getattr(self, "_gateway_loop", None)
+        gateway_loop = getattr(self, "_gateway_loop", None)
+        if (
+            gateway_loop is not None
+            and gateway_loop.is_running()
+            and not gateway_loop.is_closed()
+        ):
+            # Adapter instances and their per-session apply locks belong to
+            # the canonical gateway loop, even when this callback arrives
+            # from another running loop/thread.
+            loop = gateway_loop
+        else:
+            # Partial runners and startup tests may not have established the
+            # canonical loop yet.  In that case only, use the caller's loop.
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
         if loop is None or loop.is_closed():
             return
         generation = self._reserve_adapter_title_generation(session_id)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5702,6 +5702,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _shutdown_watchdog_done: Optional["threading.Event"] = None
     _platform_lock_takeover_on_start: bool = False
     _reconnect_watcher_task: Optional["asyncio.Task"] = None
+    _adapter_title_state_init_lock = threading.Lock()
 
     def __init__(self, config: Optional[GatewayConfig] = None):
         global _gateway_runner_ref
@@ -5818,6 +5819,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Set on gateway stop so the recreate-on-shutdown path can't resurrect
         # the pool during a real shutdown.
         self._executor_closing = False
+        # Title callbacks may be scheduled both on the gateway loop and from
+        # the auto-title worker thread.  Generations are therefore assigned
+        # under a synchronous lock before either caller can yield, while the
+        # actual adapter writes are serialized on the gateway loop.
+        self._adapter_title_state_lock = threading.Lock()
+        self._adapter_title_generations: Dict[str, int] = {}
+        self._adapter_title_pending: Dict[str, int] = {}
+        self._adapter_title_apply_locks: Dict[str, asyncio.Lock] = {}
         # ALL per-session state (turn / conversation / persistent scopes)
         # lives in one container — see gateway/session_state.py.  Access via
         # self._session_state(key) (get-or-create) or
@@ -19257,53 +19266,115 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             inspect.getattr_static(adapter, "on_session_title_changed", None)
         )
 
+    def _ensure_adapter_title_state(self) -> None:
+        """Lazily initialize title ordering state for partial test runners."""
+        if hasattr(self, "_adapter_title_state_lock"):
+            return
+        with self._adapter_title_state_init_lock:
+            if not hasattr(self, "_adapter_title_state_lock"):
+                self._adapter_title_state_lock = threading.Lock()
+                self._adapter_title_generations = {}
+                self._adapter_title_pending = {}
+                self._adapter_title_apply_locks = {}
+
+    def _reserve_adapter_title_generation(self, session_id: str) -> int:
+        self._ensure_adapter_title_state()
+        key = str(session_id)
+        with self._adapter_title_state_lock:
+            generation = self._adapter_title_generations.get(key, 0) + 1
+            self._adapter_title_generations[key] = generation
+            self._adapter_title_pending[key] = (
+                self._adapter_title_pending.get(key, 0) + 1
+            )
+            return generation
+
+    def _release_adapter_title_generation(self, session_id: str) -> None:
+        """Drop idle per-session ordering state after every task has exited."""
+        key = str(session_id)
+        with self._adapter_title_state_lock:
+            pending = self._adapter_title_pending.get(key, 0) - 1
+            if pending > 0:
+                self._adapter_title_pending[key] = pending
+                return
+            self._adapter_title_pending.pop(key, None)
+            self._adapter_title_generations.pop(key, None)
+            self._adapter_title_apply_locks.pop(key, None)
+
     async def _propagate_session_title_to_adapter(
         self,
         source: SessionSource,
         session_id: str,
         title: str,
+        generation: Optional[int] = None,
     ) -> None:
         """Best-effort title propagation through an adapter's optional hook."""
         if not title or not self._adapter_supports_session_title_propagation(source):
             return
+        owns_generation = generation is None
+        if generation is None:
+            generation = self._reserve_adapter_title_generation(session_id)
         try:
-            current_entry = await self.async_session_store.get_or_create_session(source)
-        except Exception:
-            logger.debug(
-                "Could not validate current session before adapter title propagation",
-                exc_info=True,
-            )
-            return
-        if str(getattr(current_entry, "session_id", "")) != str(session_id):
-            return
-        session_db = getattr(self, "_session_db", None)
-        if session_db is None:
-            return
-        try:
-            current_title = await session_db.get_session_title(session_id)
-        except Exception:
-            logger.debug(
-                "Could not validate current title before adapter title propagation",
-                exc_info=True,
-            )
-            return
-        if current_title != title:
-            return
-        adapter = self._adapter_for_source(source)
-        if adapter is None:
-            return
-        title_hook = getattr(adapter, "on_session_title_changed", None)
-        if not callable(title_hook):
-            return
-        try:
-            result = title_hook(source, title)
-            if inspect.isawaitable(result):
-                await result
-        except Exception:
-            logger.debug(
-                "Adapter session-title propagation failed",
-                exc_info=True,
-            )
+            try:
+                current_entry = await self.async_session_store.get_or_create_session(source)
+            except Exception:
+                logger.debug(
+                    "Could not validate current session before adapter title propagation",
+                    exc_info=True,
+                )
+                return
+            if str(getattr(current_entry, "session_id", "")) != str(session_id):
+                return
+            session_db = getattr(self, "_session_db", None)
+            if session_db is None:
+                return
+            try:
+                current_title = await session_db.get_session_title(session_id)
+            except Exception:
+                logger.debug(
+                    "Could not validate current title before adapter title propagation",
+                    exc_info=True,
+                )
+                return
+            if current_title != title:
+                return
+            try:
+                key = str(session_id)
+                with self._adapter_title_state_lock:
+                    apply_lock = self._adapter_title_apply_locks.setdefault(
+                        key, asyncio.Lock()
+                    )
+                async with apply_lock:
+                    with self._adapter_title_state_lock:
+                        if self._adapter_title_generations.get(key) != generation:
+                            return
+                    # Revalidate under the application lock.  These are the
+                    # authoritative checks immediately before the adapter write;
+                    # the earlier checks are only a cheap fast-fail path.
+                    current_entry = (
+                        await self.async_session_store.get_or_create_session(source)
+                    )
+                    if str(getattr(current_entry, "session_id", "")) != key:
+                        return
+                    current_title = await session_db.get_session_title(session_id)
+                    if current_title != title:
+                        return
+                    with self._adapter_title_state_lock:
+                        if self._adapter_title_generations.get(key) != generation:
+                            return
+                    adapter = self._adapter_for_source(source)
+                    if adapter is None:
+                        return
+                    title_hook = getattr(adapter, "on_session_title_changed", None)
+                    if not callable(title_hook):
+                        return
+                    result = title_hook(source, title)
+                    if inspect.isawaitable(result):
+                        await result
+            except Exception:
+                logger.debug("Adapter session-title propagation failed", exc_info=True)
+        finally:
+            if owns_generation:
+                self._release_adapter_title_generation(session_id)
 
     def _schedule_adapter_session_title_propagation(
         self,
@@ -19320,6 +19391,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             loop = getattr(self, "_gateway_loop", None)
         if loop is None or loop.is_closed():
             return
+        generation = self._reserve_adapter_title_generation(session_id)
         try:
             copied_source = dataclasses.replace(source)
         except Exception:
@@ -19329,12 +19401,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 copied_source,
                 session_id,
                 title,
+                generation,
             ),
             loop,
             logger=logger,
             log_message="Adapter session-title propagation failed to schedule",
         )
         if future is None:
+            self._release_adapter_title_generation(session_id)
             return
 
         def _log_rename_failure(fut) -> None:
@@ -19342,6 +19416,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 fut.result()
             except Exception:
                 logger.debug("Adapter session-title propagation failed", exc_info=True)
+            finally:
+                self._release_adapter_title_generation(session_id)
 
         future.add_done_callback(_log_rename_failure)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5532,8 +5532,8 @@ class TurnRunner:
                         effective_session_id,
                         title,
                     )
-                elif self._runner._is_matrix_dynamic_room_name_lane(ctx.source):
-                    maybe_auto_title_kwargs["title_callback"] = lambda title: self._runner._schedule_matrix_semantic_room_rename(
+                elif self._runner._adapter_supports_session_title_propagation(ctx.source):
+                    maybe_auto_title_kwargs["title_callback"] = lambda title: self._runner._schedule_adapter_session_title_propagation(
                         ctx.source,
                         effective_session_id,
                         title,
@@ -19243,58 +19243,63 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         future.add_done_callback(_log_rename_failure)
 
-    @staticmethod
-    def _is_matrix_dynamic_room_name_lane(source: SessionSource) -> bool:
-        """Return True for Matrix DMs eligible for opt-in dynamic room names."""
-        return bool(
-            source.platform == Platform.MATRIX
-            and source.chat_type == "dm"
-            and source.chat_id
+    def _adapter_supports_session_title_propagation(
+        self,
+        source: SessionSource,
+    ) -> bool:
+        """Return whether the source adapter exposes the optional title hook."""
+        adapter = self._adapter_for_source(source)
+        if adapter is None:
+            return False
+        # Static lookup keeps permissive mocks from inventing the hook while
+        # still allowing adapters to install a concrete per-instance callback.
+        return callable(
+            inspect.getattr_static(adapter, "on_session_title_changed", None)
         )
 
-    async def _rename_matrix_room_for_session_title(
+    async def _propagate_session_title_to_adapter(
         self,
         source: SessionSource,
         session_id: str,
         title: str,
     ) -> None:
-        """Best-effort Matrix room rename from a generated session title."""
-        if not self._is_matrix_dynamic_room_name_lane(source):
+        """Best-effort title propagation through an adapter's optional hook."""
+        if not title or not self._adapter_supports_session_title_propagation(source):
             return
         try:
             current_entry = await self.async_session_store.get_or_create_session(source)
         except Exception:
             logger.debug(
-                "Could not validate current Matrix session before room rename",
+                "Could not validate current session before adapter title propagation",
                 exc_info=True,
             )
             return
         if str(getattr(current_entry, "session_id", "")) != str(session_id):
             return
-        adapter = self._adapter_for_source(source) if getattr(self, "adapters", None) else None
+        adapter = self._adapter_for_source(source)
         if adapter is None:
             return
-        set_semantic_room_name = getattr(adapter, "set_semantic_room_name", None)
-        if not callable(set_semantic_room_name):
+        title_hook = getattr(adapter, "on_session_title_changed", None)
+        if not callable(title_hook):
             return
         try:
-            result = set_semantic_room_name(str(source.chat_id), title)
+            result = title_hook(source, title)
             if inspect.isawaitable(result):
                 await result
         except Exception:
             logger.debug(
-                "Failed to rename Matrix room for generated session title",
+                "Adapter session-title propagation failed",
                 exc_info=True,
             )
 
-    def _schedule_matrix_semantic_room_rename(
+    def _schedule_adapter_session_title_propagation(
         self,
         source: SessionSource,
         session_id: str,
         title: str,
     ) -> None:
-        """Schedule Matrix room rename from the auto-title background thread."""
-        if not title or not self._is_matrix_dynamic_room_name_lane(source):
+        """Schedule an optional adapter title hook from any caller thread."""
+        if not title or not self._adapter_supports_session_title_propagation(source):
             return
         try:
             loop = asyncio.get_running_loop()
@@ -19307,14 +19312,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             copied_source = source
         future = safe_schedule_threadsafe(
-            self._rename_matrix_room_for_session_title(
+            self._propagate_session_title_to_adapter(
                 copied_source,
                 session_id,
                 title,
             ),
             loop,
             logger=logger,
-            log_message="Matrix semantic room rename failed to schedule",
+            log_message="Adapter session-title propagation failed to schedule",
         )
         if future is None:
             return
@@ -19323,7 +19328,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             try:
                 fut.result()
             except Exception:
-                logger.debug("Matrix semantic room rename failed", exc_info=True)
+                logger.debug("Adapter session-title propagation failed", exc_info=True)
 
         future.add_done_callback(_log_rename_failure)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5532,6 +5532,12 @@ class TurnRunner:
                         effective_session_id,
                         title,
                     )
+                elif self._runner._is_matrix_dynamic_room_name_lane(ctx.source):
+                    maybe_auto_title_kwargs["title_callback"] = lambda title: self._runner._schedule_matrix_semantic_room_rename(
+                        ctx.source,
+                        effective_session_id,
+                        title,
+                    )
                 maybe_auto_title(
                     getattr(self._runner._session_db, "_db", self._runner._session_db),
                     effective_session_id,
@@ -19234,6 +19240,90 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 fut.result()
             except Exception:
                 logger.debug("Discord semantic thread rename failed", exc_info=True)
+
+        future.add_done_callback(_log_rename_failure)
+
+    @staticmethod
+    def _is_matrix_dynamic_room_name_lane(source: SessionSource) -> bool:
+        """Return True for Matrix DMs eligible for opt-in dynamic room names."""
+        return bool(
+            source.platform == Platform.MATRIX
+            and source.chat_type == "dm"
+            and source.chat_id
+        )
+
+    async def _rename_matrix_room_for_session_title(
+        self,
+        source: SessionSource,
+        session_id: str,
+        title: str,
+    ) -> None:
+        """Best-effort Matrix room rename from a generated session title."""
+        if not self._is_matrix_dynamic_room_name_lane(source):
+            return
+        try:
+            current_entry = await self.async_session_store.get_or_create_session(source)
+        except Exception:
+            logger.debug(
+                "Could not validate current Matrix session before room rename",
+                exc_info=True,
+            )
+            return
+        if str(getattr(current_entry, "session_id", "")) != str(session_id):
+            return
+        adapter = self._adapter_for_source(source) if getattr(self, "adapters", None) else None
+        if adapter is None:
+            return
+        set_semantic_room_name = getattr(adapter, "set_semantic_room_name", None)
+        if not callable(set_semantic_room_name):
+            return
+        try:
+            result = set_semantic_room_name(str(source.chat_id), title)
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            logger.debug(
+                "Failed to rename Matrix room for generated session title",
+                exc_info=True,
+            )
+
+    def _schedule_matrix_semantic_room_rename(
+        self,
+        source: SessionSource,
+        session_id: str,
+        title: str,
+    ) -> None:
+        """Schedule Matrix room rename from the auto-title background thread."""
+        if not title or not self._is_matrix_dynamic_room_name_lane(source):
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = getattr(self, "_gateway_loop", None)
+        if loop is None or loop.is_closed():
+            return
+        try:
+            copied_source = dataclasses.replace(source)
+        except Exception:
+            copied_source = source
+        future = safe_schedule_threadsafe(
+            self._rename_matrix_room_for_session_title(
+                copied_source,
+                session_id,
+                title,
+            ),
+            loop,
+            logger=logger,
+            log_message="Matrix semantic room rename failed to schedule",
+        )
+        if future is None:
+            return
+
+        def _log_rename_failure(fut) -> None:
+            try:
+                fut.result()
+            except Exception:
+                logger.debug("Matrix semantic room rename failed", exc_info=True)
 
         future.add_done_callback(_log_rename_failure)
 

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -114,6 +114,12 @@ _SESSION_PROFILE: ContextVar = ContextVar("HERMES_SESSION_PROFILE", default=_UNS
 # setting ``supports_async_delivery = False`` on the adapter class; the gateway
 # propagates that into this contextvar at session-bind time.
 _SESSION_ASYNC_DELIVERY: ContextVar = ContextVar("HERMES_SESSION_ASYNC_DELIVERY", default=_UNSET)
+# Gateway-local capability for tools that operate on the current chat.  The
+# callable is deliberately task-local: a module-global callback would retain a
+# runner (and its profile/config) across shutdowns and test cases.
+_CURRENT_CHAT_RENAME_CALLBACK: ContextVar = ContextVar(
+    "HERMES_CURRENT_CHAT_RENAME_CALLBACK", default=_UNSET
+)
 
 # Cron auto-delivery vars — set per-job in run_job() so concurrent jobs
 # don't clobber each other's delivery targets.
@@ -212,6 +218,7 @@ def set_session_vars(
     cwd: str = "",
     async_delivery: bool = True,
     ui_session_id: str = "",
+    current_chat_rename_callback=None,
 ) -> list:
     """Set all session context variables and return reset tokens.
 
@@ -248,6 +255,7 @@ def set_session_vars(
         _SESSION_MESSAGE_ID.set(message_id),
         _SESSION_PROFILE.set(profile),
         _SESSION_ASYNC_DELIVERY.set(bool(async_delivery)),
+        _CURRENT_CHAT_RENAME_CALLBACK.set(current_chat_rename_callback),
     ]
     try:
         from agent.runtime_cwd import set_session_cwd
@@ -290,6 +298,7 @@ def clear_session_vars(tokens: list) -> None:
     # behavior (CLI / unaware paths), not be mistaken for an opted-out
     # stateless adapter.
     _SESSION_ASYNC_DELIVERY.set(_UNSET)
+    _CURRENT_CHAT_RENAME_CALLBACK.set(_UNSET)
     try:
         from agent.runtime_cwd import clear_session_cwd
 
@@ -338,12 +347,19 @@ def reset_session_vars() -> None:
     # same inheritance-leak reason as the mapped vars above — see clear_session_vars,
     # which resets this var on the handler-exit path for the symmetric concern.
     _SESSION_ASYNC_DELIVERY.set(_UNSET)
+    _CURRENT_CHAT_RENAME_CALLBACK.set(_UNSET)
     try:
         from agent.runtime_cwd import clear_session_cwd
 
         clear_session_cwd()
     except Exception:
         pass
+
+
+def get_current_chat_rename_callback():
+    """Return the gateway-local current-chat rename capability, if bound."""
+    callback = _CURRENT_CHAT_RENAME_CALLBACK.get()
+    return None if callback is _UNSET else callback
 
 
 def get_session_env(name: str, default: str = "") -> str:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2629,6 +2629,11 @@ class GatewaySlashCommandsMixin:
             state = mgr.pause(reason="user-paused")
             if state is None:
                 return t("gateway.goal.no_goal_set")
+            schedule_semantic_refresh = getattr(
+                self, "_schedule_adapter_semantic_base_refresh", None
+            )
+            if callable(schedule_semantic_refresh):
+                schedule_semantic_refresh(event.source, session_entry.session_id)
             try:
                 adapter = self.adapters.get(event.source.platform) if event.source else None
                 _quick_key = self._session_key_for_source(event.source) if event.source else None
@@ -2642,11 +2647,21 @@ class GatewaySlashCommandsMixin:
             state = mgr.resume()
             if state is None:
                 return t("gateway.goal.no_resume")
+            schedule_semantic_refresh = getattr(
+                self, "_schedule_adapter_semantic_base_refresh", None
+            )
+            if callable(schedule_semantic_refresh):
+                schedule_semantic_refresh(event.source, session_entry.session_id)
             return t("gateway.goal.resumed", goal=state.goal)
 
         if lower in {"clear", "stop", "done"}:
             had = mgr.has_goal()
             mgr.clear()
+            schedule_semantic_refresh = getattr(
+                self, "_schedule_adapter_semantic_base_refresh", None
+            )
+            if callable(schedule_semantic_refresh):
+                schedule_semantic_refresh(event.source, session_entry.session_id)
             try:
                 adapter = self.adapters.get(event.source.platform) if event.source else None
                 _quick_key = self._session_key_for_source(event.source) if event.source else None
@@ -2714,6 +2729,14 @@ class GatewaySlashCommandsMixin:
             state = mgr.set(args, contract=contract)
         except ValueError as exc:
             return t("gateway.goal.invalid", error=str(exc))
+
+        # The persisted epic is authoritative for semantic room naming. Queue
+        # its refresh before kickoff so an auto-title from that turn cannot win.
+        schedule_semantic_refresh = getattr(
+            self, "_schedule_adapter_semantic_base_refresh", None
+        )
+        if callable(schedule_semantic_refresh):
+            schedule_semantic_refresh(event.source, session_entry.session_id)
 
         # Queue the goal text as an immediate first turn so the agent
         # starts making progress. The post-turn hook takes over after.
@@ -4322,17 +4345,20 @@ class GatewaySlashCommandsMixin:
                                 "Failed to rename Telegram topic from /title",
                                 exc_info=True,
                             )
-                    schedule_adapter_title = getattr(
-                        self, "_schedule_adapter_session_title_propagation", None
-                    )
-                    if callable(schedule_adapter_title):
-                        try:
-                            schedule_adapter_title(source, session_id, sanitized)
-                        except Exception:
-                            logger.debug(
-                                "Failed to propagate /title through platform adapter",
-                                exc_info=True,
+                    try:
+                        if self._adapter_supports_semantic_base_refresh(source):
+                            self._schedule_adapter_semantic_base_refresh(
+                                source, session_id
                             )
+                        elif self._adapter_supports_session_title_propagation(source):
+                            self._schedule_adapter_session_title_propagation(
+                                source, session_id, sanitized
+                            )
+                    except Exception:
+                        logger.debug(
+                            "Failed to propagate /title through platform adapter",
+                            exc_info=True,
+                        )
                     return t("gateway.title.set_to", title=sanitized)
                 else:
                     return t("gateway.title.not_found")

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4322,6 +4322,22 @@ class GatewaySlashCommandsMixin:
                                 "Failed to rename Telegram topic from /title",
                                 exc_info=True,
                             )
+                    schedule_matrix_rename = getattr(
+                        self, "_schedule_matrix_semantic_room_rename", None
+                    )
+                    if callable(schedule_matrix_rename):
+                        try:
+                            await asyncio.to_thread(
+                                schedule_matrix_rename,
+                                source,
+                                session_id,
+                                sanitized,
+                            )
+                        except Exception:
+                            logger.debug(
+                                "Failed to rename Matrix room from /title",
+                                exc_info=True,
+                            )
                     return t("gateway.title.set_to", title=sanitized)
                 else:
                     return t("gateway.title.not_found")

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4316,26 +4316,21 @@ class GatewaySlashCommandsMixin:
                     )
                     if callable(schedule_rename):
                         try:
-                            await asyncio.to_thread(schedule_rename, source, session_id, sanitized)
+                            schedule_rename(source, session_id, sanitized)
                         except Exception:
                             logger.debug(
                                 "Failed to rename Telegram topic from /title",
                                 exc_info=True,
                             )
-                    schedule_matrix_rename = getattr(
-                        self, "_schedule_matrix_semantic_room_rename", None
+                    schedule_adapter_title = getattr(
+                        self, "_schedule_adapter_session_title_propagation", None
                     )
-                    if callable(schedule_matrix_rename):
+                    if callable(schedule_adapter_title):
                         try:
-                            await asyncio.to_thread(
-                                schedule_matrix_rename,
-                                source,
-                                session_id,
-                                sanitized,
-                            )
+                            schedule_adapter_title(source, session_id, sanitized)
                         except Exception:
                             logger.debug(
-                                "Failed to rename Matrix room from /title",
+                                "Failed to propagate /title through platform adapter",
                                 exc_info=True,
                             )
                     return t("gateway.title.set_to", title=sanitized)

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -209,6 +209,7 @@ def _homeassistant_credentials_present() -> bool:
 # server admin, Slack workspace admin, etc.).  Keeps every other platform's
 # checklist from filling up with irrelevant toggles.
 _TOOLSET_PLATFORM_RESTRICTIONS: Dict[str, Set[str]] = {
+    "chat_title": {"matrix"},
     "discord": {"discord"},
     "discord_admin": {"discord"},
 }
@@ -2474,6 +2475,14 @@ def _get_platform_tools(
             enabled_toolsets.update(enabled_mcp_servers)
     else:
         enabled_toolsets.update(explicit_mcp_servers)
+
+    # Apply platform restrictions to recovered and explicitly-passed-through
+    # non-configurable toolsets too.  In particular, chat_title is a narrow
+    # Matrix-native capability and must not be enabled by naming it on another
+    # platform.
+    enabled_toolsets = {
+        ts for ts in enabled_toolsets if _toolset_allowed_for_platform(ts, platform)
+    }
 
     # Honor agent.disabled_toolsets from config.yaml — allows users to
     # globally suppress specific toolsets (e.g. "memory") across all

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1158,6 +1158,7 @@ class MatrixAdapter(BasePlatformAdapter):
         self._dynamic_room_name_initialized: Set[str] = set()
         self._dynamic_room_name_active: Dict[str, int] = {}
         self._dynamic_room_name_active_turns: Set[tuple[str, str]] = set()
+        self._dynamic_room_name_session_keys: Dict[str, Set[str]] = {}
         self._dynamic_room_name_last_sent: Dict[str, str] = {}
         self._dynamic_room_name_superseded_sent: Dict[str, Set[str]] = {}
         self._dynamic_room_name_terminal_external_checks: Set[str] = set()
@@ -3741,7 +3742,7 @@ class MatrixAdapter(BasePlatformAdapter):
         # Room-name state is intentionally runtime-owned and binary. Outcomes
         # remain visible through message reactions, but can never control or be
         # smuggled into the room title by an AI-generated semantic title.
-        prefix = "🟡" if self._dynamic_room_name_active.get(room_id, 0) else "🟢"
+        prefix = "🟡" if self._dynamic_room_name_is_active(room_id) else "🟢"
         name = f"{prefix} {base}"
         return await self._send_dynamic_room_name(room_id, name)
 
@@ -3784,10 +3785,51 @@ class MatrixAdapter(BasePlatformAdapter):
         message_id = event.message_id or f"event:{id(event)}"
         return room_id, str(message_id)
 
+    def _remember_dynamic_room_name_session(
+        self, room_id: str, session_key: str,
+    ) -> None:
+        """Retain only keys that currently own background work for this room.
+
+        A room can legitimately have concurrent thread/session work, so this
+        is a set rather than one "latest" key.  Keys are removed as soon as
+        their probe goes inactive (and opportunistically on every render),
+        preventing session resets in a long-lived room from accumulating
+        stale namespaces.
+        """
+        if not session_key:
+            return
+        keys = self._dynamic_room_name_session_keys.setdefault(room_id, set())
+        if self.has_session_background_work(session_key):
+            keys.add(session_key)
+        else:
+            keys.discard(session_key)
+        if not keys:
+            self._dynamic_room_name_session_keys.pop(room_id, None)
+
+    def _dynamic_room_name_is_active(self, room_id: str) -> bool:
+        """Return foreground-or-owned-background activity for this DM only."""
+        if self._dynamic_room_name_active.get(room_id, 0):
+            return True
+        keys = self._dynamic_room_name_session_keys.get(room_id)
+        if not keys:
+            return False
+        active_keys = {
+            session_key for session_key in keys
+            if self.has_session_background_work(session_key)
+        }
+        if active_keys:
+            self._dynamic_room_name_session_keys[room_id] = active_keys
+            return True
+        self._dynamic_room_name_session_keys.pop(room_id, None)
+        return False
+
     async def _update_dynamic_room_name_for_start(self, event: MessageEvent) -> bool:
         if not self._dynamic_room_name_allowed(event):
             return True
         room_id = str(event.source.chat_id)
+        self._remember_dynamic_room_name_session(
+            room_id, str(getattr(event, "_gateway_session_key", "") or "")
+        )
         turn_key = self._dynamic_room_name_turn_key(event)
         if turn_key in self._dynamic_room_name_active_turns:
             return False
@@ -3806,16 +3848,39 @@ class MatrixAdapter(BasePlatformAdapter):
         if not self._dynamic_room_name_allowed(event):
             return True
         room_id = str(event.source.chat_id)
+        self._remember_dynamic_room_name_session(
+            room_id, str(getattr(event, "_gateway_session_key", "") or "")
+        )
         turn_key = self._dynamic_room_name_turn_key(event)
         if turn_key not in self._dynamic_room_name_active_turns:
             return False
         self._dynamic_room_name_active_turns.remove(turn_key)
         remaining = max(0, self._dynamic_room_name_active.get(room_id, 1) - 1)
         self._dynamic_room_name_active[room_id] = remaining
-        if not remaining:
+        if not remaining and not self._dynamic_room_name_is_active(room_id):
             self._dynamic_room_name_terminal_external_checks.add(room_id)
         self._schedule_dynamic_room_name_render(room_id)
         return True
+
+    async def on_session_background_work_changed(
+        self,
+        source: SessionSource,
+        session_key: str,
+    ) -> None:
+        """Refresh an opted-in DM after its exact background work changes."""
+        if not (
+            self._dynamic_room_name_enabled
+            and self._client
+            and session_key
+            and source.chat_id
+            and str(source.chat_type).lower() == "dm"
+        ):
+            return
+        room_id = str(source.chat_id)
+        self._remember_dynamic_room_name_session(room_id, session_key)
+        if not self._dynamic_room_name_is_active(room_id):
+            self._dynamic_room_name_terminal_external_checks.add(room_id)
+        self._schedule_dynamic_room_name_render(room_id)
 
     async def set_semantic_room_name(self, room_id: str, title: str) -> bool:
         """Apply an auto-generated session title while preserving runtime activity."""

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1156,7 +1156,6 @@ class MatrixAdapter(BasePlatformAdapter):
         self._dynamic_room_name_bases: Dict[str, str] = {}
         self._dynamic_room_name_recovered_bases: Dict[str, str] = {}
         self._dynamic_room_name_initialized: Set[str] = set()
-        self._dynamic_room_name_status: Dict[str, str] = {}
         self._dynamic_room_name_active: Dict[str, int] = {}
         self._dynamic_room_name_active_turns: Set[tuple[str, str]] = set()
         self._dynamic_room_name_last_sent: Dict[str, str] = {}
@@ -3633,9 +3632,10 @@ class MatrixAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _sanitize_dynamic_room_name(title: str) -> str:
-        """Return a short, stable Matrix room name without nested status icons."""
+        """Return a short base name without model-controlled status icons."""
         cleaned = re.sub(r"\s+", " ", str(title or "")).strip()
-        cleaned = re.sub(r"^(?:[🟡✅🔴❌⏹]\s*)+", "", cleaned).strip()
+        cleaned = re.sub(r"[🟡🟢✅🔴❌⏹]", "", cleaned)
+        cleaned = re.sub(r"\s+", " ", cleaned).strip()
         if not cleaned:
             return ""
         if len(cleaned) > 60:
@@ -3700,7 +3700,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def _render_dynamic_room_name(self, room_id: str) -> bool:
         # Serialize each room's state writes. Recompute after acquiring the lock
-        # so a delayed working update cannot overwrite a newer terminal state.
+        # so a delayed working update cannot overwrite a newer idle state.
         lock = self._dynamic_room_name_locks.setdefault(room_id, asyncio.Lock())
         async with lock:
             await self._initialize_dynamic_room_name_base(room_id)
@@ -3708,8 +3708,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def _render_dynamic_room_name_locked(self, room_id: str) -> bool:
         """Render while the caller holds this room's dynamic-name lock."""
-        status = self._dynamic_room_name_status.get(room_id, "idle")
-        # Immediately before a terminal render, notice a human/client rename
+        # Immediately before an idle render, notice a human/client rename
         # that happened while Hermes was working.  Only a value different from
         # our last successful write is external.  This read runs under the same
         # room lock as authoritative semantic-base updates, so a delayed read
@@ -3739,13 +3738,11 @@ class MatrixAdapter(BasePlatformAdapter):
         base = self._dynamic_room_name_base(room_id)
         if not base:
             return False
-        prefix = {
-            "working": "🟡",
-            "success": "✅",
-            "failure": "🔴",
-            "cancelled": "🔴",
-        }.get(status)
-        name = f"{prefix} {base}" if prefix else base
+        # Room-name state is intentionally runtime-owned and binary. Outcomes
+        # remain visible through message reactions, but can never control or be
+        # smuggled into the room title by an AI-generated semantic title.
+        prefix = "🟡" if self._dynamic_room_name_active.get(room_id, 0) else "🟢"
+        name = f"{prefix} {base}"
         return await self._send_dynamic_room_name(room_id, name)
 
     def _schedule_dynamic_room_name_render(self, room_id: str) -> None:
@@ -3798,7 +3795,6 @@ class MatrixAdapter(BasePlatformAdapter):
         self._dynamic_room_name_active[room_id] = (
             self._dynamic_room_name_active.get(room_id, 0) + 1
         )
-        self._dynamic_room_name_status[room_id] = "working"
         self._schedule_dynamic_room_name_render(room_id)
         return True
 
@@ -3816,21 +3812,13 @@ class MatrixAdapter(BasePlatformAdapter):
         self._dynamic_room_name_active_turns.remove(turn_key)
         remaining = max(0, self._dynamic_room_name_active.get(room_id, 1) - 1)
         self._dynamic_room_name_active[room_id] = remaining
-        if remaining:
-            self._dynamic_room_name_status[room_id] = "working"
-        elif outcome == ProcessingOutcome.SUCCESS:
-            self._dynamic_room_name_status[room_id] = "success"
-        elif outcome == ProcessingOutcome.CANCELLED:
-            self._dynamic_room_name_status[room_id] = "cancelled"
-        else:
-            self._dynamic_room_name_status[room_id] = "failure"
         if not remaining:
             self._dynamic_room_name_terminal_external_checks.add(room_id)
         self._schedule_dynamic_room_name_render(room_id)
         return True
 
     async def set_semantic_room_name(self, room_id: str, title: str) -> bool:
-        """Apply an auto-generated session title while preserving task status."""
+        """Apply an auto-generated session title while preserving runtime activity."""
         if not self._dynamic_room_name_enabled or not room_id:
             return False
         room_id = str(room_id)
@@ -3870,7 +3858,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     # Matrix state reads can briefly return any preceding write
                     # from a chain of authoritative tool-driven semantic
                     # updates. Remember the whole superseded chain until the
-                    # single terminal reconciliation consumes it, so no stale
+                    # single idle reconciliation consumes it, so no stale
                     # echo can be mistaken for a human rename.
                     self._dynamic_room_name_superseded_sent.setdefault(
                         room_id, set()

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -131,6 +131,7 @@ except ImportError:
     TrustState = _TrustStateStub  # type: ignore[misc,assignment]
 
 from gateway.config import Platform, PlatformConfig
+from gateway.session import SessionSource
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -3718,6 +3719,20 @@ class MatrixAdapter(BasePlatformAdapter):
             title
         )
         return await self._render_dynamic_room_name(str(room_id))
+
+    async def on_session_title_changed(
+        self,
+        source: SessionSource,
+        title: str,
+    ) -> bool:
+        """Propagate a session title to an opted-in Matrix DM room."""
+        if not (
+            self._dynamic_room_name_enabled
+            and source.chat_id
+            and str(source.chat_type).lower() == "dm"
+        ):
+            return False
+        return await self.set_semantic_room_name(str(source.chat_id), title)
 
     async def _on_reaction(self, event: Any) -> None:
         """Handle incoming reaction events."""

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1154,10 +1154,14 @@ class MatrixAdapter(BasePlatformAdapter):
         else:
             self._dynamic_room_name_enabled = bool(dynamic_room_name)
         self._dynamic_room_name_bases: Dict[str, str] = {}
+        self._dynamic_room_name_recovered_bases: Dict[str, str] = {}
+        self._dynamic_room_name_initialized: Set[str] = set()
         self._dynamic_room_name_status: Dict[str, str] = {}
         self._dynamic_room_name_active: Dict[str, int] = {}
         self._dynamic_room_name_active_turns: Set[tuple[str, str]] = set()
         self._dynamic_room_name_last_sent: Dict[str, str] = {}
+        self._dynamic_room_name_superseded_sent: Dict[str, Set[str]] = {}
+        self._dynamic_room_name_terminal_external_checks: Set[str] = set()
         self._dynamic_room_name_locks: Dict[str, asyncio.Lock] = {}
         self._dynamic_room_name_tasks: Set[asyncio.Task] = set()
         self._dynamic_room_name_room_tasks: Dict[str, asyncio.Task] = {}
@@ -1824,6 +1828,8 @@ class MatrixAdapter(BasePlatformAdapter):
             await asyncio.gather(*room_name_tasks, return_exceptions=True)
         self._dynamic_room_name_tasks.clear()
         self._dynamic_room_name_room_tasks.clear()
+        self._dynamic_room_name_terminal_external_checks.clear()
+        self._dynamic_room_name_superseded_sent.clear()
 
         # Close the SQLite crypto store database.
         if hasattr(self, "_crypto_db") and self._crypto_db:
@@ -3631,7 +3637,7 @@ class MatrixAdapter(BasePlatformAdapter):
         cleaned = re.sub(r"\s+", " ", str(title or "")).strip()
         cleaned = re.sub(r"^(?:[🟡✅🔴❌⏹]\s*)+", "", cleaned).strip()
         if not cleaned:
-            return "Hermes"
+            return ""
         if len(cleaned) > 60:
             cleaned = cleaned[:57].rstrip() + "..."
         return cleaned
@@ -3645,18 +3651,14 @@ class MatrixAdapter(BasePlatformAdapter):
             and str(event.source.chat_type).lower() == "dm"
         )
 
-    def _dynamic_room_name_base(self, room_id: str) -> str:
-        base = self._dynamic_room_name_bases.get(room_id)
-        if base:
-            return base
-        self._dynamic_room_name_bases[room_id] = "Hermes"
-        return "Hermes"
+    def _dynamic_room_name_base(self, room_id: str) -> str | None:
+        return self._dynamic_room_name_bases.get(room_id) or None
 
     async def _initialize_dynamic_room_name_base(self, room_id: str) -> None:
         """Recover the stable base from room state on the first render."""
-        if room_id in self._dynamic_room_name_bases:
+        if room_id in self._dynamic_room_name_initialized:
             return
-        base = "Hermes"
+        base = ""
         try:
             current_name = await asyncio.wait_for(
                 self._get_room_name(room_id),
@@ -3670,10 +3672,10 @@ class MatrixAdapter(BasePlatformAdapter):
                 room_id,
                 exc_info=True,
             )
-        # A semantic-title callback may have installed a newer base while the
-        # state request was in flight. Never replace that newer in-memory value.
-        if room_id not in self._dynamic_room_name_bases:
-            self._dynamic_room_name_bases[room_id] = base
+        self._dynamic_room_name_initialized.add(room_id)
+        if base:
+            self._dynamic_room_name_recovered_bases[room_id] = base
+            self._dynamic_room_name_bases.setdefault(room_id, base)
 
     async def _send_dynamic_room_name(self, room_id: str, name: str) -> bool:
         """Best-effort, deduplicated ``m.room.name`` state update."""
@@ -3702,16 +3704,49 @@ class MatrixAdapter(BasePlatformAdapter):
         lock = self._dynamic_room_name_locks.setdefault(room_id, asyncio.Lock())
         async with lock:
             await self._initialize_dynamic_room_name_base(room_id)
-            base = self._dynamic_room_name_base(room_id)
-            status = self._dynamic_room_name_status.get(room_id, "idle")
-            prefix = {
-                "working": "🟡",
-                "success": "✅",
-                "failure": "🔴",
-                "cancelled": "🔴",
-            }.get(status)
-            name = f"{prefix} {base}" if prefix else base
-            return await self._send_dynamic_room_name(room_id, name)
+            return await self._render_dynamic_room_name_locked(room_id)
+
+    async def _render_dynamic_room_name_locked(self, room_id: str) -> bool:
+        """Render while the caller holds this room's dynamic-name lock."""
+        status = self._dynamic_room_name_status.get(room_id, "idle")
+        # Immediately before a terminal render, notice a human/client rename
+        # that happened while Hermes was working.  Only a value different from
+        # our last successful write is external.  This read runs under the same
+        # room lock as authoritative semantic-base updates, so a delayed read
+        # can never overwrite a newer tool rename: the newer update either ran
+        # first (and is observed as last_sent) or runs after and wins.
+        if room_id in self._dynamic_room_name_terminal_external_checks:
+            self._dynamic_room_name_terminal_external_checks.discard(room_id)
+            superseded_sent = self._dynamic_room_name_superseded_sent.pop(
+                room_id, set()
+            )
+            try:
+                current_name = await asyncio.wait_for(
+                    self._get_room_name(room_id),
+                    timeout=self._dynamic_room_name_timeout_seconds,
+                )
+            except Exception:
+                current_name = None
+            if (
+                current_name
+                and current_name != self._dynamic_room_name_last_sent.get(room_id)
+                and current_name not in superseded_sent
+            ):
+                external_base = self._sanitize_dynamic_room_name(current_name)
+                if external_base:
+                    self._dynamic_room_name_bases[room_id] = external_base
+                    self._dynamic_room_name_recovered_bases[room_id] = external_base
+        base = self._dynamic_room_name_base(room_id)
+        if not base:
+            return False
+        prefix = {
+            "working": "🟡",
+            "success": "✅",
+            "failure": "🔴",
+            "cancelled": "🔴",
+        }.get(status)
+        name = f"{prefix} {base}" if prefix else base
+        return await self._send_dynamic_room_name(room_id, name)
 
     def _schedule_dynamic_room_name_render(self, room_id: str) -> None:
         """Queue a best-effort room-state write without blocking message intake."""
@@ -3760,12 +3795,6 @@ class MatrixAdapter(BasePlatformAdapter):
         if turn_key in self._dynamic_room_name_active_turns:
             return False
         self._dynamic_room_name_active_turns.add(turn_key)
-        if room_id not in self._dynamic_room_name_bases:
-            chat_name = getattr(event.source, "chat_name", None)
-            if isinstance(chat_name, str) and chat_name.strip():
-                self._dynamic_room_name_bases[room_id] = (
-                    self._sanitize_dynamic_room_name(chat_name)
-                )
         self._dynamic_room_name_active[room_id] = (
             self._dynamic_room_name_active.get(room_id, 0) + 1
         )
@@ -3795,6 +3824,8 @@ class MatrixAdapter(BasePlatformAdapter):
             self._dynamic_room_name_status[room_id] = "cancelled"
         else:
             self._dynamic_room_name_status[room_id] = "failure"
+        if not remaining:
+            self._dynamic_room_name_terminal_external_checks.add(room_id)
         self._schedule_dynamic_room_name_render(room_id)
         return True
 
@@ -3802,10 +3833,66 @@ class MatrixAdapter(BasePlatformAdapter):
         """Apply an auto-generated session title while preserving task status."""
         if not self._dynamic_room_name_enabled or not room_id:
             return False
-        self._dynamic_room_name_bases[str(room_id)] = self._sanitize_dynamic_room_name(
-            title
+        room_id = str(room_id)
+        base = self._sanitize_dynamic_room_name(title)
+        lock = self._dynamic_room_name_locks.setdefault(room_id, asyncio.Lock())
+        async with lock:
+            await self._initialize_dynamic_room_name_base(room_id)
+            if base:
+                self._dynamic_room_name_bases[room_id] = base
+            return await self._render_dynamic_room_name_locked(room_id)
+
+    async def on_session_semantic_base_changed(
+        self,
+        source: SessionSource,
+        base: str | None,
+    ) -> bool:
+        """Apply the gateway-resolved goal/title base to an opted-in DM."""
+        if not (
+            self._dynamic_room_name_enabled
+            and source.chat_id
+            and str(source.chat_type).lower() == "dm"
+        ):
+            return False
+        room_id = str(source.chat_id)
+        sanitized = self._sanitize_dynamic_room_name(base) if base else ""
+        lock = self._dynamic_room_name_locks.setdefault(room_id, asyncio.Lock())
+        async with lock:
+            # Capture the pre-authoritative room base before the first goal/title
+            # replaces it. The read is bounded by the normal Matrix timeout.
+            await self._initialize_dynamic_room_name_base(room_id)
+            if sanitized:
+                previous_sent = self._dynamic_room_name_last_sent.get(room_id)
+                if (
+                    previous_sent
+                    and sanitized != self._dynamic_room_name_base(room_id)
+                ):
+                    # Matrix state reads can briefly return any preceding write
+                    # from a chain of authoritative tool-driven semantic
+                    # updates. Remember the whole superseded chain until the
+                    # single terminal reconciliation consumes it, so no stale
+                    # echo can be mistaken for a human rename.
+                    self._dynamic_room_name_superseded_sent.setdefault(
+                        room_id, set()
+                    ).add(previous_sent)
+                self._dynamic_room_name_bases[room_id] = sanitized
+            else:
+                recovered = self._dynamic_room_name_recovered_bases.get(room_id)
+                if recovered:
+                    self._dynamic_room_name_bases[room_id] = recovered
+                else:
+                    self._dynamic_room_name_bases.pop(room_id, None)
+                    return False
+            return await self._render_dynamic_room_name_locked(room_id)
+
+    def supports_session_semantic_base_refresh(self, source: SessionSource) -> bool:
+        """Declare whether this Matrix session opted into live room renames."""
+        return bool(
+            self._dynamic_room_name_enabled
+            and self._client
+            and source.chat_id
+            and str(source.chat_type).lower() == "dm"
         )
-        return await self._render_dynamic_room_name(str(room_id))
 
     async def on_session_title_changed(
         self,

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3658,7 +3658,10 @@ class MatrixAdapter(BasePlatformAdapter):
             return
         base = "Hermes"
         try:
-            current_name = await self._get_room_name(room_id)
+            current_name = await asyncio.wait_for(
+                self._get_room_name(room_id),
+                timeout=self._dynamic_room_name_timeout_seconds,
+            )
             if current_name:
                 base = self._sanitize_dynamic_room_name(current_name)
         except Exception:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3652,6 +3652,26 @@ class MatrixAdapter(BasePlatformAdapter):
         self._dynamic_room_name_bases[room_id] = "Hermes"
         return "Hermes"
 
+    async def _initialize_dynamic_room_name_base(self, room_id: str) -> None:
+        """Recover the stable base from room state on the first render."""
+        if room_id in self._dynamic_room_name_bases:
+            return
+        base = "Hermes"
+        try:
+            current_name = await self._get_room_name(room_id)
+            if current_name:
+                base = self._sanitize_dynamic_room_name(current_name)
+        except Exception:
+            logger.debug(
+                "Matrix: failed to initialize dynamic room name for %s",
+                room_id,
+                exc_info=True,
+            )
+        # A semantic-title callback may have installed a newer base while the
+        # state request was in flight. Never replace that newer in-memory value.
+        if room_id not in self._dynamic_room_name_bases:
+            self._dynamic_room_name_bases[room_id] = base
+
     async def _send_dynamic_room_name(self, room_id: str, name: str) -> bool:
         """Best-effort, deduplicated ``m.room.name`` state update."""
         if not self._client or not self._dynamic_room_name_enabled:
@@ -3678,6 +3698,7 @@ class MatrixAdapter(BasePlatformAdapter):
         # so a delayed working update cannot overwrite a newer terminal state.
         lock = self._dynamic_room_name_locks.setdefault(room_id, asyncio.Lock())
         async with lock:
+            await self._initialize_dynamic_room_name_base(room_id)
             base = self._dynamic_room_name_base(room_id)
             status = self._dynamic_room_name_status.get(room_id, "idle")
             prefix = {

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1156,8 +1156,11 @@ class MatrixAdapter(BasePlatformAdapter):
         self._dynamic_room_name_bases: Dict[str, str] = {}
         self._dynamic_room_name_status: Dict[str, str] = {}
         self._dynamic_room_name_active: Dict[str, int] = {}
+        self._dynamic_room_name_active_turns: Set[tuple[str, str]] = set()
         self._dynamic_room_name_last_sent: Dict[str, str] = {}
         self._dynamic_room_name_locks: Dict[str, asyncio.Lock] = {}
+        self._dynamic_room_name_tasks: Set[asyncio.Task] = set()
+        self._dynamic_room_name_room_tasks: Dict[str, asyncio.Task] = {}
         self._dynamic_room_name_timeout_seconds = 2.0
 
         # Proxy support — resolve once at init, reuse for all HTTP traffic.
@@ -1812,6 +1815,15 @@ class MatrixAdapter(BasePlatformAdapter):
         if redaction_tasks:
             await asyncio.gather(*redaction_tasks, return_exceptions=True)
         self._reaction_redaction_tasks.clear()
+
+        room_name_tasks = list(self._dynamic_room_name_tasks)
+        for task in room_name_tasks:
+            if not task.done():
+                task.cancel()
+        if room_name_tasks:
+            await asyncio.gather(*room_name_tasks, return_exceptions=True)
+        self._dynamic_room_name_tasks.clear()
+        self._dynamic_room_name_room_tasks.clear()
 
         # Close the SQLite crypto store database.
         if hasattr(self, "_crypto_db") and self._crypto_db:
@@ -3572,7 +3584,8 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Mark a DM busy and add an eyes reaction for the inbound message."""
-        await self._update_dynamic_room_name_for_start(event)
+        if not await self._update_dynamic_room_name_for_start(event):
+            return
         if not self._reactions_enabled:
             return
         msg_id = event.message_id
@@ -3588,7 +3601,8 @@ class MatrixAdapter(BasePlatformAdapter):
         outcome: ProcessingOutcome,
     ) -> None:
         """Mark a DM complete and replace the processing reaction."""
-        await self._update_dynamic_room_name_for_completion(event, outcome)
+        if not await self._update_dynamic_room_name_for_completion(event, outcome):
+            return
         if not self._reactions_enabled:
             return
         msg_id = event.message_id
@@ -3675,10 +3689,53 @@ class MatrixAdapter(BasePlatformAdapter):
             name = f"{prefix} {base}" if prefix else base
             return await self._send_dynamic_room_name(room_id, name)
 
-    async def _update_dynamic_room_name_for_start(self, event: MessageEvent) -> None:
-        if not self._dynamic_room_name_allowed(event):
-            return
+    def _schedule_dynamic_room_name_render(self, room_id: str) -> None:
+        """Queue a best-effort room-state write without blocking message intake."""
+        previous = self._dynamic_room_name_room_tasks.get(room_id)
+
+        async def _render_after_previous() -> None:
+            if previous is not None:
+                try:
+                    await previous
+                except (asyncio.CancelledError, Exception):
+                    pass
+            await self._render_dynamic_room_name(room_id)
+
+        task = asyncio.create_task(_render_after_previous())
+        self._dynamic_room_name_tasks.add(task)
+        self._dynamic_room_name_room_tasks[room_id] = task
+
+        def _finished(done: asyncio.Task) -> None:
+            self._dynamic_room_name_tasks.discard(done)
+            if self._dynamic_room_name_room_tasks.get(room_id) is done:
+                self._dynamic_room_name_room_tasks.pop(room_id, None)
+            try:
+                done.result()
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.debug(
+                    "Matrix: detached dynamic room rename failed for %s",
+                    room_id,
+                    exc_info=True,
+                )
+
+        task.add_done_callback(_finished)
+
+    @staticmethod
+    def _dynamic_room_name_turn_key(event: MessageEvent) -> tuple[str, str]:
         room_id = str(event.source.chat_id)
+        message_id = event.message_id or f"event:{id(event)}"
+        return room_id, str(message_id)
+
+    async def _update_dynamic_room_name_for_start(self, event: MessageEvent) -> bool:
+        if not self._dynamic_room_name_allowed(event):
+            return True
+        room_id = str(event.source.chat_id)
+        turn_key = self._dynamic_room_name_turn_key(event)
+        if turn_key in self._dynamic_room_name_active_turns:
+            return False
+        self._dynamic_room_name_active_turns.add(turn_key)
         if room_id not in self._dynamic_room_name_bases:
             chat_name = getattr(event.source, "chat_name", None)
             if isinstance(chat_name, str) and chat_name.strip():
@@ -3689,16 +3746,21 @@ class MatrixAdapter(BasePlatformAdapter):
             self._dynamic_room_name_active.get(room_id, 0) + 1
         )
         self._dynamic_room_name_status[room_id] = "working"
-        await self._render_dynamic_room_name(room_id)
+        self._schedule_dynamic_room_name_render(room_id)
+        return True
 
     async def _update_dynamic_room_name_for_completion(
         self,
         event: MessageEvent,
         outcome: ProcessingOutcome,
-    ) -> None:
+    ) -> bool:
         if not self._dynamic_room_name_allowed(event):
-            return
+            return True
         room_id = str(event.source.chat_id)
+        turn_key = self._dynamic_room_name_turn_key(event)
+        if turn_key not in self._dynamic_room_name_active_turns:
+            return False
+        self._dynamic_room_name_active_turns.remove(turn_key)
         remaining = max(0, self._dynamic_room_name_active.get(room_id, 1) - 1)
         self._dynamic_room_name_active[room_id] = remaining
         if remaining:
@@ -3709,7 +3771,8 @@ class MatrixAdapter(BasePlatformAdapter):
             self._dynamic_room_name_status[room_id] = "cancelled"
         else:
             self._dynamic_room_name_status[room_id] = "failure"
-        await self._render_dynamic_room_name(room_id)
+        self._schedule_dynamic_room_name_render(room_id)
+        return True
 
     async def set_semantic_room_name(self, room_id: str, title: str) -> bool:
         """Apply an auto-generated session title while preserving task status."""

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3629,11 +3629,11 @@ class MatrixAdapter(BasePlatformAdapter):
     def _sanitize_dynamic_room_name(title: str) -> str:
         """Return a short, stable Matrix room name without nested status icons."""
         cleaned = re.sub(r"\s+", " ", str(title or "")).strip()
-        cleaned = re.sub(r"^[🟡✅❌⏹]\s*", "", cleaned).strip()
+        cleaned = re.sub(r"^(?:[🟡✅🔴❌⏹]\s*)+", "", cleaned).strip()
         if not cleaned:
             return "Hermes"
-        if len(cleaned) > 80:
-            cleaned = cleaned[:77].rstrip() + "..."
+        if len(cleaned) > 60:
+            cleaned = cleaned[:57].rstrip() + "..."
         return cleaned
 
     def _dynamic_room_name_allowed(self, event: MessageEvent) -> bool:
@@ -3683,8 +3683,8 @@ class MatrixAdapter(BasePlatformAdapter):
             prefix = {
                 "working": "🟡",
                 "success": "✅",
-                "failure": "❌",
-                "cancelled": "⏹",
+                "failure": "🔴",
+                "cancelled": "🔴",
             }.get(status)
             name = f"{prefix} {base}" if prefix else base
             return await self._send_dynamic_room_name(room_id, name)

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -47,6 +47,10 @@ Environment variables:
                               when requester metadata is available (default: true)
     MATRIX_APPROVAL_TIMEOUT_SECONDS
                               Reaction approval/model-picker timeout (default: 300)
+    HERMES_MATRIX_DYNAMIC_ROOM_NAME
+                              Internal config bridge for matrix.dynamic_room_name.
+                              When enabled, DM room names follow processing state
+                              and the generated semantic session title.
 """
 
 from __future__ import annotations
@@ -1000,6 +1004,8 @@ class MatrixAdapter(BasePlatformAdapter):
     # overrides both from _resolve_max_message_length().
     max_message_length = DEFAULT_MAX_MESSAGE_LENGTH
     _split_threshold = DEFAULT_MAX_MESSAGE_LENGTH - 100
+    _dynamic_room_name_enabled = False
+    _dynamic_room_name_timeout_seconds = 2.0
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.MATRIX)
@@ -1130,6 +1136,28 @@ class MatrixAdapter(BasePlatformAdapter):
         # if that changes, add a config.yaml entry rather than an env var.
         self._reaction_redaction_delay_seconds = 5.0
         self._reaction_redaction_tasks: Set[asyncio.Task] = set()
+
+        # Optional Element-visible task state. This is deliberately DM-only:
+        # renaming a shared project room on every turn would be surprising and
+        # would create noisy room-state history for every participant.
+        dynamic_room_name = config.extra.get("dynamic_room_name")
+        if dynamic_room_name is None:
+            dynamic_room_name = os.getenv("HERMES_MATRIX_DYNAMIC_ROOM_NAME", "false")
+        if isinstance(dynamic_room_name, str):
+            self._dynamic_room_name_enabled = dynamic_room_name.lower() in {
+                "true",
+                "1",
+                "yes",
+                "on",
+            }
+        else:
+            self._dynamic_room_name_enabled = bool(dynamic_room_name)
+        self._dynamic_room_name_bases: Dict[str, str] = {}
+        self._dynamic_room_name_status: Dict[str, str] = {}
+        self._dynamic_room_name_active: Dict[str, int] = {}
+        self._dynamic_room_name_last_sent: Dict[str, str] = {}
+        self._dynamic_room_name_locks: Dict[str, asyncio.Lock] = {}
+        self._dynamic_room_name_timeout_seconds = 2.0
 
         # Proxy support — resolve once at init, reuse for all HTTP traffic.
         self._proxy_url: str | None = resolve_proxy_url(platform_env_var="MATRIX_PROXY")
@@ -3542,7 +3570,8 @@ class MatrixAdapter(BasePlatformAdapter):
         task.add_done_callback(self._reaction_redaction_tasks.discard)
 
     async def on_processing_start(self, event: MessageEvent) -> None:
-        """Add eyes reaction when the agent starts processing a message."""
+        """Mark a DM busy and add an eyes reaction for the inbound message."""
+        await self._update_dynamic_room_name_for_start(event)
         if not self._reactions_enabled:
             return
         msg_id = event.message_id
@@ -3557,7 +3586,8 @@ class MatrixAdapter(BasePlatformAdapter):
         event: MessageEvent,
         outcome: ProcessingOutcome,
     ) -> None:
-        """Replace eyes with checkmark (success) or cross (failure)."""
+        """Mark a DM complete and replace the processing reaction."""
+        await self._update_dynamic_room_name_for_completion(event, outcome)
         if not self._reactions_enabled:
             return
         msg_id = event.message_id
@@ -3579,6 +3609,115 @@ class MatrixAdapter(BasePlatformAdapter):
             msg_id,
             "\u2705" if outcome == ProcessingOutcome.SUCCESS else "\u274c",
         )
+
+    @staticmethod
+    def _sanitize_dynamic_room_name(title: str) -> str:
+        """Return a short, stable Matrix room name without nested status icons."""
+        cleaned = re.sub(r"\s+", " ", str(title or "")).strip()
+        cleaned = re.sub(r"^[🟡✅❌⏹]\s*", "", cleaned).strip()
+        if not cleaned:
+            return "Hermes"
+        if len(cleaned) > 80:
+            cleaned = cleaned[:77].rstrip() + "..."
+        return cleaned
+
+    def _dynamic_room_name_allowed(self, event: MessageEvent) -> bool:
+        """Limit automatic room-state changes to explicitly enabled Matrix DMs."""
+        return bool(
+            self._dynamic_room_name_enabled
+            and self._client
+            and event.source.chat_id
+            and str(event.source.chat_type).lower() == "dm"
+        )
+
+    def _dynamic_room_name_base(self, room_id: str) -> str:
+        base = self._dynamic_room_name_bases.get(room_id)
+        if base:
+            return base
+        self._dynamic_room_name_bases[room_id] = "Hermes"
+        return "Hermes"
+
+    async def _send_dynamic_room_name(self, room_id: str, name: str) -> bool:
+        """Best-effort, deduplicated ``m.room.name`` state update."""
+        if not self._client or not self._dynamic_room_name_enabled:
+            return False
+        if self._dynamic_room_name_last_sent.get(room_id) == name:
+            return True
+        try:
+            await asyncio.wait_for(
+                self._client.send_state_event(
+                    RoomID(room_id),
+                    EventType.ROOM_NAME,
+                    {"name": name},
+                ),
+                timeout=self._dynamic_room_name_timeout_seconds,
+            )
+        except Exception as exc:
+            logger.debug("Matrix: dynamic room rename failed for %s: %s", room_id, exc)
+            return False
+        self._dynamic_room_name_last_sent[room_id] = name
+        return True
+
+    async def _render_dynamic_room_name(self, room_id: str) -> bool:
+        # Serialize each room's state writes. Recompute after acquiring the lock
+        # so a delayed working update cannot overwrite a newer terminal state.
+        lock = self._dynamic_room_name_locks.setdefault(room_id, asyncio.Lock())
+        async with lock:
+            base = self._dynamic_room_name_base(room_id)
+            status = self._dynamic_room_name_status.get(room_id, "idle")
+            prefix = {
+                "working": "🟡",
+                "success": "✅",
+                "failure": "❌",
+                "cancelled": "⏹",
+            }.get(status)
+            name = f"{prefix} {base}" if prefix else base
+            return await self._send_dynamic_room_name(room_id, name)
+
+    async def _update_dynamic_room_name_for_start(self, event: MessageEvent) -> None:
+        if not self._dynamic_room_name_allowed(event):
+            return
+        room_id = str(event.source.chat_id)
+        if room_id not in self._dynamic_room_name_bases:
+            chat_name = getattr(event.source, "chat_name", None)
+            if isinstance(chat_name, str) and chat_name.strip():
+                self._dynamic_room_name_bases[room_id] = (
+                    self._sanitize_dynamic_room_name(chat_name)
+                )
+        self._dynamic_room_name_active[room_id] = (
+            self._dynamic_room_name_active.get(room_id, 0) + 1
+        )
+        self._dynamic_room_name_status[room_id] = "working"
+        await self._render_dynamic_room_name(room_id)
+
+    async def _update_dynamic_room_name_for_completion(
+        self,
+        event: MessageEvent,
+        outcome: ProcessingOutcome,
+    ) -> None:
+        if not self._dynamic_room_name_allowed(event):
+            return
+        room_id = str(event.source.chat_id)
+        remaining = max(0, self._dynamic_room_name_active.get(room_id, 1) - 1)
+        self._dynamic_room_name_active[room_id] = remaining
+        if remaining:
+            self._dynamic_room_name_status[room_id] = "working"
+        elif outcome == ProcessingOutcome.SUCCESS:
+            self._dynamic_room_name_status[room_id] = "success"
+        elif outcome == ProcessingOutcome.CANCELLED:
+            self._dynamic_room_name_status[room_id] = "cancelled"
+        else:
+            self._dynamic_room_name_status[room_id] = "failure"
+        await self._render_dynamic_room_name(room_id)
+
+    async def set_semantic_room_name(self, room_id: str, title: str) -> bool:
+        """Apply an auto-generated session title while preserving task status."""
+        if not self._dynamic_room_name_enabled or not room_id:
+            return False
+        self._dynamic_room_name_bases[str(room_id)] = self._sanitize_dynamic_room_name(
+            title
+        )
+        return await self._render_dynamic_room_name(str(room_id))
 
     async def _on_reaction(self, event: Any) -> None:
         """Handle incoming reaction events."""
@@ -4974,6 +5113,12 @@ def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
         os.environ["MATRIX_DM_MENTION_THREADS"] = str(matrix_cfg["dm_mention_threads"]).lower()
     if "max_message_length" in matrix_cfg and not os.getenv("MATRIX_MAX_MESSAGE_LENGTH"):
         os.environ["MATRIX_MAX_MESSAGE_LENGTH"] = str(matrix_cfg["max_message_length"])
+    if "dynamic_room_name" in matrix_cfg and not os.getenv(
+        "HERMES_MATRIX_DYNAMIC_ROOM_NAME"
+    ):
+        os.environ["HERMES_MATRIX_DYNAMIC_ROOM_NAME"] = str(
+            matrix_cfg["dynamic_room_name"]
+        ).lower()
     return None
 
 

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -158,6 +158,43 @@ async def test_consumed_completion_skips_raw_notification_without_agent_notify(
 
 
 @pytest.mark.asyncio
+async def test_terminal_process_refreshes_session_status_after_failed_agent_injection(
+    monkeypatch, tmp_path
+):
+    """A failed synthetic delivery cannot leave a completed DM marked busy."""
+    import tools.process_registry as pr_module
+
+    sessions = [SimpleNamespace(
+        output_buffer="done\n", exited=True, exit_code=0, command="echo done",
+        started_at=1.0,
+    )]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner._deliver_completion_notification = AsyncMock(return_value=False)
+    runner._refresh_session_background_work = AsyncMock()
+    watcher = _watcher_dict()
+    watcher.update({
+        "session_key": "agent:main:matrix:dm:!room:ex",
+        "platform": "matrix",
+        "chat_type": "dm",
+        "chat_id": "!room:ex",
+        "notify_on_complete": True,
+    })
+
+    await runner._run_process_watcher(watcher)
+
+    runner._refresh_session_background_work.assert_awaited_once()
+    assert runner._refresh_session_background_work.await_args.args[0]["session_key"] == (
+        "agent:main:matrix:dm:!room:ex"
+    )
+
+
+@pytest.mark.asyncio
 async def test_inject_watch_notification_routes_from_session_store_origin(monkeypatch, tmp_path):
     from gateway.session import SessionSource
 

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -9,6 +9,7 @@ state (when available) is acknowledged through its authoritative SQLite API.
 import asyncio
 import json
 import queue
+import threading
 from collections import OrderedDict
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -168,6 +169,7 @@ def test_failed_async_injection_is_retried_and_only_success_is_acked(
         handle_message=AsyncMock(side_effect=[RuntimeError("temporary"), None])
     )
     runner = _runner(adapter)
+    runner._refresh_session_background_work = AsyncMock()
     _stop_after_sleeps(monkeypatch, runner, count=3)
 
     from tools import async_delegation
@@ -184,6 +186,97 @@ def test_failed_async_injection_is_retried_and_only_success_is_acked(
 
     assert adapter.handle_message.await_count == 2
     assert acknowledgements == ["deleg_duplicate"]
+    # A terminal delegate refreshes its owning status even when its first
+    # synthetic completion injection fails and is retried.
+    assert runner._refresh_session_background_work.await_count == 2
+
+
+def test_async_status_refresh_waits_for_terminal_finalization(
+    monkeypatch, isolated_registry,
+):
+    """A queue consumer cannot render from the producer's ``finalizing`` gap."""
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    terminal = threading.Event()
+    event = _async_event("deleg_finalizing_race")
+    event["_finalization_complete"] = terminal
+    isolated.put(event)
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+
+    async def _delivery(_text, _event):
+        assert not terminal.is_set()
+        # Model the worker's immediately-following _finish_finalization().
+        asyncio.get_running_loop().call_soon(terminal.set)
+        return None
+
+    async def _refresh(_event):
+        assert terminal.is_set(), "refresh observed async record while finalizing"
+
+    runner._deliver_completion_notification = _delivery
+    runner._refresh_session_background_work = _refresh
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+
+def test_async_status_refresh_fails_open_after_unset_finalization_timeout(
+    monkeypatch, isolated_registry, caplog,
+):
+    """A corrupted never-set handoff signal cannot wedge the gateway watcher."""
+    import gateway.run as gateway_run
+
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    terminal = threading.Event()
+    event = _async_event("deleg_finalization_timeout")
+    event["_finalization_complete"] = terminal
+    isolated.put(event)
+    timeout = 0.01
+    wait = MagicMock(wraps=terminal.wait)
+    monkeypatch.setattr(terminal, "wait", wait)
+    monkeypatch.setattr(
+        gateway_run,
+        "_ASYNC_DELEGATION_FINALIZATION_WAIT_TIMEOUT_SECS",
+        timeout,
+    )
+
+    runner = _runner(SimpleNamespace(handle_message=AsyncMock()))
+    refreshed = AsyncMock()
+    runner._refresh_session_background_work = refreshed
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+
+    # The real Event stays unset. Its timeout return lets the watcher proceed
+    # to the fail-open status refresh rather than awaiting the signal forever.
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    assert not terminal.is_set()
+    wait.assert_called_once_with(timeout)
+    refreshed.assert_awaited_once_with(event)
+    assert "finalization signal timed out" in caplog.text
+
+
+def test_background_status_refresh_uses_the_owning_multiplex_adapter():
+    default_adapter = SimpleNamespace(on_session_background_work_changed=AsyncMock())
+    profile_adapter = SimpleNamespace(on_session_background_work_changed=AsyncMock())
+    source = SessionSource(
+        platform=Platform.MATRIX,
+        chat_id="!room:ex",
+        chat_type="dm",
+        profile="work",
+    )
+    session_key = "agent:work:matrix:dm:!room:ex"
+    runner = _runner(default_adapter, origins={session_key: SimpleNamespace(origin=source)})
+    runner.adapters = {Platform.MATRIX: default_adapter}
+    runner._profile_adapters = {"work": {Platform.MATRIX: profile_adapter}}
+
+    asyncio.run(runner._refresh_session_background_work({"session_key": session_key}))
+
+    profile_adapter.on_session_background_work_changed.assert_awaited_once_with(
+        source, session_key
+    )
+    default_adapter.on_session_background_work_changed.assert_not_awaited()
 
 
 def _persist_pending_completion(event):

--- a/tests/gateway/test_current_chat_rename.py
+++ b/tests/gateway/test_current_chat_rename.py
@@ -1,0 +1,142 @@
+import asyncio
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+def _runner(adapter, *, session_id="session-1"):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {Platform.MATRIX: adapter}
+    runner._session_db = SimpleNamespace(
+        set_session_title=AsyncMock(return_value=True),
+    )
+    runner.session_store = SimpleNamespace()
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=AsyncMock(
+            return_value=SimpleNamespace(session_id=session_id)
+        )
+    )
+    runner._adapter_title_state_lock = threading.Lock()
+    runner._adapter_title_generations = {}
+    runner._adapter_title_pending = {}
+    runner._adapter_title_apply_locks = {}
+    runner._session_key_for_source = lambda _source: "matrix:room"
+    runner._is_session_run_current = lambda _key, generation: generation == 7
+    return runner
+
+
+def _source():
+    return SessionSource(
+        platform=Platform.MATRIX,
+        chat_id="!room:example.org",
+        chat_type="dm",
+        user_id="@user:example.org",
+    )
+
+
+@pytest.mark.asyncio
+async def test_successful_current_session_rename_persists_then_updates_adapter():
+    adapter = SimpleNamespace(on_session_semantic_base_changed=AsyncMock(return_value=True))
+    runner = _runner(adapter)
+    generation = runner._reserve_adapter_title_generation("session-1")
+    try:
+        with patch("hermes_cli.goals.GoalManager") as manager_cls:
+            manager_cls.return_value.is_active.return_value = False
+            result = await runner._rename_current_gateway_chat(
+                _source(), "matrix:room", "session-1", 7, "Fortress", generation
+            )
+    finally:
+        runner._release_adapter_title_generation("session-1")
+
+    assert result == {"success": True, "title": "Fortress", "visible_base": "Fortress"}
+    runner._session_db.set_session_title.assert_awaited_once_with("session-1", "Fortress")
+    adapter.on_session_semantic_base_changed.assert_awaited_once_with(_source(), "Fortress")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["resumed", "stale-run"])
+async def test_stale_or_resumed_turn_cannot_rename(failure):
+    adapter = SimpleNamespace(on_session_semantic_base_changed=AsyncMock(return_value=True))
+    runner = _runner(adapter, session_id="session-2" if failure == "resumed" else "session-1")
+    if failure == "stale-run":
+        runner._is_session_run_current = lambda *_args: False
+    generation = runner._reserve_adapter_title_generation("session-1")
+    try:
+        result = await runner._rename_current_gateway_chat(
+            _source(), "matrix:room", "session-1", 7, "Stale", generation
+        )
+    finally:
+        runner._release_adapter_title_generation("session-1")
+
+    assert result["success"] is False
+    runner._session_db.set_session_title.assert_not_awaited()
+    adapter.on_session_semantic_base_changed.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_rename_latest_wins():
+    adapter = SimpleNamespace(on_session_semantic_base_changed=AsyncMock(return_value=True))
+    runner = _runner(adapter)
+    first_validation_started = asyncio.Event()
+    release_first_validation = asyncio.Event()
+    calls = 0
+
+    async def validating(_source):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            first_validation_started.set()
+            await release_first_validation.wait()
+        return SimpleNamespace(session_id="session-1")
+
+    runner._async_session_store.get_or_create_session.side_effect = validating
+    old_generation = runner._reserve_adapter_title_generation("session-1")
+    old = asyncio.create_task(runner._rename_current_gateway_chat(
+        _source(), "matrix:room", "session-1", 7, "Old", old_generation
+    ))
+    await first_validation_started.wait()
+    new_generation = runner._reserve_adapter_title_generation("session-1")
+    new = asyncio.create_task(runner._rename_current_gateway_chat(
+        _source(), "matrix:room", "session-1", 7, "New", new_generation
+    ))
+    release_first_validation.set()
+    old_result, new_result = await asyncio.gather(old, new)
+    runner._release_adapter_title_generation("session-1")
+    runner._release_adapter_title_generation("session-1")
+
+    assert old_result["success"] is False
+    assert new_result["success"] is True
+    runner._session_db.set_session_title.assert_awaited_once_with("session-1", "New")
+    adapter.on_session_semantic_base_changed.assert_awaited_once_with(_source(), "New")
+
+
+@pytest.mark.asyncio
+async def test_active_goal_precedes_tool_title_but_title_is_persisted_fallback():
+    adapter = SimpleNamespace(on_session_semantic_base_changed=AsyncMock(return_value=True))
+    runner = _runner(adapter)
+    manager = MagicMock()
+    manager.is_active.return_value = True
+    manager.state = SimpleNamespace(goal="Active fortress goal")
+    generation = runner._reserve_adapter_title_generation("session-1")
+    try:
+        with patch("hermes_cli.goals.GoalManager", return_value=manager):
+            result = await runner._rename_current_gateway_chat(
+                _source(), "matrix:room", "session-1", 7, "Fallback title", generation
+            )
+    finally:
+        runner._release_adapter_title_generation("session-1")
+
+    runner._session_db.set_session_title.assert_awaited_once_with(
+        "session-1", "Fallback title"
+    )
+    adapter.on_session_semantic_base_changed.assert_awaited_once_with(
+        _source(), "Active fortress goal"
+    )
+    assert result["visible_base"] == "Active fortress goal"

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -353,6 +353,9 @@ async def test_adapter_title_propagation_invokes_optional_hook():
             return_value=SimpleNamespace(session_id="session-1")
         ),
     )
+    runner._session_db = SimpleNamespace(
+        get_session_title=AsyncMock(return_value="Current Session Title")
+    )
 
     adapter = SimpleNamespace(on_session_title_changed=AsyncMock())
     runner.adapters = {Platform.TELEGRAM: adapter}  # type: ignore[dict-item]
@@ -367,6 +370,34 @@ async def test_adapter_title_propagation_invokes_optional_hook():
         _make_source(),
         "Current Session Title",
     )
+
+
+@pytest.mark.asyncio
+async def test_adapter_title_propagation_does_not_overwrite_newer_manual_title(tmp_path):
+    from hermes_state import AsyncSessionDB, SessionDB
+
+    runner = _make_runner()
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=AsyncMock(
+            return_value=SimpleNamespace(session_id="session-1")
+        ),
+    )
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.create_session("session-1", "matrix")
+    session_db.set_session_title("session-1", "New Manual Title")
+    runner._session_db = AsyncSessionDB(session_db)
+    adapter = SimpleNamespace(on_session_title_changed=AsyncMock())
+    runner.adapters = {Platform.TELEGRAM: adapter}  # type: ignore[dict-item]
+
+    await runner._propagate_session_title_to_adapter(
+        _make_source(),
+        "session-1",
+        "Old Generated Title",
+    )
+
+    adapter.on_session_title_changed.assert_not_awaited()
+    session_db.close()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -100,6 +100,24 @@ def _make_discord_auto_thread_source() -> SessionSource:
     )
 
 
+def _make_matrix_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.MATRIX,
+        chat_id="!room:matrix.org",
+        chat_type="dm",
+        user_id="@user:matrix.org",
+    )
+
+
+def _make_matrix_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.MATRIX,
+        chat_id="!room:matrix.org",
+        chat_type="dm",
+        user_id="@user:matrix.org",
+    )
+
+
 def _make_event(text: str) -> MessageEvent:
     return MessageEvent(text=text, source=_make_source(), message_id="m1")
 
@@ -169,4 +187,72 @@ async def test_session_fast_override_beats_config_default(monkeypatch, tmp_path)
     # A different session still gets the config default.
     assert runner._resolve_session_service_tier(session_key="other-session") == "priority"
 
+
+@pytest.mark.asyncio
+async def test_run_agent_passes_matrix_room_name_title_callback(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+    runner._session_db = SimpleNamespace(_db=MagicMock())  # type: ignore[assignment]
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+    monkeypatch.setattr(
+        tools_config,
+        "_get_platform_tools",
+        lambda user_config, platform_key: {"core"},
+    )
+
+    with patch("agent.title_generator.maybe_auto_title") as mock_title:
+        await runner._run_agent(
+            message="raw user prompt",
+            context_prompt="",
+            history=[],
+            source=_make_matrix_source(),
+            session_id="session-1",
+            session_key="agent:main:matrix:dm:!room:matrix.org",
+        )
+
+    mock_title.assert_called_once()
+    callback = mock_title.call_args.kwargs["title_callback"]
+    with patch.object(runner, "_schedule_matrix_semantic_room_rename") as mock_schedule:
+        callback("Semantic Session Title")
+    mock_schedule.assert_called_once_with(
+        _make_matrix_source(),
+        "session-1",
+        "Semantic Session Title",
+    )
+
+
+@pytest.mark.asyncio
+async def test_matrix_room_rename_ignores_stale_session_title():
+    runner = _make_runner()
+    adapter = SimpleNamespace(set_semantic_room_name=AsyncMock())
+    runner.adapters = {Platform.MATRIX: adapter}  # type: ignore[dict-item]
+    runner.session_store = SimpleNamespace(  # type: ignore[assignment]
+        get_or_create_session=lambda source: SimpleNamespace(session_id="new-session")
+    )
+
+    await runner._rename_matrix_room_for_session_title(
+        _make_matrix_source(),
+        "old-session",
+        "Old Session Title",
+    )
+
+    adapter.set_semantic_room_name.assert_not_awaited()
 

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -1,5 +1,6 @@
 """Tests for gateway /fast support and Priority Processing routing."""
 
+import asyncio
 import sys
 import threading
 import types
@@ -398,6 +399,64 @@ async def test_adapter_title_propagation_does_not_overwrite_newer_manual_title(t
 
     adapter.on_session_title_changed.assert_not_awaited()
     session_db.close()
+
+
+@pytest.mark.asyncio
+async def test_adapter_title_propagation_stale_validated_write_cannot_overwrite_newer():
+    """A delayed older callback cannot apply after a newer scheduled title."""
+    runner = _make_runner()
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=AsyncMock(
+            return_value=SimpleNamespace(session_id="session-1")
+        ),
+    )
+    old_title_validating = asyncio.Event()
+    release_old_validation = asyncio.Event()
+    persisted_title = "Old Title"
+
+    async def get_session_title(_session_id):
+        if persisted_title == "Old Title":
+            old_title_validating.set()
+            await release_old_validation.wait()
+            return "Old Title"
+        return persisted_title
+
+    runner._session_db = SimpleNamespace(get_session_title=get_session_title)
+    applied = []
+    adapter = SimpleNamespace(
+        on_session_title_changed=AsyncMock(
+            side_effect=lambda _source, title: applied.append(title)
+        )
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}  # type: ignore[dict-item]
+
+    old_generation = runner._reserve_adapter_title_generation("session-1")
+    old_task = asyncio.create_task(
+        runner._propagate_session_title_to_adapter(
+            _make_source(), "session-1", "Old Title", old_generation
+        )
+    )
+    await old_title_validating.wait()
+
+    persisted_title = "New Title"
+    new_generation = runner._reserve_adapter_title_generation("session-1")
+    try:
+        await runner._propagate_session_title_to_adapter(
+            _make_source(), "session-1", "New Title", new_generation
+        )
+        release_old_validation.set()
+        await old_task
+    finally:
+        release_old_validation.set()
+        await old_task
+        runner._release_adapter_title_generation("session-1")
+        runner._release_adapter_title_generation("session-1")
+
+    assert applied == ["New Title"]
+    assert runner._adapter_title_generations == {}
+    assert runner._adapter_title_pending == {}
+    assert runner._adapter_title_apply_locks == {}
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -374,6 +374,60 @@ async def test_adapter_title_propagation_invokes_optional_hook():
 
 
 @pytest.mark.asyncio
+async def test_adapter_title_propagation_schedules_foreign_callback_on_gateway_loop():
+    runner = _make_runner()
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=AsyncMock(
+            return_value=SimpleNamespace(session_id="session-1")
+        ),
+    )
+    runner._session_db = SimpleNamespace(
+        get_session_title=AsyncMock(return_value="Current Session Title")
+    )
+    callback_loops = []
+
+    async def on_session_title_changed(_source, _title):
+        callback_loops.append(asyncio.get_running_loop())
+
+    adapter = SimpleNamespace(on_session_title_changed=on_session_title_changed)
+    runner.adapters = {Platform.TELEGRAM: adapter}  # type: ignore[dict-item]
+
+    gateway_loop = asyncio.new_event_loop()
+    gateway_ready = threading.Event()
+
+    def run_gateway_loop():
+        asyncio.set_event_loop(gateway_loop)
+        gateway_ready.set()
+        gateway_loop.run_forever()
+
+    gateway_thread = threading.Thread(target=run_gateway_loop)
+    gateway_thread.start()
+    assert gateway_ready.wait(timeout=2)
+    runner._gateway_loop = gateway_loop
+    foreign_loop = asyncio.get_running_loop()
+
+    try:
+        runner._schedule_adapter_session_title_propagation(
+            _make_source(), "session-1", "Current Session Title"
+        )
+        for _ in range(200):
+            if callback_loops and not runner._adapter_title_apply_locks:
+                break
+            await asyncio.sleep(0.01)
+    finally:
+        gateway_loop.call_soon_threadsafe(gateway_loop.stop)
+        gateway_thread.join(timeout=2)
+        gateway_loop.close()
+
+    assert callback_loops == [gateway_loop]
+    assert callback_loops[0] is not foreign_loop
+    assert runner._adapter_title_apply_locks == {}
+    assert runner._adapter_title_generations == {}
+    assert runner._adapter_title_pending == {}
+
+
+@pytest.mark.asyncio
 async def test_adapter_title_propagation_does_not_overwrite_newer_manual_title(tmp_path):
     from hermes_state import AsyncSessionDB, SessionDB
 

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -130,6 +130,26 @@ class _TitleAwareAdapter(BasePlatformAdapter):
     async def on_session_title_changed(self, source, title):
         return None
 
+    async def on_session_semantic_base_changed(self, source, base):
+        return None
+
+
+class _LegacyTitleAwareAdapter(BasePlatformAdapter):
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return None
+
+    async def on_session_title_changed(self, source, title):
+        return None
+
 
 def test_turn_route_injects_priority_processing_without_changing_runtime():
     runner = _make_runner()
@@ -336,12 +356,91 @@ async def test_run_agent_passes_optional_adapter_title_callback(monkeypatch, tmp
 
     mock_title.assert_called_once()
     callback = mock_title.call_args.kwargs["title_callback"]
-    with patch.object(runner, "_schedule_adapter_session_title_propagation") as mock_schedule:
+    with patch.object(runner, "_schedule_adapter_semantic_base_refresh") as mock_schedule:
         callback("Semantic Session Title")
     mock_schedule.assert_called_once_with(
         _make_matrix_source(),
         "session-1",
-        "Semantic Session Title",
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_agent_retains_legacy_title_callback_without_semantic_hook(
+    monkeypatch, tmp_path
+):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+    runner._session_db = SimpleNamespace(_db=MagicMock())  # type: ignore[assignment]
+    runner.adapters = {
+        Platform.TELEGRAM: _LegacyTitleAwareAdapter(
+            PlatformConfig(), Platform.TELEGRAM
+        )
+    }
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+    import hermes_cli.tools_config as tools_config
+    monkeypatch.setattr(
+        tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"}
+    )
+
+    with patch("agent.title_generator.maybe_auto_title") as mock_title:
+        await runner._run_agent(
+            message="raw user prompt",
+            context_prompt="",
+            history=[],
+            source=_make_source(),
+            session_id="session-1",
+            session_key="agent:main:telegram:dm:12345",
+        )
+
+    callback = mock_title.call_args.kwargs["title_callback"]
+    with patch.object(runner, "_schedule_adapter_semantic_base_refresh") as semantic, patch.object(
+        runner, "_schedule_adapter_session_title_propagation"
+    ) as legacy:
+        callback("Semantic Session Title")
+    semantic.assert_not_called()
+    legacy.assert_called_once_with(
+        _make_source(), "session-1", "Semantic Session Title"
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_turn_goal_completion_refreshes_semantic_base_immediately():
+    runner = _make_runner()
+    runner.config = SimpleNamespace(goals=SimpleNamespace(max_turns=5))
+    runner._schedule_adapter_semantic_base_refresh = MagicMock()
+    manager = MagicMock()
+    manager.is_active.side_effect = [True, False]
+    manager.evaluate_after_turn.return_value = {
+        "should_continue": False,
+        "message": "",
+    }
+
+    with patch("hermes_cli.goals.GoalManager", return_value=manager):
+        await runner._post_turn_goal_continuation(
+            session_entry=SimpleNamespace(session_id="session-1"),
+            source=_make_source(),
+            final_response="finished",
+        )
+
+    manager.evaluate_after_turn.assert_called_once()
+    runner._schedule_adapter_semantic_base_refresh.assert_called_once_with(
+        _make_source(), "session-1"
     )
 
 
@@ -536,3 +635,142 @@ async def test_adapter_title_propagation_ignores_stale_session():
     )
 
     adapter.on_session_title_changed.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("goal_status", ["paused", "done"])
+async def test_semantic_base_refresh_uses_title_when_goal_not_active(goal_status):
+    runner = _make_runner()
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=AsyncMock(return_value=SimpleNamespace(session_id="session-1"))
+    )
+    runner._session_db = SimpleNamespace(
+        get_session_title=AsyncMock(return_value="Persisted session title")
+    )
+    applied = []
+    adapter = SimpleNamespace(
+        on_session_semantic_base_changed=AsyncMock(
+            side_effect=lambda _source, base: applied.append(base)
+        )
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}  # type: ignore[dict-item]
+    fake_manager = MagicMock()
+    fake_manager.is_active.return_value = False
+    fake_manager.state = SimpleNamespace(goal="Old epic", status=goal_status)
+    generation = runner._reserve_adapter_title_generation("session-1")
+    try:
+        with patch("hermes_cli.goals.GoalManager", return_value=fake_manager):
+            await runner._refresh_adapter_semantic_base(
+                _make_source(), "session-1", generation
+            )
+    finally:
+        runner._release_adapter_title_generation("session-1")
+    assert applied == ["Persisted session title"]
+
+
+@pytest.mark.asyncio
+async def test_semantic_base_refresh_active_goal_precedes_persisted_title():
+    runner = _make_runner()
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=AsyncMock(return_value=SimpleNamespace(session_id="session-1"))
+    )
+    runner._session_db = SimpleNamespace(
+        get_session_title=AsyncMock(return_value="Delayed auto title")
+    )
+    adapter = SimpleNamespace(on_session_semantic_base_changed=AsyncMock())
+    runner.adapters = {Platform.TELEGRAM: adapter}  # type: ignore[dict-item]
+    fake_manager = MagicMock()
+    fake_manager.is_active.return_value = True
+    fake_manager.state = SimpleNamespace(goal="Authoritative epic")
+    generation = runner._reserve_adapter_title_generation("session-1")
+    try:
+        with patch("hermes_cli.goals.GoalManager", return_value=fake_manager):
+            await runner._refresh_adapter_semantic_base(
+                _make_source(), "session-1", generation
+            )
+    finally:
+        runner._release_adapter_title_generation("session-1")
+    adapter.on_session_semantic_base_changed.assert_awaited_once_with(
+        _make_source(), "Authoritative epic"
+    )
+    runner._session_db.get_session_title.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_semantic_base_refresh_no_persisted_source_delegates_recovery():
+    runner = _make_runner()
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=AsyncMock(return_value=SimpleNamespace(session_id="session-1"))
+    )
+    runner._session_db = SimpleNamespace(get_session_title=AsyncMock(return_value=None))
+    adapter = SimpleNamespace(on_session_semantic_base_changed=AsyncMock())
+    runner.adapters = {Platform.TELEGRAM: adapter}  # type: ignore[dict-item]
+    fake_manager = MagicMock()
+    fake_manager.is_active.return_value = False
+    generation = runner._reserve_adapter_title_generation("session-1")
+    try:
+        with patch("hermes_cli.goals.GoalManager", return_value=fake_manager):
+            await runner._refresh_adapter_semantic_base(
+                _make_source(), "session-1", generation
+            )
+    finally:
+        runner._release_adapter_title_generation("session-1")
+    adapter.on_session_semantic_base_changed.assert_awaited_once_with(
+        _make_source(), None
+    )
+
+
+@pytest.mark.asyncio
+async def test_delayed_auto_title_refresh_cannot_overwrite_newer_active_epic():
+    runner = _make_runner()
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=AsyncMock(
+            return_value=SimpleNamespace(session_id="session-1")
+        ),
+    )
+    title_read_started = asyncio.Event()
+    release_title_read = asyncio.Event()
+
+    async def delayed_title(_session_id):
+        title_read_started.set()
+        await release_title_read.wait()
+        return "Stale auto title"
+
+    runner._session_db = SimpleNamespace(get_session_title=delayed_title)
+    adapter = SimpleNamespace(on_session_semantic_base_changed=AsyncMock())
+    runner.adapters = {Platform.TELEGRAM: adapter}  # type: ignore[dict-item]
+    goal_active = False
+
+    def manager_factory(*_args, **_kwargs):
+        manager = MagicMock()
+        manager.is_active.return_value = goal_active
+        manager.state = SimpleNamespace(goal="New active epic")
+        return manager
+
+    old_generation = runner._reserve_adapter_title_generation("session-1")
+    with patch("hermes_cli.goals.GoalManager", side_effect=manager_factory):
+        old_task = asyncio.create_task(
+            runner._refresh_adapter_semantic_base(
+                _make_source(), "session-1", old_generation
+            )
+        )
+        await title_read_started.wait()
+        goal_active = True
+        new_generation = runner._reserve_adapter_title_generation("session-1")
+        new_task = asyncio.create_task(
+            runner._refresh_adapter_semantic_base(
+                _make_source(), "session-1", new_generation
+            )
+        )
+        release_title_read.set()
+        await asyncio.gather(old_task, new_task)
+    runner._release_adapter_title_generation("session-1")
+    runner._release_adapter_title_generation("session-1")
+
+    adapter.on_session_semantic_base_changed.assert_awaited_once_with(
+        _make_source(), "New active epic"
+    )

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -10,8 +10,8 @@ import pytest
 import yaml
 
 import gateway.run as gateway_run
-from gateway.config import Platform
-from gateway.platforms.base import MessageEvent
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent
 from gateway.session import SessionSource
 
 
@@ -109,17 +109,25 @@ def _make_matrix_source() -> SessionSource:
     )
 
 
-def _make_matrix_source() -> SessionSource:
-    return SessionSource(
-        platform=Platform.MATRIX,
-        chat_id="!room:matrix.org",
-        chat_type="dm",
-        user_id="@user:matrix.org",
-    )
-
-
 def _make_event(text: str) -> MessageEvent:
     return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+class _TitleAwareAdapter(BasePlatformAdapter):
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return None
+
+    async def on_session_title_changed(self, source, title):
+        return None
 
 
 def test_turn_route_injects_priority_processing_without_changing_runtime():
@@ -189,10 +197,107 @@ async def test_session_fast_override_beats_config_default(monkeypatch, tmp_path)
 
 
 @pytest.mark.asyncio
-async def test_run_agent_passes_matrix_room_name_title_callback(monkeypatch, tmp_path):
+async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+
+    (tmp_path / "config.yaml").write_text("agent:\n  service_tier: fast\n", encoding="utf-8")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    # ``_load_service_tier`` was refactored to call ``_load_gateway_runtime_config``
+    # (which wraps ``_load_gateway_config`` plus env-expansion).  Since the test
+    # stubs ``_load_gateway_config`` to ``{}``, also stub the runtime wrapper
+    # directly so the priority routing assertions still exercise the live tier.
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_runtime_config",
+        lambda: {"agent": {"service_tier": "fast"}},
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    _CapturingAgent.last_init = None
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init["service_tier"] == "priority"
+    assert _CapturingAgent.last_init["request_overrides"] == {"service_tier": "priority"}
+
+
+@pytest.mark.asyncio
+async def test_run_agent_passes_discord_auto_thread_title_callback(monkeypatch, tmp_path):
     _install_fake_agent(monkeypatch)
     runner = _make_runner()
     runner._session_db = SimpleNamespace(_db=MagicMock())  # type: ignore[assignment]
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    with patch("agent.title_generator.maybe_auto_title") as mock_title:
+        await runner._run_agent(
+            message="raw user prompt",
+            context_prompt="",
+            history=[],
+            source=_make_discord_auto_thread_source(),
+            session_id="session-1",
+            session_key="agent:main:discord:thread:999",
+        )
+
+    mock_title.assert_called_once()
+    callback = mock_title.call_args.kwargs["title_callback"]
+    with patch.object(runner, "_schedule_discord_semantic_thread_rename") as mock_schedule:
+        callback("Semantic Session Title")
+    mock_schedule.assert_called_once()
+    assert mock_schedule.call_args.args[1] == "session-1"
+    assert mock_schedule.call_args.args[2] == "Semantic Session Title"
+
+
+@pytest.mark.asyncio
+async def test_run_agent_passes_optional_adapter_title_callback(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+    runner._session_db = SimpleNamespace(_db=MagicMock())  # type: ignore[assignment]
+
+    adapter = _TitleAwareAdapter(PlatformConfig(), Platform.MATRIX)
+    runner.adapters = {Platform.MATRIX: adapter}  # type: ignore[dict-item]
 
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
@@ -230,7 +335,7 @@ async def test_run_agent_passes_matrix_room_name_title_callback(monkeypatch, tmp
 
     mock_title.assert_called_once()
     callback = mock_title.call_args.kwargs["title_callback"]
-    with patch.object(runner, "_schedule_matrix_semantic_room_rename") as mock_schedule:
+    with patch.object(runner, "_schedule_adapter_session_title_propagation") as mock_schedule:
         callback("Semantic Session Title")
     mock_schedule.assert_called_once_with(
         _make_matrix_source(),
@@ -240,19 +345,50 @@ async def test_run_agent_passes_matrix_room_name_title_callback(monkeypatch, tmp
 
 
 @pytest.mark.asyncio
-async def test_matrix_room_rename_ignores_stale_session_title():
+async def test_adapter_title_propagation_invokes_optional_hook():
     runner = _make_runner()
-    adapter = SimpleNamespace(set_semantic_room_name=AsyncMock())
-    runner.adapters = {Platform.MATRIX: adapter}  # type: ignore[dict-item]
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=AsyncMock(
+            return_value=SimpleNamespace(session_id="session-1")
+        ),
+    )
+
+    adapter = SimpleNamespace(on_session_title_changed=AsyncMock())
+    runner.adapters = {Platform.TELEGRAM: adapter}  # type: ignore[dict-item]
+
+    await runner._propagate_session_title_to_adapter(
+        _make_source(),
+        "session-1",
+        "Current Session Title",
+    )
+
+    adapter.on_session_title_changed.assert_awaited_once_with(
+        _make_source(),
+        "Current Session Title",
+    )
+
+
+@pytest.mark.asyncio
+async def test_adapter_title_propagation_ignores_stale_session():
+    runner = _make_runner()
+
+    adapter = SimpleNamespace(on_session_title_changed=AsyncMock())
+    runner.adapters = {Platform.TELEGRAM: adapter}  # type: ignore[dict-item]
     runner.session_store = SimpleNamespace(  # type: ignore[assignment]
         get_or_create_session=lambda source: SimpleNamespace(session_id="new-session")
     )
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=AsyncMock(
+            return_value=SimpleNamespace(session_id="new-session")
+        ),
+    )
 
-    await runner._rename_matrix_room_for_session_title(
-        _make_matrix_source(),
+    await runner._propagate_session_title_to_adapter(
+        _make_source(),
         "old-session",
         "Old Session Title",
     )
 
-    adapter.set_semantic_room_name.assert_not_awaited()
-
+    adapter.on_session_title_changed.assert_not_awaited()

--- a/tests/gateway/test_goal_max_turns_config.py
+++ b/tests/gateway/test_goal_max_turns_config.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import MagicMock
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType
@@ -38,6 +39,7 @@ async def test_gateway_goal_uses_goals_max_turns_from_full_config(tmp_path, monk
     runner.session_store = _FakeSessionStore()
     runner.adapters = {}
     runner._queued_events = {}
+    runner._schedule_adapter_semantic_base_refresh = MagicMock()
 
     event = MessageEvent(
         text="/goal ship the benchmark",
@@ -58,5 +60,65 @@ async def test_gateway_goal_uses_goals_max_turns_from_full_config(tmp_path, monk
         state = goals.GoalManager("sid-gateway-goal-config").state
         assert state is not None
         assert state.max_turns == 7
+        runner._schedule_adapter_semantic_base_refresh.assert_called_once_with(
+            event.source, "sid-gateway-goal-config"
+        )
+    finally:
+        goals._DB_CACHE.clear()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command", "initial_status", "expected_status"),
+    [
+        ("pause", "active", "paused"),
+        ("resume", "paused", "active"),
+        ("clear", "active", "cleared"),
+        ("stop", "active", "cleared"),
+        ("done", "active", "cleared"),
+    ],
+)
+async def test_goal_status_changes_refresh_semantic_base_after_persistence(
+    tmp_path, monkeypatch, command, initial_status, expected_status
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    goals._DB_CACHE.clear()
+    manager = goals.GoalManager("sid-gateway-goal-config")
+    manager.set("ship the benchmark")
+    if initial_status == "paused":
+        manager.pause()
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="token")}
+    )
+    runner.session_store = _FakeSessionStore()
+    runner.adapters = {}
+    runner._queued_events = {}
+    observed_statuses = []
+    runner._schedule_adapter_semantic_base_refresh = MagicMock(
+        side_effect=lambda _source, sid: observed_statuses.append(
+            goals.GoalManager(sid).state.status
+        )
+    )
+    event = MessageEvent(
+        text=f"/goal {command}",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="chat-goal-config",
+            chat_type="channel",
+            user_id="user-goal-config",
+        ),
+    )
+
+    try:
+        await GatewayRunner._handle_goal_command(runner, event)
+        assert observed_statuses == [expected_status]
+        runner._schedule_adapter_semantic_base_refresh.assert_called_once_with(
+            event.source, "sid-gateway-goal-config"
+        )
     finally:
         goals._DB_CACHE.clear()

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1814,7 +1814,7 @@ class TestMatrixDynamicRoomNames:
             call.args[2]["name"]
             for call in self.adapter._client.send_state_event.await_args_list
         ]
-        assert names == ["🟡 Add dynamic Matrix room names", "✅ Add dynamic Matrix room names"]
+        assert names == ["🟡 Add dynamic Matrix room names", "🟢 Add dynamic Matrix room names"]
 
     @pytest.mark.asyncio
     async def test_restart_preserves_existing_semantic_room_name(self):
@@ -1836,7 +1836,7 @@ class TestMatrixDynamicRoomNames:
         ]
         assert names == [
             "🟡 Existing semantic title",
-            "✅ Existing semantic title",
+            "🟢 Existing semantic title",
         ]
         assert self.adapter._client.get_state_event.await_count == 2
         self.adapter._client.get_state_event.assert_awaited_with(
@@ -1861,7 +1861,7 @@ class TestMatrixDynamicRoomNames:
         await self._drain_room_name_tasks()
 
         assert self.adapter._client.send_state_event.await_args.args[2]["name"] == (
-            "✅ Fortress"
+            "🟢 Fortress"
         )
 
     @pytest.mark.asyncio
@@ -1881,7 +1881,7 @@ class TestMatrixDynamicRoomNames:
         await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
         await self._drain_room_name_tasks()
 
-        assert self.adapter._client.send_state_event.await_args.args[2]["name"] == "✅ Hermes"
+        assert self.adapter._client.send_state_event.await_args.args[2]["name"] == "🟢 Hermes"
 
     @pytest.mark.asyncio
     async def test_stale_state_after_tool_title_does_not_roll_back_on_completion(self):
@@ -1903,7 +1903,7 @@ class TestMatrixDynamicRoomNames:
         await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
         await self._drain_room_name_tasks()
 
-        assert self.adapter._client.send_state_event.await_args.args[2]["name"] == "✅ New"
+        assert self.adapter._client.send_state_event.await_args.args[2]["name"] == "🟢 New"
         assert self.adapter._dynamic_room_name_bases["!room:ex"] == "New"
 
     @pytest.mark.asyncio
@@ -1917,7 +1917,6 @@ class TestMatrixDynamicRoomNames:
         self.adapter._dynamic_room_name_last_sent[room_id] = "🟡 A"
         self.adapter._dynamic_room_name_active_turns.add((room_id, "$msg1"))
         self.adapter._dynamic_room_name_active[room_id] = 1
-        self.adapter._dynamic_room_name_status[room_id] = "working"
 
         assert await self.adapter.on_session_semantic_base_changed(event.source, "B")
         assert await self.adapter.on_session_semantic_base_changed(event.source, "C")
@@ -1930,7 +1929,7 @@ class TestMatrixDynamicRoomNames:
         await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
         await self._drain_room_name_tasks()
 
-        assert self.adapter._client.send_state_event.await_args.args[2]["name"] == "✅ C"
+        assert self.adapter._client.send_state_event.await_args.args[2]["name"] == "🟢 C"
         assert self.adapter._dynamic_room_name_bases[room_id] == "C"
         assert room_id not in self.adapter._dynamic_room_name_superseded_sent
         assert room_id not in self.adapter._dynamic_room_name_terminal_external_checks
@@ -1946,7 +1945,7 @@ class TestMatrixDynamicRoomNames:
         await self._drain_room_name_tasks()
 
         assert self.adapter._client.send_state_event.await_args.args[2]["name"] == (
-            "✅ Fortress"
+            "🟢 Fortress"
         )
         assert self.adapter._dynamic_room_name_bases[room_id] == "Fortress"
 
@@ -1984,7 +1983,7 @@ class TestMatrixDynamicRoomNames:
             call.args[2]["name"]
             for call in self.adapter._client.send_state_event.await_args_list
         ]
-        assert names[-1] == "✅ New authoritative base"
+        assert names[-1] == "🟢 New authoritative base"
         assert self.adapter._dynamic_room_name_bases["!room:ex"] == (
             "New authoritative base"
         )
@@ -2039,7 +2038,7 @@ class TestMatrixDynamicRoomNames:
             call.args[2]["name"]
             for call in self.adapter._client.send_state_event.await_args_list
         ]
-        assert names == ["🟡 Semantic title", "✅ Semantic title"]
+        assert names == ["🟡 Semantic title", "🟢 Semantic title"]
 
     @pytest.mark.asyncio
     async def test_newer_semantic_title_wins_over_delayed_initial_state_read(self):
@@ -2067,7 +2066,7 @@ class TestMatrixDynamicRoomNames:
             call.args[2]["name"]
             for call in self.adapter._client.send_state_event.await_args_list
         ]
-        assert names == ["Newer authoritative epic"]
+        assert names == ["🟢 Newer authoritative epic"]
         assert self.adapter._dynamic_room_name_bases["!room:ex"] == (
             "Newer authoritative epic"
         )
@@ -2091,7 +2090,7 @@ class TestMatrixDynamicRoomNames:
             call.args[2]["name"]
             for call in self.adapter._client.send_state_event.await_args_list
         ]
-        assert names == ["Active epic", "Original Matrix room"]
+        assert names == ["🟢 Active epic", "🟢 Original Matrix room"]
         assert self.adapter._dynamic_room_name_bases["!room:ex"] == (
             "Original Matrix room"
         )
@@ -2121,7 +2120,7 @@ class TestMatrixDynamicRoomNames:
         assert "!room:ex" not in self.adapter._dynamic_room_name_bases
 
     @pytest.mark.asyncio
-    async def test_failure_and_cancelled_share_unsuccessful_terminal_state(self):
+    async def test_failure_and_cancelled_return_room_name_to_idle(self):
         from gateway.platforms.base import ProcessingOutcome
 
         event = self._event()
@@ -2140,18 +2139,61 @@ class TestMatrixDynamicRoomNames:
             for call in self.adapter._client.send_state_event.await_args_list
         ]
         assert names == [
-            "🟡 Existing epic", "🔴 Existing epic",
-            "🟡 Existing epic", "🔴 Existing epic",
+            "🟡 Existing epic", "🟢 Existing epic",
+            "🟡 Existing epic", "🟢 Existing epic",
         ]
 
-    def test_title_sanitization_strips_lifecycle_prefixes_and_truncates(self):
+    def test_title_sanitization_strips_all_lifecycle_icons_and_truncates(self):
         sanitize = self.adapter._sanitize_dynamic_room_name
 
-        assert sanitize("🟡 ✅ 🔴 ❌ ⏹ Task title") == "Task title"
+        assert sanitize("🟡 🟢 ✅ 🔴 ❌ ⏹ Task title") == "Task title"
+        assert sanitize("Task 🟡 🟢 ✅ 🔴 ❌ ⏹ title") == "Task title"
         title = "界" * 61
         sanitized = sanitize(title)
         assert sanitized == ("界" * 57) + "..."
         assert len(sanitized) == 60
+
+    @pytest.mark.asyncio
+    async def test_semantic_titles_cannot_override_runtime_room_name_status(self):
+        """AI-supplied lifecycle icons are base text only, never room state."""
+        event = self._event()
+        status_icons = "🟢 🟡 ✅ 🔴 ❌ ⏹"
+
+        await self.adapter.set_semantic_room_name(
+            "!room:ex", f"{status_icons} Direct title"
+        )
+        await self.adapter.on_session_title_changed(
+            event.source, f"{status_icons} Session title"
+        )
+        await self.adapter.on_session_semantic_base_changed(
+            event.source, f"{status_icons} Goal title"
+        )
+        await self.adapter.on_processing_start(event)
+        await self._drain_room_name_tasks()
+        await self.adapter.set_semantic_room_name(
+            "!room:ex", f"{status_icons} Direct working"
+        )
+        await self.adapter.on_session_title_changed(
+            event.source, f"{status_icons} Session working"
+        )
+        await self.adapter.on_session_semantic_base_changed(
+            event.source, f"{status_icons} Goal working"
+        )
+
+        names = [
+            call.args[2]["name"]
+            for call in self.adapter._client.send_state_event.await_args_list
+        ]
+        assert names == [
+            "🟢 Direct title",
+            "🟢 Session title",
+            "🟢 Goal title",
+            "🟡 Goal title",
+            "🟡 Direct working",
+            "🟡 Session working",
+            "🟡 Goal working",
+        ]
+        assert self.adapter._dynamic_room_name_bases["!room:ex"] == "Goal working"
 
     @pytest.mark.asyncio
     async def test_truncated_base_stays_stable_across_lifecycle_transitions(self):
@@ -2171,7 +2213,7 @@ class TestMatrixDynamicRoomNames:
             call.args[2]["name"]
             for call in self.adapter._client.send_state_event.await_args_list
         ]
-        assert names == [expected_base, f"🟡 {expected_base}", f"🔴 {expected_base}"]
+        assert names == [f"🟢 {expected_base}", f"🟡 {expected_base}", f"🟢 {expected_base}"]
         assert len(expected_base) == 60
 
     @pytest.mark.asyncio
@@ -2222,7 +2264,7 @@ class TestMatrixDynamicRoomNames:
             call.args[2]["name"]
             for call in self.adapter._client.send_state_event.await_args_list
         ]
-        assert names == ["🟡 Existing epic", "✅ Existing epic"]
+        assert names == ["🟡 Existing epic", "🟢 Existing epic"]
 
     @pytest.mark.asyncio
     async def test_state_event_failure_is_best_effort(self):
@@ -2260,7 +2302,6 @@ class TestMatrixDynamicRoomNames:
         await self.adapter.on_processing_complete(first, ProcessingOutcome.CANCELLED)
 
         assert self.adapter._dynamic_room_name_active["!room:ex"] == 1
-        assert self.adapter._dynamic_room_name_status["!room:ex"] == "working"
 
         await self.adapter.on_processing_complete(second, ProcessingOutcome.SUCCESS)
         assert self.adapter._dynamic_room_name_active["!room:ex"] == 0
@@ -2297,7 +2338,7 @@ class TestMatrixDynamicRoomNames:
             call.args[2]["name"]
             for call in self.adapter._client.send_state_event.await_args_list
         ]
-        assert names == ["🟡 Existing epic", "✅ Existing epic"]
+        assert names == ["🟡 Existing epic", "🟢 Existing epic"]
 
     def test_yaml_config_bridge_enables_feature(self, monkeypatch):
         from plugins.platforms.matrix.adapter import MatrixAdapter, _apply_yaml_config

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1817,6 +1817,223 @@ class TestMatrixDynamicRoomNames:
         assert names == ["🟡 Add dynamic Matrix room names", "🟢 Add dynamic Matrix room names"]
 
     @pytest.mark.asyncio
+    async def test_runner_stamps_work_profile_key_before_matrix_completion_probe(
+        self, monkeypatch, tmp_path,
+    ):
+        """The real runner path replaces Base's profile-agnostic fallback."""
+        from gateway.config import GatewayConfig
+        from gateway.platforms.base import MessageEvent, ProcessingOutcome
+        from gateway.run import GatewayRunner
+        from gateway.session import SessionSource
+        import tools.async_delegation as async_delegation
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        runner = GatewayRunner(GatewayConfig(multiplex_profiles=True))
+        runner._profile_adapters = {"work": {Platform.MATRIX: self.adapter}}
+        runner._wire_adapter_background_work_probe(self.adapter)
+        # Stop after the runner's real ``_session_key_for_source`` path. The
+        # blocked claim keeps this test focused without manually stamping the
+        # event or running an agent turn.
+        runner._claim_active_session_slot = MagicMock(return_value=(None, "stop"))
+        source = SessionSource(
+            platform=Platform.MATRIX,
+            chat_id="!room:ex",
+            chat_type="dm",
+            user_id="u1",
+            profile="work",
+        )
+        event = MessageEvent(
+            text="add dynamic Matrix room names",
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message={},
+            message_id="$work",
+            internal=True,
+        )
+
+        await runner._handle_message(event)
+
+        session_key = "agent:work:matrix:dm:!room:ex"
+        assert event._gateway_session_key == session_key
+        self.adapter._dynamic_room_name_bases["!room:ex"] = event.text
+        with async_delegation._records_lock:
+            async_delegation._records["delegation-work"] = {
+                "status": "running", "session_key": session_key,
+            }
+        try:
+            await self.adapter.on_processing_start(event)
+            await self._drain_room_name_tasks()
+            await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+            await self._drain_room_name_tasks()
+        finally:
+            with async_delegation._records_lock:
+                async_delegation._records.pop("delegation-work", None)
+
+        assert self.adapter._client.send_state_event.await_args.args[2]["name"] == (
+            "🟡 add dynamic Matrix room names"
+        )
+
+    def test_background_probe_is_wired_for_default_and_multiplex_adapters(self):
+        """Both adapter maps receive the runner-owned activity predicate."""
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.has_owned_background_work_for_session = lambda key: key == "owned"
+        default_adapter = _make_adapter()
+        work_adapter = _make_adapter()
+
+        GatewayRunner._wire_adapter_background_work_probe(runner, default_adapter)
+        GatewayRunner._wire_adapter_background_work_probe(runner, work_adapter)
+
+        assert default_adapter.has_session_background_work("owned") is True
+        assert work_adapter.has_session_background_work("other") is False
+        assert work_adapter.has_session_background_work("owned") is True
+
+    @pytest.mark.asyncio
+    async def test_same_session_async_delegation_keeps_room_busy_after_foreground_completion(self):
+        """An async delegate belongs to its spawning gateway session only."""
+        from gateway.platforms.base import ProcessingOutcome
+        import tools.async_delegation as async_delegation
+
+        session_key = "agent:main:matrix:dm:!room:ex"
+        event = self._event()
+        self.adapter._dynamic_room_name_bases["!room:ex"] = event.text
+        event._gateway_session_key = session_key
+        with async_delegation._records_lock:
+            async_delegation._records["delegation-room"] = {
+                "status": "running",
+                "session_key": session_key,
+            }
+        self.adapter.set_session_background_work_probe(
+            async_delegation.has_active_for_session
+        )
+
+        await self.adapter.on_processing_start(event)
+        await self._drain_room_name_tasks()
+        await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+        await self._drain_room_name_tasks()
+        with async_delegation._records_lock:
+            async_delegation._records.pop("delegation-room", None)
+
+        names = [
+            call.args[2]["name"]
+            for call in self.adapter._client.send_state_event.await_args_list
+        ]
+        assert names == ["🟡 add dynamic Matrix room names"]
+
+    @pytest.mark.asyncio
+    async def test_same_session_tracked_process_keeps_room_busy_after_foreground_completion(
+        self, monkeypatch
+    ):
+        """A tracked terminal process keeps only its own Matrix session busy."""
+        from gateway.platforms.base import ProcessingOutcome
+        from tools.process_registry import process_registry
+
+        session_key = "agent:main:matrix:dm:!room:ex"
+        event = self._event()
+        self.adapter._dynamic_room_name_bases["!room:ex"] = event.text
+        event._gateway_session_key = session_key
+        monkeypatch.setattr(
+            process_registry,
+            "has_active_for_session",
+            lambda key: key == session_key,
+        )
+        self.adapter.set_session_background_work_probe(
+            process_registry.has_active_for_session
+        )
+
+        await self.adapter.on_processing_start(event)
+        await self._drain_room_name_tasks()
+        await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+        await self._drain_room_name_tasks()
+
+        names = [
+            call.args[2]["name"]
+            for call in self.adapter._client.send_state_event.await_args_list
+        ]
+        assert names == ["🟡 add dynamic Matrix room names"]
+
+    @pytest.mark.asyncio
+    async def test_other_session_background_work_does_not_keep_room_busy(self):
+        """Background work from a different session cannot leak into this DM."""
+        from gateway.platforms.base import ProcessingOutcome
+
+        event = self._event()
+        self.adapter._dynamic_room_name_bases["!room:ex"] = event.text
+        event._gateway_session_key = "agent:main:matrix:dm:!room:ex"
+        self.adapter.set_session_background_work_probe(
+            lambda key: key == "agent:main:matrix:dm:!other-room:ex"
+        )
+
+        await self.adapter.on_processing_start(event)
+        await self._drain_room_name_tasks()
+        await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+        await self._drain_room_name_tasks()
+
+        assert self.adapter._client.send_state_event.await_args.args[2]["name"] == (
+            "🟢 add dynamic Matrix room names"
+        )
+
+    @pytest.mark.asyncio
+    async def test_last_background_completion_refreshes_room_to_green(self):
+        """Watcher finalization refreshes the room even without an agent turn."""
+        from gateway.platforms.base import ProcessingOutcome
+
+        session_key = "agent:main:matrix:dm:!room:ex"
+        background_active = True
+        event = self._event()
+        self.adapter._dynamic_room_name_bases["!room:ex"] = event.text
+        event._gateway_session_key = session_key
+        self.adapter.set_session_background_work_probe(lambda key: key == session_key and background_active)
+
+        await self.adapter.on_processing_start(event)
+        await self._drain_room_name_tasks()
+        await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+        await self._drain_room_name_tasks()
+        background_active = False
+        await self.adapter.on_session_background_work_changed(event.source, session_key)
+        await self._drain_room_name_tasks()
+
+        assert "!room:ex" not in self.adapter._dynamic_room_name_session_keys
+
+        names = [
+            call.args[2]["name"]
+            for call in self.adapter._client.send_state_event.await_args_list
+        ]
+        assert names == [
+            "🟡 add dynamic Matrix room names",
+            "🟢 add dynamic Matrix room names",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_foreground_and_background_work_cannot_turn_room_green_early(self):
+        from gateway.platforms.base import ProcessingOutcome
+
+        background_session_key = "agent:main:matrix:dm:!room:ex"
+        first = self._event()
+        self.adapter._dynamic_room_name_bases["!room:ex"] = first.text
+        first._gateway_session_key = background_session_key
+        second = self._event()
+        second.message_id = "$msg2"
+        second._gateway_session_key = "agent:main:matrix:dm:!room:ex:thread-two"
+        self.adapter.set_session_background_work_probe(
+            lambda key: key == background_session_key
+        )
+
+        await self.adapter.on_processing_start(first)
+        await self.adapter.on_processing_start(second)
+        await self._drain_room_name_tasks()
+        await self.adapter.on_processing_complete(first, ProcessingOutcome.SUCCESS)
+        await self.adapter.on_processing_complete(second, ProcessingOutcome.SUCCESS)
+        await self._drain_room_name_tasks()
+
+        names = [
+            call.args[2]["name"]
+            for call in self.adapter._client.send_state_event.await_args_list
+        ]
+        assert names == ["🟡 add dynamic Matrix room names"]
+
+    @pytest.mark.asyncio
     async def test_restart_preserves_existing_semantic_room_name(self):
         from gateway.platforms.base import ProcessingOutcome
 

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -5,6 +5,7 @@ import stat
 import sys
 import time
 import types
+
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 
@@ -1751,6 +1752,132 @@ class TestMatrixLinkSanitization:
         result = MatrixAdapter._sanitize_link_url('http://x"y')
         assert '"' not in result
         assert "&quot;" in result
+
+
+# ---------------------------------------------------------------------------
+# Dynamic room names
+# ---------------------------------------------------------------------------
+
+
+class TestMatrixDynamicRoomNames:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._reactions_enabled = False
+        self.adapter._dynamic_room_name_enabled = True
+        self.adapter._client = MagicMock()
+        self.adapter._client.send_state_event = AsyncMock(return_value="$room-name")
+
+    @staticmethod
+    def _event(chat_type="dm"):
+        from gateway.platforms.base import MessageEvent, MessageType
+
+        source = MagicMock()
+        source.chat_id = "!room:ex"
+        source.chat_type = chat_type
+        return MessageEvent(
+            text="add dynamic Matrix room names",
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message={},
+            message_id="$msg1",
+        )
+
+    @pytest.mark.asyncio
+    async def test_processing_and_semantic_title_update_room_name(self):
+        from gateway.platforms.base import ProcessingOutcome
+
+        event = self._event()
+
+        await self.adapter.on_processing_start(event)
+        await self.adapter.set_semantic_room_name(
+            "!room:ex", "Add dynamic Matrix room names"
+        )
+        await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+        names = [
+            call.args[2]["name"]
+            for call in self.adapter._client.send_state_event.await_args_list
+        ]
+        assert names == [
+            "🟡 Hermes",
+            "🟡 Add dynamic Matrix room names",
+            "✅ Add dynamic Matrix room names",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_failure_and_cancelled_have_distinct_terminal_states(self):
+        from gateway.platforms.base import ProcessingOutcome
+
+        event = self._event()
+        await self.adapter.on_processing_start(event)
+        await self.adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
+        await self.adapter.on_processing_start(event)
+        await self.adapter.on_processing_complete(event, ProcessingOutcome.CANCELLED)
+
+        names = [
+            call.args[2]["name"]
+            for call in self.adapter._client.send_state_event.await_args_list
+        ]
+        assert names == ["🟡 Hermes", "❌ Hermes", "🟡 Hermes", "⏹ Hermes"]
+
+    @pytest.mark.asyncio
+    async def test_disabled_or_group_room_does_not_rename(self):
+        event = self._event(chat_type="group")
+        await self.adapter.on_processing_start(event)
+        self.adapter._client.send_state_event.assert_not_awaited()
+
+        self.adapter._dynamic_room_name_enabled = False
+        event.source.chat_type = "dm"
+        await self.adapter.on_processing_start(event)
+        self.adapter._client.send_state_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_state_updates_are_deduplicated_for_overlapping_turns(self):
+        from gateway.platforms.base import ProcessingOutcome
+
+        async def delayed_send(*args, **kwargs):
+            await asyncio.sleep(0.01)
+            return "$room-name"
+
+        self.adapter._client.send_state_event.side_effect = delayed_send
+        event = self._event()
+        await asyncio.gather(
+            self.adapter.on_processing_start(event),
+            self.adapter.on_processing_start(event),
+        )
+        await asyncio.gather(
+            self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS),
+            self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS),
+        )
+
+        names = [
+            call.args[2]["name"]
+            for call in self.adapter._client.send_state_event.await_args_list
+        ]
+        assert names == ["🟡 Hermes", "✅ Hermes"]
+
+    @pytest.mark.asyncio
+    async def test_state_event_failure_is_best_effort(self):
+        self.adapter._client.send_state_event.side_effect = PermissionError("forbidden")
+
+        await self.adapter.on_processing_start(self._event())
+
+        self.adapter._client.send_state_event.assert_awaited_once()
+
+    def test_yaml_config_bridge_enables_feature(self, monkeypatch):
+        from plugins.platforms.matrix.adapter import MatrixAdapter, _apply_yaml_config
+
+        monkeypatch.delenv("HERMES_MATRIX_DYNAMIC_ROOM_NAME", raising=False)
+        _apply_yaml_config({}, {"dynamic_room_name": True})
+
+        adapter = MatrixAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="syt_test_token",
+                extra={"homeserver": "https://matrix.example.org"},
+            )
+        )
+        assert adapter._dynamic_room_name_enabled is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1814,6 +1814,79 @@ class TestMatrixDynamicRoomNames:
         ]
 
     @pytest.mark.asyncio
+    async def test_restart_preserves_existing_semantic_room_name(self):
+        from gateway.platforms.base import ProcessingOutcome
+
+        self.adapter._client.get_state_event = AsyncMock(
+            return_value={"name": "✅ Existing semantic title"}
+        )
+        event = self._event()
+
+        await self.adapter.on_processing_start(event)
+        await self._drain_room_name_tasks()
+        await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+        await self._drain_room_name_tasks()
+
+        names = [
+            call.args[2]["name"]
+            for call in self.adapter._client.send_state_event.await_args_list
+        ]
+        assert names == [
+            "🟡 Existing semantic title",
+            "✅ Existing semantic title",
+        ]
+        self.adapter._client.get_state_event.assert_awaited_once_with(
+            "!room:ex", "m.room.name"
+        )
+
+    @pytest.mark.asyncio
+    async def test_initial_room_name_read_failure_falls_back_to_hermes(self):
+        self.adapter._client.get_state_event = AsyncMock(
+            side_effect=PermissionError("forbidden")
+        )
+
+        await self.adapter.on_processing_start(self._event())
+        await self._drain_room_name_tasks()
+
+        names = [
+            call.args[2]["name"]
+            for call in self.adapter._client.send_state_event.await_args_list
+        ]
+        assert names == ["🟡 Hermes"]
+
+    @pytest.mark.asyncio
+    async def test_newer_semantic_title_wins_over_delayed_initial_state_read(self):
+        initial_read_started = asyncio.Event()
+        release_initial_read = asyncio.Event()
+
+        async def delayed_room_name(*args, **kwargs):
+            initial_read_started.set()
+            await release_initial_read.wait()
+            return {"name": "✅ Stale persisted title"}
+
+        self.adapter._client.get_state_event = AsyncMock(side_effect=delayed_room_name)
+        event = self._event()
+
+        await self.adapter.on_processing_start(event)
+        await asyncio.wait_for(initial_read_started.wait(), timeout=0.05)
+        newer_title = asyncio.create_task(
+            self.adapter.on_session_title_changed(event.source, "Newer semantic title")
+        )
+        await asyncio.sleep(0)
+        release_initial_read.set()
+        await newer_title
+        await self._drain_room_name_tasks()
+
+        names = [
+            call.args[2]["name"]
+            for call in self.adapter._client.send_state_event.await_args_list
+        ]
+        assert names == ["🟡 Newer semantic title"]
+        assert self.adapter._dynamic_room_name_bases["!room:ex"] == (
+            "Newer semantic title"
+        )
+
+    @pytest.mark.asyncio
     async def test_failure_and_cancelled_share_unsuccessful_terminal_state(self):
         from gateway.platforms.base import ProcessingOutcome
 

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1144,6 +1144,9 @@ class TestMatrixPasswordLoginDeviceId:
                 "user_id": "@bot:example.org",
                 "password": "secret",
                 "device_id": "STABLE_PW_DEVICE",
+                # This test covers password login/device identity, not E2EE.
+                # Keep it independent of locally installed crypto extras.
+                "encryption": False,
             },
         )
         adapter = MatrixAdapter(config)
@@ -1662,11 +1665,15 @@ class TestMatrixDisconnect:
         fake_client = MagicMock()
         fake_client.api = mock_api
         adapter._client = fake_client
+        adapter._dynamic_room_name_terminal_external_checks.add("!room:ex")
+        adapter._dynamic_room_name_superseded_sent["!room:ex"] = {"🟡 Old"}
 
         await adapter.disconnect()
 
         mock_session.close.assert_awaited_once()
         assert adapter._client is None
+        assert not adapter._dynamic_room_name_terminal_external_checks
+        assert not adapter._dynamic_room_name_superseded_sent
 
 
 # ---------------------------------------------------------------------------
@@ -1807,11 +1814,7 @@ class TestMatrixDynamicRoomNames:
             call.args[2]["name"]
             for call in self.adapter._client.send_state_event.await_args_list
         ]
-        assert names == [
-            "🟡 Hermes",
-            "🟡 Add dynamic Matrix room names",
-            "✅ Add dynamic Matrix room names",
-        ]
+        assert names == ["🟡 Add dynamic Matrix room names", "✅ Add dynamic Matrix room names"]
 
     @pytest.mark.asyncio
     async def test_restart_preserves_existing_semantic_room_name(self):
@@ -1835,12 +1838,159 @@ class TestMatrixDynamicRoomNames:
             "🟡 Existing semantic title",
             "✅ Existing semantic title",
         ]
-        self.adapter._client.get_state_event.assert_awaited_once_with(
+        assert self.adapter._client.get_state_event.await_count == 2
+        self.adapter._client.get_state_event.assert_awaited_with(
             "!room:ex", "m.room.name"
         )
 
     @pytest.mark.asyncio
-    async def test_initial_room_name_read_failure_falls_back_to_hermes(self):
+    async def test_manual_external_rename_is_adopted_on_completion(self):
+        from gateway.platforms.base import ProcessingOutcome
+
+        event = self._event()
+        self.adapter._dynamic_room_name_bases["!room:ex"] = "Hermes"
+        self.adapter._dynamic_room_name_initialized.add("!room:ex")
+        self.adapter._dynamic_room_name_last_sent["!room:ex"] = "🟡 Hermes"
+        self.adapter._dynamic_room_name_active_turns.add(("!room:ex", "$msg1"))
+        self.adapter._dynamic_room_name_active["!room:ex"] = 1
+        self.adapter._client.get_state_event = AsyncMock(
+            return_value={"name": "🟡 Fortress"}
+        )
+
+        await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+        await self._drain_room_name_tasks()
+
+        assert self.adapter._client.send_state_event.await_args.args[2]["name"] == (
+            "✅ Fortress"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_external_rename_keeps_existing_base_on_completion(self):
+        from gateway.platforms.base import ProcessingOutcome
+
+        event = self._event()
+        self.adapter._dynamic_room_name_bases["!room:ex"] = "Hermes"
+        self.adapter._dynamic_room_name_initialized.add("!room:ex")
+        self.adapter._dynamic_room_name_last_sent["!room:ex"] = "🟡 Hermes"
+        self.adapter._dynamic_room_name_active_turns.add(("!room:ex", "$msg1"))
+        self.adapter._dynamic_room_name_active["!room:ex"] = 1
+        self.adapter._client.get_state_event = AsyncMock(
+            return_value={"name": "🟡 Hermes"}
+        )
+
+        await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+        await self._drain_room_name_tasks()
+
+        assert self.adapter._client.send_state_event.await_args.args[2]["name"] == "✅ Hermes"
+
+    @pytest.mark.asyncio
+    async def test_stale_state_after_tool_title_does_not_roll_back_on_completion(self):
+        from gateway.platforms.base import ProcessingOutcome
+
+        event = self._event()
+        self.adapter._dynamic_room_name_bases["!room:ex"] = "Old"
+        self.adapter._dynamic_room_name_initialized.add("!room:ex")
+        self.adapter._dynamic_room_name_last_sent["!room:ex"] = "🟡 Old"
+        self.adapter._dynamic_room_name_active_turns.add(("!room:ex", "$msg1"))
+        self.adapter._dynamic_room_name_active["!room:ex"] = 1
+
+        assert await self.adapter.on_session_semantic_base_changed(
+            event.source, "New"
+        )
+        self.adapter._client.get_state_event = AsyncMock(
+            return_value={"name": "🟡 Old"}
+        )
+        await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+        await self._drain_room_name_tasks()
+
+        assert self.adapter._client.send_state_event.await_args.args[2]["name"] == "✅ New"
+        assert self.adapter._dynamic_room_name_bases["!room:ex"] == "New"
+
+    @pytest.mark.asyncio
+    async def test_stale_echo_from_full_rename_chain_is_consumed_once(self):
+        from gateway.platforms.base import ProcessingOutcome
+
+        event = self._event()
+        room_id = "!room:ex"
+        self.adapter._dynamic_room_name_bases[room_id] = "A"
+        self.adapter._dynamic_room_name_initialized.add(room_id)
+        self.adapter._dynamic_room_name_last_sent[room_id] = "🟡 A"
+        self.adapter._dynamic_room_name_active_turns.add((room_id, "$msg1"))
+        self.adapter._dynamic_room_name_active[room_id] = 1
+        self.adapter._dynamic_room_name_status[room_id] = "working"
+
+        assert await self.adapter.on_session_semantic_base_changed(event.source, "B")
+        assert await self.adapter.on_session_semantic_base_changed(event.source, "C")
+        assert self.adapter._dynamic_room_name_superseded_sent[room_id] == {
+            "🟡 A",
+            "🟡 B",
+        }
+
+        self.adapter._client.get_state_event = AsyncMock(return_value={"name": "🟡 A"})
+        await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+        await self._drain_room_name_tasks()
+
+        assert self.adapter._client.send_state_event.await_args.args[2]["name"] == "✅ C"
+        assert self.adapter._dynamic_room_name_bases[room_id] == "C"
+        assert room_id not in self.adapter._dynamic_room_name_superseded_sent
+        assert room_id not in self.adapter._dynamic_room_name_terminal_external_checks
+
+        later = self._event()
+        later.message_id = "$msg2"
+        await self.adapter.on_processing_start(later)
+        await self._drain_room_name_tasks()
+        self.adapter._client.get_state_event = AsyncMock(
+            return_value={"name": "🟡 Fortress"}
+        )
+        await self.adapter.on_processing_complete(later, ProcessingOutcome.SUCCESS)
+        await self._drain_room_name_tasks()
+
+        assert self.adapter._client.send_state_event.await_args.args[2]["name"] == (
+            "✅ Fortress"
+        )
+        assert self.adapter._dynamic_room_name_bases[room_id] == "Fortress"
+
+    @pytest.mark.asyncio
+    async def test_delayed_external_read_cannot_overwrite_newer_tool_base(self):
+        from gateway.platforms.base import ProcessingOutcome
+
+        event = self._event()
+        self.adapter._dynamic_room_name_bases["!room:ex"] = "Hermes"
+        self.adapter._dynamic_room_name_initialized.add("!room:ex")
+        self.adapter._dynamic_room_name_last_sent["!room:ex"] = "🟡 Hermes"
+        self.adapter._dynamic_room_name_active_turns.add(("!room:ex", "$msg1"))
+        self.adapter._dynamic_room_name_active["!room:ex"] = 1
+        read_started = asyncio.Event()
+        release_read = asyncio.Event()
+
+        async def delayed_external_name(*_args):
+            read_started.set()
+            await release_read.wait()
+            return {"name": "🟡 External stale base"}
+
+        self.adapter._client.get_state_event = AsyncMock(side_effect=delayed_external_name)
+        await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+        await read_started.wait()
+        authoritative = asyncio.create_task(
+            self.adapter.on_session_semantic_base_changed(
+                event.source, "New authoritative base"
+            )
+        )
+        release_read.set()
+        await self._drain_room_name_tasks()
+        assert await authoritative
+
+        names = [
+            call.args[2]["name"]
+            for call in self.adapter._client.send_state_event.await_args_list
+        ]
+        assert names[-1] == "✅ New authoritative base"
+        assert self.adapter._dynamic_room_name_bases["!room:ex"] == (
+            "New authoritative base"
+        )
+
+    @pytest.mark.asyncio
+    async def test_initial_room_name_read_failure_does_not_rename(self):
         self.adapter._client.get_state_event = AsyncMock(
             side_effect=PermissionError("forbidden")
         )
@@ -1852,7 +2002,7 @@ class TestMatrixDynamicRoomNames:
             call.args[2]["name"]
             for call in self.adapter._client.send_state_event.await_args_list
         ]
-        assert names == ["🟡 Hermes"]
+        assert names == []
 
     @pytest.mark.asyncio
     async def test_initial_room_name_read_timeout_does_not_block_lifecycle(self):
@@ -1879,7 +2029,7 @@ class TestMatrixDynamicRoomNames:
         await asyncio.wait_for(self._drain_room_name_tasks(), timeout=0.1)
 
         assert read_cancelled.is_set()
-        assert self.adapter._dynamic_room_name_bases["!room:ex"] == "Hermes"
+        assert "!room:ex" not in self.adapter._dynamic_room_name_bases
 
         await self.adapter.on_session_title_changed(event.source, "Semantic title")
         await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
@@ -1889,7 +2039,7 @@ class TestMatrixDynamicRoomNames:
             call.args[2]["name"]
             for call in self.adapter._client.send_state_event.await_args_list
         ]
-        assert names == ["🟡 Hermes", "🟡 Semantic title", "✅ Semantic title"]
+        assert names == ["🟡 Semantic title", "✅ Semantic title"]
 
     @pytest.mark.asyncio
     async def test_newer_semantic_title_wins_over_delayed_initial_state_read(self):
@@ -1904,30 +2054,78 @@ class TestMatrixDynamicRoomNames:
         self.adapter._client.get_state_event = AsyncMock(side_effect=delayed_room_name)
         event = self._event()
 
-        await self.adapter.on_processing_start(event)
-        await asyncio.wait_for(initial_read_started.wait(), timeout=0.05)
         newer_title = asyncio.create_task(
-            self.adapter.on_session_title_changed(event.source, "Newer semantic title")
+            self.adapter.on_session_semantic_base_changed(
+                event.source, "Newer authoritative epic"
+            )
         )
-        await asyncio.sleep(0)
+        await asyncio.wait_for(initial_read_started.wait(), timeout=0.05)
         release_initial_read.set()
         await newer_title
-        await self._drain_room_name_tasks()
 
         names = [
             call.args[2]["name"]
             for call in self.adapter._client.send_state_event.await_args_list
         ]
-        assert names == ["🟡 Newer semantic title"]
+        assert names == ["Newer authoritative epic"]
         assert self.adapter._dynamic_room_name_bases["!room:ex"] == (
-            "Newer semantic title"
+            "Newer authoritative epic"
         )
+        assert self.adapter._dynamic_room_name_recovered_bases["!room:ex"] == (
+            "Stale persisted title"
+        )
+
+    @pytest.mark.asyncio
+    async def test_cleared_authoritative_base_restores_preexisting_room_title(self):
+        self.adapter._client.get_state_event = AsyncMock(
+            return_value={"name": "Original Matrix room"}
+        )
+        source = self._event().source
+
+        assert await self.adapter.on_session_semantic_base_changed(
+            source, "Active epic"
+        )
+        assert await self.adapter.on_session_semantic_base_changed(source, None)
+
+        names = [
+            call.args[2]["name"]
+            for call in self.adapter._client.send_state_event.await_args_list
+        ]
+        assert names == ["Active epic", "Original Matrix room"]
+        assert self.adapter._dynamic_room_name_bases["!room:ex"] == (
+            "Original Matrix room"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "room_state",
+        [None, PermissionError("forbidden")],
+        ids=["untitled", "unreadable"],
+    )
+    async def test_cleared_authoritative_base_leaves_unrecoverable_room_unchanged(
+        self, room_state
+    ):
+        if isinstance(room_state, Exception):
+            self.adapter._client.get_state_event = AsyncMock(side_effect=room_state)
+        else:
+            self.adapter._client.get_state_event = AsyncMock(return_value=room_state)
+        source = self._event().source
+
+        assert await self.adapter.on_session_semantic_base_changed(
+            source, "Active epic"
+        )
+        self.adapter._client.send_state_event.reset_mock()
+
+        assert not await self.adapter.on_session_semantic_base_changed(source, None)
+        self.adapter._client.send_state_event.assert_not_awaited()
+        assert "!room:ex" not in self.adapter._dynamic_room_name_bases
 
     @pytest.mark.asyncio
     async def test_failure_and_cancelled_share_unsuccessful_terminal_state(self):
         from gateway.platforms.base import ProcessingOutcome
 
         event = self._event()
+        self.adapter._dynamic_room_name_bases["!room:ex"] = "Existing epic"
         await self.adapter.on_processing_start(event)
         await self._drain_room_name_tasks()
         await self.adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
@@ -1941,7 +2139,10 @@ class TestMatrixDynamicRoomNames:
             call.args[2]["name"]
             for call in self.adapter._client.send_state_event.await_args_list
         ]
-        assert names == ["🟡 Hermes", "🔴 Hermes", "🟡 Hermes", "🔴 Hermes"]
+        assert names == [
+            "🟡 Existing epic", "🔴 Existing epic",
+            "🟡 Existing epic", "🔴 Existing epic",
+        ]
 
     def test_title_sanitization_strips_lifecycle_prefixes_and_truncates(self):
         sanitize = self.adapter._sanitize_dynamic_room_name
@@ -2005,6 +2206,7 @@ class TestMatrixDynamicRoomNames:
 
         self.adapter._client.send_state_event.side_effect = delayed_send
         event = self._event()
+        self.adapter._dynamic_room_name_bases["!room:ex"] = "Existing epic"
         await asyncio.gather(
             self.adapter.on_processing_start(event),
             self.adapter.on_processing_start(event),
@@ -2020,11 +2222,12 @@ class TestMatrixDynamicRoomNames:
             call.args[2]["name"]
             for call in self.adapter._client.send_state_event.await_args_list
         ]
-        assert names == ["🟡 Hermes", "✅ Hermes"]
+        assert names == ["🟡 Existing epic", "✅ Existing epic"]
 
     @pytest.mark.asyncio
     async def test_state_event_failure_is_best_effort(self):
         self.adapter._client.send_state_event.side_effect = PermissionError("forbidden")
+        self.adapter._dynamic_room_name_bases["!room:ex"] = "Existing epic"
 
         await self.adapter.on_processing_start(self._event())
         await self._drain_room_name_tasks()
@@ -2079,6 +2282,7 @@ class TestMatrixDynamicRoomNames:
 
         self.adapter._client.send_state_event.side_effect = hanging_first_send
         event = self._event()
+        self.adapter._dynamic_room_name_bases["!room:ex"] = "Existing epic"
 
         await asyncio.wait_for(self.adapter.on_processing_start(event), timeout=0.05)
         await asyncio.wait_for(first_send_started.wait(), timeout=0.05)
@@ -2093,7 +2297,7 @@ class TestMatrixDynamicRoomNames:
             call.args[2]["name"]
             for call in self.adapter._client.send_state_event.await_args_list
         ]
-        assert names == ["🟡 Hermes", "✅ Hermes"]
+        assert names == ["🟡 Existing epic", "✅ Existing epic"]
 
     def test_yaml_config_bridge_enables_feature(self, monkeypatch):
         from plugins.platforms.matrix.adapter import MatrixAdapter, _apply_yaml_config

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1782,6 +1782,13 @@ class TestMatrixDynamicRoomNames:
             message_id="$msg1",
         )
 
+    async def _drain_room_name_tasks(self):
+        while self.adapter._dynamic_room_name_tasks:
+            await asyncio.gather(
+                *tuple(self.adapter._dynamic_room_name_tasks),
+                return_exceptions=True,
+            )
+
     @pytest.mark.asyncio
     async def test_processing_and_semantic_title_update_room_name(self):
         from gateway.platforms.base import ProcessingOutcome
@@ -1789,10 +1796,12 @@ class TestMatrixDynamicRoomNames:
         event = self._event()
 
         await self.adapter.on_processing_start(event)
+        await self._drain_room_name_tasks()
         await self.adapter.on_session_title_changed(
             event.source, "Add dynamic Matrix room names"
         )
         await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+        await self._drain_room_name_tasks()
 
         names = [
             call.args[2]["name"]
@@ -1810,9 +1819,13 @@ class TestMatrixDynamicRoomNames:
 
         event = self._event()
         await self.adapter.on_processing_start(event)
+        await self._drain_room_name_tasks()
         await self.adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
+        await self._drain_room_name_tasks()
         await self.adapter.on_processing_start(event)
+        await self._drain_room_name_tasks()
         await self.adapter.on_processing_complete(event, ProcessingOutcome.CANCELLED)
+        await self._drain_room_name_tasks()
 
         names = [
             call.args[2]["name"]
@@ -1856,10 +1869,12 @@ class TestMatrixDynamicRoomNames:
             self.adapter.on_processing_start(event),
             self.adapter.on_processing_start(event),
         )
+        await self._drain_room_name_tasks()
         await asyncio.gather(
             self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS),
             self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS),
         )
+        await self._drain_room_name_tasks()
 
         names = [
             call.args[2]["name"]
@@ -1872,8 +1887,73 @@ class TestMatrixDynamicRoomNames:
         self.adapter._client.send_state_event.side_effect = PermissionError("forbidden")
 
         await self.adapter.on_processing_start(self._event())
+        await self._drain_room_name_tasks()
 
         self.adapter._client.send_state_event.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_completion_retry_is_idempotent_with_two_turns(self):
+        from gateway.platforms.base import ProcessingOutcome
+
+        first = self._event()
+        second = self._event()
+        second.message_id = "$msg2"
+        await self.adapter.on_processing_start(first)
+        await self.adapter.on_processing_start(second)
+
+        release_completion_write = asyncio.Event()
+
+        async def hanging_completion_write(*args, **kwargs):
+            await release_completion_write.wait()
+            return "$room-name"
+
+        self.adapter._dynamic_room_name_last_sent["!room:ex"] = "stale"
+        self.adapter._client.send_state_event.side_effect = hanging_completion_write
+
+        await asyncio.wait_for(
+            self.adapter.on_processing_complete(first, ProcessingOutcome.CANCELLED),
+            timeout=0.05,
+        )
+        await self.adapter.on_processing_complete(first, ProcessingOutcome.CANCELLED)
+
+        assert self.adapter._dynamic_room_name_active["!room:ex"] == 1
+        assert self.adapter._dynamic_room_name_status["!room:ex"] == "working"
+
+        await self.adapter.on_processing_complete(second, ProcessingOutcome.SUCCESS)
+        assert self.adapter._dynamic_room_name_active["!room:ex"] == 0
+        release_completion_write.set()
+        await self._drain_room_name_tasks()
+
+    @pytest.mark.asyncio
+    async def test_processing_room_name_writes_are_detached_and_latest_wins(self):
+        from gateway.platforms.base import ProcessingOutcome
+
+        first_send_started = asyncio.Event()
+        release_first_send = asyncio.Event()
+
+        async def hanging_first_send(*args, **kwargs):
+            if not first_send_started.is_set():
+                first_send_started.set()
+                await release_first_send.wait()
+            return "$room-name"
+
+        self.adapter._client.send_state_event.side_effect = hanging_first_send
+        event = self._event()
+
+        await asyncio.wait_for(self.adapter.on_processing_start(event), timeout=0.05)
+        await asyncio.wait_for(first_send_started.wait(), timeout=0.05)
+        await asyncio.wait_for(
+            self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS),
+            timeout=0.05,
+        )
+        release_first_send.set()
+        await self._drain_room_name_tasks()
+
+        names = [
+            call.args[2]["name"]
+            for call in self.adapter._client.send_state_event.await_args_list
+        ]
+        assert names == ["🟡 Hermes", "✅ Hermes"]
 
     def test_yaml_config_bridge_enables_feature(self, monkeypatch):
         from plugins.platforms.matrix.adapter import MatrixAdapter, _apply_yaml_config

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1814,7 +1814,7 @@ class TestMatrixDynamicRoomNames:
         ]
 
     @pytest.mark.asyncio
-    async def test_failure_and_cancelled_have_distinct_terminal_states(self):
+    async def test_failure_and_cancelled_share_unsuccessful_terminal_state(self):
         from gateway.platforms.base import ProcessingOutcome
 
         event = self._event()
@@ -1831,7 +1831,37 @@ class TestMatrixDynamicRoomNames:
             call.args[2]["name"]
             for call in self.adapter._client.send_state_event.await_args_list
         ]
-        assert names == ["🟡 Hermes", "❌ Hermes", "🟡 Hermes", "⏹ Hermes"]
+        assert names == ["🟡 Hermes", "🔴 Hermes", "🟡 Hermes", "🔴 Hermes"]
+
+    def test_title_sanitization_strips_lifecycle_prefixes_and_truncates(self):
+        sanitize = self.adapter._sanitize_dynamic_room_name
+
+        assert sanitize("🟡 ✅ 🔴 ❌ ⏹ Task title") == "Task title"
+        title = "界" * 61
+        sanitized = sanitize(title)
+        assert sanitized == ("界" * 57) + "..."
+        assert len(sanitized) == 60
+
+    @pytest.mark.asyncio
+    async def test_truncated_base_stays_stable_across_lifecycle_transitions(self):
+        from gateway.platforms.base import ProcessingOutcome
+
+        event = self._event()
+        title = "Task " + ("界" * 80)
+        expected_base = self.adapter._sanitize_dynamic_room_name(title)
+
+        await self.adapter.on_session_title_changed(event.source, title)
+        await self.adapter.on_processing_start(event)
+        await self._drain_room_name_tasks()
+        await self.adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
+        await self._drain_room_name_tasks()
+
+        names = [
+            call.args[2]["name"]
+            for call in self.adapter._client.send_state_event.await_args_list
+        ]
+        assert names == [expected_base, f"🟡 {expected_base}", f"🔴 {expected_base}"]
+        assert len(expected_base) == 60
 
     @pytest.mark.asyncio
     async def test_disabled_or_group_room_does_not_rename(self):

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1855,6 +1855,43 @@ class TestMatrixDynamicRoomNames:
         assert names == ["🟡 Hermes"]
 
     @pytest.mark.asyncio
+    async def test_initial_room_name_read_timeout_does_not_block_lifecycle(self):
+        from gateway.platforms.base import ProcessingOutcome
+
+        read_started = asyncio.Event()
+        read_cancelled = asyncio.Event()
+
+        async def never_returning_room_name(*args, **kwargs):
+            read_started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                read_cancelled.set()
+
+        self.adapter._dynamic_room_name_timeout_seconds = 0.01
+        self.adapter._client.get_state_event = AsyncMock(
+            side_effect=never_returning_room_name
+        )
+        event = self._event()
+
+        await asyncio.wait_for(self.adapter.on_processing_start(event), timeout=0.05)
+        await asyncio.wait_for(read_started.wait(), timeout=0.05)
+        await asyncio.wait_for(self._drain_room_name_tasks(), timeout=0.1)
+
+        assert read_cancelled.is_set()
+        assert self.adapter._dynamic_room_name_bases["!room:ex"] == "Hermes"
+
+        await self.adapter.on_session_title_changed(event.source, "Semantic title")
+        await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+        await asyncio.wait_for(self._drain_room_name_tasks(), timeout=0.1)
+
+        names = [
+            call.args[2]["name"]
+            for call in self.adapter._client.send_state_event.await_args_list
+        ]
+        assert names == ["🟡 Hermes", "🟡 Semantic title", "✅ Semantic title"]
+
+    @pytest.mark.asyncio
     async def test_newer_semantic_title_wins_over_delayed_initial_state_read(self):
         initial_read_started = asyncio.Event()
         release_initial_read = asyncio.Event()

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1789,8 +1789,8 @@ class TestMatrixDynamicRoomNames:
         event = self._event()
 
         await self.adapter.on_processing_start(event)
-        await self.adapter.set_semantic_room_name(
-            "!room:ex", "Add dynamic Matrix room names"
+        await self.adapter.on_session_title_changed(
+            event.source, "Add dynamic Matrix room names"
         )
         await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
 
@@ -1829,6 +1829,17 @@ class TestMatrixDynamicRoomNames:
         self.adapter._dynamic_room_name_enabled = False
         event.source.chat_type = "dm"
         await self.adapter.on_processing_start(event)
+        self.adapter._client.send_state_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_title_hook_is_limited_to_opted_in_dms(self):
+        event = self._event(chat_type="group")
+        assert not await self.adapter.on_session_title_changed(event.source, "Group")
+        self.adapter._client.send_state_event.assert_not_awaited()
+
+        self.adapter._dynamic_room_name_enabled = False
+        event.source.chat_type = "dm"
+        assert not await self.adapter.on_session_title_changed(event.source, "DM")
         self.adapter._client.send_state_event.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_title_command.py
+++ b/tests/gateway/test_title_command.py
@@ -32,10 +32,15 @@ def _make_runner(session_db=None):
     runner = object.__new__(GatewayRunner)
     runner.adapters = {}
     runner._voice_mode = {}
+    runner._schedule_telegram_topic_title_rename = MagicMock()
+    runner._schedule_adapter_session_title_propagation = MagicMock()
     # Gateway holds the async facade; the slash handlers await it.
     if session_db is not None:
-        from hermes_state import AsyncSessionDB
-        session_db = AsyncSessionDB(session_db)
+        session_db = SimpleNamespace(
+            get_session_title=AsyncMock(side_effect=session_db.get_session_title),
+            create_session=AsyncMock(side_effect=session_db.create_session),
+            set_session_title=AsyncMock(side_effect=session_db.set_session_title),
+        )
     runner._session_db = session_db
 
     # Mock session_store that returns a session entry with a known session_id
@@ -45,6 +50,10 @@ def _make_runner(session_db=None):
     mock_store = MagicMock()
     mock_store.get_or_create_session.return_value = mock_session_entry
     runner.session_store = mock_store
+    runner._async_session_store = SimpleNamespace(
+        _store=mock_store,
+        get_or_create_session=AsyncMock(return_value=mock_session_entry),
+    )
 
     return runner
 
@@ -118,7 +127,7 @@ class TestHandleTitleCommand:
         db.create_session("test_session_123", "matrix")
 
         runner = _make_runner(session_db=db)
-        runner._schedule_matrix_semantic_room_rename = MagicMock()
+        runner._schedule_adapter_session_title_propagation = MagicMock()
 
         event = _make_event(
             text="/title Matrix Task Name",
@@ -129,7 +138,7 @@ class TestHandleTitleCommand:
         result = await runner._handle_title_command(event)
 
         assert "Matrix Task Name" in result
-        runner._schedule_matrix_semantic_room_rename.assert_called_once_with(
+        runner._schedule_adapter_session_title_propagation.assert_called_once_with(
             event.source, "test_session_123", "Matrix Task Name"
         )
         db.close()

--- a/tests/gateway/test_title_command.py
+++ b/tests/gateway/test_title_command.py
@@ -34,6 +34,7 @@ def _make_runner(session_db=None):
     runner._voice_mode = {}
     runner._schedule_telegram_topic_title_rename = MagicMock()
     runner._schedule_adapter_session_title_propagation = MagicMock()
+    runner._schedule_adapter_semantic_base_refresh = MagicMock()
     # Gateway holds the async facade; the slash handlers await it.
     if session_db is not None:
         session_db = SimpleNamespace(
@@ -127,7 +128,10 @@ class TestHandleTitleCommand:
         db.create_session("test_session_123", "matrix")
 
         runner = _make_runner(session_db=db)
-        runner._schedule_adapter_session_title_propagation = MagicMock()
+        runner.adapters[Platform.MATRIX] = SimpleNamespace(
+            on_session_semantic_base_changed=AsyncMock()
+        )
+        runner._schedule_adapter_semantic_base_refresh = MagicMock()
 
         event = _make_event(
             text="/title Matrix Task Name",
@@ -138,9 +142,64 @@ class TestHandleTitleCommand:
         result = await runner._handle_title_command(event)
 
         assert "Matrix Task Name" in result
-        runner._schedule_adapter_session_title_propagation.assert_called_once_with(
-            event.source, "test_session_123", "Matrix Task Name"
+        runner._schedule_adapter_semantic_base_refresh.assert_called_once_with(
+            event.source, "test_session_123"
         )
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_set_title_propagates_to_legacy_only_adapter(self, tmp_path):
+        """Legacy adapters receive the sanitized title through their title hook."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "discord")
+
+        runner = _make_runner(session_db=db)
+        runner.adapters[Platform.DISCORD] = SimpleNamespace(
+            on_session_title_changed=AsyncMock()
+        )
+        event = _make_event(
+            text="/title Legacy\x00 Room",
+            platform=Platform.DISCORD,
+        )
+
+        result = await runner._handle_title_command(event)
+
+        assert "Legacy Room" in result
+        runner._schedule_adapter_session_title_propagation.assert_called_once_with(
+            event.source, "test_session_123", "Legacy Room"
+        )
+        runner._schedule_adapter_semantic_base_refresh.assert_not_called()
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_set_title_prefers_semantic_hook_over_legacy_hook(self, tmp_path):
+        """Semantic refresh wins so an active goal remains the visible base."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "matrix")
+
+        runner = _make_runner(session_db=db)
+        runner.adapters[Platform.MATRIX] = SimpleNamespace(
+            on_session_semantic_base_changed=AsyncMock(),
+            on_session_title_changed=AsyncMock(),
+        )
+        event = _make_event(
+            text="/title Matrix Session Title",
+            platform=Platform.MATRIX,
+            user_id="@user:matrix.org",
+            chat_id="!room:matrix.org",
+        )
+
+        result = await runner._handle_title_command(event)
+
+        assert "Matrix Session Title" in result
+        runner._schedule_adapter_semantic_base_refresh.assert_called_once_with(
+            event.source, "test_session_123"
+        )
+        runner._schedule_adapter_session_title_propagation.assert_not_called()
         db.close()
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_title_command.py
+++ b/tests/gateway/test_title_command.py
@@ -110,6 +110,31 @@ class TestHandleTitleCommand:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_set_title_propagates_to_matrix_room_rename(self, tmp_path):
+        """/title <name> also updates an enabled Matrix DM room name."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "matrix")
+
+        runner = _make_runner(session_db=db)
+        runner._schedule_matrix_semantic_room_rename = MagicMock()
+
+        event = _make_event(
+            text="/title Matrix Task Name",
+            platform=Platform.MATRIX,
+            user_id="@user:matrix.org",
+            chat_id="!room:matrix.org",
+        )
+        result = await runner._handle_title_command(event)
+
+        assert "Matrix Task Name" in result
+        runner._schedule_matrix_semantic_room_rename.assert_called_once_with(
+            event.source, "test_session_123", "Matrix Task Name"
+        )
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_show_title_does_not_rename_topic(self, tmp_path):
         """Showing the title (no arg) must not trigger a topic rename."""
         from hermes_state import SessionDB

--- a/tests/tools/test_set_chat_title.py
+++ b/tests/tools/test_set_chat_title.py
@@ -1,0 +1,127 @@
+import json
+
+from gateway.session_context import clear_session_vars, set_session_vars
+from model_tools import (
+    _clear_tool_defs_cache,
+    get_tool_definitions,
+    handle_function_call,
+)
+from tools.registry import invalidate_check_fn_cache, registry
+from tools.set_chat_title_tool import SET_CHAT_TITLE_SCHEMA
+from toolsets import resolve_toolset
+
+
+def test_schema_is_single_argument_and_gives_safe_semantic_guidance():
+    parameters = SET_CHAT_TITLE_SCHEMA["parameters"]
+
+    assert list(parameters["properties"]) == ["title"]
+    assert parameters["required"] == ["title"]
+    assert parameters["additionalProperties"] is False
+    guidance = " ".join(
+        (
+            SET_CHAT_TITLE_SCHEMA["description"],
+            parameters["properties"]["title"]["description"],
+        )
+    )
+    assert "CURRENT chat only" in guidance
+    assert "semantic base" in guidance
+    assert "omit lifecycle status emoji" in guidance
+    assert "gateway adds lifecycle status" in guidance
+    assert "Never inspect platform credentials" in guidance
+    assert "API scripts" in guidance
+
+
+def test_only_matrix_platform_bundle_resolves_set_chat_title():
+    assert "set_chat_title" in resolve_toolset("hermes-matrix")
+    for toolset in ("hermes-cli", "hermes-telegram", "hermes-api-server"):
+        assert "set_chat_title" not in resolve_toolset(toolset)
+
+
+def test_model_tools_registry_dispatch_uses_bound_gateway_context():
+    calls = []
+    tokens = set_session_vars(
+        platform="matrix",
+        current_chat_rename_callback=lambda title: (
+            calls.append(title) or {"success": True, "title": title}
+        ),
+    )
+    invalidate_check_fn_cache()
+    try:
+        entry = registry.get_entry("set_chat_title")
+        assert entry is not None
+        assert entry.check_fn()
+        result = json.loads(
+            handle_function_call("set_chat_title", {"title": "Fortress"})
+        )
+    finally:
+        clear_session_vars(tokens)
+        invalidate_check_fn_cache()
+
+    assert result == {"success": True, "title": "Fortress"}
+    assert calls == ["Fortress"]
+
+
+def _definition_names(toolsets):
+    return {
+        definition["function"]["name"]
+        for definition in get_tool_definitions(
+            enabled_toolsets=toolsets,
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+    }
+
+
+def test_unbound_cached_schema_build_does_not_hide_later_bound_matrix_tool():
+    unbound_tokens = set_session_vars(platform="matrix")
+    invalidate_check_fn_cache()
+    _clear_tool_defs_cache()
+    try:
+        assert "set_chat_title" in _definition_names(["hermes-matrix"])
+        tokens = set_session_vars(
+            platform="matrix",
+            current_chat_rename_callback=lambda _title: {"success": True},
+        )
+        try:
+            assert "set_chat_title" in _definition_names(["hermes-matrix"])
+        finally:
+            clear_session_vars(tokens)
+    finally:
+        clear_session_vars(unbound_tokens)
+        invalidate_check_fn_cache()
+        _clear_tool_defs_cache()
+
+
+def test_bound_first_schema_build_never_leaks_into_non_matrix_toolsets():
+    tokens = set_session_vars(
+        platform="matrix",
+        current_chat_rename_callback=lambda _title: {"success": True},
+    )
+    invalidate_check_fn_cache()
+    _clear_tool_defs_cache()
+    try:
+        assert "set_chat_title" in _definition_names(["hermes-matrix"])
+        for toolset in ("hermes-cli", "hermes-telegram", "hermes-api-server"):
+            assert "set_chat_title" not in _definition_names([toolset])
+    finally:
+        clear_session_vars(tokens)
+        invalidate_check_fn_cache()
+        _clear_tool_defs_cache()
+
+
+def test_direct_registry_dispatch_truthfully_rejects_unsupported_context():
+    tokens = set_session_vars(platform="telegram")
+    invalidate_check_fn_cache()
+    try:
+        entry = registry.get_entry("set_chat_title")
+        assert entry is not None
+        assert entry.check_fn()
+        result = json.loads(
+            registry.dispatch("set_chat_title", {"title": "Fortress"})
+        )
+    finally:
+        clear_session_vars(tokens)
+        invalidate_check_fn_cache()
+
+    assert "error" in result
+    assert "Matrix gateway session" in result["error"]

--- a/tests/tools/test_set_chat_title.py
+++ b/tests/tools/test_set_chat_title.py
@@ -1,5 +1,7 @@
 import json
 
+import yaml
+
 from gateway.session_context import clear_session_vars, set_session_vars
 from model_tools import (
     _clear_tool_defs_cache,
@@ -35,6 +37,83 @@ def test_only_matrix_platform_bundle_resolves_set_chat_title():
     assert "set_chat_title" in resolve_toolset("hermes-matrix")
     for toolset in ("hermes-cli", "hermes-telegram", "hermes-api-server"):
         assert "set_chat_title" not in resolve_toolset(toolset)
+
+
+def test_saved_legacy_config_resolves_matrix_title_schema_only_for_matrix(
+    tmp_path, monkeypatch
+):
+    """A live-style saved config can predate the Matrix platform entry."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "platform_toolsets": {
+                    "cli": ["hermes-cli"],
+                    "telegram": ["hermes-telegram"],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli.config import load_config
+    from hermes_cli.tools_config import _get_platform_tools
+
+    config = load_config()
+    tokens = set_session_vars(
+        platform="matrix",
+        current_chat_rename_callback=lambda _title: {"success": True},
+    )
+    invalidate_check_fn_cache()
+    _clear_tool_defs_cache()
+    try:
+        matrix_toolsets = _get_platform_tools(
+            config, "matrix", include_default_mcp_servers=False
+        )
+        assert "chat_title" in matrix_toolsets
+        assert "hermes-matrix" not in matrix_toolsets
+        assert "set_chat_title" in _definition_names(matrix_toolsets)
+
+        for platform in ("cli", "telegram"):
+            enabled = _get_platform_tools(
+                config, platform, include_default_mcp_servers=False
+            )
+            assert "chat_title" not in enabled
+            assert "set_chat_title" not in _definition_names(enabled)
+    finally:
+        clear_session_vars(tokens)
+        invalidate_check_fn_cache()
+        _clear_tool_defs_cache()
+
+
+def test_explicit_matrix_config_keeps_native_title_tool_and_global_opt_out():
+    from hermes_cli.tools_config import _get_platform_tools
+
+    config = {"platform_toolsets": {"matrix": ["web"]}}
+    enabled = _get_platform_tools(
+        config, "matrix", include_default_mcp_servers=False
+    )
+    assert "chat_title" in enabled
+    assert "set_chat_title" in _definition_names(enabled)
+
+    config["agent"] = {"disabled_toolsets": ["chat_title"]}
+    enabled = _get_platform_tools(
+        config, "matrix", include_default_mcp_servers=False
+    )
+    assert "chat_title" not in enabled
+    assert "set_chat_title" not in _definition_names(enabled)
+
+
+def test_chat_title_cannot_be_explicitly_enabled_on_other_platforms():
+    from hermes_cli.tools_config import _get_platform_tools
+
+    for platform in ("cli", "telegram"):
+        config = {"platform_toolsets": {platform: ["chat_title"]}}
+        assert "chat_title" not in _get_platform_tools(
+            config, platform, include_default_mcp_servers=False
+        )
 
 
 def test_model_tools_registry_dispatch_uses_bound_gateway_context():

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -548,6 +548,18 @@ def active_count() -> int:
         )
 
 
+def has_active_for_session(session_key: str) -> bool:
+    """Whether an exact gateway session still owns an async delegation."""
+    if not session_key:
+        return False
+    with _records_lock:
+        return any(
+            record.get("session_key") == session_key
+            and record.get("status") in {"running", "stalling", "finalizing"}
+            for record in _records.values()
+        )
+
+
 def active_task_count() -> int:
     """Number of async delegation TASKS (child subagents) currently running.
 
@@ -774,8 +786,12 @@ def _finalize(delegation_id: str, result: Dict[str, Any], status: str) -> None:
         return
     event_record, _interrupt_fn = claimed
 
-    _push_completion_event(event_record, result, status)
-    _finish_finalization(delegation_id, status)
+    try:
+        _push_completion_event(event_record, result, status)
+    finally:
+        # Keep publication before terminal state, but never strand a record in
+        # ``finalizing`` if durable persistence or queueing unexpectedly fails.
+        _finish_finalization(delegation_id, status)
 
 
 def _begin_finalization(
@@ -794,6 +810,10 @@ def _begin_finalization(
         interrupt_fn = record.get("interrupt_fn")
         record["interrupt_fn"] = None  # drop the closure; child is done
         record["progress_fn"] = None  # stop stale-monitor sampling
+        # The event is deliberately published before we flip the durable
+        # record terminal. Give same-process consumers a lifecycle handoff so a
+        # status refresh cannot observe this short-lived ``finalizing`` state.
+        record["_finalization_complete"] = threading.Event()
         event_record = dict(record)
 
     return event_record, interrupt_fn
@@ -804,7 +824,12 @@ def _finish_finalization(delegation_id: str, status: str) -> None:
         record = _records.get(delegation_id)
         if record is not None:
             record["status"] = status
+            completion_signal = record.get("_finalization_complete")
+        else:
+            completion_signal = None
         _prune_completed_locked()
+    if completion_signal is not None:
+        completion_signal.set()
 
 
 def _push_completion_event(
@@ -866,6 +891,12 @@ def _push_completion_event(
         if _k in result:
             evt[_k] = result[_k]
     _persist_completion(evt, result)
+    # This in-memory handoff never enters the durable payload. It preserves
+    # publish-before-terminal ordering while letting the gateway defer its
+    # cosmetic status refresh until ``_finish_finalization`` has run.
+    completion_signal = record.get("_finalization_complete")
+    if completion_signal is not None:
+        evt["_finalization_complete"] = completion_signal
     try:
         process_registry.completion_queue.put(evt)
     except Exception as exc:  # pragma: no cover
@@ -1017,8 +1048,10 @@ def _finalize_batch(
         return
     event_record, _interrupt_fn = claimed
 
-    _push_batch_completion_event(event_record, combined, status)
-    _finish_finalization(delegation_id, status)
+    try:
+        _push_batch_completion_event(event_record, combined, status)
+    finally:
+        _finish_finalization(delegation_id, status)
 
 
 def _push_batch_completion_event(
@@ -1075,6 +1108,9 @@ def _push_batch_completion_event(
         if _k in combined:
             evt[_k] = combined[_k]
     _persist_completion(evt, combined)
+    completion_signal = event_record.get("_finalization_complete")
+    if completion_signal is not None:
+        evt["_finalization_complete"] = completion_signal
     try:
         process_registry.completion_queue.put(evt)
     except Exception as exc:  # pragma: no cover
@@ -1239,32 +1275,34 @@ def _finalize_stalled(delegation_id: str) -> None:
         ),
         "stall_grace_seconds": _STALL_GRACE_SECONDS,
     }
-    if event_record.get("is_batch"):
-        _push_batch_completion_event(
-            event_record,
-            {
-                "results": [],
-                "error": error,
-                "total_duration_seconds": duration,
-                **stall_meta,
-            },
-            "stalled",
-        )
-    else:
-        _push_completion_event(
-            event_record,
-            {
-                "status": "stalled",
-                "summary": None,
-                "error": error,
-                "api_calls": 0,
-                "duration_seconds": duration,
-                "exit_reason": "stalled",
-                **stall_meta,
-            },
-            "stalled",
-        )
-    _finish_finalization(delegation_id, "stalled")
+    try:
+        if event_record.get("is_batch"):
+            _push_batch_completion_event(
+                event_record,
+                {
+                    "results": [],
+                    "error": error,
+                    "total_duration_seconds": duration,
+                    **stall_meta,
+                },
+                "stalled",
+            )
+        else:
+            _push_completion_event(
+                event_record,
+                {
+                    "status": "stalled",
+                    "summary": None,
+                    "error": error,
+                    "api_calls": 0,
+                    "duration_seconds": duration,
+                    "exit_reason": "stalled",
+                    **stall_meta,
+                },
+                "stalled",
+            )
+    finally:
+        _finish_finalization(delegation_id, "stalled")
 
 
 def _children_activity_from_token(token: Any, now: float) -> Optional[List]:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -201,7 +201,7 @@ async def _send_telegram_message_with_retry(bot, *, attempts: int = 3, **kwargs)
 SEND_MESSAGE_SCHEMA = {
     "name": "send_message",
     "description": (
-        "Send a message to a connected messaging platform, or list available targets.\n\n"
+        "Send a message to a connected messaging platform or list available targets.\n\n"
         "IMPORTANT: When the user asks to send to a specific channel or person "
         "(not just a bare platform name), call send_message(action='list') FIRST to see "
         "available targets, then send to the correct one.\n"
@@ -231,7 +231,7 @@ SEND_MESSAGE_SCHEMA = {
             "message_id": {
                 "type": "string",
                 "description": "For action='react'/'unreact': id of the message to react to. Omit to target the most recent message received in that chat (usually the one being replied to)."
-            }
+            },
         },
         "required": []
     }

--- a/tools/set_chat_title_tool.py
+++ b/tools/set_chat_title_tool.py
@@ -1,0 +1,89 @@
+"""Gateway-bound semantic title tool for the current Matrix chat."""
+
+import json
+
+from tools.registry import registry, tool_error
+
+
+SET_CHAT_TITLE_SCHEMA = {
+    "name": "set_chat_title",
+    "description": (
+        "Set the semantic title of the CURRENT chat only. Pass only the title's "
+        "semantic base and omit lifecycle status emoji such as 🟡, ✅, or 🔴; "
+        "the gateway adds lifecycle status automatically. Never inspect platform "
+        "credentials or write platform API scripts to rename a chat."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "description": (
+                    "Required semantic-base title for the CURRENT chat only. Omit "
+                    "status emoji; the gateway adds lifecycle status."
+                ),
+            },
+        },
+        "required": ["title"],
+        "additionalProperties": False,
+    },
+}
+
+
+def _current_chat_title_callback():
+    """Return the task-local gateway capability, failing closed off-gateway."""
+    try:
+        from gateway.session_context import (
+            get_current_chat_rename_callback,
+            get_session_env,
+        )
+
+        if get_session_env("HERMES_SESSION_PLATFORM", "") != "matrix":
+            return None
+        callback = get_current_chat_rename_callback()
+        return callback if callable(callback) else None
+    except Exception:
+        return None
+
+
+def check_set_chat_title_requirements():
+    """Keep schema availability stable for the Matrix-only toolset.
+
+    Tool-definition and requirement results are cached across gateway turns,
+    so availability must not depend on task-local session ContextVars.  The
+    handler performs the authoritative platform and callback checks at every
+    dispatch instead.
+    """
+    return True
+
+
+def set_chat_title_tool(args, **_kwargs):
+    """Rename the bound current chat through the gateway-owned callback."""
+    callback = _current_chat_title_callback()
+    if callback is None:
+        return tool_error(
+            "set_chat_title is only available for the current chat in a live, "
+            "supported Matrix gateway session."
+        )
+
+    title = str(args.get("title") or "").strip()
+    if not title:
+        return tool_error("'title' must be a non-empty semantic-base title")
+    try:
+        result = callback(title)
+    except Exception as exc:
+        return tool_error(f"Current chat title update failed: {exc}")
+    if not isinstance(result, dict):
+        result = {"success": bool(result)}
+    return json.dumps(result)
+
+
+registry.register(
+    name="set_chat_title",
+    toolset="chat_title",
+    schema=SET_CHAT_TITLE_SCHEMA,
+    handler=set_chat_title_tool,
+    check_fn=check_set_chat_title_requirements,
+    description="Set the semantic title of the current supported gateway chat",
+    emoji="🏷️",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -535,7 +535,7 @@ TOOLSETS = {
 
     "hermes-matrix": {
         "description": "Matrix bot toolset - decentralized encrypted messaging (full access)",
-        "tools": _HERMES_CORE_TOOLS,
+        "tools": _HERMES_CORE_TOOLS + ["set_chat_title"],
         "includes": []
     },
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -539,6 +539,15 @@ TOOLSETS = {
         "includes": []
     },
 
+    # Static counterpart for the registry-owned Matrix title tool.  Platform
+    # resolution reverse-maps composites through static toolsets, so leaving
+    # this registry-only makes hermes-matrix's extra impossible to recover.
+    "chat_title": {
+        "description": "Rename the current supported gateway chat",
+        "tools": ["set_chat_title"],
+        "includes": []
+    },
+
     "hermes-dingtalk": {
         "description": "DingTalk bot toolset - enterprise messaging platform (full access)",
         "tools": _HERMES_CORE_TOOLS,

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -97,6 +97,7 @@ matrix:
   session_scope: room             # auto|room|thread; room is recommended for project rooms
   auto_thread: true               # Auto-create threads for responses (default: true)
   dm_mention_threads: false       # Create thread when @mentioned in DM (default: false)
+  dynamic_room_name: false        # Rename DMs to show task state/title (default: false)
   max_message_length: 16000       # Outbound chunk size in chars (default: 16000, max: 65535)
 ```
 
@@ -123,6 +124,23 @@ MATRIX_ALLOW_ROOM_MENTIONS=false
 :::tip Room-wide mentions
 Hermes sends structured Matrix user mentions for explicit Matrix IDs such as `@alice:example.org`. Room-wide `@room` notifications are disabled by default; set `MATRIX_ALLOW_ROOM_MENTIONS=true` only in rooms where the bot is allowed to notify everyone.
 :::
+
+### Dynamic Element Room Names
+
+Set `matrix.dynamic_room_name: true` to make a Matrix DM's Element-visible room
+name follow the current Hermes task:
+
+- `🟡` while Hermes is processing
+- `✅` after success
+- `❌` after failure
+- `⏹` after cancellation
+
+When Hermes generates a semantic session title—or when you use `/title`—that
+title becomes the room-name text while preserving the current status icon.
+Updates are deduplicated and limited to DMs so shared project rooms do not gain
+noisy room-state history. The bot account must have permission to send the
+`m.room.name` state event; a permission failure is logged and does not fail the
+agent turn.
 
 :::note
 If you are upgrading from a version that did not have `MATRIX_REQUIRE_MENTION`, the bot previously responded to all messages in rooms. To preserve that behavior, set `MATRIX_REQUIRE_MENTION=false`.

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -131,8 +131,14 @@ Set `matrix.dynamic_room_name: true` to show the current Hermes activity in
 Matrix DM room names. This setting defaults to `false` and applies only to DMs.
 Hermes adds a status icon to the title:
 
-- `🟡` while one or more Hermes turns are active
-- `🟢` when no Hermes turns are active
+- `🟡` while one or more Hermes foreground turns are active, or Hermes-owned
+  background work for that DM's exact gateway session is still active
+- `🟢` only when that DM has no active foreground turns and no owned background
+  work
+
+“Owned background work” follows Hermes's existing session-process ownership:
+every running process tracked for that exact session counts, including a
+long-lived daemon. Hermes does not guess whether a process is still awaited.
 
 Hermes chooses the title from the active goal first, then the session title,
 and finally the existing room name. If none is available, the room name stays

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -97,7 +97,7 @@ matrix:
   session_scope: room             # auto|room|thread; room is recommended for project rooms
   auto_thread: true               # Auto-create threads for responses (default: true)
   dm_mention_threads: false       # Create thread when @mentioned in DM (default: false)
-  dynamic_room_name: false        # Rename DMs to show task state/title (default: false)
+  dynamic_room_name: false        # Rename DMs to show Hermes activity/title (default: false)
   max_message_length: 16000       # Outbound chunk size in chars (default: 16000, max: 65535)
 ```
 
@@ -131,18 +131,19 @@ Set `matrix.dynamic_room_name: true` to show the current Hermes activity in
 Matrix DM room names. This setting defaults to `false` and applies only to DMs.
 Hermes adds a status icon to the title:
 
-- `🟡` while Hermes is processing
-- `✅` after success
-- `🔴` after failure or cancellation
+- `🟡` while one or more Hermes turns are active
+- `🟢` when no Hermes turns are active
 
 Hermes chooses the title from the active goal first, then the session title,
 and finally the existing room name. If none is available, the room name stays
-unchanged. For example, a successful chat might be named
-`✅ Project planning`. Long names may be shortened.
+unchanged. For example, an idle chat might be named `🟢 Project planning`.
+Long names may be shortened.
 
 You can also ask Hermes to rename the current chat; provide the meaningful
-title and Hermes will add the appropriate status icon. Meaningful names you set
-manually are respected rather than replaced unnecessarily.
+title and Hermes will add the current runtime icon. Status icons in generated
+titles are ignored, so the model cannot override whether the room is working
+or idle. Meaningful names you set manually are respected rather than replaced
+unnecessarily.
 
 Complete both setup steps:
 
@@ -166,7 +167,7 @@ every other power-level field.
 :::
 
 To verify the setup, send a message in the DM. The room title should move from
-`🟡` to `✅`. If it remains unchanged, check the room permissions; Hermes should
+`🟡` to `🟢`. If it remains unchanged, check the room permissions; Hermes should
 still answer normally even when it cannot rename the room.
 
 :::note

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -134,12 +134,26 @@ name follow the current Hermes task:
 - `✅` after success
 - `🔴` after any unsuccessful terminal outcome (failure or cancellation)
 
-When Hermes generates a semantic session title—or when you use `/title`—that
-title becomes the room-name text while preserving the current status icon. Any
+The active persisted goal/epic is the authoritative room-name text. When there
+is no active goal (including paused or done goals), the persisted session title
+is used; if that is absent, Hermes recovers the existing Matrix room name.
+You can also ask the agent to rename the current chat. It uses the dedicated
+gateway-bound `set_chat_title` tool and needs no Matrix credentials or custom
+API script. This tool is exposed only to Matrix gateway conversations whose
+current room supports semantic-title refresh; it is not part of the CLI or
+other platform toolsets. The supplied title is the semantic base only; Hermes
+adds the lifecycle icon. While a goal is active, that goal remains visible and
+the requested title is persisted as the fallback for after the goal ends.
+When none of those sources can be read, Hermes leaves the room name unchanged.
+Any
 current or legacy lifecycle prefix (`🟡`, `✅`, `🔴`, `❌`, or `⏹`) is stripped
 to prevent nesting. The stable title base is deterministically truncated to at
 most 60 Unicode code points, including a trailing `...` when truncation occurs,
 and is retained unchanged across lifecycle transitions.
+If you rename the room manually in Matrix while Hermes is processing, the
+terminal lifecycle update adopts that sanitized name (for example,
+`🟡 Fortress Google CAPTCHA` becomes `✅ Fortress Google CAPTCHA`). A newer
+authoritative agent rename always wins over a delayed room-state read.
 Updates are deduplicated and limited to DMs so shared project rooms do not gain
 noisy room-state history. The bot account must have permission to send the
 `m.room.name` state event; a permission failure is logged and does not fail the

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -144,8 +144,30 @@ You can also ask Hermes to rename the current chat; provide the meaningful
 title and Hermes will add the appropriate status icon. Meaningful names you set
 manually are respected rather than replaced unnecessarily.
 
-The bot must have permission to change the room name. If it does not, the agent
-turn continues normally and the room name remains unchanged.
+Complete both setup steps:
+
+1. Set `matrix.dynamic_room_name: true` in `~/.hermes/config.yaml`, then restart
+   or reload the gateway so the configuration takes effect.
+2. In each existing Matrix DM, give the bot the least-privilege permission
+   needed to rename that room. In Element Web/Desktop, open the DM, then go to
+   **Room settings → Roles & Permissions**, find **Change room name**, and allow
+   **Members** (power level `0`), or the equivalent level already held by the
+   bot. Client wording may vary. Do not promote the bot to Moderator or Admin
+   solely for this feature.
+
+Room-name permission is configured per room for existing DMs. Newly created
+rooms also need a policy that lets the bot rename them, unless they are already
+configured that way.
+
+:::note Advanced least-privilege configuration
+If the client or administration interface does not expose this setting, set
+only the event-specific `m.room.name` power-level threshold to `0`. Preserve
+every other power-level field.
+:::
+
+To verify the setup, send a message in the DM. The room title should move from
+`🟡` to `✅`. If it remains unchanged, check the room permissions; Hermes should
+still answer normally even when it cannot rename the room.
 
 :::note
 If you are upgrading from a version that did not have `MATRIX_REQUIRE_MENTION`, the bot previously responded to all messages in rooms. To preserve that behavior, set `MATRIX_REQUIRE_MENTION=false`.

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -132,11 +132,14 @@ name follow the current Hermes task:
 
 - `🟡` while Hermes is processing
 - `✅` after success
-- `❌` after failure
-- `⏹` after cancellation
+- `🔴` after any unsuccessful terminal outcome (failure or cancellation)
 
 When Hermes generates a semantic session title—or when you use `/title`—that
-title becomes the room-name text while preserving the current status icon.
+title becomes the room-name text while preserving the current status icon. Any
+current or legacy lifecycle prefix (`🟡`, `✅`, `🔴`, `❌`, or `⏹`) is stripped
+to prevent nesting. The stable title base is deterministically truncated to at
+most 60 Unicode code points, including a trailing `...` when truncation occurs,
+and is retained unchanged across lifecycle transitions.
 Updates are deduplicated and limited to DMs so shared project rooms do not gain
 noisy room-state history. The bot account must have permission to send the
 `m.room.name` state event; a permission failure is logged and does not fail the

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -125,39 +125,27 @@ MATRIX_ALLOW_ROOM_MENTIONS=false
 Hermes sends structured Matrix user mentions for explicit Matrix IDs such as `@alice:example.org`. Room-wide `@room` notifications are disabled by default; set `MATRIX_ALLOW_ROOM_MENTIONS=true` only in rooms where the bot is allowed to notify everyone.
 :::
 
-### Dynamic Element Room Names
+### Dynamic DM Room Names
 
-Set `matrix.dynamic_room_name: true` to make a Matrix DM's Element-visible room
-name follow the current Hermes task:
+Set `matrix.dynamic_room_name: true` to show the current Hermes activity in
+Matrix DM room names. This setting defaults to `false` and applies only to DMs.
+Hermes adds a status icon to the title:
 
 - `🟡` while Hermes is processing
 - `✅` after success
-- `🔴` after any unsuccessful terminal outcome (failure or cancellation)
+- `🔴` after failure or cancellation
 
-The active persisted goal/epic is the authoritative room-name text. When there
-is no active goal (including paused or done goals), the persisted session title
-is used; if that is absent, Hermes recovers the existing Matrix room name.
-You can also ask the agent to rename the current chat. It uses the dedicated
-gateway-bound `set_chat_title` tool and needs no Matrix credentials or custom
-API script. This tool is exposed only to Matrix gateway conversations whose
-current room supports semantic-title refresh; it is not part of the CLI or
-other platform toolsets. The supplied title is the semantic base only; Hermes
-adds the lifecycle icon. While a goal is active, that goal remains visible and
-the requested title is persisted as the fallback for after the goal ends.
-When none of those sources can be read, Hermes leaves the room name unchanged.
-Any
-current or legacy lifecycle prefix (`🟡`, `✅`, `🔴`, `❌`, or `⏹`) is stripped
-to prevent nesting. The stable title base is deterministically truncated to at
-most 60 Unicode code points, including a trailing `...` when truncation occurs,
-and is retained unchanged across lifecycle transitions.
-If you rename the room manually in Matrix while Hermes is processing, the
-terminal lifecycle update adopts that sanitized name (for example,
-`🟡 Fortress Google CAPTCHA` becomes `✅ Fortress Google CAPTCHA`). A newer
-authoritative agent rename always wins over a delayed room-state read.
-Updates are deduplicated and limited to DMs so shared project rooms do not gain
-noisy room-state history. The bot account must have permission to send the
-`m.room.name` state event; a permission failure is logged and does not fail the
-agent turn.
+Hermes chooses the title from the active goal first, then the session title,
+and finally the existing room name. If none is available, the room name stays
+unchanged. For example, a successful chat might be named
+`✅ Project planning`. Long names may be shortened.
+
+You can also ask Hermes to rename the current chat; provide the meaningful
+title and Hermes will add the appropriate status icon. Meaningful names you set
+manually are respected rather than replaced unnecessarily.
+
+The bot must have permission to change the room name. If it does not, the agent
+turn continues normally and the room name remains unchanged.
 
 :::note
 If you are upgrading from a version that did not have `MATRIX_REQUIRE_MENTION`, the bot previously responded to all messages in rooms. To preserve that behavior, set `MATRIX_REQUIRE_MENTION=false`.


### PR DESCRIPTION
## Summary
- add opt-in dynamic Matrix DM titles driven by active goal/session semantic state
- preserve meaningful external titles and explicit `/title` behavior across lifecycle transitions
- add a Matrix-only, current-session-bound `set_chat_title` agent tool; no room ID, access token, or general messaging capability
- resolve the narrow title tool through real per-platform gateway toolset selection, including legacy saved configs
- handle stale Matrix state reads without rolling back newer authoritative tool renames

## Security
- current room/session is inferred from gateway task-local context
- no Matrix credentials are exposed to the agent
- arbitrary `send_message` remains unavailable
- `set_chat_title` is excluded from CLI and non-Matrix platform schemas
- Matrix power levels remain authoritative

## Verification
- 196 focused lifecycle, Matrix adapter, gateway dispatch, platform resolver, and agent-schema tests pass
- live Matrix room permissions migrated separately with least-privilege `m.room.name: 0`
