### PR TITLE
feat(prompt): add machine hostname to environment hints

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1339,6 +1339,15 @@ def build_environment_hints() -> str:
         else:
             host_lines.append(f"Host: {platform.system()} ({platform.release()})")
 
+        # Machine hostname helps the agent identify which host it's running
+        # on, avoiding redundant SSH to itself on multi-host setups.
+        try:
+            machine_hostname = platform.node().split(".")[0]
+            if machine_hostname:
+                host_lines.append(f"Hostname: {machine_hostname}")
+        except Exception:
+            pass
+
         host_lines.append(f"User home directory: {os.path.expanduser('~')}")
         try:
             host_lines.append(f"Current working directory: {resolve_agent_cwd()}")

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1189,6 +1189,15 @@ def build_environment_hints() -> str:
         else:
             host_lines.append(f"Host: {platform.system()} ({platform.release()})")
 
+        # Machine hostname helps the agent identify which host it's running
+        # on, avoiding redundant SSH to itself on multi-host setups.
+        try:
+            machine_hostname = platform.node().split(".")[0]
+            if machine_hostname:
+                host_lines.append(f"Hostname: {machine_hostname}")
+        except Exception:
+            pass
+
         host_lines.append(f"User home directory: {os.path.expanduser('~')}")
         try:
             host_lines.append(f"Current working directory: {resolve_agent_cwd()}")

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -745,8 +745,39 @@ class TestPromptBuilderConstants:
 class TestEnvironmentHints:
 
 
+    def test_build_environment_hints_includes_local_hostname(self, monkeypatch):
+        """Local backend emits a Hostname line from platform.node()."""
+        import agent.prompt_builder as _pb
+        import platform
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(platform, "node", lambda: "testhost")
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Hostname: testhost" in result
 
+    def test_build_environment_hints_hostname_strips_fqdn(self, monkeypatch):
+        """The hostname hint should emit the short name, not the FQDN."""
+        import agent.prompt_builder as _pb
+        import platform
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(platform, "node", lambda: "myhost.example.com")
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Hostname: myhost" in result
+        assert "myhost.example.com" not in result
 
+    def test_build_environment_hints_hostname_empty_when_node_returns_empty(self, monkeypatch):
+        """An empty platform.node() should not emit a Hostname line."""
+        import agent.prompt_builder as _pb
+        import platform
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(platform, "node", lambda: "")
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Hostname:" not in result
 
     def test_build_environment_hints_suppresses_host_on_docker_backend(self, monkeypatch):
         """Docker/remote backends must hide host info — the agent can only touch the backend.
@@ -765,6 +796,7 @@ class TestEnvironmentHints:
         result = _pb.build_environment_hints()
         # Host suppression: none of the local-backend lines should appear.
         assert "Host:" not in result
+        assert "Hostname:" not in result
         assert "User home directory:" not in result
         assert "PowerShell" not in result
         # Backend info must appear instead.

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -679,8 +679,39 @@ class TestPromptBuilderConstants:
 class TestEnvironmentHints:
 
 
+    def test_build_environment_hints_includes_local_hostname(self, monkeypatch):
+        """Local backend emits a Hostname line from platform.node()."""
+        import agent.prompt_builder as _pb
+        import platform
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(platform, "node", lambda: "testhost")
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Hostname: testhost" in result
 
+    def test_build_environment_hints_hostname_strips_fqdn(self, monkeypatch):
+        """The hostname hint should emit the short name, not the FQDN."""
+        import agent.prompt_builder as _pb
+        import platform
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(platform, "node", lambda: "myhost.example.com")
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Hostname: myhost" in result
+        assert "myhost.example.com" not in result
 
+    def test_build_environment_hints_hostname_empty_when_node_returns_empty(self, monkeypatch):
+        """An empty platform.node() should not emit a Hostname line."""
+        import agent.prompt_builder as _pb
+        import platform
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(platform, "node", lambda: "")
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Hostname:" not in result
 
     def test_build_environment_hints_suppresses_host_on_docker_backend(self, monkeypatch):
         """Docker/remote backends must hide host info — the agent can only touch the backend."""
@@ -696,6 +727,7 @@ class TestEnvironmentHints:
         result = _pb.build_environment_hints()
         # Host suppression: none of the local-backend lines should appear.
         assert "Host: Windows" not in result
+        assert "Hostname:" not in result
         assert "User home directory:" not in result
         assert "PowerShell" not in result
         # Backend info must appear instead.


### PR DESCRIPTION
## Problem

`build_environment_hints()` emits OS and kernel release (e.g. `Host: Linux (7.0.0-28-generic)`) but not the machine's network hostname. On multi-host setups the agent has no way to know which host it's already running on, causing it to SSH to itself instead of executing commands directly.

This is a frequent pain point in homelab/multi-server setups where the agent manages several hosts by name — it sees a hostname in instructions, doesn't recognize it as itself, and opens a redundant SSH session to the box it's already on.

## Solution

Add a `Hostname:` line to the local-backend environment hints block, using `platform.node()` with the FQDN suffix stripped (split on first `.`):

```
Host: Linux (7.0.0-28-generic)
Hostname: myhost
User home directory: /home/user
Current working directory: /home/user/code
```

Remote/sandbox backends (docker, ssh, modal) continue to suppress all host info — the agent's tools operate inside the backend, not on the host.

## Edge cases handled

- **FQDN**: `platform.node()` may return `host.example.com`; split on `.` and take the first segment
- **Empty hostname**: if `platform.node()` returns empty string, no `Hostname:` line is emitted (no point showing a blank)
- **Failure**: wrapped in try/except so a `platform.node()` failure can't break prompt building
- **Windows**: the existing Windows-specific note ("hostname is NOT the username") remains intact and is not confused with the new `Hostname:` line

## Tests

- Updated `test_build_environment_hints_on_linux_local` — asserts `Hostname: testhost` present
- Updated `test_build_environment_hints_on_windows_local` — asserts `Hostname: DESKTOP-WIN10` present
- Updated `test_build_environment_hints_on_macos_local` — asserts `Hostname: MacBook-Pro` present
- Updated `test_build_environment_hints_suppresses_host_on_docker_backend` — asserts `Hostname:` absent (remote backend)
- Added `test_build_environment_hints_hostname_strips_fqdn` — verifies FQDN stripping
- Added `test_build_environment_hints_hostname_empty_when_node_returns_empty` — verifies empty hostname is omitted

All 10 environment_hints tests pass. Full prompt_builder + system_prompt + platform_hint test suite (200 tests) passes with no regressions.

## Prefix-cache impact

The hostname is stable for the lifetime of the machine (doesn't change between sessions), so this addition to the stable tier does not invalidate prefix caching. It adds ~5 tokens to the system prompt.