### PR TITLE
fix(i18n): replace double-escaped \\n with \n in picker_title across all locales

### DIFF
--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -124,7 +124,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nHuidige modus: `{mode}`\\n\\nKies \\'n opsie:"
+    picker_title:          "⚡ **Priority Processing**\n\nHuidige modus: `{mode}`\n\nKies \\'n opsie:"
     choice_fast:           "fast — Priority Processing aan"
     choice_normal:         "normal — standaardverwerking"
 
@@ -197,7 +197,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` word nie ondersteun nie. Gebruik `/reasoning <level> --global` om die globale verstek te verander."
     reset_done:                "🧠 ✓ Sessie-redenering-oorskryf verwyder; val terug op globale konfigurasie."
     unknown_arg:               "⚠️ Onbekende argument: `{arg}`\n\n**Geldige vlakke:** none, minimal, low, medium, high, xhigh, max, ultra\n**Vertoon:** show, hide\n**Permanent:** voeg `--global` by om verby hierdie sessie te stoor"
-    picker_title:              "🧠 **Redenering-instellings**\\n\\n**Inspanning:** `{level}`\\n**Bereik:** {scope}\\n**Vertoon:** {display}\\n\\nKies \\'n opsie:"
+    picker_title:              "🧠 **Redenering-instellings**\n\n**Inspanning:** `{level}`\n**Bereik:** {scope}\n**Vertoon:** {display}\n\nKies \\'n opsie:"
     choice_none:               "none — deaktiveer redenering"
     choice_reset:              "reset — vee sessie-oorskrywing uit"
     choice_show:               "wys redenering in antwoorde"

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nHuidige modus: `{mode}`\\n\\nKies \\'n opsie:"
+    picker_title:          "⚡ **Priority Processing**\n\nHuidige modus: `{mode}`\n\nKies \\'n opsie:"
     choice_fast:           "fast — Priority Processing aan"
     choice_normal:         "normal — standaardverwerking"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` word nie ondersteun nie. Gebruik `/reasoning <level> --global` om die globale verstek te verander."
     reset_done:                "🧠 ✓ Sessie-redenering-oorskryf verwyder; val terug op globale konfigurasie."
     unknown_arg:               "⚠️ Onbekende argument: `{arg}`\n\n**Geldige vlakke:** none, minimal, low, medium, high, xhigh, max, ultra\n**Vertoon:** show, hide\n**Permanent:** voeg `--global` by om verby hierdie sessie te stoor"
-    picker_title:              "🧠 **Redenering-instellings**\\n\\n**Inspanning:** `{level}`\\n**Bereik:** {scope}\\n**Vertoon:** {display}\\n\\nKies \\'n opsie:"
+    picker_title:              "🧠 **Redenering-instellings**\n\n**Inspanning:** `{level}`\n**Bereik:** {scope}\n**Vertoon:** {display}\n\nKies \\'n opsie:"
     choice_none:               "none — deaktiveer redenering"
     choice_reset:              "reset — vee sessie-oorskrywing uit"
     choice_show:               "wys redenering in antwoorde"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -124,7 +124,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nAktueller Modus: `{mode}`\\n\\nOption wählen:"
+    picker_title:          "⚡ **Priority Processing**\n\nAktueller Modus: `{mode}`\n\nOption wählen:"
     choice_fast:           "fast — Priority Processing an"
     choice_normal:         "normal — Standardverarbeitung"
 
@@ -197,7 +197,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` wird nicht unterstützt. Verwenden Sie `/reasoning <level> --global`, um den globalen Standard zu ändern."
     reset_done:                "🧠 ✓ Sitzungs-Reasoning-Override gelöscht; Rückfall auf globale Konfiguration."
     unknown_arg:               "⚠️ Unbekanntes Argument: `{arg}`\n\n**Gültige Stärken:** none, minimal, low, medium, high, xhigh, max, ultra\n**Anzeige:** show, hide\n**Speichern:** `--global` hinzufügen, um über die Sitzung hinaus zu speichern"
-    picker_title:              "🧠 **Reasoning-Einstellungen**\\n\\n**Stärke:** `{level}`\\n**Geltungsbereich:** {scope}\\n**Anzeige:** {display}\\n\\nOption wählen:"
+    picker_title:              "🧠 **Reasoning-Einstellungen**\n\n**Stärke:** `{level}`\n**Geltungsbereich:** {scope}\n**Anzeige:** {display}\n\nOption wählen:"
     choice_none:               "none — Reasoning deaktivieren"
     choice_reset:              "reset — Sitzungs-Override löschen"
     choice_show:               "Reasoning in Antworten anzeigen"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nAktueller Modus: `{mode}`\\n\\nOption wählen:"
+    picker_title:          "⚡ **Priority Processing**\n\nAktueller Modus: `{mode}`\n\nOption wählen:"
     choice_fast:           "fast — Priority Processing an"
     choice_normal:         "normal — Standardverarbeitung"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` wird nicht unterstützt. Verwenden Sie `/reasoning <level> --global`, um den globalen Standard zu ändern."
     reset_done:                "🧠 ✓ Sitzungs-Reasoning-Override gelöscht; Rückfall auf globale Konfiguration."
     unknown_arg:               "⚠️ Unbekanntes Argument: `{arg}`\n\n**Gültige Stärken:** none, minimal, low, medium, high, xhigh, max, ultra\n**Anzeige:** show, hide\n**Speichern:** `--global` hinzufügen, um über die Sitzung hinaus zu speichern"
-    picker_title:              "🧠 **Reasoning-Einstellungen**\\n\\n**Stärke:** `{level}`\\n**Geltungsbereich:** {scope}\\n**Anzeige:** {display}\\n\\nOption wählen:"
+    picker_title:              "🧠 **Reasoning-Einstellungen**\n\n**Stärke:** `{level}`\n**Geltungsbereich:** {scope}\n**Anzeige:** {display}\n\nOption wählen:"
     choice_none:               "none — Reasoning deaktivieren"
     choice_reset:              "reset — Sitzungs-Override löschen"
     choice_show:               "Reasoning in Antworten anzeigen"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -124,7 +124,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nModo actual: `{mode}`\\n\\nElige una opción:"
+    picker_title:          "⚡ **Priority Processing**\n\nModo actual: `{mode}`\n\nElige una opción:"
     choice_fast:           "fast — Priority Processing activado"
     choice_normal:         "normal — procesamiento estándar"
 
