### PR TITLE
fix(hindsight): isolate embedded profile base url

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -516,7 +516,11 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
 
     current_provider = config.get("llm_provider", "")
     current_model = config.get("llm_model", "")
-    current_base_url = config.get("llm_base_url") or os.environ.get("HINDSIGHT_API_LLM_BASE_URL", "")
+    # Use the profile config as the source of truth. The profile env file is
+    # materialized from Hermes setup/runtime config; inheriting a process-wide
+    # HINDSIGHT_API_LLM_BASE_URL here lets the operator's current environment
+    # leak into unrelated profiles (for example, OpenRouter into native OpenAI).
+    current_base_url = config.get("llm_base_url", "")
 
     # The embedded daemon expects OpenAI wire format for these providers.
     daemon_provider = "openai" if current_provider in {"openai_compatible", "openrouter"} else current_provider

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -417,6 +417,27 @@ class TestConfig:
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
 
+    def test_embedded_profile_env_does_not_inherit_ambient_llm_base_url(self, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_API_LLM_BASE_URL", "https://openrouter.example/v1")
+
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai-codex",
+            "llm_model": "gpt-5.5",
+        })
+
+        assert "HINDSIGHT_API_LLM_BASE_URL" not in env
+
+    def test_embedded_profile_env_keeps_configured_llm_base_url(self, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_API_LLM_BASE_URL", "https://openrouter.example/v1")
+
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai_compatible",
+            "llm_model": "custom-model",
+            "llm_base_url": "http://localhost:11434/v1",
+        })
+
+        assert env["HINDSIGHT_API_LLM_BASE_URL"] == "http://localhost:11434/v1"
+
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
         captured = {}
 


### PR DESCRIPTION
## What does this PR do?

This PR makes `_build_embedded_profile_env()` use the active Hermes profile config as the source of truth for `llm_base_url` when materializing embedded Hindsight profile env files.

Before this change, a process-wide `HINDSIGHT_API_LLM_BASE_URL` could be copied into a newly materialized embedded profile even when that profile did not configure `llm_base_url`:

```python
config.get("llm_base_url") or os.environ.get("HINDSIGHT_API_LLM_BASE_URL", "")
```

That can leak an operator’s ambient provider endpoint into an unrelated profile. For example, a shell environment configured for OpenRouter/custom endpoint usage could accidentally add `HINDSIGHT_API_LLM_BASE_URL` to an embedded profile using a native/OAuth-style provider such as `openai-codex`.

After this change:

- explicitly configured profile `llm_base_url` values are still preserved
- ambient/process-wide `HINDSIGHT_API_LLM_BASE_URL` is no longer inherited when the active profile does not configure `llm_base_url`
- newly materialized embedded profile env files reflect profile config instead of unrelated operator environment state

## Related Issue

No exact issue found for this specific ambient `HINDSIGHT_API_LLM_BASE_URL` leakage case.

Related adjacent work searched:

- #6282 added explicit `llm_base_url` support and intentionally avoided a universal OpenRouter default.
- #35052, #61070, and #63936 touch embedded Hindsight env materialization or rematerialization, but none appears to isolate ambient `HINDSIGHT_API_LLM_BASE_URL` leakage when the active profile does not configure `llm_base_url`.
- #39414, #66187, #21809, and #34365 cover adjacent embedded-profile propagation gaps, especially database URL and embedding/provider-auth handling, but not this base-url isolation case.

Note: review discussion on #63936 separately calls out stale `HINDSIGHT_API_LLM_BASE_URL` removal behavior for already-materialized profiles. This PR focuses on preventing new ambient leakage during profile env materialization.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/hindsight/__init__.py`
  - Changed `_build_embedded_profile_env()` so `HINDSIGHT_API_LLM_BASE_URL` is emitted only from explicit profile `llm_base_url` config.
  - Removed the ambient `os.environ.get("HINDSIGHT_API_LLM_BASE_URL", "")` fallback from embedded profile env materialization.

- `tests/plugins/memory/test_hindsight_provider.py`
  - Added regression coverage proving a profile without `llm_base_url` does not inherit ambient `HINDSIGHT_API_LLM_BASE_URL`.
  - Added regression coverage proving an explicitly configured `llm_base_url` is still preserved.

## How to Test

1. Run the focused Hindsight provider test file:

   ```bash
   python -m pytest -q -o 'addopts=' tests/plugins/memory/test_hindsight_provider.py
   ```

2. Confirm the regression case where an ambient base URL is present but the profile has no `llm_base_url`:

   ```python
   monkeypatch.setenv("HINDSIGHT_API_LLM_BASE_URL", "https://openrouter.example/v1")

   env = _build_embedded_profile_env({
       "llm_provider": "openai-codex",
       "llm_model": "gpt-5.5",
   })

   assert "HINDSIGHT_API_LLM_BASE_URL" not in env
   ```

3. Confirm the explicit custom base URL case still works:

   ```python
   env = _build_embedded_profile_env({
       "llm_provider": "openai_compatible",
       "llm_model": "custom-model",
       "llm_base_url": "http://localhost:11434/v1",
   })

   assert env["HINDSIGHT_API_LLM_BASE_URL"] == "http://localhost:11434/v1"
   ```

Local verification run:

```bash
/home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest -q -o 'addopts=' tests/plugins/memory/test_hindsight_provider.py
```

Result:

```text
118 passed in 8.66s
```

## Checklist

### Code

- [x] I've read the [[Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [[existing PRs](https://github.com/NousResearch/hermes-agent/pulls)](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [[compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — this PR does not add or change a skill.

## Screenshots / Logs

Focused test output:

```text
........................................................................ [ 61%]
..............................................                           [100%]
118 passed in 8.66s
```