### PR TITLE
fix(providers): route kimi-coding-cn alias to domestic provider with KIMI_CN_API_KEY

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -39,6 +39,7 @@ class HermesOverlay:
     is_aggregator: bool = False
     auth_type: str = "api_key"            # api_key | oauth_device_code | oauth_external | external_process
     extra_env_vars: Tuple[str, ...] = ()  # env vars models.dev doesn't list
+    env_vars_override: Tuple[str, ...] = ()  # replace models.dev env vars when provider identity differs
     base_url_override: str = ""           # override if models.dev URL is wrong/missing
     base_url_env_var: str = ""            # env var for user-custom base URL
 
@@ -110,6 +111,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     "kimi-for-coding": HermesOverlay(
         transport="openai_chat",
         base_url_env_var="KIMI_BASE_URL",
+    ),
+    "kimi-coding-cn": HermesOverlay(
+        transport="openai_chat",
+        env_vars_override=("KIMI_CN_API_KEY",),
+        base_url_override="https://api.moonshot.cn/v1",
+        base_url_env_var="KIMI_CN_BASE_URL",
     ),
     "stepfun": HermesOverlay(
         transport="openai_chat",
@@ -276,7 +283,9 @@ ALIASES: Dict[str, str] = {
     # kimi-for-coding (models.dev ID)
     "kimi": "kimi-for-coding",
     "kimi-coding": "kimi-for-coding",
-    "kimi-coding-cn": "kimi-for-coding",
+    "kimi-coding-cn": "kimi-coding-cn",
+    "kimi-cn": "kimi-coding-cn",
+    "moonshot-cn": "kimi-coding-cn",
     "moonshot": "kimi-for-coding",
 
     # stepfun
@@ -451,7 +460,7 @@ def get_provider(name: str) -> Optional[ProviderDef]:
         base_url_override = overlay.base_url_override if overlay else ""
 
         # Combine env vars: models.dev env + hermes extra
-        env_vars = list(mdev_info.env)
+        env_vars = list(overlay.env_vars_override) if overlay and overlay.env_vars_override else list(mdev_info.env)
         if overlay and overlay.extra_env_vars:
             for ev in overlay.extra_env_vars:
                 if ev not in env_vars:

--- a/tests/hermes_cli/test_kimi_cn_provider_resolution.py
+++ b/tests/hermes_cli/test_kimi_cn_provider_resolution.py
@@ -1,0 +1,15 @@
+"""Regression tests for explicit Kimi China model switching."""
+
+import pytest
+
+from hermes_cli.providers import resolve_provider_full
+
+
+@pytest.mark.parametrize("slug", ["kimi-coding-cn", "kimi-cn", "moonshot-cn"])
+def test_kimi_cn_provider_resolves_to_domestic_endpoint(slug):
+    provider = resolve_provider_full(slug)
+
+    assert provider is not None
+    assert provider.id == "kimi-coding-cn"
+    assert provider.api_key_env_vars == ("KIMI_CN_API_KEY",)
+    assert provider.base_url == "https://api.moonshot.cn/v1"


### PR DESCRIPTION
## Problem

The `kimi-coding-cn` provider alias was incorrectly mapped to `kimi-for-coding` (international), which looks for `KIMI_API_KEY` instead of `KIMI_CN_API_KEY`. This caused users with a valid `KIMI_CN_API_KEY` to see 'Kimi not configured' and prevented switching to Kimi China models.

Kimi operates two completely independent API surfaces:
- **International**: `api.kimi.com` / `api.moonshot.ai`, keyed by `KIMI_API_KEY`
- **China domestic**: `api.moonshot.cn`, keyed by `KIMI_CN_API_KEY`

The alias chain was routing CN users to the international provider, which naturally couldn't find their key.

## Root Cause

In `hermes_cli/providers.py`, the alias map had:
```python
"kimi-coding-cn": "kimi-for-coding",
```

This sent all CN traffic through the international provider, which looks for `KIMI_API_KEY` (wrong env var) and hits `api.kimi.com` (wrong endpoint).

## Fix

1. **New `env_vars_override` mechanism**: A provider overlay can now replace models.dev env vars entirely when the provider identity differs from the models.dev ID. Previously only `extra_env_vars` existed, which could only append.

2. **New `kimi-coding-cn` overlay** with:
   - `env_vars_override=("KIMI_CN_API_KEY",)`
   - `base_url_override="https://api.moonshot.cn/v1"`

3. **Fixed alias routing**:
   ```python
   "kimi-coding-cn": "kimi-coding-cn",  # was: "kimi-for-coding"
   "kimi-cn": "kimi-coding-cn",          # new convenience alias
   "moonshot-cn": "kimi-coding-cn",      # new convenience alias
   ```

4. **Tests**: Regression tests for all three CN aliases verifying correct provider ID, env var, and base URL resolution.

## Verification

```
tests/hermes_cli/test_kimi_cn_provider_resolution.py::test_kimi_cn_provider_resolves_to_domestic_endpoint[kimi-coding-cn] PASSED
tests/hermes_cli/test_kimi_cn_provider_resolution.py::test_kimi_cn_provider_resolves_to_domestic_endpoint[kimi-cn] PASSED
tests/hermes_cli/test_kimi_cn_provider_resolution.py::test_kimi_cn_provider_resolves_to_domestic_endpoint[moonshot-cn] PASSED
```

This fix was already validated in production by a user with `KIMI_CN_API_KEY` set — model switching to `kimi-k3` now resolves correctly and the model responds.