### PR TITLE
fix(desktop): drill into project folders before listing sessions

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.test.tsx
@@ -1,12 +1,20 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo } from '@/hermes'
+import type * as ProjectStoreModule from '@/store/projects'
 
 import { SidebarSessionsSection } from '../sessions-section'
 
 import { EnteredProjectContent } from './entered-content'
 import type { SidebarProjectTree, SidebarSessionGroup, SidebarWorkspaceTree } from './workspace-groups'
+
+const projectStoreMocks = vi.hoisted(() => ({ switchBranchInRepo: vi.fn() }))
+
+vi.mock('@/store/projects', async importOriginal => ({
+  ...(await importOriginal<typeof ProjectStoreModule>()),
+  switchBranchInRepo: projectStoreMocks.switchBranchInRepo
+}))
 
 let nextSession = 0
 
@@ -30,8 +38,13 @@ function session(title: string, startedAt: number, cwd: string): SessionInfo {
   }
 }
 
-function lane(id: string, label: string, sessions: SessionInfo[]): SidebarSessionGroup {
-  return { id, label, path: id, sessions }
+function lane(
+  id: string,
+  label: string,
+  sessions: SessionInfo[],
+  options: Partial<Pick<SidebarSessionGroup, 'isHome' | 'isMain' | 'path'>> = {}
+): SidebarSessionGroup {
+  return { id, label, path: id, sessions, ...options }
 }
 
 function repo(id: string, label: string, groups: SidebarSessionGroup[]): SidebarWorkspaceTree {
@@ -60,19 +73,29 @@ function chatRows(sessions: SessionInfo[]) {
 
 function fixture() {
   const cards = repo('/workspace/clawdified/cards', 'Business cards', [
-    lane('/workspace/clawdified/cards::main', 'main', [
-      session('Cards chat 1', 10, '/workspace/clawdified/cards'),
-      session('Cards chat 2', 20, '/workspace/clawdified/cards'),
-      session('Cards chat 3', 30, '/workspace/clawdified/cards'),
-      session('Cards chat 4', 40, '/workspace/clawdified/cards'),
-      session('Cards chat 7', 70, '/workspace/clawdified/cards'),
-      session('Cards chat 8', 80, '/workspace/clawdified/cards'),
-      session('Cards chat 9', 90, '/workspace/clawdified/cards')
-    ]),
-    lane('/workspace/clawdified/cards::concept', 'concept', [
-      session('Cards chat 5', 50, '/workspace/clawdified/cards'),
-      session('Cards chat 6', 60, '/workspace/clawdified/cards')
-    ])
+    lane(
+      '/workspace/clawdified/cards::main',
+      'main',
+      [
+        session('Cards chat 1', 10, '/workspace/clawdified/cards'),
+        session('Cards chat 2', 20, '/workspace/clawdified/cards'),
+        session('Cards chat 3', 30, '/workspace/clawdified/cards'),
+        session('Cards chat 4', 40, '/workspace/clawdified/cards'),
+        session('Cards chat 7', 70, '/workspace/clawdified/cards'),
+        session('Cards chat 8', 80, '/workspace/clawdified/cards'),
+        session('Cards chat 9', 90, '/workspace/clawdified/cards')
+      ],
+      { isHome: true, isMain: true, path: '/workspace/clawdified/cards' }
+    ),
+    lane(
+      '/workspace/clawdified/cards::concept',
+      'concept',
+      [
+        session('Cards chat 5', 50, '/workspace/clawdified/cards'),
+        session('Cards chat 6', 60, '/workspace/clawdified/cards')
+      ],
+      { path: '/workspace/clawdified/cards/.worktrees/concept' }
+    )
   ])
 
   const website = repo('/workspace/clawdified/website', 'Website', [
@@ -87,6 +110,11 @@ afterEach(() => {
   window.localStorage.clear()
 })
 
+beforeEach(() => {
+  projectStoreMocks.switchBranchInRepo.mockReset()
+  projectStoreMocks.switchBranchInRepo.mockResolvedValue(undefined)
+})
+
 describe('EnteredProjectContent folder drill-down', () => {
   it('shows only folder rows until the user chooses one in a multi-folder project', () => {
     const { project } = fixture()
@@ -96,12 +124,12 @@ describe('EnteredProjectContent folder drill-down', () => {
       <EnteredProjectContent focusedRepoId={null} onFocusRepo={onFocusRepo} project={project} renderRows={chatRows} />
     )
 
-    expect(screen.getByRole('button', { name: 'Open Business cards' })).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Open Website' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Business cards' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Website' })).toBeTruthy()
     expect(screen.queryByText('Cards chat 1')).toBeNull()
     expect(screen.queryByText('Website chat')).toBeNull()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Open Business cards' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Business cards' }))
     expect(onFocusRepo).toHaveBeenCalledWith('/workspace/clawdified/cards')
   })
 
@@ -141,8 +169,86 @@ describe('EnteredProjectContent folder drill-down', () => {
       expect(screen.getByText(`Cards chat ${index}`)).toBeTruthy()
     }
 
-    expect(screen.queryByRole('button', { name: 'Open Business cards' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Business cards' })).toBeNull()
     expect(screen.queryByLabelText(/Show .* more/)).toBeNull()
+  })
+
+  it('deduplicates chats across lanes and globally sorts them by recency', () => {
+    const repoPath = '/workspace/clawdified/sorted'
+    const older = session('Older chat', 10, repoPath)
+    const duplicate = session('Duplicate chat', 20, repoPath)
+    const newest = session('Newest chat', 30, `${repoPath}/.worktrees/concept`)
+
+    const sortedRepo = repo(repoPath, 'Sorted chats', [
+      lane(`${repoPath}::main`, 'main', [older, duplicate], { isHome: true, isMain: true, path: repoPath }),
+      lane(`${repoPath}::concept`, 'concept', [duplicate, newest], { path: `${repoPath}/.worktrees/concept` })
+    ])
+
+    render(<EnteredProjectContent project={project([sortedRepo])} renderRows={chatRows} />)
+
+    expect(screen.getAllByText(/^(Newest|Duplicate|Older) chat$/).map(row => row.textContent)).toEqual([
+      'Newest chat',
+      'Duplicate chat',
+      'Older chat'
+    ])
+    expect(screen.getAllByText('Duplicate chat')).toHaveLength(1)
+  })
+
+  it('preserves linked-worktree targeting and controls inside a focused folder', async () => {
+    const { project } = fixture()
+    const onNewSession = vi.fn()
+
+    render(
+      <EnteredProjectContent
+        focusedRepoId="/workspace/clawdified/cards"
+        onNewSession={onNewSession}
+        project={project}
+        renderRows={chatRows}
+      />
+    )
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'New session in Business cards' }), {
+      button: 0,
+      ctrlKey: false,
+      pointerType: 'mouse'
+    })
+
+    const worktreeTarget = await screen.findByRole('menuitem', { name: 'New session in concept' })
+
+    const worktreeActions = screen.getByRole('menuitem', { name: 'concept' })
+
+    fireEvent.pointerMove(worktreeActions, { pointerType: 'mouse' })
+    expect(await screen.findByRole('menuitem', { name: 'Remove worktree…' })).toBeTruthy()
+    fireEvent.click(worktreeTarget)
+
+    await waitFor(() => expect(onNewSession).toHaveBeenCalledWith('/workspace/clawdified/cards/.worktrees/concept'))
+    expect(screen.queryByLabelText(/Show .* more/)).toBeNull()
+  })
+
+  it('switches the primary lane branch before creating a session there', async () => {
+    const { project } = fixture()
+    const onNewSession = vi.fn()
+
+    render(
+      <EnteredProjectContent
+        focusedRepoId="/workspace/clawdified/cards"
+        onNewSession={onNewSession}
+        project={project}
+        renderRows={chatRows}
+      />
+    )
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'New session in Business cards' }), {
+      button: 0,
+      ctrlKey: false,
+      pointerType: 'mouse'
+    })
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'New session in main' }))
+
+    await waitFor(() => {
+      expect(projectStoreMocks.switchBranchInRepo).toHaveBeenCalledWith('/workspace/clawdified/cards', 'main')
+      expect(onNewSession).toHaveBeenCalledWith('/workspace/clawdified/cards')
+    })
   })
 })
 
