### PR TITLE
fix(compression): add pre-LLM feasibility check to skip costly no-op summaries

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -885,6 +885,7 @@ class ContextCompressor(ContextEngine):
         self._last_aux_model_failure_model = None
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
+        self._prellm_skip_count = 0
         self._fallback_compression_streak = 0
         self._verify_compaction_cleared_threshold = False
         self._last_compression_made_progress = False
@@ -925,6 +926,7 @@ class ContextCompressor(ContextEngine):
         self._last_aux_model_failure_model = None
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
+        self._prellm_skip_count = 0
         self._fallback_compression_streak = 0
         self._verify_compaction_cleared_threshold = False
         self._last_compression_made_progress = False
@@ -1212,6 +1214,7 @@ class ContextCompressor(ContextEngine):
         self.last_compression_rough_tokens = 0
         self.awaiting_real_usage_after_compression = False
         self._ineffective_compression_count = 0
+        self._prellm_skip_count = 0
         if runtime_changed:
             self._fallback_compression_streak = 0
             self._persist_fallback_compression_streak()
@@ -1406,6 +1409,7 @@ class ContextCompressor(ContextEngine):
         # Anti-thrashing: track whether last compression was effective
         self._last_compression_savings_pct: float = 100.0
         self._ineffective_compression_count: int = 0
+        self._prellm_skip_count: int = 0
         # Consecutive completed deterministic-fallback boundaries. Unlike the
         # real-usage effectiveness counter, ordinary fitting responses must not
         # reset this breaker; only a healthy completed summary does.
@@ -3472,11 +3476,51 @@ This compaction should PRIORITISE preserving all information related to the focu
 
         # Phase 3: Generate structured summary
         summary_focus_topic = focus_topic or self._derive_auto_focus_topic(messages)
-        summary = self._generate_summary(
-            turns_to_summarize,
-            focus_topic=summary_focus_topic,
-            memory_context=memory_context,
-        )
+
+        # Pre-LLM feasibility check: if the middle section is too small to
+        # yield meaningful token savings, skip the expensive LLM summarization
+        # call and fall through to the deterministic message-dropping path
+        # (which is cheap and always applicable).  Without this guard a
+        # tool-heavy session where the protected tail already holds most of
+        # the tokens can burn 500+ seconds on a summary call that replaces a
+        # few lightweight messages, leaving the total token count essentially
+        # unchanged.
+        #
+        # Only fires after at least one prior real-usage ineffectiveness
+        # strike.  The check READS ``_ineffective_compression_count`` but
+        # never writes it: that strike counter is fed exclusively by real
+        # provider token counts (see the anti-thrashing verdict in
+        # _update_token_usage), and consumers latch at >= 2 to disable
+        # compression entirely.  Feasibility skips are tracked separately
+        # in ``_prellm_skip_count`` for observability.
+        #
+        # Skipped when ``force=True`` (manual /compress) so auth/error
+        # handling paths are always exercised on explicit user request.
+        feasibility_skip = False
+        if not force and self._ineffective_compression_count >= 1:
+            middle_tokens = estimate_messages_tokens_rough(turns_to_summarize)
+            if middle_tokens < int(self.threshold_tokens * 0.1):
+                feasibility_skip = True
+                self._prellm_skip_count += 1
+                self._last_compression_savings_pct = 0.0
+                if not self.quiet_mode:
+                    logger.warning(
+                        "Compression: middle section (%d tokens at indices "
+                        "%d-%d) is below 10%% of threshold (%d tokens) — "
+                        "skipping LLM summarization, proceeding with "
+                        "deterministic message dropping. prellm_skip_count=%d",
+                        middle_tokens, compress_start, compress_end,
+                        self.threshold_tokens, self._prellm_skip_count,
+                    )
+
+        if feasibility_skip:
+            summary = None  # No LLM call; Phase 4 inserts the deterministic fallback
+        else:
+            summary = self._generate_summary(
+                turns_to_summarize,
+                focus_topic=summary_focus_topic,
+                memory_context=memory_context,
+            )
 
         # If summary generation failed, behavior splits on
         # ``abort_on_summary_failure`` (config: compression.abort_on_summary_failure):
@@ -3498,7 +3542,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         # of these cases, rotating into a child session with a placeholder
         # summary degrades the conversation for zero benefit. Preserve it
         # unchanged until access is restored or connectivity recovers.
