### PR TITLE
fix(telegram): preserve fatal recovery handoff

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2357,11 +2357,11 @@ class TelegramAdapter(BasePlatformAdapter):
         if attempt > MAX_NETWORK_RETRIES:
             message = (
                 "Telegram polling could not reconnect after %d network error retries. "
-                "Restarting gateway." % MAX_NETWORK_RETRIES
+                "Escalating to gateway recovery." % MAX_NETWORK_RETRIES
             )
             logger.error("[%s] %s Last error: %s", self.name, message, _redact_telegram_error_text(error))
             self._set_fatal_error("telegram_network_error", message, retryable=True)
-            await self._notify_fatal_error()
+            await self._handoff_polling_fatal_error()
             return
 
         delay = min(BASE_DELAY * (2 ** (attempt - 1)), MAX_DELAY)
@@ -2982,7 +2982,22 @@ class TelegramAdapter(BasePlatformAdapter):
                 self.name, stop_error, exc_info=True,
             )
         if not _already_fatal:
-            await self._notify_fatal_error()
+            await self._handoff_polling_fatal_error()
+
+    async def _handoff_polling_fatal_error(self) -> None:
+        """Notify the runner without letting child teardown cancel this owner.
+
+        The runner bounds adapter cleanup in a child task.  ``disconnect()``
+        cancels the tracked polling-recovery task, so retaining the current
+        notifier in ``_polling_error_task`` would cancel the fatal callback
+        before the runner can finish its reconnect or shutdown decision.
+        Release only the current owner; unrelated recovery tasks remain under
+        teardown control.
+        """
+        current_task = asyncio.current_task()
+        if self._polling_error_task is current_task:
+            self._polling_error_task = None
+        await self._notify_fatal_error()
 
     async def _create_dm_topic(
         self,

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -294,6 +294,32 @@ async def test_polling_conflict_becomes_fatal_after_retries(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_conflict_exhaustion_hands_off_before_child_disconnect():
+    """The conflict recovery owner must survive its fatal callback handoff."""
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._polling_conflict_count = 5  # MAX_CONFLICT_RETRIES
+    disconnect_tasks = []
+
+    async def fatal_handler(failed_adapter):
+        disconnect_task = asyncio.create_task(failed_adapter.disconnect())
+        disconnect_tasks.append(disconnect_task)
+        await asyncio.wait({disconnect_task})
+
+    adapter.set_fatal_error_handler(fatal_handler)
+
+    conflict = type("Conflict", (Exception,), {})
+    recovery_task = asyncio.create_task(
+        adapter._handle_polling_conflict(conflict("getUpdates conflict"))
+    )
+    adapter._polling_error_task = recovery_task
+    result = await asyncio.gather(recovery_task, return_exceptions=True)
+    await asyncio.gather(*disconnect_tasks, return_exceptions=True)
+
+    assert result == [None]
+    assert adapter._polling_error_task is None
+
+
+@pytest.mark.asyncio
 async def test_connect_marks_retryable_fatal_error_for_startup_network_failure(monkeypatch):
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
 
@@ -730,4 +756,3 @@ async def test_conflict_callback_disarms_before_scheduling(monkeypatch):
     for _ in range(10):
         await asyncio.sleep(0)
     await _cancel_heartbeat(adapter)
-

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from gateway.config import PlatformConfig
+from gateway.config import GatewayConfig, Platform, PlatformConfig
 
 
 def _ensure_telegram_mock():
@@ -37,6 +37,7 @@ _ensure_telegram_mock()
 
 from plugins.platforms.telegram import adapter as tg_adapter  # noqa: E402
 from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+from gateway.run import GatewayRunner  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
@@ -222,6 +223,40 @@ async def test_reconnect_triggers_fatal_after_max_retries():
     assert adapter.has_fatal_error
     assert adapter.fatal_error_code == "telegram_network_error"
     fatal_handler.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_retry_exhaustion_queues_reconnect_before_child_disconnect(tmp_path):
+    """Fatal teardown must not cancel the gateway's reconnect handoff.
+
+    The gateway runs ``disconnect()`` in a bounded child task.  If the current
+    polling-recovery owner remains in ``_polling_error_task``, Telegram teardown
+    cancels that parent while it is still awaiting the fatal handler, so the
+    handler never gets to queue background reconnection.
+    """
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="test-token")
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+    adapter = _make_adapter()
+    adapter._polling_network_error_count = 10  # MAX_NETWORK_RETRIES
+    adapter.set_fatal_error_handler(runner._handle_adapter_fatal_error)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.delivery_router.adapters = runner.adapters
+
+    recovery_task = asyncio.create_task(
+        adapter._handle_polling_network_error(Exception("still failing"))
+    )
+    adapter._polling_error_task = recovery_task
+    result = await asyncio.gather(recovery_task, return_exceptions=True)
+
+    assert result == [None]
+    assert runner.adapters == {}
+    assert Platform.TELEGRAM in runner._failed_platforms
+    assert runner._failed_platforms[Platform.TELEGRAM]["attempts"] == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #68406

## Summary

- release the current Telegram polling-recovery task's ownership before invoking the fatal-error handler
- preserve bounded teardown of unrelated polling lifecycle tasks
- cover both network retry exhaustion and polling-conflict exhaustion
- replace the misleading `Restarting gateway` message with `Escalating to gateway recovery`

## Root cause

The terminal retry handler can itself be the task stored in `_polling_error_task`. The gateway fatal-error callback runs `disconnect()` in a bounded child task. Telegram teardown then sees the parent recovery task as independently cancellable and cancels it while that parent is still awaiting the fatal callback.

For retryable network failures, that cancellation can unwind the runner after it removes the failed adapter but before it adds the platform to `_failed_platforms`. The process remains alive with no Telegram adapter and no background reconnect scheduled. The same task-ownership inversion also affects the non-retryable polling-conflict terminal path.

The new handoff helper clears `_polling_error_task` only when it is the current notifier. Other recovery tasks remain tracked and are still cancelled and awaited during teardown.

## Validation

- `scripts/run_tests.sh tests/gateway/test_telegram_network_reconnect.py tests/gateway/test_telegram_conflict.py tests/gateway/test_safe_adapter_disconnect.py tests/gateway/test_bounded_adapter_teardown.py -q` — 72 passed
- `scripts/run_tests.sh tests/gateway/test_runner_fatal_adapter.py -q -k 'not test_runner_requests_clean_exit_for_nonretryable_startup_conflict' --file-timeout 30 --file-retries 0` — 6 passed
- `ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_network_reconnect.py tests/gateway/test_telegram_conflict.py`
- `git diff --check`

## Baseline note

`test_runner_requests_clean_exit_for_nonretryable_startup_conflict` hangs in this local environment on both this branch and an unmodified `upstream/main` worktree, so it was excluded from the focused runner test command above. The changed Telegram recovery, conflict, and bounded teardown suites pass in full.
