### PR TITLE
fix(desktop): preserve model after reauthentication

### DIFF
--- a/apps/desktop/src/store/onboarding.test.ts
+++ b/apps/desktop/src/store/onboarding.test.ts
@@ -365,6 +365,81 @@ describe('OAuth onboarding', () => {
     expect(recommendedIndex).toBeGreaterThan(optionsIndex)
     expect(setIndex).toBeGreaterThan(recommendedIndex)
   })
+
+  it('preserves the configured model when reauthenticating its provider', async () => {
+    const configuredModel = 'vendor/user-selected-model'
+    const recommendedModel = 'vendor/recommended-model'
+    const calls: { body?: unknown; path: string }[] = []
+
+    installApiMock(async ({ body, path }: { body?: unknown; path: string }) => {
+      calls.push({ body, path })
+
+      if (path === '/api/providers/oauth/nous/submit') {
+        return { ok: true, status: 'approved' }
+      }
+
+      if (path === '/api/model/info') {
+        return { model: configuredModel, provider: 'nous' }
+      }
+
+      if (path.startsWith('/api/model/options')) {
+        return {
+          providers: [{ name: 'Nous Portal', slug: 'nous', models: [recommendedModel] }]
+        }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    const requestGateway: OnboardingContext['requestGateway'] = async (method, params) => {
+      if (method === 'reload.env') {
+        return {} as never
+      }
+
+      if (method === 'setup.status') {
+        return { provider_configured: true } as never
+      }
+
+      if (method === 'setup.runtime_check') {
+        expect(params).toEqual({ provider: 'nous' })
+
+        return { ok: true } as never
+      }
+
+      throw new Error(`unexpected gateway method: ${method}`)
+    }
+
+    $desktopOnboarding.set(
+      baseState({
+        configured: true,
+        manual: true,
+        flow: {
+          status: 'awaiting_user',
+          provider: provider('nous', 'Nous Portal'),
+          start: {
+            auth_url: 'https://portal.example/auth',
+            expires_in: 600,
+            flow: 'pkce',
+            session_id: 'reauth-session'
+          },
+          code: 'fresh-code'
+        }
+      })
+    )
+
+    await submitOnboardingCode(onboardingContext(requestGateway))
+
+    const state = $desktopOnboarding.get()
+    expect(state.flow.status).toBe('confirming_model')
+
+    if (state.flow.status === 'confirming_model') {
+      expect(state.flow.currentModel).toBe(configuredModel)
+      expect(state.flow.providerSlug).toBe('nous')
+    }
+
+    expect(calls.some(call => call.path === '/api/model/set')).toBe(false)
+    expect(calls.some(call => call.path.startsWith('/api/model/options'))).toBe(false)
+  })
 })
 
 describe('saveOnboardingLocalEndpoint', () => {

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -2,6 +2,7 @@ import { atom } from 'nanostores'
 
 import {
   cancelOAuthSession,
+  getGlobalModelInfo,
   getGlobalModelOptions,
   getRecommendedDefaultModel,
   listOAuthProviders,
@@ -225,9 +226,10 @@ function notifyGatewayTools(tools: string[] | undefined) {
 }
 
 // After credentials are persisted, ask the backend which provider+models
-// are now authenticated. Pick the first curated model for the matching
-// provider as a sensible default, persist it via /api/model/set, and
-// transition to the model-confirmation step. If anything goes wrong
+// are now authenticated. For first-time setup, pick a recommended model for
+// the matching provider and persist it via /api/model/set. Reauthentication
+// keeps that provider's configured model. Then transition to the
+// model-confirmation step. If anything goes wrong
 // fetching options (no providers returned, network error), the caller
 // falls through to completing onboarding without showing the confirm
 // card — the user gets the undefined-model auto-selection behaviour
@@ -291,6 +293,26 @@ async function fetchProviderDefaultModel(
   }
 }
 
+async function fetchExistingProviderModel(
+  preferredSlugs: string[]
+): Promise<null | { providerSlug: string; defaultModel: string }> {
+  try {
+    const current = await getGlobalModelInfo()
+    const providerSlug = current.provider.trim()
+    const defaultModel = current.model.trim()
+    const preferred = preferredSlugs.map(slug => slug.toLowerCase())
+
+    if (providerSlug && defaultModel && preferred.includes(providerSlug.toLowerCase())) {
+      return { providerSlug, defaultModel }
+    }
+  } catch {
+    // Older/unavailable backends may not expose model info. Fall back to the
+    // existing first-time setup behavior below.
+  }
+
+  return null
+}
+
 // After OAuth/API-key success: reload the backend env, verify runtime,
 // then either show the model-confirm step or fall straight through to
 // completion if we can't determine a default.
@@ -310,9 +332,13 @@ async function completeWithModelConfirm(
 ) {
   await ctx.requestGateway('reload.env').catch(() => undefined)
 
-  const defaults = await fetchProviderDefaultModel(preferredSlugs)
+  // A successful sign-in can be either first-time setup or reauthentication.
+  // In the latter case the configured model is already the user's choice, so
+  // keep it instead of replacing it with today's recommended catalog entry.
+  const existing = await fetchExistingProviderModel(preferredSlugs)
+  const defaults = existing ?? (await fetchProviderDefaultModel(preferredSlugs))
 
-  if (defaults) {
+  if (defaults && !existing) {
     // Persist the chosen provider/model before the runtime gate so a stale
     // config provider (e.g. anthropic from a prior failed setup) cannot make
     // setup.runtime_check validate the wrong backend after a fresh OAuth login.


### PR DESCRIPTION
## What changed

Signing back into the current provider now keeps the model the user already selected. First-time setup and intentional provider changes still choose and confirm a recommended model.

## Why

The shared sign-in completion path saved the first recommended model before showing confirmation, which could silently replace an existing choice.

## Tests

- Desktop UI suite: 1,711 passed, 1 skipped
- Typecheck, lint, and formatting passed

Fixes #68144