-        if not summary and (
+        if not summary and not feasibility_skip and (
             self.abort_on_summary_failure
             or self._last_summary_auth_failure
             or self._last_summary_network_failure
@@ -3556,13 +3600,18 @@ This compaction should PRIORITISE preserving all information related to the focu
         # content-free "N messages were removed" marker.
         if not summary:
             if not self.quiet_mode:
-                logger.warning("Summary generation failed — inserting deterministic fallback context summary")
+                if feasibility_skip:
+                    logger.info("Feasibility skip — inserting deterministic fallback context summary")
+                else:
+                    logger.warning("Summary generation failed — inserting deterministic fallback context summary")
             n_dropped = compress_end - compress_start
             self._last_summary_dropped_count = n_dropped
             self._last_summary_fallback_used = True
             summary = self._build_static_fallback_summary(
                 turns_to_summarize,
-                reason=self._last_summary_error,
+                # A stale error from an earlier real failure must not be
+                # embedded into a deliberate feasibility skip's fallback.
+                reason=None if feasibility_skip else self._last_summary_error,
             )
 
         _merge_summary_into_tail = False

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -3741,3 +3741,118 @@ class TestDoubleCompactionSummaryRole:
             "summary of earlier turns" in (m.get("content") or "")
             for m in result
         )
+
+
+class TestPreLlmFeasibilityCheck:
+    """Tests for the pre-LLM feasibility skip in compress().
+
+    When the middle section is < 10% of threshold tokens AND at least one
+    prior real-usage ineffectiveness strike has been recorded, the expensive
+    LLM summarization call is skipped and the deterministic fallback is used
+    instead. The skip must NOT increment _ineffective_compression_count (the
+    strike counter that latches at >=2) and must NOT trip the abort branch
+    via stale _last_summary_auth_failure / _last_summary_network_failure flags.
+    """
+
+    def _make_messages(self, n_pairs=10, content="short reply"):
+        """Build a message list large enough to survive compress()'s early exits.
+
+        compress() bails if n_messages <= protect_head_size + 4, and again
+        if compress_start >= compress_end (tail budget covers everything).
+        With protect_first_n=2 → head=2, protect_last_n=2, we need enough
+        middle turns to produce compress_start < compress_end.  10 pairs
+        (21 messages including system) is comfortably past both gates.
+        """
+        msgs = [{"role": "system", "content": "system prompt"}]
+        for i in range(n_pairs):
+            msgs.append({"role": "user", "content": f"question {i}"})
+            msgs.append({"role": "assistant", "content": content})
+        return msgs
+
+    def test_skip_does_not_increment_strike_counter(self, compressor):
+        """Feasibility skip must use _prellm_skip_count, not _ineffective_compression_count."""
+        compressor._ineffective_compression_count = 1  # one prior real strike
+        msgs = self._make_messages()
+
+        with patch("agent.context_compressor.call_llm") as mock_llm, \
+             patch.object(compressor, "_generate_summary") as mock_gen:
+            mock_llm.return_value = (None, None)
+            # Middle section is tiny → feasibility skip fires
+            compressor.compress(msgs, force=False)
+
+        # The strike counter must NOT have been incremented by the skip
+        assert compressor._ineffective_compression_count == 1
+        # The pre-LLM skip counter should have been incremented
+        assert compressor._prellm_skip_count >= 1
+        # _generate_summary must NOT have been called
+        mock_gen.assert_not_called()
+
+    def test_skip_does_not_trip_abort_on_stale_auth_failure(self, compressor):
+        """A feasibility skip must not trip the abort branch even if
+        _last_summary_auth_failure is stale True from a prior cycle."""
+        compressor._ineffective_compression_count = 1
+        compressor._last_summary_auth_failure = True  # stale from prior failure
+        msgs = self._make_messages()
+
+        with patch("agent.context_compressor.call_llm") as mock_llm, \
+             patch.object(compressor, "_generate_summary") as mock_gen:
+            mock_llm.return_value = (None, None)
+            result = compressor.compress(msgs, force=False)
+
+        # Should NOT abort — should produce compressed output with fallback
+        assert result is not None
+        assert len(result) > 0
+        mock_gen.assert_not_called()
+
+    def test_skip_does_not_trip_abort_on_stale_network_failure(self, compressor):
+        """Same as above but for _last_summary_network_failure."""
+        compressor._ineffective_compression_count = 1
+        compressor._last_summary_network_failure = True  # stale
+        msgs = self._make_messages()
+
+        with patch("agent.context_compressor.call_llm") as mock_llm, \
+             patch.object(compressor, "_generate_summary") as mock_gen:
+            mock_llm.return_value = (None, None)
+            result = compressor.compress(msgs, force=False)
+
+        assert result is not None
+        assert len(result) > 0
+        mock_gen.assert_not_called()
+
+    def test_no_skip_when_force_true(self, compressor):
+        """force=True (manual /compress) must bypass the feasibility check."""
+        compressor._ineffective_compression_count = 1
+        msgs = self._make_messages()
+
+        with patch("agent.context_compressor.call_llm") as mock_llm, \
+             patch.object(compressor, "_generate_summary", return_value="LLM summary") as mock_gen:
+            mock_llm.return_value = (None, None)
+            compressor.compress(msgs, force=True)
+
+        # _generate_summary MUST have been called despite tiny middle section
+        mock_gen.assert_called_once()
+        assert compressor._prellm_skip_count == 0
+
+    def test_no_skip_when_no_prior_strikes(self, compressor):
+        """No prior ineffectiveness strikes → feasibility check doesn't fire."""
+        compressor._ineffective_compression_count = 0
+        msgs = self._make_messages()
+
+        with patch("agent.context_compressor.call_llm") as mock_llm, \
+             patch.object(compressor, "_generate_summary", return_value="LLM summary") as mock_gen:
+            mock_llm.return_value = (None, None)
+            compressor.compress(msgs, force=False)
+
+        mock_gen.assert_called_once()
+        assert compressor._prellm_skip_count == 0
+
+    def test_skip_count_resets_on_session_reset(self, compressor):
+        """_prellm_skip_count must reset alongside _ineffective_compression_count."""
+        compressor._prellm_skip_count = 5
+        compressor._ineffective_compression_count = 2
+
+        # on_session_reset() resets all per-session counters
+        compressor.on_session_reset()
+
+        assert compressor._prellm_skip_count == 0
+        assert compressor._ineffective_compression_count == 0


### PR DESCRIPTION
## What does this PR do?

When the middle section is < 10% of threshold tokens **and** at least one prior real-usage ineffectiveness strike has been recorded, this change skips the expensive LLM summarization call and falls through to the deterministic message-dropping path.

Without this guard, a tool-heavy session where the protected tail already holds most of the tokens can burn 500+ seconds on a summary call that replaces a few lightweight messages with negligible token savings.

Supersedes the feasibility-check half of #60451 per @GottZ's review. The echo-back half is in a separate companion PR. These two PRs touch different regions of `context_compressor.py` and can be reviewed/merged independently in any order.

### Blocking fixes from @GottZ's review

1. **Separate `_prellm_skip_count` counter** — never increments `_ineffective_compression_count` (the strike counter that latches at ≥2 to disable compression entirely). One real strike + one skip must NOT permanently lock out compression until `/new`.
2. **`feasibility_skip` sentinel flag** — exempts skips from the abort branch (`abort_on_summary_failure` / `_last_summary_auth_failure` / `_last_summary_network_failure`). A stale failure flag from a prior cycle must not turn a deliberate skip into a full abort.
3. **`reason=None`** for feasibility-skip fallbacks — a stale `_last_summary_error` from an earlier real failure must not be embedded into the skip's deterministic fallback marker.
4. **`info`-level logging** for feasibility-skip fallbacks (not `warning`) — this is an intentional optimization, not a failure.

## Related Issue

Fixes #60451 (partial — feasibility-check half)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`agent/context_compressor.py`** — Pre-LLM feasibility check in Phase 3 of `compress()`:
  - Add `_prellm_skip_count` to all four init/reset sites (`__init__`, `on_session_reset`, `on_session_start`, `bind_session_state`-adjacent type-annotated block)
  - Skip logic: when `not force` and `_ineffective_compression_count >= 1` and `middle_tokens < threshold_tokens * 0.1`, set `feasibility_skip = True`, increment `_prellm_skip_count`, skip `_generate_summary()`
  - Guard abort branch with `not feasibility_skip` so stale auth/network failure flags don't turn a skip into an abort
  - Pass `reason=None` to `_build_static_fallback_summary()` for feasibility skips
  - `info`-level log for feasibility-skip fallback, `warning` for real failures
- **`tests/agent/test_context_compressor.py`** — 6 regression tests (`TestPreLlmFeasibilityCheck`)

### Design

- Skipped when `force=True` (manual `/compress`) so auth/error handling paths are always exercised on explicit user request.
- Only fires after `≥1` prior real-usage ineffectiveness strike — first compression always gets a full LLM attempt.
- `_prellm_skip_count` resets on `on_session_reset()` alongside all other per-session counters.

## How to Test

1. `.venv/bin/python -m pytest tests/agent/test_context_compressor.py::TestPreLlmFeasibilityCheck -v` — 6 new tests
2. `.venv/bin/python -m pytest tests/agent/test_context_compressor.py -q` — full suite (188 passed)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```
tests/agent/test_context_compressor.py::TestPreLlmFeasibilityCheck::test_skip_does_not_increment_strike_counter PASSED
tests/agent/test_context_compressor.py::TestPreLlmFeasibilityCheck::test_skip_does_not_trip_abort_on_stale_auth_failure PASSED
tests/agent/test_context_compressor.py::TestPreLlmFeasibilityCheck::test_skip_does_not_trip_abort_on_stale_network_failure PASSED
tests/agent/test_context_compressor.py::TestPreLlmFeasibilityCheck::test_no_skip_when_force_true PASSED
tests/agent/test_context_compressor.py::TestPreLlmFeasibilityCheck::test_no_skip_when_no_prior_strikes PASSED
tests/agent/test_context_compressor.py::TestPreLlmFeasibilityCheck::test_skip_count_resets_on_session_reset PASSED

============================= 188 passed in 4.39s ==============================
```

Co-authored-by: Cursor <cursoragent@cursor.com>
Co-authored-by: TRON <tron-agent@agentmail.to>