### PR TITLE
fix(desktop): allow new chats in non-git projects

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
@@ -112,14 +112,17 @@ function RepoFlatSection({
   // git-worktree lanes) so out-of-tree/sibling worktrees — which exist as visual
   // lanes before the snapshot carries their sessions — get the new row. The
   // overlay drops lanes it empties, so re-merge to restore still-real worktrees.
-  const overlaidGroups = useMemo(() => {
+  const overlaidRepo = useMemo(() => {
+    const mergedRepo = { ...repo, groups: mergedGroups }
+
     if (!(liveSessions?.length || removedSessionIds?.size)) {
-      return mergedGroups
+      return mergedRepo
     }
 
-    const { groups } = overlayRepoLanes({ ...repo, groups: mergedGroups }, liveSessions ?? [], removedSessionIds)
+    const overlaid = overlayRepoLanes(mergedRepo, liveSessions ?? [], removedSessionIds)
+    const groups = mergeRepoWorktreeGroups(overlaid, discoveredWorktrees)
 
-    return mergeRepoWorktreeGroups({ id: repo.id, path: repo.path, groups }, discoveredWorktrees)
+    return { ...overlaid, groups }
   }, [repo, mergedGroups, discoveredWorktrees, liveSessions, removedSessionIds])
 
   const discoveredWorktreePaths = useMemo(
@@ -135,7 +138,7 @@ function RepoFlatSection({
   // Main lanes are always visible; linked worktrees can be user-dismissed.
   // A live `git worktree list` hit wins over an old dismissal: if git says the
   // worktree exists again (or still exists after "hide from sidebar"), surface it.
-  const ordered = overlaidGroups.filter(
+  const ordered = overlaidRepo.groups.filter(
     group =>
       group.isMain || !dismissedWorktrees.includes(group.id) || (group.path && discoveredWorktreePaths.has(group.path))
   )
@@ -169,6 +172,7 @@ function RepoFlatSection({
     <>
       {ordered.map(group => (
         <SidebarWorkspaceGroup
+          gitKind={overlaidRepo.gitKind}
           group={group}
           key={group.id}
           // The kanban bucket is read-only: it aggregates many task worktrees, so

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.test.tsx
@@ -1,0 +1,189 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+import { I18nProvider } from '@/i18n'
+import { notifyError } from '@/store/notifications'
+import { switchBranchInRepo } from '@/store/projects'
+
+import { EnteredProjectContent } from './entered-content'
+import { SidebarWorkspaceGroup } from './workspace-group'
+import type { SidebarProjectTree, SidebarSessionGroup } from './workspace-groups'
+
+vi.mock('@/store/notifications', () => ({ notifyError: vi.fn() }))
+vi.mock('@/store/profile', () => ({ newSessionInProfile: vi.fn() }))
+vi.mock('@/store/projects', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>()
+
+  return { ...actual, switchBranchInRepo: vi.fn() }
+})
+
+const lane = (git: boolean, overrides: Partial<SidebarSessionGroup> = {}): SidebarSessionGroup => ({
+  id: git ? '/repo::branch::main' : '/work/notes',
+  isMain: true,
+  label: git ? 'main' : 'notes',
+  path: git ? '/repo' : '/work/notes',
+  sessions: [],
+  ...overrides
+})
+
+function renderGroup(
+  group: SidebarSessionGroup,
+  onNewSession: (path: null | string) => void,
+  gitKind?: 'directory' | 'git'
+) {
+  return render(
+    <I18nProvider configClient={null}>
+      <SidebarWorkspaceGroup gitKind={gitKind} group={group} onNewSession={onNewSession} renderRows={() => null} />
+    </I18nProvider>
+  )
+}
+
+const liveSession = (overrides: Partial<SessionInfo> = {}): SessionInfo => ({
+  archived: false,
+  cwd: '/repo',
+  ended_at: null,
+  id: 'fresh',
+  input_tokens: 0,
+  is_active: true,
+  last_active: 1_000,
+  message_count: 0,
+  model: 'claude',
+  output_tokens: 0,
+  preview: null,
+  source: 'cli',
+  started_at: 1_000,
+  title: null,
+  tool_call_count: 0,
+  ...overrides
+})
+
+describe('SidebarWorkspaceGroup new session behavior', () => {
+  beforeEach(() => {
+    vi.mocked(switchBranchInRepo).mockReset().mockResolvedValue()
+    vi.mocked(notifyError).mockReset()
+  })
+
+  afterEach(cleanup)
+
+  it('creates directly in a non-git directory lane without switching a branch', async () => {
+    const onNewSession = vi.fn()
+
+    renderGroup(lane(false), onNewSession, 'directory')
+    fireEvent.click(screen.getByRole('button', { name: 'New session in notes' }))
+
+    await waitFor(() => expect(onNewSession).toHaveBeenCalledWith('/work/notes'))
+    expect(switchBranchInRepo).not.toHaveBeenCalled()
+  })
+
+  it('switches a real branch before creating the session', async () => {
+    const calls: string[] = []
+    const onNewSession = vi.fn(() => calls.push('create'))
+
+    vi.mocked(switchBranchInRepo).mockImplementation(async () => {
+      calls.push('switch')
+    })
+
+    renderGroup(lane(true), onNewSession, 'git')
+    fireEvent.click(screen.getByRole('button', { name: 'New session in main' }))
+
+    await waitFor(() => expect(onNewSession).toHaveBeenCalledWith('/repo'))
+    expect(switchBranchInRepo).toHaveBeenCalledWith('/repo', 'main')
+    expect(calls).toEqual(['switch', 'create'])
+  })
+
+  it('propagates optimistic git capability through entered project rendering before creating', async () => {
+    const calls: string[] = []
+    const onNewSession = vi.fn(() => calls.push('create'))
+
+    const project: SidebarProjectTree = {
+      id: '/repo',
+      label: 'repo',
+      path: '/repo',
+      repos: [
+        {
+          id: '/repo',
+          gitKind: 'directory',
+          groups: [],
+          label: 'repo',
+          path: '/repo',
+          sessionCount: 0
+        }
+      ],
+      sessionCount: 0
+    }
+
+    vi.mocked(switchBranchInRepo).mockImplementation(async () => {
+      calls.push('switch')
+    })
+
+    render(
+      <I18nProvider configClient={null}>
+        <EnteredProjectContent
+          liveSessions={[liveSession({ git_branch: 'release', git_repo_root: '/repo' })]}
+          onNewSession={onNewSession}
+          project={project}
+          renderRows={() => null}
+        />
+      </I18nProvider>
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'New session in release' }))
+
+    await waitFor(() => expect(onNewSession).toHaveBeenCalledWith('/repo'))
+    expect(switchBranchInRepo).toHaveBeenCalledWith('/repo', 'release')
+    expect(calls).toEqual(['switch', 'create'])
+  })
+
+  it('reports a real branch-switch failure and does not create a session', async () => {
+    const failure = new Error('branch is checked out elsewhere')
+    const onNewSession = vi.fn()
+
+    vi.mocked(switchBranchInRepo).mockRejectedValue(failure)
+
+    renderGroup(lane(true), onNewSession, 'git')
+    fireEvent.click(screen.getByRole('button', { name: 'New session in main' }))
+
+    await waitFor(() => expect(notifyError).toHaveBeenCalledWith(failure, 'Could not switch to main'))
+    expect(onNewSession).not.toHaveBeenCalled()
+  })
+
+  it('keeps switching canonical branch lanes from an older backend', async () => {
+    const onNewSession = vi.fn()
+
+    renderGroup(lane(true, { id: '/repo::branch::release', label: 'release' }), onNewSession)
+    fireEvent.click(screen.getByRole('button', { name: 'New session in release' }))
+
+    await waitFor(() => expect(onNewSession).toHaveBeenCalledWith('/repo'))
+    expect(switchBranchInRepo).toHaveBeenCalledWith('/repo', 'release')
+  })
+
+  it('does not switch a path-backed lane from an older backend', async () => {
+    const onNewSession = vi.fn()
+
+    renderGroup(lane(false), onNewSession)
+    fireEvent.click(screen.getByRole('button', { name: 'New session in notes' }))
+
+    await waitFor(() => expect(onNewSession).toHaveBeenCalledWith('/work/notes'))
+    expect(switchBranchInRepo).not.toHaveBeenCalled()
+  })
+
+  it('does not switch a legacy lane whose branch id and label disagree', async () => {
+    const onNewSession = vi.fn()
+
+    renderGroup(lane(true, { id: '/repo::branch::release', label: 'main' }), onNewSession)
+    fireEvent.click(screen.getByRole('button', { name: 'New session in main' }))
+
+    await waitFor(() => expect(onNewSession).toHaveBeenCalledWith('/repo'))
+    expect(switchBranchInRepo).not.toHaveBeenCalled()
+  })
+
+  it('does not switch a path-backed fallback lane inside a repo promoted to git', async () => {
+    const onNewSession = vi.fn()
+
+    renderGroup(lane(false), onNewSession, 'git')
+    fireEvent.click(screen.getByRole('button', { name: 'New session in notes' }))
+
+    await waitFor(() => expect(onNewSession).toHaveBeenCalledWith('/work/notes'))
+    expect(switchBranchInRepo).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.test.tsx
@@ -11,7 +11,11 @@ import { SidebarWorkspaceGroup } from './workspace-group'
 import type { SidebarProjectTree, SidebarSessionGroup } from './workspace-groups'
 
 vi.mock('@/store/notifications', () => ({ notifyError: vi.fn() }))
-vi.mock('@/store/profile', () => ({ newSessionInProfile: vi.fn() }))
+vi.mock('@/store/profile', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>()
+
+  return { ...actual, newSessionInProfile: vi.fn() }
+})
 vi.mock('@/store/projects', async importOriginal => {
   const actual = await importOriginal<Record<string, unknown>>()
 

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
@@ -19,7 +19,7 @@ import { SidebarGroupRow, SidebarRowLead, SidebarRowLink, SidebarRowStack } from
 import { rankSessions } from '../order'
 
 import { PROJECT_PREVIEW_COUNT, SIDEBAR_GROUP_PAGE, useWorkspaceNodeOpen } from './model'
-import type { SidebarSessionGroup } from './workspace-groups'
+import { isBranchTargetLane, type SidebarRepoGitKind, type SidebarSessionGroup } from './workspace-groups'
 import {
   WorkspaceAddButton,
   WorkspaceContextMenu,
@@ -29,6 +29,7 @@ import {
 } from './workspace-header'
 
 interface SidebarWorkspaceGroupProps {
+  gitKind?: SidebarRepoGitKind
   group: SidebarSessionGroup
   renderRows: (sessions: SessionInfo[]) => React.ReactNode
   onNewSession?: (path: null | string) => void
@@ -37,7 +38,13 @@ interface SidebarWorkspaceGroupProps {
   onRemove?: () => void
 }
 
-export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemove }: SidebarWorkspaceGroupProps) {
+export function SidebarWorkspaceGroup({
+  gitKind,
+  group,
+  renderRows,
+  onNewSession,
+  onRemove
+}: SidebarWorkspaceGroupProps) {
   const { t } = useI18n()
   const s = t.sidebar
   const isProfileGroup = group.mode === 'profile'
@@ -90,7 +97,7 @@ export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemov
     // Main-checkout lanes are branch-labeled views over the same repo root path.
     // Clicking "+" on `main` should open on `main`, not whatever branch the root
     // currently sits on (`test0`, etc.), so explicitly switch first.
-    if (group.isMain && group.path && group.label) {
+    if (isBranchTargetLane(group, gitKind) && group.path && group.label) {
       try {
         await switchBranchInRepo(group.path, group.label)
       } catch (err) {

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
@@ -14,7 +14,7 @@ import { SidebarRowStack } from '../chrome'
 import { SidebarLoadMoreRow } from '../load-more-row'
 
 import { SIDEBAR_GROUP_PAGE, useWorkspaceNodeOpen } from './model'
-import type { SidebarSessionGroup } from './workspace-groups'
+import { isBranchTargetLane, type SidebarRepoGitKind, type SidebarSessionGroup } from './workspace-groups'
 import {
   WorkspaceAddButton,
   WorkspaceContextMenu,
@@ -24,6 +24,7 @@ import {
 } from './workspace-header'
 
 interface SidebarWorkspaceGroupProps {
+  gitKind?: SidebarRepoGitKind
   group: SidebarSessionGroup
   renderRows: (sessions: SessionInfo[]) => React.ReactNode
   onNewSession?: (path: null | string) => void
@@ -32,7 +33,13 @@ interface SidebarWorkspaceGroupProps {
   onRemove?: () => void
 }
 
-export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemove }: SidebarWorkspaceGroupProps) {
+export function SidebarWorkspaceGroup({
+  gitKind,
+  group,
+  renderRows,
+  onNewSession,
+  onRemove
+}: SidebarWorkspaceGroupProps) {
   const { t } = useI18n()
   const s = t.sidebar
   const isProfileGroup = group.mode === 'profile'
@@ -96,7 +103,7 @@ export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemov
     // Main-checkout lanes are branch-labeled views over the same repo root path.
     // Clicking "+" on `main` should open on `main`, not whatever branch the root
     // currently sits on (`test0`, etc.), so explicitly switch first.
-    if (group.isMain && group.path && group.label) {
+    if (isBranchTargetLane(group, gitKind) && group.path && group.label) {
       try {
         await switchBranchInRepo(group.path, group.label)
       } catch (err) {

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -6,6 +6,7 @@ import type { ProjectInfo, SessionInfo } from '@/types/hermes'
 import {
   baseName,
   excludeProjectSessions,
+  isBranchTargetLane,
   kanbanWorktreeDir,
   liveSessionProjectId,
   mergeRepoWorktreeGroups,
@@ -623,11 +624,221 @@ describe('sessionProjectColor', () => {
 })
 
 describe('overlayLiveLanes', () => {
+  it('keeps a first live session in a seeded non-git project as a directory lane', () => {
+    const project = projectNode({
+      id: 'p_notes',
+      repos: [
+        {
+          id: '/work/notes',
+          gitKind: 'directory',
+          label: 'notes',
+          path: '/work/notes',
+          sessionCount: 0,
+          groups: []
+        }
+      ]
+    })
+
+    const overlaid = overlayLiveLanes(project, [makeSession('/work/notes', { id: 'fresh' })])
+    const optimistic = overlaid.repos[0].groups[0]
+
+    expect(optimistic).toMatchObject({
+      id: '/work/notes',
+      isMain: true,
+      label: 'notes',
+      path: '/work/notes'
+    })
+    expect(optimistic.id).not.toContain('::branch::')
+  })
+
+  it('uses a conservative directory lane for an empty legacy repo snapshot', () => {
+    const project = projectNode({
+      id: 'p_notes',
+      repos: [{ id: '/work/notes', label: 'notes', path: '/work/notes', sessionCount: 0, groups: [] }]
+    })
+
+    const overlaid = overlayLiveLanes(project, [makeSession('/work/notes', { id: 'fresh' })])
+    const optimistic = overlaid.repos[0].groups[0]
+
+    expect(optimistic).toMatchObject({ id: '/work/notes', label: 'notes', path: '/work/notes' })
+    expect(optimistic.id).not.toContain('::branch::')
+  })
+
+  it('uses git_repo_root to promote a fresh legacy snapshot to a branch lane', () => {
+    const project = projectNode({
+      id: '/repo',
+      repos: [{ id: '/repo', label: 'repo', path: '/repo', sessionCount: 0, groups: [] }]
+    })
+
+    const overlaid = overlayLiveLanes(project, [
+      makeSession('/repo', { git_branch: 'release', git_repo_root: '/repo', id: 'fresh' })
+    ])
+
+    expect(overlaid.repos[0].groups[0]).toMatchObject({
+      id: '/repo::branch::release',
+      label: 'release',
+      path: '/repo'
+    })
+  })
+
+  it('lets fresh session git metadata supersede a stale directory snapshot', () => {
+    const project = projectNode({
+      id: '/repo',
+      repos: [
+        {
+          id: '/repo',
+          gitKind: 'directory',
+          label: 'repo',
+          path: '/repo',
+          sessionCount: 0,
+          groups: []
+        }
+      ]
+    })
+
+    const overlaid = overlayLiveLanes(project, [
+      makeSession('/repo', { git_branch: 'main', git_repo_root: '/repo', id: 'fresh' })
+    ])
+
+    const repo = overlaid.repos[0]
+    const branchLane = repo.groups[0]
+
+    expect(repo.gitKind).toBe('git')
+    expect(branchLane.id).toBe('/repo::branch::main')
+    expect(isBranchTargetLane(branchLane, repo.gitKind)).toBe(true)
+  })
+
+  it('promotes repo capability when a matching git session joins an existing linked-worktree lane', () => {
+    const project = projectNode({
+      id: '/repo',
+      repos: [
+        {
+          id: '/repo',
+          gitKind: 'directory',
+          label: 'repo',
+          path: '/repo',
+          sessionCount: 0,
+          groups: [lane({ id: '/repo-linked', label: 'linked', path: '/repo-linked' })]
+        }
+      ]
+    })
+
+    const overlaid = overlayLiveLanes(project, [
+      makeSession('/repo-linked', { git_branch: 'linked', git_repo_root: '/repo', id: 'fresh' })
+    ])
+
+    const repo = overlaid.repos[0]
+
+    expect(repo.gitKind).toBe('git')
+    expect(repo.groups).toHaveLength(1)
+    expect(repo.groups[0].sessions.map(session => session.id)).toEqual(['fresh'])
+  })
+
+  it('only promotes the matching repo for a nested git session', () => {
+    const project = projectNode({
+      id: 'p_workspace',
+      repos: [
+        {
+          id: '/work',
+          gitKind: 'directory',
+          label: 'work',
+          path: '/work',
+          sessionCount: 0,
+          groups: []
+        },
+        {
+          id: '/work/app',
+          gitKind: 'directory',
+          label: 'app',
+          path: '/work/app',
+          sessionCount: 0,
+          groups: []
+        }
+      ]
+    })
+
+    const live = [makeSession('/work/app', { git_branch: 'feature/nested', git_repo_root: '/work/app', id: 'fresh' })]
+
+    const overlaid = overlayLiveLanes(project, live)
+    const parent = overlaid.repos.find(repo => repo.path === '/work')
+    const matching = overlaid.repos.find(repo => repo.path === '/work/app')
+
+    expect(parent?.groups).toEqual([])
+    expect(parent?.gitKind).toBe('directory')
+    expect(matching?.gitKind).toBe('git')
+    expect(matching?.groups).toHaveLength(1)
+    expect(matching?.groups[0]).toMatchObject({
+      id: '/work/app::branch::feature/nested',
+      label: 'feature/nested',
+      path: '/work/app',
+      sessions: [expect.objectContaining({ id: 'fresh' })]
+    })
+    expect(overlaid.sessionCount).toBe(1)
+  })
+
+  it('does not inject a nested repo session into a matching historical lane owned by its parent', () => {
+    const project = projectNode({
+      id: 'p_workspace',
+      repos: [
+        {
+          id: '/work',
+          gitKind: 'directory',
+          label: 'work',
+          path: '/work',
+          sessionCount: 1,
+          groups: [
+            lane({
+              id: '/work/app',
+              label: 'app',
+              path: '/work/app',
+              sessions: [makeSession('/work/app', { id: 'historical' })]
+            })
+          ]
+        },
+        {
+          id: '/work/app',
+          gitKind: 'directory',
+          label: 'app',
+          path: '/work/app',
+          sessionCount: 0,
+          groups: []
+        }
+      ]
+    })
+
+    const overlaid = overlayLiveLanes(project, [
+      makeSession('/work/app', { git_branch: 'feature/nested', git_repo_root: '/work/app', id: 'fresh' })
+    ])
+
+    const parent = overlaid.repos.find(repo => repo.path === '/work')
+    const child = overlaid.repos.find(repo => repo.path === '/work/app')
+
+    expect(parent?.gitKind).toBe('directory')
+    expect(parent?.groups).toHaveLength(1)
+    expect(parent?.groups[0].sessions.map(session => session.id)).toEqual(['historical'])
+    expect(child?.gitKind).toBe('git')
+    expect(child?.groups).toHaveLength(1)
+    expect(child?.groups[0]).toMatchObject({
+      id: '/work/app::branch::feature/nested',
+      sessions: [expect.objectContaining({ id: 'fresh' })]
+    })
+    expect(overlaid.sessionCount).toBe(2)
+  })
+
   it('injects a live session into the matching main lane instantly', () => {
     const project = projectNode({
       id: '/www/app',
       isAuto: true,
-      repos: [{ id: '/www/app', label: 'app', path: '/www/app', sessionCount: 0, groups: [] }]
+      repos: [
+        {
+          id: '/www/app',
+          gitKind: 'git',
+          label: 'app',
+          path: '/www/app',
+          sessionCount: 0,
+          groups: []
+        }
+      ]
     })
 
     const live = [makeSession('/www/app', { id: 'fresh', git_branch: 'main' })]
@@ -646,7 +857,16 @@ describe('overlayLiveLanes', () => {
     const project = projectNode({
       id: '/www/app',
       isAuto: true,
-      repos: [{ id: '/www/app', label: 'app', path: '/www/app', sessionCount: 0, groups: [] }]
+      repos: [
+        {
+          id: '/www/app',
+          gitKind: 'git',
+          label: 'app',
+          path: '/www/app',
+          sessionCount: 0,
+          groups: []
+        }
+      ]
     })
 
     const live = [makeSession('/www/app/.worktrees/baby', { id: 'fresh' })]
@@ -662,7 +882,16 @@ describe('overlayLiveLanes', () => {
     const project = projectNode({
       id: '/www/app',
       isAuto: true,
-      repos: [{ id: '/www/app', label: 'app', path: '/www/app', sessionCount: 0, groups: [] }]
+      repos: [
+        {
+          id: '/www/app',
+          gitKind: 'git',
+          label: 'app',
+          path: '/www/app',
+          sessionCount: 0,
+          groups: []
+        }
+      ]
     })
 
     const live = [makeSession('/www/app/.worktrees/t_abc12345', { id: 'k' })]

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -708,6 +708,33 @@ describe('overlayLiveLanes', () => {
     expect(isBranchTargetLane(branchLane, repo.gitKind)).toBe(true)
   })
 
+  it('uses live Git capability for every row when the snapshot is a stale directory', () => {
+    const project = projectNode({
+      id: '/repo',
+      repos: [
+        {
+          id: '/repo',
+          gitKind: 'directory',
+          label: 'repo',
+          path: '/repo',
+          sessionCount: 0,
+          groups: []
+        }
+      ]
+    })
+
+    const overlaid = overlayLiveLanes(project, [
+      makeSession('/repo', { git_branch: 'main', git_repo_root: '/repo', id: 'git-evidence' }),
+      makeSession('/repo', { git_branch: 'feature/fresh', id: 'fresh-without-root' })
+    ])
+
+    const repo = overlaid.repos[0]
+
+    expect(repo.gitKind).toBe('git')
+    expect(repo.groups.map(group => group.id)).toEqual(['/repo::branch::main', '/repo::branch::feature/fresh'])
+    expect(repo.groups.some(group => group.id === '/repo')).toBe(false)
+  })
+
   it('promotes repo capability when a matching git session joins an existing linked-worktree lane', () => {
     const project = projectNode({
       id: '/repo',

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -32,11 +32,17 @@ export interface SidebarSessionGroup {
   sourceId?: string
 }
 
+export type SidebarRepoGitKind = 'directory' | 'git'
+
 /** A repo node: holds its branch/worktree lanes (`repo -> lane -> sessions`). */
 export interface SidebarWorkspaceTree {
   id: string
   label: string
   path: null | string
+  // Backend-owned capability. Optional only for compatibility with runtimes
+  // predating this discriminator; each folder in a multi-folder project may
+  // differ, so this belongs on the repo node rather than the project.
+  gitKind?: SidebarRepoGitKind
   groups: SidebarSessionGroup[]
   sessionCount: number
 }
@@ -130,6 +136,32 @@ export const isDetachedSession = (session: SessionInfo): boolean =>
 /** The one definition of a main-checkout lane id (must match the backend tree). */
 export const branchLaneId = (repoRoot: string, branch?: string): string =>
   `${repoRoot}::branch::${(branch ?? '').trim()}`
+
+/** Whether clicking a lane targets a branch in the repo's main checkout. */
+export function isBranchTargetLane(group: SidebarSessionGroup, gitKind: SidebarRepoGitKind | undefined): boolean {
+  if (!group.isMain || group.isKanban) {
+    return false
+  }
+
+  if (gitKind === 'directory') {
+    return false
+  }
+
+  // Both current and legacy backends must supply the canonical branch-lane
+  // identity rooted at this lane's path. A repo can contain mixed historical
+  // evidence, so repo-level Git capability alone cannot promote a path-backed
+  // `isMain` fallback lane into a branch target.
+  const marker = '::branch::'
+  const markerAt = group.id.lastIndexOf(marker)
+  const branch = markerAt > 0 ? group.id.slice(markerAt + marker.length).trim() : ''
+
+  return Boolean(
+    group.path &&
+    markerAt > 0 &&
+    pathKey(group.id.slice(0, markerAt)) === pathKey(group.path) &&
+    branch === group.label.trim()
+  )
+}
 
 /** A session's recency stamp (last activity, falling back to creation). */
 export const sessionRecency = (session: SessionInfo): number => session.last_active || session.started_at || 0
@@ -452,17 +484,45 @@ const upsertSession = (rows: SessionInfo[], session: SessionInfo): SessionInfo[]
   [session, ...rows.filter(row => row.id !== session.id)].sort((a, b) => sessionRecency(b) - sessionRecency(a))
 
 /**
- * The lane a live session belongs to WITHIN a known repo root, by path — the
- * entered project already knows its repo roots, so we don't need the session's
- * (often-unset, on a fresh row) git_repo_root. Mirrors the backend's lane ids:
- * main checkout -> branch lane, `.worktrees/t_<hex>` -> kanban, any other
- * `.worktrees/<slug>` -> that worktree's own lane.
+ * The lane a live session belongs to WITHIN a known repo node. Git repos use
+ * branch/worktree identities; directory repos use the backend's path-backed
+ * fallback. A fresh row may not carry git metadata yet, so the repo capability
+ * is the baseline. When `git_repo_root` is present it is stronger, newer
+ * evidence when it identifies THIS repo (the directory may have been
+ * initialized after the snapshot) and also promotes snapshots from older
+ * backends that predate `gitKind`.
  */
-function liveLaneForRepo(repoRoot: string, session: SessionInfo): null | SidebarSessionGroup {
+function liveLaneForRepo(repo: SidebarWorkspaceTree, session: SessionInfo): null | SidebarSessionGroup {
+  const repoRoot = (repo.path || '').trim()
   const cwd = (session.cwd || '').trim()
 
   if (!cwd || !isPathUnder(repoRoot, cwd)) {
     return null
+  }
+
+  const sessionGitRoot = (session.git_repo_root || '').trim()
+  const hasMatchingGitRoot = Boolean(sessionGitRoot) && pathKey(sessionGitRoot) === pathKey(repoRoot)
+
+  // A nested repo's session also sits under each parent folder. Its explicit
+  // git root is ownership evidence: do not duplicate it into an enclosing
+  // directory/repo lane, nor use it to promote that parent to Git.
+  if (sessionGitRoot && !hasMatchingGitRoot) {
+    return null
+  }
+
+  const isGit =
+    repo.gitKind === 'git' ||
+    hasMatchingGitRoot ||
+    (repo.gitKind === undefined && repo.groups.some(group => isBranchTargetLane(group, undefined)))
+
+  if (!isGit) {
+    return {
+      id: repoRoot,
+      isMain: true,
+      label: baseName(repoRoot) || repo.label,
+      path: repoRoot,
+      sessions: []
+    }
   }
 
   const wt = cwd.match(/^(.*[/\\]\.worktrees)[/\\]([^/\\]+)/)
@@ -496,6 +556,15 @@ export function overlayRepoLanes(
   removed: ReadonlySet<string> = NO_REMOVED
 ): SidebarWorkspaceTree {
   const repoRootKey = pathKey(repo.path)
+
+  const effectiveGitKind = live.some(session => {
+    const sessionGitRoot = (session.git_repo_root || '').trim()
+
+    return !removed.has(session.id) && Boolean(sessionGitRoot) && pathKey(sessionGitRoot) === repoRootKey
+  })
+    ? 'git'
+    : repo.gitKind
+
   let changed = false
   // Lanes that arrived with no rows are not eviction casualties — they're real
   // structure (a `git worktree list` lane, or one whose sessions are pinned
@@ -519,6 +588,18 @@ export function overlayRepoLanes(
     const cwd = (session.cwd || '').trim()
 
     if (removed.has(session.id) || !cwd) {
+      continue
+    }
+
+    const sessionGitRoot = (session.git_repo_root || '').trim()
+
+    // Explicit git ownership is stronger than path containment. Apply it
+    // before matching existing lanes too: a parent directory may retain a
+    // historical lane whose path is now a nested repo, but that must not make
+    // the parent absorb the nested repo's fresh live session. Linked
+    // worktrees still pass because their git root is the owning repo root even
+    // when their cwd lives elsewhere.
+    if (sessionGitRoot && pathKey(sessionGitRoot) !== repoRootKey) {
       continue
     }
 
@@ -550,7 +631,7 @@ export function overlayRepoLanes(
     // key a worktree lane off the git-probed root OR a branch-style id), then
     // the main-lane label; create it when the snapshot lacked it.
     if (!lane) {
-      const placed = repo.path ? liveLaneForRepo(repo.path, session) : null
+      const placed = repo.path ? liveLaneForRepo(repo, session) : null
 
       if (!placed) {
         continue
@@ -604,14 +685,14 @@ export function overlayRepoLanes(
   }
 
   if (!changed) {
-    return repo
+    return effectiveGitKind === repo.gitKind ? repo : { ...repo, gitKind: effectiveGitKind }
   }
 
   // Drop lanes emptied by eviction (the server only emits non-empty lanes; the
   // git-worktree enhancer re-adds any still-real worktree as an empty lane).
   const groups = sortWorktreeGroups(lanes.filter(g => g.sessions.length > 0 || emptyOnInput.has(g.id)))
 
-  return { ...repo, groups, sessionCount: groups.reduce((n, g) => n + g.sessions.length, 0) }
+  return { ...repo, gitKind: effectiveGitKind, groups, sessionCount: groups.reduce((n, g) => n + g.sessions.length, 0) }
 }
 
 /**

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -565,6 +565,8 @@ export function overlayRepoLanes(
     ? 'git'
     : repo.gitKind
 
+  const placementRepo = effectiveGitKind === repo.gitKind ? repo : { ...repo, gitKind: effectiveGitKind }
+
   let changed = false
   // Lanes that arrived with no rows are not eviction casualties — they're real
   // structure (a `git worktree list` lane, or one whose sessions are pinned
@@ -631,7 +633,7 @@ export function overlayRepoLanes(
     // key a worktree lane off the git-probed root OR a branch-style id), then
     // the main-lane label; create it when the snapshot lacked it.
     if (!lane) {
-      const placed = repo.path ? liveLaneForRepo(repo, session) : null
+      const placed = repo.path ? liveLaneForRepo(placementRepo, session) : null
 
       if (!placed) {
         continue

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -36,11 +36,17 @@ export interface SidebarSessionGroup {
   hasMore?: boolean
 }
 
+export type SidebarRepoGitKind = 'directory' | 'git'
+
 /** A repo node: holds its branch/worktree lanes (`repo -> lane -> sessions`). */
 export interface SidebarWorkspaceTree {
   id: string
   label: string
   path: null | string
+  // Backend-owned capability. Optional only for compatibility with runtimes
+  // predating this discriminator; each folder in a multi-folder project may
+  // differ, so this belongs on the repo node rather than the project.
+  gitKind?: SidebarRepoGitKind
   groups: SidebarSessionGroup[]
   sessionCount: number
 }
@@ -130,6 +136,32 @@ export const isDetachedSession = (session: SessionInfo): boolean =>
 /** The one definition of a main-checkout lane id (must match the backend tree). */
 export const branchLaneId = (repoRoot: string, branch?: string): string =>
   `${repoRoot}::branch::${(branch ?? '').trim()}`
+
+/** Whether clicking a lane targets a branch in the repo's main checkout. */
+export function isBranchTargetLane(group: SidebarSessionGroup, gitKind: SidebarRepoGitKind | undefined): boolean {
+  if (!group.isMain || group.isKanban) {
+    return false
+  }
+
+  if (gitKind === 'directory') {
+    return false
+  }
+
+  // Both current and legacy backends must supply the canonical branch-lane
+  // identity rooted at this lane's path. A repo can contain mixed historical
+  // evidence, so repo-level Git capability alone cannot promote a path-backed
+  // `isMain` fallback lane into a branch target.
+  const marker = '::branch::'
+  const markerAt = group.id.lastIndexOf(marker)
+  const branch = markerAt > 0 ? group.id.slice(markerAt + marker.length).trim() : ''
+
+  return Boolean(
+    group.path &&
+    markerAt > 0 &&
+    pathKey(group.id.slice(0, markerAt)) === pathKey(group.path) &&
+    branch === group.label.trim()
+  )
+}
 
 /** A session's recency stamp (last activity, falling back to creation). */
 export const sessionRecency = (session: SessionInfo): number => session.last_active || session.started_at || 0
@@ -452,17 +484,45 @@ const upsertSession = (rows: SessionInfo[], session: SessionInfo): SessionInfo[]
   [session, ...rows.filter(row => row.id !== session.id)].sort((a, b) => b.started_at - a.started_at)
 
 /**
- * The lane a live session belongs to WITHIN a known repo root, by path — the
- * entered project already knows its repo roots, so we don't need the session's
- * (often-unset, on a fresh row) git_repo_root. Mirrors the backend's lane ids:
- * main checkout -> branch lane, `.worktrees/t_<hex>` -> kanban, any other
- * `.worktrees/<slug>` -> that worktree's own lane.
+ * The lane a live session belongs to WITHIN a known repo node. Git repos use
+ * branch/worktree identities; directory repos use the backend's path-backed
+ * fallback. A fresh row may not carry git metadata yet, so the repo capability
+ * is the baseline. When `git_repo_root` is present it is stronger, newer
+ * evidence when it identifies THIS repo (the directory may have been
+ * initialized after the snapshot) and also promotes snapshots from older
+ * backends that predate `gitKind`.
  */
-function liveLaneForRepo(repoRoot: string, session: SessionInfo): null | SidebarSessionGroup {
+function liveLaneForRepo(repo: SidebarWorkspaceTree, session: SessionInfo): null | SidebarSessionGroup {
+  const repoRoot = (repo.path || '').trim()
   const cwd = (session.cwd || '').trim()
 
   if (!cwd || !isPathUnder(repoRoot, cwd)) {
     return null
+  }
+
+  const sessionGitRoot = (session.git_repo_root || '').trim()
+  const hasMatchingGitRoot = Boolean(sessionGitRoot) && pathKey(sessionGitRoot) === pathKey(repoRoot)
+
+  // A nested repo's session also sits under each parent folder. Its explicit
+  // git root is ownership evidence: do not duplicate it into an enclosing
+  // directory/repo lane, nor use it to promote that parent to Git.
+  if (sessionGitRoot && !hasMatchingGitRoot) {
+    return null
+  }
+
+  const isGit =
+    repo.gitKind === 'git' ||
+    hasMatchingGitRoot ||
+    (repo.gitKind === undefined && repo.groups.some(group => isBranchTargetLane(group, undefined)))
+
+  if (!isGit) {
+    return {
+      id: repoRoot,
+      isMain: true,
+      label: baseName(repoRoot) || repo.label,
+      path: repoRoot,
+      sessions: []
+    }
   }
 
   const wt = cwd.match(/^(.*[/\\]\.worktrees)[/\\]([^/\\]+)/)
@@ -496,6 +556,15 @@ export function overlayRepoLanes(
   removed: ReadonlySet<string> = NO_REMOVED
 ): SidebarWorkspaceTree {
   const repoRootKey = pathKey(repo.path)
+
+  const effectiveGitKind = live.some(session => {
+    const sessionGitRoot = (session.git_repo_root || '').trim()
+
+    return !removed.has(session.id) && Boolean(sessionGitRoot) && pathKey(sessionGitRoot) === repoRootKey
+  })
+    ? 'git'
+    : repo.gitKind
+
   let changed = false
   // Lanes that arrived with no rows are not eviction casualties — they're real
   // structure (a `git worktree list` lane, or one whose sessions are pinned
@@ -519,6 +588,18 @@ export function overlayRepoLanes(
     const cwd = (session.cwd || '').trim()
 
     if (removed.has(session.id) || !cwd) {
+      continue
+    }
+
+    const sessionGitRoot = (session.git_repo_root || '').trim()
+
+    // Explicit git ownership is stronger than path containment. Apply it
+    // before matching existing lanes too: a parent directory may retain a
+    // historical lane whose path is now a nested repo, but that must not make
+    // the parent absorb the nested repo's fresh live session. Linked
+    // worktrees still pass because their git root is the owning repo root even
+    // when their cwd lives elsewhere.
+    if (sessionGitRoot && pathKey(sessionGitRoot) !== repoRootKey) {
       continue
     }
 
@@ -550,7 +631,7 @@ export function overlayRepoLanes(
     // key a worktree lane off the git-probed root OR a branch-style id), then
     // the main-lane label; create it when the snapshot lacked it.
     if (!lane) {
-      const placed = repo.path ? liveLaneForRepo(repo.path, session) : null
+      const placed = repo.path ? liveLaneForRepo(repo, session) : null
 
       if (!placed) {
         continue
@@ -576,14 +657,14 @@ export function overlayRepoLanes(
   }
 
   if (!changed) {
-    return repo
+    return effectiveGitKind === repo.gitKind ? repo : { ...repo, gitKind: effectiveGitKind }
   }
 
   // Drop lanes emptied by eviction (the server only emits non-empty lanes; the
   // git-worktree enhancer re-adds any still-real worktree as an empty lane).
   const groups = sortWorktreeGroups(lanes.filter(g => g.sessions.length > 0 || emptyOnInput.has(g.id)))
 
-  return { ...repo, groups, sessionCount: groups.reduce((n, g) => n + g.sessions.length, 0) }
+  return { ...repo, gitKind: effectiveGitKind, groups, sessionCount: groups.reduce((n, g) => n + g.sessions.length, 0) }
 }
 
 /**

--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -668,36 +668,26 @@ def test_colliding_repo_basenames_disambiguate_labels():
     assert labels == ["x/proj", "y/proj"]
 
 
-def test_non_git_folder_uses_branch_lane_id():
-    """#53329: _place_by_heuristic must use _branch_lane_id for non-git folders.
+def test_non_git_folder_keeps_path_lane_identity():
+    """A plain directory is not a branch target.
 
-    Before the fix, non-git folders got a lane key equal to the raw path,
-    while the desktop overlay expected ::branch::main. This caused duplicate
-    lanes (one from backend, one from overlay).
+    Its stable raw-path lane id lets the Desktop distinguish it from a Git
+    ``::branch::main`` lane and avoid attempting a meaningless branch switch
+    before creating a chat.
     """
     result = pt._place_by_heuristic("/home/user/my-project")
     assert result is not None
-    assert result["lane_key"] == pt._branch_lane_id(
-        "/home/user/my-project", pt.DEFAULT_BRANCH_LABEL
-    ), (
-        f"Expected lane_key to use _branch_lane_id scheme but got "
-        f"{result['lane_key']!r}"
-    )
-    # The label should still be the folder basename
+    assert result["lane_key"] == "/home/user/my-project"
     assert result["lane_label"] == "my-project"
-    # Must be marked as main lane
     assert result["is_main"] is True
+    assert result["git_kind"] == "directory"
 
 
-def test_non_git_folder_lane_matches_overlay_scheme():
-    """#53329: verify the lane key format matches what the overlay expects."""
+def test_non_git_folder_never_claims_a_branch_lane_id():
     result = pt._place_by_heuristic("/data/work/folder-x")
     assert result is not None
-    # Overlay expects: <path>::branch::main
-    expected = "/data/work/folder-x::branch::main"
-    assert result["lane_key"] == expected, (
-        f"Expected lane_key={expected!r} but got {result['lane_key']!r}"
-    )
+    assert result["lane_key"] == "/data/work/folder-x"
+    assert result["lane_key"] != "/data/work/folder-x::branch::main"
 
 
 def test_heuristic_lane_ids_for_kanban_and_wt_suffix_are_unchanged():

--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -96,6 +96,7 @@ def test_main_checkout_groups_by_recorded_branch_with_stable_lane_ids():
     # Trunk sorts ahead of the feature branch; both live in the main checkout.
     assert [g["label"] for repo in project["repos"] for g in repo["groups"]] == ["main", "feature"]
     assert all(g["isMain"] for repo in project["repos"] for g in repo["groups"])
+    assert project["repos"][0]["gitKind"] == "git"
 
 
 def test_linked_worktrees_fold_under_their_common_repo_root():
@@ -280,6 +281,27 @@ def test_persisted_repo_root_used_when_no_live_probe():
     project = next(p for p in tree["projects"] if p["id"] == "/repo")
 
     assert _lane_ids(project) == ["/repo::branch::main"]
+    assert project["repos"][0]["gitKind"] == "git"
+
+
+def test_persisted_git_evidence_promotes_a_repo_without_relabeling_path_fallback_lanes():
+    # Historical rows may disagree: one has only a cwd (path fallback), while a
+    # newer row persisted the common git root. Repo capability becomes Git, but
+    # the old path lane keeps its non-branch identity so the renderer cannot
+    # mistake its directory basename for a branch target.
+    sessions = [
+        _session("/repo"),
+        _session("/repo/src", branch="main", repo_root="/repo"),
+    ]
+
+    tree = pt.build_tree([], sessions, [], resolve=None, hydrate=True)
+    repo = tree["projects"][0]["repos"][0]
+
+    assert repo["gitKind"] == "git"
+    assert {group["id"] for group in repo["groups"]} == {
+        "/repo",
+        "/repo::branch::main",
+    }
 
 
 def test_non_git_cwd_preserves_legacy_workspace_grouping():
@@ -295,9 +317,8 @@ def test_non_git_cwd_preserves_legacy_workspace_grouping():
     assert project["isAuto"] is True
     assert project["label"] == "notes"
     assert project["sessionCount"] == 1
-    # Branch-style lane id (#53329): keying this lane by the raw path used to
-    # fork a duplicate lane against the live overlay's `::branch::main` id.
-    assert _lane_ids(project) == ["/work/notes::branch::main"]
+    assert _lane_ids(project) == ["/work/notes"]
+    assert project["repos"][0]["gitKind"] == "directory"
     assert tree["scoped_session_ids"] == [legacy["id"]]
 
 
@@ -418,9 +439,36 @@ def test_discovered_repo_with_no_sessions_becomes_zero_session_project():
     fresh = next(p for p in tree["projects"] if p["id"] == "/www/fresh")
     assert fresh["isAuto"] is True
     assert fresh["sessionCount"] == 0
+    assert fresh["repos"][0]["gitKind"] == "git"
     assert fresh["repos"][0]["groups"] == []
 
 
+def test_explicit_project_with_no_sessions_seeds_its_folders_as_repos():
+    # A brand-new (or unloaded) project must still expose its declared folders as
+    # repos so the entered view renders and the desktop's optimistic overlay has a
+    # lane to place a freshly-created session into (otherwise it only shows after a
+    # full tree refresh).
+    project = _project("p_new", "New", ["/work/blank"])
+
+    tree = pt.build_tree([project], [], [], resolve=None, hydrate=True)
+
+    node = next(p for p in tree["projects"] if p["id"] == "p_new")
+    assert node["sessionCount"] == 0
+    assert [r["path"] for r in node["repos"]] == ["/work/blank"]
+    assert node["repos"][0]["groups"] == []
+
+
+def test_seeded_project_folders_report_git_capability_from_the_live_probe():
+    project = _project("p_mixed", "Mixed", ["/work/app", "/work/notes"])
+    resolve = _resolver({"/work/app": ("/work/app", "/work/app")})
+
+    tree = pt.build_tree([project], [], [], resolve, hydrate=True)
+
+    node = next(p for p in tree["projects"] if p["id"] == "p_mixed")
+    assert {repo["path"]: repo["gitKind"] for repo in node["repos"]} == {
+        "/work/app": "git",
+        "/work/notes": "directory",
+    }
 def test_seeded_folder_repo_does_not_duplicate_a_session_derived_repo():
     # When a folder already has sessions (same git root), seeding must not add a
     # second repo for the same path.

--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -304,6 +304,25 @@ def test_persisted_git_evidence_promotes_a_repo_without_relabeling_path_fallback
     }
 
 
+def test_persisted_git_evidence_promotes_existing_heuristic_lane_without_relabeling():
+    # Both rows collapse to the same kanban lane. The first creates it from a
+    # path-only heuristic; the later persisted root must upgrade that existing
+    # entry's capability without replacing its stable lane identity.
+    sessions = [
+        _session("/repo/.worktrees/t_aaaaaaaa"),
+        _session("/repo/.worktrees/t_bbbbbbbb", repo_root="/repo"),
+    ]
+
+    tree = pt.build_tree([], sessions, [], resolve=None, hydrate=True)
+    repo = tree["projects"][0]["repos"][0]
+
+    assert repo["gitKind"] == "git"
+    assert len(repo["groups"]) == 1
+    assert repo["groups"][0]["id"] == "/repo::kanban"
+    assert repo["groups"][0]["label"] == "kanban"
+    assert len(repo["groups"][0]["sessions"]) == 2
+
+
 def test_non_git_cwd_preserves_legacy_workspace_grouping():
     # Before first-class Projects, every non-empty session cwd appeared as a
     # workspace even when it was not a git repo. Historical sessions must keep

--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -222,6 +222,25 @@ def test_persisted_git_evidence_promotes_a_repo_without_relabeling_path_fallback
     }
 
 
+def test_persisted_git_evidence_promotes_existing_heuristic_lane_without_relabeling():
+    # Both rows collapse to the same kanban lane. The first creates it from a
+    # path-only heuristic; the later persisted root must upgrade that existing
+    # entry's capability without replacing its stable lane identity.
+    sessions = [
+        _session("/repo/.worktrees/t_aaaaaaaa"),
+        _session("/repo/.worktrees/t_bbbbbbbb", repo_root="/repo"),
+    ]
+
+    tree = pt.build_tree([], sessions, [], resolve=None, hydrate=True)
+    repo = tree["projects"][0]["repos"][0]
+
+    assert repo["gitKind"] == "git"
+    assert len(repo["groups"]) == 1
+    assert repo["groups"][0]["id"] == "/repo::kanban"
+    assert repo["groups"][0]["label"] == "kanban"
+    assert len(repo["groups"][0]["sessions"]) == 2
+
+
 def test_non_git_cwd_preserves_legacy_workspace_grouping():
     # Before first-class Projects, every non-empty session cwd appeared as a
     # workspace even when it was not a git repo. Historical sessions must keep

--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -96,6 +96,7 @@ def test_main_checkout_groups_by_recorded_branch_with_stable_lane_ids():
     # Trunk sorts ahead of the feature branch; both live in the main checkout.
     assert [g["label"] for repo in project["repos"] for g in repo["groups"]] == ["main", "feature"]
     assert all(g["isMain"] for repo in project["repos"] for g in repo["groups"])
+    assert project["repos"][0]["gitKind"] == "git"
 
 
 def test_linked_worktrees_fold_under_their_common_repo_root():
@@ -198,6 +199,27 @@ def test_persisted_repo_root_used_when_no_live_probe():
     project = next(p for p in tree["projects"] if p["id"] == "/repo")
 
     assert _lane_ids(project) == ["/repo::branch::main"]
+    assert project["repos"][0]["gitKind"] == "git"
+
+
+def test_persisted_git_evidence_promotes_a_repo_without_relabeling_path_fallback_lanes():
+    # Historical rows may disagree: one has only a cwd (path fallback), while a
+    # newer row persisted the common git root. Repo capability becomes Git, but
+    # the old path lane keeps its non-branch identity so the renderer cannot
+    # mistake its directory basename for a branch target.
+    sessions = [
+        _session("/repo"),
+        _session("/repo/src", branch="main", repo_root="/repo"),
+    ]
+
+    tree = pt.build_tree([], sessions, [], resolve=None, hydrate=True)
+    repo = tree["projects"][0]["repos"][0]
+
+    assert repo["gitKind"] == "git"
+    assert {group["id"] for group in repo["groups"]} == {
+        "/repo",
+        "/repo::branch::main",
+    }
 
 
 def test_non_git_cwd_preserves_legacy_workspace_grouping():
@@ -214,6 +236,7 @@ def test_non_git_cwd_preserves_legacy_workspace_grouping():
     assert project["label"] == "notes"
     assert project["sessionCount"] == 1
     assert _lane_ids(project) == ["/work/notes"]
+    assert project["repos"][0]["gitKind"] == "directory"
     assert tree["scoped_session_ids"] == [legacy["id"]]
 
 
@@ -334,9 +357,36 @@ def test_discovered_repo_with_no_sessions_becomes_zero_session_project():
     fresh = next(p for p in tree["projects"] if p["id"] == "/www/fresh")
     assert fresh["isAuto"] is True
     assert fresh["sessionCount"] == 0
+    assert fresh["repos"][0]["gitKind"] == "git"
     assert fresh["repos"][0]["groups"] == []
 
 
+def test_explicit_project_with_no_sessions_seeds_its_folders_as_repos():
+    # A brand-new (or unloaded) project must still expose its declared folders as
+    # repos so the entered view renders and the desktop's optimistic overlay has a
+    # lane to place a freshly-created session into (otherwise it only shows after a
+    # full tree refresh).
+    project = _project("p_new", "New", ["/work/blank"])
+
+    tree = pt.build_tree([project], [], [], resolve=None, hydrate=True)
+
+    node = next(p for p in tree["projects"] if p["id"] == "p_new")
+    assert node["sessionCount"] == 0
+    assert [r["path"] for r in node["repos"]] == ["/work/blank"]
+    assert node["repos"][0]["groups"] == []
+
+
+def test_seeded_project_folders_report_git_capability_from_the_live_probe():
+    project = _project("p_mixed", "Mixed", ["/work/app", "/work/notes"])
+    resolve = _resolver({"/work/app": ("/work/app", "/work/app")})
+
+    tree = pt.build_tree([project], [], [], resolve, hydrate=True)
+
+    node = next(p for p in tree["projects"] if p["id"] == "p_mixed")
+    assert {repo["path"]: repo["gitKind"] for repo in node["repos"]} == {
+        "/work/app": "git",
+        "/work/notes": "directory",
+    }
 def test_seeded_folder_repo_does_not_duplicate_a_session_derived_repo():
     # When a folder already has sessions (same git root), seeding must not add a
     # second repo for the same path.

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -262,7 +262,7 @@ def _place(cwd: str, branch: str, resolve: Optional[Resolve], persisted_root: st
     sibling_root = _probe_sibling_worktree(cwd, resolve) if resolve else ""
     if sibling_root:
         b = (branch or "").strip() or DEFAULT_BRANCH_LABEL
-        return _placement(sibling_root, _branch_lane_id(sibling_root, b), b, sibling_root, True, False)
+        return _placement(sibling_root, _branch_lane_id(sibling_root, b), b, sibling_root, True, False, True)
 
     return _place_by_heuristic(cwd)
 
@@ -372,6 +372,8 @@ def _build_repos(sessions: list[dict], resolve: Optional[Resolve], hydrate: bool
                 "git_kind": placement["git_kind"],
             }
             lanes[lane_identity] = entry
+        elif placement["git_kind"] == "git":
+            entry["git_kind"] = "git"
         entry["group"]["sessions"].append(session)
 
     repos: dict[str, dict] = {}

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -154,6 +154,7 @@ def _placement(
     lane_path: str,
     is_main: bool,
     is_kanban: bool,
+    is_git: bool,
 ) -> dict:
     return {
         "repo_key": repo_root,
@@ -164,6 +165,7 @@ def _placement(
         "lane_path": lane_path,
         "is_main": is_main,
         "is_kanban": is_kanban,
+        "git_kind": "git" if is_git else "directory",
     }
 
 
@@ -214,14 +216,14 @@ def _place_by_heuristic(path: str) -> Optional[dict]:
     kanban_dir = kanban_worktree_dir(path)
     if kanban_dir:
         repo_path = re.sub(r"[/\\]+$", "", _with_base_name(kanban_dir, ""))
-        return _placement(repo_path, _kanban_lane_id(repo_path), "kanban", kanban_dir, False, True)
+        return _placement(repo_path, _kanban_lane_id(repo_path), "kanban", kanban_dir, False, True, False)
 
     m = re.match(r"^(.+)-wt-(.+)$", base)
     if m:
         repo_path = _with_base_name(path, m.group(1))
-        return _placement(repo_path, path, m.group(2), path, False, False)
+        return _placement(repo_path, path, m.group(2), path, False, False, False)
 
-    return _placement(path, _branch_lane_id(path, DEFAULT_BRANCH_LABEL), base, path, True, False)
+    return _placement(path, path, base, path, True, False, False)
 
 
 def _place(cwd: str, branch: str, resolve: Optional[Resolve], persisted_root: str) -> Optional[dict]:
@@ -236,23 +238,23 @@ def _place(cwd: str, branch: str, resolve: Optional[Resolve], persisted_root: st
             # Unrecorded branch folds into the one trunk lane, so a repo never
             # shows two "main" lanes (recorded "main" + the empty-branch bucket).
             b = (branch or "").strip() or DEFAULT_BRANCH_LABEL
-            return _placement(repo_root, _branch_lane_id(repo_root, b), b, repo_root, True, False)
+            return _placement(repo_root, _branch_lane_id(repo_root, b), b, repo_root, True, False, True)
 
         kanban_dir = kanban_worktree_dir(worktree_root)
         if kanban_dir:
-            return _placement(repo_root, _kanban_lane_id(repo_root), "kanban", kanban_dir, False, True)
+            return _placement(repo_root, _kanban_lane_id(repo_root), "kanban", kanban_dir, False, True, True)
 
         label = base_name(worktree_root) or worktree_root
-        return _placement(repo_root, worktree_root, label, worktree_root, False, False)
+        return _placement(repo_root, worktree_root, label, worktree_root, False, False, True)
 
     # No live probe: trust the backend-persisted root (group by it, split main by
     # the session's recorded branch). Kanban tasks still collapse by path shape.
     if persisted_root:
         kanban_dir = kanban_worktree_dir(cwd)
         if kanban_dir:
-            return _placement(persisted_root, _kanban_lane_id(persisted_root), "kanban", kanban_dir, False, True)
+            return _placement(persisted_root, _kanban_lane_id(persisted_root), "kanban", kanban_dir, False, True, True)
         b = (branch or "").strip() or DEFAULT_BRANCH_LABEL
-        return _placement(persisted_root, _branch_lane_id(persisted_root, b), b, persisted_root, True, False)
+        return _placement(persisted_root, _branch_lane_id(persisted_root, b), b, persisted_root, True, False, True)
 
     # Unresolvable cwd: a deleted ``<repo>-<suffix>`` worktree still belongs to
     # its parent. It has no checkout to return to, so absorb it into the trunk
@@ -367,6 +369,7 @@ def _build_repos(sessions: list[dict], resolve: Optional[Resolve], hydrate: bool
                 "repo_key": placement["repo_key"],
                 "repo_label": placement["repo_label"],
                 "repo_path": placement["repo_path"],
+                "git_kind": placement["git_kind"],
             }
             lanes[lane_identity] = entry
         entry["group"]["sessions"].append(session)
@@ -384,10 +387,15 @@ def _build_repos(sessions: list[dict], resolve: Optional[Resolve], hydrate: bool
                 "id": entry["repo_key"],
                 "label": entry["repo_label"],
                 "path": entry["repo_path"],
+                "gitKind": entry["git_kind"],
                 "groups": [],
                 "sessionCount": 0,
             }
             repos[repo_identity] = repo
+        elif entry["git_kind"] == "git":
+            # A persisted/live git placement is stronger evidence than a
+            # path-only heuristic if historical rows happen to share a root.
+            repo["gitKind"] = "git"
         repo["groups"].append(group)
         repo["sessionCount"] += count
 
@@ -440,7 +448,16 @@ def _seed_folder_repos(
         root_key = _path_key(root)
         if not root_key or root_key in seen:
             continue
-        seeded.append({"id": root, "label": base_name(root) or root, "path": root, "groups": [], "sessionCount": 0})
+        seeded.append(
+            {
+                "id": root,
+                "label": base_name(root) or root,
+                "path": root,
+                "gitKind": "git" if info and info.get("repo_root") else "directory",
+                "groups": [],
+                "sessionCount": 0,
+            }
+        )
         seen.add(root_key)
 
     if len(seeded) != len(repos):
@@ -739,7 +756,16 @@ def build_tree(
                 pid=root,
                 label=label,
                 path=root,
-                repos=[{"id": root, "label": label, "path": root, "groups": [], "sessionCount": 0}],
+                repos=[
+                    {
+                        "id": root,
+                        "label": label,
+                        "path": root,
+                        "gitKind": "git",
+                        "groups": [],
+                        "sessionCount": 0,
+                    }
+                ],
                 session_count=int(repo.get("sessions") or 0),
                 last_active=float(repo.get("last_active") or 0),
                 preview_sessions=[],

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -154,6 +154,7 @@ def _placement(
     lane_path: str,
     is_main: bool,
     is_kanban: bool,
+    is_git: bool,
 ) -> dict:
     return {
         "repo_key": repo_root,
@@ -164,6 +165,7 @@ def _placement(
         "lane_path": lane_path,
         "is_main": is_main,
         "is_kanban": is_kanban,
+        "git_kind": "git" if is_git else "directory",
     }
 
 
@@ -214,14 +216,14 @@ def _place_by_heuristic(path: str) -> Optional[dict]:
     kanban_dir = kanban_worktree_dir(path)
     if kanban_dir:
         repo_path = re.sub(r"[/\\]+$", "", _with_base_name(kanban_dir, ""))
-        return _placement(repo_path, _kanban_lane_id(repo_path), "kanban", kanban_dir, False, True)
+        return _placement(repo_path, _kanban_lane_id(repo_path), "kanban", kanban_dir, False, True, False)
 
     m = re.match(r"^(.+)-wt-(.+)$", base)
     if m:
         repo_path = _with_base_name(path, m.group(1))
-        return _placement(repo_path, path, m.group(2), path, False, False)
+        return _placement(repo_path, path, m.group(2), path, False, False, False)
 
-    return _placement(path, path, base, path, True, False)
+    return _placement(path, path, base, path, True, False, False)
 
 
 def _place(cwd: str, branch: str, resolve: Optional[Resolve], persisted_root: str) -> Optional[dict]:
@@ -236,23 +238,23 @@ def _place(cwd: str, branch: str, resolve: Optional[Resolve], persisted_root: st
             # Unrecorded branch folds into the one trunk lane, so a repo never
             # shows two "main" lanes (recorded "main" + the empty-branch bucket).
             b = (branch or "").strip() or DEFAULT_BRANCH_LABEL
-            return _placement(repo_root, _branch_lane_id(repo_root, b), b, repo_root, True, False)
+            return _placement(repo_root, _branch_lane_id(repo_root, b), b, repo_root, True, False, True)
 
         kanban_dir = kanban_worktree_dir(worktree_root)
         if kanban_dir:
-            return _placement(repo_root, _kanban_lane_id(repo_root), "kanban", kanban_dir, False, True)
+            return _placement(repo_root, _kanban_lane_id(repo_root), "kanban", kanban_dir, False, True, True)
 
         label = base_name(worktree_root) or worktree_root
-        return _placement(repo_root, worktree_root, label, worktree_root, False, False)
+        return _placement(repo_root, worktree_root, label, worktree_root, False, False, True)
 
     # No live probe: trust the backend-persisted root (group by it, split main by
     # the session's recorded branch). Kanban tasks still collapse by path shape.
     if persisted_root:
         kanban_dir = kanban_worktree_dir(cwd)
         if kanban_dir:
-            return _placement(persisted_root, _kanban_lane_id(persisted_root), "kanban", kanban_dir, False, True)
+            return _placement(persisted_root, _kanban_lane_id(persisted_root), "kanban", kanban_dir, False, True, True)
         b = (branch or "").strip() or DEFAULT_BRANCH_LABEL
-        return _placement(persisted_root, _branch_lane_id(persisted_root, b), b, persisted_root, True, False)
+        return _placement(persisted_root, _branch_lane_id(persisted_root, b), b, persisted_root, True, False, True)
 
     # Unresolvable cwd: a deleted ``<repo>-<suffix>`` worktree still belongs to
     # its parent. It has no checkout to return to, so absorb it into the trunk
@@ -367,6 +369,7 @@ def _build_repos(sessions: list[dict], resolve: Optional[Resolve], hydrate: bool
                 "repo_key": placement["repo_key"],
                 "repo_label": placement["repo_label"],
                 "repo_path": placement["repo_path"],
+                "git_kind": placement["git_kind"],
             }
             lanes[lane_identity] = entry
         entry["group"]["sessions"].append(session)
@@ -386,10 +389,15 @@ def _build_repos(sessions: list[dict], resolve: Optional[Resolve], hydrate: bool
                 "id": entry["repo_key"],
                 "label": entry["repo_label"],
                 "path": entry["repo_path"],
+                "gitKind": entry["git_kind"],
                 "groups": [],
                 "sessionCount": 0,
             }
             repos[repo_identity] = repo
+        elif entry["git_kind"] == "git":
+            # A persisted/live git placement is stronger evidence than a
+            # path-only heuristic if historical rows happen to share a root.
+            repo["gitKind"] = "git"
         repo["groups"].append(group)
         repo["sessionCount"] += count
 
@@ -433,7 +441,16 @@ def _seed_folder_repos(
         root_key = _path_key(root)
         if not root_key or root_key in seen:
             continue
-        seeded.append({"id": root, "label": base_name(root) or root, "path": root, "groups": [], "sessionCount": 0})
+        seeded.append(
+            {
+                "id": root,
+                "label": base_name(root) or root,
+                "path": root,
+                "gitKind": "git" if info and info.get("repo_root") else "directory",
+                "groups": [],
+                "sessionCount": 0,
+            }
+        )
         seen.add(root_key)
 
     if len(seeded) != len(repos):
@@ -715,7 +732,16 @@ def build_tree(
                 pid=root,
                 label=label,
                 path=root,
-                repos=[{"id": root, "label": label, "path": root, "groups": [], "sessionCount": 0}],
+                repos=[
+                    {
+                        "id": root,
+                        "label": label,
+                        "path": root,
+                        "gitKind": "git",
+                        "groups": [],
+                        "sessionCount": 0,
+                    }
+                ],
                 session_count=int(repo.get("sessions") or 0),
                 last_active=float(repo.get("last_active") or 0),
                 preview_sessions=[],


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop failure when creating another chat in a Project backed by a normal, non-Git directory.

The project tree's path-only fallback lanes are marked `isMain`, but they aren't Git branches. The renderer previously treated every `isMain` lane as branch-switchable, so `git switch` failed with `fatal: not a git repository` and blocked chat creation.

This change adds an explicit repo-level Git capability to the project tree and only switches branches for canonical Git branch lanes. It preserves real Git switch-before-create behavior and visible switch errors, while keeping path-backed directory lanes branch-free. The optimistic live-session overlay also carries and updates this capability without duplicating nested repositories into parent directory lanes.

## Related Issue

Fixes #68192

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add repo-level `gitKind` metadata to backend project-tree snapshots.
- Keep non-Git directory lanes path-backed and skip branch switching for them.
- Require canonical branch lane identity before switching a real Git checkout.
- Preserve compatibility with legacy backend snapshots.
- Promote stale optimistic snapshots only from matching `git_repo_root` evidence.
- Prevent nested Git sessions from being absorbed by a parent directory's historical lane.
- Add backend, overlay, and full React click-path regression coverage.

## How to Test

1. Create a Desktop Project whose folder is not a Git repository.
2. Create the first chat in that Project.
3. Click **New session** in the resulting directory lane.
4. Confirm the new chat opens without `hermes:git:branchSwitch` or `fatal: not a git repository`.
5. In a real Git Project, confirm a canonical branch lane still switches to its branch before creating the session, and a real switch failure still blocks creation with an error.

Automated verification performed:

- Full Desktop UI suite under Node 22: 208 files, 1725 passed, 1 skipped.
- Targeted Desktop UI: 2 files, 61 passed.
- Targeted Python project-tree/RPC tests: 45 passed.
- Desktop TypeScript typecheck passed.
- Ruff, ESLint, Prettier, and `git diff --check` passed.

A local full `scripts/run_tests.sh` attempt was not clean because this machine lacks the optional `acp` module and has proxy/macOS-specific unrelated failures (including localhost traffic using a SOCKS proxy and `/tmp` vs `/private/tmp`). No failure involved the changed project-tree/sidebar code; the targeted Python tests pass.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing PRs and found no duplicate.
- [x] My PR contains only changes related to this bug fix.
- [ ] I've run `pytest tests/ -q` and all tests pass locally (see environment note above).
- [x] I've added tests for the bug fix.
- [x] I've tested the automated suite on macOS 26.3 arm64.

### Documentation & Housekeeping

- [x] Documentation update: N/A — no user-facing API or configuration change.
- [x] `cli-config.yaml.example` update: N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A.
- [x] Cross-platform impact considered: path identity retains existing POSIX/Windows normalization behavior.
- [x] Tool descriptions/schemas update: N/A.
