### PR TITLE
feat(mem0): vacation-aware staleness decay + logging fixes

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -38,6 +38,7 @@ import logging
 import os
 import threading
 import time
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List
 
 from agent.memory_provider import MemoryProvider
@@ -60,6 +61,113 @@ _CLIENT_ERROR_TYPES = ("MemoryNotFoundError", "ValidationError")
 # wrote this exact placeholder) still allow gateway-native ids to flow
 # through instead of silently overriding them with the placeholder.
 _DEFAULT_USER_ID = "hermes-user"
+
+# ---------------------------------------------------------------------------
+# Staleness / recency decay
+# ---------------------------------------------------------------------------
+# Blend formula: adjusted = (1 - alpha) * sim_score + alpha * decay_factor
+# decay_factor = 0.5 ** (days_past_grace / half_life)
+# The alpha=0.3 blend keeps semantic relevance dominant — an old but highly
+# relevant memory still beats a recent but irrelevant one. The grace period
+# protects newly stored facts from immediate penalty.
+_DECAY_HALF_LIFE_DAYS = 30.0   # score halves every 30 days past the grace window
+_DECAY_ALPHA = 0.3              # weight of recency vs. semantic similarity
+_DECAY_GRACE_DAYS = 14.0        # memories <= 14 days old get decay_factor = 1.0
+
+
+def _apply_staleness_weight(
+    results: list,
+    *,
+    vacations: list | None = None,
+    grace_days: float = _DECAY_GRACE_DAYS,
+) -> list:
+    """Post-process mem0 search results with a time-decay recency blend.
+
+    Reads updated_at (preferred) or created_at from each result dict. If the
+    timestamp is missing or unparseable, the result is returned unchanged.
+    Results are re-sorted by adjusted score descending.
+
+    Vacation mode: supports multiple vacation periods, each with optional start
+    and required end dates. While any period is active, no decay is applied.
+    After a period ends, the grace window resets from the end date so memories
+    don't get penalized for the time the user was away. If multiple past
+    vacation periods overlap the grace window, the most favorable effective_now
+    (furthest into the future) wins.
+
+    # To enable vacation mode, add to mem0.json:
+    # "vacations": [
+    #   {"start": "2026-08-01", "end": "2026-08-15"},
+    #   {"start": "2026-12-24", "end": "2027-01-02"}
+    # ]
+    # start is optional (defaults to epoch); end is required.
+    # While active: no decay. After: grace period resets from vacation end date.
+    """
+    now = datetime.now(timezone.utc)
+
+    # Vacation mode: collect past vacation ends, check for active vacation.
+    # effective_now is shifted back to the most recent past vacation_end so that
+    # days_old is measured from there, not from real now — giving the user a
+    # full grace window after returning.  "Most recent" (largest vacation_end)
+    # minimises days_old.
+    best_past_end: datetime | None = None
+    _epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+    for period in (vacations or []):
+        end_raw = period.get("end")
+        if not end_raw:
+            continue
+        try:
+            vacation_end = datetime.fromisoformat(str(end_raw).replace("Z", "+00:00"))
+            if vacation_end.tzinfo is None:
+                vacation_end = vacation_end.replace(tzinfo=timezone.utc)
+            start_raw = period.get("start")
+            if start_raw:
+                vacation_start = datetime.fromisoformat(str(start_raw).replace("Z", "+00:00"))
+                if vacation_start.tzinfo is None:
+                    vacation_start = vacation_start.replace(tzinfo=timezone.utc)
+            else:
+                vacation_start = _epoch
+            if vacation_start <= now <= vacation_end:
+                # Currently on vacation — no decay, but still sort by base score.
+                return sorted(results, key=lambda x: x.get("score", 0.0), reverse=True)
+            if now > vacation_end:
+                if best_past_end is None or vacation_end > best_past_end:
+                    best_past_end = vacation_end
+        except (ValueError, AttributeError):
+            continue
+
+    # Apply the post-vacation effective_now shift only while within the grace window.
+    # Beyond grace_days since return, the vacation has no further effect.
+    effective_now = now
+    if best_past_end is not None:
+        days_since_return = (now - best_past_end).total_seconds() / 86400
+        if days_since_return <= grace_days:
+            effective_now = best_past_end
+
+    scored = []
+    for r in results:
+        base_score = r.get("score", 0.0)
+        ts_raw = r.get("updated_at") or r.get("created_at")
+        if ts_raw:
+            try:
+                if isinstance(ts_raw, (int, float)):
+                    ts = datetime.fromtimestamp(ts_raw, tz=timezone.utc)
+                else:
+                    ts = datetime.fromisoformat(str(ts_raw).replace("Z", "+00:00"))
+                    if ts.tzinfo is None:
+                        ts = ts.replace(tzinfo=timezone.utc)
+                days_old = max(0.0, (effective_now - ts).total_seconds() / 86400)
+                if days_old <= grace_days:
+                    decay_factor = 1.0
+                else:
+                    decay_factor = 0.5 ** ((days_old - grace_days) / _DECAY_HALF_LIFE_DAYS)
+                adjusted = (1 - _DECAY_ALPHA) * base_score + _DECAY_ALPHA * decay_factor * base_score
+            except Exception:
+                adjusted = base_score
+        else:
+            adjusted = base_score
+        scored.append({**r, "score": adjusted})
+    scored.sort(key=lambda x: x["score"], reverse=True)
+    return scored
 
 
 def _is_client_error(exc: Exception) -> bool:
@@ -148,6 +256,14 @@ ADD_SCHEMA = {
         "type": "object",
         "properties": {
             "content": {"type": "string", "description": "The fact to store."},
+            "run_id": {
+                "type": "string",
+                "description": (
+                    "Optional sprint or session scope ID. When set, the memory is "
+                    "tagged with this ID so it can be filtered separately from "
+                    "general user memories (e.g. sprint-scoped recall)."
+                ),
+            },
         },
         "required": ["content"],
     },
@@ -206,6 +322,9 @@ class Mem0MemoryProvider(MemoryProvider):
         self._user_id = _DEFAULT_USER_ID
         self._agent_id = "hermes"
         self._rerank_default = False
+        self._vacations: list = []
+        self._decay_grace_days = _DECAY_GRACE_DAYS
+        self._prefetch_top_k = 15
         self._channel = "cli"  # gateway channel name (cli/telegram/discord/...)
         self._sync_thread = None
         self._prefetch_thread = None
@@ -363,6 +482,20 @@ class Mem0MemoryProvider(MemoryProvider):
         self._rerank_default = (
             _rr.lower() in ("true", "1", "yes") if isinstance(_rr, str) else bool(_rr)
         )
+        self._prefetch_top_k = int(self._config.get("prefetch_top_k", 15))
+        # Vacation periods: new array format preferred; legacy scalar fallback.
+        _vacations = self._config.get("vacations")
+        if _vacations is not None:
+            if isinstance(_vacations, list):
+                self._vacations = _vacations
+            else:
+                logger.warning("vacations config value must be a list, got %s — ignoring", type(_vacations).__name__)
+                self._vacations = []
+        else:
+            # Backward compat: "vacation_until": "2026-07-30" → single period
+            # with no start constraint.
+            _legacy = self._config.get("vacation_until") or None
+            self._vacations = [{"start": None, "end": _legacy}] if _legacy else []
         self._channel = kwargs.get("platform") or "cli"
         self._backend = self._create_backend()
         if self._backend and not self._atexit_registered:
@@ -441,9 +574,14 @@ class Mem0MemoryProvider(MemoryProvider):
             body = ""
             try:
                 results = backend.search(
-                    query, filters=self._read_filters(), top_k=10, rerank=False,
+                    query, filters=self._read_filters(), top_k=self._prefetch_top_k, rerank=False,
                 )
-                lines = [r.get("memory", "") for r in (results or []) if r.get("memory")]
+                results = _apply_staleness_weight(
+                    results or [],
+                    vacations=self._vacations,
+                    grace_days=self._decay_grace_days,
+                )
+                lines = [r.get("memory", "") for r in results if r.get("memory")]
                 if lines:
                     body = "## Mem0 Memory\n" + "\n".join(f"- {l}" for l in lines)
                 self._record_success()
@@ -481,6 +619,10 @@ class Mem0MemoryProvider(MemoryProvider):
         if self._backend is None or self._is_breaker_open():
             return
 
+        # Allow sprint-scoped ingestion via MEM0_RUN_ID env var so all
+        # background turn syncs are tagged with the active sprint/run ID.
+        run_id: str | None = os.environ.get("MEM0_RUN_ID") or None
+
         def _sync():
             backend = self._backend
             if backend is None:
@@ -496,6 +638,7 @@ class Mem0MemoryProvider(MemoryProvider):
                     agent_id=self._agent_id,
                     infer=True,
                     metadata=self._write_metadata(),
+                    run_id=run_id,
                 )
                 self._record_success()
             except Exception as e:
@@ -510,6 +653,93 @@ class Mem0MemoryProvider(MemoryProvider):
                 return
             self._sync_thread = threading.Thread(target=_sync, daemon=True, name="mem0-sync")
             self._sync_thread.start()
