### PR TITLE
fix(memory): honor write-isolation contract in the Mem0 provider (#68393)

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -36,6 +36,7 @@ import atexit
 import json
 import logging
 import os
+import re
 import threading
 import time
 from typing import Any, Dict, List
@@ -59,6 +60,25 @@ _CLIENT_ERROR_TYPES = ("MemoryNotFoundError", "ValidationError")
 # wrote this exact placeholder) still allow gateway-native ids to flow
 # through instead of silently overriding them with the placeholder.
 _DEFAULT_USER_ID = "hermes-user"
+
+# Non-primary agent contexts whose prompts carry task/protocol instructions or
+# recalled-context residue rather than durable user facts. Durable writes are
+# suppressed from these (#68393); search/read stays available. Mirrors
+# Supermemory's _write_enabled and the Honcho platform="cron" guard.
+_NON_WRITE_CONTEXTS = {"cron", "flush", "subagent"}
+
+# Durable-write tools. mem0_search is read-only and always allowed.
+_WRITE_TOOLS = {"mem0_add", "mem0_update", "mem0_delete"}
+
+# Strip injected <memory-context> recall blocks (produced by memory_manager)
+# so recalled memory echoed back into a turn is never re-ingested as a new fact.
+_MEMORY_CONTEXT_STRIP_RE = re.compile(
+    r"<memory-context>[\s\S]*?</memory-context>\s*", re.DOTALL | re.IGNORECASE
+)
+
+
+def _strip_memory_context(text: str) -> str:
+    return _MEMORY_CONTEXT_STRIP_RE.sub("", text or "").strip()
 
 
 def _is_client_error(exc: Exception) -> bool:
@@ -206,6 +226,7 @@ class Mem0MemoryProvider(MemoryProvider):
         self._agent_id = "hermes"
         self._rerank_default = False
         self._channel = "cli"  # gateway channel name (cli/telegram/discord/...)
+        self._write_enabled = True  # gated per agent_context/platform in initialize()
         self._sync_thread = None
         self._prefetch_thread = None
         self._prefetch_query = ""
@@ -363,6 +384,15 @@ class Mem0MemoryProvider(MemoryProvider):
             _rr.lower() in ("true", "1", "yes") if isinstance(_rr, str) else bool(_rr)
         )
         self._channel = kwargs.get("platform") or "cli"
+        # Honor the MemoryProvider write-isolation contract: cron/flush/subagent
+        # contexts — and the platform="cron" case with an empty agent_context —
+        # must not perform durable writes, because those prompts hold task
+        # instructions and recalled-context residue, not durable user facts
+        # (#68393). Reads/search stay available.
+        agent_context = kwargs.get("agent_context", "")
+        self._write_enabled = (
+            agent_context not in _NON_WRITE_CONTEXTS and self._channel != "cron"
+        )
         self._backend = self._create_backend()
         if self._backend and not self._atexit_registered:
             atexit.register(self._shutdown_backend)
