### PR TITLE
fix(desktop): stop removed composer attachments resurrecting on session switch

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -179,6 +179,23 @@ export function useComposerDraft({
   const stashAt = (scope: string | null, text = draftRef.current, attachments = attachmentScope.$attachments.get()) =>
     stashSessionDraft(scope, text, attachments)
 
+  // Keep the per-session draft stash in lockstep with structural attachment
+  // mutations (add/remove/clear/replace). Attachment-only edits do not go
+  // through the text-driven debounced persist path, so without this a
+  // remove-then-session-switch reloads the pre-remove snapshot and the chip
+  // resurrects (#68417). Upload-state-only mutations do not notify.
+  useEffect(() => {
+    attachmentScope.setOnChange(attachments => {
+      if (isBrowsingHistory(sessionIdRef.current) || queueEditRef.current) {
+        return
+      }
+
+      stashSessionDraft(draftScopeRef.current, draftRef.current, attachments)
+    })
+
+    return () => attachmentScope.setOnChange(null)
+  }, [attachmentScope, queueEditRef])
+
   const loadIntoComposer = (text: string, attachments: ComposerAttachment[]) => {
     attachmentScope.$attachments.set(cloneAttachments(attachments))
     paintDraft(text, false)

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -1,11 +1,13 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   $composerAttachments,
   addComposerAttachment,
+  clearComposerAttachments,
   clearSessionDraft,
   type ComposerAttachment,
-  migrateSessionDraft,
+  createComposerAttachmentScope,
+  mainComposerScope,
   removeComposerAttachment,
   SESSION_DRAFTS_STORAGE_KEY,
   stashSessionDraft,
@@ -15,6 +17,41 @@ import {
 
 function attachment(overrides: Partial<ComposerAttachment> & Pick<ComposerAttachment, 'id'>): ComposerAttachment {
   return { kind: 'file', label: 'doc.pdf', ...overrides }
+}
+
+/** Some node/vitest host combos ship a non-functional localStorage stub
+ *  (`getItem`/`clear` missing). Provide an in-memory implementation so draft
+ *  persistence tests exercise real store behavior rather than the host stub. */
+function installMemoryLocalStorage() {
+  const data = new Map<string, string>()
+  const storage: Storage = {
+    get length() {
+      return data.size
+    },
+    clear() {
+      data.clear()
+    },
+    getItem(key) {
+      return data.has(key) ? data.get(key)! : null
+    },
+    key(index) {
+      return [...data.keys()][index] ?? null
+    },
+    removeItem(key) {
+      data.delete(key)
+    },
+    setItem(key, value) {
+      data.set(key, String(value))
+    }
+  }
+
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: storage,
+    writable: true
+  })
+
+  return storage
 }
 
 describe('updateComposerAttachment', () => {
@@ -48,6 +85,10 @@ describe('updateComposerAttachment', () => {
 })
 
 describe('session drafts', () => {
+  beforeEach(() => {
+    installMemoryLocalStorage()
+  })
+
   afterEach(() => {
     for (const scope of ['session-a', 'session-b', null]) {
       clearSessionDraft(scope)
@@ -107,29 +148,85 @@ describe('session drafts', () => {
 
     expect(takeSessionDraft('session-a').attachments[0]?.label).toBe('doc.pdf')
   })
+})
 
-  it('migrates a tip-keyed draft onto the post-compression tip', () => {
-    const tipBefore = '20260720_062637_ad96b3'
-    const tipAfter = '20260720_071049_a28905'
-
-    stashSessionDraft(tipBefore, 'half typed while thinking', [])
-
-    expect(migrateSessionDraft(tipBefore, tipAfter)).toBe(true)
-    expect(takeSessionDraft(tipAfter).text).toBe('half typed while thinking')
-    expect(takeSessionDraft(tipBefore).text).toBe('')
-
-    clearSessionDraft(tipAfter)
+describe('attachment scope change notifications (#68417)', () => {
+  beforeEach(() => {
+    installMemoryLocalStorage()
   })
 
-  it('does not overwrite a non-empty destination draft during migration', () => {
-    stashSessionDraft('from', 'old tip draft', [])
-    stashSessionDraft('to', 'already typed on new tip', [])
+  afterEach(() => {
+    $composerAttachments.set([])
+    clearComposerAttachments()
+    mainComposerScope.setOnChange(null)
 
-    expect(migrateSessionDraft('from', 'to')).toBe(false)
-    expect(takeSessionDraft('to').text).toBe('already typed on new tip')
-    expect(takeSessionDraft('from').text).toBe('old tip draft')
+    for (const scope of ['session-a', 'session-b', null]) {
+      clearSessionDraft(scope)
+    }
 
-    clearSessionDraft('from')
-    clearSessionDraft('to')
+    window.localStorage.clear()
+  })
+
+  it('notifies on structural add/remove/clear but not upload-state-only changes', () => {
+    const scope = createComposerAttachmentScope()
+    const seen: number[] = []
+
+    scope.setOnChange(attachments => {
+      seen.push(attachments.length)
+    })
+
+    scope.add(attachment({ id: 'file:a' }))
+    scope.setUploadState('file:a', 'uploading')
+    scope.remove('file:a')
+    scope.add(attachment({ id: 'file:b' }))
+    scope.clear()
+    // No-op clear must not re-notify.
+    scope.clear()
+    // Missing id must not re-notify.
+    scope.remove('file:missing')
+
+    expect(seen).toEqual([1, 0, 1, 0])
+  })
+
+  it('does not resurrect removed attachments after a session-scope restore', () => {
+    // Mirrors the desktop composer path:
+    // 1) stash attachments with the session
+    // 2) user removes a chip (onChange immediately re-stashes)
+    // 3) session leave/re-enter reloads via takeSessionDraft + loadIntoComposer
+    const scope = createComposerAttachmentScope()
+
+    scope.setOnChange(attachments => {
+      stashSessionDraft('session-a', 'still typing', attachments)
+    })
+
+    scope.add(attachment({ id: 'file:a', label: 'IndexTest.html' }))
+    scope.add(attachment({ id: 'file:b', label: 'WechatTest.html' }))
+    expect(takeSessionDraft('session-a').attachments.map(a => a.id)).toEqual(['file:a', 'file:b'])
+
+    // User clicks × on both chips without typing (no text-debounce path).
+    scope.remove('file:a')
+    scope.remove('file:b')
+    expect(scope.$attachments.get()).toHaveLength(0)
+    expect(takeSessionDraft('session-a').attachments).toEqual([])
+
+    // Session switch away + back restores from the stash — must stay empty.
+    const restored = takeSessionDraft('session-a')
+    scope.$attachments.set(restored.attachments.map(a => ({ ...a })))
+
+    expect(scope.$attachments.get()).toEqual([])
+    expect(restored.text).toBe('still typing')
+  })
+
+  it('wires the main composer helpers through the same notification path', () => {
+    const onChange = vi.fn()
+
+    mainComposerScope.setOnChange(onChange)
+    addComposerAttachment(attachment({ id: 'file:main' }))
+    removeComposerAttachment('file:main')
+    clearComposerAttachments()
+    mainComposerScope.setOnChange(null)
+
+    expect(onChange).toHaveBeenCalled()
+    expect($composerAttachments.get()).toEqual([])
   })
 })

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -34,13 +34,26 @@ export interface ComposerAttachmentScope {
   add(attachment: ComposerAttachment): void
   clear(): void
   remove(id: string): ComposerAttachment | null
+  /**
+   * Optional observer for structural attachment changes (add / remove / clear /
+   * replace). Used by the composer draft engine to keep the per-session stash
+   * in sync so chips do not resurrect after a session switch (#68417).
+   * Upload-state-only mutations intentionally do not notify.
+   */
+  setOnChange(cb: ((attachments: ComposerAttachment[]) => void) | null): void
   setUploadState(id: string, uploadState?: ComposerAttachment['uploadState']): void
   update(attachment: ComposerAttachment): boolean
 }
 
 export function createComposerAttachmentScope($attachments = atom<ComposerAttachment[]>([])): ComposerAttachmentScope {
+  let onChange: ((attachments: ComposerAttachment[]) => void) | null = null
+  const emitChange = () => onChange?.($attachments.get())
+
   return {
     $attachments,
+    setOnChange(cb) {
+      onChange = cb
+    },
     add(attachment) {
       const previous = $attachments.get()
       const next = upsertAttachment(previous, attachment)
@@ -49,14 +62,32 @@ export function createComposerAttachmentScope($attachments = atom<ComposerAttach
       if (next.length > previous.length && attachment.kind !== 'url') {
         triggerHaptic('selection')
       }
+
+      // Notify even when an existing id was replaced — callers (draft stash)
+      // need the latest snapshot after any structural mutation.
+      emitChange()
     },
     clear() {
+      if ($attachments.get().length === 0) {
+        return
+      }
+
       $attachments.set([])
+      emitChange()
     },
     remove(id) {
       const current = $attachments.get()
       const removed = current.find(attachment => attachment.id === id) || null
+
+      if (!removed) {
+        return null
+      }
+
       $attachments.set(current.filter(attachment => attachment.id !== id))
+      // Persist immediately — the text-driven draft debounce does not fire on
+      // attachment-only edits, so without this a session switch reloads the
+      // pre-remove stash and the chip resurrects (#68417 / #58251).
+      emitChange()
 
       return removed
     },
@@ -83,6 +114,8 @@ export function createComposerAttachmentScope($attachments = atom<ComposerAttach
       const next = [...current]
       next[index] = attachment
       $attachments.set(next)
+      // Treat full replacement as structural (path/session binding, etc.).
+      emitChange()
 
       return true
     }


### PR DESCRIPTION
## Summary
- Fix Desktop composer bug where clicking `×` on attachment chips only updated the live UI atom, so switching sessions and returning restored the removed attachments from the per-session draft stash.
- Notify on structural attachment mutations (`add` / `remove` / `clear` / full `update`) and immediately re-stash the current draft scope from the composer draft engine.
- Add regression coverage for remove-then-restore and notification semantics.

Fixes #68417

## Root cause
Composer draft persistence has two layers:
1. Live UI attachments (`$composerAttachments` / attachment scope)
2. Per-session draft stash (`stashSessionDraft` / `takeSessionDraft`)

`removeAttachment()` only mutated the live atom. The text-driven debounced stash path does not fire on attachment-only edits, so leave/re-enter reloaded the pre-remove snapshot via `takeSessionDraft()` + `loadIntoComposer()`.

## Test plan
- [x] `cd apps/desktop && npm test -- --run src/store/composer.test.ts` (11/11 passed)
- [ ] Manual: attach files in Desktop → click `×` → switch session → switch back → chips stay gone
- [ ] Manual: remove mid-upload image chip → upload completion does not resurrect it (existing behavior preserved)

## Notes
- Upload-state-only mutations intentionally do not notify, to avoid noisy draft rewrites during upload progress.
- Related historical issues: #58251, #61191