### PR TITLE
feat(discord): route tool progress as replies when auto_thread is off

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -524,6 +524,38 @@ def _resolve_progress_thread_id(platform: Any, source_thread_id: Any, event_mess
     return None
 
 
+def _resolve_progress_reply_to(
+    platform: Any,
+    source_thread_id: Any,
+    event_message_id: Any,
+) -> Optional[str]:
+    """Return the message ID that progress/status bubbles should reply to.
+
+    On Slack and Mattermost, progress messages thread under the user's
+    original message.  Feishu and Mattermost use ``reply_to`` when the
+    message originates inside an existing thread.
+
+    On Discord with ``auto_thread`` disabled (no ``source_thread_id``),
+    progress messages reply to the user's original message via Discord's
+    message-reference mechanism (the "replying to…" chip).  This mirrors
+    Slack's behaviour: text response inline, tool progress as replies.
+    When ``auto_thread`` is enabled, ``source_thread_id`` is set and
+    progress is routed to the thread via ``_resolve_progress_thread_id``
+    instead, so we return ``None`` here to avoid double-routing.
+    """
+    platform_value = getattr(platform, "value", platform)
+    platform_key = str(platform_value or "").lower()
+    if not event_message_id:
+        return None
+    # Feishu / Mattermost: reply_to when inside an existing thread
+    if platform_key in {"feishu", "mattermost"} and source_thread_id:
+        return str(event_message_id)
+    # Discord: reply_to when NOT in a thread (auto_thread off)
+    if platform_key == "discord" and not source_thread_id:
+        return str(event_message_id)
+    return None
+
+
 def _has_platform_display_override(user_config: dict, platform_key: str, setting: str) -> bool:
     """Return True when display.platforms.<platform> explicitly sets setting."""
     display = user_config.get("display") if isinstance(user_config, dict) else None
@@ -19446,10 +19478,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else {"thread_id": _progress_thread_id}
         ) if _progress_thread_id else None
         _progress_metadata = _non_conversational_metadata(_progress_metadata, platform=source.platform)
-        _progress_reply_to = (
-            event_message_id
-            if source.platform in (Platform.FEISHU, Platform.MATTERMOST) and source.thread_id and event_message_id
-            else None
+        _progress_reply_to = _resolve_progress_reply_to(
+            source.platform, source.thread_id, event_message_id,
         )
 
         async def write_tool_log():

--- a/tests/gateway/test_discord_progress_reply.py
+++ b/tests/gateway/test_discord_progress_reply.py
@@ -1,0 +1,102 @@
+"""Tests for Discord progress reply_to routing.
+
+When auto_thread is disabled (no source.thread_id), Discord progress
+messages should reply to the user's original message via Discord's
+message-reference mechanism, mirroring Slack's behaviour where tool
+progress nests under the user's message and the final text response
+goes inline in the channel.
+"""
+import pytest
+
+from gateway.config import Platform
+from gateway.run import (
+    _resolve_progress_reply_to,
+    _resolve_progress_thread_id,
+)
+
+
+class TestDiscordProgressReplyTo:
+    """Discord progress reply_to resolution."""
+
+    def test_discord_no_thread_uses_event_message_id(self):
+        """With auto_thread off, progress should reply to the user's message."""
+        assert _resolve_progress_reply_to(
+            Platform.DISCORD,
+            source_thread_id=None,
+            event_message_id="123456789",
+        ) == "123456789"
+
+    def test_discord_with_thread_returns_none(self):
+        """With auto_thread on, progress goes to the thread, not reply_to."""
+        assert _resolve_progress_reply_to(
+            Platform.DISCORD,
+            source_thread_id="987654321",
+            event_message_id="123456789",
+        ) is None
+
+    def test_discord_no_event_message_id_returns_none(self):
+        assert _resolve_progress_reply_to(
+            Platform.DISCORD,
+            source_thread_id=None,
+            event_message_id=None,
+        ) is None
+
+    def test_discord_progress_thread_id_still_none(self):
+        """Discord should NOT use event_message_id as a thread_id.
+
+        Discord threads are real channels, not reply chains like Slack.
+        Progress routing uses reply_to, not thread_id.
+        """
+        assert _resolve_progress_thread_id(
+            Platform.DISCORD,
+            source_thread_id=None,
+            event_message_id="123456789",
+        ) is None
+
+    def test_discord_thread_progress_thread_id_uses_source_thread(self):
+        """When inside a thread, progress should target that thread."""
+        assert _resolve_progress_thread_id(
+            Platform.DISCORD,
+            source_thread_id="thread_abc",
+            event_message_id="msg_123",
+        ) == "thread_abc"
+
+
+class TestProgressReplyToParity:
+    """Ensure existing platform behaviour is unchanged."""
+
+    def test_feishu_threaded_uses_reply_to(self):
+        assert _resolve_progress_reply_to(
+            Platform.FEISHU,
+            source_thread_id="thread_abc",
+            event_message_id="msg_123",
+        ) == "msg_123"
+
+    def test_feishu_no_thread_returns_none(self):
+        assert _resolve_progress_reply_to(
+            Platform.FEISHU,
+            source_thread_id=None,
+            event_message_id="msg_123",
+        ) is None
+
+    def test_mattermost_threaded_uses_reply_to(self):
+        assert _resolve_progress_reply_to(
+            Platform.MATTERMOST,
+            source_thread_id="thread_abc",
+            event_message_id="msg_123",
+        ) == "msg_123"
+
+    def test_telegram_returns_none(self):
+        assert _resolve_progress_reply_to(
+            Platform.TELEGRAM,
+            source_thread_id=None,
+            event_message_id="12345",
+        ) is None
+
+    def test_slack_returns_none(self):
+        """Slack uses thread_id for progress, not reply_to."""
+        assert _resolve_progress_reply_to(
+            Platform.SLACK,
+            source_thread_id=None,
+            event_message_id="1234567890.000001",
+        ) is None


### PR DESCRIPTION
## Problem

When `DISCORD_AUTO_THREAD` is disabled, tool-progress messages (🔍/⚙️/💻 bubbles) are sent inline in the channel, polluting the conversation with noisy status updates. The final text response also goes inline, so there's no visual separation between tool activity and the answer.

Slack handles this well: tool progress nests under the user's original message as a reply thread, and the text response lands flat in the channel. Discord has no equivalent behaviour — progress goes inline when auto_thread is off.

## Fix

Extract `_resolve_progress_reply_to()` helper (mirroring the existing `_resolve_progress_thread_id()` pattern) and add Discord support:

- When `source.thread_id` is `None` (auto_thread off), progress messages reply to the user's original message via Discord's message-reference mechanism (the "replying to…" chip)
- The final text response still goes inline in the channel
- When auto_thread is enabled, `source.thread_id` is set and progress is routed to the thread via `_resolve_progress_thread_id()` instead, so `_resolve_progress_reply_to()` returns `None` to avoid double-routing

This mirrors Slack's behaviour: text response inline, tool progress as replies.

## Changes

- `gateway/run.py`: extract `_resolve_progress_reply_to()` helper, add Discord to the reply_to resolution
- `tests/gateway/test_discord_progress_reply.py`: 10 new tests covering Discord behaviour and parity with existing platforms

## Test Plan

- [x] `test_discord_progress_reply.py` — 10/10 passed
- [x] `test_mattermost.py::TestMattermostProgressThreadRouting` — 3/3 passed (no regression)
- [ ] CI