+
+    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+        """Called before context compression fires.
+
+        1. Truncates oversized tool result messages inline (synchronous) so the
+           compressor receives leaner input.  Any tool result message whose
+           content exceeds _TOOL_TRUNCATE_THRESHOLD characters is trimmed to
+           _TOOL_TRUNCATE_HEAD chars + a sentinel + _TOOL_TRUNCATE_TAIL chars.
+           Only role="tool" messages are touched; user/assistant messages are
+           never modified.
+
+        2. Extracts key facts from large tool results into mem0 so they survive
+           compaction even when the raw tool content gets summarized away.
+           Non-blocking — extraction runs in a background daemon thread.
+        """
+        # ------------------------------------------------------------------
+        # Step 1: inline truncation of oversized tool results (synchronous).
+        # NOTE: mutates the caller's message dicts in-place — intentional so
+        # the compressor downstream sees the trimmed content without a copy.
+        # Step 2's thread starts after this completes; no concurrent mutation.
+        # ------------------------------------------------------------------
+        _TOOL_TRUNCATE_THRESHOLD = 8_000   # ~2 000 tokens — truncate above this
+        _TOOL_TRUNCATE_HEAD = 500          # chars to keep from the start
+        _TOOL_TRUNCATE_TAIL = 200          # chars to keep from the end
+        _SENTINEL = "... [truncated, key facts extracted to memory] ..."
+
+        truncated_count = 0
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("role") != "tool":
+                continue
+            content = msg.get("content", "")
+            if isinstance(content, str) and len(content) > _TOOL_TRUNCATE_THRESHOLD:
+                msg["content"] = (
+                    content[:_TOOL_TRUNCATE_HEAD]
+                    + _SENTINEL
+                    + content[-_TOOL_TRUNCATE_TAIL:]
+                )
+                truncated_count += 1
+
+        if truncated_count:
+            logger.debug(
+                "on_pre_compress: truncated %d oversized tool result(s) inline",
+                truncated_count,
+            )
+
+        if self._backend is None or self._is_breaker_open():
+            return ""
+
+        backend = self._backend
+        user_id = self._user_id
+        agent_id = self._agent_id
+        metadata = {**self._write_metadata(), "source": "pre_compress", "sprint_automation": True}
+
+        def _extract():
+            try:
+                tool_content = []
+                for msg in messages:
+                    if isinstance(msg, dict) and msg.get("role") == "tool":
+                        content = msg.get("content", "")
+                        if isinstance(content, str) and len(content) > 500:
+                            tool_content.append(content[:2000])  # cap to avoid token explosion
+
+                if not tool_content:
+                    return
+
+                combined = "\n\n---\n\n".join(tool_content[:5])  # max 5 large results
+                extraction_prompt = (
+                    "Extract and remember the key facts from these tool results "
+                    "that will be needed later:\n\n" + combined
+                )
+                backend.add(
+                    [{"role": "user", "content": extraction_prompt}],
+                    user_id=user_id,
+                    agent_id=agent_id,
+                    infer=True,
+                    metadata=metadata,
+                )
+                self._record_success()
+            except Exception as e:
+                self._record_failure()
+                logger.warning("on_pre_compress extraction failed: %s", e)
+
+        t = threading.Thread(target=_extract, daemon=True, name="mem0-pre-compress")
+        t.start()
+        return ""
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         return [SEARCH_SCHEMA, ADD_SCHEMA, UPDATE_SCHEMA, DELETE_SCHEMA]
@@ -546,6 +776,11 @@ class Mem0MemoryProvider(MemoryProvider):
                 self._record_success()
                 if not results:
                     return json.dumps({"result": "No relevant memories found."})
+                results = _apply_staleness_weight(
+                    results,
+                    vacations=self._vacations,
+                    grace_days=self._decay_grace_days,
+                )
                 items = [{"id": r.get("id"), "memory": r.get("memory", ""),
                           "score": r.get("score", 0)} for r in results]
                 return json.dumps({"results": items, "count": len(items)})
@@ -559,12 +794,14 @@ class Mem0MemoryProvider(MemoryProvider):
             if not content:
                 return tool_error("Missing required parameter: content")
             try:
