### PR TITLE
fix(whatsapp): canonicalize device-suffixed reply IDs

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -41,6 +41,7 @@ import {
   extractBridgeEvent,
   inferMediaType,
   mediaPayloadForFile,
+  normalizeWhatsAppId,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
 } from './bridge_helpers.js';
@@ -192,11 +193,6 @@ function rememberSentMessage(sent, payload) {
 
 function trackSentMessageId(sent) {
   rememberSentId(sent?.key?.id);
-}
-
-function normalizeWhatsAppId(value) {
-  if (!value) return '';
-  return String(value).replace(':', '@');
 }
 
 function redactWhatsAppId(value) {
@@ -757,6 +753,11 @@ async function startSocket() {
         bodyLength: event.body.length,
         hasMedia: event.hasMedia,
         mediaType: event.mediaType,
+        hasQuotedMessage: event.hasQuotedMessage,
+        quotedParticipantPresent: !!event.quotedParticipant,
+        quotedParticipantMatchesBot: !!event.quotedParticipant && botIds.includes(event.quotedParticipant),
+        quotedParticipantDomain: event.quotedParticipant?.split('@')[1] || '',
+        botIdDomains: Array.from(new Set(botIds.map(id => id.split('@')[1]).filter(Boolean))),
         queueLength: messageQueue.length,
       });
       if (messageQueue.length > MAX_QUEUE_SIZE) {

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -19,9 +19,31 @@ import {
   appendMediaFailureNote,
   extractBridgeEvent,
   mediaPayloadForFile,
+  normalizeWhatsAppId,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
 } from './bridge_helpers.js';
+
+// -- WhatsApp identifier normalization ------------------------------------
+{
+  const deviceSuffixedLid = '123456789:1@lid';
+  const suffixFreeLid = '123456789@lid';
+  assert.equal(normalizeWhatsAppId(deviceSuffixedLid), suffixFreeLid);
+  assert.equal(normalizeWhatsAppId(suffixFreeLid), suffixFreeLid);
+  assert.equal(
+    normalizeWhatsAppId(deviceSuffixedLid),
+    normalizeWhatsAppId(suffixFreeLid),
+  );
+  assert.equal(
+    normalizeWhatsAppId('15551234567:47@s.whatsapp.net'),
+    '15551234567@s.whatsapp.net',
+  );
+  assert.notEqual(
+    normalizeWhatsAppId(deviceSuffixedLid),
+    normalizeWhatsAppId('987654321@lid'),
+  );
+  console.log('  ✓ device-suffixed JIDs canonicalize without collapsing accounts');
+}
 
 // -- quoted outbound text -------------------------------------------------
 {

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -15,7 +15,7 @@ export const MIME_MAP = {
 
 export function normalizeWhatsAppId(value) {
   if (!value) return '';
-  return String(value).replace(':', '@');
+  return String(value).replace(/:[^@]+(?=@)/, '');
 }
 
 export function getMessageContent(msg) {

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -87,7 +87,29 @@ def test_group_messages_can_require_direct_trigger_via_config():
             quotedParticipant="15551230000@lid",
         )
     ) is True
+    # The JavaScript bridge canonicalizes device-suffixed bot identities before
+    # this strict Python gate sees the event. A native reply still routes when
+    # the quote uses the suffix-free LID form.
+    assert adapter._should_process_message(
+        _group_message(
+            "replying",
+            botIds=["123456789@lid"],
+            quotedParticipant="123456789@lid",
+        )
+    ) is True
     assert adapter._should_process_message(_group_message("/status")) is True
+
+
+def test_group_reply_to_other_participant_remains_ignored():
+    adapter = _make_adapter(require_mention=True, group_policy="open")
+
+    assert adapter._should_process_message(
+        _group_message(
+            "replying",
+            botIds=["123456789@lid"],
+            quotedParticipant="987654321@lid",
+        )
+    ) is False
 
 
 def test_regex_mention_patterns_allow_custom_wake_words():


### PR DESCRIPTION
## Summary

Fix native replies to a WhatsApp bot in mention-gated groups when Baileys represents the same account as both `account:device@domain` and `account@domain`.

- Canonicalize JIDs by stripping only the device suffix immediately before `@`, preserving the account and domain.
- Use the exported `bridge_helpers.js` normalizer from `bridge.js` instead of maintaining a second divergent implementation.
- Keep the Python group gate strict: it receives canonical bridge data and still requires an exact quoted-participant/bot-ID match.
- Add opt-in `WHATSAPP_DEBUG` structural diagnostics for reply routing, without message content or full JIDs.

## Why this shape

The bridge's former `String(value).replace(':', '@')` converted `account:device@lid` to `account@device@lid`, preventing strict reply identity matching. The bridge-helper normalizer is used for both `botIds` and inbound quote/mention identities, ensuring equivalent forms compare equal at the bridge boundary.

Related prior proposals: #29112, #7323, and #41873. This patch is rebased on current `main`, where normalization is shared through `scripts/whatsapp-bridge/bridge_helpers.js`; it intentionally retains domains rather than using the allowlist normalizer that collapses identities to bare account values.

## Verification

- `node bridge.native.test.mjs`
- `scripts/run_tests.sh tests/gateway/test_whatsapp_group_gating.py -q`
- `scripts/run_tests.sh tests/gateway/test_whatsapp_formatting.py -q`
- `node --check scripts/whatsapp-bridge/bridge.js`
- `git diff --check`
- Live validation: native reply without an explicit `@` mention successfully routed in an allowlisted group with `require_mention: true`.
