### PR TITLE
feat(goals): join owned async delegations before completion

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9597,9 +9597,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         from tools.async_delegation import (
             claim_event_delivery,
             complete_event_delivery,
+            recover_stale_goal_reconciliation_claims,
+            release_event_delivery,
         )
 
         session_key = getattr(self, "session_id", "") or ""
+        now = time.monotonic()
+        if now - float(getattr(self, "_last_goal_claim_recovery_at", 0.0) or 0.0) >= 30.0:
+            self._last_goal_claim_recovery_at = now
+            completion_queue = getattr(process_registry, "completion_queue", None)
+            if completion_queue is not None:
+                recover_stale_goal_reconciliation_claims(completion_queue)
         for event, synthetic_message in process_registry.drain_notifications(
             session_key=session_key,
             owns_event=self._owns_process_notification,
@@ -9607,8 +9615,63 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             claim = claim_event_delivery(event, consumer)
             if claim is None:
                 continue
-            self._pending_input.put(synthetic_message)
-            complete_event_delivery(event, claim)
+            decision: Dict[str, Any] = {}
+            try:
+                prompt = synthetic_message
+                if event.get("type") == "async_delegation":
+                    from hermes_cli.goals import prepare_goal_delegation_delivery
+
+                    decision = prepare_goal_delegation_delivery(
+                        event,
+                        synthetic_message,
+                        current_session_id=session_key,
+                        consumer=consumer,
+                    )
+                    prompt = decision.get("prompt")
+                    status_message = str(decision.get("status_message") or "")
+                    if status_message:
+                        _cprint(f"  {_DIM}{status_message}{_RST}")
+                # A goal-owned claim is carried as an internal input envelope;
+                # transport delivery and semantic reconciliation stay separate.
+                if prompt:
+                    claim_id = str(decision.get("reconciliation_claim") or "")
+                    if claim_id:
+                        self._pending_input.put({
+                            "text": prompt,
+                            "goal_reconciliation": {
+                                "claim_id": claim_id,
+                                "goal_id": decision.get("goal_id"),
+                                "session_id": decision.get("goal_session_id"),
+                                "attempt": decision.get("reconciliation_attempt", 1),
+                            },
+                        })
+                    else:
+                        self._pending_input.put(prompt)
+                complete_event_delivery(event, claim)
+            except Exception:
+                claim_id = str(decision.get("reconciliation_claim") or "")
+                if claim_id:
+                    try:
+                        from hermes_cli.goals import release_goal_reconciliation_turn
+
+                        release_goal_reconciliation_turn(
+                            claim_id,
+                            goal_id=str(decision.get("goal_id") or ""),
+                            session_id=str(
+                                decision.get("goal_session_id") or self.session_id
+                            ),
+                            attempt=int(decision.get("reconciliation_attempt", 1) or 1),
+                            turn_started=False,
+                            requeue=False,
+                        )
+                    except Exception:
+                        logger.debug(
+                            "Failed to release CLI reconciliation claim after enqueue failure",
+                            exc_info=True,
+                        )
+                release_event_delivery(event, claim)
+                process_registry.completion_queue.put(event)
+                raise
 
     def _drain_interrupt_queue_to_pending_input(self) -> None:
         """Move stray messages from ``_interrupt_queue`` into ``_pending_input``.
@@ -11966,6 +12029,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # this to True. Early returns (credential refresh failure, etc.)
         # leave it False, which is correct — those aren't user interrupts.
         self._last_turn_interrupted = False
+        self._last_turn_failed = False
+        self._last_turn_partial = False
 
         # Refresh provider credentials if needed (handles key rotation transparently)
         if not self._ensure_runtime_credentials():
@@ -12433,7 +12498,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             sys.stdout.flush()
             time.sleep(0.15)
 
-            # Update history with full conversation
+            # Update history with full conversation. Preserve the structured turn
+            # outcome so internal reconciliation envelopes do not mistake a
+            # non-empty partial/error response for successful consumption.
+            self._last_turn_failed = bool(result and result.get("failed"))
+            self._last_turn_partial = bool(result and result.get("partial"))
             self.conversation_history = result.get("messages", self.conversation_history) if result else self.conversation_history
 
             # If auto-compression fired mid-turn, the agent created a new
@@ -15189,6 +15258,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     # post-resize transient suppression should end here.
                     self._status_bar_suppressed_after_resize = False
 
+                    reconciliation = {}
+                    if isinstance(user_input, dict) and user_input.get("goal_reconciliation"):
+                        reconciliation = dict(user_input.get("goal_reconciliation") or {})
+                        user_input = str(user_input.get("text") or "")
+
                     # Unpack image payload: (text, [Path, ...]) or plain str
                     submit_images = []
                     if isinstance(user_input, tuple):
@@ -15261,7 +15335,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     if paste_refs:
                         user_input = self._expand_paste_references(user_input)
                     print()
-                    self._print_user_message_preview(user_input)
+                    if not reconciliation:
+                        self._print_user_message_preview(user_input)
                     
                     # Show image attachment count
                     if submit_images:
@@ -15274,8 +15349,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     self._pet_reasoning = False
                     app.invalidate()  # Refresh status line
 
+                    turn_response = None
                     try:
-                        self.chat(user_input, images=submit_images or None)
+                        turn_response = self.chat(user_input, images=submit_images or None)
                     finally:
                         self._agent_running = False
                         self._spinner_text = ""
@@ -15284,6 +15360,35 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         self._last_scrollback_tool = ""
                         self._pet_reasoning = False
                         self._pet_react_turn_end()
+
+                        if reconciliation:
+                            try:
+                                claim_id = str(reconciliation.get("claim_id") or "")
+                                from hermes_cli.goals import reconciliation_turn_succeeded
+
+                                if claim_id and reconciliation_turn_succeeded(
+                                    turn_response,
+                                    interrupted=self._last_turn_interrupted,
+                                    failed=getattr(self, "_last_turn_failed", False),
+                                    partial=getattr(self, "_last_turn_partial", False),
+                                ):
+                                    from hermes_cli.goals import complete_goal_reconciliation_turn
+
+                                    complete_goal_reconciliation_turn(claim_id)
+                                elif claim_id:
+                                    from hermes_cli.goals import release_goal_reconciliation_turn
+
+                                    release_goal_reconciliation_turn(
+                                        claim_id,
+                                        session_id=str(reconciliation.get("session_id") or self.session_id),
+                                        goal_id=str(reconciliation.get("goal_id") or ""),
+                                        attempt=int(reconciliation.get("attempt", 1) or 1),
+                                    )
+                            except Exception:
+                                logging.debug(
+                                    "goal reconciliation finalization failed",
+                                    exc_info=True,
+                                )
 
                         app.invalidate()  # Refresh status line
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11755,8 +11755,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._running_agents_ts[_quick_key] = time.time()
         self._persist_active_agents()
         _run_generation = self._begin_session_run_generation(_quick_key)
+        _reconciliation = {}
+        if isinstance(getattr(event, "metadata", None), dict):
+            raw_reconciliation = event.metadata.get("goal_reconciliation")
+            if isinstance(raw_reconciliation, dict):
+                _reconciliation = raw_reconciliation
+        _reconciliation_finalized = False
 
         try:
+            if _reconciliation:
+                _reconciliation["_turn_started"] = True
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
             # Goal continuation: after the agent returns a final response
             # for this turn, check any standing /goal — the judge will
@@ -11770,6 +11778,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _final_text = str(_agent_result.get("final_response") or "")
                 elif isinstance(_agent_result, str):
                     _final_text = _agent_result
+                if _reconciliation:
+                    claim_id = str(_reconciliation.get("claim_id") or "")
+                    from hermes_cli.goals import reconciliation_turn_succeeded
+
+                    result_meta = _agent_result if isinstance(_agent_result, dict) else {}
+                    turn_succeeded = reconciliation_turn_succeeded(
+                        _final_text,
+                        interrupted=bool(result_meta.get("interrupted")),
+                        failed=bool(result_meta.get("failed")),
+                        partial=bool(result_meta.get("partial")),
+                        error=bool(result_meta.get("error")),
+                    )
+                    if claim_id and turn_succeeded:
+                        from hermes_cli.goals import complete_goal_reconciliation_turn
+
+                        complete_goal_reconciliation_turn(claim_id)
+                        _reconciliation["_completed"] = True
+                        _reconciliation_finalized = True
+                    elif claim_id:
+                        from hermes_cli.goals import release_goal_reconciliation_turn
+
+                        release_goal_reconciliation_turn(
+                            claim_id,
+                            session_id=str(_reconciliation.get("session_id") or ""),
+                            goal_id=str(_reconciliation.get("goal_id") or ""),
+                            attempt=int(_reconciliation.get("attempt", 1) or 1),
+                        )
+                        _reconciliation["_released"] = True
+                        _reconciliation_finalized = True
                 # Skip for empty responses (interrupted / errored) — the
                 # judge would almost always say "continue" and we'd loop
                 # on error. Let the user drive the next turn.
@@ -11788,6 +11825,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("goal continuation hook failed: %s", _goal_exc)
             return _agent_result
         finally:
+            if _reconciliation and not _reconciliation_finalized:
+                try:
+                    from hermes_cli.goals import release_goal_reconciliation_turn
+
+                    release_goal_reconciliation_turn(
+                        str(_reconciliation.get("claim_id") or ""),
+                        session_id=str(_reconciliation.get("session_id") or ""),
+                        goal_id=str(_reconciliation.get("goal_id") or ""),
+                        attempt=int(_reconciliation.get("attempt", 1) or 1),
+                    )
+                    _reconciliation["_released"] = True
+                except Exception:
+                    logger.debug("goal reconciliation release failed", exc_info=True)
             # MoA one-shot restore must run on EVERY exit path, not just
             # success. The restore data lives on the per-turn event object
             # (_moa_restore_override), which is discarded once the event goes
@@ -17217,7 +17267,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
 
     async def _inject_watch_notification(
-        self, synth_text: str, evt: dict,
+        self, synth_text: str, evt: dict, *, internal_metadata: Optional[dict] = None,
     ) -> Optional[bool]:
         """Inject a watch/completion notification as a synthetic message event.
 
@@ -17244,7 +17294,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not adapter:
             return None
         try:
-            metadata = {}
+            metadata = dict(internal_metadata or {})
             parent_session_id = str(evt.get("parent_session_id") or "").strip()
             if parent_session_id:
                 metadata["gateway_session_id"] = parent_session_id
@@ -17356,7 +17406,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         identity = self._completion_delivery_identity(evt)
         durable_claim_id = ""
         durable_delegation_id = ""
-        if evt.get("type") == "async_delegation":
+        if evt.get("type") == "async_delegation" and not evt.get("semantic_recovery"):
             durable_delegation_id = str(evt.get("delegation_id") or "")
             if durable_delegation_id:
                 try:
@@ -17426,10 +17476,57 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._completion_deliveries_inflight.add(identity)
 
         accepted = False
+        reconciliation = {}
         try:
-            injection_result = await self._inject_watch_notification(synth_text, evt)
-            if injection_result is not True:
-                return injection_result
+            delivery_text = synth_text
+            if evt.get("type") == "async_delegation":
+                # Even a coalesced intermediate completion needs a valid owner
+                # route before its durable result can be acknowledged.
+                source = self._build_process_event_source(evt)
+                if not source:
+                    return None
+                quick_key = self._session_key_for_source(source)
+                if quick_key in getattr(self, "_running_agents", {}):
+                    # Do not mutate join state while the dispatching parent turn
+                    # is still being judged.  The watcher retries once the
+                    # session boundary is idle, matching CLI/TUI ordering.
+                    return False
+                from hermes_cli.goals import prepare_goal_delegation_delivery
+
+                decision = prepare_goal_delegation_delivery(
+                    evt,
+                    synth_text,
+                    consumer="gateway-goal-reconciliation",
+                )
+                delivery_text = decision.get("prompt")
+                status_message = str(decision.get("status_message") or "")
+                if status_message:
+                    logger.info("Goal-owned async join: %s", status_message)
+                    if decision.get("classification") == "paused":
+                        await self._send_goal_status_notice(source, status_message)
+                claim_id = str(decision.get("reconciliation_claim") or "")
+                if claim_id:
+                    reconciliation = {
+                        "claim_id": claim_id,
+                        "goal_id": decision.get("goal_id"),
+                        "session_id": decision.get("goal_session_id"),
+                        "attempt": decision.get("reconciliation_attempt", 1),
+                        "delegation_ids": decision.get("delegation_ids") or [],
+                    }
+
+            if delivery_text:
+                injection_result = await self._inject_watch_notification(
+                    delivery_text,
+                    evt,
+                    internal_metadata=(
+                        {"goal_reconciliation": reconciliation} if reconciliation else None
+                    ),
+                )
+                if injection_result is not True:
+                    return injection_result
+            # No prompt means this transport event found no claimable mailbox
+            # batch (for example a sibling event covered by an in-flight claim)
+            # or the goal is paused. The durable row remains authoritative.
             accepted = True
 
             if identity is not None:
@@ -17471,6 +17568,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                 except Exception:
                     logger.debug("Could not release durable completion claim", exc_info=True)
+            if (
+                reconciliation
+                and not accepted
+                and not reconciliation.get("_released")
+                and not reconciliation.get("_completed")
+            ):
+                try:
+                    from hermes_cli.goals import release_goal_reconciliation_turn
+
+                    release_goal_reconciliation_turn(
+                        str(reconciliation.get("claim_id") or ""),
+                        session_id=str(reconciliation.get("session_id") or ""),
+                        goal_id=str(reconciliation.get("goal_id") or ""),
+                        attempt=int(reconciliation.get("attempt", 1) or 1),
+                        turn_started=bool(reconciliation.get("_turn_started")),
+                        requeue=False,
+                    )
+                except Exception:
+                    logger.debug("Could not release goal reconciliation claim", exc_info=True)
 
     def _enrich_async_delegation_routing(self, evt: dict) -> None:
         """Fill platform/chat_id/thread_id/chat_type on an async-delegation event.
@@ -17508,9 +17624,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         handled by ``_run_process_watcher`` / the post-turn drain).
         """
         await asyncio.sleep(3)  # let platforms finish connecting
+        from tools.async_delegation import recover_stale_goal_reconciliation_claims
         from tools.process_registry import process_registry as _pr
+        last_claim_recovery_at = 0.0
         while self._running:
             try:
+                now = time.monotonic()
+                if now - last_claim_recovery_at >= 30.0:
+                    last_claim_recovery_at = now
+                    recover_stale_goal_reconciliation_claims(_pr.completion_queue)
                 # Peek the queue for async-delegation events. We must NOT
                 # consume watch/completion events here (other drains own them),
                 # so requeue anything that isn't ours.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2396,6 +2396,71 @@ class GatewaySlashCommandsMixin:
             state = mgr.resume()
             if state is None:
                 return t("gateway.goal.no_resume")
+            decision = {}
+            try:
+                from hermes_cli.goals import prepare_goal_resume, get_goal_work_snapshot
+
+                adapters = getattr(self, "adapters", {})
+                session_key_for_source = getattr(self, "_session_key_for_source")
+                enqueue_fifo = getattr(self, "_enqueue_fifo")
+                adapter = adapters.get(event.source.platform) if event.source else None
+                _quick_key = session_key_for_source(event.source) if event.source else None
+                if adapter and _quick_key:
+                    decision = prepare_goal_resume(
+                        session_entry.session_id,
+                        consumer="gateway-goal-resume",
+                    )
+                    prompt = decision.get("prompt")
+                    if not prompt:
+                        snapshot = get_goal_work_snapshot(state.goal_id)
+                        outstanding = sum(
+                            int(snapshot.get(key, 0))
+                            for key in (
+                                "running_count",
+                                "terminal_unreconciled_count",
+                                "claimed_count",
+                            )
+                        )
+                        if outstanding:
+                            return t("gateway.goal.resumed", goal=state.goal) + " (waiting for required async work)"
+                        prompt = mgr.next_continuation_prompt() or state.goal
+                    metadata = {}
+                    if decision.get("reconciliation_claim"):
+                        metadata["goal_reconciliation"] = {
+                            "claim_id": decision.get("reconciliation_claim"),
+                            "goal_id": decision.get("goal_id"),
+                            "session_id": decision.get("goal_session_id"),
+                            "attempt": decision.get("reconciliation_attempt", 1),
+                            "delegation_ids": decision.get("delegation_ids") or [],
+                        }
+                    resume_event = MessageEvent(
+                        text=prompt,
+                        message_type=MessageType.TEXT,
+                        source=event.source,
+                        message_id=event.message_id,
+                        channel_prompt=event.channel_prompt,
+                        internal=bool(metadata),
+                        metadata=metadata,
+                    )
+                    enqueue_fifo(_quick_key, resume_event, adapter)
+            except Exception as exc:
+                claim_id = str(decision.get("reconciliation_claim") or "")
+                if claim_id:
+                    try:
+                        from hermes_cli.goals import release_goal_reconciliation_turn
+
+                        release_goal_reconciliation_turn(
+                            claim_id,
+                            session_id=str(
+                                decision.get("goal_session_id") or session_entry.session_id
+                            ),
+                            goal_id=str(decision.get("goal_id") or ""),
+                            attempt=int(decision.get("reconciliation_attempt", 1) or 1),
+                            turn_started=False,
+                        )
+                    except Exception:
+                        pass
+                logger.debug("goal resume enqueue failed: %s", exc)
             return t("gateway.goal.resumed", goal=state.goal)
 
         if lower in {"clear", "stop", "done"}:

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2093,10 +2093,64 @@ class CLICommandsMixin:
                 _cprint(f"  {_DIM}No goal to resume.{_RST}")
             else:
                 _cprint(f"  ▶ Goal resumed: {state.goal}")
-                _cprint(
-                    f"  {_DIM}Send any message (or press Enter on an empty prompt "
-                    f"is a no-op; type 'continue' to kick it off).{_RST}"
-                )
+                decision = {}
+                try:
+                    from hermes_cli.goals import prepare_goal_resume, get_goal_work_snapshot
+
+                    pending_input = getattr(self, "_pending_input")
+                    decision = prepare_goal_resume(
+                        self.session_id,
+                        consumer="cli-goal-resume",
+                    )
+                    if decision.get("prompt"):
+                        pending_input.put({
+                            "text": decision["prompt"],
+                            "goal_reconciliation": {
+                                "claim_id": decision.get("reconciliation_claim"),
+                                "goal_id": decision.get("goal_id"),
+                                "session_id": decision.get("goal_session_id"),
+                                "attempt": decision.get("reconciliation_attempt", 1),
+                            },
+                        })
+                    else:
+                        snapshot = get_goal_work_snapshot(state.goal_id)
+                        outstanding = sum(
+                            int(snapshot.get(key, 0))
+                            for key in (
+                                "running_count",
+                                "terminal_unreconciled_count",
+                                "claimed_count",
+                            )
+                        )
+                        if outstanding:
+                            _cprint(
+                                f"  {_DIM}Waiting for required async work; "
+                                "completed results will resume the goal automatically."
+                                f"{_RST}"
+                            )
+                        else:
+                            pending_input.put(mgr.next_continuation_prompt() or state.goal)
+                except Exception:
+                    claim_id = str(decision.get("reconciliation_claim") or "")
+                    if claim_id:
+                        try:
+                            from hermes_cli import goals as goal_module
+
+                            getattr(goal_module, "release_goal_reconciliation_turn")(
+                                claim_id,
+                                session_id=str(
+                                    decision.get("goal_session_id") or self.session_id
+                                ),
+                                goal_id=str(decision.get("goal_id") or ""),
+                                attempt=int(decision.get("reconciliation_attempt", 1) or 1),
+                                turn_started=False,
+                            )
+                        except Exception:
+                            pass
+                    _cprint(
+                        f"  {_DIM}Could not enqueue the resumed goal; send "
+                        f"'continue' to kick it off.{_RST}"
+                    )
             return
 
         if lower in {"clear", "stop", "done"}:

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -33,6 +33,7 @@ import json
 import logging
 import re
 import time
+import uuid
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
@@ -66,6 +67,7 @@ _JUDGE_RESPONSE_SNIPPET_CHARS = 4000
 # exhausted with every reply shaped like `judge returned empty response` or
 # `judge reply was not JSON`.
 DEFAULT_MAX_CONSECUTIVE_PARSE_FAILURES = 3
+DEFAULT_MAX_CONSECUTIVE_RECONCILIATION_FAILURES = 3
 # Transport failures (API auth errors 401, timeouts, DNS, etc.) are also
 # tracked and auto-pause the loop after this many consecutive failures.
 # A broken/invalid API key returns 401 every call — the loop must not
@@ -442,6 +444,12 @@ class GoalState:
     # constraints / boundaries / stop_when). Empty by default; a goal with
     # no contract behaves exactly like the original free-form goal.
     contract: GoalContract = field(default_factory=GoalContract)
+    # Stable identity for the logical goal.  Append-only placement preserves
+    # every positional argument accepted before goal-owned delegation existed.
+    # Session ids rotate during compression, so async work cannot safely use
+    # the persistence key as its owner; ``goal_id`` migrates with the state.
+    goal_id: str = ""
+
 
     def to_json(self) -> str:
         data = asdict(self)
@@ -457,6 +465,7 @@ class GoalState:
             subgoals = [str(s).strip() for s in raw_subgoals if str(s).strip()]
         return cls(
             goal=data.get("goal", ""),
+            goal_id=str(data.get("goal_id") or ""),
             status=data.get("status", "active"),
             turns_used=int(data.get("turns_used", 0) or 0),
             max_turns=int(data.get("max_turns", DEFAULT_MAX_TURNS) or DEFAULT_MAX_TURNS),
@@ -516,7 +525,8 @@ def _get_session_db() -> Optional[Any]:
         from hermes_constants import get_hermes_home
         from hermes_state import SessionDB
 
-        home = str(get_hermes_home())
+        home_path = get_hermes_home()
+        home = str(home_path)
     except Exception as exc:  # pragma: no cover
         logger.debug("GoalManager: SessionDB bootstrap failed (%s)", exc)
         return None
@@ -525,7 +535,9 @@ def _get_session_db() -> Optional[Any]:
     if cached is not None:
         return cached
     try:
-        db = SessionDB()
+        # Pass the resolved path explicitly.  SessionDB's module-level default
+        # may have been imported under another profile before this call.
+        db = SessionDB(db_path=home_path / "state.db")
     except Exception as exc:  # pragma: no cover
         logger.debug("GoalManager: SessionDB() raised (%s)", exc)
         return None
@@ -548,7 +560,20 @@ def load_goal(session_id: str) -> Optional[GoalState]:
     if not raw:
         return None
     try:
-        return GoalState.from_json(raw)
+        state = GoalState.from_json(raw)
+        if not state.goal_id:
+            # Deterministic backfill prevents two concurrent legacy loads from
+            # minting different owners before either can persist its migration.
+            state.goal_id = "goal_" + uuid.uuid5(
+                uuid.NAMESPACE_URL,
+                f"hermes-goal:{session_id}:{state.created_at}:{state.goal}",
+            ).hex
+            if not db.compare_and_set_meta(_meta_key(session_id), raw, state.to_json()):
+                # A concurrent clear/replacement won after our read. Reload it
+                # rather than overwriting that lifecycle transition with the
+                # legacy active state merely to persist the ID backfill.
+                return load_goal(session_id)
+        return state
     except Exception as exc:
         logger.warning("GoalManager: could not parse stored goal for %s: %s", session_id, exc)
         return None
@@ -574,6 +599,8 @@ def clear_goal(session_id: str) -> None:
         return
     state.status = "cleared"
     save_goal(session_id, state)
+    if state.goal_id:
+        _abandon_goal_work(state.goal_id, "goal cleared")
 
 
 def migrate_goal_to_session(old_session_id: str, new_session_id: str, *, reason: str = "") -> bool:
@@ -602,8 +629,11 @@ def migrate_goal_to_session(old_session_id: str, new_session_id: str, *, reason:
         if load_goal(new_session_id) is not None:
             return False
         save_goal(new_session_id, state)
-        # Archive the parent's row so it isn't double-counted as active.
-        clear_goal(old_session_id)
+        # Archive the parent's row without abandoning required work: this is
+        # the same logical goal moving across a compression boundary.
+        source_marker = GoalState.from_json(state.to_json())
+        source_marker.status = "cleared"
+        save_goal(old_session_id, source_marker)
         logger.debug(
             "GoalManager: migrated goal %s -> %s (%s)",
             old_session_id, new_session_id, reason or "rotation",
@@ -1072,8 +1102,34 @@ def _extract_json_object(raw: str) -> Optional[Dict[str, Any]]:
 
 
 # ──────────────────────────────────────────────────────────────────────
-# GoalManager — the orchestration surface CLI + gateway talk to
+# Async-delegation join normalization
 # ──────────────────────────────────────────────────────────────────────
+
+
+def get_goal_work_snapshot(goal_id: str) -> Dict[str, Any]:
+    """Read required async work lazily so goals remain usable in light installs."""
+    if not goal_id:
+        return {"available": True}
+    try:
+        from tools.async_delegation import get_goal_work_snapshot
+
+        return get_goal_work_snapshot(goal_id)
+    except Exception as exc:
+        logger.debug("goal work snapshot unavailable for %s: %s", goal_id, exc)
+        return {"goal_id": goal_id, "available": False, "error": str(exc)}
+
+
+def _abandon_goal_work(goal_id: str, reason: str) -> int:
+    if not goal_id:
+        return 0
+    try:
+        from tools.async_delegation import abandon_goal_work
+
+        return abandon_goal_work(goal_id, reason)
+    except Exception as exc:
+        logger.debug("goal work abandon failed for %s: %s", goal_id, exc)
+        return 0
+
 
 
 class GoalManager:
@@ -1120,7 +1176,36 @@ class GoalManager:
         turns = f"{s.turns_used}/{s.max_turns} turns"
         sub = f", {len(s.subgoals)} subgoal{'s' if len(s.subgoals) != 1 else ''}" if s.subgoals else ""
         con = ", contract" if self.has_contract() else ""
-        meta = f"{turns}{sub}{con}"
+        snapshot = get_goal_work_snapshot(s.goal_id)
+        running = int(snapshot.get("running_count", 0))
+        ready = int(snapshot.get("terminal_unreconciled_count", 0))
+        claimed = int(snapshot.get("claimed_count", 0))
+        required = int(snapshot.get("required_count", 0))
+        join = ""
+        if snapshot.get("available") is False:
+            join = ", async=unavailable (completion blocked)"
+        elif required:
+            ids = ",".join(str(value) for value in snapshot.get("delegation_ids", [])[:5])
+            raw_tokens = snapshot.get("tokens")
+            tokens = raw_tokens if isinstance(raw_tokens, dict) else {}
+            token_total = sum(int(tokens.get(key, 0) or 0) for key in ("input", "output", "reasoning"))
+            last_error = " ".join(str(snapshot.get("last_error") or "").split())[:120]
+            attempt = int(snapshot.get("max_attempt", 0) or 0)
+            join = (
+                f", async={running} running/"
+                f"{int(snapshot.get('completed_count', 0))} completed/"
+                f"{ready} ready/{claimed} claimed/"
+                f"{int(snapshot.get('reconciled_count', 0))} reconciled/"
+                f"{int(snapshot.get('abandoned_count', 0))} abandoned/"
+                f"{int(snapshot.get('failed_count', 0))} failed"
+                f" [{ids}], usage={int(snapshot.get('api_calls', 0))} calls/"
+                f"{token_total} tok/${float(snapshot.get('cost_usd', 0.0) or 0.0):.4f}"
+            )
+            if attempt:
+                join += f", attempt={attempt}"
+            if last_error:
+                join += f", last_error={last_error}"
+        meta = f"{turns}{sub}{con}{join}"
         if s.status == "active":
             if s.waiting_on_session and _session_waiting(s.waiting_on_session):
                 wr = s.waiting_reason or f"session {s.waiting_on_session}"
@@ -1146,8 +1231,10 @@ class GoalManager:
         goal = (goal or "").strip()
         if not goal:
             raise ValueError("goal text is empty")
+        old_goal_id = self._state.goal_id if self._state is not None else ""
         state = GoalState(
             goal=goal,
+            goal_id=f"goal_{uuid.uuid4().hex}",
             status="active",
             turns_used=0,
             max_turns=int(max_turns) if max_turns else self.default_max_turns,
@@ -1157,6 +1244,11 @@ class GoalManager:
         )
         self._state = state
         save_goal(self.session_id, state)
+        if old_goal_id:
+            # Publish the new owner before abandonment closes the dispatch race:
+            # a concurrent old-goal dispatch either lands before this sweep or
+            # fails its post-persist ownership revalidation.
+            _abandon_goal_work(old_goal_id, "goal replaced")
         return state
 
     def set_contract(self, contract: GoalContract) -> Optional[GoalState]:
@@ -1203,17 +1295,40 @@ class GoalManager:
     def clear(self) -> None:
         if self._state is None:
             return
+        goal_id = self._state.goal_id
         self._state.status = "cleared"
         save_goal(self.session_id, self._state)
+        if goal_id:
+            _abandon_goal_work(goal_id, "goal cleared")
         self._state = None
 
     def mark_done(self, reason: str) -> None:
         if not self._state:
             return
+        snapshot = get_goal_work_snapshot(self._state.goal_id)
+        outstanding = (
+            int(snapshot.get("running_count", 0))
+            + int(snapshot.get("terminal_unreconciled_count", 0))
+            + int(snapshot.get("claimed_count", 0))
+        )
+        if snapshot.get("available") is False or outstanding:
+            blocked_reason = (
+                "required async mailbox unavailable"
+                if snapshot.get("available") is False
+                else f"waiting for {outstanding} required async delegation result(s)"
+            )
+            self._state.last_verdict = "waiting_for_reconciliation"
+            self._state.last_reason = blocked_reason
+            if self._state.turns_used >= self._state.max_turns:
+                self._state.status = "paused"
+                self._state.paused_reason = f"turn budget exhausted while {blocked_reason}"
+            save_goal(self.session_id, self._state)
+            return
         self._state.status = "done"
         self._state.last_verdict = "done"
         self._state.last_reason = reason
         save_goal(self.session_id, self._state)
+
 
     # --- /subgoal user controls ---------------------------------------
 
@@ -1418,6 +1533,7 @@ class GoalManager:
                 "message": "",
             }
 
+
         # Wait barrier: if the loop is parked (on a live process OR a time
         # deadline that hasn't passed), quiesce — do NOT burn a turn or call
         # the judge. Resumes automatically once the barrier clears.
@@ -1497,6 +1613,62 @@ class GoalManager:
             }
 
         if verdict == "done":
+            snapshot = get_goal_work_snapshot(state.goal_id)
+            if snapshot.get("available") is False:
+                state.last_verdict = "waiting_for_reconciliation"
+                state.last_reason = "required async mailbox unavailable; refusing terminal transition"
+                if state.turns_used >= state.max_turns:
+                    state.status = "paused"
+                    state.paused_reason = (
+                        "turn budget exhausted while required async mailbox was unavailable"
+                    )
+                save_goal(self.session_id, state)
+                return {
+                    "status": state.status,
+                    "should_continue": False,
+                    "continuation_prompt": None,
+                    "verdict": "waiting_for_reconciliation",
+                    "reason": state.last_reason,
+                    "message": "⏳ Goal completion blocked — async mailbox unavailable.",
+                    "turns_used": state.turns_used,
+                    "max_turns": state.max_turns,
+                }
+            running = int(snapshot.get("running_count", 0))
+            unreconciled = int(snapshot.get("terminal_unreconciled_count", 0))
+            claimed = int(snapshot.get("claimed_count", 0))
+            if running or unreconciled or claimed:
+                ids = [str(value) for value in snapshot.get("delegation_ids", [])[:5]]
+                detail = ", ".join(ids)
+                if running:
+                    waiting_verdict = "waiting_for_required_work"
+                    waiting_reason = f"{running} required async delegation(s) still running"
+                else:
+                    waiting_verdict = "waiting_for_reconciliation"
+                    waiting_reason = (
+                        f"{unreconciled + claimed} required async delegation result(s) "
+                        "await reconciliation"
+                    )
+                if detail:
+                    waiting_reason = f"{waiting_reason}: {detail}"
+                state.last_reason = f"candidate done blocked — {waiting_reason}; judge: {reason}"
+                if state.turns_used >= state.max_turns:
+                    state.status = "paused"
+                    state.paused_reason = f"required work pending at turn budget: {waiting_reason}"
+                    message = (
+                        f"⏸ Goal paused — {state.turns_used}/{state.max_turns} turns used "
+                        f"with {waiting_reason}. Use /goal resume after the work settles."
+                    )
+                else:
+                    message = f"⏳ Goal candidate complete; {waiting_reason}."
+                save_goal(self.session_id, state)
+                return {
+                    "status": state.status,
+                    "should_continue": False,
+                    "continuation_prompt": None,
+                    "verdict": waiting_verdict,
+                    "reason": waiting_reason,
+                    "message": message,
+                }
             state.status = "done"
             save_goal(self.session_id, state)
             return {
@@ -1628,6 +1800,256 @@ class GoalManager:
         if not self._state.has_contract():
             return "(no completion contract — set one with /goal draft <objective> or inline field: value lines)"
         return self._state.contract.render_block()
+
+
+def _load_goal_owner_strict(session_id: str) -> Optional[GoalState]:
+    """Read goal ownership without conflating storage failure with no goal."""
+    if not session_id:
+        return None
+    db = _get_session_db()
+    if db is None:
+        raise RuntimeError("goal persistence is unavailable")
+    raw = db.get_meta(_meta_key(session_id))
+    if not raw:
+        return None
+    state = GoalState.from_json(raw)
+    if not state.goal_id:
+        state.goal_id = "goal_" + uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"hermes-goal:{session_id}:{state.created_at}:{state.goal}",
+        ).hex
+        if not db.compare_and_set_meta(_meta_key(session_id), raw, state.to_json()):
+            return _load_goal_owner_strict(session_id)
+    return state
+
+
+def capture_goal_delegation_owner(session_id: str) -> Optional[Dict[str, Any]]:
+    """Capture the stable owner, raising when ownership cannot be inspected."""
+    state = _load_goal_owner_strict(session_id)
+    if state is None or state.status != "active" or not state.goal_id:
+        return None
+    return {"goal_id": state.goal_id, "requires_goal_join": True}
+
+
+def goal_owner_is_current(session_id: str, goal_id: str) -> bool:
+    state = _load_goal_owner_strict(session_id)
+    return bool(
+        state is not None
+        and state.status == "active"
+        and state.goal_id == str(goal_id or "")
+    )
+
+
+def _goal_session_candidates(event: Dict[str, Any], current_session_id: str = "") -> List[str]:
+    """Return raw + compression-resolved session ids for completion ownership."""
+    raw_candidates = [
+        current_session_id,
+        str(event.get("goal_owner_session_id") or ""),
+        str(event.get("parent_session_id") or ""),
+        str(event.get("session_key") or ""),
+    ]
+    db = _get_session_db()
+    candidates: List[str] = []
+    for raw in raw_candidates:
+        raw = str(raw or "").strip()
+        if not raw:
+            continue
+        resolved = raw
+        if db is not None:
+            try:
+                resolved = str(db.resolve_resume_session_id(raw) or raw)
+            except Exception:
+                resolved = raw
+        for value in (resolved, raw):
+            if value and value not in candidates:
+                candidates.append(value)
+    return candidates
+
+
+def _claim_reconciliation_for_state(
+    state: GoalState,
+    *,
+    session_id: str,
+    consumer: str,
+) -> Dict[str, Any]:
+    from tools.async_delegation import claim_goal_reconciliation
+    from tools.process_registry import format_goal_reconciliation_claim
+
+    snapshot = get_goal_work_snapshot(state.goal_id)
+    if snapshot.get("overflow"):
+        GoalManager(session_id).pause("required async mailbox exceeded 1000 pending rows")
+        return {
+            "classification": "paused",
+            "prompt": None,
+            "status_message": (
+                "Goal paused: required async mailbox exceeded 1000 pending rows; "
+                "inspect /goal status and resume after reducing the backlog."
+            ),
+        }
+    if state.status != "active":
+        pending = int(snapshot.get("terminal_unreconciled_count", 0))
+        return {
+            "classification": "paused",
+            "prompt": None,
+            "status_message": (
+                f"Goal paused; retained {pending} async delegation result(s) "
+                "for /goal resume."
+            ),
+        }
+    claim = claim_goal_reconciliation(state.goal_id, consumer)
+    if claim is None:
+        return {
+            "classification": "current",
+            "prompt": None,
+            "status_message": "",
+        }
+    prompt = format_goal_reconciliation_claim(claim, goal=state.goal)
+    return {
+        "classification": "current",
+        "prompt": prompt,
+        "status_message": (
+            f"Reconciling {len(claim.get('delegation_ids') or [])} async "
+            "delegation result(s) with the standing goal."
+        ),
+        "reconciliation_claim": claim.get("claim_id"),
+        "goal_id": state.goal_id,
+        "goal_session_id": session_id,
+        "delegation_ids": list(claim.get("delegation_ids") or []),
+        "reconciliation_attempt": int(claim.get("attempt", 1) or 1),
+    }
+
+
+def prepare_goal_delegation_delivery(
+    event: Dict[str, Any],
+    passive_prompt: str,
+    *,
+    current_session_id: str = "",
+    consumer: str = "goal-reconciliation",
+) -> Dict[str, Any]:
+    """Claim a coalesced mailbox batch for a current goal-owned completion."""
+    if (
+        event.get("type") != "async_delegation"
+        or not event.get("goal_id")
+        or not event.get("requires_goal_join")
+    ):
+        return {
+            "classification": "unowned",
+            "prompt": passive_prompt,
+            "status_message": "",
+        }
+
+    event_goal_id = str(event.get("goal_id") or "")
+    for session_id in _goal_session_candidates(event, current_session_id):
+        state = GoalManager(session_id).state
+        if state is None or state.goal_id != event_goal_id:
+            continue
+        return _claim_reconciliation_for_state(
+            state,
+            session_id=session_id,
+            consumer=consumer,
+        )
+
+    return {
+        "classification": "superseded",
+        "prompt": passive_prompt,
+        "status_message": "",
+    }
+
+
+def prepare_goal_resume(session_id: str, *, consumer: str) -> Dict[str, Any]:
+    """Claim retained mailbox work before an ordinary resumed continuation."""
+    manager = GoalManager(session_id)
+    state = manager.state
+    if state is None or state.status != "active":
+        return {"prompt": None}
+    return _claim_reconciliation_for_state(
+        state,
+        session_id=session_id,
+        consumer=consumer,
+    )
+
+def complete_goal_reconciliation_turn(claim_id: str) -> bool:
+    """Acknowledge semantic rows only after the parent turn succeeded."""
+    from tools.async_delegation import (
+        build_goal_reconciliation_followup_event,
+        complete_goal_reconciliation,
+    )
+    from tools.process_registry import process_registry
+
+    completed = complete_goal_reconciliation(claim_id)
+    if completed:
+        followup = build_goal_reconciliation_followup_event(claim_id)
+        if followup:
+            process_registry.completion_queue.put(followup)
+    return completed
+
+
+def reconciliation_turn_succeeded(
+    final_text: Any,
+    *,
+    interrupted: bool = False,
+    failed: bool = False,
+    partial: bool = False,
+    error: bool = False,
+) -> bool:
+    """One success predicate shared by every reconciliation delivery surface."""
+    return bool(
+        isinstance(final_text, str)
+        and final_text.strip()
+        and not interrupted
+        and not failed
+        and not partial
+        and not error
+    )
+
+
+def _queue_goal_reconciliation_retry(goal_id: str, session_id: str) -> None:
+    from tools.async_delegation import build_goal_reconciliation_retry_event
+    from tools.process_registry import process_registry
+
+    retry_event = build_goal_reconciliation_retry_event(goal_id, session_id)
+    if retry_event is not None:
+        process_registry.completion_queue.put(retry_event)
+
+
+def release_goal_reconciliation_turn(
+    claim_id: str,
+    *,
+    session_id: str,
+    goal_id: str,
+    attempt: int,
+    turn_started: bool = True,
+    requeue: bool = True,
+) -> bool:
+    """Release a failed turn and auto-pause after three failed attempts."""
+    from tools.async_delegation import release_goal_reconciliation
+
+    released = release_goal_reconciliation(
+        claim_id,
+        decrement_attempt=not turn_started,
+    )
+    if not turn_started:
+        if released and requeue:
+            try:
+                _queue_goal_reconciliation_retry(goal_id, session_id)
+            except Exception:
+                logger.exception("Failed to queue goal reconciliation retry for %s", goal_id)
+        return released
+    attempt = int(attempt or 0)
+    if released and attempt < DEFAULT_MAX_CONSECUTIVE_RECONCILIATION_FAILURES:
+        try:
+            _queue_goal_reconciliation_retry(goal_id, session_id)
+        except Exception:
+            logger.exception("Failed to queue goal reconciliation retry for %s", goal_id)
+    if released and attempt >= DEFAULT_MAX_CONSECUTIVE_RECONCILIATION_FAILURES:
+        manager = GoalManager(session_id)
+        state = manager.state
+        if state is not None and state.goal_id == goal_id and state.status == "active":
+            manager.pause(
+                "async delegation reconciliation failed "
+                f"{attempt} times; use /goal resume to retry"
+            )
+    return released
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1003,7 +1003,16 @@ CREATE TABLE IF NOT EXISTS async_delegations (
     owner_started_at INTEGER,
     task_json TEXT,
     delivery_claim TEXT,
-    delivery_claimed_at REAL
+    delivery_claimed_at REAL,
+    goal_id TEXT NOT NULL DEFAULT '',
+    requires_goal_join INTEGER NOT NULL DEFAULT 0,
+    parent_delegation_id TEXT NOT NULL DEFAULT '',
+    goal_owner_session_id TEXT NOT NULL DEFAULT '',
+    reconciliation_state TEXT NOT NULL DEFAULT 'not_required',
+    reconciliation_claim TEXT,
+    reconciliation_claimed_at REAL,
+    reconciliation_attempts INTEGER NOT NULL DEFAULT 0,
+    reconciled_at REAL
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
@@ -1033,6 +1042,8 @@ CREATE INDEX IF NOT EXISTS idx_sessions_gateway_peer
     ON sessions(source, user_id, chat_id, chat_type, thread_id, started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_sessions_handoff_state
     ON sessions(handoff_state, started_at);
+CREATE INDEX IF NOT EXISTS idx_async_delegations_goal_reconciliation
+    ON async_delegations(goal_id, requires_goal_join, reconciliation_state, state);
 """
 
 # ── Deferred FTS rebuild bookkeeping (schema v23) ──
@@ -8830,6 +8841,17 @@ class SessionDB:
                 (key, value),
             )
         self._execute_write(_do)
+
+    def compare_and_set_meta(self, key: str, expected: str, value: str) -> bool:
+        """Replace an existing meta value only when it is still *expected*."""
+        def _do(conn):
+            cursor = conn.execute(
+                "UPDATE state_meta SET value = ? WHERE key = ? AND value = ?",
+                (value, key, expected),
+            )
+            return cursor.rowcount == 1
+
+        return bool(self._execute_write(_do))
 
     def apply_telegram_topic_migration(self) -> None:
         """Create Telegram DM topic-mode tables on explicit /topic opt-in.

--- a/tests/cli/test_cli_async_delegation_delivery.py
+++ b/tests/cli/test_cli_async_delegation_delivery.py
@@ -1,7 +1,9 @@
 """Regression coverage for CLI async-delegation completion ownership."""
 
 import queue
+from unittest.mock import MagicMock
 
+import pytest
 from cli import HermesCLI
 
 
@@ -73,4 +75,206 @@ def test_cli_completion_ownership_accepts_compression_lineage():
             "type": "async_delegation",
             "session_key": "pre-compression-session",
         }
+    )
+
+
+def test_cli_goal_owned_intermediate_completion_is_acked_without_parent_turn(
+    monkeypatch,
+):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "visible-session"
+    cli._pending_input = queue.Queue()
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_joining",
+        "session_key": "visible-session",
+        "goal_id": "goal-id",
+        "requires_goal_join": True,
+    }
+
+    class FakeRegistry:
+        def drain_notifications(self, *, session_key="", owns_event=None):
+            assert session_key == "visible-session"
+            assert owns_event is not None
+            assert owns_event(event)
+            return [(event, "legacy completion payload")]
+
+    completed = []
+    monkeypatch.setattr("tools.process_registry.process_registry", FakeRegistry())
+    monkeypatch.setattr(
+        "tools.async_delegation.claim_event_delivery",
+        lambda _evt, _consumer: "claim-token",
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.complete_event_delivery",
+        lambda evt, token: completed.append((evt, token)),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.goals.prepare_goal_delegation_delivery",
+        lambda *_args, **_kwargs: {
+            "classification": "current",
+            "prompt": None,
+            "status_message": "waiting for one more",
+        },
+    )
+
+    cli._drain_process_notifications("cli-idle")
+
+    assert cli._pending_input.empty()
+    assert completed == [(event, "claim-token")]
+
+
+def test_cli_goal_owned_claim_is_enqueued_as_internal_envelope(monkeypatch):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "visible-session"
+    cli._pending_input = queue.Queue()
+    event = {"type": "async_delegation", "delegation_id": "deleg_join"}
+
+    class FakeRegistry:
+        @staticmethod
+        def drain_notifications(**_kwargs):
+            return [(event, "legacy completion")]
+
+    monkeypatch.setattr("tools.process_registry.process_registry", FakeRegistry())
+    monkeypatch.setattr("tools.async_delegation.claim_event_delivery", lambda *_a, **_k: "transport")
+    monkeypatch.setattr("tools.async_delegation.complete_event_delivery", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        "hermes_cli.goals.prepare_goal_delegation_delivery",
+        lambda *_a, **_k: {
+            "classification": "current",
+            "prompt": "reconcile this batch",
+            "status_message": "",
+            "reconciliation_claim": "recon-1",
+            "reconciliation_attempt": 2,
+            "goal_id": "goal-1",
+            "goal_session_id": "visible-session",
+        },
+    )
+
+    cli._drain_process_notifications(consumer="cli-test")
+
+    envelope = cli._pending_input.get_nowait()
+    assert envelope["text"] == "reconcile this batch"
+    assert envelope["goal_reconciliation"] == {
+        "claim_id": "recon-1",
+        "goal_id": "goal-1",
+        "session_id": "visible-session",
+        "attempt": 2,
+    }
+
+
+def test_cli_enqueue_failure_releases_transport_and_reconciliation(monkeypatch):
+    from hermes_cli import goals
+    from tools import async_delegation as ad
+
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-owned-fail",
+        "session_key": "visible-session",
+        "goal_id": "goal-id",
+        "requires_goal_join": True,
+        "status": "completed",
+        "task": {"goal": "work"},
+    }
+
+    class _Registry:
+        completion_queue = queue.Queue()
+
+        @staticmethod
+        def drain_notifications(**_kwargs):
+            return [(event, "raw completion")]
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "visible-session"
+    cli._pending_input = MagicMock()
+    cli._pending_input.put.side_effect = RuntimeError("queue closed")
+    monkeypatch.setattr("tools.process_registry.process_registry", _Registry())
+    monkeypatch.setattr(ad, "claim_event_delivery", lambda *_a, **_k: "transport-claim")
+    release_transport = MagicMock()
+    monkeypatch.setattr(ad, "release_event_delivery", release_transport)
+    monkeypatch.setattr(
+        goals,
+        "prepare_goal_delegation_delivery",
+        lambda *_a, **_k: {
+            "classification": "current",
+            "prompt": "joined results",
+            "reconciliation_claim": "recon-1",
+            "goal_id": "goal-id",
+            "goal_session_id": "visible-session",
+            "reconciliation_attempt": 1,
+        },
+    )
+    release_reconciliation = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        goals, "release_goal_reconciliation_turn", release_reconciliation
+    )
+
+    with pytest.raises(RuntimeError, match="queue closed"):
+        cli._drain_process_notifications("cli-idle")
+
+    release_transport.assert_called_once_with(event, "transport-claim")
+    release_reconciliation.assert_called_once_with(
+        "recon-1",
+        goal_id="goal-id",
+        session_id="visible-session",
+        attempt=1,
+        turn_started=False,
+        requeue=False,
+    )
+    assert _Registry.completion_queue.get_nowait() == event
+
+
+def test_cli_goal_resume_enqueues_the_next_turn(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli.goals import GoalManager
+
+    manager = GoalManager("resume-session")
+    manager.set("finish the release")
+    manager.pause("test")
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "resume-session"
+    cli._pending_input = queue.Queue()
+
+    assert cli._handle_goal_command("/goal resume") is None
+    prompt = cli._pending_input.get_nowait()
+    assert "Continue working toward this goal" in prompt
+    assert "finish the release" in prompt
+
+
+def test_cli_goal_resume_releases_claim_when_enqueue_fails(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import hermes_cli.goals as goals
+
+    manager = goals.GoalManager("resume-session")
+    manager.set("reconcile before continuing")
+    manager.pause("test")
+    monkeypatch.setattr(
+        goals,
+        "prepare_goal_resume",
+        lambda *_a, **_k: {
+            "prompt": "internal reconciliation",
+            "reconciliation_claim": "recon-resume",
+            "reconciliation_attempt": 2,
+            "goal_id": "goal-id",
+            "goal_session_id": "resume-session",
+            "delegation_ids": ["deleg-a"],
+        },
+    )
+    release = MagicMock(return_value={"released": True})
+    monkeypatch.setattr(goals, "release_goal_reconciliation_turn", release)
+    broken_queue = MagicMock()
+    broken_queue.put.side_effect = RuntimeError("queue closed")
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "resume-session"
+    cli._pending_input = broken_queue
+
+    assert cli._handle_goal_command("/goal resume") is None
+
+    release.assert_called_once_with(
+        "recon-resume",
+        session_id="resume-session",
+        goal_id="goal-id",
+        attempt=2,
+        turn_started=False,
     )

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -112,6 +112,82 @@ def test_duplicate_async_queue_replay_injects_once(monkeypatch, isolated_registr
     adapter.handle_message.assert_awaited_once()
 
 
+def test_goal_owned_intermediate_completion_commits_without_adapter_turn(monkeypatch):
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    event = _async_event("deleg_joining")
+    event.update({"goal_id": "goal-1", "requires_goal_join": True})
+    monkeypatch.setattr(
+        "hermes_cli.goals.prepare_goal_delegation_delivery",
+        lambda *_args, **_kwargs: {
+            "classification": "current",
+            "prompt": None,
+            "status_message": "waiting for one more",
+        },
+    )
+
+    assert asyncio.run(
+        runner._deliver_completion_notification("legacy completion", event)
+    ) is True
+    adapter.handle_message.assert_not_awaited()
+
+
+def test_goal_owned_completion_defers_while_parent_turn_is_running(monkeypatch):
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    event = _async_event("deleg_busy")
+    event.update({"goal_id": "goal-1", "requires_goal_join": True})
+    source = runner._build_process_event_source(event)
+    assert source is not None
+    quick_key = runner._session_key_for_source(source)
+    runner._running_agents = {quick_key: object()}
+    prepare = MagicMock()
+    monkeypatch.setattr(
+        "hermes_cli.goals.prepare_goal_delegation_delivery",
+        prepare,
+    )
+
+    assert asyncio.run(
+        runner._deliver_completion_notification("legacy completion", event)
+    ) is False
+    prepare.assert_not_called()
+    adapter.handle_message.assert_not_awaited()
+
+
+def test_goal_owned_claim_reaches_gateway_as_internal_metadata(monkeypatch):
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    event = _async_event("deleg_reconcile")
+    event.update({"goal_id": "goal-1", "requires_goal_join": True})
+    monkeypatch.setattr(
+        "hermes_cli.goals.prepare_goal_delegation_delivery",
+        lambda *_args, **_kwargs: {
+            "classification": "current",
+            "prompt": "reconcile this batch",
+            "status_message": "",
+            "reconciliation_claim": "recon-1",
+            "reconciliation_attempt": 2,
+            "goal_id": "goal-1",
+            "goal_session_id": "gateway-session",
+            "delegation_ids": ["deleg_reconcile"],
+        },
+    )
+
+    assert asyncio.run(
+        runner._deliver_completion_notification("completion", event)
+    ) is True
+
+    injected = adapter.handle_message.await_args.args[0]
+    assert injected.internal is True
+    assert injected.metadata["goal_reconciliation"] == {
+        "claim_id": "recon-1",
+        "goal_id": "goal-1",
+        "session_id": "gateway-session",
+        "attempt": 2,
+        "delegation_ids": ["deleg_reconcile"],
+    }
+
+
 def test_unroutable_async_event_is_not_requeued_forever(
     monkeypatch, isolated_registry,
 ):

--- a/tests/gateway/test_goal_max_turns_config.py
+++ b/tests/gateway/test_goal_max_turns_config.py
@@ -1,3 +1,6 @@
+from unittest.mock import MagicMock
+from typing import Any
+
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
@@ -58,5 +61,111 @@ async def test_gateway_goal_uses_goals_max_turns_from_full_config(tmp_path, monk
         state = goals.GoalManager("sid-gateway-goal-config").state
         assert state is not None
         assert state.max_turns == 7
+    finally:
+        goals._DB_CACHE.clear()
+
+
+@pytest.mark.asyncio
+async def test_gateway_goal_resume_enqueues_the_next_turn(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    goals._DB_CACHE.clear()
+
+    runner: Any = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="token")}
+    )
+    runner.session_store = _FakeSessionStore()
+    adapter = object()
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._queued_events = {}
+    runner._session_key_for_source = lambda _source: "quick-resume"
+    runner._enqueue_fifo = MagicMock()
+
+    manager = goals.GoalManager(_FakeSessionEntry.session_id)
+    manager.set("resume this standing goal")
+    manager.pause("test")
+    event = MessageEvent(
+        text="/goal resume",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="chat-goal-config",
+            chat_type="channel",
+            user_id="user-goal-config",
+        ),
+        message_id="msg-goal-resume",
+    )
+
+    response = await GatewayRunner._handle_goal_command(runner, event)
+
+    try:
+        assert "Goal resumed" in response
+        runner._enqueue_fifo.assert_called_once()
+        assert runner._enqueue_fifo.call_args is not None
+        queued_event = runner._enqueue_fifo.call_args.args[1]
+        assert "Continue working toward this goal" in queued_event.text
+    finally:
+        goals._DB_CACHE.clear()
+
+
+@pytest.mark.asyncio
+async def test_gateway_goal_resume_releases_claim_when_enqueue_fails(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    goals._DB_CACHE.clear()
+
+    runner: Any = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="token")}
+    )
+    runner.session_store = _FakeSessionStore()
+    runner.adapters = {Platform.DISCORD: object()}
+    runner._queued_events = {}
+    runner._session_key_for_source = lambda _source: "quick-resume"
+    runner._enqueue_fifo = MagicMock(side_effect=RuntimeError("fifo unavailable"))
+
+    manager = goals.GoalManager(_FakeSessionEntry.session_id)
+    manager.set("reconcile this work")
+    manager.pause("test")
+    monkeypatch.setattr(
+        goals,
+        "prepare_goal_resume",
+        lambda *_a, **_k: {
+            "prompt": "internal reconciliation",
+            "reconciliation_claim": "recon-gateway",
+            "reconciliation_attempt": 3,
+            "goal_id": "goal-id",
+            "goal_session_id": _FakeSessionEntry.session_id,
+            "delegation_ids": ["deleg-a"],
+        },
+    )
+    release = MagicMock(return_value={"released": True})
+    monkeypatch.setattr(goals, "release_goal_reconciliation_turn", release)
+    event = MessageEvent(
+        text="/goal resume",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="chat-goal-config",
+            chat_type="channel",
+            user_id="user-goal-config",
+        ),
+        message_id="msg-goal-resume-failure",
+    )
+
+    response = await GatewayRunner._handle_goal_command(runner, event)
+
+    try:
+        assert "Goal resumed" in response
+        release.assert_called_once_with(
+            "recon-gateway",
+            session_id=_FakeSessionEntry.session_id,
+            goal_id="goal-id",
+            attempt=3,
+            turn_started=False,
+        )
     finally:
         goals._DB_CACHE.clear()

