### PR TITLE
feat(anthropic): add native web search and fetch

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -441,8 +441,7 @@ def _is_third_party_anthropic_endpoint(base_url: str | None) -> bool:
     normalized = _normalize_base_url_text(base_url)
     if not normalized:
         return False  # No base_url = direct Anthropic API
-    normalized = normalized.rstrip("/").lower()
-    if "anthropic.com" in normalized:
+    if base_url_host_matches(normalized, "anthropic.com"):
         return False  # Direct Anthropic API — OAuth applies
     return True  # Any other endpoint is a third-party proxy
 
@@ -1690,11 +1689,11 @@ def convert_tools_to_anthropic(
 ) -> List[Dict]:
     """Convert OpenAI tool definitions to Anthropic format.
 
-    A function schema may carry an ``_anthropic_server_tool`` marker.  On
-    Anthropic's native endpoint that marker replaces the client-side function
-    definition with Anthropic's server-tool spec.  Compatible third-party
-    endpoints keep the ordinary function definition because support for
-    Anthropic-hosted tools cannot be assumed there.
+    A function schema may carry a generic ``_hermes_server_tool`` binding. On
+    Anthropic's native endpoint a matching binding replaces the client-side
+    function definition with its provider-native spec. Compatible third-party
+    endpoints omit server-only tools because neither the endpoint nor Hermes's
+    local dispatcher can execute them.
     """
     if not tools:
         return []
