### PR TITLE
fix(kanban): let scoped board override worker pins

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -518,19 +518,23 @@ def kanban_db_path(board: Optional[str] = None) -> Path:
 
     Resolution (highest precedence first):
 
-    1. ``HERMES_KANBAN_DB`` env var — pins the path directly. Honoured for
+    1. A scoped board override from the CLI ``--board`` flag. This is an
+       explicit operator choice and must beat worker-env pins so readback /
+       repair commands can inspect another board from inside a claimed worker.
+    2. ``HERMES_KANBAN_DB`` env var — pins the path directly. Honoured for
        back-compat and for the dispatcher→worker handoff (defense in
        depth: dispatcher injects this into worker env so workers are
        immune to any path-resolution disagreement).
-    2. When ``board`` arg is None, the active board from
+    3. When ``board`` arg is None, the active board from
        :func:`get_current_board` is used.
-    3. Board ``default`` → ``<root>/kanban.db`` (back-compat path).
+    4. Board ``default`` → ``<root>/kanban.db`` (back-compat path).
        Other boards → ``<root>/kanban/boards/<slug>/kanban.db``.
     """
+    scoped = (_CURRENT_BOARD_OVERRIDE.get() or "").strip()
+    slug = _normalize_board_slug(scoped) if scoped else _normalize_board_slug(board)
     override = os.environ.get("HERMES_KANBAN_DB", "").strip()
-    if override:
+    if override and not scoped:
         return Path(override).expanduser()
-    slug = _normalize_board_slug(board)
     if slug is None:
         slug = get_current_board()
     if slug == DEFAULT_BOARD:
@@ -542,17 +546,19 @@ def workspaces_root(board: Optional[str] = None) -> Path:
     """Return the directory under which ``scratch`` workspaces are created.
 
     Anchored per-board so workspaces don't leak between projects.
-    ``HERMES_KANBAN_WORKSPACES_ROOT`` pins the path directly (highest
-    precedence) — the dispatcher injects this into worker env.
+    A scoped board override from the CLI ``--board`` flag beats
+    ``HERMES_KANBAN_WORKSPACES_ROOT``; otherwise that env var pins the path
+    directly (for the dispatcher→worker handoff).
 
     ``default`` keeps the legacy path ``<root>/kanban/workspaces/`` so
     that existing scratch workspaces from before the boards feature are
     preserved. Other boards use ``<root>/kanban/boards/<slug>/workspaces/``.
     """
+    scoped = (_CURRENT_BOARD_OVERRIDE.get() or "").strip()
+    slug = _normalize_board_slug(scoped) if scoped else _normalize_board_slug(board)
     override = os.environ.get("HERMES_KANBAN_WORKSPACES_ROOT", "").strip()
-    if override:
+    if override and not scoped:
         return Path(override).expanduser()
-    slug = _normalize_board_slug(board)
     if slug is None:
         slug = get_current_board()
     if slug == DEFAULT_BOARD:

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -310,6 +310,29 @@ def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch
     assert beta_titles == ["beta-task"]
 
 
+def test_board_override_beats_worker_db_pin(kanban_home, monkeypatch):
+    """CLI --board is an explicit operator override, even inside a worker env."""
+    kb.create_board("alpha")
+    kb.create_board("beta")
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(kb.kanban_db_path(board="alpha")))
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACES_ROOT", str(kb.workspaces_root(board="alpha")))
+
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+
+    args = parser.parse_args(["kanban", "--board", "beta", "create", "beta-task"])
+    assert kc.kanban_command(args) == 0
+
+    with kb.scoped_current_board("alpha"), kb.connect_closing() as conn:
+        alpha_titles = [row.title for row in kb.list_tasks(conn, limit=100)]
+    with kb.scoped_current_board("beta"), kb.connect_closing() as conn:
+        beta_titles = [row.title for row in kb.list_tasks(conn, limit=100)]
+
+    assert alpha_titles == []
+    assert beta_titles == ["beta-task"]
+
+
 # ---------------------------------------------------------------------------
 # Integration with the COMMAND_REGISTRY
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- let a scoped CLI `--board` override (`scoped_current_board()`) beat worker-env pins in `kanban_db_path()` and `workspaces_root()`
- preserve unscoped/direct `board=` behavior so `HERMES_KANBAN_DB` and `HERMES_KANBAN_WORKSPACES_ROOT` still pin worker paths
- add regression coverage for creating on a different board from inside a worker-pinned environment

## Verification
- `git diff --check -- hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_cli.py`
- `git diff -- hermes_cli/kanban_db.py | grep -E 'NEGATIVE_GATE|approval_required|provider rate_limited|dependency block|rate_limited|respawn_guarded|pending_approval' || true`
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_boards.py -q -k 'board_override_beats_worker_db_pin or board_override_is_isolated_per_concurrent_call or env_var_db_override_still_wins'` -> 3 passed, 0 failed
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_boards.py -q -k 'env_var_workspaces_override or env_var_db_override_still_wins'` -> 2 passed, 0 failed

## Notes
- Commit for this repair staged only `hermes_cli/kanban_db.py` and `tests/hermes_cli/test_kanban_cli.py`.
- Existing unrelated local modifications were preserved and not committed: `agent/credential_pool.py`, `hermes_cli/auth_commands.py`, `tests/hermes_cli/test_auth_commands.py`, `tests/hermes_cli/test_kanban_block_kinds.py`.
