### PR TITLE
fix(compression): cap oversized tool results inside the protected tail

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -277,6 +277,19 @@ _SUMMARY_TOKENS_CEILING = 10_000
 # Placeholder used when pruning old tool results
 _PRUNED_TOOL_PLACEHOLDER = "[Old tool output cleared to save context space]"
 
+# Hard per-message cap for tool results inside the PROTECTED tail.  The
+# tail-budget walk protects recent messages wholesale, so a single recent
+# 60KB tool result (delegation transcript, build log, huge JSON list)
+# survives every compression pass untouched — the measured 26-07-20 failure:
+# a 246-message session compacted to 246 messages at ~398K tokens because
+# the oversized blobs all sat inside the protected tail, and the retry
+# loop ended in "Cannot compress further".  Tool results over the cap are
+# head+tail truncated (data-preserving, keeps the parts models actually
+# reference) instead of exempted.  ~16K chars ≈ 4K tokens per result.
+_TAIL_TOOL_RESULT_MAX_CHARS = 16_000
+_TAIL_TOOL_RESULT_HEAD = 10_000
+_TAIL_TOOL_RESULT_TAIL = 4_000
+
 # Chars per token rough estimate
 _CHARS_PER_TOKEN = 4
 # Flat token cost per attached image part.  Real cost varies by provider and
@@ -1805,6 +1818,37 @@ class ContextCompressor(ContextEngine):
                 new_tcs.append(tc)
             if modified:
                 result[i] = {**msg, "tool_calls": new_tcs}
+
+        # Pass 4: Cap oversized tool results inside the PROTECTED tail.
+        # Tail protection is wholesale — a recent 60KB tool result (delegation
+        # transcript, build log, big JSON dump) is exempt from Pass 2 and
+        # survives every compaction, so a session whose bulk lives in recent
+        # tool results compacts to the same size and the retry loop dies with
+        # "Cannot compress further" (measured 26-07-20: 246 -> 246 messages at
+        # ~398K tokens).  Head+tail truncation keeps the parts models actually
+        # reference while bounding any single result to ~4K tokens.  The last
+        # few messages are exempt: the current exchange's tool output may be
+        # exactly what the model is working on right now.
+        _tail_exempt_last = 3
+        for i in range(prune_boundary, len(result) - _tail_exempt_last):
+            msg = result[i]
+            if msg.get("role") != "tool":
+                continue
+            content = msg.get("content", "")
+            if not isinstance(content, str):
+                continue
+            if len(content) <= _TAIL_TOOL_RESULT_MAX_CHARS:
+                continue
+            omitted = len(content) - _TAIL_TOOL_RESULT_HEAD - _TAIL_TOOL_RESULT_TAIL
+            truncated = (
+                content[:_TAIL_TOOL_RESULT_HEAD]
+                + f"\n...[{omitted:,} chars truncated during context compression]...\n"
+                + content[-_TAIL_TOOL_RESULT_TAIL:]
+            )
+            new_msg = {**msg, "content": truncated}
+            drop_stale_api_content(new_msg)
+            result[i] = new_msg
+            pruned += 1
 
         return result, pruned
 

