### PR TITLE
feat: add opt-in subagent non-convergence guardrail

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1594,6 +1594,27 @@ def init_agent(
         )
     except Exception as _tlg_err:
         _ra().logger.warning("Tool loop guardrail config ignored: %s", _tlg_err)
+
+    # Opt-in non-convergence tracking is scoped to delegate_task children. The
+    # setting lives under ``delegation`` and must not alter parent/cron agents.
+    agent._progress_tracker = None
+    try:
+        from agent.delegation_context import is_delegated_child_context
+        from agent.progress_tracker import ProgressTracker
+
+        if is_delegated_child_context():
+            _delegation_cfg = _agent_cfg.get("delegation", {})
+            _pt_cfg = (
+                _delegation_cfg.get("progress_tracker", {})
+                if isinstance(_delegation_cfg, dict)
+                else {}
+            )
+            _progress_tracker = ProgressTracker.from_mapping(_pt_cfg)
+            if _progress_tracker.enabled:
+                agent._progress_tracker = _progress_tracker
+    except Exception as _pt_err:
+        _ra().logger.warning("Progress tracker config ignored: %s", _pt_err)
+
     # Cache only the derived auxiliary compression context override that is
     # needed later by the startup feasibility check.  Avoid exposing a
     # broad pseudo-public config object on the agent instance.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6021,6 +6021,9 @@ def run_conversation(
 
                 previous_msg = messages[-1] if messages else None
                 current_interim_visible = agent._interim_assistant_visible_text(assistant_msg)
