### PR TITLE
feat(cron): attribute OpenRouter usage by job

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3366,6 +3366,12 @@ def run_job(
             load_soul_identity=True,
             skip_memory=True,  # Cron system prompts would corrupt user representations
             platform="cron",
+            # OpenRouter exposes the top-level `user` field as the
+            # `external_user` Analytics dimension. Keep it stable across runs so
+            # all spend for one job groups into the same bucket.
+            request_overrides=(
+                {"user": f"cron:{job_id}"} if runtime_provider == "openrouter" else None
+            ),
             session_id=_cron_session_id,
             session_db=_session_db,
         )

--- a/tests/cron/test_openrouter_attribution.py
+++ b/tests/cron/test_openrouter_attribution.py
@@ -1,0 +1,53 @@
+"""OpenRouter Analytics attribution for cron jobs (#66117)."""
+
+from collections.abc import Mapping
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from cron.scheduler import run_job
+
+
+def _run_job_with_provider(tmp_path, provider: str) -> Mapping[str, Any]:
+    job = {
+        "id": "a1b2c3d4e5f6",
+        "name": "daily cost report",
+        "prompt": "summarize costs",
+    }
+    fake_db = MagicMock()
+
+    with (
+        patch("cron.scheduler._hermes_home", tmp_path),
+        patch("cron.scheduler._resolve_origin", return_value=None),
+        patch("hermes_cli.env_loader.load_hermes_dotenv"),
+        patch("hermes_cli.env_loader.reset_secret_source_cache"),
+        patch("hermes_state.SessionDB", return_value=fake_db),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "api_key": "test-key",
+                "base_url": "https://example.invalid/v1",
+                "provider": provider,
+                "api_mode": "chat_completions",
+            },
+        ),
+        patch("run_agent.AIAgent") as agent_cls,
+    ):
+        agent_cls.return_value.run_conversation.return_value = {"final_response": "ok"}
+
+        success, _, _, error = run_job(job)
+
+    assert success is True
+    assert error is None
+    return agent_cls.call_args.kwargs
+
+
+def test_openrouter_cron_job_sets_stable_external_user(tmp_path):
+    kwargs = _run_job_with_provider(tmp_path, "openrouter")
+
+    assert kwargs["request_overrides"] == {"user": "cron:a1b2c3d4e5f6"}
+
+
+def test_non_openrouter_cron_job_does_not_set_external_user(tmp_path):
+    kwargs = _run_job_with_provider(tmp_path, "nous")
+
+    assert kwargs["request_overrides"] is None


### PR DESCRIPTION
## What does this PR do?

Adds stable per-cron-job attribution to OpenRouter requests. When a cron job resolves to OpenRouter, the scheduler passes `user: "cron:<job_id>"` as a top-level request override. OpenRouter exposes this value as the `external_user` Analytics dimension, so usage and spend from repeated runs group under one job instead of being indistinguishable from other agent traffic.

The override is gated on the resolved provider. Non-OpenRouter cron jobs are unchanged.

## Related Issue

Fixes #66117

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py`: add the stable `cron:<job_id>` OpenRouter request override after runtime provider resolution, including fallback resolution.
- `tests/cron/test_openrouter_attribution.py`: verify OpenRouter receives the attribution value and other providers do not.

## How to Test

1. Run `scripts/run_tests.sh tests/cron/test_openrouter_attribution.py tests/cron/test_scheduler.py tests/cron/test_sessiondb_init_hang.py tests/providers/test_profile_wiring.py -q`.
2. Confirm the OpenRouter case constructs `AIAgent` with `request_overrides={"user": "cron:<job_id>"}`.
3. Confirm a non-OpenRouter provider receives `request_overrides=None`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no OS-specific behavior; Windows footgun scan passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

TDD evidence:

- RED on upstream behavior: the OpenRouter regression test failed because `request_overrides` was absent.
- GREEN: affected CI-parity suites passed, `250 passed, 0 failed`.
- Final focused rerun after fixture cleanup: `24 passed, 0 failed`.
- `ruff check` passed for both changed files.
- `scripts/check-windows-footguns.py` passed for both changed files.

Full-suite evidence:

- Created a clean CI-parity environment with `uv sync --locked --python 3.11 --extra all --extra dev`.
- `scripts/run_tests.sh` completed all 2,124 test files (approximately 40,753 tests).
- The new `tests/cron/test_openrouter_attribution.py` passed in that full run.
- The run reported 28 failures across 14 unrelated files. Re-running those exact 14 files from detached `upstream/main` with the same locked venv produced the exact same 28 failures, so this branch adds zero failures.
- The baseline failures are primarily existing macOS/platform assumptions (`systemctl`, Linux abstract sockets, `/tmp` versus `/private/tmp`, BSD utility behavior) plus existing test-isolation failures outside the changed cron code.

The full-suite checkbox remains intentionally unchecked because the repository baseline is not fully green on macOS, even though the branch-versus-upstream comparison is clean.
