### PR TITLE
fix(cron): isolate standalone fallback from live adapters

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1939,8 +1939,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 target_errors.append(msg)
                 delivery_errors.extend(target_errors)
                 continue
-            # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            # Standalone path: run the async send in a fresh event loop (safe
+            # from any thread), but do not let the shared helper rediscover the
+            # live adapter this scheduler phase already rejected.
+            coro = _send_to_platform(
+                platform,
+                pconfig,
+                chat_id,
+                cleaned_delivery_content,
+                thread_id=thread_id,
+                media_files=media_files,
+                allow_live_adapter=False,
+            )
             try:
                 result = asyncio.run(coro)
             except RuntimeError as run_err:
@@ -1969,7 +1979,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 try:
                     pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
                     try:
-                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                        future = pool.submit(
+                            asyncio.run,
+                            _send_to_platform(
+                                platform,
+                                pconfig,
+                                chat_id,
+                                cleaned_delivery_content,
+                                thread_id=thread_id,
+                                media_files=media_files,
+                                allow_live_adapter=False,
+                            ),
+                        )
                         result = future.result(timeout=30)
                     finally:
                         pool.shutdown(wait=False)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -3958,6 +3958,184 @@ class TestDeliverResultTimeoutCancelsFuture:
         assert not sent_metadata.get("direct_messages_topic_id")
 
 