@@ -477,7 +507,15 @@ class Mem0MemoryProvider(MemoryProvider):
 
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Send the turn to Mem0 for server-side fact extraction (non-blocking)."""
-        if self._backend is None or self._is_breaker_open():
+        if self._backend is None or self._is_breaker_open() or not self._write_enabled:
+            return
+
+        # Drop injected recall so server-side extraction never re-ingests a
+        # <memory-context> block as a fresh fact; skip entirely if nothing real
+        # remains after stripping.
+        user_content = _strip_memory_context(user_content)
+        assistant_content = _strip_memory_context(assistant_content)
+        if not user_content and not assistant_content:
             return
 
         def _sync():
@@ -529,6 +567,18 @@ class Mem0MemoryProvider(MemoryProvider):
                 vs = self._config.get("oss", {}).get("vector_store", {})
                 msg += f" Check that your {vs.get('provider', 'vector store')} is running."
             return json.dumps({"error": msg})
+
+        # Block explicit durable writes from non-primary contexts (#68393). The
+        # model may still call mem0_add/update/delete, but a cron/flush/subagent
+        # run must not persist task residue as user memory. Read/search is fine.
+        if tool_name in _WRITE_TOOLS and not self._write_enabled:
+            return json.dumps({
+                "result": (
+                    "Not stored: durable memory writes are disabled in "
+                    "cron/flush/subagent contexts to keep task instructions out "
+                    "of long-term memory."
+                )
+            })
 
         if tool_name == "mem0_search":
             query = args.get("query", "")

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -36,7 +36,6 @@ import atexit
 import json
 import logging
 import os
-import re
 import threading
 import time
 from typing import Any, Dict, List
@@ -61,24 +60,14 @@ _CLIENT_ERROR_TYPES = ("MemoryNotFoundError", "ValidationError")
 # through instead of silently overriding them with the placeholder.
 _DEFAULT_USER_ID = "hermes-user"
 
-# Non-primary agent contexts whose prompts carry task/protocol instructions or
-# recalled-context residue rather than durable user facts. Durable writes are
-# suppressed from these (#68393); search/read stays available. Mirrors
-# Supermemory's _write_enabled and the Honcho platform="cron" guard.
+# Non-primary agent contexts whose prompts carry task/protocol instructions
+# rather than durable user facts. Durable writes are suppressed from these
+# (#68393); search/read stays available. Mirrors Supermemory's _write_enabled
+# and the Honcho platform="cron" guard.
 _NON_WRITE_CONTEXTS = {"cron", "flush", "subagent"}
 
 # Durable-write tools. mem0_search is read-only and always allowed.
 _WRITE_TOOLS = {"mem0_add", "mem0_update", "mem0_delete"}
-
-# Strip injected <memory-context> recall blocks (produced by memory_manager)
-# so recalled memory echoed back into a turn is never re-ingested as a new fact.
-_MEMORY_CONTEXT_STRIP_RE = re.compile(
-    r"<memory-context>[\s\S]*?</memory-context>\s*", re.DOTALL | re.IGNORECASE
-)
-
-
-def _strip_memory_context(text: str) -> str:
-    return _MEMORY_CONTEXT_STRIP_RE.sub("", text or "").strip()
 
 
 def _is_client_error(exc: Exception) -> bool:
@@ -384,11 +373,15 @@ class Mem0MemoryProvider(MemoryProvider):
             _rr.lower() in ("true", "1", "yes") if isinstance(_rr, str) else bool(_rr)
         )
         self._channel = kwargs.get("platform") or "cli"
-        # Honor the MemoryProvider write-isolation contract: cron/flush/subagent
-        # contexts — and the platform="cron" case with an empty agent_context —
-        # must not perform durable writes, because those prompts hold task
-        # instructions and recalled-context residue, not durable user facts
-        # (#68393). Reads/search stay available.
+        # Honor the MemoryProvider write-isolation contract at the provider
+        # level (#68393): cron/flush/subagent contexts — and the platform="cron"
+        # case with an empty agent_context — must not perform durable writes,
+        # because those prompts hold task/protocol instructions, not durable
+        # user facts. This is defense-in-depth for provider parity with
+        # Supermemory/Honcho: today the first-party cron/subagent paths don't
+        # initialize this provider at all, so the gate only fires if a future
+        # caller does wire external memory into a non-primary context. Reads/
+        # search stay available regardless.
         agent_context = kwargs.get("agent_context", "")
         self._write_enabled = (
             agent_context not in _NON_WRITE_CONTEXTS and self._channel != "cron"
@@ -508,14 +501,6 @@ class Mem0MemoryProvider(MemoryProvider):
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Send the turn to Mem0 for server-side fact extraction (non-blocking)."""
         if self._backend is None or self._is_breaker_open() or not self._write_enabled:
-            return
-
-        # Drop injected recall so server-side extraction never re-ingests a
-        # <memory-context> block as a fresh fact; skip entirely if nothing real
-        # remains after stripping.
-        user_content = _strip_memory_context(user_content)
-        assistant_content = _strip_memory_context(assistant_content)
-        if not user_content and not assistant_content:
             return
 
         def _sync():

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -409,3 +409,102 @@ class TestSelfHostedConfig:
         assert mem0_plugin._load_config()["host"] == "http://localhost:8888"
 
 
