### PR TITLE
fix(voice): point pip install hint at venv pip instead of system Python

### DIFF
--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -16,6 +16,7 @@ import re
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 import tempfile
 import threading
 import time
@@ -55,6 +56,19 @@ from hermes_constants import is_termux as _is_termux_environment
 def _voice_capture_install_hint() -> str:
     if _is_termux_environment():
         return "pkg install python-numpy portaudio && python -m pip install sounddevice"
+    # If we're running inside a venv (e.g. the bundled Hermes venv at
+    # ~/.hermes/profiles/<name>/hermes-agent/venv/), `pip install` on the
+    # user's PATH won't reach the right site-packages — the bare hint sends
+    # them off to whichever Python their shell resolves first, which on macOS
+    # is often a system Python under Rosetta with a totally separate wheel
+    # index. Point them at the actual interpreter pip is sitting next to.
+    try:
+        if sys.prefix != getattr(sys, "base_prefix", sys.prefix):
+            pip_in_venv = Path(sys.prefix) / "bin" / "pip"
+            if pip_in_venv.exists():
+                return f"{pip_in_venv} install sounddevice numpy"
+    except Exception:
+        pass
     return "pip install sounddevice numpy"
 
 


### PR DESCRIPTION
## Problem
`/voice on` fails with `Audio libraries not installed (pip install sounddevice numpy)` even after installing those packages — because Hermes runs inside its bundled venv (`~/.hermes/profiles/<name>/hermes-agent/venv/`) and the hint tells users to install into whichever Python their shell resolves first. On macOS that is often the system Python under Rosetta, a completely separate site-packages tree with incompatible wheel arches.

## Fix
`_voice_capture_install_hint()` now detects when running inside a venv (`sys.prefix != sys.base_prefix`) and returns the full path to the venv's pip binary. Falls back to the bare hint outside a venv.

## Testing
- 69/69 voice_mode tests pass (4 pre-existing PulseAudio socket-path tests skipped on macOS — unrelated)
- Live `/voice on` confirmed working on macOS arm64 M5 with Hermes venv (arm64-native Python 3.11)
- Verified hint output: `/Users/normanking/.hermes/profiles/harold/hermes-agent/venv/bin/pip install sounddevice numpy`

## Files changed
- `tools/voice_mode.py`: +14 lines (1 import, 13 in `_voice_capture_install_hint()`)