+                current_interim_has_new_text = (
+                    agent._interim_assistant_has_new_visible_text(assistant_msg)
+                )
                 previous_interim_visible = (
                     agent._interim_assistant_visible_text(previous_msg)
                     if isinstance(previous_msg, dict)
@@ -6054,6 +6057,15 @@ def run_conversation(
                         tc for tc in assistant_message.tool_calls
                         if tc.function.name in agent.valid_tool_names
                     ]
+
+                agent._start_progress_iteration(
+                    messages,
+                    tool_call_count=len(assistant_message.tool_calls or []),
+                    had_text=bool(
+                        current_interim_has_new_text
+                        and not duplicate_previous_interim
+                    ),
+                )
 
                 _tool_turn_persisted = None
                 try:

--- a/agent/progress_tracker.py
+++ b/agent/progress_tracker.py
@@ -1,0 +1,105 @@
+"""Opt-in non-convergence tracking for delegated child agents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping
+
+_DEFAULT_WARN_AFTER = 15
+_DEFAULT_HALT_AFTER = 25
+
+
+@dataclass(frozen=True)
+class ProgressDecision:
+    """Decision produced after one model/tool iteration."""
+
+    action: Literal["none", "warn", "halt"] = "none"
+    count: int = 0
+    message: str = ""
+
+
+def _positive_int(value: Any, default: int) -> int:
+    if isinstance(value, bool):
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _opt_in_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return value == 1
+
+
+class ProgressTracker:
+    """Count delegated-child iterations that produce no convergence signal."""
+
+    def __init__(
+        self,
+        *,
+        warn_after: int = _DEFAULT_WARN_AFTER,
+        halt_after: int = _DEFAULT_HALT_AFTER,
+        enabled: Any = False,
+    ) -> None:
+        self.warn_after = _positive_int(warn_after, _DEFAULT_WARN_AFTER)
+        self.halt_after = max(
+            self.warn_after,
+            _positive_int(halt_after, _DEFAULT_HALT_AFTER),
+        )
+        self.enabled = _opt_in_bool(enabled)
+        self._iterations_since_progress = 0
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | None) -> "ProgressTracker":
+        """Build a tracker from ``delegation.progress_tracker`` config."""
+        if not isinstance(data, Mapping):
+            return cls()
+        return cls(
+            enabled=data.get("enabled", False),
+            warn_after=data.get("warn_after", _DEFAULT_WARN_AFTER),
+            halt_after=data.get("halt_after", _DEFAULT_HALT_AFTER),
+        )
+
+    @property
+    def iterations_since_progress(self) -> int:
+        return self._iterations_since_progress
+
+    def finish_iteration(self, *, made_progress: bool) -> ProgressDecision:
+        """Record one complete model/tool round and return its decision."""
+        if not self.enabled:
+            return ProgressDecision()
+        if made_progress:
+            self._iterations_since_progress = 0
+            return ProgressDecision()
+
+        self._iterations_since_progress += 1
+        count = self._iterations_since_progress
+        if count >= self.halt_after:
+            return ProgressDecision(
+                action="halt",
+                count=count,
+                message=(
+                    f"Subagent stopped after {count} iterations without "
+                    "user-visible text or a successful file change."
+                ),
+            )
+        if count >= self.warn_after:
+            return ProgressDecision(
+                action="warn",
+                count=count,
+                message=(
+                    f"[PROGRESS TRACKER: {count} iterations without user-visible "
+                    "text or a successful file change. This subagent is not "
+                    "converging; finish the task or return the useful findings now.]"
+                ),
+            )
+        return ProgressDecision(count=count)
+
+    def reset(self) -> None:
+        """Clear state at the beginning of a new user turn."""
+        self._iterations_since_progress = 0

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -149,6 +149,9 @@ def _flush_session_db_after_tool_progress(
     transcript survives destructive-but-valid tool calls.
     """
     try:
+        _prepare_progress = getattr(agent, "_prepare_progress_before_tool_flush", None)
+        if callable(_prepare_progress):
+            _prepare_progress(messages)
         persisted = agent._flush_messages_to_session_db(messages) is not False
         if not persisted:
             agent._incremental_persistence_failed = True
@@ -1160,6 +1163,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             tool_duration = 0.0
         else:
             function_name, function_args, function_result, tool_duration, is_error, blocked, middleware_trace = r
+            mutation_result = function_result
             name = function_name
             args = function_args
             progress_function_name = function_name
@@ -1185,7 +1189,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             if not blocked:
                 try:
                     agent._record_file_mutation_result(
-                        function_name, function_args, function_result, is_error,
+                        function_name, function_args, mutation_result, is_error,
                     )
                 except Exception as _ver_err:
                     logging.debug("file-mutation verifier record failed: %s", _ver_err)
@@ -1813,6 +1817,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Log tool errors to the persistent error log so [error] tags
         # in the UI always have a corresponding detailed entry on disk.
         _is_error_result, _ = _detect_tool_failure(function_name, function_result)
+        mutation_result = function_result
         # The agent-runtime tools above (todo, session_search, memory,
         # context-engine, memory-manager, clarify, delegate_task) are
         # dispatched inline — they never reach handle_function_call, so the
@@ -1857,7 +1862,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         if not _execution_blocked:
             try:
                 agent._record_file_mutation_result(
-                    function_name, function_args, function_result, _is_error_result,
+                    function_name, function_args, mutation_result, _is_error_result,
                 )
             except Exception as _ver_err:
                 logging.debug("file-mutation verifier record failed: %s", _ver_err)

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -466,6 +466,9 @@ def build_turn_context(
     agent._unicode_sanitization_passes = 0
     agent._tool_guardrails.reset_for_turn()
     agent._tool_guardrail_halt_decision = None
+    _progress_tracker = getattr(agent, "_progress_tracker", None)
+    if _progress_tracker is not None:
+        _progress_tracker.reset()
     _reset_consol = getattr(agent._memory_store, "reset_consolidation_failures", None)
     if callable(_reset_consol):
         _reset_consol()

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1254,6 +1254,14 @@ delegation:
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.
   #                                           # Supported: openrouter, nous, zai, kimi-coding, minimax
+  # Opt-in non-convergence circuit breaker for delegated children. It counts
+  # complete tool rounds with neither user-visible text nor a successful
+  # write_file/patch result. This complements the iteration budget; it does
+  # not determine whether read-only research is useful.
+  progress_tracker:
+    enabled: false                            # Disabled by default; enable only for runaway children
+    warn_after: 15                            # Add a convergence warning after N stalled rounds
+    halt_after: 25                            # Stop the child through the controlled-halt path
 
 # =============================================================================
 # Honcho Integration (Cross-Session User Modeling)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1574,6 +1574,13 @@ DEFAULT_CONFIG = {
         "inherit_mcp_toolsets": True,
         "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
+        # Opt-in circuit breaker for delegated children that keep calling tools
+        # without producing user-visible text or landing a file mutation.
+        "progress_tracker": {
+            "enabled": False,
+            "warn_after": 15,
+            "halt_after": 25,
+        },
         # Subagent summaries return to the parent's context verbatim. A batch
         # fan-out (N children) returns N summaries at once, which can exceed
         # the parent's context window and trigger a compression/429 death

--- a/run_agent.py
+++ b/run_agent.py
@@ -3279,6 +3279,8 @@ class AIAgent:
             return
         landed = file_mutation_result_landed(tool_name, result)
         if landed:
+            if getattr(self, "_progress_tracker", None) is not None:
+                self._progress_iteration_made_progress = True
             changed = getattr(self, "_turn_file_mutation_paths", None)
             if changed is not None:
                 changed.update(_extract_landed_file_mutation_paths(tool_name, args, result))
@@ -5613,6 +5615,28 @@ class AIAgent:
         content = assistant_msg.get("content")
         return self._strip_think_blocks(flatten_message_text(content)).strip()
 
+    def _interim_assistant_has_new_visible_text(
+        self, assistant_msg: Dict[str, Any]
+    ) -> bool:
+        """Return whether interim emission would surface previously unseen text."""
+        commentary_parts = self._extract_codex_interim_visible_parts(assistant_msg)
+        if commentary_parts:
+            pending_keys: set[str] = set()
+            for part in commentary_parts:
+                key = self._normalize_interim_visible_text(part)
+                if not key or key in pending_keys:
+                    continue
+                pending_keys.add(key)
+                if not self._interim_text_was_delivered(part):
+                    return True
+            return False
+        visible = self._interim_assistant_visible_text(assistant_msg)
+        return bool(
+            visible
+            and visible != "(empty)"
+            and not self._interim_text_was_delivered(visible)
+        )
+
     def _interim_text_was_delivered(self, text: str) -> bool:
         normalized = self._normalize_interim_visible_text(text)
         if not normalized:
@@ -6805,12 +6829,81 @@ class AIAgent:
             if token is not None:
                 reset_conversation_context(token)
 
+    def _start_progress_iteration(
+        self,
+        messages: list,
+        *,
+        tool_call_count: int,
+        had_text: bool,
+    ) -> None:
+        """Initialize one delegated-child tool round before persistence."""
+        if getattr(self, "_progress_tracker", None) is None:
+            return
+        self._progress_iteration_made_progress = False
+        self._progress_iteration_had_text = had_text
+        self._progress_iteration_remaining_results = max(0, int(tool_call_count))
+        self._progress_iteration_completed = False
+        if self._progress_iteration_remaining_results == 0:
+            self._complete_progress_iteration(messages)
+
+    def _prepare_progress_before_tool_flush(self, messages: list) -> None:
+        """Complete tracking immediately before the final tool result is durable."""
+        if getattr(self, "_progress_tracker", None) is None:
+            return
+        remaining = getattr(self, "_progress_iteration_remaining_results", 0)
+        if remaining <= 0:
+            return
+        remaining -= 1
+        self._progress_iteration_remaining_results = remaining
+        if remaining == 0:
+            self._complete_progress_iteration(messages)
+
+    def _complete_progress_iteration(self, messages: list) -> None:
+        """Evaluate the round and attach guidance before its final DB flush."""
+        tracker = getattr(self, "_progress_tracker", None)
+        if tracker is None or getattr(self, "_progress_iteration_completed", False):
+            return
+        self._progress_iteration_completed = True
+        made_progress = bool(
+            getattr(self, "_progress_iteration_had_text", False)
+            or getattr(self, "_progress_iteration_made_progress", False)
+        )
+        decision = tracker.finish_iteration(made_progress=made_progress)
+        if decision.action not in {"warn", "halt"}:
+            return
+
+        for message in reversed(messages):
+            if not isinstance(message, dict) or message.get("role") != "tool":
+                continue
+            content = message.get("content")
+            if isinstance(content, str):
+                message["content"] = f"{content}\n\n{decision.message}"
+            elif isinstance(content, list):
+                content.append({"type": "text", "text": decision.message})
+            break
+
+        if decision.action == "halt":
+            self._set_tool_guardrail_halt(
+                ToolGuardrailDecision(
+                    action="halt",
+                    code="subagent_non_convergence_halt",
+                    message=decision.message,
+                    count=decision.count,
+                )
+            )
+
     def _set_tool_guardrail_halt(self, decision: ToolGuardrailDecision) -> None:
         """Record the first guardrail decision that should stop this turn."""
         if decision.should_halt and self._tool_guardrail_halt_decision is None:
             self._tool_guardrail_halt_decision = decision
 
     def _toolguard_controlled_halt_response(self, decision: ToolGuardrailDecision) -> str:
+        if decision.code == "subagent_non_convergence_halt":
+            return (
+                "I stopped this delegated task because the non-convergence "
+                f"guardrail observed {decision.count} consecutive tool rounds "
+                "without user-visible text or a successful file change."
+            )
         tool = decision.tool_name or "a tool"
         return (
             f"I stopped retrying {tool} because it hit the tool-call guardrail "

--- a/tests/agent/test_progress_tracker.py
+++ b/tests/agent/test_progress_tracker.py
@@ -1,0 +1,93 @@
+"""Unit tests for delegated-child non-convergence tracking."""
+
+from agent.progress_tracker import ProgressTracker
+from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+
+def test_default_config_keeps_non_convergence_guardrail_opt_in():
+    assert DEFAULT_CONFIG["delegation"]["progress_tracker"] == {
+        "enabled": False,
+        "warn_after": 15,
+        "halt_after": 25,
+    }
+
+
+class TestProgressTracker:
+    def test_disabled_by_default(self):
+        tracker = ProgressTracker()
+
+        for _ in range(50):
+            decision = tracker.finish_iteration(made_progress=False)
+
+        assert decision.action == "none"
+        assert decision.count == 0
+
+    def test_warns_at_configured_threshold(self):
+        tracker = ProgressTracker(enabled=True, warn_after=2, halt_after=4)
+
+        assert tracker.finish_iteration(made_progress=False).action == "none"
+        decision = tracker.finish_iteration(made_progress=False)
+
+        assert decision.action == "warn"
+        assert decision.count == 2
+        assert "not converging" in decision.message
+
+    def test_halts_at_configured_threshold(self):
+        tracker = ProgressTracker(enabled=True, warn_after=2, halt_after=3)
+
+        tracker.finish_iteration(made_progress=False)
+        tracker.finish_iteration(made_progress=False)
+        decision = tracker.finish_iteration(made_progress=False)
+
+        assert decision.action == "halt"
+        assert decision.count == 3
+        assert "stopped" in decision.message.lower()
+
+    def test_progress_resets_stalled_iteration_count(self):
+        tracker = ProgressTracker(enabled=True, warn_after=2, halt_after=4)
+        tracker.finish_iteration(made_progress=False)
+        assert tracker.iterations_since_progress == 1
+
+        decision = tracker.finish_iteration(made_progress=True)
+
+        assert decision.action == "none"
+        assert tracker.iterations_since_progress == 0
+
+    def test_reset_clears_state_for_a_new_user_turn(self):
+        tracker = ProgressTracker(enabled=True, warn_after=2, halt_after=4)
+        tracker.finish_iteration(made_progress=False)
+        tracker.finish_iteration(made_progress=False)
+        assert tracker.iterations_since_progress == 2
+
+        tracker.reset()
+
+        assert tracker.iterations_since_progress == 0
+        assert tracker.finish_iteration(made_progress=False).action == "none"
+
+    def test_from_mapping_is_opt_in(self):
+        assert ProgressTracker.from_mapping({"warn_after": 2}).enabled is False
+        assert ProgressTracker.from_mapping({"enabled": True}).enabled is True
+
+    def test_false_like_strings_do_not_enable_tracker(self):
+        for value in ("false", "no", "off", "0", ""):
+            assert ProgressTracker.from_mapping({"enabled": value}).enabled is False
+
+    def test_true_like_strings_enable_tracker(self):
+        for value in ("true", "yes", "on", "1"):
+            assert ProgressTracker.from_mapping({"enabled": value}).enabled is True
+
+    def test_from_mapping_normalizes_invalid_thresholds(self):
+        tracker = ProgressTracker.from_mapping(
+            {"enabled": True, "warn_after": "bad", "halt_after": -1}
+        )
+
+        assert tracker.warn_after == 15
+        assert tracker.halt_after == 25
+
+    def test_halt_threshold_cannot_precede_warning_threshold(self):
+        tracker = ProgressTracker.from_mapping(
+            {"enabled": True, "warn_after": 10, "halt_after": 5}
+        )
+
+        assert tracker.warn_after == 10
+        assert tracker.halt_after == 10

--- a/tests/run_agent/test_progress_tracker_runtime.py
+++ b/tests/run_agent/test_progress_tracker_runtime.py
@@ -1,0 +1,483 @@
+"""Runtime coverage for delegated-child non-convergence guardrails."""
+
+from contextlib import nullcontext
+from copy import deepcopy
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.delegation_context import delegated_child_context
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _progress_config(*, enabled: bool = True, warn_after: int = 2, halt_after: int = 3) -> dict:
+    return {
+        "delegation": {
+            "progress_tracker": {
+                "enabled": enabled,
+                "warn_after": warn_after,
+                "halt_after": halt_after,
+            }
+        }
+    }
+
+
+def _make_agent(
+    *tool_names: str,
+    config: dict | None = None,
+    delegated: bool = False,
+    max_iterations: int = 10,
+) -> AIAgent:
+    context = delegated_child_context() if delegated else nullcontext()
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value=config or {}),
+        patch("hermes_cli.config.load_config_readonly", return_value=config or {}),
+        patch("run_agent.OpenAI"),
+        context,
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            max_iterations=max_iterations,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _tool_call(name: str, call_id: str, arguments: dict | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=json.dumps(arguments or {})),
+    )
+
+
+def _response(
+    *,
+    content: str = "",
+    tool_calls: list[SimpleNamespace] | None = None,
+) -> SimpleNamespace:
+    finish_reason = "tool_calls" if tool_calls else "stop"
+    message = SimpleNamespace(content=content, tool_calls=tool_calls)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason=finish_reason)],
+        model="test/model",
+        usage=None,
+    )
+
+
+def _run(agent: AIAgent, prompt: str = "work autonomously") -> dict:
+    agent._disable_streaming = True
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        return agent.run_conversation(prompt)
+
+
+def test_enabled_delegation_tracker_is_not_installed_on_parent_agent():
+    agent = _make_agent("web_search", config=_progress_config(), delegated=False)
+
+    assert agent._progress_tracker is None
+
+
+def test_enabled_delegation_tracker_is_installed_on_child_agent():
+    agent = _make_agent("web_search", config=_progress_config(), delegated=True)
+
+    assert agent._progress_tracker is not None
+    assert agent._progress_tracker.enabled is True
+
+
+def test_disabled_delegation_tracker_is_not_installed_on_child_agent():
+    agent = _make_agent(
+        "web_search",
+        config=_progress_config(enabled=False),
+        delegated=True,
+    )
+
+    assert agent._progress_tracker is None
+
+
+def test_non_mutating_rounds_warn_then_take_controlled_halt_path():
+    agent = _make_agent(
+        "web_search",
+        config=_progress_config(warn_after=2, halt_after=3),
+        delegated=True,
+    )
+    agent.client.chat.completions.create.side_effect = [
+        *[
+            _response(tool_calls=[_tool_call("web_search", f"call-{index}")])
+            for index in range(1, 7)
+        ],
+        _response(content="late completion"),
+    ]
+
+    with patch("run_agent.handle_function_call", return_value=json.dumps({"results": []})) as dispatch:
+        result = _run(agent)
+
+    assert dispatch.call_count == 3
+    assert result["turn_exit_reason"] == "guardrail_halt"
+    assert "non-convergence" in result["final_response"]
+    tool_contents = [
+        message["content"]
+        for message in result["messages"]
+        if message.get("role") == "tool"
+    ]
+    assert any("PROGRESS TRACKER" in content for content in tool_contents)
+
+
+def test_warning_is_present_when_tool_result_is_first_persisted():
+    agent = _make_agent(
+        "web_search",
+        config=_progress_config(warn_after=1, halt_after=3),
+        delegated=True,
+    )
+    agent.client.chat.completions.create.side_effect = [
+        _response(tool_calls=[_tool_call("web_search", "search-1")]),
+        _response(content="done"),
+    ]
+    persisted_snapshots: list[list[dict]] = []
+
+    def capture_flush(messages, *_args, **_kwargs):
+        persisted_snapshots.append(deepcopy(messages))
+        return True
+
+    agent._flush_messages_to_session_db = capture_flush
+    with patch("run_agent.handle_function_call", return_value=json.dumps({"results": []})):
+        result = _run(agent)
+
+    assert result["final_response"] == "done"
+    persisted_tool_contents = [
+        message["content"]
+        for snapshot in persisted_snapshots
+        for message in snapshot
+        if message.get("role") == "tool"
+    ]
+    assert any("PROGRESS TRACKER" in content for content in persisted_tool_contents)
+
+
+def test_successful_write_result_resets_progress_and_allows_completion():
+    agent = _make_agent(
+        "write_file",
+        config=_progress_config(warn_after=2, halt_after=3),
+        delegated=True,
+    )
+    agent.client.chat.completions.create.side_effect = [
+        *[
+            _response(
+                tool_calls=[
+                    _tool_call(
+                        "write_file",
+                        f"write-{index}",
+                        {"path": f"/tmp/out-{index}.txt", "content": "done"},
+                    )
+                ]
+            )
+            for index in range(1, 4)
+        ],
+        _response(content="completed"),
+    ]
+    landed = json.dumps({"bytes_written": 4, "resolved_path": "/tmp/out.txt"})
+
+    with (
+        patch("run_agent.handle_function_call", return_value=landed) as dispatch,
+        patch.object(
+            agent,
+            "_append_guardrail_observation",
+            side_effect=lambda _name, _args, value, **_kwargs: (
+                f"{value}\n\n[existing guardrail guidance]"
+            ),
+        ),
+    ):
+        result = _run(agent)
+
+    assert dispatch.call_count == 3
+    assert result["turn_exit_reason"].startswith("text_response")
+    assert result["final_response"] == "completed"
+    assert agent._progress_tracker.iterations_since_progress == 0
+
+
+def test_failed_write_results_do_not_reset_progress():
+    agent = _make_agent(
+        "write_file",
+        config=_progress_config(warn_after=2, halt_after=3),
+        delegated=True,
+    )
+    agent.client.chat.completions.create.side_effect = [
+        _response(
+            tool_calls=[
+                _tool_call(
+                    "write_file",
+                    f"failed-{index}",
+                    {"path": "/tmp/out.txt", "content": "done"},
+                )
+            ]
+        )
+        for index in range(1, 5)
+    ]
+
+    with patch(
+        "run_agent.handle_function_call",
+        return_value=json.dumps({"error": "permission denied"}),
+    ) as dispatch:
+        result = _run(agent)
+
+    assert dispatch.call_count == 3
+    assert result["turn_exit_reason"] == "guardrail_halt"
+
+
+def test_concurrent_batch_counts_as_one_iteration():
+    agent = _make_agent(
+        "web_search",
+        config=_progress_config(warn_after=3, halt_after=5),
+        delegated=True,
+    )
+    agent.client.chat.completions.create.side_effect = [
+        _response(
+            tool_calls=[
+                _tool_call("web_search", "search-1", {"query": "one"}),
+                _tool_call("web_search", "search-2", {"query": "two"}),
+            ]
+        ),
+        _response(content="done"),
+    ]
+
+    with patch("run_agent.handle_function_call", return_value=json.dumps({"results": []})):
+        result = _run(agent)
+
+    assert result["final_response"] == "done"
+    assert agent._progress_tracker.iterations_since_progress == 1
+
+
+def test_segmented_batch_uses_successful_write_result_as_progress():
+    agent = _make_agent(
+        "web_search",
+        "write_file",
+        config=_progress_config(warn_after=2, halt_after=3),
+        delegated=True,
+    )
+    agent.client.chat.completions.create.side_effect = [
+        _response(
+            tool_calls=[
+                _tool_call("web_search", "before", {"query": "one"}),
+                _tool_call(
+                    "write_file",
+                    "write",
+                    {"path": "/tmp/out.txt", "content": "done"},
+                ),
+                _tool_call("web_search", "after", {"query": "two"}),
+            ]
+        ),
+        _response(content="done"),
+    ]
+
+    def dispatch(name, _args, _task_id, **_kwargs):
+        if name == "write_file":
+            return json.dumps({"bytes_written": 4, "resolved_path": "/tmp/out.txt"})
+        return json.dumps({"results": []})
+
+    with patch("run_agent.handle_function_call", side_effect=dispatch):
+        result = _run(agent)
+
+    assert result["final_response"] == "done"
+    assert agent._progress_tracker.iterations_since_progress == 0
+
+
+def test_blocked_write_does_not_count_as_progress():
+    agent = _make_agent(
+        "write_file",
+        config=_progress_config(warn_after=3, halt_after=5),
+        delegated=True,
+    )
+    agent.client.chat.completions.create.side_effect = [
+        _response(
+            tool_calls=[
+                _tool_call(
+                    "write_file",
+                    "blocked",
+                    {"path": "/tmp/out.txt", "content": "done"},
+                )
+            ]
+        ),
+        _response(content="done"),
+    ]
+
+    with (
+        patch("hermes_cli.plugins.resolve_pre_tool_block", return_value="blocked by policy"),
+        patch("run_agent.handle_function_call") as dispatch,
+    ):
+        result = _run(agent)
+
+    dispatch.assert_not_called()
+    assert result["final_response"] == "done"
+    assert agent._progress_tracker.iterations_since_progress == 1
+
+
+def test_cancelled_write_result_does_not_count_as_progress():
+    agent = _make_agent(
+        "write_file",
+        config=_progress_config(),
+        delegated=True,
+    )
+    agent._turn_failed_file_mutations = {}
+    agent._turn_file_mutation_paths = set()
+    agent._progress_iteration_made_progress = False
+
+    agent._record_file_mutation_result(
+        "write_file",
+        {"path": "/tmp/out.txt", "content": "done"},
+        json.dumps({"error": "cancelled"}),
+        True,
+    )
+
+    assert agent._progress_iteration_made_progress is False
+
+
+def test_user_visible_text_with_tool_calls_counts_as_progress():
+    agent = _make_agent(
+        "web_search",
+        config=_progress_config(warn_after=2, halt_after=3),
+        delegated=True,
+    )
+    agent.client.chat.completions.create.side_effect = [
+        *[
+            _response(
+                content=f"Useful finding {index}",
+                tool_calls=[_tool_call("web_search", f"search-{index}")],
+            )
+            for index in range(1, 4)
+        ],
+        _response(content="done"),
+    ]
+
+    with patch("run_agent.handle_function_call", return_value=json.dumps({"results": []})):
+        result = _run(agent)
+
+    assert result["final_response"] == "done"
+    assert agent._progress_tracker.iterations_since_progress == 0
+
+
+def test_structured_interim_text_counts_as_progress():
+    agent = _make_agent(
+        "web_search",
+        config=_progress_config(warn_after=2, halt_after=3),
+        delegated=True,
+    )
+    agent.client.chat.completions.create.side_effect = [
+        *[
+            _response(tool_calls=[_tool_call("web_search", f"search-{index}")])
+            for index in range(1, 4)
+        ],
+        _response(content="done"),
+    ]
+
+    agent.interim_assistant_callback = MagicMock()
+
+    def visible_text(message):
+        tool_calls = message.get("tool_calls") or []
+        if not tool_calls:
+            return ""
+        return f"structured commentary {tool_calls[0]['id']}"
+
+    with (
+        patch("run_agent.handle_function_call", return_value=json.dumps({"results": []})),
+        patch.object(agent, "_interim_assistant_visible_text", side_effect=visible_text),
+    ):
+        result = _run(agent)
+
+    assert result["final_response"] == "done"
+    assert agent._progress_tracker.iterations_since_progress == 0
+
+
+def test_withheld_top_level_text_does_not_count_as_visible_progress():
+    agent = _make_agent(
+        "web_search",
+        config=_progress_config(warn_after=2, halt_after=3),
+        delegated=True,
+    )
+    agent.client.chat.completions.create.side_effect = [
+        *[
+            _response(
+                content=f"withheld answer {index}",
+                tool_calls=[_tool_call("web_search", f"search-{index}")],
+            )
+            for index in range(1, 4)
+        ],
+        _response(content="unreachable"),
+    ]
+
+    with (
+        patch("run_agent.handle_function_call", return_value=json.dumps({"results": []})),
+        patch.object(agent, "_interim_assistant_visible_text", return_value=""),
+    ):
+        result = _run(agent)
+
+    assert result["turn_exit_reason"] == "guardrail_halt"
+    assert agent.client.chat.completions.create.call_count == 3
+
+
+def test_repeated_already_delivered_text_does_not_evade_halt():
+    agent = _make_agent(
+        "web_search",
+        config=_progress_config(warn_after=2, halt_after=3),
+        delegated=True,
+    )
+    agent.interim_assistant_callback = MagicMock()
+    agent.client.chat.completions.create.side_effect = [
+        *[
+            _response(
+                content="same update",
+                tool_calls=[_tool_call("web_search", f"search-{index}")],
+            )
+            for index in range(1, 6)
+        ],
+        _response(content="unreachable"),
+    ]
+
+    with patch("run_agent.handle_function_call", return_value=json.dumps({"results": []})):
+        result = _run(agent)
+
+    assert result["turn_exit_reason"] == "guardrail_halt"
+    assert agent.client.chat.completions.create.call_count == 4
+    agent.interim_assistant_callback.assert_called_once()
+
+
+def test_new_user_turn_resets_stale_progress_state():
+    agent = _make_agent(
+        "web_search",
+        config=_progress_config(warn_after=2, halt_after=3),
+        delegated=True,
+    )
+    agent._progress_tracker.finish_iteration(made_progress=False)
+    agent._progress_tracker.finish_iteration(made_progress=False)
+    assert agent._progress_tracker.iterations_since_progress == 2
+    agent.client.chat.completions.create.return_value = _response(content="done")
+
+    result = _run(agent, "new request")
+
+    assert result["final_response"] == "done"
+    assert agent._progress_tracker.iterations_since_progress == 0


