### PR TITLE
fix(kanban): preserve bridge-managed sticky blocks

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3362,7 +3362,7 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
       ``kanban_block(reason="review-required: ...")`` (or somebody ran
       ``hermes kanban block <id>``).  This is a deliberate handoff that
       should stay blocked until an operator unblocks it.  The block tool
-      The block tool emits a ``"blocked"`` event row in ``task_events``.
+      emits a ``"blocked"`` event row in ``task_events``.
       Out-of-process bridge workers use the equivalent ``"bridge_blocked"``
       transition and clear it with ``"bridge_requeued"`` or
       ``"bridge_dispatched"``.
@@ -3373,26 +3373,44 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
       automatically once the underlying conditions change (e.g. parents
       finish, transient infra error clears).
 
-    The cheapest signal that distinguishes the two is the most recent
-    ``"blocked"`` / ``"unblocked"`` event for the task.  If the most
-    recent one is ``"blocked"`` (or there is a ``"blocked"`` event and
-    no ``"unblocked"`` event has fired since), the task is sticky and
-    ``recompute_ready`` must *not* auto-promote it.
-
-    Returns ``False`` when there is no such event at all (e.g. the task
-    was set to ``status='blocked'`` by the circuit breaker or by direct
-    DB manipulation) — preserves the pre-#28712 auto-recover semantics
-    for that path.
+    Canonical and bridge lifecycles are independent: only ``unblocked``
+    clears a canonical block, while a bridge block is cleared by a later
+    bridge clear transition or by ``unblocked``.  A persisted, non-dependency
+    ``block_kind`` is a fail-closed fallback when recovery preserved the task
+    row but lost its sticky event.  Circuit-breaker rows have no such block
+    classification and retain their pre-#28712 auto-recover semantics.
     """
     row = conn.execute(
-        "SELECT kind FROM task_events "
+        "SELECT "
+        "MAX(CASE WHEN kind = 'blocked' THEN id END) AS canonical_block, "
+        "MAX(CASE WHEN kind = 'unblocked' THEN id END) AS canonical_unblock, "
+        "MAX(CASE WHEN kind = 'bridge_blocked' THEN id END) AS bridge_block, "
+        "MAX(CASE WHEN kind IN ('bridge_requeued', 'bridge_dispatched') "
+        "THEN id END) AS bridge_clear "
+        "FROM task_events "
         "WHERE task_id = ? AND kind IN "
         "('blocked', 'unblocked', 'bridge_blocked', "
-        "'bridge_requeued', 'bridge_dispatched') "
-        "ORDER BY id DESC LIMIT 1",
+        "'bridge_requeued', 'bridge_dispatched')",
         (task_id,),
     ).fetchone()
-    return bool(row) and row["kind"] in {"blocked", "bridge_blocked"}
+    canonical_block = int(row["canonical_block"] or 0)
+    canonical_unblock = int(row["canonical_unblock"] or 0)
+    bridge_block = int(row["bridge_block"] or 0)
+    bridge_clear = int(row["bridge_clear"] or 0)
+
+    if canonical_block > canonical_unblock:
+        return True
+    if bridge_block > max(bridge_clear, canonical_unblock):
+        return True
+
+    task = conn.execute(
+        "SELECT status, block_kind FROM tasks WHERE id = ?", (task_id,),
+    ).fetchone()
+    return bool(
+        task
+        and task["status"] == "blocked"
+        and task["block_kind"] in (VALID_BLOCK_KINDS - {"dependency"})
+    )
 
 
 def recompute_ready(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1170,6 +1170,12 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- to ``blocked`` for a human. Preserved across unblock so a re-block for
     -- the SAME kind can be recognised as a loop.
     block_kind           TEXT,
+    -- Durable authority bit for canonical worker/operator blocks. Unlike
+    -- ``block_kind`` this is cleared only by repository-owned release paths.
+    -- A DB trigger rejects blocked -> ready/running updates that leave it set,
+    -- so raw bridge SQL cannot erase the visible block fields first and append
+    -- a bridge receipt afterward.
+    operator_blocked     INTEGER NOT NULL DEFAULT 0,
     -- Unblock-loop counter. Incremented each time a task is re-blocked for the
     -- same truly-blocked reason after having been unblocked. When it reaches
     -- BLOCK_RECURRENCE_LIMIT the task is routed to ``triage`` instead of
@@ -1977,6 +1983,17 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # generic human blocker — same behaviour they had before the column.
         _add_column_if_missing(conn, "tasks", "block_kind", "block_kind TEXT")
 
+    if "operator_blocked" not in cols:
+        # Canonical worker/operator blocks need a durable DB-authority bit.
+        # The legacy event log is backfilled below before the guard trigger is
+        # installed, so already-blocked rows are protected on first upgrade.
+        _add_column_if_missing(
+            conn,
+            "tasks",
+            "operator_blocked",
+            "operator_blocked INTEGER NOT NULL DEFAULT 0",
+        )
+
     if "block_recurrences" not in cols:
         # Unblock-loop counter. Existing rows start at 0, so the loop breaker
         # only begins counting from the first re-block after this migration.
@@ -2099,6 +2116,84 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         )
 
     _rebuild_drifted_tables(conn)
+    _install_operator_block_guard(conn)
+
+
+_OPERATOR_BLOCK_GUARD_TRIGGER = "trg_tasks_operator_block_guard"
+
+
+def _install_operator_block_guard(conn: sqlite3.Connection) -> None:
+    """Backfill and install the DB-level canonical-block transition guard.
+
+    ``kanban_bridge_state.py`` and other broker clients can execute raw SQL,
+    bypassing Python transition helpers entirely. The durable
+    ``operator_blocked`` bit is therefore enforced by SQLite itself: changing
+    a protected row to ``ready`` or ``running`` without clearing that bit in
+    the same authoritative update aborts the whole transaction before a later
+    bridge event can make the rewrite look legitimate.
+
+    The fallback backfill intentionally applies only when no sticky lifecycle
+    event survived. An active ``bridge_blocked`` row may also carry
+    ``block_kind='needs_input'`` but is owned by the independent bridge channel
+    and must remain releasable by a bridge transition.
+    """
+    task_columns = {
+        row["name"] for row in conn.execute("PRAGMA table_info(tasks)")
+    }
+    if not {"status", "block_kind", "operator_blocked"} <= task_columns:
+        # Some migration-unit harnesses intentionally construct only the
+        # additive columns. Real Kanban schemas always have these base fields;
+        # skip guard installation rather than making the additive pass depend
+        # on a synthetic table being otherwise complete.
+        return
+
+    conn.execute(
+        """
+        UPDATE tasks
+           SET operator_blocked = 1
+         WHERE status = 'blocked'
+           AND operator_blocked = 0
+           AND (
+               COALESCE((
+                   SELECT MAX(e.id) FROM task_events e
+                    WHERE e.task_id = tasks.id AND e.kind = 'blocked'
+               ), 0) > COALESCE((
+                   SELECT MAX(e.id) FROM task_events e
+                    WHERE e.task_id = tasks.id AND e.kind = 'unblocked'
+               ), 0)
+               OR (
+                   block_kind IN ('needs_input', 'capability', 'transient')
+                   AND NOT EXISTS (
+                       SELECT 1 FROM task_events e
+                        WHERE e.task_id = tasks.id
+                          AND e.kind IN (
+                              'blocked', 'unblocked', 'bridge_blocked',
+                              'bridge_requeued', 'bridge_dispatched'
+                          )
+                   )
+               )
+           )
+        """
+    )
+    # Recreate rather than CREATE IF NOT EXISTS so upgrades cannot retain an
+    # older trigger body under the same stable schema-object name.
+    conn.execute(f"DROP TRIGGER IF EXISTS {_OPERATOR_BLOCK_GUARD_TRIGGER}")
+    conn.execute(
+        f"""
+        CREATE TRIGGER {_OPERATOR_BLOCK_GUARD_TRIGGER}
+        BEFORE UPDATE OF status ON tasks
+        FOR EACH ROW
+        WHEN OLD.operator_blocked = 1
+         AND NEW.operator_blocked = 1
+         AND NEW.status IN ('ready', 'running')
+        BEGIN
+            SELECT RAISE(
+                ABORT,
+                'operator-blocked task requires authoritative unblock'
+            );
+        END
+        """
+    )
 
 
 # Legacy DBs defined these tables with a ``TEXT PRIMARY KEY`` id (or, for
@@ -3380,6 +3475,13 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     row but lost its sticky event.  Circuit-breaker rows have no such block
     classification and retain their pre-#28712 auto-recover semantics.
     """
