### PR TITLE
feat(plugins): user-defined tools via ~/.hermes/tools/*.yaml

### DIFF
--- a/plugins/yaml_tools/README.md
+++ b/plugins/yaml_tools/README.md
@@ -1,0 +1,79 @@
+# yaml_tools — user-defined tools via YAML
+
+Define your own agent tools by dropping a YAML file in `~/.hermes/tools/`. No
+Python plugin required. Each file defines one tool that appears in the agent's
+`custom` toolset alongside the built-ins.
+
+This is the lightweight middle ground between **skills** (markdown instructions
+that only *describe* how to use existing tools) and **plugins** (full Python
+packages). A YAML tool is a real, callable, schema-typed tool.
+
+## Example
+
+```yaml
+# ~/.hermes/tools/my_search.yaml
+name: my_search
+description: "Search my internal documentation"
+command: 'curl -s "https://internal-docs/search?q=$QUERY"'
+parameters:
+  query:
+    type: string
+    description: "Search query"
+    required: true
+timeout: 60          # optional, seconds (default 60, capped at 600)
+```
+
+The agent can now call `my_search(query="onboarding")`.
+
+## File format
+
+One file per tool. Extension `.yaml` or `.yml`.
+
+| Key | Required | Meaning |
+| --- | --- | --- |
+| `name` | yes | Tool name the model calls. Letters, digits, underscores; must start with a letter or underscore. |
+| `description` | recommended | What the tool does (shown to the model). |
+| `command` | yes | Shell command run with `bash -c`. Reference parameters as environment variables (see below). |
+| `parameters` | no | Mapping of parameter name → spec. |
+| `timeout` | no | Max seconds the command may run (default `60`, capped at `600`). |
+
+Each parameter spec accepts:
+
+| Key | Meaning |
+| --- | --- |
+| `type` | `string` (default), `number`, `integer`, or `boolean`. |
+| `description` | Shown to the model. |
+| `required` | `true` to mark the parameter required. |
+| `enum` | Optional list of allowed values. |
+
+## How parameters reach the command
+
+Each supplied parameter value is exported to the command's environment under
+**both** its exact name and its upper-cased name, so a parameter `query` is
+available as `$query` and `$QUERY`. Booleans are rendered as `true` / `false`.
+
+```yaml
+command: 'echo "greeting is $greeting"'   # $greeting or $GREETING both work
+```
+
+## Security
+
+Parameter **values** supplied by the model are passed as environment variables,
+never interpolated into the command string. bash does not re-parse the result
+of a variable expansion for command substitution, so a value such as
+`$(rm -rf ~)` or `"; rm -rf ~ ; "` is treated as a literal string and never
+executed. The command **template** itself is authored by you (trusted); only
+the argument values come from the model.
+
+Quote your expansions (`"$QUERY"`, not `$QUERY`) to also avoid word-splitting
+and globbing on values that contain spaces or shell glob characters.
+
+## Behaviour notes
+
+- Files are discovered at startup. Add/change a file, then restart Hermes.
+- A malformed file is logged and skipped — it never breaks startup.
+- A tool whose `name` collides with a built-in is skipped (built-ins are never
+  overridden).
+- The `custom` toolset is part of the default set; disable it like any other
+  toolset if you don't want user tools loaded.
+- `bash` must be available on `PATH`.

--- a/plugins/yaml_tools/README.md
+++ b/plugins/yaml_tools/README.md
@@ -14,7 +14,7 @@ packages). A YAML tool is a real, callable, schema-typed tool.
 # ~/.hermes/tools/my_search.yaml
 name: my_search
 description: "Search my internal documentation"
-command: 'curl -s "https://internal-docs/search?q=$QUERY"'
+command: 'curl -s "https://internal-docs/search?q=$HERMES_TOOL_ARG_QUERY"'
 parameters:
   query:
     type: string
@@ -33,7 +33,7 @@ One file per tool. Extension `.yaml` or `.yml`.
 | --- | --- | --- |
 | `name` | yes | Tool name the model calls. Letters, digits, underscores; must start with a letter or underscore. |
 | `description` | recommended | What the tool does (shown to the model). |
-| `command` | yes | Shell command run with `bash -c`. Reference parameters as environment variables (see below). |
+| `command` | yes | Shell command run by the configured terminal backend. Reference parameters as `HERMES_TOOL_ARG_*` variables (see below). |
 | `parameters` | no | Mapping of parameter name → spec. |
 | `timeout` | no | Max seconds the command may run (default `60`, capped at `600`). |
 
@@ -48,32 +48,48 @@ Each parameter spec accepts:
 
 ## How parameters reach the command
 
-Each supplied parameter value is exported to the command's environment under
-**both** its exact name and its upper-cased name, so a parameter `query` is
-available as `$query` and `$QUERY`. Booleans are rendered as `true` / `false`.
+Each declared parameter is exported under the dedicated, upper-cased
+`HERMES_TOOL_ARG_<NAME>` namespace. A parameter named `query` is therefore
+available as `$HERMES_TOOL_ARG_QUERY`; booleans are rendered as `true` /
+`false`. An omitted optional parameter is exported as an empty string.
 
 ```yaml
-command: 'echo "greeting is $greeting"'   # $greeting or $GREETING both work
+command: 'echo "greeting is $HERMES_TOOL_ARG_GREETING"'
+```
+
+The dedicated prefix prevents model arguments such as `path` from replacing
+ambient variables such as `PATH`. Environment variables and API keys made
+available by the selected terminal backend remain accessible under their
+original names:
+
+```yaml
+command: 'curl -H "Authorization: Bearer $INTERNAL_API_KEY" \
+  "https://example.test/search?q=$HERMES_TOOL_ARG_QUERY"'
 ```
 
 ## Security
 
-Parameter **values** supplied by the model are passed as environment variables,
-never interpolated into the command string. bash does not re-parse the result
-of a variable expansion for command substitution, so a value such as
-`$(rm -rf ~)` or `"; rm -rf ~ ; "` is treated as a literal string and never
-executed. The command **template** itself is authored by you (trusted); only
-the argument values come from the model.
+Parameter values are shell-quoted into environment assignments inside an
+isolated subshell. A value such as `$(touch /tmp/example)` or `"; echo bad"`
+therefore remains data instead of becoming extra shell syntax. The complete
+wrapper then runs through the normal `terminal` tool, including its configured
+local/container/SSH backend, command approval checks, bounded output capture,
+timeouts, and descendant-process cleanup.
 
-Quote your expansions (`"$QUERY"`, not `$QUERY`) to also avoid word-splitting
-and globbing on values that contain spaces or shell glob characters.
+The command template is trusted code. Quote parameter expansions
+(`"$HERMES_TOOL_ARG_QUERY"`, not `$HERMES_TOOL_ARG_QUERY`) to avoid
+word-splitting and globbing, and do not pass model parameters to `eval` or use
+them deliberately as command text. Dangerous-looking parameter data may
+conservatively trigger the normal approval prompt.
+
+Model arguments are visible in the effective terminal command and should not
+be used to transport secrets. Put API keys in the ambient environment instead.
 
 ## Behaviour notes
 
 - Files are discovered at startup. Add/change a file, then restart Hermes.
 - A malformed file is logged and skipped — it never breaks startup.
-- A tool whose `name` collides with a built-in is skipped (built-ins are never
-  overridden).
+- Built-ins are never overridden by a YAML tool with the same name.
 - The `custom` toolset is part of the default set; disable it like any other
   toolset if you don't want user tools loaded.
 - `bash` must be available on `PATH`.

--- a/plugins/yaml_tools/__init__.py
+++ b/plugins/yaml_tools/__init__.py
@@ -1,0 +1,260 @@
+"""User-defined tools from declarative YAML files.
+
+Drop a file in ``~/.hermes/tools/<tool>.yaml`` and it becomes a first-class
+tool the agent can call — no Python plugin required::
+
+    # ~/.hermes/tools/my_search.yaml
+    name: my_search
+    description: "Search my internal documentation"
+    command: 'curl -s "https://internal-docs/search?q=$QUERY"'
+    parameters:
+      query:
+        type: string
+        description: "Search query"
+        required: true
+    timeout: 60          # optional, seconds (capped)
+
+Each file defines exactly one tool. It is registered under the ``custom``
+toolset (which auto-appears in the default tool set and can be toggled like any
+other toolset).
+
+Security — why this is injection-safe
+-------------------------------------
+Parameter values supplied by the model are passed to the command as
+**environment variables** (both the parameter name and its upper-cased form),
+never interpolated into the command string. bash does not re-parse the *result*
+of a variable expansion for command substitution, so a value such as
+``$(rm -rf ~)`` or ``"; rm -rf ~ ; "`` is treated as a literal string, not
+executed. The command template is authored by the user (trusted); only the
+argument *values* come from the model.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Callable, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_TOOLSET = "custom"
+_EMOJI = "🔧"
+_DEFAULT_TIMEOUT = 60
+_MAX_TIMEOUT = 600
+_MAX_OUTPUT_CHARS = 100_000
+_ALLOWED_PARAM_TYPES = {"string", "number", "integer", "boolean"}
+# Tool and parameter names must be valid identifiers so they are safe as both
+# function-call names and environment-variable names.
+_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def register(ctx) -> None:
+    """Discover ``~/.hermes/tools/*.yaml`` and register each as a tool.
+
+    Called once by the plugin loader. Never raises: a malformed file or a
+    name collision is logged and skipped so it can't break agent startup.
+    """
+    for path in _iter_tool_files():
+        try:
+            spec = _load_spec(path)
+        except Exception as exc:
+            logger.warning("yaml_tools: skipping %s — %s", path, exc)
+            continue
+        name, schema, command, timeout = spec
+        handler = _make_handler(command, list(schema["parameters"]["properties"]), timeout)
+        try:
+            ctx.register_tool(
+                name=name,
+                toolset=_TOOLSET,
+                schema=schema,
+                handler=handler,
+                description=schema.get("description", ""),
+                emoji=_EMOJI,
+            )
+        except Exception as exc:
+            # Most likely a name collision with a built-in or another YAML
+            # tool. We never override built-ins, so just skip this one.
+            logger.warning(
+                "yaml_tools: could not register tool %r from %s — %s",
+                name, path, exc,
+            )
+        else:
+            logger.debug("yaml_tools: registered custom tool %r from %s", name, path)
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+def _tools_dir() -> Path:
+    from hermes_constants import get_hermes_home
+    return get_hermes_home() / "tools"
+
+
+def _iter_tool_files():
+    d = _tools_dir()
+    if not d.is_dir():
+        return
+    for path in sorted(d.iterdir()):
+        if path.is_file() and path.suffix.lower() in {".yaml", ".yml"}:
+            yield path
+
+
+# ---------------------------------------------------------------------------
+# Parsing / schema construction
+# ---------------------------------------------------------------------------
+
+def _load_spec(path: Path) -> Tuple[str, dict, str, int]:
+    """Parse and validate one tool file.
+
+    Returns ``(name, schema, command, timeout)`` or raises ``ValueError`` with
+    a human-readable reason.
+    """
+    from utils import fast_safe_load
+
+    raw = fast_safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("top-level YAML must be a mapping")
+
+    name = raw.get("name")
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("'name' is required and must be a non-empty string")
+    name = name.strip()
+    if not _NAME_RE.match(name):
+        raise ValueError(
+            f"invalid tool name {name!r}: use letters, digits and underscores, "
+            "starting with a letter or underscore"
+        )
+
+    description = raw.get("description", "")
+    if not isinstance(description, str):
+        raise ValueError("'description' must be a string")
+
+    command = raw.get("command")
+    if not isinstance(command, str) or not command.strip():
+        raise ValueError("'command' is required and must be a non-empty string")
+
+    timeout = _coerce_timeout(raw.get("timeout"))
+
+    parameters = raw.get("parameters") or {}
+    if not isinstance(parameters, dict):
+        raise ValueError("'parameters' must be a mapping of name -> spec")
+
+    properties: dict = {}
+    required: list = []
+    for pname, pspec in parameters.items():
+        pname = str(pname)
+        if not _NAME_RE.match(pname):
+            raise ValueError(
+                f"invalid parameter name {pname!r}: use letters, digits and "
+                "underscores, starting with a letter or underscore"
+            )
+        pspec = pspec or {}
+        if not isinstance(pspec, dict):
+            raise ValueError(f"parameter {pname!r} spec must be a mapping")
+        ptype = pspec.get("type", "string")
+        if ptype not in _ALLOWED_PARAM_TYPES:
+            raise ValueError(
+                f"parameter {pname!r} has unsupported type {ptype!r}; "
+                f"allowed: {sorted(_ALLOWED_PARAM_TYPES)}"
+            )
+        prop: dict = {"type": ptype}
+        pdesc = pspec.get("description")
+        if pdesc is not None:
+            prop["description"] = str(pdesc)
+        enum = pspec.get("enum")
+        if isinstance(enum, list) and enum:
+            prop["enum"] = enum
+        properties[pname] = prop
+        if pspec.get("required"):
+            required.append(pname)
+
+    schema = {
+        "name": name,
+        "description": description,
+        "parameters": {
+            "type": "object",
+            "properties": properties,
+            "required": required,
+        },
+    }
+    return name, schema, command, timeout
+
+
+def _coerce_timeout(value: Any) -> int:
+    if value is None:
+        return _DEFAULT_TIMEOUT
+    try:
+        seconds = int(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"'timeout' must be a whole number of seconds, got {value!r}")
+    if seconds <= 0:
+        raise ValueError("'timeout' must be a positive number of seconds")
+    return min(seconds, _MAX_TIMEOUT)
+
+
+# ---------------------------------------------------------------------------
+# Execution
+# ---------------------------------------------------------------------------
+
+def _make_handler(command: str, param_names: list, timeout: int) -> Callable:
+    def handler(args: Optional[dict] = None, **kwargs) -> str:
+        from tools.registry import tool_error, tool_result
+
+        args = args or {}
+        env = os.environ.copy()
+        for pname in param_names:
+            value = args.get(pname)
+            if value is None:
+                continue
+            rendered = _stringify(value)
+            # Expose the value under both the exact parameter name and its
+            # upper-cased form so `$query` and `$QUERY` both work in templates.
+            env[pname] = rendered
+            env[pname.upper()] = rendered
+
+        bash = _find_bash()
+        if bash is None:
+            return tool_error(
+                "bash is required to run YAML tools but was not found on PATH",
+                success=False,
+            )
+        try:
+            proc = subprocess.run(
+                [bash, "-c", command],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                env=env,
+            )
+        except subprocess.TimeoutExpired:
+            return tool_error(f"Command timed out after {timeout}s", success=False)
+        except Exception as exc:  # pragma: no cover - defensive
+            return tool_error(f"Command failed to start: {exc}", success=False)
+
+        output = (proc.stdout or "") + (proc.stderr or "")
+        if len(output) > _MAX_OUTPUT_CHARS:
+            output = output[:_MAX_OUTPUT_CHARS] + "\n… [output truncated]"
+        if proc.returncode != 0:
+            return tool_error(
+                f"Command exited with status {proc.returncode}",
+                success=False,
+                output=output,
+            )
+        return tool_result(output=output, exit_code=0)
+
+    return handler
+
+
+def _stringify(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def _find_bash() -> Optional[str]:
+    import shutil
+    return shutil.which("bash") or shutil.which("bash.exe")

--- a/plugins/yaml_tools/__init__.py
+++ b/plugins/yaml_tools/__init__.py
@@ -6,44 +6,35 @@ tool the agent can call — no Python plugin required::
     # ~/.hermes/tools/my_search.yaml
     name: my_search
     description: "Search my internal documentation"
-    command: 'curl -s "https://internal-docs/search?q=$QUERY"'
+    command: 'curl -s "https://internal-docs/search?q=$HERMES_TOOL_ARG_QUERY"'
     parameters:
       query:
         type: string
         description: "Search query"
         required: true
-    timeout: 60          # optional, seconds (capped)
+    timeout: 60
 
-Each file defines exactly one tool. It is registered under the ``custom``
-toolset (which auto-appears in the default tool set and can be toggled like any
-other toolset).
+Each file defines exactly one tool. Model-supplied parameters are exposed only
+under the dedicated ``HERMES_TOOL_ARG_<NAME>`` namespace, so a parameter such
+as ``path`` cannot overwrite inherited ``PATH`` or another execution-sensitive
+variable. Values are shell-quoted into assignments inside a subshell, then the
+whole command is dispatched through Hermes' ``terminal`` tool. This preserves
+the configured local/container/SSH isolation and reuses its approval checks,
+bounded output capture, timeout handling, and descendant-process cleanup.
 
-Security — why this is injection-safe
--------------------------------------
-Parameter values supplied by the model are passed to the command as
-**environment variables** (both the parameter name and its upper-cased form),
-never interpolated into the command string. bash does not re-parse the *result*
-of a variable expansion for command substitution, so a value such as
-``$(rm -rf ~)`` or ``"; rm -rf ~ ; "`` is treated as a literal string, not
-executed. The command template is authored by the user (trusted); only the
-argument *values* come from the model.
-
-Parameters may not map to execution-sensitive environment variables (``PATH``,
-``LD_PRELOAD``, …) — those are rejected at load time (see ``_RESERVED_ENV``) so
-a value can't hijack how the shell resolves commands. Each invocation still
-goes through the normal command-approval pipeline (#68187), and output is
-captured with a hard size bound while the command runs in its own process
-group so a timeout kills its descendants too.
+The command template is user-authored and trusted. Authors should still quote
+parameter expansions (for example, ``"$HERMES_TOOL_ARG_QUERY"``) to prevent
+word splitting and glob expansion, and must not pass model values to ``eval``
+or otherwise use them deliberately as command text.
 """
 
 from __future__ import annotations
 
 import logging
-import os
 import re
-import subprocess
+import shlex
 from pathlib import Path
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Mapping, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -51,41 +42,51 @@ _TOOLSET = "custom"
 _EMOJI = "🔧"
 _DEFAULT_TIMEOUT = 60
 _MAX_TIMEOUT = 600
-_MAX_OUTPUT_CHARS = 100_000
 _ALLOWED_PARAM_TYPES = {"string", "number", "integer", "boolean"}
-# Tool and parameter names must be valid identifiers so they are safe as both
-# function-call names and environment-variable names.
 _NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-
-# Parameter values are exported as environment variables (see _make_handler).
-# These names control how the shell / dynamic loader resolves and runs
-# executables, so a model-supplied value landing in one would turn an argument
-# into command hijacking or code execution (e.g. a `path` parameter clobbering
-# PATH, or `ld_preload` -> LD_PRELOAD). Parameters may not map to them; the
-# check is case-insensitive so it covers both the exact and upper-cased
-# spelling the handler exports.
-_RESERVED_ENV = frozenset({
-    "PATH", "IFS", "ENV", "BASH_ENV", "BASHOPTS", "SHELLOPTS", "PS4",
-    "PROMPT_COMMAND", "GLOBIGNORE", "CDPATH",
-    "LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT", "LD_PROFILE",
-    "DYLD_INSERT_LIBRARIES", "DYLD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH",
-})
+_ARG_ENV_PREFIX = "HERMES_TOOL_ARG_"
 
 
 def register(ctx) -> None:
-    """Discover ``~/.hermes/tools/*.yaml`` and register each as a tool.
+    """Discover ``~/.hermes/tools/*.yaml`` and register each valid tool.
 
-    Called once by the plugin loader. Never raises: a malformed file or a
-    name collision is logged and skipped so it can't break agent startup.
+    A malformed file or a registration rejected by the host is logged and
+    skipped so one user file cannot break agent startup.
     """
     for path in _iter_tool_files():
         try:
-            spec = _load_spec(path)
+            name, schema, command, timeout = _load_spec(path)
         except Exception as exc:
             logger.warning("yaml_tools: skipping %s — %s", path, exc)
             continue
-        name, schema, command, timeout = spec
-        handler = _make_handler(command, list(schema["parameters"]["properties"]), timeout)
+
+        # ToolRegistry.register() deliberately rejects a cross-toolset name
+        # collision by returning without raising. Check that case first so
+        # PluginContext cannot subsequently misattribute the pre-existing tool
+        # to this plugin as successfully registered. An existing ``custom``
+        # entry is allowed through: force-reloading plugins must replace the
+        # prior handler/spec in the same registry.
+        from tools.registry import registry
+
+        existing = registry.get_entry(name)
+        if existing is not None and existing.toolset != _TOOLSET:
+            logger.warning(
+                "yaml_tools: skipping %s — tool %r is already registered "
+                "by toolset %r",
+                path,
+                name,
+                existing.toolset,
+            )
+            continue
+
+        parameters = schema["parameters"]
+        handler = _make_handler(
+            ctx.dispatch_tool,
+            command,
+            list(parameters["properties"]),
+            timeout,
+            required_names=parameters["required"],
+        )
         try:
             ctx.register_tool(
                 name=name,
@@ -96,11 +97,11 @@ def register(ctx) -> None:
                 emoji=_EMOJI,
             )
         except Exception as exc:
-            # Most likely a name collision with a built-in or another YAML
-            # tool. We never override built-ins, so just skip this one.
             logger.warning(
                 "yaml_tools: could not register tool %r from %s — %s",
-                name, path, exc,
+                name,
+                path,
+                exc,
             )
         else:
             logger.debug("yaml_tools: registered custom tool %r from %s", name, path)
@@ -112,14 +113,15 @@ def register(ctx) -> None:
 
 def _tools_dir() -> Path:
     from hermes_constants import get_hermes_home
+
     return get_hermes_home() / "tools"
 
 
 def _iter_tool_files():
-    d = _tools_dir()
-    if not d.is_dir():
+    directory = _tools_dir()
+    if not directory.is_dir():
         return
-    for path in sorted(d.iterdir()):
+    for path in sorted(directory.iterdir()):
         if path.is_file() and path.suffix.lower() in {".yaml", ".yml"}:
             yield path
 
@@ -129,11 +131,7 @@ def _iter_tool_files():
 # ---------------------------------------------------------------------------
 
 def _load_spec(path: Path) -> Tuple[str, dict, str, int]:
-    """Parse and validate one tool file.
-
-    Returns ``(name, schema, command, timeout)`` or raises ``ValueError`` with
-    a human-readable reason.
-    """
+    """Parse one tool file as ``(name, schema, command, timeout)``."""
     from utils import fast_safe_load
 
     raw = fast_safe_load(path.read_text(encoding="utf-8"))
@@ -166,19 +164,25 @@ def _load_spec(path: Path) -> Tuple[str, dict, str, int]:
 
     properties: dict = {}
     required: list = []
-    for pname, pspec in parameters.items():
-        pname = str(pname)
+    env_names: dict[str, str] = {}
+    for raw_pname, pspec in parameters.items():
+        pname = str(raw_pname)
         if not _NAME_RE.match(pname):
             raise ValueError(
                 f"invalid parameter name {pname!r}: use letters, digits and "
                 "underscores, starting with a letter or underscore"
             )
-        if pname.upper() in _RESERVED_ENV:
+
+        env_name = _parameter_env_name(pname)
+        previous = env_names.get(env_name)
+        if previous is not None:
             raise ValueError(
-                f"parameter name {pname!r} is reserved: it maps to the "
-                f"environment variable {pname.upper()}, which controls how the "
-                "shell resolves and runs commands — rename the parameter"
+                f"parameters {previous!r} and {pname!r} map to the same "
+                f"environment variable {env_name}; names must differ when "
+                "compared case-insensitively"
             )
+        env_names[env_name] = pname
+
         pspec = pspec or {}
         if not isinstance(pspec, dict):
             raise ValueError(f"parameter {pname!r} spec must be a mapping")
@@ -188,6 +192,7 @@ def _load_spec(path: Path) -> Tuple[str, dict, str, int]:
                 f"parameter {pname!r} has unsupported type {ptype!r}; "
                 f"allowed: {sorted(_ALLOWED_PARAM_TYPES)}"
             )
+
         prop: dict = {"type": ptype}
         pdesc = pspec.get("description")
         if pdesc is not None:
@@ -227,150 +232,79 @@ def _coerce_timeout(value: Any) -> int:
 # Execution
 # ---------------------------------------------------------------------------
 
-def _make_handler(command: str, param_names: list, timeout: int) -> Callable:
-    def handler(args: Optional[dict] = None, **kwargs) -> str:
-        from tools.registry import tool_error, tool_result
+def _make_handler(
+    dispatch_tool: Callable,
+    command: str,
+    param_names: list,
+    timeout: int,
+    *,
+    required_names=(),
+) -> Callable:
+    """Build a handler that delegates execution to the registered terminal."""
+    required_names = tuple(required_names)
 
-        args = args or {}
-        env = os.environ.copy()
-        for pname in param_names:
-            value = args.get(pname)
-            if value is None:
-                continue
-            rendered = _stringify(value)
-            # Expose the value under both the exact parameter name and its
-            # upper-cased form so `$query` and `$QUERY` both work in templates.
-            # Never write an execution-sensitive variable (defense in depth —
-            # such parameter names are already rejected at load time).
-            for candidate in (pname, pname.upper()):
-                if candidate.upper() in _RESERVED_ENV:
-                    continue
-                env[candidate] = rendered
+    def handler(args: dict | None = None, **kwargs) -> str:
+        from tools.registry import tool_error
 
-        bash = _find_bash()
-        if bash is None:
+        if args is None:
+            args = {}
+        if not isinstance(args, dict):
+            return tool_error("Tool arguments must be an object", success=False)
+
+        missing = [
+            pname for pname in required_names
+            if pname not in args or args[pname] is None
+        ]
+        if missing:
             return tool_error(
-                "bash is required to run YAML tools but was not found on PATH",
-                success=False,
-            )
-
-        # #68187: custom-tool calls go through the normal approval pipeline.
-        # The command template is user-authored, but a dangerous or hardline
-        # pattern in it must still be gated exactly like a `terminal` command
-        # (hardline block, deny rules, yolo bypass, interactive prompt).
-        try:
-            from tools.approval import check_dangerous_command
-            approval = check_dangerous_command(command, env_type="local")
-        except Exception as exc:  # pragma: no cover - the gate must not fail open
-            return tool_error(f"Approval check failed: {exc}", success=False)
-        if not approval.get("approved", False):
-            return tool_error(
-                approval.get("message") or "Command blocked by the approval guard.",
+                f"Missing required parameter(s): {', '.join(missing)}",
                 success=False,
             )
 
         try:
-            output, timed_out, returncode = _run_bounded(bash, command, env, timeout)
-        except Exception as exc:  # pragma: no cover - defensive
-            return tool_error(f"Command failed to start: {exc}", success=False)
-        if timed_out:
-            return tool_error(f"Command timed out after {timeout}s", success=False)
-        if returncode != 0:
-            return tool_error(
-                f"Command exited with status {returncode}",
-                success=False,
-                output=output,
-            )
-        return tool_result(output=output, exit_code=0)
+            runtime_command = _build_terminal_command(command, param_names, args)
+        except ValueError as exc:
+            return tool_error(str(exc), success=False)
+
+        return dispatch_tool(
+            "terminal",
+            {"command": runtime_command, "timeout": timeout},
+            **kwargs,
+        )
 
     return handler
 
 
-def _run_bounded(
-    bash: str, command: str, env: dict, timeout: int,
-) -> Tuple[str, bool, Optional[int]]:
-    """Run ``bash -c command`` with bounded memory and clean timeout kill.
+def _build_terminal_command(
+    command: str,
+    param_names: list,
+    args: Mapping[str, Any],
+) -> str:
+    """Wrap a trusted template with isolated, shell-quoted parameter exports.
 
-    Returns ``(output, timed_out, returncode)``. Output is captured
-    incrementally and stops accumulating at ``_MAX_OUTPUT_CHARS`` (the child
-    keeps draining so it never blocks on a full pipe), so a runaway command
-    cannot exhaust memory before truncation. The child runs in its own process
-    group; on timeout the whole group is killed so orphaned descendants don't
-    leak.
+    Every declared parameter is assigned on every invocation. Missing optional
+    values become an empty string, shadowing any same-named inherited value.
+    The closing parenthesis is on its own line so a trailing comment in the
+    user-authored template cannot consume it.
     """
-    import threading
-
-    kwargs: dict = {}
-    if os.name == "posix":
-        kwargs["start_new_session"] = True  # own process group for killpg
-    else:  # pragma: no cover - windows
-        kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-
-    proc = subprocess.Popen(
-        [bash, "-c", command],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        env=env,
-        **kwargs,
-    )
-
-    chunks: list = []
-    captured = 0
-    truncated = False
-
-    def _drain() -> None:
-        nonlocal captured, truncated
-        try:
-            for piece in iter(lambda: proc.stdout.read(8192), ""):
-                room = _MAX_OUTPUT_CHARS - captured
-                if room > 0:
-                    chunks.append(piece[:room])
-                    captured += min(len(piece), room)
-                if len(piece) > room:
-                    truncated = True  # keep looping to drain (and discard) the rest
-        except Exception:  # pragma: no cover - pipe closed under us
-            pass
-        finally:
-            try:
-                proc.stdout.close()
-            except Exception:
-                pass
-
-    reader = threading.Thread(target=_drain, daemon=True)
-    reader.start()
-    try:
-        proc.wait(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        _terminate_group(proc)
-        proc.wait()
-        reader.join(timeout=2)
-        return "".join(chunks), True, None
-    reader.join(timeout=2)
-    output = "".join(chunks)
-    if truncated:
-        output += "\n… [output truncated]"
-    return output, False, proc.returncode
+    lines = ["("]
+    for pname in param_names:
+        value = args.get(pname)
+        rendered = "" if value is None else _stringify(value)
+        if "\x00" in rendered:
+            raise ValueError(f"parameter {pname!r} contains NUL, which is not supported")
+        lines.append(
+            f"export {_parameter_env_name(pname)}={shlex.quote(rendered)}"
+        )
+    lines.extend((command, ")"))
+    return "\n".join(lines)
 
 
-def _terminate_group(proc: "subprocess.Popen") -> None:
-    """SIGKILL the child's whole process group (POSIX), else kill the child."""
-    try:
-        if os.name == "posix":
-            import signal
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        else:  # pragma: no cover - windows
-            proc.kill()
-    except Exception:  # pragma: no cover - already gone
-        pass
+def _parameter_env_name(parameter_name: str) -> str:
+    return f"{_ARG_ENV_PREFIX}{parameter_name.upper()}"
 
 
 def _stringify(value: Any) -> str:
     if isinstance(value, bool):
         return "true" if value else "false"
     return str(value)
-
-
-def _find_bash() -> Optional[str]:
-    import shutil
-    return shutil.which("bash") or shutil.which("bash.exe")

--- a/plugins/yaml_tools/__init__.py
+++ b/plugins/yaml_tools/__init__.py
@@ -27,6 +27,13 @@ of a variable expansion for command substitution, so a value such as
 ``$(rm -rf ~)`` or ``"; rm -rf ~ ; "`` is treated as a literal string, not
 executed. The command template is authored by the user (trusted); only the
 argument *values* come from the model.
+
+Parameters may not map to execution-sensitive environment variables (``PATH``,
+``LD_PRELOAD``, …) — those are rejected at load time (see ``_RESERVED_ENV``) so
+a value can't hijack how the shell resolves commands. Each invocation still
+goes through the normal command-approval pipeline (#68187), and output is
+captured with a hard size bound while the command runs in its own process
+group so a timeout kills its descendants too.
 """
 
 from __future__ import annotations
@@ -49,6 +56,20 @@ _ALLOWED_PARAM_TYPES = {"string", "number", "integer", "boolean"}
 # Tool and parameter names must be valid identifiers so they are safe as both
 # function-call names and environment-variable names.
 _NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# Parameter values are exported as environment variables (see _make_handler).
+# These names control how the shell / dynamic loader resolves and runs
+# executables, so a model-supplied value landing in one would turn an argument
+# into command hijacking or code execution (e.g. a `path` parameter clobbering
+# PATH, or `ld_preload` -> LD_PRELOAD). Parameters may not map to them; the
+# check is case-insensitive so it covers both the exact and upper-cased
+# spelling the handler exports.
+_RESERVED_ENV = frozenset({
+    "PATH", "IFS", "ENV", "BASH_ENV", "BASHOPTS", "SHELLOPTS", "PS4",
+    "PROMPT_COMMAND", "GLOBIGNORE", "CDPATH",
+    "LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT", "LD_PROFILE",
+    "DYLD_INSERT_LIBRARIES", "DYLD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH",
+})
 
 
 def register(ctx) -> None:
@@ -152,6 +173,12 @@ def _load_spec(path: Path) -> Tuple[str, dict, str, int]:
                 f"invalid parameter name {pname!r}: use letters, digits and "
                 "underscores, starting with a letter or underscore"
             )
+        if pname.upper() in _RESERVED_ENV:
+            raise ValueError(
+                f"parameter name {pname!r} is reserved: it maps to the "
+                f"environment variable {pname.upper()}, which controls how the "
+                "shell resolves and runs commands — rename the parameter"
+            )
         pspec = pspec or {}
         if not isinstance(pspec, dict):
             raise ValueError(f"parameter {pname!r} spec must be a mapping")
@@ -213,8 +240,12 @@ def _make_handler(command: str, param_names: list, timeout: int) -> Callable:
             rendered = _stringify(value)
             # Expose the value under both the exact parameter name and its
             # upper-cased form so `$query` and `$QUERY` both work in templates.
-            env[pname] = rendered
-            env[pname.upper()] = rendered
+            # Never write an execution-sensitive variable (defense in depth —
+            # such parameter names are already rejected at load time).
+            for candidate in (pname, pname.upper()):
+                if candidate.upper() in _RESERVED_ENV:
+                    continue
+                env[candidate] = rendered
 
         bash = _find_bash()
         if bash is None:
@@ -222,31 +253,116 @@ def _make_handler(command: str, param_names: list, timeout: int) -> Callable:
                 "bash is required to run YAML tools but was not found on PATH",
                 success=False,
             )
+
+        # #68187: custom-tool calls go through the normal approval pipeline.
+        # The command template is user-authored, but a dangerous or hardline
+        # pattern in it must still be gated exactly like a `terminal` command
+        # (hardline block, deny rules, yolo bypass, interactive prompt).
         try:
-            proc = subprocess.run(
-                [bash, "-c", command],
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                env=env,
+            from tools.approval import check_dangerous_command
+            approval = check_dangerous_command(command, env_type="local")
+        except Exception as exc:  # pragma: no cover - the gate must not fail open
+            return tool_error(f"Approval check failed: {exc}", success=False)
+        if not approval.get("approved", False):
+            return tool_error(
+                approval.get("message") or "Command blocked by the approval guard.",
+                success=False,
             )
-        except subprocess.TimeoutExpired:
-            return tool_error(f"Command timed out after {timeout}s", success=False)
+
+        try:
+            output, timed_out, returncode = _run_bounded(bash, command, env, timeout)
         except Exception as exc:  # pragma: no cover - defensive
             return tool_error(f"Command failed to start: {exc}", success=False)
-
-        output = (proc.stdout or "") + (proc.stderr or "")
-        if len(output) > _MAX_OUTPUT_CHARS:
-            output = output[:_MAX_OUTPUT_CHARS] + "\n… [output truncated]"
-        if proc.returncode != 0:
+        if timed_out:
+            return tool_error(f"Command timed out after {timeout}s", success=False)
+        if returncode != 0:
             return tool_error(
-                f"Command exited with status {proc.returncode}",
+                f"Command exited with status {returncode}",
                 success=False,
                 output=output,
             )
         return tool_result(output=output, exit_code=0)
 
     return handler
+
+
+def _run_bounded(
+    bash: str, command: str, env: dict, timeout: int,
+) -> Tuple[str, bool, Optional[int]]:
+    """Run ``bash -c command`` with bounded memory and clean timeout kill.
+
+    Returns ``(output, timed_out, returncode)``. Output is captured
+    incrementally and stops accumulating at ``_MAX_OUTPUT_CHARS`` (the child
+    keeps draining so it never blocks on a full pipe), so a runaway command
+    cannot exhaust memory before truncation. The child runs in its own process
+    group; on timeout the whole group is killed so orphaned descendants don't
+    leak.
+    """
+    import threading
+
+    kwargs: dict = {}
+    if os.name == "posix":
+        kwargs["start_new_session"] = True  # own process group for killpg
+    else:  # pragma: no cover - windows
+        kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+
+    proc = subprocess.Popen(
+        [bash, "-c", command],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        env=env,
+        **kwargs,
+    )
+
+    chunks: list = []
+    captured = 0
+    truncated = False
+
+    def _drain() -> None:
+        nonlocal captured, truncated
+        try:
+            for piece in iter(lambda: proc.stdout.read(8192), ""):
+                room = _MAX_OUTPUT_CHARS - captured
+                if room > 0:
+                    chunks.append(piece[:room])
+                    captured += min(len(piece), room)
+                if len(piece) > room:
+                    truncated = True  # keep looping to drain (and discard) the rest
+        except Exception:  # pragma: no cover - pipe closed under us
+            pass
+        finally:
+            try:
+                proc.stdout.close()
+            except Exception:
+                pass
+
+    reader = threading.Thread(target=_drain, daemon=True)
+    reader.start()
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _terminate_group(proc)
+        proc.wait()
+        reader.join(timeout=2)
+        return "".join(chunks), True, None
+    reader.join(timeout=2)
+    output = "".join(chunks)
+    if truncated:
+        output += "\n… [output truncated]"
+    return output, False, proc.returncode
+
+
+def _terminate_group(proc: "subprocess.Popen") -> None:
+    """SIGKILL the child's whole process group (POSIX), else kill the child."""
+    try:
+        if os.name == "posix":
+            import signal
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        else:  # pragma: no cover - windows
+            proc.kill()
+    except Exception:  # pragma: no cover - already gone
+        pass
 
 
 def _stringify(value: Any) -> str:

--- a/plugins/yaml_tools/plugin.yaml
+++ b/plugins/yaml_tools/plugin.yaml
@@ -1,0 +1,5 @@
+name: yaml_tools
+version: 1.0.0
+description: "User-defined tools from declarative YAML files in ~/.hermes/tools/*.yaml. Each file defines one callable tool (name, description, parameters, shell command) that appears in the agent's `custom` toolset — no Python plugin required. Parameter values are passed to the command as environment variables, never interpolated into the command string, so model-supplied values cannot inject shell."
+author: NousResearch
+kind: backend

--- a/plugins/yaml_tools/plugin.yaml
+++ b/plugins/yaml_tools/plugin.yaml
@@ -1,5 +1,5 @@
 name: yaml_tools
 version: 1.0.0
-description: "User-defined tools from declarative YAML files in ~/.hermes/tools/*.yaml. Each file defines one callable tool (name, description, parameters, shell command) that appears in the agent's `custom` toolset — no Python plugin required. Parameter values are passed to the command as environment variables, never interpolated into the command string, so model-supplied values cannot inject shell."
+description: "User-defined tools from declarative YAML files in ~/.hermes/tools/*.yaml. Each file defines one callable tool (name, description, parameters, shell command) in the agent's `custom` toolset — no Python plugin required. Model parameters use dedicated HERMES_TOOL_ARG_* variables, and execution reuses the guarded terminal pipeline."
 author: NousResearch
 kind: backend

--- a/tests/plugins/test_yaml_tools.py
+++ b/tests/plugins/test_yaml_tools.py
@@ -1,0 +1,220 @@
+"""Tests for the yaml_tools plugin (user-defined tools via ~/.hermes/tools/*.yaml).
+
+Covers:
+  * schema construction from a YAML spec (types, required, enum, description)
+  * validation / rejection of malformed specs
+  * discovery + registration through a fake plugin context
+  * malformed files and name collisions are skipped, never fatal
+  * command execution: parameter passing (name + UPPER form), non-zero exit,
+    timeout, output capture
+  * SECURITY: model-supplied argument values cannot inject shell
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from plugins.yaml_tools import (
+    _coerce_timeout,
+    _load_spec,
+    _make_handler,
+    register,
+)
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="bash not available"
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake plugin context — collects register_tool() calls like the real loader.
+# ---------------------------------------------------------------------------
+
+class _FakeCtx:
+    def __init__(self, collide=()):
+        self.registered = {}
+        self._collide = set(collide)
+
+    def register_tool(self, *, name, toolset, schema, handler, description="", emoji=""):
+        if name in self._collide:
+            raise ValueError(f"tool '{name}' already registered by another toolset")
+        self.registered[name] = {
+            "toolset": toolset, "schema": schema, "handler": handler,
+            "description": description, "emoji": emoji,
+        }
+
+
+def _write_tool(home, filename, text):
+    tools = home / "tools"
+    tools.mkdir(exist_ok=True)
+    (tools / filename).write_text(text, encoding="utf-8")
+
+
+@pytest.fixture()
+def home(tmp_path, monkeypatch):
+    h = tmp_path / ".hermes"
+    h.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(h))
+    return h
+
+
+# ---------------------------------------------------------------------------
+# Schema construction
+# ---------------------------------------------------------------------------
+
+def test_load_spec_builds_function_schema(home):
+    _write_tool(home, "greet.yaml", (
+        "name: greet\n"
+        "description: Say hi\n"
+        "command: 'echo hi $who'\n"
+        "parameters:\n"
+        "  who:\n"
+        "    type: string\n"
+        "    description: whom to greet\n"
+        "    required: true\n"
+        "  loud:\n"
+        "    type: boolean\n"
+    ))
+    name, schema, command, timeout = _load_spec(home / "tools" / "greet.yaml")
+    assert name == "greet"
+    assert command == "echo hi $who"
+    assert timeout == 60  # default
+    assert schema["name"] == "greet"
+    assert schema["parameters"]["type"] == "object"
+    assert schema["parameters"]["properties"]["who"] == {
+        "type": "string", "description": "whom to greet",
+    }
+    assert schema["parameters"]["properties"]["loud"] == {"type": "boolean"}
+    assert schema["parameters"]["required"] == ["who"]
+
+
+def test_load_spec_enum_and_timeout_cap(home):
+    _write_tool(home, "pick.yaml", (
+        "name: pick\n"
+        "command: 'echo $mode'\n"
+        "timeout: 99999\n"
+        "parameters:\n"
+        "  mode:\n"
+        "    type: string\n"
+        "    enum: [a, b, c]\n"
+    ))
+    _, schema, _, timeout = _load_spec(home / "tools" / "pick.yaml")
+    assert schema["parameters"]["properties"]["mode"]["enum"] == ["a", "b", "c"]
+    assert timeout == 600  # capped at _MAX_TIMEOUT
+
+
+@pytest.mark.parametrize("body,reason", [
+    ("description: no name\ncommand: 'echo x'\n", "missing name"),
+    ("name: no_cmd\n", "missing command"),
+    ("name: 'bad name'\ncommand: 'echo x'\n", "invalid tool name"),
+    ("name: ok\ncommand: 'echo x'\nparameters:\n  q:\n    type: date\n", "bad type"),
+    ("name: ok\ncommand: 'echo x'\ntimeout: -5\n", "bad timeout"),
+    ("- just\n- a\n- list\n", "not a mapping"),
+])
+def test_load_spec_rejects_malformed(home, body, reason):
+    _write_tool(home, "bad.yaml", body)
+    with pytest.raises(ValueError):
+        _load_spec(home / "tools" / "bad.yaml")
+
+
+def test_coerce_timeout_defaults_and_bounds():
+    assert _coerce_timeout(None) == 60
+    assert _coerce_timeout(30) == 30
+    assert _coerce_timeout(10_000) == 600
+    with pytest.raises(ValueError):
+        _coerce_timeout(0)
+    with pytest.raises(ValueError):
+        _coerce_timeout("soon")
+
+
+# ---------------------------------------------------------------------------
+# Discovery + registration
+# ---------------------------------------------------------------------------
+
+def test_register_discovers_and_skips_malformed(home):
+    _write_tool(home, "good.yaml", "name: good\ncommand: 'echo ok'\n")
+    _write_tool(home, "broken.yaml", "name: 'has space'\ncommand: 'echo no'\n")
+    _write_tool(home, "notyaml.txt", "name: ignored\ncommand: 'echo no'\n")
+    ctx = _FakeCtx()
+    register(ctx)
+    assert set(ctx.registered) == {"good"}
+    assert ctx.registered["good"]["toolset"] == "custom"
+
+
+def test_register_survives_name_collision(home):
+    # A YAML tool whose name collides with a built-in: the fake ctx raises
+    # (like the real registry); register() must skip it, not crash.
+    _write_tool(home, "dup.yaml", "name: read_file\ncommand: 'echo no'\n")
+    _write_tool(home, "fine.yaml", "name: fine\ncommand: 'echo yes'\n")
+    ctx = _FakeCtx(collide={"read_file"})
+    register(ctx)  # must not raise
+    assert set(ctx.registered) == {"fine"}
+
+
+def test_register_no_tools_dir_is_noop(home):
+    ctx = _FakeCtx()
+    register(ctx)  # ~/.hermes/tools/ does not exist
+    assert ctx.registered == {}
+
+
+# ---------------------------------------------------------------------------
+# Execution
+# ---------------------------------------------------------------------------
+
+def _handler_for(command, params, timeout=60):
+    return _make_handler(command, params, timeout)
+
+
+def test_handler_passes_params_as_env_name_and_upper():
+    # Template references both $greeting (exact) and $NAME (upper-cased).
+    h = _handler_for('echo "$greeting $NAME"', ["greeting", "name"])
+    out = json.loads(h({"greeting": "hello", "name": "ada"}))
+    assert out["exit_code"] == 0
+    assert out["output"].strip() == "hello ada"
+
+
+def test_handler_boolean_stringified():
+    h = _handler_for('echo "$flag"', ["flag"])
+    assert json.loads(h({"flag": True}))["output"].strip() == "true"
+
+
+def test_handler_nonzero_exit_is_error():
+    h = _handler_for("exit 3", [])
+    out = json.loads(h({}))
+    assert out["error"].startswith("Command exited with status 3")
+    assert out["success"] is False
+
+
+def test_handler_timeout():
+    # Patch subprocess.run to raise TimeoutExpired so we exercise the handler's
+    # timeout branch without spawning/killing a real long-running process
+    # (the test harness's live-system guard blocks the os.kill cleanup that a
+    # real timeout would trigger).
+    h = _handler_for("sleep 5", [], timeout=1)
+    with patch("plugins.yaml_tools.subprocess.run",
+               side_effect=subprocess.TimeoutExpired(cmd="sleep 5", timeout=1)):
+        out = json.loads(h({}))
+    assert "timed out after 1s" in out["error"]
+    assert out["success"] is False
+
+
+def test_handler_shell_injection_is_neutralized(tmp_path):
+    # The classic attack: a parameter value carrying shell metacharacters.
+    # With env-var passing the value is inert — no command substitution, no
+    # extra command runs, the sentinel file is never created.
+    sentinel = tmp_path / "PWNED"
+    h = _handler_for('echo "value=$arg"', ["arg"])
+    payload = f'$(touch {sentinel}); echo INJECTED'
+    out = json.loads(h({"arg": payload}))
+    assert not sentinel.exists()                 # no command executed
+    assert out["output"].strip() == f"value={payload}"  # value stayed literal
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/plugins/test_yaml_tools.py
+++ b/tests/plugins/test_yaml_tools.py
@@ -1,25 +1,18 @@
-"""Tests for the yaml_tools plugin (user-defined tools via ~/.hermes/tools/*.yaml).
-
-Covers:
-  * schema construction from a YAML spec (types, required, enum, description)
-  * validation / rejection of malformed specs
-  * discovery + registration through a fake plugin context
-  * malformed files and name collisions are skipped, never fatal
-  * command execution: parameter passing (name + UPPER form), non-zero exit,
-    timeout, output capture
-  * SECURITY: model-supplied argument values cannot inject shell
-"""
+"""Tests for declarative tools discovered from ``~/.hermes/tools/*.yaml``."""
 
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
-from unittest.mock import patch
+import sys
+from pathlib import Path
 
 import pytest
 
 from plugins.yaml_tools import (
+    _build_terminal_command,
     _coerce_timeout,
     _load_spec,
     _make_handler,
@@ -31,22 +24,36 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-# ---------------------------------------------------------------------------
-# Fake plugin context — collects register_tool() calls like the real loader.
-# ---------------------------------------------------------------------------
-
 class _FakeCtx:
+    """Small registration double for parser/discovery unit tests."""
+
     def __init__(self, collide=()):
         self.registered = {}
         self._collide = set(collide)
 
     def register_tool(self, *, name, toolset, schema, handler, description="", emoji=""):
         if name in self._collide:
-            raise ValueError(f"tool '{name}' already registered by another toolset")
+            raise ValueError(f"tool {name!r} already registered")
         self.registered[name] = {
-            "toolset": toolset, "schema": schema, "handler": handler,
-            "description": description, "emoji": emoji,
+            "toolset": toolset,
+            "schema": schema,
+            "handler": handler,
+            "description": description,
+            "emoji": emoji,
         }
+
+    def dispatch_tool(self, tool_name, args, **kwargs):  # pragma: no cover - registration only
+        raise AssertionError("registered handlers are not invoked by these unit tests")
+
+
+class _DispatchSpy:
+    def __init__(self, response=None):
+        self.calls = []
+        self.response = response or json.dumps({"output": "ok", "exit_code": 0})
+
+    def __call__(self, tool_name, args, **kwargs):
+        self.calls.append((tool_name, args, kwargs))
+        return self.response
 
 
 def _write_tool(home, filename, text):
@@ -57,10 +64,27 @@ def _write_tool(home, filename, text):
 
 @pytest.fixture()
 def home(tmp_path, monkeypatch):
-    h = tmp_path / ".hermes"
-    h.mkdir()
-    monkeypatch.setenv("HERMES_HOME", str(h))
-    return h
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    return hermes_home
+
+
+@pytest.fixture()
+def isolated_registry(monkeypatch):
+    """Give the real PluginManager an isolated copy of registry state."""
+    import tools.terminal_tool as terminal_mod
+    from tools.registry import registry
+
+    for attr in (
+        "_tools",
+        "_toolset_checks",
+        "_toolset_aliases",
+        "_plugin_override_policy",
+    ):
+        monkeypatch.setattr(registry, attr, getattr(registry, attr).copy())
+    monkeypatch.setattr(registry, "_generation", registry._generation)
+    return registry, terminal_mod
 
 
 # ---------------------------------------------------------------------------
@@ -71,7 +95,7 @@ def test_load_spec_builds_function_schema(home):
     _write_tool(home, "greet.yaml", (
         "name: greet\n"
         "description: Say hi\n"
-        "command: 'echo hi $who'\n"
+        "command: 'echo hi $HERMES_TOOL_ARG_WHO'\n"
         "parameters:\n"
         "  who:\n"
         "    type: string\n"
@@ -82,8 +106,8 @@ def test_load_spec_builds_function_schema(home):
     ))
     name, schema, command, timeout = _load_spec(home / "tools" / "greet.yaml")
     assert name == "greet"
-    assert command == "echo hi $who"
-    assert timeout == 60  # default
+    assert command == "echo hi $HERMES_TOOL_ARG_WHO"
+    assert timeout == 60
     assert schema["name"] == "greet"
     assert schema["parameters"]["type"] == "object"
     assert schema["parameters"]["properties"]["who"] == {
@@ -96,7 +120,7 @@ def test_load_spec_builds_function_schema(home):
 def test_load_spec_enum_and_timeout_cap(home):
     _write_tool(home, "pick.yaml", (
         "name: pick\n"
-        "command: 'echo $mode'\n"
+        "command: 'echo $HERMES_TOOL_ARG_MODE'\n"
         "timeout: 99999\n"
         "parameters:\n"
         "  mode:\n"
@@ -105,21 +129,33 @@ def test_load_spec_enum_and_timeout_cap(home):
     ))
     _, schema, _, timeout = _load_spec(home / "tools" / "pick.yaml")
     assert schema["parameters"]["properties"]["mode"]["enum"] == ["a", "b", "c"]
-    assert timeout == 600  # capped at _MAX_TIMEOUT
+    assert timeout == 600
 
 
-@pytest.mark.parametrize("body,reason", [
-    ("description: no name\ncommand: 'echo x'\n", "missing name"),
-    ("name: no_cmd\n", "missing command"),
-    ("name: 'bad name'\ncommand: 'echo x'\n", "invalid tool name"),
-    ("name: ok\ncommand: 'echo x'\nparameters:\n  q:\n    type: date\n", "bad type"),
-    ("name: ok\ncommand: 'echo x'\ntimeout: -5\n", "bad timeout"),
-    ("- just\n- a\n- list\n", "not a mapping"),
+@pytest.mark.parametrize("body", [
+    "description: no name\ncommand: 'echo x'\n",
+    "name: no_cmd\n",
+    "name: 'bad name'\ncommand: 'echo x'\n",
+    "name: ok\ncommand: 'echo x'\nparameters:\n  q:\n    type: date\n",
+    "name: ok\ncommand: 'echo x'\ntimeout: -5\n",
+    "- just\n- a\n- list\n",
 ])
-def test_load_spec_rejects_malformed(home, body, reason):
+def test_load_spec_rejects_malformed(home, body):
     _write_tool(home, "bad.yaml", body)
     with pytest.raises(ValueError):
         _load_spec(home / "tools" / "bad.yaml")
+
+
+def test_load_spec_rejects_case_folded_parameter_collision(home):
+    _write_tool(home, "collision.yaml", (
+        "name: collision\n"
+        "command: 'echo x'\n"
+        "parameters:\n"
+        "  query: {type: string}\n"
+        "  QUERY: {type: string}\n"
+    ))
+    with pytest.raises(ValueError, match="same environment variable"):
+        _load_spec(home / "tools" / "collision.yaml")
 
 
 def test_coerce_timeout_defaults_and_bounds():
@@ -146,117 +182,325 @@ def test_register_discovers_and_skips_malformed(home):
     assert ctx.registered["good"]["toolset"] == "custom"
 
 
-def test_register_survives_name_collision(home):
-    # A YAML tool whose name collides with a built-in: the fake ctx raises
-    # (like the real registry); register() must skip it, not crash.
-    _write_tool(home, "dup.yaml", "name: read_file\ncommand: 'echo no'\n")
+def test_register_survives_context_rejection(home):
+    _write_tool(home, "dup.yaml", "name: context_rejected\ncommand: 'echo no'\n")
     _write_tool(home, "fine.yaml", "name: fine\ncommand: 'echo yes'\n")
-    ctx = _FakeCtx(collide={"read_file"})
-    register(ctx)  # must not raise
+    ctx = _FakeCtx(collide={"context_rejected"})
+    register(ctx)
     assert set(ctx.registered) == {"fine"}
 
 
 def test_register_no_tools_dir_is_noop(home):
     ctx = _FakeCtx()
-    register(ctx)  # ~/.hermes/tools/ does not exist
+    register(ctx)
     assert ctx.registered == {}
 
 
 # ---------------------------------------------------------------------------
-# Execution
+# Execution contract
 # ---------------------------------------------------------------------------
 
-def _handler_for(command, params, timeout=60):
-    return _make_handler(command, params, timeout)
+def _handler_for(command, params, timeout=60, response=None):
+    dispatch = _DispatchSpy(response)
+    return _make_handler(dispatch, command, params, timeout), dispatch
 
 
-def test_handler_passes_params_as_env_name_and_upper():
-    # Template references both $greeting (exact) and $NAME (upper-cased).
-    h = _handler_for('echo "$greeting $NAME"', ["greeting", "name"])
-    out = json.loads(h({"greeting": "hello", "name": "ada"}))
-    assert out["exit_code"] == 0
-    assert out["output"].strip() == "hello ada"
+def _run_bash(command, *, env=None):
+    return subprocess.run(
+        [shutil.which("bash"), "-c", command],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_handler_routes_namespaced_params_through_terminal():
+    handler, dispatch = _handler_for(
+        'printf "%s %s" "$HERMES_TOOL_ARG_GREETING" "$HERMES_TOOL_ARG_NAME"',
+        ["greeting", "name"],
+        timeout=37,
+    )
+    result = handler(
+        {"greeting": "hello", "name": "ada"},
+        task_id="task-unit",
+        session_id="session-unit",
+    )
+    assert json.loads(result) == {"output": "ok", "exit_code": 0}
+    assert len(dispatch.calls) == 1
+    tool_name, terminal_args, kwargs = dispatch.calls[0]
+    assert tool_name == "terminal"
+    assert terminal_args["timeout"] == 37
+    assert kwargs == {"task_id": "task-unit", "session_id": "session-unit"}
+    completed = _run_bash(terminal_args["command"])
+    assert completed.returncode == 0
+    assert completed.stdout == "hello ada"
 
 
 def test_handler_boolean_stringified():
-    h = _handler_for('echo "$flag"', ["flag"])
-    assert json.loads(h({"flag": True}))["output"].strip() == "true"
+    handler, dispatch = _handler_for(
+        'printf %s "$HERMES_TOOL_ARG_FLAG"', ["flag"]
+    )
+    handler({"flag": True})
+    completed = _run_bash(dispatch.calls[0][1]["command"])
+    assert completed.stdout == "true"
 
 
-def test_handler_nonzero_exit_is_error():
-    h = _handler_for("exit 3", [])
-    out = json.loads(h({}))
-    assert out["error"].startswith("Command exited with status 3")
-    assert out["success"] is False
+def test_handler_returns_terminal_pending_approval_unchanged():
+    pending = {
+        "output": "",
+        "exit_code": -1,
+        "error": "",
+        "status": "pending_approval",
+        "approval_pending": True,
+        "pattern_key": "dangerous-test",
+    }
+    response = json.dumps(pending)
+    handler, dispatch = _handler_for("rm -rf /", [], response=response)
+    assert handler({}) == response
+    assert dispatch.calls[0][0] == "terminal"
 
 
-def test_handler_timeout():
-    # Patch _run_bounded to report a timeout so we exercise the handler's
-    # timeout branch without spawning/killing a real long-running process
-    # (the test harness's live-system guard blocks the killpg cleanup that a
-    # real timeout would trigger).
-    h = _handler_for("sleep 5", [], timeout=1)
-    with patch("plugins.yaml_tools._run_bounded", return_value=("", True, None)):
-        out = json.loads(h({}))
-    assert "timed out after 1s" in out["error"]
-    assert out["success"] is False
+def test_handler_rejects_missing_required_parameter_without_dispatching():
+    dispatch = _DispatchSpy()
+    handler = _make_handler(
+        dispatch,
+        'printf %s "$HERMES_TOOL_ARG_QUERY"',
+        ["query"],
+        60,
+        required_names=["query"],
+    )
+    result = json.loads(handler({}))
+    assert "Missing required parameter" in result["error"]
+    assert result["success"] is False
+    assert dispatch.calls == []
 
 
-def test_reserved_param_name_rejected_at_load(home):
-    # A parameter that maps to an execution-sensitive env var (PATH, LD_PRELOAD,
-    # …) must be refused so a model value can't hijack command resolution.
-    _write_tool(home, "hijack.yaml", (
-        "name: hijack\n"
-        "command: 'echo hi'\n"
-        "parameters:\n"
-        "  path:\n"
-        "    type: string\n"
-    ))
-    with pytest.raises(ValueError):
-        _load_spec(home / "tools" / "hijack.yaml")
+def test_missing_optional_parameter_shadows_inherited_value():
+    command = _build_terminal_command(
+        'printf %s "$HERMES_TOOL_ARG_QUERY"', ["query"], {}
+    )
+    run_env = os.environ.copy()
+    run_env["HERMES_TOOL_ARG_QUERY"] = "stale-host-value"
+    completed = _run_bash(command, env=run_env)
+    assert completed.returncode == 0
+    assert completed.stdout == ""
 
 
-def test_handler_does_not_clobber_reserved_env():
-    # Even if a reserved name slipped through, the handler must not overwrite
-    # PATH with a model value — the real PATH stays intact.
-    h = _handler_for('echo "$PATH"', ["PATH"])
-    out = json.loads(h({"PATH": "/tmp/evil"}))
-    assert out["exit_code"] == 0
-    assert "/tmp/evil" != out["output"].strip()
+def test_template_trailing_comment_does_not_consume_subshell_close():
+    command = _build_terminal_command("printf ok # trailing comment", [], {})
+    completed = _run_bash(command)
+    assert completed.returncode == 0
+    assert completed.stdout == "ok"
 
 
-def test_handler_runs_through_approval_gate():
-    # A denied command must not execute; the guard's message is surfaced.
-    h = _handler_for("echo hi", [])
-    with patch("tools.approval.check_dangerous_command",
-               return_value={"approved": False, "message": "nope"}):
-        out = json.loads(h({}))
-    assert out["success"] is False
-    assert "nope" in out["error"]
+def test_model_params_do_not_clobber_inherited_environment():
+    command = _build_terminal_command(
+        'printf "%s|%s|%s" "$HERMES_TOOL_ARG_PATH" "$PATH" "$TEST_API_KEY"',
+        ["path"],
+        {"path": "/model/value"},
+    )
+    run_env = os.environ.copy()
+    run_env["PATH"] = "/ambient/path"
+    run_env["TEST_API_KEY"] = "ambient-secret"
+    completed = _run_bash(command, env=run_env)
+    assert completed.returncode == 0
+    assert completed.stdout == "/model/value|/ambient/path|ambient-secret"
 
 
-def test_handler_bounds_large_output():
-    # Output larger than the cap is truncated rather than buffered whole.
-    from plugins.yaml_tools import _MAX_OUTPUT_CHARS
-    h = _handler_for(f'yes X | head -c {_MAX_OUTPUT_CHARS * 2}', [])
-    out = json.loads(h({}))
-    assert out["exit_code"] == 0
-    assert len(out["output"]) <= _MAX_OUTPUT_CHARS + 64
-    assert "output truncated" in out["output"]
+def test_handler_rejects_nul_without_dispatching():
+    handler, dispatch = _handler_for("printf ignored", ["query"])
+    result = json.loads(handler({"query": "before\x00after"}))
+    assert "NUL" in result["error"]
+    assert result["success"] is False
+    assert dispatch.calls == []
 
 
-def test_handler_shell_injection_is_neutralized(tmp_path):
-    # The classic attack: a parameter value carrying shell metacharacters.
-    # With env-var passing the value is inert — no command substitution, no
-    # extra command runs, the sentinel file is never created.
+def test_shell_injection_is_neutralized(tmp_path):
     sentinel = tmp_path / "PWNED"
-    h = _handler_for('echo "value=$arg"', ["arg"])
-    payload = f'$(touch {sentinel}); echo INJECTED'
-    out = json.loads(h({"arg": payload}))
-    assert not sentinel.exists()                 # no command executed
-    assert out["output"].strip() == f"value={payload}"  # value stayed literal
+    payload = f"$(touch {sentinel}); printf INJECTED; 'quoted'"
+    command = _build_terminal_command(
+        'printf "value=%s" "$HERMES_TOOL_ARG_ARG"',
+        ["arg"],
+        {"arg": payload},
+    )
+    completed = _run_bash(command)
+    assert completed.returncode == 0
+    assert completed.stdout == f"value={payload}"
+    assert not sentinel.exists()
+
+
+def test_terminal_environment_eval_layer_preserves_quoting(tmp_path):
+    """Exercise the extra eval layer used by real terminal environments."""
+    from tools.environments.local import LocalEnvironment
+
+    sentinel = tmp_path / "PWNED_THROUGH_EVAL"
+    payload = f"line one\n$(touch {sentinel}); 'single' \\ backslash"
+    command = _build_terminal_command(
+        'printf %s "$HERMES_TOOL_ARG_ARG"', ["arg"], {"arg": payload}
+    )
+    environment = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+    try:
+        result = environment.execute(command, timeout=10, bounded_capture=True)
+    finally:
+        environment.cleanup()
+    assert result["returncode"] == 0
+    assert result["output"] == payload
+    assert not sentinel.exists()
+
+
+def test_plugin_manager_registry_e2e(
+    home, isolated_registry, monkeypatch, tmp_path,
+):
+    """Exercise YAML discovery -> PluginManager -> registry -> terminal."""
+    registry, terminal_mod = isolated_registry
+    tool_name = "yaml_tools_e2e_probe"
+    sentinel = tmp_path / "PWNED_E2E"
+    payload = f"$(touch {sentinel}); printf INJECTED; 'quoted'"
+    _write_tool(home, "e2e.yaml", (
+        f"name: {tool_name}\n"
+        "description: E2E custom tool\n"
+        "command: >-\n"
+        "  printf '%s|%s|%s|%s'\n"
+        "  \"$HERMES_TOOL_ARG_QUERY\" \"$PATH\" \"$QUERY\" \"$TEST_API_KEY\"\n"
+        "timeout: 37\n"
+        "parameters:\n"
+        "  query:\n"
+        "    type: string\n"
+        "    required: true\n"
+    ))
+    _write_tool(home, "terminal-collision.yaml", (
+        "name: terminal\n"
+        "description: Must not replace or claim the built-in\n"
+        "command: 'printf collision'\n"
+    ))
+
+    pending = {
+        "output": "",
+        "exit_code": -1,
+        "error": "",
+        "status": "pending_approval",
+        "approval_pending": True,
+        "pattern_key": "e2e-approval",
+    }
+    terminal_calls = []
+
+    def fake_terminal_tool(**kwargs):
+        terminal_calls.append(kwargs)
+        return json.dumps(pending)
+
+    monkeypatch.setattr(terminal_mod, "terminal_tool", fake_terminal_tool)
+
+    from hermes_cli.plugins import PluginManager
+    from toolsets import resolve_toolset
+
+    plugin_dir = Path(__file__).resolve().parents[2] / "plugins" / "yaml_tools"
+    manager = PluginManager()
+    manifest = manager._parse_manifest(
+        plugin_dir / "plugin.yaml", plugin_dir, "bundled", ""
+    )
+    assert manifest is not None
+
+    parent_module_name = "hermes_plugins"
+    module_name = "hermes_plugins.yaml_tools"
+    previous_parent_module = sys.modules.get(parent_module_name)
+    previous_module = sys.modules.get(module_name)
+    try:
+        original_terminal_entry = registry.get_entry("terminal")
+        assert original_terminal_entry is not None
+        manager._load_plugin(manifest)
+
+        loaded = manager._plugins[manifest.key or manifest.name]
+        assert loaded.error is None
+        assert set(loaded.tools_registered) == {tool_name}
+        assert manager._plugin_tool_names == {tool_name}
+        assert registry.get_entry(tool_name) is not None
+        assert registry.get_entry("terminal") is original_terminal_entry
+        assert tool_name in resolve_toolset("custom")
+        definitions = registry.get_definitions({tool_name}, quiet=True)
+        assert definitions[0]["function"]["name"] == tool_name
+        assert definitions[0]["function"]["parameters"]["required"] == ["query"]
+        assert registry.get_entry("terminal").handler is terminal_mod._handle_terminal
+
+        dispatch_trace = []
+        real_dispatch = registry.dispatch
+
+        def traced_dispatch(name, args, **kwargs):
+            dispatch_trace.append(name)
+            return real_dispatch(name, args, **kwargs)
+
+        monkeypatch.setattr(registry, "dispatch", traced_dispatch)
+        result = registry.dispatch(
+            tool_name,
+            {"query": payload},
+            task_id="task-e2e",
+            session_id="session-e2e",
+        )
+        assert json.loads(result) == pending
+        assert dispatch_trace == [tool_name, "terminal"]
+        assert len(terminal_calls) == 1
+        call = terminal_calls[0]
+        assert call["timeout"] == 37
+        assert call["task_id"] == "task-e2e"
+        assert call["session_id"] == "session-e2e"
+
+        runtime_command = call["command"]
+        assert "export HERMES_TOOL_ARG_QUERY=" in runtime_command
+        assert "export QUERY=" not in runtime_command
+
+        run_env = os.environ.copy()
+        ambient_path = run_env.get("PATH", "")
+        run_env.update({
+            "PATH": ambient_path,
+            "QUERY": "ambient-query",
+            "TEST_API_KEY": "ambient-secret",
+        })
+        completed = _run_bash(runtime_command, env=run_env)
+        assert completed.returncode == 0
+        assert completed.stdout == (
+            f"{payload}|{ambient_path}|ambient-query|ambient-secret"
+        )
+        assert not sentinel.exists()
+
+        # PluginManager's force path clears its own attribution state but
+        # intentionally keeps registry entries. A reload must replace this
+        # plugin's prior custom handler instead of treating it as a collision.
+        previous_handler = registry.get_entry(tool_name).handler
+        _write_tool(home, "e2e.yaml", (
+            f"name: {tool_name}\n"
+            "description: Reloaded E2E custom tool\n"
+            "command: 'printf \"reloaded:%s\" \"$HERMES_TOOL_ARG_QUERY\"'\n"
+            "parameters:\n"
+            "  query:\n"
+            "    type: string\n"
+            "    required: true\n"
+        ))
+        manager._plugins.clear()
+        manager._plugin_tool_names.clear()
+        dispatch_trace.clear()
+        terminal_calls.clear()
+
+        manager._load_plugin(manifest)
+        reloaded = manager._plugins[manifest.key or manifest.name]
+        assert set(reloaded.tools_registered) == {tool_name}
+        assert registry.get_entry(tool_name).handler is not previous_handler
+        result = registry.dispatch(tool_name, {"query": "fresh"})
+        assert json.loads(result) == pending
+        assert dispatch_trace == [tool_name, "terminal"]
+        assert len(terminal_calls) == 1
+        completed = _run_bash(terminal_calls[0]["command"])
+        assert completed.returncode == 0
+        assert completed.stdout == "reloaded:fresh"
+    finally:
+        if previous_module is None:
+            sys.modules.pop(module_name, None)
+        else:
+            sys.modules[module_name] = previous_module
+        if previous_parent_module is None:
+            sys.modules.pop(parent_module_name, None)
+        else:
+            sys.modules[parent_module_name] = previous_parent_module
 
 
 if __name__ == "__main__":
-    import sys
-    sys.exit(pytest.main([__file__, "-v"]))
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/plugins/test_yaml_tools.py
+++ b/tests/plugins/test_yaml_tools.py
@@ -191,16 +191,58 @@ def test_handler_nonzero_exit_is_error():
 
 
 def test_handler_timeout():
-    # Patch subprocess.run to raise TimeoutExpired so we exercise the handler's
+    # Patch _run_bounded to report a timeout so we exercise the handler's
     # timeout branch without spawning/killing a real long-running process
-    # (the test harness's live-system guard blocks the os.kill cleanup that a
+    # (the test harness's live-system guard blocks the killpg cleanup that a
     # real timeout would trigger).
     h = _handler_for("sleep 5", [], timeout=1)
-    with patch("plugins.yaml_tools.subprocess.run",
-               side_effect=subprocess.TimeoutExpired(cmd="sleep 5", timeout=1)):
+    with patch("plugins.yaml_tools._run_bounded", return_value=("", True, None)):
         out = json.loads(h({}))
     assert "timed out after 1s" in out["error"]
     assert out["success"] is False
+
+
+def test_reserved_param_name_rejected_at_load(home):
+    # A parameter that maps to an execution-sensitive env var (PATH, LD_PRELOAD,
+    # …) must be refused so a model value can't hijack command resolution.
+    _write_tool(home, "hijack.yaml", (
+        "name: hijack\n"
+        "command: 'echo hi'\n"
+        "parameters:\n"
+        "  path:\n"
+        "    type: string\n"
+    ))
+    with pytest.raises(ValueError):
+        _load_spec(home / "tools" / "hijack.yaml")
+
+
+def test_handler_does_not_clobber_reserved_env():
+    # Even if a reserved name slipped through, the handler must not overwrite
+    # PATH with a model value — the real PATH stays intact.
+    h = _handler_for('echo "$PATH"', ["PATH"])
+    out = json.loads(h({"PATH": "/tmp/evil"}))
+    assert out["exit_code"] == 0
+    assert "/tmp/evil" != out["output"].strip()
+
+
+def test_handler_runs_through_approval_gate():
+    # A denied command must not execute; the guard's message is surfaced.
+    h = _handler_for("echo hi", [])
+    with patch("tools.approval.check_dangerous_command",
+               return_value={"approved": False, "message": "nope"}):
+        out = json.loads(h({}))
+    assert out["success"] is False
+    assert "nope" in out["error"]
+
+
+def test_handler_bounds_large_output():
+    # Output larger than the cap is truncated rather than buffered whole.
+    from plugins.yaml_tools import _MAX_OUTPUT_CHARS
+    h = _handler_for(f'yes X | head -c {_MAX_OUTPUT_CHARS * 2}', [])
+    out = json.loads(h({}))
+    assert out["exit_code"] == 0
+    assert len(out["output"]) <= _MAX_OUTPUT_CHARS + 64
+    assert "output truncated" in out["output"]
 
 
 def test_handler_shell_injection_is_neutralized(tmp_path):

--- a/tests/plugins/test_yaml_tools.py
+++ b/tests/plugins/test_yaml_tools.py
@@ -391,12 +391,12 @@ def test_plugin_manager_registry_e2e(
 
     monkeypatch.setattr(terminal_mod, "terminal_tool", fake_terminal_tool)
 
-    from hermes_cli.plugins import PluginManager
+    from hermes_cli.plugins import PluginManager, parse_manifest_file
     from toolsets import resolve_toolset
 
     plugin_dir = Path(__file__).resolve().parents[2] / "plugins" / "yaml_tools"
     manager = PluginManager()
-    manifest = manager._parse_manifest(
+    manifest = parse_manifest_file(
         plugin_dir / "plugin.yaml", plugin_dir, "bundled", ""
     )
     assert manifest is not None

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -57,6 +57,7 @@ Or in-session:
 | `code_execution` | `execute_code` | Run Python scripts that call Hermes tools programmatically. |
 | `coding` | composite (`file` + `terminal` + `search` + `web` + `skills` + `browser` + `todo` + `memory` + `session_search` + `clarify` + `code_execution` + `delegation` + `vision`) | Coding-focused bundle for software work: file editing, terminal, search, web docs, skills, browser, delegate, and code execution. |
 | `cronjob` | `cronjob` | Schedule and manage recurring tasks. |
+| `custom` | (user-defined) | User-authored tools discovered from `~/.hermes/tools/*.yaml` — one file per tool (`name`, `description`, `parameters`, shell `command`). Registered by the bundled `yaml_tools` plugin. Parameter values are passed to the command as environment variables, so model-supplied values cannot inject shell. |
 | `debugging` | composite (`file` + `terminal` + `web`) | Debug bundle — file, process/terminal, web extract/search. |
 | `delegation` | `delegate_task` | Spawn isolated subagent instances for parallel work. |
 | `discord` | `discord` | Core Discord text/embed/DM actions (gateway-only). Active on the `hermes-discord` toolset. |

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -57,7 +57,7 @@ Or in-session:
 | `code_execution` | `execute_code` | Run Python scripts that call Hermes tools programmatically. |
 | `coding` | composite (`file` + `terminal` + `search` + `web` + `skills` + `browser` + `todo` + `memory` + `session_search` + `clarify` + `code_execution` + `delegation` + `vision`) | Coding-focused bundle for software work: file editing, terminal, search, web docs, skills, browser, delegate, and code execution. |
 | `cronjob` | `cronjob` | Schedule and manage recurring tasks. |
-| `custom` | (user-defined) | User-authored tools discovered from `~/.hermes/tools/*.yaml` — one file per tool (`name`, `description`, `parameters`, shell `command`). Registered by the bundled `yaml_tools` plugin. Parameter values are passed to the command as environment variables, so model-supplied values cannot inject shell. |
+| `custom` | (user-defined) | User-authored tools discovered from `~/.hermes/tools/*.yaml` — one file per tool (`name`, `description`, `parameters`, shell `command`). Registered by the bundled `yaml_tools` plugin. Parameters are exposed as shell-quoted `HERMES_TOOL_ARG_*` variables, and commands run through the normal guarded `terminal` pipeline. |
 | `debugging` | composite (`file` + `terminal` + `web`) | Debug bundle — file, process/terminal, web extract/search. |
 | `delegation` | `delegate_task` | Spawn isolated subagent instances for parallel work. |
 | `discord` | `discord` | Core Discord text/embed/DM actions (gateway-only). Active on the `hermes-discord` toolset. |


### PR DESCRIPTION
Closes #68187.

## What

Adds a lightweight way for users to define first-class agent tools without
writing Python: drop one YAML file per tool in `~/.hermes/tools/`.

```yaml
# ~/.hermes/tools/my_search.yaml
name: my_search
description: "Search my internal documentation"
command: 'curl -s "https://internal-docs/search?q=$HERMES_TOOL_ARG_QUERY"'
parameters:
  query:
    type: string
    description: "Search query"
    required: true
timeout: 60
```

The agent can then call `my_search(query="onboarding")` as a real tool in the
`custom` toolset.

## How

The bundled `yaml_tools` backend plugin uses the existing plugin loader and
registry, with no core execution path changes. At startup it scans
`~/.hermes/tools/*.yaml`, validates each definition, builds its JSON Schema,
and registers it under the dynamically discoverable `custom` toolset.

Each invocation:

1. Exports declared model parameters inside a subshell under the dedicated
   `HERMES_TOOL_ARG_<NAME>` namespace. Values are protected with
   `shlex.quote`; omitted optional parameters are set to an empty string so
   inherited or previous values cannot bleed into a call.
2. Delegates the complete command through `PluginContext.dispatch_tool()` to
   the registered `terminal` tool, forwarding task/session context and the
   configured timeout.

That reuses the selected local/container/SSH backend and its normal approval
pipeline, bounded output capture, timeout handling, interrupt behavior, and
descendant-process cleanup. Ambient variables and API keys made available by
that terminal backend remain accessible under their original names; model
parameters cannot overwrite `PATH`, loader variables, or other inherited env.

The command template is trusted user-authored code. Parameter expansions must
be quoted and must not be passed to `eval` or deliberately used as command
text. Model arguments are visible in the effective terminal command, so
secrets should be supplied through the terminal backend's environment instead.

## Testing

- 24 focused tests cover parsing/schema generation, validation, required and
  optional parameters, case-folded namespace collisions, shell metacharacters,
  NUL rejection, inherited environment preservation, and the terminal
  environment's additional `eval` layer.
- A real PluginManager/registry E2E test proves YAML discovery and attribution,
  `custom` toolset/schema visibility, nested dispatch order
  (`custom tool -> terminal`), task/session/timeout forwarding, pending-approval
  response passthrough, built-in collision safety, and force-reload behavior.
- The focused plugin/registry/toolset suite passes on a clean merge simulation
  against current `main`.

## Files

- `plugins/yaml_tools/{plugin.yaml, __init__.py, README.md}`
- `tests/plugins/test_yaml_tools.py`
- `website/docs/reference/toolsets-reference.md`

Discovery runs at startup; add or change a file, then restart Hermes. Hot reload
can be layered on later without changing the YAML format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