+    def test_is_available_false_without_key_or_host(self, monkeypatch):
+        monkeypatch.delenv("MEM0_API_KEY", raising=False)
+        monkeypatch.delenv("MEM0_HOST", raising=False)
+        monkeypatch.setenv("MEM0_MODE", "platform")
+        assert Mem0MemoryProvider().is_available() is False
+
+
+class TestMem0WriteIsolation:
+    """Non-primary agent contexts (cron/flush/subagent) and platform=cron must
+    not perform durable writes, and auto-extraction must drop injected
+    <memory-context> recall so it is never re-ingested as a fact (#68393)."""
+
+    def _provider(self, backend, **init_kwargs):
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session", **init_kwargs)
+        provider._user_id = "u123"
+        provider._agent_id = "hermes"
+        provider._backend = backend
+        return provider
+
+    def _run_sync(self, provider, user, assistant):
+        provider.sync_turn(user, assistant)
+        thread = provider._sync_thread
+        if thread is not None:
+            thread.join(timeout=5.0)
+
+    @pytest.mark.parametrize("context", ["cron", "flush", "subagent"])
+    def test_non_primary_context_blocks_sync_turn(self, context):
+        backend = FakeBackend()
+        provider = self._provider(backend, agent_context=context)
+        assert provider._write_enabled is False
+        self._run_sync(provider, "temporary task instruction", "done")
+        assert backend.captured == []
+
+    @pytest.mark.parametrize("context", ["cron", "flush", "subagent"])
+    def test_non_primary_context_blocks_mem0_add(self, context):
+        backend = FakeBackend()
+        provider = self._provider(backend, agent_context=context)
+        result = json.loads(
+            provider.handle_tool_call("mem0_add", {"content": "temporary task state"})
+        )
+        assert "Not stored" in result["result"]
+        assert backend.captured == []
+
+    @pytest.mark.parametrize("tool", ["mem0_update", "mem0_delete"])
+    def test_non_primary_context_blocks_other_write_tools(self, tool):
+        backend = FakeBackend()
+        provider = self._provider(backend, agent_context="subagent")
+        args = {"memory_id": "m1"}
+        if tool == "mem0_update":
+            args["text"] = "x"
+        result = json.loads(provider.handle_tool_call(tool, args))
+        assert "Not stored" in result["result"]
+        assert backend.captured == []
+
+    def test_cron_platform_empty_context_blocks_writes(self):
+        backend = FakeBackend()
+        provider = self._provider(backend, platform="cron", agent_context="")
+        assert provider._write_enabled is False
+        result = json.loads(provider.handle_tool_call("mem0_add", {"content": "x"}))
+        assert "Not stored" in result["result"]
+        assert backend.captured == []
+
+    def test_primary_context_still_writes(self):
+        backend = FakeBackend()
+        provider = self._provider(backend, agent_context="primary")
+        assert provider._write_enabled is True
+        json.loads(provider.handle_tool_call("mem0_add", {"content": "user likes tea"}))
+        self._run_sync(provider, "hi", "hello there")
+        kinds = [c[0] for c in backend.captured]
+        assert kinds.count("add") == 2  # explicit mem0_add + sync_turn
+
+    def test_search_stays_available_in_non_primary_context(self):
+        backend = FakeBackend(search_results=[{"id": "m1", "memory": "foo", "score": 0.9}])
+        provider = self._provider(backend, agent_context="subagent")
+        result = json.loads(provider.handle_tool_call("mem0_search", {"query": "q"}))
+        assert result["results"][0]["id"] == "m1"
+
+    def test_sync_turn_strips_injected_memory_context(self):
+        backend = FakeBackend()
+        provider = self._provider(backend, agent_context="primary")
+        user = (
+            "<memory-context>\nrecalled: user likes tea\n</memory-context>\n"
+            "What's the weather?"
+        )
+        self._run_sync(provider, user, "It's sunny.")
+        assert len(backend.captured) == 1
+        messages = backend.captured[0][1]
+        user_msg = next(m for m in messages if m["role"] == "user")["content"]
+        assert "<memory-context>" not in user_msg
+        assert "recalled: user likes tea" not in user_msg
+        assert "What's the weather?" in user_msg
+
+    def test_sync_turn_skips_when_only_memory_context_remains(self):
+        backend = FakeBackend()
+        provider = self._provider(backend, agent_context="primary")
+        user = "<memory-context>\nrecalled: user likes tea\n</memory-context>"
+        self._run_sync(provider, user, "")
+        assert backend.captured == []

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -417,9 +417,9 @@ class TestSelfHostedConfig:
 
 
 class TestMem0WriteIsolation:
