### PR TITLE
fix(agent): show startup fallback model

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -340,6 +340,7 @@ def init_agent(
     parent_session_id: str = None,
     iteration_budget: "IterationBudget" = None,
     fallback_model: Dict[str, Any] = None,
+    initial_fallback_from: Dict[str, str] = None,
     credential_pool=None,
     checkpoints_enabled: bool = False,
     checkpoint_max_snapshots: int = 20,
@@ -573,7 +574,6 @@ def init_agent(
     agent.reaction_callback = reaction_callback
     agent.tool_gen_callback = tool_gen_callback
 
-    
     # Tool execution state — allows _vprint during tool execution
     # even when stream consumers are registered (no tokens streaming then)
     agent._executing_tools = False
@@ -1063,6 +1063,11 @@ def init_agent(
                             explicit_api_key=_fb_explicit_key,
                         )
                         if _fb_client is not None:
+                            if not initial_fallback_from:
+                                initial_fallback_from = {
+                                    "provider": agent.provider,
+                                    "model": agent.model,
+                                }
                             agent.provider = _fb["provider"]
                             agent.model = _fb_model or _fb["model"]
                             agent._fallback_activated = True
@@ -1195,6 +1200,16 @@ def init_agent(
     agent._fallback_activated = getattr(agent, "_fallback_activated", False)
     # Legacy attribute kept for backward compat (tests, external callers)
     agent._fallback_model = agent._fallback_chain[0] if agent._fallback_chain else None
+    if initial_fallback_from:
+        _fallback_notice = (
+            f"⚠️ Default model unavailable — using fallback: "
+            f"{agent.model} via {agent.provider}"
+        )
+        # Use the same success/failure-safe delivery contract as runtime
+        # failover: successful turns surface one notice, while a terminal
+        # failure flushes the buffered line instead.
+        agent._pending_fallback_notice = _fallback_notice
+        agent._buffer_status(_fallback_notice)
     if agent._fallback_chain and not agent.quiet_mode:
         if len(agent._fallback_chain) == 1:
             fb = agent._fallback_chain[0]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2166,6 +2166,11 @@ def _try_resolve_fallback_provider() -> dict | None:
         fb_list = get_fallback_chain(cfg)
         if not fb_list:
             return None
+        model_cfg = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
+        initial_fallback_from = {
+            "provider": str(model_cfg.get("provider") or cfg.get("provider") or ""),
+            "model": str(_resolve_gateway_model(cfg) or ""),
+        }
         for entry in fb_list:
             try:
                 from hermes_cli.fallback_config import resolve_entry_api_key
@@ -2193,6 +2198,7 @@ def _try_resolve_fallback_provider() -> dict | None:
                     "args": list(runtime.get("args") or []),
                     "credential_pool": runtime.get("credential_pool"),
                     "model": entry.get("model"),
+                    "initial_fallback_from": initial_fallback_from,
                 }
             except Exception as fb_exc:
                 logger.debug("Fallback entry %s failed: %s", entry.get("provider"), fb_exc)
@@ -4277,6 +4283,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "args": list(runtime_kwargs.get("args") or []),
             "credential_pool": runtime_kwargs.get("credential_pool"),
             "max_tokens": runtime_kwargs.get("max_tokens"),
+            "initial_fallback_from": runtime_kwargs.get("initial_fallback_from"),
         }
         route = {
             "model": model,

--- a/run_agent.py
+++ b/run_agent.py
@@ -487,6 +487,7 @@ class AIAgent:
         parent_session_id: str = None,
         iteration_budget: "IterationBudget" = None,
         fallback_model: Dict[str, Any] = None,
+        initial_fallback_from: Dict[str, str] = None,
         credential_pool=None,
         checkpoints_enabled: bool = False,
         checkpoint_max_snapshots: int = 20,
@@ -563,6 +564,7 @@ class AIAgent:
             parent_session_id=parent_session_id,
             iteration_budget=iteration_budget,
             fallback_model=fallback_model,
+            initial_fallback_from=initial_fallback_from,
             credential_pool=credential_pool,
             checkpoints_enabled=checkpoints_enabled,
             checkpoint_max_snapshots=checkpoint_max_snapshots,
@@ -1030,11 +1032,11 @@ class AIAgent:
 
         A provider/model switch is a durable state change operators must see,
         unlike transient retry chatter that ``_clear_status_buffer`` drops.
-        ``try_activate_fallback`` records the switch in
-        ``self._pending_fallback_notice``; this emits it exactly once via
-        ``_emit_status`` and then clears it, so a successful fallback still
-        produces one visible notice.  On terminal failure the buffered switch
-        line is flushed instead (and this notice discarded) — see
+        Fallback selection records the switch in
+        ``self._pending_fallback_notice``; this emits it exactly once through
+        the driver's structured notice rail, or through status output for
+        consumers without one. On terminal failure the buffered switch line is
+        flushed instead (and this notice discarded) — see
         ``_flush_status_buffer`` — so the user always sees the switch once.
         """
         try:
@@ -1043,7 +1045,18 @@ class AIAgent:
                 # Clear before emitting so a (swallowed) callback error can't
                 # leave the notice set for a stale re-emit on a later turn.
                 self._pending_fallback_notice = None
-                self._emit_status(notice)
+                if self.notice_callback:
+                    from agent.credits_tracker import AgentNotice
+
+                    self._emit_notice(AgentNotice(
+                        text=notice,
+                        level="warn",
+                        kind="ttl",
+                        ttl_ms=8000,
+                        key="model.fallback",
+                    ))
+                else:
+                    self._emit_status(notice)
         except Exception:
             # Never break the conversation loop on a notice hiccup.
             pass

--- a/tests/gateway/test_session_model_override_routing.py
+++ b/tests/gateway/test_session_model_override_routing.py
@@ -217,6 +217,10 @@ fallback_providers:
     assert model == "minimax/minimax-m2.7"
     assert runtime_kwargs["provider"] == "openrouter"
     assert runtime_kwargs["api_key"] == "sk-openrouter"
+    assert runtime_kwargs["initial_fallback_from"] == {
+        "provider": "openai-codex",
+        "model": "gpt-5.5",
+    }
 
 
 def test_gateway_auth_fallback_resolves_key_env_for_custom_provider(tmp_path, monkeypatch):
@@ -260,4 +264,3 @@ fallback_providers:
     assert runtime_kwargs["api_key"] == "env-secret"
     assert runtime_kwargs["base_url"] == "https://fallback.example/v1"
     assert runtime_kwargs["model"] == "fallback-model"
-

--- a/tests/run_agent/test_init_fallback_on_exhausted_pool.py
+++ b/tests/run_agent/test_init_fallback_on_exhausted_pool.py
@@ -47,6 +47,9 @@ def test_init_tries_fallback_when_primary_returns_none():
         assert agent.provider == "tencent-token-plan"
         assert agent.model == "kimi2.5"
         assert agent._fallback_activated is True
+        notice = "⚠️ Default model unavailable — using fallback: kimi2.5 via tencent-token-plan"
+        assert agent._pending_fallback_notice == notice
+        assert agent._retry_status_buffer == [("status", notice)]
 
 
 def test_init_raises_when_no_fallback_configured():

--- a/tests/run_agent/test_retry_status_buffer.py
+++ b/tests/run_agent/test_retry_status_buffer.py
@@ -19,6 +19,7 @@ def _make_bare_agent():
     agent = object.__new__(AIAgent)
     agent.log_prefix = ""
     agent.status_callback = None
+    agent.notice_callback = None
     agent.suppress_status_output = False
     agent._mute_post_response = False
     agent._executing_tools = False
@@ -161,6 +162,24 @@ def test_pending_fallback_notice_emitted_once_on_success():
     # A second success path with no new fallback emits nothing.
     agent._emit_pending_fallback_notice()
     assert emitted == ["🔄 Switched to fallback model: m1 via p1 → m2 via p2"]
+
+
+def test_pending_fallback_notice_uses_structured_notice_when_supported():
+    agent = _make_bare_agent()
+    statuses = []
+    notices = []
+    agent._emit_status = statuses.append
+    agent.notice_callback = notices.append
+    agent._pending_fallback_notice = "fallback selected"
+
+    agent._emit_pending_fallback_notice()
+
+    assert statuses == []
+    assert len(notices) == 1
+    assert notices[0].text == "fallback selected"
+    assert notices[0].level == "warn"
+    assert notices[0].kind == "ttl"
+    assert notices[0].key == "model.fallback"
 
 
 def test_pending_fallback_notice_noop_when_unset():

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11092,6 +11092,10 @@ class TestResolveRuntimeWithFallback:
         assert captured["provider"] == "deepseek"
         assert captured["base_url"] == "https://fallback.invalid/v1"
         assert captured["api_key"] == "fb-tok"
+        assert captured["initial_fallback_from"] == {
+            "provider": "openai-codex",
+            "model": "gpt-5.5",
+        }
 
 
 def test_get_usage_does_not_substitute_cumulative_total_for_context_used():

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5048,6 +5048,7 @@ def _make_agent(
     # Prefer a per-session model override (set by a prior in-session /model
     # switch) over global config/env resolution. Resume-time stored sessions may
     # also pass scalar model/provider/runtime knobs from the persisted DB row.
+    initial_fallback_from = None
     if isinstance(model_override, dict) and model_override.get("model"):
         model = str(model_override.get("model") or "")
         requested_provider = model_override.get("provider") or provider_override or None
@@ -5083,6 +5084,10 @@ def _make_agent(
         if resolution.used_fallback:
             if not resolution.selected_model:
                 raise RuntimeError("Auth fallback resolved without a model")
+            initial_fallback_from = {
+                "provider": str(requested_provider or ""),
+                "model": model,
+            }
             model = resolution.selected_model
         else:
             # The switch already resolved concrete credentials/endpoint; honor
@@ -5108,6 +5113,10 @@ def _make_agent(
         if resolution.used_fallback:
             if not resolution.selected_model:
                 raise RuntimeError("Auth fallback resolved without a model")
+            initial_fallback_from = {
+                "provider": str(requested_provider or ""),
+                "model": model,
+            }
             model = resolution.selected_model
     _pr = _load_provider_routing()
     return AIAgent(
@@ -5155,6 +5164,7 @@ def _make_agent(
         skip_context_files=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         skip_memory=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         fallback_model=_load_fallback_model(),
+        initial_fallback_from=initial_fallback_from,
         **_agent_cbs(sid),
     )
 


### PR DESCRIPTION
## What changed

When startup switches away from an unavailable default model, users now see one warning naming the model and provider actually in use. Gateway, desktop, terminal UI, and direct runtime paths share the existing notice or status channel.

## Why

Startup fallback was silent outside the classic command-line path, making unexpected model behavior hard to explain. The notice does not alter conversation history, prompts, or cache keys.

## Tests

- 417 targeted fallback and runtime tests passed
- Lint and diff checks passed

Fixes #68057