### PR TITLE
feat(auxiliary): add explicit quota-only fallback chains

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3902,7 +3902,7 @@ def _call_fallback_candidate_sync(
         logger.warning(
             "Auxiliary %s: fallback candidate %s has a stale/unrefreshable "
             "credential (%s) — skipping to next fallback",
-            task or "call", fb_label, fb_err,
+            task or "call", fb_label, type(fb_err).__name__,
         )
         return None
 
@@ -3965,7 +3965,7 @@ async def _call_fallback_candidate_async(
         logger.warning(
             "Auxiliary %s (async): fallback candidate %s has a stale/unrefreshable "
             "credential (%s) — skipping to next fallback",
-            task or "call", fb_label, fb_err,
+            task or "call", fb_label, type(fb_err).__name__,
         )
         return None
 
@@ -6411,6 +6411,186 @@ def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
     return task_config
 
 
+_EXPLICIT_QUOTA_MARKERS = frozenset({
+    "insufficient_quota",
+    "quota_exhausted",
+    "usage_limit_reached",
+})
+_MISSING_QUOTA_STATUS = object()
+
+
+def _capture_explicit_quota_fallback_chain(
+    task: str,
+) -> Optional[Tuple[Dict[str, Any], ...]]:
+    """Validate and materialize an opt-in, configured-only quota chain."""
+    task_config = _get_auxiliary_task_config(task)
+    if "fallback_on" not in task_config:
+        return None
+
+    fallback_on = task_config.get("fallback_on")
+    if not isinstance(fallback_on, (list, tuple)) or tuple(fallback_on) != (
+        "quota_exhausted",
+    ):
+        raise ValueError(
+            f"auxiliary.{task}.fallback_on must be exactly [quota_exhausted]"
+        )
+
+    chain = task_config.get("fallback_chain")
+    if not isinstance(chain, (list, tuple)) or not chain:
+        raise ValueError(
+            f"auxiliary.{task}.fallback_chain must be a non-empty list or tuple"
+        )
+    for index, entry in enumerate(chain):
+        if entry.__class__ is not dict:
+            raise ValueError(
+                f"auxiliary.{task}.fallback_chain[{index}] must be a plain mapping"
+            )
+        provider = entry.get("provider")
+        model = entry.get("model")
+        if not isinstance(provider, str) or not provider.strip():
+            raise ValueError(
+                f"auxiliary.{task}.fallback_chain[{index}].provider must be a non-empty string"
+            )
+        if not isinstance(model, str) or not model.strip():
+            raise ValueError(
+                f"auxiliary.{task}.fallback_chain[{index}].model must be a non-empty string"
+            )
+        if provider.strip().lower() in {"auto", "main"}:
+            raise ValueError(
+                f"auxiliary.{task}.fallback_chain[{index}].provider must be explicit"
+            )
+    return tuple(chain)
+
+
+def _is_explicit_aux_quota_error(exc: BaseException) -> bool:
+    """Match only exact structured quota markers on the primary exception."""
+    body = getattr(exc, "body", None)
+    if not isinstance(body, dict) or body.__class__ is not dict:
+        return False
+
+    status = getattr(exc, "status_code", _MISSING_QUOTA_STATUS)
+    if status is not _MISSING_QUOTA_STATUS:
+        if status.__class__ is not int or status not in {402, 429}:
+            return False
+
+    nested = body.get("error")
+    data_layers = [body]
+    if isinstance(nested, dict) and nested.__class__ is dict:
+        data_layers.append(nested)
+    for data in data_layers:
+        for field in ("code", "type", "reason"):
+            value = data.get(field)
+            if isinstance(value, str) and value.strip().lower() in _EXPLICIT_QUOTA_MARKERS:
+                return True
+    return False
+
+
+def _try_explicit_quota_fallback_sync(
+    task: str,
+    chain: Tuple[Dict[str, Any], ...],
+    *,
+    messages: list,
+    temperature: Optional[float],
+    max_tokens: Optional[int],
+    tools: Optional[list],
+    effective_timeout: float,
+    effective_extra_body: dict,
+    reasoning_config: Optional[dict],
+) -> Optional[Any]:
+    """Try each explicitly configured quota fallback index once."""
+    for index, entry in enumerate(chain):
+        provider = entry["provider"].strip()
+        model = entry["model"].strip()
+        try:
+            client, resolved_model = _resolve_fallback_entry(entry)
+        except Exception as exc:
+            logger.info(
+                "Auxiliary %s: quota fallback[%d] %s/%s resolve failed (%s)",
+                task, index, provider, model, type(exc).__name__,
+            )
+            continue
+        if client is None:
+            logger.info(
+                "Auxiliary %s: quota fallback[%d] %s/%s unavailable",
+                task, index, provider, model,
+            )
+            continue
+        label = f"fallback_chain[{index}]({provider})"
+        try:
+            response = _call_fallback_candidate_sync(
+                client, resolved_model or model, label,
+                task=task, messages=messages, temperature=temperature,
+                max_tokens=max_tokens, tools=tools,
+                effective_timeout=effective_timeout,
+                effective_extra_body=effective_extra_body,
+                reasoning_config=reasoning_config,
+            )
+        except Exception as exc:
+            logger.info(
+                "Auxiliary %s: quota fallback[%d] %s/%s failed (%s)",
+                task, index, provider, model, type(exc).__name__,
+            )
+            continue
+        if response is not None:
+            return response
+    return None
+
+
+async def _try_explicit_quota_fallback_async(
+    task: str,
+    chain: Tuple[Dict[str, Any], ...],
+    *,
+    messages: list,
+    temperature: Optional[float],
+    max_tokens: Optional[int],
+    tools: Optional[list],
+    effective_timeout: float,
+    effective_extra_body: dict,
+    reasoning_config: Optional[dict],
+) -> Optional[Any]:
+    """Async mirror of :func:`_try_explicit_quota_fallback_sync`."""
+    for index, entry in enumerate(chain):
+        provider = entry["provider"].strip()
+        model = entry["model"].strip()
+        try:
+            client, resolved_model = _resolve_fallback_entry(entry)
+            if client is not None:
+                client, resolved_model = _to_async_client(
+                    client, resolved_model or model, is_vision=(task == "vision")
+                )
+        except Exception as exc:
+            logger.info(
+                "Auxiliary %s (async): quota fallback[%d] %s/%s resolve failed (%s)",
+                task, index, provider, model, type(exc).__name__,
+            )
+            continue
+        if client is None:
+            logger.info(
+                "Auxiliary %s (async): quota fallback[%d] %s/%s unavailable",
+                task, index, provider, model,
+            )
+            continue
+        label = f"fallback_chain[{index}]({provider})"
+        try:
+            response = await _call_fallback_candidate_async(
+                client, resolved_model or model, label,
+                task=task, messages=messages, temperature=temperature,
+                max_tokens=max_tokens, tools=tools,
+                effective_timeout=effective_timeout,
+                effective_extra_body=effective_extra_body,
+                reasoning_config=reasoning_config,
+            )
+        except Exception as exc:
+            logger.info(
+                "Auxiliary %s (async): quota fallback[%d] %s/%s failed (%s)",
+                task, index, provider, model, type(exc).__name__,
+            )
+            continue
+        if response is not None:
+            return response
+    return None
+
+
 def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float:
     """Read timeout from auxiliary.{task}.timeout in config, falling back to *default*."""
     if not task:
@@ -6965,6 +7145,9 @@ def call_llm(
     # concurrent /model switch produce a key for one runtime and a client for
     # another.
     main_runtime = _normalize_main_runtime(main_runtime)
+    quota_fallback_chain = _capture_explicit_quota_fallback_chain(task)
+    if quota_fallback_chain is not None and stream:
+        raise ValueError("explicit quota fallback does not support stream=True")
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
     if api_mode:
@@ -6981,7 +7164,8 @@ def call_llm(
             async_mode=False,
             main_runtime=main_runtime,
         )
-        if client is None and resolved_provider != "auto" and not resolved_base_url:
+        if (client is None and resolved_provider != "auto" and not resolved_base_url
+                and quota_fallback_chain is None):
             logger.warning(
                 "Vision provider %s unavailable, falling back to auto vision backends",
                 resolved_provider,
@@ -7014,7 +7198,8 @@ def call_llm(
             # tasks because fallback entries may use OAuth / credential-pool
             # auth (for example openai-codex).
             _explicit = (resolved_provider or "").strip().lower()
-            if _explicit and _explicit not in {"auto", "openrouter", "custom"}:
+            if (quota_fallback_chain is None and _explicit
+                    and _explicit not in {"auto", "openrouter", "custom"}):
                 fb_client, fb_model, fb_label = _try_configured_fallback_for_unavailable_client(
                     task, _explicit,
                 )
@@ -7032,7 +7217,8 @@ def call_llm(
             # Pass model=None so each provider uses its own default —
             # resolved_model may be an OpenRouter-format slug that doesn't
             # work on other providers.
-            if client is None and not resolved_base_url:
+            if (quota_fallback_chain is None and client is None
+                    and not resolved_base_url):
                 logger.info("Auxiliary %s: provider %s unavailable, trying auto-detection chain",
                             task or "call", resolved_provider)
                 client, final_model = _get_cached_client("auto", main_runtime=main_runtime, task=task)
@@ -7064,6 +7250,21 @@ def call_llm(
     _client_base = str(getattr(client, "base_url", "") or "")
     if _is_anthropic_compat_endpoint(resolved_provider, _client_base):
         kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
+
+    def _finish_explicit_quota_retry(retry_err: BaseException) -> Any:
+        if quota_fallback_chain is None:
+            raise retry_err
+        quota_response = _try_explicit_quota_fallback_sync(
+            task, quota_fallback_chain,
+            messages=messages, temperature=temperature,
+            max_tokens=max_tokens, tools=tools,
+            effective_timeout=effective_timeout,
+            effective_extra_body=effective_extra_body,
+            reasoning_config=reasoning_config,
+        )
+        if quota_response is not None:
+            return quota_response
+        raise retry_err
 
     # Streaming path: return the raw SDK Stream iterator directly. This is used by
     # the MoA aggregator so its tokens stream to the user. It deliberately skips
@@ -7152,6 +7353,9 @@ def call_llm(
                 return _validate_llm_response(
                     client.chat.completions.create(**retry_kwargs), task)
             except Exception as retry_err:
+                if (quota_fallback_chain is not None
+                        and _is_explicit_aux_quota_error(retry_err)):
+                    return _finish_explicit_quota_retry(retry_err)
                 retry_err_str = str(retry_err)
                 # If retry still fails, fall through to the max_tokens /
                 # payment / auth chains below using the temperature-stripped
@@ -7190,6 +7394,9 @@ def call_llm(
                 return _validate_llm_response(
                     client.chat.completions.create(**kwargs), task)
             except Exception as retry_err:
+                if (quota_fallback_chain is not None
+                        and _is_explicit_aux_quota_error(retry_err)):
+                    return _finish_explicit_quota_retry(retry_err)
                 # If the max_tokens retry also hits a payment or connection
                 # error, fall through to the fallback chain below.
                 if not (_is_payment_error(retry_err) or _is_connection_error(retry_err) or _is_rate_limit_error(retry_err)):
@@ -7220,6 +7427,9 @@ def call_llm(
                     return _validate_llm_response(
                         client.chat.completions.create(**kwargs), task)
                 except Exception as retry_err:
+                    if (quota_fallback_chain is not None
+                            and _is_explicit_aux_quota_error(retry_err)):
+                        return _finish_explicit_quota_retry(retry_err)
                     first_err = retry_err
 
         # ── Nous auth refresh parity with main agent ──────────────────
@@ -7253,6 +7463,9 @@ def call_llm(
                     return _validate_llm_response(
                         refreshed_client.chat.completions.create(**kwargs), task)
                 except Exception as retry_err:
+                    if (quota_fallback_chain is not None
+                            and _is_explicit_aux_quota_error(retry_err)):
+                        return _finish_explicit_quota_retry(retry_err)
                     if not (
                         _is_auth_error(retry_err)
                         or _is_payment_error(retry_err)
@@ -7278,8 +7491,14 @@ def call_llm(
                             task or "call")
                 if refreshed_model and refreshed_model != kwargs.get("model"):
                     kwargs["model"] = refreshed_model
-                return _validate_llm_response(
-                    refreshed_client.chat.completions.create(**kwargs), task)
+                try:
+                    return _validate_llm_response(
+                        refreshed_client.chat.completions.create(**kwargs), task)
+                except Exception as retry_err:
+                    if (quota_fallback_chain is not None
+                            and _is_explicit_aux_quota_error(retry_err)):
+                        return _finish_explicit_quota_retry(retry_err)
+                    raise
 
         # ── Auth refresh retry ───────────────────────────────────────
         auth_refresh_provider = _auth_refresh_provider_for_route(
@@ -7296,23 +7515,29 @@ def call_llm(
                     "Auxiliary %s: refreshed %s credentials after auth error, retrying",
                     task or "call", auth_refresh_provider,
                 )
-                return _retry_same_provider_sync(
-                    task=task,
-                    resolved_provider=auth_refresh_provider,
-                    resolved_model=resolved_model or final_model,
-                    resolved_base_url=resolved_base_url,
-                    resolved_api_key=resolved_api_key,
-                    resolved_api_mode=resolved_api_mode,
-                    main_runtime=main_runtime,
-                    final_model=final_model,
-                    messages=messages,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    tools=tools,
-                    effective_timeout=effective_timeout,
-                    effective_extra_body=effective_extra_body,
-                    reasoning_config=reasoning_config,
-                )
+                try:
+                    return _retry_same_provider_sync(
+                        task=task,
+                        resolved_provider=auth_refresh_provider,
+                        resolved_model=resolved_model or final_model,
+                        resolved_base_url=resolved_base_url,
+                        resolved_api_key=resolved_api_key,
+                        resolved_api_mode=resolved_api_mode,
+                        main_runtime=main_runtime,
+                        final_model=final_model,
+                        messages=messages,
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                        tools=tools,
+                        effective_timeout=effective_timeout,
+                        effective_extra_body=effective_extra_body,
+                        reasoning_config=reasoning_config,
+                    )
+                except Exception as retry_err:
+                    if (quota_fallback_chain is not None
+                            and _is_explicit_aux_quota_error(retry_err)):
+                        return _finish_explicit_quota_retry(retry_err)
+                    raise
 
         # ── Same-provider credential-pool recovery ─────────────────────
         pool_provider = _recoverable_pool_provider(resolved_provider, client, main_runtime=main_runtime)
@@ -7330,6 +7555,9 @@ def call_llm(
                     return _validate_llm_response(
                         client.chat.completions.create(**kwargs), task)
                 except Exception as retry_err:
+                    if (quota_fallback_chain is not None
+                            and _is_explicit_aux_quota_error(retry_err)):
+                        return _finish_explicit_quota_retry(retry_err)
                     if not (_is_auth_error(retry_err) or _is_payment_error(retry_err) or _is_rate_limit_error(retry_err)):
                         raise
                     recovery_err = retry_err
@@ -7357,6 +7585,9 @@ def call_llm(
                         reasoning_config=reasoning_config,
                     )
                 except Exception as retry2_err:
+                    if (quota_fallback_chain is not None
+                            and _is_explicit_aux_quota_error(retry2_err)):
+                        return _finish_explicit_quota_retry(retry2_err)
                     # The rotated key also hit a quota/auth wall.  Mark it
                     # immediately so concurrent processes don't make a
                     # redundant API call to discover it's exhausted too.
@@ -7394,6 +7625,20 @@ def call_llm(
         # auxiliary task on the floor (silent compression failure /
         # message loss). Auth is NOT a capacity error: it only bypasses
         # the explicit-provider gate when the user is in auto mode.
+        if quota_fallback_chain is not None:
+            if _is_explicit_aux_quota_error(first_err):
+                quota_response = _try_explicit_quota_fallback_sync(
+                    task, quota_fallback_chain,
+                    messages=messages, temperature=temperature,
+                    max_tokens=max_tokens, tools=tools,
+                    effective_timeout=effective_timeout,
+                    effective_extra_body=effective_extra_body,
+                    reasoning_config=reasoning_config,
+                )
+                if quota_response is not None:
+                    return quota_response
+            raise
+
         should_fallback = (
             _is_auth_error(first_err)
             or _is_payment_error(first_err)
@@ -7596,6 +7841,7 @@ async def async_call_llm(
     # Keep every async phase on the same runtime identity, even if another
     # session switches models while this task is awaiting network I/O.
     main_runtime = _normalize_main_runtime(main_runtime)
+    quota_fallback_chain = _capture_explicit_quota_fallback_chain(task)
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
     effective_extra_body = _get_task_extra_body(task)
@@ -7610,7 +7856,8 @@ async def async_call_llm(
             async_mode=True,
             main_runtime=main_runtime,
         )
-        if client is None and resolved_provider != "auto" and not resolved_base_url:
+        if (client is None and resolved_provider != "auto" and not resolved_base_url
+                and quota_fallback_chain is None):
             logger.warning(
                 "Vision provider %s unavailable, falling back to auto vision backends",
                 resolved_provider,
@@ -7639,7 +7886,8 @@ async def async_call_llm(
         )
         if client is None:
             _explicit = (resolved_provider or "").strip().lower()
-            if _explicit and _explicit not in {"auto", "openrouter", "custom"}:
+            if (quota_fallback_chain is None and _explicit
+                    and _explicit not in {"auto", "openrouter", "custom"}):
                 fb_client, fb_model, fb_label = _try_configured_fallback_for_unavailable_client(
                     task, _explicit,
                 )
@@ -7654,7 +7902,8 @@ async def async_call_llm(
                         f"was found. Set the {_explicit.upper()}_API_KEY environment "
                         f"variable, or switch to a different provider with `hermes model`."
                     )
-            if client is None and not resolved_base_url:
+            if (quota_fallback_chain is None and client is None
+                    and not resolved_base_url):
                 logger.info("Auxiliary %s: provider %s unavailable, trying auto-detection chain",
                             task or "call", resolved_provider)
                 client, final_model = _get_cached_client("auto", async_mode=True, main_runtime=main_runtime, task=task)
@@ -7679,6 +7928,21 @@ async def async_call_llm(
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
     if _is_anthropic_compat_endpoint(resolved_provider, _client_base):
         kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
+
+    async def _finish_explicit_quota_retry(retry_err: BaseException) -> Any:
+        if quota_fallback_chain is None:
+            raise retry_err
+        quota_response = await _try_explicit_quota_fallback_async(
+            task, quota_fallback_chain,
+            messages=messages, temperature=temperature,
+            max_tokens=max_tokens, tools=tools,
+            effective_timeout=effective_timeout,
+            effective_extra_body=effective_extra_body,
+            reasoning_config=reasoning_config,
+        )
+        if quota_response is not None:
+            return quota_response
+        raise retry_err
 
     try:
         # Retry ONCE on the same provider for a transient transport blip
@@ -7720,6 +7984,9 @@ async def async_call_llm(
                 return _validate_llm_response(
                     await client.chat.completions.create(**retry_kwargs), task)
             except Exception as retry_err:
+                if (quota_fallback_chain is not None
+                        and _is_explicit_aux_quota_error(retry_err)):
+                    return await _finish_explicit_quota_retry(retry_err)
                 retry_err_str = str(retry_err)
                 if not (
                     _is_payment_error(retry_err)
@@ -7754,6 +8021,9 @@ async def async_call_llm(
                 return _validate_llm_response(
                     await client.chat.completions.create(**kwargs), task)
             except Exception as retry_err:
+                if (quota_fallback_chain is not None
+                        and _is_explicit_aux_quota_error(retry_err)):
+                    return await _finish_explicit_quota_retry(retry_err)
                 # If the max_tokens retry also hits a payment or connection
                 # error, fall through to the fallback chain below.
                 if not (_is_payment_error(retry_err) or _is_connection_error(retry_err) or _is_rate_limit_error(retry_err)):
@@ -7783,6 +8053,9 @@ async def async_call_llm(
                     return _validate_llm_response(
                         await client.chat.completions.create(**kwargs), task)
                 except Exception as retry_err:
+                    if (quota_fallback_chain is not None
+                            and _is_explicit_aux_quota_error(retry_err)):
+                        return await _finish_explicit_quota_retry(retry_err)
                     first_err = retry_err
 
         # ── Nous auth refresh parity with main agent ──────────────────
@@ -7815,6 +8088,9 @@ async def async_call_llm(
                     return _validate_llm_response(
                         await refreshed_client.chat.completions.create(**kwargs), task)
                 except Exception as retry_err:
+                    if (quota_fallback_chain is not None
+                            and _is_explicit_aux_quota_error(retry_err)):
+                        return await _finish_explicit_quota_retry(retry_err)
                     if not (
                         _is_auth_error(retry_err)
                         or _is_payment_error(retry_err)
@@ -7839,8 +8115,14 @@ async def async_call_llm(
                             task or "call")
                 if refreshed_model and refreshed_model != kwargs.get("model"):
                     kwargs["model"] = refreshed_model
-                return _validate_llm_response(
-                    await refreshed_client.chat.completions.create(**kwargs), task)
+                try:
+                    return _validate_llm_response(
+                        await refreshed_client.chat.completions.create(**kwargs), task)
+                except Exception as retry_err:
+                    if (quota_fallback_chain is not None
+                            and _is_explicit_aux_quota_error(retry_err)):
+                        return await _finish_explicit_quota_retry(retry_err)
+                    raise
 
         # ── Auth refresh retry (mirrors sync call_llm) ───────────────
         auth_refresh_provider = _auth_refresh_provider_for_route(
@@ -7857,22 +8139,28 @@ async def async_call_llm(
                     "Auxiliary %s (async): refreshed %s credentials after auth error, retrying",
                     task or "call", auth_refresh_provider,
                 )
-                return await _retry_same_provider_async(
-                    task=task,
-                    resolved_provider=auth_refresh_provider,
-                    resolved_model=resolved_model or final_model,
-                    resolved_base_url=resolved_base_url,
-                    resolved_api_key=resolved_api_key,
-                    resolved_api_mode=resolved_api_mode,
-                    final_model=final_model,
-                    messages=messages,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    tools=tools,
-                    effective_timeout=effective_timeout,
-                    effective_extra_body=effective_extra_body,
-                    reasoning_config=reasoning_config,
-                )
+                try:
+                    return await _retry_same_provider_async(
+                        task=task,
+                        resolved_provider=auth_refresh_provider,
+                        resolved_model=resolved_model or final_model,
+                        resolved_base_url=resolved_base_url,
+                        resolved_api_key=resolved_api_key,
+                        resolved_api_mode=resolved_api_mode,
+                        final_model=final_model,
+                        messages=messages,
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                        tools=tools,
+                        effective_timeout=effective_timeout,
+                        effective_extra_body=effective_extra_body,
+                        reasoning_config=reasoning_config,
+                    )
+                except Exception as retry_err:
+                    if (quota_fallback_chain is not None
+                            and _is_explicit_aux_quota_error(retry_err)):
+                        return await _finish_explicit_quota_retry(retry_err)
+                    raise
 
         # ── Same-provider credential-pool recovery (mirrors sync) ─────
         pool_provider = _recoverable_pool_provider(resolved_provider, client, main_runtime=main_runtime)
@@ -7886,6 +8174,9 @@ async def async_call_llm(
                     return _validate_llm_response(
                         await client.chat.completions.create(**kwargs), task)
                 except Exception as retry_err:
+                    if (quota_fallback_chain is not None
+                            and _is_explicit_aux_quota_error(retry_err)):
+                        return await _finish_explicit_quota_retry(retry_err)
                     if not (_is_auth_error(retry_err) or _is_payment_error(retry_err) or _is_rate_limit_error(retry_err)):
                         raise
                     recovery_err = retry_err
@@ -7912,6 +8203,9 @@ async def async_call_llm(
                         reasoning_config=reasoning_config,
                     )
                 except Exception as retry2_err:
+                    if (quota_fallback_chain is not None
+                            and _is_explicit_aux_quota_error(retry2_err)):
+                        return await _finish_explicit_quota_retry(retry2_err)
                     if (_is_payment_error(retry2_err) or _is_auth_error(retry2_err)
                             or _is_rate_limit_error(retry2_err)):
                         _recover_provider_pool(pool_provider, retry2_err)
@@ -7924,6 +8218,20 @@ async def async_call_llm(
         # falls back in auto mode just like the sync call_llm() path. Auth is
         # NOT a capacity error, so on an explicit provider it still respects
         # the user's choice (handled by the is_auto/is_capacity_error gate).
+        if quota_fallback_chain is not None:
+            if _is_explicit_aux_quota_error(first_err):
+                quota_response = await _try_explicit_quota_fallback_async(
+                    task, quota_fallback_chain,
+                    messages=messages, temperature=temperature,
+                    max_tokens=max_tokens, tools=tools,
+                    effective_timeout=effective_timeout,
+                    effective_extra_body=effective_extra_body,
+                    reasoning_config=reasoning_config,
+                )
+                if quota_response is not None:
+                    return quota_response
+            raise
+
         should_fallback = (
             _is_auth_error(first_err)
             or _is_payment_error(first_err)

--- a/tests/agent/test_auxiliary_quota_fallback.py
+++ b/tests/agent/test_auxiliary_quota_fallback.py
@@ -1,0 +1,607 @@
+"""Public contract tests for opt-in auxiliary quota fallback."""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from itertools import product
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import agent.auxiliary_client as auxiliary_client
+
+
+_MISSING = object()
+_CHAIN = [
+    {"provider": "nous", "model": "fallback-one"},
+    {"provider": "openai", "model": "fallback-two"},
+]
+
+
+class _PrimaryError(Exception):
+    pass
+
+
+class _QuotaExhaustedError(_PrimaryError):
+    pass
+
+
+class _EntryDict(dict):
+    pass
+
+
+def _response(content: str):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+
+def _config(*, chain=_CHAIN, fallback_on=["quota_exhausted"]):
+    return {"fallback_on": fallback_on, "fallback_chain": chain}
+
+
+def _quota_error(
+    field="code",
+    value="insufficient_quota",
+    *,
+    envelope=False,
+    status=_MISSING,
+):
+    error = _PrimaryError("primary request failed")
+    marker = {field: value}
+    error.body = {"error": marker} if envelope else marker
+    if status is not _MISSING:
+        error.status_code = status
+    return error
+
+
+class _PublicHarness:
+    def __init__(self, mode, error, config, resolutions=(), outcomes=()):
+        self.mode = mode
+        self.error = error
+        self.config = config
+        self.resolutions = list(resolutions)
+        self.resolve_order = []
+        self.call_order = []
+        self.primary = MagicMock()
+        create = (
+            AsyncMock(side_effect=error)
+            if mode == "async"
+            else MagicMock(side_effect=error)
+        )
+        self.primary.chat.completions.create = create
+        self.candidates = [
+            self._candidate(index, outcome) for index, outcome in enumerate(outcomes)
+        ]
+        self.implicit = {
+            name: MagicMock(return_value=(None, None, ""))
+            for name in (
+                "_try_configured_fallback_chain",
+                "_try_main_fallback_chain",
+                "_try_payment_fallback",
+                "_try_main_agent_model_fallback",
+            )
+        }
+
+    def _candidate(self, index, outcome):
+        client = MagicMock()
+
+        def run(**_kwargs):
+            self.call_order.append(index)
+            if isinstance(outcome, BaseException):
+                raise outcome
+            return _response(outcome)
+
+        client.chat.completions.create = (
+            AsyncMock(side_effect=run)
+            if self.mode == "async"
+            else MagicMock(side_effect=run)
+        )
+        return client
+
+    def _resolve(self, entry):
+        self.resolve_order.append(entry["model"])
+        selected = self.resolutions.pop(0)
+        if selected is None:
+            return None, None
+        return self.candidates[selected], entry["model"]
+
+    async def invoke(self, *, stream=False, call_overrides=None):
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.object(
+                    auxiliary_client,
+                    "_get_auxiliary_task_config",
+                    return_value=self.config,
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    auxiliary_client,
+                    "_resolve_task_provider_model",
+                    return_value=("primary", "primary-model", None, None, None),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    auxiliary_client,
+                    "_get_cached_client",
+                    return_value=(self.primary, "primary-model"),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    auxiliary_client,
+                    "_resolve_fallback_entry",
+                    side_effect=self._resolve,
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    auxiliary_client,
+                    "_to_async_client",
+                    side_effect=lambda client, model, **_kwargs: (client, model),
+                )
+            )
+            for name, mock in self.implicit.items():
+                stack.enter_context(patch.object(auxiliary_client, name, mock))
+            call = dict(
+                task="title_generation",
+                messages=[{"role": "user", "content": "title"}],
+            )
+            call.update(call_overrides or {})
+            if self.mode == "async":
+                return await auxiliary_client.async_call_llm(**call)
+            return auxiliary_client.call_llm(**call, stream=stream)
+
+    def assert_no_implicit_routes(self):
+        for mock in self.implicit.values():
+            mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["sync", "async"])
+@pytest.mark.parametrize(
+    "scenario,resolutions,outcomes,expected_calls,expected_content",
+    [
+        ("first-success", [0], ["first", "unused"], [0], "first"),
+        (
+            "second-success",
+            [0, 1],
+            [ValueError("candidate failed"), "second"],
+            [0, 1],
+            "second",
+        ),
+        ("resolve-unavailable", [None, 1], ["unused", "second"], [1], "second"),
+    ],
+)
+async def test_configured_chain_walks_in_order(
+    mode, scenario, resolutions, outcomes, expected_calls, expected_content
+):
+    chain = tuple(_CHAIN) if mode == "sync" and scenario == "first-success" else _CHAIN
+    harness = _PublicHarness(
+        mode, _quota_error(), _config(chain=chain), resolutions, outcomes
+    )
+
+    result = await harness.invoke()
+
+    assert result.choices[0].message.content == expected_content
+    assert harness.call_order == expected_calls
+    assert harness.resolve_order == [
+        entry["model"] for entry in chain[: len(resolutions)]
+    ]
+    harness.assert_no_implicit_routes()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["sync", "async"])
+async def test_all_candidates_fail_reraises_same_primary_object(mode, caplog):
+    primary = _quota_error(value=" quota_exhausted ", status=429)
+    primary.body["secret"] = "do-not-log-this"
+    harness = _PublicHarness(
+        mode,
+        primary,
+        _config(),
+        [0, 1],
+        [ValueError("first failed"), RuntimeError("second failed")],
+    )
+
+    with caplog.at_level("INFO", logger="agent.auxiliary_client"):
+        with pytest.raises(_PrimaryError) as caught:
+            await harness.invoke()
+
+    assert caught.value is primary
+    assert caught.value.__cause__ is primary.__cause__
+    assert caught.value.__context__ is primary.__context__
+    assert harness.call_order == [0, 1]
+    assert "do-not-log-this" not in caplog.text
+    harness.assert_no_implicit_routes()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_entries_are_each_attempted_once():
+    duplicate = {"provider": "nous", "model": "same-model"}
+    harness = _PublicHarness(
+        "sync",
+        _quota_error(),
+        _config(chain=[duplicate, duplicate]),
+        [0, 1],
+        [ValueError("first index failed"), "second index"],
+    )
+
+    result = await harness.invoke()
+
+    assert result.choices[0].message.content == "second index"
+    assert harness.resolve_order == ["same-model", "same-model"]
+    assert harness.call_order == [0, 1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "field,envelope,status",
+    list(product(("code", "type", "reason"), (False, True), (_MISSING, 402, 429))),
+)
+async def test_exact_structured_quota_markers_trigger(field, envelope, status):
+    harness = _PublicHarness(
+        "sync",
+        _quota_error(field, " Usage_Limit_Reached ", envelope=envelope, status=status),
+        _config(),
+        [0],
+        ["fallback"],
+    )
+
+    result = await harness.invoke()
+
+    assert result.choices[0].message.content == "fallback"
+    assert harness.call_order == [0]
+    harness.assert_no_implicit_routes()
+
+
+def _nonquota_error(case):
+    if case == "message-only":
+        return _PrimaryError("quota_exhausted")
+    if case == "bare-429":
+        error = _PrimaryError("rate limited")
+        error.status_code = 429
+        return error
+    if case in {"RESOURCE_EXHAUSTED", "quota_exceeded"}:
+        return _quota_error(value=case)
+    if case == "status-bool":
+        return _quota_error(status=True)
+    if case == "status-string":
+        return _quota_error(status="429")
+    if case.startswith("status-"):
+        return _quota_error(status=int(case.removeprefix("status-")))
+    if case == "body-message":
+        error = _PrimaryError("primary failed")
+        error.body = {"message": "quota_exhausted"}
+        return error
+    if case == "class-name":
+        return _QuotaExhaustedError("primary failed")
+    if case == "response-json":
+        error = _PrimaryError("primary failed")
+        setattr(error, "response", SimpleNamespace(json=MagicMock()))
+        return error
+    if case == "body-subclass":
+        error = _PrimaryError("primary failed")
+        setattr(error, "body", _EntryDict(code="quota_exhausted"))
+        return error
+    if case == "cause":
+        error = _PrimaryError("outer")
+        error.__cause__ = _quota_error()
+        return error
+    error = _PrimaryError("outer")
+    error.__context__ = _quota_error()
+    return error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mode,case",
+    [
+        ("sync", "message-only"),
+        ("async", "bare-429"),
+        ("sync", "RESOURCE_EXHAUSTED"),
+        ("async", "quota_exceeded"),
+        ("sync", "status-401"),
+        ("async", "status-403"),
+        ("sync", "status-500"),
+        ("async", "status-bool"),
+        ("sync", "status-string"),
+        ("async", "body-message"),
+        ("sync", "class-name"),
+        ("async", "response-json"),
+        ("sync", "body-subclass"),
+        ("sync", "cause"),
+        ("async", "context"),
+    ],
+)
+async def test_nonquota_signals_never_leave_primary_route(mode, case):
+    primary = _nonquota_error(case)
+    harness = _PublicHarness(mode, primary, _config(), [], [])
+
+    with pytest.raises(_PrimaryError) as caught:
+        await harness.invoke()
+
+    assert caught.value is primary
+    assert harness.resolve_order == []
+    assert harness.call_order == []
+    harness.assert_no_implicit_routes()
+    if case == "response-json":
+        getattr(primary, "response").json.assert_not_called()
+
+
+_VALID_CHAIN = [{"provider": "nous", "model": "fallback-model"}]
+_INVALID_CONFIGS = [
+    ("sync", {"fallback_on": "quota_exhausted", "fallback_chain": _VALID_CHAIN}),
+    ("async", {"fallback_on": ["other"], "fallback_chain": _VALID_CHAIN}),
+    (
+        "sync",
+        {"fallback_on": ["quota_exhausted", "other"], "fallback_chain": _VALID_CHAIN},
+    ),
+    ("async", {"fallback_on": ["quota_exhausted"], "fallback_chain": []}),
+    ("sync", {"fallback_on": ["quota_exhausted"], "fallback_chain": {}}),
+    ("async", {"fallback_on": ["quota_exhausted"], "fallback_chain": [[]]}),
+    (
+        "sync",
+        {
+            "fallback_on": ["quota_exhausted"],
+            "fallback_chain": [{"provider": "", "model": "m"}],
+        },
+    ),
+    (
+        "async",
+        {
+            "fallback_on": ["quota_exhausted"],
+            "fallback_chain": [{"provider": "p", "model": ""}],
+        },
+    ),
+    (
+        "sync",
+        {
+            "fallback_on": ["quota_exhausted"],
+            "fallback_chain": [{"provider": "auto", "model": "m"}],
+        },
+    ),
+    (
+        "async",
+        {
+            "fallback_on": ["quota_exhausted"],
+            "fallback_chain": [{"provider": "main", "model": "m"}],
+        },
+    ),
+    (
+        "sync",
+        {
+            "fallback_on": ["quota_exhausted"],
+            "fallback_chain": [_EntryDict(provider="p", model="m")],
+        },
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode,config", _INVALID_CONFIGS)
+async def test_invalid_opt_in_config_is_rejected_before_primary(mode, config):
+    harness = _PublicHarness(mode, _quota_error(), config)
+
+    with pytest.raises(ValueError, match="fallback"):
+        await harness.invoke()
+
+    harness.primary.chat.completions.create.assert_not_called()
+    harness.assert_no_implicit_routes()
+
+
+def test_sync_stream_is_rejected_before_primary():
+    config = _config()
+    with (
+        patch.object(
+            auxiliary_client, "_get_auxiliary_task_config", return_value=config
+        ),
+        patch.object(
+            auxiliary_client, "_resolve_task_provider_model"
+        ) as resolve_primary,
+    ):
+        with pytest.raises(ValueError, match="stream"):
+            auxiliary_client.call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "title"}],
+                stream=True,
+            )
+    resolve_primary.assert_not_called()
+
+
+def test_missing_fallback_on_preserves_legacy_fallback():
+    primary = MagicMock()
+    payment_error = _PrimaryError("payment required")
+    payment_error.status_code = 402
+    primary.chat.completions.create.side_effect = payment_error
+    fallback = MagicMock()
+    fallback.chat.completions.create.return_value = _response("legacy fallback")
+    with (
+        patch.object(
+            auxiliary_client,
+            "_get_auxiliary_task_config",
+            return_value={"fallback_chain": _CHAIN},
+        ),
+        patch.object(
+            auxiliary_client,
+            "_resolve_task_provider_model",
+            return_value=("primary", "primary-model", None, None, None),
+        ),
+        patch.object(
+            auxiliary_client,
+            "_get_cached_client",
+            return_value=(primary, "primary-model"),
+        ),
+        patch.object(
+            auxiliary_client,
+            "_try_configured_fallback_chain",
+            return_value=(fallback, "legacy-model", "fallback_chain[0](nous)"),
+        ) as legacy_chain,
+    ):
+        result = auxiliary_client.call_llm(
+            task="title_generation",
+            messages=[{"role": "user", "content": "title"}],
+        )
+
+    assert result.choices[0].message.content == "legacy fallback"
+    legacy_chain.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["sync", "async"])
+@pytest.mark.parametrize("field", ["code", "type", "reason"])
+async def test_direct_marker_is_not_shadowed_by_unrelated_error_mapping(mode, field):
+    primary = _quota_error(field, "quota_exhausted")
+    getattr(primary, "body")["error"] = {"message": "unrelated details"}
+    harness = _PublicHarness(mode, primary, _config(), [0], ["fallback"])
+
+    result = await harness.invoke()
+
+    assert result.choices[0].message.content == "fallback"
+    assert harness.call_order == [0]
+    harness.assert_no_implicit_routes()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["sync", "async"])
+@pytest.mark.parametrize(
+    "body,expected_fallback",
+    [
+        ({"error": {"reason": "usage_limit_reached"}}, True),
+        ({"error": {"error": {"reason": "usage_limit_reached"}}}, False),
+    ],
+)
+async def test_error_envelope_is_exactly_one_level(mode, body, expected_fallback):
+    primary = _PrimaryError("primary request failed")
+    setattr(primary, "body", body)
+    harness = _PublicHarness(
+        mode,
+        primary,
+        _config(),
+        [0] if expected_fallback else [],
+        ["fallback"] if expected_fallback else [],
+    )
+
+    if expected_fallback:
+        result = await harness.invoke()
+        assert result.choices[0].message.content == "fallback"
+        assert harness.call_order == [0]
+    else:
+        with pytest.raises(_PrimaryError) as caught:
+            await harness.invoke()
+        assert caught.value is primary
+        assert harness.call_order == []
+    harness.assert_no_implicit_routes()
+
+
+def _auth_error(message="expired credential"):
+    error = _PrimaryError(message)
+    setattr(error, "status_code", 401)
+    return error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["sync", "async"])
+@pytest.mark.parametrize("final_kind", ["success", "all-fail", "nonquota"])
+async def test_generic_credential_refresh_retry_preserves_quota_contract(
+    mode, final_kind
+):
+    retry_error = (
+        RuntimeError("ordinary retry failure")
+        if final_kind == "nonquota"
+        else _quota_error("reason", "usage_limit_reached")
+    )
+    resolutions = []
+    outcomes = []
+    if final_kind == "success":
+        resolutions, outcomes = [0], ["fallback"]
+    elif final_kind == "all-fail":
+        resolutions = [0, 1]
+        outcomes = [ValueError("candidate one"), RuntimeError("candidate two")]
+    harness = _PublicHarness(mode, _auth_error(), _config(), resolutions, outcomes)
+    retry_name = (
+        "_retry_same_provider_async" if mode == "async" else "_retry_same_provider_sync"
+    )
+    retry_mock = (
+        AsyncMock(side_effect=retry_error)
+        if mode == "async"
+        else MagicMock(side_effect=retry_error)
+    )
+
+    with (
+        patch.object(
+            auxiliary_client, "_refresh_provider_credentials", return_value=True
+        ),
+        patch.object(auxiliary_client, retry_name, retry_mock),
+    ):
+        if final_kind == "success":
+            result = await harness.invoke()
+            assert result.choices[0].message.content == "fallback"
+            assert harness.call_order == [0]
+        else:
+            expected_calls = [0, 1] if final_kind == "all-fail" else []
+            with pytest.raises(type(retry_error)) as caught:
+                await harness.invoke()
+            assert caught.value is retry_error
+            assert harness.call_order == expected_calls
+    harness.assert_no_implicit_routes()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["sync", "async"])
+@pytest.mark.parametrize("retry_class", ["unsupported-temperature", "max-tokens"])
+async def test_parameter_repair_retry_quota_reaches_explicit_chain(mode, retry_class):
+    retry_error = _quota_error("type", "insufficient_quota")
+    parameter = (
+        "temperature" if retry_class == "unsupported-temperature" else "max_tokens"
+    )
+    first_error = RuntimeError(f"Unsupported parameter: {parameter}")
+    harness = _PublicHarness(mode, first_error, _config(), [0], ["fallback"])
+    harness.primary.base_url = "https://example.test/anthropic"
+    create = (
+        AsyncMock(side_effect=[first_error, retry_error])
+        if mode == "async"
+        else MagicMock(side_effect=[first_error, retry_error])
+    )
+    harness.primary.chat.completions.create = create
+    call_overrides = (
+        {"temperature": 0.3}
+        if retry_class == "unsupported-temperature"
+        else {"max_tokens": 100}
+    )
+
+    result = await harness.invoke(call_overrides=call_overrides)
+
+    assert result.choices[0].message.content == "fallback"
+    assert harness.call_order == [0]
+    harness.assert_no_implicit_routes()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["sync", "async"])
+async def test_stale_candidate_warning_redacts_exception_body(mode, caplog):
+    sentinel = "SENTINEL-API-KEY-super-secret"
+    harness = _PublicHarness(
+        mode,
+        _quota_error(),
+        _config(),
+        [0, 1],
+        [_auth_error(f"401 provider body API_KEY={sentinel}"), "second"],
+    )
+
+    with (
+        patch.object(
+            auxiliary_client, "_refresh_provider_credentials", return_value=False
+        ),
+        caplog.at_level("WARNING", logger="agent.auxiliary_client"),
+    ):
+        result = await harness.invoke()
+
+    assert result.choices[0].message.content == "second"
+    assert harness.call_order == [0, 1]
+    assert sentinel not in caplog.text
+    assert "_PrimaryError" in caplog.text
+    harness.assert_no_implicit_routes()

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -310,6 +310,31 @@ auxiliary:
 
 ## Auxiliary Capacity-Error Fallback
 
+### Opt in to explicit quota-only fallback
+
+Set `fallback_on: [quota_exhausted]` when an auxiliary task should use only its configured chain after a confirmed quota error:
+
+```yaml
+auxiliary:
+  compression:
+    provider: openrouter
+    model: google/gemini-3-flash-preview
+    fallback_on: [quota_exhausted]
+    fallback_chain:
+      - provider: nous
+        model: anthropic/claude-sonnet-4
+      - provider: openai
+        model: gpt-4o-mini
+```
+
+This opt-in accepts only the exact structured values `insufficient_quota`, `quota_exhausted`, or `usage_limit_reached` in the primary exception body's `code`, `type`, or `reason` field, either directly or inside one `error` object. If the exception includes a status code, it must be integer `402` or `429`; a bare status code or quota-looking message is not enough.
+
+After the primary provider's existing retries finish, Hermes tries each configured entry once, in order. An unavailable or failed entry is skipped. The first valid response wins; if the chain is exhausted, Hermes re-raises the original primary error. This mode does not append the main agent, top-level `fallback_providers`, `auto` discovery, or other implicit routes.
+
+The opt-in is validated before the primary request. It requires a non-empty chain whose entries have explicit, non-empty `provider` and `model` strings; `auto` and `main` are not valid candidate providers. Synchronous streaming calls are not supported in this mode.
+
+If `fallback_on` is omitted, the legacy capacity-error behavior described below is unchanged.
+
 When you set an explicit auxiliary provider (e.g. `auxiliary.vision.provider: glm`), Hermes treats that as your preferred choice — but if the provider literally cannot serve the request because of a **capacity error** (HTTP 402 payment required, HTTP 429 daily-quota exhaustion, connection failure), Hermes falls back through a layered chain instead of failing silently:
 
 1. **Primary aux provider** — the one you configured (tried first, always)


### PR DESCRIPTION
## Summary

- add task-level, opt-in `fallback_on: [quota_exhausted]` with an explicit ordered `fallback_chain`
- recognize only narrow structured quota markers from the primary/retry exception body
- preserve legacy behavior when opt-in is absent, and preserve sync/async parity across same-provider retry exits
- continue across explicit candidate failures without appending implicit providers or routes
- document the configuration and add public-path behavioral coverage

## Scope

This is intentionally narrow. It does **not** add credential/config/runtime snapshotting, implicit `main`/`auto` fallback, provider discovery, health routing, or a general policy framework.

## Validation

- focused quota-fallback suite: **77 passed**
- adjacent legacy retry suites: **56 passed across 5 files**
- Ruff, format check, production `py_compile`, commit hooks, `git diff --check`, and `git show --check`: **passed**
- full Python aggregate: **43,432 passed / 9 failed**, 100% complete, no runner error
  - exact-base serial A/B found **0 stable target-only failures**; all 7 stable target failures matched the immutable base
- development Node aggregate: raw nonzero on both target and immutable base
  - all 19 stable target failures matched the exact base; **0 stable target-only failures**

## Review

- initial independent review found three narrow control-flow/logging issues; all were fixed with public-path RED/GREEN tests
- fresh clean-room final review on exact HEAD: **PASS / CLEAN**, zero findings
- final publication security/noise audit: **PASS / CLEAN**, zero findings
- the attempted CSA tier-4 session was unavailable before reviewer execution because of a bwrap session-path infrastructure failure; tracked in RyderFreeman4Logos/cli-sub-agent#2849. Repository-mandated native frozen-HEAD review was used as the transport fallback without lowering the contract.