--- a/tests/agent/test_compressor_tail_tool_result_cap.py
+++ b/tests/agent/test_compressor_tail_tool_result_cap.py
@@ -1,0 +1,124 @@
+"""Tests for the Pass-4 tail tool-result cap in _prune_old_tool_results.
+
+Regression for the 26-07-20 incident: a 246-message session whose bulk sat
+in RECENT oversized tool results (60KB job lists, 52KB build logs, 50KB
+delegation transcripts) compacted to the same message count / token size
+because tail protection exempted those blobs wholesale, ending in
+"Cannot compress further".
+"""
+
+from __future__ import annotations
+
+from agent.context_compressor import (
+    ContextCompressor,
+    _TAIL_TOOL_RESULT_MAX_CHARS,
+)
+
+
+def _make_compressor(**kwargs):
+    return ContextCompressor(
+        model="test-model",
+        config_context_length=200_000,
+        quiet_mode=True,
+        **kwargs,
+    )
+
+
+def _tool_pair(idx: int, content: str):
+    call_id = f"call_{idx}"
+    return [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": call_id, "content": content},
+    ]
+
+
+def test_oversized_tail_tool_result_is_truncated():
+    comp = _make_compressor()
+    big = "x" * (_TAIL_TOOL_RESULT_MAX_CHARS * 4)  # 64K chars, well over cap
+    messages = [{"role": "system", "content": "sys"}]
+    messages += [{"role": "user", "content": "do the thing"}]
+    # Oversized tool result that lands INSIDE the protected tail but outside
+    # the last-3 exemption window.
+    messages += _tool_pair(1, big)
+    # Padding turns so the big result is not within the last 3 messages.
+    messages += [
+        {"role": "assistant", "content": "working on it"},
+        {"role": "user", "content": "ok"},
+        {"role": "assistant", "content": "done"},
+    ]
+    pruned_msgs, pruned_count = comp._prune_old_tool_results(
+        messages, protect_tail_count=20, protect_tail_tokens=comp.tail_token_budget,
+    )
+    tool_msgs = [m for m in pruned_msgs if m.get("role") == "tool"]
+    assert len(tool_msgs) == 1
+    assert len(tool_msgs[0]["content"]) < len(big)
+    assert "truncated during context compression" in tool_msgs[0]["content"]
+    assert pruned_count >= 1
+
+
+def test_recent_tool_result_in_exempt_window_is_kept():
+    comp = _make_compressor()
+    big = "y" * (_TAIL_TOOL_RESULT_MAX_CHARS * 2)
+    messages = [{"role": "system", "content": "sys"}]
+    messages += [{"role": "user", "content": "go"}]
+    messages += [{"role": "assistant", "content": "padding"}]
+    # The big tool result is one of the LAST 3 messages — current work,
+    # must survive untouched.
+    messages += _tool_pair(1, big)
+    pruned_msgs, _ = comp._prune_old_tool_results(
+        messages, protect_tail_count=20, protect_tail_tokens=comp.tail_token_budget,
+    )
+    tool_msgs = [m for m in pruned_msgs if m.get("role") == "tool"]
+    assert tool_msgs[0]["content"] == big
+
+
+def test_small_tail_tool_results_untouched():
+    comp = _make_compressor()
+    small = "z" * 500
+    messages = [{"role": "system", "content": "sys"}]
+    messages += [{"role": "user", "content": "go"}]
+    messages += _tool_pair(1, small)
+    messages += [
+        {"role": "assistant", "content": "a"},
+        {"role": "user", "content": "b"},
+        {"role": "assistant", "content": "c"},
+    ]
+    pruned_msgs, _ = comp._prune_old_tool_results(
+        messages, protect_tail_count=20, protect_tail_tokens=comp.tail_token_budget,
+    )
+    tool_msgs = [m for m in pruned_msgs if m.get("role") == "tool"]
+    assert tool_msgs[0]["content"] == small
+
+
+def test_many_oversized_tail_results_all_capped():
+    """The incident shape: many recent oversized tool results."""
+    comp = _make_compressor()
+    messages = [{"role": "system", "content": "sys"}]
+    messages += [{"role": "user", "content": "go"}]
+    for i in range(6):
+        # Distinct contents so dedup (Pass 1) doesn't collapse them.
+        messages += _tool_pair(i, f"blob{i}-" + ("w" * 50_000))
+    messages += [
+        {"role": "assistant", "content": "a"},
+        {"role": "user", "content": "b"},
+        {"role": "assistant", "content": "c"},
+    ]
+    pre = sum(len(str(m.get("content", ""))) for m in messages)
+    pruned_msgs, pruned_count = comp._prune_old_tool_results(
+        messages, protect_tail_count=20, protect_tail_tokens=comp.tail_token_budget,
+    )
+    post = sum(len(str(m.get("content", ""))) for m in pruned_msgs)
+    assert post < pre * 0.5, f"expected >50% shrink, got {pre} -> {post}"
+    for m in pruned_msgs:
+        if m.get("role") == "tool":
+            assert len(m["content"]) <= _TAIL_TOOL_RESULT_MAX_CHARS + 200


