### PR TITLE
fix(cli): mask credential-shaped values in config set/get and webhook subscribe

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -8252,6 +8252,31 @@ _SECRET_CONFIG_KEYS = frozenset({
     "bearer",
     "jwt",
 })
+# Suffix patterns for credential-shaped keys that don't match the exact
+# _SECRET_CONFIG_KEYS set — e.g. ``bot_token``, ``webhook_secret``,
+# ``my_custom_api_key``.  These are checked via ``endswith()`` on the
+# leaf key name.
+_SECRET_CONFIG_SUFFIXES = (
+    "_api_key",
+    "_api_token",
+    "_access_token",
+    "_auth_token",
+    "_refresh_token",
+    "_bearer_token",
+    "_client_secret",
+    "_id_token",
+    "_oauth_token",
+    "_private_key",
+    "_session_token",
+    "_secret_key",
+    "_password",
+    "_passwd",
+    "_secret",
+    "_token",
+    "_credential",
+    "_credentials",
+)
+
 
 
 def redact_config_value(value: Any, _depth: int = 0) -> Any:
@@ -8273,7 +8298,10 @@ def redact_config_value(value: Any, _depth: int = 0) -> Any:
     if isinstance(value, dict):
         out = {}
         for k, v in value.items():
-            if isinstance(k, str) and k.lower() in _SECRET_CONFIG_KEYS and isinstance(v, str) and v:
+            if isinstance(k, str) and v and (
+                k.lower() in _SECRET_CONFIG_KEYS
+                or k.lower().endswith(_SECRET_CONFIG_SUFFIXES)
+            ):
                 out[k] = mask_secret(v)
             else:
                 out[k] = redact_config_value(v, _depth + 1)
@@ -8825,7 +8853,13 @@ def set_config_value(key: str, value: str, force: bool = False):
     # (lowercase, so it misses the .env api_keys list above) and would otherwise
     # print the raw secret to the terminal.
     _leaf_key = key.rsplit(".", 1)[-1].lower()
-    if _leaf_key in _SECRET_CONFIG_KEYS and isinstance(value, str) and value:
+    if (
+        isinstance(value, str) and value
+        and (
+            _leaf_key in _SECRET_CONFIG_KEYS
+            or _leaf_key.endswith(_SECRET_CONFIG_SUFFIXES)
+        )
+    ):
         from agent.redact import mask_secret
         _display_value = mask_secret(value)
     else:
@@ -8861,6 +8895,13 @@ def get_config_value(key: str, *, as_json: bool = False):
     if value is _MISSING:
         print(f"Config key not set: {key}", file=sys.stderr)
         sys.exit(1)
+
+    # Mask credential-shaped values before printing
+    if isinstance(value, str) and value:
+        _leaf_key = key.rsplit(".", 1)[-1].lower()
+        if _leaf_key in _SECRET_CONFIG_KEYS or _leaf_key.endswith(_SECRET_CONFIG_SUFFIXES):
+            from agent.redact import mask_secret
+            value = mask_secret(value)
 
     print(_format_config_get_value(value, as_json=as_json))
 

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -205,7 +205,8 @@ def _cmd_subscribe(args):
 
     print(f"\n  {status} webhook subscription: {name}")
     print(f"  URL:    {base_url}/webhooks/{name}")
-    print(f"  Secret: {secret}")
+    from agent.redact import mask_secret
+    print(f"  Secret: {mask_secret(secret)}")
     if events:
         print(f"  Events: {', '.join(events)}")
     else:


### PR DESCRIPTION
Fixes #68040

## Problem

Two CLI surfaces leak full credential values to stdout:

1. **`hermes config set`** — suffix-shaped keys like `bot_token`, `webhook_secret`, `my_custom_api_key` miss the exact-match `_SECRET_CONFIG_KEYS` set and echo the full value.

2. **`hermes webhook subscribe`** — always prints the full generated HMAC secret with no masking.

## Fix

- Add `_SECRET_CONFIG_SUFFIXES` tuple for suffix-based matching (e.g. `_token`, `_secret`, `_api_key`). Bare `_key` is deliberately excluded so identifier-shaped keys like `session_key` keep echoing for debuggability.
- Update `set_config_value()` echo, `redact_config_value()`, and `get_config_value()` to check both exact and suffix matches.
- Mask the HMAC secret in `webhook subscribe` output.

## Verification

```python
assert 'bot_token'.endswith(_SECRET_CONFIG_SUFFIXES)  # masked
assert 'webhook_secret'.endswith(_SECRET_CONFIG_SUFFIXES)  # masked
assert not 'session_key'.endswith(_SECRET_CONFIG_SUFFIXES)  # not masked
```