### PR TITLE
fix(gateway): set gateway_runner on built-in adapters so profile_routes works for Signal

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7679,6 +7679,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 continue
             
             # Set up message + fatal error handlers
+            adapter.gateway_runner = self  # built-in adapters (e.g. Signal) need this to resolve gateway.profile_routes in build_source
             adapter.set_message_handler(self._handle_message)
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)


### PR DESCRIPTION
## Summary
Native profile routing (`gateway.multiplex_profiles` + `gateway.profile_routes`) never takes effect for **Signal**: every inbound message falls back to the default/active profile even when a route matches.

## Root cause
`build_source` resolves the routed profile only when the adapter has a runner back-reference:

```py
runner = getattr(self, "gateway_runner", None)
if runner is not None:
    profile = runner._profile_name_for_source(...)
```

In `_create_adapter`, `adapter.gateway_runner` is assigned only on (a) the plugin-registry path, (b) the built-in `api_server` branch, and (c) the built-in `webhook` branch. Built-in messaging adapters returned directly (e.g. `return SignalAdapter(config)`) never get it, so `runner` is `None` and `profile_routes` is silently skipped.

Signal is currently the only built-in messaging adapter (Telegram/Discord/Slack/etc. are bundled plugins wired via the registry path), so Signal is the affected platform.

## Reproduction
1. Multiplexed gateway (`gateway.multiplex_profiles: true`), default profile owns the Signal connection.
2. A `gateway.profile_routes` entry maps a Signal group `chat_id` to a secondary profile.
3. Send a message in that group.
- Expected: turn runs under the routed profile (`agent:<profile>:...`).
- Actual: runs under default (`agent:main:...`); the route is never applied.

## Fix
Assign `adapter.gateway_runner = self` at the adapter-setup site alongside the other `adapter.set_*` wiring, so every built-in adapter receives it (consistent with the plugin path and api_server/webhook).

## Verification
With the fix, a routed Signal group message runs under the correct profile home (`Loaded environment variables from .../profiles/<name>/.env`, session key `agent:<name>:...`) instead of default.