### PR TITLE
fix: avoid false matrix lazy refresh activation

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -316,15 +316,26 @@ class TestActiveFeatures:
         assert "memory.hindsight" not in active
         assert "platform.slack" not in active
 
-    def test_multi_package_feature_active_if_any_present(self, monkeypatch):
-        # platform.slack has 3 packages; only one needs to be present
-        # for the feature to count as active (user activated it before,
-        # one transitive may have been uninstalled separately).
+    def test_multi_package_feature_active_if_any_unique_package_present(self, monkeypatch):
+        # platform.slack has shared security pins like aiohttp, but a unique
+        # package such as slack-bolt is still enough to prove activation.
         monkeypatch.setattr(
             ld, "_is_present",
             lambda spec: ld._pkg_name_from_spec(spec) == "slack-bolt",
         )
         assert "platform.slack" in ld.active_features()
+
+    def test_shared_transitive_pin_alone_does_not_activate_matrix(self, monkeypatch):
+        # aiohttp is mirrored into several messaging features as a shared
+        # security pin. Its presence alone must not make Matrix look active.
+        monkeypatch.setattr(
+            ld, "_is_present",
+            lambda spec: ld._pkg_name_from_spec(spec) == "aiohttp",
+        )
+        active = ld.active_features()
+        assert "platform.matrix" not in active
+        assert "platform.slack" not in active
+        assert "platform.discord" not in active
 
 
 class TestRefreshActiveFeatures:

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -570,6 +570,36 @@ def _is_present(spec: str) -> bool:
         return False
 
 
+def _activation_specs(feature: str) -> tuple[str, ...]:
+    """Return the specs that should count as evidence a feature was enabled.
+
+    Some lazy features intentionally mirror shared transitive security pins
+    such as ``aiohttp``. Presence of a shared package alone is not evidence
+    that the feature itself was ever activated; otherwise an unrelated backend
+    can make another feature look active and trigger a doomed refresh during
+    ``hermes update``.
+
+    Heuristic:
+    - Prefer packages unique to this feature across :data:`LAZY_DEPS`.
+    - If every package is shared, fall back to all specs so purely-shared
+      feature bundles still remain refreshable.
+    """
+    specs = LAZY_DEPS.get(feature, ())
+    if not specs:
+        return ()
+
+    counts: dict[str, int] = {}
+    for feature_specs in LAZY_DEPS.values():
+        for spec in feature_specs:
+            pkg = _pkg_name_from_spec(spec)
+            counts[pkg] = counts.get(pkg, 0) + 1
+
+    unique_specs = tuple(
+        spec for spec in specs if counts.get(_pkg_name_from_spec(spec), 0) == 1
+    )
+    return unique_specs or specs
+
+
 def _core_constraints_file() -> Optional[Path]:
     """Write a pip constraints file pinning every package already importable
     in the core environment to its installed version.
@@ -858,16 +888,17 @@ def feature_install_command(feature: str) -> Optional[str]:
 def active_features() -> list[str]:
     """Return the list of features the user has ever lazy-installed.
 
-    A feature counts as "active" if at least one of its declared packages
+    A feature counts as "active" if at least one of its activation specs
     is currently installed in the venv (presence check, ignoring version).
-    Features the user has never enabled stay quiet.
+    Shared transitive pins alone do not count unless the feature has no
+    feature-unique packages to key off.
 
     Used by ``hermes update`` to figure out which lazy backends need a
     refresh pass when pins move in :data:`LAZY_DEPS`.
     """
     active = []
-    for feature, specs in LAZY_DEPS.items():
-        if any(_is_present(s) for s in specs):
+    for feature in LAZY_DEPS:
+        if any(_is_present(s) for s in _activation_specs(feature)):
             active.append(feature)
     return active
 


### PR DESCRIPTION
## Summary
- add `_activation_specs()` so lazy feature activation prefers feature-unique packages
- stop shared transitive pins like `aiohttp` from falsely marking `platform.matrix` as active
- add regression coverage for the shared-pin case in `test_lazy_deps.py`

## Test Plan
- `scripts/run_tests.sh tests/tools/test_lazy_deps.py -q`

## Context
This prevents `hermes update` from needlessly trying to refresh the Matrix lazy backend on installs that only carry shared messaging security pins.