### PR DESCRIPTION
## Problem

Delegated child agents can spend their entire iteration budget making different tool calls without producing user-visible output or landing work. Existing `tool_loop_guardrails` detects repeated tool-call patterns, but it does not catch this broader non-convergence case.

Related to #414. This circuit breaker complements iteration-budget handling; it does not replace it.

## Solution

Add an opt-in non-convergence circuit breaker scoped strictly to `delegate_task` children.

The tracker evaluates one complete model/tool round at a time:

- user-visible assistant text counts as progress;
- a confirmed successful `write_file` or `patch` result counts as progress;
- read-only calls, failed mutations, blocked calls, and cancelled calls do not;
- `warn_after` adds convergence guidance to the last tool result;
- `halt_after` enters Hermes' existing controlled-halt path and terminates the child loop deterministically.

The feature is disabled by default because a long read-only investigation may be productive even when it has not produced output yet.

## Configuration

```yaml
delegation:
  progress_tracker:
    enabled: false
    warn_after: 15
    halt_after: 25
```

## Changes

- `agent/progress_tracker.py`
  - structured `none` / `warn` / `halt` decisions;
  - validated thresholds;
  - explicit per-user-turn reset.
- `agent/agent_init.py`
  - tracker initialization only inside delegated-child construction context;
  - disabled configuration installs no runtime tracker.
- `agent/conversation_loop.py` and `run_agent.py`
  - one tracker update per complete tool round;
  - result-aware progress through the existing file-mutation verifier;
  - warning injection and deterministic controlled halt.
- `hermes_cli/config_defaults.py` and `cli-config.yaml.example`
  - opt-in defaults and accurate behavior documentation.
- Tests cover:
  - parent/child scoping and disabled behavior;
  - turn reset and strict false-like opt-in parsing;
  - successful and failed writes, including decorated successful results;
  - read-only, blocked, and cancelled calls;
  - sequential, concurrent, and segmented execution;
  - structured, withheld, and duplicate interim text;
  - warning durability and real controlled halt.

## Validation

```text
65 targeted tests passed
python compileall passed
git diff --check passed
```

A broader `tests/agent tests/run_agent` run reached the existing optional-dependency failures in the local minimal test environment (`pytest-asyncio` and `anthropic` are not installed); the focused runtime, guardrail, and file-mutation suites pass.

## Risk

The heuristic cannot know whether a long read-only investigation is useful. It is therefore delegated-child-only, configurable, and disabled by default.