+class TestDeliverResultStandaloneIsolation:
+    def test_matrix_fallback_does_not_rediscover_failed_live_adapter(self, monkeypatch):
+        """Once cron rejects a live Matrix send, standalone delivery must use
+        an ephemeral adapter rather than rediscovering the gateway adapter."""
+        import asyncio
+        from concurrent.futures import Future
+        from types import SimpleNamespace
+
+        from gateway.config import Platform
+        import plugins.platforms.matrix.adapter as matrix_module
+
+        live_send_calls = []
+        ephemeral_calls = []
+
+        class LiveMatrixAdapter:
+            splits_long_messages = True
+
+            async def send(self, chat_id, content, metadata=None):
+                live_send_calls.append((chat_id, content, metadata))
+                return SimpleNamespace(
+                    success=False,
+                    error="temporary Matrix API stall",
+                    raw_response=None,
+                )
+
+        class EphemeralMatrixAdapter:
+            def __init__(self, config):
+                ephemeral_calls.append(("init", config))
+
+            async def connect(self):
+                ephemeral_calls.append(("connect",))
+                return True
+
+            async def send(self, chat_id, content, metadata=None):
+                ephemeral_calls.append(("send", chat_id, content, metadata))
+                return SimpleNamespace(success=True, message_id="$standalone")
+
+            async def disconnect(self):
+                ephemeral_calls.append(("disconnect",))
+
+        pconfig = SimpleNamespace(
+            enabled=True,
+            token=None,
+            extra={"homeserver": "https://matrix.example.com"},
+        )
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.MATRIX: pconfig}
+        mock_cfg.filter_silence_narration = False
+
+        live_adapter = LiveMatrixAdapter()
+        runner = SimpleNamespace(adapters={Platform.MATRIX: live_adapter})
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def run_on_gateway_loop(coro, _loop):
+            future = Future()
+            try:
+                future.set_result(asyncio.run(coro))
+            except BaseException as exc:  # mirror run_coroutine_threadsafe
+                future.set_exception(exc)
+            return future
+
+        job = {
+            "id": "matrix-live-failure",
+            "deliver": "origin",
+            "origin": {"platform": "matrix", "chat_id": "!room:example.com"},
+        }
+
+        monkeypatch.setattr(matrix_module, "MatrixAdapter", EphemeralMatrixAdapter)
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=run_on_gateway_loop), \
+             patch("gateway.run._gateway_runner_ref", return_value=runner):
+            result = _deliver_result(
+                job,
+                "Matrix cron result",
+                adapters={Platform.MATRIX: live_adapter},
+                loop=loop,
+            )
+
+        assert len(live_send_calls) == 1, "standalone fallback reused the failed live Matrix adapter"
+        assert ephemeral_calls == [
+            ("init", pconfig),
+            ("connect",),
+            ("send", "!room:example.com", "Matrix cron result", None),
+            ("disconnect",),
+        ]
+        assert result is None
+
+    def test_plugin_fallback_uses_registered_standalone_sender(self):
+        """The standalone phase must also bypass live adapters discovered by
+        the generic plugin send path."""
+        import asyncio
+        from concurrent.futures import Future
+        from types import SimpleNamespace
+
+        from gateway.config import Platform
+        from gateway.platform_registry import PlatformEntry, platform_registry
+
+        live_send_calls = []
+        standalone_calls = []
+
+        class LivePluginAdapter:
+            async def send(self, chat_id, content, metadata=None):
+                live_send_calls.append((chat_id, content, metadata))
+                return SimpleNamespace(
+                    success=False,
+                    error="temporary plugin API stall",
+                    raw_response=None,
+                )
+
+        async def standalone_send(pconfig, chat_id, content, **kwargs):
+            standalone_calls.append((pconfig, chat_id, content, kwargs))
+            return {"success": True, "message_id": "standalone-plugin-message"}
+
+        platform_name = "cron_fallback_test"
+        entry = PlatformEntry(
+            name=platform_name,
+            label="Cron Fallback Test",
+            adapter_factory=lambda config: None,
+            check_fn=lambda: True,
+            standalone_sender_fn=standalone_send,
+        )
+        platform_registry.register(entry)
+        try:
+            platform = Platform(platform_name)
+            pconfig = SimpleNamespace(enabled=True, token=None, extra={})
+            mock_cfg = MagicMock()
+            mock_cfg.platforms = {platform: pconfig}
+            mock_cfg.filter_silence_narration = False
+
+            live_adapter = LivePluginAdapter()
+            runner = SimpleNamespace(adapters={platform: live_adapter})
+            loop = MagicMock()
+            loop.is_running.return_value = True
+
+            def run_on_gateway_loop(coro, _loop):
+                future = Future()
+                try:
+                    future.set_result(asyncio.run(coro))
+                except BaseException as exc:  # mirror run_coroutine_threadsafe
+                    future.set_exception(exc)
+                return future
+
+            job = {
+                "id": "plugin-live-failure",
+                "deliver": f"{platform_name}:room-1",
+            }
+
+            with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+                 patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+                 patch("asyncio.run_coroutine_threadsafe", side_effect=run_on_gateway_loop), \
+                 patch("gateway.run._gateway_runner_ref", return_value=runner):
+                result = _deliver_result(
+                    job,
+                    "Plugin cron result",
+                    adapters={platform: live_adapter},
+                    loop=loop,
+                )
+        finally:
+            platform_registry.unregister(platform_name)
+            Platform._value2member_map_.pop(platform_name, None)
+            Platform._member_map_.pop(platform_name.upper(), None)
+
+        assert platform_name not in Platform._value2member_map_
+        assert platform_name.upper() not in Platform._member_map_
+        assert len(live_send_calls) == 1, "standalone fallback reused the failed live plugin adapter"
+        assert standalone_calls == [
+            (
+                pconfig,
+                "room-1",
+                "Plugin cron result",
+                {"thread_id": None, "media_files": [], "force_document": False},
+            )
+        ]
+        assert result is None
+
+
 class TestDeliverResultLiveAdapterUnconfirmed:
     """Regression for #47056.
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -3138,6 +3138,28 @@ class TestSendViaAdapterStandaloneFallback:
         assert "standalone_sender_fn" in result["error"]
 
     @pytest.mark.asyncio
+    async def test_disabled_live_reuse_reports_missing_standalone_sender(self):
+        """The fallback-only path must not imply that the gateway is down."""
+        from tools.send_message_tool import _send_via_adapter
+        from gateway.platform_registry import platform_registry
+
+        platform_registry.register(self._make_entry(None))
+        try:
+            result = await _send_via_adapter(
+                _FakePlatform("fakeplatform"),
+                SimpleNamespace(extra={}),
+                "chat-1",
+                "hi",
+                allow_live_adapter=False,
+            )
+        finally:
+            platform_registry.unregister("fakeplatform")
+
+        assert "live adapter reuse is disabled" in result["error"].lower()
+        assert "no standalone_sender_fn" in result["error"]
+        assert "is the gateway running" not in result["error"].lower()
+
+    @pytest.mark.asyncio
     async def test_standalone_sender_fn_raises_is_caught_and_formatted(self, monkeypatch):
         """Hook raises: error dict has 'Plugin standalone send failed: ...'"""
         from tools.send_message_tool import _send_via_adapter

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -691,9 +691,14 @@ async def _send_via_adapter(
     thread_id=None,
     media_files=None,
     force_document=False,
+    allow_live_adapter=True,
 ):
-    """Send a message via a live gateway adapter, with a standalone fallback
-    for out-of-process callers (e.g. cron running separately from the gateway).
+    """Send through a live adapter when allowed, then a standalone sender.
+
+    ``allow_live_adapter=False`` starts directly at the registered standalone
+    sender.  Cron uses that after its own live-adapter attempt has failed so
+    this helper cannot rediscover and retry the rejected adapter from a new
+    event loop.
 
     Order of attempts:
       1. Live in-process adapter via ``_gateway_runner_ref()`` (the path that
@@ -705,11 +710,12 @@ async def _send_via_adapter(
     """
     platform_name = platform.value if hasattr(platform, "value") else str(platform)
     runner = None
