### PR TITLE
feat(state): add sessions.trigram_fts config flag to disable the trigram FTS index

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3206,6 +3206,17 @@ DEFAULT_CONFIG = {
         # GBs of disk on heavy users.  Opt in only if you have an external
         # tool that consumes the JSON files directly.
         "write_json_snapshots": False,
+        # Secondary FTS5 index using the trigram tokenizer (messages_fts_trigram
+        # in hermes_state), which powers CJK and arbitrary-substring recall in
+        # session_search.  Its INSERT/UPDATE/DELETE triggers fire on every
+        # message write, so on a heavy state.db it roughly doubles FTS write
+        # cost and disk footprint.  Set false to skip creating the trigram
+        # table+triggers (and drop the triggers on the next open); CJK and
+        # substring search then fall back to LIKE — the same graceful path
+        # taken when the SQLite build lacks the trigram tokenizer.  Existing
+        # index data is reclaimed by the next optimize_fts()/VACUUM.  Default
+        # true — parity with prior behaviour.
+        "trigram_fts": True,
     },
 
     # Contextual first-touch onboarding hints (see agent/onboarding.py).

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1187,6 +1187,42 @@ class SessionDB:
                 pass
 
     @staticmethod
+    def _drop_trigram_fts_triggers(cursor: sqlite3.Cursor) -> None:
+        """Drop only the trigram write triggers, leaving base FTS intact.
+
+        Used when ``sessions.trigram_fts`` is off: dropping the triggers
+        stops every message write from paying the trigram-index cost, without
+        the heavier ``DROP TABLE`` of the shadow index (deferred to
+        ``optimize_fts()``).
+        """
+        for trigger in _FTS_TRIGGERS:
+            if "trigram" not in trigger:
+                continue
+            try:
+                cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+            except sqlite3.OperationalError:
+                pass
+
+    def _trigram_fts_enabled(self) -> bool:
+        """Whether the trigram FTS5 index should be maintained.
+
+        Reads ``sessions.trigram_fts`` (default ``True``) through a deferred
+        import so the storage layer stays free of a config import cycle — the
+        same pattern the CLI and gateway callers use. A single global read
+        (rather than a per-construction argument threaded through ~30
+        ``SessionDB`` call sites) keeps every open in agreement, so the
+        trigram schema cannot oscillate between concurrent processes. Fails
+        safe to ``True`` (index on, prior behaviour) on any config error.
+        """
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            sessions_cfg = load_config_readonly().get("sessions") or {}
+            return bool(sessions_cfg.get("trigram_fts", True))
+        except Exception:
+            return True
+
+    @staticmethod
     def _fts_trigger_count(cursor: sqlite3.Cursor) -> int:
         placeholders = ",".join("?" for _ in _FTS_TRIGGERS)
         row = cursor.execute(
@@ -1641,7 +1677,9 @@ class SessionDB:
                 # v11+ code drops and rebuilds both FTS tables below, so doing
                 # the v10-only trigram backfill first only burns startup time
                 # and WAL space before v11 throws the work away.
-                if fts5_available:
+                if fts5_available and not self._trigram_fts_enabled():
+                    pass  # trigram disabled via sessions.trigram_fts — skip build
+                elif fts5_available:
                     _fts_trigram_exists = self._fts_table_probe(
                         cursor, "messages_fts_trigram"
                     )
@@ -1699,18 +1737,25 @@ class SessionDB:
                                 "COALESCE(tool_calls, '') "
                                 "FROM messages"
                             )