@@ -197,7 +197,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` no es compatible. Usa `/reasoning <level> --global` para cambiar el valor global por defecto."
     reset_done:                "🧠 ✓ Anulación de razonamiento de la sesión borrada; volviendo a la configuración global."
     unknown_arg:               "⚠️ Argumento desconocido: `{arg}`\n\n**Niveles válidos:** none, minimal, low, medium, high, xhigh, max, ultra\n**Visualización:** show, hide\n**Persistir:** añade `--global` para guardar más allá de esta sesión"
-    picker_title:              "🧠 **Ajustes de razonamiento**\\n\\n**Esfuerzo:** `{level}`\\n**Alcance:** {scope}\\n**Visualización:** {display}\\n\\nElige una opción:"
+    picker_title:              "🧠 **Ajustes de razonamiento**\n\n**Esfuerzo:** `{level}`\n**Alcance:** {scope}\n**Visualización:** {display}\n\nElige una opción:"
     choice_none:               "none — desactivar razonamiento"
     choice_reset:              "reset — borrar el ajuste de sesión"
     choice_show:               "mostrar razonamiento en respuestas"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nModo actual: `{mode}`\\n\\nElige una opción:"
+    picker_title:          "⚡ **Priority Processing**\n\nModo actual: `{mode}`\n\nElige una opción:"
     choice_fast:           "fast — Priority Processing activado"
     choice_normal:         "normal — procesamiento estándar"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` no es compatible. Usa `/reasoning <level> --global` para cambiar el valor global por defecto."
     reset_done:                "🧠 ✓ Anulación de razonamiento de la sesión borrada; volviendo a la configuración global."
     unknown_arg:               "⚠️ Argumento desconocido: `{arg}`\n\n**Niveles válidos:** none, minimal, low, medium, high, xhigh, max, ultra\n**Visualización:** show, hide\n**Persistir:** añade `--global` para guardar más allá de esta sesión"
-    picker_title:              "🧠 **Ajustes de razonamiento**\\n\\n**Esfuerzo:** `{level}`\\n**Alcance:** {scope}\\n**Visualización:** {display}\\n\\nElige una opción:"
+    picker_title:              "🧠 **Ajustes de razonamiento**\n\n**Esfuerzo:** `{level}`\n**Alcance:** {scope}\n**Visualización:** {display}\n\nElige una opción:"
     choice_none:               "none — desactivar razonamiento"
     choice_reset:              "reset — borrar el ajuste de sesión"
     choice_show:               "mostrar razonamiento en respuestas"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -124,7 +124,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nMode actuel : `{mode}`\\n\\nChoisissez une option :"
+    picker_title:          "⚡ **Priority Processing**\n\nMode actuel : `{mode}`\n\nChoisissez une option :"
     choice_fast:           "fast — Priority Processing activé"
     choice_normal:         "normal — traitement standard"
 
@@ -197,7 +197,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` n'est pas pris en charge. Utilisez `/reasoning <level> --global` pour modifier la valeur globale par défaut."
     reset_done:                "🧠 ✓ Remplacement de raisonnement de la session effacé ; retour à la configuration globale."
     unknown_arg:               "⚠️ Argument inconnu : `{arg}`\n\n**Niveaux valides :** none, minimal, low, medium, high, xhigh, max, ultra\n**Affichage :** show, hide\n**Persister :** ajoutez `--global` pour enregistrer au-delà de cette session"
-    picker_title:              "🧠 **Paramètres de raisonnement**\\n\\n**Effort :** `{level}`\\n**Portée :** {scope}\\n**Affichage :** {display}\\n\\nChoisissez une option :"
+    picker_title:              "🧠 **Paramètres de raisonnement**\n\n**Effort :** `{level}`\n**Portée :** {scope}\n**Affichage :** {display}\n\nChoisissez une option :"
     choice_none:               "none — désactiver le raisonnement"
     choice_reset:              "reset — effacer le réglage de session"
     choice_show:               "afficher le raisonnement dans les réponses"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nMode actuel : `{mode}`\\n\\nChoisissez une option :"
+    picker_title:          "⚡ **Priority Processing**\n\nMode actuel : `{mode}`\n\nChoisissez une option :"
     choice_fast:           "fast — Priority Processing activé"
     choice_normal:         "normal — traitement standard"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` n'est pas pris en charge. Utilisez `/reasoning <level> --global` pour modifier la valeur globale par défaut."
     reset_done:                "🧠 ✓ Remplacement de raisonnement de la session effacé ; retour à la configuration globale."
     unknown_arg:               "⚠️ Argument inconnu : `{arg}`\n\n**Niveaux valides :** none, minimal, low, medium, high, xhigh, max, ultra\n**Affichage :** show, hide\n**Persister :** ajoutez `--global` pour enregistrer au-delà de cette session"
-    picker_title:              "🧠 **Paramètres de raisonnement**\\n\\n**Effort :** `{level}`\\n**Portée :** {scope}\\n**Affichage :** {display}\\n\\nChoisissez une option :"
+    picker_title:              "🧠 **Paramètres de raisonnement**\n\n**Effort :** `{level}`\n**Portée :** {scope}\n**Affichage :** {display}\n\nChoisissez une option :"
     choice_none:               "none — désactiver le raisonnement"
     choice_reset:              "reset — effacer le réglage de session"
     choice_show:               "afficher le raisonnement dans les réponses"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -128,7 +128,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nMód reatha: `{mode}`\\n\\nRoghnaigh rogha:"
+    picker_title:          "⚡ **Priority Processing**\n\nMód reatha: `{mode}`\n\nRoghnaigh rogha:"
     choice_fast:           "fast — Priority Processing ar siúl"
     choice_normal:         "normal — gnáthphróiseáil"
 
@@ -201,7 +201,7 @@ gateway:
     reset_global_unsupported:  "⚠️ Ní thacaítear le `/reasoning reset --global`. Úsáid `/reasoning <level> --global` chun an réamhshocrú domhanda a athrú."
     reset_done:                "🧠 ✓ Sárú réasúnaíochta seisiúin glanta; ag titim siar ar an gcumraíocht dhomhanda."
     unknown_arg:               "⚠️ Argóint anaithnid: `{arg}`\n\n**Leibhéil bhailí:** none, minimal, low, medium, high, xhigh, max, ultra\n**Taispeáint:** show, hide\n**Coinnigh:** cuir `--global` leis chun sábháil thar an seisiún seo"