--- a/tests/hermes_cli/test_goal_async_delegation_join.py
+++ b/tests/hermes_cli/test_goal_async_delegation_join.py
@@ -1,0 +1,510 @@
+"""Durable standing-goal ownership for asynchronous delegations."""
+
+from __future__ import annotations
+
+import queue
+import time
+import json
+
+import pytest
+
+import hermes_cli.goals as goals
+import tools.async_delegation as ad
+from tools.process_registry import process_registry
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    goals._DB_CACHE.clear()
+    ad._reset_for_tests()
+    while True:
+        try:
+            process_registry.completion_queue.get_nowait()
+        except queue.Empty:
+            break
+    yield
+    ad._reset_for_tests()
+    goals._DB_CACHE.clear()
+
+
+def _dispatch(goal_id: str, delegation_id: str, result: dict, *, blocker=None):
+    def runner():
+        if blocker is not None:
+            blocker.wait(timeout=5)
+        return result
+
+    return ad.dispatch_async_delegation(
+        goal=f"work for {delegation_id}",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="session-a",
+        parent_session_id="session-a",
+        goal_id=goal_id,
+        requires_goal_join=True,
+        goal_owner_session_id="session-a",
+        delegation_id=delegation_id,
+        runner=runner,
+    )
+
+
+def _event(delegation_id: str):
+    deadline = time.time() + 5
+    deferred = []
+    try:
+        while time.time() < deadline:
+            try:
+                event = process_registry.completion_queue.get(timeout=0.05)
+            except queue.Empty:
+                continue
+            if event.get("delegation_id") == delegation_id:
+                return event
+            deferred.append(event)
+    finally:
+        for event in deferred:
+            process_registry.completion_queue.put(event)
+    raise AssertionError(f"no completion event for {delegation_id}")
+
+
+def test_goal_db_uses_current_profile_after_state_module_import(tmp_path, monkeypatch):
+    import hermes_state
+
+    target_home = tmp_path / "active-profile"
+    monkeypatch.setenv("HERMES_HOME", str(target_home))
+    monkeypatch.setattr(
+        hermes_state,
+        "DEFAULT_DB_PATH",
+        tmp_path / "previous-profile" / "state.db",
+    )
+    goals._DB_CACHE.clear()
+
+    db = goals._get_session_db()
+    assert db is not None
+    assert db.db_path == target_home / "state.db"
+
+
+def test_goal_id_is_append_only_for_positional_constructor_compatibility():
+    state = goals.GoalState("legacy positional goal", "paused")
+
+    assert state.status == "paused"
+    assert state.goal_id == ""
+
+
+def test_goal_owner_capture_fails_closed_when_persistence_is_unavailable(monkeypatch):
+    monkeypatch.setattr(goals, "_get_session_db", lambda: None)
+
+    with pytest.raises(RuntimeError, match="persistence is unavailable"):
+        goals.capture_goal_delegation_owner("session-a")
+
+
+def test_terminal_results_are_claimed_once_and_block_done_until_reconciled(monkeypatch):
+    manager = goals.GoalManager("session-a")
+    state = manager.set("Ship the verified change", max_turns=8)
+
+    _dispatch(
+        state.goal_id,
+        "deleg_one",
+        {
+            "status": "completed",
+            "summary": "first verified result",
+            "tokens": {"input": 11, "output": 7, "reasoning": 3},
+            "cost_usd": 0.01,
+        },
+    )
+    _dispatch(
+        state.goal_id,
+        "deleg_two",
+        {
+            "status": "error",
+            "summary": "second worker failed after partial progress",
+            "error": "verification command failed",
+            "tokens": {"input": 5, "output": 2},
+            "cost_usd": 0.02,
+        },
+    )
+    first_event = _event("deleg_one")
+    second_event = _event("deleg_two")
+
+    monkeypatch.setattr(goals, "judge_goal", lambda *a, **k: ("done", "done", False, None, False))
+    blocked = goals.GoalManager("session-a").evaluate_after_turn("children dispatched")
+    assert blocked["verdict"] == "waiting_for_reconciliation"
+    current = goals.GoalManager("session-a").state
+    assert current is not None
+    assert current.status == "active"
+
+    decision = goals.prepare_goal_delegation_delivery(
+        first_event,
+        "legacy completion",
+        current_session_id="session-a",
+        consumer="test",
+    )
+    assert decision["classification"] == "current"
+    assert "first verified result" in decision["prompt"]
+    assert "second worker failed after partial progress" in decision["prompt"]
+    assert "verification command failed" in decision["prompt"]
+    assert sorted(decision["delegation_ids"]) == ["deleg_one", "deleg_two"]
+    assert decision["reconciliation_attempt"] == 1
+
+    snapshot = ad.get_goal_work_snapshot(state.goal_id)
+    assert snapshot["claimed_count"] == 2
+    assert snapshot["terminal_unreconciled_count"] == 0
+    assert snapshot["tokens"] == {"input": 16, "output": 9, "reasoning": 3}
+    assert snapshot["cost_usd"] == pytest.approx(0.03)
+    assert snapshot["completed_count"] == 1
+    assert snapshot["failed_count"] == 1
+
+    sibling = goals.prepare_goal_delegation_delivery(
+        second_event,
+        "legacy completion",
+        current_session_id="session-a",
+        consumer="test",
+    )
+    assert sibling["prompt"] is None
+
+    assert goals.complete_goal_reconciliation_turn(decision["reconciliation_claim"])
+    assert ad.get_goal_work_snapshot(state.goal_id)["reconciled_count"] == 2
+    finished = goals.GoalManager("session-a").evaluate_after_turn("results integrated")
+    assert finished["status"] == "done"
+
+
+def test_running_required_work_blocks_done_and_budget_exhaustion_pauses(monkeypatch):
+    import threading
+
+    blocker = threading.Event()
+    state = goals.GoalManager("session-a").set("Wait for proof", max_turns=1)
+    _dispatch(
+        state.goal_id,
+        "deleg_running",
+        {"status": "completed", "summary": "proof"},
+        blocker=blocker,
+    )
+    status_line = goals.GoalManager("session-a").status_line()
+    assert "async=1 running" in status_line
+    assert "deleg_running" in status_line
+    monkeypatch.setattr(goals, "judge_goal", lambda *a, **k: ("done", "done", False, None, False))
+
+    verdict = goals.GoalManager("session-a").evaluate_after_turn("dispatched")
+    assert verdict["status"] == "paused"
+    assert "required async delegation" in verdict["reason"]
+    current = goals.GoalManager("session-a").state
+    assert current is not None
+    assert current.status == "paused"
+    blocker.set()
+    _event("deleg_running")
+
+
+def test_direct_mark_done_and_snapshot_failure_are_fail_closed(monkeypatch):
+    manager = goals.GoalManager("session-a")
+    state = manager.set("cannot finish early")
+    _dispatch(
+        state.goal_id,
+        "deleg_mark_done_guard",
+        {"status": "completed", "summary": "awaiting reconciliation"},
+    )
+    _event("deleg_mark_done_guard")
+
+    manager.mark_done("claimed success")
+    guarded = goals.GoalManager("session-a").state
+    assert guarded is not None
+    assert guarded.status == "active"
+    assert guarded.last_verdict == "waiting_for_reconciliation"
+
+    monkeypatch.setattr(
+        goals,
+        "get_goal_work_snapshot",
+        lambda _goal_id: {"available": False, "error": "database offline"},
+    )
+    monkeypatch.setattr(goals, "judge_goal", lambda *a, **k: ("done", "done", False, None, False))
+    decision = goals.GoalManager("session-a").evaluate_after_turn("looks complete")
+    assert decision["verdict"] == "waiting_for_reconciliation"
+    assert decision["status"] == "active"
+    assert "unavailable" in decision["reason"]
+
+
+@pytest.mark.parametrize(
+    "flags",
+    [
+        {"interrupted": True},
+        {"failed": True},
+        {"partial": True},
+        {"error": True},
+    ],
+)
+def test_reconciliation_success_rejects_nonempty_failed_or_partial_turns(flags):
+    assert not goals.reconciliation_turn_succeeded("partial but visible output", **flags)
+    assert goals.reconciliation_turn_succeeded("fully reconciled")
+
+
+def test_paused_completion_waits_for_explicit_resume_and_preserves_goal_id():
+    manager = goals.GoalManager("session-a")
+    state = manager.set("Resume safely", max_turns=8)
+    original_goal_id = state.goal_id
+    _dispatch(
+        state.goal_id,
+        "deleg_paused",
+        {"status": "completed", "summary": "ready while paused"},
+    )
+    event = _event("deleg_paused")
+    manager.pause("user-paused")
+
+    paused = goals.prepare_goal_delegation_delivery(
+        event,
+        "legacy completion",
+        current_session_id="session-a",
+        consumer="test",
+    )
+    assert paused["classification"] == "paused"
+    assert paused["prompt"] is None
+    assert ad.get_goal_work_snapshot(original_goal_id)["terminal_unreconciled_count"] == 1
+
+    resumed = goals.GoalManager("session-a").resume()
+    assert resumed is not None
+    assert resumed.goal_id == original_goal_id
+    decision = goals.prepare_goal_resume("session-a", consumer="test-resume")
+    assert "ready while paused" in decision["prompt"]
+    assert decision["reconciliation_claim"]
+
+
+def test_three_failed_reconciliation_turns_auto_pause_goal():
+    state = goals.GoalManager("session-a").set("Retry boundedly", max_turns=8)
+    _dispatch(
+        state.goal_id,
+        "deleg_retry",
+        {"status": "completed", "summary": "needs integration"},
+    )
+    event = _event("deleg_retry")
+
+    for attempt in range(1, 4):
+        decision = goals.prepare_goal_delegation_delivery(
+            event,
+            "legacy completion",
+            current_session_id="session-a",
+            consumer=f"attempt-{attempt}",
+        )
+        assert decision["reconciliation_attempt"] == attempt
+        assert goals.release_goal_reconciliation_turn(
+            decision["reconciliation_claim"],
+            session_id="session-a",
+            goal_id=state.goal_id,
+            attempt=attempt,
+        )
+        if attempt < 3:
+            event = process_registry.completion_queue.get_nowait()
+            assert event.get("semantic_recovery") is True
+
+    paused = goals.GoalManager("session-a").state
+    assert paused is not None
+    assert paused.status == "paused"
+    assert "failed 3 times" in (paused.paused_reason or "")
+    assert process_registry.completion_queue.empty()
+
+
+def test_goal_replacement_abandons_old_work_and_late_result_is_passive():
+    import threading
+
+    blocker = threading.Event()
+    manager = goals.GoalManager("session-a")
+    old = manager.set("Old objective")
+    _dispatch(
+        old.goal_id,
+        "deleg_old",
+        {"status": "completed", "summary": "late old result"},
+        blocker=blocker,
+    )
+
+    new = manager.set("Replacement objective")
+    assert new.goal_id != old.goal_id
+    assert ad.get_goal_work_snapshot(old.goal_id)["abandoned_count"] == 1
+
+    blocker.set()
+    event = _event("deleg_old")
+    decision = goals.prepare_goal_delegation_delivery(
+        event,
+        "passive late result",
+        current_session_id="session-a",
+        consumer="test",
+    )
+    assert decision["classification"] == "superseded"
+    assert decision["prompt"] == "passive late result"
+    assert ad.get_goal_work_snapshot(new.goal_id)["required_count"] == 0
+
+
+def test_replacement_before_nested_insert_rejects_stale_required_work(monkeypatch):
+    manager = goals.GoalManager("session-a")
+    old = manager.set("old objective")
+    captured = {}
+    real_abandon = ad.abandon_goal_work
+
+    def dispatch_then_abandon(goal_id, reason):
+        captured.update(
+            _dispatch(
+                goal_id,
+                "deleg_replacement_race",
+                {"status": "completed", "summary": "raced replacement"},
+            )
+        )
+        return real_abandon(goal_id, reason)
+
+    monkeypatch.setattr(goals, "_abandon_goal_work", dispatch_then_abandon)
+    replacement = manager.set("replacement objective")
+
+    assert replacement.goal_id != old.goal_id
+    assert captured["status"] == "rejected"
+    assert ad.get_durable_delegation("deleg_replacement_race") is None
+
+
+def test_clear_before_nested_insert_rejects_stale_required_work():
+    manager = goals.GoalManager("session-a")
+    old = manager.set("objective to clear")
+    manager.clear()
+
+    dispatched = _dispatch(
+        old.goal_id,
+        "deleg_clear_race",
+        {"status": "completed", "summary": "stale clear work"},
+    )
+
+    assert dispatched["status"] == "rejected"
+    assert ad.get_durable_delegation("deleg_clear_race") is None
+
+
+def test_reconciliation_retry_keeps_root_owner_across_nested_session():
+    manager = goals.GoalManager("root-session")
+    state = manager.set("Root objective")
+    dispatched = ad.dispatch_async_delegation(
+        goal="nested evidence",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="nested-session",
+        parent_session_id="nested-session",
+        goal_id=state.goal_id,
+        requires_goal_join=True,
+        goal_owner_session_id="root-session",
+        delegation_id="deleg_nested_retry_owner",
+        runner=lambda: {"status": "completed", "summary": "nested result"},
+    )
+    completion = _event(dispatched["delegation_id"])
+
+    retry = ad._goal_reconciliation_retry_event(
+        state.goal_id,
+        "nested-session",
+        completion,
+    )
+    assert retry["goal_owner_session_id"] == "root-session"
+
+    decision = goals.prepare_goal_delegation_delivery(
+        retry,
+        "legacy completion",
+        current_session_id="nested-session",
+        consumer="test-retry",
+    )
+    assert decision["classification"] == "current"
+    assert decision["goal_id"] == state.goal_id
+
+
+@pytest.mark.parametrize("mutation", ["replace", "clear"])
+def test_nested_insert_committing_before_goal_mutation_is_caught_by_sweep(
+    monkeypatch, mutation,
+):
+    from concurrent.futures import ThreadPoolExecutor
+    import threading
+
+    old = goals.GoalManager("session-a").set("old concurrent objective")
+    validation_entered = threading.Event()
+    allow_insert = threading.Event()
+    replacement_done = threading.Event()
+    real_validate = ad._goal_owner_is_current_in_transaction
+
+    def pause_after_validation(conn, owner_session_id, goal_id):
+        current = real_validate(conn, owner_session_id, goal_id)
+        validation_entered.set()
+        assert allow_insert.wait(timeout=5)
+        return current
+
+    monkeypatch.setattr(ad, "_goal_owner_is_current_in_transaction", pause_after_validation)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        dispatch_future = executor.submit(
+            _dispatch,
+            old.goal_id,
+            "deleg_insert_wins_race",
+            {"status": "completed", "summary": "inserted before replacement"},
+        )
+        assert validation_entered.wait(timeout=5)
+
+        def mutate_goal():
+            manager = goals.GoalManager("session-a")
+            if mutation == "replace":
+                manager.set("replacement concurrent objective")
+            else:
+                manager.clear()
+            replacement_done.set()
+
+        replacement_future = executor.submit(mutate_goal)
+        assert not replacement_done.wait(timeout=0.05)
+        allow_insert.set()
+        assert dispatch_future.result(timeout=5)["status"] == "dispatched"
+        replacement_future.result(timeout=5)
+
+    row = ad.get_durable_delegation("deleg_insert_wins_race")
+    assert row is not None
+    assert row["reconciliation_state"] == "abandoned"
+
+
+def test_delegation_started_without_goal_remains_passive_after_goal_is_set():
+    dispatched = ad.dispatch_async_delegation(
+        goal="independent work",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="session-a",
+        parent_session_id="session-a",
+        runner=lambda: {"status": "completed", "summary": "independent result"},
+    )
+    event = _event(dispatched["delegation_id"])
+    state = goals.GoalManager("session-a").set("Later objective")
+
+    durable = ad.get_durable_delegation(dispatched["delegation_id"])
+    assert durable is not None
+    assert durable["requires_goal_join"] is False
+    assert durable["reconciliation_state"] == "not_required"
+    decision = goals.prepare_goal_delegation_delivery(
+        event,
+        "passive independent result",
+        current_session_id="session-a",
+        consumer="test",
+    )
+    assert decision == {
+        "classification": "unowned",
+        "prompt": "passive independent result",
+        "status_message": "",
+    }
+    assert ad.get_goal_work_snapshot(state.goal_id)["required_count"] == 0
+
+
+def test_legacy_goal_backfill_and_compression_keep_stable_identity():
+    db = goals._get_session_db()
+    assert db is not None
+    db.set_meta(
+        goals._meta_key("old-session"),
+        json.dumps({"goal": "legacy objective", "status": "active", "max_turns": 5}),
+    )
+
+    loaded = goals.load_goal("old-session")
+    assert loaded is not None
+    assert loaded.goal_id.startswith("goal_")
+    loaded_again = goals.load_goal("old-session")
+    assert loaded_again is not None
+    assert loaded_again.goal_id == loaded.goal_id
+
+    assert goals.migrate_goal_to_session("old-session", "new-session", reason="test")
+    migrated = goals.load_goal("new-session")
+    assert migrated is not None
+    assert migrated.goal_id == loaded.goal_id
+    source = goals.load_goal("old-session")
+    assert source is not None
+    assert source.status == "cleared"

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4372,6 +4372,18 @@ class TestSchemaInit:
         from hermes_state import SCHEMA_SQL
 
         expected = SessionDB._parse_schema_columns(SCHEMA_SQL)
