### PR TITLE
fix(prompt): forbid MEDIA: tags in the api_server platform hint

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -884,7 +884,13 @@ PLATFORM_HINTS = {
         "You're responding through an API server. The rendering layer is unknown — "
         "assume plain text. No markdown formatting (no asterisks, bullets, headers, "
         "code fences). Treat this like a conversation, not a document. Keep responses "
-        "brief and natural."
+        "brief and natural. "
+        "File/media delivery: do NOT emit MEDIA:/path tags in your response — "
+        "that convention is only intercepted on messaging platforms (Telegram, "
+        "WebUI, etc.); here it renders as literal, unusable text exposing a raw "
+        "host filesystem path to the caller. If a registered file-delivery tool "
+        "is available in your toolset, use it; otherwise there is no channel to "
+        "deliver a file on this platform."
     ),
     "webui": (
         "You are in the Hermes WebUI, a browser-based chat interface. "

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1103,6 +1103,19 @@ class TestPromptBuilderConstants:
         hint = PLATFORM_HINTS["whatsapp_cloud"]
         assert "MEDIA:" in hint
 
+    def test_api_server_hint_forbids_media_tag(self):
+        """api_server has no MEDIA: interception (unlike telegram/webui/etc.,
+        which resolve it to an attachment or a validated/inlined data URL) —
+        _handle_runs never calls the resolver other api_server endpoints use.
+        Without an explicit prohibition, the model's general cross-platform
+        habit of using MEDIA:/path for file delivery (correct and taught for
+        several other platforms in this same dict) can surface here too, with
+        no interception to catch it: the tag renders as literal text in the
+        response, exposing a raw host filesystem path to the API caller."""
+        hint = PLATFORM_HINTS["api_server"]
+        assert "MEDIA:" in hint
+        assert "not" in hint.lower()
+
     def test_markdown_converting_platform_hints_do_not_forbid_markdown(self):
         """#12224 — WhatsApp (Baileys) and Signal adapters actively convert
         markdown to native formatting (gateway/platforms/whatsapp_common.py


### PR DESCRIPTION
## What does this PR do?

Every `PLATFORM_HINTS` entry for a platform with an actual MEDIA:-tag interception mechanism
(Telegram, WhatsApp, Discord, Slack, Signal, WebUI, desktop) correctly teaches the model to use
`MEDIA:/path/to/file` for file delivery. The `cli` entry, which has no interception mechanism,
explicitly tells the model the opposite — don't emit the tag, state the path in plain text
instead — because on CLI it would otherwise render as inert literal text.

`api_server`'s entry had neither instruction. Its `/v1/runs` handler never routes the final
response through any MEDIA:-tag resolver (confirmed against source — none of the four call sites
of the api_server module's tag resolver are inside the runs-endpoint handler), so a `MEDIA:/path`
tag there renders as inert literal text in the API response, exposing a raw host filesystem path
to the caller with no file ever actually delivered. Nothing api_server-specific told the model
not to use a convention it's correctly taught for several sibling platforms in this same dict, so
the general cross-platform habit can surface on api_server too, with no interception to catch it
— unlike every platform where the convention is actually supported, and unlike `cli` where an
explicit prohibition already closes the same gap.

## Related Issue

No existing issue — found via source review while working on api_server platform behavior. Happy
to file one first if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `agent/prompt_builder.py`: appended a MEDIA:-tag prohibition to `PLATFORM_HINTS["api_server"]`,
  mirroring `cli`'s wording but adapted for api_server's actual constraint — no "state the path in
  plain text" fallback, since a typical API caller has no filesystem access to the host at all.
  Points at "a registered file-delivery tool" generically (not naming any specific tool), since
  api_server toolsets are deployment-defined.
- `tests/agent/test_prompt_builder.py`: added `test_api_server_hint_forbids_media_tag` to
  `TestPromptBuilderConstants`, alongside the existing per-platform hint-content tests.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_prompt_builder.py` — 167 passed, including the new test.
2. Manual: build a real system prompt for `platform="api_server"` through
   `agent.system_prompt.build_system_prompt_parts` and confirm the prohibition text appears
   (verified locally — output included below).
3. `python scripts/check-windows-footguns.py agent/prompt_builder.py tests/agent/test_prompt_builder.py`
   — clean, 0 findings (pure string content, no OS-touching code).

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs/issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/agent/test_prompt_builder.py` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Ubuntu, via WSL2 host)

### Documentation & Housekeeping
- [x] I've updated relevant documentation — N/A (no user-facing docs describe platform-hint internals)
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md`/`AGENTS.md` — N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact — N/A (pure string content, footgun scan clean)
- [x] I've updated tool descriptions/schemas — N/A (no tool behavior changed)

## Screenshots / Logs

Manual verification — assembled system prompt for `platform="api_server"`, last line is the new
prohibition:

```
You're responding through an API server. The rendering layer is unknown — assume plain text. No
markdown formatting (no asterisks, bullets, headers, code fences). Treat this like a
conversation, not a document. Keep responses brief and natural. File/media delivery: do NOT emit
MEDIA:/path tags in your response — that convention is only intercepted on messaging platforms
(Telegram, WebUI, etc.); here it renders as literal, unusable text exposing a raw host filesystem
path to the caller. If a registered file-delivery tool is available in your toolset, use it;
otherwise there is no channel to deliver a file on this platform.
```