### PR TITLE
fix(agent): protect vars() call against RuntimeError in response debug logging

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1622,7 +1622,10 @@ def run_conversation(
                     # Check for x-openrouter-provider or similar metadata
                     if provider_name == "Unknown" and response:
                         # Log all response attributes for debugging
-                        resp_attrs = {k: str(v)[:100] for k, v in vars(response).items() if not k.startswith('_')}
+                        try:
+                            resp_attrs = {k: str(v)[:100] for k, v in vars(response).items() if not k.startswith('_')}
+                        except (TypeError, RuntimeError):
+                            resp_attrs = {"_error": f"cannot inspect response of type {type(response).__name__}"}
                         if agent.verbose_logging:
                             logging.debug(f"Response attributes for invalid response: {resp_attrs}")
                     


### PR DESCRIPTION
## Problem

The `vars(response)` call in `conversation_loop.py` line 1625 crashes when response objects don't have `__dict__`. This causes **all cron jobs** to fail with:

```
RuntimeError: vars() argument must have __dict__ attribute
```

This bug has been recurring for days across multiple cron jobs (健康检查, ProbeDB日报, etc.).

## Root Cause

When a model provider returns an error response that lacks `__dict__`, the debug logging code tries `vars(response)` which throws `RuntimeError`. This is inside the error-handling path itself, so it crashes the entire conversation loop.

## Fix

Wrap `vars(response)` in `try/except(TypeError, RuntimeError)`, same pattern used elsewhere in the codebase. On failure, return a fallback dict with the type name.

## Why This Keeps Breaking

My previous local fixes kept getting overwritten by `git pull` syncing with upstream. This PR makes the fix permanent.