### PR TITLE
fix(honcho): enforce saveMessages write containment + reject gateway-internal turns

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -29,6 +29,28 @@ from tools.registry import tool_error
 logger = logging.getLogger(__name__)
 
 
+# Gateway-internal notifications can arrive through the same user-role channel
+# as genuine user messages. They are execution metadata, not conversation, and
+# must never become durable personal memory. Keep this deliberately anchored:
+# a human discussing one of these strings mid-message is still valid input.
+_INTERNAL_GATEWAY_TURN_RE = re.compile(
+    r"^\s*(?:"
+    r"\[ASYNC (?:BATCH|DELEGATION) COMPLETE\]|"
+    r"\[CONTEXT COMPACTION(?:\s*[—-]\s*REFERENCE ONLY)?\]|"
+    r"\[PRIOR CONTEXT(?:\s*[—-]\s*FOR REFERENCE ONLY)?\]|"
+    r"\[Your active task list was preserved across context compression\]|"
+    r"A background fan-out of \d+ subagent\(s\) you dispatched earlier has finished\.|"
+    r"A background (?:process|subagent|delegation) .* (?:has )?(?:finished|completed)\."
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _is_internal_gateway_turn(text: str) -> bool:
+    """Return True for machine-generated gateway/delegation notifications."""
+    return bool(_INTERNAL_GATEWAY_TURN_RE.match(text or ""))
+
+
 # ---------------------------------------------------------------------------
 # Tool schemas (moved from tools/honcho_tools.py)
 # ---------------------------------------------------------------------------
@@ -1333,6 +1355,14 @@ class HonchoMemoryProvider(MemoryProvider):
         """
         if self._cron_skipped:
             return
+        # ``saveMessages`` is the operator's hard write gate. Previously it
+        # was parsed into HonchoClientConfig but never enforced here, so a
+        # cached hybrid provider kept writing even after containment was set.
+        if self._config and not getattr(self._config, "save_messages", True):
+            return
+        if _is_internal_gateway_turn(user_content):
+            logger.debug("Honcho sync skipped machine-generated gateway turn")
+            return
         if self._recall_mode == "tools" and not self._session_ready():
             return
         if not self._session_ready():
@@ -1342,6 +1372,8 @@ class HonchoMemoryProvider(MemoryProvider):
         msg_limit = self._config.message_max_chars if self._config else 25000
         clean_user_content = sanitize_context(user_content or "").strip()
         clean_assistant_content = sanitize_context(assistant_content or "").strip()
+        if not clean_user_content or not clean_assistant_content:
+            return
 
         def _sync():
             try:

--- a/tests/test_honcho_startup_fail_open.py
+++ b/tests/test_honcho_startup_fail_open.py
@@ -391,6 +391,58 @@ def test_honcho_sync_turn_strips_memory_context_but_keeps_user_text():
     ]
 
 
+def test_honcho_sync_turn_saves_when_human_quotes_gateway_phrase():
+    """The gateway-turn filter is anchored (``re.match`` + leading ``^``): a
+    human *discussing* one of the wrapper phrases mid-message is genuine input
+    and must still be saved. Guards against over-blocking real conversation."""
+    provider, added = _ready_sync_provider()
+    human_turns = [
+        "Can you explain what '[ASYNC DELEGATION COMPLETE]' means in the logs?",
+        "Earlier the tool printed [CONTEXT COMPACTION — REFERENCE ONLY]; why?",
+        "Note: a background process that has finished should still page me.",
+    ]
+
+    for user_content in human_turns:
+        provider.sync_turn(user_content, "Sure — here is what that means.")
+    if provider._sync_thread is not None:
+        provider._sync_thread.join(timeout=1)
+
+    assert [role for role, _ in added] == ["user", "assistant"] * len(human_turns)
+    assert [content for role, content in added if role == "user"] == human_turns
+
+
+def test_honcho_sync_turn_drops_prior_context_and_background_process_wrappers():
+    """Cover the remaining anchored wrapper branches: PRIOR CONTEXT and the
+    background process/subagent/delegation completion sentence."""
+    provider, added = _ready_sync_provider()
+    internal_turns = [
+        "[PRIOR CONTEXT — FOR REFERENCE ONLY]\nolder transcript",
+        "A background process you started has finished.",
+        "A background delegation you dispatched earlier has completed.",
+    ]
+
+    for user_content in internal_turns:
+        provider.sync_turn(user_content, "technical status report")
+
+    assert provider._sync_thread is None
+    assert added == []
+
+
+def test_honcho_sync_turn_rejects_context_only_turn():
+    """A turn whose user content is only injected memory-context sanitizes to
+    empty and must not persist an empty user message (the empty-content gate)."""
+    provider, added = _ready_sync_provider()
+    context_only = (
+        "<memory-context>\n[System note: recalled context]\nold data\n"
+        "</memory-context>"
+    )
+
+    provider.sync_turn(context_only, "Acknowledged.")
+
+    assert provider._sync_thread is None
+    assert added == []
+
+
 def test_honcho_system_prompt_advertises_active_while_background_init_runs(monkeypatch):
     """Prompt metadata should not require a completed network session."""
     provider = HonchoMemoryProvider()

--- a/tests/test_honcho_startup_fail_open.py
+++ b/tests/test_honcho_startup_fail_open.py
@@ -6,6 +6,7 @@ import json
 import threading
 import time
 from types import SimpleNamespace
+from typing import Any, cast
 
 from plugins.memory.honcho import HonchoMemoryProvider
 
@@ -34,6 +35,7 @@ def _configured_hybrid_config() -> _FakeHonchoConfig:
         reasoning_level_cap="high",
         context_tokens=None,
         message_max_chars=25000,
+        save_messages=True,
         session_strategy="per-directory",
     )
 
@@ -316,6 +318,77 @@ def test_honcho_sync_turn_waits_for_full_background_startup(monkeypatch):
             provider._prefetch_thread.join(timeout=1)
 
     assert provider._session_initialized is True
+
+
+def _ready_sync_provider(*, save_messages: bool = True):
+    added = []
+
+    class Session:
+        def add_message(self, role, content):
+            added.append((role, content))
+
+    class Manager:
+        def get_or_create(self, session_key):
+            return Session()
+
+        def _flush_session(self, session):
+            pass
+
+    provider = HonchoMemoryProvider()
+    cfg = _configured_hybrid_config()
+    cfg.save_messages = save_messages
+    unsafe_provider = cast(Any, provider)
+    unsafe_provider._config = cfg
+    unsafe_provider._manager = Manager()
+    provider._session_key = "test-session"
+    provider._session_initialized = True
+    return provider, added
+
+
+def test_honcho_sync_turn_honors_save_messages_false():
+    provider, added = _ready_sync_provider(save_messages=False)
+
+    provider.sync_turn("remember me", "acknowledged")
+
+    assert provider._sync_thread is None
+    assert added == []
+
+
+def test_honcho_sync_turn_drops_internal_gateway_notifications():
+    provider, added = _ready_sync_provider()
+    internal_turns = [
+        "[ASYNC BATCH COMPLETE]\nreview output",
+        "[CONTEXT COMPACTION — REFERENCE ONLY]\nsummary",
+        "[Your active task list was preserved across context compression]\n- task",
+        (
+            "A background fan-out of 1 subagent(s) you dispatched earlier has "
+            "finished. All ran in parallel."
+        ),
+    ]
+
+    for user_content in internal_turns:
+        provider.sync_turn(user_content, "technical status report")
+
+    assert provider._sync_thread is None
+    assert added == []
+
+
+def test_honcho_sync_turn_strips_memory_context_but_keeps_user_text():
+    provider, added = _ready_sync_provider()
+    user_content = (
+        "What should I remember?\n\n"
+        "<memory-context>\n[System note: recalled context]\nold data\n"
+        "</memory-context>"
+    )
+
+    provider.sync_turn(user_content, "Remember the explicit preference only.")
+    assert provider._sync_thread is not None
+    provider._sync_thread.join(timeout=1)
+
+    assert added == [
+        ("user", "What should I remember?"),
+        ("assistant", "Remember the explicit preference only."),
+    ]
 
 
 def test_honcho_system_prompt_advertises_active_while_background_init_runs(monkeypatch):


### PR DESCRIPTION
## What

`saveMessages: false` was parsed into `HonchoClientConfig` but never enforced at the
final write method (`HonchoMemoryProvider.sync_turn`). Once a tools-only Honcho session
was initialized, `sync_turn` still persisted every user/assistant turn and enqueued
representation work — so the operator's write-containment setting was silently bypassed
for any already-initialized provider.

This change enforces containment at that final write method:

1. **`saveMessages=false` hard gate** — if the resolved config disables message writes,
   `sync_turn` returns before creating a session or adding any message.
2. **Anchored gateway-internal turn rejection** — whole-turn machine notifications that
   arrive on the user-role channel (async delegation/batch completion, context
   compaction, prior-context, task-restoration, background-process/subagent completion)
   are dropped instead of persisted as personal memory.
3. **Empty / context-only turn rejection** — a turn whose user content sanitizes to
   empty (e.g. only an injected `<memory-context>` block) no longer persists an empty
   message.

## Why anchored

The gateway-turn filter uses `re.match` against a leading (`^`) pattern, not a substring
search — so a human *quoting or discussing* one of those phrases mid-message is still
saved normally. The gate defaults open when the attribute is absent
(`getattr(cfg, "save_messages", True)`) and closes only when explicitly `False`.

## Tests

`tests/test_honcho_startup_fail_open.py` covers: the already-initialized-provider bypass
under `save_messages=False` (no write thread, no messages), each gateway-wrapper class,
memory-context stripping that keeps real user text, the anchored false-positive guard,
the `PRIOR CONTEXT` + background-process variants, and context-only rejection. 17 in-file
tests plus the broader Honcho footprint (565 tests) pass.

## Relation to #62510

The same containment commit is bundled in #62510 alongside unrelated proxy work. This PR
is the focused, independently-reviewable extraction of just the containment change (with
expanded tests) rebased onto current `main`.
