### PR TITLE
fix(termux): resolve PROJECT_ROOT NameError in Termux fast-version path

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -362,9 +362,11 @@ def _read_openai_version_fast() -> str | None:
 
 def _print_fast_version_info() -> None:
     from hermes_cli import __release_date__, __version__
+    from pathlib import Path
 
     print(f"Hermes Agent v{__version__} ({__release_date__})")
-    print(f"Install directory: {PROJECT_ROOT}")
+    project_root = Path(__file__).parent.parent.resolve()
+    print(f"Install directory: {project_root}")
 
     print(f"Python: {sys.version.split()[0]}")
 


### PR DESCRIPTION
## Problema

`hermes --version` ir bet kokia `hermes` komanda ant Termux/Android krenta su:
```
NameError: name 'PROJECT_ROOT' is not defined
```

Priežastis: `_print_fast_version_info()` (367 eilutė) naudoja `PROJECT_ROOT`, bet jis apibrėžtas tik 461 eilutėje. Ant Termux ši funkcija iškviečiama modulio importo metu, todėl nulaužo viską.

## Pataisymas

Skaičiuoti `project_root` lokaliai su `Path(__file__).parent.parent.resolve()` funkcijos viduje, užuot pasikliavus modulio lygio kintamuoju.

## Testuota

- Termux/Android ARM64, Python 3.14.6, Hermes v0.19.0