### PR TITLE
fix(memory): isolate providers and preserve Hindsight config

### DIFF
--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -39,6 +39,26 @@ _MEMORY_PLUGINS_DIR = Path(__file__).parent
 _USER_NAMESPACE = "_hermes_user_memory"
 
 
+def _get_disabled_provider_names() -> set[str]:
+    """Return profile-scoped memory providers blocked by ``plugins.disabled``.
+
+    Memory providers are exclusive plugins and bypass the general plugin
+    scanner, so they must enforce the same explicit deny-list here.  This lets
+    a restricted profile block a bundled provider even if somebody later
+    changes ``memory.provider`` to that name.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        disabled = cfg_get(config, "plugins", "disabled", default=[])
+        if not isinstance(disabled, list):
+            return set()
+        return {str(name).strip() for name in disabled if str(name).strip()}
+    except Exception:
+        return set()
+
+
 def _register_synthetic_package(name: str, search_locations: List[str]) -> None:
     """Register an empty package shell in sys.modules.
 
@@ -93,6 +113,7 @@ def _iter_provider_dirs() -> List[Tuple[str, Path]]:
     Scans bundled first, then user-installed.  Bundled takes precedence
     on name collisions (first-seen wins via ``seen`` set).
     """
+    disabled = _get_disabled_provider_names()
     seen: set = set()
     dirs: List[Tuple[str, Path]] = []
 
@@ -102,6 +123,8 @@ def _iter_provider_dirs() -> List[Tuple[str, Path]]:
             if not child.is_dir() or child.name.startswith(("_", ".")):
                 continue
             if not (child / "__init__.py").exists():
+                continue
+            if child.name in disabled or f"memory/{child.name}" in disabled:
                 continue
             seen.add(child.name)
             dirs.append((child.name, child))
@@ -114,6 +137,8 @@ def _iter_provider_dirs() -> List[Tuple[str, Path]]:
                 continue
             if child.name in seen:
                 continue  # bundled takes precedence
+            if child.name in disabled or f"memory/{child.name}" in disabled:
+                continue
             if not _is_memory_provider_dir(child):
                 continue  # skip non-memory plugins
             dirs.append((child.name, child))
@@ -126,6 +151,10 @@ def find_provider_dir(name: str) -> Optional[Path]:
 
     Checks bundled first, then user-installed.
     """
+    disabled = _get_disabled_provider_names()
+    if name in disabled or f"memory/{name}" in disabled:
+        logger.info("Memory provider '%s' is blocked by plugins.disabled", name)
+        return None
     # Bundled
     bundled = _MEMORY_PLUGINS_DIR / name
     if bundled.is_dir() and (bundled / "__init__.py").exists():

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -504,8 +504,14 @@ def _load_simple_env(path) -> dict[str, str]:
     return values
 
 
-def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None) -> dict[str, str]:
+def _build_embedded_profile_env(
+    config: dict[str, Any],
+    *,
+    llm_api_key: str | None = None,
+    existing: dict[str, str] | None = None,
+) -> dict[str, str]:
     """Build the profile-scoped env file that standalone hindsight-embed consumes."""
+    existing = existing or {}
     current_key = llm_api_key
     if current_key is None:
         current_key = (
@@ -514,9 +520,15 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
             or os.environ.get("HINDSIGHT_LLM_API_KEY", "")
         )
 
-    current_provider = config.get("llm_provider", "")
-    current_model = config.get("llm_model", "")
-    current_base_url = config.get("llm_base_url") or os.environ.get("HINDSIGHT_API_LLM_BASE_URL", "")
+    current_provider = config.get("llm_provider", "") or existing.get("HINDSIGHT_API_LLM_PROVIDER", "")
+    current_model = config.get("llm_model", "") or existing.get("HINDSIGHT_API_LLM_MODEL", "")
+    current_base_url = (
+        config.get("llm_base_url")
+        or os.environ.get("HINDSIGHT_API_LLM_BASE_URL", "")
+        or existing.get("HINDSIGHT_API_LLM_BASE_URL", "")
+    )
+    if not current_key:
+        current_key = existing.get("HINDSIGHT_API_LLM_API_KEY", "")
 
     # The embedded daemon expects OpenAI wire format for these providers.
     daemon_provider = "openai" if current_provider in {"openai_compatible", "openrouter"} else current_provider
