### PR TITLE
fix(packaging): ship bundled skills in wheel by unifying data-files in setup.py (#66733)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -312,29 +312,6 @@ hermes-acp = "acp_adapter.entry:main"
 [tool.setuptools]
 py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils", "mcp_serve"]
 
-[tool.setuptools.data-files]
-# i18n catalogs. locales/ is a bare data directory (no __init__.py), so it is
-# neither a package (packages.find) nor package-data (which attaches to a
-# package). data-files ships it in the wheel; MANIFEST.in `graft locales`
-# ships it in the sdist. Without this, sealed installs (pip wheel, Nix store
-# venv) drop the catalogs and gateway/CLI commands surface raw i18n keys like
-# `gateway.reset.header_default` (#27632, #35374, #23943).
-locales = ["locales/*.yaml"]
-# Shipped MCP catalog (optional-mcps/<name>/manifest.yaml). Same bare-data-dir
-# case as locales: data-files ships it in the wheel, `graft optional-mcps` in
-# MANIFEST.in ships it in the sdist. Without this, `hermes mcp catalog` and the
-# dashboard catalog screen come up empty on packaged installs even though the
-# manifests exist in the repo (hermes_cli/mcp_catalog.py:_catalog_root resolves
-# the packaged dir; list_catalog() returns [] when it's missing).
-#
-# data-files flattens every glob match into its single target dir, so each
-# catalog entry needs its OWN target to preserve the per-entry directory the
-# catalog iterates over (a shared `optional-mcps/*/*` glob would collapse all
-# manifests into one colliding optional-mcps/manifest.yaml). One target per
-# entry; tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>.
-"optional-mcps/linear" = ["optional-mcps/linear/manifest.yaml"]
-"optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
-
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]
 gateway = ["assets/**/*"]

--- a/setup.py
+++ b/setup.py
@@ -83,5 +83,7 @@ setup(
     data_files=[
         *_data_file_tree("skills"),
         *_data_file_tree("optional-skills"),
+        *_data_file_tree("locales"),
+        *_data_file_tree("optional-mcps"),
     ]
 )

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -249,12 +249,14 @@ def test_locale_catalogs_ship_in_both_wheel_and_sdist():
     declared as setuptools data-files (wheel) AND grafted in MANIFEST.in
     (sdist). Without both, sealed installs drop the catalogs and gateway/CLI
     commands surface raw i18n keys like `gateway.reset.header_default`.
+
+    All bare data directories (locales, optional-mcps, skills, optional-skills)
+    are declared via ``_data_file_tree()`` in setup.py's ``data_files`` list.
     """
-    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
-    data_files = data["tool"]["setuptools"].get("data-files", {})
-    assert data_files.get("locales") == ["locales/*.yaml"], (
-        "pyproject [tool.setuptools.data-files] must declare "
-        'locales = ["locales/*.yaml"] so the wheel ships i18n catalogs'
+    setup_py = (REPO_ROOT / "setup.py").read_text(encoding="utf-8")
+    assert '_data_file_tree("locales")' in setup_py, (
+        "setup.py data_files must include _data_file_tree('locales') "
+        "so the wheel ships i18n catalogs"
     )
 
     manifest = (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

`[tool.setuptools.data-files]` in `pyproject.toml` overrides `setup.py`'s `data_files` when both are present. Since the pyproject section only declared `locales` and `optional-mcps`, the `skills/` and `optional-skills/` directories were silently dropped from the wheel.

This means `pip install hermes-agent` ships zero bundled skills — `hermes_constants._get_packaged_data_dir("skills")` returns `None`, and `tools/skills_sync.py` has nothing to sync to `~/.hermes/skills/`.

## Fix

Move `locales` and `optional-mcps` into `setup.py`'s `data_files` (via the existing `_data_file_tree()` helper), then remove the `[tool.setuptools.data-files]` section entirely. `setup.py` is now the single source of truth for all four bare data directories:

- `skills/`
- `optional-skills/`
- `locales/`
- `optional-mcps/`

This preserves the same installation semantics — `_data_file_tree()` produces identical `(directory, [files])` tuples for all four trees — while eliminating the override that caused the regression.

## Verification

```
$ python3 -m pytest tests/test_packaging_metadata.py -x
11 passed
```

Updated `test_locale_catalogs_ship_in_both_wheel_and_sdist` to check `setup.py` instead of the removed `pyproject.toml` section.

Fixes #66733