+        goal_work_columns = {
+            "goal_id",
+            "requires_goal_join",
+            "parent_delegation_id",
+            "goal_owner_session_id",
+            "reconciliation_state",
+            "reconciliation_claim",
+            "reconciliation_claimed_at",
+            "reconciliation_attempts",
+            "reconciled_at",
+        }
+        assert goal_work_columns <= set(expected["async_delegations"])
         for table_name, declared_cols in expected.items():
             live_cols = {
                 r[1]
@@ -4384,6 +4396,69 @@ class TestSchemaInit:
                     f"Column {col_name} declared in SCHEMA_SQL for {table_name} "
                     f"but missing from live DB. Live columns: {live_cols}"
                 )
+        indexes = {
+            row[1]
+            for row in db._conn.execute(
+                'PRAGMA index_list("async_delegations")'
+            ).fetchall()
+        }
+        assert "idx_async_delegations_goal_reconciliation" in indexes
+
+    def test_goal_work_columns_and_index_migrate_from_legacy_table(self, tmp_path):
+        db_path = tmp_path / "legacy-async.db"
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                """CREATE TABLE async_delegations (
+                    delegation_id TEXT PRIMARY KEY,
+                    origin_session TEXT NOT NULL,
+                    origin_ui_session_id TEXT NOT NULL DEFAULT '',
+                    parent_session_id TEXT,
+                    state TEXT NOT NULL,
+                    dispatched_at REAL NOT NULL,
+                    completed_at REAL,
+                    updated_at REAL NOT NULL,
+                    event_json TEXT,
+                    result_json TEXT,
+                    delivery_state TEXT NOT NULL DEFAULT 'pending',
+                    delivery_attempts INTEGER NOT NULL DEFAULT 0,
+                    delivered_at REAL,
+                    owner_pid INTEGER,
+                    owner_started_at INTEGER,
+                    task_json TEXT,
+                    delivery_claim TEXT,
+                    delivery_claimed_at REAL
+                )"""
+            )
+
+        migrated = SessionDB(db_path=db_path)
+        migrated_conn = migrated._conn
+        assert migrated_conn is not None
+        columns = {
+            row[1]
+            for row in migrated_conn.execute(
+                'PRAGMA table_info("async_delegations")'
+            ).fetchall()
+        }
+        indexes = {
+            row[1]
+            for row in migrated_conn.execute(
+                'PRAGMA index_list("async_delegations")'
+            ).fetchall()
+        }
+        migrated.close()
+
+        assert {
+            "goal_id",
+            "requires_goal_join",
+            "parent_delegation_id",
+            "goal_owner_session_id",
+            "reconciliation_state",
+            "reconciliation_claim",
+            "reconciliation_claimed_at",
+            "reconciliation_attempts",
+            "reconciled_at",
+        } <= columns
+        assert "idx_async_delegations_goal_reconciliation" in indexes
 
 
 class TestTitleUniqueness:
@@ -5211,6 +5286,14 @@ class TestStateMeta:
         """set_meta overwrites existing value (ON CONFLICT DO UPDATE)."""
         db.set_meta("key", "v1")
         db.set_meta("key", "v2")
+        assert db.get_meta("key") == "v2"
+
+    def test_compare_and_set_meta_does_not_overwrite_a_concurrent_value(self, db):
+        db.set_meta("key", "v1")
+
+        assert db.compare_and_set_meta("key", "stale", "replacement") is False
+        assert db.get_meta("key") == "v1"
+        assert db.compare_and_set_meta("key", "v1", "v2") is True
         assert db.get_meta("key") == "v2"
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -37,6 +37,46 @@ def _neuter_agent_prewarm_timer(request, monkeypatch):
     yield
 
 
+@pytest.fixture(autouse=True)
+def _join_notification_pollers_started_by_test(monkeypatch):
+    """Keep process-global completion pollers inside their creating test.
+
+    Several session-init tests remove their session from ``server._sessions``
+    during cleanup. The poller still owns the original session dict, so losing
+    that reference before setting its stop event lets a daemon thread consume
+    a later test's replacement completion queue. Track the concrete thread at
+    creation and join it after signalling shutdown.
+    """
+    original_start = server._start_notification_poller
+    started = []
+
+    def _tracked_start(*args, **kwargs):
+        original_thread = server.threading.Thread
+        created = []
+
+        def _capture_thread(*thread_args, **thread_kwargs):
+            thread = original_thread(*thread_args, **thread_kwargs)
+            created.append(thread)
+            return thread
+
+        server.threading.Thread = _capture_thread
+        try:
+            stop = original_start(*args, **kwargs)
+        finally:
+            server.threading.Thread = original_thread
+        started.append((stop, created[-1] if created else None))
+        return stop
+
+    monkeypatch.setattr(server, "_start_notification_poller", _tracked_start)
+    yield
+
+    for stop, _thread in started:
+        stop.set()
+    for _stop, thread in started:
+        if thread is not None and hasattr(thread, "join"):
+            thread.join(timeout=1.0)
+
+
 def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()