-    picker_title:              "🧠 **Socruithe Réasúnaíochta**\\n\\n**Iarracht:** `{level}`\\n**Scóip:** {scope}\\n**Taispeáint:** {display}\\n\\nRoghnaigh rogha:"
+    picker_title:              "🧠 **Socruithe Réasúnaíochta**\n\n**Iarracht:** `{level}`\n**Scóip:** {scope}\n**Taispeáint:** {display}\n\nRoghnaigh rogha:"
     choice_none:               "none — díchumasaigh réasúnaíocht"
     choice_reset:              "reset — glan sárú an tseisiúin"
     choice_show:               "taispeáin réasúnaíocht sna freagraí"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -138,7 +138,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nMód reatha: `{mode}`\\n\\nRoghnaigh rogha:"
+    picker_title:          "⚡ **Priority Processing**\n\nMód reatha: `{mode}`\n\nRoghnaigh rogha:"
     choice_fast:           "fast — Priority Processing ar siúl"
     choice_normal:         "normal — gnáthphróiseáil"
 
@@ -217,7 +217,7 @@ gateway:
     reset_global_unsupported:  "⚠️ Ní thacaítear le `/reasoning reset --global`. Úsáid `/reasoning <level> --global` chun an réamhshocrú domhanda a athrú."
     reset_done:                "🧠 ✓ Sárú réasúnaíochta seisiúin glanta; ag titim siar ar an gcumraíocht dhomhanda."
     unknown_arg:               "⚠️ Argóint anaithnid: `{arg}`\n\n**Leibhéil bhailí:** none, minimal, low, medium, high, xhigh, max, ultra\n**Taispeáint:** show, hide\n**Coinnigh:** cuir `--global` leis chun sábháil thar an seisiún seo"
-    picker_title:              "🧠 **Socruithe Réasúnaíochta**\\n\\n**Iarracht:** `{level}`\\n**Scóip:** {scope}\\n**Taispeáint:** {display}\\n\\nRoghnaigh rogha:"
+    picker_title:              "🧠 **Socruithe Réasúnaíochta**\n\n**Iarracht:** `{level}`\n**Scóip:** {scope}\n**Taispeáint:** {display}\n\nRoghnaigh rogha:"
     choice_none:               "none — díchumasaigh réasúnaíocht"
     choice_reset:              "reset — glan sárú an tseisiúin"
     choice_show:               "taispeáin réasúnaíocht sna freagraí"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -124,7 +124,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nJelenlegi mód: `{mode}`\\n\\nVálassz egy opciót:"
+    picker_title:          "⚡ **Priority Processing**\n\nJelenlegi mód: `{mode}`\n\nVálassz egy opciót:"
     choice_fast:           "fast — Priority Processing bekapcsolva"
     choice_normal:         "normal — normál feldolgozás"
 
@@ -197,7 +197,7 @@ gateway:
     reset_global_unsupported:  "⚠️ A `/reasoning reset --global` nem támogatott. Használd a `/reasoning <level> --global` parancsot a globális alapérték módosításához."
     reset_done:                "🧠 ✓ A munkamenet gondolkodási felülbírálása törölve; visszaállás a globális konfigurációra."
     unknown_arg:               "⚠️ Ismeretlen argumentum: `{arg}`\n\n**Érvényes szintek:** none, minimal, low, medium, high, xhigh, max, ultra\n**Megjelenítés:** show, hide\n**Megőrzés:** add hozzá a `--global` opciót a munkameneten túli mentéshez"
-    picker_title:              "🧠 **Gondolkodási beállítások**\\n\\n**Erőfeszítés:** `{level}`\\n**Hatókör:** {scope}\\n**Megjelenítés:** {display}\\n\\nVálassz egy opciót:"
+    picker_title:              "🧠 **Gondolkodási beállítások**\n\n**Erőfeszítés:** `{level}`\n**Hatókör:** {scope}\n**Megjelenítés:** {display}\n\nVálassz egy opciót:"
     choice_none:               "none — gondolkodás kikapcsolása"
     choice_reset:              "reset — munkameneti felülbírálás törlése"
     choice_show:               "gondolkodás megjelenítése a válaszokban"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nJelenlegi mód: `{mode}`\\n\\nVálassz egy opciót:"
+    picker_title:          "⚡ **Priority Processing**\n\nJelenlegi mód: `{mode}`\n\nVálassz egy opciót:"
     choice_fast:           "fast — Priority Processing bekapcsolva"
     choice_normal:         "normal — normál feldolgozás"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ A `/reasoning reset --global` nem támogatott. Használd a `/reasoning <level> --global` parancsot a globális alapérték módosításához."
     reset_done:                "🧠 ✓ A munkamenet gondolkodási felülbírálása törölve; visszaállás a globális konfigurációra."
     unknown_arg:               "⚠️ Ismeretlen argumentum: `{arg}`\n\n**Érvényes szintek:** none, minimal, low, medium, high, xhigh, max, ultra\n**Megjelenítés:** show, hide\n**Megőrzés:** add hozzá a `--global` opciót a munkameneten túli mentéshez"
-    picker_title:              "🧠 **Gondolkodási beállítások**\\n\\n**Erőfeszítés:** `{level}`\\n**Hatókör:** {scope}\\n**Megjelenítés:** {display}\\n\\nVálassz egy opciót:"
+    picker_title:              "🧠 **Gondolkodási beállítások**\n\n**Erőfeszítés:** `{level}`\n**Hatókör:** {scope}\n**Megjelenítés:** {display}\n\nVálassz egy opciót:"
     choice_none:               "none — gondolkodás kikapcsolása"
     choice_reset:              "reset — munkameneti felülbírálás törlése"
     choice_show:               "gondolkodás megjelenítése a válaszokban"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -124,7 +124,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nModalità attuale: `{mode}`\\n\\nScegli un\\'opzione:"
+    picker_title:          "⚡ **Priority Processing**\n\nModalità attuale: `{mode}`\n\nScegli un\\'opzione:"
     choice_fast:           "fast — Priority Processing attivo"
     choice_normal:         "normal — elaborazione standard"
 
