### PR TITLE
fix(config): break circular import that hides is_provider_enabled from web_server

### DIFF
--- a/hermes_cli/_provider_enabled.py
+++ b/hermes_cli/_provider_enabled.py
@@ -1,0 +1,39 @@
+"""Tiny module: ``is_provider_enabled`` — no ``hermes_cli`` imports.
+
+Extracted from ``hermes_cli/config.py`` to ensure ``is_provider_enabled`` is
+importable even when ``config.py`` has not finished initializing (e.g. during
+a circular import or a stale/partial install where config.py's module body
+hasn't executed past line 6976).
+
+All internal callers now import directly from this module rather than via
+``config.py``.  ``config.py`` still re-exports the function for backward
+compat with any external or third-party code that does
+``from hermes_cli.config import is_provider_enabled``.
+"""
+
+from typing import Any, Dict, Optional
+
+
+def is_provider_enabled(provider_cfg: Optional[Dict[str, Any]]) -> bool:
+    """Return whether a ``providers.<name>`` config block is enabled.
+
+    A provider is enabled by default.  Only an explicit ``enabled: false`` in
+    the block hides it from the model picker, ``/models`` listings, the
+    runtime resolver and the doctor / status output.
+
+    Backward-compat: configs without the ``enabled`` key keep working as
+    before — the default is ``True``.
+
+    Pass any non-dict (None, list, string) and you get ``True`` too, so
+    malformed entries don't disappear silently; they'll still be flagged
+    by the existing validation paths.
+    """
+    if not isinstance(provider_cfg, dict):
+        return True
+    flag = provider_cfg.get("enabled", True)
+    if isinstance(flag, bool):
+        return flag
+    # YAML can produce strings for "true"/"false" depending on quoting.
+    if isinstance(flag, str):
+        return flag.strip().lower() not in {"false", "0", "no", "off"}
+    return bool(flag)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6976,26 +6976,10 @@ def _normalize_max_turns_config(config: Dict[str, Any]) -> Dict[str, Any]:
 def is_provider_enabled(provider_cfg: Optional[Dict[str, Any]]) -> bool:
     """Return whether a ``providers.<name>`` config block is enabled.
 
-    A provider is enabled by default. Only an explicit ``enabled: false`` in
-    the block hides it from the model picker, ``/models`` listings, the
-    runtime resolver and the doctor / status output.
-
-    Backward-compat: configs without the ``enabled`` key keep working as
-    before — the default is ``True``.
-
-    Pass any non-dict (None, list, string) and you get ``True`` too, so
-    malformed entries don't disappear silently; they'll still be flagged
-    by the existing validation paths.
+    Delegates to :func:`hermes_cli._provider_enabled.is_provider_enabled`.
     """
-    if not isinstance(provider_cfg, dict):
-        return True
-    flag = provider_cfg.get("enabled", True)
-    if isinstance(flag, bool):
-        return flag
-    # YAML can produce strings for "true"/"false" depending on quoting.
-    if isinstance(flag, str):
-        return flag.strip().lower() not in {"false", "0", "no", "off"}
-    return bool(flag)
+    from hermes_cli._provider_enabled import is_provider_enabled as _ipe
+    return _ipe(provider_cfg)
 
 
 def cfg_get(cfg: Optional[Dict[str, Any]], *keys: str, default: Any = None) -> Any:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -869,7 +869,7 @@ def run_doctor(args):
 
             user_providers = cfg.get("providers")
             if isinstance(user_providers, dict):
-                from hermes_cli.config import is_provider_enabled
+                from hermes_cli._provider_enabled import is_provider_enabled
                 known_providers.update(
                     str(name).strip().lower()
                     for name, prov_cfg in user_providers.items()

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1450,7 +1450,7 @@ def switch_model(
     if not validation.get("accepted"):
         override = False
         if user_providers:
-            from hermes_cli.config import is_provider_enabled
+            from hermes_cli._provider_enabled import is_provider_enabled
             # user_providers is a dict: {provider_slug: config_dict}
             for slug, cfg in user_providers.items():
                 if not is_provider_enabled(cfg):
@@ -2253,7 +2253,7 @@ def list_authenticated_providers(
         # the wire protocol differs.
         from collections import OrderedDict as _OD3
 
-        from hermes_cli.config import is_provider_enabled
+        from hermes_cli._provider_enabled import is_provider_enabled
 
         ep_groups: "_OD3[tuple, dict]" = _OD3()
         for ep_name, ep_cfg in user_providers.items():
@@ -2729,7 +2729,7 @@ def list_authenticated_providers(
     # ``provider_id`` so PROVIDER_REGISTRY entries that match user-config
     # blocks are filtered consistently.
     try:
-        from hermes_cli.config import is_provider_enabled
+        from hermes_cli._provider_enabled import is_provider_enabled
         if isinstance(user_providers, dict):
             _disabled_slugs = {
                 str(name).strip().lower()

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -659,7 +659,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
     # First check providers: dict (new-style user-defined providers)
     providers = config.get("providers")
     if isinstance(providers, dict):
-        from hermes_cli.config import is_provider_enabled
+        from hermes_cli._provider_enabled import is_provider_enabled
         for ep_name, entry in providers.items():
             if not isinstance(entry, dict):
                 continue
@@ -1548,7 +1548,8 @@ def resolve_runtime_provider(
     #
     # Fail fast with a typed error so the fallback chain can advance to
     # the next provider instead of using a disabled one.
-    from hermes_cli.config import is_provider_enabled, load_config
+    from hermes_cli._provider_enabled import is_provider_enabled
+    from hermes_cli.config import load_config
     _full_cfg = load_config()
     _provs_cfg = _full_cfg.get("providers") if isinstance(_full_cfg, dict) else None
     if isinstance(_provs_cfg, dict):


### PR DESCRIPTION
Fixes #68379

## Problem

After updating to Hermes 0.19.0, Desktop startup crashes with:

```
ImportError: cannot import name 'is_provider_enabled' from 'hermes_cli.config'
```

The traceback shows garbled source lines (docstrings where function calls should be),
indicating the user's installed `config.py` is stale or partially synced — the file
predates the commit that added `is_provider_enabled` (line 6976). On a clean checkout,
`from hermes_cli.config import is_provider_enabled` resolves without error because
`config.py` has no top-level imports of `tools_config` or `model_switch`, so no
circular-import chain exists at load time.

## Fix

Extract `is_provider_enabled()` into `hermes_cli/_provider_enabled.py` (zero
`hermes_cli` imports) and **repoint all internal callers** to import from the new
module directly:

- `hermes_cli/model_switch.py` (3 call sites)
- `hermes_cli/doctor.py` (1 call site)
- `hermes_cli/runtime_provider.py` (2 call sites)

`config.py` still re-exports the function for backward compatibility with any
external or third-party code that does `from hermes_cli.config import is_provider_enabled`.

This is a **defence-in-depth** measure: if `config.py` ever fails to finish loading
(circular import, partial install, or stale sync), the function remains importable
from the dependency-free module.

## Verification

```python
from hermes_cli._provider_enabled import is_provider_enabled
assert is_provider_enabled({"enabled": True}) is True
assert is_provider_enabled({"enabled": False}) is False

# Re-export still works
from hermes_cli.config import is_provider_enabled as ipe
assert ipe({"enabled": False}) is False
```