### PR TITLE
fix(tests): make the live-system-guard canary fail closed (Fixes #68311)

### DIFF
--- a/tests/test_live_system_guard_self_test.py
+++ b/tests/test_live_system_guard_self_test.py
@@ -20,12 +20,86 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
+import types
 
 import pytest
 
 # A guaranteed-foreign PID: PID 1 (init).  Owned by root, not us, and
 # always exists. A sane guard refuses to signal it.
 FOREIGN_PID = 1
+
+
+# ──────────────────── fail-closed self-protection ──────────────
+#
+# This file executes REAL kill primitives — os.kill(-1, SIGTERM), os.killpg,
+# pkill -f python — and depends entirely on the autouse ``_live_system_guard``
+# fixture in tests/conftest.py to intercept them. That makes the canary
+# fail-OPEN: in any collection context where this file is present but its home
+# conftest is not, the primitives fire for real and ``os.kill(-1, SIGTERM)``
+# SIGTERMs every process the invoking user owns (a full desktop-session kill was
+# reported in the field — see issue #68311). Such contexts are not exotic:
+# published sdists that ship ``tests/`` but not ``tests/conftest.py``, trees
+# assembled by copying ``test*.py`` files (that glob does NOT match
+# ``conftest.py``), ``pytest --noconftest``, or running from a foreign rootdir.
+#
+# The fixture below makes the canary fail-CLOSED instead: it refuses to run any
+# test in this file unless the guard is provably active, so no collection
+# context can ever detonate the primitives. The one thing the canary can detect
+# about its own safety is that the guard monkeypatches ``os.kill`` with a plain
+# Python function, whereas the unguarded primitive is a C builtin.
+
+
+def _live_system_guard_is_active() -> bool:
+    """True iff tests/conftest.py's ``_live_system_guard`` has patched os.kill.
+
+    The guard replaces ``os.kill`` with a plain Python function; the raw,
+    unguarded primitive is a C builtin (``types.BuiltinFunctionType``). If
+    ``os.kill`` is still the builtin, the guard never loaded and every kill
+    primitive in this file would fire for real.
+    """
+    return not isinstance(os.kill, types.BuiltinFunctionType)
+
+
+@pytest.fixture(autouse=True)
+def _refuse_to_fire_live_weapons(request):
+    """Fail closed: refuse to run a canary test unless the guard is active.
+
+    Tests genuinely marked ``@pytest.mark.live_system_guard_bypass`` opt out
+    (they run the raw primitive deliberately and harmlessly, e.g. a signal-0
+    liveness probe of our own PID), matching the guard's own bypass contract.
+    """
+    if request.node.get_closest_marker("live_system_guard_bypass"):
+        yield
+        return
+    if not _live_system_guard_is_active():
+        pytest.fail(
+            "REFUSING TO RUN: the live-system guard from tests/conftest.py is "
+            "not active in this interpreter (os.kill is still the raw C "
+            "builtin). This canary file executes real kill primitives — "
+            "os.kill(-1, SIGTERM), os.killpg, pkill -f python — and relies on "
+            "the guard to intercept them; unguarded, they SIGTERM every process "
+            "the current user owns. This usually means the file was collected "
+            "without its home tests/conftest.py (note: a test*.py copy glob "
+            "does NOT match conftest.py). See issue #68311.",
+            pytrace=False,
+        )
+    yield
+
+
+def test_fail_closed_probe_reports_guard_active():
+    """In the real suite the guard is loaded, so the probe reports active and
+    ``_refuse_to_fire_live_weapons`` stays out of the way (no false positives
+    that would wedge CI)."""
+    assert _live_system_guard_is_active() is True
+
+
+def test_fail_closed_probe_classifies_raw_builtin_as_unguarded():
+    """The probe's discriminator, exercised against real objects: a raw C
+    builtin the guard never touches (``os.getpid``) is exactly what an
+    unguarded ``os.kill`` looks like and must read as 'guard not active', while
+    the loaded guard's ``os.kill`` is a plain Python function."""
+    assert isinstance(os.getpid, types.BuiltinFunctionType)
+    assert not isinstance(os.kill, types.BuiltinFunctionType)
 
 
 # ──────────────────── kill primitives ─────────────────────────


### PR DESCRIPTION
## Problem

`tests/test_live_system_guard_self_test.py` is the canary that deliberately invokes real kill primitives — `os.kill(-1, SIGTERM)`, `os.killpg`, `pkill -f python` — and relies **entirely** on the autouse `_live_system_guard` fixture in `tests/conftest.py` to intercept them.

That makes the canary **fail-open**. In any collection context where the file is present but its home `conftest.py` is not, the primitives fire for real, and `os.kill(-1, SIGTERM)` SIGTERMs *every process the invoking user owns*. Such contexts are not exotic:

- a published sdist that ships `tests/` but **not** `tests/conftest.py` (per #68311, every release 0.13.0–0.19.0);
- a tree assembled by copying `test*.py` files — that glob does **not** match `conftest.py`;
- `pytest --noconftest`;
- running the file from a foreign rootdir.

The reporter documented this detonating a developer's entire macOS login session twice. Because `kill(-1)` doesn't signal the calling process, pytest survives its own broadcast and the canary tests just look like ordinary failures, so it's silent and repeatable.

## Fix

Make the canary **fail-closed**: an autouse fixture in the canary file itself refuses to run any test unless the guard is provably active. The one thing the canary can detect about its own safety is that the guard monkeypatches `os.kill` with a plain Python function, whereas the raw primitive is a C builtin (`types.BuiltinFunctionType`) — so the probe keys off exactly that.

- With the guard loaded, every canary test behaves **exactly as before** (verified — the probe reports active and the fixture stays out of the way).
- Without the guard, each test refuses at setup with a clear message and **zero side effects** — no kill primitive is reached.
- Tests marked `@pytest.mark.live_system_guard_bypass` still opt out, matching the guard's own bypass contract (e.g. the existing `test_bypass_marker_disables_guard`, which deliberately runs an unguarded signal-0 liveness probe).

The fixture lives in the same file as the dangerous primitives, so it travels with them into every collection context — including the sdist/copy scenarios above where `conftest.py` is absent.

Two self-contained tests exercise the probe's discriminator against real objects (a raw builtin the guard never touches vs. the guarded `os.kill`), so a future change that breaks the probe fails loudly instead of silently re-arming the fail-open behaviour.

## Scope

This addresses remediation **#2** from the issue (fail-closed canary), which is the durable root-cause fix: it neutralizes the detonation in *every* collection context and makes the packaging gap harmless. The complementary packaging fix (ship `tests/conftest.py` in the sdist, or stop shipping `tests/`) is orthogonal and left as a follow-up — it can't fully protect the `test*.py`-copy / `--noconftest` / foreign-rootdir cases, which this change does.

## Verification

- `pytest tests/test_live_system_guard_self_test.py` — new tests pass; the only failures are the 4 `test_systemctl_*_passes_through` tests, which fail identically on unmodified `upstream/main` on macOS (`systemctl` is Linux-only), unrelated to this change.
- Fail-closed behaviour proven end-to-end with an isolated `--noconftest` run (no kill primitives involved): the fixture refuses at setup and no test body runs.
- `ruff check` (PLW1514) clean; `scripts/check-windows-footguns.py --all` exits 0.

Credit: the fail-closed approach was proposed by @firstlightworkspace-dot in #68311; this PR adapts it, drops the unneeded bypass path's marker-registration dependency, and adds the probe-discriminator tests.