### PR TITLE
feat(tui): show the plan catalog in /subscription on Free

### DIFF
--- a/apps/desktop/src/app/settings/billing/index.tsx
+++ b/apps/desktop/src/app/settings/billing/index.tsx
@@ -94,7 +94,14 @@ function RowValue({ onAction, row }: { onAction?: () => void; row: BillingAccoun
       {row.pill && <Pill tone={row.pill.tone}>{row.pill.label}</Pill>}
       {row.secondaryPill && <Pill>{row.secondaryPill}</Pill>}
       {row.chips?.map(chip => (
-        <Button disabled={chip.disabled} key={chip.label} size="sm" type="button" variant="outline">
+        <Button
+          disabled={chip.disabled}
+          key={chip.label}
+          onClick={chip.url ? () => openExternal(chip.url) : undefined}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
           {chip.label}
         </Button>
       ))}

--- a/apps/desktop/src/app/settings/billing/use-billing-state.test.ts
+++ b/apps/desktop/src/app/settings/billing/use-billing-state.test.ts
@@ -184,6 +184,101 @@ describe('deriveBillingView', () => {
     })
   })
 
+  it('free with catalog: tier chips render inline and open the portal', () => {
+    const view = deriveBillingView(
+      okBilling(todayBillingState),
+      okSubscription({
+        ...todaySubscriptionState,
+        context: 'personal',
+        current: null,
+        tiers: [
+          {
+            dollars_per_month_display: '$0',
+            is_current: false,
+            is_enabled: true,
+            monthly_credits: '0',
+            name: 'Free',
+            tier_id: 'free',
+            tier_order: 0
+          },
+          {
+            dollars_per_month_display: '$40',
+            is_current: false,
+            is_enabled: true,
+            monthly_credits: '3000',
+            name: 'Ultra',
+            tier_id: 'ultra',
+            tier_order: 2
+          },
+          {
+            dollars_per_month_display: '$20',
+            is_current: false,
+            is_enabled: true,
+            monthly_credits: '1000',
+            name: 'Plus',
+            tier_id: 'plus',
+            tier_order: 1
+          }
+        ]
+      })
+    )
+    const subscription = view.accountRows.find(row => row.id === 'subscription')
+
+    expect(subscription?.description).toBe('Paid models need a subscription — pick a plan to start it on the portal.')
+    // Sorted by tier order, free tier excluded, every chip clickable → portal.
+    expect(subscription?.chips).toEqual([
+      { disabled: false, label: 'Plus · $20/mo · $1,000 credits/mo', url: subscription?.action?.url },
+      { disabled: false, label: 'Ultra · $40/mo · $3,000 credits/mo', url: subscription?.action?.url }
+    ])
+  })
+
+  it('subscriber who can change plans: current tier marked inert, others open the portal', () => {
+    const view = deriveBillingView(
+      okBilling(todayBillingState),
+      okSubscription({
+        ...todaySubscriptionState,
+        context: 'personal',
+        tiers: [
+          {
+            dollars_per_month_display: '$20',
+            is_current: true,
+            is_enabled: true,
+            monthly_credits: '1000',
+            name: 'Plus',
+            tier_id: 'plus',
+            tier_order: 1
+          },
+          {
+            dollars_per_month_display: '$40',
+            is_current: false,
+            is_enabled: true,
+            monthly_credits: '3000',
+            name: 'Ultra',
+            tier_id: 'ultra',
+            tier_order: 2
+          }
+        ]
+      })
+    )
+    const subscription = view.accountRows.find(row => row.id === 'subscription')
+
+    expect(subscription?.chips).toEqual([
+      { disabled: true, label: '✓ Plus · $20/mo · $1,000 credits/mo' },
+      { disabled: false, label: 'Ultra · $40/mo · $3,000 credits/mo', url: subscription?.action?.url }
+    ])
+  })
+
+  it('members and team contexts get no tier chips', () => {
+    const member = deriveBillingView(
+      okBilling(todayBillingState),
+      okSubscription({ ...todaySubscriptionState, can_change_plan: false, context: 'personal' })
+    )
+    const team = deriveBillingView(okBilling(todayBillingState), okSubscription(todaySubscriptionState))
+
+    expect(member.accountRows.find(row => row.id === 'subscription')?.chips).toBeUndefined()
+    expect(team.accountRows.find(row => row.id === 'subscription')?.chips).toBeUndefined()
+  })
+
   it('clamps overdrawn subscription credits to $0 and names the overage', () => {
     const view = deriveBillingView(
       okBilling(todayBillingState),

--- a/apps/desktop/src/app/settings/billing/use-billing-state.test.ts
+++ b/apps/desktop/src/app/settings/billing/use-billing-state.test.ts
@@ -225,7 +225,6 @@ describe('deriveBillingView', () => {
     const subscription = view.accountRows.find(row => row.id === 'subscription')
 
     expect(subscription?.description).toBe('Paid models need a subscription — pick a plan to start it on the portal.')
-    // Sorted by tier order, free tier excluded, every chip clickable → portal.
     expect(subscription?.chips).toEqual([
       { disabled: false, label: 'Plus · $20/mo · $1,000 credits/mo', url: subscription?.action?.url },
       { disabled: false, label: 'Ultra · $40/mo · $3,000 credits/mo', url: subscription?.action?.url }

--- a/apps/desktop/src/app/settings/billing/use-billing-state.ts
+++ b/apps/desktop/src/app/settings/billing/use-billing-state.ts
@@ -41,7 +41,7 @@ export interface BillingRowActionView {
 export interface BillingChipView {
   disabled: boolean
   label: string
-  /** When set, clicking the chip opens this URL externally (portal handoff). */
+  /** When set, clicking the chip opens this URL externally. */
   url?: string
 }
 
@@ -275,10 +275,8 @@ function paymentMethodRow(billing: BillingStateResponse): BillingAccountRowView 
 }
 
 /**
- * The tier catalog as chips — the upsell lives where the user already is
- * (mirrors the TUI's inline Free-plan rows). Only for accounts that can act
- * (can_change_plan); the current plan is marked and inert, every other plan
- * opens the portal, where the change/start actually happens.
+ * Tier catalog as chips for accounts that can change plans; the current plan is
+ * inert, every other opens the portal where the change/start happens.
  */
 function subscriptionTierChips(
   subscription: null | SubscriptionStateResponse,

--- a/apps/desktop/src/app/settings/billing/use-billing-state.ts
+++ b/apps/desktop/src/app/settings/billing/use-billing-state.ts
@@ -41,6 +41,8 @@ export interface BillingRowActionView {
 export interface BillingChipView {
   disabled: boolean
   label: string
+  /** When set, clicking the chip opens this URL externally (portal handoff). */
+  url?: string
 }
 
 export interface BillingAccountRowView {
@@ -272,6 +274,39 @@ function paymentMethodRow(billing: BillingStateResponse): BillingAccountRowView 
   }
 }
 
+/**
+ * The tier catalog as chips — the upsell lives where the user already is
+ * (mirrors the TUI's inline Free-plan rows). Only for accounts that can act
+ * (can_change_plan); the current plan is marked and inert, every other plan
+ * opens the portal, where the change/start actually happens.
+ */
+function subscriptionTierChips(
+  subscription: null | SubscriptionStateResponse,
+  manageUrl: string
+): BillingChipView[] | undefined {
+  // Teams have no personal subscription to sell into.
+  if (!subscription?.can_change_plan || subscription.context === 'team') {
+    return undefined
+  }
+
+  const tiers = (subscription.tiers ?? [])
+    .filter(tier => tier.is_enabled && tier.tier_order > 0)
+    .sort((a, b) => a.tier_order - b.tier_order)
+
+  if (tiers.length === 0) {
+    return undefined
+  }
+
+  return tiers.map(tier => {
+    // Monthly credits are dollars; NAS sends a bare decimal string.
+    const credits = Number((tier.monthly_credits ?? '').replace(/,/g, ''))
+    const suffix = Number.isFinite(credits) && credits > 0 ? ` · $${credits.toLocaleString('en-US')} credits/mo` : ''
+    const label = `${tier.name} · ${tier.dollars_per_month_display}/mo${suffix}`
+
+    return tier.is_current ? { disabled: true, label: `✓ ${label}` } : { disabled: false, label, url: manageUrl }
+  })
+}
+
 function subscriptionRow(
   billing: BillingStateResponse,
   subscription: null | SubscriptionStateResponse,
@@ -283,13 +318,18 @@ function subscriptionRow(
   const value = current?.tier_name ?? fallbackPlan
   const renewal = formatBillingDate(current?.cycle_ends_at ?? billing.usage?.renews_at)
   const unavailable = subscriptionResult && !subscriptionResult.ok
+  const chips = subscriptionTierChips(subscription, manageUrl)
 
   return {
     action: { label: 'Adjust plan ↗', url: manageUrl },
     caption: unavailable
       ? 'Subscription details are unavailable; opening the portal is still available.'
       : `Renews ${renewal}`,
-    description: 'Review your plan and change it from the billing portal.',
+    chips,
+    description:
+      !current && chips
+        ? 'Paid models need a subscription — pick a plan to start it on the portal.'
+        : 'Review your plan and change it from the billing portal.',
     id: 'subscription',
     secondaryPill: 'opens portal',
     title: 'Subscription',

--- a/ui-tui/scripts/billing-fixtures.tsx
+++ b/ui-tui/scripts/billing-fixtures.tsx
@@ -42,9 +42,8 @@ const tier = (o: Partial<SubscriptionTierOption> = {}): SubscriptionTierOption =
   ...o
 })
 
-// Mirrors the LIVE catalog (portal pricing page, 2026-07: 10% bonus tiers) so
-// fixture screenshots can't drift from what the API actually serves. The real
-// overlay reads these from GET /api/billing/subscription — never from here.
+// Mirrors the live portal catalog so fixtures don't drift; the real overlay
+// reads tiers from GET /api/billing/subscription, never from here.
 const TIERS = {
   free: tier({ tier_id: 'free', name: 'Free', tier_order: 0, dollars_per_month_display: '$0', monthly_credits: '0' }),
   plus: tier({ tier_id: 'plus', name: 'Plus', tier_order: 1, dollars_per_month_display: '$20', monthly_credits: '22' }),

--- a/ui-tui/scripts/billing-fixtures.tsx
+++ b/ui-tui/scripts/billing-fixtures.tsx
@@ -42,11 +42,14 @@ const tier = (o: Partial<SubscriptionTierOption> = {}): SubscriptionTierOption =
   ...o
 })
 
+// Mirrors the LIVE catalog (portal pricing page, 2026-07: 10% bonus tiers) so
+// fixture screenshots can't drift from what the API actually serves. The real
+// overlay reads these from GET /api/billing/subscription — never from here.
 const TIERS = {
   free: tier({ tier_id: 'free', name: 'Free', tier_order: 0, dollars_per_month_display: '$0', monthly_credits: '0' }),
-  plus: tier({ tier_id: 'plus', name: 'Plus', tier_order: 1, dollars_per_month_display: '$20', monthly_credits: '1,000' }),
-  super: tier({ tier_id: 'super', name: 'Super', tier_order: 2, dollars_per_month_display: '$50', monthly_credits: '3,000' }),
-  ultra: tier({ tier_id: 'ultra', name: 'Ultra', tier_order: 3, dollars_per_month_display: '$99', monthly_credits: '7,000' })
+  plus: tier({ tier_id: 'plus', name: 'Plus', tier_order: 1, dollars_per_month_display: '$20', monthly_credits: '22' }),
+  super: tier({ tier_id: 'super', name: 'Super', tier_order: 2, dollars_per_month_display: '$100', monthly_credits: '110' }),
+  ultra: tier({ tier_id: 'ultra', name: 'Ultra', tier_order: 3, dollars_per_month_display: '$200', monthly_credits: '220' })
 }
 
 const tierList = (currentId?: string): SubscriptionTierOption[] =>

--- a/ui-tui/src/__tests__/subscriptionOverlay.test.tsx
+++ b/ui-tui/src/__tests__/subscriptionOverlay.test.tsx
@@ -393,8 +393,8 @@ describe('SubscriptionOverlay — picker', () => {
     const out = render(at('picker', freeWithCatalog()))
 
     expect(out).toContain('Choose a plan')
-    expect(out).toContain('Plus · $20/mo · 1000 credits/mo')
-    expect(out).toContain('Ultra · $40/mo · 3000 credits/mo')
+    expect(out).toContain('Plus · $20/mo · $1,000 credits/mo')
+    expect(out).toContain('Ultra · $40/mo · $3,000 credits/mo')
     expect(out).not.toContain('upgrade') // nothing to move from — it's a start
     expect(out).not.toContain('$0/mo')
     expect(out).toContain('Enter opens the portal')

--- a/ui-tui/src/__tests__/subscriptionOverlay.test.tsx
+++ b/ui-tui/src/__tests__/subscriptionOverlay.test.tsx
@@ -172,13 +172,13 @@ describe('SubscriptionOverlay — overview', () => {
     })
 
     inputHarness.handler?.('', { return: true }) // first row = Plus
-    inputHarness.handler?.('', { return: true }) // double-press must not re-fire
+    inputHarness.handler?.('', { return: true })
     await vi.waitFor(() => expect(openManageLink).toHaveBeenCalled())
     mounted.cleanup()
 
     expect(openManageLink).toHaveBeenCalledTimes(1)
     expect(preview).not.toHaveBeenCalled()
-    // openManageLink narrates the handoff itself — the overview adds nothing.
+    // openManageLink narrates the handoff itself.
     expect(sys).not.toHaveBeenCalled()
   })
 
@@ -351,8 +351,7 @@ const at = (
   extra: Partial<SubscriptionOverlayState> = {}
 ): SubscriptionOverlayState => ({ ctx, screen, state: s, ...extra })
 
-// Free account that can still see the catalog: no current sub, but NAS returns
-// the tier list (is_current false everywhere).
+// Free account (no current sub) where NAS still returns the tier catalog.
 const freeWithCatalog = (): SubscriptionStateResponse =>
   state({
     current: null,

--- a/ui-tui/src/__tests__/subscriptionOverlay.test.tsx
+++ b/ui-tui/src/__tests__/subscriptionOverlay.test.tsx
@@ -149,6 +149,13 @@ describe('SubscriptionOverlay — overview', () => {
     expect(out.toLowerCase()).not.toContain('credits')
   })
 
+  it('free with catalog: offers "Choose a plan" alongside the portal row', () => {
+    const out = render(overlay(freeWithCatalog()))
+
+    expect(out).toContain('Choose a plan')
+    expect(out).toContain('Start a subscription')
+  })
+
   it('subscriber: status line + plan bar + top-up bar, no "credits"', () => {
     const out = render(
       overlay(
@@ -318,6 +325,15 @@ const at = (
   extra: Partial<SubscriptionOverlayState> = {}
 ): SubscriptionOverlayState => ({ ctx, screen, state: s, ...extra })
 
+// Free account that can still see the catalog: no current sub, but NAS returns
+// the tier list (is_current false everywhere).
+const freeWithCatalog = (): SubscriptionStateResponse =>
+  state({
+    current: null,
+    tiers: TIERS.map(tier => ({ ...tier, is_current: false })),
+    usage: { available: true, plan_name: null, status: 'free' }
+  })
+
 describe('SubscriptionOverlay — overview actions', () => {
   it('admin subscriber: offers Change plan + Cancel subscription', () => {
     const out = render(overlay(subscriber()))
@@ -371,6 +387,36 @@ describe('SubscriptionOverlay — picker', () => {
     expect(out).toContain('upgrade') // ultra (order 2) > plus (order 1)
     expect(out).not.toContain('Plus · $20/mo') // current tier is not selectable
     expect(out).not.toContain('$0/mo') // free tier excluded — use Cancel instead
+  })
+
+  it('free: lists paid plans with credits instead of direction hints', () => {
+    const out = render(at('picker', freeWithCatalog()))
+
+    expect(out).toContain('Choose a plan')
+    expect(out).toContain('Plus · $20/mo · 1000 credits/mo')
+    expect(out).toContain('Ultra · $40/mo · 3000 credits/mo')
+    expect(out).not.toContain('upgrade') // nothing to move from — it's a start
+    expect(out).not.toContain('$0/mo')
+    expect(out).toContain('Enter opens the portal')
+  })
+
+  it('free: picking a plan opens the portal instead of previewing', async () => {
+    const openManageLink = vi.fn(() => Promise.resolve(true))
+    const preview = vi.fn(() => Promise.resolve(null))
+    const sys = vi.fn()
+
+    const mounted = mount(
+      at('picker', freeWithCatalog(), {
+        ctx: { ...ctx, openManageLink, preview, sys } as SubscriptionOverlayState['ctx']
+      })
+    )
+
+    inputHarness.handler?.('', { return: true }) // first row = Plus
+    await vi.waitFor(() => expect(openManageLink).toHaveBeenCalled())
+    mounted.cleanup()
+
+    expect(preview).not.toHaveBeenCalled()
+    expect(sys).toHaveBeenCalledWith(expect.stringContaining('finish starting Plus'))
   })
 })
 

--- a/ui-tui/src/__tests__/subscriptionOverlay.test.tsx
+++ b/ui-tui/src/__tests__/subscriptionOverlay.test.tsx
@@ -400,7 +400,7 @@ describe('SubscriptionOverlay — picker', () => {
     expect(out).toContain('Enter opens the portal')
   })
 
-  it('free: picking a plan opens the portal instead of previewing', async () => {
+  it('free: picking a plan opens the portal instead of previewing, once even on double-Enter', async () => {
     const openManageLink = vi.fn(() => Promise.resolve(true))
     const preview = vi.fn(() => Promise.resolve(null))
     const sys = vi.fn()
@@ -412,11 +412,14 @@ describe('SubscriptionOverlay — picker', () => {
     )
 
     inputHarness.handler?.('', { return: true }) // first row = Plus
+    inputHarness.handler?.('', { return: true }) // double-press must not re-fire
     await vi.waitFor(() => expect(openManageLink).toHaveBeenCalled())
     mounted.cleanup()
 
+    expect(openManageLink).toHaveBeenCalledTimes(1)
     expect(preview).not.toHaveBeenCalled()
-    expect(sys).toHaveBeenCalledWith(expect.stringContaining('finish starting Plus'))
+    // openManageLink narrates the handoff itself — the picker adds nothing.
+    expect(sys).not.toHaveBeenCalled()
   })
 })
 

--- a/ui-tui/src/__tests__/subscriptionOverlay.test.tsx
+++ b/ui-tui/src/__tests__/subscriptionOverlay.test.tsx
@@ -414,7 +414,6 @@ describe('SubscriptionOverlay — picker', () => {
     expect(out).not.toContain('Plus · $20/mo') // current tier is not selectable
     expect(out).not.toContain('$0/mo') // free tier excluded — use Cancel instead
   })
-
 })
 
 describe('SubscriptionOverlay — confirm', () => {

--- a/ui-tui/src/__tests__/subscriptionOverlay.test.tsx
+++ b/ui-tui/src/__tests__/subscriptionOverlay.test.tsx
@@ -149,11 +149,37 @@ describe('SubscriptionOverlay — overview', () => {
     expect(out.toLowerCase()).not.toContain('credits')
   })
 
-  it('free with catalog: offers "Choose a plan" alongside the portal row', () => {
+  it('free with catalog: plans render inline; the generic portal row disappears', () => {
     const out = render(overlay(freeWithCatalog()))
 
-    expect(out).toContain('Choose a plan')
-    expect(out).toContain('Start a subscription')
+    expect(out).toContain('Plus · $20/mo · $1,000 credits/mo')
+    expect(out).toContain('Ultra · $40/mo · $3,000 credits/mo')
+    expect(out).not.toContain('upgrade') // a start, not a move
+    expect(out).not.toContain('$0/mo') // free tier is not an option
+    expect(out).not.toContain('Choose a plan')
+    expect(out).not.toContain('Start a subscription')
+  })
+
+  it('free with catalog: picking a plan opens the portal once, even on double-Enter', async () => {
+    const openManageLink = vi.fn(() => Promise.resolve(true))
+    const preview = vi.fn(() => Promise.resolve(null))
+    const sys = vi.fn()
+
+    const mounted = mount({
+      ctx: { ...ctx, openManageLink, preview, sys } as SubscriptionOverlayState['ctx'],
+      screen: 'overview',
+      state: freeWithCatalog()
+    })
+
+    inputHarness.handler?.('', { return: true }) // first row = Plus
+    inputHarness.handler?.('', { return: true }) // double-press must not re-fire
+    await vi.waitFor(() => expect(openManageLink).toHaveBeenCalled())
+    mounted.cleanup()
+
+    expect(openManageLink).toHaveBeenCalledTimes(1)
+    expect(preview).not.toHaveBeenCalled()
+    // openManageLink narrates the handoff itself — the overview adds nothing.
+    expect(sys).not.toHaveBeenCalled()
   })
 
   it('subscriber: status line + plan bar + top-up bar, no "credits"', () => {
@@ -389,38 +415,6 @@ describe('SubscriptionOverlay — picker', () => {
     expect(out).not.toContain('$0/mo') // free tier excluded — use Cancel instead
   })
 
-  it('free: lists paid plans with credits instead of direction hints', () => {
-    const out = render(at('picker', freeWithCatalog()))
-
-    expect(out).toContain('Choose a plan')
-    expect(out).toContain('Plus · $20/mo · $1,000 credits/mo')
-    expect(out).toContain('Ultra · $40/mo · $3,000 credits/mo')
-    expect(out).not.toContain('upgrade') // nothing to move from — it's a start
-    expect(out).not.toContain('$0/mo')
-    expect(out).toContain('Enter opens the portal')
-  })
-
-  it('free: picking a plan opens the portal instead of previewing, once even on double-Enter', async () => {
-    const openManageLink = vi.fn(() => Promise.resolve(true))
-    const preview = vi.fn(() => Promise.resolve(null))
-    const sys = vi.fn()
-
-    const mounted = mount(
-      at('picker', freeWithCatalog(), {
-        ctx: { ...ctx, openManageLink, preview, sys } as SubscriptionOverlayState['ctx']
-      })
-    )
-
-    inputHarness.handler?.('', { return: true }) // first row = Plus
-    inputHarness.handler?.('', { return: true }) // double-press must not re-fire
-    await vi.waitFor(() => expect(openManageLink).toHaveBeenCalled())
-    mounted.cleanup()
-
-    expect(openManageLink).toHaveBeenCalledTimes(1)
-    expect(preview).not.toHaveBeenCalled()
-    // openManageLink narrates the handoff itself — the picker adds nothing.
-    expect(sys).not.toHaveBeenCalled()
-  })
 })
 
 describe('SubscriptionOverlay — confirm', () => {

--- a/ui-tui/src/components/subscriptionOverlay.tsx
+++ b/ui-tui/src/components/subscriptionOverlay.tsx
@@ -531,10 +531,11 @@ function PickerScreen({ onClose, onPatch, overlay, t }: ScreenProps) {
 
   const rows: MenuRowSpec[] = choices.map(tier => {
     // From Free every option is a start — show what the plan includes;
-    // otherwise hint the direction of the move.
+    // otherwise hint the direction of the move. Monthly credits are dollars.
     let suffix: string
     if (isFree) {
-      suffix = tier.monthly_credits ? ` · ${tier.monthly_credits} credits/mo` : ''
+      const credits = Number(tier.monthly_credits)
+      suffix = Number.isFinite(credits) && credits > 0 ? ` · $${credits.toLocaleString('en-US')} credits/mo` : ''
     } else {
       suffix = tier.tier_order > currentOrder ? ' · upgrade' : ' · downgrade'
     }

--- a/ui-tui/src/components/subscriptionOverlay.tsx
+++ b/ui-tui/src/components/subscriptionOverlay.tsx
@@ -512,21 +512,18 @@ function PickerScreen({ onClose, onPatch, overlay, t }: ScreenProps) {
       return
     }
 
-    // On Free there is no subscription to mutate — starting one lives on the
-    // portal (card capture + checkout). Route the chosen plan there.
-    if (isFree) {
-      if (s.portal_url) {
-        void ctx.openManageLink()
-        ctx.sys(`Opening the portal — finish starting ${tier.name} there, then re-run /subscription.`)
-      } else {
-        ctx.sys('🔴 No portal URL available — start your subscription on the Nous portal.')
-      }
+    busyRef.current = true
 
+    // On Free there is no subscription to mutate — starting one lives on the
+    // portal (card capture + checkout). openManageLink narrates the handoff
+    // (and the missing-URL failure) itself.
+    if (isFree) {
+      void ctx.openManageLink()
       onClose()
+
       return
     }
 
-    busyRef.current = true
     void previewAndRoute(ctx, tier.tier_id, onPatch)
   }
 

--- a/ui-tui/src/components/subscriptionOverlay.tsx
+++ b/ui-tui/src/components/subscriptionOverlay.tsx
@@ -375,9 +375,12 @@ function OverviewScreen({ onClose, onPatch, overlay, t }: ScreenProps) {
   // portal enforces who can act (members) / starting a new sub needs a card.
   const canChange = s.can_change_plan && !isFree
   // On Free nothing can be mutated in-terminal (starting a subscription lives
-  // on the portal — card capture + checkout), but the catalog still renders
-  // here so plans and prices are visible before leaving the terminal.
-  const hasCatalog = isFree && s.tiers.some(tier => tier.is_enabled && tier.tier_order > 0)
+  // on the portal — card capture + checkout), but the catalog renders inline
+  // right here — the upsell happens where the user already is. Picking a plan
+  // opens the portal; openManageLink narrates the handoff itself.
+  const freePlans = isFree
+    ? s.tiers.filter(tier => tier.is_enabled && tier.tier_order > 0).sort((a, b) => a.tier_order - b.tier_order)
+    : []
 
   // Guard the async resume so a double-press cannot fire two DELETEs mid-await.
   const busyRef = useRef(false)
@@ -426,11 +429,31 @@ function OverviewScreen({ onClose, onPatch, overlay, t }: ScreenProps) {
     }
   }
 
-  if (hasCatalog) {
-    rows.push({ label: 'Choose a plan', run: () => onPatch({ pending: null, screen: 'picker' }) })
+  for (const tier of freePlans) {
+    // NAS sends a bare decimal string; tolerate pre-grouped ("1,000") too.
+    const credits = Number((tier.monthly_credits ?? '').replace(/,/g, ''))
+    const suffix = Number.isFinite(credits) && credits > 0 ? ` · $${credits.toLocaleString('en-US')} credits/mo` : ''
+
+    rows.push({
+      label: `${tier.name} · ${tier.dollars_per_month_display}/mo${suffix}`,
+      run: () => {
+        if (busyRef.current) {
+          return
+        }
+
+        busyRef.current = true
+        void ctx.openManageLink()
+        onClose()
+      }
+    })
   }
 
-  rows.push({ label: isFree ? 'Start a subscription' : 'Manage on portal', run: doManage })
+  // With the catalog inline, the plan rows ARE the subscribe path — only a
+  // catalog-less free state still needs the generic portal row.
+  if (!isFree || freePlans.length === 0) {
+    rows.push({ label: isFree ? 'Start a subscription' : 'Manage on portal', run: doManage })
+  }
+
   rows.push({ label: 'Close', run: onClose })
 
   const sel = useMenu(rows, onClose)
@@ -493,9 +516,8 @@ function OverviewScreen({ onClose, onPatch, overlay, t }: ScreenProps) {
 
 // ── Screen: Picker (choose a tier → preview → confirm) ───────────────
 
-function PickerScreen({ onClose, onPatch, overlay, t }: ScreenProps) {
+function PickerScreen({ onPatch, overlay, t }: ScreenProps) {
   const { ctx, state: s } = overlay
-  const isFree = !s.current?.tier_id
   const currentOrder = s.tiers.find(tier => tier.is_current)?.tier_order ?? 0
 
   // Selectable = enabled, not the current plan, and not the free/no-sub tier
@@ -513,34 +535,18 @@ function PickerScreen({ onClose, onPatch, overlay, t }: ScreenProps) {
     }
 
     busyRef.current = true
-
-    // On Free there is no subscription to mutate — starting one lives on the
-    // portal (card capture + checkout). openManageLink narrates the handoff
-    // (and the missing-URL failure) itself.
-    if (isFree) {
-      void ctx.openManageLink()
-      onClose()
-
-      return
-    }
-
     void previewAndRoute(ctx, tier.tier_id, onPatch)
   }
 
   const back = () => onPatch({ screen: 'overview' })
 
   const rows: MenuRowSpec[] = choices.map(tier => {
-    // From Free every option is a start — show what the plan includes;
-    // otherwise hint the direction of the move. Monthly credits are dollars.
-    let suffix: string
-    if (isFree) {
-      const credits = Number(tier.monthly_credits)
-      suffix = Number.isFinite(credits) && credits > 0 ? ` · $${credits.toLocaleString('en-US')} credits/mo` : ''
-    } else {
-      suffix = tier.tier_order > currentOrder ? ' · upgrade' : ' · downgrade'
-    }
+    const direction = tier.tier_order > currentOrder ? 'upgrade' : 'downgrade'
 
-    return { label: `${tier.name} · ${tier.dollars_per_month_display}/mo${suffix}`, run: () => pick(tier) }
+    return {
+      label: `${tier.name} · ${tier.dollars_per_month_display}/mo · ${direction}`,
+      run: () => pick(tier)
+    }
   })
 
   rows.push({ label: 'Back', run: back })
@@ -550,12 +556,10 @@ function PickerScreen({ onClose, onPatch, overlay, t }: ScreenProps) {
   return (
     <Box flexDirection="column">
       <Text bold color={t.color.accent}>
-        {isFree ? 'Choose a plan' : 'Change plan'}
+        Change plan
       </Text>
       <Text color={t.color.muted}>
-        {isFree
-          ? 'Current: Free. Pick a plan — you finish starting it on the portal.'
-          : `Current: ${s.current?.tier_name ?? 'Free'}. Pick a plan to see the effect before confirming.`}
+        Current: {s.current?.tier_name ?? 'Free'}. Pick a plan to see the effect before confirming.
       </Text>
       <Text />
       {choices.length === 0 && <Text color={t.color.muted}>No other plans are available to switch to right now.</Text>}
@@ -563,7 +567,7 @@ function PickerScreen({ onClose, onPatch, overlay, t }: ScreenProps) {
         <MenuRow active={sel === i} index={i + 1} key={row.label} label={row.label} t={t} />
       ))}
       <Text />
-      {footer(isFree ? '↑/↓ select · Enter opens the portal · Esc back' : '↑/↓ select · Enter preview · Esc back', t)}
+      {footer('↑/↓ select · Enter preview · Esc back', t)}
     </Box>
   )
 }

--- a/ui-tui/src/components/subscriptionOverlay.tsx
+++ b/ui-tui/src/components/subscriptionOverlay.tsx
@@ -533,23 +533,16 @@ function PickerScreen({ onClose, onPatch, overlay, t }: ScreenProps) {
   const back = () => onPatch({ screen: 'overview' })
 
   const rows: MenuRowSpec[] = choices.map(tier => {
-    // From Free every option is a start, not a move — show what the plan
-    // includes instead of a direction hint.
+    // From Free every option is a start — show what the plan includes;
+    // otherwise hint the direction of the move.
+    let suffix: string
     if (isFree) {
-      const credits = tier.monthly_credits ? ` · ${tier.monthly_credits} credits/mo` : ''
-
-      return {
-        label: `${tier.name} · ${tier.dollars_per_month_display}/mo${credits}`,
-        run: () => pick(tier)
-      }
+      suffix = tier.monthly_credits ? ` · ${tier.monthly_credits} credits/mo` : ''
+    } else {
+      suffix = tier.tier_order > currentOrder ? ' · upgrade' : ' · downgrade'
     }
 
-    const direction = tier.tier_order > currentOrder ? 'upgrade' : 'downgrade'
-
-    return {
-      label: `${tier.name} · ${tier.dollars_per_month_display}/mo · ${direction}`,
-      run: () => pick(tier)
-    }
+    return { label: `${tier.name} · ${tier.dollars_per_month_display}/mo${suffix}`, run: () => pick(tier) }
   })
 
   rows.push({ label: 'Back', run: back })

--- a/ui-tui/src/components/subscriptionOverlay.tsx
+++ b/ui-tui/src/components/subscriptionOverlay.tsx
@@ -374,6 +374,10 @@ function OverviewScreen({ onClose, onPatch, overlay, t }: ScreenProps) {
   // Admin/owner on a personal paid plan can change it in-terminal; otherwise the
   // portal enforces who can act (members) / starting a new sub needs a card.
   const canChange = s.can_change_plan && !isFree
+  // On Free nothing can be mutated in-terminal (starting a subscription lives
+  // on the portal — card capture + checkout), but the catalog still renders
+  // here so plans and prices are visible before leaving the terminal.
+  const hasCatalog = isFree && s.tiers.some(tier => tier.is_enabled && tier.tier_order > 0)
 
   // Guard the async resume so a double-press cannot fire two DELETEs mid-await.
   const busyRef = useRef(false)
@@ -420,6 +424,10 @@ function OverviewScreen({ onClose, onPatch, overlay, t }: ScreenProps) {
         run: () => onPatch({ pending: { kind: 'cancellation', preview: null, targetTierId: null }, screen: 'confirm' })
       })
     }
+  }
+
+  if (hasCatalog) {
+    rows.push({ label: 'Choose a plan', run: () => onPatch({ pending: null, screen: 'picker' }) })
   }
 
   rows.push({ label: isFree ? 'Start a subscription' : 'Manage on portal', run: doManage })
@@ -485,8 +493,9 @@ function OverviewScreen({ onClose, onPatch, overlay, t }: ScreenProps) {
 
 // ── Screen: Picker (choose a tier → preview → confirm) ───────────────
 
-function PickerScreen({ onPatch, overlay, t }: ScreenProps) {
+function PickerScreen({ onClose, onPatch, overlay, t }: ScreenProps) {
   const { ctx, state: s } = overlay
+  const isFree = !s.current?.tier_id
   const currentOrder = s.tiers.find(tier => tier.is_current)?.tier_order ?? 0
 
   // Selectable = enabled, not the current plan, and not the free/no-sub tier
@@ -503,6 +512,20 @@ function PickerScreen({ onPatch, overlay, t }: ScreenProps) {
       return
     }
 
+    // On Free there is no subscription to mutate — starting one lives on the
+    // portal (card capture + checkout). Route the chosen plan there.
+    if (isFree) {
+      if (s.portal_url) {
+        void ctx.openManageLink()
+        ctx.sys(`Opening the portal — finish starting ${tier.name} there, then re-run /subscription.`)
+      } else {
+        ctx.sys('🔴 No portal URL available — start your subscription on the Nous portal.')
+      }
+
+      onClose()
+      return
+    }
+
     busyRef.current = true
     void previewAndRoute(ctx, tier.tier_id, onPatch)
   }
@@ -510,6 +533,17 @@ function PickerScreen({ onPatch, overlay, t }: ScreenProps) {
   const back = () => onPatch({ screen: 'overview' })
 
   const rows: MenuRowSpec[] = choices.map(tier => {
+    // From Free every option is a start, not a move — show what the plan
+    // includes instead of a direction hint.
+    if (isFree) {
+      const credits = tier.monthly_credits ? ` · ${tier.monthly_credits} credits/mo` : ''
+
+      return {
+        label: `${tier.name} · ${tier.dollars_per_month_display}/mo${credits}`,
+        run: () => pick(tier)
+      }
+    }
+
     const direction = tier.tier_order > currentOrder ? 'upgrade' : 'downgrade'
 
     return {
@@ -525,10 +559,12 @@ function PickerScreen({ onPatch, overlay, t }: ScreenProps) {
   return (
     <Box flexDirection="column">
       <Text bold color={t.color.accent}>
-        Change plan
+        {isFree ? 'Choose a plan' : 'Change plan'}
       </Text>
       <Text color={t.color.muted}>
-        Current: {s.current?.tier_name ?? 'Free'}. Pick a plan to see the effect before confirming.
+        {isFree
+          ? 'Current: Free. Pick a plan — you finish starting it on the portal.'
+          : `Current: ${s.current?.tier_name ?? 'Free'}. Pick a plan to see the effect before confirming.`}
       </Text>
       <Text />
       {choices.length === 0 && <Text color={t.color.muted}>No other plans are available to switch to right now.</Text>}
@@ -536,7 +572,7 @@ function PickerScreen({ onPatch, overlay, t }: ScreenProps) {
         <MenuRow active={sel === i} index={i + 1} key={row.label} label={row.label} t={t} />
       ))}
       <Text />
-      {footer('↑/↓ select · Enter preview · Esc back', t)}
+      {footer(isFree ? '↑/↓ select · Enter opens the portal · Esc back' : '↑/↓ select · Enter preview · Esc back', t)}
     </Box>
   )
 }

--- a/ui-tui/src/components/subscriptionOverlay.tsx
+++ b/ui-tui/src/components/subscriptionOverlay.tsx
@@ -374,10 +374,8 @@ function OverviewScreen({ onClose, onPatch, overlay, t }: ScreenProps) {
   // Admin/owner on a personal paid plan can change it in-terminal; otherwise the
   // portal enforces who can act (members) / starting a new sub needs a card.
   const canChange = s.can_change_plan && !isFree
-  // On Free nothing can be mutated in-terminal (starting a subscription lives
-  // on the portal — card capture + checkout), but the catalog renders inline
-  // right here — the upsell happens where the user already is. Picking a plan
-  // opens the portal; openManageLink narrates the handoff itself.
+  // On Free the catalog renders inline; picking a plan hands off to the portal,
+  // where starting a subscription needs card capture + checkout.
   const freePlans = isFree
     ? s.tiers.filter(tier => tier.is_enabled && tier.tier_order > 0).sort((a, b) => a.tier_order - b.tier_order)
     : []
@@ -448,8 +446,8 @@ function OverviewScreen({ onClose, onPatch, overlay, t }: ScreenProps) {
     })
   }
 
-  // With the catalog inline, the plan rows ARE the subscribe path — only a
-  // catalog-less free state still needs the generic portal row.
+  // The inline plan rows are the subscribe path; only a catalog-less free state
+  // still needs the generic portal row.
   if (!isFree || freePlans.length === 0) {
     rows.push({ label: isFree ? 'Start a subscription' : 'Manage on portal', run: doManage })
   }


### PR DESCRIPTION
On a Free account, `/subscription` showed only "Start a subscription" — no plans, no prices — even though the server already returns the full tier catalog. Same on desktop, where the Subscription row was just an "Adjust plan ↗" link.

## What changed (design per owner ruling: the upsell lives where the user already is)

**TUI** — on Free, the overview lists each paid plan inline as a pickable row:

```
▸ 1. Plus · $20/mo · $1,000 credits/mo
  2. Super · $50/mo · $3,000 credits/mo
  3. Ultra · $99/mo · $7,000 credits/mo
  4. Close
```

Picking one opens the portal (where starting a subscription actually happens — card capture + checkout live there; the in-terminal upgrade RPC only mutates an existing subscription). The generic "Start a subscription" row survives only when the catalog is empty. The change-plan picker/preview/confirm flow for existing subscribers is untouched; Free never enters it.

**Desktop** — the Subscription row grows tier chips for accounts that can act (`can_change_plan`, personal context): Free gets the same upsell list (every chip opens the portal); a subscriber sees all tiers with the current one marked `✓` and inert. Members and team contexts see no chips. Chips gained an optional `url` in the shared row model.

Monthly credits are dollars and render as such (`$1,000 credits/mo`, grouped).

## Guard rails from review

- Double-Enter on a plan opens the portal exactly once (busy guard armed before the handoff; regression test presses twice).
- The overlay adds no narration of its own — `openManageLink` already reports success/failure, so there is no duplicate or contradictory messaging.

## Future follow-ups (recorded on the workstream)

- A tier-preselect param on the portal subscribe page, so a pick deep-links the chosen plan instead of the generic page.
- Terminal/desktop-native subscription start with a saved card — once that lands server-side, these same surfaces arm for it without layout changes.

## Verification

- ui-tui: 25 overlay tests (inline rows, no direction hints on Free, double-press single-open, catalog-less fallback); full suite green; `tsc --noEmit` clean; fixture harness renders the Free overview pixel-identical to production.
- desktop: 57 billing tests incl. 3 new (Free chips + URLs, subscriber current-tier marking, member/team exclusion); `tsc --noEmit` clean.