### PR TITLE
fix(desktop): preserve dragging with empty titlebar slots

### DIFF
--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -31,6 +31,7 @@ import {
 import { SidebarProvider } from '@/components/ui/sidebar'
 import { discoverBundledPlugins } from '@/contrib/plugins'
 import { Slot } from '@/contrib/react/slot'
+import { useContributions } from '@/contrib/react/use-contributions'
 import { registry } from '@/contrib/registry'
 import { discoverRuntimePlugins } from '@/contrib/runtime-loader'
 import { sessionTitle as storedSessionTitle } from '@/lib/chat-runtime'
@@ -600,6 +601,26 @@ $filePreviewTarget.listen(target => target && revealPreview())
 
 // ---------------------------------------------------------------------------
 
+interface TitlebarSlotProps {
+  area: 'titleBar.center' | 'titleBar.left' | 'titleBar.right'
+  className: string
+  style?: CSSProperties
+}
+
+function TitlebarSlot({ area, className, style }: TitlebarSlotProps) {
+  const items = useContributions(area)
+
+  if (items.length === 0) {
+    return null
+  }
+
+  return (
+    <div className={className} style={style}>
+      <Slot area={area} />
+    </div>
+  )
+}
+
 export function ContribController() {
   const sidebarOpen = useStore($sidebarOpen)
 
@@ -641,26 +662,25 @@ export function ContribController() {
               aria-hidden="true"
               className="pointer-events-none absolute inset-y-0 left-[calc(var(--titlebar-controls-left,14px)+(var(--titlebar-control-size,1.25rem)*2)+0.75rem)] right-[calc(var(--titlebar-tools-right,0.75rem)+var(--titlebar-tools-width,5.5rem)+0.75rem)] [-webkit-app-region:drag]"
             />
-            <div
+            <TitlebarSlot
+              area="titleBar.left"
               className="pointer-events-auto absolute z-10 flex w-max items-center gap-2 [-webkit-app-region:no-drag]"
               style={{
                 left: 'max(calc(var(--workspace-left, 0px) + 0.5rem), calc(var(--titlebar-controls-left, 14px) + 2 * var(--titlebar-control-size, 1.25rem) + 1rem))'
               }}
-            >
-              <Slot area="titleBar.left" />
-            </div>
-            <div className="pointer-events-auto absolute left-1/2 top-1/2 z-10 flex w-max -translate-x-1/2 -translate-y-1/2 items-center gap-2 [-webkit-app-region:no-drag]">
-              <Slot area="titleBar.center" />
-            </div>
-            <div
+            />
+            <TitlebarSlot
+              area="titleBar.center"
+              className="pointer-events-auto absolute left-1/2 top-1/2 z-10 flex w-max -translate-x-1/2 -translate-y-1/2 items-center gap-2 [-webkit-app-region:no-drag]"
+            />
+            <TitlebarSlot
+              area="titleBar.right"
               className="pointer-events-auto absolute z-10 flex w-max items-center gap-2 [-webkit-app-region:no-drag]"
               style={{
                 right:
                   'max(calc(var(--workspace-right, 0px) + 0.5rem), calc(var(--titlebar-tools-right, 0.75rem) + 4 * (var(--titlebar-control-size, 1.25rem) + 0.25rem) + 0.5rem))'
               }}
-            >
-              <Slot area="titleBar.right" />
-            </div>
+            />
           </div>
 
           <LayoutTreeRoot />


### PR DESCRIPTION
## What does this PR do?

Keeps the intentionally empty Desktop titlebar draggable after project and sidebar layout hydration.

`Slot` already returns `null` when an area has no contributions, but the controller still mounted three absolute `no-drag` wrappers around those empty slots. The left and right wrappers also move with `--workspace-left` and `--workspace-right` as the project layout hydrates. On Windows, that could leave Electron's native app-region hit testing stale, so the blank center stopped dragging until another layout invalidation such as a window resize or text selection.

This change omits each wrapper while its contribution area is empty. When a plugin contributes an item, the same positioned, clickable `no-drag` wrapper is rendered as before. The center remains intentionally empty and no session title is restored.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a small titlebar-slot wrapper that subscribes to its contribution area.
- Do not mount invisible `no-drag` regions for empty left, center, or right titlebar areas.
- Preserve the existing positioning and clickable `no-drag` behavior whenever an area has contributions.

## How to Test

1. Open Hermes Desktop in a repository project.
2. Drag the window from the blank center strip immediately after launch.
3. Wait for the project and sidebar state to finish loading, then drag from the same center strip again without first resizing the window or selecting text.
4. Confirm titlebar controls remain clickable and any contributed titlebar items remain clickable.

Manual validation on Windows 11 used a packaged Desktop build and confirmed the blank center remained draggable after the project/sidebar load that previously triggered the failure.

Focused validation on a clean worktree based directly on current `main`:

- `npx prettier --check src/app/contrib/controller.tsx`
- `npx eslint src/app/contrib/controller.tsx`
- `npm run typecheck`
- `npm run build`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not applicable to this Desktop-only TypeScript change)
- [ ] I've added tests for my changes (native Electron app-region hit testing is not exercised by jsdom; this was verified in a packaged Windows build)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A: no user-facing workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A: no config changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A: no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility): existing Electron drag/no-drag semantics are preserved
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A: no tool behavior changed

## Screenshots / Logs

The production Desktop build, typecheck, formatting check, and focused lint all pass. The packaged Windows build was manually exercised across project/sidebar hydration.