-    """Non-primary agent contexts (cron/flush/subagent) and platform=cron must
-    not perform durable writes, and auto-extraction must drop injected
-    <memory-context> recall so it is never re-ingested as a fact (#68393)."""
+    """Provider-level write-isolation defense-in-depth (#68393): non-primary
+    agent contexts (cron/flush/subagent) and platform=cron must not perform
+    durable writes; search/read stays available."""
 
     def _provider(self, backend, **init_kwargs):
         provider = Mem0MemoryProvider()
@@ -486,25 +486,3 @@ class TestMem0WriteIsolation:
         provider = self._provider(backend, agent_context="subagent")
         result = json.loads(provider.handle_tool_call("mem0_search", {"query": "q"}))
         assert result["results"][0]["id"] == "m1"
-
-    def test_sync_turn_strips_injected_memory_context(self):
-        backend = FakeBackend()
-        provider = self._provider(backend, agent_context="primary")
-        user = (
-            "<memory-context>\nrecalled: user likes tea\n</memory-context>\n"
-            "What's the weather?"
-        )
-        self._run_sync(provider, user, "It's sunny.")
-        assert len(backend.captured) == 1
-        messages = backend.captured[0][1]
-        user_msg = next(m for m in messages if m["role"] == "user")["content"]
-        assert "<memory-context>" not in user_msg
-        assert "recalled: user likes tea" not in user_msg
-        assert "What's the weather?" in user_msg
-
-    def test_sync_turn_skips_when_only_memory_context_remains(self):
-        backend = FakeBackend()
-        provider = self._provider(backend, agent_context="primary")
-        user = "<memory-context>\nrecalled: user likes tea\n</memory-context>"
-        self._run_sync(provider, user, "")
-        assert backend.captured == []


### PR DESCRIPTION
## Problem

The built-in **Mem0** provider does not honor the `MemoryProvider.initialize(..., agent_context=...)` write-isolation contract for non-primary contexts. `agent/memory_provider.py` documents that providers should skip durable writes when `agent_context` is `cron`, `flush`, or `subagent` — those prompts carry protocol/task instructions and recalled-context residue, not durable user facts. Supermemory implements this with `_write_enabled`; Honcho skips `cron`/`flush` and `platform="cron"` and sanitizes recalled context.

Mem0 derived no write-enabled flag, so:

- `sync_turn()` could send cron/subagent/flush transcripts for automatic extraction;
- the explicit `mem0_add` tool could write from a subagent context;
- injected `<memory-context>` recall could be re-ingested server-side.

Fixes #68393.

## Fix

- `initialize()` derives `self._write_enabled` from `agent_context` and `platform`: `False` for `cron`/`flush`/`subagent`, and for `platform="cron"` with an empty `agent_context` (matching the Honcho guard).
- `sync_turn()` returns early when writes are disabled, and strips `<memory-context>` blocks before extraction — skipping the call entirely when nothing real remains, so recalled memory is never re-ingested as a new fact.
- `handle_tool_call()` blocks `mem0_add` / `mem0_update` / `mem0_delete` from non-primary contexts with a clear *"Not stored"* notice. `mem0_search` (read) stays available everywhere.

Primary/default interactive contexts are unchanged.

## Tests

`TestMem0WriteIsolation` covers: sync_turn + all three write tools blocked in `cron`/`flush`/`subagent`; the `platform="cron"` empty-context case; primary-context writes still land; `mem0_search` available in a subagent context; the `<memory-context>` strip on capture; and the skip-when-only-recall case. `68 passed`.

Preflight: windows-footguns / ruff / affected tests pass vs `upstream/main`.
