### PR TITLE
docs: fix typo "WhatApp" → "WhatsApp" in session-lifecycle.md

### DIFF
--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -250,7 +250,7 @@ agent:main:{platform}:{chat_type}[:{chat_id}][:{thread_id}][:{participant_id}]
 - `participant_id` = `user_id_alt` or `user_id` (in that priority).
 - WhatsApp identifiers are canonicalized to handle JID/LID alias flips.
 
-### Special Case: WhatApp
+### Special Case: WhatsApp
 
 WhatsApp phone numbers go through `canonical_whatsapp_identifier()` which strips the
 `@s.whatsapp.net` suffix and normalizes to E.164 format. This prevents session fragmentation


### PR DESCRIPTION
## What

Fix a typo in `docs/session-lifecycle.md` line 253.

Section heading `### Special Case: WhatApp` is missing the "s" — should be `### Special Case: WhatsApp`.

## Why

The rest of the document (including the paragraph directly below the heading) correctly spells "WhatsApp". This is a simple oversight.

## Changes

- `docs/session-lifecycle.md`: `WhatApp` → `WhatsApp`