### PR TITLE
fix(desktop): dedupe aliased profile databases

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4312,6 +4312,36 @@ def get_sessions(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+def _unique_profile_db_targets(
+    targets: List[Tuple[str, Path]],
+) -> List[Tuple[str, Path]]:
+    """Keep the first profile for each physical ``state.db``.
+
+    Profile directories can alias one another (most commonly via symlinks).
+    Scanning those entries independently duplicates every session and inflates
+    aggregate totals.  File identity also catches hard-link aliases while the
+    first target preserves ``list_profiles()`` ownership ordering (default
+    first).  Identity-check failures are left for the endpoint's existing
+    error path.
+    """
+    unique: List[Tuple[str, Path]] = []
+    seen: List[Path] = []
+    for name, home in targets:
+        db_path = Path(home) / "state.db"
+        if not db_path.exists():
+            continue
+        try:
+            duplicate = any(db_path.samefile(existing) for existing in seen)
+        except OSError:
+            unique.append((name, home))
+            continue
+        if duplicate:
+            continue
+        seen.append(db_path)
+        unique.append((name, home))
+    return unique
+
+
 @app.get("/api/profiles/sessions")
 def get_profiles_sessions(
     limit: int = 20,
@@ -4357,6 +4387,7 @@ def get_profiles_sessions(
             targets = []
         if not targets:
             targets.append(("default", profiles_mod.get_profile_dir("default")))
+    targets = _unique_profile_db_targets(targets)
 
     min_message_count = max(0, min_messages)
     archived_only = archived == "only"
@@ -4478,6 +4509,7 @@ def get_profiles_sessions_sidebar(
         targets = []
     if not targets:
         targets.append(("default", profiles_mod.get_profile_dir("default")))
+    targets = _unique_profile_db_targets(targets)
 
     recents_scope = (recents_profile or "all").strip() or "all"
     recents_exclude_list = [s for s in (recents_exclude or "").split(",") if s.strip()]

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1820,6 +1820,90 @@ class TestWebServerEndpoints:
         assert row["is_default_profile"] is True
         assert isinstance(data.get("errors"), list)
 
+    def test_profiles_sessions_dedupes_symlinked_profile_database(
+        self, tmp_path, monkeypatch
+    ):
+        """A profile alias for the same state.db must not duplicate rows/counts."""
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+        from hermes_cli import profiles as profiles_mod
+
+        default_home = get_hermes_home()
+        db = SessionDB()
+        try:
+            db.create_session(session_id="physical-db-once", source="desktop")
+            db.append_message("physical-db-once", role="user", content="hi")
+        finally:
+            db.close()
+
+        alias_home = tmp_path / "alias"
+        alias_home.mkdir()
+        try:
+            (alias_home / "state.db").symlink_to(default_home / "state.db")
+        except OSError as exc:
+            pytest.skip(f"symlink creation unavailable: {exc}")
+
+        monkeypatch.setattr(
+            profiles_mod,
+            "list_profiles",
+            lambda: [
+                SimpleNamespace(name="default", path=default_home),
+                SimpleNamespace(name="alias", path=alias_home),
+            ],
+        )
+
+        listed = self.client.get("/api/profiles/sessions?limit=20&min_messages=0").json()
+        rows = [s for s in listed["sessions"] if s["id"] == "physical-db-once"]
+        assert len(rows) == 1
+        assert rows[0]["profile"] == "default"
+        assert listed["total"] == 1
+        assert listed["profile_totals"] == {"default": 1}
+
+        sidebar = self.client.get(
+            "/api/profiles/sessions/sidebar"
+            "?recents_profile=all&recents_exclude=cron"
+        ).json()
+        rows = [
+            s
+            for s in sidebar["recents"]["sessions"]
+            if s["id"] == "physical-db-once"
+        ]
+        assert len(rows) == 1
+        assert rows[0]["profile"] == "default"
+        assert sidebar["recents"]["total"] == 1
+        assert sidebar["recents"]["profile_totals"] == {"default": 1}
+
+    def test_profiles_sessions_keeps_distinct_profile_databases(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_state import SessionDB
+        from hermes_cli import profiles as profiles_mod
+
+        homes = [tmp_path / "alpha", tmp_path / "beta"]
+        for name, home in zip(("alpha", "beta"), homes):
+            home.mkdir()
+            db = SessionDB(db_path=home / "state.db")
+            try:
+                db.create_session(session_id=f"{name}-session", source="desktop")
+                db.append_message(f"{name}-session", role="user", content="hi")
+            finally:
+                db.close()
+
+        monkeypatch.setattr(
+            profiles_mod,
+            "list_profiles",
+            lambda: [
+                SimpleNamespace(name="alpha", path=homes[0]),
+                SimpleNamespace(name="beta", path=homes[1]),
+            ],
+        )
+
+        data = self.client.get("/api/profiles/sessions?limit=20&min_messages=0").json()
+        rows = {s["id"]: s["profile"] for s in data["sessions"]}
+        assert rows == {"alpha-session": "alpha", "beta-session": "beta"}
+        assert data["total"] == 2
+        assert data["profile_totals"] == {"alpha": 1, "beta": 1}
+
     def test_profiles_sessions_rejects_unknown_archived_value(self):
         resp = self.client.get("/api/profiles/sessions?archived=bogus")
         assert resp.status_code == 400


### PR DESCRIPTION
## Summary\n- Deduplicate profile targets by physical state.db before aggregating /api/profiles/sessions and /api/profiles/sessions/sidebar\n- Preserve first-seen ownership tagging and keep distinct profile databases untouched\n- Add regressions for aliased and distinct profile databases\n\n## Verification\n- python3.11 -m pytest tests/hermes_cli/test_web_server.py -k 'profiles_sessions_dedupes or profiles_sessions_keeps_distinct_profile_databases' -q\n- python3.11 -m pytest tests/hermes_cli/test_web_server.py -q\n- python3.11 -m compileall hermes_cli/web_server.py tests/hermes_cli/test_web_server.py\n- git diff --check\n\nCloses #68299