### PR TITLE
fix(desktop): restore assistant messages after chat switches

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -22,6 +22,7 @@ import {
   speakText,
   transcribeAudio
 } from './hermes'
+import { chatMessageText, toChatMessages } from './lib/chat-messages'
 import { refreshActiveProfile } from './store/profile'
 
 const emptySessionsResponse = {
@@ -328,6 +329,29 @@ describe('Hermes REST helpers', () => {
       path: '/api/sessions/session-1/messages?profile=xiaoxuxu',
       profile: 'xiaoxuxu'
     })
+  })
+
+  it('normalizes persisted transcript rows before desktop hydration', async () => {
+    api.mockResolvedValue({
+      data: [
+        { content: 'first question', role: 'user', timestamp: 1 },
+        { content: 'first answer', role: 'assistant', timestamp: 2 },
+        { content: 'second question', role: 'user', timestamp: 3 },
+        { content: 'second answer', role: 'assistant', timestamp: 4 }
+      ],
+      object: 'list',
+      session_id: 'session-1'
+    })
+
+    const persisted = await getSessionMessages('session-1')
+    const hydrated = toChatMessages(persisted.messages)
+
+    expect(hydrated.map(message => [message.role, chatMessageText(message)])).toEqual([
+      ['user', 'first question'],
+      ['assistant', 'first answer'],
+      ['user', 'second question'],
+      ['assistant', 'second answer']
+    ])
   })
 
   it('bounds blocking TTS synthesis timeouts by text length', () => {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -46,6 +46,7 @@ import type {
   ProfileSoul,
   ProfilesResponse,
   SessionInfo,
+  SessionMessage,
   SessionMessagesResponse,
   SessionSearchResponse,
   SkillHubPreview,
@@ -567,13 +568,31 @@ export function getSession(id: string, profile?: string | null): Promise<Session
 // this GET to the remote backend (which serves its own state.db); for a local
 // profile the primary opens that profile's state.db via ?profile=. Omit for
 // the current/default profile.
-export function getSessionMessages(id: string, profile?: string | null): Promise<SessionMessagesResponse> {
+export async function getSessionMessages(id: string, profile?: string | null): Promise<SessionMessagesResponse> {
   const suffix = profile ? `?profile=${encodeURIComponent(profile)}` : ''
 
-  return window.hermesDesktop.api<SessionMessagesResponse>({
+  const response = await window.hermesDesktop.api<{
+    data?: SessionMessage[]
+    messages?: SessionMessage[]
+    session_id?: string
+  }>({
     ...(profile ? { profile } : {}),
     path: `/api/sessions/${encodeURIComponent(id)}/messages${suffix}`
   })
+
+  // The REST endpoint follows the OpenAI list envelope and returns transcript
+  // rows as `data`. Keep accepting `messages` for older/alternate backends, but
+  // normalize at this boundary so every hydration path sees one shape.
+  const messages = Array.isArray(response.messages) ? response.messages : response.data
+
+  if (!Array.isArray(messages)) {
+    throw new Error('Hermes session messages response did not contain a message list.')
+  }
+
+  return {
+    messages,
+    session_id: response.session_id || id
+  }
 }
 
 export function deleteSession(id: string, profile?: string | null): Promise<{ ok: boolean }> {


### PR DESCRIPTION
## What changed

Persisted session messages are now normalized from the backend response before Desktop rebuilds a chat. Both the current response field and the older compatibility field are accepted.

## Why

The backend returns transcript rows under `data`, while Desktop read `messages`. That prevented saved assistant replies from repairing an incomplete live view after switching chats.

## Tests

- Desktop suite: 2,207 passed, 2 skipped
- Typecheck and lint passed

Fixes #68321