### PR TITLE
fix(slack): edit status bubbles in place instead of posting new ones

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -478,6 +478,14 @@ class SlackAdapter(BasePlatformAdapter):
         # cache bridges lifecycle and message delivery ordering.
         self._agent_view_contexts: Dict[Tuple[str, str], Dict[str, str]] = {}
         self._AGENT_VIEW_CONTEXTS_MAX = 5000
+        # Status-bubble dedup (issue #30045, extended to Slack): remember the
+        # message ts of the last status bubble per (channel, thread, status
+        # key) so repeated progress callbacks (compression retries, fallback
+        # switches, ...) edit ONE message in place instead of appending a new
+        # bubble per event — long retry loops used to spam threads with
+        # dozens of out-of-order status messages.
+        self._status_message_ids: Dict[Tuple[str, str, str], str] = {}
+        self._STATUS_MESSAGE_IDS_MAX = 2000
         # Cache for _fetch_thread_context results: cache_key → _ThreadContextCache
         self._thread_context_cache: Dict[str, _ThreadContextCache] = {}
         self._THREAD_CACHE_TTL = 60.0
@@ -1528,6 +1536,49 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[Slack] Ephemeral send error: %s", e, exc_info=True)
             return SendResult(success=False, error=str(e))
+
+    async def send_or_update_status(
+        self,
+        chat_id: str,
+        status_key: str,
+        content: str,
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a status message, or edit the previous one with the same key.
+
+        Issue #30045 (Telegram) extended to Slack: progress/status callbacks
+        (context-pressure, compression retries, model fallback, lifecycle)
+        used to append a fresh bubble on every call, spamming threads during
+        long retry loops. The first call posts and the message ts is
+        remembered; subsequent calls with the same (channel, thread,
+        status_key) edit that message in place via ``chat.update``. If the
+        edit fails (message deleted, too old, ...) the cached ts is dropped
+        and a fresh message is sent.
+        """
+        thread_ts = self._resolve_thread_ts(None, metadata) or ""
+        key = (str(chat_id), str(thread_ts), str(status_key))
+        cached_id = self._status_message_ids.get(key)
+        if cached_id is not None:
+            result = await self.edit_message(
+                chat_id, cached_id, content, finalize=False, metadata=metadata,
+            )
+            if result.success:
+                if result.message_id:
+                    self._status_message_ids[key] = str(result.message_id)
+                return result
+            # Edit failed — clear the cached ts and fall through to a fresh send.
+            self._status_message_ids.pop(key, None)
+        result = await self.send(chat_id, content, metadata=metadata)
+        if result.success and result.message_id:
+            if len(self._status_message_ids) >= self._STATUS_MESSAGE_IDS_MAX:
+                # Simple FIFO trim: drop the oldest half to bound memory.
+                for stale in list(self._status_message_ids)[
+                    : self._STATUS_MESSAGE_IDS_MAX // 2
+                ]:
+                    self._status_message_ids.pop(stale, None)
+            self._status_message_ids[key] = str(result.message_id)
+        return result
 
     async def edit_message(
         self,

--- a/tests/gateway/test_slack_status_update.py
+++ b/tests/gateway/test_slack_status_update.py
@@ -1,0 +1,144 @@
+"""Tests for SlackAdapter.send_or_update_status (issue #30045, Slack).
+
+The status-update path must:
+  1. Send a fresh message on the first call for a (channel, thread, key).
+  2. Edit that same message on subsequent calls with the same key.
+  3. Fall back to sending fresh when the cached message edit fails.
+  4. Keep distinct keys and distinct threads independent.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _ensure_slack_mock():
+    if "slack_bolt" in sys.modules and hasattr(sys.modules["slack_bolt"], "__file__"):
+        return
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    slack_bolt.adapter.socket_mode.async_handler.AsyncSocketModeHandler = MagicMock
+    slack_sdk = MagicMock()
+    slack_sdk.web.async_client.AsyncWebClient = MagicMock
+    for name, mod in [
+        ("slack_bolt", slack_bolt),
+        ("slack_bolt.async_app", slack_bolt.async_app),
+        ("slack_bolt.adapter", slack_bolt.adapter),
+        ("slack_bolt.adapter.socket_mode", slack_bolt.adapter.socket_mode),
+        (
+            "slack_bolt.adapter.socket_mode.async_handler",
+            slack_bolt.adapter.socket_mode.async_handler,
+        ),
+        ("slack_sdk", slack_sdk),
+        ("slack_sdk.web", slack_sdk.web),
+        ("slack_sdk.web.async_client", slack_sdk.web.async_client),
+    ]:
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("aiohttp", MagicMock())
+
+
+_ensure_slack_mock()
+
+import plugins.platforms.slack.adapter as _slack_mod  # noqa: E402
+
+_slack_mod.SLACK_AVAILABLE = True
+
+from gateway.config import PlatformConfig  # noqa: E402
+from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
+
+
+@pytest.fixture()
+def adapter():
+    config = PlatformConfig(enabled=True, token="***")
+    a = SlackAdapter(config)
+    a._app = MagicMock()
+    client = AsyncMock()
+    client.chat_postMessage = AsyncMock(
+        side_effect=lambda **kw: {"ok": True, "ts": f"ts_{client.chat_postMessage.call_count}"}
+    )
+    client.chat_update = AsyncMock(return_value={"ok": True})
+    a._get_client = MagicMock(return_value=client)
+    a._bot_user_id = "U_BOT"
+    a._running = True
+    a.stop_typing = AsyncMock()
+    return a
+
+
+METADATA = {"thread_id": "1784585355.415219"}
+
+
+@pytest.mark.asyncio
+async def test_first_call_sends_fresh(adapter):
+    result = await adapter.send_or_update_status(
+        "C_CHAN", "context_pressure", "compressing 1/3", metadata=METADATA
+    )
+    assert result.success
+    client = adapter._get_client.return_value
+    assert client.chat_postMessage.call_count == 1
+    assert client.chat_update.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_second_call_edits_same_message(adapter):
+    r1 = await adapter.send_or_update_status(
+        "C_CHAN", "context_pressure", "compressing 1/3", metadata=METADATA
+    )
+    r2 = await adapter.send_or_update_status(
+        "C_CHAN", "context_pressure", "compressing 2/3", metadata=METADATA
+    )
+    assert r1.success and r2.success
+    client = adapter._get_client.return_value
+    assert client.chat_postMessage.call_count == 1
+    assert client.chat_update.call_count == 1
+    # The edit must target the ts of the first send.
+    assert client.chat_update.call_args.kwargs["ts"] == r1.message_id
+
+
+@pytest.mark.asyncio
+async def test_edit_failure_falls_back_to_fresh_send(adapter):
+    await adapter.send_or_update_status(
+        "C_CHAN", "context_pressure", "compressing 1/3", metadata=METADATA
+    )
+    client = adapter._get_client.return_value
+    client.chat_update = AsyncMock(side_effect=RuntimeError("message_not_found"))
+    r2 = await adapter.send_or_update_status(
+        "C_CHAN", "context_pressure", "compressing 2/3", metadata=METADATA
+    )
+    assert r2.success
+    assert client.chat_postMessage.call_count == 2
+    # Cached id was replaced: a third call edits the NEW message.
+    client.chat_update = AsyncMock(return_value={"ok": True})
+    r3 = await adapter.send_or_update_status(
+        "C_CHAN", "context_pressure", "compressing 3/3", metadata=METADATA
+    )
+    assert r3.success
+    assert client.chat_update.call_args.kwargs["ts"] == r2.message_id
+
+
+@pytest.mark.asyncio
+async def test_distinct_keys_do_not_crosstalk(adapter):
+    await adapter.send_or_update_status(
+        "C_CHAN", "context_pressure", "compressing", metadata=METADATA
+    )
+    await adapter.send_or_update_status(
+        "C_CHAN", "model_fallback", "falling back", metadata=METADATA
+    )
+    client = adapter._get_client.return_value
+    assert client.chat_postMessage.call_count == 2
+    assert client.chat_update.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_distinct_threads_do_not_crosstalk(adapter):
+    await adapter.send_or_update_status(
+        "C_CHAN", "context_pressure", "compressing", metadata={"thread_id": "111.1"}
+    )
+    await adapter.send_or_update_status(
+        "C_CHAN", "context_pressure", "compressing", metadata={"thread_id": "222.2"}
+    )
+    client = adapter._get_client.return_value
+    assert client.chat_postMessage.call_count == 2
+    assert client.chat_update.call_count == 0


### PR DESCRIPTION
[Bob]

## Symptom

During a compression/fallback retry loop, a Slack thread received a dozen separate, out-of-order status bubbles within ~3 minutes (live capture, 26-07-20):

```
:arrows_counterclockwise: Primary model failed — switching to fallback: codex/gpt-5.6-sol ...
:compression: Context too large (~355,194 tokens) — compressing (3/3)...
:warning: Model declined to respond (safety refusal) — trying fallback...
:compression: Compressed 331 → 120 messages, retrying...
:compression: Compressed 239 → 233 messages, retrying...
:compression: Context too large (~357,559 tokens) — compressing (2/3)...
:compression: Context too large (~371,951 tokens) — compressing (1/3)...
Context length exceeded: max compression attempts (3) reached.
:compression: Compressed 244 → 242 messages, retrying...
```

Note the ordering: "(3/3)" arrives before "(2/3)" and "(1/3)" — each event is an independent async `chat.postMessage`, so arrival order isn't delivery order, which makes the spam actively misleading on top of noisy.

## Root cause

`gateway/run.py:515` (`_send_or_update_status_coro`) already implements the right behavior — edit the previous bubble for the same `status_key` — but only **when the adapter implements `send_or_update_status`**:

```python
sender = getattr(adapter, "send_or_update_status", None)
if callable(sender):
    return await sender(chat_id, status_key, content, metadata=metadata)
return await adapter.send(chat_id, content, metadata=metadata)
```

Only the Telegram adapter implements it (#30045). Slack falls through to `adapter.send` — one fresh thread message per status event.

## Fix

Implement `send_or_update_status` on the Slack adapter following the Telegram pattern:

- first call posts and caches the message `ts` keyed by **`(channel, thread_ts, status_key)`** — thread-scoped, unlike Telegram's `(chat_id, status_key)`, because a single Slack channel multiplexes many concurrent sessions as threads; a channel-scoped key would cross-edit status bubbles between unrelated threads
- subsequent calls edit that message via the existing `edit_message` → `chat.update` path (`finalize=False`, so no Block Kit re-derivation per progress tick)
- edit failure (message deleted, `cant_update_message`, too old) drops the cached ts and falls back to a fresh send, re-caching the new ts
- cache is FIFO-bounded (2000 entries, halved on overflow) so long-lived gateways don't grow it unbounded

No gateway/core changes needed — `_send_or_update_status_coro` picks the method up via the existing `getattr` probe, and the status cleanup path (`_cleanup_msg_ids`) is unaffected since it tracks whatever `message_id` the adapter returns.

## Tests

`tests/gateway/test_slack_status_update.py` (5 tests):
- fresh send on first call
- in-place edit on second call, targeting the first send's ts
- fallback-to-fresh on edit failure + re-cache of the new ts (third call edits the replacement)
- no cross-talk between distinct status keys
- no cross-talk between distinct threads (the Slack-specific hazard)

```
5 passed
```

Existing Slack + Telegram gateway suites (263 tests) green on the branch.