+    task = conn.execute(
+        "SELECT status, block_kind, operator_blocked FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if task and bool(task["operator_blocked"]):
+        return True
+
     row = conn.execute(
         "SELECT "
         "MAX(CASE WHEN kind = 'blocked' THEN id END) AS canonical_block, "
@@ -3403,9 +3505,6 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     if bridge_block > max(bridge_clear, canonical_unblock):
         return True
 
-    task = conn.execute(
-        "SELECT status, block_kind FROM tasks WHERE id = ?", (task_id,),
-    ).fetchone()
     return bool(
         task
         and task["status"] == "blocked"
@@ -4196,6 +4295,7 @@ def complete_task(
                        claim_expires= NULL,
                        worker_pid   = NULL,
                        block_kind   = NULL,
+                       operator_blocked = 0,
                        block_recurrences = 0
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked')
@@ -4213,6 +4313,7 @@ def complete_task(
                        claim_expires= NULL,
                        worker_pid   = NULL,
                        block_kind   = NULL,
+                       operator_blocked = 0,
                        block_recurrences = 0
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked')
@@ -4964,7 +5065,8 @@ def block_task(
                        claim_lock    = NULL,
                        claim_expires = NULL,
                        worker_pid    = NULL,
-                       block_kind    = ?
+                       block_kind    = ?,
+                       operator_blocked = 0
                  WHERE id = ?
                    AND status IN ('running', 'ready')
                 """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
@@ -5018,7 +5120,8 @@ def block_task(
                        claim_expires = NULL,
                        worker_pid    = NULL,
                        block_kind    = ?,
-                       block_recurrences = ?
+                       block_recurrences = ?,
+                       operator_blocked = 0
                  WHERE id = ?
                    AND status IN ('running', 'ready')
                 """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
@@ -5057,7 +5160,8 @@ def block_task(
                            claim_expires = NULL,
                            worker_pid    = NULL,
                            block_kind    = ?,
-                           block_recurrences = ?
+                           block_recurrences = ?,
+                           operator_blocked = 1
                      WHERE id = ?
                        AND status IN ('running', 'ready')
                     """,
@@ -5072,7 +5176,8 @@ def block_task(
                            claim_expires = NULL,
                            worker_pid    = NULL,
                            block_kind    = ?,
-                           block_recurrences = ?
+                           block_recurrences = ?,
+                           operator_blocked = 1
                      WHERE id = ?
                        AND status IN ('running', 'ready')
                        AND current_run_id = ?
@@ -5142,6 +5247,12 @@ def promote_task(
         return False, (
             f"task {task_id} is {cur_status!r}; promote only applies to "
             f"'todo' or 'blocked'"
+        )
+
+    if cur_status == "blocked" and _has_sticky_block(conn, task_id):
+        return False, (
+            f"task {task_id} is explicitly blocked; use unblock so the "
+            "canonical operator block is released atomically"
         )
 
     if not force:
@@ -5235,6 +5346,7 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         # start for the dispatcher's retry budget.
         cur = conn.execute(
             "UPDATE tasks SET status = ?, current_run_id = NULL, "
+            "operator_blocked = 0, "
             "consecutive_failures = 0, last_failure_error = NULL "
             "WHERE id = ? AND status IN ('blocked', 'scheduled')",
             (new_status, task_id),
@@ -5565,7 +5677,7 @@ def decompose_triage_task(
 def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
     with write_txn(conn):
         cur = conn.execute(
-            "UPDATE tasks SET status = 'archived', "
+            "UPDATE tasks SET status = 'archived', operator_blocked = 0, "
             "    claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
             "WHERE id = ? AND status != 'archived'",
             (task_id,),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2132,10 +2132,12 @@ def _install_operator_block_guard(conn: sqlite3.Connection) -> None:
     the same authoritative update aborts the whole transaction before a later
     bridge event can make the rewrite look legitimate.
 
-    The fallback backfill intentionally applies only when no sticky lifecycle
-    event survived. An active ``bridge_blocked`` row may also carry
-    ``block_kind='needs_input'`` but is owned by the independent bridge channel
-    and must remain releasable by a bridge transition.
+    Upgrade custody uses all surviving durable evidence. A classified blocked
+    row is fail-closed unless it is demonstrably owned by an active bridge
+    lifecycle or by circuit-breaker failure evidence. In particular, a latest
+    ``task_runs.outcome='blocked'`` preserves a canonical re-block when recovery
+    lost only its newest ``blocked`` event but older block/unblock history
+    survived.
     """
     task_columns = {
         row["name"] for row in conn.execute("PRAGMA table_info(tasks)")
@@ -2149,30 +2151,63 @@ def _install_operator_block_guard(conn: sqlite3.Connection) -> None:
 
     conn.execute(
         """
+        WITH block_evidence AS (
+            SELECT
+                t.id,
+                t.block_kind,
+                COALESCE(MAX(CASE WHEN e.kind = 'blocked' THEN e.id END), 0)
+                    AS canonical_block,
+                COALESCE(MAX(CASE WHEN e.kind = 'unblocked' THEN e.id END), 0)
+                    AS canonical_unblock,
+                COALESCE(MAX(CASE WHEN e.kind = 'bridge_blocked' THEN e.id END), 0)
+                    AS bridge_block,
+                COALESCE(MAX(CASE
+                    WHEN e.kind IN ('bridge_requeued', 'bridge_dispatched')
+                    THEN e.id END), 0) AS bridge_clear,
+                COALESCE(MAX(CASE WHEN e.kind = 'gave_up' THEN e.id END), 0)
+                    AS gave_up,
+                (
+                    SELECT r.outcome
+                      FROM task_runs r
+                     WHERE r.task_id = t.id
+                     ORDER BY r.id DESC
+                     LIMIT 1
+                ) AS latest_run_outcome
+              FROM tasks t
+              LEFT JOIN task_events e
+                ON e.task_id = t.id
+               AND e.kind IN (
+                   'blocked', 'unblocked', 'bridge_blocked',
+                   'bridge_requeued', 'bridge_dispatched', 'gave_up'
+               )
+             WHERE t.status = 'blocked'
+               AND t.operator_blocked = 0
+             GROUP BY t.id, t.block_kind
+        )
         UPDATE tasks
            SET operator_blocked = 1
-         WHERE status = 'blocked'
-           AND operator_blocked = 0
-           AND (
-               COALESCE((
-                   SELECT MAX(e.id) FROM task_events e
-                    WHERE e.task_id = tasks.id AND e.kind = 'blocked'
-               ), 0) > COALESCE((
-                   SELECT MAX(e.id) FROM task_events e
-                    WHERE e.task_id = tasks.id AND e.kind = 'unblocked'
-               ), 0)
-               OR (
-                   block_kind IN ('needs_input', 'capability', 'transient')
-                   AND NOT EXISTS (
-                       SELECT 1 FROM task_events e
-                        WHERE e.task_id = tasks.id
-                          AND e.kind IN (
-                              'blocked', 'unblocked', 'bridge_blocked',
-                              'bridge_requeued', 'bridge_dispatched'
-                          )
-                   )
-               )
-           )
+         WHERE id IN (
+             SELECT id
+               FROM block_evidence
+              WHERE canonical_block > canonical_unblock
+                 OR (
+                     block_kind IN ('needs_input', 'capability', 'transient')
+                     AND bridge_block <= MAX(bridge_clear, canonical_unblock)
+                     AND (
+                         latest_run_outcome = 'blocked'
+                         OR (
+                             COALESCE(latest_run_outcome, '') NOT IN (
+                                 'gave_up', 'spawn_failed', 'crashed',
+                                 'timed_out', 'failed'
+                             )
+                             AND gave_up <= MAX(
+                                 canonical_block, canonical_unblock,
+                                 bridge_block, bridge_clear
+                             )
+                         )
+                     )
+                 )
+         )
         """
     )
     # Recreate rather than CREATE IF NOT EXISTS so upgrades cannot retain an
@@ -3472,8 +3507,10 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     clears a canonical block, while a bridge block is cleared by a later
     bridge clear transition or by ``unblocked``.  A persisted, non-dependency
     ``block_kind`` is a fail-closed fallback when recovery preserved the task
-    row but lost its sticky event.  Circuit-breaker rows have no such block
-    classification and retain their pre-#28712 auto-recover semantics.
+    row but lost its sticky event. Because explicit unblock preserves that
+    classification for recurrence detection, a later circuit-breaker row is
+    distinguished by its latest failure-run or ``gave_up`` evidence and keeps
+    the pre-#28712 auto-recover semantics.
     """
     task = conn.execute(
         "SELECT status, block_kind, operator_blocked FROM tasks WHERE id = ?",
@@ -3488,28 +3525,52 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
         "MAX(CASE WHEN kind = 'unblocked' THEN id END) AS canonical_unblock, "
         "MAX(CASE WHEN kind = 'bridge_blocked' THEN id END) AS bridge_block, "
         "MAX(CASE WHEN kind IN ('bridge_requeued', 'bridge_dispatched') "
-        "THEN id END) AS bridge_clear "
+        "THEN id END) AS bridge_clear, "
+        "MAX(CASE WHEN kind = 'gave_up' THEN id END) AS gave_up "
         "FROM task_events "
         "WHERE task_id = ? AND kind IN "
         "('blocked', 'unblocked', 'bridge_blocked', "
-        "'bridge_requeued', 'bridge_dispatched')",
+        "'bridge_requeued', 'bridge_dispatched', 'gave_up')",
         (task_id,),
     ).fetchone()
     canonical_block = int(row["canonical_block"] or 0)
     canonical_unblock = int(row["canonical_unblock"] or 0)
     bridge_block = int(row["bridge_block"] or 0)
     bridge_clear = int(row["bridge_clear"] or 0)
+    gave_up = int(row["gave_up"] or 0)
 
     if canonical_block > canonical_unblock:
         return True
     if bridge_block > max(bridge_clear, canonical_unblock):
         return True
 
-    return bool(
+    classified_recovery = bool(
         task
         and task["status"] == "blocked"
         and task["block_kind"] in (VALID_BLOCK_KINDS - {"dependency"})
     )
+    if not classified_recovery:
+        return False
+
+    latest_run = conn.execute(
+        "SELECT outcome FROM task_runs WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    latest_outcome = latest_run["outcome"] if latest_run else None
+    if latest_outcome == "blocked":
+        return True
+    if latest_outcome in {
+        "gave_up", "spawn_failed", "crashed", "timed_out", "failed",
+    }:
+        return False
+    if gave_up > max(
+        canonical_block, canonical_unblock, bridge_block, bridge_clear,
+    ):
+        return False
+
+    # Recovery preserved a classified blocked row but no authoritative release
+    # or circuit-breaker evidence. Ambiguity is an operator gate: fail closed.
+    return True
 
 
 def recompute_ready(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3362,7 +3362,10 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
       ``kanban_block(reason="review-required: ...")`` (or somebody ran
       ``hermes kanban block <id>``).  This is a deliberate handoff that
       should stay blocked until an operator unblocks it.  The block tool
-      emits a ``"blocked"`` event row in ``task_events``.
+      The block tool emits a ``"blocked"`` event row in ``task_events``.
+      Out-of-process bridge workers use the equivalent ``"bridge_blocked"``
+      transition and clear it with ``"bridge_requeued"`` or
+      ``"bridge_dispatched"``.
 
     * **Circuit-breaker** — ``_record_task_failure`` tripped after
       repeated crashes / spawn failures / timeouts.  This emits
@@ -3383,11 +3386,13 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     """
     row = conn.execute(
         "SELECT kind FROM task_events "
-        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
+        "WHERE task_id = ? AND kind IN "
+        "('blocked', 'unblocked', 'bridge_blocked', "
+        "'bridge_requeued', 'bridge_dispatched') "
         "ORDER BY id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
-    return bool(row) and row["kind"] == "blocked"
+    return bool(row) and row["kind"] in {"blocked", "bridge_blocked"}
 
 
 def recompute_ready(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2137,7 +2137,9 @@ def _install_operator_block_guard(conn: sqlite3.Connection) -> None:
     lifecycle or by circuit-breaker failure evidence. In particular, a latest
     ``task_runs.outcome='blocked'`` preserves a canonical re-block when recovery
     lost only its newest ``blocked`` event but older block/unblock history
-    survived.
+    survived. A failure run is considered current only when the task row still
+    carries a matching failure counter and error; a stale crash run alone is
+    ambiguous and therefore remains an operator gate.
     """
     task_columns = {
         row["name"] for row in conn.execute("PRAGMA table_info(tasks)")
@@ -2155,6 +2157,8 @@ def _install_operator_block_guard(conn: sqlite3.Connection) -> None:
             SELECT
                 t.id,
                 t.block_kind,
+                t.consecutive_failures,
+                t.last_failure_error,
                 COALESCE(MAX(CASE WHEN e.kind = 'blocked' THEN e.id END), 0)
                     AS canonical_block,
                 COALESCE(MAX(CASE WHEN e.kind = 'unblocked' THEN e.id END), 0)
@@ -2172,7 +2176,14 @@ def _install_operator_block_guard(conn: sqlite3.Connection) -> None:
                      WHERE r.task_id = t.id
                      ORDER BY r.id DESC
                      LIMIT 1
-                ) AS latest_run_outcome
+                ) AS latest_run_outcome,
+                (
+                    SELECT r.error
+                      FROM task_runs r
+                     WHERE r.task_id = t.id
+                     ORDER BY r.id DESC
+                     LIMIT 1
+                ) AS latest_run_error
               FROM tasks t
               LEFT JOIN task_events e
                 ON e.task_id = t.id
@@ -2182,7 +2193,9 @@ def _install_operator_block_guard(conn: sqlite3.Connection) -> None:
                )
              WHERE t.status = 'blocked'
                AND t.operator_blocked = 0
-             GROUP BY t.id, t.block_kind
+             GROUP BY
+                 t.id, t.block_kind, t.consecutive_failures,
+                 t.last_failure_error
         )
         UPDATE tasks
            SET operator_blocked = 1
@@ -2193,16 +2206,18 @@ def _install_operator_block_guard(conn: sqlite3.Connection) -> None:
                  OR (
                      block_kind IN ('needs_input', 'capability', 'transient')
                      AND bridge_block <= MAX(bridge_clear, canonical_unblock)
-                     AND (
-                         latest_run_outcome = 'blocked'
+                     AND NOT (
+                         gave_up > MAX(
+                             canonical_block, canonical_unblock,
+                             bridge_block, bridge_clear
+                         )
                          OR (
-                             COALESCE(latest_run_outcome, '') NOT IN (
+                             COALESCE(consecutive_failures, 0) > 0
+                             AND last_failure_error IS NOT NULL
+                             AND latest_run_error = last_failure_error
+                             AND latest_run_outcome IN (
                                  'gave_up', 'spawn_failed', 'crashed',
                                  'timed_out', 'failed'
-                             )
-                             AND gave_up <= MAX(
-                                 canonical_block, canonical_unblock,
-                                 bridge_block, bridge_clear
                              )
                          )
                      )
@@ -3513,7 +3528,9 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     the pre-#28712 auto-recover semantics.
     """
     task = conn.execute(
-        "SELECT status, block_kind, operator_blocked FROM tasks WHERE id = ?",
+        "SELECT status, block_kind, operator_blocked, "
+        "consecutive_failures, last_failure_error "
+        "FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if task and bool(task["operator_blocked"]):
@@ -3553,18 +3570,22 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
         return False
 
     latest_run = conn.execute(
-        "SELECT outcome FROM task_runs WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+        "SELECT outcome, error FROM task_runs WHERE task_id = ? "
+        "ORDER BY id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
     latest_outcome = latest_run["outcome"] if latest_run else None
-    if latest_outcome == "blocked":
-        return True
-    if latest_outcome in {
-        "gave_up", "spawn_failed", "crashed", "timed_out", "failed",
-    }:
-        return False
     if gave_up > max(
         canonical_block, canonical_unblock, bridge_block, bridge_clear,
+    ):
+        return False
+    if (
+        latest_outcome in {
+            "gave_up", "spawn_failed", "crashed", "timed_out", "failed",
+        }
+        and int(task["consecutive_failures"] or 0) > 0
+        and task["last_failure_error"] is not None
+        and latest_run["error"] == task["last_failure_error"]
     ):
         return False
 

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -478,6 +478,79 @@ def test_init_backfills_recovered_reblock_with_missing_latest_event(
         assert kb.claim_task(conn, tid, claimer="test:claim") is None
 
 
+@pytest.mark.parametrize(
+    "clear_event",
+    ["bridge_requeued", "bridge_dispatched"],
+)
+def test_init_fail_closes_replayed_block_over_stale_crash_run(
+    kanban_home: Path,
+    clear_event: str,
+) -> None:
+    """A stale crash run cannot erase a later status-replay operator gate.
+
+    This is the selected-recovery shape of incident task ``t_fb8f9f0f``:
+    replay restored ``blocked``/``needs_input`` with no current failure fields,
+    while an older pre-recovery run remained ``crashed``. The run alone is not
+    current circuit-breaker evidence, so ambiguous recovery must fail closed.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title=f"replayed gate vs {clear_event}")
+        claimed = kb.claim_task(conn, tid, claimer="test:pre-recovery")
+        assert claimed is not None
+        with kb.write_txn(conn):
+            assert kb._end_run(
+                conn,
+                tid,
+                outcome="crashed",
+                status="crashed",
+                error="older pre-recovery crash",
+            ) is not None
+            conn.execute(
+                """UPDATE tasks
+                      SET status = 'blocked', block_kind = 'needs_input',
+                          operator_blocked = 0, consecutive_failures = 0,
+                          last_failure_error = NULL, claim_lock = NULL,
+                          claim_expires = NULL, worker_pid = NULL
+                    WHERE id = ?""",
+                (tid,),
+            )
+            conn.execute(
+                "DELETE FROM task_events WHERE task_id=? AND kind IN "
+                "('blocked', 'unblocked', 'bridge_blocked', "
+                "'bridge_requeued', 'bridge_dispatched', 'gave_up')",
+                (tid,),
+            )
+        conn.execute(f"DROP TRIGGER IF EXISTS {kb._OPERATOR_BLOCK_GUARD_TRIGGER}")
+        conn.commit()
+        row = conn.execute(
+            "SELECT status, block_kind, consecutive_failures, last_failure_error "
+            "FROM tasks WHERE id=?",
+            (tid,),
+        ).fetchone()
+        assert row is not None
+        assert (
+            row["status"], row["block_kind"], row["consecutive_failures"],
+            row["last_failure_error"],
+        ) == ("blocked", "needs_input", 0, None)
+        assert conn.execute(
+            "SELECT outcome FROM task_runs WHERE task_id=? ORDER BY id DESC LIMIT 1",
+            (tid,),
+        ).fetchone()["outcome"] == "crashed"
+
+    kb.init_db()
+    with kb.connect() as conn:
+        assert conn.execute(
+            "SELECT operator_blocked FROM tasks WHERE id=?", (tid,),
+        ).fetchone()["operator_blocked"] == 1
+        with pytest.raises(
+            sqlite3.IntegrityError,
+            match="operator-blocked task requires authoritative unblock",
+        ):
+            _apply_real_bridge_transition(conn, tid, clear_event)
+        assert kb.recompute_ready(conn) == 0
+        assert kb.claim_task(conn, tid, claimer="test:claim") is None
+
+
 def test_init_does_not_claim_stale_block_kind_after_circuit_breaker(
     kanban_home: Path,
 ) -> None:
@@ -518,6 +591,13 @@ def test_init_does_not_claim_stale_block_kind_after_circuit_breaker(
             "SELECT outcome FROM task_runs WHERE task_id=? ORDER BY id DESC LIMIT 1",
             (tid,),
         ).fetchone()["outcome"] == "gave_up"
+        # Prove current task-row failure state plus the failure run is enough to
+        # retain automatic circuit-breaker recovery even if its gave_up event
+        # was lost from the recovered event tail.
+        conn.execute(
+            "DELETE FROM task_events WHERE task_id=? AND kind='gave_up'", (tid,),
+        )
+        conn.commit()
 
     kb.init_db()
     with kb.connect() as conn:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -282,6 +282,74 @@ def test_bridge_block_is_sticky_until_bridge_clear_transition(
         assert kb.claim_task(conn, canonical) is None
 
 
+def _apply_real_bridge_transition(
+    conn: sqlite3.Connection,
+    task_id: str,
+    clear_event: str,
+) -> None:
+    """Execute the live bridge's exact UPDATE-then-event transaction."""
+    now = int(time.time())
+    with kb.write_txn(conn):
+        if clear_event == "bridge_dispatched":
+            conn.execute(
+                """UPDATE tasks
+                   SET status = 'running', assignee = ?,
+                       started_at = COALESCE(started_at, ?), completed_at = NULL,
+                       workspace_path = COALESCE(?, workspace_path),
+                       branch_name = COALESCE(?, branch_name),
+                       claim_lock = ?, claim_expires = ?, worker_pid = ?,
+                       last_heartbeat_at = ?, current_run_id = NULL,
+                       block_kind = NULL, last_failure_error = NULL
+                   WHERE id = ?""",
+                (
+                    "orchestrator",
+                    now,
+                    None,
+                    None,
+                    "acp:test:external",
+                    now + 7200,
+                    None,
+                    now,
+                    task_id,
+                ),
+            )
+        else:
+            conn.execute(
+                """UPDATE tasks
+                   SET status = ?, assignee = ?, completed_at = ?,
+                       workspace_path = COALESCE(?, workspace_path),
+                       branch_name = COALESCE(?, branch_name),
+                       claim_lock = NULL, claim_expires = NULL, worker_pid = NULL,
+                       last_heartbeat_at = ?, current_run_id = NULL,
+                       block_kind = CASE WHEN ? = 'blocked' THEN 'needs_input' ELSE NULL END,
+                       last_failure_error = COALESCE(?, last_failure_error),
+                       result = COALESCE(?, result)
+                   WHERE id = ?""",
+                (
+                    "ready",
+                    "orchestrator",
+                    None,
+                    None,
+                    None,
+                    now,
+                    "ready",
+                    None,
+                    None,
+                    task_id,
+                ),
+            )
+        conn.execute(
+            "INSERT INTO task_events(task_id, run_id, kind, payload, created_at) "
+            "VALUES (?, NULL, ?, ?, ?)",
+            (
+                task_id,
+                clear_event,
+                json.dumps({"from": "blocked", "to": clear_event}),
+                now,
+            ),
+        )
+
+
 @pytest.mark.parametrize(
     "clear_event",
     ["bridge_requeued", "bridge_dispatched"],
@@ -308,75 +376,11 @@ def test_canonical_block_rejects_real_bridge_update_before_event(
             kind="needs_input",
             expected_run_id=claimed.current_run_id,
         )
-        now = int(time.time())
-
         with pytest.raises(
             sqlite3.IntegrityError,
             match="operator-blocked task requires authoritative unblock",
         ):
-            with kb.write_txn(conn):
-                if clear_event == "bridge_dispatched":
-                    # Exact column/update order from kanban_bridge_state.py's
-                    # ``state == 'running'`` branch.
-                    conn.execute(
-                        """UPDATE tasks
-                           SET status = 'running', assignee = ?,
-                               started_at = COALESCE(started_at, ?), completed_at = NULL,
-                               workspace_path = COALESCE(?, workspace_path),
-                               branch_name = COALESCE(?, branch_name),
-                               claim_lock = ?, claim_expires = ?, worker_pid = ?,
-                               last_heartbeat_at = ?, current_run_id = NULL,
-                               block_kind = NULL, last_failure_error = NULL
-                           WHERE id = ?""",
-                        (
-                            "orchestrator",
-                            now,
-                            None,
-                            None,
-                            "acp:test:external",
-                            now + 7200,
-                            None,
-                            now,
-                            tid,
-                        ),
-                    )
-                else:
-                    # Exact column/update order from the writer's generic
-                    # branch when ``state == 'ready'``.
-                    conn.execute(
-                        """UPDATE tasks
-                           SET status = ?, assignee = ?, completed_at = ?,
-                               workspace_path = COALESCE(?, workspace_path),
-                               branch_name = COALESCE(?, branch_name),
-                               claim_lock = NULL, claim_expires = NULL, worker_pid = NULL,
-                               last_heartbeat_at = ?, current_run_id = NULL,
-                               block_kind = CASE WHEN ? = 'blocked' THEN 'needs_input' ELSE NULL END,
-                               last_failure_error = COALESCE(?, last_failure_error),
-                               result = COALESCE(?, result)
-                           WHERE id = ?""",
-                        (
-                            "ready",
-                            "orchestrator",
-                            None,
-                            None,
-                            None,
-                            now,
-                            "ready",
-                            None,
-                            None,
-                            tid,
-                        ),
-                    )
-                conn.execute(
-                    "INSERT INTO task_events(task_id, run_id, kind, payload, created_at) "
-                    "VALUES (?, NULL, ?, ?, ?)",
-                    (
-                        tid,
-                        clear_event,
-                        json.dumps({"from": "blocked", "to": clear_event}),
-                        now,
-                    ),
-                )
+            _apply_real_bridge_transition(conn, tid, clear_event)
 
         task = kb.get_task(conn, tid)
         assert task is not None
@@ -391,6 +395,139 @@ def test_canonical_block_rejects_real_bridge_update_before_event(
             (tid, clear_event),
         ).fetchone()["n"] == 0
         assert kb.claim_task(conn, tid, claimer="test:claim") is None
+
+
+@pytest.mark.parametrize(
+    "clear_event",
+    ["bridge_requeued", "bridge_dispatched"],
+)
+def test_init_backfills_recovered_reblock_with_missing_latest_event(
+    kanban_home: Path,
+    clear_event: str,
+) -> None:
+    """A surviving blocked run must preserve a recovered canonical re-block."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title=f"recovered reblock vs {clear_event}")
+        first = kb.claim_task(conn, tid, claimer="test:first")
+        assert first is not None
+        assert kb.block_task(
+            conn,
+            tid,
+            reason="review-required: first operator gate",
+            kind="needs_input",
+            expected_run_id=first.current_run_id,
+        )
+        assert kb.unblock_task(conn, tid)
+
+        second = kb.claim_task(conn, tid, claimer="test:second")
+        assert second is not None
+        assert kb.block_task(
+            conn,
+            tid,
+            reason="capability gate after recovery",
+            kind="capability",
+            expected_run_id=second.current_run_id,
+        )
+        latest_run = conn.execute(
+            "SELECT outcome FROM task_runs WHERE task_id=? ORDER BY id DESC LIMIT 1",
+            (tid,),
+        ).fetchone()
+        assert latest_run is not None and latest_run["outcome"] == "blocked"
+
+        # Model an upgrade from a recovered DB: the new authority column starts
+        # at its additive default, and only the newest canonical block event was
+        # lost. Older blocked -> unblocked history still survives, which must not
+        # outweigh the current classified row plus its latest blocked run.
+        conn.execute(
+            "DELETE FROM task_events WHERE id = ("
+            "SELECT MAX(id) FROM task_events WHERE task_id=? AND kind='blocked')",
+            (tid,),
+        )
+        conn.execute("UPDATE tasks SET operator_blocked=0 WHERE id=?", (tid,))
+        conn.execute(f"DROP TRIGGER IF EXISTS {kb._OPERATOR_BLOCK_GUARD_TRIGGER}")
+        conn.commit()
+        lifecycle = [
+            row["kind"]
+            for row in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id=? "
+                "AND kind IN ('blocked', 'unblocked') ORDER BY id",
+                (tid,),
+            )
+        ]
+        assert lifecycle == ["blocked", "unblocked"]
+
+    kb.init_db()
+    with kb.connect() as conn:
+        row = conn.execute(
+            "SELECT status, block_kind, operator_blocked FROM tasks WHERE id=?",
+            (tid,),
+        ).fetchone()
+        assert row is not None
+        assert (row["status"], row["block_kind"], row["operator_blocked"]) == (
+            "blocked", "capability", 1,
+        )
+        with pytest.raises(
+            sqlite3.IntegrityError,
+            match="operator-blocked task requires authoritative unblock",
+        ):
+            _apply_real_bridge_transition(conn, tid, clear_event)
+        assert conn.execute(
+            "SELECT COUNT(*) AS n FROM task_events WHERE task_id=? AND kind=?",
+            (tid, clear_event),
+        ).fetchone()["n"] == 0
+        assert kb.claim_task(conn, tid, claimer="test:claim") is None
+
+
+def test_init_does_not_claim_stale_block_kind_after_circuit_breaker(
+    kanban_home: Path,
+) -> None:
+    """Known failure-run evidence keeps circuit-breaker recovery automatic."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="operator unblock then circuit breaker")
+        first = kb.claim_task(conn, tid, claimer="test:first")
+        assert first is not None
+        assert kb.block_task(
+            conn,
+            tid,
+            reason="review-required: prior operator gate",
+            kind="needs_input",
+            expected_run_id=first.current_run_id,
+        )
+        assert kb.unblock_task(conn, tid)
+
+        second = kb.claim_task(conn, tid, claimer="test:second")
+        assert second is not None
+        assert kb._record_task_failure(
+            conn,
+            tid,
+            "transient spawn failure",
+            outcome="spawn_failed",
+            failure_limit=1,
+            release_claim=True,
+            end_run=True,
+        )
+        row = conn.execute(
+            "SELECT status, block_kind, operator_blocked FROM tasks WHERE id=?",
+            (tid,),
+        ).fetchone()
+        assert row is not None
+        assert (row["status"], row["block_kind"], row["operator_blocked"]) == (
+            "blocked", "needs_input", 0,
+        )
+        assert conn.execute(
+            "SELECT outcome FROM task_runs WHERE task_id=? ORDER BY id DESC LIMIT 1",
+            (tid,),
+        ).fetchone()["outcome"] == "gave_up"
+
+    kb.init_db()
+    with kb.connect() as conn:
+        assert conn.execute(
+            "SELECT operator_blocked FROM tasks WHERE id=?", (tid,),
+        ).fetchone()["operator_blocked"] == 0
+        assert kb.recompute_ready(conn, failure_limit=2) == 1
+        recovered = kb.get_task(conn, tid)
+        assert recovered is not None
+        assert recovered.status == "ready"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -13,6 +13,7 @@ These tests pin down:
 
 * Worker / operator-initiated blocks are sticky and survive
   ``recompute_ready``.
+* Out-of-process bridge blocks obey the same sticky lifecycle.
 * Circuit-breaker blocks (``gave_up`` event, status flipped via
   ``_record_task_failure``) still auto-recover — the original intent
   of #40c1decb3 is preserved.
@@ -97,6 +98,54 @@ def test_worker_block_on_child_with_done_parents_is_still_sticky(kanban_home: Pa
         promoted = kb.recompute_ready(conn)
         assert promoted == 0
         assert kb.get_task(conn, child).status == "blocked"
+
+
+# ---------------------------------------------------------------------------
+# Out-of-process bridge blocks must share the sticky lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("clear_event", ["bridge_requeued", "bridge_dispatched"])
+def test_bridge_block_is_sticky_until_bridge_clear_transition(
+    kanban_home: Path,
+    clear_event: str,
+) -> None:
+    """A bridge-managed worker emits bridge-specific transition names.
+
+    Treating ``bridge_blocked`` as ordinary direct DB manipulation lets the
+    dispatcher immediately re-promote review-gated work.  A later explicit
+    bridge requeue or dispatch must clear that sticky state, just like
+    ``unblock_task`` clears a canonical worker block.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="bridge-managed review")
+        now = int(time.time())
+        conn.execute("UPDATE tasks SET status='blocked' WHERE id=?", (tid,))
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'bridge_blocked', NULL, ?)",
+            (tid, now),
+        )
+        conn.commit()
+
+        assert kb.recompute_ready(conn) == 0
+        blocked_task = kb.get_task(conn, tid)
+        assert blocked_task is not None
+        assert blocked_task.status == "blocked"
+
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, ?, NULL, ?)",
+            (tid, clear_event, now + 1),
+        )
+        conn.commit()
+
+        # A later transient status-only block is recoverable once the bridge
+        # has explicitly cleared its prior review gate.
+        assert kb.recompute_ready(conn) == 1
+        ready_task = kb.get_task(conn, tid)
+        assert ready_task is not None
+        assert ready_task.status == "ready"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -30,6 +30,8 @@ landed via #28754 / #28781 ahead of this fix.
 
 from __future__ import annotations
 
+import json
+import sqlite3
 import time
 from pathlib import Path
 
@@ -70,6 +72,12 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
         )
         assert kb.get_task(conn, tid).status == "blocked"
 
+        promoted_ok, promote_error = kb.promote_task(
+            conn, tid, actor="test-operator", force=True,
+        )
+        assert not promoted_ok
+        assert promote_error is not None and "use unblock" in promote_error
+
         # Hammer the promotion code — exactly the dispatcher loop's
         # behaviour, just compressed in time.
         for _ in range(5):
@@ -89,6 +97,76 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
         assert recovered is not None
         assert recovered.status == "blocked"
         assert kb.claim_task(conn, tid) is None
+
+
+def test_init_backfills_recovered_canonical_block_without_claiming_bridge_block(
+    kanban_home: Path,
+) -> None:
+    """Upgrade backfill protects event-loss rows but not the bridge channel."""
+    with kb.connect() as conn:
+        recovered = kb.create_task(conn, title="recovered canonical block")
+        conn.execute(
+            "UPDATE tasks SET status='blocked', block_kind='needs_input', "
+            "operator_blocked=0 WHERE id=?",
+            (recovered,),
+        )
+        conn.execute(
+            "DELETE FROM task_events WHERE task_id=? AND kind IN "
+            "('blocked', 'unblocked', 'bridge_blocked', "
+            "'bridge_requeued', 'bridge_dispatched')",
+            (recovered,),
+        )
+
+        bridge = kb.create_task(conn, title="bridge-owned block")
+        conn.execute(
+            "UPDATE tasks SET status='blocked', block_kind='needs_input', "
+            "operator_blocked=0 WHERE id=?",
+            (bridge,),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'bridge_blocked', NULL, ?)",
+            (bridge, int(time.time())),
+        )
+
+    # Force the additive migration/backfill pass, as an upgraded install does
+    # on its first connection after restart.
+    kb.init_db()
+    with kb.connect() as conn:
+        flags = {
+            row["id"]: row["operator_blocked"]
+            for row in conn.execute(
+                "SELECT id, operator_blocked FROM tasks WHERE id IN (?, ?)",
+                (recovered, bridge),
+            )
+        }
+        assert flags == {recovered: 1, bridge: 0}
+        assert conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='trigger' AND name=?",
+            (kb._OPERATOR_BLOCK_GUARD_TRIGGER,),
+        ).fetchone() is not None
+
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "UPDATE tasks SET status='ready', block_kind=NULL WHERE id=?",
+                (recovered,),
+            )
+
+        # A bridge-owned block remains on its independent lifecycle and is not
+        # accidentally converted into a canonical operator block by backfill.
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status='ready', block_kind=NULL WHERE id=?",
+                (bridge,),
+            )
+            conn.execute(
+                "INSERT INTO task_events (task_id, kind, payload, created_at) "
+                "VALUES (?, 'bridge_requeued', NULL, ?)",
+                (bridge, int(time.time())),
+            )
+        bridge_task = kb.get_task(conn, bridge)
+        assert bridge_task is not None
+        assert bridge_task.status == "ready"
 
 
 def test_worker_block_on_child_with_done_parents_is_still_sticky(kanban_home: Path) -> None:
@@ -202,6 +280,117 @@ def test_bridge_block_is_sticky_until_bridge_clear_transition(
         assert canonical_task is not None
         assert canonical_task.status == "blocked"
         assert kb.claim_task(conn, canonical) is None
+
+
+@pytest.mark.parametrize(
+    "clear_event",
+    ["bridge_requeued", "bridge_dispatched"],
+)
+def test_canonical_block_rejects_real_bridge_update_before_event(
+    kanban_home: Path,
+    clear_event: str,
+) -> None:
+    """The live bridge rewrites the task before appending its receipt.
+
+    Model that exact update+event transaction for both ready and running
+    transitions. SQLite authority must abort the rewrite atomically; checking
+    an event predicate later in ``recompute_ready`` or ``claim_task`` is too
+    late because the visible blocked state has already been erased.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title=f"canonical block vs {clear_event}")
+        claimed = kb.claim_task(conn, tid, claimer="test:worker")
+        assert claimed is not None
+        assert kb.block_task(
+            conn,
+            tid,
+            reason="review-required: operator approval",
+            kind="needs_input",
+            expected_run_id=claimed.current_run_id,
+        )
+        now = int(time.time())
+
+        with pytest.raises(
+            sqlite3.IntegrityError,
+            match="operator-blocked task requires authoritative unblock",
+        ):
+            with kb.write_txn(conn):
+                if clear_event == "bridge_dispatched":
+                    # Exact column/update order from kanban_bridge_state.py's
+                    # ``state == 'running'`` branch.
+                    conn.execute(
+                        """UPDATE tasks
+                           SET status = 'running', assignee = ?,
+                               started_at = COALESCE(started_at, ?), completed_at = NULL,
+                               workspace_path = COALESCE(?, workspace_path),
+                               branch_name = COALESCE(?, branch_name),
+                               claim_lock = ?, claim_expires = ?, worker_pid = ?,
+                               last_heartbeat_at = ?, current_run_id = NULL,
+                               block_kind = NULL, last_failure_error = NULL
+                           WHERE id = ?""",
+                        (
+                            "orchestrator",
+                            now,
+                            None,
+                            None,
+                            "acp:test:external",
+                            now + 7200,
+                            None,
+                            now,
+                            tid,
+                        ),
+                    )
+                else:
+                    # Exact column/update order from the writer's generic
+                    # branch when ``state == 'ready'``.
+                    conn.execute(
+                        """UPDATE tasks
+                           SET status = ?, assignee = ?, completed_at = ?,
+                               workspace_path = COALESCE(?, workspace_path),
+                               branch_name = COALESCE(?, branch_name),
+                               claim_lock = NULL, claim_expires = NULL, worker_pid = NULL,
+                               last_heartbeat_at = ?, current_run_id = NULL,
+                               block_kind = CASE WHEN ? = 'blocked' THEN 'needs_input' ELSE NULL END,
+                               last_failure_error = COALESCE(?, last_failure_error),
+                               result = COALESCE(?, result)
+                           WHERE id = ?""",
+                        (
+                            "ready",
+                            "orchestrator",
+                            None,
+                            None,
+                            None,
+                            now,
+                            "ready",
+                            None,
+                            None,
+                            tid,
+                        ),
+                    )
+                conn.execute(
+                    "INSERT INTO task_events(task_id, run_id, kind, payload, created_at) "
+                    "VALUES (?, NULL, ?, ?, ?)",
+                    (
+                        tid,
+                        clear_event,
+                        json.dumps({"from": "blocked", "to": clear_event}),
+                        now,
+                    ),
+                )
+
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+        assert task.block_kind == "needs_input"
+        assert conn.execute(
+            "SELECT operator_blocked FROM tasks WHERE id = ?", (tid,),
+        ).fetchone()["operator_blocked"] == 1
+        assert conn.execute(
+            "SELECT COUNT(*) AS n FROM task_events "
+            "WHERE task_id = ? AND kind = ?",
+            (tid, clear_event),
+        ).fetchone()["n"] == 0
+        assert kb.claim_task(conn, tid, claimer="test:claim") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -65,6 +65,7 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
         assert kb.block_task(
             conn, tid,
             reason="review-required: please verify ACL change",
+            kind="needs_input",
             expected_run_id=kb.get_task(conn, tid).current_run_id,
         )
         assert kb.get_task(conn, tid).status == "blocked"
@@ -75,6 +76,19 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
             promoted = kb.recompute_ready(conn)
             assert promoted == 0, "worker-blocked task must not auto-promote"
             assert kb.get_task(conn, tid).status == "blocked"
+
+        # Recovery can preserve the classified blocked task row while losing
+        # the event tail. Fail closed on that durable classification instead
+        # of silently promoting the recovered task.
+        conn.execute(
+            "DELETE FROM task_events WHERE task_id=? AND kind='blocked'", (tid,),
+        )
+        conn.commit()
+        assert kb.recompute_ready(conn) == 0
+        recovered = kb.get_task(conn, tid)
+        assert recovered is not None
+        assert recovered.status == "blocked"
+        assert kb.claim_task(conn, tid) is None
 
 
 def test_worker_block_on_child_with_done_parents_is_still_sticky(kanban_home: Path) -> None:
@@ -146,6 +160,48 @@ def test_bridge_block_is_sticky_until_bridge_clear_transition(
         ready_task = kb.get_task(conn, tid)
         assert ready_task is not None
         assert ready_task.status == "ready"
+
+        # A canonical operator unblock is also authorized to clear an older
+        # bridge block.
+        canonical_clear = kb.create_task(conn, title="bridge block, operator clear")
+        conn.execute(
+            "UPDATE tasks SET status='blocked' WHERE id=?", (canonical_clear,),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'bridge_blocked', NULL, ?)",
+            (canonical_clear, now + 2),
+        )
+        conn.commit()
+        assert kb.unblock_task(conn, canonical_clear)
+        assert not kb._has_sticky_block(conn, canonical_clear)
+
+        # Bridge receipts only clear the bridge channel. They must never
+        # substitute for the canonical `unblocked` event required to release
+        # an operator block.
+        canonical = kb.create_task(conn, title="canonical operator review")
+        assert kb.claim_task(conn, canonical) is not None
+        canonical_task = kb.get_task(conn, canonical)
+        assert canonical_task is not None
+        assert kb.block_task(
+            conn,
+            canonical,
+            reason="review-required: operator approval",
+            kind="needs_input",
+            expected_run_id=canonical_task.current_run_id,
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, ?, NULL, ?)",
+            (canonical, clear_event, now + 2),
+        )
+        conn.commit()
+
+        assert kb.recompute_ready(conn) == 0
+        canonical_task = kb.get_task(conn, canonical)
+        assert canonical_task is not None
+        assert canonical_task.status == "blocked"
+        assert kb.claim_task(conn, canonical) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Status — REVIEW_REQUIRED on exact head `ae5c82ffb91d943981573e23e88e0ece00530080`

R5 closes the stale-crash-run recovery gap found by the preserved selected-recovery replay. Fresh independent security review of this exact head is still required before landing or any cutover.

## Summary

- keep canonical operator and bridge-managed sticky lifecycles independent
- reject raw bridge `ready` / `running` rewrites while canonical authority is active
- backfill authority for recovered classified blocks when sticky events were lost
- distinguish current circuit-breaker evidence from stale pre-recovery attempt history
- preserve bridge-owned release and demonstrable circuit-breaker auto-recovery
- fail closed on ambiguous recovered block state

## Incident bugs closed

1. Core sticky detection originally ignored `bridge_blocked`.
2. A bridge clear receipt could override an unrelated canonical operator block.
3. Recovery could preserve `status='blocked'` / `block_kind` while losing the sticky event tail, making critical tasks promotable and claimable.
4. The live bridge performs raw `UPDATE`-then-event transactions, bypassing Python transition helpers.
5. A canonical re-block could lose only its newest `blocked` event while older `blocked -> unblocked` history survived.
6. Selected recovery could replay an operator block over an older crashed run; treating that stale run alone as current circuit-breaker evidence made `t_fb8f9f0f` promotable/claimable.

## Fix

`operator_blocked` is a durable SQLite authority bit maintained by canonical repository transitions. A `BEFORE UPDATE OF status` trigger aborts raw transitions to `ready` or `running` unless an authoritative repository release clears the bit in the same transaction.

Upgrade/runtime custody evaluates canonical events, the independent bridge lifecycle, task-row failure state, the latest task run, and `gave_up` evidence together:

- active canonical block -> protected until canonical `unblocked`
- active bridge block -> remains bridge-owned and bridge-releasable
- recovered classified row with surviving canonical/run authority -> protected
- surviving `gave_up` newer than sticky lifecycle -> circuit-breaker recoverable
- failure run -> circuit-breaker evidence only when the current task row has a positive failure count and matching non-null failure error
- stale crash/failure run without matching current row evidence -> ambiguous and fail closed

## Verification

- Preserved selected-recovery source SHA `8efcfcc6…`: before R5, `t_fb8f9f0f` promoted and claim succeeded; after R5, both critical tasks are operator-blocked/sticky and reject claims
- Focused sticky + DB suite: `246 passed`
- Promote/block-kind/DB-init suites: `32 passed`
- Prior adversarial matrix + re-block acceptance overlay: `8 passed`
- Current-main no-commit merge (`e57918ac…`): conflict-free; `246 passed` + `32 passed`; merge aborted
- Ruff, `py_compile`, and diff checks: clean
- PR scope: 2 files (+746/-18); GitHub reports OPEN/MERGEABLE at exact head `ae5c82ffb91d943981573e23e88e0ece00530080`
- Frozen evidence: task `t_bb3de8f9` attachment #679; ZIP SHA `9baca586a9755a088106fc193fdbe45ca36ebe46e3e3fd2305f3573365f4b85c`

## Deployment precondition

Run the upgraded Kanban DB init/migration while writers are frozen, before resuming any raw bridge writer, so the authority backfill and trigger are installed before bridge transactions can execute.

## Safety

No live database/evidence, recovery/reindex, service/timer/gateway/bridge, install, merge, deployment, or production mutation was performed. Fresh independent exact-head security review is required before landing or any cutover.