-    try:
-        from gateway.run import _gateway_runner_ref
-        runner = _gateway_runner_ref()
-    except Exception:
-        runner = None
+    if allow_live_adapter:
+        try:
+            from gateway.run import _gateway_runner_ref
+            runner = _gateway_runner_ref()
+        except Exception:
+            runner = None
 
     if runner is not None:
         try:
@@ -767,6 +773,14 @@ async def _send_via_adapter(
             )
         }
 
+    if not allow_live_adapter:
+        return {
+            "error": (
+                f"Live adapter reuse is disabled for platform '{platform_name}', "
+                f"and no standalone_sender_fn is registered."
+            )
+        }
+
     return {
         "error": (
             f"No live adapter for platform '{platform_name}'. Is the gateway "
@@ -777,12 +791,25 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(
+    platform,
+    pconfig,
+    chat_id,
+    message,
+    thread_id=None,
+    media_files=None,
+    force_document=False,
+    allow_live_adapter=True,
+):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
     using the same smart-splitting algorithm as the gateway adapters
     (preserves code-block boundaries, adds part indicators).
+
+    ``allow_live_adapter`` defaults to the historical send_message behavior.
+    Callers that already attempted a live adapter can disable rediscovery while
+    retaining each platform's one-shot, ephemeral, or registered sender path.
     """
     from gateway.config import Platform
 
@@ -921,6 +948,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 chunk,
                 media_files=media_files if is_last else [],
                 thread_id=thread_id,
+                allow_live_adapter=allow_live_adapter,
             )
             if isinstance(result, dict) and result.get("error"):
                 return result
@@ -952,6 +980,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 chat_id,
                 chunk,
                 media_files=media_files if is_last else None,
+                allow_live_adapter=allow_live_adapter,
             )
             if isinstance(result, dict) and result.get("error"):
                 return result
@@ -1080,7 +1109,11 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.QQBOT:
             result = await _send_qqbot(pconfig, chat_id, chunk)
         elif platform == Platform.YUANBAO:
-            result = await _send_yuanbao(chat_id, chunk)
+            result = await _send_yuanbao(
+                chat_id,
+                chunk,
+                allow_live_adapter=allow_live_adapter,
+            )
         else:
             # Plugin platform: route through the gateway's live adapter if
             # available, otherwise the plugin's standalone_sender_fn.
@@ -1092,6 +1125,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 thread_id=thread_id,
                 media_files=media_files,
                 force_document=force_document,
+                allow_live_adapter=allow_live_adapter,
             )
 
         if isinstance(result, dict) and result.get("error"):
@@ -1657,7 +1691,14 @@ async def _send_signal(extra, chat_id, message, media_files=None):
 # (_send_matrix_via_adapter below stays — it's the native-media upload path.)
 
 
-async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, thread_id=None):
+async def _send_matrix_via_adapter(
+    pconfig,
+    chat_id,
+    message,
+    media_files=None,
+    thread_id=None,
+    allow_live_adapter=True,
+):
     """Send via the Matrix adapter so native Matrix media uploads are preserved.
 
     When a live gateway adapter is available (i.e. the tool runs inside a
@@ -1665,8 +1706,8 @@ async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, 
     session for all sends.  This avoids per-message E2EE re-init storms
     that exhaust recipient OTKs and silently drop messages (issue #46310).
 
-    Falls back to an ephemeral connect/disconnect cycle only when no gateway
-    is running (standalone cron, ``hermes send`` CLI).
+    Falls back to an ephemeral connect/disconnect cycle when no gateway is
+    running or when the caller explicitly disallows live-adapter reuse.
     """
     media_files = media_files or []
     metadata = {"thread_id": thread_id} if thread_id else None
@@ -1681,23 +1722,24 @@ async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, 
     # silent fall-through here would re-introduce the exact reconnect storm
     # this fix prevents.
     live_adapter = None
-    runner = None
-    try:
-        from gateway.run import _gateway_runner_ref
-        runner = _gateway_runner_ref()
-    except Exception:
+    if allow_live_adapter:
         runner = None
-    if runner is not None:
         try:
-            from gateway.config import Platform
-            live_adapter = runner.adapters.get(Platform.MATRIX)
+            from gateway.run import _gateway_runner_ref
+            runner = _gateway_runner_ref()
         except Exception:
-            logger.warning(
-                "Matrix: live gateway adapter lookup failed; falling back to an "
-                "ephemeral connect (may re-init E2EE per send, see #46310)",
-                exc_info=True,
-            )
-            live_adapter = None
+            runner = None
+        if runner is not None:
+            try:
+                from gateway.config import Platform
+                live_adapter = runner.adapters.get(Platform.MATRIX)
+            except Exception:
+                logger.warning(
+                    "Matrix: live gateway adapter lookup failed; falling back to an "
+                    "ephemeral connect (may re-init E2EE per send, see #46310)",
+                    exc_info=True,
+                )
+                live_adapter = None
 
     if live_adapter is not None:
         # NOTE: the live adapter is owned by the gateway — we must NOT
@@ -1929,17 +1971,31 @@ async def _send_qqbot(pconfig, chat_id, message):
         return _error(f"QQBot send failed: {e}")
 
 
-async def _send_yuanbao(chat_id, message, media_files=None):
+async def _send_yuanbao(
+    chat_id,
+    message,
+    media_files=None,
+    allow_live_adapter=True,
+):
     """Send via Yuanbao using the running gateway adapter's WebSocket connection.
 
     Yuanbao uses a persistent WebSocket — unlike HTTP-based platforms, we
     cannot create a throwaway client.  We obtain the running singleton from
     the adapter module itself (``get_active_adapter``).
 
+    When live-adapter reuse is disabled, fail explicitly without consulting
+    that singleton; Yuanbao has no standalone transport to use instead.
+
     chat_id format:
       - Group: "group:<group_code>"
       - DM:    "direct:<account_id>" or just "<account_id>"
     """
+    if not allow_live_adapter:
+        return _error(
+            "Yuanbao has no standalone sender; live adapter reuse is disabled "
+            "for this delivery attempt."
+        )
+
     try:
         from gateway.platforms.yuanbao import get_active_adapter, send_yuanbao_direct
     except ImportError:


### PR DESCRIPTION
## Summary

Prevent cron's second-stage delivery fallback from rediscovering and reusing the same gateway-owned live adapter that the scheduler already rejected.

The production Matrix failure sequence was:

1. the scheduler correctly scheduled the first send on the gateway loop;
2. the live Matrix send returned a real failure during a temporary API stall;
3. `_deliver_result()` entered its documented standalone fallback under `asyncio.run()` in the cron worker thread;
4. `_send_to_platform()` rediscovered the global gateway runner and awaited the same loop-bound Matrix adapter from the fresh loop;
5. aiohttp raised `Timeout context manager should be used inside a task`.

## Fix

- Add an internal, default-on `allow_live_adapter` option to the shared send path.
- Keep all existing callers and the scheduler's first live-adapter attempt unchanged.
- Set `allow_live_adapter=False` only after `_deliver_result()` has entered its standalone phase, including the fresh-thread retry path.
- Propagate the option through Matrix, generic plugin, and live-only Yuanbao paths:
  - Matrix uses its existing ephemeral, E2EE-capable adapter path.
  - Registered plugins use their `standalone_sender_fn`.
  - Yuanbao fails explicitly because it has no standalone transport, instead of retrying its live WebSocket adapter from the wrong loop.

This is narrower than #62956: it does not key behavior off process-wide `HERMES_CRON_SESSION`, disable the scheduled gateway cron live path, or change normal `send_message` Matrix adapter reuse. It complements #63586, which passes gateway context into manual immediate runs but does not protect the post-live-failure fallback. Credit to #62956 for independently identifying the wrong-loop Matrix symptom in manual cron delivery.

## TDD evidence

On current `origin/main`, the new behavioral regressions failed because both Matrix and a generic plugin called their failed live adapter twice:

```text
2 failed
AssertionError: standalone fallback reused the failed live Matrix adapter
assert 2 == 1
AssertionError: standalone fallback reused the failed live plugin adapter
assert 2 == 1
```

After the fix:

```text
2 passed
```

## Verification

Tested on Linux 7.1.3-2-cachyos with Python 3.11.15.

```text
scripts/run_tests.sh tests/cron/ tests/tools/test_send_message_tool.py tests/tools/test_send_message_missing_platforms.py tests/gateway/test_matrix.py -q
1155 passed, 0 failed

uv run ruff check cron/scheduler.py tools/send_message_tool.py tests/cron/test_scheduler.py tests/tools/test_send_message_tool.py
All checks passed!

python3 -m py_compile cron/scheduler.py tools/send_message_tool.py tests/cron/test_scheduler.py tests/tools/test_send_message_tool.py
# exit 0

git diff --check
# exit 0
```

## Related

- #61495
- #62956
- #63586
- #46310 (normal same-loop Matrix live-adapter reuse remains preserved)
