### PR TITLE
fix(tui_gateway): deliver leftover steer as next turn (Desktop)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6450,6 +6450,70 @@ def test_session_steer_errors_when_agent_has_no_steer_method():
     assert resp["error"]["code"] == 4010
 
 
+def test_prompt_submit_delivers_leftover_steer_as_next_turn(monkeypatch):
+    """Desktop parity: leftover pending_steer must not be silently dropped.
+
+    When /steer lands after the last tool batch (or during a hard API fail with
+    no further tool window), run_conversation returns result['pending_steer'].
+    CLI and messaging gateway re-queue it; TUI/Desktop must too.
+    """
+    prompts: list[str] = []
+
+    class _Agent:
+        def __init__(self):
+            self._calls = 0
+
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **kwargs
+        ):
+            prompts.append(prompt)
+            self._calls += 1
+            if self._calls == 1:
+                return {
+                    "final_response": "done without more tools",
+                    "messages": [{"role": "assistant", "content": "done without more tools"}],
+                    "pending_steer": "why did the model swap?",
+                }
+            return {
+                "final_response": "handled steer",
+                "messages": [{"role": "assistant", "content": "handled steer"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    server._sessions["sid"] = _session(agent=_Agent())
+    emits: list[tuple] = []
+    try:
+        monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+        monkeypatch.setattr(server, "_get_usage", lambda _a: {})
+        monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
+        monkeypatch.setattr(server, "_emit", lambda *a: emits.append(a))
+        monkeypatch.setattr(server, "_drain_queued_prompt", lambda *_a: False)
+
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "hi"},
+            }
+        )
+        assert resp.get("result")
+        assert prompts == ["hi", "why did the model swap?"]
+        status_texts = [
+            a[2].get("text", "")
+            for a in emits
+            if a[0] == "status.update" and isinstance(a[2], dict)
+        ]
+        assert any("Steer delivered as next turn" in t for t in status_texts)
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_session_info_includes_mcp_servers(monkeypatch):
     fake_status = [
         {"name": "github", "transport": "http", "tools": 12, "connected": True},

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6493,7 +6493,8 @@ def test_prompt_submit_delivers_leftover_steer_as_next_turn(monkeypatch):
         monkeypatch.setattr(server, "_get_usage", lambda _a: {})
         monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
         monkeypatch.setattr(server, "_emit", lambda *a: emits.append(a))
-        monkeypatch.setattr(server, "_drain_queued_prompt", lambda *_a: False)
+        # Do NOT stub _drain_queued_prompt — leftover steer is delivered through
+        # the real enqueue+drain path (parity with CLI leftover handling).
 
         resp = server.handle_request(
             {

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9932,6 +9932,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         session_tokens = []
         home_token = None  # per-turn HERMES_HOME override for a resumed remote profile
         goal_followup = None  # set by the post-turn goal hook below
+        steer_followup = None  # leftover /steer after last tool batch
         one_turn_restore = session.pop("one_turn_model_restore", None)
         try:
             from tools.approval import (
@@ -10190,6 +10191,15 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 lr = result.get("last_reasoning")
                 if isinstance(lr, str) and lr.strip():
                     last_reasoning = lr.strip()
+                # Leftover /steer: if a steer arrived after the last tool batch
+                # (or during a hard API failure with no further tool window),
+                # the agent cannot inject it into a tool result. Hand it back
+                # so we deliver it as the next user turn (parity with CLI and
+                # messaging gateway). Without this, Desktop shows "Steer queued"
+                # while the text is silently dropped.
+                _leftover_steer = result.get("pending_steer")
+                if isinstance(_leftover_steer, str) and _leftover_steer.strip():
+                    steer_followup = _leftover_steer.strip()
             else:
                 raw = str(result)
                 status = "complete"
@@ -10398,6 +10408,36 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         # the goal judge / notifications re-evaluate at the end of that turn.
         if _drain_queued_prompt(rid, sid, session):
             return
+
+        # Deliver leftover steer as the next turn when the model never got a
+        # tool-result injection window. User mid-turn queue already drained
+        # above wins over this auto follow-up.
+        if steer_followup:
+            with session["history_lock"]:
+                if session.get("running"):
+                    return
+                session["running"] = True
+            try:
+                _emit("message.start", sid)
+                # System note so the transcript shows the steer was promoted
+                # from mid-turn queue to a real turn (not lost).
+                _emit(
+                    "status.update",
+                    sid,
+                    {
+                        "kind": "steer",
+                        "text": "Steer delivered as next turn (no tool window left on prior turn).",
+                    },
+                )
+                _run_prompt_submit(rid, sid, session, steer_followup)
+            except Exception as _steer_exc:
+                print(
+                    f"[tui_gateway] leftover steer dispatch failed: "
+                    f"{type(_steer_exc).__name__}: {_steer_exc}",
+                    file=sys.stderr,
+                )
+                with session["history_lock"]:
+                    session["running"] = False
 
         # Chain a goal-continuation turn if the judge said so. We do
         # this AFTER the finally releases session["running"], so the

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10406,38 +10406,21 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         # A user prompt that arrived mid-turn (interrupt + queue) wins over
         # every auto follow-up below — drain it first and skip them this cycle;
         # the goal judge / notifications re-evaluate at the end of that turn.
+        # Leftover steer must not be dropped when a user queue wins: stash it
+        # behind that queue so it still runs (CLI puts leftover steer on
+        # _pending_input instead of discarding).
+        if steer_followup:
+            _emit(
+                "status.update",
+                sid,
+                {
+                    "kind": "steer",
+                    "text": "Steer delivered as next turn (no tool window left on prior turn).",
+                },
+            )
+            _enqueue_prompt(session, steer_followup, session.get("transport"))
         if _drain_queued_prompt(rid, sid, session):
             return
-
-        # Deliver leftover steer as the next turn when the model never got a
-        # tool-result injection window. User mid-turn queue already drained
-        # above wins over this auto follow-up.
-        if steer_followup:
-            with session["history_lock"]:
-                if session.get("running"):
-                    return
-                session["running"] = True
-            try:
-                _emit("message.start", sid)
-                # System note so the transcript shows the steer was promoted
-                # from mid-turn queue to a real turn (not lost).
-                _emit(
-                    "status.update",
-                    sid,
-                    {
-                        "kind": "steer",
-                        "text": "Steer delivered as next turn (no tool window left on prior turn).",
-                    },
-                )
-                _run_prompt_submit(rid, sid, session, steer_followup)
-            except Exception as _steer_exc:
-                print(
-                    f"[tui_gateway] leftover steer dispatch failed: "
-                    f"{type(_steer_exc).__name__}: {_steer_exc}",
-                    file=sys.stderr,
-                )
-                with session["history_lock"]:
-                    session["running"] = False
 
         # Chain a goal-continuation turn if the judge said so. We do
         # this AFTER the finally releases session["running"], so the


### PR DESCRIPTION
## Problem

Desktop `session.steer` shows **Steer queued** while the model often never sees the text. Steer injects only into the next tool result. When the turn ends (final assistant message, hard API 400, no further tools), `run_conversation` returns `result['pending_steer']`.

- CLI: re-queues leftover steer onto `_pending_input`
- Messaging gateway: delivers leftover steer as next turn
- **TUI/Desktop (`tui_gateway`)**: dropped it

## Fix

After `prompt.submit` completes, if `pending_steer` is set:

1. Emit a short status note
2. `_enqueue_prompt` the leftover (merge-safe if a user queue already exists)
3. `_drain_queued_prompt` so it runs as the next turn
4. Return so stale goal auto-followups from the prior turn do not double-fire

## Tests

```text
pytest tests/test_tui_gateway_server.py::test_prompt_submit_delivers_leftover_steer_as_next_turn -q
# 1 passed
```

## Evidence

Desktop dogfood 2026-07-21: mid-turn steer about model swap never reached the agent after HTTP 400; UI claimed queued.

## Review

Claude Fable 5 xhigh: ship-with-changes (race drop paths) — applied via enqueue-before-drain.
Codex dual review timed out; fixes match CLI/gateway parity.

## Risk

Low. Additive delivery path. User mid-turn queue still wins order; leftover is merged behind it rather than discarded.