### PR TITLE
fix(cli): rebuild Wave 2 Windows worktree port

### DIFF
--- a/.github/merge-coverage.json
+++ b/.github/merge-coverage.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "candidate_commits": [
+    "29ea2dd05ee7fa3b8721cde1ed5bc4fe8ab29f6a"
+  ],
+  "manual_port_commits": [],
+  "candidate_patches": [],
+  "policy_tests": [
+    "worktree-quarantine"
+  ],
+  "allowed_target_paths": [
+    ".github/merge-coverage.json"
+  ]
+}

--- a/cli.py
+++ b/cli.py
@@ -1682,29 +1682,53 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True) -> Optional[D
     return info
 
 
-def _worktree_has_unpushed_commits(worktree_path: str, timeout: int = 10) -> bool:
-    """Return whether a worktree has commits not reachable from any remote branch.
+def _ref_has_unique_commits(
+    repo_path: str,
+    ref: str,
+    excluded_local_refs: Optional[set[str]] = None,
+    timeout: int = 10,
+) -> bool:
+    """Return whether *ref* has commits not backed by a safe comparison ref.
 
-    ``git log HEAD --not --remotes`` compares against remote-tracking refs under
-    ``refs/remotes/*``. If a repo has no remote-tracking refs yet, there is no
-    usable remote baseline to compare against, so treat it as having no
-    "unpushed" commits.
+    Remote-tracking refs are preferred. Without them, compare against other
+    local branches; probe failures preserve the worktree.
     """
     import subprocess
 
     try:
         remote_refs = subprocess.run(
             ["git", "for-each-ref", "--format=%(refname)", "refs/remotes"],
-            capture_output=True, text=True, timeout=timeout, cwd=worktree_path,
+            capture_output=True, text=True, timeout=timeout, cwd=repo_path,
         )
         if remote_refs.returncode != 0:
             return True
-        if not remote_refs.stdout.strip():
-            return False
+        if remote_refs.stdout.strip():
+            result = subprocess.run(
+                ["git", "log", "--oneline", ref, "--not", "--remotes"],
+                capture_output=True, text=True, timeout=timeout, cwd=repo_path,
+            )
+            if result.returncode != 0:
+                return True
+            return bool(result.stdout.strip())
+
+        local_refs_result = subprocess.run(
+            ["git", "for-each-ref", "--format=%(refname)", "refs/heads"],
+            capture_output=True, text=True, timeout=timeout, cwd=repo_path,
+        )
+        if local_refs_result.returncode != 0:
+            return True
+        excluded = excluded_local_refs or set()
+        comparison_refs = [
+            candidate.strip()
+            for candidate in local_refs_result.stdout.splitlines()
+            if candidate.strip() and candidate.strip() not in excluded
+        ]
+        if not comparison_refs:
+            return True
 
         result = subprocess.run(
-            ["git", "log", "--oneline", "HEAD", "--not", "--remotes"],
-            capture_output=True, text=True, timeout=timeout, cwd=worktree_path,
+            ["git", "log", "--oneline", ref, "--not", *comparison_refs],
+            capture_output=True, text=True, timeout=timeout, cwd=repo_path,
         )
         if result.returncode != 0:
             return True
@@ -1713,18 +1737,56 @@ def _worktree_has_unpushed_commits(worktree_path: str, timeout: int = 10) -> boo
         return True
 
 
-def _worktree_is_dirty(worktree_path: str, timeout: int = 10) -> bool:
-    """Return whether a worktree has uncommitted changes (staged, unstaged, or
-    untracked).
+def _worktree_has_unpushed_commits(worktree_path: str, timeout: int = 10) -> bool:
+    """Return whether removing this worktree could make commits unreachable."""
+    import subprocess
 
-    Fails SAFE: on any error returns True so callers do not delete a worktree
-    whose state they cannot determine.
-    """
+    try:
+        symbolic_ref = subprocess.run(
+            ["git", "symbolic-ref", "--quiet", "HEAD"],
+            capture_output=True, text=True, timeout=timeout, cwd=worktree_path,
+        )
+    except Exception:
+        return True
+    if symbolic_ref.returncode == 0:
+        excluded = symbolic_ref.stdout.strip()
+        if (
+            not excluded.startswith("refs/heads/")
+            or len(excluded) <= len("refs/heads/")
+            or any(character.isspace() for character in excluded)
+        ):
+            return True
+        try:
+            valid_ref = subprocess.run(
+                ["git", "check-ref-format", excluded],
+                capture_output=True, text=True, timeout=timeout, cwd=worktree_path,
+            )
+        except Exception:
+            return True
+        if valid_ref.returncode != 0:
+            return True
+    elif symbolic_ref.returncode == 1:
+        excluded = None
+    else:
+        return True
+    return _ref_has_unique_commits(
+        worktree_path,
+        "HEAD",
+        excluded_local_refs={excluded} if excluded else set(),
+        timeout=timeout,
+    )
+
+
+def _worktree_is_dirty(worktree_path: str, timeout: int = 10) -> bool:
+    """Return whether a worktree has staged, untracked, or ignored data."""
     import subprocess
 
     try:
         result = subprocess.run(
-            ["git", "status", "--porcelain"],
+            [
+                "git", "status", "--porcelain=v1", "-z",
+                "--untracked-files=all", "--ignored=matching",
+            ],
             capture_output=True, text=True, timeout=timeout, cwd=worktree_path,
         )
         if result.returncode != 0:
@@ -1734,8 +1796,183 @@ def _worktree_is_dirty(worktree_path: str, timeout: int = 10) -> bool:
         return True
 
 
+def _snapshot_local_branch(
+    repo_root: str, branch: str, timeout: int = 10,
+) -> Optional[tuple[str, str]]:
+    """Return a validated local-branch ref and immutable commit snapshot."""
+    import subprocess
+
+    if not branch or any(character.isspace() for character in branch):
+        return None
+    ref = f"refs/heads/{branch}"
+    try:
+        if subprocess.run(
+            ["git", "check-ref-format", ref], capture_output=True, text=True,
+            timeout=timeout, cwd=repo_root,
+        ).returncode != 0:
+            return None
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"],
+            capture_output=True, text=True, timeout=timeout, cwd=repo_root,
+        )
+        oid = result.stdout.strip()
+        if result.returncode or len(oid) not in (40, 64):
+            return None
+        if any(character not in "0123456789abcdefABCDEF" for character in oid):
+            return None
+        return ref, oid
+    except Exception:
+        return None
+
+
+def _archive_branch_snapshot(
+    repo_root: str, branch: str, expected_oid: str, timeout: int = 10,
+) -> Optional[str]:
+    """Create a durable recovery ref before moving a clean worktree."""
+    import subprocess
+
+    archive_ref = f"refs/hermes/archive/{branch}/{expected_oid}"
+    try:
+        if subprocess.run(
+            ["git", "check-ref-format", archive_ref], capture_output=True,
+            text=True, timeout=timeout, cwd=repo_root,
+        ).returncode != 0:
+            return None
+        create = subprocess.run(
+            ["git", "update-ref", archive_ref, expected_oid, ""],
+            capture_output=True, text=True, timeout=timeout, cwd=repo_root,
+        )
+        if create.returncode == 0:
+            return archive_ref
+        existing = subprocess.run(
+            ["git", "rev-parse", "--verify", f"{archive_ref}^{{commit}}"],
+            capture_output=True, text=True, timeout=timeout, cwd=repo_root,
+        )
+        if existing.returncode == 0 and existing.stdout.strip() == expected_oid:
+            return archive_ref
+    except Exception:
+        pass
+    return None
+
+
+def _capture_worktree_branch_snapshot(
+    repo_root: str,
+    worktree_path: str,
+    expected_branch: Optional[str] = None,
+    timeout: int = 10,
+) -> Optional[tuple[str, str, str]]:
+    """Capture a branch snapshot only when the worktree HEAD agrees with it."""
+    import subprocess
+
+    try:
+        branch_result = subprocess.run(
+            ["git", "branch", "--show-current"], capture_output=True,
+            text=True, timeout=timeout, cwd=worktree_path,
+        )
+        branch = branch_result.stdout.strip()
+        if branch_result.returncode or not branch:
+            return None
+        if expected_branch is not None and branch != expected_branch:
+            return None
+        snapshot = _snapshot_local_branch(repo_root, branch, timeout=timeout)
+        if snapshot is None:
+            return None
+        ref, branch_oid = snapshot
+        head_result = subprocess.run(
+            ["git", "rev-parse", "--verify", "HEAD^{commit}"],
+            capture_output=True, text=True, timeout=timeout, cwd=worktree_path,
+        )
+        if head_result.returncode or head_result.stdout.strip() != branch_oid:
+            return None
+        return branch, ref, branch_oid
+    except Exception:
+        return None
+
+
+def _archive_worktree_if_unchanged(
+    repo_root: str,
+    worktree_path: str,
+    expected_branch: Optional[str] = None,
+    timeout: int = 15,
+) -> Dict[str, str]:
+    """Quarantine a provably clean worktree without deleting its bytes or ref."""
+    import subprocess
+
+    if _worktree_is_dirty(worktree_path, timeout=timeout):
+        return {"status": "preserved", "reason": "dirty_or_status_failure"}
+    snapshot = _capture_worktree_branch_snapshot(
+        repo_root, worktree_path, expected_branch=expected_branch, timeout=timeout,
+    )
+    if snapshot is None:
+        return {"status": "preserved", "reason": "branch_snapshot_failure"}
+    branch, ref, expected_oid = snapshot
+    if _ref_has_unique_commits(
+        repo_root, expected_oid, excluded_local_refs={ref}, timeout=timeout,
+    ):
+        return {"status": "preserved", "reason": "unique_commits", "branch": branch}
+    if _worktree_is_dirty(worktree_path, timeout=timeout):
+        return {"status": "preserved", "reason": "dirty_or_status_failure", "branch": branch}
+    if _archive_branch_snapshot(repo_root, branch, expected_oid, timeout=timeout) is None:
+        return {"status": "preserved", "reason": "archive_ref_failure", "branch": branch}
+
+    archive_root = Path(repo_root) / ".worktrees" / ".archive"
+    archive_path = archive_root / Path(worktree_path).name
+    try:
+        archive_root.mkdir(parents=True, exist_ok=True)
+    except Exception:
+        return {"status": "preserved", "reason": "archive_directory_failure", "branch": branch}
+    if archive_path.exists():
+        return {"status": "preserved", "reason": "archive_destination_exists", "branch": branch}
+    try:
+        moved = subprocess.run(
+            ["git", "worktree", "move", worktree_path, str(archive_path)],
+            capture_output=True, text=True, timeout=timeout, cwd=repo_root,
+        )
+    except Exception:
+        moved = None
+    if archive_path.exists():
+        return {
+            "status": "archived_branch_preserved",
+            "reason": "move_success" if moved and moved.returncode == 0 else "archive_present",
+            "branch": branch,
+            "path": str(archive_path),
+        }
+    return {"status": "failed", "reason": "move_failed", "branch": branch}
+
+
+def _worktree_lock_owned_by_current_process(
+    repo_root: str, worktree_path: str, timeout: int = 10,
+) -> Optional[bool]:
+    """Return True for this process's lock, False unlocked, None otherwise."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"], capture_output=True,
+            text=True, timeout=timeout, cwd=repo_root,
+        )
+        if result.returncode != 0:
+            return None
+    except Exception:
+        return None
+    target = Path(worktree_path).resolve()
+    current: Optional[Path] = None
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            try:
+                current = Path(line[len("worktree "):].strip()).resolve()
+            except Exception:
+                current = None
+        elif (line == "locked" or line.startswith("locked ")) and current == target:
+            reason = line[len("locked"):].strip()
+            if reason == f"hermes pid={os.getpid()}":
+                return True
+            return None
+    return False
+
+
 def _worktree_lock_is_live(repo_root: str, worktree_path: str, timeout: int = 10):
-    """Classify a worktree's git lock as live, dead, or absent.
+    """Classify a worktree's lock as live, dead, unknown, or absent.
 
     ``hermes -w`` locks each worktree with reason ``hermes pid=<pid>`` so a
     concurrent hermes process' startup prune leaves an in-use worktree alone.
@@ -1745,8 +1982,8 @@ def _worktree_lock_is_live(repo_root: str, worktree_path: str, timeout: int = 10
     pruner tell the two apart:
 
     - ``"live"``  — locked and the owning pid is still running (skip it).
-    - ``"dead"``  — locked but the owning pid is gone, or the reason isn't a
-                    parseable hermes lock (safe to unlock + reap).
+    - ``"dead"``  — a parseable Hermes lock whose owning pid is gone.
+    - ``"unknown"`` — a foreign or malformed lock (never unlock it).
     - ``None``    — not locked at all.
 
     Fails SAFE toward ``"live"``: if git can't be queried at all we cannot
@@ -1777,13 +2014,9 @@ def _worktree_lock_is_live(repo_root: str, worktree_path: str, timeout: int = 10
             if current != target:
                 continue
             reason = line[len("locked"):].strip()
-            m = re.search(r"hermes pid=(\d+)", reason)
+            m = re.fullmatch(r"hermes pid=(\d+)", reason)
             if not m:
-                # Locked by something we don't recognize as a hermes session
-                # (or lock reason unavailable). Treat as dead — a foreign lock
-                # on a hermes -w worktree is almost certainly a leftover, and
-                # the age/dirty/unpushed gates already ran before we got here.
-                return "dead"
+                return "unknown"
             pid = int(m.group(1))
             if pid == os.getpid():
                 return "live"
@@ -1797,13 +2030,7 @@ def _worktree_lock_is_live(repo_root: str, worktree_path: str, timeout: int = 10
 
 
 def _cleanup_worktree(info: Dict[str, str] = None) -> None:
-    """Remove a worktree and its branch on exit.
-
-    Preserves the worktree only if it has unpushed commits (real work
-    that hasn't been pushed to any remote).  Uncommitted changes alone
-    (untracked files, test artifacts) are not enough to keep it — agent
-    work lives in commits/PRs, not the working tree.
-    """
+    """Quarantine a provably clean worktree without deleting branch history."""
     global _active_worktree
     info = info or _active_worktree
     if not info:
@@ -1819,44 +2046,43 @@ def _cleanup_worktree(info: Dict[str, str] = None) -> None:
         return
 
     has_unpushed = _worktree_has_unpushed_commits(wt_path, timeout=10)
+    is_dirty = _worktree_is_dirty(wt_path, timeout=10)
 
-    if has_unpushed:
-        print(f"\n\033[33m⚠ Worktree has unpushed commits, keeping: {wt_path}\033[0m")
-        print(f"  To clean up manually: git worktree remove --force {wt_path}")
+    if has_unpushed or is_dirty:
+        reasons = []
+        if has_unpushed:
+            reasons.append("unique commits or reachability probe failure")
+        if is_dirty:
+            reasons.append("uncommitted or ignored data")
+        print(f"\n\033[33m⚠ Worktree has {' and '.join(reasons)}, keeping: {wt_path}\033[0m")
         _active_worktree = None
         return
 
-    # Remove worktree (even if working tree is dirty — uncommitted
-    # changes without unpushed commits are just artifacts)
-    # Unlock first so `git worktree remove` isn't blocked by the lock we
-    # placed at creation time.  Fail-soft — never block cleanup.
-    try:
-        subprocess.run(
-            ["git", "worktree", "unlock", wt_path],
-            capture_output=True, text=True, timeout=10, cwd=repo_root,
-        )
-    except Exception as e:
-        logger.debug("git worktree unlock failed (non-fatal): %s", e)
-
-    try:
-        subprocess.run(
-            ["git", "worktree", "remove", wt_path, "--force"],
-            capture_output=True, text=True, timeout=15, cwd=repo_root,
-        )
-    except Exception as e:
-        logger.debug("Failed to remove worktree: %s", e)
-
-    # Delete the branch
-    try:
-        subprocess.run(
-            ["git", "branch", "-D", branch],
-            capture_output=True, text=True, timeout=10, cwd=repo_root,
-        )
-    except Exception as e:
-        logger.debug("Failed to delete branch %s: %s", branch, e)
-
+    lock_owned = _worktree_lock_owned_by_current_process(repo_root, wt_path, timeout=10)
+    if lock_owned is None:
+        _active_worktree = None
+        print(f"\n\033[33m⚠ Worktree lock ownership unknown, preserving: {wt_path}\033[0m")
+        return
+    if lock_owned:
+        try:
+            unlocked = subprocess.run(
+                ["git", "worktree", "unlock", wt_path], capture_output=True,
+                text=True, timeout=10, cwd=repo_root,
+            )
+        except Exception:
+            unlocked = None
+        if unlocked is None or unlocked.returncode != 0:
+            _active_worktree = None
+            print(f"\n\033[33m⚠ Worktree unlock failed, preserving: {wt_path}\033[0m")
+            return
+    outcome = _archive_worktree_if_unchanged(
+        repo_root, wt_path, expected_branch=branch, timeout=15,
+    )
     _active_worktree = None
-    print(f"\033[32m✓ Worktree cleaned up: {wt_path}\033[0m")
+    if outcome["status"] == "archived_branch_preserved":
+        print(f"\033[32m✓ Worktree archived for recovery: {wt_path} -> {outcome['path']}\033[0m")
+    else:
+        print(f"\n\033[33m⚠ Worktree archival did not complete; preserving: {wt_path}\033[0m")
 
 
 def _run_state_db_auto_maintenance(session_db) -> None:
@@ -1938,28 +2164,7 @@ def _run_checkpoint_auto_maintenance() -> None:
 
 
 def _prune_stale_worktrees(repo_root: str, max_age_hours: int = 24) -> None:
-    """Remove stale worktrees and orphaned branches on startup.
-
-    Age-based tiers (aggressive cleanup keeps ``.worktrees/`` from growing
-    unbounded):
-    - Under max_age_hours (24h): skip — session may still be active.
-    - 24h–72h: remove if no unpushed commits.
-    - Over 72h: force remove regardless (nothing should sit this long).
-
-    Lock handling (orthogonal to age): ``hermes -w`` locks each worktree with
-    reason ``hermes pid=<pid>`` so a concurrent hermes process leaves an in-use
-    worktree alone. A *live*-locked worktree is skipped at any age; a
-    *dead*-locked one (owning pid gone — a crashed session) is unlocked first
-    so ``git worktree remove --force`` can actually reap it, otherwise those
-    leftovers accumulate forever (``remove --force`` refuses a locked tree).
-
-    Branch deletion is gated on ``git worktree remove`` succeeding, so a failed
-    removal never orphans the branch (which would drop easy reachability of any
-    commits still in the worktree).
-
-    Also prunes orphaned ``hermes/*`` and ``pr-*`` local branches that
-    have no corresponding worktree.
-    """
+    """Quarantine stale clean worktrees; never age-delete work or branches."""
     import subprocess
     import time
 
@@ -1970,8 +2175,6 @@ def _prune_stale_worktrees(repo_root: str, max_age_hours: int = 24) -> None:
 
     now = time.time()
     soft_cutoff = now - (max_age_hours * 3600)       # 24h default
-    hard_cutoff = now - (max_age_hours * 3 * 3600)   # 72h default
-
     for entry in worktrees_dir.iterdir():
         if not entry.is_dir() or not entry.name.startswith("hermes-"):
             continue
@@ -1984,77 +2187,35 @@ def _prune_stale_worktrees(repo_root: str, max_age_hours: int = 24) -> None:
         except Exception:
             continue
 
-        force = mtime <= hard_cutoff  # Over 72h — reap aggressively
-
-        # Never delete real work, regardless of age. Unpushed commits and
-        # uncommitted changes may be a crashed session's in-flight work; the
-        # >72h tier reaps only abandoned *clean, fully-pushed* worktrees (the
-        # scratch trees that actually cause .worktrees/ bloat).
         if _worktree_has_unpushed_commits(str(entry), timeout=5):
-            continue  # Has unpushed commits or can't check — skip
-        if not force:
-            # 24h–72h tier is conservative: unpushed check above is enough.
-            pass
-        elif _worktree_is_dirty(str(entry), timeout=5):
-            continue  # >72h but dirty — preserve uncommitted work
+            continue
+        if _worktree_is_dirty(str(entry), timeout=5):
+            continue
 
-        # Respect git-native session locks. A lock owned by a still-running
-        # hermes process means the worktree is actively in use — never touch
-        # it. A lock whose owning pid is gone is a crashed session's leftover:
-        # unlock it so `git worktree remove --force` (single -f) can reap it,
-        # otherwise dead-locked worktrees pile up indefinitely.
         lock_state = _worktree_lock_is_live(repo_root, str(entry), timeout=5)
-        if lock_state == "live":
-            logger.debug("Skipping live-locked worktree: %s", entry.name)
+        if lock_state in {"live", "unknown"}:
+            logger.debug("Skipping %s-locked worktree: %s", lock_state, entry.name)
             continue
         if lock_state == "dead":
             try:
-                subprocess.run(
+                unlock_result = subprocess.run(
                     ["git", "worktree", "unlock", str(entry)],
                     capture_output=True, text=True, timeout=10, cwd=repo_root,
                 )
             except Exception as e:
                 logger.debug("Failed to unlock dead worktree %s: %s", entry.name, e)
-
-        # Safe to remove
-        try:
-            branch_result = subprocess.run(
-                ["git", "branch", "--show-current"],
-                capture_output=True, text=True, timeout=5, cwd=str(entry),
-            )
-            branch = branch_result.stdout.strip()
-
-            remove_result = subprocess.run(
-                ["git", "worktree", "remove", str(entry), "--force"],
-                capture_output=True, text=True, timeout=15, cwd=repo_root,
-            )
-            if remove_result.returncode != 0:
-                # Removal failed — keep the branch so any commits stay
-                # reachable rather than orphaning it.
-                logger.debug(
-                    "Failed to remove worktree %s: %s",
-                    entry.name, remove_result.stderr.strip(),
-                )
                 continue
-            if branch:
-                subprocess.run(
-                    ["git", "branch", "-D", branch],
-                    capture_output=True, text=True, timeout=10, cwd=repo_root,
-                )
-            logger.debug("Pruned stale worktree: %s (force=%s)", entry.name, force)
-        except Exception as e:
-            logger.debug("Failed to prune worktree %s: %s", entry.name, e)
+            if unlock_result.returncode != 0:
+                continue
+
+        outcome = _archive_worktree_if_unchanged(repo_root, str(entry), timeout=15)
+        logger.debug("Stale worktree %s: %s", entry.name, outcome["status"])
 
     _prune_orphaned_branches(repo_root)
 
 
 def _prune_orphaned_branches(repo_root: str) -> None:
-    """Delete local ``hermes/hermes-*`` and ``pr-*`` branches with no worktree.
-
-    These are auto-generated by ``hermes -w`` sessions and PR review
-    workflows respectively.  Once their worktree is gone they serve no
-    purpose and just accumulate.
-    """
+    """Archive generated orphan branches without dropping their tips."""
     import subprocess
 
     try:
@@ -2075,9 +2236,16 @@ def _prune_orphaned_branches(repo_root: str) -> None:
             ["git", "worktree", "list", "--porcelain"],
             capture_output=True, text=True, timeout=10, cwd=repo_root,
         )
+        if wt_result.returncode != 0:
+            return
+        saw_worktree = False
         for line in wt_result.stdout.split("\n"):
             if line.startswith("branch refs/heads/"):
                 active_branches.add(line.split("branch refs/heads/", 1)[-1].strip())
+            elif line.startswith("worktree "):
+                saw_worktree = True
+        if not saw_worktree:
+            return
     except Exception:
         return  # Can't determine active branches — bail
 
@@ -2100,21 +2268,45 @@ def _prune_orphaned_branches(repo_root: str) -> None:
         and (b.startswith("hermes/hermes-") or b.startswith("pr-"))
     ]
 
-    if not orphaned:
-        return
+    orphan_refs = {f"refs/heads/{branch}" for branch in orphaned}
+    archivable: list[tuple[str, str, str]] = []
+    for branch in orphaned:
+        snapshot = _snapshot_local_branch(repo_root, branch, timeout=10)
+        if snapshot is None:
+            continue
+        ref, expected_oid = snapshot
+        if _ref_has_unique_commits(
+            repo_root, expected_oid, excluded_local_refs=orphan_refs, timeout=10,
+        ):
+            continue
+        archivable.append((branch, ref, expected_oid))
 
-    # Delete in batches
-    for i in range(0, len(orphaned), 50):
-        batch = orphaned[i:i + 50]
+    archived_count = 0
+    for branch, ref, expected_oid in archivable:
         try:
-            subprocess.run(
-                ["git", "branch", "-D"] + batch,
-                capture_output=True, text=True, timeout=30, cwd=repo_root,
+            latest_worktrees = subprocess.run(
+                ["git", "worktree", "list", "--porcelain"], capture_output=True,
+                text=True, timeout=10, cwd=repo_root,
             )
+            if latest_worktrees.returncode != 0:
+                continue
+            if f"branch {ref}" in latest_worktrees.stdout.splitlines():
+                continue
+            if _snapshot_local_branch(repo_root, branch, timeout=10) != (ref, expected_oid):
+                continue
+            if _archive_branch_snapshot(repo_root, branch, expected_oid, timeout=10) is None:
+                continue
+            archive_branch = f"hermes/archive/{branch.replace('/', '__')}-{uuid.uuid4().hex[:8]}"
+            rename_result = subprocess.run(
+                ["git", "branch", "-m", branch, archive_branch],
+                capture_output=True, text=True, timeout=10, cwd=repo_root,
+            )
+            if rename_result.returncode == 0:
+                archived_count += 1
         except Exception as e:
-            logger.debug("Failed to prune orphaned branches: %s", e)
+            logger.debug("Failed to archive orphaned branch %s: %s", branch, e)
 
-    logger.debug("Pruned %d orphaned branches", len(orphaned))
+    logger.debug("Archived %d orphaned branches", archived_count)
 
 # ============================================================================
 # ASCII Art & Branding

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -508,11 +508,13 @@ class TestMultipleWorktrees:
             assert not Path(info["path"]).exists()
 
 
-class TestWorktreeDirectorySymlink:
-    """Test .worktreeinclude with directories (symlinked)."""
+class TestWorktreeDirectoryInclude:
+    """Test .worktreeinclude directory materialization."""
 
     def test_symlinks_directory(self, git_repo):
-        """Directories in .worktreeinclude should be symlinked."""
+        """Directories are linked, or copied on Windows without symlink privilege."""
+        import cli
+
         # Create a .venv directory
         venv_dir = git_repo / ".venv" / "lib"
         venv_dir.mkdir(parents=True)
@@ -527,19 +529,16 @@ class TestWorktreeDirectorySymlink:
 
         (git_repo / ".worktreeinclude").write_text(".venv/\n")
 
-        info = _setup_worktree(str(git_repo))
+        info = cli._setup_worktree(str(git_repo))
         assert info is not None
 
         wt_path = Path(info["path"])
-        src = git_repo / ".venv"
         dst = wt_path / ".venv"
 
-        # Manually symlink (mirrors cli.py logic)
-        if not dst.exists():
-            dst.parent.mkdir(parents=True, exist_ok=True)
-            os.symlink(str(src.resolve()), str(dst))
-
-        assert dst.is_symlink()
+        if os.name == "nt":
+            assert dst.is_symlink() or dst.is_dir()
+        else:
+            assert dst.is_symlink()
         assert (dst / "lib" / "marker.txt").read_text() == "venv marker"
 
 
@@ -1013,19 +1012,19 @@ class TestSystemPromptInjection:
         assert "commit and push" in wt_note
 
 
-class TestWorktreeLockReaping:
-    """Exercise the REAL cli._prune_stale_worktrees lock/dirty/unpushed logic.
+class TestWorktreeLockQuarantine:
+    """Exercise the REAL recovery-first stale-worktree policy.
 
     Unlike the reimplementation-based tests above, these import the actual
     production functions so the behavior contract is enforced against the
     shipped code:
 
-    - live-locked (owning pid running)  -> never reaped, any age
-    - dead-locked clean (owning pid gone) -> unlocked + reaped (fixes the
-      accumulation bug: `git worktree remove --force` refuses a locked tree)
-    - dirty (uncommitted) at >72h        -> preserved
+    - live-locked (owning pid running)  -> never moved, any age
+    - dead-locked clean (owning pid gone) -> unlocked + quarantined
+    - dirty (uncommitted) at any stale age -> preserved
     - unpushed commits at any age        -> preserved
-    - clean/unlocked stale               -> reaped (aggressive cleanup intact)
+    - clean/unlocked stale               -> quarantined with branch and archive
+      ref retained
     """
 
     @staticmethod
@@ -1053,22 +1052,41 @@ class TestWorktreeLockReaping:
             subprocess.run(["git", "commit", "-m", "wip"], cwd=p, capture_output=True)
         if dirty:
             (p / "dirty.txt").write_text("uncommitted")
-        TestWorktreeLockReaping._age(p, age_h)
+        TestWorktreeLockQuarantine._age(p, age_h)
         return p
 
     def test_live_locked_survives_at_any_age(self, git_repo):
         import cli
         wt = self._mk(cli, git_repo, "hermes-live", pid=os.getpid())
         cli._prune_stale_worktrees(str(git_repo))
-        assert wt.exists(), "live-locked worktree (this pid) must never be reaped"
+        assert wt.exists(), "live-locked worktree (this pid) must never be moved"
 
-    def test_dead_locked_clean_is_reaped(self, git_repo):
+    def test_foreign_locked_survives_as_unknown(self, git_repo):
+        import cli
+        wt = self._mk(cli, git_repo, "hermes-foreign", pid=None)
+        subprocess.run(
+            ["git", "worktree", "lock", "--reason", "foreign wrapper pid=999999", str(wt)],
+            cwd=git_repo, capture_output=True, check=True,
+        )
+        cli._prune_stale_worktrees(str(git_repo))
+        assert wt.exists(), "foreign/unknown locks must never be unlocked or moved"
+
+    def test_dead_locked_clean_is_quarantined(self, git_repo):
         import cli
         wt = self._mk(cli, git_repo, "hermes-dead", pid=999999)
-        # sanity: this is the accumulation bug — remove --force alone can't do it
         assert cli._worktree_lock_is_live(str(git_repo), str(wt)) == "dead"
         cli._prune_stale_worktrees(str(git_repo))
-        assert not wt.exists(), "dead-locked clean worktree should be unlocked + reaped"
+        archive = git_repo / ".worktrees" / ".archive" / wt.name
+        assert not wt.exists() and archive.exists()
+        branch = f"hermes/{wt.name}"
+        oid = subprocess.run(
+            ["git", "rev-parse", f"refs/heads/{branch}"], cwd=git_repo,
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        assert subprocess.run(
+            ["git", "show-ref", "--verify", f"refs/hermes/archive/{branch}/{oid}"],
+            cwd=git_repo, capture_output=True,
+        ).returncode == 0
 
     def test_dead_locked_dirty_survives(self, git_repo):
         import cli
@@ -1082,11 +1100,57 @@ class TestWorktreeLockReaping:
         cli._prune_stale_worktrees(str(git_repo))
         assert wt.exists(), "dead-locked worktree with unpushed commits must survive"
 
-    def test_unlocked_clean_stale_is_reaped(self, git_repo):
+    def test_unlocked_clean_stale_is_quarantined(self, git_repo):
         import cli
         wt = self._mk(cli, git_repo, "hermes-nolock", pid=None)
         cli._prune_stale_worktrees(str(git_repo))
-        assert not wt.exists(), "clean unlocked stale worktree should be reaped"
+        archive = git_repo / ".worktrees" / ".archive" / wt.name
+        assert not wt.exists() and archive.exists()
+        branch = f"hermes/{wt.name}"
+        oid = subprocess.run(
+            ["git", "rev-parse", f"refs/heads/{branch}"], cwd=git_repo,
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        assert subprocess.run(
+            ["git", "show-ref", "--verify", f"refs/hermes/archive/{branch}/{oid}"],
+            cwd=git_repo, capture_output=True,
+        ).returncode == 0
+
+    def test_exit_cleanup_preserves_dirty_worktree(self, git_repo):
+        import cli
+        wt = self._mk(cli, git_repo, "hermes-exit-dirty", dirty=True, age_h=1)
+        cli._cleanup_worktree({
+            "path": str(wt), "branch": f"hermes/{wt.name}", "repo_root": str(git_repo),
+        })
+        assert wt.exists(), "exit cleanup must preserve dirty worktree data"
+
+    def test_exit_cleanup_quarantines_clean_worktree(self, git_repo):
+        import cli
+        wt = self._mk(cli, git_repo, "hermes-exit-clean", age_h=1)
+        cli._cleanup_worktree({
+            "path": str(wt), "branch": f"hermes/{wt.name}", "repo_root": str(git_repo),
+        })
+        archive = git_repo / ".worktrees" / ".archive" / wt.name
+        assert not wt.exists() and archive.exists()
+        assert subprocess.run(
+            ["git", "show-ref", "--verify", f"refs/heads/hermes/{wt.name}"],
+            cwd=git_repo, capture_output=True,
+        ).returncode == 0
+
+    def test_quarantine_move_failure_preserves_original_worktree(self, git_repo, monkeypatch):
+        import cli
+        wt = self._mk(cli, git_repo, "hermes-move-failure", age_h=1)
+        original_run = subprocess.run
+
+        def fail_move(command, *args, **kwargs):
+            if command[:3] == ["git", "worktree", "move"]:
+                return subprocess.CompletedProcess(command, 1, "", "forced move failure")
+            return original_run(command, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", fail_move)
+        outcome = cli._archive_worktree_if_unchanged(str(git_repo), str(wt))
+        assert outcome["status"] == "failed"
+        assert wt.exists(), "a failed quarantine move must preserve the source worktree"
 
     def test_dirty_survives_over_72h(self, git_repo):
         import cli
@@ -1137,10 +1201,10 @@ class TestWorktreeLockPredicate:
         p = self._mk_locked(git_repo, "hermes-dead", "hermes pid=999999")
         assert cli._worktree_lock_is_live(str(git_repo), str(p)) == "dead"
 
-    def test_foreign_lock_reason_returns_dead(self, git_repo):
+    def test_foreign_lock_reason_returns_unknown(self, git_repo):
         import cli
         p = self._mk_locked(git_repo, "hermes-foreign", "some other tool")
-        assert cli._worktree_lock_is_live(str(git_repo), str(p)) == "dead"
+        assert cli._worktree_lock_is_live(str(git_repo), str(p)) == "unknown"
 
     def test_bad_repo_root_fails_safe_to_live(self, tmp_path):
         import cli

--- a/tests/cli/test_worktree_security.py
+++ b/tests/cli/test_worktree_security.py
@@ -1,5 +1,6 @@
 """Security-focused integration tests for CLI worktree setup."""
 
+import os
 import subprocess
 from pathlib import Path
 
@@ -81,7 +82,12 @@ class TestWorktreeIncludeSecurity:
 
         outside_file = git_repo.parent / "linked-secret.txt"
         outside_file.write_text("LINKED SECRET")
-        (git_repo / "leak.txt").symlink_to(outside_file)
+        try:
+            (git_repo / "leak.txt").symlink_to(outside_file)
+        except OSError as exc:
+            if os.name == "nt" and getattr(exc, "winerror", None) == 1314:
+                pytest.skip("Windows symlink creation requires Developer Mode or elevated privilege")
+            raise
         (git_repo / ".worktreeinclude").write_text("leak.txt\n")
 
         info = None
@@ -124,7 +130,12 @@ class TestWorktreeIncludeSecurity:
             assert info is not None
 
             linked_dir = Path(info["path"]) / ".venv"
-            assert linked_dir.is_symlink()
+            if os.name == "nt":
+                # Windows may lack symlink privilege; production deliberately
+                # falls back to a local copy in that case.
+                assert linked_dir.is_symlink() or linked_dir.is_dir()
+            else:
+                assert linked_dir.is_symlink()
             assert (linked_dir / "lib" / "marker.txt").read_text() == "venv marker"
         finally:
             _force_remove_worktree(info)


### PR DESCRIPTION
## What changed

- Rebuilt the Wave 2 Windows worktree-quarantine port as the atomic commit `29ea2dd05ee7fa3b8721cde1ed5bc4fe8ab29f6a` directly on current upstream `main` (`7651764ce`).
- Registered that exact SHA in `.github/merge-coverage.json`.

## Why

The fail-closed merge-coverage guard requires the implementation and its two Windows contract tests to remain in one port commit. The upstream base advanced with paste-history recall, so this update rebuilds the same port on that current base rather than carrying stale history.

## Validation

- `python -m pytest tests/cli/test_worktree.py tests/cli/test_worktree_security.py --basetemp=C:\hermes-test-temp\wave2-origin-r2 -q`
  - `61 passed, 1 skipped`
- Manifest JSON parsed and its candidate SHA was checked against `git rev-parse HEAD` before registration.
- `git diff --check`

## Impact

This preserves the Windows fallback worktree quarantine contract without broadening the merge-coverage allowlist.