@@ -197,7 +197,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` non è supportato. Usa `/reasoning <level> --global` per cambiare il valore predefinito globale."
     reset_done:                "🧠 ✓ Override di reasoning della sessione cancellato; ripristino della configurazione globale."
     unknown_arg:               "⚠️ Argomento sconosciuto: `{arg}`\n\n**Livelli validi:** none, minimal, low, medium, high, xhigh, max, ultra\n**Visualizzazione:** show, hide\n**Persistenza:** aggiungi `--global` per salvare oltre questa sessione"
-    picker_title:              "🧠 **Impostazioni di reasoning**\\n\\n**Sforzo:** `{level}`\\n**Ambito:** {scope}\\n**Visualizzazione:** {display}\\n\\nScegli un\\'opzione:"
+    picker_title:              "🧠 **Impostazioni di reasoning**\n\n**Sforzo:** `{level}`\n**Ambito:** {scope}\n**Visualizzazione:** {display}\n\nScegli un\\'opzione:"
     choice_none:               "none — disattiva il reasoning"
     choice_reset:              "reset — cancella l'override di sessione"
     choice_show:               "mostra il reasoning nelle risposte"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nModalità attuale: `{mode}`\\n\\nScegli un\\'opzione:"
+    picker_title:          "⚡ **Priority Processing**\n\nModalità attuale: `{mode}`\n\nScegli un\\'opzione:"
     choice_fast:           "fast — Priority Processing attivo"
     choice_normal:         "normal — elaborazione standard"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` non è supportato. Usa `/reasoning <level> --global` per cambiare il valore predefinito globale."
     reset_done:                "🧠 ✓ Override di reasoning della sessione cancellato; ripristino della configurazione globale."
     unknown_arg:               "⚠️ Argomento sconosciuto: `{arg}`\n\n**Livelli validi:** none, minimal, low, medium, high, xhigh, max, ultra\n**Visualizzazione:** show, hide\n**Persistenza:** aggiungi `--global` per salvare oltre questa sessione"
-    picker_title:              "🧠 **Impostazioni di reasoning**\\n\\n**Sforzo:** `{level}`\\n**Ambito:** {scope}\\n**Visualizzazione:** {display}\\n\\nScegli un\\'opzione:"
+    picker_title:              "🧠 **Impostazioni di reasoning**\n\n**Sforzo:** `{level}`\n**Ambito:** {scope}\n**Visualizzazione:** {display}\n\nScegli un\\'opzione:"
     choice_none:               "none — disattiva il reasoning"
     choice_reset:              "reset — cancella l'override di sessione"
     choice_show:               "mostra il reasoning nelle risposte"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -124,7 +124,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\n現在のモード: `{mode}`\\n\\nオプションを選択:"
+    picker_title:          "⚡ **Priority Processing**\n\n現在のモード: `{mode}`\n\nオプションを選択:"
     choice_fast:           "fast — Priority Processing オン"
     choice_normal:         "normal — 標準処理"
 
@@ -197,7 +197,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` はサポートされていません。グローバルのデフォルトを変更するには `/reasoning <level> --global` を使用してください。"
     reset_done:                "🧠 ✓ セッションの推論オーバーライドをクリアしました。グローバル設定にフォールバックします。"
     unknown_arg:               "⚠️ 不明な引数: `{arg}`\n\n**有効なレベル:** none, minimal, low, medium, high, xhigh, max, ultra\n**表示:** show, hide\n**永続化:** セッションを越えて保存するには `--global` を追加"
-    picker_title:              "🧠 **推論設定**\\n\\n**強度:** `{level}`\\n**スコープ:** {scope}\\n**表示:** {display}\\n\\nオプションを選択:"
+    picker_title:              "🧠 **推論設定**\n\n**強度:** `{level}`\n**スコープ:** {scope}\n**表示:** {display}\n\nオプションを選択:"
     choice_none:               "none — 推論を無効化"
     choice_reset:              "reset — セッション上書きをクリア"
     choice_show:               "返信に推論を表示"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\n現在のモード: `{mode}`\\n\\nオプションを選択:"
+    picker_title:          "⚡ **Priority Processing**\n\n現在のモード: `{mode}`\n\nオプションを選択:"
     choice_fast:           "fast — Priority Processing オン"
     choice_normal:         "normal — 標準処理"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` はサポートされていません。グローバルのデフォルトを変更するには `/reasoning <level> --global` を使用してください。"
     reset_done:                "🧠 ✓ セッションの推論オーバーライドをクリアしました。グローバル設定にフォールバックします。"
     unknown_arg:               "⚠️ 不明な引数: `{arg}`\n\n**有効なレベル:** none, minimal, low, medium, high, xhigh, max, ultra\n**表示:** show, hide\n**永続化:** セッションを越えて保存するには `--global` を追加"
-    picker_title:              "🧠 **推論設定**\\n\\n**強度:** `{level}`\\n**スコープ:** {scope}\\n**表示:** {display}\\n\\nオプションを選択:"
+    picker_title:              "🧠 **推論設定**\n\n**強度:** `{level}`\n**スコープ:** {scope}\n**表示:** {display}\n\nオプションを選択:"
     choice_none:               "none — 推論を無効化"
     choice_reset:              "reset — セッション上書きをクリア"
     choice_show:               "返信に推論を表示"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -124,7 +124,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\n현재 모드: `{mode}`\\n\\n옵션을 선택하세요:"
+    picker_title:          "⚡ **Priority Processing**\n\n현재 모드: `{mode}`\n\n옵션을 선택하세요:"
     choice_fast:           "fast — Priority Processing 켜기"
     choice_normal:         "normal — 표준 처리"
 
@@ -197,7 +197,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global`은 지원되지 않습니다. 전역 기본값을 변경하려면 `/reasoning <level> --global`을 사용하세요."
     reset_done:                "🧠 ✓ 세션 추론 재정의가 해제되었습니다. 전역 설정으로 돌아갑니다."
     unknown_arg:               "⚠️ 알 수 없는 인수: `{arg}`\n\n**유효한 수준:** none, minimal, low, medium, high, xhigh, max, ultra\n**표시:** show, hide\n**영구화:** 이 세션을 넘어 저장하려면 `--global`을 추가하세요"
-    picker_title:              "🧠 **추론 설정**\\n\\n**노력:** `{level}`\\n**범위:** {scope}\\n**표시:** {display}\\n\\n옵션을 선택하세요:"
+    picker_title:              "🧠 **추론 설정**\n\n**노력:** `{level}`\n**범위:** {scope}\n**표시:** {display}\n\n옵션을 선택하세요:"
     choice_none:               "none — 추론 비활성화"
     choice_reset:              "reset — 세션 재정의 초기화"
     choice_show:               "응답에 추론 표시"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\n현재 모드: `{mode}`\\n\\n옵션을 선택하세요:"
+    picker_title:          "⚡ **Priority Processing**\n\n현재 모드: `{mode}`\n\n옵션을 선택하세요:"
     choice_fast:           "fast — Priority Processing 켜기"
     choice_normal:         "normal — 표준 처리"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global`은 지원되지 않습니다. 전역 기본값을 변경하려면 `/reasoning <level> --global`을 사용하세요."
     reset_done:                "🧠 ✓ 세션 추론 재정의가 해제되었습니다. 전역 설정으로 돌아갑니다."
     unknown_arg:               "⚠️ 알 수 없는 인수: `{arg}`\n\n**유효한 수준:** none, minimal, low, medium, high, xhigh, max, ultra\n**표시:** show, hide\n**영구화:** 이 세션을 넘어 저장하려면 `--global`을 추가하세요"
