### PR TITLE
feat(desktop): add safe code-client deep links

### DIFF
--- a/apps/desktop/electron/code-client-deep-link.test.ts
+++ b/apps/desktop/electron/code-client-deep-link.test.ts
@@ -16,8 +16,14 @@ describe('codeClientDeepLink', () => {
   })
 
   it('accepts absolute Windows paths without shell interpretation', () => {
-    expect(codeClientDeepLink({ client: 'codex', cwd: 'C:\\Users\\test\\repo', prompt: '' })).toBe(
+    expect(codeClientDeepLink({ client: 'codex', cwd: 'C:\\Users\\test\\repo', prompt: '' }, 'win32')).toBe(
       'codex://new?path=C%3A%5CUsers%5Ctest%5Crepo'
+    )
+  })
+
+  it.each(['/rooted', '\\rooted'])('rejects drive-relative Windows roots: %s', cwd => {
+    expect(() => codeClientDeepLink({ client: 'codex', cwd, prompt: '' }, 'win32')).toThrow(
+      'Invalid local working directory'
     )
   })
 
@@ -27,6 +33,8 @@ describe('codeClientDeepLink', () => {
     ['../repo', 'traversal'],
     ['/Users/test/../repo', 'absolute traversal'],
     ['//server/share', 'network'],
+    ['/\\server\\share', 'mixed-separator network'],
+    ['\\/server/share', 'mixed-separator network'],
     ['/Users/test/repo\nother', 'control']
   ])('rejects %s paths (%s)', cwd => {
     expect(() => codeClientDeepLink({ client: 'codex', cwd, prompt: '' })).toThrow('Invalid local working directory')

--- a/apps/desktop/electron/code-client-deep-link.test.ts
+++ b/apps/desktop/electron/code-client-deep-link.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { codeClientDeepLink } from './code-client-deep-link'
+
+describe('codeClientDeepLink', () => {
+  it('builds an inert Codex composer deep link', () => {
+    expect(
+      codeClientDeepLink({ client: 'codex', cwd: '/Users/test/repo', prompt: 'Review notes/today.md' })
+    ).toBe('codex://new?path=%2FUsers%2Ftest%2Frepo&prompt=Review%20notes%2Ftoday.md')
+  })
+
+  it('builds an inert Claude Code composer deep link', () => {
+    expect(
+      codeClientDeepLink({ client: 'claude-code', cwd: '/Users/test/repo', prompt: 'Review notes/today.md' })
+    ).toBe('claude-cli://open?cwd=%2FUsers%2Ftest%2Frepo&q=Review%20notes%2Ftoday.md')
+  })
+
+  it('accepts absolute Windows paths without shell interpretation', () => {
+    expect(codeClientDeepLink({ client: 'codex', cwd: 'C:\\Users\\test\\repo', prompt: '' })).toBe(
+      'codex://new?path=C%3A%5CUsers%5Ctest%5Crepo'
+    )
+  })
+
+  it.each([
+    ['', 'empty'],
+    ['relative/repo', 'relative'],
+    ['../repo', 'traversal'],
+    ['/Users/test/../repo', 'absolute traversal'],
+    ['//server/share', 'network'],
+    ['/Users/test/repo\nother', 'control']
+  ])('rejects %s paths (%s)', cwd => {
+    expect(() => codeClientDeepLink({ client: 'codex', cwd, prompt: '' })).toThrow('Invalid local working directory')
+  })
+
+  it('rejects unsupported clients', () => {
+    expect(() => codeClientDeepLink({ client: 'terminal' as never, cwd: '/Users/test/repo', prompt: '' })).toThrow(
+      'Unsupported code client'
+    )
+  })
+
+  it.each([null, {}, { client: 'codex', cwd: '/Users/test/repo' }, { client: 'codex', cwd: 42, prompt: '' }])(
+    'rejects malformed IPC payloads',
+    input => {
+      expect(() => codeClientDeepLink(input as never)).toThrow('Invalid code client request')
+    }
+  )
+
+  it('rejects oversized prompts', () => {
+    expect(() => codeClientDeepLink({ client: 'claude-code', cwd: '/Users/test/repo', prompt: 'x'.repeat(5001) })).toThrow(
+      'Prompt exceeds 5000 characters'
+    )
+  })
+})

--- a/apps/desktop/electron/code-client-deep-link.test.ts
+++ b/apps/desktop/electron/code-client-deep-link.test.ts
@@ -5,20 +5,24 @@ import { codeClientDeepLink } from './code-client-deep-link'
 describe('codeClientDeepLink', () => {
   it('builds an inert Codex composer deep link', () => {
     expect(
-      codeClientDeepLink({ client: 'codex', cwd: '/Users/test/repo', prompt: 'Review notes/today.md' })
+      codeClientDeepLink({ client: 'codex', cwd: '/Users/test/repo', prompt: 'Review notes/today.md' }, 'darwin')
     ).toBe('codex://new?path=%2FUsers%2Ftest%2Frepo&prompt=Review%20notes%2Ftoday.md')
   })
 
   it('builds an inert Claude Code composer deep link', () => {
     expect(
-      codeClientDeepLink({ client: 'claude-code', cwd: '/Users/test/repo', prompt: 'Review notes/today.md' })
+      codeClientDeepLink(
+        { client: 'claude-code', cwd: '/Users/test/repo', prompt: 'Review notes/today.md' },
+        'darwin'
+      )
     ).toBe('claude-cli://open?cwd=%2FUsers%2Ftest%2Frepo&q=Review%20notes%2Ftoday.md')
   })
 
-  it('accepts absolute Windows paths without shell interpretation', () => {
-    expect(codeClientDeepLink({ client: 'codex', cwd: 'C:\\Users\\test\\repo', prompt: '' }, 'win32')).toBe(
-      'codex://new?path=C%3A%5CUsers%5Ctest%5Crepo'
-    )
+  it.each([
+    ['C:\\Users\\test\\repo', 'codex://new?path=C%3A%5CUsers%5Ctest%5Crepo'],
+    ['C:/Users/test/repo', 'codex://new?path=C%3A%2FUsers%2Ftest%2Frepo']
+  ])('accepts a fully qualified Windows path: %s', (cwd, expected) => {
+    expect(codeClientDeepLink({ client: 'codex', cwd, prompt: '' }, 'win32')).toBe(expected)
   })
 
   it.each(['/rooted', '\\rooted'])('rejects drive-relative Windows roots: %s', cwd => {

--- a/apps/desktop/electron/code-client-deep-link.ts
+++ b/apps/desktop/electron/code-client-deep-link.ts
@@ -1,5 +1,3 @@
-import path from 'node:path'
-
 export type CodeClient = 'claude-code' | 'codex'
 
 export interface CodeClientLaunch {
@@ -8,23 +6,37 @@ export interface CodeClientLaunch {
   prompt: string
 }
 
-const UNSAFE_PATH_CHARACTERS = /[\u0000-\u001f\u007f-\u009f\u200b-\u200f\u202a-\u202e\u2060-\u206f]/
 const PARENT_SEGMENT = /(?:^|[\\/])\.\.(?:[\\/]|$)/
 const MAX_PROMPT_LENGTH = 5000
 
-function validLocalDirectory(value: string): boolean {
+function hasUnsafePathCharacters(value: string): boolean {
+  return [...value].some(character => {
+    const codePoint = character.codePointAt(0) ?? 0
+
+    return (
+      codePoint <= 0x1f ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      (codePoint >= 0x200b && codePoint <= 0x200f) ||
+      (codePoint >= 0x202a && codePoint <= 0x202e) ||
+      (codePoint >= 0x2060 && codePoint <= 0x206f)
+    )
+  })
+}
+
+function validLocalDirectory(value: string, platform: NodeJS.Platform): boolean {
+  const fullyQualified = platform === 'win32' ? /^[A-Za-z]:[\\/]/.test(value) : value.startsWith('/')
+
   return (
     value.length > 0 &&
-    (path.posix.isAbsolute(value) || path.win32.isAbsolute(value)) &&
-    !value.startsWith('//') &&
-    !value.startsWith('\\\\') &&
-    !UNSAFE_PATH_CHARACTERS.test(value) &&
+    fullyQualified &&
+    !/^[\\/]{2}/.test(value) &&
+    !hasUnsafePathCharacters(value) &&
     !PARENT_SEGMENT.test(value)
   )
 }
 
 /** Build an official, review-before-send code-client deep link. */
-export function codeClientDeepLink(value: unknown): string {
+export function codeClientDeepLink(value: unknown, platform: NodeJS.Platform = process.platform): string {
   if (!value || typeof value !== 'object') {
     throw new Error('Invalid code client request')
   }
@@ -39,7 +51,7 @@ export function codeClientDeepLink(value: unknown): string {
     throw new Error('Unsupported code client')
   }
 
-  if (!validLocalDirectory(input.cwd)) {
+  if (!validLocalDirectory(input.cwd, platform)) {
     throw new Error('Invalid local working directory')
   }
 

--- a/apps/desktop/electron/code-client-deep-link.ts
+++ b/apps/desktop/electron/code-client-deep-link.ts
@@ -1,0 +1,59 @@
+import path from 'node:path'
+
+export type CodeClient = 'claude-code' | 'codex'
+
+export interface CodeClientLaunch {
+  client: CodeClient
+  cwd: string
+  prompt: string
+}
+
+const UNSAFE_PATH_CHARACTERS = /[\u0000-\u001f\u007f-\u009f\u200b-\u200f\u202a-\u202e\u2060-\u206f]/
+const PARENT_SEGMENT = /(?:^|[\\/])\.\.(?:[\\/]|$)/
+const MAX_PROMPT_LENGTH = 5000
+
+function validLocalDirectory(value: string): boolean {
+  return (
+    value.length > 0 &&
+    (path.posix.isAbsolute(value) || path.win32.isAbsolute(value)) &&
+    !value.startsWith('//') &&
+    !value.startsWith('\\\\') &&
+    !UNSAFE_PATH_CHARACTERS.test(value) &&
+    !PARENT_SEGMENT.test(value)
+  )
+}
+
+/** Build an official, review-before-send code-client deep link. */
+export function codeClientDeepLink(value: unknown): string {
+  if (!value || typeof value !== 'object') {
+    throw new Error('Invalid code client request')
+  }
+
+  const input = value as Partial<CodeClientLaunch>
+
+  if (typeof input.client !== 'string' || typeof input.cwd !== 'string' || typeof input.prompt !== 'string') {
+    throw new Error('Invalid code client request')
+  }
+
+  if (input.client !== 'codex' && input.client !== 'claude-code') {
+    throw new Error('Unsupported code client')
+  }
+
+  if (!validLocalDirectory(input.cwd)) {
+    throw new Error('Invalid local working directory')
+  }
+
+  if (input.prompt.length > MAX_PROMPT_LENGTH) {
+    throw new Error(`Prompt exceeds ${MAX_PROMPT_LENGTH} characters`)
+  }
+
+  if (input.client === 'codex') {
+    const prompt = input.prompt ? `&prompt=${encodeURIComponent(input.prompt)}` : ''
+
+    return `codex://new?path=${encodeURIComponent(input.cwd)}${prompt}`
+  }
+
+  const prompt = input.prompt ? `&q=${encodeURIComponent(input.prompt)}` : ''
+
+  return `claude-cli://open?cwd=${encodeURIComponent(input.cwd)}${prompt}`
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -39,6 +39,7 @@ import { waitForDashboardPortAnnouncement } from './backend-ready'
 import { shouldLatchBackendStartFailure } from './backend-start-failure'
 import { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } from './bootstrap-platform'
 import { runBootstrap } from './bootstrap-runner'
+import { codeClientDeepLink } from './code-client-deep-link'
 import {
   authModeFromStatus,
   buildGatewayWsUrl,
@@ -8777,6 +8778,10 @@ ipcMain.handle('hermes:openExternal', (_event, url) => {
   if (!openExternalUrl(url)) {
     throw new Error('Invalid external URL')
   }
+})
+
+ipcMain.handle('hermes:code-client:open', async (_event, payload) => {
+  await shell.openExternal(codeClientDeepLink(payload))
 })
 
 ipcMain.handle('hermes:openPreviewInBrowser', async (_event, url) => {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -83,6 +83,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   setKeepAwake: on => ipcRenderer.send('hermes:keep-awake', on),
   setPreviewShortcutActive: active => ipcRenderer.send('hermes:previewShortcutActive', Boolean(active)),
   openExternal: url => ipcRenderer.invoke('hermes:openExternal', url),
+  openCodeClient: payload => ipcRenderer.invoke('hermes:code-client:open', payload),
   openPreviewInBrowser: url => ipcRenderer.invoke('hermes:openPreviewInBrowser', url),
   fetchLinkTitle: url => ipcRenderer.invoke('hermes:fetchLinkTitle', url),
   sanitizeWorkspaceCwd: cwd => ipcRenderer.invoke('hermes:workspace:sanitize', cwd),

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -97,6 +97,7 @@ declare global {
       setKeepAwake?: (on: boolean) => void
       setPreviewShortcutActive?: (active: boolean) => void
       openExternal: (url: string) => Promise<void>
+      openCodeClient: (payload: DesktopCodeClientLaunch) => Promise<void>
       openPreviewInBrowser?: (url: string) => Promise<void>
       fetchLinkTitle: (url: string) => Promise<string>
       sanitizeWorkspaceCwd: (cwd?: null | string) => Promise<{ cwd: string; sanitized: boolean }>
@@ -231,6 +232,12 @@ declare global {
       }
     }
   }
+}
+
+export interface DesktopCodeClientLaunch {
+  client: 'claude-code' | 'codex'
+  cwd: string
+  prompt: string
 }
 
 export interface DesktopMarketplaceSearchItem {

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -25,8 +25,8 @@ import { onGatewayEvent } from '@/contrib/events'
 import { getLogs, getStatus } from '@/hermes'
 import { $gateway } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
+import { $filePreviewTarget, type PreviewTarget } from '@/store/preview'
 import { $activeGatewayProfile } from '@/store/profile'
-import { $filePreviewTarget } from '@/store/preview'
 import { $activeSessionId, $currentCwd, $currentModel, $gatewayState } from '@/store/session'
 import { runGatewayRestart } from '@/store/system-actions'
 
@@ -72,8 +72,6 @@ export const host = {
     gateway: readonlyAtom<string>($gatewayState),
     /** Current main model slug. */
     model: readonlyAtom<string>($currentModel),
-    /** Active file-preview target, or null when no file tab is selected. */
-    previewTarget: readonlyAtom($filePreviewTarget),
     /** Profile the live gateway is routed to. */
     profile: readonlyAtom<string>($activeGatewayProfile),
     /** Window geometry ({ width, height, narrow }). */
@@ -90,6 +88,13 @@ export const host = {
 
   /** Tail an app log file (`agent` / `errors` / `gateway` / `gui` / …). */
   logs: async (...args: Parameters<typeof getLogs>) => getLogs(...args),
+
+  /** Immutable snapshot of the active file-preview target. */
+  previewTarget: (): null | Readonly<PreviewTarget> => {
+    const target = $filePreviewTarget.get()
+
+    return target ? Object.freeze({ ...target }) : null
+  },
 
   /** Open a review-before-send prompt in an allowlisted local code client. */
   openCodeClient: async (input: CodeClientLaunch): Promise<void> => {
@@ -204,7 +209,6 @@ export type {
   PluginRestOptions,
   PluginStorage
 } from '@/contrib/plugin'
-export type { PreviewTarget } from '@/store/preview'
 
 // -- contracts ----------------------------------------------------------------
 

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -26,6 +26,7 @@ import { getLogs, getStatus } from '@/hermes'
 import { $gateway } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile } from '@/store/profile'
+import { $filePreviewTarget } from '@/store/preview'
 import { $activeSessionId, $currentCwd, $currentModel, $gatewayState } from '@/store/session'
 import { runGatewayRestart } from '@/store/system-actions'
 
@@ -39,6 +40,12 @@ export interface ViewportRect {
   height: number
   /** Below the app's sidebar-collapse breakpoint (rails become overlays). */
   narrow: boolean
+}
+
+export interface CodeClientLaunch {
+  client: 'claude-code' | 'codex'
+  cwd: string
+  prompt: string
 }
 
 const readViewport = (): ViewportRect => ({
@@ -65,6 +72,8 @@ export const host = {
     gateway: readonlyAtom<string>($gatewayState),
     /** Current main model slug. */
     model: readonlyAtom<string>($currentModel),
+    /** Active file-preview target, or null when no file tab is selected. */
+    previewTarget: readonlyAtom($filePreviewTarget),
     /** Profile the live gateway is routed to. */
     profile: readonlyAtom<string>($activeGatewayProfile),
     /** Window geometry ({ width, height, narrow }). */
@@ -81,6 +90,17 @@ export const host = {
 
   /** Tail an app log file (`agent` / `errors` / `gateway` / `gui` / …). */
   logs: async (...args: Parameters<typeof getLogs>) => getLogs(...args),
+
+  /** Open a review-before-send prompt in an allowlisted local code client. */
+  openCodeClient: async (input: CodeClientLaunch): Promise<void> => {
+    const openCodeClient = window.hermesDesktop?.openCodeClient
+
+    if (!openCodeClient) {
+      throw new Error('Code-client launch is unavailable outside Hermes Desktop')
+    }
+
+    await openCodeClient(input)
+  },
 
   /** Navigate the app router (hash routes, e.g. '/command-center?section=system'). */
   navigate: (path: string) => {
@@ -184,6 +204,7 @@ export type {
   PluginRestOptions,
   PluginStorage
 } from '@/contrib/plugin'
+export type { PreviewTarget } from '@/store/preview'
 
 // -- contracts ----------------------------------------------------------------
 

--- a/apps/desktop/src/sdk/open-code-client.test.ts
+++ b/apps/desktop/src/sdk/open-code-client.test.ts
@@ -1,5 +1,17 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+const preview = vi.hoisted(() => ({
+  target: {
+    kind: 'file' as const,
+    label: 'today.md',
+    path: '/Users/test/repo/today.md',
+    source: '/Users/test/repo/today.md',
+    url: 'file:///Users/test/repo/today.md'
+  }
+}))
+
+vi.mock('@/store/preview', () => ({ $filePreviewTarget: { get: () => preview.target } }))
+
 import { host } from './index'
 
 describe('host.openCodeClient', () => {
@@ -24,5 +36,13 @@ describe('host.openCodeClient', () => {
     await expect(
       host.openCodeClient({ client: 'claude-code', cwd: '/Users/test/repo', prompt: 'Review notes/today.md' })
     ).rejects.toThrow('Code-client launch is unavailable')
+  })
+
+  it('returns a frozen copy of the active preview target', () => {
+    const target = host.previewTarget()
+
+    expect(target).not.toBeNull()
+    expect(target).not.toBe(preview.target)
+    expect(Object.isFrozen(target)).toBe(true)
   })
 })

--- a/apps/desktop/src/sdk/open-code-client.test.ts
+++ b/apps/desktop/src/sdk/open-code-client.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { host } from './index'
+
+describe('host.openCodeClient', () => {
+  afterEach(() => {
+    Reflect.deleteProperty(window, 'hermesDesktop')
+  })
+
+  it('delegates only to the curated desktop bridge', async () => {
+    const openCodeClient = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { openCodeClient }
+    })
+    const input = { client: 'codex' as const, cwd: '/Users/test/repo', prompt: 'Review notes/today.md' }
+
+    await host.openCodeClient(input)
+
+    expect(openCodeClient).toHaveBeenCalledWith(input)
+  })
+
+  it('fails safely outside the desktop shell', async () => {
+    await expect(
+      host.openCodeClient({ client: 'claude-code', cwd: '/Users/test/repo', prompt: 'Review notes/today.md' })
+    ).rejects.toThrow('Code-client launch is unavailable')
+  })
+})


### PR DESCRIPTION
1|## Summary
2|
3|- add a curated `host.openCodeClient(...)` plugin action for Codex and Claude Code
4|- build only the vendors' documented review-before-send deep links
5|- expose the active file-preview target as a frozen snapshot
6|- validate IPC payloads and reject unsupported clients, malformed data, relative/network/traversal/control-character paths, and prompts over 5,000 characters
7|
8|## Why
9|
10|This provides the narrow host capability needed for a standalone file-preview plugin without granting generic shell execution or arbitrary protocol launching. It follows the repository's contribution guidance: product-specific UI remains a plugin, while core only widens the reusable plugin surface.
11|
12|The generated links use the official forms:
13|
14|- Codex: `codex://new?path=...&prompt=...`
15|- Claude Code: `claude-cli://open?cwd=...&q=...`
16|
17|Both clients prefill a prompt for review; neither sends it automatically.
18|
19|Enables the standalone-plugin implementation proposed in #68268.
20|
21|## Security boundary
22|
23|- allowlisted clients only: `codex`, `claude-code`
24|- no command strings, subprocesses, or shell invocation
25|- only fully qualified local directories for the current OS; UNC/network (including mixed separators), drive-relative Windows roots, traversal, and control-character paths fail closed
26|- untrusted IPC payloads are validated in Electron main before `shell.openExternal`
27|- prompts are URL-encoded and capped at 5,000 characters
28|
29|## Verification
30|
31|- `npm run typecheck` (from `apps/desktop`)
32|- `npm run lint` (0 errors; 9 pre-existing warnings outside this change)
33|- `vitest run --project ui --project electron`
34|  - 257 test files passed
35|  - 2,199 tests passed, 2 skipped
36|- `npm run build`
37|- focused deep-link and plugin-host tests rerun after final URL encoding change
38|- `git diff --check`
39|
40|The focused tests were written first and failed before each implementation step.
41|
42|An independent security review identified mixed-separator UNC handling and the original atom-shaped preview exposure. The follow-up commit adds regression tests, OS-specific fully qualified path validation, and a frozen cloned preview snapshot.
43|
44|## References
45|
46|- https://developers.openai.com/codex/reference/commands#deep-links
47|- https://code.claude.com/docs/en/deep-links
48|