### PR TITLE
fix(gateway): preserve Discord handoff sessions in threads

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8298,14 +8298,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             dest_chat_type = "dm"
             dest_user_id = home_chat_id if is_telegram_private_chat else "system:handoff"
 
+        # Discord exposes each thread as its own channel. Its inbound adapter
+        # therefore uses the thread ID for both ``chat_id`` and ``thread_id``;
+        # retain the home channel only as the parent. Match that source shape
+        # here so the handoff binding is reused by later thread messages.
+        dest_chat_id = home_chat_id
+        dest_parent_chat_id = None
+        if platform == Platform.DISCORD and effective_thread_id:
+            dest_chat_id = effective_thread_id
+            dest_parent_chat_id = home_chat_id
+
         dest_source = SessionSource(
             platform=platform,
-            chat_id=home_chat_id,
+            chat_id=dest_chat_id,
             chat_name=home.name,
             chat_type=dest_chat_type,
             user_id=dest_user_id,
             user_name="Handoff",
             thread_id=effective_thread_id,
+            parent_chat_id=dest_parent_chat_id,
         )
 
         # Compute the gateway's session_key for that destination using the

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -850,6 +850,51 @@ async def test_handoff_to_telegram_dm_topic_uses_dm_lane_not_generic_thread(tmp_
 
 
 @pytest.mark.asyncio
+async def test_handoff_to_discord_thread_uses_discord_inbound_thread_lane():
+    """A Discord handoff must bind the same session key as a thread reply."""
+    runner = _make_runner()
+    runner.config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.config.platforms[Platform.DISCORD].home_channel = HomeChannel(
+        platform=Platform.DISCORD,
+        chat_id="parent-channel",
+        name="Discord home",
+    )
+    adapter = MagicMock()
+    adapter.create_handoff_thread = AsyncMock(return_value="thread-channel")
+    adapter.send = AsyncMock(return_value=SimpleNamespace(success=True))
+    runner.adapters = {Platform.DISCORD: adapter}
+    captured = {}
+
+    async def fake_handle_message(event):
+        captured["source"] = event.source
+        return "handoff ok"
+
+    runner._handle_message = AsyncMock(side_effect=fake_handle_message)
+
+    await runner._process_handoff({
+        "id": "cli-session",
+        "title": "CLI work",
+        "handoff_platform": "discord",
+    })
+
+    inbound_source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="thread-channel",
+        chat_type="thread",
+        user_id="a-real-user",
+        thread_id="thread-channel",
+        parent_chat_id="parent-channel",
+    )
+    expected_key = build_session_key(inbound_source)
+    runner.session_store.switch_session.assert_called_once_with(expected_key, "cli-session")
+    assert captured["source"].chat_id == "thread-channel"
+    assert captured["source"].thread_id == "thread-channel"
+    assert captured["source"].parent_chat_id == "parent-channel"
+
+
+@pytest.mark.asyncio
 async def test_topic_root_command_creates_and_pins_system_topic(tmp_path, monkeypatch):
     import gateway.run as gateway_run
 


### PR DESCRIPTION
Fixes #31550

## What changed and why

Per the reporter's July 20 clarification, a Discord `/handoff` could create and deliver into the new thread but bind `switch_session()` using the parent channel as `chat_id`. Incoming Discord thread replies instead use the thread ID as both `chat_id` and `thread_id`, so they resolved to a different session key and started fresh.

The handoff source now mirrors the inbound Discord thread shape: the thread ID is its `chat_id` and `thread_id`, while the configured home channel is retained as `parent_chat_id`. This makes the existing session binding persist to later replies without changing the low-level `create_thread` tool contract. A regression test covers the exact synthetic-handoff and inbound-reply key match.

## How to test

- Run `pytest tests/gateway/test_telegram_topic_mode.py -q --timeout=60` (46 passed).
- Run `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` after installing the test environment's FastAPI/uvicorn extras. In this worker environment, it stops during collection because those packages are unavailable and the lazy installer cannot modify the externally managed Python.

## What platforms tested on

- macOS development environment, using mocked Discord gateway handoff and inbound-thread sources.
- Not tested against a live Discord server.

<!-- autocontrib:worker-id=issue-followup-7e514545 kind=pr-open -->