### PR TITLE
fix(desktop): open chats from the skills view

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -753,9 +753,10 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     onRemoveAttachment: id => void composer.removeAttachment(id),
     onRestoreToMessage: restoreToMessage,
     // Already on screen (open tile, or the main session)? Jump to its tab;
-    // otherwise load it into main.
+    // otherwise load it into main. The main session still needs its chat route
+    // restored when the workspace is showing a full-page view.
     onResumeSession: sessionId => {
-      if (!focusOpenSession(sessionId)) {
+      if (focusOpenSession(sessionId) !== 'tile') {
         navigate(sessionRoute(sessionId))
       }
     },

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { group, split } from '@/components/pane-shell/tree/model'
 import type { SessionTile } from '@/store/session-states'
-import { orderTilesByTree, selectionHomesToWorkspace } from '@/store/session-states'
+import { openSessionSurface, orderTilesByTree, selectionHomesToWorkspace } from '@/store/session-states'
 
 const tile = (storedSessionId: string): SessionTile => ({ storedSessionId })
 const tilePane = (id: string) => `session-tile:${id}`
@@ -42,5 +42,18 @@ describe('selectionHomesToWorkspace', () => {
 
   it('skips homing when the selected id is already an open tile', () => {
     expect(selectionHomesToWorkspace('a', tiles)).toBe(false)
+  })
+})
+
+describe('openSessionSurface', () => {
+  const tiles = [tile('side')]
+
+  it('distinguishes the selected main chat from an open tile', () => {
+    expect(openSessionSurface('main', 'main', tiles)).toBe('main')
+    expect(openSessionSurface('side', 'main', tiles)).toBe('tile')
+  })
+
+  it('returns null when the session must be loaded into main', () => {
+    expect(openSessionSurface('other', 'main', tiles)).toBeNull()
   })
 })

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -540,13 +540,28 @@ export function openSessionTile(
   }
 }
 
+export type OpenSessionSurface = 'main' | 'tile'
+
+export function openSessionSurface(
+  storedSessionId: string,
+  selectedStoredSessionId: null | string,
+  tiles: readonly SessionTile[]
+): null | OpenSessionSurface {
+  if (tiles.some(t => t.storedSessionId === storedSessionId)) {
+    return 'tile'
+  }
+
+  return storedSessionId === selectedStoredSessionId ? 'main' : null
+}
+
 /** If a session is already ON SCREEN — an open tile OR the one loaded in main —
- *  front its tab (and focus its zone) and return true. A sidebar click on an
- *  already-open chat JUMPS to its tab instead of reloading it; `false` means the
- *  caller must load it into main. Covers the two dead clicks: an open tile, and
- *  the main session while focus sits on a tile (route unchanged → no reload). */
-export function focusOpenSession(storedSessionId: string): boolean {
-  if ($sessionTiles.get().some(t => t.storedSessionId === storedSessionId)) {
+ *  front its tab (and focus its zone) and identify which surface owns it. A
+ *  sidebar click on an already-open chat JUMPS to its tab instead of reloading
+ *  it; `null` means the caller must load it into main. */
+export function focusOpenSession(storedSessionId: string): null | OpenSessionSurface {
+  const surface = openSessionSurface(storedSessionId, $selectedStoredSessionId.get(), $sessionTiles.get())
+
+  if (surface === 'tile') {
     const paneId = `${TILE_PANE_PREFIX}${storedSessionId}`
     revealTreePane(paneId) // un-dismiss + adopt + front in its group
     const tree = $layoutTree.get()
@@ -556,19 +571,19 @@ export function focusOpenSession(storedSessionId: string): boolean {
       noteActiveTreeGroup(group.id)
     }
 
-    return true
+    return surface
   }
 
   // Already the main session: front the workspace tab and drop tile focus so
   // the readouts + sidebar highlight come home (a no-op when main is focused).
-  if (storedSessionId === $selectedStoredSessionId.get()) {
+  if (surface === 'main') {
     revealTreePane('workspace')
     noteActiveTreeGroup(null)
 
-    return true
+    return surface
   }
 
-  return false
+  return null
 }
 
 // Closed-tab stack for ⌘⇧T reopen (in-memory) — keyed PER PROFILE like the


### PR DESCRIPTION
## What changed

Clicking a sidebar session now returns to its chat when Skills & Tools is open. Sessions displayed in a separate tile still focus that tile instead.

## Why

The click handler treated the main chat and separate tiles as the same surface, so it swallowed the navigation back to chat.

## Tests

- Desktop test suite: 2,208 passed, 2 skipped
- Typecheck and lint passed

Fixes #68302