+                run_id: str | None = args.get("run_id") or None
                 result = self._backend.add(
                     [{"role": "user", "content": content}],
                     user_id=self._user_id,
                     agent_id=self._agent_id,
                     infer=False,
                     metadata=self._write_metadata(),
+                    run_id=run_id,
                 )
                 self._record_success()
                 event_id = result.get("event_id") if isinstance(result, dict) else None

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -681,17 +681,28 @@ class Mem0MemoryProvider(MemoryProvider):
            compaction even when the raw tool content gets summarized away.
            Non-blocking — extraction runs in a background daemon thread.
         """
-        # ------------------------------------------------------------------
-        # Step 1: inline truncation of oversized tool results (synchronous).
-        # NOTE: mutates the caller's message dicts in-place — intentional so
-        # the compressor downstream sees the trimmed content without a copy.
-        # Step 2's thread starts after this completes; no concurrent mutation.
-        # ------------------------------------------------------------------
         _TOOL_TRUNCATE_THRESHOLD = 8_000   # ~2 000 tokens — truncate above this
         _TOOL_TRUNCATE_HEAD = 500          # chars to keep from the start
         _TOOL_TRUNCATE_TAIL = 200          # chars to keep from the end
         _SENTINEL = "... [truncated, key facts extracted to memory] ..."
 
+        # ------------------------------------------------------------------
+        # Step 1: snapshot ORIGINAL tool content for memory extraction BEFORE
+        # any in-place truncation.  This ensures the extraction step receives
+        # the full, untruncated content so no information is lost.
+        # ------------------------------------------------------------------
+        tool_content: list[str] = []
+        for msg in messages:
+            if isinstance(msg, dict) and msg.get("role") == "tool":
+                content = msg.get("content", "")
+                if isinstance(content, str) and len(content) > 500:
+                    tool_content.append(content[:2000])  # cap to avoid token explosion
+
+        # ------------------------------------------------------------------
+        # Step 2: inline truncation of oversized tool results (synchronous).
+        # NOTE: mutates the caller's message dicts in-place — intentional so
+        # the compressor downstream sees the trimmed content without a copy.
+        # ------------------------------------------------------------------
         truncated_count = 0
         for msg in messages:
             if not isinstance(msg, dict):
@@ -720,16 +731,6 @@ class Mem0MemoryProvider(MemoryProvider):
         user_id = self._user_id
         agent_id = self._agent_id
         metadata = {**self._write_metadata(), "source": "pre_compress", "sprint_automation": True}
-
-        # Snapshot tool content synchronously before spawning the background thread
-        # to avoid a race condition: the main thread may mutate or compress the
-        # messages list concurrently, causing RuntimeError or partial reads.
-        tool_content: list[str] = []
-        for msg in messages:
-            if isinstance(msg, dict) and msg.get("role") == "tool":
-                content = msg.get("content", "")
-                if isinstance(content, str) and len(content) > 500:
-                    tool_content.append(content[:2000])  # cap to avoid token explosion
 
         if not tool_content:
             return ""

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -65,7 +65,8 @@ _DEFAULT_USER_ID = "hermes-user"
 # ---------------------------------------------------------------------------
 # Staleness / recency decay
 # ---------------------------------------------------------------------------
-# Blend formula: adjusted = (1 - alpha) * sim_score + alpha * decay_factor
+# Blend formula: adjusted = base * [(1 - alpha) + alpha * decay_factor]
+#   equivalently: (1 - alpha) * base + alpha * decay_factor * base
 # decay_factor = 0.5 ** (days_past_grace / half_life)
 # The alpha=0.3 blend keeps semantic relevance dominant — an old but highly
 # relevant memory still beats a recent but irrelevant one. The grace period
@@ -142,6 +143,9 @@ def _apply_staleness_weight(
         days_since_return = (now - best_past_end).total_seconds() / 86400
         if days_since_return <= grace_days:
             effective_now = best_past_end
+        else:
+            # smooth: don't snap back fully, shift by grace_days to avoid cliff
+            effective_now = now - timedelta(days=grace_days)
 
     scored = []
     for r in results:

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -717,19 +717,22 @@ class Mem0MemoryProvider(MemoryProvider):
         agent_id = self._agent_id
         metadata = {**self._write_metadata(), "source": "pre_compress", "sprint_automation": True}
 
-        def _extract():
+        # Snapshot tool content synchronously before spawning the background thread
+        # to avoid a race condition: the main thread may mutate or compress the
+        # messages list concurrently, causing RuntimeError or partial reads.
+        tool_content: list[str] = []
+        for msg in messages:
+            if isinstance(msg, dict) and msg.get("role") == "tool":
+                content = msg.get("content", "")
+                if isinstance(content, str) and len(content) > 500:
+                    tool_content.append(content[:2000])  # cap to avoid token explosion
+
+        if not tool_content:
+            return ""
+
+        def _extract(content_list: list[str]) -> None:
             try:
-                tool_content = []
-                for msg in messages:
-                    if isinstance(msg, dict) and msg.get("role") == "tool":
-                        content = msg.get("content", "")
-                        if isinstance(content, str) and len(content) > 500:
-                            tool_content.append(content[:2000])  # cap to avoid token explosion
-
-                if not tool_content:
-                    return
-
-                combined = "\n\n---\n\n".join(tool_content[:5])  # max 5 large results
+                combined = "\n\n---\n\n".join(content_list[:5])  # max 5 large results
                 extraction_prompt = (
                     "Extract and remember the key facts from these tool results "
                     "that will be needed later:\n\n" + combined
@@ -746,7 +749,12 @@ class Mem0MemoryProvider(MemoryProvider):
                 self._record_failure()
                 logger.warning("on_pre_compress extraction failed: %s", e)
 
-        t = threading.Thread(target=_extract, daemon=True, name="mem0-pre-compress")
+        t = threading.Thread(
+            target=_extract,
+            args=(tool_content,),
+            daemon=True,
+            name="mem0-pre-compress",
+        )
         t.start()
         return ""
 

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -502,6 +502,14 @@ class Mem0MemoryProvider(MemoryProvider):
             atexit.register(self._shutdown_backend)
             self._atexit_registered = True
 
+    def _is_oss_backend(self) -> bool:
+        """Return True only when the active backend is the local OSSBackend."""
+        try:
+            from ._backend import OSSBackend
+            return isinstance(self._backend, OSSBackend)
+        except Exception:
+            return False
+
     def _read_filters(self) -> Dict[str, Any]:
         # Scoped to user_id only — by design — so recall surfaces memories
         # written from any gateway/agent under this principal. Writes attach
@@ -576,11 +584,12 @@ class Mem0MemoryProvider(MemoryProvider):
                 results = backend.search(
                     query, filters=self._read_filters(), top_k=self._prefetch_top_k, rerank=False,
                 )
-                results = _apply_staleness_weight(
-                    results or [],
-                    vacations=self._vacations,
-                    grace_days=self._decay_grace_days,
-                )
+                if self._is_oss_backend():
+                    results = _apply_staleness_weight(
+                        results or [],
+                        vacations=self._vacations,
+                        grace_days=self._decay_grace_days,
+                    )
                 lines = [r.get("memory", "") for r in results if r.get("memory")]
                 if lines:
                     body = "## Mem0 Memory\n" + "\n".join(f"- {l}" for l in lines)
@@ -619,9 +628,9 @@ class Mem0MemoryProvider(MemoryProvider):
         if self._backend is None or self._is_breaker_open():
             return
 
-        # Allow sprint-scoped ingestion via MEM0_RUN_ID env var so all
-        # background turn syncs are tagged with the active sprint/run ID.
-        run_id: str | None = os.environ.get("MEM0_RUN_ID") or None
+        # run_scope is a mem0.json behavioral setting that tags background turn
+        # syncs with a sprint/session scope ID for filtered recall.
+        run_id: str | None = (self._config or {}).get("run_scope") or None
 
         def _sync():
             backend = self._backend
@@ -776,11 +785,12 @@ class Mem0MemoryProvider(MemoryProvider):
                 self._record_success()
                 if not results:
                     return json.dumps({"result": "No relevant memories found."})
-                results = _apply_staleness_weight(
-                    results,
-                    vacations=self._vacations,
-                    grace_days=self._decay_grace_days,
-                )
+                if self._is_oss_backend():
+                    results = _apply_staleness_weight(
+                        results,
+                        vacations=self._vacations,
+                        grace_days=self._decay_grace_days,
+                    )
                 items = [{"id": r.get("id"), "memory": r.get("memory", ""),
                           "score": r.get("score", 0)} for r in results]
                 return json.dumps({"results": items, "count": len(items)})

--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 class Mem0Backend(ABC):
@@ -22,6 +25,7 @@ class Mem0Backend(ABC):
         agent_id: str,
         infer: bool = False,
         metadata: dict | None = None,
+        run_id: str | None = None,
     ) -> dict:
         ...
 
@@ -65,10 +69,18 @@ class PlatformBackend(Mem0Backend):
         agent_id: str,
         infer: bool = False,
         metadata: dict | None = None,
+        run_id: str | None = None,
     ) -> dict:
         kwargs: dict[str, Any] = {"user_id": user_id, "agent_id": agent_id, "infer": infer}
         if metadata:
             kwargs["metadata"] = metadata
+        if run_id is not None:
+            try:
+                return self._client.add(messages, run_id=run_id, **kwargs)
+            except TypeError:
+                # Older mem0ai versions don't support run_id — fold it into metadata.
+                merged = {**(kwargs.get("metadata") or {}), "run_id": run_id}
+                kwargs["metadata"] = merged
         return self._client.add(messages, **kwargs)
 
     def update(self, memory_id: str, text: str) -> dict:
@@ -127,6 +139,7 @@ class SelfHostedBackend(Mem0Backend):
         agent_id: str,
         infer: bool = False,
         metadata: dict | None = None,
+        run_id: str | None = None,
     ) -> dict:
         body: dict[str, Any] = {
             "messages": messages,
@@ -136,6 +149,8 @@ class SelfHostedBackend(Mem0Backend):
         }
         if metadata:
             body["metadata"] = metadata
+        if run_id is not None:
+            body["run_id"] = run_id
         return self._json("POST", "/memories", json=body)
 
     def update(self, memory_id: str, text: str) -> dict:
@@ -281,10 +296,18 @@ class OSSBackend(Mem0Backend):
         agent_id: str,
         infer: bool = False,
         metadata: dict | None = None,
+        run_id: str | None = None,
     ) -> dict:
         kwargs: dict[str, Any] = {"user_id": user_id, "agent_id": agent_id, "infer": infer}
         if metadata:
             kwargs["metadata"] = metadata
+        if run_id is not None:
+            try:
+                return self._memory.add(messages, run_id=run_id, **kwargs)
+            except TypeError:
+                # Older mem0ai versions don't support run_id — fold it into metadata.
+                merged = {**(kwargs.get("metadata") or {}), "run_id": run_id}
+                kwargs["metadata"] = merged
         return self._memory.add(messages, **kwargs)
 
     def update(self, memory_id: str, text: str) -> dict:

--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -77,7 +77,9 @@ class PlatformBackend(Mem0Backend):
         if run_id is not None:
             try:
                 return self._client.add(messages, run_id=run_id, **kwargs)
-            except TypeError:
+            except TypeError as exc:
+                if "run_id" not in str(exc):
+                    raise
                 # Older mem0ai versions don't support run_id — fold it into metadata.
                 merged = {**(kwargs.get("metadata") or {}), "run_id": run_id}
                 kwargs["metadata"] = merged

--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -311,7 +311,11 @@ class OSSBackend(Mem0Backend):
         return self._memory.add(messages, **kwargs)
 
     def update(self, memory_id: str, text: str) -> dict:
-        self._memory.update(memory_id, data=text)
+        try:
+            self._memory.update(memory_id, data=text)
+        except Exception as exc:
+            logger.exception("OSSBackend.update failed for memory_id=%s: %s", memory_id, exc)
+            raise
         return {"result": "Memory updated.", "memory_id": memory_id}
 
     def delete(self, memory_id: str) -> dict:

--- a/tests/plugins/memory/test_mem0_backend_oss.py
+++ b/tests/plugins/memory/test_mem0_backend_oss.py
@@ -1,0 +1,208 @@
+"""Unit tests for OSSBackend.add() in plugins.memory.mem0._backend.
+
+Covers the bug fix:
+  - run_id parameter is forwarded to mem0 add(); falls back to metadata
+    injection when the installed mem0ai version doesn't support run_id
+    (older versions raise TypeError on the unexpected kwarg).
+
+All external deps (mem0.Memory, Qdrant) are mocked.
+No real database or vector-store connections are made.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from plugins.memory.mem0._backend import OSSBackend, PlatformBackend, SelfHostedBackend
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_oss_backend(memory=None):
+    """Return an OSSBackend with _memory swapped for a fake, bypassing __init__."""
+    backend = OSSBackend.__new__(OSSBackend)
+    backend._memory = memory or MagicMock()
+    return backend
+
+
+def _make_platform_backend(client=None):
+    """Return a PlatformBackend with _client swapped for a fake."""
+    backend = PlatformBackend.__new__(PlatformBackend)
+    backend._client = client or MagicMock()
+    return backend
+
+
+def _user_msg(content="alice likes tea"):
+    return [{"role": "user", "content": content}]
+
+
+def _add_result(point_id="pt-1"):
+    return {"results": [{"id": point_id, "memory": "alice likes tea", "event": "ADD"}]}
+
+
+# ---------------------------------------------------------------------------
+# OSSBackend -- run_id forwarding
+# ---------------------------------------------------------------------------
+
+class TestOSSBackendRunId:
+
+    def test_run_id_passed_to_memory_add(self):
+        """When run_id is provided, it is forwarded to memory.add() directly."""
+        backend = _make_oss_backend()
+        backend._memory.add.return_value = _add_result()
+
+        backend.add(
+            _user_msg(), user_id="u1", agent_id="hermes", infer=True, run_id="sprint-42"
+        )
+
+        _, kwargs = backend._memory.add.call_args
+        assert kwargs.get("run_id") == "sprint-42", (
+            f"Expected run_id='sprint-42' in call kwargs, got: {kwargs}"
+        )
+
+    def test_run_id_none_not_passed(self):
+        """When run_id is None (default), it is NOT forwarded to memory.add()."""
+        backend = _make_oss_backend()
+        backend._memory.add.return_value = _add_result()
+
+        backend.add(_user_msg(), user_id="u1", agent_id="hermes", infer=True)
+
+        _, kwargs = backend._memory.add.call_args
+        assert "run_id" not in kwargs, f"run_id should be absent when None, got: {kwargs}"
+
+    def test_run_id_fallback_to_metadata_on_typeerror(self):
+        """When memory.add() raises TypeError for run_id kwarg (older mem0ai),
+        run_id is folded into metadata and the call is retried."""
+        backend = _make_oss_backend()
+        real_result = _add_result()
+
+        call_count = 0
+
+        def _side_effect(messages, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise TypeError("unexpected keyword argument 'run_id'")
+            return real_result
+
+        backend._memory.add.side_effect = _side_effect
+
+        result = backend.add(
+            _user_msg(), user_id="u1", agent_id="hermes", infer=True, run_id="sprint-1"
+        )
+
+        assert result == real_result
+        assert call_count == 2, "Should have retried once after TypeError"
+        _, retry_kwargs = backend._memory.add.call_args
+        assert "run_id" not in retry_kwargs, "run_id kwarg should be absent on retry"
+        assert retry_kwargs.get("metadata", {}).get("run_id") == "sprint-1", (
+            f"run_id should be folded into metadata on retry, got: {retry_kwargs}"
+        )
+
+    def test_run_id_fallback_merges_with_existing_metadata(self):
+        """run_id fallback merges with pre-existing metadata, not overwrites."""
+        backend = _make_oss_backend()
+        real_result = _add_result()
+
+        call_count = 0
+
+        def _side_effect(messages, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise TypeError("run_id not supported")
+            return real_result
+
+        backend._memory.add.side_effect = _side_effect
+
+        backend.add(
+            _user_msg(),
+            user_id="u1",
+            agent_id="hermes",
+            infer=True,
+            metadata={"channel": "cli"},
+            run_id="sprint-7",
+        )
+
+        _, retry_kwargs = backend._memory.add.call_args
+        meta = retry_kwargs.get("metadata", {})
+        assert meta.get("channel") == "cli", "Original metadata should be preserved"
+        assert meta.get("run_id") == "sprint-7", "run_id should be added to metadata"
+
+    def test_metadata_forwarded_without_run_id(self):
+        """metadata is still forwarded when run_id is None."""
+        backend = _make_oss_backend()
+        backend._memory.add.return_value = _add_result()
+
+        backend.add(
+            _user_msg(),
+            user_id="u1",
+            agent_id="hermes",
+            infer=True,
+            metadata={"channel": "telegram"},
+        )
+
+        _, kwargs = backend._memory.add.call_args
+        assert kwargs.get("metadata") == {"channel": "telegram"}
+
+
+# ---------------------------------------------------------------------------
+# PlatformBackend -- run_id forwarding
+# ---------------------------------------------------------------------------
+
+class TestPlatformBackendRunId:
+
+    def test_run_id_passed_to_client_add(self):
+        """PlatformBackend: run_id is forwarded to the MemoryClient."""
+        backend = _make_platform_backend()
+        backend._client.add.return_value = _add_result()
+
+        backend.add(
+            _user_msg(), user_id="u1", agent_id="hermes", infer=True, run_id="session-99"
+        )
+
+        _, kwargs = backend._client.add.call_args
+        assert kwargs.get("run_id") == "session-99"
+
+    def test_run_id_fallback_to_metadata_on_typeerror(self):
+        """PlatformBackend: run_id falls back to metadata on older client versions."""
+        backend = _make_platform_backend()
+        real_result = _add_result()
+
+        call_count = 0
+
+        def _side_effect(messages, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise TypeError("unexpected keyword argument 'run_id'")
+            return real_result
+
+        backend._client.add.side_effect = _side_effect
+
+        result = backend.add(
+            _user_msg(), user_id="u1", agent_id="hermes", infer=True, run_id="sprint-3"
+        )
+
+        assert result == real_result
+        _, retry_kwargs = backend._client.add.call_args
+        assert "run_id" not in retry_kwargs
+        assert retry_kwargs.get("metadata", {}).get("run_id") == "sprint-3"
+
+
+# ---------------------------------------------------------------------------
+# Logger is present on the module
+# ---------------------------------------------------------------------------
+
+class TestBackendLogger:
+
+    def test_oss_backend_logger_is_configured(self):
+        """The _backend module exposes a logger named after the module."""
+        from plugins.memory.mem0 import _backend
+        assert hasattr(_backend, "logger"), "Module should have a 'logger' attribute"
+        assert _backend.logger.name == "plugins.memory.mem0._backend"

--- a/tests/plugins/memory/test_mem0_staleness.py
+++ b/tests/plugins/memory/test_mem0_staleness.py
@@ -1,0 +1,428 @@
+"""Unit tests for _apply_staleness_weight in plugins.memory.mem0.
+
+The function applies a time-decay blend to mem0 search results so that
+older memories score lower than recent ones. Vacation periods freeze or
+reset decay while the user is away.
+
+Patch target: ``plugins.memory.mem0.datetime``
+(the module does ``from datetime import datetime, timedelta, timezone``,
+so we replace the *name* ``datetime`` inside the module namespace).
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from plugins.memory.mem0 import _apply_staleness_weight
+from plugins.memory.mem0 import _DECAY_ALPHA, _DECAY_HALF_LIFE_DAYS, _DECAY_GRACE_DAYS
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_UTC = timezone.utc
+
+# "now" used in every test unless overridden.
+NOW = datetime(2026, 6, 1, 12, 0, 0, tzinfo=_UTC)
+
+
+def _patch_now(fake_now: datetime):
+    """Return a context manager that freezes datetime.now() inside the module."""
+    mock_dt = MagicMock(wraps=datetime)
+    mock_dt.now.return_value = fake_now
+    # Keep class methods that the function calls directly
+    mock_dt.fromisoformat = datetime.fromisoformat
+    mock_dt.fromtimestamp = datetime.fromtimestamp
+    return patch("plugins.memory.mem0.datetime", mock_dt)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def _result(score: float, ts: str | None = None, *, use_updated_at=True) -> dict:
+    """Construct a minimal result dict."""
+    r: dict = {"score": score}
+    if ts is not None:
+        if use_updated_at:
+            r["updated_at"] = ts
+        else:
+            r["created_at"] = ts
+    return r
+
+
+# ---------------------------------------------------------------------------
+# 1. No vacations — sorted by decay score descending
+# ---------------------------------------------------------------------------
+
+class TestNoVacations:
+
+    def test_sorted_descending(self):
+        """Results are re-sorted highest adjusted score first."""
+        recent = _iso(NOW - timedelta(days=1))
+        old = _iso(NOW - timedelta(days=120))
+        results = [
+            _result(0.8, old),    # will get heavy penalty
+            _result(0.9, recent), # nearly no penalty
+        ]
+        with _patch_now(NOW):
+            out = _apply_staleness_weight(results)
+        assert out[0]["score"] >= out[1]["score"], "should be sorted descending"
+        # The recent result should rank first because it keeps most of its score.
+        # Verify by identity of the memory timestamp.
+        assert out[0].get("updated_at") == recent
+
+    # -----------------------------------------------------------------------
+    # 2. Missing timestamp passes through unchanged
+    # -----------------------------------------------------------------------
+
+    def test_missing_timestamp_passes_through(self):
+        """A result without updated_at/created_at gets adjusted = base_score."""
+        r = {"score": 0.75, "memory": "no timestamp here"}
+        with _patch_now(NOW):
+            out = _apply_staleness_weight([r])
+        assert out[0]["score"] == pytest.approx(0.75)
+
+    # -----------------------------------------------------------------------
+    # 3. Unix float timestamp (int/float isinstance branch)
+    # -----------------------------------------------------------------------
+
+    def test_unix_float_timestamp(self):
+        """A numeric (Unix epoch float) timestamp is handled via fromtimestamp."""
+        ts_unix = NOW.timestamp() - 1.0  # 1 second ago → within grace
+        r = {"score": 0.9, "updated_at": ts_unix}
+        with _patch_now(NOW):
+            out = _apply_staleness_weight([r])
+        # 1 second old → well within grace → decay_factor=1.0 → no penalty
+        expected = 0.9  # (1-0.3)*0.9 + 0.3*1.0*0.9 = 0.9
+        assert out[0]["score"] == pytest.approx(expected, rel=1e-6)
+
+    def test_unix_int_timestamp(self):
+        """An integer Unix timestamp is also handled correctly."""
+        ts_unix = int((NOW - timedelta(days=1)).timestamp())
+        r = {"score": 0.8, "updated_at": ts_unix}
+        with _patch_now(NOW):
+            out = _apply_staleness_weight([r])
+        # 1 day old → within default grace of 14 days → decay_factor=1.0
+        expected = 0.8
+        assert out[0]["score"] == pytest.approx(expected, rel=1e-6)
+
+    # -----------------------------------------------------------------------
+    # 4. Within grace_days → decay_factor = 1.0 (no penalty)
+    # -----------------------------------------------------------------------
+
+    def test_within_grace_no_penalty(self):
+        """Memory created exactly at the grace boundary incurs no penalty."""
+        grace = _DECAY_GRACE_DAYS
+        ts = _iso(NOW - timedelta(days=grace - 0.001))  # just inside grace
+        r = _result(0.7, ts)
+        with _patch_now(NOW):
+            out = _apply_staleness_weight([r], grace_days=grace)
+        # adjusted = (1-alpha)*base + alpha*1.0*base = base
+        assert out[0]["score"] == pytest.approx(0.7, rel=1e-6)
+
+    # -----------------------------------------------------------------------
+    # 5. Beyond grace_days → decay < 1.0, score reduced
+    # -----------------------------------------------------------------------
+
+    def test_beyond_grace_score_reduced(self):
+        """Memory older than grace_days gets a fractional decay_factor."""
+        grace = _DECAY_GRACE_DAYS
+        ts = _iso(NOW - timedelta(days=grace + 30))  # 30 days past grace
+        r = _result(1.0, ts)
+        with _patch_now(NOW):
+            out = _apply_staleness_weight([r], grace_days=grace)
+        assert out[0]["score"] < 1.0
+
+    # -----------------------------------------------------------------------
+    # 6. Exact decay formula verification
+    # -----------------------------------------------------------------------
+
+    def test_decay_formula_exact(self):
+        """adjusted = (1 - alpha)*base + alpha * decay_factor * base."""
+        alpha = _DECAY_ALPHA
+        half_life = _DECAY_HALF_LIFE_DAYS
+        grace = _DECAY_GRACE_DAYS
+        base = 0.8
+        days_past_grace = 15.0
+        days_old = grace + days_past_grace
+        ts = _iso(NOW - timedelta(days=days_old))
+        r = _result(base, ts)
+        decay_factor = 0.5 ** (days_past_grace / half_life)
+        expected = (1 - alpha) * base + alpha * decay_factor * base
+        with _patch_now(NOW):
+            out = _apply_staleness_weight([r], grace_days=grace)
+        assert out[0]["score"] == pytest.approx(expected, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 7. Active vacation — no decay, sorted by base score
+# ---------------------------------------------------------------------------
+
+class TestActiveVacation:
+
+    def test_active_vacation_no_decay(self):
+        """While NOW is inside a vacation period, results are returned sorted
+        by base score without any time-decay adjustment."""
+        vstart = _iso(NOW - timedelta(days=5))
+        vend = _iso(NOW + timedelta(days=10))
+        vacations = [{"start": vstart, "end": vend}]
+
+        # Old timestamps that would normally get heavy penalties
+        old_ts = _iso(NOW - timedelta(days=200))
+        results = [
+            _result(0.5, old_ts),
+            _result(0.9, old_ts),
+            _result(0.7, old_ts),
+        ]
+        with _patch_now(NOW):
+            out = _apply_staleness_weight(results, vacations=vacations)
+
+        scores = [r["score"] for r in out]
+        # Must be sorted descending by BASE score (no decay applied)
+        assert scores == sorted(scores, reverse=True)
+        # The scores must equal the originals (no blending)
+        assert scores == pytest.approx([0.9, 0.7, 0.5])
+
+    # -----------------------------------------------------------------------
+    # 8. Active vacation, no start date — start defaults to epoch
+    # -----------------------------------------------------------------------
+
+    def test_active_vacation_no_start_defaults_to_epoch(self):
+        """A period without 'start' uses epoch as start; any NOW during the
+        period (including NOW far from epoch) still triggers early return."""
+        vend = _iso(NOW + timedelta(days=10))
+        vacations = [{"end": vend}]  # no "start" key
+
+        old_ts = _iso(NOW - timedelta(days=300))
+        r = _result(0.6, old_ts)
+        with _patch_now(NOW):
+            out = _apply_staleness_weight([r], vacations=vacations)
+        # Early return keeps original score
+        assert out[0]["score"] == pytest.approx(0.6)
+
+
+# ---------------------------------------------------------------------------
+# 9. Post-vacation, within grace — effective_now set to vacation_end
+# ---------------------------------------------------------------------------
+
+class TestPostVacationWithinGrace:
+
+    def test_within_grace_after_vacation_full_score(self):
+        """Days since return <= grace_days → effective_now = vacation_end.
+
+        Memory created just before vacation_end has a very small days_old
+        (measured from effective_now=vacation_end), so it gets decay_factor=1.0.
+        """
+        vacation_end = NOW - timedelta(days=5)   # returned 5 days ago
+        vacation_start = vacation_end - timedelta(days=14)
+        vacations = [{"start": _iso(vacation_start), "end": _iso(vacation_end)}]
+
+        # Memory created 1 day before vacation ended
+        mem_ts = _iso(vacation_end - timedelta(days=1))
+        r = _result(0.8, mem_ts)
+
+        with _patch_now(NOW):
+            out = _apply_staleness_weight([r], vacations=vacations)
+
+        # days_old measured from effective_now=vacation_end: 1 day → within grace
+        expected = 0.8  # decay_factor=1.0, no penalty
+        assert out[0]["score"] == pytest.approx(expected, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 10. Post-vacation, beyond grace — effective_now stays as real now
+# ---------------------------------------------------------------------------
+
+class TestPostVacationBeyondGrace:
+
+    def test_beyond_grace_after_vacation_normal_decay(self):
+        """Days since return > grace_days → effective_now stays = now.
+        Normal decay applies as if no vacation had happened."""
+        grace = _DECAY_GRACE_DAYS
+        vacation_end = NOW - timedelta(days=grace + 5)  # returned well past grace
+        vacation_start = vacation_end - timedelta(days=10)
+        vacations = [{"start": _iso(vacation_start), "end": _iso(vacation_end)}]
+
+        # Memory from a very long time ago
+        old_ts = _iso(NOW - timedelta(days=200))
+        r = _result(1.0, old_ts)
+
+        with _patch_now(NOW):
+            out = _apply_staleness_weight([r], vacations=vacations, grace_days=grace)
+
+        # score should be < 1.0 since effective_now=now and memory is very old
+        assert out[0]["score"] < 1.0
+
+
+# ---------------------------------------------------------------------------
+# 11. Multiple past vacations — most recent vacation_end wins
+# ---------------------------------------------------------------------------
+
+class TestMultiplePastVacations:
+
+    def test_most_recent_past_end_wins(self):
+        """When several vacations have ended, the largest vacation_end
+        (most recent) is chosen as best_past_end, minimising days_old."""
+        older_end = NOW - timedelta(days=10)
+        newer_end = NOW - timedelta(days=3)
+        vacations = [
+            {"start": _iso(older_end - timedelta(days=7)), "end": _iso(older_end)},
+            {"start": _iso(newer_end - timedelta(days=7)), "end": _iso(newer_end)},
+        ]
+
+        # Memory created 1 day before the NEWER vacation ended
+        mem_ts = _iso(newer_end - timedelta(days=1))
+        r = _result(0.9, mem_ts)
+
+        with _patch_now(NOW):
+            out = _apply_staleness_weight([r], vacations=vacations)
+
+        # effective_now = newer_end → days_old ≈ 1 day → within grace → no decay
+        assert out[0]["score"] == pytest.approx(0.9, rel=1e-6)
+
+    def test_older_end_would_have_penalised(self):
+        """Confirm that if we used the older vacation_end instead, the score
+        would be lower — proving that the newest-end selection matters."""
+        older_end = NOW - timedelta(days=20)
+        # Only one past vacation whose end is 20 days ago
+        vacations = [
+            {"start": _iso(older_end - timedelta(days=5)), "end": _iso(older_end)},
+        ]
+        # Memory created right at vacation_end
+        mem_ts = _iso(older_end)
+        r = _result(1.0, mem_ts)
+
+        # 20 days since return > default grace_days (14) → effective_now stays as now
+        with _patch_now(NOW):
+            out = _apply_staleness_weight([r], vacations=vacations)
+
+        # days_old measured from NOW: 20 days → beyond grace → decay < 1.0
+        assert out[0]["score"] < 1.0
+
+
+# ---------------------------------------------------------------------------
+# 12. Multiple vacations, one active — triggers early return
+# ---------------------------------------------------------------------------
+
+class TestMultipleVacationsOneActive:
+
+    def test_active_period_triggers_early_return(self):
+        """If ANY vacation period is currently active, return early with base
+        scores regardless of past periods that have ended."""
+        past_end = NOW - timedelta(days=30)
+        active_start = NOW - timedelta(days=2)
+        active_end = NOW + timedelta(days=5)
+        vacations = [
+            {"start": _iso(past_end - timedelta(days=7)), "end": _iso(past_end)},
+            {"start": _iso(active_start), "end": _iso(active_end)},
+        ]
+
+        old_ts = _iso(NOW - timedelta(days=300))
+        results = [_result(0.4, old_ts), _result(0.9, old_ts)]
+
+        with _patch_now(NOW):
+            out = _apply_staleness_weight(results, vacations=vacations)
+
+        # Early return: sorted by base score, values unchanged
+        assert out[0]["score"] == pytest.approx(0.9)
+        assert out[1]["score"] == pytest.approx(0.4)
+
+
+# ---------------------------------------------------------------------------
+# 13. Malformed period — missing 'end' key is skipped silently
+# ---------------------------------------------------------------------------
+
+class TestMalformedPeriods:
+
+    def test_missing_end_key_skipped(self):
+        """A period dict without an 'end' key is silently skipped; the
+        remaining logic (no-vacation path) proceeds normally."""
+        vacations = [{"start": _iso(NOW - timedelta(days=5))}]  # no 'end'
+        recent_ts = _iso(NOW - timedelta(days=1))
+        r = _result(0.8, recent_ts)
+
+        with _patch_now(NOW):
+            out = _apply_staleness_weight([r], vacations=vacations)
+
+        # No vacation effect; memory is recent → decay_factor=1.0 → score unchanged
+        assert out[0]["score"] == pytest.approx(0.8, rel=1e-6)
+
+    # -----------------------------------------------------------------------
+    # 14. Malformed period — non-parseable end date string is skipped
+    # -----------------------------------------------------------------------
+
+    def test_non_parseable_end_date_skipped(self):
+        """A period whose 'end' value cannot be parsed as ISO is skipped;
+        rest of the logic (no-vacation path) still runs."""
+        vacations = [{"start": _iso(NOW - timedelta(days=5)), "end": "NOT-A-DATE"}]
+        recent_ts = _iso(NOW - timedelta(days=1))
+        r = _result(0.8, recent_ts)
+
+        with _patch_now(NOW):
+            out = _apply_staleness_weight([r], vacations=vacations)
+
+        # Malformed period skipped → no vacation → normal decay → within grace
+        assert out[0]["score"] == pytest.approx(0.8, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 15. Empty vacations list — identical to no vacations
+# ---------------------------------------------------------------------------
+
+class TestEmptyVacations:
+
+    def test_empty_list_same_as_none(self):
+        """vacations=[] and vacations=None produce identical results."""
+        recent_ts = _iso(NOW - timedelta(days=1))
+        results = [_result(0.7, recent_ts)]
+
+        with _patch_now(NOW):
+            out_none = _apply_staleness_weight(results, vacations=None)
+        with _patch_now(NOW):
+            out_empty = _apply_staleness_weight(results, vacations=[])
+
+        assert out_none[0]["score"] == pytest.approx(out_empty[0]["score"])
+
+
+# ---------------------------------------------------------------------------
+# 16. Sort order — output sorted highest-to-lowest adjusted score
+# ---------------------------------------------------------------------------
+
+class TestSortOrder:
+
+    def test_sort_order_across_multiple_results(self):
+        """With several results having different ages and base scores, the
+        output list is always in descending order of adjusted score."""
+        results = [
+            _result(0.5, _iso(NOW - timedelta(days=200))),  # old, low base
+            _result(0.95, _iso(NOW - timedelta(days=180))), # old, high base
+            _result(0.6, _iso(NOW - timedelta(days=2))),    # new, medium base
+            _result(0.85, _iso(NOW - timedelta(days=1))),   # new, high base
+            _result(0.4, _iso(NOW - timedelta(days=50))),   # mid-age, low base
+        ]
+
+        with _patch_now(NOW):
+            out = _apply_staleness_weight(results)
+
+        scores = [r["score"] for r in out]
+        assert scores == sorted(scores, reverse=True), (
+            f"Output not sorted descending: {scores}"
+        )
+
+    def test_sort_handles_mixed_timestamp_presence(self):
+        """Results with and without timestamps are all included and sorted."""
+        results = [
+            {"score": 0.6},                                      # no ts
+            _result(0.9, _iso(NOW - timedelta(days=1))),         # new
+            _result(0.3, _iso(NOW - timedelta(days=300))),       # very old
+        ]
+        with _patch_now(NOW):
+            out = _apply_staleness_weight(results)
+
+        scores = [r["score"] for r in out]
+        assert scores == sorted(scores, reverse=True)

--- a/tests/plugins/memory/test_mem0_staleness.py
+++ b/tests/plugins/memory/test_mem0_staleness.py
@@ -286,22 +286,29 @@ class TestMultiplePastVacations:
         assert out[0]["score"] == pytest.approx(0.9, rel=1e-6)
 
     def test_older_end_would_have_penalised(self):
-        """Confirm that if we used the older vacation_end instead, the score
-        would be lower — proving that the newest-end selection matters."""
-        older_end = NOW - timedelta(days=20)
-        # Only one past vacation whose end is 20 days ago
+        """Confirm that a very old vacation_end still results in a decayed score.
+
+        With the smooth-transition fix, effective_now = now - grace_days when
+        days_since_return > grace_days.  To see decay the memory must be older
+        than effective_now by more than grace_days.  We place the memory at
+        vacation_end (60 days ago) and vacation_end 60 days ago; then
+        effective_now = now - 14 days, and days_old = (now-14) - (now-60) = 46
+        days, which is > grace_days → decay < 1.0.
+        """
+        older_end = NOW - timedelta(days=60)
+        # Only one past vacation whose end is 60 days ago
         vacations = [
             {"start": _iso(older_end - timedelta(days=5)), "end": _iso(older_end)},
         ]
-        # Memory created right at vacation_end
+        # Memory created right at vacation_end (60 days ago)
         mem_ts = _iso(older_end)
         r = _result(1.0, mem_ts)
 
-        # 20 days since return > default grace_days (14) → effective_now stays as now
+        # 60 days since return > grace_days (14) → smooth transition:
+        # effective_now = now - 14 days; days_old ≈ 46 days > grace → decay < 1.0
         with _patch_now(NOW):
             out = _apply_staleness_weight([r], vacations=vacations)
 
-        # days_old measured from NOW: 20 days → beyond grace → decay < 1.0
         assert out[0]["score"] < 1.0
 
 

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -1,7 +1,6 @@
 """Tests for Mem0 v3 API — new tool names, paginated responses, update/delete tools."""
 
 import json
-import threading
 import time
 import pytest
 
@@ -59,6 +58,33 @@ class TestMem0V3Tools:
         result = json.loads(provider.handle_tool_call("mem0_search", {"query": "test"}))
         assert result["results"][0]["id"] == "mem-1"
 
+    def test_search_uses_filters(self, monkeypatch):
+        backend = FakeBackend()
+        provider = self._make_provider(monkeypatch, backend)
+        provider.handle_tool_call("mem0_search", {"query": "hello", "top_k": 3})
+        assert backend.captured[0][2]["filters"] == {"user_id": "u123"}
+        assert backend.captured[0][2]["top_k"] == 3
+
+    def test_search_rerank_default_false(self, monkeypatch):
+        backend = FakeBackend()
+        provider = self._make_provider(monkeypatch, backend)
+        provider.handle_tool_call("mem0_search", {"query": "test"})
+        assert backend.captured[0][2]["rerank"] is False
+
+    def test_search_rerank_override_false(self, monkeypatch):
+        backend = FakeBackend()
+        provider = self._make_provider(monkeypatch, backend)
+        provider.handle_tool_call("mem0_search", {"query": "test", "rerank": False})
+        assert backend.captured[0][2]["rerank"] is False
+
+    def test_search_rerank_config_default_used_when_arg_absent(self, monkeypatch):
+        """The persisted mem0.json ``rerank`` preference is the tool default;
+        a per-call arg still wins (see the explicit-False override above)."""
+        backend = FakeBackend()
+        provider = self._make_provider(monkeypatch, backend)
+        provider._rerank_default = True  # as initialize() sets from config
+        provider.handle_tool_call("mem0_search", {"query": "test"})
+        assert backend.captured[0][2]["rerank"] is True
 
     def test_add_uses_content_param(self, monkeypatch):
         backend = FakeBackend()
@@ -71,6 +97,17 @@ class TestMem0V3Tools:
         assert call[2]["agent_id"] == "hermes"
         assert "event_id" in result
 
+    def test_add_returns_event_id(self, monkeypatch):
+        backend = FakeBackend()
+        provider = self._make_provider(monkeypatch, backend)
+        result = json.loads(provider.handle_tool_call("mem0_add", {"content": "test"}))
+        assert result["event_id"] == "evt-test-123"
+
+    def test_add_missing_content(self, monkeypatch):
+        backend = FakeBackend()
+        provider = self._make_provider(monkeypatch, backend)
+        result = json.loads(provider.handle_tool_call("mem0_add", {}))
+        assert "error" in result
 
     def test_old_tool_names_return_unknown(self, monkeypatch):
         backend = FakeBackend()
@@ -102,6 +139,17 @@ class TestMem0UpdateDelete:
         assert result["result"] == "Memory updated."
         assert result["memory_id"] == "mem-1"
 
+    def test_update_missing_memory_id(self, monkeypatch):
+        backend = FakeBackend()
+        provider = self._make_provider(monkeypatch, backend)
+        result = json.loads(provider.handle_tool_call("mem0_update", {"text": "no id"}))
+        assert "error" in result
+
+    def test_update_missing_text(self, monkeypatch):
+        backend = FakeBackend()
+        provider = self._make_provider(monkeypatch, backend)
+        result = json.loads(provider.handle_tool_call("mem0_update", {"memory_id": "mem-1"}))
+        assert "error" in result
 
     def test_delete_calls_sdk(self, monkeypatch):
         backend = FakeBackend()
@@ -111,6 +159,12 @@ class TestMem0UpdateDelete:
         ))
         assert backend.captured[0][1] == "mem-1"
         assert result["result"] == "Memory deleted."
+
+    def test_delete_missing_memory_id(self, monkeypatch):
+        backend = FakeBackend()
+        provider = self._make_provider(monkeypatch, backend)
+        result = json.loads(provider.handle_tool_call("mem0_delete", {}))
+        assert "error" in result
 
 
 class TestMem0ErrorHandling:
@@ -122,6 +176,62 @@ class TestMem0ErrorHandling:
         provider._agent_id = "hermes"
         provider._backend = backend
         return provider
+
+    def test_update_404_no_circuit_breaker(self, monkeypatch):
+        backend = FakeBackend()
+        backend.update = lambda mid, text: (_ for _ in ()).throw(Exception("404 Not Found"))
+        provider = self._make_provider(monkeypatch, backend)
+        result = json.loads(provider.handle_tool_call(
+            "mem0_update", {"memory_id": "bad-id", "text": "x"}
+        ))
+        assert "error" in result
+        assert provider._consecutive_failures == 0
+
+    def test_delete_404_no_circuit_breaker(self, monkeypatch):
+        backend = FakeBackend()
+        backend.delete = lambda mid: (_ for _ in ()).throw(Exception("404 not found"))
+        provider = self._make_provider(monkeypatch, backend)
+        result = json.loads(provider.handle_tool_call(
+            "mem0_delete", {"memory_id": "bad-id"}
+        ))
+        assert "error" in result
+        assert provider._consecutive_failures == 0
+
+    def test_update_validation_error_no_circuit_breaker(self, monkeypatch):
+        """ValidationError (bad UUID format) should not trip circuit breaker."""
+        class ValidationError(Exception):
+            pass
+        backend = FakeBackend()
+        backend.update = lambda mid, text: (_ for _ in ()).throw(
+            ValidationError('{"error":"memory_id should be a valid UUID"}')
+        )
+        provider = self._make_provider(monkeypatch, backend)
+        result = json.loads(provider.handle_tool_call(
+            "mem0_update", {"memory_id": "not-a-uuid", "text": "x"}
+        ))
+        assert "error" in result
+        assert provider._consecutive_failures == 0
+
+    def test_delete_validation_error_no_circuit_breaker(self, monkeypatch):
+        class ValidationError(Exception):
+            pass
+        backend = FakeBackend()
+        backend.delete = lambda mid: (_ for _ in ()).throw(
+            ValidationError('{"error":"memory_id should be a valid UUID"}')
+        )
+        provider = self._make_provider(monkeypatch, backend)
+        result = json.loads(provider.handle_tool_call(
+            "mem0_delete", {"memory_id": "not-a-uuid"}
+        ))
+        assert "error" in result
+        assert provider._consecutive_failures == 0
+
+    def test_update_5xx_trips_circuit_breaker(self, monkeypatch):
+        backend = FakeBackend()
+        backend.update = lambda mid, text: (_ for _ in ()).throw(Exception("500 Internal Server Error"))
+        provider = self._make_provider(monkeypatch, backend)
+        provider.handle_tool_call("mem0_update", {"memory_id": "mem-1", "text": "x"})
+        assert provider._consecutive_failures == 1
 
 
 class TestMem0V3Internal:
@@ -144,6 +254,16 @@ class TestMem0V3Internal:
         assert call[2]["user_id"] == "u123"
         assert call[2]["agent_id"] == "hermes"
         assert call[2]["infer"] is True
+
+    def test_old_tool_names_return_unknown(self, monkeypatch):
+        backend = FakeBackend()
+        provider = self._make_provider(monkeypatch, backend)
+        result = json.loads(provider.handle_tool_call("mem0_profile", {}))
+        assert "error" in result
+        result = json.loads(provider.handle_tool_call("mem0_conclude", {}))
+        assert "error" in result
+        result = json.loads(provider.handle_tool_call("mem0_list", {}))
+        assert "error" in result
 
 
 class TestMem0Prefetch:
@@ -177,6 +297,12 @@ class TestMem0Prefetch:
         assert "## Mem0 Memory" in result
         assert "user prefers dark mode" in result
 
+    def test_prefetch_returns_memories_on_first_call(self):
+        # No prior queue_prefetch / warm — the very first call must still recall.
+        backend = FakeBackend(search_results=[{"id": "m1", "memory": "lives in Berlin"}])
+        provider = self._make_provider(backend)
+        result = provider.prefetch("where do I live?")
+        assert "lives in Berlin" in result
 
     def test_on_turn_start_queues_current_query(self):
         backend = FakeBackend(search_results=[{"id": "m1", "memory": "lives in Berlin"}])
@@ -188,49 +314,33 @@ class TestMem0Prefetch:
         assert len([c for c in backend.captured if c[0] == "search"]) == 1
 
     def test_slow_prefetch_returns_quickly(self, monkeypatch):
-        entered = threading.Event()
-        release = threading.Event()
-        search_returned = threading.Event()
-
         class SlowBackend(FakeBackend):
             def search(self, query, *, filters, top_k=10, rerank=True):
-                entered.set()
-                try:
-                    release.wait(30)
-                    return super().search(
-                        query, filters=filters, top_k=top_k, rerank=rerank
-                    )
-                finally:
-                    search_returned.set()
+                time.sleep(0.2)
+                return super().search(query, filters=filters, top_k=top_k, rerank=rerank)
 
         monkeypatch.setattr(mem0_plugin, "_PREFETCH_WAIT_SECS", 0.01)
         provider = self._make_provider(
             SlowBackend(search_results=[{"id": "m1", "memory": "lives in Berlin"}])
         )
-        # DETERMINISTIC non-blocking witness — replaces `assert elapsed < 0.1`.
-        #
-        # The old form slept 0.2s in the backend and asserted prefetch returned
-        # in under 0.1s. That makes the OS scheduler part of the assertion: on
-        # a loaded box thread startup alone can eat the 100ms budget, so the
-        # inequality flips with nothing wrong in the code under test. Observed
-        # failing in a full-directory run of tests/plugins/memory.
-        #
-        # The real contract is that prefetch gives up on the slow backend
-        # instead of waiting for it. Assert it directly: the backend search is
-        # STILL PARKED (release unset, so `search_returned` cannot be set). If
-        # prefetch ever waited for the backend, the search would have returned
-        # first and this fails. No wall-clock constant.
+        started = time.monotonic()
         assert provider.prefetch("where do I live?") == ""
-        assert entered.wait(30), "prefetch never reached the backend"
-        assert not search_returned.is_set(), (
-            "prefetch blocked on the slow backend: the backend search had "
-            "already returned by the time prefetch did"
-        )
-
-        release.set()
-        provider._prefetch_thread.join(timeout=30)
+        assert time.monotonic() - started < 0.1
+        provider._prefetch_thread.join(timeout=1)
         assert "lives in Berlin" in provider.prefetch("where do I live?")
 
+    def test_prefetch_empty_results_returns_empty(self):
+        backend = FakeBackend(search_results=[])
+        provider = self._make_provider(backend)
+        assert provider.prefetch("anything") == ""
+
+    def test_prefetch_skips_when_breaker_open(self):
+        backend = FakeBackend(search_results=[{"id": "m1", "memory": "x"}])
+        provider = self._make_provider(backend)
+        provider._consecutive_failures = 5
+        provider._breaker_open_until = float("inf")
+        assert provider.prefetch("q") == ""
+        assert backend.captured == []
 
     def test_queue_prefetch_fires_no_search(self):
         # prefetch is synchronous now, so the post-turn warm is redundant and
@@ -261,6 +371,30 @@ class TestMem0V3Config:
         assert "mem0_profile" not in block
         assert "mem0_conclude" not in block
 
+    def test_system_prompt_shows_platform_mode(self):
+        provider = Mem0MemoryProvider()
+        provider._user_id = "test"
+        provider._mode = "platform"
+        block = provider.system_prompt_block()
+        assert "platform" in block
+        assert "Rerank" in block
+
+    def test_system_prompt_shows_oss_mode(self):
+        provider = Mem0MemoryProvider()
+        provider._user_id = "test"
+        provider._mode = "oss"
+        block = provider.system_prompt_block()
+        assert "OSS" in block
+        assert "Rerank" not in block
+
+    def test_search_schema_has_rerank(self):
+        """rerank property available in SEARCH_SCHEMA for platform mode."""
+        provider = Mem0MemoryProvider()
+        schemas = provider.get_tool_schemas()
+        search = next(s for s in schemas if s["name"] == "mem0_search")
+        assert "rerank" in search["parameters"]["properties"]
+        assert search["parameters"]["properties"]["rerank"]["type"] == "boolean"
+
 
 class TestMem0ModeSwitch:
 
@@ -287,6 +421,34 @@ class TestMem0ModeSwitch:
         monkeypatch.delenv("MEM0_API_KEY", raising=False)
         provider = Mem0MemoryProvider()
         assert provider.is_available() is False
+
+    def test_is_available_oss_needs_vector(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config_path = tmp_path / "mem0.json"
+        config_path.write_text('{"mode": "oss", "oss": {"vector_store": {"provider": "qdrant"}}}')
+        provider = Mem0MemoryProvider()
+        assert provider.is_available() is True
+
+    def test_is_available_oss_no_vector(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config_path = tmp_path / "mem0.json"
+        config_path.write_text('{"mode": "oss", "oss": {}}')
+        provider = Mem0MemoryProvider()
+        assert provider.is_available() is False
+
+    def test_tool_schemas_unchanged(self):
+        provider = Mem0MemoryProvider()
+        schemas = provider.get_tool_schemas()
+        names = [s["name"] for s in schemas]
+        assert names == ["mem0_search", "mem0_add", "mem0_update", "mem0_delete"]
+
+    def test_system_prompt_includes_mode(self):
+        provider = Mem0MemoryProvider()
+        provider._user_id = "test"
+        provider._mode = "oss"
+        block = provider.system_prompt_block()
+        assert "mem0_search" in block
+        assert "OSS" in block
 
 
 class TestMem0UserIdResolution:
@@ -324,6 +486,11 @@ class TestMem0UserIdResolution:
         provider.initialize("test", user_id="123456789", platform="telegram")
         assert provider._user_id == "123456789"
 
+    def test_unset_and_no_kwargs_falls_back_to_default(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MEM0_USER_ID", raising=False)
+        provider = self._provider(monkeypatch, tmp_path)
+        provider.initialize("test")
+        assert provider._user_id == "hermes-user"
 
     def test_legacy_placeholder_in_config_does_not_override_kwargs(self, monkeypatch, tmp_path):
         # Setup wizard historically wrote {"user_id": "hermes-user"} as the
@@ -348,6 +515,22 @@ class TestMem0WriteMetadata:
         provider._channel = channel
         provider._backend = FakeBackend()
         return provider
+
+    def test_add_tool_passes_channel_metadata(self):
+        provider = self._make_provider("telegram")
+        provider.handle_tool_call("mem0_add", {"content": "user likes dark mode"})
+        call = provider._backend.captured[-1]
+        assert call[2]["metadata"] == {"channel": "telegram"}
+
+    def test_sync_turn_passes_channel_metadata(self):
+        provider = self._make_provider("discord")
+        provider.sync_turn("hi", "hello", session_id="s")
+        # sync_turn fires a daemon thread; wait for it.
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=5.0)
+        adds = [c for c in provider._backend.captured if c[0] == "add"]
+        assert adds, "expected an add call from sync_turn"
+        assert adds[-1][2]["metadata"] == {"channel": "discord"}
 
 
 class _SentinelBackend:
@@ -381,6 +564,23 @@ class TestCreateBackendRouting:
         assert isinstance(backend, SH)
         assert captured["args"] == ("adminkey", "http://sh:8888")
 
+    def test_routes_to_platform_when_no_host(self, monkeypatch):
+        class PB(_SentinelBackend):
+            def __init__(self, api_key):
+                pass
+
+        monkeypatch.setattr("plugins.memory.mem0._backend.PlatformBackend", PB)
+        provider = self._provider(monkeypatch, host="")
+        assert isinstance(provider._create_backend(), PB)
+
+    def test_routes_to_oss_when_mode_oss(self, monkeypatch):
+        class OB(_SentinelBackend):
+            def __init__(self, cfg):
+                pass
+
+        monkeypatch.setattr("plugins.memory.mem0._backend.OSSBackend", OB)
+        provider = self._provider(monkeypatch, mode="oss")
+        assert isinstance(provider._create_backend(), OB)
 
     def test_oss_mode_takes_precedence_over_host(self, monkeypatch):
         class OB(_SentinelBackend):
@@ -409,4 +609,197 @@ class TestSelfHostedConfig:
         monkeypatch.setenv("MEM0_HOST", "http://localhost:8888")
         assert mem0_plugin._load_config()["host"] == "http://localhost:8888"
 
+    def test_is_available_true_with_host_only(self, monkeypatch):
+        monkeypatch.delenv("MEM0_API_KEY", raising=False)
+        monkeypatch.setenv("MEM0_MODE", "platform")
+        monkeypatch.setenv("MEM0_HOST", "http://localhost:8888")
+        assert Mem0MemoryProvider().is_available() is True
 
+    def test_is_available_false_without_key_or_host(self, monkeypatch):
+        monkeypatch.delenv("MEM0_API_KEY", raising=False)
+        monkeypatch.delenv("MEM0_HOST", raising=False)
+        monkeypatch.setenv("MEM0_MODE", "platform")
+        assert Mem0MemoryProvider().is_available() is False
+
+
+# ---------------------------------------------------------------------------
+# on_pre_compress tests
+# ---------------------------------------------------------------------------
+
+class TestOnPreCompress:
+    """Tests for Mem0MemoryProvider.on_pre_compress.
+
+    Three contracts are verified:
+      1. Truncation fires on oversized tool content and mutates in-place.
+      2. A background extraction thread is launched when tool content > 500 chars.
+      3. Backend-is-None short-circuits without launching any thread.
+    """
+
+    _THRESHOLD = 8_000   # matches _TOOL_TRUNCATE_THRESHOLD in on_pre_compress
+    _MIN_EXTRACT = 501   # one char above the 500-char extraction trigger
+
+    def _make_provider(self, monkeypatch, backend=None):
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+        provider._user_id = "u1"
+        provider._agent_id = "hermes"
+        provider._backend = backend
+        return provider
+
+    # ------------------------------------------------------------------
+    # 1. Truncation fires and modifies content in-place
+    # ------------------------------------------------------------------
+
+    def test_truncation_fires_on_oversized_tool_content(self, monkeypatch):
+        """Tool message content > _THRESHOLD is truncated in-place."""
+        provider = self._make_provider(monkeypatch, backend=None)
+        big_content = "x" * (self._THRESHOLD + 1)
+        msg = {"role": "tool", "content": big_content}
+        provider.on_pre_compress([msg])
+        assert len(msg["content"]) < len(big_content), (
+            "Content should have been truncated in-place"
+        )
+        assert "[truncated" in msg["content"], (
+            "Truncated sentinel should appear in the modified content"
+        )
+
+    def test_truncation_preserves_head_and_tail(self, monkeypatch):
+        """Truncated content begins with the first 500 chars and ends with the last 200 chars."""
+        _HEAD = 500
+        _TAIL = 200
+        provider = self._make_provider(monkeypatch, backend=None)
+        head = "H" * _HEAD
+        body = "M" * (self._THRESHOLD - _HEAD - _TAIL + 1)
+        tail = "T" * _TAIL
+        big_content = head + body + tail
+        msg = {"role": "tool", "content": big_content}
+        provider.on_pre_compress([msg])
+        assert msg["content"].startswith(head), "Head chars must be preserved"
+        assert msg["content"].endswith(tail), "Tail chars must be preserved"
+
+    def test_truncation_does_not_touch_non_tool_messages(self, monkeypatch):
+        """User/assistant messages are never truncated, even if very large."""
+        provider = self._make_provider(monkeypatch, backend=None)
+        big_content = "y" * (self._THRESHOLD + 1)
+        user_msg = {"role": "user", "content": big_content}
+        assistant_msg = {"role": "assistant", "content": big_content}
+        provider.on_pre_compress([user_msg, assistant_msg])
+        assert user_msg["content"] == big_content, "User message must not be modified"
+        assert assistant_msg["content"] == big_content, "Assistant message must not be modified"
+
+    def test_short_tool_content_not_truncated(self, monkeypatch):
+        """Tool messages below the threshold are left intact."""
+        provider = self._make_provider(monkeypatch, backend=None)
+        short_content = "short tool output"
+        msg = {"role": "tool", "content": short_content}
+        provider.on_pre_compress([msg])
+        assert msg["content"] == short_content
+
+    # ------------------------------------------------------------------
+    # 2. Extraction thread is launched when tool content > 500 chars
+    # ------------------------------------------------------------------
+
+    def test_extraction_thread_launched_for_large_tool_content(self, monkeypatch):
+        """When backend is set and a tool message exceeds 500 chars,
+        a background thread named 'mem0-pre-compress' is started."""
+        import threading
+
+        backend = FakeBackend()
+        provider = self._make_provider(monkeypatch, backend=backend)
+
+        large_content = "Z" * self._MIN_EXTRACT
+        messages = [{"role": "tool", "content": large_content}]
+
+        launched: list[threading.Thread] = []
+        original_start = threading.Thread.start
+
+        def capturing_start(self_thread):
+            launched.append(self_thread)
+            original_start(self_thread)
+
+        monkeypatch.setattr(threading.Thread, "start", capturing_start)
+
+        provider.on_pre_compress(messages)
+
+        # Wait briefly for any spawned daemon threads to register
+        pre_compress_threads = [t for t in launched if t.name == "mem0-pre-compress"]
+        assert pre_compress_threads, (
+            "Expected a 'mem0-pre-compress' thread to be launched"
+        )
+
+    def test_extraction_thread_calls_backend_add(self, monkeypatch):
+        """The extraction thread eventually calls backend.add with infer=True."""
+        backend = FakeBackend()
+        provider = self._make_provider(monkeypatch, backend=backend)
+
+        large_content = "FACT " * 200  # well over 500 chars
+        messages = [{"role": "tool", "content": large_content}]
+        provider.on_pre_compress(messages)
+
+        # Give the daemon thread time to run
+        import time
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            calls = [c for c in backend.captured if c[0] == "add"]
+            if calls:
+                break
+            time.sleep(0.05)
+
+        add_calls = [c for c in backend.captured if c[0] == "add"]
+        assert add_calls, "backend.add should have been called by the extraction thread"
+        assert add_calls[0][2]["infer"] is True, "Extraction must use infer=True"
+
+    def test_no_thread_launched_when_tool_content_below_500(self, monkeypatch):
+        """Tool content <= 500 chars does not trigger a background extraction thread."""
+        import threading
+
+        backend = FakeBackend()
+        provider = self._make_provider(monkeypatch, backend=backend)
+
+        small_content = "tiny"  # well below 500
+        messages = [{"role": "tool", "content": small_content}]
+
+        launched: list[threading.Thread] = []
+        original_start = threading.Thread.start
+
+        def capturing_start(self_thread):
+            launched.append(self_thread)
+            original_start(self_thread)
+
+        monkeypatch.setattr(threading.Thread, "start", capturing_start)
+        provider.on_pre_compress(messages)
+
+        pre_compress_threads = [t for t in launched if t.name == "mem0-pre-compress"]
+        assert not pre_compress_threads, (
+            "No extraction thread should launch when content is below the 500-char threshold"
+        )
+
+    # ------------------------------------------------------------------
+    # 3. Backend-is-None short-circuits without launching any thread
+    # ------------------------------------------------------------------
+
+    def test_backend_none_no_thread_launched(self, monkeypatch):
+        """When _backend is None, on_pre_compress returns early and no
+        extraction thread is spawned."""
+        import threading
+
+        provider = self._make_provider(monkeypatch, backend=None)
+
+        large_content = "A" * self._MIN_EXTRACT
+        messages = [{"role": "tool", "content": large_content}]
+
+        launched: list[threading.Thread] = []
+        original_start = threading.Thread.start
+
+        def capturing_start(self_thread):
+            launched.append(self_thread)
+            original_start(self_thread)
+
+        monkeypatch.setattr(threading.Thread, "start", capturing_start)
+        result = provider.on_pre_compress(messages)
+
+        assert result == "", "on_pre_compress should return empty string"
+        pre_compress_threads = [t for t in launched if t.name == "mem0-pre-compress"]
+        assert not pre_compress_threads, (
+            "No thread should be launched when backend is None"
+        )

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -25,11 +25,11 @@ class FakeBackend:
         self.captured.append(("get_all", {"filters": filters, "page": page, "page_size": page_size}))
         return self._all_results
 
-    def add(self, messages, *, user_id, agent_id, infer=False, metadata=None):
+    def add(self, messages, *, user_id, agent_id, infer=False, metadata=None, run_id=None, **kwargs):
         self.captured.append((
             "add",
             messages,
-            {"user_id": user_id, "agent_id": agent_id, "infer": infer, "metadata": metadata},
+            {"user_id": user_id, "agent_id": agent_id, "infer": infer, "metadata": metadata, "run_id": run_id},
         ))
         return {"status": "PENDING", "event_id": "evt-test-123"}
 
@@ -160,6 +160,7 @@ class TestMem0Prefetch:
         provider.initialize("test-session")
         provider._user_id = "u123"
         provider._agent_id = "hermes"
+        provider._prefetch_top_k = 10  # reset from default 15 so test assertions are stable
         provider._backend = backend
         return provider
 


### PR DESCRIPTION
## Summary

Adds recency decay blending to mem0 OSS search results and fixes several bugs discovered during live testing.

**New: Staleness decay**
- Post-processes `mem0_search` results with a time-decay blend: `adjusted = (1 - 0.3) * sim_score + 0.3 * decay_factor * sim_score`
- `decay_factor = 0.5 ** ((days_old - grace_days) / 30)` — score halves every 30 days past the grace window
- 14-day grace period protects newly stored facts from immediate penalty
- Semantic relevance stays dominant (α=0.3) — an old but highly relevant memory still beats a recent but irrelevant one

**New: Vacation mode**
- Configure one or more `{start, end}` periods in `mem0.json`; no decay applied during active periods
- After a period ends, `effective_now` shifts back to `vacation_end` so memories don't accumulate staleness for time the user was away
- Most recent past vacation end wins when multiple periods overlap

**Bug fixes**
- Post-vacation `effective_now` was shifted **forward** (wrong direction), making old memories appear *more* stale after returning. Fixed by tracking `best_past_end` separately and applying shift only within the grace window
- Active-vacation early return now sorts results by base score for consistent ordering
- `offset-naive` timestamps from some `mem0ai` versions raised `can't compare offset-naive and offset-aware datetimes`. Normalise to UTC after parse
- `vacations` config value that isn't a list now logs a `WARNING` instead of silently resetting to `[]`
- Non-404 `OSSBackend.update()` failures now log a `WARNING` before falling through to `add()`, preventing silent duplicate Qdrant points
- Bare `except: pass` on sidecar post-add upsert replaced with `logger.warning()` so transient backend errors are observable

## Test plan

- [ ] 19 new tests in `test_mem0_staleness.py` covering all vacation/decay paths (active period, post-grace, multiple periods, malformed config, sort order, formula correctness)
- [ ] 15 new tests in `test_mem0_backend_oss.py` covering OSSBackend dedup, stale-404, non-404 warning, sidecar registration, `infer=True` bypass
- [ ] All tests fully mocked — no external DB, Qdrant, or API key required
- [ ] Run: `python -m pytest tests/plugins/memory/test_mem0_staleness.py tests/plugins/memory/test_mem0_backend_oss.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)