### PR TITLE
chore(deps): update protobufjs to 8.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   },
   "overrides": {
     "lodash": "4.18.1",
-    "yauzl": "^3.3.1"
+    "yauzl": "^3.3.1",
+    "protobufjs": "^8.7.1"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/plugins/platforms/photon/sidecar/package-lock.json
+++ b/plugins/platforms/photon/sidecar/package-lock.json
@@ -1453,9 +1453,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.1.tgz",
-      "integrity": "sha512-s4qQPr4pU0W95iYnUInh95skjIg+3aM2sakYsw60QYanU+qWRDY2zQxOAQV6zU7ROJpSNDG9B+VSmk4dqdWWSA==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.1.tgz",
+      "integrity": "sha512-agdGHrXNTv0IrYscJPDou/PlEJk1c/hBZ9o/B5NH2i/nSPtPqacNxzgwf1CebXxFMjMrZH5sqv9uQuw96aGt/A==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -16,7 +16,7 @@
     "spectrum-ts": "8.0.0"
   },
   "overrides": {
-    "protobufjs": "8.6.1",
+    "protobufjs": "8.7.1",
     "@opentelemetry/otlp-transformer": "0.218.0",
     "@opentelemetry/otlp-exporter-base": "0.218.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.218.0",


### PR DESCRIPTION
## Summary

- Update the root npm override for `protobufjs` to `^8.7.1`.
- Update the Photon sidecar override and lockfile from `8.6.1` to `8.7.1`.
- Address the two protobufjs Dependabot advisories reported by the fork.

## Scope

This PR intentionally contains only the dependency manifest and lockfile changes. Fork-specific features, `_docs`, evidence, generated files, and unrelated dependency updates are excluded.

## Verification

- `npm install --no-fund` (root)
- `npm audit --omit=dev` (root): 0 vulnerabilities
- `npm ls protobufjs` in Photon sidecar: `protobufjs@8.7.1`
- Photon sidecar lockfile records `protobufjs` 8.7.1

The Photon sidecar postinstall patch was not run during lockfile regeneration because it is unrelated to this dependency update.