@@ -170,13 +276,47 @@ describe('SidebarSessionsSection folder focus lifecycle', () => {
 
     const view = render(section(projectContent))
 
-    fireEvent.click(screen.getByRole('button', { name: 'Open Business cards' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Business cards' }))
     expect(screen.getByText('Cards chat 1')).toBeTruthy()
 
     view.rerender(section())
     view.rerender(section(projectContent))
 
-    expect(screen.getByRole('button', { name: 'Open Business cards' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Business cards' })).toBeTruthy()
     expect(screen.queryByText('Cards chat 1')).toBeNull()
+  })
+
+  it('restores the project back row if the focused folder disappears from the live project tree', () => {
+    const { project: projectContent, website } = fixture()
+    const projectBackRow = <div>Back to projects</div>
+
+    const section = (content: SidebarProjectTree) => (
+      <SidebarSessionsSection
+        activeSessionId={null}
+        emptyState={<div>No sessions</div>}
+        label="Sessions"
+        onArchiveSession={vi.fn()}
+        onDeleteSession={vi.fn()}
+        onResumeSession={vi.fn()}
+        onToggle={vi.fn()}
+        onTogglePin={vi.fn()}
+        open
+        pinned={false}
+        projectBackRow={projectBackRow}
+        projectContent={content}
+        sessions={[]}
+        workingSessionIdSet={new Set()}
+      />
+    )
+
+    const view = render(section(projectContent))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Business cards' }))
+    expect(screen.queryByText('Back to projects')).toBeNull()
+
+    view.rerender(section(project([website])))
+
+    expect(screen.getByText('Back to projects')).toBeTruthy()
+    expect(screen.getByText('Website chat')).toBeTruthy()
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.test.tsx
@@ -1,0 +1,182 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+
+import { SidebarSessionsSection } from '../sessions-section'
+
+import { EnteredProjectContent } from './entered-content'
+import type { SidebarProjectTree, SidebarSessionGroup, SidebarWorkspaceTree } from './workspace-groups'
+
+let nextSession = 0
+
+function session(title: string, startedAt: number, cwd: string): SessionInfo {
+  return {
+    archived: false,
+    cwd,
+    ended_at: null,
+    id: `session-${nextSession++}`,
+    input_tokens: 0,
+    is_active: false,
+    last_active: startedAt,
+    message_count: 1,
+    model: 'gpt-5',
+    output_tokens: 0,
+    preview: null,
+    source: 'desktop',
+    started_at: startedAt,
+    title,
+    tool_call_count: 0
+  }
+}
+
+function lane(id: string, label: string, sessions: SessionInfo[]): SidebarSessionGroup {
+  return { id, label, path: id, sessions }
+}
+
+function repo(id: string, label: string, groups: SidebarSessionGroup[]): SidebarWorkspaceTree {
+  return {
+    groups,
+    id,
+    label,
+    path: id,
+    sessionCount: groups.reduce((total, group) => total + group.sessions.length, 0)
+  }
+}
+
+function project(repos: SidebarWorkspaceTree[]): SidebarProjectTree {
+  return {
+    id: 'clawdified-brand',
+    label: 'Clawdified Brand',
+    path: '/workspace/clawdified',
+    repos,
+    sessionCount: repos.reduce((total, item) => total + item.sessionCount, 0)
+  }
+}
+
+function chatRows(sessions: SessionInfo[]) {
+  return sessions.map(item => <div key={item.id}>{item.title}</div>)
+}
+
+function fixture() {
+  const cards = repo('/workspace/clawdified/cards', 'Business cards', [
+    lane('/workspace/clawdified/cards::main', 'main', [
+      session('Cards chat 1', 10, '/workspace/clawdified/cards'),
+      session('Cards chat 2', 20, '/workspace/clawdified/cards'),
+      session('Cards chat 3', 30, '/workspace/clawdified/cards'),
+      session('Cards chat 4', 40, '/workspace/clawdified/cards'),
+      session('Cards chat 7', 70, '/workspace/clawdified/cards'),
+      session('Cards chat 8', 80, '/workspace/clawdified/cards'),
+      session('Cards chat 9', 90, '/workspace/clawdified/cards')
+    ]),
+    lane('/workspace/clawdified/cards::concept', 'concept', [
+      session('Cards chat 5', 50, '/workspace/clawdified/cards'),
+      session('Cards chat 6', 60, '/workspace/clawdified/cards')
+    ])
+  ])
+
+  const website = repo('/workspace/clawdified/website', 'Website', [
+    lane('/workspace/clawdified/website::main', 'main', [session('Website chat', 70, '/workspace/clawdified/website')])
+  ])
+
+  return { cards, project: project([cards, website]), website }
+}
+
+afterEach(() => {
+  cleanup()
+  window.localStorage.clear()
+})
+
+describe('EnteredProjectContent folder drill-down', () => {
+  it('shows only folder rows until the user chooses one in a multi-folder project', () => {
+    const { project } = fixture()
+    const onFocusRepo = vi.fn()
+
+    render(
+      <EnteredProjectContent focusedRepoId={null} onFocusRepo={onFocusRepo} project={project} renderRows={chatRows} />
+    )
+
+    expect(screen.getByRole('button', { name: 'Open Business cards' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Open Website' })).toBeTruthy()
+    expect(screen.queryByText('Cards chat 1')).toBeNull()
+    expect(screen.queryByText('Website chat')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Business cards' }))
+    expect(onFocusRepo).toHaveBeenCalledWith('/workspace/clawdified/cards')
+  })
+
+  it('focuses one folder, hides its siblings, and renders every chat without an ellipsis', () => {
+    const { project } = fixture()
+    const onExitRepo = vi.fn()
+
+    render(
+      <EnteredProjectContent
+        focusedRepoId="/workspace/clawdified/cards"
+        onExitRepo={onExitRepo}
+        project={project}
+        renderRows={chatRows}
+      />
+    )
+
+    for (let index = 1; index <= 9; index += 1) {
+      expect(screen.getByText(`Cards chat ${index}`)).toBeTruthy()
+    }
+
+    expect(screen.queryByText('Website chat')).toBeNull()
+    expect(screen.queryByLabelText(/Show .* more/)).toBeNull()
+
+    const backButton = screen.getByText('Clawdified Brand').closest('button')
+
+    expect(backButton?.className).toContain('opacity-70')
+    fireEvent.click(backButton!)
+    expect(onExitRepo).toHaveBeenCalledOnce()
+  })
+
+  it('opens a single-folder project directly as one complete chat list', () => {
+    const { cards } = fixture()
+
+    render(<EnteredProjectContent project={project([cards])} renderRows={chatRows} />)
+
+    for (let index = 1; index <= 9; index += 1) {
+      expect(screen.getByText(`Cards chat ${index}`)).toBeTruthy()
+    }
+
+    expect(screen.queryByRole('button', { name: 'Open Business cards' })).toBeNull()
+    expect(screen.queryByLabelText(/Show .* more/)).toBeNull()
+  })
+})
+
+describe('SidebarSessionsSection folder focus lifecycle', () => {
+  it('returns to the folder list after exiting and re-entering the same project', () => {
+    const { project: projectContent } = fixture()
+
+    const section = (content?: SidebarProjectTree) => (
+      <SidebarSessionsSection
+        activeSessionId={null}
+        emptyState={<div>No sessions</div>}
+        label="Sessions"
+        onArchiveSession={vi.fn()}
+        onDeleteSession={vi.fn()}
+        onResumeSession={vi.fn()}
+        onToggle={vi.fn()}
+        onTogglePin={vi.fn()}
+        open
+        pinned={false}
+        projectContent={content}
+        sessions={[]}
+        workingSessionIdSet={new Set()}
+      />
+    )
+
+    const view = render(section(projectContent))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Business cards' }))
+    expect(screen.getByText('Cards chat 1')).toBeTruthy()
+
+    view.rerender(section())
+    view.rerender(section(projectContent))
+
+    expect(screen.getByRole('button', { name: 'Open Business cards' })).toBeTruthy()
+    expect(screen.queryByText('Cards chat 1')).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
@@ -12,12 +12,22 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
 import type { HermesGitWorktree } from '@/global'
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { $dismissedWorktreeIds, dismissWorktree } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
-import { removeWorktreePath } from '@/store/projects'
+import { removeWorktreePath, switchBranchInRepo } from '@/store/projects'
 
 import { SidebarRowStack } from '../chrome'
 
@@ -31,7 +41,7 @@ import {
   type SidebarSessionGroup,
   type SidebarWorkspaceTree
 } from './workspace-groups'
-import { WorkspaceAddButton, WorkspaceHeader } from './workspace-header'
+import { WorkspaceAddButton, WorkspaceHeader, WorkspaceMenuItems } from './workspace-header'
 
 // Multi-folder projects first render one row per repo. A focused repo — or the
 // only repo — then renders one complete, deduplicated session list across its
@@ -72,7 +82,7 @@ export function EnteredProjectContent({
         {project.repos.map(repo => (
           <div className="group/workspace flex min-h-7 items-center gap-1 px-2 text-[0.6875rem]" key={repo.id}>
             <button
-              aria-label={`Open ${repo.label}`}
+              aria-label={repo.label}
               className="flex min-w-0 flex-1 items-center gap-1.5 bg-transparent text-left font-semibold text-(--ui-text-secondary) hover:text-foreground"
               onClick={() => onFocusRepo?.(repo.id)}
               type="button"
@@ -107,27 +117,24 @@ export function EnteredProjectContent({
           <span className="truncate">{project.label}</span>
         </button>
       )}
-      <div className="flex min-h-7 items-center gap-1 px-2 text-[0.6875rem] font-semibold text-(--ui-text-secondary)">
-        <Codicon className="shrink-0 text-(--ui-text-tertiary)" name="folder-opened" size="0.75rem" />
-        <span className="min-w-0 flex-1 truncate" title={focusedRepo.path ?? undefined}>
-          {focusedRepo.label}
-        </span>
-        <span className="shrink-0 text-[0.6875rem] font-medium text-(--ui-text-quaternary)">
-          {focusedRepo.sessionCount}
-        </span>
-        {onNewSession && (
-          <WorkspaceAddButton
-            label={t.sidebar.newSessionIn(focusedRepo.label)}
-            onClick={() => onNewSession(focusedRepo.path)}
-          />
-        )}
-      </div>
       <RepoFlatSection
         discoveredWorktrees={focusedRepo.path ? repoWorktrees?.[focusedRepo.path] : undefined}
         flattenSessions
         liveSessions={liveSessions}
         onNewSession={onNewSession}
         removedSessionIds={removedSessionIds}
+        renderHeader={actions => (
+          <div className="group/workspace flex min-h-7 items-center gap-1 px-2 text-[0.6875rem] font-semibold text-(--ui-text-secondary)">
+            <Codicon className="shrink-0 text-(--ui-text-tertiary)" name="folder-opened" size="0.75rem" />
+            <span className="min-w-0 flex-1 truncate" title={focusedRepo.path ?? undefined}>
+              {focusedRepo.label}
+            </span>
+            <span className="shrink-0 text-[0.6875rem] font-medium text-(--ui-text-quaternary)">
+              {focusedRepo.sessionCount}
+            </span>
+            {actions}
+          </div>
+        )}
         renderRows={renderRows}
         repo={focusedRepo}
         showHeader={false}
@@ -143,6 +150,7 @@ function RepoFlatSection({
   onNewSession,
   discoveredWorktrees,
   flattenSessions = false,
+  renderHeader,
   liveSessions,
   removedSessionIds
 }: {
@@ -152,6 +160,7 @@ function RepoFlatSection({
   onNewSession?: (path: null | string) => void
   discoveredWorktrees?: HermesGitWorktree[]
   flattenSessions?: boolean
+  renderHeader?: (actions: React.ReactNode) => React.ReactNode
   liveSessions?: SessionInfo[]
   removedSessionIds?: ReadonlySet<string>
 }) {
@@ -320,9 +329,20 @@ function RepoFlatSection({
     </>
   )
 
+  const header = renderHeader?.(
+    <RepoActionsMenu
+      groups={ordered}
+      onNewSession={onNewSession}
+      onRemove={setRemoveTarget}
+      repoLabel={repo.label}
+      repoPath={repo.path}
+    />
+  )
+
   if (!showHeader) {
     return (
       <>
+        {header}
         {body}
         {removeDialog}
       </>
@@ -331,6 +351,7 @@ function RepoFlatSection({
 
   return (
     <SidebarRowStack>
+      {header}
       <WorkspaceHeader
         action={
           onNewSession && (
@@ -348,5 +369,86 @@ function RepoFlatSection({
       {open && <SidebarRowStack className="pl-2.5">{body}</SidebarRowStack>}
       {removeDialog}
     </SidebarRowStack>
+  )
+}
+
+function RepoActionsMenu({
+  groups,
+  repoLabel,
+  repoPath,
+  onNewSession,
+  onRemove
+}: {
+  groups: SidebarSessionGroup[]
+  repoLabel: string
+  repoPath: null | string
+  onNewSession?: (path: null | string) => void
+  onRemove: (group: SidebarSessionGroup) => void
+}) {
+  const { t } = useI18n()
+  const targets = groups.filter(group => !group.isKanban)
+  const worktrees = groups.filter(group => !group.isMain && !group.isKanban)
+
+  const startSession = async (group?: SidebarSessionGroup) => {
+    if (!onNewSession) {
+      return
+    }
+
+    if (group?.isMain && group.path && group.label) {
+      try {
+        await switchBranchInRepo(group.path, group.label)
+      } catch (err) {
+        notifyError(err, t.statusStack.coding.switchFailed(group.label))
+
+        return
+      }
+    }
+
+    onNewSession(group?.path ?? repoPath)
+  }
+
+  if (targets.length <= 1 && worktrees.length === 0) {
+    return onNewSession ? (
+      <WorkspaceAddButton label={t.sidebar.newSessionIn(repoLabel)} onClick={() => void startSession(targets[0])} />
+    ) : null
+  }
+
+  if (!onNewSession && worktrees.length === 0) {
+    return null
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          aria-label={onNewSession ? t.sidebar.newSessionIn(repoLabel) : t.sidebar.projects.menu}
+          className="grid size-4 shrink-0 place-items-center rounded-sm bg-transparent text-(--ui-text-quaternary) opacity-0 transition-opacity hover:bg-(--ui-control-hover-background) hover:text-foreground group-hover/workspace:opacity-100 data-[state=open]:opacity-100"
+          type="button"
+        >
+          <Codicon name={onNewSession ? 'add' : 'kebab-vertical'} size="0.75rem" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-52" sideOffset={6}>
+        {onNewSession &&
+          targets.map(group => (
+            <DropdownMenuItem key={`new:${group.id}`} onSelect={() => void startSession(group)}>
+              <Codicon name={group.isHome ? 'home' : 'git-branch'} size="0.875rem" />
+              <span>{t.sidebar.newSessionIn(group.label)}</span>
+            </DropdownMenuItem>
+          ))}
+        {onNewSession && worktrees.length > 0 && <DropdownMenuSeparator />}
+        {worktrees.map(group => (
+          <DropdownMenuSub key={`actions:${group.id}`}>
+            <DropdownMenuSubTrigger>
+              <Codicon name="git-branch" size="0.875rem" />
+              <span>{group.label}</span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <WorkspaceMenuItems onRemove={() => onRemove(group)} path={group.path} />
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }

--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
@@ -26,20 +26,23 @@ import { SidebarWorkspaceGroup } from './workspace-group'
 import {
   mergeRepoWorktreeGroups,
   overlayRepoLanes,
+  sessionRecency,
   type SidebarProjectTree,
   type SidebarSessionGroup,
   type SidebarWorkspaceTree
 } from './workspace-groups'
 import { WorkspaceAddButton, WorkspaceHeader } from './workspace-header'
 
-// The entered project's body. Main-checkout sessions render directly — no
-// redundant repo/branch header (the breadcrumb already names the project). Only
-// linked worktrees nest, shown by branch. Multi-folder projects keep per-repo
-// headers so the folders stay distinguishable.
+// Multi-folder projects first render one row per repo. A focused repo — or the
+// only repo — then renders one complete, deduplicated session list across its
+// primary and linked-worktree lanes.
 export function EnteredProjectContent({
   project,
   renderRows,
   onNewSession,
+  focusedRepoId,
+  onFocusRepo,
+  onExitRepo,
   repoWorktrees,
   liveSessions,
   removedSessionIds
@@ -47,30 +50,88 @@ export function EnteredProjectContent({
   project: SidebarProjectTree
   renderRows: (sessions: SessionInfo[]) => React.ReactNode
   onNewSession?: (path: null | string) => void
+  focusedRepoId?: null | string
+  onFocusRepo?: (repoId: string) => void
+  onExitRepo?: () => void
   repoWorktrees?: Record<string, HermesGitWorktree[]>
   liveSessions?: SessionInfo[]
   removedSessionIds?: ReadonlySet<string>
 }) {
+  const { t } = useI18n()
+
   if (!project.repos.length) {
     return null
   }
 
-  const single = project.repos.length === 1
+  const singleRepo = project.repos.length === 1 ? project.repos[0] : null
+  const focusedRepo = singleRepo ?? project.repos.find(repo => repo.id === focusedRepoId)
+
+  if (!focusedRepo) {
+    return (
+      <SidebarRowStack>
+        {project.repos.map(repo => (
+          <div className="group/workspace flex min-h-7 items-center gap-1 px-2 text-[0.6875rem]" key={repo.id}>
+            <button
+              aria-label={`Open ${repo.label}`}
+              className="flex min-w-0 flex-1 items-center gap-1.5 bg-transparent text-left font-semibold text-(--ui-text-secondary) hover:text-foreground"
+              onClick={() => onFocusRepo?.(repo.id)}
+              type="button"
+            >
+              <Codicon className="shrink-0 text-(--ui-text-tertiary)" name="folder" size="0.75rem" />
+              <span className="min-w-0 flex-1 truncate" title={repo.path ? `${repo.label}\n${repo.path}` : repo.label}>
+                {repo.label}
+              </span>
+              <span className="shrink-0 text-[0.6875rem] font-medium text-(--ui-text-quaternary)">
+                {repo.sessionCount}
+              </span>
+              <Codicon className="shrink-0 text-(--ui-text-tertiary)" name="chevron-right" size="0.75rem" />
+            </button>
+            {onNewSession && (
+              <WorkspaceAddButton label={t.sidebar.newSessionIn(repo.label)} onClick={() => onNewSession(repo.path)} />
+            )}
+          </div>
+        ))}
+      </SidebarRowStack>
+    )
+  }
 
   return (
     <>
-      {project.repos.map(repo => (
-        <RepoFlatSection
-          discoveredWorktrees={repo.path ? repoWorktrees?.[repo.path] : undefined}
-          key={repo.id}
-          liveSessions={liveSessions}
-          onNewSession={onNewSession}
-          removedSessionIds={removedSessionIds}
-          renderRows={renderRows}
-          repo={repo}
-          showHeader={!single}
-        />
-      ))}
+      {!singleRepo && (
+        <button
+          className="flex min-h-7 w-full items-center gap-1.5 bg-transparent px-2 text-left text-[0.6875rem] font-medium text-(--ui-text-secondary) opacity-70 hover:opacity-100"
+          onClick={onExitRepo}
+          type="button"
+        >
+          <Codicon name="chevron-left" size="0.75rem" />
+          <span className="truncate">{project.label}</span>
+        </button>
+      )}
+      <div className="flex min-h-7 items-center gap-1 px-2 text-[0.6875rem] font-semibold text-(--ui-text-secondary)">
+        <Codicon className="shrink-0 text-(--ui-text-tertiary)" name="folder-opened" size="0.75rem" />
+        <span className="min-w-0 flex-1 truncate" title={focusedRepo.path ?? undefined}>
+          {focusedRepo.label}
+        </span>
+        <span className="shrink-0 text-[0.6875rem] font-medium text-(--ui-text-quaternary)">
+          {focusedRepo.sessionCount}
+        </span>
+        {onNewSession && (
+          <WorkspaceAddButton
+            label={t.sidebar.newSessionIn(focusedRepo.label)}
+            onClick={() => onNewSession(focusedRepo.path)}
+          />
+        )}
+      </div>
+      <RepoFlatSection
+        discoveredWorktrees={focusedRepo.path ? repoWorktrees?.[focusedRepo.path] : undefined}
+        flattenSessions
+        liveSessions={liveSessions}
+        onNewSession={onNewSession}
+        removedSessionIds={removedSessionIds}
+        renderRows={renderRows}
+        repo={focusedRepo}
+        showHeader={false}
+      />
     </>
   )
 }
@@ -81,6 +142,7 @@ function RepoFlatSection({
   renderRows,
   onNewSession,
   discoveredWorktrees,
+  flattenSessions = false,
   liveSessions,
   removedSessionIds
 }: {
@@ -89,6 +151,7 @@ function RepoFlatSection({
   renderRows: (sessions: SessionInfo[]) => React.ReactNode
   onNewSession?: (path: null | string) => void
   discoveredWorktrees?: HermesGitWorktree[]
+  flattenSessions?: boolean
   liveSessions?: SessionInfo[]
   removedSessionIds?: ReadonlySet<string>
 }) {
@@ -135,6 +198,18 @@ function RepoFlatSection({
 
   const repoCount = ordered.reduce((sum, group) => sum + group.sessions.length, 0)
 
+  const flattenedSessions = useMemo(() => {
+    const byId = new Map<string, SessionInfo>()
+
+    for (const group of ordered) {
+      for (const session of group.sessions) {
+        byId.set(session.id, byId.get(session.id) ?? session)
+      }
+    }
+
+    return [...byId.values()].sort((a, b) => sessionRecency(b) - sessionRecency(a))
+  }, [ordered])
+
   // Removal asks how: actually `git worktree remove` it, or just hide the lane
   // and leave the worktree on disk. A dirty worktree escalates to a force prompt
   // instead of erroring (those changes are usually throwaway).
@@ -160,7 +235,9 @@ function RepoFlatSection({
     }
   }
 
-  const body = (
+  const body = flattenSessions ? (
+    renderRows(flattenedSessions)
+  ) : (
     <>
       {ordered.map(group => (
         <SidebarWorkspaceGroup

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx
@@ -75,18 +75,41 @@ export function WorkspaceShowMoreButton({
   )
 }
 
-// Per-worktree actions (linked worktree lanes only), mirroring the session row
-// and ProjectMenu kebab: reveal in the file manager, copy path, and remove the
-// worktree (runs a real `git worktree remove` via the caller's confirm dialog).
-export function WorkspaceMenu({ path, onRemove }: { path: null | string; onRemove: () => void }) {
+// Shared linked-worktree actions. The normal lane menu and the compact entered-
+// folder menu both use these exact items so neither surface loses management.
+export function WorkspaceMenuItems({ path, onRemove }: { path: null | string; onRemove: () => void }) {
   const { t } = useI18n()
   const p = t.sidebar.projects
+
+  return (
+    <>
+      <DropdownMenuItem disabled={!path} onSelect={() => void revealPath(path)}>
+        <Codicon name="folder-opened" size="0.875rem" />
+        <span>{p.reveal}</span>
+      </DropdownMenuItem>
+      <DropdownMenuItem disabled={!path} onSelect={() => void copyPath(path)}>
+        <Codicon name="copy" size="0.875rem" />
+        <span>{p.copyPath}</span>
+      </DropdownMenuItem>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem onSelect={onRemove} variant="destructive">
+        <Codicon name="trash" size="0.875rem" />
+        <span>{`${p.removeWorktree}…`}</span>
+      </DropdownMenuItem>
+    </>
+  )
+}
+
+// Per-worktree actions (linked worktree lanes only), mirroring the session row
+// and ProjectMenu kebab.
+export function WorkspaceMenu({ path, onRemove }: { path: null | string; onRemove: () => void }) {
+  const { t } = useI18n()
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
-          aria-label={p.menu}
+          aria-label={t.sidebar.projects.menu}
           className="grid size-4 shrink-0 place-items-center rounded-sm bg-transparent text-(--ui-text-quaternary) opacity-0 transition-opacity hover:bg-(--ui-control-hover-background) hover:text-foreground group-hover/workspace:opacity-100 data-[state=open]:opacity-100"
           onClick={event => event.stopPropagation()}
           type="button"
@@ -95,19 +118,7 @@ export function WorkspaceMenu({ path, onRemove }: { path: null | string; onRemov
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-48" sideOffset={6}>
-        <DropdownMenuItem disabled={!path} onSelect={() => void revealPath(path)}>
-          <Codicon name="folder-opened" size="0.875rem" />
-          <span>{p.reveal}</span>
-        </DropdownMenuItem>
-        <DropdownMenuItem disabled={!path} onSelect={() => void copyPath(path)}>
-          <Codicon name="copy" size="0.875rem" />
-          <span>{p.copyPath}</span>
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={onRemove} variant="destructive">
-          <Codicon name="trash" size="0.875rem" />
-          <span>{`${p.removeWorktree}…`}</span>
-        </DropdownMenuItem>
+        <WorkspaceMenuItems onRemove={onRemove} path={path} />
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -1,6 +1,6 @@
 import type { useSensors } from '@dnd-kit/core'
 import type * as React from 'react'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 
 import { SidebarPanelLabel } from '@/app/shell/sidebar-label'
 import { DisclosureCaret } from '@/components/ui/disclosure-caret'
@@ -111,8 +111,8 @@ interface SidebarSessionsSectionProps {
   // True while the backend project tree is loading (overview skeleton).
   projectsLoading?: boolean
   onEnterProject?: (id: string) => void
-  // The entered project's flattened content: main-checkout sessions render
-  // directly (no redundant repo/branch header); only linked worktrees nest.
+  // The entered project's folder drill-down and complete session list for the
+  // focused (or only) repo.
   projectContent?: SidebarProjectTree
   // Live git lanes (`git worktree list`) for repos in the entered project —
   // a VISUAL enhancer only (empty lanes), never session membership.
@@ -139,6 +139,55 @@ interface SidebarSessionsSectionProps {
   // lists (Pinned / search results) in the All-profiles view, where no group
   // header communicates ownership (#66003).
   showProfileTags?: boolean
+}
+
+interface EnteredProjectSectionProps extends Pick<
+  SidebarSessionsSectionProps,
+  | 'emptyState'
+  | 'liveSessions'
+  | 'onNewSessionInWorkspace'
+  | 'projectBackRow'
+  | 'projectRepoWorktrees'
+  | 'removedSessionIds'
+> {
+  hasProjectContent: boolean
+  projectContent: SidebarProjectTree
+  renderRows: (sessions: SessionInfo[]) => React.ReactNode
+}
+
+function EnteredProjectSection({
+  emptyState,
+  hasProjectContent,
+  liveSessions,
+  onNewSessionInWorkspace,
+  projectBackRow,
+  projectContent,
+  projectRepoWorktrees,
+  removedSessionIds,
+  renderRows
+}: EnteredProjectSectionProps) {
+  const [focusedRepoId, setFocusedRepoId] = useState<null | string>(null)
+
+  return (
+    <>
+      {!focusedRepoId && projectBackRow}
+      {hasProjectContent ? (
+        <EnteredProjectContent
+          focusedRepoId={focusedRepoId}
+          liveSessions={liveSessions}
+          onExitRepo={() => setFocusedRepoId(null)}
+          onFocusRepo={setFocusedRepoId}
+          onNewSession={onNewSessionInWorkspace}
+          project={projectContent}
+          removedSessionIds={removedSessionIds}
+          renderRows={renderRows}
+          repoWorktrees={projectRepoWorktrees}
+        />
+      ) : (
+        emptyState
+      )}
+    </>
+  )
 }
 
 export function SidebarSessionsSection({
@@ -246,21 +295,18 @@ export function SidebarSessionsSection({
     // (overlay-aware) content or a clean empty state — never a bare spinner or a
     // blank pane while lanes hydrate.
     inner = (
-      <>
-        {projectBackRow}
-        {hasProjectContent ? (
-          <EnteredProjectContent
-            liveSessions={liveSessions}
-            onNewSession={onNewSessionInWorkspace}
-            project={projectContent}
-            removedSessionIds={removedSessionIds}
-            renderRows={renderRows}
-            repoWorktrees={projectRepoWorktrees}
-          />
-        ) : (
-          emptyState
-        )}
-      </>
+      <EnteredProjectSection
+        emptyState={emptyState}
+        hasProjectContent={hasProjectContent}
+        key={projectContent.id}
+        liveSessions={liveSessions}
+        onNewSessionInWorkspace={onNewSessionInWorkspace}
+        projectBackRow={projectBackRow}
+        projectContent={projectContent}
+        projectRepoWorktrees={projectRepoWorktrees}
+        removedSessionIds={removedSessionIds}
+        renderRows={renderRows}
+      />
     )
   } else if (showEmptyState) {
     inner = emptyState

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -168,12 +168,15 @@ function EnteredProjectSection({
 }: EnteredProjectSectionProps) {
   const [focusedRepoId, setFocusedRepoId] = useState<null | string>(null)
 
+  const activeFocusedRepoId =
+    focusedRepoId && projectContent.repos.some(repo => repo.id === focusedRepoId) ? focusedRepoId : null
+
   return (
     <>
-      {!focusedRepoId && projectBackRow}
+      {!activeFocusedRepoId && projectBackRow}
       {hasProjectContent ? (
         <EnteredProjectContent
-          focusedRepoId={focusedRepoId}
+          focusedRepoId={activeFocusedRepoId}
           liveSessions={liveSessions}
           onExitRepo={() => setFocusedRepoId(null)}
           onFocusRepo={setFocusedRepoId}


### PR DESCRIPTION
## Summary

- show a folder/repository picker before sessions when an entered Desktop project has multiple folders
- show one complete, deduplicated, globally recency-sorted chat list after focusing a folder, and directly for single-folder projects
- preserve branch/worktree-specific new-session targets, primary-lane branch switching, and linked-worktree Reveal/Copy/Remove actions through a compact folder `+` menu
- reset folder focus when leaving an entered project or when the focused folder disappears from the live project tree

## Why

Entered multi-folder projects rendered every repository/worktree lane at once and paginated each lane independently. That made the sidebar noisy and could hide chats behind several `Show more` controls. This keeps the project → folder → chat hierarchy explicit without discarding branch/worktree targeting or management behavior.

## Verification

- focused sidebar/session suite: 85 passed
  - folder picker, focus lifecycle, untruncated lists, worktree actions, branch switching, workspace grouping, and session targeting
- final focused component suite: 8 passed
- full Desktop Vitest run before rebase: 2,183 passed, 2 skipped
- post-rebase Desktop run reached 2,206 passed; six unrelated parallel-load failures all passed immediately in isolated reruns (16/16, 2/2, 4/4)
- `npm run typecheck`
- touched-file ESLint and Prettier checks
- `npm run test:desktop:all` (production build + unpacked app + DMG packaging gate)
- TUI: 1,205 passed, 4 skipped; web: 97 passed; JS config/packaging: 9 passed during the clean workspace check
- `git diff --check`

### Flake note

The clean workspace aggregate check encountered one unrelated Markdown property-fuzz timeout under full parallel load after 2,182 Desktop tests had passed. The same file passed immediately in isolation (6/6; property fuzz completed in 4.36s). No test touching this change failed.
