### PR TITLE
fix(update): repair missing certifi CA bundles after updates

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7934,6 +7934,11 @@ def _install_python_dependencies_with_optional_fallback(
     try:
         _install(["install", "-e", f".[{group}]"])
         _verify_console_scripts_installed(install_cmd_prefix, env=env)
+        # A successful uv/pip exit does not prove every declared dependency
+        # reached the target venv. Verify this path too: otherwise an absent
+        # core dependency such as certifi can leave every gateway transport
+        # unable to establish TLS despite a reported-successful update.
+        _verify_core_dependencies_installed(install_cmd_prefix, env=env, group=group)
         return
     except subprocess.CalledProcessError:
         print(
@@ -8075,12 +8080,13 @@ def _verify_core_dependencies_installed(
     Reads ``pyproject.toml`` directly (so we don't trust the venv's stale
     metadata), filters out deps gated by ``;`` environment markers that don't
     apply to this platform, and runs ``importlib.metadata.version()`` in the
-    venv interpreter for each one. If anything is missing we reinstall the
-    base group with ``--reinstall`` to force uv to re-resolve, then check
-    again. We treat the final state as a warning rather than a hard failure
-    so a single broken-on-PyPI dep can't block an otherwise-successful
-    update — but the warning makes the partial install visible at the spot
-    that caused it, instead of hours later in a downstream subprocess.
+    venv interpreter for each one. When certifi is declared, it also validates
+    certifi's bundled CA file. If anything is missing we reinstall the base
+    group with ``--reinstall`` to force uv to re-resolve, then check again.
+    We treat the final state as a warning rather than a hard failure so a
+    single broken-on-PyPI dep can't block an otherwise-successful update — but
+    the warning makes the partial install visible at the spot that caused it,
+    instead of hours later in a downstream subprocess.
     """
     try:
         import tomllib  # Python 3.11+
@@ -8153,11 +8159,21 @@ def _verify_core_dependencies_installed(
 
     def _missing_deps() -> list[str]:
         check_script = (
-            "import importlib.metadata as md, sys\n"
+            "import importlib.metadata as md, os, ssl, sys\n"
             "missing=[]\n"
             "for name in sys.argv[1:]:\n"
             "    try: md.version(name)\n"
             "    except md.PackageNotFoundError: missing.append(name)\n"
+            "if 'certifi' in sys.argv[1:]:\n"
+            "    try:\n"
+            "        import certifi\n"
+            "        bundle = certifi.where()\n"
+            "        if not os.path.isfile(bundle) or os.path.getsize(bundle) < 1024:\n"
+            "            if 'certifi' not in missing: missing.append('certifi')\n"
+            "        else:\n"
+            "            ssl.create_default_context(cafile=bundle)\n"
+            "    except Exception:\n"
+            "        if 'certifi' not in missing: missing.append('certifi')\n"
             "print('\\n'.join(missing))\n"
         )
         try:
@@ -9367,12 +9383,20 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
     # just metadata) — a package can have intact dist-info but a missing
     # module after an interrupted uninstall/install cycle.
     check = (
-        "import importlib\n"
+        "import importlib, os, ssl\n"
         "mods = ['fastapi', 'uvicorn', 'pydantic', 'openai', 'yaml']\n"
         "missing = []\n"
         "for m in mods:\n"
         "    try: importlib.import_module(m)\n"
         "    except Exception as e: missing.append(f'{m}: {e}')\n"
+        "try:\n"
+        "    import certifi\n"
+        "    bundle = certifi.where()\n"
+        "    if not os.path.isfile(bundle) or os.path.getsize(bundle) < 1024:\n"
+        "        missing.append(f'certifi: invalid CA bundle at {bundle}')\n"
+        "    else:\n"
+        "        ssl.create_default_context(cafile=bundle)\n"
+        "except Exception as e: missing.append(f'certifi: {e}')\n"
         "print('\\n'.join(missing))\n"
     )
     try:

--- a/tests/hermes_cli/test_update_venv_health.py
+++ b/tests/hermes_cli/test_update_venv_health.py
@@ -95,6 +95,20 @@ def test_venv_health_healthy_when_probe_clean(tmp_path):
     assert healthy is True
 
 
+def test_venv_health_probe_includes_certifi(tmp_path):
+    """A current checkout must repair a venv that lost its TLS bundle."""
+    _fake_venv_python(tmp_path)
+    fake = SimpleNamespace(returncode=0, stdout="", stderr="")
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.object(
+        cli_main.subprocess, "run", return_value=fake
+    ) as run:
+        cli_main._venv_core_imports_healthy()
+
+    check_script = run.call_args.args[0][2]
+    assert "certifi.where()" in check_script
+    assert "ssl.create_default_context(cafile=bundle)" in check_script
+
+
 def test_venv_health_broken_interpreter_is_unhealthy(tmp_path):
     """Nonzero exit with no module list = interpreter itself is broken."""
     _fake_venv_python(tmp_path)

--- a/tests/hermes_cli/test_verify_console_scripts.py
+++ b/tests/hermes_cli/test_verify_console_scripts.py
@@ -87,12 +87,13 @@ class TestVerifyConsoleScriptsInstalled:
         names = _load_console_script_names()
         assert names == ["hermes", "hermes-agent", "hermes-acp"]
 
-    def test_primary_install_success_still_verifies_scripts(self):
+    def test_primary_install_success_still_verifies_core_dependencies(self):
         import hermes_cli.main as main_mod
 
         with patch("hermes_cli.main._is_windows", return_value=False), \
              patch("hermes_cli.main._run_quarantined_install") as mock_install, \
-             patch("hermes_cli.main._verify_console_scripts_installed") as mock_verify:
+             patch("hermes_cli.main._verify_console_scripts_installed") as mock_scripts, \
+             patch("hermes_cli.main._verify_core_dependencies_installed") as mock_deps:
             main_mod._install_python_dependencies_with_optional_fallback(
                 ["uv", "pip"], env={"VIRTUAL_ENV": "x"}
             )
@@ -102,7 +103,10 @@ class TestVerifyConsoleScriptsInstalled:
             env={"VIRTUAL_ENV": "x"},
             scripts_dir=None,
         )
-        mock_verify.assert_called_once_with(["uv", "pip"], env={"VIRTUAL_ENV": "x"})
+        mock_scripts.assert_called_once_with(["uv", "pip"], env={"VIRTUAL_ENV": "x"})
+        mock_deps.assert_called_once_with(
+            ["uv", "pip"], env={"VIRTUAL_ENV": "x"}, group="all"
+        )
 
     def test_quarantine_shims_include_declared_console_scripts(
         self, temp_pyproject, fake_scripts_dir

--- a/tests/hermes_cli/test_verify_core_dependencies.py
+++ b/tests/hermes_cli/test_verify_core_dependencies.py
@@ -16,7 +16,9 @@ The verification step:
 
 from __future__ import annotations
 
+import os
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -37,6 +39,7 @@ def temp_pyproject(tmp_path, monkeypatch):
         name = "fake"
         version = "0.0.0"
         dependencies = [
+          "certifi==2026.5.20",
           "pathspec==1.1.1",
           "pydantic==2.13.4",
           "ptyprocess>=0.7.0,<1; sys_platform != 'win32'",
@@ -104,6 +107,75 @@ class TestVerifyCoreDependencies:
             args = first_repair[0][0]  # positional: install_cmd
             assert "--reinstall" in args, f"repair install should pass --reinstall, got {args}"
             assert "-e" in args and "." in args, "first repair should be base group reinstall"
+
+    def test_verifies_certifi_bundle_when_certifi_is_declared(
+        self, temp_pyproject, fake_venv_python
+    ):
+        """A stale certifi dist-info record must not hide a missing cacert.pem."""
+        py, venv_root = fake_venv_python
+        env = {"VIRTUAL_ENV": str(venv_root)}
+        captured_commands: list[list[str]] = []
+
+        def fake_subprocess_run(cmd, **kwargs):
+            captured_commands.append(list(cmd))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("hermes_cli.main._resolve_install_target_python", return_value=py), \
+             patch("hermes_cli.main.subprocess.run", side_effect=fake_subprocess_run), \
+             patch("hermes_cli.main._run_install_with_heartbeat"):
+            from hermes_cli.main import _verify_core_dependencies_installed
+            _verify_core_dependencies_installed(["uv", "pip"], env=env)
+
+        probe = next(
+            cmd for cmd in captured_commands if any("certifi.where" in str(arg) for arg in cmd)
+        )
+        assert "certifi" in probe
+        assert "ssl.create_default_context(cafile=bundle)" in probe[2]
+
+    def test_corrupt_large_certifi_bundle_triggers_reinstall(self, temp_pyproject):
+        """A regular-but-invalid CA bundle must enter the repair path."""
+        (temp_pyproject / "pyproject.toml").write_text(textwrap.dedent("""\
+            [project]
+            name = "fake"
+            version = "0.0.0"
+            dependencies = ["certifi==2026.5.20"]
+        """))
+        bundle = temp_pyproject / "cacert.pem"
+        bundle.write_bytes(b"x" * 2_193)
+        assert bundle.stat().st_size == 2_193
+
+        fake_certifi = temp_pyproject / "certifi"
+        fake_certifi.mkdir()
+        (fake_certifi / "__init__.py").write_text(
+            f"def where():\n    return {str(bundle)!r}\n"
+        )
+        dist_info = temp_pyproject / "certifi-2026.5.20.dist-info"
+        dist_info.mkdir()
+        (dist_info / "METADATA").write_text(
+            "Metadata-Version: 2.1\nName: certifi\nVersion: 2026.5.20\n"
+        )
+
+        env = {**os.environ, "PYTHONPATH": str(temp_pyproject)}
+        real_subprocess_run = subprocess.run
+        probe_results = []
+
+        def fake_subprocess_run(cmd, **kwargs):
+            if "ssl.create_default_context(cafile=bundle)" in cmd[2]:
+                if not probe_results:
+                    result = real_subprocess_run(cmd, **kwargs)
+                    probe_results.append(result)
+                    return result
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("hermes_cli.main._resolve_install_target_python", return_value=Path(sys.executable)), \
+             patch("hermes_cli.main.subprocess.run", side_effect=fake_subprocess_run), \
+             patch("hermes_cli.main._run_install_with_heartbeat") as mock_install:
+            from hermes_cli.main import _verify_core_dependencies_installed
+            _verify_core_dependencies_installed([sys.executable, "-m", "pip"], env=env)
+
+        assert probe_results[0].stdout.strip() == "certifi"
+        assert mock_install.called, "a corrupt bundle must trigger a repair install"
+        assert "--reinstall" in mock_install.call_args_list[0].args[0]
 
     def test_falls_back_to_per_package_install_when_reinstall_did_not_help(
         self, temp_pyproject, fake_venv_python


### PR DESCRIPTION
## What changed and why

Per the reporter's clarification on 2026-07-20, `hermes update` could report success while the active gateway venv lacked `certifi` or its `cacert.pem`, leaving every HTTPS-backed platform unable to initialize. The successful dependency-install path now runs the existing core-dependency verifier, which additionally checks certifi's CA bundle and repairs an incomplete install. The current-checkout venv health probe also detects the same missing or invalid bundle and enters the existing repair flow.

Fixes #29866

## How to test

- `pytest tests/hermes_cli/test_verify_console_scripts.py tests/hermes_cli/test_verify_core_dependencies.py tests/hermes_cli/test_update_venv_health.py -q -x --timeout=60`
- `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`

## What platforms tested on

- macOS (local test environment)
- Cross-platform Python updater paths; no platform-specific APIs added

<!-- autocontrib:worker-id=issue-followup-f8510238 kind=pr-open -->