### PR TITLE
fix(email): keep SMTP TLS verification non-strict on Python 3.13

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -112,6 +112,19 @@ MAX_MESSAGE_LENGTH = 50_000
 SMTP_CONNECT_TIMEOUT = 30
 
 
+def _smtp_ssl_context() -> ssl.SSLContext:
+    """Default TLS context minus ``VERIFY_X509_STRICT``.
+
+    Python 3.13 enables strict X.509 verification by default, which rejects
+    cert chains still common at mail providers (e.g. 163.com's CA lacks a
+    critical Basic Constraints extension). Chain verification and hostname
+    checking remain on.
+    """
+    ctx = ssl.create_default_context()
+    ctx.verify_flags &= ~ssl.VERIFY_X509_STRICT
+    return ctx
+
+
 def _create_ipv4_connection(
     host: str,
     port: int,
@@ -566,7 +579,7 @@ class EmailAdapter(BasePlatformAdapter):
         Returns a connected SMTP object with TLS established — callers
         can proceed directly to ``login()``.
         """
-        ctx = ssl.create_default_context()
+        ctx = _smtp_ssl_context()
         host = self._smtp_host
         port = self._smtp_port
 
@@ -1268,7 +1281,11 @@ async def _standalone_send(
         msg["Date"] = formatdate(localtime=True)
 
         server = smtplib.SMTP(smtp_host, smtp_port)
-        server.starttls(context=_ssl.create_default_context())
+        # Self-contained (standalone_sender_fn runs out-of-process): clear
+        # Python 3.13's default VERIFY_X509_STRICT, mirroring _smtp_ssl_context.
+        _tls_ctx = _ssl.create_default_context()
+        _tls_ctx.verify_flags &= ~_ssl.VERIFY_X509_STRICT
+        server.starttls(context=_tls_ctx)
         server.login(address, password)
         server.send_message(msg)
         server.quit()

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -907,5 +907,47 @@ class TestSenderAuthentication(unittest.TestCase):
         self.assertFalse(ok, reason)
 
 
+class TestSmtpTlsContext(unittest.TestCase):
+    """SMTP TLS contexts must not use VERIFY_X509_STRICT (Python 3.13 default).
+
+    Python 3.13 enables ssl.VERIFY_X509_STRICT in create_default_context(),
+    which rejects cert chains still common at mail providers (e.g. smtp.163.com's
+    CA lacks a critical Basic Constraints extension), breaking all SMTP sending
+    with CERTIFICATE_VERIFY_FAILED. Chain verification and hostname checking
+    must stay enabled — only the strict flag is cleared.
+    """
+
+    def test_strict_flag_cleared(self):
+        import ssl
+        from plugins.platforms.email.adapter import _smtp_ssl_context
+        ctx = _smtp_ssl_context()
+        self.assertFalse(ctx.verify_flags & ssl.VERIFY_X509_STRICT)
+
+    def test_verification_still_enabled(self):
+        import ssl
+        from plugins.platforms.email.adapter import _smtp_ssl_context
+        ctx = _smtp_ssl_context()
+        self.assertEqual(ctx.verify_mode, ssl.CERT_REQUIRED)
+        self.assertTrue(ctx.check_hostname)
+
+    def test_connect_smtp_passes_relaxed_context_on_port_465(self):
+        import ssl
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "EMAIL_SMTP_PORT": "465",
+        }):
+            from plugins.platforms.email.adapter import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+        with patch("smtplib.SMTP_SSL") as mock_smtp_ssl:
+            adapter._connect_smtp()
+        ctx = mock_smtp_ssl.call_args.kwargs["context"]
+        self.assertFalse(ctx.verify_flags & ssl.VERIFY_X509_STRICT)
+        self.assertEqual(ctx.verify_mode, ssl.CERT_REQUIRED)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -611,7 +611,13 @@ class TestSendEmailStandalone(unittest.TestCase):
             self.assertTrue(result["success"])
             self.assertEqual(result["platform"], "email")
             _, kwargs = mock_server.starttls.call_args
-            self.assertIsInstance(kwargs["context"], ssl.SSLContext)
+            # This path builds its TLS context inline (it runs out-of-process and
+            # cannot import _smtp_ssl_context), so assert the policy here too.
+            tls_ctx = kwargs["context"]
+            self.assertIsInstance(tls_ctx, ssl.SSLContext)
+            self.assertFalse(tls_ctx.verify_flags & ssl.VERIFY_X509_STRICT)
+            self.assertEqual(tls_ctx.verify_mode, ssl.CERT_REQUIRED)
+            self.assertTrue(tls_ctx.check_hostname)
             send_call = mock_server.send_message.call_args[0][0]
             self.assertEqual(send_call["Subject"], "Hermes Agent")
             self.assertIn("Date", send_call)
@@ -930,23 +936,41 @@ class TestSmtpTlsContext(unittest.TestCase):
         self.assertEqual(ctx.verify_mode, ssl.CERT_REQUIRED)
         self.assertTrue(ctx.check_hostname)
 
-    def test_connect_smtp_passes_relaxed_context_on_port_465(self):
-        import ssl
+    def _make_adapter(self, port):
         from gateway.config import PlatformConfig
         with patch.dict(os.environ, {
             "EMAIL_ADDRESS": "hermes@test.com",
             "EMAIL_PASSWORD": "secret",
             "EMAIL_IMAP_HOST": "imap.test.com",
             "EMAIL_SMTP_HOST": "smtp.test.com",
-            "EMAIL_SMTP_PORT": "465",
+            "EMAIL_SMTP_PORT": port,
         }):
             from plugins.platforms.email.adapter import EmailAdapter
-            adapter = EmailAdapter(PlatformConfig(enabled=True))
-        with patch("smtplib.SMTP_SSL") as mock_smtp_ssl:
-            adapter._connect_smtp()
-        ctx = mock_smtp_ssl.call_args.kwargs["context"]
+            return EmailAdapter(PlatformConfig(enabled=True))
+
+    def _assert_relaxed(self, ctx):
+        """The context must skip only VERIFY_X509_STRICT, not verification."""
+        import ssl
+        self.assertIsInstance(ctx, ssl.SSLContext)
         self.assertFalse(ctx.verify_flags & ssl.VERIFY_X509_STRICT)
         self.assertEqual(ctx.verify_mode, ssl.CERT_REQUIRED)
+        self.assertTrue(ctx.check_hostname)
+
+    def test_connect_smtp_passes_relaxed_context_on_port_465(self):
+        adapter = self._make_adapter("465")
+        with patch("smtplib.SMTP_SSL") as mock_smtp_ssl:
+            adapter._connect_smtp()
+        self._assert_relaxed(mock_smtp_ssl.call_args.kwargs["context"])
+
+    def test_connect_smtp_passes_relaxed_context_on_starttls(self):
+        """Port 587 upgrades in-band, so STARTTLS gets the context — not the
+        constructor. Without this the relaxed context is only proven for 465."""
+        adapter = self._make_adapter("587")
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+            adapter._connect_smtp()
+        self._assert_relaxed(mock_server.starttls.call_args.kwargs["context"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

Fixes SMTP being completely broken on Python 3.13 for mail providers whose certificate chains fail the new strict X.509 rules.

Python 3.13 enables `ssl.VERIFY_X509_STRICT` by default in `ssl.create_default_context()` ([What's New in 3.13](https://docs.python.org/3/whatsnew/3.13.html#ssl)). Certificate chains still common at large mail providers fail it — e.g. `smtp.163.com` (NetEase), whose CA certificate lacks a *critical* marking on its Basic Constraints extension. On a 3.13 install the gateway then fails every SMTP connect with:

```
ERROR hermes_plugins.email_platform.adapter: [Email] SMTP connection failed:
[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
Basic Constraints of CA cert not marked critical (_ssl.c:1032)
```

…on every ~5 min reconnect, while IMAP keeps working — so the email platform receives but can never send.

The fix clears **only** the `VERIFY_X509_STRICT` flag via a shared `_smtp_ssl_context()` helper. Full chain verification (`CERT_REQUIRED`) and hostname checking stay on — this is not an "insecure mode", it just restores the pre-3.13 verification behavior that 3.11/3.12 installs get today. Both SMTP call paths are covered (the whole bug class): `_connect_smtp` (port-465 implicit TLS and STARTTLS) and the standalone out-of-process sender (kept self-contained, so the two lines are inlined there).

Unlike #20153 (closed per the env-var-for-config policy), this adds **no user-facing setting** — no env var, no config key. It's a plain bug fix restoring behavior parity across supported Python versions (3.11–3.13).

## Related Issue

No existing issue found (searched `VERIFY_X509_STRICT`, `SMTP certificate verify`, `Basic Constraints`). Closest prior art: #20153 (different scope — opt-out of verification entirely; rejected), #12236 (self-signed certs — not this case: 163.com presents a real, publicly trusted chain).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/email/adapter.py` — new `_smtp_ssl_context()` helper (default context minus `VERIFY_X509_STRICT`); used in `_connect_smtp`; equivalent two lines inlined in the standalone out-of-process sender.
- `tests/gateway/test_email.py` — new `TestSmtpTlsContext`: strict flag cleared, verification/hostname checking still enforced, and `_connect_smtp` passes the relaxed context to `SMTP_SSL` on port 465.

## How to Test

1. On Python 3.13, configure email against a provider with a legacy CA chain (e.g. `EMAIL_SMTP_HOST=smtp.163.com`, `EMAIL_SMTP_PORT=465`) and start the gateway → before this patch, SMTP fails with `CERTIFICATE_VERIFY_FAILED ... Basic Constraints of CA cert not marked critical`; after, `[Email] SMTP connection test passed.` / `✓ email connected`.
2. Minimal repro without Hermes (fails strict, succeeds with only the strict flag cleared):
   ```python
   import smtplib, ssl
   ctx = ssl.create_default_context()
   try:
       smtplib.SMTP_SSL("smtp.163.com", 465, timeout=30, context=ctx).quit()
   except ssl.SSLCertVerificationError as e:
       print("strict:", e.verify_message)   # Basic Constraints of CA cert not marked critical
   ctx = ssl.create_default_context()
   ctx.verify_flags &= ~ssl.VERIFY_X509_STRICT
   print("relaxed:", smtplib.SMTP_SSL("smtp.163.com", 465, timeout=30, context=ctx).noop())  # (250, b'OK')
   ```
3. `pytest tests/gateway/test_email.py -k TestSmtpTlsContext -v` → 3 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_email.py tests/gateway/test_email_robustness.py` — 98 passed; 2 failures (`test_email_not_loaded_without_env`, `test_spoofed_from_rejected_when_allowlisted`) reproduce identically on unpatched `main` in my environment (a live local Hermes config leaks into non-hermetic runs) and are unrelated to this change. Full suite left to CI's hermetic env.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro (10.0.26200), Python 3.13.7 — verified end-to-end against live smtp.163.com

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings only; no user-facing behavior/config change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure `ssl` stdlib flags, platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (Python 3.13, gateway log, repeating every ~5 min):

```
2026-07-20 22:26:43,431 ERROR hermes_plugins.email_platform.adapter: [Email] SMTP connection failed: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Basic Constraints of CA cert not marked critical (_ssl.c:1032)
2026-07-20 22:26:43,434 INFO gateway.run: Reconnect email failed, next retry in 300s
```

After:

```
2026-07-20 23:03:25,666 INFO hermes_plugins.email_platform.adapter: [Email] IMAP connection test passed. 28 existing messages skipped.
2026-07-20 23:03:27,675 INFO hermes_plugins.email_platform.adapter: [Email] SMTP connection test passed.
2026-07-20 23:03:27,683 INFO gateway.run: ✓ email connected
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
