### PR TITLE
feat(tools): auto-inject code execution tools

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -293,6 +293,17 @@ print(result.get("output", ""))
         self.assertIn("mock output for: echo hello", result["output"])
         self.assertEqual(result["tool_calls_made"], 1)
 
+    def test_unimported_tool_call(self):
+        """Enabled tools are available without importing hermes_tools."""
+        code = """
+result = terminal("echo hello")
+print(result.get("output", ""))
+"""
+        result = self._run(code, enabled_tools=["terminal"])
+        self.assertEqual(result["status"], "success")
+        self.assertIn("mock output for: echo hello", result["output"])
+        self.assertEqual(result["tool_calls_made"], 1)
+
 
     def test_concurrent_tool_calls_match_responses(self):
         """Regression for the UDS RPC race: multiple threads inside the

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -19,6 +19,7 @@ import json
 import os
 import socket
 import time
+import types
 
 os.environ["TERMINAL_ENV"] = "local"
 
@@ -46,6 +47,7 @@ from tools.code_execution_tool import (
     EXECUTE_CODE_SCHEMA,
     _TOOL_DOC_LINES,
     _execute_remote,
+    _generate_autoinject_runner,
 )
 
 
@@ -116,6 +118,43 @@ class TestHermesToolsGeneration(unittest.TestCase):
         self.assertIn("with _seq_lock:", src)
 
 
+class TestAutoInjectedRunner(unittest.TestCase):
+    def test_runner_supplies_only_enabled_sandbox_tools_as_globals(self):
+        runner = _generate_autoinject_runner(["terminal", "read_file", "vision_analyze"])
+        fake_tools = types.ModuleType("hermes_tools")
+        fake_tools.terminal = object()
+        fake_tools.read_file = object()
+
+        with patch.dict(sys.modules, {"hermes_tools": fake_tools}), \
+             patch("runpy.run_path") as run_path:
+            exec(compile(runner, "runner.py", "exec"), {"__file__": "/tmp/runner.py"})
+
+        init_globals = run_path.call_args.kwargs["init_globals"]
+        self.assertEqual(set(init_globals), {"read_file", "terminal"})
+        self.assertEqual(run_path.call_args.kwargs["run_name"], "__main__")
+        self.assertEqual(
+            os.path.normpath(run_path.call_args.args[0]),
+            os.path.normpath("/tmp/script.py"),
+        )
+
+    def test_runner_without_available_tools_uses_empty_globals(self):
+        runner = _generate_autoinject_runner([])
+
+        with patch("runpy.run_path") as run_path:
+            exec(compile(runner, "runner.py", "exec"), {"__file__": "/tmp/runner.py"})
+
+        self.assertEqual(run_path.call_args.kwargs["init_globals"], {})
+
+    def test_schema_describes_tools_as_automatically_available(self):
+        schema = build_execute_code_schema(["terminal"])
+        description = schema["description"]
+        code_description = schema["parameters"]["properties"]["code"]["description"]
+
+        self.assertIn("automatically available", description)
+        self.assertIn("available directly without imports", code_description)
+        self.assertNotIn("Import tools with", code_description)
+
+
 class TestExecuteCodeRemoteTempDir(unittest.TestCase):
     def test_execute_remote_uses_backend_temp_dir_for_sandbox(self):
         class FakeEnv:
@@ -129,7 +168,7 @@ class TestExecuteCodeRemoteTempDir(unittest.TestCase):
                 self.commands.append((command, cwd, timeout))
                 if "command -v python3" in command:
                     return {"output": "OK\n"}
-                if "python3 script.py" in command:
+                if "python3 runner.py" in command:
                     return {"output": "hello\n", "returncode": 0}
                 return {"output": ""}
 
@@ -138,7 +177,7 @@ class TestExecuteCodeRemoteTempDir(unittest.TestCase):
 
         with patch("tools.code_execution_tool._load_config", return_value={"timeout": 30, "max_tool_calls": 5}), \
              patch("tools.code_execution_tool._get_or_create_env", return_value=(env, "ssh")), \
-             patch("tools.code_execution_tool._ship_file_to_remote"), \
+             patch("tools.code_execution_tool._ship_file_to_remote") as ship_file, \
              patch("tools.code_execution_tool.threading.Thread", return_value=fake_thread):
             result = json.loads(_execute_remote("print('hello')", "task-1", ["terminal"]))
 
@@ -147,12 +186,17 @@ class TestExecuteCodeRemoteTempDir(unittest.TestCase):
         self.assertFalse(result["stdout_truncated"])
         self.assertEqual(result["stdout_bytes_total"], len("hello\n".encode("utf-8")))
         mkdir_cmd = env.commands[1][0]
-        run_cmd = next(cmd for cmd, _, _ in env.commands if "python3 script.py" in cmd)
+        run_cmd = next(cmd for cmd, _, _ in env.commands if "python3 runner.py" in cmd)
         cleanup_cmd = env.commands[-1][0]
         self.assertIn("mkdir -p /data/data/com.termux/files/usr/tmp/hermes_exec_", mkdir_cmd)
         self.assertIn("HERMES_RPC_DIR=/data/data/com.termux/files/usr/tmp/hermes_exec_", run_cmd)
         self.assertIn("rm -rf /data/data/com.termux/files/usr/tmp/hermes_exec_", cleanup_cmd)
         self.assertNotIn("mkdir -p /tmp/hermes_exec_", mkdir_cmd)
+        shipped = {call.args[1]: call.args[2] for call in ship_file.call_args_list}
+        script_path = next(path for path in shipped if path.endswith("/script.py"))
+        runner_path = next(path for path in shipped if path.endswith("/runner.py"))
+        self.assertEqual(shipped[script_path], "print('hello')")
+        self.assertIn("from hermes_tools import terminal", shipped[runner_path])
 
     def test_timezone_shell_quoted_in_remote_execution(self):
         """HERMES_TIMEZONE must be shell-quoted in remote env_prefix to prevent injection."""
@@ -167,7 +211,7 @@ class TestExecuteCodeRemoteTempDir(unittest.TestCase):
                 self.commands.append((command, cwd, timeout))
                 if "command -v python3" in command:
                     return {"output": "OK\n"}
-                if "python3 script.py" in command:
+                if "python3 runner.py" in command:
                     return {"output": "hello\n", "returncode": 0}
                 return {"output": ""}
 
@@ -187,7 +231,7 @@ class TestExecuteCodeRemoteTempDir(unittest.TestCase):
             result = json.loads(_execute_remote("print('hello')", "task-1", ["terminal"]))
 
         self.assertEqual(result["status"], "success")
-        run_cmd = next(cmd for cmd, _, _ in env.commands if "python3 script.py" in cmd)
+        run_cmd = next(cmd for cmd, _, _ in env.commands if "python3 runner.py" in cmd)
         # The TZ value must be shell-quoted — it should NOT contain unescaped semicolons
         self.assertNotIn("TZ=US/Eastern; echo PWNED", run_cmd,
                          "TZ value with shell metacharacters must not appear unquoted")
@@ -453,7 +497,6 @@ class TestBuildExecuteCodeSchema(unittest.TestCase):
         self.assertNotIn("web_extract(", desc)
         self.assertNotIn("write_file(", desc)
 
-
     def test_none_defaults_to_all_tools(self):
         schema_none = build_execute_code_schema(None)
         schema_all = build_execute_code_schema(SANDBOX_ALLOWED_TOOLS)
@@ -675,7 +718,7 @@ class TestHeadTailTruncation(unittest.TestCase):
                 self.commands.append((command, cwd, timeout))
                 if "command -v python3" in command:
                     return {"output": "OK\n"}
-                if "python3 script.py" in command:
+                if "python3 runner.py" in command:
                     return {"output": "HEAD\n" + ("x" * 80_000) + "\nTAIL\n", "returncode": 0}
                 return {"output": ""}
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -76,6 +76,24 @@ MAX_STDOUT_BYTES = 50_000    # 50 KB
 MAX_STDERR_BYTES = 10_000    # 10 KB
 
 
+def _generate_autoinject_runner(enabled_tools: list[str]) -> str:
+    """Generate a runner that exposes sandbox tools without rewriting source."""
+    available = sorted(set(SANDBOX_ALLOWED_TOOLS) & set(enabled_tools))
+    imports = ""
+    globals_dict = "{}"
+    if available:
+        names = ", ".join(available)
+        imports = f"from hermes_tools import {names}\n"
+        globals_dict = "{" + ", ".join(f"{name!r}: {name}" for name in available) + "}"
+    return (
+        "import os\n"
+        "import runpy\n"
+        f"{imports}"
+        "script = os.path.join(os.path.dirname(__file__), 'script.py')\n"
+        f"runpy.run_path(script, init_globals={globals_dict}, run_name='__main__')\n"
+    )
+
+
 def _assemble_stdout_result(
     head: bytes,
     tail: bytes = b"",
@@ -1062,12 +1080,16 @@ def _execute_remote(
 
         rpc_token = secrets.token_urlsafe(32)
 
-        # Generate and ship files
+        # Keep user source untouched; the runner supplies enabled tools as globals.
         tools_src = generate_hermes_tools_module(
             list(sandbox_tools), transport="file",
         )
         _ship_file_to_remote(env, f"{sandbox_dir}/hermes_tools.py", tools_src)
         _ship_file_to_remote(env, f"{sandbox_dir}/script.py", code)
+        _ship_file_to_remote(
+            env, f"{sandbox_dir}/runner.py",
+            _generate_autoinject_runner(list(sandbox_tools)),
+        )
 
         # Wrapped so the thread inherits the turn's approval context + callbacks
         # (see tools.thread_context) — else sandbox RPC tool calls lose approval
@@ -1097,7 +1119,7 @@ def _execute_remote(
         logger.info("Executing code on %s backend (task %s)...",
                      env_type, effective_task_id[:8])
         script_result = env.execute(
-            f"cd {quoted_sandbox_dir} && {env_prefix} python3 script.py",
+            f"cd {quoted_sandbox_dir} && {env_prefix} python3 runner.py",
             timeout=timeout,
         )
 
@@ -1320,9 +1342,11 @@ def execute_code(
         with open(os.path.join(tmpdir, "hermes_tools.py"), "w", encoding="utf-8") as f:
             f.write(tools_src)
 
-        # Write the user's script
+        # Keep user source untouched; the runner supplies enabled tools as globals.
         with open(os.path.join(tmpdir, "script.py"), "w", encoding="utf-8") as f:
             f.write(code)
+        with open(os.path.join(tmpdir, "runner.py"), "w", encoding="utf-8") as f:
+            f.write(_generate_autoinject_runner(list(sandbox_tools)))
 
         # --- Start RPC server ---
         rpc_token = secrets.token_urlsafe(32)
@@ -1421,10 +1445,10 @@ def execute_code(
         _mode = _get_execution_mode()
         _child_python = _resolve_child_python(_mode)
         _child_cwd = _resolve_child_cwd(_mode, tmpdir, task_id=task_id or "")
-        _script_path = os.path.join(tmpdir, "script.py")
+        _runner_path = os.path.join(tmpdir, "runner.py")
 
         proc = subprocess.Popen(
-            [_child_python, _script_path],
+            [_child_python, _runner_path],
             cwd=_child_cwd,
             env=child_env,
             stdout=subprocess.PIPE,
@@ -1927,15 +1951,6 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
         doc for name, doc in _TOOL_DOC_LINES if name in enabled_sandbox_tools
     )
 
-    # Build example import list from enabled tools
-    import_examples = [n for n in ("web_search", "terminal") if n in enabled_sandbox_tools]
-    if not import_examples:
-        import_examples = sorted(enabled_sandbox_tools)[:2]
-    if import_examples:
-        import_str = ", ".join(import_examples) + ", ..."
-    else:
-        import_str = "..."
-
     # Mode-specific CWD guidance. Project mode is the default and matches
     # terminal()'s filesystem/interpreter; strict mode retains the isolated
     # temp-dir staging and hermes-agent's own python.
@@ -1959,14 +1974,14 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
         "Use normal tool calls instead when: single tool call with no processing, "
         "you need to see the full result and apply complex reasoning, "
         "or the task requires interactive user input.\n\n"
-        f"Available via `from hermes_tools import ...`:\n\n"
+        "The following tools are automatically available without imports:\n\n"
         f"{tool_lines}\n\n"
         "Limits: 5-minute timeout, 50KB stdout cap, max 50 tool calls per script. "
         "terminal() is foreground-only (no background or pty).\n\n"
         f"{cwd_note}\n\n"
         "Print your final result to stdout. Use Python stdlib (json, re, math, csv, "
         "datetime, collections, etc.) for processing between tool calls.\n\n"
-        "Also available (no import needed — built into hermes_tools):\n"
+        "Convenience helpers available by importing them from hermes_tools:\n"
         "  json_parse(text: str) — json.loads with strict=False; use for terminal() output with control chars\n"
         "  shell_quote(s: str) — shlex.quote(); use when interpolating dynamic strings into shell commands\n"
         "  retry(fn, max_attempts=3, delay=2) — retry with exponential backoff for transient failures"
@@ -1981,9 +1996,11 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
                 "code": {
                     "type": "string",
                     "description": (
-                        "Python code to execute. Import tools with "
-                        f"`from hermes_tools import {import_str}` "
-                        "and print your final result to stdout."
+                        "Python code to execute. The listed Hermes tools are "
+                        "available directly without imports. Import convenience "
+                        "helpers with `from hermes_tools import json_parse, "
+                        "shell_quote, retry` if "
+                        "needed, and print your final result to stdout."
                     ),
                 },
             },


### PR DESCRIPTION
## What does this PR do?

Makes the `execute_code` sandbox tools available directly to user scripts without requiring `from hermes_tools import ...` boilerplate.

The implementation keeps `script.py` byte-for-byte unchanged. A small generated `runner.py` imports only the intersection of the session-enabled tools and `SANDBOX_ALLOWED_TOOLS`, then executes the original script through `runpy.run_path(..., init_globals=..., run_name="__main__")`. This preserves module docstrings, `from __future__` imports, source line numbers, and local/remote Python syntax compatibility.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a generated runner in `tools/code_execution_tool.py` that exposes only allowed and enabled sandbox tools as initial script globals.
- Kept submitted user source unchanged and used the same runner for local and remote execution backends.
- Updated the `execute_code` schema to describe direct tool availability while retaining explicit imports for convenience helpers.
- Added behavioral coverage in `tests/tools/test_code_execution.py` for tool filtering, empty toolsets, untouched remote source, runner dispatch, and schema guidance.

## How to Test

1. Run `python -m pytest tests/tools/test_code_execution.py -q -k "not TestRpcTokenAuthorization"`.
2. Run `python -m pytest tests/tools/test_code_execution_modes.py -q`.
3. Run `execute_code` with `print(callable(terminal))` and `enabled_tools=["terminal"]`; it should print `True` without an explicit import.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
42 passed, 32 skipped, 5 deselected in 13.04s
28 passed, 13 skipped in 3.34s
All checks passed! (ruff)
No Windows footguns found (2 files scanned)
execute_code E2E: {"status": "success", "output": "True\r\n", "exit_code": 0}
```

The five deselected tests are `TestRpcTokenAuthorization`; four of them currently use `socket.AF_UNIX` directly and fail on native Windows independently of this change.