### PR TITLE
fix(kanban): cap corrupt-DB quarantine backups per DB basename (#68336)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1286,6 +1286,15 @@ _INIT_LOCK = threading.RLock()
 _SQLITE_HEADER = b"SQLite format 3\x00"
 DEFAULT_BUSY_TIMEOUT_MS = 120_000
 
+# Max ``<db>.corrupt.<hash>.bak`` backups kept per DB basename (#68336). Content
+# addressing dedups repeated quarantines of the *same* corrupt bytes, but a live
+# external writer that keeps committing into an already-corrupt DB rotates the
+# sha256 on every poll, so each open makes a fresh full-size backup + sidecars —
+# unbounded (467 backups / ~1.9 GB in 8h reported). Cap the lineage: keep the
+# newest N, prune older ones at backup time. Backups of the same corrupt DB are
+# near-duplicates; retaining hundreds has no forensic value.
+_CORRUPT_BACKUP_RETENTION = 5
+
 # Bounded acquire for the cross-process init lock (#36644). The original bare
 # blocking flock had no timeout, so a wedged holder blocked the dispatcher's
 # next-tick connect forever. We retry a non-blocking acquire up to this
@@ -1618,7 +1627,58 @@ def _backup_corrupt_db(path: Path) -> Optional[Path]:
             shutil.copy2(sidecar, sidecar_backup)
         except OSError:
             pass
+    _prune_corrupt_backups(parent, base_name, keep=candidate)
     return candidate
+
+
+def _prune_corrupt_backups(parent: Path, base_name: str, *, keep: Path) -> None:
+    """Bound ``<base_name>.corrupt.<hash>.bak`` accumulation under ``parent``.
+
+    Keeps the newest :data:`_CORRUPT_BACKUP_RETENTION` backups for this DB
+    basename (always retaining ``keep``, the backup just written/reused) and
+    deletes older ones plus their ``-wal``/``-shm`` sidecars. This is what
+    bounds the disk-amplification #68336 describes: when a live writer keeps
+    mutating an already-corrupt DB, its sha256 rotates every poll and each open
+    would otherwise add a fresh full-size backup with no ceiling.
+
+    Best-effort — any filesystem error is swallowed; a failed prune must never
+    stop the caller from raising :class:`KanbanDbCorruptError`. Matching is
+    confined to ``parent`` and to the exact ``.corrupt.<16 hex>.bak`` shape so
+    unrelated files (and the live sidecars ``<base_name>-wal``/``-shm``) are
+    never touched.
+    """
+    pattern = re.compile(
+        rf"^{re.escape(base_name)}\.corrupt\.[0-9a-f]{{16}}\.bak$"
+    )
+    try:
+        entries: list[tuple[float, Path]] = []
+        for child in parent.iterdir():
+            if child.parent != parent or not pattern.match(child.name):
+                continue
+            try:
+                entries.append((child.stat().st_mtime, child))
+            except OSError:
+                continue
+    except OSError:
+        return
+    # Newest first; always retain ``keep`` even if its mtime is old (a dedup
+    # hit re-returns an existing backup we must not delete out from under us).
+    entries.sort(key=lambda item: item[0], reverse=True)
+    retained = 0
+    for _mtime, backup in entries:
+        if backup == keep:
+            continue
+        retained += 1
+        if retained < _CORRUPT_BACKUP_RETENTION:
+            continue
+        for suffix in ("", "-wal", "-shm"):
+            victim = parent / (backup.name + suffix)
+            if victim.parent != parent or not victim.exists():
+                continue
+            try:
+                victim.unlink()
+            except OSError:
+                pass
 
 
 def _guard_existing_db_is_healthy(path: Path) -> None:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4370,6 +4370,48 @@ def test_repeated_corrupt_open_reuses_single_backup(tmp_path):
     assert second_backup.exists()
 
 
+def test_rotating_corrupt_bytes_bounds_backup_count(tmp_path):
+    """A live writer that keeps mutating a corrupt DB must not flood the dir.
+
+    Regression for #68336: content addressing dedups repeated quarantines of the
+    *same* bytes, but an external process still committing into an already-corrupt
+    DB rotates the sha256 on every poll, so each open produced a fresh full-size
+    ``.corrupt.<hash>.bak`` (+ ``-wal``/``-shm`` sidecars) with no ceiling — 467
+    backups / ~1.9 GB in 8h in the report. The retention cap bounds the lineage.
+    """
+    db_path = tmp_path / "kanban.db"
+    _write_corrupt_db(db_path)
+
+    seen: set[Path] = set()
+    # Far more opens than the cap; each one changes the fingerprint first, the
+    # way a live external writer would between polls.
+    for i in range(20):
+        with db_path.open("r+b") as f:
+            f.seek(4096)
+            f.write(bytes([i & 0xFF]) * 64)
+        kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+        with pytest.raises(kb.KanbanDbCorruptError) as excinfo:
+            kb.connect(db_path=db_path)
+        backup = excinfo.value.backup_path
+        assert backup is not None
+        # The backup handed to the caller this open must survive the prune.
+        assert backup.exists()
+        seen.add(backup)
+
+    # Distinct fingerprints were produced (dedup did not mask the rotation)…
+    assert len(seen) > kb._CORRUPT_BACKUP_RETENTION
+    # …but on-disk backups stay bounded by the retention cap, not the open count.
+    remaining = list(tmp_path.glob("kanban.db.corrupt.*.bak"))
+    assert len(remaining) <= kb._CORRUPT_BACKUP_RETENTION, (
+        f"expected <= {kb._CORRUPT_BACKUP_RETENTION} backups, got {len(remaining)}"
+    )
+    # Pruned backups take their -wal/-shm sidecars with them (no orphans).
+    stems = {p.name for p in remaining}
+    for sidecar in tmp_path.glob("kanban.db.corrupt.*.bak-*"):
+        base = sidecar.name.rsplit("-", 1)[0]
+        assert base in stems, f"orphaned sidecar {sidecar.name} for pruned backup"
+
+
 def test_locked_healthy_db_does_not_classify_as_corrupt(tmp_path, monkeypatch):
     """A transient lock during the probe must not produce a .corrupt backup
     and must not be reported as :class:`KanbanDbCorruptError`. Raw sqlite


### PR DESCRIPTION
## What does this PR do?

`_backup_corrupt_db()` in `hermes_cli/kanban_db.py` content-addresses quarantine
backups by the corrupt DB's sha256 (`kanban.db.corrupt.<hash>.bak`), so repeated
opens of the *same* corrupt bytes dedup to a single backup. But if an external
process still holds direct SQLite write access to the already-corrupt DB, every
commit changes the fingerprint — so every subsequent open writes a *new*
full-size backup (plus `-wal`/`-shm` sidecars) with no ceiling. The reporter saw
**467 distinct ~4.2 MB backups (~1.9 GB, 897 files) in ~8 hours** — roughly one
per minute — from a per-minute poller racing a legacy writer.

The fix caps the lineage: keep the newest `_CORRUPT_BACKUP_RETENTION` (5) backups
per DB basename and prune older ones (with their sidecars) at backup time.
Backups of the same corrupt DB are near-duplicates, so retaining hundreds has no
forensic value; bounding disk does. The backup just written/reused is always
retained (a dedup hit must not delete the path it returns), pruning is confined
to `parent` and the exact `.corrupt.<16 hex>.bak` shape (live `-wal`/`-shm`
sidecars and unrelated files are never touched), and a failed prune is swallowed
so it can never stop the `KanbanDbCorruptError` the caller raises.

## Related Issue

Fixes #68336

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py`: add `_CORRUPT_BACKUP_RETENTION = 5`; add
  `_prune_corrupt_backups()` and call it at the end of `_backup_corrupt_db()` to
  keep the newest N `.corrupt.<hash>.bak` backups per basename and delete older
  ones plus their `-wal`/`-shm` sidecars (best-effort, path/shape-confined).
- `tests/hermes_cli/test_kanban_db.py`: add
  `test_rotating_corrupt_bytes_bounds_backup_count` — 20 opens each mutating the
  corrupt bytes first (distinct fingerprints, as a live writer would produce);
  asserts distinct backups were generated but on-disk count stays `<=` the cap,
  the current open's backup survives, and no sidecar is orphaned.

## How to Test

1. `git fetch upstream pull/68345/head` (or check out this branch).
2. Run the regression + existing corrupt-backup suite:
   `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py -k corrupt -q`
3. Result: `9 passed` (8 pre-existing + the new bound test). Manual repro from the
   issue — corrupt a kanban DB, keep one `sqlite3` connection committing a row
   each minute, run `hermes kanban list` on a loop — now settles at 5 backups
   instead of growing unbounded.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suite (`scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py -k corrupt -q`) and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (Darwin 25.5, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new constant and helper are documented inline; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys; cap is an internal constant)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — prune uses `Path.iterdir`/`unlink` and swallows `OSError`; sidecar handling matches the existing backup path
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Credits

The retention-cap approach (keep newest 5, prune oldest `.corrupt.*.bak` at
backup time) matches the idea in @janishohbergs85-star's
[#32493](https://github.com/NousResearch/hermes-agent/pull/32493), which caps the
same backup cascade. This PR reworks that idea for current `main`: #32493's diff
targets the older counter-based backup naming that predates the content-addressed
sha256 scheme + sidecar handling now in `_backup_corrupt_db`, and it's bundled
with unrelated gateway/Telegram changes. This is a focused, current, test-covered
version scoped to #68336. Maintainers may of course prefer to land #32493 instead
or fold these — their call.

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py -k corrupt -q
9 passed, 222 deselected
```