@@ -549,14 +561,42 @@ def _embedded_profile_env_path(config: dict[str, Any]):
 
 
 def _materialize_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None):
-    """Write the profile-scoped env file that standalone hindsight-embed uses."""
+    """Merge Hermes-owned settings into the embedded profile env file.
+
+    Preserve comments and Hindsight settings Hermes does not own.  In
+    particular, an incomplete profile must never erase a valid shared LLM
+    provider/model/key with blank values.
+    """
     profile_env = _embedded_profile_env_path(config)
     profile_env.parent.mkdir(parents=True, exist_ok=True)
-    env_values = _build_embedded_profile_env(config, llm_api_key=llm_api_key)
-    profile_env.write_text(
-        "".join(f"{key}={value}\n" for key, value in env_values.items()),
-        encoding="utf-8",
+    saved = _load_simple_env(profile_env)
+    env_values = _build_embedded_profile_env(
+        config,
+        llm_api_key=llm_api_key,
+        existing=saved,
     )
+    if not env_values["HINDSIGHT_API_LLM_PROVIDER"] or not env_values["HINDSIGHT_API_LLM_MODEL"]:
+        raise ValueError(
+            "Hindsight embedded mode requires non-empty llm_provider and llm_model; "
+            "refusing to write an incomplete shared profile environment."
+        )
+
+    lines = profile_env.read_text(encoding="utf-8").splitlines() if profile_env.exists() else []
+    updated: set[str] = set()
+    merged_lines: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#") and "=" in line:
+            key = line.split("=", 1)[0].strip()
+            if key in env_values:
+                merged_lines.append(f"{key}={env_values[key]}")
+                updated.add(key)
+                continue
+        merged_lines.append(line)
+    for key, value in env_values.items():
+        if key not in updated:
+            merged_lines.append(f"{key}={value}")
+    profile_env.write_text("\n".join(merged_lines).rstrip() + "\n", encoding="utf-8")
     return profile_env
 
 def _sanitize_bank_segment(value: str) -> str:
@@ -1418,13 +1458,17 @@ class HindsightMemoryProvider(MemoryProvider):
                     # Update the profile .env to match our current config so
                     # the daemon always starts with the right settings.
                     # If the config changed and the daemon is running, stop it.
-                    profile_env = _embedded_profile_env_path(self._config)
-                    expected_env = _build_embedded_profile_env(self._config)
+                    current_config = self._config or {}
+                    profile_env = _embedded_profile_env_path(current_config)
                     saved = _load_simple_env(profile_env)
-                    config_changed = saved != expected_env
+                    expected_env = _build_embedded_profile_env(current_config, existing=saved)
+                    # Extra settings in the shared profile are legitimate and
+                    # must not cause a rewrite/restart loop.  Compare only the
+                    # keys Hermes owns.
+                    config_changed = any(saved.get(key) != value for key, value in expected_env.items())
 
                     if config_changed:
-                        profile_env = _materialize_embedded_profile_env(self._config)
+                        profile_env = _materialize_embedded_profile_env(current_config)
                         if client._manager.is_running(profile):
                             with open(log_path, "a", encoding="utf-8") as f:
                                 f.write("\n=== Config changed, restarting daemon ===\n")

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -494,6 +494,16 @@ class TestPluginMemoryDiscovery:
         from plugins.memory import load_memory_provider
         assert load_memory_provider("nonexistent_provider") is None
 
+    def test_disabled_exclusive_memory_provider_cannot_load(self, monkeypatch):
+        """plugins.disabled is a hard deny-list for memory providers too."""
+        from plugins.memory import load_memory_provider
+
+        monkeypatch.setattr(
+            "plugins.memory._get_disabled_provider_names",
+            lambda: {"hindsight"},
+        )
+        assert load_memory_provider("hindsight") is None
+
 
 class TestUserInstalledProviderDiscovery:
     """Memory providers installed to $HERMES_HOME/plugins/ should be found.

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -23,6 +23,7 @@ from plugins.memory.hindsight import (
     RETAIN_SCHEMA,
     _load_config,
     _build_embedded_profile_env,
+    _materialize_embedded_profile_env,
     _normalize_observation_scopes,
     _normalize_retain_tags,
     _resolve_bank_id_template,
@@ -416,6 +417,50 @@ class TestConfig:
         })
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
+
+    def test_incomplete_config_preserves_existing_llm_settings(self):
+        env = _build_embedded_profile_env(
+            {},
+            existing={
+                "HINDSIGHT_API_LLM_PROVIDER": "ollama",
+                "HINDSIGHT_API_LLM_API_KEY": "ollama",
+                "HINDSIGHT_API_LLM_MODEL": "qwen2.5:7b",
+            },
+        )
+
+        assert env["HINDSIGHT_API_LLM_PROVIDER"] == "ollama"
+        assert env["HINDSIGHT_API_LLM_API_KEY"] == "ollama"
+        assert env["HINDSIGHT_API_LLM_MODEL"] == "qwen2.5:7b"
+
+    def test_materialize_merges_without_erasing_unowned_settings(self, tmp_path, monkeypatch):
+        profile_env = tmp_path / ".hindsight" / "profiles" / "hermes.env"
+        profile_env.parent.mkdir(parents=True)
+        profile_env.write_text(
+            "# retained comment\n"
+            "HINDSIGHT_API_LLM_PROVIDER=ollama\n"
+            "HINDSIGHT_API_LLM_API_KEY=ollama\n"
+            "HINDSIGHT_API_LLM_MODEL=qwen2.5:7b\n"
+            "HINDSIGHT_API_REFLECT_MAX_ITERATIONS=1\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        _materialize_embedded_profile_env({"profile": "hermes"})
+
+        text = profile_env.read_text(encoding="utf-8")
+        assert "# retained comment" in text
+        assert "HINDSIGHT_API_LLM_PROVIDER=ollama" in text
+        assert "HINDSIGHT_API_LLM_MODEL=qwen2.5:7b" in text
+        assert "HINDSIGHT_API_REFLECT_MAX_ITERATIONS=1" in text
+
+    def test_materialize_refuses_new_incomplete_profile(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        profile_env = tmp_path / ".hindsight" / "profiles" / "hermes.env"
+
+        with pytest.raises(ValueError, match="requires non-empty llm_provider and llm_model"):
+            _materialize_embedded_profile_env({"profile": "hermes"})
+
+        assert not profile_env.exists()
 
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
         captured = {}


### PR DESCRIPTION
## Summary

- enforce `plugins.disabled` for exclusive memory providers as well as regular plugins
- preserve existing non-empty embedded Hindsight LLM provider, model, API key, and base URL when an incomplete profile supplies blanks
- merge Hermes-owned Hindsight environment values instead of replacing the entire file
- preserve comments and unrelated Hindsight tuning settings
- fail closed when creating an embedded Hindsight profile without a usable provider and model
- compare only Hermes-owned environment keys before restarting the embedded daemon

## Problem

Memory providers bypass the normal plugin scanner. As a result, a profile-level `plugins.disabled` deny-list could not reliably block an exclusive memory provider.

Separately, the Hindsight embedded-profile materializer rewrote `~/.hindsight/profiles/<profile>.env` from scratch. An incomplete profile could therefore replace a working shared configuration with blank `HINDSIGHT_API_LLM_PROVIDER` and `HINDSIGHT_API_LLM_MODEL` values, erase unrelated tuning, and trigger a daemon restart loop.

## Verification

- targeted test suite: `221 passed`
- Python compile check: passed
- `pip check`: no broken requirements
- live profile boundary check: blocked provider is neither discoverable nor loadable, while the selected alternative provider remains available
- live Hindsight materialization check: existing environment hash unchanged and `/health` reports database connected

## Scope

This PR contains only the generic provider-deny and Hindsight environment fixes plus regression tests. Profile-specific configuration and unrelated local changes are excluded.