-    picker_title:              "🧠 **추론 설정**\\n\\n**노력:** `{level}`\\n**범위:** {scope}\\n**표시:** {display}\\n\\n옵션을 선택하세요:"
+    picker_title:              "🧠 **추론 설정**\n\n**노력:** `{level}`\n**범위:** {scope}\n**표시:** {display}\n\n옵션을 선택하세요:"
     choice_none:               "none — 추론 비활성화"
     choice_reset:              "reset — 세션 재정의 초기화"
     choice_show:               "응답에 추론 표시"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -124,7 +124,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nModo atual: `{mode}`\\n\\nEscolha uma opção:"
+    picker_title:          "⚡ **Priority Processing**\n\nModo atual: `{mode}`\n\nEscolha uma opção:"
     choice_fast:           "fast — Priority Processing ativado"
     choice_normal:         "normal — processamento padrão"
 
@@ -197,7 +197,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` não é suportado. Usa `/reasoning <level> --global` para alterar o predefinido global."
     reset_done:                "🧠 ✓ Substituição de raciocínio da sessão removida; a regressar à configuração global."
     unknown_arg:               "⚠️ Argumento desconhecido: `{arg}`\n\n**Níveis válidos:** none, minimal, low, medium, high, xhigh, max, ultra\n**Visualização:** show, hide\n**Persistir:** adiciona `--global` para guardar para além desta sessão"
-    picker_title:              "🧠 **Definições de raciocínio**\\n\\n**Esforço:** `{level}`\\n**Âmbito:** {scope}\\n**Visualização:** {display}\\n\\nEscolha uma opção:"
+    picker_title:              "🧠 **Definições de raciocínio**\n\n**Esforço:** `{level}`\n**Âmbito:** {scope}\n**Visualização:** {display}\n\nEscolha uma opção:"
     choice_none:               "none — desativar raciocínio"
     choice_reset:              "reset — limpar o override de sessão"
     choice_show:               "mostrar raciocínio nas respostas"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nModo atual: `{mode}`\\n\\nEscolha uma opção:"
+    picker_title:          "⚡ **Priority Processing**\n\nModo atual: `{mode}`\n\nEscolha uma opção:"
     choice_fast:           "fast — Priority Processing ativado"
     choice_normal:         "normal — processamento padrão"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` não é suportado. Usa `/reasoning <level> --global` para alterar o predefinido global."
     reset_done:                "🧠 ✓ Substituição de raciocínio da sessão removida; a regressar à configuração global."
     unknown_arg:               "⚠️ Argumento desconhecido: `{arg}`\n\n**Níveis válidos:** none, minimal, low, medium, high, xhigh, max, ultra\n**Visualização:** show, hide\n**Persistir:** adiciona `--global` para guardar para além desta sessão"
-    picker_title:              "🧠 **Definições de raciocínio**\\n\\n**Esforço:** `{level}`\\n**Âmbito:** {scope}\\n**Visualização:** {display}\\n\\nEscolha uma opção:"
+    picker_title:              "🧠 **Definições de raciocínio**\n\n**Esforço:** `{level}`\n**Âmbito:** {scope}\n**Visualização:** {display}\n\nEscolha uma opção:"
     choice_none:               "none — desativar raciocínio"
     choice_reset:              "reset — limpar o override de sessão"
     choice_show:               "mostrar raciocínio nas respostas"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -124,7 +124,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nТекущий режим: `{mode}`\\n\\nВыберите вариант:"
+    picker_title:          "⚡ **Priority Processing**\n\nТекущий режим: `{mode}`\n\nВыберите вариант:"
     choice_fast:           "fast — Priority Processing включён"
     choice_normal:         "normal — стандартная обработка"
 
@@ -197,7 +197,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` не поддерживается. Используйте `/reasoning <level> --global`, чтобы изменить глобальное значение по умолчанию."
     reset_done:                "🧠 ✓ Переопределение рассуждений для сеанса сброшено; возврат к глобальной конфигурации."
     unknown_arg:               "⚠️ Неизвестный аргумент: `{arg}`\n\n**Допустимые уровни:** none, minimal, low, medium, high, xhigh, max, ultra\n**Отображение:** show, hide\n**Сохранение:** добавьте `--global`, чтобы сохранить за пределами этого сеанса"
-    picker_title:              "🧠 **Настройки рассуждений**\\n\\n**Усилия:** `{level}`\\n**Область:** {scope}\\n**Отображение:** {display}\\n\\nВыберите вариант:"
+    picker_title:              "🧠 **Настройки рассуждений**\n\n**Усилия:** `{level}`\n**Область:** {scope}\n**Отображение:** {display}\n\nВыберите вариант:"
     choice_none:               "none — отключить рассуждения"
     choice_reset:              "reset — сбросить переопределение сессии"
     choice_show:               "показывать рассуждения в ответах"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nТекущий режим: `{mode}`\\n\\nВыберите вариант:"
+    picker_title:          "⚡ **Priority Processing**\n\nТекущий режим: `{mode}`\n\nВыберите вариант:"
     choice_fast:           "fast — Priority Processing включён"
     choice_normal:         "normal — стандартная обработка"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` не поддерживается. Используйте `/reasoning <level> --global`, чтобы изменить глобальное значение по умолчанию."
     reset_done:                "🧠 ✓ Переопределение рассуждений для сеанса сброшено; возврат к глобальной конфигурации."
     unknown_arg:               "⚠️ Неизвестный аргумент: `{arg}`\n\n**Допустимые уровни:** none, minimal, low, medium, high, xhigh, max, ultra\n**Отображение:** show, hide\n**Сохранение:** добавьте `--global`, чтобы сохранить за пределами этого сеанса"