@@ -3426,6 +3466,139 @@ def test_notification_poller_delivers_owned_events(
         assert status_calls[0][2]["kind"] == "process"
         assert len(delivered) == 1
         assert "proc_mine" in delivered[0]
+    finally:
+        server._sessions.pop("sid_a", None)
+        while not process_registry.completion_queue.empty():
+            process_registry.completion_queue.get_nowait()
+
+
+def test_notification_poller_journals_goal_owned_intermediate_without_turn(
+    monkeypatch,
+):
+    """TUI acknowledges an intermediate join event without one turn per child."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    delivered = []
+    emitted = []
+    sess = _session(session_key="session-a")
+    server._sessions["sid_a"] = sess
+    monkeypatch.setattr(server, "_emit", lambda *args, **_kwargs: emitted.append(args))
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda _rid, _sid, _session, text: delivered.append(text),
+    )
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.goals.prepare_goal_delegation_delivery",
+        lambda *_args, **_kwargs: {
+            "classification": "current",
+            "prompt": None,
+            "status_message": "waiting for one more delegation",
+        },
+    )
+
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    isolated_queue.put(
+        {
+            "type": "async_delegation",
+            "delegation_id": "deleg_joining",
+            "session_key": "session-a",
+            "origin_ui_session_id": "sid_a",
+            "goal_id": "goal-1",
+            "requires_goal_join": True,
+            "goal": "child work",
+            "status": "completed",
+            "summary": "child result",
+        }
+    )
+    stop = threading.Event()
+    stop.set()
+
+    try:
+        server._notification_poller_loop(stop, "sid_a", sess)
+
+        status_calls = [args for args in emitted if args[0] == "status.update"]
+        assert len(status_calls) == 1
+        assert status_calls[0][2]["text"] == "waiting for one more delegation"
+        assert delivered == []
+        assert isolated_queue.empty()
+    finally:
+        server._sessions.pop("sid_a", None)
+        while not process_registry.completion_queue.empty():
+            process_registry.completion_queue.get_nowait()
+
+
+def test_notification_poller_routes_goal_claim_envelope_through_compute_host(monkeypatch):
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    stop = threading.Event()
+    stop.set()
+    session = _session(session_key="session-a")
+    session["origin_ui_session_id"] = "sid_a"
+    server._sessions["sid_a"] = session
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_join",
+        "session_key": "session-a",
+        "origin_ui_session_id": "sid_a",
+        "goal_id": "goal-1",
+        "requires_goal_join": True,
+        "goal": "child work",
+        "status": "completed",
+        "summary": "child result",
+    }
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(event)
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_emit", lambda *_a, **_k: None)
+    submitted = []
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda _session: True)
+    monkeypatch.setattr(
+        server,
+        "_submit_prompt_to_compute_host",
+        lambda _rid, _sid, _session, prompt: (
+            submitted.append(prompt) or {"result": {"status": "streaming"}}
+        ),
+    )
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda *_a, **_k: (_ for _ in ()).throw(
+            AssertionError("isolated reconciliation must not run in-process")
+        ),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.goals.prepare_goal_delegation_delivery",
+        lambda *_a, **_k: {
+            "classification": "current",
+            "prompt": "reconcile this batch",
+            "status_message": "",
+            "reconciliation_claim": "recon-1",
+            "reconciliation_attempt": 2,
+            "goal_id": "goal-1",
+            "goal_session_id": "session-a",
+            "delegation_ids": ["deleg_join"],
+        },
+    )
+
+    try:
+        server._notification_poller_loop(stop, "sid_a", session)
+        assert submitted == [{
+            "text": "reconcile this batch",
+            "goal_reconciliation": {
+                "claim_id": "recon-1",
+                "goal_id": "goal-1",
+                "session_id": "session-a",
+                "attempt": 2,
+                "delegation_ids": ["deleg_join"],
+            },
+        }]
     finally:
         server._sessions.pop("sid_a", None)
         while not process_registry.completion_queue.empty():

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -5,9 +5,11 @@ onto the shared process_registry.completion_queue, the rich re-injection block
 formatting, capacity rejection, and crash handling.
 """
 
+from concurrent.futures import ThreadPoolExecutor
 import json
 import os
 import queue
+import sqlite3
 import subprocess
 import sys
 import threading
@@ -63,6 +65,21 @@ def _drain_for(delegation_id, timeout=5.0):
             continue
         time.sleep(0.02)
     return None
+
+
+def _install_goal_owner(goal_id: str, session_id: str = "owner") -> None:
+    with ad._connect() as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS state_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO state_meta(key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+            (
+                f"goal:{session_id}",
+                json.dumps({"goal_id": goal_id, "status": "active"}),
+            ),
+        )
 
 
 def test_dispatch_returns_immediately_without_blocking():
@@ -247,26 +264,627 @@ def test_completed_records_pruned_to_cap():
 def test_completion_is_persisted_and_delivery_can_be_acknowledged(tmp_path, monkeypatch):
     """A finished child remains pending on disk until its queue consumer acks it."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _install_goal_owner("goal-123")
     dispatched = ad.dispatch_async_delegation(
         goal="durable", context="ctx", toolsets=["terminal"], role="leaf",
         model="m", session_key="owner", parent_session_id="parent",
-        runner=lambda: {"status": "completed", "summary": "survived"},
+        goal_id="goal-123", requires_goal_join=True,
+        goal_owner_session_id="owner",
+        parent_delegation_id="deleg-parent",
+        runner=lambda: {
+            "status": "completed",
+            "summary": "survived",
+            "tokens": {"input": 9, "output": 5},
+            "cost_usd": 0.02,
+        },
     )
-    assert _drain_one() is not None
+    assert dispatched["goal_owner"] == {
+        "goal_id": "goal-123",
+        "requires_goal_join": True,
+    }
+    completion = _drain_one()
+    assert completion is not None
+    assert completion["goal_id"] == "goal-123"
+    assert completion["requires_goal_join"] is True
+    assert completion["parent_delegation_id"] == "deleg-parent"
+    assert completion["goal_owner_session_id"] == "owner"
+    assert completion["tokens"] == {"input": 9, "output": 5}
+    assert completion["cost_usd"] == 0.02
 
     restored = queue.Queue()
     assert ad.restore_undelivered_completions(restored) == 1
     row = ad.get_durable_delegation(dispatched["delegation_id"])
+    assert row is not None
     assert row["origin_session"] == "owner"
     assert row["state"] == "completed"
     assert row["result"]["summary"] == "survived"
+    assert row["goal_id"] == "goal-123"
+    assert row["requires_goal_join"] is True
+    assert row["parent_delegation_id"] == "deleg-parent"
+    assert row["goal_owner_session_id"] == "owner"
+    assert row["reconciliation_state"] == "pending"
     assert row["delivery_state"] == "pending"
     # Queue publication/restoration is not a destination delivery attempt.
     assert row["delivery_attempts"] == 0
 
     assert ad.mark_completion_delivered(dispatched["delegation_id"])
-    assert ad.restore_undelivered_completions(queue.Queue()) == 0
+    semantic = queue.Queue()
+    assert ad.restore_undelivered_completions(semantic) == 1
+    assert semantic.get_nowait()["semantic_recovery"] is True
     assert ad.get_durable_delegation(dispatched["delegation_id"])["delivery_state"] == "delivered"
+
+
+def test_completion_persistence_recovers_from_one_transient_lock(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    real_persist_once = ad._persist_completion_once
+    attempts = 0
+
+    def fail_once(event, result):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise sqlite3.OperationalError("database is locked")
+        assert not ad._DB_LOCK.locked()
+        real_persist_once(event, result)
+
+    monkeypatch.setattr(ad, "_persist_completion_once", fail_once)
+    dispatched = ad.dispatch_async_delegation(
+        goal="retry terminal write",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="owner",
+        delegation_id="deleg_transient_completion_lock",
+        runner=lambda: {"status": "completed", "summary": "persisted"},
+    )
+
+    event = _drain_for(dispatched["delegation_id"])
+    assert event is not None
+    assert attempts == 2
+    durable = ad.get_durable_delegation(dispatched["delegation_id"])
+    assert durable is not None and durable["state"] == "completed"
+    assert ad.active_count() == 0
+
+
+def test_completion_persistence_continues_after_immediate_retries_exhaust(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(ad, "_COMPLETION_PERSIST_IMMEDIATE_ATTEMPTS", 2)
+    monkeypatch.setattr(ad, "_COMPLETION_PERSIST_RETRY_BASE_SECONDS", 0.01)
+    real_persist_once = ad._persist_completion_once
+    allow_persistence = threading.Event()
+    immediate_exhausted = threading.Event()
+    attempts = 0
+
+    def locked_until_released(event, result):
+        nonlocal attempts
+        attempts += 1
+        if attempts >= 2:
+            immediate_exhausted.set()
+        if not allow_persistence.is_set():
+            raise sqlite3.OperationalError("database is locked")
+        real_persist_once(event, result)
+
+    monkeypatch.setattr(ad, "_persist_completion_once", locked_until_released)
+    dispatched = ad.dispatch_async_delegation(
+        goal="preserve terminal result",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="owner",
+        delegation_id="deleg_background_completion_retry",
+        runner=lambda: {"status": "completed", "summary": "eventual result"},
+    )
+    assert dispatched["status"] == "dispatched"
+    assert immediate_exhausted.wait(timeout=5)
+    assert process_registry.completion_queue.empty()
+    running = ad.get_durable_delegation(dispatched["delegation_id"])
+    assert running is not None and running["state"] == "running"
+    assert ad.list_async_delegations()[0]["status"] == "finalizing"
+
+    blocked = ad.dispatch_async_delegation(
+        goal="must not outgrow retry capacity",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="owner",
+        delegation_id="deleg_blocked_while_finalizing",
+        runner=lambda: {"status": "completed", "summary": "should not run"},
+        max_async_children=1,
+    )
+    assert blocked["status"] == "rejected"
+    assert "capacity reached" in blocked["error"]
+
+    allow_persistence.set()
+    event = _drain_for(dispatched["delegation_id"])
+    assert event is not None and event["summary"] == "eventual result"
+    durable = ad.get_durable_delegation(dispatched["delegation_id"])
+    assert durable is not None and durable["state"] == "completed"
+    assert ad.active_count() == 0
+
+
+def test_completion_remains_durable_when_registry_import_fails(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setitem(sys.modules, "tools.process_registry", None)
+    dispatched = ad.dispatch_async_delegation(
+        goal="persist without queue import",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="owner",
+        delegation_id="deleg_registry_import_failure",
+        runner=lambda: {"status": "completed", "summary": "durable result"},
+    )
+
+    deadline = time.monotonic() + 5.0
+    while ad.active_count() and time.monotonic() < deadline:
+        time.sleep(0.02)
+
+    durable = ad.get_durable_delegation(dispatched["delegation_id"])
+    assert durable is not None and durable["state"] == "completed"
+    assert durable["result"]["summary"] == "durable result"
+    assert ad.active_count() == 0
+
+
+def test_durable_schema_migrates_goal_ownership_columns(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    initial = ad._connect()
+    initial.close()
+
+    with sqlite3.connect(ad._db_path()) as conn:
+        conn.execute("DROP INDEX idx_async_delegations_goal_reconciliation")
+        conn.execute("ALTER TABLE async_delegations DROP COLUMN goal_id")
+        conn.execute("ALTER TABLE async_delegations DROP COLUMN requires_goal_join")
+        conn.execute("ALTER TABLE async_delegations DROP COLUMN parent_delegation_id")
+        conn.execute("ALTER TABLE async_delegations DROP COLUMN goal_owner_session_id")
+        conn.execute("ALTER TABLE async_delegations DROP COLUMN reconciliation_state")
+        conn.execute("ALTER TABLE async_delegations DROP COLUMN reconciliation_claim")
+        conn.execute("ALTER TABLE async_delegations DROP COLUMN reconciliation_claimed_at")
+        conn.execute("ALTER TABLE async_delegations DROP COLUMN reconciliation_attempts")
+        conn.execute("ALTER TABLE async_delegations DROP COLUMN reconciled_at")
+
+    with ad._connect() as conn:
+        columns = {
+            row[1]: row for row in conn.execute("PRAGMA table_info(async_delegations)")
+        }
+    assert columns["goal_id"][3] == 1  # NOT NULL
+    assert columns["goal_id"][4] == "''"  # default preserves legacy rows
+    assert columns["requires_goal_join"][4] == "0"
+    assert columns["goal_owner_session_id"][4] == "''"
+    assert columns["reconciliation_state"][4] == "'not_required'"
+    assert "reconciliation_claim" in columns
+
+
+def test_concurrent_processes_can_migrate_goal_ownership_columns(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    initial = ad._connect()
+    initial.close()
+    with sqlite3.connect(ad._db_path()) as conn:
+        conn.execute("DROP INDEX idx_async_delegations_goal_reconciliation")
+        for column in (
+            "goal_id",
+            "requires_goal_join",
+            "parent_delegation_id",
+            "goal_owner_session_id",
+            "reconciliation_state",
+            "reconciliation_claim",
+            "reconciliation_claimed_at",
+            "reconciliation_attempts",
+            "reconciled_at",
+        ):
+            conn.execute(f"ALTER TABLE async_delegations DROP COLUMN {column}")
+
+    start_file = tmp_path / "start-migration"
+    script = """
+import os
+import sys
+import time
+from tools import async_delegation as ad
+
+while not os.path.exists(sys.argv[1]):
+    time.sleep(0.01)
+with ad._connect():
+    pass
+"""
+    env = dict(os.environ)
+    workers = [
+        subprocess.Popen(
+            [sys.executable, "-c", script, str(start_file)],
+            cwd=os.getcwd(),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for _ in range(8)
+    ]
+    start_file.touch()
+    failures = []
+    for worker in workers:
+        stdout, stderr = worker.communicate(timeout=45)
+        if worker.returncode:
+            failures.append((worker.returncode, stdout, stderr))
+
+    assert failures == []
+    with ad._connect() as conn:
+        columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(async_delegations)")
+        }
+    assert "goal_id" in columns
+    assert "reconciled_at" in columns
+
+
+def test_duplicate_delegation_id_preserves_original_durable_row(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    base = {
+        "delegation_id": "deleg_fixed",
+        "goal": "original",
+        "session_key": "owner",
+        "status": "running",
+        "dispatched_at": time.time(),
+    }
+    ad._persist_dispatch(base)
+
+    with pytest.raises(sqlite3.IntegrityError):
+        ad._persist_dispatch({**base, "goal": "replacement"})
+
+    with sqlite3.connect(ad._db_path()) as conn:
+        task_json = conn.execute(
+            "SELECT task_json FROM async_delegations WHERE delegation_id='deleg_fixed'"
+        ).fetchone()[0]
+    assert json.loads(task_json)["goal"] == "original"
+
+
+def test_duplicate_live_delegation_id_does_not_replace_runner(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    gate = threading.Event()
+
+    def original_runner():
+        gate.wait(timeout=5)
+        return {"status": "completed", "summary": "original finished"}
+
+    first = ad.dispatch_async_delegation(
+        goal="original live task",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="owner",
+        delegation_id="deleg_live_fixed",
+        runner=original_runner,
+    )
+    second = ad.dispatch_async_delegation(
+        goal="replacement task",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="owner",
+        delegation_id="deleg_live_fixed",
+        runner=lambda: {"status": "completed", "summary": "replacement ran"},
+    )
+    assert first["status"] == "dispatched"
+    assert second["status"] == "rejected"
+    gate.set()
+    event = _drain_for("deleg_live_fixed")
+    assert event is not None
+    assert event["summary"] == "original finished"
+
+
+def test_dispatch_persistence_failure_releases_in_memory_slot(monkeypatch):
+    def fail_persist(_record):
+        raise OSError("disk")
+
+    monkeypatch.setattr(ad, "_persist_dispatch", fail_persist)
+
+    result = ad.dispatch_async_delegation(
+        goal="must persist",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="owner",
+        runner=lambda: {"status": "completed"},
+    )
+
+    assert result["status"] == "rejected"
+    assert ad.active_count() == 0
+    assert ad.list_async_delegations() == []
+
+    batch_result = ad.dispatch_async_delegation_batch(
+        goals=["also persist"],
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="owner",
+        runner=lambda: {"results": []},
+    )
+    assert batch_result["status"] == "rejected"
+    assert ad.active_count() == 0
+    assert ad.list_async_delegations() == []
+
+
+def test_goal_snapshot_reports_mixed_batch_child_failure(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _install_goal_owner("goal-mixed")
+    dispatched = ad.dispatch_async_delegation_batch(
+        goals=["succeeds", "fails"],
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="owner",
+        goal_id="goal-mixed",
+        requires_goal_join=True,
+        goal_owner_session_id="owner",
+        runner=lambda: {
+            "status": "completed",
+            "results": [
+                {"status": "completed", "summary": "ok"},
+                {"status": "error", "error": "child exploded"},
+            ],
+        },
+    )
+    assert _drain_for(dispatched["delegation_id"]) is not None
+
+    snapshot = ad.get_goal_work_snapshot("goal-mixed")
+    assert snapshot["completed_count"] == 1
+    assert snapshot["failed_count"] == 1
+    assert snapshot["last_error"] == "child exploded"
+
+
+def test_in_memory_pruning_keeps_finalizing_records(monkeypatch):
+    monkeypatch.setattr(ad, "_MAX_RETAINED_COMPLETED", 1)
+    with ad._records_lock:
+        ad._records.update({
+            "deleg_finalizing": {
+                "status": "finalizing",
+                "dispatched_at": 1,
+            },
+            "deleg_old": {
+                "status": "completed",
+                "completed_at": 2,
+            },
+            "deleg_new": {
+                "status": "completed",
+                "completed_at": 3,
+            },
+        })
+        ad._prune_completed_locked()
+
+    assert "deleg_finalizing" in ad._records
+    assert "deleg_old" not in ad._records
+    assert "deleg_new" in ad._records
+
+
+def test_reconciliation_claim_is_fenced_idempotent_and_stale_recoverable(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _install_goal_owner("goal-claim")
+    dispatched = ad.dispatch_async_delegation(
+        goal="claimable",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="owner",
+        goal_id="goal-claim",
+        requires_goal_join=True,
+        goal_owner_session_id="owner",
+        runner=lambda: {"status": "completed", "summary": "ready"},
+    )
+    completion = _drain_one()
+    assert completion is not None
+    assert completion["delegation_id"] == dispatched["delegation_id"]
+
+    first = ad.claim_goal_reconciliation("goal-claim", "consumer-a")
+    assert first is not None
+    assert first["attempt"] == 1
+    assert ad.claim_goal_reconciliation("goal-claim", "consumer-b") is None
+    assert ad.release_goal_reconciliation("wrong-token") is False
+    assert ad.release_goal_reconciliation(first["claim_id"]) is True
+    assert ad.release_goal_reconciliation(first["claim_id"]) is True
+
+    second = ad.claim_goal_reconciliation("goal-claim", "consumer-b")
+    assert second is not None
+    assert second["attempt"] == 2
+    with sqlite3.connect(ad._db_path()) as conn:
+        conn.execute(
+            "UPDATE async_delegations SET reconciliation_claimed_at=? WHERE delegation_id=?",
+            (time.time() - 999, dispatched["delegation_id"]),
+        )
+        conn.execute(
+            "UPDATE async_delegations SET delivery_state='delivered' WHERE delegation_id=?",
+            (dispatched["delegation_id"],),
+        )
+    restored = queue.Queue()
+    assert ad.recover_stale_goal_reconciliation_claims(restored) == 1
+    retry_event = restored.get_nowait()
+    assert retry_event["semantic_recovery"] is True
+    assert retry_event["goal_owner_session_id"] == "owner"
+    third = ad.claim_goal_reconciliation("goal-claim", "consumer-c")
+    assert third is not None
+    assert third["attempt"] == 3
+    assert ad.complete_goal_reconciliation(second["claim_id"]) is False
+    assert ad.complete_goal_reconciliation(third["claim_id"]) is True
+    assert ad.complete_goal_reconciliation(third["claim_id"]) is True
+    assert ad.get_goal_work_snapshot("goal-claim")["reconciled_count"] == 1
+
+
+def test_pruning_protects_required_unreconciled_rows(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _install_goal_owner("goal-retain")
+    dispatched = ad.dispatch_async_delegation(
+        goal="retain evidence",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="owner",
+        goal_id="goal-retain",
+        requires_goal_join=True,
+        goal_owner_session_id="owner",
+        runner=lambda: {"status": "completed", "summary": "evidence"},
+    )
+    assert _drain_one() is not None
+    delegation_id = dispatched["delegation_id"]
+    assert ad.mark_completion_delivered(delegation_id)
+    with sqlite3.connect(ad._db_path()) as conn:
+        conn.execute(
+            "UPDATE async_delegations SET delivered_at=? WHERE delegation_id=?",
+            (time.time() - 10_000, delegation_id),
+        )
+    monkeypatch.setattr(ad, "_DURABLE_RETENTION_SECONDS", 1)
+
+    ad._prune_durable_records()
+    assert ad.get_durable_delegation(delegation_id) is not None
+
+    assert ad.abandon_goal_work("goal-retain", "test cleanup") == 1
+    with sqlite3.connect(ad._db_path()) as conn:
+        conn.execute(
+            "UPDATE async_delegations SET updated_at=? WHERE delegation_id=?",
+            (time.time() - 10_000, delegation_id),
+        )
+    ad._prune_durable_records()
+    assert ad.get_durable_delegation(delegation_id) is None
+
+
+def test_reconciliation_claim_tolerates_malformed_result_json(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _install_goal_owner("goal-malformed")
+    dispatched = ad.dispatch_async_delegation(
+        goal="malformed evidence",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="owner",
+        goal_id="goal-malformed",
+        requires_goal_join=True,
+        goal_owner_session_id="owner",
+        runner=lambda: {"status": "completed", "summary": "valid first"},
+    )
+    assert _drain_one() is not None
+    with sqlite3.connect(ad._db_path()) as conn:
+        conn.execute(
+            "UPDATE async_delegations SET result_json=? WHERE delegation_id=?",
+            ("{not-json", dispatched["delegation_id"]),
+        )
+
+    claim = ad.claim_goal_reconciliation("goal-malformed", "test")
+    assert claim is not None
+    assert claim["delegations"][0]["result"] == {}
+
+
+def test_pre_turn_release_does_not_consume_retry_budget(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _install_goal_owner("goal-pre-turn")
+    ad.dispatch_async_delegation(
+        goal="enqueue later",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="owner",
+        goal_id="goal-pre-turn",
+        requires_goal_join=True,
+        goal_owner_session_id="owner",
+        runner=lambda: {"status": "completed", "summary": "ready"},
+    )
+    assert _drain_one() is not None
+    first = ad.claim_goal_reconciliation("goal-pre-turn", "test")
+    assert first is not None and first["attempt"] == 1
+    assert ad.release_goal_reconciliation(
+        first["claim_id"],
+        decrement_attempt=True,
+    )
+    second = ad.claim_goal_reconciliation("goal-pre-turn", "test")
+    assert second is not None and second["attempt"] == 1
+
+
+def test_concurrent_reconciliation_claims_have_one_winner(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _install_goal_owner("goal-contention")
+    ad.dispatch_async_delegation(
+        goal="claim once",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="owner",
+        goal_id="goal-contention",
+        requires_goal_join=True,
+        goal_owner_session_id="owner",
+        runner=lambda: {"status": "completed", "summary": "ready"},
+    )
+    assert _drain_one() is not None
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        claims = list(
+            executor.map(
+                lambda index: ad.claim_goal_reconciliation(
+                    "goal-contention", f"consumer-{index}"
+                ),
+                range(8),
+            )
+        )
+    assert len([claim for claim in claims if claim is not None]) == 1
+
+
+def test_reconciliation_claim_batches_never_hide_claimed_rows(tmp_path, monkeypatch):
+    from hermes_cli.goals import complete_goal_reconciliation_turn
+    from tools.process_registry import format_goal_reconciliation_claim
+    from tools.process_registry import process_registry
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _install_goal_owner("goal-bounded-batch")
+    for index in range(21):
+        ad.dispatch_async_delegation(
+            goal=f"work {index}",
+            context=None,
+            toolsets=None,
+            role="leaf",
+            model=None,
+            session_key="batch-session",
+            parent_session_id="batch-session",
+            goal_id="goal-bounded-batch",
+            requires_goal_join=True,
+            goal_owner_session_id="owner",
+            delegation_id=f"deleg_bounded_{index:02d}",
+            runner=lambda i=index: {
+                "status": "completed",
+                "summary": f"bounded result {i} " + ("x" * 20_000),
+            },
+        )
+        _drain_one()
+
+    claimed_ids = []
+    batch_sizes = []
+    while True:
+        claim = ad.claim_goal_reconciliation("goal-bounded-batch", "test")
+        if claim is None:
+            break
+        batch_ids = list(claim["delegation_ids"])
+        batch_sizes.append(len(batch_ids))
+        prompt = format_goal_reconciliation_claim(claim, goal="bounded goal")
+        assert len(prompt) < 60_000
+        for delegation_id in batch_ids:
+            assert f"async_delegations:{delegation_id}" in prompt
+        claimed_ids.extend(batch_ids)
+        assert complete_goal_reconciliation_turn(claim["claim_id"])
+        if len(claimed_ids) < 21:
+            followup = process_registry.completion_queue.get(timeout=1)
+            assert followup["semantic_recovery"] is True
+
+    assert batch_sizes == [10, 10, 1]
+    assert claimed_ids == [f"deleg_bounded_{index:02d}" for index in range(21)]
 
 
 def test_real_process_restart_restores_owned_completion_once(tmp_path):
@@ -487,6 +1105,60 @@ def test_delegate_task_background_routes_async_and_does_not_block(monkeypatch):
     assert "the real task" in text
 
 
+def test_delegate_task_runs_synchronously_when_goal_ownership_is_unavailable(monkeypatch):
+    from unittest.mock import MagicMock
+
+    import hermes_cli.goals as goals_module
+    import tools.delegate_tool as dt
+
+    parent = MagicMock()
+    parent._delegate_depth = 0
+    parent.session_id = "sess"
+    parent._active_children = []
+    parent._active_children_lock = None
+    fake_child = MagicMock()
+    fake_child._delegate_role = "leaf"
+    creds = {
+        "model": "m",
+        "provider": None,
+        "base_url": None,
+        "api_key": None,
+        "api_mode": None,
+        "command": None,
+        "args": None,
+    }
+    monkeypatch.setattr(dt, "_build_child_agent", lambda **_kw: fake_child)
+    monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *_a, **_k: creds)
+    monkeypatch.setattr(
+        dt,
+        "_run_single_child",
+        lambda *_a, **_k: {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "joined in the parent turn",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+            "model": "m",
+            "exit_reason": "completed",
+        },
+    )
+    monkeypatch.setattr(
+        goals_module,
+        "capture_goal_delegation_owner",
+        lambda _session_id: (_ for _ in ()).throw(RuntimeError("database locked")),
+    )
+    dispatch = MagicMock(side_effect=AssertionError("must not detach"))
+    monkeypatch.setattr(ad, "dispatch_async_delegation_batch", dispatch)
+
+    result = json.loads(
+        dt.delegate_task(goal="safe fallback", background=True, parent_agent=parent)
+    )
+
+    assert result["results"][0]["summary"] == "joined in the parent turn"
+    assert "ran synchronously" in result["note"]
+    dispatch.assert_not_called()
+
+
 def test_delegate_task_background_uses_live_tui_agent_session_id(monkeypatch):
     """TUI async delegation must route to the live/compressed agent id.
 
@@ -557,6 +1229,7 @@ def test_delegate_task_background_batch_runs_as_one_unit(monkeypatch):
     import json
     from unittest.mock import MagicMock, patch
     import tools.delegate_tool as dt
+    from hermes_cli.goals import GoalManager
 
     parent = MagicMock()
     parent._delegate_depth = 0
@@ -589,6 +1262,7 @@ def test_delegate_task_background_batch_runs_as_one_unit(monkeypatch):
     monkeypatch.setattr(dt, "_build_child_agent", lambda **kw: fake_child)
     monkeypatch.setattr(dt, "_run_single_child", _blocking_child)
     monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
+    standing_goal = GoalManager("sess").set("Finish the parent objective")
     out = dt.delegate_task(
         tasks=[{"goal": "a"}, {"goal": "b"}, {"goal": "c"}],
         background=True,
@@ -601,6 +1275,18 @@ def test_delegate_task_background_batch_runs_as_one_unit(monkeypatch):
     assert parsed["count"] == 3
     assert parsed["delegation_id"].startswith("deleg_")
     assert parsed["goals"] == ["a", "b", "c"]
+    assert parsed["goal_owner"] == {
+        "goal_id": standing_goal.goal_id,
+        "requires_goal_join": True,
+        "parent_delegation_id": "",
+    }
+    durable = ad.get_durable_delegation(parsed["delegation_id"])
+    assert durable is not None
+    assert durable["requires_goal_join"] is True
+    assert durable["reconciliation_state"] == "pending"
+    assert fake_child._root_goal_id == standing_goal.goal_id
+    assert fake_child._root_goal_owner_session_id == "sess"
+    assert fake_child._delegation_id == parsed["delegation_id"]
     # ONE background unit for the whole fan-out (not three), and the call
     # returned while all children are still blocked → chat not blocked.
     assert process_registry.completion_queue.empty()
@@ -612,6 +1298,8 @@ def test_delegate_task_background_batch_runs_as_one_unit(monkeypatch):
     assert evt is not None
     assert evt["type"] == "async_delegation"
     assert evt.get("is_batch") is True
+    assert evt["goal_id"] == standing_goal.goal_id
+    assert evt["requires_goal_join"] is True
     assert len(evt["results"]) == 3
     summaries = sorted(r["summary"] for r in evt["results"])
     assert summaries == ["done: a", "done: b", "done: c"]
@@ -622,6 +1310,63 @@ def test_delegate_task_background_batch_runs_as_one_unit(monkeypatch):
     assert "done: a" in text and "done: b" in text and "done: c" in text
     # No more events — it's a single combined completion, not N of them.
     assert _drain_one() is None
+
+
+def test_nested_async_dispatch_inherits_root_goal_and_parent_delegation(monkeypatch):
+    import json
+    from unittest.mock import MagicMock
+
+    import tools.delegate_tool as dt
+
+    parent = MagicMock()
+    parent._delegate_depth = 1
+    parent.session_id = "nested-session"
+    parent._root_goal_id = "goal-root"
+    parent._root_goal_owner_session_id = "root-owner-session"
+    parent._delegation_id = "deleg-parent"
+    parent._interrupt_requested = False
+    parent._active_children = []
+    parent._active_children_lock = None
+    child = MagicMock()
+    captured = {}
+
+    monkeypatch.setattr(dt, "_get_max_spawn_depth", lambda: 2)
+    monkeypatch.setattr(dt, "_build_child_agent", lambda **_kw: child)
+    monkeypatch.setattr(
+        dt,
+        "_resolve_delegation_credentials",
+        lambda *_a, **_k: {
+            "model": "m",
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "command": None,
+            "args": None,
+        },
+    )
+
+    def _dispatch(**kwargs):
+        captured.update(kwargs)
+        return {"status": "dispatched", "delegation_id": kwargs["delegation_id"]}
+
+    monkeypatch.setattr(ad, "dispatch_async_delegation_batch", _dispatch)
+    payload = json.loads(
+        dt.delegate_task(
+            tasks=[{"goal": "nested work"}],
+            background=True,
+            parent_agent=parent,
+        )
+    )
+
+    assert payload["status"] == "dispatched"
+    assert captured["goal_id"] == "goal-root"
+    assert captured["requires_goal_join"] is True
+    assert captured["parent_delegation_id"] == "deleg-parent"
+    assert captured["goal_owner_session_id"] == "root-owner-session"
+    assert child._root_goal_id == "goal-root"
+    assert child._root_goal_owner_session_id == "root-owner-session"
+    assert child._delegation_id == payload["delegation_id"]
 
 
 def test_model_dispatch_forces_background():

--- a/tests/tui_gateway/test_compute_host_phase1.py
+++ b/tests/tui_gateway/test_compute_host_phase1.py
@@ -77,6 +77,153 @@ def test_compute_host_frame_protocol_round_trip():
         host.close()
 
 
+def test_isolated_turn_carries_and_consumes_pending_goal_reconciliation(monkeypatch):
+    from tui_gateway import server
+
+    session = {
+        "session_key": "goal-session",
+        "history": [],
+        "history_lock": threading.RLock(),
+        "history_version": 0,
+        "attached_images": [],
+        "pending_goal_reconciliation": {
+            "claim_id": "recon-1",
+            "goal_id": "goal-1",
+            "session_id": "goal-session",
+            "attempt": 2,
+            "delegation_ids": ["deleg-1"],
+            "_prompt": "reconcile durable results",
+        },
+    }
+    captured = {}
+
+    class _Supervisor:
+        def submit_turn(self, frame, *, on_complete=None):
+            captured["frame"] = frame
+            captured["on_complete"] = on_complete
+            return frame["request_id"]
+
+    completions = []
+    monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg: _Supervisor())
+    monkeypatch.setattr(
+        server,
+        "_on_compute_host_turn_done",
+        lambda _rid, _sid, _session, frame: completions.append(frame),
+    )
+
+    response = server._submit_prompt_to_compute_host(
+        "rid-1", "sid-1", session, "reconcile durable results"
+    )
+
+    assert "error" not in response
+    assert captured["frame"]["text"] == {
+        "text": "reconcile durable results",
+        "goal_reconciliation": {
+            "claim_id": "recon-1",
+            "goal_id": "goal-1",
+            "session_id": "goal-session",
+            "attempt": 2,
+            "delegation_ids": ["deleg-1"],
+        },
+    }
+    assert "pending_goal_reconciliation" not in session
+
+    captured["on_complete"](
+        {
+            "type": "turn.error",
+            "reason": "session_busy",
+            "turn_started": False,
+            "message": "busy",
+        }
+    )
+    assert completions[0]["_goal_reconciliation"]["claim_id"] == "recon-1"
+
+
+def test_isolated_turn_restores_pending_reconciliation_on_send_failure(monkeypatch):
+    from tui_gateway import server
+
+    pending = {
+        "claim_id": "recon-1",
+        "goal_id": "goal-1",
+        "session_id": "goal-session",
+        "attempt": 1,
+        "_prompt": "reconcile durable results",
+    }
+    session = {
+        "session_key": "goal-session",
+        "history": [],
+        "history_lock": threading.RLock(),
+        "history_version": 0,
+        "attached_images": [],
+        "pending_goal_reconciliation": dict(pending),
+    }
+
+    class _BrokenSupervisor:
+        def submit_turn(self, _frame, *, on_complete=None):
+            raise RuntimeError("pipe closed")
+
+    monkeypatch.setattr(
+        server,
+        "_get_compute_host_supervisor",
+        lambda _cfg: _BrokenSupervisor(),
+    )
+
+    response = server._submit_prompt_to_compute_host(
+        "rid-1", "sid-1", session, "reconcile durable results"
+    )
+
+    assert response["error"]["code"] == 5019
+    assert session["pending_goal_reconciliation"] == pending
+
+
+def test_compute_host_error_releases_goal_reconciliation_claim(monkeypatch):
+    from unittest.mock import MagicMock
+
+    import hermes_cli.goals as goals
+    from tui_gateway import server
+
+    session = {
+        "session_key": "goal-session",
+        "history_lock": threading.RLock(),
+        "history_version": 0,
+        "running": True,
+        "agent": None,
+    }
+    release = MagicMock(return_value={"released": True})
+    monkeypatch.setattr(goals, "release_goal_reconciliation_turn", release)
+    monkeypatch.setattr(server, "_clear_inflight_turn", lambda _session: None)
+    monkeypatch.setattr(server, "_emit", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_apply_compute_host_metadata_mirror", lambda *_a: None)
+    monkeypatch.setattr(server, "_session_info", lambda *_a: {})
+    monkeypatch.setattr(server, "_drain_queued_prompt", lambda *_a: False)
+
+    server._on_compute_host_turn_done(
+        "rid-1",
+        "sid-1",
+        session,
+        {
+            "type": "turn.error",
+            "reason": "session_busy",
+            "turn_started": False,
+            "message": "busy",
+            "_goal_reconciliation": {
+                "claim_id": "recon-1",
+                "goal_id": "goal-1",
+                "session_id": "goal-session",
+                "attempt": 2,
+            },
+        },
+    )
+
+    release.assert_called_once_with(
+        "recon-1",
+        session_id="goal-session",
+        goal_id="goal-1",
+        attempt=2,
+        turn_started=False,
+    )
+
+
 def test_compute_host_interrupt_control_is_not_queued_behind_turn():
     out = io.StringIO()
     host = ComputeHost(stdout=out, max_workers=1, heartbeat_secs=0)
@@ -146,6 +293,29 @@ def test_compute_host_parent_guard_exits_when_parent_pid_changes(monkeypatch):
     assert orphan["old_ppid"] == 111
     assert orphan["ppid"] == 222
     assert isinstance(orphan["host_ns"], int)
+
+
+def test_supervisor_crash_reports_whether_each_turn_started(tmp_path):
+    completions = []
+    supervisor = HostSupervisor(
+        registry_path=tmp_path / "compute-host.json",
+        argv=[sys.executable, "-c", ""],
+        rpc_sink=lambda _frame: None,
+        autostart=False,
+    )
+    supervisor._pending_turns = {
+        "before": ("sid", completions.append, False),
+        "during": ("sid", completions.append, False),
+    }
+
+    supervisor._handle_host_frame(
+        {"type": "turn.started", "request_id": "during", "sid": "sid"}
+    )
+    supervisor._fail_pending_turns(reason="crash", message="host exited")
+
+    by_id = {frame["request_id"]: frame for frame in completions}
+    assert by_id["before"]["turn_started"] is False
+    assert by_id["during"]["turn_started"] is True
 
 
 def test_mutator_route_table_matches_prd_inventory():

--- a/tests/tui_gateway/test_goal_command.py
+++ b/tests/tui_gateway/test_goal_command.py
@@ -139,8 +139,9 @@ def test_goal_resume_reactivates(server, session):
     _call(server, "command.dispatch", name="goal", arg="write a story", session_id=sid)
     _call(server, "command.dispatch", name="goal", arg="pause", session_id=sid)
     r = _call(server, "command.dispatch", name="goal", arg="resume", session_id=sid)
-    assert r["result"]["type"] == "exec"
-    assert "resumed" in r["result"]["output"].lower()
+    assert r["result"]["type"] == "send"
+    assert "resumed" in r["result"]["notice"].lower()
+    assert "Continue working toward this goal" in r["result"]["message"]
 
     from hermes_cli.goals import GoalManager
 

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -83,6 +83,11 @@ _MAX_DURABLE_PENDING = 1000
 # instead of replaying on every restart forever.
 _MAX_DELIVERY_ATTEMPTS = 8
 _DB_LOCK = threading.Lock()
+_RECONCILIATION_CLAIM_LEASE_SECONDS = 300
+_MAX_RECONCILIATION_BATCH_ROWS = 10
+_COMPLETION_PERSIST_IMMEDIATE_ATTEMPTS = 3
+_COMPLETION_PERSIST_RETRY_BASE_SECONDS = 0.05
+_COMPLETION_PERSIST_RETRY_MAX_SECONDS = 5.0
 
 
 def _db_path():
@@ -93,40 +98,118 @@ def _connect() -> sqlite3.Connection:
     path = _db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(path, timeout=10)
-    conn.execute("PRAGMA journal_mode=WAL")
-    conn.execute(
-        """CREATE TABLE IF NOT EXISTS async_delegations (
-            delegation_id TEXT PRIMARY KEY,
-            origin_session TEXT NOT NULL,
-            origin_ui_session_id TEXT NOT NULL DEFAULT '',
-            parent_session_id TEXT,
-            state TEXT NOT NULL,
-            dispatched_at REAL NOT NULL,
-            completed_at REAL,
-            updated_at REAL NOT NULL,
-            event_json TEXT,
-            result_json TEXT,
-            delivery_state TEXT NOT NULL DEFAULT 'pending',
-            delivery_attempts INTEGER NOT NULL DEFAULT 0,
-            delivered_at REAL,
-            owner_pid INTEGER,
-            owner_started_at INTEGER,
-            task_json TEXT,
-            delivery_claim TEXT,
-            delivery_claimed_at REAL
-        )"""
+    conn.execute("PRAGMA busy_timeout=10000")
+    for attempt in range(6):
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS async_delegations (
+                    delegation_id TEXT PRIMARY KEY,
+                    origin_session TEXT NOT NULL,
+                    origin_ui_session_id TEXT NOT NULL DEFAULT '',
+                    parent_session_id TEXT,
+                    state TEXT NOT NULL,
+                    dispatched_at REAL NOT NULL,
+                    completed_at REAL,
+                    updated_at REAL NOT NULL,
+                    event_json TEXT,
+                    result_json TEXT,
+                    delivery_state TEXT NOT NULL DEFAULT 'pending',
+                    delivery_attempts INTEGER NOT NULL DEFAULT 0,
+                    delivered_at REAL,
+                    owner_pid INTEGER,
+                    owner_started_at INTEGER,
+                    task_json TEXT,
+                    delivery_claim TEXT,
+                    delivery_claimed_at REAL,
+                    goal_id TEXT NOT NULL DEFAULT '',
+                    requires_goal_join INTEGER NOT NULL DEFAULT 0,
+                    parent_delegation_id TEXT NOT NULL DEFAULT '',
+                    goal_owner_session_id TEXT NOT NULL DEFAULT '',
+                    reconciliation_state TEXT NOT NULL DEFAULT 'not_required',
+                    reconciliation_claim TEXT,
+                    reconciliation_claimed_at REAL,
+                    reconciliation_attempts INTEGER NOT NULL DEFAULT 0,
+                    reconciled_at REAL
+                )"""
+            )
+            columns = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(async_delegations)")
+            }
+            for name, sql_type in (
+                ("owner_pid", "INTEGER"),
+                ("owner_started_at", "INTEGER"),
+                ("task_json", "TEXT"),
+                ("delivery_claim", "TEXT"),
+                ("delivery_claimed_at", "REAL"),
+                ("goal_id", "TEXT NOT NULL DEFAULT ''"),
+                ("requires_goal_join", "INTEGER NOT NULL DEFAULT 0"),
+                ("parent_delegation_id", "TEXT NOT NULL DEFAULT ''"),
+                ("goal_owner_session_id", "TEXT NOT NULL DEFAULT ''"),
+                ("reconciliation_state", "TEXT NOT NULL DEFAULT 'not_required'"),
+                ("reconciliation_claim", "TEXT"),
+                ("reconciliation_claimed_at", "REAL"),
+                ("reconciliation_attempts", "INTEGER NOT NULL DEFAULT 0"),
+                ("reconciled_at", "REAL"),
+            ):
+                if name not in columns:
+                    try:
+                        conn.execute(
+                            f"ALTER TABLE async_delegations ADD COLUMN {name} {sql_type}"
+                        )
+                    except sqlite3.OperationalError as exc:
+                        # Another process may have completed the same migration
+                        # after our table-info read.
+                        if "duplicate column name" not in str(exc).lower():
+                            raise
+            conn.execute(
+                """CREATE INDEX IF NOT EXISTS idx_async_delegations_goal_reconciliation
+                   ON async_delegations(
+                       goal_id, requires_goal_join, reconciliation_state, state
+                   )"""
+            )
+            conn.commit()
+            return conn
+        except sqlite3.OperationalError as exc:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            if "locked" not in str(exc).lower() or attempt == 5:
+                conn.close()
+                raise
+            # WAL setup and additive DDL can race across CLI, gateway, and TUI
+            # processes even with SQLite's busy timeout. Re-read the schema on
+            # each bounded retry rather than assuming which DDL won.
+            time.sleep(min(0.05 * (2**attempt), 1.0))
+        except Exception:
+            conn.close()
+            raise
+    conn.close()
+    raise RuntimeError("async delegation schema initialization exhausted retries")
+
+
+def _goal_owner_is_current_in_transaction(
+    conn: sqlite3.Connection, owner_session_id: str, goal_id: str
+) -> bool:
+    """Validate required ownership on the same snapshot used by insertion."""
+    if not owner_session_id or not goal_id:
+        return False
+    row = conn.execute(
+        "SELECT value FROM state_meta WHERE key=?", (f"goal:{owner_session_id}",)
+    ).fetchone()
+    if row is None:
+        return False
+    try:
+        state = json.loads(row[0])
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return False
+    return bool(
+        isinstance(state, dict)
+        and state.get("status") == "active"
+        and str(state.get("goal_id") or "") == goal_id
     )
-    columns = {row[1] for row in conn.execute("PRAGMA table_info(async_delegations)")}
-    for name, sql_type in (
-        ("owner_pid", "INTEGER"),
-        ("owner_started_at", "INTEGER"),
-        ("task_json", "TEXT"),
-        ("delivery_claim", "TEXT"),
-        ("delivery_claimed_at", "REAL"),
-    ):
-        if name not in columns:
-            conn.execute(f"ALTER TABLE async_delegations ADD COLUMN {name} {sql_type}")
-    return conn
 
 
 def _persist_dispatch(record: Dict[str, Any]) -> None:
@@ -138,21 +221,40 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
         owner_started_at = None
     task_payload = {
         key: record.get(key)
-        for key in ("goal", "goals", "context", "toolsets", "role", "model", "is_batch")
+        for key in (
+            "goal", "goals", "context", "toolsets", "role", "model", "is_batch",
+            "goal_id", "requires_goal_join", "parent_delegation_id",
+            "goal_owner_session_id",
+        )
         if key in record
     }
     with _DB_LOCK, _connect() as conn:
+        # BEGIN IMMEDIATE serializes this read+insert with goal replacement and
+        # clear writes. If insertion wins, their later sweep sees the row; if
+        # lifecycle mutation wins, stale required work cannot be inserted.
+        conn.execute("BEGIN IMMEDIATE")
+        if record.get("requires_goal_join") and not _goal_owner_is_current_in_transaction(
+            conn,
+            str(record.get("goal_owner_session_id") or ""),
+            str(record.get("goal_id") or ""),
+        ):
+            raise RuntimeError("required async delegation goal owner is no longer current")
         conn.execute(
-            """INSERT OR REPLACE INTO async_delegations
+            """INSERT INTO async_delegations
                (delegation_id, origin_session, origin_ui_session_id,
                 parent_session_id, state, dispatched_at, updated_at,
                 delivery_state, delivery_attempts, owner_pid,
-                owner_started_at, task_json)
-               VALUES (?, ?, ?, ?, 'running', ?, ?, 'pending', 0, ?, ?, ?)""",
+                owner_started_at, task_json, goal_id, requires_goal_join,
+                parent_delegation_id, goal_owner_session_id, reconciliation_state)
+               VALUES (?, ?, ?, ?, 'running', ?, ?, 'pending', 0, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (record["delegation_id"], record.get("session_key", ""),
              record.get("origin_ui_session_id", ""), record.get("parent_session_id"),
              record["dispatched_at"], now, __import__("os").getpid(),
-             owner_started_at, json.dumps(task_payload)),
+             owner_started_at, json.dumps(task_payload), record.get("goal_id", ""),
+             int(bool(record.get("requires_goal_join"))),
+             record.get("parent_delegation_id", ""),
+             record.get("goal_owner_session_id", ""),
+             "pending" if record.get("requires_goal_join") else "not_required"),
         )
     _prune_durable_records()
 
@@ -168,11 +270,17 @@ def _prune_durable_records() -> None:
     cutoff = now - _DURABLE_RETENTION_SECONDS
     with _DB_LOCK, _connect() as conn:
         conn.execute(
-            "DELETE FROM async_delegations WHERE delivery_state='delivered' AND updated_at < ?",
+            """DELETE FROM async_delegations
+               WHERE delivery_state='delivered' AND updated_at < ?
+                 AND (requires_goal_join=0 OR reconciliation_state IN
+                      ('not_required','reconciled','abandoned'))""",
             (cutoff,),
         )
         terminal_count = conn.execute(
-            "SELECT COUNT(*) FROM async_delegations WHERE state NOT IN ('running','finalizing')"
+            """SELECT COUNT(*) FROM async_delegations
+               WHERE state NOT IN ('running','finalizing')
+                 AND (requires_goal_join=0 OR reconciliation_state IN
+                      ('not_required','reconciled','abandoned'))"""
         ).fetchone()[0]
         excess = max(0, terminal_count - _MAX_RETAINED_COMPLETED)
         if excess:
@@ -180,6 +288,8 @@ def _prune_durable_records() -> None:
                 """DELETE FROM async_delegations WHERE delegation_id IN (
                      SELECT delegation_id FROM async_delegations
                      WHERE state NOT IN ('running','finalizing')
+                       AND (requires_goal_join=0 OR reconciliation_state IN
+                            ('not_required','reconciled','abandoned'))
                      ORDER BY CASE delivery_state WHEN 'delivered' THEN 0 ELSE 1 END,
                               updated_at ASC LIMIT ?
                    )""",
@@ -187,7 +297,9 @@ def _prune_durable_records() -> None:
             )
         pending_count = conn.execute(
             """SELECT COUNT(*) FROM async_delegations
-               WHERE state NOT IN ('running','finalizing') AND delivery_state='pending'"""
+               WHERE state NOT IN ('running','finalizing') AND delivery_state='pending'
+                 AND (requires_goal_join=0 OR reconciliation_state IN
+                      ('not_required','reconciled','abandoned'))"""
         ).fetchone()[0]
         overflow = max(0, pending_count - _MAX_DURABLE_PENDING)
         if overflow:
@@ -195,22 +307,81 @@ def _prune_durable_records() -> None:
                 """DELETE FROM async_delegations WHERE delegation_id IN (
                      SELECT delegation_id FROM async_delegations
                      WHERE state NOT IN ('running','finalizing') AND delivery_state='pending'
+                       AND (requires_goal_join=0 OR reconciliation_state IN
+                            ('not_required','reconciled','abandoned'))
                      ORDER BY updated_at ASC LIMIT ?
                    )""",
                 (overflow,),
             )
 
 
-def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> None:
+def _persist_completion_once(event: Dict[str, Any], result: Dict[str, Any]) -> None:
     now = time.time()
-    with _DB_LOCK, _connect() as conn:
-        conn.execute(
-            """UPDATE async_delegations SET state=?, completed_at=?, updated_at=?,
-               event_json=?, result_json=?, delivery_state='pending'
-               WHERE delegation_id=?""",
-            (event.get("status", "completed"), event.get("completed_at", now), now,
-             json.dumps(event), json.dumps(result), event["delegation_id"]),
-        )
+    conn = _connect()
+    try:
+        with _DB_LOCK, conn:
+            conn.execute(
+                """UPDATE async_delegations SET state=?, completed_at=?, updated_at=?,
+                   event_json=?, result_json=?, delivery_state='pending'
+                   WHERE delegation_id=?""",
+                (event.get("status", "completed"), event.get("completed_at", now), now,
+                 json.dumps(event), json.dumps(result), event["delegation_id"]),
+            )
+    finally:
+        conn.close()
+
+
+def _persist_completion(
+    event: Dict[str, Any],
+    result: Dict[str, Any],
+    *,
+    on_persisted: Optional[Callable[[], None]] = None,
+) -> bool:
+    """Persist terminal state, continuing autonomously after bounded retries."""
+    last_error: Optional[sqlite3.OperationalError] = None
+    for attempt in range(_COMPLETION_PERSIST_IMMEDIATE_ATTEMPTS):
+        try:
+            _persist_completion_once(event, result)
+            return True
+        except sqlite3.OperationalError as exc:
+            last_error = exc
+            if attempt + 1 < _COMPLETION_PERSIST_IMMEDIATE_ATTEMPTS:
+                # The operation helper has released _DB_LOCK before we back off.
+                time.sleep(_COMPLETION_PERSIST_RETRY_BASE_SECONDS * (2**attempt))
+
+    saved_event = dict(event)
+    saved_result = dict(result)
+
+    def _retry_until_persisted() -> None:
+        delay = _COMPLETION_PERSIST_RETRY_BASE_SECONDS
+        while True:
+            time.sleep(delay)
+            try:
+                _persist_completion_once(saved_event, saved_result)
+            except sqlite3.OperationalError:
+                delay = min(delay * 2, _COMPLETION_PERSIST_RETRY_MAX_SECONDS)
+                continue
+            except Exception:
+                logger.exception(
+                    "Async delegation %s terminal persistence retry failed permanently",
+                    saved_event.get("delegation_id"),
+                )
+                return
+            if on_persisted is not None:
+                on_persisted()
+            return
+
+    logger.warning(
+        "Async delegation %s terminal persistence exhausted immediate retries; "
+        "continuing in background: %s",
+        event.get("delegation_id"), last_error,
+    )
+    threading.Thread(
+        target=propagate_context_to_thread(_retry_until_persisted),
+        name=f"async-persist-{event.get('delegation_id', 'unknown')}",
+        daemon=True,
+    ).start()
+    return False
 
 
 def _note_delivery_attempt(delegation_id: str) -> None:
@@ -233,11 +404,24 @@ def recover_abandoned_delegations() -> int:
         rows = conn.execute(
             """SELECT delegation_id, origin_session, origin_ui_session_id,
                       parent_session_id, dispatched_at, owner_pid,
-                      owner_started_at, task_json
+                      owner_started_at, task_json, goal_id, requires_goal_join,
+                      parent_delegation_id
                FROM async_delegations WHERE state IN ('running','finalizing')"""
         ).fetchall()
         for row in rows:
-            delegation_id, session_key, origin_ui, parent_id, dispatched_at, pid, started, task_json = row
+            (
+                delegation_id,
+                session_key,
+                origin_ui,
+                parent_id,
+                dispatched_at,
+                pid,
+                started,
+                task_json,
+                goal_id,
+                requires_goal_join,
+                parent_delegation_id,
+            ) = row
             live = False
             if pid:
                 live = _pid_exists(int(pid))
@@ -250,6 +434,10 @@ def recover_abandoned_delegations() -> int:
                 "type": "async_delegation", "delegation_id": delegation_id,
                 "session_key": session_key, "origin_ui_session_id": origin_ui,
                 "parent_session_id": parent_id, "goal": task.get("goal", ""),
+                "goal_id": goal_id or "",
+                "goal_owner_session_id": str(task.get("goal_owner_session_id") or ""),
+                "requires_goal_join": bool(requires_goal_join),
+                "parent_delegation_id": parent_delegation_id or "",
                 "goals": task.get("goals"), "context": task.get("context"),
                 "toolsets": task.get("toolsets"), "role": task.get("role"),
                 "model": task.get("model"), "is_batch": bool(task.get("is_batch")),
@@ -282,15 +470,29 @@ def restore_undelivered_completions(target_queue) -> int:
     """
     recover_abandoned_delegations()
     with _DB_LOCK, _connect() as conn:
+        conn.execute(
+            """UPDATE async_delegations
+               SET reconciliation_state='pending', reconciliation_claimed_at=NULL,
+                   updated_at=?
+               WHERE requires_goal_join=1 AND reconciliation_state='claimed'
+                 AND reconciliation_claimed_at < ?""",
+            (time.time(), time.time() - _RECONCILIATION_CLAIM_LEASE_SECONDS),
+        )
         rows = conn.execute(
-            """SELECT delegation_id, event_json FROM async_delegations
-               WHERE state != 'running' AND delivery_state='pending' AND event_json IS NOT NULL
+            """SELECT delegation_id, event_json, delivery_state FROM async_delegations
+               WHERE state NOT IN ('running','finalizing') AND event_json IS NOT NULL
+                 AND (
+                    delivery_state='pending'
+                    OR (requires_goal_join=1 AND reconciliation_state='pending')
+                 )
                ORDER BY completed_at, delegation_id"""
         ).fetchall()
-        for _delegation_id, payload in rows:
+        for _delegation_id, payload, delivery_state in rows:
             evt = json.loads(payload)
             if isinstance(evt, dict):
                 evt["restored"] = True
+                if delivery_state != "pending":
+                    evt["semantic_recovery"] = True
             target_queue.put(evt)
     return len(rows)
 
@@ -331,6 +533,8 @@ def claim_event_delivery(evt: Dict[str, Any], consumer: str) -> Optional[str]:
     """Claim a durable delegation event; non-durable events need no token."""
     if evt.get("type") != "async_delegation":
         return ""
+    if evt.get("semantic_recovery"):
+        return "semantic-recovery"
     delegation_id = str(evt.get("delegation_id") or "")
     if not delegation_id:
         return ""
@@ -412,12 +616,12 @@ def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
 
 
 def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
-    if claim_id and evt.get("type") == "async_delegation":
+    if claim_id and claim_id != "semantic-recovery" and evt.get("type") == "async_delegation":
         complete_completion_delivery(str(evt.get("delegation_id") or ""), claim_id)
 
 
 def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
-    if claim_id and evt.get("type") == "async_delegation":
+    if claim_id and claim_id != "semantic-recovery" and evt.get("type") == "async_delegation":
         release_completion_delivery(str(evt.get("delegation_id") or ""), claim_id)
 
 
@@ -425,7 +629,11 @@ def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:
     with _DB_LOCK, _connect() as conn:
         row = conn.execute(
             """SELECT origin_session, state, dispatched_at, completed_at,
-                      result_json, delivery_state, delivery_attempts
+                      result_json, delivery_state, delivery_attempts,
+                      goal_id, requires_goal_join, parent_delegation_id,
+                      goal_owner_session_id,
+                      reconciliation_state, reconciliation_claim,
+                      reconciliation_attempts, reconciled_at
                FROM async_delegations WHERE delegation_id=?""", (delegation_id,),
         ).fetchone()
     if row is None:
@@ -435,7 +643,325 @@ def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:
         "dispatched_at": row[2], "completed_at": row[3],
         "result": json.loads(row[4]) if row[4] else None,
         "delivery_state": row[5], "delivery_attempts": row[6],
+        "goal_id": row[7] or "", "requires_goal_join": bool(row[8]),
+        "parent_delegation_id": row[9] or "",
+        "goal_owner_session_id": row[10] or "",
+        "reconciliation_state": row[11], "reconciliation_claim": row[12],
+        "reconciliation_attempts": row[13], "reconciled_at": row[14],
     }
+
+
+def _result_metrics(result: Any) -> Dict[str, Any]:
+    """Return bounded observability totals from one stored result payload."""
+    totals = {
+        "api_calls": 0,
+        "tokens": {"input": 0, "output": 0, "reasoning": 0},
+        "cost_usd": 0.0,
+    }
+    if not isinstance(result, dict):
+        return totals
+    children = result.get("results")
+    if isinstance(children, list):
+        for child in children[:1000]:
+            metrics = _result_metrics(child)
+            totals["api_calls"] += metrics["api_calls"]
+            totals["cost_usd"] += metrics["cost_usd"]
+            for key in totals["tokens"]:
+                totals["tokens"][key] += metrics["tokens"][key]
+        return totals
+    try:
+        totals["api_calls"] = max(0, int(result.get("api_calls", 0) or 0))
+    except (TypeError, ValueError):
+        pass
+    tokens = result.get("tokens")
+    if isinstance(tokens, dict):
+        for key in totals["tokens"]:
+            try:
+                totals["tokens"][key] = max(0, int(tokens.get(key, 0) or 0))
+            except (TypeError, ValueError):
+                pass
+    try:
+        totals["cost_usd"] = max(0.0, float(result.get("cost_usd", 0.0) or 0.0))
+    except (TypeError, ValueError):
+        pass
+    return totals
+
+
+def _result_failure_summary(result: Any) -> str:
+    """Return the first terminal failure, including failures inside a batch."""
+    if not isinstance(result, dict):
+        return ""
+    children = result.get("results")
+    if isinstance(children, list):
+        for child in children[:1000]:
+            failure = _result_failure_summary(child)
+            if failure:
+                return failure
+    status = str(result.get("status") or "").strip().lower()
+    if status and status not in {"completed", "success", "done"}:
+        return str(result.get("error") or result.get("summary") or status)[:200]
+    return ""
+
+
+def _json_object(raw: Any) -> Dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    if not isinstance(raw, str) or not raw:
+        return {}
+    try:
+        value = json.loads(raw)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def get_goal_work_snapshot(goal_id: str) -> Dict[str, Any]:
+    """Summarize durable required work for one logical standing goal."""
+    goal_id = str(goal_id or "").strip()
+    snapshot = {
+        "goal_id": goal_id,
+        "available": True,
+        "required_count": 0,
+        "running_count": 0,
+        "completed_count": 0,
+        "terminal_unreconciled_count": 0,
+        "claimed_count": 0,
+        "reconciled_count": 0,
+        "abandoned_count": 0,
+        "failed_count": 0,
+        "delegation_ids": [],
+        "api_calls": 0,
+        "tokens": {"input": 0, "output": 0, "reasoning": 0},
+        "cost_usd": 0.0,
+        "overflow": False,
+        "max_attempt": 0,
+        "last_error": "",
+    }
+    if not goal_id:
+        return snapshot
+    with _DB_LOCK, _connect() as conn:
+        rows = conn.execute(
+            """SELECT delegation_id, state, reconciliation_state, result_json,
+                      reconciliation_attempts
+               FROM async_delegations
+               WHERE goal_id=? AND requires_goal_join=1
+               ORDER BY updated_at, delegation_id""",
+            (goal_id,),
+        ).fetchall()
+    for delegation_id, state, reconciliation_state, result_json, attempts in rows:
+        snapshot["required_count"] += 1
+        state = str(state or "unknown").lower()
+        result = _json_object(result_json)
+        if reconciliation_state == "abandoned":
+            snapshot["abandoned_count"] += 1
+        elif reconciliation_state == "reconciled":
+            snapshot["reconciled_count"] += 1
+        elif state in {"running", "finalizing"}:
+            snapshot["running_count"] += 1
+        elif reconciliation_state == "claimed":
+            snapshot["claimed_count"] += 1
+        else:
+            snapshot["terminal_unreconciled_count"] += 1
+        if reconciliation_state != "abandoned" and state not in {"running", "finalizing"}:
+            if state in {"completed", "success", "done"}:
+                snapshot["completed_count"] += 1
+            failure = _result_failure_summary(result)
+            if state not in {"completed", "success", "done"} or failure:
+                snapshot["failed_count"] += 1
+                snapshot["last_error"] = str(
+                    failure or result.get("error") or result.get("summary") or state
+                )[:200]
+        if (
+            reconciliation_state not in {"reconciled", "abandoned"}
+            and len(snapshot["delegation_ids"]) < 20
+        ):
+            snapshot["delegation_ids"].append(str(delegation_id))
+        try:
+            metrics = _result_metrics(json.loads(result_json)) if result_json else _result_metrics(None)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            metrics = _result_metrics(None)
+        snapshot["api_calls"] += metrics["api_calls"]
+        snapshot["cost_usd"] += metrics["cost_usd"]
+        snapshot["max_attempt"] = max(int(snapshot["max_attempt"]), int(attempts or 0))
+        for key in snapshot["tokens"]:
+            snapshot["tokens"][key] += metrics["tokens"][key]
+    snapshot["overflow"] = (
+        snapshot["running_count"]
+        + snapshot["terminal_unreconciled_count"]
+        + snapshot["claimed_count"]
+        > _MAX_DURABLE_PENDING
+    )
+    return snapshot
+
+
+def claim_goal_reconciliation(goal_id: str, consumer: str) -> Optional[Dict[str, Any]]:
+    """Atomically claim a bounded batch of terminal pending rows for ``goal_id``."""
+    goal_id = str(goal_id or "").strip()
+    if not goal_id:
+        return None
+    now = time.time()
+    claim_id = f"recon_{uuid.uuid4().hex}"
+    conn = _connect()
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            """UPDATE async_delegations
+               SET reconciliation_state='pending', reconciliation_claimed_at=NULL,
+                   updated_at=?
+               WHERE goal_id=? AND requires_goal_join=1
+                 AND reconciliation_state='claimed'
+                 AND reconciliation_claimed_at < ?""",
+            (now, goal_id, now - _RECONCILIATION_CLAIM_LEASE_SECONDS),
+        )
+        in_flight = conn.execute(
+            """SELECT 1 FROM async_delegations
+               WHERE goal_id=? AND requires_goal_join=1
+                 AND reconciliation_state='claimed' LIMIT 1""",
+            (goal_id,),
+        ).fetchone()
+        if in_flight:
+            conn.commit()
+            return None
+        rows = conn.execute(
+            """SELECT delegation_id FROM async_delegations
+               WHERE goal_id=? AND requires_goal_join=1
+                 AND state NOT IN ('running','finalizing')
+                 AND reconciliation_state='pending'
+               ORDER BY completed_at, delegation_id LIMIT ?""",
+            (goal_id, _MAX_RECONCILIATION_BATCH_ROWS),
+        ).fetchall()
+        if not rows:
+            conn.commit()
+            return None
+        delegation_ids = [str(row[0]) for row in rows]
+        placeholders = ",".join("?" for _ in delegation_ids)
+        conn.execute(
+            f"""UPDATE async_delegations
+                SET reconciliation_state='claimed', reconciliation_claim=?,
+                    reconciliation_claimed_at=?,
+                    reconciliation_attempts=reconciliation_attempts+1, updated_at=?
+                WHERE delegation_id IN ({placeholders})
+                  AND goal_id=? AND requires_goal_join=1
+                  AND state NOT IN ('running','finalizing')
+                  AND reconciliation_state='pending'""",
+            (claim_id, now, now, *delegation_ids, goal_id),
+        )
+        claimed = conn.execute(
+            """SELECT delegation_id, state, task_json, result_json, event_json,
+                      reconciliation_attempts, parent_delegation_id
+               FROM async_delegations WHERE reconciliation_claim=?
+                 AND reconciliation_state='claimed'
+               ORDER BY completed_at, delegation_id""",
+            (claim_id,),
+        ).fetchall()
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+    delegations = []
+    for row in claimed:
+        delegations.append({
+            "delegation_id": row[0],
+            "status": row[1],
+            "task": _json_object(row[2]),
+            "result": _json_object(row[3]),
+            "event": _json_object(row[4]),
+            "attempts": int(row[5] or 0),
+            "parent_delegation_id": row[6] or "",
+        })
+    metrics = _result_metrics({
+        "results": [item["result"] for item in delegations],
+    })
+    return {
+        "claim_id": claim_id,
+        "goal_id": goal_id,
+        "consumer": consumer,
+        "claimed_at": now,
+        "attempt": max((item["attempts"] for item in delegations), default=1),
+        "delegation_ids": [item["delegation_id"] for item in delegations],
+        "delegations": delegations,
+        "api_calls": metrics["api_calls"],
+        "tokens": metrics["tokens"],
+        "cost_usd": metrics["cost_usd"],
+    }
+
+
+def complete_goal_reconciliation(claim_id: str) -> bool:
+    """Mark a fenced reconciliation claim consumed; repeated completion is safe."""
+    claim_id = str(claim_id or "").strip()
+    if not claim_id:
+        return False
+    now = time.time()
+    with _DB_LOCK, _connect() as conn:
+        row = conn.execute(
+            """SELECT reconciliation_state FROM async_delegations
+               WHERE reconciliation_claim=? LIMIT 1""",
+            (claim_id,),
+        ).fetchone()
+        if row is None:
+            return False
+        if row[0] == "reconciled":
+            return True
+        if row[0] != "claimed":
+            return False
+        conn.execute(
+            """UPDATE async_delegations
+               SET reconciliation_state='reconciled', reconciled_at=?, updated_at=?
+               WHERE reconciliation_claim=? AND reconciliation_state='claimed'""",
+            (now, now, claim_id),
+        )
+        return True
+
+
+def release_goal_reconciliation(
+    claim_id: str,
+    *,
+    decrement_attempt: bool = False,
+) -> bool:
+    """Release a fenced claim for retry; stale/wrong tokens cannot steal rows."""
+    claim_id = str(claim_id or "").strip()
+    if not claim_id:
+        return False
+    with _DB_LOCK, _connect() as conn:
+        row = conn.execute(
+            "SELECT reconciliation_state FROM async_delegations WHERE reconciliation_claim=? LIMIT 1",
+            (claim_id,),
+        ).fetchone()
+        if row is None:
+            return False
+        if row[0] == "claimed":
+            conn.execute(
+                """UPDATE async_delegations
+                   SET reconciliation_state='pending', reconciliation_claimed_at=NULL,
+                       reconciliation_attempts=CASE WHEN ?=1
+                           THEN MAX(0, reconciliation_attempts-1)
+                           ELSE reconciliation_attempts END,
+                       updated_at=?
+                   WHERE reconciliation_claim=? AND reconciliation_state='claimed'""",
+                (1 if decrement_attempt else 0, time.time(), claim_id),
+            )
+        return row[0] in {"claimed", "pending"}
+
+
+def abandon_goal_work(goal_id: str, reason: str = "") -> int:
+    """Detach all still-required rows when a goal is cleared or replaced."""
+    goal_id = str(goal_id or "").strip()
+    if not goal_id:
+        return 0
+    with _DB_LOCK, _connect() as conn:
+        cur = conn.execute(
+            """UPDATE async_delegations
+               SET reconciliation_state='abandoned', reconciliation_claim=NULL,
+                   reconciliation_claimed_at=NULL, updated_at=?
+               WHERE goal_id=? AND requires_goal_join=1
+                 AND reconciliation_state NOT IN ('reconciled','abandoned')""",
+            (time.time(), goal_id),
+        )
+        if cur.rowcount:
+            logger.info("Abandoned %d async goal row(s) for %s: %s", cur.rowcount, goal_id, reason)
+        return cur.rowcount
 
 
 def _get_executor(max_workers: int) -> ThreadPoolExecutor:
@@ -467,6 +993,11 @@ def _new_delegation_id() -> str:
     return f"deleg_{uuid.uuid4().hex[:8]}"
 
 
+def new_delegation_id() -> str:
+    """Reserve-format a delegation id before child runners receive lineage."""
+    return _new_delegation_id()
+
+
 def _prune_completed_locked() -> None:
     """Drop the oldest completed records beyond the retention cap.
 
@@ -475,7 +1006,7 @@ def _prune_completed_locked() -> None:
     completed = [
         (rid, r)
         for rid, r in _records.items()
-        if r.get("status") != "running"
+        if r.get("status") not in {"running", "finalizing"}
     ]
     if len(completed) <= _MAX_RETAINED_COMPLETED:
         return
@@ -494,6 +1025,11 @@ def dispatch_async_delegation(
     model: Optional[str],
     session_key: str,
     parent_session_id: Optional[str] = None,
+    goal_id: str = "",
+    requires_goal_join: bool = False,
+    parent_delegation_id: str = "",
+    goal_owner_session_id: str = "",
+    delegation_id: Optional[str] = None,
     runner: Callable[[], Dict[str, Any]],
     origin_ui_session_id: str = "",
     interrupt_fn: Optional[Callable[[], None]] = None,
@@ -533,7 +1069,7 @@ def dispatch_async_delegation(
         ``{"status": "dispatched", "delegation_id": ...}`` on success, or
         ``{"status": "rejected", "error": ...}`` when at capacity.
     """
-    delegation_id = _new_delegation_id()
+    delegation_id = str(delegation_id or _new_delegation_id())
     dispatched_at = time.time()
     record: Dict[str, Any] = {
         "delegation_id": delegation_id,
@@ -545,6 +1081,10 @@ def dispatch_async_delegation(
         "session_key": session_key,
         "origin_ui_session_id": origin_ui_session_id,
         "parent_session_id": parent_session_id,
+        "goal_id": str(goal_id or ""),
+        "requires_goal_join": bool(requires_goal_join and goal_id),
+        "parent_delegation_id": str(parent_delegation_id or ""),
+        "goal_owner_session_id": str(goal_owner_session_id or ""),
         "status": "running",
         "dispatched_at": dispatched_at,
         "completed_at": None,
@@ -554,15 +1094,22 @@ def dispatch_async_delegation(
     # active_count() separately would let two concurrent dispatches (e.g.
     # from different gateway sessions) both pass the check and exceed the cap.
     with _records_lock:
-        running = sum(
-            1 for r in _records.values() if r.get("status") == "running"
+        if delegation_id in _records:
+            return {
+                "status": "rejected",
+                "error": f"Async delegation id already exists: {delegation_id}",
+            }
+        active = sum(
+            1
+            for r in _records.values()
+            if r.get("status") in {"running", "finalizing"}
         )
-        if running >= max_async_children:
+        if active >= max_async_children:
             return {
                 "status": "rejected",
                 "error": (
                     f"Async delegation capacity reached ({max_async_children} "
-                    f"running). Wait for one to finish (its result will re-enter "
+                    f"active). Wait for one to finish (its result will re-enter "
                     f"the chat), or run this task synchronously "
                     f"(background=false). Raise delegation.max_concurrent_children in "
                     f"config.yaml to allow more concurrent background subagents."
@@ -570,7 +1117,16 @@ def dispatch_async_delegation(
             }
         _records[delegation_id] = record
 
-    _persist_dispatch(record)
+    try:
+        _persist_dispatch(record)
+    except Exception as exc:  # noqa: BLE001 — dispatch must not leave a phantom slot
+        with _records_lock:
+            _records.pop(delegation_id, None)
+        logger.exception("Failed to persist async delegation %s", delegation_id)
+        return {
+            "status": "rejected",
+            "error": f"Failed to persist async delegation: {exc}",
+        }
     executor = _get_executor(max_async_children)
 
     def _worker() -> None:
@@ -609,7 +1165,21 @@ def dispatch_async_delegation(
         "Dispatched async delegation %s (session_key=%s): %s",
         delegation_id, session_key or "<cli>", (goal or "")[:80],
     )
-    return {"status": "dispatched", "delegation_id": delegation_id}
+    dispatch: Dict[str, Any] = {
+        "status": "dispatched",
+        "delegation_id": delegation_id,
+    }
+    if goal_id and requires_goal_join:
+        dispatch.update({
+            "goal_id": goal_id,
+            "requires_goal_join": True,
+            "parent_delegation_id": str(parent_delegation_id or ""),
+            "goal_owner": {
+                "goal_id": goal_id,
+                "requires_goal_join": True,
+            },
+        })
+    return dispatch
 
 
 def _finalize(delegation_id: str, result: Dict[str, Any], status: str) -> None:
@@ -627,6 +1197,9 @@ def _finalize(delegation_id: str, result: Dict[str, Any], status: str) -> None:
         event_record = dict(record)
 
     _push_completion_event(event_record, result, status)
+
+
+def _finish_in_memory_completion(delegation_id: str, status: str) -> None:
     with _records_lock:
         record = _records.get(delegation_id)
         if record is not None:
@@ -634,24 +1207,31 @@ def _finalize(delegation_id: str, result: Dict[str, Any], status: str) -> None:
         _prune_completed_locked()
 
 
+def _publish_persisted_completion(
+    delegation_id: str, status: str, event: Dict[str, Any], target_queue: Any
+) -> None:
+    try:
+        target_queue.put(event)
+    except Exception as exc:  # pragma: no cover
+        logger.error(
+            "Async delegation %s: failed to enqueue completion event; "
+            "leaving the result durable for recovery: %s",
+            delegation_id,
+            exc,
+        )
+    finally:
+        _finish_in_memory_completion(delegation_id, status)
+
+
 def _push_completion_event(
     record: Dict[str, Any], result: Dict[str, Any], status: str
 ) -> None:
     """Push a type='async_delegation' event onto the shared completion queue.
 
-    Best-effort: a failure here must not crash the worker, but it WOULD mean a
-    silently-lost result, so we log loudly.
+    Terminal state is persisted before best-effort queue publication. A queue
+    or registry failure must not crash the worker or strand goal-owned work;
+    the durable event remains available for recovery, and we log loudly.
     """
-    try:
-        from tools.process_registry import process_registry
-    except Exception as exc:  # pragma: no cover
-        logger.error(
-            "Async delegation %s finished but process_registry import failed; "
-            "result lost: %s",
-            record.get("delegation_id"), exc,
-        )
-        return
-
     summary = result.get("summary")
     error = result.get("error")
     dispatched_at = record.get("dispatched_at") or time.time()
@@ -665,6 +1245,10 @@ def _push_completion_event(
         "session_key": record.get("session_key", ""),
         "origin_ui_session_id": record.get("origin_ui_session_id", ""),
         "parent_session_id": record.get("parent_session_id"),
+        "goal_id": record.get("goal_id", ""),
+        "requires_goal_join": bool(record.get("requires_goal_join")),
+        "parent_delegation_id": record.get("parent_delegation_id", ""),
+        "goal_owner_session_id": record.get("goal_owner_session_id", ""),
         "goal": record.get("goal", ""),
         "context": record.get("context"),
         "toolsets": record.get("toolsets"),
@@ -680,16 +1264,32 @@ def _push_completion_event(
         "dispatched_at": dispatched_at,
         "completed_at": completed_at,
         "exit_reason": result.get("exit_reason"),
+        "tokens": result.get("tokens"),
+        "cost_usd": result.get("cost_usd"),
     }
-    _persist_completion(evt, result)
-    try:
-        process_registry.completion_queue.put(evt)
-    except Exception as exc:  # pragma: no cover
-        logger.error(
-            "Async delegation %s: failed to enqueue completion event; "
-            "result lost: %s",
-            record.get("delegation_id"), exc,
+    def publish() -> None:
+        try:
+            from tools.process_registry import process_registry
+        except Exception as exc:  # pragma: no cover
+            logger.error(
+                "Async delegation %s persisted but process_registry import failed; "
+                "leaving the result durable for recovery: %s",
+                record.get("delegation_id"),
+                exc,
+            )
+            _finish_in_memory_completion(
+                str(record.get("delegation_id") or ""), status
+            )
+            return
+        _publish_persisted_completion(
+            str(record.get("delegation_id") or ""),
+            status,
+            evt,
+            process_registry.completion_queue,
         )
+
+    if _persist_completion(evt, result, on_persisted=publish):
+        publish()
 
 
 def dispatch_async_delegation_batch(
@@ -701,6 +1301,10 @@ def dispatch_async_delegation_batch(
     model: Optional[str],
     session_key: str,
     parent_session_id: Optional[str] = None,
+    goal_id: str = "",
+    requires_goal_join: bool = False,
+    parent_delegation_id: str = "",
+    goal_owner_session_id: str = "",
     runner: Callable[[], Dict[str, Any]],
     origin_ui_session_id: str = "",
     interrupt_fn: Optional[Callable[[], None]] = None,
@@ -745,6 +1349,10 @@ def dispatch_async_delegation_batch(
         "session_key": session_key,
         "origin_ui_session_id": origin_ui_session_id,
         "parent_session_id": parent_session_id,
+        "goal_id": str(goal_id or ""),
+        "requires_goal_join": bool(requires_goal_join and goal_id),
+        "parent_delegation_id": str(parent_delegation_id or ""),
+        "goal_owner_session_id": str(goal_owner_session_id or ""),
         "status": "running",
         "dispatched_at": dispatched_at,
         "completed_at": None,
@@ -752,22 +1360,38 @@ def dispatch_async_delegation_batch(
         "is_batch": True,
     }
     with _records_lock:
-        running = sum(
-            1 for r in _records.values() if r.get("status") == "running"
+        if delegation_id in _records:
+            return {
+                "status": "rejected",
+                "error": f"Async delegation id already exists: {delegation_id}",
+            }
+        active = sum(
+            1
+            for r in _records.values()
+            if r.get("status") in {"running", "finalizing"}
         )
-        if running >= max_async_children:
+        if active >= max_async_children:
             return {
                 "status": "rejected",
                 "error": (
                     f"Async delegation capacity reached ({max_async_children} "
-                    f"running). Wait for one to finish (its result will re-enter "
+                    f"active). Wait for one to finish (its result will re-enter "
                     f"the chat), or raise delegation.max_concurrent_children in "
                     f"config.yaml to allow more concurrent background units."
                 ),
             }
         _records[delegation_id] = record
 
-    _persist_dispatch(record)
+    try:
+        _persist_dispatch(record)
+    except Exception as exc:  # noqa: BLE001 — dispatch must not leave a phantom slot
+        with _records_lock:
+            _records.pop(delegation_id, None)
+        logger.exception("Failed to persist async delegation batch %s", delegation_id)
+        return {
+            "status": "rejected",
+            "error": f"Failed to persist async delegation batch: {exc}",
+        }
     executor = _get_executor(max_async_children)
 
     def _worker() -> None:
@@ -811,7 +1435,17 @@ def dispatch_async_delegation_batch(
         "Dispatched async delegation batch %s (%d task(s), session_key=%s)",
         delegation_id, n, session_key or "<cli>",
     )
-    return {"status": "dispatched", "delegation_id": delegation_id}
+    dispatch: Dict[str, Any] = {
+        "status": "dispatched",
+        "delegation_id": delegation_id,
+    }
+    if goal_id and requires_goal_join:
+        dispatch.update({
+            "goal_id": goal_id,
+            "requires_goal_join": True,
+            "parent_delegation_id": str(parent_delegation_id or ""),
+        })
+    return dispatch
 
 
 def _finalize_batch(
@@ -827,16 +1461,6 @@ def _finalize_batch(
         record["interrupt_fn"] = None
         event_record = dict(record)
 
-    try:
-        from tools.process_registry import process_registry
-    except Exception as exc:  # pragma: no cover
-        logger.error(
-            "Async delegation batch %s finished but process_registry import "
-            "failed; result lost: %s",
-            delegation_id, exc,
-        )
-        return
-
     dispatched_at = event_record.get("dispatched_at") or time.time()
     completed_at = event_record.get("completed_at") or time.time()
     evt = {
@@ -845,6 +1469,10 @@ def _finalize_batch(
         "session_key": event_record.get("session_key", ""),
         "origin_ui_session_id": event_record.get("origin_ui_session_id", ""),
         "parent_session_id": event_record.get("parent_session_id"),
+        "goal_id": event_record.get("goal_id", ""),
+        "requires_goal_join": bool(event_record.get("requires_goal_join")),
+        "parent_delegation_id": event_record.get("parent_delegation_id", ""),
+        "goal_owner_session_id": event_record.get("goal_owner_session_id", ""),
         "goal": event_record.get("goal", ""),
         "goals": event_record.get("goals"),
         "context": event_record.get("context"),
@@ -865,21 +1493,24 @@ def _finalize_batch(
         "dispatched_at": dispatched_at,
         "completed_at": completed_at,
     }
-    _persist_completion(evt, combined)
-    try:
-        process_registry.completion_queue.put(evt)
-    except Exception as exc:  # pragma: no cover
-        logger.error(
-            "Async delegation batch %s: failed to enqueue completion event; "
-            "result lost: %s",
-            delegation_id, exc,
+    def publish() -> None:
+        try:
+            from tools.process_registry import process_registry
+        except Exception as exc:  # pragma: no cover
+            logger.error(
+                "Async delegation batch %s persisted but process_registry import "
+                "failed; leaving the result durable for recovery: %s",
+                delegation_id,
+                exc,
+            )
+            _finish_in_memory_completion(delegation_id, status)
+            return
+        _publish_persisted_completion(
+            delegation_id, status, evt, process_registry.completion_queue
         )
-    finally:
-        with _records_lock:
-            record = _records.get(delegation_id)
-            if record is not None:
-                record["status"] = status
-            _prune_completed_locked()
+
+    if _persist_completion(evt, combined, on_persisted=publish):
+        publish()
 
 
 def list_async_delegations() -> List[Dict[str, Any]]:
@@ -920,6 +1551,116 @@ def interrupt_all(reason: str = "shutdown") -> int:
     if count:
         logger.info("Interrupted %d async delegation(s) (%s)", count, reason)
     return count
+
+
+def _goal_reconciliation_retry_event(
+    goal_id: str,
+    session_id: str,
+    source: Dict[str, Any],
+) -> Dict[str, Any]:
+    return {
+        "type": "async_delegation",
+        "semantic_recovery": True,
+        "delegation_id": f"recon_retry_{uuid.uuid4().hex[:12]}",
+        "goal_id": goal_id,
+        "requires_goal_join": True,
+        "session_key": source.get("session_key") or session_id,
+        "origin_ui_session_id": source.get("origin_ui_session_id"),
+        "parent_session_id": source.get("parent_session_id") or session_id,
+        "parent_delegation_id": source.get("parent_delegation_id") or "",
+        "goal_owner_session_id": source.get("goal_owner_session_id") or session_id,
+        "status": "reconciliation_retry",
+        "task": {"goal": "Retry standing-goal async result reconciliation"},
+    }
+
+
+def recover_stale_goal_reconciliation_claims(target_queue) -> int:
+    """Release expired semantic claims and enqueue one fenced retry per claim."""
+    now = time.time()
+    cutoff = now - _RECONCILIATION_CLAIM_LEASE_SECONDS
+    conn = _connect()
+    recovered_events = []
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        claims = conn.execute(
+            """SELECT reconciliation_claim, goal_id, event_json, parent_session_id
+               FROM async_delegations
+               WHERE requires_goal_join=1 AND reconciliation_state='claimed'
+                 AND reconciliation_claimed_at < ?
+               GROUP BY reconciliation_claim, goal_id
+               ORDER BY MIN(reconciliation_claimed_at)""",
+            (cutoff,),
+        ).fetchall()
+        for claim_id, goal_id, event_json, parent_session_id in claims:
+            updated = conn.execute(
+                """UPDATE async_delegations
+                   SET reconciliation_state='pending', reconciliation_claimed_at=NULL,
+                       updated_at=?
+                   WHERE reconciliation_claim=? AND reconciliation_state='claimed'
+                     AND reconciliation_claimed_at < ?""",
+                (now, claim_id, cutoff),
+            ).rowcount
+            if updated:
+                recovered_events.append(
+                    _goal_reconciliation_retry_event(
+                        str(goal_id or ""),
+                        str(parent_session_id or ""),
+                        _json_object(event_json),
+                    )
+                )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+    for event in recovered_events:
+        target_queue.put(event)
+    return len(recovered_events)
+
+
+def build_goal_reconciliation_retry_event(
+    goal_id: str,
+    session_id: str,
+) -> Optional[Dict[str, Any]]:
+    """Build a queue-only wakeup for pending semantic reconciliation work."""
+    goal_id = str(goal_id or "").strip()
+    if not goal_id:
+        return None
+    with _DB_LOCK, _connect() as conn:
+        row = conn.execute(
+            """SELECT event_json FROM async_delegations
+               WHERE goal_id=? AND requires_goal_join=1
+                 AND reconciliation_state='pending'
+                 AND state NOT IN ('running','finalizing')
+               ORDER BY completed_at DESC, delegation_id DESC LIMIT 1""",
+            (goal_id,),
+        ).fetchone()
+    if row is None:
+        return None
+    source = _json_object(row[0])
+    return _goal_reconciliation_retry_event(goal_id, session_id, source)
+
+
+def build_goal_reconciliation_followup_event(
+    claim_id: str,
+) -> Optional[Dict[str, Any]]:
+    """Wake the next bounded batch after a claim reconciles successfully."""
+    claim_id = str(claim_id or "").strip()
+    if not claim_id:
+        return None
+    with _DB_LOCK, _connect() as conn:
+        owner = conn.execute(
+            """SELECT goal_id, parent_session_id
+               FROM async_delegations WHERE reconciliation_claim=? LIMIT 1""",
+            (claim_id,),
+        ).fetchone()
+    if owner is None:
+        return None
+    return build_goal_reconciliation_retry_event(
+        str(owner[0] or ""),
+        str(owner[1] or ""),
+    )
 
 
 def interrupt_for_session(

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2267,6 +2267,10 @@ def _run_single_child(
         _cost_usd = getattr(child, "session_estimated_cost_usd", None)
         _reasoning_tokens = getattr(child, "session_reasoning_tokens", 0)
         try:
+            entry["tokens"]["reasoning"] = int(_reasoning_tokens or 0)
+        except (TypeError, ValueError):
+            entry["tokens"]["reasoning"] = 0
+        try:
             _files_read = list(file_state.known_reads(child_task_id))[:40]
         except Exception:
             _files_read = []
@@ -2815,7 +2819,11 @@ def delegate_task(
             child_cost = entry.pop("_child_cost_usd", 0.0)
             try:
                 if child_cost:
-                    _children_cost_total += float(child_cost)
+                    normalized_child_cost = float(child_cost)
+                    _children_cost_total += normalized_child_cost
+                    # Keep the per-child amount in the returned/durable result
+                    # journal as well as rolling it into the parent footer.
+                    entry["cost_usd"] = normalized_child_cost
             except (TypeError, ValueError):
                 pass
             if _invoke_hook is None:
@@ -2967,7 +2975,50 @@ def delegate_task(
             if _agent_session_id:
                 _session_key = _agent_session_id
         _parent_session_id = getattr(parent_agent, "session_id", None)
+        _inherited_goal_id = getattr(parent_agent, "_root_goal_id", "")
+        _root_goal_id = _inherited_goal_id if isinstance(_inherited_goal_id, str) else ""
+        _inherited_owner_session_id = getattr(
+            parent_agent, "_root_goal_owner_session_id", ""
+        )
+        _root_goal_owner_session_id = (
+            _inherited_owner_session_id
+            if isinstance(_inherited_owner_session_id, str)
+            else ""
+        )
+        _inherited_parent_id = getattr(parent_agent, "_delegation_id", "")
+        _parent_delegation_id = (
+            _inherited_parent_id if isinstance(_inherited_parent_id, str) else ""
+        )
+        if not _root_goal_id and _parent_session_id:
+            try:
+                from hermes_cli.goals import capture_goal_delegation_owner
+
+                _goal_owner = capture_goal_delegation_owner(str(_parent_session_id))
+                _root_goal_id = str((_goal_owner or {}).get("goal_id") or "")
+                if _root_goal_id:
+                    _root_goal_owner_session_id = str(_parent_session_id)
+            except Exception:
+                logger.warning(
+                    "Could not verify standing-goal ownership; running delegation synchronously",
+                    exc_info=True,
+                )
+                _sync_result = _execute_and_aggregate()
+                if isinstance(_sync_result, dict):
+                    _sync_result["note"] = (
+                        "Background delegation was not started because durable standing-goal "
+                        "ownership could not be verified. The subagent(s) ran synchronously "
+                        "and their result is included above."
+                    )
+                return json.dumps(_sync_result, ensure_ascii=False)
         _child_agents = [c for (_, _, c) in children]
+
+        from tools.async_delegation import new_delegation_id
+
+        _outer_delegation_id = live_deleg_id or new_delegation_id()
+        for _child in _child_agents:
+            _child._root_goal_id = _root_goal_id
+            _child._root_goal_owner_session_id = _root_goal_owner_session_id
+            _child._delegation_id = _outer_delegation_id
 
         # Detach every child from the parent's interrupt-propagation list — the
         # batch's lifecycle is owned by the async registry now, not the parent
@@ -3009,12 +3060,16 @@ def delegate_task(
             session_key=_session_key,
             origin_ui_session_id=_origin_ui_session_id,
             parent_session_id=_parent_session_id,
+            goal_id=_root_goal_id,
+            requires_goal_join=bool(_root_goal_id),
+            parent_delegation_id=_parent_delegation_id,
+            goal_owner_session_id=_root_goal_owner_session_id,
             runner=_batch_runner,
             interrupt_fn=_batch_interrupt,
             max_async_children=_get_max_async_children(),
             # Reuse the live-transcript directory's id (when created) so the
             # returned delegation_id matches cache/delegation/live/<id>/.
-            delegation_id=live_deleg_id,
+            delegation_id=_outer_delegation_id,
         )
 
         if dispatch.get("status") == "dispatched":
@@ -3039,6 +3094,12 @@ def delegate_task(
                 "goals": _goals,
                 "note": note,
             }
+            if dispatch.get("goal_id"):
+                payload["goal_owner"] = {
+                    "goal_id": dispatch["goal_id"],
+                    "requires_goal_join": True,
+                    "parent_delegation_id": dispatch.get("parent_delegation_id", ""),
+                }
             if live_paths:
                 payload["live_transcripts"] = list(live_paths)
                 payload["live_transcripts_hint"] = (
@@ -3049,23 +3110,30 @@ def delegate_task(
                 )
             return json.dumps(payload, ensure_ascii=False)
 
-        # Pool at capacity / schedule failure — children are still attached
-        # (we detach above only on the parent list, but the async unit was
-        # never accepted, so re-attaching isn't needed: we just run inline).
+        # Rejected persistence/capacity means no detached unit exists. Keep the
+        # established safe fallback: execute inline and return the result.
+        _dispatch_error = str(dispatch.get("error", "rejected"))
         logger.info(
-            "delegate_task: async pool at capacity (%s); running the whole "
+            "delegate_task: background dispatch rejected (%s); running the whole "
             "batch synchronously instead.",
-            dispatch.get("error", "rejected"),
+            _dispatch_error,
         )
         _cap_result = _execute_and_aggregate()
         if isinstance(_cap_result, dict):
-            _cap_result["note"] = (
-                "The background delegation pool was at capacity "
-                "(delegation.max_concurrent_children), so the subagent(s) ran "
-                "SYNCHRONOUSLY and the result is included above. Raise "
-                "delegation.max_concurrent_children in config.yaml to allow "
-                "more concurrent background delegations."
-            )
+            if "goal owner is no longer current" in _dispatch_error:
+                _cap_result["note"] = (
+                    "The standing goal changed while background dispatch was being "
+                    "recorded, so stale required work was not detached. The "
+                    "subagent(s) ran SYNCHRONOUSLY and the result is included above."
+                )
+            else:
+                _cap_result["note"] = (
+                    "The background delegation pool was at capacity or could not "
+                    "durably accept the work, so the subagent(s) ran SYNCHRONOUSLY "
+                    "and the result is included above. Raise "
+                    "delegation.max_concurrent_children in config.yaml if the pool "
+                    "is at capacity."
+                )
         return json.dumps(_cap_result, ensure_ascii=False)
 
     # ----- Synchronous path -----

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2031,6 +2031,85 @@ def _format_age(seconds: float) -> str:
     return f"{h}h" if m == 0 else f"{h}h{m}m"
 
 
+def format_goal_reconciliation_claim(claim: dict, *, goal: str) -> str:
+    """Render one bounded internal mailbox batch without hiding claimed rows."""
+    delegations = claim.get("delegations") or []
+    lines = [
+        "[INTERNAL GOAL ASYNC-DELEGATION RECONCILIATION]",
+        f"Standing goal: {goal}",
+        f"Goal ID: {claim.get('goal_id', '')}",
+        f"Reconciliation claim: {claim.get('claim_id', '')}",
+        (
+            f"The {len(delegations)} required async delegation result(s) below "
+            "were claimed as one batch. Reconcile them into the standing goal. "
+            "Treat failures or unknown outcomes explicitly; verify mutable facts "
+            "before acting. This is an internal callback, not a user message."
+        ),
+    ]
+    row_budget = max(3000, 48000 // max(1, len(delegations)))
+    for item in delegations:
+        delegation_id = str(item.get("delegation_id") or "?")
+        task = item.get("task") if isinstance(item.get("task"), dict) else {}
+        result = item.get("result") if isinstance(item.get("result"), dict) else {}
+        row_lines = [
+            "",
+            f"--- {delegation_id} [{item.get('status', 'unknown')}] ---",
+            f"Durable result reference: async_delegations:{delegation_id}",
+        ]
+        task_goals = task.get("goals")
+        if isinstance(task_goals, list):
+            row_lines.append("Tasks: " + "; ".join(str(value)[:500] for value in task_goals[:20]))
+        elif task.get("goal"):
+            row_lines.append(f"Task: {str(task['goal'])[:1000]}")
+        child_results = result.get("results")
+        if isinstance(child_results, list):
+            detail_budget = max(1000, row_budget - sum(len(value) for value in row_lines) - 500)
+            max_children = min(len(child_results), 20)
+            per_child = max(120, detail_budget // max(1, max_children) - 80)
+            for index, child in enumerate(child_results[:max_children], start=1):
+                if not isinstance(child, dict):
+                    row_lines.append(f"Task {index}: {str(child)[:per_child]}")
+                    continue
+                summary = str(child.get("summary") or child.get("error") or "(no summary)")
+                row_lines.append(
+                    f"Task {index} [{child.get('status', 'unknown')}]: {summary[:per_child]}"
+                )
+                if child.get("summary") and child.get("error"):
+                    row_lines.append(f"Task {index} error: {str(child['error'])[:per_child]}")
+            if len(child_results) > max_children:
+                row_lines.append(
+                    f"{len(child_results) - max_children} additional child result(s) are stored at "
+                    f"async_delegations:{delegation_id}."
+                )
+        else:
+            available = max(500, row_budget - sum(len(value) for value in row_lines) - 200)
+            summary = result.get("summary") or result.get("error") or "(no summary)"
+            row_lines.append(str(summary)[:available])
+            if result.get("summary") and result.get("error"):
+                row_lines.append(f"Error: {str(result['error'])[: max(200, available // 3)]}")
+        transcripts = result.get("live_transcripts") or result.get("live_transcript")
+        if transcripts:
+            row_lines.append(f"Live transcript(s): {str(transcripts)[:1000]}")
+        row_text = "\n".join(row_lines)
+        if len(row_text) > row_budget:
+            row_text = (
+                row_text[: max(0, row_budget - 140)]
+                + f"\n[bounded; full payload: async_delegations:{delegation_id}]"
+            )
+        lines.append(row_text)
+    raw_tokens = claim.get("tokens")
+    tokens = raw_tokens if isinstance(raw_tokens, dict) else {}
+    lines.append(
+        "\nBatch totals: "
+        f"api_calls={int(claim.get('api_calls', 0) or 0)}, "
+        f"tokens={int(tokens.get('input', 0) or 0)} in/"
+        f"{int(tokens.get('output', 0) or 0)} out/"
+        f"{int(tokens.get('reasoning', 0) or 0)} reasoning, "
+        f"cost=${float(claim.get('cost_usd', 0.0) or 0.0):.6f}."
+    )
+    return "\n".join(lines)
+
+
 def _format_async_delegation(evt: dict) -> str:
     """Format an async-delegation completion into a self-contained re-injection.
 

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -346,21 +346,41 @@ class ComputeHost:
         sid = str(frame.get("sid") or "")
         request_id = str(frame.get("request_id") or uuid.uuid4().hex)
         if not sid:
-            self.emit({"type": "turn.error", "sid": sid, "request_id": request_id, "message": "sid required"})
+            self.emit(
+                {
+                    "type": "turn.error",
+                    "sid": sid,
+                    "request_id": request_id,
+                    "reason": "unknown_session",
+                    "turn_started": False,
+                    "message": "sid required",
+                }
+            )
             return
+        turn_started = False
         try:
             from tui_gateway import server
 
             session = self._ensure_server_session(server, frame)
             with session["history_lock"]:
                 if session.get("running"):
-                    self.emit({"type": "turn.error", "sid": sid, "request_id": request_id, "message": "session busy"})
+                    self.emit(
+                        {
+                            "type": "turn.error",
+                            "sid": sid,
+                            "request_id": request_id,
+                            "reason": "session_busy",
+                            "turn_started": False,
+                            "message": "session busy",
+                        }
+                    )
                     return
                 session["running"] = True
                 session["_turn_cancel_requested"] = False
                 session["last_active"] = time.time()
                 server._start_inflight_turn(session, frame.get("text") if "text" in frame else frame.get("prompt"))
             self.emit({"type": "turn.started", "sid": sid, "request_id": request_id, "started_ns": now_ns()})
+            turn_started = True
             try:
                 server._ensure_session_db_row(session)
             except Exception:
@@ -412,7 +432,16 @@ class ComputeHost:
                         server._clear_inflight_turn(session)
             except Exception:
                 pass
-            self.emit({"type": "turn.error", "sid": sid, "request_id": request_id, "reason": "exception", "message": str(exc)})
+            self.emit(
+                {
+                    "type": "turn.error",
+                    "sid": sid,
+                    "request_id": request_id,
+                    "reason": "exception",
+                    "turn_started": turn_started,
+                    "message": str(exc),
+                }
+            )
 
     def _ensure_server_session(self, server: Any, frame: dict[str, Any]) -> dict:
         sid = str(frame.get("sid") or "")

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -160,7 +160,9 @@ class HostSupervisor:
         self._closing = False
         self._stopped_respawning = False
         self._restart_times: list[float] = []
-        self._pending_turns: dict[str, tuple[str, Callable[[dict], None] | None]] = {}
+        self._pending_turns: dict[
+            str, tuple[str, Callable[[dict], None] | None, bool]
+        ] = {}
         self._pending_controls: dict[str, queue.Queue[dict]] = {}
         self._stderr_tail: list[str] = []
         self._last_progress_counter = 0
@@ -243,7 +245,7 @@ class HostSupervisor:
         payload["type"] = "turn.start"
         payload["request_id"] = request_id
         with self._lock:
-            self._pending_turns[request_id] = (sid, on_complete)
+            self._pending_turns[request_id] = (sid, on_complete, False)
         try:
             self._send_frame(payload)
         except Exception as exc:
@@ -417,6 +419,14 @@ class HostSupervisor:
             if isinstance(message, dict):
                 self.rpc_sink(message)
             return
+        if ftype == "turn.started":
+            request_id = str(frame.get("request_id") or "")
+            with self._lock:
+                pending = self._pending_turns.get(request_id)
+                if pending is not None:
+                    sid, callback, _started = pending
+                    self._pending_turns[request_id] = (sid, callback, True)
+            return
         if ftype in {"turn.end", "turn.error"}:
             self._complete_turn(frame)
             return
@@ -446,7 +456,7 @@ class HostSupervisor:
             pending = self._pending_turns.pop(request_id, None)
         if pending is None:
             return
-        _sid, cb = pending
+        _sid, cb, _started = pending
         if cb is not None:
             try:
                 cb(frame)
@@ -469,12 +479,13 @@ class HostSupervisor:
         with self._lock:
             pending = self._pending_turns
             self._pending_turns = {}
-        for request_id, (sid, cb) in pending.items():
+        for request_id, (sid, cb, turn_started) in pending.items():
             frame = {
                 "type": "turn.error",
                 "sid": sid,
                 "request_id": request_id,
                 "reason": reason,
+                "turn_started": turn_started,
                 "message": message,
             }
             self.rpc_sink(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1265,12 +1265,30 @@ def _compute_host_turn_frame(rid: str, sid: str, session: dict, text: Any) -> di
         history = list(session.get("history", []))
         history_version = int(session.get("history_version", 0))
         attached_images = list(session.get("attached_images", []))
+        pending_reconciliation = session.get("pending_goal_reconciliation")
+        pending_reconciliation = (
+            dict(pending_reconciliation)
+            if isinstance(pending_reconciliation, dict)
+            else {}
+        )
+    turn_text = text
+    if pending_reconciliation and not (
+        isinstance(text, dict) and text.get("goal_reconciliation")
+    ):
+        expected_prompt = str(pending_reconciliation.pop("_prompt", "") or "")
+        prompt_text = str(text or "")
+        if expected_prompt and prompt_text != expected_prompt:
+            prompt_text = f"{expected_prompt}\n\n[Additional user input]\n{prompt_text}"
+        turn_text = {
+            "text": prompt_text,
+            "goal_reconciliation": pending_reconciliation,
+        }
     return {
         "type": "turn.start",
         "sid": sid,
         "request_id": rid,
         "session_key": session.get("session_key") or sid,
-        "text": text,
+        "text": turn_text,
         "history": history,
         "history_version": history_version,
         "cols": int(session.get("cols", 80) or 80),
@@ -1341,6 +1359,45 @@ def _on_compute_host_turn_done(rid: str, sid: str, session: dict, frame: dict) -
     if is_error:
         message = str(frame.get("message") or "compute host turn failed")
         _emit("message.complete", sid, {"text": f"Error: {message}", "status": "error"})
+        reconciliation = frame.get("_goal_reconciliation")
+        if isinstance(reconciliation, dict) and reconciliation.get("claim_id"):
+            home_token = None
+            try:
+                profile_home = str(session.get("profile_home") or "")
+                if profile_home:
+                    from hermes_constants import set_hermes_home_override
+
+                    home_token = set_hermes_home_override(profile_home)
+                from hermes_cli.goals import release_goal_reconciliation_turn
+
+                preturn_reasons = {"send_failed", "session_busy", "unknown_session"}
+                turn_started = bool(
+                    frame.get(
+                        "turn_started",
+                        str(frame.get("reason") or "") not in preturn_reasons,
+                    )
+                )
+                release_goal_reconciliation_turn(
+                    str(reconciliation.get("claim_id") or ""),
+                    session_id=str(
+                        reconciliation.get("session_id")
+                        or session.get("session_key")
+                        or ""
+                    ),
+                    goal_id=str(reconciliation.get("goal_id") or ""),
+                    attempt=int(reconciliation.get("attempt", 1) or 1),
+                    turn_started=turn_started,
+                )
+            except Exception:
+                logger.exception("Failed to release compute-host goal reconciliation")
+            finally:
+                if home_token is not None:
+                    try:
+                        from hermes_constants import reset_hermes_home_override
+
+                        reset_hermes_home_override(home_token)
+                    except Exception:
+                        pass
     _apply_compute_host_metadata_mirror(session, frame)
     try:
         info = _session_info(session.get("agent"), session)
@@ -1354,6 +1411,22 @@ def _on_compute_host_turn_done(rid: str, sid: str, session: dict, frame: dict) -
 def _submit_prompt_to_compute_host(rid: str, sid: str, session: dict, text: Any) -> dict:
     cfg = _load_dashboard_process_isolation_config()
     frame = _compute_host_turn_frame(rid, sid, session, text)
+    packed_text = frame.get("text")
+    reconciliation = (
+        dict(packed_text.get("goal_reconciliation") or {})
+        if isinstance(packed_text, dict) and packed_text.get("goal_reconciliation")
+        else {}
+    )
+    pending_to_restore = None
+    with session["history_lock"]:
+        pending = session.get("pending_goal_reconciliation")
+        if (
+            reconciliation
+            and isinstance(pending, dict)
+            and str(pending.get("claim_id") or "")
+            == str(reconciliation.get("claim_id") or "")
+        ):
+            pending_to_restore = session.pop("pending_goal_reconciliation")
 
     def _complete(done: dict) -> None:
         # submit_turn reports a synchronous pipe failure through the callback
@@ -1362,11 +1435,17 @@ def _submit_prompt_to_compute_host(rid: str, sid: str, session: dict, text: Any)
         # duplicate terminal error.
         if done.get("reason") == "send_failed":
             return
+        if reconciliation:
+            done = dict(done)
+            done["_goal_reconciliation"] = reconciliation
         _on_compute_host_turn_done(rid, sid, session, done)
 
     try:
         _get_compute_host_supervisor(cfg).submit_turn(frame, on_complete=_complete)
     except Exception as exc:
+        if pending_to_restore is not None:
+            with session["history_lock"]:
+                session.setdefault("pending_goal_reconciliation", pending_to_restore)
         return _err(rid, 5019, f"compute-host dispatch failed: {exc}")
     with session["history_lock"]:
         session["_compute_host_active"] = True
@@ -9984,11 +10063,17 @@ def _notification_poller_loop(
     poller requeues events owned by another live session and drops addressed
     events whose owner is gone; ownerless legacy notifications remain global.
     """
+    from tools.async_delegation import recover_stale_goal_reconciliation_claims
     from tools.process_registry import process_registry, format_process_notification
 
     _emitted = set()  # dedup re-queued events so same completion isn't emitted 50 times while session is busy
+    last_claim_recovery_at = 0.0
     while not stop_event.is_set() and not session.get("_finalized"):
         try:
+            now = time.monotonic()
+            if now - last_claim_recovery_at >= 30.0:
+                last_claim_recovery_at = now
+                recover_stale_goal_reconciliation_claims(process_registry.completion_queue)
             evt = process_registry.completion_queue.get(timeout=0.5)
         except Exception:
             continue
@@ -10033,22 +10118,17 @@ def _notification_poller_loop(
         if not text:
             continue
 
-        # Only emit the same notification identity to TUI once — re-queued
-        # completions get re-emitted every 0.5s otherwise when session is busy,
-        # while distinct watch_match events from the same process must remain
-        # visible independently.
-        _dedup_key = _notification_event_dedup_key(evt)
-        if _dedup_key not in _emitted:
-            _emit("status.update", sid, {"kind": "process", "text": text})
-            _emitted.add(_dedup_key)
-
+        # Never consume a notification while an agent turn is already running.
+        # Requeue it and let the post-turn drain pick it up, avoiding nested turns.
         _requeued = False
         with session["history_lock"]:
             if session.get("running"):
+                _dedup_key = _notification_event_dedup_key(evt)
+                if _dedup_key not in _emitted:
+                    _emit("status.update", sid, {"kind": "process", "text": text})
+                    _emitted.add(_dedup_key)
                 process_registry.completion_queue.put(evt)
                 _requeued = True
-            else:
-                session["running"] = True
         if _requeued:
             # Back off before re-polling: the re-queued event keeps the queue
             # non-empty, so without a sleep this loop spins at full speed
@@ -10063,12 +10143,103 @@ def _notification_poller_loop(
         _claim = claim_event_delivery(evt, "tui-poller")
         if _claim is None:
             continue
+        reconciliation = {}
         try:
-            _emit("message.start", sid)
-            _run_prompt_submit(rid, sid, session, text)
+            prompt = text
+            classification = "unowned"
+            status_message = ""
+            decision = {}
+            if evt.get("type") == "async_delegation":
+                from hermes_cli.goals import prepare_goal_delegation_delivery
+
+                decision = prepare_goal_delegation_delivery(
+                    evt,
+                    text,
+                    current_session_id=str(session.get("session_key") or ""),
+                    consumer="tui-poller",
+                )
+                prompt = decision.get("prompt")
+                classification = str(decision.get("classification") or "")
+                status_message = str(decision.get("status_message") or "")
+
+            display_text = status_message
+            if not display_text and classification in {"unowned", "superseded"}:
+                display_text = text
+            _dedup_key = _notification_event_dedup_key(evt)
+            if display_text and _dedup_key not in _emitted:
+                _emit("status.update", sid, {"kind": "process", "text": display_text})
+                _emitted.add(_dedup_key)
+
+            if not prompt:
+                complete_event_delivery(evt, _claim)
+                continue
+
+            if decision.get("reconciliation_claim"):
+                reconciliation = {
+                    "claim_id": decision.get("reconciliation_claim"),
+                    "goal_id": decision.get("goal_id"),
+                    "session_id": decision.get("goal_session_id"),
+                    "attempt": decision.get("reconciliation_attempt", 1),
+                    "delegation_ids": decision.get("delegation_ids") or [],
+                }
+
+            with session["history_lock"]:
+                if session.get("running"):
+                    if reconciliation:
+                        from hermes_cli.goals import release_goal_reconciliation_turn
+
+                        release_goal_reconciliation_turn(
+                            str(reconciliation.get("claim_id") or ""),
+                            session_id=str(reconciliation.get("session_id") or ""),
+                            goal_id=str(reconciliation.get("goal_id") or ""),
+                            attempt=int(reconciliation.get("attempt", 1) or 1),
+                            turn_started=False,
+                            requeue=False,
+                        )
+                    release_event_delivery(evt, _claim)
+                    process_registry.completion_queue.put(evt)
+                    time.sleep(0.1)
+                    continue
+                session["running"] = True
+            turn_input = (
+                {"text": prompt, "goal_reconciliation": reconciliation}
+                if reconciliation
+                else prompt
+            )
+            if _session_uses_compute_host(session):
+                isolated_response = _submit_prompt_to_compute_host(
+                    rid,
+                    sid,
+                    session,
+                    turn_input,
+                )
+                if isolated_response.get("error"):
+                    raise RuntimeError(
+                        isolated_response["error"].get(
+                            "message", "compute-host dispatch failed"
+                        )
+                    )
+            else:
+                _emit("message.start", sid)
+                _run_prompt_submit(rid, sid, session, turn_input)
             complete_event_delivery(evt, _claim)
         except Exception as exc:
+            if reconciliation:
+                try:
+                    from hermes_cli.goals import release_goal_reconciliation_turn
+
+                    release_goal_reconciliation_turn(
+                        str(reconciliation.get("claim_id") or ""),
+                        session_id=str(reconciliation.get("session_id") or ""),
+                        goal_id=str(reconciliation.get("goal_id") or ""),
+                        attempt=int(reconciliation.get("attempt", 1) or 1),
+                        turn_started=False,
+                        requeue=False,
+                    )
+                except Exception:
+                    pass
             release_event_delivery(evt, _claim)
+            process_registry.completion_queue.put(evt)
             print(
                 f"[tui_gateway] notification poller dispatch failed: "
                 f"{type(exc).__name__}: {exc}",
@@ -10113,16 +10284,14 @@ def _notification_poller_loop(
         if not text:
             continue
 
-        _dedup_key = _notification_event_dedup_key(evt)
-        if _dedup_key not in _emitted:
-            _emit("status.update", sid, {"kind": "process", "text": text})
-            _emitted.add(_dedup_key)
-
         with session["history_lock"]:
             if session.get("running"):
+                _dedup_key = _notification_event_dedup_key(evt)
+                if _dedup_key not in _emitted:
+                    _emit("status.update", sid, {"kind": "process", "text": text})
+                    _emitted.add(_dedup_key)
                 process_registry.completion_queue.put(evt)
                 break
-            session["running"] = True
 
         rid = f"__notif__{int(time.time() * 1000)}"
         from tools.async_delegation import (
@@ -10131,12 +10300,87 @@ def _notification_poller_loop(
         _claim = claim_event_delivery(evt, "tui-poller")
         if _claim is None:
             continue
+        reconciliation = {}
         try:
-            _emit("message.start", sid)
-            _run_prompt_submit(rid, sid, session, text)
+            prompt = text
+            classification = "unowned"
+            status_message = ""
+            decision = {}
+            if evt.get("type") == "async_delegation":
+                from hermes_cli.goals import prepare_goal_delegation_delivery
+
+                decision = prepare_goal_delegation_delivery(
+                    evt,
+                    text,
+                    current_session_id=str(session.get("session_key") or ""),
+                    consumer="tui-shutdown-drain",
+                )
+                prompt = decision.get("prompt")
+                classification = str(decision.get("classification") or "")
+                status_message = str(decision.get("status_message") or "")
+
+            display_text = status_message
+            if not display_text and classification in {"unowned", "superseded"}:
+                display_text = text
+            _dedup_key = _notification_event_dedup_key(evt)
+            if display_text and _dedup_key not in _emitted:
+                _emit("status.update", sid, {"kind": "process", "text": display_text})
+                _emitted.add(_dedup_key)
+
+            if not prompt:
+                complete_event_delivery(evt, _claim)
+                continue
+
+            if decision.get("reconciliation_claim"):
+                reconciliation = {
+                    "claim_id": decision.get("reconciliation_claim"),
+                    "goal_id": decision.get("goal_id"),
+                    "session_id": decision.get("goal_session_id"),
+                    "attempt": decision.get("reconciliation_attempt", 1),
+                    "delegation_ids": decision.get("delegation_ids") or [],
+                }
+
+            with session["history_lock"]:
+                session["running"] = True
+            turn_input = (
+                {"text": prompt, "goal_reconciliation": reconciliation}
+                if reconciliation
+                else prompt
+            )
+            if _session_uses_compute_host(session):
+                isolated_response = _submit_prompt_to_compute_host(
+                    rid,
+                    sid,
+                    session,
+                    turn_input,
+                )
+                if isolated_response.get("error"):
+                    raise RuntimeError(
+                        isolated_response["error"].get(
+                            "message", "compute-host dispatch failed"
+                        )
+                    )
+            else:
+                _emit("message.start", sid)
+                _run_prompt_submit(rid, sid, session, turn_input)
             complete_event_delivery(evt, _claim)
         except Exception as exc:
+            if reconciliation:
+                try:
+                    from hermes_cli.goals import release_goal_reconciliation_turn
+
+                    release_goal_reconciliation_turn(
+                        str(reconciliation.get("claim_id") or ""),
+                        session_id=str(reconciliation.get("session_id") or ""),
+                        goal_id=str(reconciliation.get("goal_id") or ""),
+                        attempt=int(reconciliation.get("attempt", 1) or 1),
+                        turn_started=False,
+                        requeue=False,
+                    )
+                except Exception:
+                    pass
             release_event_delivery(evt, _claim)
+            process_registry.completion_queue.put(evt)
             print(
                 f"[tui_gateway] notification poller dispatch failed: "
                 f"{type(exc).__name__}: {exc}",
@@ -10232,6 +10476,17 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
 
 
 def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
+    reconciliation = {}
+    if isinstance(text, dict) and text.get("goal_reconciliation"):
+        reconciliation = dict(text.get("goal_reconciliation") or {})
+        text = str(text.get("text") or "")
+    elif isinstance(session.get("pending_goal_reconciliation"), dict):
+        pending_reconciliation = session.get("pending_goal_reconciliation") or {}
+        expected_prompt = str(pending_reconciliation.get("_prompt") or "")
+        reconciliation = dict(session.pop("pending_goal_reconciliation"))
+        reconciliation.pop("_prompt", None)
+        if expected_prompt and isinstance(text, str) and text != expected_prompt:
+            text = f"{expected_prompt}\n\n[Additional user input]\n{text}"
     with session["history_lock"]:
         history = list(session["history"])
         history_version = int(session.get("history_version", 0))
@@ -10252,6 +10507,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         session_tokens = []
         home_token = None  # per-turn HERMES_HOME override for a resumed remote profile
         goal_followup = None  # set by the post-turn goal hook below
+        reconciliation_finalized = False
         one_turn_restore = session.pop("one_turn_model_restore", None)
         try:
             from tools.approval import (
@@ -10493,7 +10749,9 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 status = (
                     "interrupted"
                     if result.get("interrupted")
-                    else "error" if result.get("error") else "complete"
+                    else "error"
+                    if result.get("error") or result.get("failed") or result.get("partial")
+                    else "complete"
                 )
                 # When the backend produced no visible response AND reported a
                 # real error (e.g. invalid model slug → provider 4xx), surface
@@ -10527,6 +10785,32 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             with session["history_lock"]:
                 _clear_inflight_turn(session)
             _emit("message.complete", sid, payload)
+
+            if reconciliation:
+                claim_id = str(reconciliation.get("claim_id") or "")
+                from hermes_cli.goals import reconciliation_turn_succeeded
+
+                if claim_id and reconciliation_turn_succeeded(
+                    raw,
+                    interrupted=bool(result.get("interrupted")) if isinstance(result, dict) else False,
+                    failed=bool(result.get("failed")) if isinstance(result, dict) else False,
+                    partial=bool(result.get("partial")) if isinstance(result, dict) else False,
+                    error=bool(result.get("error")) if isinstance(result, dict) else False,
+                ):
+                    from hermes_cli.goals import complete_goal_reconciliation_turn
+
+                    complete_goal_reconciliation_turn(claim_id)
+                    reconciliation_finalized = True
+                elif claim_id:
+                    from hermes_cli.goals import release_goal_reconciliation_turn
+
+                    release_goal_reconciliation_turn(
+                        claim_id,
+                        session_id=str(reconciliation.get("session_id") or session.get("session_key") or ""),
+                        goal_id=str(reconciliation.get("goal_id") or ""),
+                        attempt=int(reconciliation.get("attempt", 1) or 1),
+                    )
+                    reconciliation_finalized = True
 
             # ── /goal continuation (Ralph-style loop) ─────────────────
             # After every TUI turn, if a /goal is active, ask the judge
@@ -10688,6 +10972,18 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             )
             _emit("error", sid, {"message": str(e)})
         finally:
+            if reconciliation and not reconciliation_finalized:
+                try:
+                    from hermes_cli.goals import release_goal_reconciliation_turn
+
+                    release_goal_reconciliation_turn(
+                        str(reconciliation.get("claim_id") or ""),
+                        session_id=str(reconciliation.get("session_id") or session.get("session_key") or ""),
+                        goal_id=str(reconciliation.get("goal_id") or ""),
+                        attempt=int(reconciliation.get("attempt", 1) or 1),
+                    )
+                except Exception:
+                    logger.debug("TUI goal reconciliation release failed", exc_info=True)
             if one_turn_restore:
                 try:
                     _restore_agent_model_runtime(agent, one_turn_restore)
@@ -10771,19 +11067,90 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                         for pending_evt, _pending_synth in drained[index:]:
                             process_registry.completion_queue.put(pending_evt)
                         break
-                    session["running"] = True
                 from tools.async_delegation import (
                     claim_event_delivery, complete_event_delivery, release_event_delivery,
                 )
                 _claim = claim_event_delivery(_evt, "tui-post-turn")
                 if _claim is None:
                     continue
+                notification_reconciliation = {}
                 try:
+                    prompt = synth
+                    decision = {}
+                    if _evt.get("type") == "async_delegation":
+                        from hermes_cli.goals import prepare_goal_delegation_delivery
+
+                        decision = prepare_goal_delegation_delivery(
+                            _evt,
+                            synth,
+                            current_session_id=str(session.get("session_key") or ""),
+                            consumer="tui-post-turn",
+                        )
+                        prompt = decision.get("prompt")
+                        status_message = str(decision.get("status_message") or "")
+                        if status_message:
+                            _emit(
+                                "status.update",
+                                sid,
+                                {"kind": "process", "text": status_message},
+                            )
+
+                    if not prompt:
+                        complete_event_delivery(_evt, _claim)
+                        continue
+
+                    if decision.get("reconciliation_claim"):
+                        notification_reconciliation = {
+                            "claim_id": decision.get("reconciliation_claim"),
+                            "goal_id": decision.get("goal_id"),
+                            "session_id": decision.get("goal_session_id"),
+                            "attempt": decision.get("reconciliation_attempt", 1),
+                            "delegation_ids": decision.get("delegation_ids") or [],
+                        }
+
+                    with session["history_lock"]:
+                        if session.get("running"):
+                            if notification_reconciliation:
+                                from hermes_cli.goals import release_goal_reconciliation_turn
+
+                                release_goal_reconciliation_turn(
+                                    str(notification_reconciliation.get("claim_id") or ""),
+                                    session_id=str(notification_reconciliation.get("session_id") or ""),
+                                    goal_id=str(notification_reconciliation.get("goal_id") or ""),
+                                    attempt=int(notification_reconciliation.get("attempt", 1) or 1),
+                                    turn_started=False,
+                                    requeue=False,
+                                )
+                            release_event_delivery(_evt, _claim)
+                            process_registry.completion_queue.put(_evt)
+                            for pending_evt, _pending_synth in drained[index + 1:]:
+                                process_registry.completion_queue.put(pending_evt)
+                            break
+                        session["running"] = True
                     _emit("message.start", sid)
-                    _run_prompt_submit(rid, sid, session, synth)
+                    _run_prompt_submit(
+                        rid, sid, session,
+                        ({"text": prompt, "goal_reconciliation": notification_reconciliation}
+                         if notification_reconciliation else prompt),
+                    )
                     complete_event_delivery(_evt, _claim)
                 except Exception as _n_exc:
+                    if notification_reconciliation:
+                        try:
+                            from hermes_cli.goals import release_goal_reconciliation_turn
+
+                            release_goal_reconciliation_turn(
+                                str(notification_reconciliation.get("claim_id") or ""),
+                                session_id=str(notification_reconciliation.get("session_id") or ""),
+                                goal_id=str(notification_reconciliation.get("goal_id") or ""),
+                                attempt=int(notification_reconciliation.get("attempt", 1) or 1),
+                                turn_started=False,
+                                requeue=False,
+                            )
+                        except Exception:
+                            pass
                     release_event_delivery(_evt, _claim)
+                    process_registry.completion_queue.put(_evt)
                     print(
                         f"[tui_gateway] completion notification dispatch failed: "
                         f"{type(_n_exc).__name__}: {_n_exc}",
@@ -13928,14 +14295,47 @@ def _(rid, params: dict) -> dict:
             state = mgr.resume()
             if state is None:
                 return _ok(rid, {"type": "exec", "output": "No goal to resume."})
+            from hermes_cli.goals import prepare_goal_resume, get_goal_work_snapshot
+
+            decision = prepare_goal_resume(sid_key, consumer="tui-goal-resume")
+            prompt = decision.get("prompt")
+            if decision.get("reconciliation_claim"):
+                session["pending_goal_reconciliation"] = {
+                    "claim_id": decision.get("reconciliation_claim"),
+                    "goal_id": decision.get("goal_id"),
+                    "session_id": decision.get("goal_session_id"),
+                    "attempt": decision.get("reconciliation_attempt", 1),
+                    "delegation_ids": decision.get("delegation_ids") or [],
+                    "_prompt": prompt,
+                }
+            if not prompt:
+                snapshot = get_goal_work_snapshot(state.goal_id)
+                outstanding = sum(
+                    int(snapshot.get(key, 0))
+                    for key in (
+                        "running_count",
+                        "terminal_unreconciled_count",
+                        "claimed_count",
+                    )
+                )
+                if outstanding:
+                    return _ok(
+                        rid,
+                        {
+                            "type": "exec",
+                            "output": (
+                                f"▶ Goal resumed: {state.goal} "
+                                "(waiting for required async work)"
+                            ),
+                        },
+                    )
+                prompt = mgr.next_continuation_prompt() or state.goal
             return _ok(
                 rid,
                 {
-                    "type": "exec",
-                    "output": (
-                        f"▶ Goal resumed: {state.goal}\n"
-                        "Send any message to continue, or wait — I'll take the next step on the next turn."
-                    ),
+                    "type": "send",
+                    "notice": f"▶ Goal resumed: {state.goal}",
+                    "message": prompt,
                 },
             )
         if lower in {"clear", "stop", "done"}:

--- a/website/docs/user-guide/features/goals.md
+++ b/website/docs/user-guide/features/goals.md
@@ -131,6 +131,14 @@ Typical flow: the agent pushes a PR, starts a CI watcher with `terminal(backgrou
 
 ## Behavior details
 
+### Required asynchronous delegation work
+
+When Hermes starts a background `delegate_task` while a standing goal is active, that delegation becomes required work owned by the goal. The goal cannot be marked done until every required delegation has reached a terminal state and its result has been reconciled in the parent conversation. Nested delegations keep the same root goal owner, while each child retains its parent-delegation lineage.
+
+Intermediate completions are recorded without spending another model turn. Once the required work is terminal, Hermes runs an internal reconciliation turn with a bounded batch of durable results, then resumes normal goal evaluation. Each delegation keeps its own call and token limits; goal status aggregates usage and cost for observability but does not reinterpret those child budgets. A restart, session compression, or temporary delivery failure does not drop this barrier: ownership, results, claims, and retry state are persisted and stale claims are recovered automatically. If reconciliation turns repeatedly fail after starting, Hermes pauses the goal after three consecutive failures instead of silently completing or retrying forever.
+
+`/goal status` reports required async work as running, ready for reconciliation, or currently claimed. `/goal resume` reconciles ready work before issuing an ordinary continuation. Replacing or clearing a goal abandons its outstanding required work so late results cannot influence the replacement goal. Ordinary background delegations started outside a standing goal retain their existing delivery behavior and do not create a goal barrier.
+
 ### The judge
 
 After every turn, Hermes calls an auxiliary model with:
@@ -141,9 +149,9 @@ After every turn, Hermes calls an auxiliary model with:
 
 The judge is deliberately conservative: it marks a goal `done` only when the response **explicitly** confirms the goal is complete, when the final deliverable is clearly produced, or when the goal is unachievable/blocked (treated as DONE with a block reason so we don't burn budget on impossible tasks).
 
-### Fail-open semantics
+### Judge fail-open semantics
 
-If the judge errors (network blip, malformed response, unavailable aux client), Hermes treats the verdict as `continue` — a broken judge never wedges progress. The **turn budget** is the real backstop.
+If the judge errors (network blip, malformed response, unavailable aux client), Hermes treats the verdict as `continue` — a broken judge never wedges progress. The **turn budget** is the real backstop. Required-work persistence is intentionally different: if Hermes cannot verify a goal's durable async-work state, completion remains blocked until storage is available again.
 
 ### Turn budget
 


### PR DESCRIPTION
## What does this PR do?

Makes asynchronous delegations durable work owned by the active standing goal. A goal cannot transition to `done` while required delegated work is running, awaiting reconciliation, or claimed by a reconciliation turn.

The implementation keeps the async-delegation SQLite table as the single work mailbox, persists a stable root `goal_id`, and uses fenced claim/complete/release transitions so CLI, gateway, and TUI delivery can coalesce completed work without one parent turn per child. Paused goals retain terminal results without conversational injection; `/goal resume` drains the mailbox before starting generic continuation.

## Related Issue and Open Work

Partially addresses #63169 by retaining and reconciling goal-owned async results before goal completion. It does not change the broader Kanban-worker parent lifecycle, so this PR does not close that issue.

Landed on `main` and reconciled here:

- #69312 — preserves async completions across context compression and adds durable acknowledgement/drop semantics, superseding the now-closed #65820

Open work touching adjacent or overlapping integration surfaces:

- #63133 — correlate async results to parent turns
- #58349 — keep process notifications out of agent turns
- #68078 — evidence-driven goal-loop controls
- #52582 — formal goal acceptance/rejection lifecycle

The current branch has known textual overlap with #63133, #58349, #68078, and #52582. It is rebased onto `0ec4a873c`; the reconciliation preserves current `main` behavior for compression-lineage delivery, bounded terminal acknowledgement/drop handling, and delegated-agent `execute_code` access. The focused suite below validates that integration rather than treating every behind-count change as a reason for repeated rebases.

## Maintainer Decision

This PR is intentionally atomic because the correctness guarantee spans durable ownership, completion persistence, reconciliation, and every delivery surface. The `needs-decision` label is still appropriate: maintainers should decide whether this unified design is the desired direction or whether it should be staged into a durable delegation primitive followed by goal and UI integrations.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Persist stable goal ownership, the root owner session, and nested delegation lineage on async rows while preserving positional `GoalState` compatibility.
- Serialize required-work insertion against goal replacement/clear and reject stale owners transactionally, closing the late nested-dispatch race.
- Retry terminal completion persistence without sleeping under the process lock; if immediate attempts exhaust, keep the result in `finalizing` and continue autonomously until the terminal row is durable and publishable.
- Preserve the root owner session on semantic retry envelopes so nested results stay attached to the active root goal; count `finalizing` persistence retries against async capacity to bound outage behavior.
- Keep the declarative `SessionDB` schema, additive runtime migration, and deferred goal-work index in sync, including legacy-table and cross-process migration safety.
- Add durable goal-work snapshots plus atomic, token-fenced reconciliation claim/complete/release/abandon APIs.
- Bound reconciliation batches, preserve oversized results behind durable row references, recover stale leases, and protect unreconciled evidence from pruning.
- Carry typed internal reconciliation envelopes through classic CLI, gateway, inline TUI, and isolated compute-host turns; acknowledge semantic work only after a successful, non-partial parent turn.
- Fail closed when goal ownership or mailbox state cannot be verified; async dispatch falls back to a synchronous join rather than starting unowned work.
- Release and requeue claims on resume-enqueue failures, compute-host pre-turn failures, partial turns, and interrupted turns without losing reconciliation evidence.
- Block all goal terminal transitions on outstanding required work or mailbox read failure, while preserving turn-budget pauses.
- Make pause/resume/replacement/compression lifecycle behavior explicit and expose counts, IDs, attempts, failures, token totals, and cost in goal status.
- Document standing-goal async join behavior, pause/resume semantics, isolated child budgets, retries, and lifecycle abandonment.
- Add focused persistence, restart, claim contention, migration contention, replacement/clear race, retry exhaustion, retention, delivery-surface, compute-host, and lifecycle tests.
- Fence test-only TUI notification pollers to their creating test so daemon threads cannot steal a later test's process-global completion queue.

## How to Test

1. `HERMES_HOME="$(mktemp -d)" uv run --extra dev python -m pytest -q tests/hermes_cli/test_goals.py tests/hermes_cli/test_goal_async_delegation_join.py tests/tools/test_async_delegation.py tests/cli/test_cli_async_delegation_delivery.py tests/gateway/test_completion_delivery.py tests/gateway/test_goal_max_turns_config.py tests/test_hermes_state.py tests/tui_gateway/test_goal_command.py tests/tui_gateway/test_compute_host.py tests/tui_gateway/test_compute_host_phase1.py tests/test_tui_gateway_server.py`
2. `uv run --extra dev ruff check .`
3. `python scripts/check-windows-footguns.py hermes_state.py hermes_cli/goals.py hermes_cli/cli_commands_mixin.py tools/async_delegation.py tools/delegate_tool.py tools/process_registry.py cli.py gateway/run.py gateway/slash_commands.py tui_gateway/server.py tui_gateway/compute_host.py`
4. `python -m compileall -q hermes_state.py hermes_cli/goals.py hermes_cli/cli_commands_mixin.py tools/async_delegation.py tools/delegate_tool.py tools/process_registry.py cli.py gateway/run.py gateway/slash_commands.py tui_gateway/server.py tui_gateway/compute_host.py tui_gateway/host_supervisor.py`

Focused result on the rebased exact head: **1,048 passed**. The prior real-threading poller race passed **10/10** repeated runs, and the previously failing MCP session-expiry test passes with the fix inherited from current `main`. Ruff, the changed-surface Windows-footgun scan, byte compilation, and diff checks also pass. Exact-head CI is authoritative for the full matrix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora Linux 44 / Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/features/goals.md` and docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no input schema changes)

## Screenshots / Logs

Not applicable; this is lifecycle and persistence behavior covered by automated tests.

