### PR TITLE
fix(credentials): scrub the keyed `providers` schema on rotate/remove

### DIFF
--- a/hermes_cli/credential_lifecycle.py
+++ b/hermes_cli/credential_lifecycle.py
@@ -141,11 +141,18 @@ def _scrub_config_yaml_mirrors(old_value: str, new_value: str | None) -> List[st
 
     touched: List[str] = []
 
-    def _fix(section: Any, key_path: str) -> None:
+    def _fix(
+        section: Any,
+        key_path: str,
+        fields: tuple[str, ...] = ("api_key", "api"),
+    ) -> None:
         if not isinstance(section, dict):
             return
         # "api" is the legacy alias for model.api_key kept by older configs.
-        for field in ("api_key", "api"):
+        # NOTE: in the keyed ``providers`` schema ``api`` means the base_url,
+        # not a credential (see ``get_compatible_custom_providers``), so that
+        # section passes ``fields=("api_key",)`` to avoid touching a base_url.
+        for field in fields:
             current = section.get(field)
             if isinstance(current, str) and current == old_value:
                 if new_value:
@@ -168,6 +175,18 @@ def _scrub_config_yaml_mirrors(old_value: str, new_value: str | None) -> List[st
     elif isinstance(custom, dict):
         for name, entry in custom.items():
             _fix(entry, f"custom_providers.{name}")
+
+    # The keyed ``providers`` schema (v12+) is where the dashboard/desktop
+    # write custom-endpoint credentials — ``providers.<id>.api_key``. It is a
+    # real inline secret and higher-precedence than the env var, so a stale
+    # copy left here shadows a rotation (persistent 401 with a key the UI no
+    # longer shows, #62269) and survives a removal that promised to clear the
+    # credential from EVERY store. Scrub only ``api_key``; ``api`` here is the
+    # base_url alias, not a credential.
+    keyed_providers = user_config.get("providers")
+    if isinstance(keyed_providers, dict):
+        for provider_id, entry in keyed_providers.items():
+            _fix(entry, f"providers.{provider_id}", fields=("api_key",))
 
     if touched:
         require_readable_config_before_write(config_path)

--- a/tests/hermes_cli/test_credential_lifecycle.py
+++ b/tests/hermes_cli/test_credential_lifecycle.py
@@ -302,6 +302,80 @@ def test_delete_scrubs_config_yaml_mirror(hermes_home):
 
 
 # ---------------------------------------------------------------------------
+# Keyed `providers` schema (v12+) — where the dashboard writes custom
+# endpoints. Its inline api_key is a real credential and higher-precedence
+# than the env var, so a stale copy left here shadows a rotation (#62269) and
+# survives a "remove from EVERY store" delete.
+# ---------------------------------------------------------------------------
+
+
+def test_update_rotates_keyed_providers_mirror(hermes_home):
+    old = "sk-kp-" + "n" * 24
+    new = "sk-kp-" + "o" * 24
+    _write_env(hermes_home, OPENAI_API_KEY=old)
+    _write_config(
+        hermes_home,
+        "providers:\n"
+        "  myendpoint:\n"
+        "    base_url: https://llm.example.test/v1\n"
+        f"    api_key: {old}\n",
+    )
+
+    resp = client.put(
+        "/api/env", json={"key": "OPENAI_API_KEY", "value": new}, headers=HEADERS
+    )
+    assert resp.status_code == 200
+    assert "providers.myendpoint.api_key" in resp.json().get("config_updates", [])
+
+    cfg_text = hermes_home.joinpath("config.yaml").read_text(encoding="utf-8")
+    assert old not in cfg_text, "stale key in providers.<id> shadows the rotation (#62269)"
+    assert new in cfg_text, "keyed providers mirror not rotated to the new key"
+
+
+def test_delete_scrubs_keyed_providers_mirror(hermes_home):
+    old = "sk-kp-" + "p" * 24
+    _write_env(hermes_home, OPENAI_API_KEY=old)
+    _write_config(
+        hermes_home,
+        "providers:\n"
+        "  myendpoint:\n"
+        "    base_url: https://llm.example.test/v1\n"
+        f"    api_key: {old}\n",
+    )
+
+    resp = client.request(
+        "DELETE", "/api/env", json={"key": "OPENAI_API_KEY"}, headers=HEADERS
+    )
+    assert resp.status_code == 200
+    assert "providers.myendpoint.api_key" in resp.json()["config_scrubbed"]
+    cfg_text = hermes_home.joinpath("config.yaml").read_text(encoding="utf-8")
+    assert old not in cfg_text, "delete must clear the credential from EVERY store"
+
+
+def test_scrub_never_touches_providers_base_url_alias(hermes_home):
+    """In the keyed ``providers`` schema ``api`` is the base_url alias, NOT a
+    credential. Even if the .env value coincided with a base_url, the scrub
+    must not rewrite a provider's endpoint URL."""
+    old = "https://llm.example.test/v1"  # a URL that also happens to be the key value
+    _write_env(hermes_home, OPENAI_API_KEY=old)
+    _write_config(
+        hermes_home,
+        "providers:\n"
+        "  myendpoint:\n"
+        f"    api: {old}\n"          # base_url alias — must be preserved
+        "    model: my-model\n",
+    )
+
+    resp = client.request(
+        "DELETE", "/api/env", json={"key": "OPENAI_API_KEY"}, headers=HEADERS
+    )
+    assert resp.status_code == 200
+    cfg_text = hermes_home.joinpath("config.yaml").read_text(encoding="utf-8")
+    assert old in cfg_text, "providers.<id>.api is a base_url and must survive"
+    assert "providers.myendpoint.api" not in resp.json().get("config_scrubbed", [])
+
+
+# ---------------------------------------------------------------------------
 # Suppression round-trip: delete sticks, re-add lifts it
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

`_scrub_config_yaml_mirrors` reconciles the config.yaml copies of a credential
when it's rotated or removed via the dashboard. It walks `model`,
`auxiliary.<task>`, and `custom_providers.<name>` — but **not** the keyed
`providers` schema.

`providers` is not niche: `get_compatible_custom_providers` documents it as
*"the newer keyed schema"* (v12+), and it's exactly where the dashboard/desktop
write a custom endpoint's inline key — `_write_custom_endpoint` sets
`providers.<id>.api_key`. That value is a live credential: the runtime resolver
reads it (`runtime_provider` / `hermes_cli.main` / `model_switch` all read
`entry.get("api_key")` off a `providers` entry), and an inline key outranks the
env var.

So the one section the scrub skips is the one the dashboard writes to, and both
callers break on it:

- **rotation** (`save_provider_env_credential`, #62269): a stale
  `providers.<id>.api_key` is left at the OLD value and, being higher-precedence
  than the freshly-rotated env var, *shadows the rotation* — the "persistent 401
  with a key the UI no longer shows" that #62269 fixed, reintroduced for the
  newer schema.
- **removal** (`remove_provider_env_credential`): its contract is to *"remove a
  credential from EVERY store it lives in"*, yet the `providers` copy survives —
  the secret stays in config.yaml after the user asked to delete it.

## Fix

Walk `providers.<id>` too. The scrub stays value-matched (an unrelated
endpoint's key is untouched). **Only `api_key` is scrubbed here**: in the keyed
`providers` schema `api` is the *base_url* alias, not a credential (unlike
model/auxiliary/custom_providers — see `config.py` `{"api": base_url}`), so
`_fix` takes an explicit field list and this section passes `("api_key",)`. A
provider's endpoint URL is never rewritten even if it equalled the credential
string.

## Tests

`tests/hermes_cli/test_credential_lifecycle.py` drives the real `PUT`/`DELETE
/api/env` endpoints against a `providers.<id>.api_key` mirror: rotation moves it
to the new key, delete clears it, and a `providers.<id>.api` base_url alias is
preserved. The two scrub tests **fail on main** (stale key survives); the
base_url guard **passes on main** as a control. 15 pass here; 345 pass across
the credential-lifecycle + web-server suites (the one failing honcho-merge test
fails identically on clean `main`).