-    picker_title:              "🧠 **Настройки рассуждений**\\n\\n**Усилия:** `{level}`\\n**Область:** {scope}\\n**Отображение:** {display}\\n\\nВыберите вариант:"
+    picker_title:              "🧠 **Настройки рассуждений**\n\n**Усилия:** `{level}`\n**Область:** {scope}\n**Отображение:** {display}\n\nВыберите вариант:"
     choice_none:               "none — отключить рассуждения"
     choice_reset:              "reset — сбросить переопределение сессии"
     choice_show:               "показывать рассуждения в ответах"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -124,7 +124,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nMevcut mod: `{mode}`\\n\\nBir seçenek seçin:"
+    picker_title:          "⚡ **Priority Processing**\n\nMevcut mod: `{mode}`\n\nBir seçenek seçin:"
     choice_fast:           "fast — Priority Processing açık"
     choice_normal:         "normal — standart işleme"
 
@@ -197,7 +197,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` desteklenmiyor. Genel varsayılanı değiştirmek için `/reasoning <level> --global` kullanın."
     reset_done:                "🧠 ✓ Oturumun akıl yürütme geçersiz kılması temizlendi; genel yapılandırmaya geri dönülüyor."
     unknown_arg:               "⚠️ Bilinmeyen argüman: `{arg}`\n\n**Geçerli seviyeler:** none, minimal, low, medium, high, xhigh, max, ultra\n**Görüntüleme:** show, hide\n**Kalıcı:** bu oturumun ötesinde kaydetmek için `--global` ekleyin"
-    picker_title:              "🧠 **Akıl Yürütme Ayarları**\\n\\n**Güç:** `{level}`\\n**Kapsam:** {scope}\\n**Görüntüleme:** {display}\\n\\nBir seçenek seçin:"
+    picker_title:              "🧠 **Akıl Yürütme Ayarları**\n\n**Güç:** `{level}`\n**Kapsam:** {scope}\n**Görüntüleme:** {display}\n\nBir seçenek seçin:"
     choice_none:               "none — akıl yürütmeyi kapat"
     choice_reset:              "reset — oturum geçersiz kılmasını temizle"
     choice_show:               "yanıtlarda akıl yürütmeyi göster"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nMevcut mod: `{mode}`\\n\\nBir seçenek seçin:"
+    picker_title:          "⚡ **Priority Processing**\n\nMevcut mod: `{mode}`\n\nBir seçenek seçin:"
     choice_fast:           "fast — Priority Processing açık"
     choice_normal:         "normal — standart işleme"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` desteklenmiyor. Genel varsayılanı değiştirmek için `/reasoning <level> --global` kullanın."
     reset_done:                "🧠 ✓ Oturumun akıl yürütme geçersiz kılması temizlendi; genel yapılandırmaya geri dönülüyor."
     unknown_arg:               "⚠️ Bilinmeyen argüman: `{arg}`\n\n**Geçerli seviyeler:** none, minimal, low, medium, high, xhigh, max, ultra\n**Görüntüleme:** show, hide\n**Kalıcı:** bu oturumun ötesinde kaydetmek için `--global` ekleyin"
-    picker_title:              "🧠 **Akıl Yürütme Ayarları**\\n\\n**Güç:** `{level}`\\n**Kapsam:** {scope}\\n**Görüntüleme:** {display}\\n\\nBir seçenek seçin:"
+    picker_title:              "🧠 **Akıl Yürütme Ayarları**\n\n**Güç:** `{level}`\n**Kapsam:** {scope}\n**Görüntüleme:** {display}\n\nBir seçenek seçin:"
     choice_none:               "none — akıl yürütmeyi kapat"
     choice_reset:              "reset — oturum geçersiz kılmasını temizle"
     choice_show:               "yanıtlarda akıl yürütmeyi göster"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -124,7 +124,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nПоточний режим: `{mode}`\\n\\nОберіть варіант:"
+    picker_title:          "⚡ **Priority Processing**\n\nПоточний режим: `{mode}`\n\nОберіть варіант:"
     choice_fast:           "fast — Priority Processing увімкнено"
     choice_normal:         "normal — стандартна обробка"
 
@@ -197,7 +197,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` не підтримується. Використовуйте `/reasoning <level> --global`, щоб змінити глобальне значення за замовчуванням."
     reset_done:                "🧠 ✓ Перевизначення мислення для сеансу скинуто; повернення до глобальної конфігурації."
     unknown_arg:               "⚠️ Невідомий аргумент: `{arg}`\n\n**Дійсні рівні:** none, minimal, low, medium, high, xhigh, max, ultra\n**Показ:** show, hide\n**Зберегти:** додайте `--global`, щоб зберегти поза цим сеансом"
-    picker_title:              "🧠 **Налаштування мислення**\\n\\n**Зусилля:** `{level}`\\n**Область:** {scope}\\n**Показ:** {display}\\n\\nОберіть варіант:"
+    picker_title:              "🧠 **Налаштування мислення**\n\n**Зусилля:** `{level}`\n**Область:** {scope}\n**Показ:** {display}\n\nОберіть варіант:"
     choice_none:               "none — вимкнути мислення"
     choice_reset:              "reset — скинути перевизначення сесії"
     choice_show:               "показувати мислення у відповідях"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nПоточний режим: `{mode}`\\n\\nОберіть варіант:"
+    picker_title:          "⚡ **Priority Processing**\n\nПоточний режим: `{mode}`\n\nОберіть варіант:"
     choice_fast:           "fast — Priority Processing увімкнено"
     choice_normal:         "normal — стандартна обробка"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` не підтримується. Використовуйте `/reasoning <level> --global`, щоб змінити глобальне значення за замовчуванням."
     reset_done:                "🧠 ✓ Перевизначення мислення для сеансу скинуто; повернення до глобальної конфігурації."
     unknown_arg:               "⚠️ Невідомий аргумент: `{arg}`\n\n**Дійсні рівні:** none, minimal, low, medium, high, xhigh, max, ultra\n**Показ:** show, hide\n**Зберегти:** додайте `--global`, щоб зберегти поза цим сеансом"
