### PR TITLE
fix(agent): guard the optional Telegram rich-hint import in system_prompt (Fixes #68300)

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -40,11 +40,21 @@ from agent.prompt_builder import (
     SKILLS_GUIDANCE,
     STEER_CHANNEL_NOTE,
     TASK_COMPLETION_GUIDANCE,
-    TELEGRAM_RICH_MESSAGES_HINT,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
     drain_truncation_warnings,
 )
+
+try:
+    from agent.prompt_builder import TELEGRAM_RICH_MESSAGES_HINT
+except ImportError:
+    # Optional Telegram rich-Markdown hint. Guarded on its own so an
+    # intermediate/inconsistent tree — a partial deploy, an auto-updater that
+    # pulls prompt_builder.py after system_prompt.py, or a `git pull` landing
+    # between the two commits that introduced this symbol — degrades to the
+    # base hint instead of an ImportError that aborts module load and
+    # crash-loops every agent spawn on headless deployments. See issue #68300.
+    TELEGRAM_RICH_MESSAGES_HINT = ""
 from agent.runtime_cwd import resolve_context_cwd
 from hermes_constants import get_hermes_home
 from utils import is_truthy_value

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -145,3 +145,34 @@ class TestTelegramRichMessagesHint:
             stable = _stable_prompt(agent)
         assert "Standard Markdown is automatically converted" in stable
         assert "lean into it" not in stable
+
+
+class TestTelegramHintImportGuard:
+    """agent/system_prompt.py must survive an inconsistent tree in which
+    agent/prompt_builder.py does not yet define TELEGRAM_RICH_MESSAGES_HINT
+    (partial deploy / auto-updater / mid-range git pull). See issue #68300.
+    """
+
+    def test_missing_symbol_degrades_instead_of_crashing(self, monkeypatch):
+        import importlib
+
+        import agent.prompt_builder as prompt_builder
+        import agent.system_prompt as system_prompt
+
+        # Simulate the intermediate tree: the symbol isn't defined yet.
+        monkeypatch.delattr(prompt_builder, "TELEGRAM_RICH_MESSAGES_HINT")
+        try:
+            # Re-executing the module top-level imports must NOT raise
+            # ImportError — the guarded import degrades to "".
+            reloaded = importlib.reload(system_prompt)
+            assert reloaded.TELEGRAM_RICH_MESSAGES_HINT == ""
+        finally:
+            # Restore the real module so later tests see the true symbol.
+            importlib.reload(prompt_builder)
+            importlib.reload(system_prompt)
+
+    def test_symbol_present_in_a_consistent_tree(self):
+        """Sanity: in a normal tree the real hint text is imported, not ''."""
+        from agent.system_prompt import TELEGRAM_RICH_MESSAGES_HINT
+
+        assert TELEGRAM_RICH_MESSAGES_HINT != ""


### PR DESCRIPTION
## Problem

`agent/system_prompt.py` imports `TELEGRAM_RICH_MESSAGES_HINT` from `agent/prompt_builder` inside the unguarded module-top block:

```python
from agent.prompt_builder import (
    ...
    TELEGRAM_RICH_MESSAGES_HINT,
    ...
)
```

The *usage* site (gated on `platforms.telegram.extra.rich_messages`) is already wrapped in `try/except Exception`, but it never gets the chance to run: an `ImportError` on the **import line** aborts module load before any usage guard is reachable.

So any inconsistent tree where `system_prompt.py` references the symbol before `prompt_builder.py` defines it crashes every agent spawn:

```
ImportError: cannot import name 'TELEGRAM_RICH_MESSAGES_HINT' from 'agent.prompt_builder'
```

`TELEGRAM_RICH_MESSAGES_HINT` was introduced in `306e2d2`; `system_prompt.py`'s import remained unguarded through v0.19.0. The window is real for anyone whose tree can be momentarily inconsistent across these two modules — a partial CI deploy, an auto-updater that pulls one file's commit first, or a `git pull` landing between the two introducing commits. Headless/always-on gateways (launchd `KeepAlive`, systemd, cron) then **crash-loop** on every spawn until the tree is fully consistent, which is silent to the user except as repeated cron failures.

## Fix

Move the optional symbol out of the main import block into its own guarded import that degrades to `""`:

```python
try:
    from agent.prompt_builder import TELEGRAM_RICH_MESSAGES_HINT
except ImportError:
    TELEGRAM_RICH_MESSAGES_HINT = ""
```

An intermediate tree now falls back to the base Telegram hint instead of failing to import. The `""` fallback is inert at the single usage site — `_default_hint.rstrip() + " " + ""` — so behaviour in a consistent tree is unchanged.

This is remediation **#1** from the issue (the durable code-level safety net that protects any intermediate tree state). Remediation #2 (a release/atomicity gate so coupled modules never ship out of step) is a process change, orthogonal to this and left to maintainers.

## Tests

`tests/agent/test_system_prompt.py`:
- `test_missing_symbol_degrades_instead_of_crashing` — deletes the symbol from `prompt_builder`, reloads `system_prompt`, and asserts the reload does **not** raise and `TELEGRAM_RICH_MESSAGES_HINT == ""` (this test fails without the fix, since the symbol would still be in the unguarded block).
- `test_symbol_present_in_a_consistent_tree` — sanity: a normal tree imports the real hint text, not `""`.

## Verification

- `pytest tests/agent/test_system_prompt.py tests/agent/test_prompt_builder.py` → 175 passed, 1 skipped.
- `ruff check` (PLW1514) clean; `scripts/check-windows-footguns.py --all` exits 0.

Reported by @John-Kmiec in #68300, with the guarded-import patch confirmed running in their production deployment; this PR applies it with regression coverage.