-                        trigram_ok = self._ensure_fts_schema(
-                            cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
-                        )
-                        if trigram_ok:
-                            cursor.execute(
-                                "INSERT INTO messages_fts_trigram(rowid, content) "
-                                "SELECT id, "
-                                "COALESCE(content, '') || ' ' || "
-                                "COALESCE(tool_name, '') || ' ' || "
-                                "COALESCE(tool_calls, '') "
-                                "FROM messages"
+                        # The old-schema trigram table+triggers were dropped
+                        # above; only rebuild them when trigram is enabled.
+                        # When disabled this is where an existing install sheds
+                        # the index — it is dropped and never recreated.
+                        if self._trigram_fts_enabled():
+                            trigram_ok = self._ensure_fts_schema(
+                                cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
                             )
+                            if trigram_ok:
+                                cursor.execute(
+                                    "INSERT INTO messages_fts_trigram(rowid, content) "
+                                    "SELECT id, "
+                                    "COALESCE(content, '') || ' ' || "
+                                    "COALESCE(tool_name, '') || ' ' || "
+                                    "COALESCE(tool_calls, '') "
+                                    "FROM messages"
+                                )
+                        else:
+                            trigram_ok = False
                         if not base_fts_ok:
                             fts_migrations_complete = False
                         # Track trigram availability for CJK LIKE fallback.
@@ -1914,16 +1959,34 @@ class SessionDB:
             # FTS5 setup. Run the DDL even when the virtual table exists so
             # CREATE TRIGGER IF NOT EXISTS repairs trigger-only degradation from
             # an earlier no-FTS5 runtime.
-            triggers_need_repair = self._fts_trigger_count(cursor) < len(_FTS_TRIGGERS)
+            # Only expect the trigram triggers when the trigram index is
+            # enabled; otherwise their deliberate absence must not be read as
+            # damage that triggers a full FTS rebuild on every open.
+            trigram_wanted = self._trigram_fts_enabled()
+            expected_triggers = (
+                len(_FTS_TRIGGERS)
+                if trigram_wanted
+                else sum(1 for t in _FTS_TRIGGERS if "trigram" not in t)
+            )
+            triggers_need_repair = self._fts_trigger_count(cursor) < expected_triggers
             self._fts_enabled = self._ensure_fts_schema(cursor, "messages_fts", FTS_SQL)
 
             # Trigram FTS5 for CJK/substring search. This is optional relative
-            # to the main FTS table; if it cannot be created, CJK search falls
-            # back to LIKE.
+            # to the main FTS table; if it cannot be created — or is disabled
+            # via sessions.trigram_fts — CJK/substring search falls back to LIKE.
             if self._fts_enabled:
-                trigram_enabled = self._ensure_fts_schema(
-                    cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
-                )
+                if trigram_wanted:
+                    trigram_enabled = self._ensure_fts_schema(
+                        cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
+                    )
+                else:
+                    # Disabled: drop only the trigram triggers so writes stop
+                    # paying the index cost immediately. The (possibly large)
+                    # shadow table is reclaimed by optimize_fts()/VACUUM, not
+                    # here — a heavy DROP in the unlocked __init__ path could
+                    # contend with a concurrent writer and abort the open.
+                    self._drop_trigram_fts_triggers(cursor)
+                    trigram_enabled = False
                 self._trigram_available = trigram_enabled
                 if triggers_need_repair:
                     self._rebuild_fts_indexes(
@@ -7539,13 +7602,29 @@ class SessionDB:
         index internally, then VACUUM returns the freed pages to the OS.
 
         Skips any FTS table that does not exist (e.g. the trigram index when
-        disabled via ``HERMES_DISABLE_FTS_TRIGRAM`` or not yet created), so
-        it is safe to call unconditionally.
+        disabled via ``sessions.trigram_fts`` or not yet created), so it is
+        safe to call unconditionally.
+
+        When ``sessions.trigram_fts`` is off this is also the deliberate,
+        lock-held teardown point for a pre-existing trigram index: the shadow
+        table is dropped here so a following ``VACUUM`` can return its pages
+        to the OS. Keeping the heavy ``DROP`` out of ``__init__`` avoids
+        contending with concurrent writers during a plain open.
 
         Returns the number of FTS indexes that were optimized.
         """
         optimized = 0
         with self._lock:
+            if not self._trigram_fts_enabled() and self._fts_table_exists(
+                "messages_fts_trigram"
+            ):
+                try:
+                    self._drop_trigram_fts_triggers(self._conn.cursor())
+                    self._conn.execute("DROP TABLE IF EXISTS messages_fts_trigram")
+                    self._conn.commit()
+                    self._trigram_available = False
+                except sqlite3.OperationalError as exc:
+                    logger.warning("trigram FTS teardown failed: %s", exc)
             for tbl in self._FTS_TABLES:
                 if not self._fts_table_exists(tbl):
                     continue

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -749,6 +749,65 @@ class TestSessionLifecycle:
         assert SessionDB._is_fts5_unavailable_error(generic_tokenizer_err) is False
         assert SessionDB._is_fts5_unavailable_error(unrelated_err) is False
 
+    def test_trigram_fts_disabled_via_config(self, tmp_path, monkeypatch):
+        """sessions.trigram_fts=false skips the trigram index; base search survives.
+
+        Covers the three things the config knob must guarantee: (1) the trigram
+        table is never created, (2) its deliberate absence does not trip an
+        endless trigger-repair rebuild, (3) base full-text search still works
+        and substring search degrades to LIKE rather than erroring.
+        """
+        monkeypatch.setattr(
+            SessionDB, "_trigram_fts_enabled", lambda self: False
+        )
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session(session_id="s1", source="cli")
+            db.append_message("s1", role="user", content="findable needle")
+            assert db._fts_enabled is True
+            assert db._trigram_available is False
+            assert db._fts_table_exists("messages_fts_trigram") is False
+            # base word search works without the trigram index
+            assert len(db.search_messages("needle")) == 1
+        finally:
+            db.close()
+
+        # Reopening (still disabled) must be idempotent — no rebuild loop, and
+        # the trigram triggers stay absent.
+        db2 = SessionDB(db_path=db_path)
+        try:
+            assert db2._fts_table_exists("messages_fts_trigram") is False
+            with db2._lock:
+                cur = db2._conn.execute(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type='trigger' "
+                    "AND name LIKE 'messages_fts_trigram%'"
+                )
+                assert cur.fetchone()[0] == 0
+            assert len(db2.search_messages("needle")) == 1
+        finally:
+            db2.close()
+
+    def test_trigram_fts_reenable_restores_index(self, tmp_path, monkeypatch):
+        """Flipping sessions.trigram_fts back on rebuilds the trigram index."""
+        db_path = tmp_path / "state.db"
+        monkeypatch.setattr(SessionDB, "_trigram_fts_enabled", lambda self: False)
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session(session_id="s1", source="cli")
+            db.append_message("s1", role="user", content="需要索引的内容")
+            assert db._fts_table_exists("messages_fts_trigram") is False
+        finally:
+            db.close()
+
+        monkeypatch.setattr(SessionDB, "_trigram_fts_enabled", lambda self: True)
+        db2 = SessionDB(db_path=db_path)
+        try:
+            assert db2._trigram_available is True
+            assert db2._fts_table_exists("messages_fts_trigram") is True
+        finally:
+            db2.close()
+
     def test_is_trigram_unavailable_error(self):
         """Unit test: _is_trigram_unavailable_error is scoped to trigram."""
         trigram_err = sqlite3.OperationalError("no such tokenizer: trigram")

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -704,6 +704,28 @@ sessions:
 
 Active sessions are never auto-pruned, regardless of age.
 
+### Trigram Full-Text Index
+
+`session_search` is backed by two FTS5 indexes: a base word index and a
+secondary **trigram** index that adds CJK and arbitrary-substring recall. The
+trigram index has an INSERT/UPDATE/DELETE trigger on every message, so on a
+large `state.db` it roughly doubles full-text write cost and disk footprint
+(commonly the single largest contributor to `state.db` growth).
+
+If you don't need CJK or substring search, disable it:
+
+```yaml
+sessions:
+  trigram_fts: false   # default true; skip the trigram index
+```
+
+With it off, new databases never build the index and existing ones drop its
+triggers on the next open (so writes stop paying the cost immediately). CJK and
+substring queries transparently fall back to `LIKE` — the same path used when
+the SQLite build lacks the trigram tokenizer. To reclaim the disk an existing
+trigram index already occupies, run a maintenance pass (`optimize_fts()` drops
+the now-unused shadow table; a following `VACUUM` returns the pages to the OS).
+
 ### Manual Cleanup
 
 ```bash


### PR DESCRIPTION
## What does this PR do?

Adds `sessions.trigram_fts` (default `true`) — a **`config.yaml`** flag to disable the `messages_fts_trigram` FTS5 index, the secondary trigram index that powers CJK/substring recall in `session_search`.

That index carries an INSERT/UPDATE/DELETE trigger on every message and is frequently the single largest contributor to `state.db` growth (on one production install: ~273 MB of a 549 MB DB — 88% of it FTS, mostly the doubled trigram data/content shadow tables). Operators who don't need CJK or substring search can now opt out; CJK/substring queries fall back to `LIKE` — the exact graceful path already taken when the SQLite build lacks the trigram tokenizer.

### Why this approach (and why the prior attempts were closed)

This is deliberately a **config knob, not an env var**. Every earlier attempt at this feature used a `HERMES_*` environment variable and was closed under the `AGENTS.md` policy that reserves `.env`/`HERMES_*` for credentials and requires behavioral flags in `config.yaml`:

- #66690 (`HERMES_DISABLE_FTS_TRIGRAM`) — closed, config-policy
- #57761 (`HERMES_FTS_TRIGRAM=0`) — closed, dup + config-policy
- #42190, #27770, #22710 — same cluster, all closed

This PR is the first to implement the maintainers' stated requirement (a `sessions.*` config key, matching `auto_prune`/`vacuum_after_prune`/`write_json_snapshots`). It also folds in the two technical notes left on the closed cluster (#57761 → #27770): the trigger-repair count now tolerates the deliberately-absent trigram triggers, and all migration paths are covered — not just steady-state init.

## Related Issue

Fixes #55233 (and addresses the size evidence in #22478 / #43690).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `hermes_cli/config.py` — new `sessions.trigram_fts: True` default (deep-merged at read time, no `_config_version` bump needed since it's an optional default).
- `hermes_state.py`
  - `_trigram_fts_enabled()` — reads the knob via a deferred `load_config_readonly()` import (keeps the storage layer cycle-free; a single global read keeps every `SessionDB` open in agreement so the schema can't oscillate across processes).
  - `_drop_trigram_fts_triggers()` — trigger-only drop (leaves base FTS intact).
  - Gated all **three** trigram creation paths: v10 migration, v11 migration, steady-state `_init_schema`. When disabled, creation/backfill is skipped and existing trigram triggers are dropped so writes stop paying the cost immediately.
  - Trigger-repair heuristic now expects only the triggers the active config requires → no full-FTS rebuild loop on every open when trigram is off.
  - `optimize_fts()` — the deliberate, lock-held teardown point: drops the (possibly large) trigram shadow table when disabled so a following `VACUUM` reclaims the pages. The heavy `DROP` is intentionally **not** in `__init__` (avoids contending with a concurrent writer during a plain open).
- `tests/test_hermes_state.py` — two tests: disabled path (no table, base search works, no rebuild loop, idempotent reopen) and re-enable flip-back (index rebuilt).
- `website/docs/user-guide/sessions.md` — documents the knob + LIKE fallback + reclaim path.

## How to Test

```bash
pytest tests/test_hermes_state.py -q -k trigram_fts
```

1. Default (no config) → trigram index built as before (parity).
2. `sessions.trigram_fts: false` → `messages_fts_trigram` never created; `db._trigram_available is False`; base word search still returns results; substring/CJK degrade to `LIKE`.
3. Reopen while disabled → idempotent, no rebuild loop, trigram triggers stay absent.
4. Flip back to `true` → trigram index rebuilt on next open.

Verified end-to-end against real runtime deps (disabled path, idempotent reopen, flip-back) plus the config-read path (`trigram_fts: false` → `False`, absent → `True`).

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] Conventional Commits (`feat(state): ...`)
- [x] Searched existing PRs for duplicates — this supersedes the closed env-var cluster (#66690/#57761/#42190/#27770/#22710) by using `config.yaml` per `AGENTS.md`
- [x] PR contains only related changes (one logical change: the trigram config flag)
- [x] Added tests
- [x] Tested on Linux

### Documentation & Housekeeping

- [x] Updated docs (`website/docs/user-guide/sessions.md`) + inline config schema comment
- [x] `cli-config.yaml.example` — N/A (it does not enumerate the `sessions.*` keys; peers `auto_prune`/`vacuum_after_prune` are not listed there either)
- [x] `CONTRIBUTING`/`AGENTS` — N/A (no architecture change)
- [x] Cross-platform — no OS-specific calls added