-    picker_title:              "🧠 **Налаштування мислення**\\n\\n**Зусилля:** `{level}`\\n**Область:** {scope}\\n**Показ:** {display}\\n\\nОберіть варіант:"
+    picker_title:              "🧠 **Налаштування мислення**\n\n**Зусилля:** `{level}`\n**Область:** {scope}\n**Показ:** {display}\n\nОберіть варіант:"
     choice_none:               "none — вимкнути мислення"
     choice_reset:              "reset — скинути перевизначення сесії"
     choice_show:               "показувати мислення у відповідях"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -124,7 +124,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\n目前模式：`{mode}`\\n\\n請選擇："
+    picker_title:          "⚡ **Priority Processing**\n\n目前模式：`{mode}`\n\n請選擇："
     choice_fast:           "fast — 開啟 Priority Processing"
     choice_normal:         "normal — 標準處理"
 
@@ -197,7 +197,7 @@ gateway:
     reset_global_unsupported:  "⚠️ 不支援 `/reasoning reset --global`。請使用 `/reasoning <level> --global` 變更全域預設值。"
     reset_done:                "🧠 ✓ 已清除本工作階段的推理覆寫；回退至全域設定。"
     unknown_arg:               "⚠️ 未知參數：`{arg}`\n\n**有效級別：** none, minimal, low, medium, high, xhigh, max, ultra\n**顯示：** show, hide\n**持久化：** 加上 `--global` 可跨工作階段儲存"
-    picker_title:              "🧠 **推理設定**\\n\\n**強度：** `{level}`\\n**範圍：** {scope}\\n**顯示：** {display}\\n\\n請選擇："
+    picker_title:              "🧠 **推理設定**\n\n**強度：** `{level}`\n**範圍：** {scope}\n**顯示：** {display}\n\n請選擇："
     choice_none:               "none — 停用推理"
     choice_reset:              "reset — 清除工作階段覆寫"
     choice_show:               "在回覆中顯示推理"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\n目前模式：`{mode}`\\n\\n請選擇："
+    picker_title:          "⚡ **Priority Processing**\n\n目前模式：`{mode}`\n\n請選擇："
     choice_fast:           "fast — 開啟 Priority Processing"
     choice_normal:         "normal — 標準處理"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ 不支援 `/reasoning reset --global`。請使用 `/reasoning <level> --global` 變更全域預設值。"
     reset_done:                "🧠 ✓ 已清除本工作階段的推理覆寫；回退至全域設定。"
     unknown_arg:               "⚠️ 未知參數：`{arg}`\n\n**有效級別：** none, minimal, low, medium, high, xhigh, max, ultra\n**顯示：** show, hide\n**持久化：** 加上 `--global` 可跨工作階段儲存"
-    picker_title:              "🧠 **推理設定**\\n\\n**強度：** `{level}`\\n**範圍：** {scope}\\n**顯示：** {display}\\n\\n請選擇："
+    picker_title:              "🧠 **推理設定**\n\n**強度：** `{level}`\n**範圍：** {scope}\n**顯示：** {display}\n\n請選擇："
     choice_none:               "none — 停用推理"
     choice_reset:              "reset — 清除工作階段覆寫"
     choice_show:               "在回覆中顯示推理"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -124,7 +124,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **优先处理**\\n\\n当前模式：`{mode}`\\n\\n请选择："
+    picker_title:          "⚡ **优先处理**\n\n当前模式：`{mode}`\n\n请选择："
     choice_fast:           "fast — 开启优先处理"
     choice_normal:         "normal — 标准处理"
 
@@ -197,7 +197,7 @@ gateway:
     reset_global_unsupported:  "⚠️ 不支持 `/reasoning reset --global`。请使用 `/reasoning <level> --global` 修改全局默认值。"
     reset_done:                "🧠 ✓ 已清除本会话的推理覆盖；回退到全局配置。"
     unknown_arg:               "⚠️ 未知参数：`{arg}`\n\n**有效级别：** none, minimal, low, medium, high, xhigh, max, ultra\n**显示：** show, hide\n**持久化：** 添加 `--global` 以跨会话保存"
-    picker_title:              "🧠 **推理设置**\\n\\n**强度：** `{level}`\\n**作用域：** {scope}\\n**显示：** {display}\\n\\n请选择："
+    picker_title:              "🧠 **推理设置**\n\n**强度：** `{level}`\n**作用域：** {scope}\n**显示：** {display}\n\n请选择："
     choice_none:               "none — 关闭推理"
     choice_reset:              "reset — 清除会话覆盖"
     choice_show:               "在回复中显示推理"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **优先处理**\\n\\n当前模式：`{mode}`\\n\\n请选择："
+    picker_title:          "⚡ **优先处理**\n\n当前模式：`{mode}`\n\n请选择："
     choice_fast:           "fast — 开启优先处理"
     choice_normal:         "normal — 标准处理"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ 不支持 `/reasoning reset --global`。请使用 `/reasoning <level> --global` 修改全局默认值。"
     reset_done:                "🧠 ✓ 已清除本会话的推理覆盖；回退到全局配置。"
     unknown_arg:               "⚠️ 未知参数：`{arg}`\n\n**有效级别：** none, minimal, low, medium, high, xhigh, max, ultra\n**显示：** show, hide\n**持久化：** 添加 `--global` 以跨会话保存"
