### PR TITLE
fix(cronjob): accept bare model string in _resolve_model_override

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -570,7 +570,7 @@ class TestResolveModelOverride:
     def test_keeps_explicit_custom_name_unchanged(self, monkeypatch):
         import hermes_cli.runtime_provider as rp_mod
 
-        # Even if the resolver claims no entry, the canonical "custom:<name>"
+        # even if the resolver claims no entry, the canonical "custom:<name>"
         # form is never stripped or pinned.
         monkeypatch.setattr(rp_mod, "has_named_custom_provider", lambda name: False)
         provider, model = _resolve_model_override(
@@ -578,6 +578,36 @@ class TestResolveModelOverride:
         )
         assert provider == "custom:cliproxy"
         assert model == "gpt-5.4"
+
+    def test_bare_string_model_returns_none_provider(self):
+        """Regression: _resolve_model_override("anthropic/claude-haiku-4.5")
+        must return (None, "anthropic/claude-haiku-4.5"), not (None, None)."""
+        provider, model = _resolve_model_override("anthropic/claude-haiku-4.5")
+        assert provider is None
+        assert model == "anthropic/claude-haiku-4.5"
+
+    def test_bare_string_model_whitespace_stripped(self):
+        provider, model = _resolve_model_override("  gpt-4  ")
+        assert provider is None
+        assert model == "gpt-4"
+
+    def test_bare_string_model_empty_returns_none_none(self):
+        provider, model = _resolve_model_override("   ")
+        assert provider is None
+        assert model is None
+
+    def test_dict_model_still_works(self):
+        """Dict path must not be broken by the bare-string addition."""
+        provider, model = _resolve_model_override(
+            {"provider": "nous", "model": "claude-haiku-4.5"}
+        )
+        assert provider == "nous"
+        assert model == "claude-haiku-4.5"
+
+    def test_none_returns_none_none(self):
+        provider, model = _resolve_model_override(None)
+        assert provider is None
+        assert model is None
 
 
 class TestLocalDeliveryNotice:

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -379,9 +379,18 @@ def _resolve_model_override(model_obj: Optional[Dict[str, Any]]) -> tuple:
     If provider is omitted, pins the current main provider from config so the
     job doesn't drift when the user later changes their default via hermes model.
 
+    Accepts both the declared object shape ``{"model": "...", "provider": "..."}``
+    and a bare model string (e.g. ``"gpt-4"``) for backward compat with the
+    ``action=update`` path where the LLM may send a flat string.
+
     Returns (provider_str_or_none, model_str_or_none).
     """
-    if not model_obj or not isinstance(model_obj, dict):
+    if not model_obj:
+        return (None, None)
+    if isinstance(model_obj, str):
+        # LLM sent a bare model string instead of {model: "..."}
+        return (None, model_obj.strip() or None)
+    if not isinstance(model_obj, dict):
         return (None, None)
     model_name = (model_obj.get("model") or "").strip() or None
     provider_name = (model_obj.get("provider") or "").strip() or None


### PR DESCRIPTION
Fixes #68380

## Problem

`cronjob action=update` silently drops the `model` field when the LLM
sends a flat string (e.g. `"gpt-4"`) instead of the declared object
shape `{"model": "gpt-4"}`.  The provider updates fine because it is
a top-level string, but `_resolve_model_override` guards on
`isinstance(model_obj, dict)` and returns `(None, None)` for strings —
the model value is lost entirely while the tool reports success.

## Fix

`_resolve_model_override` now accepts both shapes:
- `{"model": "...", "provider": "..."}` — existing object shape (unchanged)
- `"gpt-4"` — bare string treated as model name, no provider override

The lambda wrapper on line 1123 already passes `args.get("model")`
through `_resolve_model_override` before calling `cronjob()`, so both
dict and string shapes are resolved before reaching the update handler.

## Regression tests

Added 5 new tests to `TestResolveModelOverride` (8 total):

- `test_bare_string_model_returns_none_provider` — `"anthropic/claude-haiku-4.5"` → `(None, "anthropic/claude-haiku-4.5")`
- `test_bare_string_model_whitespace_stripped` — `"  gpt-4  "` → `(None, "gpt-4")`
- `test_bare_string_model_empty_returns_none_none` — `"   "` → `(None, None)`
- `test_dict_model_still_works` — dict path unaffected
- `test_none_returns_none_none` — None path unaffected

All 8 tests pass.

## Verification

```python
# Bare string (new path)
assert _resolve_model_override("anthropic/claude-haiku-4.5") == (None, "anthropic/claude-haiku-4.5")

# Dict shape (existing path, unchanged)
assert _resolve_model_override({"model": "gpt-4", "provider": "openai"}) == ("openai", "gpt-4")

# None (unchanged)
assert _resolve_model_override(None) == (None, None)
```