@@ -1703,6 +1702,35 @@ def convert_tools_to_anthropic(
     for t in tools:
         fn = t.get("function", {})
         name = fn.get("name", "")
+        server_binding = fn.get("_hermes_server_tool")
+        if server_binding is not None:
+            server_spec = (
+                server_binding.get("definition")
+                if isinstance(server_binding, dict)
+                and server_binding.get("api_mode") == "anthropic_messages"
+                else None
+            )
+            if (
+                isinstance(server_spec, dict)
+                and server_spec.get("type")
+                and not _is_third_party_anthropic_endpoint(base_url)
+            ):
+                server_name = server_spec.get("name", "")
+                if server_name and server_name in seen_names:
+                    logger.warning(
+                        "convert_tools_to_anthropic: duplicate tool name '%s' "
+                        "— dropping second occurrence",
+                        server_name,
+                    )
+                else:
+                    result.append(copy.deepcopy(server_spec))
+                    if server_name:
+                        seen_names.add(server_name)
+            # Server-only bindings never degrade to local function tools. A
+            # third-party Anthropic-compatible endpoint cannot execute the
+            # native definition, while the selected local backend is also
+            # intentionally non-executable.
+            continue
         # Defensive dedup: Anthropic rejects requests with duplicate tool
         # names.  Upstream injection paths already dedup, but this guard
         # converts a hard API failure into a warning.  See: #18478
@@ -1715,14 +1743,6 @@ def convert_tools_to_anthropic(
             continue
         if name:
             seen_names.add(name)
-        server_spec = fn.get("_anthropic_server_tool")
-        if (
-            isinstance(server_spec, dict)
-            and server_spec.get("type")
-            and not _is_third_party_anthropic_endpoint(base_url)
-        ):
-            result.append(copy.deepcopy(server_spec))
-            continue
         anthropic_tool: Dict[str, Any] = {
             "name": name,
             "description": fn.get("description", ""),

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1685,8 +1685,17 @@ def _normalize_tool_input_schema(schema: Any) -> Dict[str, Any]:
     return normalized
 
 
-def convert_tools_to_anthropic(tools: List[Dict]) -> List[Dict]:
-    """Convert OpenAI tool definitions to Anthropic format."""
+def convert_tools_to_anthropic(
+    tools: List[Dict], base_url: str | None = None
+) -> List[Dict]:
+    """Convert OpenAI tool definitions to Anthropic format.
+
+    A function schema may carry an ``_anthropic_server_tool`` marker.  On
+    Anthropic's native endpoint that marker replaces the client-side function
+    definition with Anthropic's server-tool spec.  Compatible third-party
+    endpoints keep the ordinary function definition because support for
+    Anthropic-hosted tools cannot be assumed there.
+    """
     if not tools:
         return []
     result = []
@@ -1706,6 +1715,14 @@ def convert_tools_to_anthropic(tools: List[Dict]) -> List[Dict]:
             continue
         if name:
             seen_names.add(name)
+        server_spec = fn.get("_anthropic_server_tool")
+        if (
+            isinstance(server_spec, dict)
+            and server_spec.get("type")
+            and not _is_third_party_anthropic_endpoint(base_url)
+        ):
+            result.append(copy.deepcopy(server_spec))
+            continue
         anthropic_tool: Dict[str, Any] = {
             "name": name,
             "description": fn.get("description", ""),
@@ -1924,6 +1941,25 @@ def _sanitize_replay_block(b: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         }
         if isinstance(b.get("cache_control"), dict):
             out["cache_control"] = b["cache_control"]
+        return out
+    if btype == "server_tool_use":
+        out = {
+            "type": "server_tool_use",
+            "id": b.get("id", ""),
+            "name": b.get("name", ""),
+            "input": copy.deepcopy(b.get("input", {})),
+        }
+        if isinstance(b.get("cache_control"), dict):
+            out["cache_control"] = copy.deepcopy(b["cache_control"])
+        return out
+    if btype in {"web_search_tool_result", "web_fetch_tool_result"}:
+        out = {
+            "type": btype,
+            "tool_use_id": b.get("tool_use_id", ""),
+            "content": copy.deepcopy(b.get("content")),
+        }
+        if isinstance(b.get("cache_control"), dict):
+            out["cache_control"] = copy.deepcopy(b["cache_control"])
         return out
     if btype == "image":
         src = b.get("source")
@@ -2531,7 +2567,9 @@ def build_anthropic_kwargs(
     system, anthropic_messages = convert_messages_to_anthropic(
         messages, base_url=base_url, model=model
     )
-    anthropic_tools = convert_tools_to_anthropic(tools) if tools else []
+    anthropic_tools = (
+        convert_tools_to_anthropic(tools, base_url=base_url) if tools else []
+    )
 
     model = normalize_model_name(model, preserve_dots=preserve_dots)
     # effective_max_tokens = output cap for this call (≠ total context window)
@@ -2600,6 +2638,11 @@ def build_anthropic_kwargs(
 
         if anthropic_tools:
             for tool in anthropic_tools:
+                # Server tools have a versioned ``type`` and a canonical name
+                # that Anthropic itself intercepts. Prefixing that name turns
+                # it back into an ordinary client tool and breaks execution.
+                if "type" in tool:
+                    continue
                 if "name" in tool:
                     tool["name"] = _to_oauth_wire_name(tool["name"])
 

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1684,6 +1684,28 @@ def _normalize_tool_input_schema(schema: Any) -> Dict[str, Any]:
     return normalized
 
 
+# Server-only tools already reported as withheld from a compatible
+# third-party endpoint, as ``(tool_name, base_url)``. Tool conversion runs on
+# every request, so the diagnosis is emitted once per process rather than once
+# per turn. A duplicate line from a benign race is harmless.
+_reported_third_party_server_tool_drops: set = set()
+
+
+def _report_third_party_server_tool_drop(name: str, base_url: str | None) -> None:
+    """Log, once per process, a server-only tool withheld from a proxy endpoint."""
+    key = (name, str(base_url or ""))
+    if key in _reported_third_party_server_tool_drops:
+        return
+    _reported_third_party_server_tool_drops.add(key)
+    logger.warning(
+        "Tool %r only runs inside Anthropic's own Messages API; %s is a "
+        "compatible third-party endpoint, so the tool is omitted from these "
+        "requests and the model cannot call it. Select a backend this "
+        "endpoint supports (`hermes tools`) to restore this capability.",
+        name, base_url or "the configured endpoint",
+    )
+
+
 def convert_tools_to_anthropic(
     tools: List[Dict], base_url: str | None = None
 ) -> List[Dict]:
@@ -1710,22 +1732,26 @@ def convert_tools_to_anthropic(
                 and server_binding.get("api_mode") == "anthropic_messages"
                 else None
             )
-            if (
-                isinstance(server_spec, dict)
-                and server_spec.get("type")
-                and not _is_third_party_anthropic_endpoint(base_url)
-            ):
-                server_name = server_spec.get("name", "")
-                if server_name and server_name in seen_names:
-                    logger.warning(
-                        "convert_tools_to_anthropic: duplicate tool name '%s' "
-                        "— dropping second occurrence",
-                        server_name,
-                    )
+            if isinstance(server_spec, dict) and server_spec.get("type"):
+                if _is_third_party_anthropic_endpoint(base_url):
+                    # The endpoint speaks the Messages API but is not assumed
+                    # to host Anthropic's server-side tools, so the tool is
+                    # withheld. Say so: the operator enabled this capability
+                    # and would otherwise watch it vanish from the request
+                    # with no diagnosis anywhere.
+                    _report_third_party_server_tool_drop(name, base_url)
                 else:
-                    result.append(copy.deepcopy(server_spec))
-                    if server_name:
-                        seen_names.add(server_name)
+                    server_name = server_spec.get("name", "")
+                    if server_name and server_name in seen_names:
+                        logger.warning(
+                            "convert_tools_to_anthropic: duplicate tool name '%s' "
+                            "— dropping second occurrence",
+                            server_name,
+                        )
+                    else:
+                        result.append(copy.deepcopy(server_spec))
+                        if server_name:
+                            seen_names.add(server_name)
             # Server-only bindings never degrade to local function tools. A
             # third-party Anthropic-compatible endpoint cannot execute the
             # native definition, while the selected local backend is also

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -488,6 +488,10 @@ def _apply_claude_code_identity(system, anthropic_tools, anthropic_messages, to_
                 text = text.replace(old, new)
             block["text"] = _apply_oauth_prose_aliases(text)
     for tool in anthropic_tools or []:
+        # Server tools carry a versioned ``type`` and a canonical name Anthropic itself intercepts;
+        # renaming one turns it back into an ordinary client tool and breaks execution.
+        if "type" in tool:
+            continue
         if "name" in tool:
             tool["name"] = to_wire(tool["name"])
         if isinstance(tool.get("description"), str):
@@ -545,7 +549,7 @@ def build_anthropic_kwargs(
     dots (DashScope: qwen3.5-plus); a third-party ``base_url`` strips thinking signatures;
     ``fast_mode`` adds ``extra_body.speed="fast"`` plus the fast-mode beta on native Anthropic only."""
     system, anthropic_messages = convert_messages_to_anthropic(messages, base_url=base_url, model=model)
-    anthropic_tools = convert_tools_to_anthropic(tools) if tools else []
+    anthropic_tools = convert_tools_to_anthropic(tools, base_url=base_url) if tools else []
     # Nous Portal routes on its own catalog ids (``anthropic/claude-opus-4.8``); normalizing would
     # make the model unresolvable there (prefix AND dots kept).
     if not _is_nous_portal_endpoint(base_url):

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -571,8 +571,11 @@ def build_anthropic_kwargs(
         elif tool_choice is None or isinstance(tool_choice, str):
             # A forced tool name goes through the OAuth normalizer too: every tools[] entry is
             # mcp__-prefixed/aliased there, so the literal would leak and name a nonexistent tool.
+            # Server tools are the exception — they keep their canonical name in tools[] (see
+            # _apply_claude_code_identity), so forcing one must name it verbatim.
+            forced_server_tool = any("type" in t and t.get("name") == tool_choice for t in anthropic_tools)
             kwargs["tool_choice"] = _TOOL_CHOICE_MAP.get(tool_choice) or {
-                "type": "tool", "name": to_wire(tool_choice) if to_wire else tool_choice
+                "type": "tool", "name": to_wire(tool_choice) if to_wire and not forced_server_tool else tool_choice
             }
     # Map reasoning_config to Anthropic's thinking parameter. Claude 4.6+ models use adaptive thinking +
     # output_config.effort. Older models use manual thinking with budget_tokens. MiniMax Anthropic-compat

--- a/agent/anthropic_endpoints.py
+++ b/agent/anthropic_endpoints.py
@@ -26,10 +26,11 @@ def _normalized_lower(base_url) -> str:
 
 
 def _is_third_party_anthropic_endpoint(base_url: str | None) -> bool:
-    """Any non-anthropic.com endpoint (own x-api-key keys; skip OAuth detection). No base_url =
-    direct Anthropic API."""
-    normalized = _normalized_lower(base_url)
-    return bool(normalized) and "anthropic.com" not in normalized
+    """Any endpoint not hosted on anthropic.com or a subdomain of it (own x-api-key keys; skip
+    OAuth detection). Hostname match, not substring, so ``api.anthropic.com.example`` and
+    ``proxy.example/api.anthropic.com`` are third-party. No base_url = direct Anthropic API."""
+    normalized = _normalize_base_url_text(base_url)
+    return bool(normalized) and not base_url_host_matches(normalized, "anthropic.com")
 
 
 def _is_kimi_coding_endpoint(base_url: str | None) -> bool:

--- a/agent/anthropic_message_convert.py
+++ b/agent/anthropic_message_convert.py
@@ -143,9 +143,13 @@ def _normalize_tool_input_schema(schema: Any) -> Dict[str, Any]:
     return normalized
 
 
-def convert_tools_to_anthropic(tools: List[Dict]) -> List[Dict]:
+def convert_tools_to_anthropic(tools: List[Dict], base_url: str | None = None) -> List[Dict]:
     """Convert OpenAI tool definitions to Anthropic format. Duplicate names are dropped with a
-    warning (Anthropic hard-400s on them); ``cache_control`` on the OpenAI tool dict is forwarded."""
+    warning (Anthropic hard-400s on them); ``cache_control`` on the OpenAI tool dict is forwarded.
+    A function schema may carry an ``_anthropic_server_tool`` marker: on Anthropic's native endpoint
+    it replaces the client-side function definition with a copy of that server-tool spec;
+    compatible third-party endpoints keep the ordinary function definition because support for
+    Anthropic-hosted tools cannot be assumed there."""
     result = []
     seen_names: set = set()
     for t in tools or []:
@@ -158,6 +162,10 @@ def convert_tools_to_anthropic(tools: List[Dict]) -> List[Dict]:
             continue
         if name:
             seen_names.add(name)
+        server_spec = fn.get("_anthropic_server_tool")
+        if isinstance(server_spec, dict) and server_spec.get("type") and not _is_third_party_anthropic_endpoint(base_url):
+            result.append(copy.deepcopy(server_spec))
+            continue
         anthropic_tool: Dict[str, Any] = {
             "name": name, "description": fn.get("description", ""),
             "input_schema": _normalize_tool_input_schema(fn.get("parameters") or {}),
@@ -301,9 +309,23 @@ def _replay_image(b: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     return {"type": "image", "source": src} if isinstance(src, dict) else None
 
 
+def _replay_server_tool_use(b: Dict[str, Any]) -> Dict[str, Any]:
+    out = {
+        "type": "server_tool_use", "id": b.get("id", ""), "name": b.get("name", ""),
+        "input": copy.deepcopy(b.get("input", {})),
+    }
+    return _carry_cache_control(out, b, copy=True)
+
+
+def _replay_server_tool_result(b: Dict[str, Any]) -> Dict[str, Any]:
+    out = {"type": b["type"], "tool_use_id": b.get("tool_use_id", ""), "content": copy.deepcopy(b.get("content"))}
+    return _carry_cache_control(out, b, copy=True)
+
+
 _REPLAY_SANITIZERS = {
     "text": _replay_text, "thinking": _replay_thinking, "redacted_thinking": _replay_redacted_thinking,
-    "tool_use": _replay_tool_use, "image": _replay_image,
+    "tool_use": _replay_tool_use, "image": _replay_image, "server_tool_use": _replay_server_tool_use,
+    "web_search_tool_result": _replay_server_tool_result, "web_fetch_tool_result": _replay_server_tool_result,
 }
 
 

--- a/agent/anthropic_message_convert.py
+++ b/agent/anthropic_message_convert.py
@@ -146,15 +146,35 @@ def _normalize_tool_input_schema(schema: Any) -> Dict[str, Any]:
 def convert_tools_to_anthropic(tools: List[Dict], base_url: str | None = None) -> List[Dict]:
     """Convert OpenAI tool definitions to Anthropic format. Duplicate names are dropped with a
     warning (Anthropic hard-400s on them); ``cache_control`` on the OpenAI tool dict is forwarded.
-    A function schema may carry an ``_anthropic_server_tool`` marker: on Anthropic's native endpoint
-    it replaces the client-side function definition with a copy of that server-tool spec;
-    compatible third-party endpoints keep the ordinary function definition because support for
-    Anthropic-hosted tools cannot be assumed there."""
+    A function schema may carry a generic ``_hermes_server_tool`` binding: on Anthropic's native
+    endpoint a matching binding replaces the client-side function definition with a copy of its
+    provider-native spec. Compatible third-party endpoints omit server-only tools because neither
+    the endpoint nor Hermes's local dispatcher can execute them."""
     result = []
     seen_names: set = set()
     for t in tools or []:
         fn = t.get("function", {})
         name = fn.get("name", "")
+        if (server_binding := fn.get("_hermes_server_tool")) is not None:
+            server_spec = (
+                server_binding.get("definition")
+                if isinstance(server_binding, dict) and server_binding.get("api_mode") == "anthropic_messages"
+                else None
+            )
+            if isinstance(server_spec, dict) and server_spec.get("type") and not _is_third_party_anthropic_endpoint(base_url):
+                server_name = server_spec.get("name", "")
+                if server_name and server_name in seen_names:
+                    logger.warning(
+                        "convert_tools_to_anthropic: duplicate tool name '%s' — dropping second occurrence", server_name
+                    )
+                else:
+                    result.append(copy.deepcopy(server_spec))
+                    if server_name:
+                        seen_names.add(server_name)
+            # Server-only bindings never degrade to local function tools: a third-party
+            # Anthropic-compatible endpoint cannot execute the native definition, while the selected
+            # local backend is also intentionally non-executable.
+            continue
         # Defensive dedup: Anthropic rejects requests with duplicate tool names. Upstream injection paths
         # already dedup, but this guard converts a hard API failure into a warning. See: #18478
         if name and name in seen_names:
@@ -162,10 +182,6 @@ def convert_tools_to_anthropic(tools: List[Dict], base_url: str | None = None) -
             continue
         if name:
             seen_names.add(name)
-        server_spec = fn.get("_anthropic_server_tool")
-        if isinstance(server_spec, dict) and server_spec.get("type") and not _is_third_party_anthropic_endpoint(base_url):
-            result.append(copy.deepcopy(server_spec))
-            continue
         anthropic_tool: Dict[str, Any] = {
             "name": name, "description": fn.get("description", ""),
             "input_schema": _normalize_tool_input_schema(fn.get("parameters") or {}),

--- a/agent/anthropic_message_convert.py
+++ b/agent/anthropic_message_convert.py
@@ -143,6 +143,26 @@ def _normalize_tool_input_schema(schema: Any) -> Dict[str, Any]:
     return normalized
 
 
+# Server-only tools already reported as withheld from a compatible third-party endpoint, as
+# ``(tool_name, base_url)``. Tool conversion runs on every request, so the diagnosis is emitted
+# once per process rather than once per turn. A duplicate line from a benign race is harmless.
+_reported_third_party_server_tool_drops: set = set()
+
+
+def _report_third_party_server_tool_drop(name: str, base_url: str | None) -> None:
+    """Log, once per process, a server-only tool withheld from a proxy endpoint."""
+    key = (name, str(base_url or ""))
+    if key in _reported_third_party_server_tool_drops:
+        return
+    _reported_third_party_server_tool_drops.add(key)
+    logger.warning(
+        "Tool %r only runs inside Anthropic's own Messages API; %s is a compatible third-party endpoint, "
+        "so the tool is omitted from these requests and the model cannot call it. Select a backend this "
+        "endpoint supports (`hermes tools`) to restore this capability.",
+        name, base_url or "the configured endpoint",
+    )
+
+
 def convert_tools_to_anthropic(tools: List[Dict], base_url: str | None = None) -> List[Dict]:
     """Convert OpenAI tool definitions to Anthropic format. Duplicate names are dropped with a
     warning (Anthropic hard-400s on them); ``cache_control`` on the OpenAI tool dict is forwarded.
@@ -161,16 +181,24 @@ def convert_tools_to_anthropic(tools: List[Dict], base_url: str | None = None) -
                 if isinstance(server_binding, dict) and server_binding.get("api_mode") == "anthropic_messages"
                 else None
             )
-            if isinstance(server_spec, dict) and server_spec.get("type") and not _is_third_party_anthropic_endpoint(base_url):
-                server_name = server_spec.get("name", "")
-                if server_name and server_name in seen_names:
-                    logger.warning(
-                        "convert_tools_to_anthropic: duplicate tool name '%s' — dropping second occurrence", server_name
-                    )
+            if isinstance(server_spec, dict) and server_spec.get("type"):
+                if _is_third_party_anthropic_endpoint(base_url):
+                    # The endpoint speaks the Messages API but is not assumed to host Anthropic's
+                    # server-side tools, so the tool is withheld. Say so: the operator enabled this
+                    # capability and would otherwise watch it vanish from the request with no
+                    # diagnosis anywhere.
+                    _report_third_party_server_tool_drop(name, base_url)
                 else:
-                    result.append(copy.deepcopy(server_spec))
-                    if server_name:
-                        seen_names.add(server_name)
+                    server_name = server_spec.get("name", "")
+                    if server_name and server_name in seen_names:
+                        logger.warning(
+                            "convert_tools_to_anthropic: duplicate tool name '%s' — dropping second occurrence",
+                            server_name,
+                        )
+                    else:
+                        result.append(copy.deepcopy(server_spec))
+                        if server_name:
+                            seen_names.add(server_name)
             # Server-only bindings never degrade to local function tools: a third-party
             # Anthropic-compatible endpoint cannot execute the native definition, while the selected
             # local backend is also intentionally non-executable.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -680,6 +680,7 @@ def run_conversation(
     interrupted = False
     failed = False
     codex_ack_continuations = 0
+    anthropic_pause_continuations = 0
     length_continue_retries = 0
     truncated_tool_call_retries = 0
     truncated_response_parts: List[str] = []
@@ -4512,6 +4513,71 @@ def run_conversation(
                     )
             except Exception:
                 pass
+
+            # Anthropic server tools may pause their internal agentic loop and
+            # require the exact assistant content to be submitted again.  This
+            # is provider continuation state, not a client tool call: append no
+            # synthetic user/tool message, preserve the native blocks, and let
+            # the next normal loop iteration rebuild the request.  Bound the
+            # continuation count so a pathological upstream cannot consume the
+            # entire agent budget without giving the fallback chain a chance.
+            if (
+                agent.api_mode == "anthropic_messages"
+                and finish_reason == "pause_turn"
+            ):
+                anthropic_pause_continuations += 1
+                paused_msg = agent._build_assistant_message(
+                    assistant_message, finish_reason
+                )
+                messages.append(paused_msg)
+                agent._emit_interim_assistant_message(paused_msg)
+                try:
+                    agent._flush_messages_to_session_db(
+                        messages, conversation_history
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Anthropic pause_turn persistence failed "
+                        "(session=%s): %s",
+                        agent.session_id or "none",
+                        exc,
+                    )
+
+                if anthropic_pause_continuations < 3:
+                    agent._buffer_vprint(
+                        "↻ Anthropic server tool paused; continuing turn "
+                        f"({anthropic_pause_continuations}/3)"
+                    )
+                    continue
+
+                if agent._has_pending_fallback():
+                    agent._buffer_status(
+                        "⚠️ Anthropic server tool paused repeatedly — trying fallback..."
+                    )
+                if agent._try_activate_fallback():
+                    active_system_prompt = _sync_failover_system_message(
+                        agent, api_messages, active_system_prompt
+                    )
+                    anthropic_pause_continuations = 0
+                    retry_count = 0
+                    continue
+
+                agent._flush_status_buffer()
+                agent._cleanup_task_resources(effective_task_id)
+                agent._persist_session(messages, conversation_history)
+                _pause_error = (
+                    "Anthropic server tool did not finish after 3 pause_turn "
+                    "continuations."
+                )
+                return {
+                    "final_response": _pause_error,
+                    "messages": messages,
+                    "api_calls": api_call_count,
+                    "completed": False,
+                    "partial": True,
+                    "error": _pause_error,
+                }
+            anthropic_pause_continuations = 0
 
             # Handle assistant response
             if assistant_message.content and not agent.quiet_mode:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1306,6 +1306,8 @@ class _LoopState:
     interrupted: bool = False
     failed: bool = False
     codex_ack_continuations: int = 0
+    # Consecutive Anthropic ``pause_turn`` continuations; any other response resets it.
+    anthropic_pause_continuations: int = 0
     length_continue_retries: int = 0
     # Per-turn backstop for the refunding restarts (redirect / rebuilt-for-fallback).
     # Unlike ``retry_count`` (rebound to 0 each iteration) this accumulates for the whole

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -94,6 +94,8 @@ class AnthropicTransport(ProviderTransport):
         reasoning_parts = []
         reasoning_details = []
         tool_calls = []
+        citation_sources = []
+        seen_citation_urls = set()
         # Verbatim, order-preserving copy of every content block in the turn.
         # Anthropic signs each thinking block against the turn content that
         # PRECEDES it at its position; when a turn interleaves thinking and
@@ -119,6 +121,22 @@ class AnthropicTransport(ProviderTransport):
                     ordered_blocks.append(clean_block)
             if block.type == "text":
                 text_parts.append(block.text)
+                # Anthropic returns citations as structured metadata rather
+                # than inline Markdown.  Preserve that metadata for replay
+                # (ordered_blocks above) and also render a compact source list
+                # into Hermes' provider-neutral text channel so CLI/gateway
+                # users do not lose the URLs.
+                for citation in getattr(block, "citations", None) or []:
+                    citation_dict = _to_plain_data(citation)
+                    if not isinstance(citation_dict, dict):
+                        continue
+                    url = citation_dict.get("url")
+                    if not isinstance(url, str) or not url or url in seen_citation_urls:
+                        continue
+                    seen_citation_urls.add(url)
+                    title = citation_dict.get("title") or citation_dict.get("cited_text") or url
+                    title = " ".join(str(title).split())
+                    citation_sources.append((title, url))
             elif block.type in ("thinking", "redacted_thinking"):
                 if block.type == "thinking":
                     reasoning_parts.append(block.thinking)
@@ -179,11 +197,32 @@ class AnthropicTransport(ProviderTransport):
             isinstance(b, dict) and b.get("type") == "tool_use"
             for b in ordered_blocks
         )
-        if _has_signed_thinking and _has_tool_use:
+        _has_server_tool_blocks = any(
+            isinstance(b, dict)
+            and (
+                b.get("type") == "server_tool_use"
+                or b.get("type") in {
+                    "web_search_tool_result", "web_fetch_tool_result",
+                }
+            )
+            for b in ordered_blocks
+        )
+        if (_has_signed_thinking and _has_tool_use) or _has_server_tool_blocks:
             provider_data["anthropic_content_blocks"] = ordered_blocks
 
+        normalized_content = "\n".join(text_parts) if text_parts else None
+        if citation_sources:
+            sources = "\n".join(
+                f"- {title}: {url}" for title, url in citation_sources
+            )
+            normalized_content = (
+                f"{normalized_content}\n\nSources:\n{sources}"
+                if normalized_content
+                else f"Sources:\n{sources}"
+            )
+
         return NormalizedResponse(
-            content="\n".join(text_parts) if text_parts else None,
+            content=normalized_content,
             tool_calls=tool_calls or None,
             finish_reason=finish_reason,
             reasoning="\n\n".join(reasoning_parts) if reasoning_parts else None,
@@ -238,6 +277,7 @@ class AnthropicTransport(ProviderTransport):
         "stop_sequence": "stop",
         "refusal": "content_filter",
         "model_context_window_exceeded": "length",
+        "pause_turn": "pause_turn",
     }
 
     def map_finish_reason(self, raw_reason: str) -> str:

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -96,6 +96,14 @@ class AnthropicTransport(ProviderTransport):
         tool_calls = []
         citation_sources = []
         seen_citation_urls = set()
+
+        def _add_citation_source(url: Any, title: Any = None) -> None:
+            if not isinstance(url, str) or not url or url in seen_citation_urls:
+                return
+            seen_citation_urls.add(url)
+            normalized_title = " ".join(str(title or url).split())
+            citation_sources.append((normalized_title, url))
+
         # Verbatim, order-preserving copy of every content block in the turn.
         # Anthropic signs each thinking block against the turn content that
         # PRECEDES it at its position; when a turn interleaves thinking and
@@ -131,12 +139,22 @@ class AnthropicTransport(ProviderTransport):
                     if not isinstance(citation_dict, dict):
                         continue
                     url = citation_dict.get("url")
-                    if not isinstance(url, str) or not url or url in seen_citation_urls:
-                        continue
-                    seen_citation_urls.add(url)
                     title = citation_dict.get("title") or citation_dict.get("cited_text") or url
-                    title = " ".join(str(title).split())
-                    citation_sources.append((title, url))
+                    _add_citation_source(url, title)
+            elif block.type == "web_fetch_tool_result":
+                # Fetch citations may use document-relative locations without
+                # carrying a URL on the text block.  The server result itself
+                # remains the authoritative source for the fetched URL, so
+                # surface it in Hermes' neutral text channel as a fallback.
+                result_content = (
+                    clean_block.get("content")
+                    if isinstance(clean_block, dict)
+                    else None
+                )
+                if isinstance(result_content, dict):
+                    _add_citation_source(
+                        result_content.get("url"), result_content.get("title")
+                    )
             elif block.type in ("thinking", "redacted_thinking"):
                 if block.type == "thinking":
                     reasoning_parts.append(block.thinking)
@@ -213,7 +231,8 @@ class AnthropicTransport(ProviderTransport):
         normalized_content = "\n".join(text_parts) if text_parts else None
         if citation_sources:
             sources = "\n".join(
-                f"- {title}: {url}" for title, url in citation_sources
+                f"- {url}" if title == url else f"- {title}: {url}"
+                for title, url in citation_sources
             )
             normalized_content = (
                 f"{normalized_content}\n\nSources:\n{sources}"

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -36,7 +36,7 @@ class AnthropicTransport(ProviderTransport):
         """Convert OpenAI tool schemas to Anthropic input_schema format."""
         from agent.anthropic_adapter import convert_tools_to_anthropic
 
-        return convert_tools_to_anthropic(tools)
+        return convert_tools_to_anthropic(self.project_tools(tools) or [])
 
     def build_kwargs(
         self,
@@ -62,6 +62,7 @@ class AnthropicTransport(ProviderTransport):
         """
         from agent.anthropic_adapter import build_anthropic_kwargs
 
+        tools = self.project_tools(tools)
         return build_anthropic_kwargs(
             model=model,
             messages=messages,

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -7,6 +7,8 @@ from agent.transports.types import NormalizedResponse, ToolCall
 
 _MCP_PREFIX = "mcp__"
 _THINKING_TYPES = ("thinking", "redacted_thinking")
+# Blocks of an Anthropic-executed server tool (native web search / fetch).
+_SERVER_TOOL_BLOCK_TYPES = ("server_tool_use", "web_search_tool_result", "web_fetch_tool_result")
 
 
 def _unprefix_oauth_tool_name(name: str) -> str:
@@ -35,7 +37,7 @@ class AnthropicTransport(ProviderTransport):
 
     _STOP_REASON_MAP = {
         "end_turn": "stop", "tool_use": "tool_calls", "max_tokens": "length", "stop_sequence": "stop",
-        "refusal": "content_filter", "model_context_window_exceeded": "length",
+        "refusal": "content_filter", "model_context_window_exceeded": "length", "pause_turn": "pause_turn",
     }
 
     @property
@@ -68,6 +70,7 @@ class AnthropicTransport(ProviderTransport):
         from agent.anthropic_message_convert import _sanitize_replay_block, _to_plain_data
         strip_tool_prefix = kwargs.get("strip_tool_prefix", False)
         text_parts, reasoning_parts, reasoning_details, tool_calls = [], [], [], []
+        citation_sources, seen_citation_urls = [], set()
         # Anthropic signs each thinking block against the blocks PRECEDING it; when thinking
         # interleaves with tool_use the parallel lists lose that order and replay -> HTTP 400.
         ordered_blocks = []
@@ -79,6 +82,19 @@ class AnthropicTransport(ProviderTransport):
                 ordered_blocks.append(clean_block)
             if block.type == "text":
                 text_parts.append(block.text)
+                # Citations arrive as structured metadata, not inline Markdown: ordered_blocks keeps them for
+                # replay, and a compact source list is rendered into the neutral text channel below so
+                # CLI/gateway users do not lose the URLs.
+                for citation in getattr(block, "citations", None) or []:
+                    citation_dict = _to_plain_data(citation)
+                    if not isinstance(citation_dict, dict):
+                        continue
+                    url = citation_dict.get("url")
+                    if not isinstance(url, str) or not url or url in seen_citation_urls:
+                        continue
+                    seen_citation_urls.add(url)
+                    title = citation_dict.get("title") or citation_dict.get("cited_text") or url
+                    citation_sources.append((" ".join(str(title).split()), url))
             elif block.type in _THINKING_TYPES:
                 if block.type == "thinking":
                     reasoning_parts.append(block.thinking)
@@ -91,12 +107,19 @@ class AnthropicTransport(ProviderTransport):
                     name = _unprefix_oauth_tool_name(name)
                 tool_calls.append(ToolCall(id=block.id, name=name, arguments=json.dumps(block.input)))
         provider_data = {"reasoning_details": reasoning_details} if reasoning_details else {}
-        # Ordered channel only for the shape the parallel lists reconstruct wrongly.
+        # Ordered channel only for the shapes the parallel lists cannot reconstruct: signed thinking
+        # interleaved with tool_use, and server-tool blocks, which no parallel list carries at all.
         signed = any(b.get("type") in _THINKING_TYPES and (b.get("signature") or b.get("data")) for b in ordered_blocks)
-        if signed and any(b.get("type") == "tool_use" for b in ordered_blocks):
+        if (signed and any(b.get("type") == "tool_use" for b in ordered_blocks)) or any(
+            b.get("type") in _SERVER_TOOL_BLOCK_TYPES for b in ordered_blocks
+        ):
             provider_data["anthropic_content_blocks"] = ordered_blocks
+        content = "\n".join(text_parts) if text_parts else None
+        if citation_sources:
+            sources = "Sources:\n" + "\n".join(f"- {title}: {url}" for title, url in citation_sources)
+            content = f"{content}\n\n{sources}" if content else sources
         return NormalizedResponse(
-            content="\n".join(text_parts) if text_parts else None, tool_calls=tool_calls or None,
+            content=content, tool_calls=tool_calls or None,
             finish_reason=self.response_finish_reason(response),
             reasoning="\n\n".join(reasoning_parts) if reasoning_parts else None, usage=None,
             provider_data=provider_data or None,

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -71,6 +71,13 @@ class AnthropicTransport(ProviderTransport):
         strip_tool_prefix = kwargs.get("strip_tool_prefix", False)
         text_parts, reasoning_parts, reasoning_details, tool_calls = [], [], [], []
         citation_sources, seen_citation_urls = [], set()
+
+        def _add_citation_source(url: Any, title: Any = None) -> None:
+            if not isinstance(url, str) or not url or url in seen_citation_urls:
+                return
+            seen_citation_urls.add(url)
+            citation_sources.append((" ".join(str(title or url).split()), url))
+
         # Anthropic signs each thinking block against the blocks PRECEDING it; when thinking
         # interleaves with tool_use the parallel lists lose that order and replay -> HTTP 400.
         ordered_blocks = []
@@ -90,11 +97,13 @@ class AnthropicTransport(ProviderTransport):
                     if not isinstance(citation_dict, dict):
                         continue
                     url = citation_dict.get("url")
-                    if not isinstance(url, str) or not url or url in seen_citation_urls:
-                        continue
-                    seen_citation_urls.add(url)
-                    title = citation_dict.get("title") or citation_dict.get("cited_text") or url
-                    citation_sources.append((" ".join(str(title).split()), url))
+                    _add_citation_source(url, citation_dict.get("title") or citation_dict.get("cited_text") or url)
+            elif block.type == "web_fetch_tool_result":
+                # Fetch citations may use document-relative locations with no URL on the text block; the
+                # server result stays the authoritative source for the fetched URL, so surface it as a fallback.
+                result_content = (clean_block or {}).get("content")
+                if isinstance(result_content, dict):
+                    _add_citation_source(result_content.get("url"), result_content.get("title"))
             elif block.type in _THINKING_TYPES:
                 if block.type == "thinking":
                     reasoning_parts.append(block.thinking)
@@ -116,7 +125,9 @@ class AnthropicTransport(ProviderTransport):
             provider_data["anthropic_content_blocks"] = ordered_blocks
         content = "\n".join(text_parts) if text_parts else None
         if citation_sources:
-            sources = "Sources:\n" + "\n".join(f"- {title}: {url}" for title, url in citation_sources)
+            sources = "Sources:\n" + "\n".join(
+                f"- {url}" if title == url else f"- {title}: {url}" for title, url in citation_sources
+            )
             content = f"{content}\n\n{sources}" if content else sources
         return NormalizedResponse(
             content=content, tool_calls=tool_calls or None,

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -52,7 +52,7 @@ class AnthropicTransport(ProviderTransport):
     def convert_tools(self, tools: List[Dict[str, Any]]) -> Any:
         """Convert OpenAI tool schemas to Anthropic input_schema format."""
         from agent.anthropic_message_convert import convert_tools_to_anthropic
-        return convert_tools_to_anthropic(tools)
+        return convert_tools_to_anthropic(self.project_tools(tools) or [])
 
     def build_kwargs(
         self, model: str, messages: List[Dict[str, Any]], tools: Optional[List[Dict[str, Any]]] = None, **params,
@@ -60,7 +60,7 @@ class AnthropicTransport(ProviderTransport):
         """Build Anthropic messages.create() kwargs (converts messages and tools internally)."""
         from agent.anthropic_adapter import build_anthropic_kwargs
         return build_anthropic_kwargs(
-            model=model, messages=messages, tools=tools,
+            model=model, messages=messages, tools=self.project_tools(tools),
             **{key: params.get(key, default) for key, default in _BUILD_KWARG_DEFAULTS.items()},
         )
 

--- a/agent/transports/base.py
+++ b/agent/transports/base.py
@@ -13,6 +13,46 @@ from typing import Any, Dict, List, Optional
 from agent.transports.types import NormalizedResponse
 
 
+_HERMES_SERVER_TOOL_KEY = "_hermes_server_tool"
+
+
+def project_tools_for_transport(
+    tools: Optional[List[Dict[str, Any]]], api_mode: str
+) -> Optional[List[Dict[str, Any]]]:
+    """Project logical Hermes tools onto one provider transport.
+
+    A function definition carrying ``_hermes_server_tool`` is server-only: it
+    may be advertised solely to the api_mode named by that binding.  The
+    target transport consumes the binding and emits its provider-native tool
+    definition; every other transport omits the tool entirely.  This keeps
+    Hermes-internal metadata off the wire and prevents fallbacks from exposing
+    a client function whose handler cannot execute locally.
+
+    Ordinary tools retain their original objects so the common path does not
+    copy the complete tool list on every request.
+    """
+    if tools is None:
+        return None
+
+    projected: List[Dict[str, Any]] = []
+    changed = False
+    for tool in tools:
+        function = tool.get("function") if isinstance(tool, dict) else None
+        if not isinstance(function, dict) or _HERMES_SERVER_TOOL_KEY not in function:
+            projected.append(tool)
+            continue
+
+        binding = function.get(_HERMES_SERVER_TOOL_KEY)
+        if isinstance(binding, dict) and binding.get("api_mode") == api_mode:
+            projected.append(tool)
+        else:
+            changed = True
+        # A malformed or foreign binding is deliberately omitted. Forwarding
+        # it either leaks internal metadata or exposes an unexecutable tool.
+
+    return projected if changed else tools
+
+
 class ProviderTransport(ABC):
     """Base class for provider-specific format conversion and normalization."""
 
@@ -87,3 +127,9 @@ class ProviderTransport(ABC):
         with different stop reason vocabularies.
         """
         return raw_reason
+
+    def project_tools(
+        self, tools: Optional[List[Dict[str, Any]]]
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Return only tool definitions executable through this transport."""
+        return project_tools_for_transport(tools, self.api_mode)

--- a/agent/transports/base.py
+++ b/agent/transports/base.py
@@ -7,13 +7,46 @@ It does NOT own: client construction, streaming, credential refresh,
 prompt caching, interrupt handling, or retry logic.  Those stay on AIAgent.
 """
 
+import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
 from agent.transports.types import NormalizedResponse
 
 
+logger = logging.getLogger(__name__)
+
 _HERMES_SERVER_TOOL_KEY = "_hermes_server_tool"
+
+# Server-only drops the operator has already been told about, as
+# ``(tool_name, required_api_mode, active_api_mode)``.  Projection runs on
+# every request, so without this the same diagnosis would repeat once per
+# turn for the whole session.  A duplicate line from a benign race is
+# harmless; a missing one is not, so no lock is taken.
+_reported_server_tool_drops: set = set()
+
+
+def report_server_tool_drop(
+    name: str, required_api_mode: Any, api_mode: str
+) -> None:
+    """Log, once per process, that a server-only tool is being withheld.
+
+    Dropping a tool the operator enabled is a silent capability loss: the tool
+    is advertised by ``hermes tools`` and counted at startup, yet the model
+    never sees it and therefore can never surface the handler's own error.
+    Naming the mismatch and the remedy is the only diagnostic this path has.
+    """
+    key = (name, str(required_api_mode), api_mode)
+    if key in _reported_server_tool_drops:
+        return
+    _reported_server_tool_drops.add(key)
+    logger.warning(
+        "Tool %r runs inside the provider's API and is bound to api_mode %r, "
+        "but the active model uses %r — it is omitted from these requests and "
+        "the model cannot call it. Select a backend the active model supports "
+        "(`hermes tools`) to restore this capability.",
+        name, required_api_mode, api_mode,
+    )
 
 
 def project_tools_for_transport(
@@ -26,7 +59,10 @@ def project_tools_for_transport(
     target transport consumes the binding and emits its provider-native tool
     definition; every other transport omits the tool entirely.  This keeps
     Hermes-internal metadata off the wire and prevents fallbacks from exposing
-    a client function whose handler cannot execute locally.
+    a client function whose handler cannot execute locally.  Each omission is
+    reported once (see :func:`report_server_tool_drop`) so an operator whose
+    model cannot run a tool they enabled is told why, rather than losing the
+    capability without a trace.
 
     Ordinary tools retain their original objects so the common path does not
     copy the complete tool list on every request.
@@ -47,6 +83,11 @@ def project_tools_for_transport(
             projected.append(tool)
         else:
             changed = True
+            report_server_tool_drop(
+                function.get("name", "<unnamed>"),
+                binding.get("api_mode") if isinstance(binding, dict) else binding,
+                api_mode,
+            )
         # A malformed or foreign binding is deliberately omitted. Forwarding
         # it either leaks internal metadata or exposes an unexecutable tool.
 

--- a/agent/transports/base.py
+++ b/agent/transports/base.py
@@ -8,6 +8,38 @@ from typing import Any, Dict, List, Optional
 
 from agent.transports.types import NormalizedResponse
 
+_HERMES_SERVER_TOOL_KEY = "_hermes_server_tool"
+
+
+def project_tools_for_transport(
+    tools: Optional[List[Dict[str, Any]]], api_mode: str,
+) -> Optional[List[Dict[str, Any]]]:
+    """Project logical Hermes tools onto one provider transport.
+
+    A function definition carrying ``_hermes_server_tool`` is server-only: it may be advertised solely to the
+    api_mode named by that binding. The target transport consumes the binding and emits its provider-native
+    tool definition; every other transport omits the tool entirely. This keeps Hermes-internal metadata off
+    the wire and prevents fallbacks from exposing a client function whose handler cannot execute locally.
+    Ordinary tools retain their original objects so the common path does not copy the tool list per request.
+    """
+    if tools is None:
+        return None
+    projected: List[Dict[str, Any]] = []
+    changed = False
+    for tool in tools:
+        function = tool.get("function") if isinstance(tool, dict) else None
+        if not isinstance(function, dict) or _HERMES_SERVER_TOOL_KEY not in function:
+            projected.append(tool)
+            continue
+        binding = function.get(_HERMES_SERVER_TOOL_KEY)
+        if isinstance(binding, dict) and binding.get("api_mode") == api_mode:
+            projected.append(tool)
+        else:
+            # A malformed or foreign binding is deliberately omitted: forwarding it either leaks internal
+            # metadata or exposes an unexecutable tool.
+            changed = True
+    return projected if changed else tools
+
 
 class ProviderTransport(ABC):
     """Base class for provider-specific format conversion and normalization."""
@@ -51,3 +83,7 @@ class ProviderTransport(ABC):
     def map_finish_reason(self, raw_reason: str) -> str:
         """Map a provider stop reason via ``_STOP_REASON_MAP`` (unknown -> 'stop'); passthrough when no map."""
         return raw_reason if self._STOP_REASON_MAP is None else self._STOP_REASON_MAP.get(raw_reason, "stop")
+
+    def project_tools(self, tools: Optional[List[Dict[str, Any]]]) -> Optional[List[Dict[str, Any]]]:
+        """Return only tool definitions executable through this transport."""
+        return project_tools_for_transport(tools, self.api_mode)

--- a/agent/transports/base.py
+++ b/agent/transports/base.py
@@ -3,12 +3,39 @@ A transport owns one api_mode's data path (convert_messages -> convert_tools -> 
 -> normalize_response), NOT client construction, streaming, credentials, caching, interrupts
 or retries — those stay on AIAgent."""
 
+import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
 from agent.transports.types import NormalizedResponse
 
+logger = logging.getLogger(__name__)
+
 _HERMES_SERVER_TOOL_KEY = "_hermes_server_tool"
+
+# Server-only drops already reported, as ``(tool_name, required_api_mode, active_api_mode)``. Projection runs
+# on every request, so without this the same diagnosis would repeat every turn. A duplicate line from a
+# benign race is harmless; a missing one is not, so no lock is taken.
+_reported_server_tool_drops: set = set()
+
+
+def report_server_tool_drop(name: str, required_api_mode: Any, api_mode: str) -> None:
+    """Log, once per process, that a server-only tool is being withheld.
+
+    Dropping a tool the operator enabled is a silent capability loss: ``hermes tools`` lists it and startup
+    counts it, yet the model never sees it and so can never surface the handler's own error. Naming the
+    mismatch and the remedy is the only diagnostic this path has.
+    """
+    key = (name, str(required_api_mode), api_mode)
+    if key in _reported_server_tool_drops:
+        return
+    _reported_server_tool_drops.add(key)
+    logger.warning(
+        "Tool %r runs inside the provider's API and is bound to api_mode %r, but the active model uses %r — "
+        "it is omitted from these requests and the model cannot call it. Select a backend the active model "
+        "supports (`hermes tools`) to restore this capability.",
+        name, required_api_mode, api_mode,
+    )
 
 
 def project_tools_for_transport(
@@ -20,6 +47,8 @@ def project_tools_for_transport(
     api_mode named by that binding. The target transport consumes the binding and emits its provider-native
     tool definition; every other transport omits the tool entirely. This keeps Hermes-internal metadata off
     the wire and prevents fallbacks from exposing a client function whose handler cannot execute locally.
+    Each omission is reported once (see :func:`report_server_tool_drop`), so an operator whose model cannot
+    run a tool they enabled is told why rather than losing the capability without a trace.
     Ordinary tools retain their original objects so the common path does not copy the tool list per request.
     """
     if tools is None:
@@ -38,6 +67,11 @@ def project_tools_for_transport(
             # A malformed or foreign binding is deliberately omitted: forwarding it either leaks internal
             # metadata or exposes an unexecutable tool.
             changed = True
+            report_server_tool_drop(
+                function.get("name", "<unnamed>"),
+                binding.get("api_mode") if isinstance(binding, dict) else binding,
+                api_mode,
+            )
     return projected if changed else tools
 
 

--- a/agent/transports/bedrock.py
+++ b/agent/transports/bedrock.py
@@ -27,7 +27,7 @@ class BedrockTransport(ProviderTransport):
     def convert_tools(self, tools: List[Dict[str, Any]]) -> Any:
         """Convert OpenAI tool schemas to Bedrock Converse toolConfig."""
         from agent.bedrock_adapter import convert_tools_to_converse
-        return convert_tools_to_converse(tools)
+        return convert_tools_to_converse(self.project_tools(tools) or [])
 
     def build_kwargs(
         self,
@@ -50,6 +50,7 @@ class BedrockTransport(ProviderTransport):
 
         region = params.get("region", "us-east-1")
         guardrail = params.get("guardrail_config")
+        tools = self.project_tools(tools)
 
         kwargs = build_converse_kwargs(
             model=model,

--- a/agent/transports/bedrock.py
+++ b/agent/transports/bedrock.py
@@ -31,7 +31,7 @@ class BedrockTransport(ProviderTransport):
     def convert_tools(self, tools: List[Dict[str, Any]]) -> Any:
         """Convert OpenAI tool schemas to Bedrock Converse toolConfig."""
         from agent.bedrock_adapter import convert_tools_to_converse
-        return convert_tools_to_converse(tools)
+        return convert_tools_to_converse(self.project_tools(tools) or [])
 
     def build_kwargs(
         self, model: str, messages: List[Dict[str, Any]],
@@ -41,7 +41,7 @@ class BedrockTransport(ProviderTransport):
         from agent.bedrock_adapter import build_converse_kwargs
 
         kwargs = build_converse_kwargs(
-            model=model, messages=messages, tools=tools, max_tokens=params.get("max_tokens"),
+            model=model, messages=messages, tools=self.project_tools(tools), max_tokens=params.get("max_tokens"),
             temperature=params.get("temperature"), guardrail_config=params.get("guardrail_config"),
         )
         # Sentinel keys for dispatch — agent pops these before the boto3 call

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -274,8 +274,8 @@ class ChatCompletionsTransport(ProviderTransport):
         return sanitized
 
     def convert_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """Tools are already in OpenAI format — identity."""
-        return tools
+        """Project tools for this transport; ordinary tools stay OpenAI-shaped."""
+        return self.project_tools(tools) or []
 
     def build_kwargs(
         self,
@@ -332,6 +332,7 @@ class ChatCompletionsTransport(ProviderTransport):
         # Pass model so the Gemini thought_signature (extra_content) is kept for
         # Gemini targets and stripped for strict non-Gemini providers.
         sanitized = self.convert_messages(messages, model=model)
+        tools = self.convert_tools(tools) if tools else tools
 
         # ── Provider profile: single-path when present ──────────────────
         _profile = params.get("provider_profile")

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -355,8 +355,8 @@ class ChatCompletionsTransport(ProviderTransport):
         return [m if s is None else s for m, s in sanitized_pairs]
 
     def convert_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """Tools are already in OpenAI format — identity."""
-        return tools
+        """Project tools for this transport; ordinary tools stay OpenAI-shaped."""
+        return self.project_tools(tools) or []
 
     def build_kwargs(
         self, model: str, messages: list[dict[str, Any]], tools: list[dict[str, Any]] | None = None, **params,
@@ -367,6 +367,7 @@ class ChatCompletionsTransport(ProviderTransport):
         path below (is_kimi, is_openrouter, ...) is only reached for unregistered providers.
         """
         sanitized = self.convert_messages(messages, model=model)
+        tools = self.convert_tools(tools) if tools else tools
         _profile = params.get("provider_profile")
         if _profile:
             return self._build_kwargs_from_profile(_profile, model, sanitized, tools, params)

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -105,7 +105,7 @@ class ResponsesApiTransport(ProviderTransport):
     def convert_tools(self, tools: List[Dict[str, Any]]) -> Any:
         """Convert OpenAI tool schemas to Responses API function definitions."""
         from agent.codex_responses_adapter import _responses_tools
-        return _responses_tools(tools)
+        return _responses_tools(self.project_tools(tools))
 
     def build_kwargs(
         self,
@@ -186,7 +186,7 @@ class ResponsesApiTransport(ProviderTransport):
             _effort_clamp.update({"xhigh": "high", "max": "high", "ultra": "high"})
         reasoning_effort = _effort_clamp.get(reasoning_effort, reasoning_effort)
 
-        response_tools = _responses_tools(tools)
+        response_tools = self.convert_tools(tools)
 
         # xAI server-side web search.
         #

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -524,7 +524,7 @@ class ResponsesApiTransport(ProviderTransport):
         """Convert OpenAI tool schemas to Responses API function definitions."""
         from agent.codex_responses_adapter import _responses_tools
 
-        return _responses_tools(tools)
+        return _responses_tools(self.project_tools(tools))
 
     def build_kwargs(
         self, model: str, messages: list[dict[str, Any]], tools: Optional[list[dict[str, Any]]] = None, **params,

--- a/agent/turn_response_intake.py
+++ b/agent/turn_response_intake.py
@@ -1,7 +1,8 @@
 """Response intake for the conversation turn loop: normalize the raw provider response into
 the assistant message, splice agent-as-provider projections, fire ``post_api_request``, relay
-reasoning to the progress callback, and apply the incomplete-scratchpad / Codex-incomplete
-continuation guards. Nothing here imports ``agent.conversation_loop`` at module level (cycle).
+reasoning to the progress callback, and apply the Anthropic ``pause_turn``, incomplete-scratchpad
+and Codex-incomplete continuation guards. Nothing here imports ``agent.conversation_loop`` at
+module level (cycle).
 """
 
 from __future__ import annotations
@@ -12,6 +13,7 @@ import logging
 import re
 from typing import Any, Dict, Optional
 
+from agent.message_metadata import append_message
 from agent.provider_projection import splice_provider_projection
 from agent.trajectory import has_incomplete_scratchpad
 from agent.turn_truncation import continue_codex_incomplete, normalize_response_for_agent, partial_result
@@ -24,12 +26,15 @@ _REASONING_TAG_RE = re.compile(r'</?(?:REASONING_SCRATCHPAD|think|reasoning)>')
 @dataclass
 class ResponseIntakeVerdict:
     """``action``: ``"fallthrough"`` (process ``assistant_message``), ``"continue"`` (retry the
-    iteration: incomplete scratchpad / Codex continuation) or ``"return"`` (``result`` is the
-    turn's result dict). ``assistant_message``/``finish_reason`` are the normalized outputs."""
+    iteration: incomplete scratchpad / Codex or Anthropic ``pause_turn`` continuation / fallback
+    switch) or ``"return"`` (``result`` is the turn's result dict). ``assistant_message``/
+    ``finish_reason`` are the normalized outputs; the other fields are the loop locals rebound."""
 
     action: str
     assistant_message: Any
     finish_reason: Any
+    active_system_prompt: Any
+    anthropic_pause_continuations: int
     result: Optional[Dict[str, Any]] = None
 
 
@@ -115,7 +120,7 @@ def _relay_thinking(agent: Any, content: str) -> None:
 def normalize_model_response(
     agent: Any, *, response: Any, messages: Any, api_messages: Any, conversation_history: Any,
     api_call_count: Any, api_duration: Any, api_start_time: Any, api_request_id: Any,
-    effective_task_id: Any, turn_id: Any,
+    effective_task_id: Any, turn_id: Any, active_system_prompt: Any, anthropic_pause_continuations: int,
 ) -> ResponseIntakeVerdict:
     """Normalize ``response`` into ``assistant_message`` (str content, never dict/list) and run
     the post-response hooks and continuation guards, in the original order."""
@@ -125,7 +130,8 @@ def normalize_model_response(
     def _verdict(action: str, result: Optional[Dict[str, Any]] = None) -> ResponseIntakeVerdict:
         return ResponseIntakeVerdict(
             action=action, assistant_message=assistant_message, finish_reason=finish_reason,
-            result=result,
+            active_system_prompt=active_system_prompt,
+            anthropic_pause_continuations=anthropic_pause_continuations, result=result,
         )
 
     if assistant_message.content is not None and not isinstance(assistant_message.content, str):
@@ -140,6 +146,43 @@ def normalize_model_response(
         api_call_count=api_call_count, api_duration=api_duration, api_start_time=api_start_time,
         api_request_id=api_request_id, effective_task_id=effective_task_id, turn_id=turn_id,
     )
+
+    # Anthropic server tools may pause their internal agentic loop and require the exact
+    # assistant content to be submitted again. This is provider continuation state, not a
+    # client tool call: append no synthetic user/tool message, preserve the native blocks, and
+    # let the next loop iteration rebuild the request. Bound the consecutive continuations so a
+    # pathological upstream cannot consume the whole agent budget without giving the fallback
+    # chain a chance.
+    if agent.api_mode == "anthropic_messages" and finish_reason == "pause_turn":
+        anthropic_pause_continuations += 1
+        paused_msg = agent._build_assistant_message(assistant_message, finish_reason)
+        append_message(messages, paused_msg)
+        agent._emit_interim_assistant_message(paused_msg)
+        try:
+            agent._flush_messages_to_session_db(messages, conversation_history)
+        except Exception as exc:
+            logger.warning(
+                "Anthropic pause_turn persistence failed (session=%s): %s", agent.session_id or "none", exc,
+            )
+        if anthropic_pause_continuations < 3:
+            agent._buffer_vprint(
+                f"↻ Anthropic server tool paused; continuing turn ({anthropic_pause_continuations}/3)"
+            )
+            return _verdict("continue")
+        if agent._has_pending_fallback():
+            agent._buffer_status("⚠️ Anthropic server tool paused repeatedly — trying fallback...")
+        if agent._try_activate_fallback():
+            from agent.conversation_loop import _sync_failover_system_message
+            active_system_prompt = _sync_failover_system_message(agent, api_messages, active_system_prompt)
+            anthropic_pause_continuations = 0
+            return _verdict("continue")
+        agent._flush_status_buffer()
+        agent._cleanup_task_resources(effective_task_id)
+        agent._persist_session(messages, conversation_history)
+        return _verdict("return", partial_result(
+            messages, api_call_count, "Anthropic server tool did not finish after 3 pause_turn continuations."
+        ))
+    anthropic_pause_continuations = 0
 
     content = assistant_message.content
     if content and not agent.quiet_mode:

--- a/hermes_cli/doctor_tools.py
+++ b/hermes_cli/doctor_tools.py
@@ -58,11 +58,52 @@ def _doctor_tool_availability_detail(toolset: str) -> str:
     return ""
 
 
+def _doctor_unrunnable_web_backend_detail(capability: str) -> str:
+    """Detail for a web capability whose backend cannot run at all, else ``""``.
+
+    *capability* is ``"search"`` or ``"extract"``. An empty return means the selection is
+    dispatchable and the registry rows decide readiness as usual.
+
+    Anthropic's native ``web_search``/``web_fetch`` are not a client-side provider and never
+    register one: they execute inside the Anthropic Messages API request itself, so they are
+    runnable only while the configured model is served by Anthropic. The registry cannot see
+    that — ``anthropic`` is not a registered backend, so ``get_active_*_provider()`` falls
+    through to the availability walk and the keyless tier and hands the rows a healthy provider
+    this install never reaches. Doctor would then tick green a capability that is switched off
+    (the ``web`` toolset is gated on ``tools.web_tools.check_web_api_key``, which reports False
+    here) — the false green #78412 asked these rows to prevent.
+
+    The runnability tests come from ``tools.web_tools`` so the tool gate, the ``hermes tools``
+    picker and doctor all answer from one predicate.
+    """
+    try:
+        from tools.web_tools import (
+            _anthropic_native_endpoint_selected, _get_extract_backend, _get_search_backend, _is_backend_available)
+        backend = _get_search_backend() if capability == "search" else _get_extract_backend()
+        if backend != "anthropic":
+            return ""
+        # Two ways this selection cannot run, with different remedies, so two details rather than one
+        # vague line. Runnability is the question, not the endpoint alone: an Anthropic-served model with
+        # no Anthropic credential also leaves the toolset off, and a green row there is the same false tick.
+        if not _anthropic_native_endpoint_selected():
+            return ("(anthropic selected; its web tools run only inside Anthropic-served model requests -- "
+                    "switch the model to Anthropic or pick another backend with `hermes tools`)")
+        if not _is_backend_available("anthropic"):
+            return ("(anthropic selected, but no Anthropic credential was found -- set ANTHROPIC_API_KEY or "
+                    "CLAUDE_CODE_OAUTH_TOKEN, or pick another backend with `hermes tools`)")
+    except Exception:
+        # Diagnostics must never be the thing that breaks doctor.
+        return ""
+    return ""
+
+
 def _doctor_web_capability_rows() -> list[tuple[str, str, str]]:
     """Return ``(status, label, detail)`` rows (status ``ok``/``warn``) for web search/extract readiness.
 
     Uses the same active-provider resolvers as the tools but reports ``is_available()``
     readiness, so an explicitly selected but unconfigured backend does not look healthy.
+    A selection no provider can execute at all is caught before the resolvers run — see
+    :func:`_doctor_unrunnable_web_backend_detail`.
 
     See #78412.
     """
@@ -74,7 +115,12 @@ def _doctor_web_capability_rows() -> list[tuple[str, str, str]]:
         _ensure_web_plugins_loaded()
     except Exception:
         return rows
-    for capability, getter in (("web search", get_active_search_provider), ("web extract", get_active_extract_provider)):
+    for capability, selector, getter in (("web search", "search", get_active_search_provider),
+                                         ("web extract", "extract", get_active_extract_provider)):
+        unrunnable = _doctor_unrunnable_web_backend_detail(selector)
+        if unrunnable:
+            rows.append(("warn", capability, unrunnable))
+            continue
         try:
             provider = getter()
         except Exception:

--- a/hermes_cli/doctor_tools.py
+++ b/hermes_cli/doctor_tools.py
@@ -58,11 +58,18 @@ def _doctor_tool_availability_detail(toolset: str) -> str:
     return ""
 
 
-def _doctor_unrunnable_web_backend_detail(capability: str) -> str:
-    """Detail for a web capability whose backend cannot run at all, else ``""``.
+def _doctor_anthropic_web_row(capability: str) -> tuple[str, str] | None:
+    """``(status, detail)`` for a web capability routed to Anthropic, else ``None``.
 
-    *capability* is ``"search"`` or ``"extract"``. An empty return means the selection is
-    dispatchable and the registry rows decide readiness as usual.
+    *capability* is ``"search"`` or ``"extract"``. ``None`` means the selection is not
+    Anthropic and the registry rows decide readiness as usual.
+
+    The registry cannot answer for this backend at all -- ``anthropic`` is not a registered
+    provider, so ``get_active_*_provider()`` walks past it and returns whoever the availability
+    walk or the keyless ring lands on. Letting that name reach the row reports a provider the
+    request will never touch: with a working Anthropic selection doctor printed
+    ``web search (tavily)``. So this answers the whole row, healthy case included, instead of
+    only vetoing the unhealthy ones.
 
     Anthropic's native ``web_search``/``web_fetch`` are not a client-side provider and never
     register one: they execute inside the Anthropic Messages API request itself, so they are
@@ -81,20 +88,20 @@ def _doctor_unrunnable_web_backend_detail(capability: str) -> str:
             _anthropic_native_endpoint_selected, _get_extract_backend, _get_search_backend, _is_backend_available)
         backend = _get_search_backend() if capability == "search" else _get_extract_backend()
         if backend != "anthropic":
-            return ""
+            return None
         # Two ways this selection cannot run, with different remedies, so two details rather than one
         # vague line. Runnability is the question, not the endpoint alone: an Anthropic-served model with
         # no Anthropic credential also leaves the toolset off, and a green row there is the same false tick.
         if not _anthropic_native_endpoint_selected():
-            return ("(anthropic selected; its web tools run only inside Anthropic-served model requests -- "
-                    "switch the model to Anthropic or pick another backend with `hermes tools`)")
+            return ("warn", "(anthropic selected; its web tools run only inside Anthropic-served model requests -- "
+                            "switch the model to Anthropic or pick another backend with `hermes tools`)")
         if not _is_backend_available("anthropic"):
-            return ("(anthropic selected, but no Anthropic credential was found -- set ANTHROPIC_API_KEY or "
-                    "CLAUDE_CODE_OAUTH_TOKEN, or pick another backend with `hermes tools`)")
+            return ("warn", "(anthropic selected, but no Anthropic credential was found -- set ANTHROPIC_API_KEY or "
+                            "CLAUDE_CODE_OAUTH_TOKEN, or pick another backend with `hermes tools`)")
+        return ("ok", "(anthropic; runs inside the Anthropic Messages API request)")
     except Exception:
         # Diagnostics must never be the thing that breaks doctor.
-        return ""
-    return ""
+        return None
 
 
 def _doctor_web_capability_rows() -> list[tuple[str, str, str]]:
@@ -102,8 +109,8 @@ def _doctor_web_capability_rows() -> list[tuple[str, str, str]]:
 
     Uses the same active-provider resolvers as the tools but reports ``is_available()``
     readiness, so an explicitly selected but unconfigured backend does not look healthy.
-    A selection no provider can execute at all is caught before the resolvers run — see
-    :func:`_doctor_unrunnable_web_backend_detail`.
+    An Anthropic selection is answered before the resolvers run — the registry cannot see it
+    at all; see :func:`_doctor_anthropic_web_row`.
 
     See #78412.
     """
@@ -117,9 +124,10 @@ def _doctor_web_capability_rows() -> list[tuple[str, str, str]]:
         return rows
     for capability, selector, getter in (("web search", "search", get_active_search_provider),
                                          ("web extract", "extract", get_active_extract_provider)):
-        unrunnable = _doctor_unrunnable_web_backend_detail(selector)
-        if unrunnable:
-            rows.append(("warn", capability, unrunnable))
+        anthropic_row = _doctor_anthropic_web_row(selector)
+        if anthropic_row is not None:
+            status, detail = anthropic_row
+            rows.append((status, capability, detail))
             continue
         try:
             provider = getter()

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -400,6 +400,13 @@ TOOL_CATEGORIES = {
         # See PR #25182 for the migration rationale.
         "providers": [
             {
+                "name": "Anthropic Web Search & Fetch",
+                "badge": "native",
+                "tag": "Uses the Anthropic key already configured for the model",
+                "web_backend": "anthropic",
+                "env_vars": [],
+            },
+            {
                 "name": "Nous Subscription",
                 "badge": "subscription",
                 "tag": "Managed Firecrawl billed to your subscription",

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -271,6 +271,9 @@ TOOL_CATEGORIES = {
         # Provider rows come from plugins.web.<vendor> via _plugin_web_search_providers(). Only the two
         # non-provider firecrawl setup-flow rows live here: managed via Nous subscription, and self-hosted.
         "providers": [
+            {"name": "Anthropic Web Search & Fetch", "badge": "native",
+             "tag": "Uses the Anthropic key already configured for the model",
+             "web_backend": "anthropic", "env_vars": []},
             {"name": "Nous Subscription", "badge": "subscription", "tag": "Managed Firecrawl billed to your subscription",
              "web_backend": "firecrawl", "env_vars": [], **_NOUS, "managed_nous_feature": "web",
              "override_env_vars": ["FIRECRAWL_API_KEY", "FIRECRAWL_API_URL"]},

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -270,16 +270,24 @@ TOOL_CATEGORIES = {
         "icon": "🔍",
         # Provider rows come from plugins.web.<vendor> via _plugin_web_search_providers(). Only the two
         # non-provider firecrawl setup-flow rows live here: managed via Nous subscription, and self-hosted.
+        # Plus one deliberate exception, listed LAST: "Anthropic Web Search & Fetch" is a real backend that cannot
+        # be a plugin row. It is not a WebSearchProvider at all — it binds web_search/web_extract onto Anthropic's
+        # server-side tools, which run inside the Messages API request rather than through any client-side
+        # dispatch, so _plugin_web_search_providers() has nothing to enumerate. It must not be index 0:
+        # _detect_active_provider_index falls back to the first row, and an opt-in paid backend that only works on
+        # Anthropic-served models must never be the pre-selected default. The docs table
+        # (website/docs/user-guide/features/web-search.md) lists it second-to-last, just before xAI; plugin rows
+        # are appended after this whole block, so last-of-the-hardcoded-rows is the closest the picker can get.
         "providers": [
-            {"name": "Anthropic Web Search & Fetch", "badge": "native",
-             "tag": "Uses the Anthropic key already configured for the model",
-             "web_backend": "anthropic", "env_vars": []},
             {"name": "Nous Subscription", "badge": "subscription", "tag": "Managed Firecrawl billed to your subscription",
              "web_backend": "firecrawl", "env_vars": [], **_NOUS, "managed_nous_feature": "web",
              "override_env_vars": ["FIRECRAWL_API_KEY", "FIRECRAWL_API_URL"]},
             {"name": "Firecrawl Self-Hosted", "badge": "free · self-hosted", "tag": "Run your own Firecrawl instance (Docker)",
              "web_backend": "firecrawl",
              "env_vars": [_key("FIRECRAWL_API_URL", "Your Firecrawl instance URL (e.g., http://localhost:3002)")]},
+            {"name": "Anthropic Web Search & Fetch", "badge": "native",
+             "tag": "Uses the Anthropic key already configured for the model",
+             "web_backend": "anthropic", "env_vars": []},
         ],
     },
     "image_gen": {

--- a/hermes_cli/tools_config_providers.py
+++ b/hermes_cli/tools_config_providers.py
@@ -293,7 +293,9 @@ def _configure_tool_category(ts_key: str, cat: dict, config: dict, *, force_fres
         sub_marker = ""
         if not reconfigure and p.get("managed_nous_feature"):
             sub_marker = "  ★ Included with your Nous subscription" if _nous_logged_in else "  ★ via Nous Portal (login on select)"
-        provider_choices.append(f"{p['name']}{badge}{tag}{configured}{sub_marker}")
+        # A row can be the stored selection and still be inert on this model (see _provider_unusable_note) — say
+        # so instead of showing a bare "[active]".
+        provider_choices.append(f"{p['name']}{badge}{tag}{configured}{_provider_unusable_note(p)}{sub_marker}")
 
     if not reconfigure:
         provider_choices.append("Skip — keep defaults / configure later")
@@ -464,6 +466,30 @@ def _is_provider_active(provider: dict, config: dict, *, force_fresh: bool = Fal
         if _has_marker(provider, marker):
             return check(provider, config)
     return False
+
+
+def _provider_unusable_note(provider: dict) -> str:
+    """Picker marker for a row the current setup cannot actually run, else ``""``.
+    ``_is_provider_active`` answers "is this row the stored selection?", and for the Anthropic web row that stays
+    yes even when nothing can execute it. Anthropic's ``web_search``/``web_fetch`` are not a credential and have no
+    client-side provider to fall back to: they run inside the Anthropic Messages API request, so the row is usable
+    only while the configured model is served by Anthropic. On any other model the binding is stripped before the
+    request goes out and the ``web`` toolset reports unconfigured, so a bare ``[active]`` would say the opposite.
+    A label marker (same shape as the Nous ``★`` marker) rather than part of ``_is_provider_active``, which also
+    drives the default cursor and the GUI's current-provider lookup — those must keep pointing at the stored
+    selection. The endpoint test comes from ``tools.web_tools`` so the picker, doctor and the tool gate all answer
+    from one predicate."""
+    if provider.get("web_backend") != "anthropic":
+        return ""
+    try:
+        from tools.web_tools import _anthropic_native_endpoint_selected
+
+        if _anthropic_native_endpoint_selected():
+            return ""
+    except Exception:
+        # An annotation must never be the thing that breaks the picker.
+        return ""
+    return "  ⚠ Not usable on the current model — needs an Anthropic-served model"
 
 
 def _detect_active_provider_index(providers: list, config: dict, *, force_fresh: bool = False) -> int:

--- a/tests/agent/test_anthropic_output_field_leak.py
+++ b/tests/agent/test_anthropic_output_field_leak.py
@@ -58,7 +58,45 @@ class TestSanitizeReplayBlock:
         assert out["citations"] == real
 
     def test_unknown_type_dropped(self):
-        assert _sanitize_replay_block({"type": "server_tool_use", "foo": 1}) is None
+        assert _sanitize_replay_block({"type": "future_tool_result", "foo": 1}) is None
+
+    @pytest.mark.parametrize(
+        ("block_type", "expected_content"),
+        [
+            ("web_search_tool_result", [{"type": "web_search_result", "url": "https://example.com"}]),
+            ("web_fetch_tool_result", {"type": "web_fetch_result", "url": "https://example.com"}),
+        ],
+    )
+    def test_server_tool_results_round_trip_without_output_only_fields(
+        self, block_type, expected_content
+    ):
+        out = _sanitize_replay_block({
+            "type": block_type,
+            "tool_use_id": "srvtoolu_1",
+            "content": expected_content,
+            "caller": {"type": "direct"},
+            "response_only": "drop-me",
+        })
+        assert out == {
+            "type": block_type,
+            "tool_use_id": "srvtoolu_1",
+            "content": expected_content,
+        }
+
+    def test_server_tool_use_round_trips(self):
+        out = _sanitize_replay_block({
+            "type": "server_tool_use",
+            "id": "srvtoolu_1",
+            "name": "web_search",
+            "input": {"query": "Hermes Agent"},
+            "caller": {"type": "direct"},
+        })
+        assert out == {
+            "type": "server_tool_use",
+            "id": "srvtoolu_1",
+            "name": "web_search",
+            "input": {"query": "Hermes Agent"},
+        }
 
 
 class TestContentPartConversion:

--- a/tests/agent/test_anthropic_output_field_leak.py
+++ b/tests/agent/test_anthropic_output_field_leak.py
@@ -38,7 +38,45 @@ class TestSanitizeReplayBlock:
 
 
     def test_unknown_type_dropped(self):
-        assert _sanitize_replay_block({"type": "server_tool_use", "foo": 1}) is None
+        assert _sanitize_replay_block({"type": "future_tool_result", "foo": 1}) is None
+
+    @pytest.mark.parametrize(
+        ("block_type", "expected_content"),
+        [
+            ("web_search_tool_result", [{"type": "web_search_result", "url": "https://example.com"}]),
+            ("web_fetch_tool_result", {"type": "web_fetch_result", "url": "https://example.com"}),
+        ],
+    )
+    def test_server_tool_results_round_trip_without_output_only_fields(
+        self, block_type, expected_content
+    ):
+        out = _sanitize_replay_block({
+            "type": block_type,
+            "tool_use_id": "srvtoolu_1",
+            "content": expected_content,
+            "caller": {"type": "direct"},
+            "response_only": "drop-me",
+        })
+        assert out == {
+            "type": block_type,
+            "tool_use_id": "srvtoolu_1",
+            "content": expected_content,
+        }
+
+    def test_server_tool_use_round_trips(self):
+        out = _sanitize_replay_block({
+            "type": "server_tool_use",
+            "id": "srvtoolu_1",
+            "name": "web_search",
+            "input": {"query": "Hermes Agent"},
+            "caller": {"type": "direct"},
+        })
+        assert out == {
+            "type": "server_tool_use",
+            "id": "srvtoolu_1",
+            "name": "web_search",
+            "input": {"query": "Hermes Agent"},
+        }
 
 
 class TestContentPartConversion:

--- a/tests/agent/test_anthropic_pause_turn_loop.py
+++ b/tests/agent/test_anthropic_pause_turn_loop.py
@@ -1,0 +1,345 @@
+"""Loop-level behavior for Anthropic's ``pause_turn`` continuation.
+
+``tests/agent/test_anthropic_web_server_tools.py`` covers the transport half:
+``pause_turn`` survives ``map_finish_reason`` and normalization as its own stop
+reason rather than collapsing into ``stop``. That is necessary but not
+sufficient — the behavior that matters lives in ``agent/conversation_loop.py``,
+which treats the pause as *provider continuation state* rather than a client
+tool call:
+
+* the exact assistant content is appended and replayed, with **no** synthetic
+  user or tool message inserted (Anthropic requires the original blocks back);
+* the paused turn is persisted, and a persistence failure must not abort the
+  continuation — the turn is still recoverable from the live message list;
+* continuations are bounded so a pathological upstream cannot silently consume
+  the whole agent budget;
+* on hitting that bound the fallback chain gets a chance, and only if no
+  fallback exists does the turn end as an explicit partial failure.
+
+These drive the real ``run_conversation`` against an in-process mock Anthropic
+Messages endpoint, so the assertions are on observable turn behavior — request
+count, replayed payloads, result shape — not on a snapshot of internals.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+# Repo root = three levels up from tests/agent/<file>.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+def _is_messages_path(path: str) -> bool:
+    """True only for the Messages create endpoint.
+
+    ``/v1/messages/count_tokens`` deliberately does not match.
+    """
+    return path.rstrip("/").endswith("/v1/messages")
+
+
+class _MockAnthropicHandler(BaseHTTPRequestHandler):
+    """Minimal Anthropic Messages endpoint driven by a queued response list.
+
+    Only ``/v1/messages`` draws from the queue. The agent also POSTs probe
+    endpoints (``/api/show`` for model capabilities, ``/v1/messages/count_tokens``
+    for request sizing); letting those consume queued responses would shift every
+    test's script by one and make the suite pass or fail on probe timing rather
+    than on loop behavior.
+    """
+
+    captured_requests: list = []
+    response_queue: list = []
+
+    def do_POST(self):  # noqa: N802 (http.server API)
+        length = int(self.headers.get("Content-Length", 0))
+        req = json.loads(self.rfile.read(length).decode())
+        type(self).captured_requests.append((self.path, req))
+
+        if not _is_messages_path(self.path):
+            self._reply({})
+            return
+
+        if type(self).response_queue:
+            resp = type(self).response_queue.pop(0)
+        else:
+            # Exhausting the script means the loop ran longer than the test
+            # scripted for. Answer with a marker the assertions won't accept
+            # rather than silently extending the conversation.
+            resp = _text_resp("UNSCRIPTED")
+        self._reply(resp)
+
+    def _reply(self, payload: dict) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):  # noqa: A002 - stdlib signature
+        """Silence per-request stderr noise."""
+        return
+
+
+def _pause_resp(query: str = "current weather") -> dict:
+    """A server-tool turn Anthropic paused mid-flight."""
+    return {
+        "id": "msg_pause",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-test",
+        "stop_reason": "pause_turn",
+        "content": [
+            {
+                "type": "server_tool_use",
+                "id": "srvtoolu_1",
+                "name": "web_search",
+                "input": {"query": query},
+            }
+        ],
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+
+
+def _tool_use_resp() -> dict:
+    """A client tool call — any non-pause turn that keeps the loop iterating.
+
+    The tool is deliberately unregistered: dispatch answers with an error the
+    loop feeds back to the model, which is enough to advance the turn without
+    standing up a real toolset.
+    """
+    return {
+        "id": "msg_tool",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-test",
+        "stop_reason": "tool_use",
+        "content": [
+            {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "no_such_tool",
+                "input": {},
+            }
+        ],
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+
+
+def _text_resp(text: str) -> dict:
+    return {
+        "id": "msg_done",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-test",
+        "stop_reason": "end_turn",
+        "content": [{"type": "text", "text": text}],
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+
+
+@pytest.fixture()
+def agent_env():
+    """Mock Anthropic endpoint + a real agent pointed at it; yields (agent, handler).
+
+    ``HERMES_HOME`` isolation is not done here: conftest's autouse
+    ``_hermetic_environment`` already redirects it to a per-test tempdir. Nor are
+    modules purged from ``sys.modules`` — the runner gives every test file its own
+    interpreter (see conftest's "Module-level state reset" note), so a purge buys
+    nothing and actively breaks sibling files: re-importing ``agent.transports``
+    builds a second, empty transport registry while modules imported earlier still
+    hold the first, so ``get_transport`` starts returning None for them.
+    """
+    _MockAnthropicHandler.captured_requests = []
+    _MockAnthropicHandler.response_queue = []
+    srv = HTTPServer(("127.0.0.1", 0), _MockAnthropicHandler)
+    port = srv.server_address[1]
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+
+    # The file log handler opens <HERMES_HOME>/logs eagerly and floods stderr with
+    # FileNotFoundError tracebacks when it is missing.
+    os.makedirs(os.path.join(os.environ["HERMES_HOME"], "logs"), exist_ok=True)
+
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url=f"http://127.0.0.1:{port}",
+        provider="anthropic",
+        api_mode="anthropic_messages",
+        model="claude-test",
+        max_iterations=10,
+        enabled_toolsets=[],
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        save_trajectories=False,
+        platform="cli",
+    )
+    # Streaming would need an SSE mock; the pause branch is transport-shape
+    # agnostic, so keep the mock endpoint plain JSON. Set dynamically because
+    # the agent reads this flag with getattr and never declares it.
+    setattr(agent, "_disable_streaming", True)  # noqa: B010
+
+    try:
+        yield agent, _MockAnthropicHandler
+    finally:
+        srv.shutdown()
+        srv.server_close()  # shutdown() stops serving; the socket needs closing too
+        thread.join(timeout=5)
+
+
+def _message_calls(handler) -> list[dict]:
+    """Bodies of the Messages-API creates, in order.
+
+    Probe POSTs are excluded: counting them as turns would make the
+    continuation-budget assertions silently wrong.
+    """
+    return [body for path, body in handler.captured_requests if _is_messages_path(path)]
+
+
+def _roles(messages) -> list[str]:
+    return [m.get("role") for m in messages if isinstance(m, dict)]
+
+
+def test_pause_turn_continues_without_synthetic_user_or_tool_message(agent_env):
+    """A paused turn is replayed as-is: no fabricated user/tool message."""
+    agent, handler = agent_env
+    handler.response_queue.append(_pause_resp())
+    handler.response_queue.append(_text_resp("Finished after the pause."))
+
+    result = agent.run_conversation("what is the weather", conversation_history=[], task_id="t")
+
+    # The pause consumed one request and the continuation a second one.
+    calls = _message_calls(handler)
+    assert len(calls) == 2
+    assert result["completed"] is True
+    assert "Finished after the pause." in (result["final_response"] or "")
+
+    # The continuation request must carry the paused assistant turn back and
+    # must NOT invent a user/tool message to carry it.
+    replayed = calls[1]["messages"]
+    assert replayed[-1]["role"] == "assistant"
+    assert _roles(replayed).count("user") == 1
+    assert not any(m.get("role") == "tool" for m in replayed)
+
+    # Anthropic requires the native blocks back verbatim — a paused turn
+    # replayed as flattened text would be rejected upstream, and that is
+    # exactly what a well-meaning "normalize everything to a string" change
+    # would do. Pin the block, its id, and its input.
+    blocks = replayed[-1]["content"]
+    assert isinstance(blocks, list), blocks
+    server_uses = [b for b in blocks if isinstance(b, dict) and b.get("type") == "server_tool_use"]
+    assert len(server_uses) == 1, blocks
+    assert server_uses[0]["id"] == "srvtoolu_1"
+    assert server_uses[0]["name"] == "web_search"
+    assert server_uses[0]["input"] == {"query": "current weather"}
+
+
+def test_pause_turn_persistence_failure_is_reported_and_not_fatal(agent_env, monkeypatch, caplog):
+    """A failed flush is named at the pause site, not absorbed anonymously.
+
+    The turn surviving is necessary but not distinguishing: an outer recovery
+    handler would swallow the exception and finish the turn anyway. What the
+    local ``try/except`` buys is a *diagnosable* failure — the operator sees
+    which write failed and for which session, instead of a silent gap between
+    a paused turn and its continuation.
+    """
+    agent, handler = agent_env
+    handler.response_queue.append(_pause_resp())
+    handler.response_queue.append(_text_resp("Survived a bad flush."))
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("session db unavailable")
+
+    monkeypatch.setattr(agent, "_flush_messages_to_session_db", _boom)
+
+    with caplog.at_level("WARNING", logger="agent.conversation_loop"):
+        result = agent.run_conversation("what is the weather", conversation_history=[], task_id="t")
+
+    assert len(_message_calls(handler)) == 2
+    assert result["completed"] is True
+    assert "Survived a bad flush." in (result["final_response"] or "")
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert any("pause_turn persistence failed" in msg for msg in warnings), warnings
+    assert any("session db unavailable" in msg for msg in warnings), warnings
+
+
+def test_repeated_pause_turn_without_fallback_ends_as_partial(agent_env, monkeypatch):
+    """The continuation budget is bounded and the turn fails loudly, not silently."""
+    agent, handler = agent_env
+    for _ in range(6):
+        handler.response_queue.append(_pause_resp())
+
+    monkeypatch.setattr(agent, "_has_pending_fallback", lambda *_a, **_k: False)
+    monkeypatch.setattr(agent, "_try_activate_fallback", lambda *_a, **_k: False)
+
+    result = agent.run_conversation("what is the weather", conversation_history=[], task_id="t")
+
+    # Bounded: it must not burn the whole max_iterations budget on pauses.
+    assert len(_message_calls(handler)) == 3
+    assert result["completed"] is False
+    assert result["partial"] is True
+    assert "pause_turn" in (result["error"] or "")
+
+
+def test_repeated_pause_turn_activates_fallback_when_available(agent_env, monkeypatch):
+    """Hitting the bound hands the turn to the fallback chain before giving up."""
+    agent, handler = agent_env
+    for _ in range(3):
+        handler.response_queue.append(_pause_resp())
+    handler.response_queue.append(_text_resp("Fallback answered."))
+
+    activated = {"n": 0}
+
+    def _activate(*_args, **_kwargs):
+        activated["n"] += 1
+        return True
+
+    monkeypatch.setattr(agent, "_has_pending_fallback", lambda *_a, **_k: True)
+    monkeypatch.setattr(agent, "_try_activate_fallback", _activate)
+
+    result = agent.run_conversation("what is the weather", conversation_history=[], task_id="t")
+
+    assert activated["n"] == 1
+    assert result["completed"] is True
+    assert "Fallback answered." in (result["final_response"] or "")
+
+
+def test_pause_budget_is_per_pause_run_not_cumulative(agent_env, monkeypatch):
+    """Progress clears the budget: pauses must not accumulate across a whole turn.
+
+    The bound exists to catch an upstream stuck in a pause loop, not to cap how
+    many times a long turn may legitimately pause. Two pauses, then real
+    progress, then two more pauses is five API calls and four pauses — well over
+    the limit of 3 cumulatively, but never three *consecutively*. Without the
+    per-run reset this turn would die as a false positive.
+    """
+    agent, handler = agent_env
+    handler.response_queue.extend([
+        _pause_resp(),
+        _pause_resp(),
+        _tool_use_resp(),   # progress: breaks the pause run
+        _pause_resp(),
+        _pause_resp(),
+        _text_resp("Finished after four pauses."),
+    ])
+
+    monkeypatch.setattr(agent, "_has_pending_fallback", lambda *_a, **_k: False)
+    monkeypatch.setattr(agent, "_try_activate_fallback", lambda *_a, **_k: False)
+
+    result = agent.run_conversation("q1", conversation_history=[], task_id="t1")
+
+    assert len(_message_calls(handler)) == 6
+    assert result["completed"] is True
+    assert "Finished after four pauses." in (result["final_response"] or "")

--- a/tests/agent/test_anthropic_pause_turn_loop.py
+++ b/tests/agent/test_anthropic_pause_turn_loop.py
@@ -1,0 +1,349 @@
+"""Loop-level behavior for Anthropic's ``pause_turn`` continuation.
+
+``tests/agent/test_anthropic_web_server_tools.py`` covers the transport half:
+``pause_turn`` survives ``map_finish_reason`` and normalization as its own stop
+reason rather than collapsing into ``stop``. That is necessary but not
+sufficient — the behavior that matters lives in the turn loop's response intake
+(``agent/turn_response_intake.py``, driven by ``agent/conversation_loop.py``),
+which treats the pause as *provider continuation state* rather than a client
+tool call:
+
+* the exact assistant content is appended and replayed, with **no** synthetic
+  user or tool message inserted (Anthropic requires the original blocks back);
+* the paused turn is persisted, and a persistence failure must not abort the
+  continuation — the turn is still recoverable from the live message list;
+* continuations are bounded so a pathological upstream cannot silently consume
+  the whole agent budget;
+* on hitting that bound the fallback chain gets a chance, and only if no
+  fallback exists does the turn end as an explicit partial failure.
+
+These drive the real ``run_conversation`` against an in-process mock Anthropic
+Messages endpoint, so the assertions are on observable turn behavior — request
+count, replayed payloads, result shape — not on a snapshot of internals.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+pytest.importorskip("anthropic")  # the agent under test builds a real client from the optional SDK
+
+# Repo root = three levels up from tests/agent/<file>.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+def _is_messages_path(path: str) -> bool:
+    """True only for the Messages create endpoint.
+
+    ``/v1/messages/count_tokens`` deliberately does not match.
+    """
+    return path.rstrip("/").endswith("/v1/messages")
+
+
+class _MockAnthropicHandler(BaseHTTPRequestHandler):
+    """Minimal Anthropic Messages endpoint driven by a queued response list.
+
+    Only ``/v1/messages`` draws from the queue. The agent also POSTs probe
+    endpoints (``/api/show`` for model capabilities, ``/v1/messages/count_tokens``
+    for request sizing); letting those consume queued responses would shift every
+    test's script by one and make the suite pass or fail on probe timing rather
+    than on loop behavior.
+    """
+
+    captured_requests: list = []
+    response_queue: list = []
+
+    def do_POST(self):  # noqa: N802 (http.server API)
+        length = int(self.headers.get("Content-Length", 0))
+        req = json.loads(self.rfile.read(length).decode())
+        type(self).captured_requests.append((self.path, req))
+
+        if not _is_messages_path(self.path):
+            self._reply({})
+            return
+
+        if type(self).response_queue:
+            resp = type(self).response_queue.pop(0)
+        else:
+            # Exhausting the script means the loop ran longer than the test
+            # scripted for. Answer with a marker the assertions won't accept
+            # rather than silently extending the conversation.
+            resp = _text_resp("UNSCRIPTED")
+        self._reply(resp)
+
+    def _reply(self, payload: dict) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):  # noqa: A002 - stdlib signature
+        """Silence per-request stderr noise."""
+        return
+
+
+def _pause_resp(query: str = "current weather") -> dict:
+    """A server-tool turn Anthropic paused mid-flight."""
+    return {
+        "id": "msg_pause",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-test",
+        "stop_reason": "pause_turn",
+        "content": [
+            {
+                "type": "server_tool_use",
+                "id": "srvtoolu_1",
+                "name": "web_search",
+                "input": {"query": query},
+            }
+        ],
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+
+
+def _tool_use_resp() -> dict:
+    """A client tool call — any non-pause turn that keeps the loop iterating.
+
+    The tool is deliberately unregistered: dispatch answers with an error the
+    loop feeds back to the model, which is enough to advance the turn without
+    standing up a real toolset.
+    """
+    return {
+        "id": "msg_tool",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-test",
+        "stop_reason": "tool_use",
+        "content": [
+            {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "no_such_tool",
+                "input": {},
+            }
+        ],
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+
+
+def _text_resp(text: str) -> dict:
+    return {
+        "id": "msg_done",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-test",
+        "stop_reason": "end_turn",
+        "content": [{"type": "text", "text": text}],
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+
+
+@pytest.fixture()
+def agent_env():
+    """Mock Anthropic endpoint + a real agent pointed at it; yields (agent, handler).
+
+    ``HERMES_HOME`` isolation is not done here: conftest's autouse
+    ``_hermetic_environment`` already redirects it to a per-test tempdir. Nor are
+    modules purged from ``sys.modules`` — the runner gives every test file its own
+    interpreter (see conftest's "Module-level state reset" note), so a purge buys
+    nothing and actively breaks sibling files: re-importing ``agent.transports``
+    builds a second, empty transport registry while modules imported earlier still
+    hold the first, so ``get_transport`` starts returning None for them.
+    """
+    _MockAnthropicHandler.captured_requests = []
+    _MockAnthropicHandler.response_queue = []
+    srv = HTTPServer(("127.0.0.1", 0), _MockAnthropicHandler)
+    port = srv.server_address[1]
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+
+    # The file log handler opens <HERMES_HOME>/logs eagerly and floods stderr with
+    # FileNotFoundError tracebacks when it is missing.
+    os.makedirs(os.path.join(os.environ["HERMES_HOME"], "logs"), exist_ok=True)
+
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url=f"http://127.0.0.1:{port}",
+        provider="anthropic",
+        api_mode="anthropic_messages",
+        model="claude-test",
+        max_iterations=10,
+        enabled_toolsets=[],
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        save_trajectories=False,
+        platform="cli",
+    )
+    # Streaming would need an SSE mock; the pause branch is transport-shape
+    # agnostic, so keep the mock endpoint plain JSON (the same switch
+    # ``model.streaming: false`` seeds at init).
+    agent._disable_streaming = True
+
+    try:
+        yield agent, _MockAnthropicHandler
+    finally:
+        srv.shutdown()
+        srv.server_close()  # shutdown() stops serving; the socket needs closing too
+        thread.join(timeout=5)
+
+
+def _message_calls(handler) -> list[dict]:
+    """Bodies of the Messages-API creates, in order.
+
+    Probe POSTs are excluded: counting them as turns would make the
+    continuation-budget assertions silently wrong.
+    """
+    return [body for path, body in handler.captured_requests if _is_messages_path(path)]
+
+
+def _roles(messages) -> list[str]:
+    return [m.get("role") for m in messages if isinstance(m, dict)]
+
+
+def test_pause_turn_continues_without_synthetic_user_or_tool_message(agent_env):
+    """A paused turn is replayed as-is: no fabricated user/tool message."""
+    agent, handler = agent_env
+    handler.response_queue.append(_pause_resp())
+    handler.response_queue.append(_text_resp("Finished after the pause."))
+
+    result = agent.run_conversation("what is the weather", conversation_history=[], task_id="t")
+
+    # The pause consumed one request and the continuation a second one.
+    calls = _message_calls(handler)
+    assert len(calls) == 2
+    assert result["completed"] is True
+    assert "Finished after the pause." in (result["final_response"] or "")
+
+    # The continuation request must carry the paused assistant turn back and
+    # must NOT invent a user/tool message to carry it.
+    replayed = calls[1]["messages"]
+    assert replayed[-1]["role"] == "assistant"
+    assert _roles(replayed).count("user") == 1
+    assert not any(m.get("role") == "tool" for m in replayed)
+
+    # Anthropic requires the native blocks back verbatim — a paused turn
+    # replayed as flattened text would be rejected upstream, and that is
+    # exactly what a well-meaning "normalize everything to a string" change
+    # would do. Pin the block, its id, and its input.
+    blocks = replayed[-1]["content"]
+    assert isinstance(blocks, list), blocks
+    server_uses = [b for b in blocks if isinstance(b, dict) and b.get("type") == "server_tool_use"]
+    assert len(server_uses) == 1, blocks
+    assert server_uses[0]["id"] == "srvtoolu_1"
+    assert server_uses[0]["name"] == "web_search"
+    assert server_uses[0]["input"] == {"query": "current weather"}
+
+
+def test_pause_turn_persistence_failure_is_reported_and_not_fatal(agent_env, monkeypatch, caplog):
+    """A failed flush is named at the pause site, not absorbed anonymously.
+
+    The turn surviving is necessary but not distinguishing: an outer recovery
+    handler would swallow the exception and finish the turn anyway. What the
+    local ``try/except`` buys is a *diagnosable* failure — the operator sees
+    which write failed and for which session, instead of a silent gap between
+    a paused turn and its continuation.
+    """
+    agent, handler = agent_env
+    handler.response_queue.append(_pause_resp())
+    handler.response_queue.append(_text_resp("Survived a bad flush."))
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("session db unavailable")
+
+    monkeypatch.setattr(agent, "_flush_messages_to_session_db", _boom)
+
+    # The agent/turn_*.py phase modules log under the loop's logger name.
+    with caplog.at_level("WARNING", logger="agent.conversation_loop"):
+        result = agent.run_conversation("what is the weather", conversation_history=[], task_id="t")
+
+    assert len(_message_calls(handler)) == 2
+    assert result["completed"] is True
+    assert "Survived a bad flush." in (result["final_response"] or "")
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert any("pause_turn persistence failed" in msg for msg in warnings), warnings
+    assert any("session db unavailable" in msg for msg in warnings), warnings
+
+
+def test_repeated_pause_turn_without_fallback_ends_as_partial(agent_env, monkeypatch):
+    """The continuation budget is bounded and the turn fails loudly, not silently."""
+    agent, handler = agent_env
+    for _ in range(6):
+        handler.response_queue.append(_pause_resp())
+
+    monkeypatch.setattr(agent, "_has_pending_fallback", lambda *_a, **_k: False)
+    monkeypatch.setattr(agent, "_try_activate_fallback", lambda *_a, **_k: False)
+
+    result = agent.run_conversation("what is the weather", conversation_history=[], task_id="t")
+
+    # Bounded: it must not burn the whole max_iterations budget on pauses.
+    assert len(_message_calls(handler)) == 3
+    assert result["completed"] is False
+    assert result["partial"] is True
+    assert "pause_turn" in (result["error"] or "")
+
+
+def test_repeated_pause_turn_activates_fallback_when_available(agent_env, monkeypatch):
+    """Hitting the bound hands the turn to the fallback chain before giving up."""
+    agent, handler = agent_env
+    for _ in range(3):
+        handler.response_queue.append(_pause_resp())
+    handler.response_queue.append(_text_resp("Fallback answered."))
+
+    activated = {"n": 0}
+
+    def _activate(*_args, **_kwargs):
+        activated["n"] += 1
+        return True
+
+    monkeypatch.setattr(agent, "_has_pending_fallback", lambda *_a, **_k: True)
+    monkeypatch.setattr(agent, "_try_activate_fallback", _activate)
+
+    result = agent.run_conversation("what is the weather", conversation_history=[], task_id="t")
+
+    assert activated["n"] == 1
+    assert result["completed"] is True
+    assert "Fallback answered." in (result["final_response"] or "")
+
+
+def test_pause_budget_is_per_pause_run_not_cumulative(agent_env, monkeypatch):
+    """Progress clears the budget: pauses must not accumulate across a whole turn.
+
+    The bound exists to catch an upstream stuck in a pause loop, not to cap how
+    many times a long turn may legitimately pause. Two pauses, then real
+    progress, then two more pauses is five API calls and four pauses — well over
+    the limit of 3 cumulatively, but never three *consecutively*. Without the
+    per-run reset this turn would die as a false positive.
+    """
+    agent, handler = agent_env
+    handler.response_queue.extend([
+        _pause_resp(),
+        _pause_resp(),
+        _tool_use_resp(),   # progress: breaks the pause run
+        _pause_resp(),
+        _pause_resp(),
+        _text_resp("Finished after four pauses."),
+    ])
+
+    monkeypatch.setattr(agent, "_has_pending_fallback", lambda *_a, **_k: False)
+    monkeypatch.setattr(agent, "_try_activate_fallback", lambda *_a, **_k: False)
+
+    result = agent.run_conversation("q1", conversation_history=[], task_id="t1")
+
+    assert len(_message_calls(handler)) == 6
+    assert result["completed"] is True
+    assert "Finished after four pauses." in (result["final_response"] or "")

--- a/tests/agent/test_anthropic_web_server_tools.py
+++ b/tests/agent/test_anthropic_web_server_tools.py
@@ -133,6 +133,7 @@ def test_web_fetch_blocks_use_the_same_round_trip_channel():
     assert [block["type"] for block in normalized.anthropic_content_blocks] == [
         "server_tool_use", "web_fetch_tool_result", "text",
     ]
+    assert normalized.content.endswith("Sources:\n- https://example.com")
 
 
 def test_pause_turn_remains_distinct_for_the_conversation_loop():

--- a/tests/agent/test_anthropic_web_server_tools.py
+++ b/tests/agent/test_anthropic_web_server_tools.py
@@ -2,11 +2,17 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 from agent.anthropic_adapter import (
+    _is_third_party_anthropic_endpoint,
     convert_messages_to_anthropic,
     convert_tools_to_anthropic,
 )
 from agent.transports.anthropic import AnthropicTransport
+from agent.transports.bedrock import BedrockTransport
+from agent.transports.chat_completions import ChatCompletionsTransport
+from agent.transports.codex import ResponsesApiTransport
 
 
 def _tool(name: str, server_spec: dict) -> dict:
@@ -16,7 +22,10 @@ def _tool(name: str, server_spec: dict) -> dict:
             "name": name,
             "description": name,
             "parameters": {"type": "object", "properties": {}},
-            "_anthropic_server_tool": server_spec,
+            "_hermes_server_tool": {
+                "api_mode": "anthropic_messages",
+                "definition": server_spec,
+            },
         },
     }
 
@@ -39,7 +48,7 @@ def test_native_endpoint_replaces_web_functions_with_server_tools():
     ]
 
 
-def test_compatible_third_party_endpoint_keeps_local_function_tools():
+def test_compatible_third_party_endpoint_omits_server_only_tools():
     tools = [_tool("web_search", {
         "type": "web_search_20250305", "name": "web_search", "max_uses": 5,
     })]
@@ -48,9 +57,55 @@ def test_compatible_third_party_endpoint_keeps_local_function_tools():
         tools, base_url="https://api.minimax.io/anthropic"
     )
 
-    assert converted[0]["name"] == "web_search"
-    assert converted[0]["input_schema"]["type"] == "object"
-    assert "type" not in converted[0]
+    assert converted == []
+
+
+def test_anthropic_native_endpoint_detection_uses_hostname_boundaries():
+    assert not _is_third_party_anthropic_endpoint("https://api.anthropic.com/v1")
+    assert _is_third_party_anthropic_endpoint(
+        "https://api.anthropic.com.example/v1"
+    )
+    assert _is_third_party_anthropic_endpoint(
+        "https://proxy.example/v1/api.anthropic.com"
+    )
+
+
+@pytest.mark.parametrize(
+    "transport",
+    [ChatCompletionsTransport(), BedrockTransport(), ResponsesApiTransport()],
+)
+def test_server_only_tools_are_omitted_from_foreign_transports(transport):
+    ordinary = {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+    server_only = _tool("web_search", {
+        "type": "web_search_20250305", "name": "web_search", "max_uses": 5,
+    })
+
+    projected = transport.project_tools([ordinary, server_only])
+    converted = transport.convert_tools([ordinary, server_only])
+
+    assert projected == [ordinary]
+    assert "_hermes_server_tool" not in str(projected)
+    assert "web_search" not in str(converted)
+    assert "_hermes_server_tool" not in str(converted)
+
+
+def test_chat_completions_kwargs_never_leak_server_tool_metadata():
+    kwargs = ChatCompletionsTransport().build_kwargs(
+        model="example/model",
+        messages=[{"role": "user", "content": "hello"}],
+        tools=[_tool("web_search", {
+            "type": "web_search_20250305", "name": "web_search", "max_uses": 5,
+        })],
+    )
+
+    assert "tools" not in kwargs
+    assert "_hermes_server_tool" not in str(kwargs)
 
 
 def test_server_blocks_are_captured_and_replayed_in_original_order():
@@ -184,7 +239,9 @@ def test_dynamic_markers_follow_per_capability_selection(monkeypatch):
     search = web_tools._anthropic_web_search_schema_overrides()
     extract = web_tools._anthropic_web_fetch_schema_overrides()
 
-    assert search["_anthropic_server_tool"]["name"] == "web_search"
+    binding = search["_hermes_server_tool"]
+    assert binding["api_mode"] == "anthropic_messages"
+    assert binding["definition"]["name"] == "web_search"
     assert extract == {}
 
 

--- a/tests/agent/test_anthropic_web_server_tools.py
+++ b/tests/agent/test_anthropic_web_server_tools.py
@@ -1,0 +1,197 @@
+"""Behavior contracts for Anthropic-native web search and fetch."""
+
+from types import SimpleNamespace
+
+from agent.anthropic_adapter import (
+    convert_messages_to_anthropic,
+    convert_tools_to_anthropic,
+)
+from agent.transports.anthropic import AnthropicTransport
+
+
+def _tool(name: str, server_spec: dict) -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": name,
+            "parameters": {"type": "object", "properties": {}},
+            "_anthropic_server_tool": server_spec,
+        },
+    }
+
+
+def test_native_endpoint_replaces_web_functions_with_server_tools():
+    tools = [
+        _tool("web_search", {
+            "type": "web_search_20250305", "name": "web_search", "max_uses": 5,
+        }),
+        _tool("web_extract", {
+            "type": "web_fetch_20250910", "name": "web_fetch", "max_uses": 5,
+        }),
+    ]
+
+    converted = convert_tools_to_anthropic(tools, base_url="https://api.anthropic.com")
+
+    assert converted == [
+        {"type": "web_search_20250305", "name": "web_search", "max_uses": 5},
+        {"type": "web_fetch_20250910", "name": "web_fetch", "max_uses": 5},
+    ]
+
+
+def test_compatible_third_party_endpoint_keeps_local_function_tools():
+    tools = [_tool("web_search", {
+        "type": "web_search_20250305", "name": "web_search", "max_uses": 5,
+    })]
+
+    converted = convert_tools_to_anthropic(
+        tools, base_url="https://api.minimax.io/anthropic"
+    )
+
+    assert converted[0]["name"] == "web_search"
+    assert converted[0]["input_schema"]["type"] == "object"
+    assert "type" not in converted[0]
+
+
+def test_server_blocks_are_captured_and_replayed_in_original_order():
+    response = SimpleNamespace(
+        stop_reason="end_turn",
+        content=[
+            SimpleNamespace(
+                type="server_tool_use",
+                id="srvtoolu_1",
+                name="web_search",
+                input={"query": "Hermes Agent"},
+            ),
+            SimpleNamespace(
+                type="web_search_tool_result",
+                tool_use_id="srvtoolu_1",
+                content=[{
+                    "type": "web_search_result",
+                    "title": "Hermes",
+                    "url": "https://example.com/hermes",
+                }],
+            ),
+            SimpleNamespace(
+                type="text",
+                text="Hermes is an agent.",
+                citations=[{
+                    "type": "web_search_result_location",
+                    "title": "Hermes",
+                    "url": "https://example.com/hermes",
+                }],
+            ),
+        ],
+    )
+
+    normalized = AnthropicTransport().normalize_response(response)
+    stored = {
+        "role": "assistant",
+        "content": normalized.content,
+        "anthropic_content_blocks": normalized.anthropic_content_blocks,
+    }
+    _, replayed = convert_messages_to_anthropic([
+        {"role": "user", "content": "Find Hermes"},
+        stored,
+    ])
+
+    blocks = replayed[-1]["content"]
+    assert [block["type"] for block in blocks] == [
+        "server_tool_use", "web_search_tool_result", "text",
+    ]
+    assert blocks[-1]["citations"][0]["url"] == "https://example.com/hermes"
+    assert normalized.content.endswith(
+        "Sources:\n- Hermes: https://example.com/hermes"
+    )
+
+
+def test_web_fetch_blocks_use_the_same_round_trip_channel():
+    response = SimpleNamespace(
+        stop_reason="end_turn",
+        content=[
+            SimpleNamespace(
+                type="server_tool_use",
+                id="srvtoolu_fetch",
+                name="web_fetch",
+                input={"url": "https://example.com"},
+            ),
+            SimpleNamespace(
+                type="web_fetch_tool_result",
+                tool_use_id="srvtoolu_fetch",
+                content={
+                    "type": "web_fetch_result",
+                    "url": "https://example.com",
+                    "content": {"type": "document", "source": {"type": "text", "data": "ok"}},
+                },
+            ),
+            SimpleNamespace(type="text", text="Fetched."),
+        ],
+    )
+
+    normalized = AnthropicTransport().normalize_response(response)
+
+    assert [block["type"] for block in normalized.anthropic_content_blocks] == [
+        "server_tool_use", "web_fetch_tool_result", "text",
+    ]
+
+
+def test_pause_turn_remains_distinct_for_the_conversation_loop():
+    transport = AnthropicTransport()
+    response = SimpleNamespace(
+        stop_reason="pause_turn",
+        content=[SimpleNamespace(
+            type="server_tool_use",
+            id="srvtoolu_1",
+            name="web_search",
+            input={"query": "long research"},
+        )],
+    )
+
+    normalized = transport.normalize_response(response)
+
+    assert transport.map_finish_reason("pause_turn") == "pause_turn"
+    assert normalized.finish_reason == "pause_turn"
+    assert normalized.anthropic_content_blocks[0]["id"] == "srvtoolu_1"
+
+
+def test_model_key_does_not_implicitly_replace_the_web_backend(monkeypatch):
+    from tools import web_tools
+
+    monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+    monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
+    monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)
+    monkeypatch.setattr(web_tools, "_list_registered_web_providers", lambda: [])
+    keys = {"ANTHROPIC_API_KEY": "sk-ant-api-test"}
+    monkeypatch.setattr(web_tools, "_has_env", lambda name: bool(keys.get(name)))
+
+    assert web_tools._get_backend() != "anthropic"
+    assert not web_tools.check_web_api_key()
+
+    monkeypatch.setattr(
+        web_tools, "_load_web_config", lambda: {"backend": "anthropic"}
+    )
+    assert web_tools._get_backend() == "anthropic"
+    assert web_tools.check_web_api_key()
+
+
+def test_dynamic_markers_follow_per_capability_selection(monkeypatch):
+    from tools import web_tools
+
+    monkeypatch.setattr(web_tools, "_get_search_backend", lambda: "anthropic")
+    monkeypatch.setattr(web_tools, "_get_extract_backend", lambda: "brave-free")
+
+    search = web_tools._anthropic_web_search_schema_overrides()
+    extract = web_tools._anthropic_web_fetch_schema_overrides()
+
+    assert search["_anthropic_server_tool"]["name"] == "web_search"
+    assert extract == {}
+
+
+def test_tools_picker_exposes_anthropic_without_requesting_a_second_key():
+    from hermes_cli.tools_config import TOOL_CATEGORIES
+
+    providers = TOOL_CATEGORIES["web"]["providers"]
+    anthropic = next(p for p in providers if p.get("web_backend") == "anthropic")
+
+    assert anthropic["env_vars"] == []
+    assert "already configured" in anthropic["tag"]

--- a/tests/agent/test_anthropic_web_server_tools.py
+++ b/tests/agent/test_anthropic_web_server_tools.py
@@ -414,3 +414,37 @@ def test_third_party_endpoint_drop_is_reported_once(caplog):
     assert "third_party_probe_tool" in message
     assert "api.minimax.io" in message
     assert "hermes tools" in message
+
+
+def test_native_web_fetch_bounds_the_content_it_injects(anthropic_key):
+    """A server-side fetch must carry a content ceiling of its own.
+
+    The local ``web_extract`` path is bounded before a result reaches the model
+    (auxiliary summariser, then ``max_result_size_chars`` on the registry
+    entry).  The native fetch runs inside Anthropic's request, so neither guard
+    ever sees it: without ``max_content_tokens`` one large page is injected
+    whole and — because the block is preserved for replay — resent on every
+    later turn of the session.
+    """
+    from tools import registry, web_tools
+
+    _write_hermes_config("""
+        model:
+          provider: anthropic
+        web:
+          backend: anthropic
+    """)
+
+    definition = web_tools._anthropic_web_fetch_schema_overrides()
+    definition = definition["_hermes_server_tool"]["definition"]
+
+    cap = definition.get("max_content_tokens")
+    assert isinstance(cap, int) and cap > 0, definition
+
+    # Tie the ceiling to the local cap rather than freezing a number: the two
+    # bound the same thing on two paths, and a reader who raises one should be
+    # told to look at the other. ~4 chars/token, so the native ceiling stays
+    # within an order of magnitude of the local one.
+    local_chars = registry.registry.get_entry("web_extract").max_result_size_chars
+    assert local_chars is not None
+    assert local_chars / 40 <= cap <= local_chars, (cap, local_chars)

--- a/tests/agent/test_anthropic_web_server_tools.py
+++ b/tests/agent/test_anthropic_web_server_tools.py
@@ -1,5 +1,7 @@
 """Behavior contracts for Anthropic-native web search and fetch."""
 
+import logging
+import textwrap
 from types import SimpleNamespace
 
 import pytest
@@ -253,3 +255,162 @@ def test_tools_picker_exposes_anthropic_without_requesting_a_second_key():
 
     assert anthropic["env_vars"] == []
     assert "already configured" in anthropic["tag"]
+
+
+# ---------------------------------------------------------------------------
+# The selected backend must match what the active model can actually execute.
+#
+# These drive the real config file under the per-test HERMES_HOME rather than
+# patching the loaders, because the bug they cover was a resolution bug: the
+# backend was "available" on evidence (an API key) that says nothing about
+# whether the model can run the tool.
+# ---------------------------------------------------------------------------
+
+def _write_hermes_config(body: str) -> None:
+    from hermes_cli.config import get_config_path
+
+    path = get_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+
+
+@pytest.fixture()
+def anthropic_key(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api-test")
+
+
+def test_anthropic_backend_is_unavailable_on_a_non_anthropic_model(anthropic_key):
+    """A model credential must not advertise web access the model cannot use.
+
+    The tools only execute inside Anthropic's Messages API, so on any other
+    transport every request drops them.  Reporting the backend as available
+    would light the whole ``web`` toolset up — banner, ``hermes tools``,
+    ``valid_tool_names`` — for an agent with no web capability at all.
+    """
+    from tools import web_tools
+
+    _write_hermes_config("""
+        model:
+          provider: openrouter
+          base_url: https://openrouter.ai/api/v1
+        web:
+          backend: anthropic
+    """)
+
+    assert web_tools._is_backend_available("anthropic") is False
+    assert web_tools.check_web_api_key() is False
+
+
+def test_anthropic_backend_stays_available_on_anthropic_models(anthropic_key):
+    from tools import web_tools
+
+    _write_hermes_config("""
+        model:
+          provider: anthropic
+        web:
+          backend: anthropic
+    """)
+
+    assert web_tools._is_backend_available("anthropic") is True
+    assert web_tools.check_web_api_key() is True
+
+
+def test_compatible_third_party_endpoint_does_not_advertise_web_tools(anthropic_key):
+    """A ``…/anthropic`` proxy speaks the protocol but does not host the tools."""
+    from tools import web_tools
+
+    _write_hermes_config("""
+        model:
+          provider: minimax
+          base_url: https://api.minimax.io/anthropic
+          api_mode: anthropic_messages
+        web:
+          backend: anthropic
+    """)
+
+    assert web_tools._is_backend_available("anthropic") is False
+    assert web_tools.check_web_api_key() is False
+
+
+def test_unclassifiable_model_config_keeps_web_available(anthropic_key):
+    """Never strip a capability on a config this cannot read as non-Anthropic."""
+    from tools import web_tools
+
+    _write_hermes_config("""
+        web:
+          backend: anthropic
+    """)
+
+    assert web_tools._is_backend_available("anthropic") is True
+    assert web_tools.check_web_api_key() is True
+
+
+def test_unexecutable_selection_keeps_the_tool_shaped_so_it_can_explain(
+    anthropic_key, monkeypatch
+):
+    """When another backend keeps ``web`` alive, the tool must stay callable.
+
+    Attaching the server-only binding here would strip ``web_search`` from
+    every request while ``hermes tools`` still lists it — the handler's own
+    "cannot run locally" error is unreachable for a tool nobody can call.
+    """
+    from tools import web_tools
+
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-test")
+
+    _write_hermes_config("""
+        model:
+          provider: openrouter
+          base_url: https://openrouter.ai/api/v1
+        web:
+          backend: anthropic
+          extract_backend: tavily
+    """)
+
+    assert web_tools.check_web_api_key() is True
+    assert web_tools._get_search_backend() == "anthropic"
+    assert web_tools._anthropic_web_search_schema_overrides() == {}
+    assert web_tools._anthropic_web_fetch_schema_overrides() == {}
+    assert "hermes tools" in web_tools.web_search_tool("anything")
+
+
+def test_dropping_a_server_only_tool_is_reported_once(caplog):
+    """The projection must not remove a user-visible capability in silence.
+
+    The tool name is unique to this test so the report's once-per-process
+    suppression is exercised here rather than pre-consumed by another case.
+    """
+    tools = [_tool("projection_probe_tool", {
+        "type": "web_search_20250305", "name": "web_search", "max_uses": 5,
+    })]
+
+    with caplog.at_level(logging.WARNING, logger="agent.transports.base"):
+        assert ChatCompletionsTransport().project_tools(tools) == []
+        assert ChatCompletionsTransport().project_tools(tools) == []
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert "projection_probe_tool" in message
+    assert "anthropic_messages" in message
+    assert "chat_completions" in message
+    assert "hermes tools" in message
+
+
+def test_third_party_endpoint_drop_is_reported_once(caplog):
+    tools = [_tool("third_party_probe_tool", {
+        "type": "web_search_20250305", "name": "web_search", "max_uses": 5,
+    })]
+
+    with caplog.at_level(logging.WARNING, logger="agent.anthropic_adapter"):
+        for _ in range(2):
+            assert convert_tools_to_anthropic(
+                tools, base_url="https://api.minimax.io/anthropic"
+            ) == []
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert "third_party_probe_tool" in message
+    assert "api.minimax.io" in message
+    assert "hermes tools" in message

--- a/tests/agent/test_anthropic_web_server_tools.py
+++ b/tests/agent/test_anthropic_web_server_tools.py
@@ -1,0 +1,194 @@
+"""Behavior contracts for Anthropic-native web search and fetch."""
+
+from types import SimpleNamespace
+
+from agent.anthropic_message_convert import convert_messages_to_anthropic, convert_tools_to_anthropic
+from agent.transports.anthropic import AnthropicTransport
+
+
+def _tool(name: str, server_spec: dict) -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": name,
+            "parameters": {"type": "object", "properties": {}},
+            "_anthropic_server_tool": server_spec,
+        },
+    }
+
+
+def test_native_endpoint_replaces_web_functions_with_server_tools():
+    tools = [
+        _tool("web_search", {
+            "type": "web_search_20250305", "name": "web_search", "max_uses": 5,
+        }),
+        _tool("web_extract", {
+            "type": "web_fetch_20250910", "name": "web_fetch", "max_uses": 5,
+        }),
+    ]
+
+    converted = convert_tools_to_anthropic(tools, base_url="https://api.anthropic.com")
+
+    assert converted == [
+        {"type": "web_search_20250305", "name": "web_search", "max_uses": 5},
+        {"type": "web_fetch_20250910", "name": "web_fetch", "max_uses": 5},
+    ]
+
+
+def test_compatible_third_party_endpoint_keeps_local_function_tools():
+    tools = [_tool("web_search", {
+        "type": "web_search_20250305", "name": "web_search", "max_uses": 5,
+    })]
+
+    converted = convert_tools_to_anthropic(
+        tools, base_url="https://api.minimax.io/anthropic"
+    )
+
+    assert converted[0]["name"] == "web_search"
+    assert converted[0]["input_schema"]["type"] == "object"
+    assert "type" not in converted[0]
+
+
+def test_server_blocks_are_captured_and_replayed_in_original_order():
+    response = SimpleNamespace(
+        stop_reason="end_turn",
+        content=[
+            SimpleNamespace(
+                type="server_tool_use",
+                id="srvtoolu_1",
+                name="web_search",
+                input={"query": "Hermes Agent"},
+            ),
+            SimpleNamespace(
+                type="web_search_tool_result",
+                tool_use_id="srvtoolu_1",
+                content=[{
+                    "type": "web_search_result",
+                    "title": "Hermes",
+                    "url": "https://example.com/hermes",
+                }],
+            ),
+            SimpleNamespace(
+                type="text",
+                text="Hermes is an agent.",
+                citations=[{
+                    "type": "web_search_result_location",
+                    "title": "Hermes",
+                    "url": "https://example.com/hermes",
+                }],
+            ),
+        ],
+    )
+
+    normalized = AnthropicTransport().normalize_response(response)
+    stored = {
+        "role": "assistant",
+        "content": normalized.content,
+        "anthropic_content_blocks": normalized.anthropic_content_blocks,
+    }
+    _, replayed = convert_messages_to_anthropic([
+        {"role": "user", "content": "Find Hermes"},
+        stored,
+    ])
+
+    blocks = replayed[-1]["content"]
+    assert [block["type"] for block in blocks] == [
+        "server_tool_use", "web_search_tool_result", "text",
+    ]
+    assert blocks[-1]["citations"][0]["url"] == "https://example.com/hermes"
+    assert normalized.content.endswith(
+        "Sources:\n- Hermes: https://example.com/hermes"
+    )
+
+
+def test_web_fetch_blocks_use_the_same_round_trip_channel():
+    response = SimpleNamespace(
+        stop_reason="end_turn",
+        content=[
+            SimpleNamespace(
+                type="server_tool_use",
+                id="srvtoolu_fetch",
+                name="web_fetch",
+                input={"url": "https://example.com"},
+            ),
+            SimpleNamespace(
+                type="web_fetch_tool_result",
+                tool_use_id="srvtoolu_fetch",
+                content={
+                    "type": "web_fetch_result",
+                    "url": "https://example.com",
+                    "content": {"type": "document", "source": {"type": "text", "data": "ok"}},
+                },
+            ),
+            SimpleNamespace(type="text", text="Fetched."),
+        ],
+    )
+
+    normalized = AnthropicTransport().normalize_response(response)
+
+    assert [block["type"] for block in normalized.anthropic_content_blocks] == [
+        "server_tool_use", "web_fetch_tool_result", "text",
+    ]
+
+
+def test_pause_turn_remains_distinct_for_the_conversation_loop():
+    transport = AnthropicTransport()
+    response = SimpleNamespace(
+        stop_reason="pause_turn",
+        content=[SimpleNamespace(
+            type="server_tool_use",
+            id="srvtoolu_1",
+            name="web_search",
+            input={"query": "long research"},
+        )],
+    )
+
+    normalized = transport.normalize_response(response)
+
+    assert transport.map_finish_reason("pause_turn") == "pause_turn"
+    assert normalized.finish_reason == "pause_turn"
+    assert normalized.anthropic_content_blocks[0]["id"] == "srvtoolu_1"
+
+
+def test_model_key_does_not_implicitly_replace_the_web_backend(monkeypatch):
+    from tools import web_tools
+
+    monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+    monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
+    monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)
+    monkeypatch.setattr(web_tools, "_list_registered_web_providers", lambda: [])
+    keys = {"ANTHROPIC_API_KEY": "sk-ant-api-test"}
+    monkeypatch.setattr(web_tools, "_has_env", lambda name: bool(keys.get(name)))
+
+    assert web_tools._get_backend() != "anthropic"
+    assert not web_tools.check_web_api_key()
+
+    monkeypatch.setattr(
+        web_tools, "_load_web_config", lambda: {"backend": "anthropic"}
+    )
+    assert web_tools._get_backend() == "anthropic"
+    assert web_tools.check_web_api_key()
+
+
+def test_dynamic_markers_follow_per_capability_selection(monkeypatch):
+    from tools import web_tools
+
+    monkeypatch.setattr(web_tools, "_get_search_backend", lambda: "anthropic")
+    monkeypatch.setattr(web_tools, "_get_extract_backend", lambda: "brave-free")
+
+    search = web_tools._anthropic_web_search_schema_overrides()
+    extract = web_tools._anthropic_web_fetch_schema_overrides()
+
+    assert search["_anthropic_server_tool"]["name"] == "web_search"
+    assert extract == {}
+
+
+def test_tools_picker_exposes_anthropic_without_requesting_a_second_key():
+    from hermes_cli.tools_config import TOOL_CATEGORIES
+
+    providers = TOOL_CATEGORIES["web"]["providers"]
+    anthropic = next(p for p in providers if p.get("web_backend") == "anthropic")
+
+    assert anthropic["env_vars"] == []
+    assert "already configured" in anthropic["tag"]

--- a/tests/agent/test_anthropic_web_server_tools.py
+++ b/tests/agent/test_anthropic_web_server_tools.py
@@ -2,8 +2,14 @@
 
 from types import SimpleNamespace
 
+import pytest
+
+from agent.anthropic_endpoints import _is_third_party_anthropic_endpoint
 from agent.anthropic_message_convert import convert_messages_to_anthropic, convert_tools_to_anthropic
 from agent.transports.anthropic import AnthropicTransport
+from agent.transports.bedrock import BedrockTransport
+from agent.transports.chat_completions import ChatCompletionsTransport
+from agent.transports.codex import ResponsesApiTransport
 
 
 def _tool(name: str, server_spec: dict) -> dict:
@@ -13,7 +19,10 @@ def _tool(name: str, server_spec: dict) -> dict:
             "name": name,
             "description": name,
             "parameters": {"type": "object", "properties": {}},
-            "_anthropic_server_tool": server_spec,
+            "_hermes_server_tool": {
+                "api_mode": "anthropic_messages",
+                "definition": server_spec,
+            },
         },
     }
 
@@ -36,7 +45,7 @@ def test_native_endpoint_replaces_web_functions_with_server_tools():
     ]
 
 
-def test_compatible_third_party_endpoint_keeps_local_function_tools():
+def test_compatible_third_party_endpoint_omits_server_only_tools():
     tools = [_tool("web_search", {
         "type": "web_search_20250305", "name": "web_search", "max_uses": 5,
     })]
@@ -45,9 +54,55 @@ def test_compatible_third_party_endpoint_keeps_local_function_tools():
         tools, base_url="https://api.minimax.io/anthropic"
     )
 
-    assert converted[0]["name"] == "web_search"
-    assert converted[0]["input_schema"]["type"] == "object"
-    assert "type" not in converted[0]
+    assert converted == []
+
+
+def test_anthropic_native_endpoint_detection_uses_hostname_boundaries():
+    assert not _is_third_party_anthropic_endpoint("https://api.anthropic.com/v1")
+    assert _is_third_party_anthropic_endpoint(
+        "https://api.anthropic.com.example/v1"
+    )
+    assert _is_third_party_anthropic_endpoint(
+        "https://proxy.example/v1/api.anthropic.com"
+    )
+
+
+@pytest.mark.parametrize(
+    "transport",
+    [ChatCompletionsTransport(), BedrockTransport(), ResponsesApiTransport()],
+)
+def test_server_only_tools_are_omitted_from_foreign_transports(transport):
+    ordinary = {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+    server_only = _tool("web_search", {
+        "type": "web_search_20250305", "name": "web_search", "max_uses": 5,
+    })
+
+    projected = transport.project_tools([ordinary, server_only])
+    converted = transport.convert_tools([ordinary, server_only])
+
+    assert projected == [ordinary]
+    assert "_hermes_server_tool" not in str(projected)
+    assert "web_search" not in str(converted)
+    assert "_hermes_server_tool" not in str(converted)
+
+
+def test_chat_completions_kwargs_never_leak_server_tool_metadata():
+    kwargs = ChatCompletionsTransport().build_kwargs(
+        model="example/model",
+        messages=[{"role": "user", "content": "hello"}],
+        tools=[_tool("web_search", {
+            "type": "web_search_20250305", "name": "web_search", "max_uses": 5,
+        })],
+    )
+
+    assert "tools" not in kwargs
+    assert "_hermes_server_tool" not in str(kwargs)
 
 
 def test_server_blocks_are_captured_and_replayed_in_original_order():
@@ -181,7 +236,9 @@ def test_dynamic_markers_follow_per_capability_selection(monkeypatch):
     search = web_tools._anthropic_web_search_schema_overrides()
     extract = web_tools._anthropic_web_fetch_schema_overrides()
 
-    assert search["_anthropic_server_tool"]["name"] == "web_search"
+    binding = search["_hermes_server_tool"]
+    assert binding["api_mode"] == "anthropic_messages"
+    assert binding["definition"]["name"] == "web_search"
     assert extract == {}
 
 

--- a/tests/agent/test_anthropic_web_server_tools.py
+++ b/tests/agent/test_anthropic_web_server_tools.py
@@ -130,6 +130,7 @@ def test_web_fetch_blocks_use_the_same_round_trip_channel():
     assert [block["type"] for block in normalized.anthropic_content_blocks] == [
         "server_tool_use", "web_fetch_tool_result", "text",
     ]
+    assert normalized.content.endswith("Sources:\n- https://example.com")
 
 
 def test_pause_turn_remains_distinct_for_the_conversation_loop():

--- a/tests/agent/test_anthropic_web_server_tools.py
+++ b/tests/agent/test_anthropic_web_server_tools.py
@@ -92,6 +92,30 @@ def test_oauth_forcing_a_server_tool_keeps_its_canonical_name():
     }
 
 
+def test_server_only_tools_are_never_deferred_behind_tool_search(monkeypatch):
+    """``tools.tool_search.defer`` may name core tools, but a server-only def has no local
+    handler: deferred, it would vanish from the request and ``tool_call`` would reach the
+    local "cannot run" stub instead of the provider."""
+    import tools.tool_search as tool_search
+
+    server = _tool("web_search", {
+        "type": "web_search_20250305", "name": "web_search", "max_uses": 5,
+    })
+    plain = {"type": "function", "function": {
+        "name": "web_extract", "description": "web_extract",
+        "parameters": {"type": "object", "properties": {}},
+    }}
+    defer = frozenset({"web_search", "web_extract"})
+
+    assert tool_search.classify_tools([server, plain], defer) == ([server], [plain])
+
+    monkeypatch.setattr(
+        tool_search, "load_config_readonly",
+        lambda: SimpleNamespace(effective_defer_tools=defer),
+    )
+    assert tool_search.scoped_deferrable_names([server, plain]) == frozenset({"web_extract"})
+
+
 def test_anthropic_native_endpoint_detection_uses_hostname_boundaries():
     assert not _is_third_party_anthropic_endpoint("https://api.anthropic.com/v1")
     assert _is_third_party_anthropic_endpoint(

--- a/tests/agent/test_anthropic_web_server_tools.py
+++ b/tests/agent/test_anthropic_web_server_tools.py
@@ -60,6 +60,38 @@ def test_compatible_third_party_endpoint_omits_server_only_tools():
     assert converted == []
 
 
+def test_oauth_forcing_a_server_tool_keeps_its_canonical_name():
+    """OAuth renames client tools to ``mcp__*`` but leaves server tools alone — in ``tools[]``
+    and in a forced ``tool_choice`` alike, or the request names a tool that does not exist."""
+    from agent.anthropic_adapter import build_anthropic_kwargs
+
+    tools = [
+        _tool("web_search", {
+            "type": "web_search_20250305", "name": "web_search", "max_uses": 5,
+        }),
+        {"type": "function", "function": {
+            "name": "read_file", "description": "read_file",
+            "parameters": {"type": "object", "properties": {}},
+        }},
+    ]
+    common = dict(
+        model="claude-sonnet-4-6", messages=[{"role": "user", "content": "hi"}],
+        tools=tools, max_tokens=1024, reasoning_config=None, is_oauth=True,
+        base_url="https://api.anthropic.com",
+    )
+
+    forced = build_anthropic_kwargs(tool_choice="web_search", **common)
+
+    assert {t["name"]: t.get("type") for t in forced["tools"]} == {
+        "web_search": "web_search_20250305", "mcp__read_file": None,
+    }
+    assert forced["tool_choice"] == {"type": "tool", "name": "web_search"}
+    # Client tools still take the OAuth wire name.
+    assert build_anthropic_kwargs(tool_choice="read_file", **common)["tool_choice"] == {
+        "type": "tool", "name": "mcp__read_file",
+    }
+
+
 def test_anthropic_native_endpoint_detection_uses_hostname_boundaries():
     assert not _is_third_party_anthropic_endpoint("https://api.anthropic.com/v1")
     assert _is_third_party_anthropic_endpoint(

--- a/tests/agent/test_anthropic_web_server_tools.py
+++ b/tests/agent/test_anthropic_web_server_tools.py
@@ -1,5 +1,7 @@
 """Behavior contracts for Anthropic-native web search and fetch."""
 
+import logging
+import textwrap
 from types import SimpleNamespace
 
 import pytest
@@ -250,3 +252,162 @@ def test_tools_picker_exposes_anthropic_without_requesting_a_second_key():
 
     assert anthropic["env_vars"] == []
     assert "already configured" in anthropic["tag"]
+
+
+# ---------------------------------------------------------------------------
+# The selected backend must match what the active model can actually execute.
+#
+# These drive the real config file under the per-test HERMES_HOME rather than
+# patching the loaders, because the bug they cover was a resolution bug: the
+# backend was "available" on evidence (an API key) that says nothing about
+# whether the model can run the tool.
+# ---------------------------------------------------------------------------
+
+def _write_hermes_config(body: str) -> None:
+    from hermes_cli.config import get_config_path
+
+    path = get_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+
+
+@pytest.fixture()
+def anthropic_key(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api-test")
+
+
+def test_anthropic_backend_is_unavailable_on_a_non_anthropic_model(anthropic_key):
+    """A model credential must not advertise web access the model cannot use.
+
+    The tools only execute inside Anthropic's Messages API, so on any other
+    transport every request drops them.  Reporting the backend as available
+    would light the whole ``web`` toolset up — banner, ``hermes tools``,
+    ``valid_tool_names`` — for an agent with no web capability at all.
+    """
+    from tools import web_tools
+
+    _write_hermes_config("""
+        model:
+          provider: openrouter
+          base_url: https://openrouter.ai/api/v1
+        web:
+          backend: anthropic
+    """)
+
+    assert web_tools._is_backend_available("anthropic") is False
+    assert web_tools.check_web_api_key() is False
+
+
+def test_anthropic_backend_stays_available_on_anthropic_models(anthropic_key):
+    from tools import web_tools
+
+    _write_hermes_config("""
+        model:
+          provider: anthropic
+        web:
+          backend: anthropic
+    """)
+
+    assert web_tools._is_backend_available("anthropic") is True
+    assert web_tools.check_web_api_key() is True
+
+
+def test_compatible_third_party_endpoint_does_not_advertise_web_tools(anthropic_key):
+    """A ``…/anthropic`` proxy speaks the protocol but does not host the tools."""
+    from tools import web_tools
+
+    _write_hermes_config("""
+        model:
+          provider: minimax
+          base_url: https://api.minimax.io/anthropic
+          api_mode: anthropic_messages
+        web:
+          backend: anthropic
+    """)
+
+    assert web_tools._is_backend_available("anthropic") is False
+    assert web_tools.check_web_api_key() is False
+
+
+def test_unclassifiable_model_config_keeps_web_available(anthropic_key):
+    """Never strip a capability on a config this cannot read as non-Anthropic."""
+    from tools import web_tools
+
+    _write_hermes_config("""
+        web:
+          backend: anthropic
+    """)
+
+    assert web_tools._is_backend_available("anthropic") is True
+    assert web_tools.check_web_api_key() is True
+
+
+def test_unexecutable_selection_keeps_the_tool_shaped_so_it_can_explain(
+    anthropic_key, monkeypatch
+):
+    """When another backend keeps ``web`` alive, the tool must stay callable.
+
+    Attaching the server-only binding here would strip ``web_search`` from
+    every request while ``hermes tools`` still lists it — the handler's own
+    "cannot run locally" error is unreachable for a tool nobody can call.
+    """
+    from tools import web_tools
+
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-test")
+
+    _write_hermes_config("""
+        model:
+          provider: openrouter
+          base_url: https://openrouter.ai/api/v1
+        web:
+          backend: anthropic
+          extract_backend: tavily
+    """)
+
+    assert web_tools.check_web_api_key() is True
+    assert web_tools._get_search_backend() == "anthropic"
+    assert web_tools._anthropic_web_search_schema_overrides() == {}
+    assert web_tools._anthropic_web_fetch_schema_overrides() == {}
+    assert "hermes tools" in web_tools.web_search_tool("anything")
+
+
+def test_dropping_a_server_only_tool_is_reported_once(caplog):
+    """The projection must not remove a user-visible capability in silence.
+
+    The tool name is unique to this test so the report's once-per-process
+    suppression is exercised here rather than pre-consumed by another case.
+    """
+    tools = [_tool("projection_probe_tool", {
+        "type": "web_search_20250305", "name": "web_search", "max_uses": 5,
+    })]
+
+    with caplog.at_level(logging.WARNING, logger="agent.transports.base"):
+        assert ChatCompletionsTransport().project_tools(tools) == []
+        assert ChatCompletionsTransport().project_tools(tools) == []
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert "projection_probe_tool" in message
+    assert "anthropic_messages" in message
+    assert "chat_completions" in message
+    assert "hermes tools" in message
+
+
+def test_third_party_endpoint_drop_is_reported_once(caplog):
+    tools = [_tool("third_party_probe_tool", {
+        "type": "web_search_20250305", "name": "web_search", "max_uses": 5,
+    })]
+
+    with caplog.at_level(logging.WARNING, logger="agent.anthropic_message_convert"):
+        for _ in range(2):
+            assert convert_tools_to_anthropic(
+                tools, base_url="https://api.minimax.io/anthropic"
+            ) == []
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert "third_party_probe_tool" in message
+    assert "api.minimax.io" in message
+    assert "hermes tools" in message

--- a/tests/agent/test_anthropic_web_server_tools.py
+++ b/tests/agent/test_anthropic_web_server_tools.py
@@ -1,5 +1,6 @@
 """Behavior contracts for Anthropic-native web search and fetch."""
 
+import json
 import logging
 import textwrap
 from types import SimpleNamespace
@@ -210,6 +211,7 @@ def test_pause_turn_remains_distinct_for_the_conversation_loop():
 
 
 def test_model_key_does_not_implicitly_replace_the_web_backend(monkeypatch):
+    from agent import web_search_registry
     from tools import web_tools
 
     monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
@@ -218,6 +220,15 @@ def test_model_key_does_not_implicitly_replace_the_web_backend(monkeypatch):
     monkeypatch.setattr(web_tools, "_list_registered_web_providers", lambda: [])
     keys = {"ANTHROPIC_API_KEY": "sk-ant-api-test"}
     monkeypatch.setattr(web_tools, "_has_env", lambda name: bool(keys.get(name)))
+    # Disable the keyless free tier. With it on, a ring provider reports ready
+    # on zero credentials, so ``check_web_api_key()`` returns True no matter
+    # what the Anthropic key does — masking exactly what this test asserts
+    # (see test_web_keyless_fallback.py for the tier's own coverage). Patching
+    # the registry module is enough: every reader late-imports the symbol from
+    # it inside the function body, so the rebound name is what runs. Turning
+    # the tier off also removes the per-process ring rotation, which would
+    # otherwise make ``_get_backend()`` return a different vendor per run.
+    monkeypatch.setattr(web_search_registry, "_keyless_tier_enabled", lambda: False)
 
     assert web_tools._get_backend() != "anthropic"
     assert not web_tools.check_web_api_key()
@@ -371,6 +382,110 @@ def test_unexecutable_selection_keeps_the_tool_shaped_so_it_can_explain(
     assert "hermes tools" in web_tools.web_search_tool("anything")
 
 
+def test_per_capability_anthropic_selection_hides_web_on_a_foreign_model(
+    anthropic_key, monkeypatch
+):
+    """``web.backend`` is not the only way to select an unrunnable backend.
+
+    ``web.search_backend``/``web.extract_backend`` are resolved strictly — the
+    stored name is returned with no availability probe and no fallback — so a
+    per-capability selection routes exactly like the shared key.  With BOTH
+    capabilities pinned to ``anthropic`` on a transport that cannot carry the
+    server-side tools, nothing can serve either one, and an unrelated web
+    credential must not light the toolset up on their behalf.
+
+    ``TAVILY_API_KEY`` is that unrelated credential: it is what makes this
+    case return True if the readiness gate looks only at ``web.backend``.
+    ``keyless_fallback: false`` keeps Tavily the sole witness, so a failure
+    here can never be blamed on the free-tier ring.
+    """
+    from tools import web_tools
+
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-test")
+
+    _write_hermes_config("""
+        model:
+          provider: openrouter
+          base_url: https://openrouter.ai/api/v1
+        web:
+          search_backend: anthropic
+          extract_backend: anthropic
+          keyless_fallback: false
+    """)
+
+    assert web_tools._get_search_backend() == "anthropic"
+    assert web_tools._get_extract_backend() == "anthropic"
+    assert web_tools._is_backend_available("anthropic") is False
+    assert web_tools._is_backend_available("tavily") is True
+    assert web_tools.check_web_api_key() is False
+
+
+def test_one_capability_stuck_on_anthropic_leaves_the_other_serving(
+    anthropic_key, monkeypatch
+):
+    """Only a total loss of web hides the toolset; a half-broken split stays.
+
+    Extract still routes to a backend that runs locally, so ``web`` must stay
+    available — hiding it would take away a capability the agent really has.
+    The stuck capability is not silently dropped either: ``web_search`` keeps
+    its ordinary shape and answers with the typed ``tool_error`` that says why
+    it cannot run and what to do about it.
+    """
+    from tools import web_tools
+
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-test")
+
+    _write_hermes_config("""
+        model:
+          provider: openrouter
+          base_url: https://openrouter.ai/api/v1
+        web:
+          search_backend: anthropic
+          extract_backend: tavily
+          keyless_fallback: false
+    """)
+
+    assert web_tools._get_search_backend() == "anthropic"
+    assert web_tools._get_extract_backend() == "tavily"
+    assert web_tools.check_web_api_key() is True
+
+    payload = json.loads(web_tools.web_search_tool("anything"))
+    assert "results" not in payload
+    assert "cannot be executed by Hermes locally" in payload["error"]
+    assert "hermes tools" in payload["error"]
+
+
+def test_a_keyless_capability_still_counts_as_web(anthropic_key):
+    """The half-broken split must not be widened to the keyless free tier.
+
+    ``_is_backend_available`` is keyless-blind, so the credential-free half of
+    this config looks unavailable to every probe in the readiness gate — yet
+    the free-tier ring really does serve it.  A gate that hides ``web`` as
+    soon as *either* capability lands on ``anthropic`` would take that away.
+
+    The Anthropic key IS present here (``anthropic_key``), so the False below
+    is about the transport, not a missing credential — which is exactly the
+    situation a user lands in after selecting ``anthropic`` for search.
+
+    Deliberately asserts no backend name: ``_keyless_preference()`` is seeded
+    per process, so which ring vendor answers differs from run to run.
+    """
+    from tools import web_tools
+
+    _write_hermes_config("""
+        model:
+          provider: openrouter
+          base_url: https://openrouter.ai/api/v1
+        web:
+          search_backend: anthropic
+          extract_backend: exa
+    """)
+
+    assert web_tools._is_backend_available("anthropic") is False
+    assert web_tools._is_backend_available("exa") is False
+    assert web_tools.check_web_api_key() is True
+
+
 def test_dropping_a_server_only_tool_is_reported_once(caplog):
     """The projection must not remove a user-visible capability in silence.
 
@@ -417,11 +532,11 @@ def test_native_web_fetch_bounds_the_content_it_injects(anthropic_key):
     """A server-side fetch must carry a content ceiling of its own.
 
     The local ``web_extract`` path is bounded before a result reaches the model
-    (auxiliary summariser, then ``max_result_size_chars`` on the registry
-    entry).  The native fetch runs inside Anthropic's request, so neither guard
-    ever sees it: without ``max_content_tokens`` one large page is injected
-    whole and — because the block is preserved for replay — resent on every
-    later turn of the session.
+    (the ``web.extract_char_limit`` head+tail window, then
+    ``max_result_size_chars`` on the registry entry).  The native fetch runs
+    inside Anthropic's request, so neither guard ever sees it: without
+    ``max_content_tokens`` one large page is injected whole and — because the
+    block is preserved for replay — resent on every later turn of the session.
     """
     from tools import registry, web_tools
 

--- a/tests/agent/test_anthropic_web_server_tools.py
+++ b/tests/agent/test_anthropic_web_server_tools.py
@@ -411,3 +411,37 @@ def test_third_party_endpoint_drop_is_reported_once(caplog):
     assert "third_party_probe_tool" in message
     assert "api.minimax.io" in message
     assert "hermes tools" in message
+
+
+def test_native_web_fetch_bounds_the_content_it_injects(anthropic_key):
+    """A server-side fetch must carry a content ceiling of its own.
+
+    The local ``web_extract`` path is bounded before a result reaches the model
+    (auxiliary summariser, then ``max_result_size_chars`` on the registry
+    entry).  The native fetch runs inside Anthropic's request, so neither guard
+    ever sees it: without ``max_content_tokens`` one large page is injected
+    whole and — because the block is preserved for replay — resent on every
+    later turn of the session.
+    """
+    from tools import registry, web_tools
+
+    _write_hermes_config("""
+        model:
+          provider: anthropic
+        web:
+          backend: anthropic
+    """)
+
+    definition = web_tools._anthropic_web_fetch_schema_overrides()
+    definition = definition["_hermes_server_tool"]["definition"]
+
+    cap = definition.get("max_content_tokens")
+    assert isinstance(cap, int) and cap > 0, definition
+
+    # Tie the ceiling to the local cap rather than freezing a number: the two
+    # bound the same thing on two paths, and a reader who raises one should be
+    # told to look at the other. ~4 chars/token, so the native ceiling stays
+    # within an order of magnitude of the local one.
+    local_chars = registry.registry.get_entry("web_extract").max_result_size_chars
+    assert local_chars is not None
+    assert local_chars / 40 <= cap <= local_chars, (cap, local_chars)

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -160,6 +160,76 @@ class TestDoctorToolAvailabilitySummary:
             ("ok", "web extract", "(ddgs)"),
         ]
 
+    def test_anthropic_backend_warns_when_the_model_is_not_anthropic(self, monkeypatch):
+        """The registry cannot see that anthropic is unrunnable here.
+
+        ``anthropic`` is not a registered backend, so the active-provider walk
+        falls through it to the keyless ring and hands these rows a healthy
+        provider this install never reaches — the false green #78412 asked the
+        rows to prevent, one backend over.
+        """
+        monkeypatch.setattr(
+            "tools.web_tools._get_search_backend", lambda: "anthropic"
+        )
+        monkeypatch.setattr(
+            "tools.web_tools._get_extract_backend", lambda: "anthropic"
+        )
+        monkeypatch.setattr(
+            "tools.web_tools._anthropic_native_endpoint_selected", lambda: False
+        )
+
+        detail = doctor_tools._doctor_unrunnable_web_backend_detail("search")
+
+        assert "switch the model to Anthropic" in detail
+
+    def test_anthropic_backend_warns_when_the_credential_is_missing(self, monkeypatch):
+        """An Anthropic-served model still needs the credential.
+
+        Keying the gate on the endpoint alone would print a green row for a
+        capability the ``web`` toolset has switched off, with a remedy that
+        does not apply.
+        """
+        monkeypatch.setattr(
+            "tools.web_tools._get_search_backend", lambda: "anthropic"
+        )
+        monkeypatch.setattr(
+            "tools.web_tools._get_extract_backend", lambda: "anthropic"
+        )
+        monkeypatch.setattr(
+            "tools.web_tools._anthropic_native_endpoint_selected", lambda: True
+        )
+        monkeypatch.setattr(
+            "tools.web_tools._is_backend_available", lambda _backend: False
+        )
+
+        detail = doctor_tools._doctor_unrunnable_web_backend_detail("search")
+
+        assert "no Anthropic credential" in detail
+        assert "switch the model" not in detail
+
+    def test_anthropic_backend_is_silent_when_it_can_actually_run(self, monkeypatch):
+        monkeypatch.setattr(
+            "tools.web_tools._get_search_backend", lambda: "anthropic"
+        )
+        monkeypatch.setattr(
+            "tools.web_tools._get_extract_backend", lambda: "anthropic"
+        )
+        monkeypatch.setattr(
+            "tools.web_tools._anthropic_native_endpoint_selected", lambda: True
+        )
+        monkeypatch.setattr(
+            "tools.web_tools._is_backend_available", lambda _backend: True
+        )
+
+        assert doctor_tools._doctor_unrunnable_web_backend_detail("search") == ""
+
+    def test_other_backends_are_not_second_guessed(self, monkeypatch):
+        """Only the anthropic selection is special-cased here."""
+        monkeypatch.setattr("tools.web_tools._get_search_backend", lambda: "tavily")
+        monkeypatch.setattr("tools.web_tools._get_extract_backend", lambda: "tavily")
+
+        assert doctor_tools._doctor_unrunnable_web_backend_detail("search") == ""
+
 
 class TestDoctorEnvFileEncoding:
     """Regression for #18637 (bug 3): `hermes doctor` crashed on Windows

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -178,8 +178,9 @@ class TestDoctorToolAvailabilitySummary:
             "tools.web_tools._anthropic_native_endpoint_selected", lambda: False
         )
 
-        detail = doctor_tools._doctor_unrunnable_web_backend_detail("search")
+        status, detail = doctor_tools._doctor_anthropic_web_row("search")
 
+        assert status == "warn"
         assert "switch the model to Anthropic" in detail
 
     def test_anthropic_backend_warns_when_the_credential_is_missing(self, monkeypatch):
@@ -202,8 +203,9 @@ class TestDoctorToolAvailabilitySummary:
             "tools.web_tools._is_backend_available", lambda _backend: False
         )
 
-        detail = doctor_tools._doctor_unrunnable_web_backend_detail("search")
+        status, detail = doctor_tools._doctor_anthropic_web_row("search")
 
+        assert status == "warn"
         assert "no Anthropic credential" in detail
         assert "switch the model" not in detail
 
@@ -221,14 +223,53 @@ class TestDoctorToolAvailabilitySummary:
             "tools.web_tools._is_backend_available", lambda _backend: True
         )
 
-        assert doctor_tools._doctor_unrunnable_web_backend_detail("search") == ""
+        status, detail = doctor_tools._doctor_anthropic_web_row("search")
+
+        assert status == "ok"
+        assert "anthropic" in detail
+
+    def test_runnable_anthropic_row_does_not_name_another_provider(self, monkeypatch):
+        """The registry cannot answer for anthropic, so it must not be asked.
+
+        ``anthropic`` is not a registered provider: the active-provider walk
+        goes straight past it and returns whoever the availability walk or the
+        keyless ring lands on. Before this row answered the healthy case too,
+        a working Anthropic selection printed ``web search (tavily)`` — a
+        provider the request never touches.
+        """
+        monkeypatch.setattr("tools.web_tools._get_search_backend", lambda: "anthropic")
+        monkeypatch.setattr("tools.web_tools._get_extract_backend", lambda: "anthropic")
+        monkeypatch.setattr(
+            "tools.web_tools._anthropic_native_endpoint_selected", lambda: True
+        )
+        monkeypatch.setattr("tools.web_tools._is_backend_available", lambda _b: True)
+
+        class _Ring:
+            name = "tavily"
+
+            def is_available(self):
+                return True
+
+        monkeypatch.setattr(
+            "agent.web_search_registry.get_active_search_provider", lambda: _Ring()
+        )
+        monkeypatch.setattr(
+            "agent.web_search_registry.get_active_extract_provider", lambda: _Ring()
+        )
+
+        rows = doctor_tools._doctor_web_capability_rows()
+
+        assert rows
+        assert all(status == "ok" for status, _, _ in rows)
+        assert not any("tavily" in detail for _, _, detail in rows), rows
+        assert all("anthropic" in detail for _, _, detail in rows)
 
     def test_other_backends_are_not_second_guessed(self, monkeypatch):
         """Only the anthropic selection is special-cased here."""
         monkeypatch.setattr("tools.web_tools._get_search_backend", lambda: "tavily")
         monkeypatch.setattr("tools.web_tools._get_extract_backend", lambda: "tavily")
 
-        assert doctor_tools._doctor_unrunnable_web_backend_detail("search") == ""
+        assert doctor_tools._doctor_anthropic_web_row("search") is None
 
 
 class TestDoctorEnvFileEncoding:

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -159,15 +159,24 @@ def _tool_def_names(tool_defs: Iterable[Dict[str, Any]]) -> Iterable[str]:
     return (_fn(td).get("name", "") for td in tool_defs)
 
 
+def _is_server_only(td: Dict[str, Any]) -> bool:
+    """A provider-executed def (``_hermes_server_tool`` binding, e.g. native Anthropic web
+    search) has no local handler, so it never defers — even when ``defer`` names it. It must
+    reach the transport, which either runs it natively or drops it; behind the bridge it
+    would vanish from the request and ``tool_call`` would land on the local stub."""
+    return "_hermes_server_tool" in _fn(td)
+
+
 def classify_tools(tool_defs: List[Dict[str, Any]], defer_tools: Optional[frozenset] = None,
                    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Split a tool-defs list into (visible, deferrable); bridge tools are dropped (re-added
-    after classification)."""
+    after classification) and server-only defs stay visible."""
     visible: List[Dict[str, Any]] = []
     deferrable: List[Dict[str, Any]] = []
     for td, name in zip(tool_defs, _tool_def_names(tool_defs)):
         if name not in BRIDGE_TOOL_NAMES:
-            (deferrable if is_deferrable_tool_name(name, defer_tools) else visible).append(td)
+            deferred = is_deferrable_tool_name(name, defer_tools) and not _is_server_only(td)
+            (deferrable if deferred else visible).append(td)
     return visible, deferrable
 
 
@@ -526,8 +535,8 @@ def scoped_deferrable_names(tool_defs: List[Dict[str, Any]]) -> frozenset[str]:
     universe ``tool_call`` may reach. Gates bridge dispatch AND the executor unwrap so a
     restricted session cannot invoke an out-of-scope tool via the bridge."""
     defer_tools = load_config_readonly().effective_defer_tools
-    return frozenset(n for n in _tool_def_names(tool_defs)
-                     if n and is_deferrable_tool_name(n, defer_tools))
+    return frozenset(n for td, n in zip(tool_defs, _tool_def_names(tool_defs))
+                     if n and not _is_server_only(td) and is_deferrable_tool_name(n, defer_tools))
 
 
 def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any], Optional[str]]:

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -169,7 +169,10 @@ def _load_web_config() -> dict:
 # WebSearchProvider. Keep the two sets aligned by hand: if xai ever ships as
 # a registered provider, drop it here so the registry path takes over.
 _LEGACY_WEB_BACKENDS = frozenset(
-    {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}
+    {
+        "parallel", "firecrawl", "tavily", "exa", "searxng",
+        "brave-free", "ddgs", "xai", "anthropic",
+    }
 )
 
 
@@ -349,6 +352,13 @@ def _is_backend_available(backend: str) -> bool:
             return has_xai_credentials()
         except Exception:
             return False
+    if backend == "anthropic":
+        # Native server-side web tools execute inside the Anthropic Messages
+        # API request.  Availability must stay a cheap credential probe: this
+        # function runs while schemas are assembled and while `hermes tools`
+        # paints.  get_env_value() (via _has_env) covers both the process env
+        # and ~/.hermes/.env, including the API key collected at setup.
+        return _has_env("ANTHROPIC_API_KEY") or _has_env("CLAUDE_CODE_OAUTH_TOKEN")
     return False
 
 
@@ -398,6 +408,8 @@ def _web_requires_env() -> list[str]:
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_SCHEME",
         "TOOL_GATEWAY_USER_TOKEN",
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_CODE_OAUTH_TOKEN",
     ]
 
 
@@ -684,6 +696,12 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         )
 
         backend = _get_search_backend()
+        if backend == "anthropic":
+            return tool_error(
+                "Anthropic web search is a server-side Messages API tool and "
+                "cannot be executed by Hermes locally. Use an Anthropic model "
+                "with api_mode=anthropic_messages, or select another web.search_backend."
+            )
         provider = _wsp_get_provider(backend) if backend else None
         if provider is None or not provider.supports_search():
             # Fall back to availability-walked active provider when the
@@ -856,6 +874,12 @@ async def web_extract_tool(
             results = []
         else:
             backend = _get_extract_backend()
+            if backend == "anthropic":
+                return tool_error(
+                    "Anthropic web fetch is a server-side Messages API tool and "
+                    "cannot be executed by Hermes locally. Use an Anthropic model "
+                    "with api_mode=anthropic_messages, or select another web.extract_backend."
+                )
 
             # All seven providers (brave-free, ddgs, searxng, exa, parallel,
             # tavily, firecrawl) now live as plugins. The dispatcher is a
@@ -1059,12 +1083,22 @@ def check_web_api_key() -> bool:
     """
     # ``or ""``: a null ``web.backend`` value yields None from ``.get``, and
     # ``None.lower()`` would raise. Mirrors ``_get_backend``.
-    configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured and _is_backend_available(configured):
+    config = _load_web_config()
+    configured_backends = {
+        str(config.get(key) or "").lower().strip()
+        for key in ("backend", "search_backend", "extract_backend")
+    }
+    configured_backends.discard("")
+    if any(_is_backend_available(backend) for backend in configured_backends):
         return True
     # Any built-in backend with credentials present. This is a boolean OR, so
     # unlike _get_backend() the probe order is irrelevant.
-    if any(_is_backend_available(backend) for backend in _LEGACY_WEB_BACKENDS):
+    # Anthropic is deliberately explicit-only.  Its credential is primarily
+    # a model credential and may coexist with an OpenRouter or other active
+    # transport; treating it as a generic web-provider key would expose local
+    # web functions that cannot execute on that transport.
+    auto_detectable = _LEGACY_WEB_BACKENDS - {"anthropic"}
+    if any(_is_backend_available(backend) for backend in auto_detectable):
         return True
     # Any plugin-registered provider the registry considers active for either
     # capability. Delegating to the registry's own availability-filtered
@@ -1211,6 +1245,39 @@ WEB_EXTRACT_SCHEMA = {
     }
 }
 
+
+def _anthropic_web_search_schema_overrides() -> dict:
+    """Expose Anthropic's native search spec only when it is selected.
+
+    Keeping the marker out of the static schema matters: an Anthropic user
+    may deliberately select Brave, SearXNG, or another local provider.  In
+    that case the adapter must leave ``web_search`` function-shaped so Hermes
+    dispatches it through the normal provider registry.
+    """
+    if _get_search_backend() != "anthropic":
+        return {}
+    return {
+        "_anthropic_server_tool": {
+            "type": "web_search_20250305",
+            "name": "web_search",
+            "max_uses": 5,
+        }
+    }
+
+
+def _anthropic_web_fetch_schema_overrides() -> dict:
+    """Expose Anthropic web_fetch in place of Hermes web_extract when selected."""
+    if _get_extract_backend() != "anthropic":
+        return {}
+    return {
+        "_anthropic_server_tool": {
+            "type": "web_fetch_20250910",
+            "name": "web_fetch",
+            "max_uses": 5,
+            "citations": {"enabled": True},
+        }
+    }
+
 registry.register(
     name="web_search",
     toolset="web",
@@ -1220,6 +1287,7 @@ registry.register(
     requires_env=_web_requires_env(),
     emoji="🔍",
     max_result_size_chars=100_000,
+    dynamic_schema_overrides=_anthropic_web_search_schema_overrides,
 )
 registry.register(
     name="web_extract",
@@ -1235,4 +1303,5 @@ registry.register(
     is_async=True,
     emoji="📄",
     max_result_size_chars=100_000,
+    dynamic_schema_overrides=_anthropic_web_fetch_schema_overrides,
 )

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1257,10 +1257,13 @@ def _anthropic_web_search_schema_overrides() -> dict:
     if _get_search_backend() != "anthropic":
         return {}
     return {
-        "_anthropic_server_tool": {
-            "type": "web_search_20250305",
-            "name": "web_search",
-            "max_uses": 5,
+        "_hermes_server_tool": {
+            "api_mode": "anthropic_messages",
+            "definition": {
+                "type": "web_search_20250305",
+                "name": "web_search",
+                "max_uses": 5,
+            },
         }
     }
 
@@ -1270,11 +1273,14 @@ def _anthropic_web_fetch_schema_overrides() -> dict:
     if _get_extract_backend() != "anthropic":
         return {}
     return {
-        "_anthropic_server_tool": {
-            "type": "web_fetch_20250910",
-            "name": "web_fetch",
-            "max_uses": 5,
-            "citations": {"enabled": True},
+        "_hermes_server_tool": {
+            "api_mode": "anthropic_messages",
+            "definition": {
+                "type": "web_fetch_20250910",
+                "name": "web_fetch",
+                "max_uses": 5,
+                "citations": {"enabled": True},
+            },
         }
     }
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1348,6 +1348,23 @@ def _anthropic_web_search_schema_overrides() -> dict:
     }
 
 
+# Ceiling on how much fetched page text Anthropic may load into the context.
+#
+# The local ``web_extract`` path is bounded twice before a result reaches the
+# model: the auxiliary summariser, and ``max_result_size_chars`` on the registry
+# entry below.  The native fetch executes inside the Messages API request, so
+# neither guard ever sees it — an unbounded fetch would be injected whole and,
+# because it is preserved for replay, resent on every later turn of the session.
+# Bound it server-side at the same order of magnitude as the local cap
+# (100_000 chars, ~4 chars/token) so choosing this backend does not silently
+# change how much of a page can land in the context.
+#
+# Approximate by Anthropic's own definition, and explicitly NOT applied to
+# binary content such as PDFs — a large PDF is still bounded only by the
+# context window.
+_ANTHROPIC_WEB_FETCH_MAX_CONTENT_TOKENS = 25_000
+
+
 def _anthropic_web_fetch_schema_overrides() -> dict:
     """Expose Anthropic web_fetch in place of Hermes web_extract when selected."""
     if _get_extract_backend() != "anthropic":
@@ -1363,6 +1380,7 @@ def _anthropic_web_fetch_schema_overrides() -> dict:
                 "type": "web_fetch_20250910",
                 "name": "web_fetch",
                 "max_uses": 5,
+                "max_content_tokens": _ANTHROPIC_WEB_FETCH_MAX_CONTENT_TOKENS,
                 "citations": {"enabled": True},
             },
         }

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -156,6 +156,64 @@ def _load_web_config() -> dict:
         return {}
 
 
+def _load_model_config() -> dict:
+    """Load the ``model:`` section from ~/.hermes/config.yaml.
+
+    Legacy configs store ``model`` as a bare string (the model name), so the
+    isinstance guard keeps the ``-> dict`` contract for every caller.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        model_cfg = load_config().get("model")
+        return model_cfg if isinstance(model_cfg, dict) else {}
+    except (ImportError, Exception):
+        return {}
+
+
+def _anthropic_native_endpoint_selected() -> bool:
+    """Return True when the configured model is served by Anthropic itself.
+
+    Anthropic's ``web_search`` / ``web_fetch`` are not credentials — they run
+    *inside* the Messages API request.  Hermes can therefore only offer them
+    when the active model is reached through Anthropic's own endpoint: every
+    other transport strips the server-only binding
+    (``agent.transports.base.project_tools_for_transport``) and a compatible
+    third-party Messages endpoint is not assumed to host the tools either
+    (``agent.anthropic_adapter.convert_tools_to_anthropic``).  Without this
+    gate an ANTHROPIC_API_KEY kept for some other purpose lit the whole ``web``
+    toolset up on an OpenRouter (or any non-Anthropic) model, while both tools
+    were silently removed from every request — the agent was told it could
+    search the web and then had no web capability at all.
+
+    Resolved from persisted model config only.  This runs while tool schemas
+    are assembled and on every ``hermes tools`` repaint, so it must stay a
+    cheap, network-free read: no runtime provider resolution, no models.dev
+    lookup.  Config that identifies no endpoint at all is treated as reachable
+    so an install this cannot classify never loses web access silently — the
+    request-time projection stays the authority on what reaches the wire.
+    """
+    model_cfg = _load_model_config()
+    base_url = str(model_cfg.get("base_url") or "").strip()
+    if base_url:
+        # An explicit endpoint decides on its own: Azure, Bedrock, a proxy, or
+        # a ``…/anthropic`` compatible endpoint may speak the protocol without
+        # hosting the tools.  Hostname matching (never substring) so a
+        # lookalike host cannot pose as the real API.
+        from utils import base_url_host_matches
+
+        return base_url_host_matches(base_url, "anthropic.com")
+    provider = str(model_cfg.get("provider") or "").strip()
+    if provider:
+        from hermes_cli.providers import normalize_provider
+
+        return normalize_provider(provider) == "anthropic"
+    api_mode = str(model_cfg.get("api_mode") or "").strip().lower()
+    if api_mode:
+        return api_mode == "anthropic_messages"
+    return True
+
+
 # The built-in web backends whose availability is driven by hardcoded
 # env-var / package / OAuth probes below. Any name NOT in this set is a
 # candidate plugin-registered provider and must be resolved through the
@@ -354,10 +412,14 @@ def _is_backend_available(backend: str) -> bool:
             return False
     if backend == "anthropic":
         # Native server-side web tools execute inside the Anthropic Messages
-        # API request.  Availability must stay a cheap credential probe: this
-        # function runs while schemas are assembled and while `hermes tools`
-        # paints.  get_env_value() (via _has_env) covers both the process env
-        # and ~/.hermes/.env, including the API key collected at setup.
+        # API request, so a credential alone does not make them usable — the
+        # active model must also be reached through Anthropic's own endpoint.
+        # Both probes stay cheap (config read + env lookup): this function runs
+        # while schemas are assembled and while `hermes tools` paints.
+        # get_env_value() (via _has_env) covers both the process env and
+        # ~/.hermes/.env, including the API key collected at setup.
+        if not _anthropic_native_endpoint_selected():
+            return False
         return _has_env("ANTHROPIC_API_KEY") or _has_env("CLAUDE_CODE_OAUTH_TOKEN")
     return False
 
@@ -699,8 +761,9 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         if backend == "anthropic":
             return tool_error(
                 "Anthropic web search is a server-side Messages API tool and "
-                "cannot be executed by Hermes locally. Use an Anthropic model "
-                "with api_mode=anthropic_messages, or select another web.search_backend."
+                "cannot be executed by Hermes locally. Use a model served by "
+                "Anthropic's own Messages API, or select another web search "
+                "backend with `hermes tools`."
             )
         provider = _wsp_get_provider(backend) if backend else None
         if provider is None or not provider.supports_search():
@@ -877,8 +940,9 @@ async def web_extract_tool(
             if backend == "anthropic":
                 return tool_error(
                     "Anthropic web fetch is a server-side Messages API tool and "
-                    "cannot be executed by Hermes locally. Use an Anthropic model "
-                    "with api_mode=anthropic_messages, or select another web.extract_backend."
+                    "cannot be executed by Hermes locally. Use a model served by "
+                    "Anthropic's own Messages API, or select another web extract "
+                    "backend with `hermes tools`."
                 )
 
             # All seven providers (brave-free, ddgs, searxng, exa, parallel,
@@ -1091,6 +1155,15 @@ def check_web_api_key() -> bool:
     configured_backends.discard("")
     if any(_is_backend_available(backend) for backend in configured_backends):
         return True
+    # A shared ``web.backend`` is honored unconditionally by ``_get_backend()``,
+    # so once an explicit Anthropic selection is unusable no credential
+    # elsewhere can serve either capability: every dispatch resolves back to
+    # "anthropic" and fails. Reporting the toolset as available here would
+    # advertise web access the agent does not have. The per-capability
+    # overrides are already covered by the check above — they fall back to
+    # another backend on their own when unavailable.
+    if str(config.get("backend") or "").lower().strip() == "anthropic":
+        return False
     # Any built-in backend with credentials present. This is a boolean OR, so
     # unlike _get_backend() the probe order is irrelevant.
     # Anthropic is deliberately explicit-only.  Its credential is primarily
@@ -1256,6 +1329,13 @@ def _anthropic_web_search_schema_overrides() -> dict:
     """
     if _get_search_backend() != "anthropic":
         return {}
+    if not _anthropic_native_endpoint_selected():
+        # The configured model cannot execute the server tool, and a binding
+        # it cannot execute is stripped from the request without a trace.
+        # Leaving the schema function-shaped keeps ``web_search`` dispatchable
+        # so its handler can tell the agent why the call fails and what to
+        # change, instead of the capability vanishing silently.
+        return {}
     return {
         "_hermes_server_tool": {
             "api_mode": "anthropic_messages",
@@ -1271,6 +1351,10 @@ def _anthropic_web_search_schema_overrides() -> dict:
 def _anthropic_web_fetch_schema_overrides() -> dict:
     """Expose Anthropic web_fetch in place of Hermes web_extract when selected."""
     if _get_extract_backend() != "anthropic":
+        return {}
+    if not _anthropic_native_endpoint_selected():
+        # See _anthropic_web_search_schema_overrides: stay function-shaped so
+        # the handler can report the mismatch instead of disappearing.
         return {}
     return {
         "_hermes_server_tool": {

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -173,6 +173,14 @@ def _xai_available() -> bool:
         return False
 
 
+def _anthropic_available() -> bool:
+    # Native server-side web tools execute inside the Anthropic Messages API request. Availability must stay
+    # a cheap credential probe: it runs while schemas are assembled and while `hermes tools` paints.
+    # get_env_value() (via _has_env) covers both the process env and ~/.hermes/.env, including the API key
+    # collected at setup.
+    return _has_env("ANTHROPIC_API_KEY") or _has_env("CLAUDE_CODE_OAUTH_TOKEN")
+
+
 # Built-in backends -> cheap availability probes; any other name is a plugin provider resolved via the
 # registry's ``is_available()``. Lambdas so test patches of module-level helpers (_ddgs_package_importable,
 # check_firecrawl_api_key) are honored at call time. ``xai`` is probed via has_xai_credentials(), not a
@@ -189,6 +197,7 @@ _BUILTIN_AVAILABILITY = {
     "brave-free": lambda: _has_env("BRAVE_SEARCH_API_KEY"),
     "ddgs": lambda: _ddgs_package_importable(),
     "xai": _xai_available,
+    "anthropic": _anthropic_available,
 }
 _LEGACY_WEB_BACKENDS = frozenset(_BUILTIN_AVAILABILITY)
 
@@ -221,7 +230,7 @@ def _web_requires_env() -> list[str]:
     return [
         "EXA_API_KEY", "PARALLEL_API_KEY", "TAVILY_API_KEY", "PERPLEXITY_API_KEY", "KEENABLE_API_KEY", "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL", "FIRECRAWL_GATEWAY_URL", "TOOL_GATEWAY_DOMAIN", "TOOL_GATEWAY_SCHEME",
-        "TOOL_GATEWAY_USER_TOKEN",
+        "TOOL_GATEWAY_USER_TOKEN", "ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN",
     ]
 
 _debug = DebugSession("web_tools", env_var="WEB_TOOLS_DEBUG")
@@ -286,6 +295,12 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         _ensure_web_plugins_loaded()
         from agent.web_search_registry import get_active_search_provider, get_provider as _wsp_get_provider
         backend = _get_search_backend()
+        if backend == "anthropic":
+            return tool_error(
+                "Anthropic web search is a server-side Messages API tool and "
+                "cannot be executed by Hermes locally. Use an Anthropic model "
+                "with api_mode=anthropic_messages, or select another web.search_backend."
+            )
         provider = _wsp_get_provider(backend) if backend else None
         if provider is None or not provider.supports_search():
             if provider is None and backend and selection_exists("web"):
@@ -374,6 +389,12 @@ async def web_extract_tool(urls: List[Any], format: str = None, char_limit: Opti
         results = []
         if safe_urls:
             backend = _get_extract_backend()
+            if backend == "anthropic":
+                return tool_error(
+                    "Anthropic web fetch is a server-side Messages API tool and "
+                    "cannot be executed by Hermes locally. Use an Anthropic model "
+                    "with api_mode=anthropic_messages, or select another web.extract_backend."
+                )
             _ensure_web_plugins_loaded()
             provider, error_json = _resolve_extract_provider(backend)
             if error_json is not None:
@@ -430,9 +451,16 @@ def check_web_api_key() -> bool:
 
     See #28651, #31873.
     """
-    # Boolean OR over configured + built-ins — probe order is irrelevant here.
-    candidates = [c for c in (_configured_backend(),) if c] + list(_LEGACY_WEB_BACKENDS)
-    if any(_is_backend_available(backend) for backend in candidates):
+    # Boolean OR over configured + built-ins — probe order is irrelevant here. The per-capability keys are
+    # selections too: ``web.search_backend`` / ``web.extract_backend`` route a capability on their own.
+    configured_backends = {_configured_backend(k) for k in ("backend", "search_backend", "extract_backend")}
+    configured_backends.discard("")
+    if any(_is_backend_available(backend) for backend in configured_backends):
+        return True
+    # Anthropic is deliberately explicit-only. Its credential is primarily a model credential and may coexist
+    # with an OpenRouter or other active transport; treating it as a generic web-provider key would expose
+    # local web functions that cannot execute on that transport.
+    if any(_is_backend_available(backend) for backend in _LEGACY_WEB_BACKENDS - {"anthropic"}):
         return True
     # Plugin path. Discovery must run first: check_fn fires at tool-registration time, before any dispatch.
     try:
@@ -493,11 +521,44 @@ WEB_EXTRACT_SCHEMA = {
     }
 }
 
+
+def _anthropic_web_search_schema_overrides() -> dict:
+    """Expose Anthropic's native search spec only when it is selected.
+
+    Keeping the marker out of the static schema matters: an Anthropic user may deliberately select Brave,
+    SearXNG, or another local provider. In that case the adapter must leave ``web_search`` function-shaped
+    so Hermes dispatches it through the normal provider registry.
+    """
+    if _get_search_backend() != "anthropic":
+        return {}
+    return {
+        "_anthropic_server_tool": {
+            "type": "web_search_20250305",
+            "name": "web_search",
+            "max_uses": 5,
+        }
+    }
+
+
+def _anthropic_web_fetch_schema_overrides() -> dict:
+    """Expose Anthropic web_fetch in place of Hermes web_extract when selected."""
+    if _get_extract_backend() != "anthropic":
+        return {}
+    return {
+        "_anthropic_server_tool": {
+            "type": "web_fetch_20250910",
+            "name": "web_fetch",
+            "max_uses": 5,
+            "citations": {"enabled": True},
+        }
+    }
+
+
 registry.register(
     name="web_search", toolset="web", schema=WEB_SEARCH_SCHEMA,
     handler=lambda args, **kw: web_search_tool(args.get("query", ""), limit=args.get("limit", 5)),
     check_fn=check_web_api_key, requires_env=_web_requires_env(), emoji="🔍",
-    max_result_size_chars=100_000,
+    max_result_size_chars=100_000, dynamic_schema_overrides=_anthropic_web_search_schema_overrides,
 )
 registry.register(
     name="web_extract", toolset="web", schema=WEB_EXTRACT_SCHEMA,
@@ -506,7 +567,7 @@ registry.register(
         char_limit=args.get("char_limit"),
     ),
     check_fn=check_web_api_key, requires_env=_web_requires_env(), is_async=True, emoji="📄",
-    max_result_size_chars=100_000,
+    max_result_size_chars=100_000, dynamic_schema_overrides=_anthropic_web_fetch_schema_overrides,
 )
 
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -532,10 +532,13 @@ def _anthropic_web_search_schema_overrides() -> dict:
     if _get_search_backend() != "anthropic":
         return {}
     return {
-        "_anthropic_server_tool": {
-            "type": "web_search_20250305",
-            "name": "web_search",
-            "max_uses": 5,
+        "_hermes_server_tool": {
+            "api_mode": "anthropic_messages",
+            "definition": {
+                "type": "web_search_20250305",
+                "name": "web_search",
+                "max_uses": 5,
+            },
         }
     }
 
@@ -545,11 +548,14 @@ def _anthropic_web_fetch_schema_overrides() -> dict:
     if _get_extract_backend() != "anthropic":
         return {}
     return {
-        "_anthropic_server_tool": {
-            "type": "web_fetch_20250910",
-            "name": "web_fetch",
-            "max_uses": 5,
-            "citations": {"enabled": True},
+        "_hermes_server_tool": {
+            "api_mode": "anthropic_messages",
+            "definition": {
+                "type": "web_fetch_20250910",
+                "name": "web_fetch",
+                "max_uses": 5,
+                "citations": {"enabled": True},
+            },
         }
     }
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -608,6 +608,20 @@ def _anthropic_web_search_schema_overrides() -> dict:
     }
 
 
+# Ceiling on how much fetched page text Anthropic may load into the context.
+#
+# The local ``web_extract`` path is bounded twice before a result reaches the model: the auxiliary
+# summariser, and ``max_result_size_chars`` on the registry entry below. The native fetch executes inside
+# the Messages API request, so neither guard ever sees it — an unbounded fetch would be injected whole and,
+# because it is preserved for replay, resent on every later turn of the session. Bound it server-side at the
+# same order of magnitude as the local cap (100_000 chars, ~4 chars/token) so choosing this backend does not
+# silently change how much of a page can land in the context.
+#
+# Approximate by Anthropic's own definition, and explicitly NOT applied to binary content such as PDFs — a
+# large PDF is still bounded only by the context window.
+_ANTHROPIC_WEB_FETCH_MAX_CONTENT_TOKENS = 25_000
+
+
 def _anthropic_web_fetch_schema_overrides() -> dict:
     """Expose Anthropic web_fetch in place of Hermes web_extract when selected."""
     if _get_extract_backend() != "anthropic":
@@ -623,6 +637,7 @@ def _anthropic_web_fetch_schema_overrides() -> dict:
                 "type": "web_fetch_20250910",
                 "name": "web_fetch",
                 "max_uses": 5,
+                "max_content_tokens": _ANTHROPIC_WEB_FETCH_MAX_CONTENT_TOKENS,
                 "citations": {"enabled": True},
             },
         }

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -223,6 +223,15 @@ def _anthropic_native_endpoint_selected() -> bool:
 def _anthropic_available() -> bool:
     # Native server-side web tools execute inside the Anthropic Messages API request, so a credential alone
     # does not make them usable — the active model must also be reached through Anthropic's own endpoint.
+    #
+    # Deliberately NOT given tavily's "explicitly configured ⇒ available" treatment in the table below. That
+    # shortcut is sound for a client-side provider: selecting it means the user intends to use it, and the
+    # dispatcher can still print a precise "set TAVILY_API_KEY" error at call time. Here there is no
+    # dispatcher to reach — on a non-Anthropic transport the binding is stripped from the request before it
+    # goes out, so an "available" answer would advertise a capability that silently does nothing. Selecting
+    # anthropic is exactly the configuration this probe has to be able to answer False for; do not harmonize
+    # the asymmetry.
+    #
     # Both probes stay cheap (config read + env lookup): this runs while schemas are assembled and while
     # `hermes tools` paints. get_env_value() (via _has_env) covers both the process env and ~/.hermes/.env,
     # including the API key collected at setup.
@@ -233,8 +242,17 @@ def _anthropic_available() -> bool:
 
 # Built-in backends -> cheap availability probes; any other name is a plugin provider resolved via the
 # registry's ``is_available()``. Lambdas so test patches of module-level helpers (_ddgs_package_importable,
-# check_firecrawl_api_key) are honored at call time. ``xai`` is probed via has_xai_credentials(), not a
-# registered provider, though the registry's _LEGACY_PREFERENCE omits it — drop it if xai ever registers.
+# check_firecrawl_api_key) are honored at call time. Three names are absent from the registry's
+# _LEGACY_PREFERENCE, each for a different reason:
+#   - ``xai``       — probed via has_xai_credentials() (env var OR auth.json OAuth) rather than by the walk;
+#                     kept out of the credential-autodetect order so an OAuth session is not treated as a
+#                     web credential.
+#   - ``keenable``  — a registered provider, but a keyless-ring member rather than a member of the
+#                     credential-autodetect walk; the cheap env probe here is the availability answer for it.
+#   - ``anthropic`` — a server-side Messages API binding, never a registered WebSearchProvider: it cannot be
+#                     dispatched locally at all, so no registry lookup could ever answer for it.
+# Keep the sets aligned by hand: if any of them ever joins _LEGACY_PREFERENCE as a registered provider,
+# drop it here so the registry path takes over.
 _BUILTIN_AVAILABILITY = {
     "exa": lambda: _has_env("EXA_API_KEY"),
     "parallel": lambda: _has_env("PARALLEL_API_KEY"),
@@ -346,12 +364,16 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         from agent.web_search_registry import get_active_search_provider, get_provider as _wsp_get_provider
         backend = _get_search_backend()
         if backend == "anthropic":
-            return tool_error(
+            # Reached only when the binding was NOT attached to the request (non-Anthropic transport, or a
+            # compatible third-party endpoint): when it is attached, Anthropic runs the search server-side
+            # and this handler is never called. Traced like every other web_search failure path so
+            # `hermes debug` shows why the call produced nothing.
+            return _finish_debug("web_search_tool", debug_call_data, (
                 "Anthropic web search is a server-side Messages API tool and "
                 "cannot be executed by Hermes locally. Use a model served by "
                 "Anthropic's own Messages API, or select another web search "
                 "backend with `hermes tools`."
-            )
+            ))
         provider = _wsp_get_provider(backend) if backend else None
         if provider is None or not provider.supports_search():
             if provider is None and backend and selection_exists("web"):
@@ -501,6 +523,11 @@ def check_web_api_key() -> bool:
     A plugin-registered provider reporting ``is_available()`` must light the tools up even with no
     built-in credentials; resolution funnels through :func:`_is_backend_available`.
 
+    One selection cannot be served by any credential: Anthropic's native web tools execute inside the
+    Messages API request, so on a transport that cannot carry them nothing else can run them either. When the
+    effective routing sends BOTH capabilities there, this reports the toolset as unavailable rather than
+    advertising web access the agent does not have.
+
     See #28651, #31873.
     """
     # Boolean OR over configured + built-ins — probe order is irrelevant here. The per-capability keys are
@@ -509,16 +536,32 @@ def check_web_api_key() -> bool:
     configured_backends.discard("")
     if any(_is_backend_available(backend) for backend in configured_backends):
         return True
-    # A shared ``web.backend`` is honored unconditionally by ``_get_backend()``, so once an explicit Anthropic
-    # selection is unusable no credential elsewhere can serve either capability: every dispatch resolves
-    # back to "anthropic" and fails. Reporting the toolset as available here would advertise web access the
-    # agent does not have. The per-capability overrides are already covered by the check above — they fall
-    # back to another backend on their own when unavailable.
-    if _configured_backend() == "anthropic":
+    # Selection is strict on BOTH the shared key and the per-capability overrides: ``_get_backend()``,
+    # ``_get_search_backend()`` and ``_get_extract_backend()`` return a stored name with no availability
+    # probe and no fallback, so the raw config keys do not describe the runtime routing. Resolve the
+    # effective backends and bail only when EVERY capability lands on an Anthropic selection the active
+    # transport cannot execute — nothing else can serve either tool, so reporting the toolset as available
+    # would advertise web access the agent does not have. When only one capability is stuck on anthropic,
+    # the other still serves and the stuck tool explains itself at dispatch.
+    #
+    # Guarded on the config read so a never-configured install never pays for backend resolution (which
+    # walks the keyless ring). The guard is exact: "anthropic" is in neither the autodetect ladder nor the
+    # keyless ring, so neither resolver can return it unless it was configured.
+    # ``_is_backend_available("anthropic")`` is already known False here — the name is in
+    # ``configured_backends`` and the probe above did not return.
+    if "anthropic" in configured_backends and all(
+        backend == "anthropic" for backend in (_get_search_backend(), _get_extract_backend())
+    ):
         return False
     # Anthropic is deliberately explicit-only. Its credential is primarily a model credential and may coexist
     # with an OpenRouter or other active transport; treating it as a generic web-provider key would expose
     # local web functions that cannot execute on that transport.
+    #
+    # The subtraction is load-bearing, not decorative: it is what
+    # ``test_model_key_does_not_implicitly_replace_the_web_backend`` asserts — an ANTHROPIC_API_KEY with no
+    # web selection at all must leave web off. (It is NOT what keeps upstream's ``test_no_credentials_fails``
+    # honest; ``tests/conftest.py``'s autouse ``_hermetic_environment`` strips credential-shaped env vars, so
+    # no key is visible there either way.)
     if any(_is_backend_available(backend) for backend in _LEGACY_WEB_BACKENDS - {"anthropic"}):
         return True
     # Plugin path. Discovery must run first: check_fn fires at tool-registration time, before any dispatch.
@@ -610,12 +653,16 @@ def _anthropic_web_search_schema_overrides() -> dict:
 
 # Ceiling on how much fetched page text Anthropic may load into the context.
 #
-# The local ``web_extract`` path is bounded twice before a result reaches the model: the auxiliary
-# summariser, and ``max_result_size_chars`` on the registry entry below. The native fetch executes inside
-# the Messages API request, so neither guard ever sees it — an unbounded fetch would be injected whole and,
-# because it is preserved for replay, resent on every later turn of the session. Bound it server-side at the
-# same order of magnitude as the local cap (100_000 chars, ~4 chars/token) so choosing this backend does not
-# silently change how much of a page can land in the context.
+# The local ``web_extract`` path is bounded twice before a result reaches the model: the
+# ``web.extract_char_limit`` head+tail window applied per page (``tools.web_tools_truncate``'s
+# ``_truncate_with_footer``, default ``DEFAULT_EXTRACT_CHAR_LIMIT`` = 15000 chars, with the full text spilled
+# to disk), and ``max_result_size_chars`` on the registry entry below. There is no LLM summarization on this
+# path at all.
+#
+# The native fetch executes inside the Messages API request, so neither guard ever sees it — an unbounded
+# fetch would be injected whole and, because it is preserved for replay, resent on every later turn of the
+# session. Bound it server-side at the same order of magnitude as the local cap (100_000 chars, ~4
+# chars/token) so choosing this backend does not silently change how much of a page can land in the context.
 #
 # Approximate by Anthropic's own definition, and explicitly NOT applied to binary content such as PDFs — a
 # large PDF is still bounded only by the context window.

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -61,6 +61,17 @@ def _load_web_config() -> dict:
         return {}
 
 
+def _load_model_config() -> dict:
+    """Load the ``model:`` section from config.yaml; always a dict (legacy configs store ``model`` as a bare
+    model-name string, which yields ``{}``)."""
+    try:
+        from hermes_cli.config import load_config
+        model_cfg = load_config().get("model")
+        return model_cfg if isinstance(model_cfg, dict) else {}
+    except Exception:
+        return {}
+
+
 def _configured_backend(key: str = "backend") -> str:
     """Lower-cased, stripped ``web.<key>`` value ("" when unset/null)."""
     return (_load_web_config().get(key) or "").lower().strip()
@@ -173,11 +184,50 @@ def _xai_available() -> bool:
         return False
 
 
+def _anthropic_native_endpoint_selected() -> bool:
+    """True when the configured model is served by Anthropic itself.
+
+    Anthropic's ``web_search`` / ``web_fetch`` are not credentials — they run *inside* the Messages API
+    request, so Hermes can only offer them when the active model is reached through Anthropic's own
+    endpoint: every other transport strips the server-only binding
+    (``agent.transports.base.project_tools_for_transport``), and a compatible third-party Messages endpoint
+    is not assumed to host the tools either (``agent.anthropic_message_convert.convert_tools_to_anthropic``).
+    Without this gate an ANTHROPIC_API_KEY kept for some other purpose lit the whole ``web`` toolset up on
+    an OpenRouter (or any non-Anthropic) model while both tools were silently removed from every request —
+    the agent was told it could search the web and then had no web capability at all.
+
+    Resolved from persisted model config only: this runs while tool schemas are assembled and on every
+    ``hermes tools`` repaint, so it must stay a cheap, network-free read (no runtime provider resolution,
+    no models.dev lookup). Config that identifies no endpoint at all is treated as reachable so an install
+    this cannot classify never loses web access silently — request-time projection stays the authority on
+    what reaches the wire.
+    """
+    model_cfg = _load_model_config()
+    base_url = str(model_cfg.get("base_url") or "").strip()
+    if base_url:
+        # An explicit endpoint decides on its own: Azure, Bedrock, a proxy, or a ``…/anthropic`` compatible
+        # endpoint may speak the protocol without hosting the tools. Hostname matching (never substring) so
+        # a lookalike host cannot pose as the real API.
+        from utils import base_url_host_matches
+        return base_url_host_matches(base_url, "anthropic.com")
+    provider = str(model_cfg.get("provider") or "").strip()
+    if provider:
+        from hermes_cli.providers import normalize_provider
+        return normalize_provider(provider) == "anthropic"
+    api_mode = str(model_cfg.get("api_mode") or "").strip().lower()
+    if api_mode:
+        return api_mode == "anthropic_messages"
+    return True
+
+
 def _anthropic_available() -> bool:
-    # Native server-side web tools execute inside the Anthropic Messages API request. Availability must stay
-    # a cheap credential probe: it runs while schemas are assembled and while `hermes tools` paints.
-    # get_env_value() (via _has_env) covers both the process env and ~/.hermes/.env, including the API key
-    # collected at setup.
+    # Native server-side web tools execute inside the Anthropic Messages API request, so a credential alone
+    # does not make them usable — the active model must also be reached through Anthropic's own endpoint.
+    # Both probes stay cheap (config read + env lookup): this runs while schemas are assembled and while
+    # `hermes tools` paints. get_env_value() (via _has_env) covers both the process env and ~/.hermes/.env,
+    # including the API key collected at setup.
+    if not _anthropic_native_endpoint_selected():
+        return False
     return _has_env("ANTHROPIC_API_KEY") or _has_env("CLAUDE_CODE_OAUTH_TOKEN")
 
 
@@ -298,8 +348,9 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         if backend == "anthropic":
             return tool_error(
                 "Anthropic web search is a server-side Messages API tool and "
-                "cannot be executed by Hermes locally. Use an Anthropic model "
-                "with api_mode=anthropic_messages, or select another web.search_backend."
+                "cannot be executed by Hermes locally. Use a model served by "
+                "Anthropic's own Messages API, or select another web search "
+                "backend with `hermes tools`."
             )
         provider = _wsp_get_provider(backend) if backend else None
         if provider is None or not provider.supports_search():
@@ -392,8 +443,9 @@ async def web_extract_tool(urls: List[Any], format: str = None, char_limit: Opti
             if backend == "anthropic":
                 return tool_error(
                     "Anthropic web fetch is a server-side Messages API tool and "
-                    "cannot be executed by Hermes locally. Use an Anthropic model "
-                    "with api_mode=anthropic_messages, or select another web.extract_backend."
+                    "cannot be executed by Hermes locally. Use a model served by "
+                    "Anthropic's own Messages API, or select another web extract "
+                    "backend with `hermes tools`."
                 )
             _ensure_web_plugins_loaded()
             provider, error_json = _resolve_extract_provider(backend)
@@ -457,6 +509,13 @@ def check_web_api_key() -> bool:
     configured_backends.discard("")
     if any(_is_backend_available(backend) for backend in configured_backends):
         return True
+    # A shared ``web.backend`` is honored unconditionally by ``_get_backend()``, so once an explicit Anthropic
+    # selection is unusable no credential elsewhere can serve either capability: every dispatch resolves
+    # back to "anthropic" and fails. Reporting the toolset as available here would advertise web access the
+    # agent does not have. The per-capability overrides are already covered by the check above — they fall
+    # back to another backend on their own when unavailable.
+    if _configured_backend() == "anthropic":
+        return False
     # Anthropic is deliberately explicit-only. Its credential is primarily a model credential and may coexist
     # with an OpenRouter or other active transport; treating it as a generic web-provider key would expose
     # local web functions that cannot execute on that transport.
@@ -531,6 +590,12 @@ def _anthropic_web_search_schema_overrides() -> dict:
     """
     if _get_search_backend() != "anthropic":
         return {}
+    if not _anthropic_native_endpoint_selected():
+        # The configured model cannot execute the server tool, and a binding it cannot execute is stripped
+        # from the request without a trace. Leaving the schema function-shaped keeps ``web_search``
+        # dispatchable so its handler can tell the agent why the call fails and what to change, instead of
+        # the capability vanishing silently.
+        return {}
     return {
         "_hermes_server_tool": {
             "api_mode": "anthropic_messages",
@@ -546,6 +611,10 @@ def _anthropic_web_search_schema_overrides() -> dict:
 def _anthropic_web_fetch_schema_overrides() -> dict:
     """Expose Anthropic web_fetch in place of Hermes web_extract when selected."""
     if _get_extract_backend() != "anthropic":
+        return {}
+    if not _anthropic_native_endpoint_selected():
+        # See _anthropic_web_search_schema_overrides: stay function-shaped so the handler can report the
+        # mismatch instead of disappearing.
         return {}
     return {
         "_hermes_server_tool": {

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -18,6 +18,7 @@ Both are configured through a single backend selection. Providers are chosen via
 
 | Provider | Env Var | Search | Extract | Free tier |
 |----------|---------|--------|---------|-----------|
+| **Anthropic (native)** | `ANTHROPIC_API_KEY` | ✔ | ✔ | Paid API usage |
 | **Firecrawl** (default) | `FIRECRAWL_API_KEY` | ✔ | ✔ | 500 credits/mo |
 | **SearXNG** | `SEARXNG_URL` | ✔ | — | ✔ Free (self-hosted) |
 | **Brave Search (free tier)** | `BRAVE_SEARCH_API_KEY` | ✔ | — | 2 000 queries/mo |
@@ -30,6 +31,13 @@ Both are configured through a single backend selection. Providers are chosen via
 Brave Search, DDGS, and xAI are **search-only** — pair any of them with Firecrawl/Tavily/Exa/Parallel when you also need `web_extract`. DDGS uses the [`ddgs` Python package](https://pypi.org/project/ddgs/) under the hood; if it isn't already installed, run `pip install ddgs` (or let Hermes lazy-install it on first use). xAI runs Grok's server-side `web_search` tool on the Responses API — results are LLM-generated rather than index-backed, so titles, descriptions, and URL choice are all model output (see the [trust-model caveat](#xai-grok) below).
 
 **Per-capability split:** you can use different providers for search and extract independently — for example SearXNG (free) for search and Firecrawl for extract. See [Per-capability configuration](#per-capability-configuration) below.
+
+When Anthropic is selected, Hermes maps its existing `web_search` and
+`web_extract` capabilities to Anthropic's server-side `web_search` and
+`web_fetch` tools. The tools run inside the Messages API request, use the same
+Anthropic credential as the model, and return source citations in Claude's
+response. Compatible third-party Anthropic endpoints are not assumed to host
+these tools; on those endpoints Hermes keeps the normal client-side web tools.
 
 :::tip Nous Subscribers
 If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, web search and extract are available through the **[Tool Gateway](tool-gateway.md)** via managed Firecrawl — no API key needed. New installs can run `hermes setup --portal` to log in and turn on all gateway tools at once; existing installs can flip just web via `hermes tools`.
@@ -84,6 +92,22 @@ Run `hermes tools`, navigate to **Web Search & Extract**, and pick a provider. T
 ```bash
 hermes tools
 ```
+
+### Anthropic (native)
+
+Choose **Anthropic Web Search & Fetch** in `hermes tools`, or configure it
+directly:
+
+```yaml
+web:
+  backend: anthropic
+```
+
+No additional credential is required when `ANTHROPIC_API_KEY` was already
+configured for the model. Search uses `web_search_20250305`; fetch uses
+`web_fetch_20250910` with citations enabled. Both are capped at five uses per
+model request. Anthropic web search has a per-search charge in addition to
+normal token usage.
 
 ---
 

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -37,7 +37,11 @@ When Anthropic is selected, Hermes maps its existing `web_search` and
 `web_fetch` tools. The tools run inside the Messages API request, use the same
 Anthropic credential as the model, and return source citations in Claude's
 response. Compatible third-party Anthropic endpoints are not assumed to host
-these tools; on those endpoints Hermes keeps the normal client-side web tools.
+these tools, so Hermes omits them from those requests entirely. They cannot
+fall back to client-side execution either — these tools only ever run inside
+Anthropic's API. With `anthropic` selected on such an endpoint, `web_search`
+and `web_extract` report that the tool is unavailable; pick another backend
+to keep web access there.
 
 :::tip Nous Subscribers
 If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, web search and extract are available through the **[Tool Gateway](tool-gateway.md)** via managed Firecrawl — no API key needed. New installs can run `hermes setup --portal` to log in and turn on all gateway tools at once; existing installs can flip just web via `hermes tools`.

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -114,8 +114,11 @@ No additional credential is required when `ANTHROPIC_API_KEY` was already
 configured for the model, but the model itself must be served by Anthropic's
 own API — the key alone does not enable this backend elsewhere. Search uses
 `web_search_20250305`; fetch uses `web_fetch_20250910` with citations enabled.
-Both are capped at five uses per model request. Anthropic web search has a
-per-search charge in addition to normal token usage.
+Both are capped at five uses per model request, and fetched page text is capped
+at roughly 25 000 tokens so a single large page cannot fill the context window
+— note that Anthropic applies this limit to text only, not to binary content
+such as PDFs. Anthropic web search has a per-search charge in addition to
+normal token usage.
 
 ---
 

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -36,12 +36,15 @@ When Anthropic is selected, Hermes maps its existing `web_search` and
 `web_extract` capabilities to Anthropic's server-side `web_search` and
 `web_fetch` tools. The tools run inside the Messages API request, use the same
 Anthropic credential as the model, and return source citations in Claude's
-response. Compatible third-party Anthropic endpoints are not assumed to host
-these tools, so Hermes omits them from those requests entirely. They cannot
-fall back to client-side execution either — these tools only ever run inside
-Anthropic's API. With `anthropic` selected on such an endpoint, `web_search`
-and `web_extract` report that the tool is unavailable; pick another backend
-to keep web access there.
+response. They only ever execute there: there is no client-side fallback, no
+other transport carries them, and compatible third-party Anthropic endpoints
+are not assumed to host them. Hermes therefore counts `anthropic` as a usable
+backend only while the model is served by Anthropic itself — on any other
+model the `web` toolset reports as unconfigured instead of advertising tools
+no request can carry, and `hermes tools` asks you to pick another backend.
+Should a second backend keep `web` enabled while `anthropic` stays selected
+for one capability, that tool remains callable and reports that it cannot run
+locally.
 
 :::tip Nous Subscribers
 If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, web search and extract are available through the **[Tool Gateway](tool-gateway.md)** via managed Firecrawl — no API key needed. New installs can run `hermes setup --portal` to log in and turn on all gateway tools at once; existing installs can flip just web via `hermes tools`.
@@ -108,10 +111,11 @@ web:
 ```
 
 No additional credential is required when `ANTHROPIC_API_KEY` was already
-configured for the model. Search uses `web_search_20250305`; fetch uses
-`web_fetch_20250910` with citations enabled. Both are capped at five uses per
-model request. Anthropic web search has a per-search charge in addition to
-normal token usage.
+configured for the model, but the model itself must be served by Anthropic's
+own API — the key alone does not enable this backend elsewhere. Search uses
+`web_search_20250305`; fetch uses `web_fetch_20250910` with citations enabled.
+Both are capped at five uses per model request. Anthropic web search has a
+per-search charge in addition to normal token usage.
 
 ---
 

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -45,7 +45,11 @@ When Anthropic is selected, Hermes maps its existing `web_search` and
 `web_fetch` tools. The tools run inside the Messages API request, use the same
 Anthropic credential as the model, and return source citations in Claude's
 response. Compatible third-party Anthropic endpoints are not assumed to host
-these tools; on those endpoints Hermes keeps the normal client-side web tools.
+these tools, so Hermes omits them from those requests entirely. They cannot
+fall back to client-side execution either — these tools only ever run inside
+Anthropic's API. With `anthropic` selected on such an endpoint, `web_search`
+and `web_extract` report that the tool is unavailable; pick another backend
+to keep web access there.
 
 :::tip Nous Subscribers
 If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, web search and extract are available through the **[Tool Gateway](tool-gateway.md)** via managed Firecrawl — no API key needed. New installs can run `hermes setup --portal` to log in and turn on all gateway tools at once; existing installs can flip just web via `hermes tools`.

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -27,6 +27,7 @@ Both are configured through a single backend selection. Providers are chosen via
 | **Tavily** | `TAVILY_API_KEY` (optional) | ✔ | ✔ | ✔ Opt-in keyless when selected |
 | **Perplexity** | `PERPLEXITY_API_KEY` | ✔ | ✔ (query-relevant snippets) | Paid (per-request Search API pricing) |
 | **Keenable** | `KEENABLE_API_KEY` (optional) | ✔ | ✔ | ✔ Keyless ring member · paid with key |
+| **Anthropic (native)** | `ANTHROPIC_API_KEY` | ✔ | ✔ | Paid API usage |
 | **xAI (Grok)** | `XAI_API_KEY` or `hermes auth add xai-oauth` | ✔ | — | Paid (SuperGrok or per-token) |
 
 Brave Search, DDGS, and xAI are **search-only** — pair any of them with Firecrawl/Tavily/Perplexity/Keenable/Exa/Parallel when you also need `web_extract`. DDGS uses the [`ddgs` Python package](https://pypi.org/project/ddgs/) under the hood; if it isn't already installed, run `pip install ddgs` (or let Hermes lazy-install it on first use). xAI runs Grok's server-side `web_search` tool on the Responses API — results are LLM-generated rather than index-backed, so titles, descriptions, and URL choice are all model output (see the [trust-model caveat](#xai-grok) below).
@@ -38,6 +39,13 @@ A fresh install with **no web credentials at all** gets working `web_search` and
 :::
 
 **Choosing free vs paid explicitly:** in `hermes tools`, Exa, Parallel, and Keenable each appear as two rows — **Free (keyless)** and **Paid (API key)**. Picking Free pins that vendor's anonymous endpoint (even if you later add a key); picking Paid pins the keyed path (a missing key then errors instead of silently downgrading to the free tier). The selection is stored as `web.provider_tier.<name>: free|paid`; leave it unset for auto (key present → paid, otherwise the keyless ring).
+
+When Anthropic is selected, Hermes maps its existing `web_search` and
+`web_extract` capabilities to Anthropic's server-side `web_search` and
+`web_fetch` tools. The tools run inside the Messages API request, use the same
+Anthropic credential as the model, and return source citations in Claude's
+response. Compatible third-party Anthropic endpoints are not assumed to host
+these tools; on those endpoints Hermes keeps the normal client-side web tools.
 
 :::tip Nous Subscribers
 If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, web search and extract are available through the **[Tool Gateway](tool-gateway.md)** via managed Firecrawl — no API key needed. New installs can run `hermes setup --portal` to log in and turn on all gateway tools at once; existing installs can flip just web via `hermes tools`.
@@ -108,6 +116,22 @@ Run `hermes tools`, navigate to **Web Search & Extract**, and pick a provider. T
 ```bash
 hermes tools
 ```
+
+### Anthropic (native)
+
+Choose **Anthropic Web Search & Fetch** in `hermes tools`, or configure it
+directly:
+
+```yaml
+web:
+  backend: anthropic
+```
+
+No additional credential is required when `ANTHROPIC_API_KEY` was already
+configured for the model. Search uses `web_search_20250305`; fetch uses
+`web_fetch_20250910` with citations enabled. Both are capped at five uses per
+model request. Anthropic web search has a per-search charge in addition to
+normal token usage.
 
 ---
 

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -344,6 +344,8 @@ No additional credential is required when `ANTHROPIC_API_KEY` (or `CLAUDE_CODE_O
 
 **No `[TRUNCATED]` footers here:** `web.extract_char_limit` and the head+tail window described [above](#how-web_extract-handles-long-pages) bound results that pass through Hermes, and the native fetch never does — it runs inside the Messages API request, so the ~25 000-token server-side cap is what bounds it instead.
 
+**No result caching either:** the [result cache](#result-caching) covers calls Hermes executes, so `web.cache_enabled`, `web.cache_ttl_minutes` and `web.cache_exempt_hosts` have no effect on this backend — a repeated search runs, and is billed, again.
+
 ---
 
 ### xAI (Grok) {#xai-grok}

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -44,12 +44,15 @@ When Anthropic is selected, Hermes maps its existing `web_search` and
 `web_extract` capabilities to Anthropic's server-side `web_search` and
 `web_fetch` tools. The tools run inside the Messages API request, use the same
 Anthropic credential as the model, and return source citations in Claude's
-response. Compatible third-party Anthropic endpoints are not assumed to host
-these tools, so Hermes omits them from those requests entirely. They cannot
-fall back to client-side execution either — these tools only ever run inside
-Anthropic's API. With `anthropic` selected on such an endpoint, `web_search`
-and `web_extract` report that the tool is unavailable; pick another backend
-to keep web access there.
+response. They only ever execute there: there is no client-side fallback, no
+other transport carries them, and compatible third-party Anthropic endpoints
+are not assumed to host them. Hermes therefore counts `anthropic` as a usable
+backend only while the model is served by Anthropic itself — on any other
+model the `web` toolset reports as unconfigured instead of advertising tools
+no request can carry, and `hermes tools` asks you to pick another backend.
+Should a second backend keep `web` enabled while `anthropic` stays selected
+for one capability, that tool remains callable and reports that it cannot run
+locally.
 
 :::tip Nous Subscribers
 If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, web search and extract are available through the **[Tool Gateway](tool-gateway.md)** via managed Firecrawl — no API key needed. New installs can run `hermes setup --portal` to log in and turn on all gateway tools at once; existing installs can flip just web via `hermes tools`.
@@ -132,10 +135,11 @@ web:
 ```
 
 No additional credential is required when `ANTHROPIC_API_KEY` was already
-configured for the model. Search uses `web_search_20250305`; fetch uses
-`web_fetch_20250910` with citations enabled. Both are capped at five uses per
-model request. Anthropic web search has a per-search charge in addition to
-normal token usage.
+configured for the model, but the model itself must be served by Anthropic's
+own API — the key alone does not enable this backend elsewhere. Search uses
+`web_search_20250305`; fetch uses `web_fetch_20250910` with citations enabled.
+Both are capped at five uses per model request. Anthropic web search has a
+per-search charge in addition to normal token usage.
 
 ---
 

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -138,8 +138,11 @@ No additional credential is required when `ANTHROPIC_API_KEY` was already
 configured for the model, but the model itself must be served by Anthropic's
 own API — the key alone does not enable this backend elsewhere. Search uses
 `web_search_20250305`; fetch uses `web_fetch_20250910` with citations enabled.
-Both are capped at five uses per model request. Anthropic web search has a
-per-search charge in addition to normal token usage.
+Both are capped at five uses per model request, and fetched page text is capped
+at roughly 25 000 tokens so a single large page cannot fill the context window
+— note that Anthropic applies this limit to text only, not to binary content
+such as PDFs. Anthropic web search has a per-search charge in addition to
+normal token usage.
 
 ---
 

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -27,7 +27,7 @@ Both are configured through a single backend selection. Providers are chosen via
 | **Tavily** | `TAVILY_API_KEY` (optional) | ✔ | ✔ | ✔ Opt-in keyless when selected |
 | **Perplexity** | `PERPLEXITY_API_KEY` | ✔ | ✔ (query-relevant snippets) | Paid (per-request Search API pricing) |
 | **Keenable** | `KEENABLE_API_KEY` (optional) | ✔ | ✔ | ✔ Keyless ring member · paid with key |
-| **Anthropic (native)** | `ANTHROPIC_API_KEY` | ✔ | ✔ | Paid API usage |
+| **Anthropic (native)** | `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` (the model's own credential — Anthropic-served models only) | ✔ | ✔ | Paid (per-search charge + tokens) |
 | **xAI (Grok)** | `XAI_API_KEY` or `hermes auth add xai-oauth` | ✔ | — | Paid (SuperGrok or per-token) |
 
 Brave Search, DDGS, and xAI are **search-only** — pair any of them with Firecrawl/Tavily/Perplexity/Keenable/Exa/Parallel when you also need `web_extract`. DDGS uses the [`ddgs` Python package](https://pypi.org/project/ddgs/) under the hood; if it isn't already installed, run `pip install ddgs` (or let Hermes lazy-install it on first use). xAI runs Grok's server-side `web_search` tool on the Responses API — results are LLM-generated rather than index-backed, so titles, descriptions, and URL choice are all model output (see the [trust-model caveat](#xai-grok) below).
@@ -40,19 +40,7 @@ A fresh install with **no web credentials at all** gets working `web_search` and
 
 **Choosing free vs paid explicitly:** in `hermes tools`, Exa, Parallel, and Keenable each appear as two rows — **Free (keyless)** and **Paid (API key)**. Picking Free pins that vendor's anonymous endpoint (even if you later add a key); picking Paid pins the keyed path (a missing key then errors instead of silently downgrading to the free tier). The selection is stored as `web.provider_tier.<name>: free|paid`; leave it unset for auto (key present → paid, otherwise the keyless ring).
 
-When Anthropic is selected, Hermes maps its existing `web_search` and
-`web_extract` capabilities to Anthropic's server-side `web_search` and
-`web_fetch` tools. The tools run inside the Messages API request, use the same
-Anthropic credential as the model, and return source citations in Claude's
-response. They only ever execute there: there is no client-side fallback, no
-other transport carries them, and compatible third-party Anthropic endpoints
-are not assumed to host them. Hermes therefore counts `anthropic` as a usable
-backend only while the model is served by Anthropic itself — on any other
-model the `web` toolset reports as unconfigured instead of advertising tools
-no request can carry, and `hermes tools` asks you to pick another backend.
-Should a second backend keep `web` enabled while `anthropic` stays selected
-for one capability, that tool remains callable and reports that it cannot run
-locally.
+**Anthropic (native) runs inside the model request:** selecting `anthropic` maps `web_search` and `web_extract` onto Anthropic's server-side `web_search` and `web_fetch` tools. They execute inside the Messages API call, reuse the same Anthropic credential as the model, and return source citations in Claude's response — and they only ever execute there. There is no client-side fallback, no other transport carries them, and compatible third-party Anthropic endpoints are not assumed to host them. Hermes therefore counts `anthropic` as usable only while the model is served by Anthropic itself: when every web capability routes to `anthropic` on a model served elsewhere, the `web` toolset reports as unconfigured rather than advertising tools no request can carry. `hermes tools` keeps listing Anthropic as your stored selection — the picker never overrides a choice you made — but marks the row **not usable on the current model**. The keyless free tier does not cover that gap — an explicit `web.backend` outranks it — so web stays off until you select a backend the active model can reach. If another backend keeps `web` enabled while `anthropic` stays selected for just one capability, that tool remains callable and reports that it cannot run locally (nothing is dispatched, so the one-shot keyless rescue has nothing to rescue). See [Anthropic (native)](#anthropic-native) for setup.
 
 :::tip Nous Subscribers
 If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, web search and extract are available through the **[Tool Gateway](tool-gateway.md)** via managed Firecrawl — no API key needed. New installs can run `hermes setup --portal` to log in and turn on all gateway tools at once; existing installs can flip just web via `hermes tools`.
@@ -123,26 +111,6 @@ Run `hermes tools`, navigate to **Web Search & Extract**, and pick a provider. T
 ```bash
 hermes tools
 ```
-
-### Anthropic (native)
-
-Choose **Anthropic Web Search & Fetch** in `hermes tools`, or configure it
-directly:
-
-```yaml
-web:
-  backend: anthropic
-```
-
-No additional credential is required when `ANTHROPIC_API_KEY` was already
-configured for the model, but the model itself must be served by Anthropic's
-own API — the key alone does not enable this backend elsewhere. Search uses
-`web_search_20250305`; fetch uses `web_fetch_20250910` with citations enabled.
-Both are capped at five uses per model request, and fetched page text is capped
-at roughly 25 000 tokens so a single large page cannot fill the context window
-— note that Anthropic applies this limit to text only, not to binary content
-such as PDFs. Anthropic web search has a per-search charge in addition to
-normal token usage.
 
 ---
 
@@ -363,6 +331,21 @@ Get access at [parallel.ai](https://parallel.ai).
 
 ---
 
+### Anthropic (native) {#anthropic-native}
+
+Choose **Anthropic Web Search & Fetch** in `hermes tools`, or configure it directly:
+
+```yaml
+web:
+  backend: anthropic
+```
+
+No additional credential is required when `ANTHROPIC_API_KEY` (or `CLAUDE_CODE_OAUTH_TOKEN`) was already configured for the model, but the model itself must be served by Anthropic's own API — the key alone does not enable this backend elsewhere. Search uses `web_search_20250305`; fetch uses `web_fetch_20250910` with citations enabled. Both are capped at five uses per model request, and fetched page text is capped at roughly 25 000 tokens so a single large page cannot fill the context window — note that Anthropic applies this limit to text only, not to binary content such as PDFs. Anthropic web search has a per-search charge in addition to normal token usage.
+
+**No `[TRUNCATED]` footers here:** `web.extract_char_limit` and the head+tail window described [above](#how-web_extract-handles-long-pages) bound results that pass through Hermes, and the native fetch never does — it runs inside the Messages API request, so the ~25 000-token server-side cap is what bounds it instead.
+
+---
+
 ### xAI (Grok) {#xai-grok}
 
 Routes `web_search` through Grok's server-side [web_search tool](https://docs.x.ai/developers/tools/web-search) on the Responses API. Grok runs the actual searching and returns the top results as structured JSON.
@@ -419,7 +402,7 @@ Set one provider for all web capabilities:
 ```yaml
 # ~/.hermes/config.yaml
 web:
-  backend: "searxng"   # firecrawl | searxng | brave-free | ddgs | tavily | perplexity | keenable | exa | parallel | xai
+  backend: "searxng"   # firecrawl | searxng | brave-free | ddgs | tavily | perplexity | keenable | exa | parallel | anthropic | xai
 ```
 
 ### Per-capability configuration
@@ -461,6 +444,8 @@ If no backend has **ever** been selected (no `web.backend` / per-capability key 
 **One-shot keyless rescue for keyed backends:** when your chosen/keyed backend fails a call (bad key, outage, upstream 5xx), that single call automatically retries on the keyless free-tier ring instead of erroring — the result notes which vendor served it and why (`rescued_from` / `backend_error`). The failover is never sticky: the very next `web_search`/`web_extract` call attempts your chosen backend again. Disable with `web.keyless_rescue: false` (also off whenever `keyless_fallback` is off).
 
 xAI Web Search is **not** in the auto-detection chain — having `XAI_API_KEY` set (or being signed in via xAI Grok OAuth) does not automatically route web traffic through xAI, since those credentials are also used for inference / TTS / image gen and the user may want a different backend for web. Opt in explicitly with `web.backend: "xai"`.
+
+Anthropic's native web tools are **not** in the auto-detection chain either, for the same reason plus a stronger one: `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` is a model credential that says nothing about which endpoint serves the model, and the tools only run on Anthropic's own endpoint. An Anthropic-only install with no web selection is therefore served by the keyless ring like any other credential-free install. Opt in explicitly with `web.backend: "anthropic"`.
 
 ---
 
@@ -521,6 +506,8 @@ Switch to a self-hosted instance (see [Option A](#option-a--self-host-with-docke
 ### `web_extract` returns truncated content with a `[TRUNCATED]` footer
 
 That's expected for pages over the character budget. The footer names the on-disk file holding the full clean text and the exact `read_file` call to page through the omitted middle. To see more inline, raise `web.extract_char_limit` in `config.yaml` or pass a larger `char_limit` on the call.
+
+Neither knob has any effect on the [Anthropic (native)](#anthropic-native) backend — its fetch is bounded server-side and never produces a `[TRUNCATED]` footer.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Adds support for Anthropic's native server-side web search and web
fetch tools while preserving Hermes' existing provider-neutral `web_search` and
`web_extract` capabilities.

When `web.backend: anthropic` is selected and Hermes is talking directly to the
Anthropic Messages API, the adapter maps:

- `web_search` to `web_search_20250305`
- `web_extract` to `web_fetch_20250910` with citations enabled

The implementation deliberately does not add a local `WebSearchProvider`:
Anthropic executes these tools inside the Messages API request, so the correct
integration boundary is the Anthropic adapter/transport rather than the local
provider registry. The logical server-only binding is projected per transport:
direct Anthropic receives the native definition, while third-party Anthropic
endpoints and non-Anthropic fallbacks omit the unexecutable tool entirely.

The change also preserves native server-tool blocks across turns, exposes
citations to CLI/gateway clients as a compact source list, and handles
Anthropic's `pause_turn` continuation without inserting a synthetic user or
tool message.

## Related Issue

Related to #25234, which explored native Anthropic web search but was closed
without merging. This PR is a focused implementation against current `main`;
the original author is credited in the commit trailer.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a generic internal server-only tool binding to the existing web schemas
  when the Anthropic backend is explicitly selected.
- Serialize native web search/fetch specs only for the direct Anthropic
  endpoint; omit them from compatible third-party and fallback transports.
- Project server-only tools at the transport boundary so Hermes metadata never
  reaches Chat Completions, Bedrock, or Responses API wire payloads.
- Detect native Anthropic endpoints with hostname-boundary matching rather than
  substring matching.
- Safely capture and replay `server_tool_use`, `web_search_tool_result`, and
  `web_fetch_tool_result` blocks in their original order.
- Preserve `pause_turn` as a distinct stop reason and continue it up to a
  bounded limit before falling back or returning a partial error.
- Preserve structured citation metadata for replay and render source URLs in
  Hermes' provider-neutral response text.
- Add **Anthropic Web Search & Fetch** to `hermes tools` without requesting a
  second API key.
- Document configuration, tool versions, endpoint behavior, and usage limits.
- Add behavioral coverage for serialization, replay, citations, continuation,
  explicit backend selection, per-capability selection, and CLI configuration.

## Design and compatibility notes

- Anthropic is explicit-only: merely having `ANTHROPIC_API_KEY` does not replace
  an existing web backend. This avoids selecting an unavailable server-side
  backend when the active model uses OpenRouter or another transport.
- Existing Brave, SearXNG, Firecrawl, Tavily, Exa, Parallel, DDGS, and custom
  provider paths are unchanged.
- `web_search` and `web_fetch` each use `max_uses: 5` per model request.
- No beta header is required for the selected stable tool versions.
- Anthropic performs fetches server-side, so its URL/provenance and private-IP
  protections apply instead of Hermes' local fetch guard.

## How to Test

1. Configure a direct Anthropic model and `ANTHROPIC_API_KEY`.
2. Run `hermes config set web.backend anthropic`.
3. Ask Hermes to search for current information and then fetch one of the
   returned URLs; verify that the answer contains source URLs.
4. Switch to a third-party Anthropic-compatible endpoint or Chat Completions
   fallback and verify the server-only tools are omitted from the request.
5. Run:

   ```bash
   scripts/run_tests.sh \
     tests/agent/test_anthropic_web_server_tools.py \
     tests/agent/test_anthropic_output_field_leak.py \
     tests/agent/transports/test_transport.py \
     tests/agent/test_anthropic_thinking_block_order.py
   ```

Validation completed:

- 13/13 feature contracts, 228/228 transport regressions, and 221/221 affected
  Anthropic adapter/replay tests passed locally.
- The fork CI built the production amd64 image and passed an in-container
  native-tool serialization smoke test.
- `ruff check`, `py_compile`, and `git diff --check` passed for the changed
  files.
- `scripts/check-windows-footguns.py --diff origin/main` reported no findings.
- Paid live tests against the direct Anthropic API passed on
  `claude-sonnet-4-6`: one `web_search` and two `web_fetch` executions. The
  response contained the expected server-use/result blocks, Anthropic usage
  reported exactly one server-tool request per call, block order survived
  replay, output-only fields stayed off the request path, and source URLs were
  exposed in normalized CLI/gateway text. The first fetch run revealed a
  missing source-URL fallback for document-relative citations; this was fixed,
  covered by a regression assertion, and confirmed by the second live fetch.
- The hardened transport projection was then revalidated with another paid
  live `web_search` and `web_fetch`: Anthropic reported exactly one matching
  server-tool request per call, search/fetch exposed 2/1 normalized source URLs,
  and native block order survived replay. The same run confirmed that a
  third-party Anthropic endpoint and Chat Completions fallback omit the
  server-only binding entirely.

CI evidence:
https://github.com/akinfold/hermes-agent/actions/runs/29794982779

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, plus GitHub Actions Ubuntu for tests and image build

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new config key)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this is an adapter/transport integration. The linked GitHub
Actions run contains the focused test, image-build, and container smoke-test
logs.