### PR TITLE
fix(approval): honor 16-token verdict cap on every route + disable reasoning for guard (#68263)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6631,6 +6631,7 @@ def _build_call_kwargs(
     extra_body: Optional[dict] = None,
     reasoning_config: Optional[dict] = None,
     base_url: Optional[str] = None,
+    force_max_tokens: bool = False,
 ) -> dict:
     """Build kwargs for .chat.completions.create() with model/provider adjustments."""
     kwargs: Dict[str, Any] = {
@@ -6677,6 +6678,12 @@ def _build_call_kwargs(
         # 200 with an empty choices[] payload when max_tokens is omitted. The main
         # NVIDIA chat path already sends an output cap via the provider profile;
         # preserve it on the auxiliary path too.
+        # ``force_max_tokens=True`` is the third exception: a caller that has a
+        # deliberate, bounded cap it MUST honor on every route (the smart-approval
+        # guard asks for a 16-token single-word verdict). Without it, OpenAI-
+        # compatible routes silently drop the cap and reasoning models can spend
+        # the entire completion budget on hidden reasoning before emitting the
+        # verdict (#68263).
         _effective_base = base_url or (
             _current_custom_base_url() if provider == "custom" else ""
         )
@@ -6686,7 +6693,8 @@ def _build_call_kwargs(
             or base_url_host_matches(_effective_base, "integrate.api.nvidia.com")
         )
         if (
-            _is_anthropic_compat_endpoint(provider, _effective_base)
+            force_max_tokens
+            or _is_anthropic_compat_endpoint(provider, _effective_base)
             or _is_nvidia_nim
         ):
             kwargs["max_tokens"] = max_tokens
@@ -6924,6 +6932,7 @@ def call_llm(
     api_mode: str = None,
     stream: bool = False,
     stream_options: dict = None,
+    force_max_tokens: bool = False,
 ) -> Any:
     """Centralized synchronous LLM call.
 
@@ -7058,7 +7067,8 @@ def call_llm(
         temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         reasoning_config=reasoning_config,
-        base_url=_base_info or resolved_base_url)
+        base_url=_base_info or resolved_base_url,
+        force_max_tokens=force_max_tokens)
 
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
     _client_base = str(getattr(client, "base_url", "") or "")

--- a/tests/tools/test_smart_approval_injection.py
+++ b/tests/tools/test_smart_approval_injection.py
@@ -206,5 +206,76 @@ class TestSmartApprovePromptHardening(unittest.TestCase):
         assert _smart_approve("rm -rf /", "recursive delete") == "escalate"
 
 
+# ── Issue #68263: bounded verdict cap honored on every route ────────────────
+
+
+class TestSmartApproveBoundedVerdict(unittest.TestCase):
+    """Regression tests for issue #68263.
+
+    The smart-approval guard asks for a 16-token single-word verdict. Two
+    bugs broke that contract:
+
+    1. The auxiliary path silently drops an explicit ``max_tokens`` on
+       OpenAI-compatible routes, so reasoning models spent the whole
+       completion budget on hidden reasoning before the verdict.
+    2. Reasoning models burn budget on hidden reasoning regardless.
+
+    The fix passes ``force_max_tokens=True`` (honor the cap on every route)
+    and ``reasoning_config={"enabled": False}`` (no hidden reasoning) to the
+    guard LLM call.
+    """
+
+    def _make_response(self, answer: str):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = answer
+        return mock_response
+
+    @patch("agent.auxiliary_client.call_llm")
+    def test_force_max_tokens_passed(self, mock_call_llm):
+        mock_call_llm.return_value = self._make_response("APPROVE")
+        _smart_approve("ls -la", "list files")
+        kwargs = mock_call_llm.call_args.kwargs
+        assert kwargs.get("max_tokens") == 16
+        assert kwargs.get("force_max_tokens") is True
+
+    @patch("agent.auxiliary_client.call_llm")
+    def test_reasoning_disabled_for_guard(self, mock_call_llm):
+        mock_call_llm.return_value = self._make_response("DENY")
+        _smart_approve("rm -rf /", "recursive delete")
+        kwargs = mock_call_llm.call_args.kwargs
+        assert kwargs.get("reasoning_config") == {"enabled": False}
+
+
+class TestBuildCallKwargsForceMaxTokens(unittest.TestCase):
+    """_build_call_kwargs must honor force_max_tokens on every provider route."""
+
+    def _kwargs(self, provider, max_tokens, force_max_tokens=False, base_url=None):
+        from agent.auxiliary_client import _build_call_kwargs
+        return _build_call_kwargs(
+            provider, "some/model", [{"role": "user", "content": "x"}],
+            max_tokens=max_tokens, force_max_tokens=force_max_tokens,
+            base_url=base_url,
+        )
+
+    def test_force_max_tokens_sent_on_openai_compatible(self):
+        """OpenAI-compatible routes must NOT drop the cap when forced (#68263)."""
+        kwargs = self._kwargs("openai", 16, force_max_tokens=True)
+        assert kwargs.get("max_tokens") == 16
+
+    def test_force_max_tokens_sent_on_openrouter(self):
+        kwargs = self._kwargs("openrouter", 16, force_max_tokens=True)
+        assert kwargs.get("max_tokens") == 16
+
+    def test_openai_compatible_still_drops_cap_without_force(self):
+        """Default behavior preserved: no forced cap -> omit max_tokens on OAI routes."""
+        kwargs = self._kwargs("openai", 16, force_max_tokens=False)
+        assert "max_tokens" not in kwargs
+
+    def test_force_max_tokens_sent_on_anthropic_compat(self):
+        kwargs = self._kwargs("anthropic", 16, force_max_tokens=True)
+        assert kwargs.get("max_tokens") == 16
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2619,6 +2619,16 @@ def _smart_approve(command: str, description: str) -> str:
             ],
             temperature=0,
             max_tokens=16,
+            # Honor the 16-token verdict cap on EVERY provider route. By
+            # default the auxiliary path drops an explicit max_tokens on
+            # OpenAI-compatible endpoints, which let reasoning models spend the
+            # whole completion budget on hidden reasoning before the one-word
+            # verdict (#68263).
+            force_max_tokens=True,
+            # Disable reasoning for the guard LLM: a reasoning model would burn
+            # tokens on hidden reasoning before emitting the verdict, defeating
+            # the cap above and slowing every approval.
+            reasoning_config={"enabled": False},
         )
 
         answer = (response.choices[0].message.content or "").strip().upper()


### PR DESCRIPTION
Closes #68263

Smart approvals hardcoded max_tokens=16, but the auxiliary path silently dropped an explicit max_tokens on OpenAI-compatible routes. Reasoning models then spent the entire completion budget on hidden reasoning before emitting the one-word verdict, and for most providers the cap was never sent at all.

- Added force_max_tokens to call_llm / _build_call_kwargs so a deliberate bounded cap is honored on every provider route.
- _smart_approve now passes force_max_tokens=True and reasoning_config={'enabled': False} so the guard LLM emits a bounded, non-reasoned verdict.

Default auxiliary behavior (no forced cap) is unchanged. Tested: added regression tests in tests/tools/test_smart_approval_injection.py (force_max_tokens + reasoning disabled passed to call_llm, and _build_call_kwargs honors force on OpenAI/OpenRouter/Anthropic while still omitting the cap without force).