-    picker_title:              "🧠 **推理设置**\\n\\n**强度：** `{level}`\\n**作用域：** {scope}\\n**显示：** {display}\\n\\n请选择："
+    picker_title:              "🧠 **推理设置**\n\n**强度：** `{level}`\n**作用域：** {scope}\n**显示：** {display}\n\n请选择："
     choice_none:               "none — 关闭推理"
     choice_reset:              "reset — 清除会话覆盖"
     choice_show:               "在回复中显示推理"

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -227,3 +227,60 @@ def test_t_resolves_real_string_in_source_checkout():
     regressions independent of packaging."""
     assert i18n.t("gateway.reset.header_default", lang="en") != "gateway.reset.header_default"
     assert i18n.t("gateway.status.header", lang="en") != "gateway.status.header"
+
+
+# ---------------------------------------------------------------------------
+# Newline consistency -- picker_title and other multi-line keys must contain
+# actual newline characters (\n), not the literal two-character sequence
+# backslash-n (\\n).  A double-escaped \\n in a YAML double-quoted string
+# produces a literal backslash + 'n' in the parsed value, which renders as
+# visible "\n" text on platforms like Telegram instead of a line break.
+# ---------------------------------------------------------------------------
+
+_PICKER_TITLE_KEYS = [
+    "gateway.fast.picker_title",
+    "gateway.reasoning.picker_title",
+]
+
+
+@pytest.mark.parametrize("lang", [l for l in i18n.SUPPORTED_LANGUAGES if l != "en"])
+@pytest.mark.parametrize("key", _PICKER_TITLE_KEYS)
+def test_picker_title_has_real_newlines(lang: str, key: str):
+    """picker_title values must contain actual newlines, not literal \\n.
+
+    Regression: several locales had ``\\\\n`` in the YAML source (double-escaped),
+    which YAML parses as the two-character sequence ``\\n`` rather than a
+    newline.  The English catalog uses ``\\n`` (single escape) correctly.
+    """
+    flat = _flatten(_load_raw(lang))
+    value = flat.get(key, "")
+    assert value, f"{lang}.yaml missing key {key}"
+    # Must contain at least one real newline
+    assert "\n" in value, (
+        f"{lang}.yaml key={key!r}: no real newline found. "
+        f"Value starts with: {value[:80]!r}"
+    )
+    # Must NOT contain the literal two-char sequence backslash-n
+    literal_bs_n = chr(92) + "n"
+    assert literal_bs_n not in value, (
+        f"{lang}.yaml key={key!r}: contains literal backslash-n (double-escaped). "
+        f"Value starts with: {value[:80]!r}"
+    )
+
+
+@pytest.mark.parametrize("lang", list(i18n.SUPPORTED_LANGUAGES))
+@pytest.mark.parametrize("key", _PICKER_TITLE_KEYS)
+def test_picker_title_newline_count_matches_english(lang: str, key: str):
+    """The number of newlines in picker_title must match the English catalog.
+
+    If en.yaml has 4 newlines and a translation has 0, the picker renders as
+    a single unreadable line.  This catches both the double-escape bug and
+    accidental newline stripping during translation.
+    """
+    en_flat = _flatten(_load_raw("en"))
+    lang_flat = _flatten(_load_raw(lang))
+    en_count = en_flat[key].count("\n")
+    lang_count = lang_flat.get(key, "").count("\n")
+    assert lang_count == en_count, (
+        f"{lang}.yaml key={key!r}: {lang_count} newlines vs English {en_count}"
+    )

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -140,3 +140,62 @@ def test_locales_dir_env_override_ignored_when_missing(tmp_path, monkeypatch):
     assert result.name == "locales"
 
 
+
+
+
+
+# ---------------------------------------------------------------------------
+# Newline consistency -- picker_title and other multi-line keys must contain
+# actual newline characters (\n), not the literal two-character sequence
+# backslash-n (\\n).  A double-escaped \\n in a YAML double-quoted string
+# produces a literal backslash + 'n' in the parsed value, which renders as
+# visible "\n" text on platforms like Telegram instead of a line break.
+# ---------------------------------------------------------------------------
+
+_PICKER_TITLE_KEYS = [
+    "gateway.fast.picker_title",
+    "gateway.reasoning.picker_title",
+]
+
+
+@pytest.mark.parametrize("lang", [l for l in i18n.SUPPORTED_LANGUAGES if l != "en"])
+@pytest.mark.parametrize("key", _PICKER_TITLE_KEYS)
+def test_picker_title_has_real_newlines(lang: str, key: str):
+    """picker_title values must contain actual newlines, not literal \\n.
+
+    Regression: several locales had ``\\\\n`` in the YAML source (double-escaped),
+    which YAML parses as the two-character sequence ``\\n`` rather than a
+    newline.  The English catalog uses ``\\n`` (single escape) correctly.
+    """
+    flat = _flatten(_load_raw(lang))
+    value = flat.get(key, "")
+    assert value, f"{lang}.yaml missing key {key}"
+    # Must contain at least one real newline
+    assert "\n" in value, (
+        f"{lang}.yaml key={key!r}: no real newline found. "
+        f"Value starts with: {value[:80]!r}"
+    )
+    # Must NOT contain the literal two-char sequence backslash-n
+    literal_bs_n = chr(92) + "n"
+    assert literal_bs_n not in value, (
+        f"{lang}.yaml key={key!r}: contains literal backslash-n (double-escaped). "
+        f"Value starts with: {value[:80]!r}"
+    )
+
+
+@pytest.mark.parametrize("lang", list(i18n.SUPPORTED_LANGUAGES))
+@pytest.mark.parametrize("key", _PICKER_TITLE_KEYS)
+def test_picker_title_newline_count_matches_english(lang: str, key: str):
+    """The number of newlines in picker_title must match the English catalog.
+
+    If en.yaml has 4 newlines and a translation has 0, the picker renders as
+    a single unreadable line.  This catches both the double-escape bug and
+    accidental newline stripping during translation.
+    """
+    en_flat = _flatten(_load_raw("en"))
+    lang_flat = _flatten(_load_raw(lang))
+    en_count = en_flat[key].count("\n")
+    lang_count = lang_flat.get(key, "").count("\n")
+    assert lang_count == en_count, (
+        f"{lang}.yaml key={key!r}: {lang_count} newlines vs English {en_count}"
+    )


### PR DESCRIPTION
## Summary

Fixes #68411

All 15 non-English locale files had `\\n` (literal backslash-n) in `gateway.fast.picker_title` and `gateway.reasoning.picker_title` instead of `\n` (real newline escape). YAML double-quoted strings parse `\\n` as the two-character sequence backslash+n, causing Telegram and other platforms to display visible `\n` text in inline keyboard titles instead of line breaks.

### Before (ja)

```
🧠 **推論設定**\n\n**強度:** medium\n**スコープ:** グローバル設定\n**表示:** オフ\n\nオプションを選択:
```

### After (ja)

```
🧠 **推論設定**

**強度:** medium
**スコープ:** グローバル設定
**表示:** オフ

オプションを選択:
```

## Changes

- **15 locale files**: Replace `\\n` with `\n` in `picker_title` values (`af`, `de`, `es`, `fr`, `ga`, `hu`, `it`, `ja`, `ko`, `pt`, `ru`, `tr`, `uk`, `zh`, `zh-hant`)
- **tests/agent/test_i18n.py**: Add two regression tests:
  - `test_picker_title_has_real_newlines` — asserts real newlines exist and no literal backslash-n sequence remains
  - `test_picker_title_newline_count_matches_english` — asserts newline count parity with `en.yaml`

## Testing

```
$ pytest tests/agent/test_i18n.py -v
============================= 109 passed in 4.62s ==============================
```

All 109 tests pass, including 60 new parametrized test cases (15 locales × 2 keys × 2 tests).