### PR DESCRIPTION
[Bob]

## Symptom

Long tool-heavy sessions still reach `Context length exceeded (...). Cannot compress further.` even after multiple automatic compactions — the failure class reported in #61932.

Field measurement (26-07-20, Slack gateway session, `codex/gpt-5.6-sol` fallback): a 246-message session compacted **246 → 246 messages at ~398K rough tokens**, then the overflow retry loop exhausted:

```
agent.conversation_compression: context compression done: session=... messages=245->246 rough_tokens=~398,247
agent.conversation_loop: Context length exceeded: 368,489 tokens. Cannot compress further.
```

Session store inspection: ~1.07MB total content, **1.04MB in 144 tool messages**, top 10 recent tool results 60,648 / 52,090 / 51,464 / 49,820 / 49,664 / 37,900 / 36,936 / 35,974 / 34,717 / 29,683 chars (delegation live transcripts, a build log, a 74-job cron-list JSON) — all inside the protected tail.

## Root cause

`_prune_old_tool_results` (`agent/context_compressor.py:1662`) computes a prune boundary from `protect_tail_tokens` and exempts everything behind it **wholesale — with no per-message size limit**. Pass 2 (informative-summary replacement) and Pass 3 (tool_call arg truncation) both iterate only `range(prune_boundary)`. A recent 60KB tool result is therefore untouchable by every pass, and when the session's token bulk sits in recent tool results, compaction converges to a fixed point above the context limit.

Standalone repro (script posted on #61932) on current `main` (`477c08b44`), using the measured incident shape:

```
rough tokens: 113,992 -> 113,992   pruned_count: 0   savings: 0.0%
tool results >16K chars surviving prune: 10
```

## Fix

Add **Pass 4** to `_prune_old_tool_results`: tool results larger than `_TAIL_TOOL_RESULT_MAX_CHARS` (16K chars) **inside the protected tail** are head+tail truncated (10K head + 4K tail ≈ 4K tokens per result) instead of exempted.

Design notes:

- **Data-preserving, not destructive**: keeps the head (command echo, structure, first results) and tail (exit status, summary lines) that models actually reference; the omitted middle is labeled with an exact char count.
- **Last 3 messages exempt** (`_tail_exempt_last`): the current exchange's tool output may be exactly what the model is mid-reasoning over. This also keeps the fix safe for the "big read_file the user just asked about" case.
- **`drop_stale_api_content` on rewrite**: the api_content sidecar (exact bytes previously sent) is stale after truncation; dropping it prevents replay from resending pre-truncation bytes — same invariant the summary-merge path maintains.
- Pass 4 runs inside the existing prune pre-pass, so it benefits every compression entry point (preflight, overflow retry, manual `/compress`) without touching the summarizer or the tail-cut walk.

Same repro with this branch:

```
rough tokens: 113,992 -> 39,405   pruned_count: 10   savings: 65.4%
tool results >16K chars surviving prune: 0
```

0% → 65.4% reduction on the exact failure shape; the compress→retry loop now makes progress instead of dead-ending.

## Tests

`tests/agent/test_compressor_tail_tool_result_cap.py` (4 tests):
- oversized tail tool result gets truncated (with the truncation marker)
- result within the last-3 exempt window survives byte-identical
- small tail results untouched
- incident shape (many recent oversized results) shrinks >50%

```
4 passed
```

Full compression-related suite (`-k compress`, 456 tests) green on the branch.

Fixes #61932
