### PR TITLE
fix: treat [object Object] sentinel as absent in Telegram reply_to_text

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9063,6 +9063,13 @@ class TelegramAdapter(BasePlatformAdapter):
                     or message.reply_to_message.caption
                     or None
                 )
+                # Telegram echoes rich messages (sendRichMessage, Bot API 10.1)
+                # as the literal string "[object Object]" in reply_to_message.text
+                # instead of returning empty/None. Treat this sentinel as absent
+                # so the rich-reply and sent-store fallbacks below can recover the
+                # real content.
+                if reply_to_text == "[object Object]":
+                    reply_to_text = None
                 if not reply_to_text:
                     # Prefer Telegram's native rich-message echo when present;
                     # keep the local send-time index only as a fallback for

--- a/tests/gateway/test_telegram_reply_quote.py
+++ b/tests/gateway/test_telegram_reply_quote.py
@@ -142,3 +142,29 @@ def test_empty_quote_text_falls_back_to_full_reply():
     event = adapter._build_message_event(msg, MessageType.TEXT)
 
     assert event.reply_to_text == "Prior message body"
+
+
+def test_object_object_sentinel_treated_as_absent():
+    """Telegram echoes rich messages as '[object Object]' in reply_to_message.text.
+
+    When a user replies to a sendRichMessage (Bot API 10.1) message, Telegram
+    does NOT echo the rich content back — it returns the literal string
+    ``[object Object]`` as ``.text``. The adapter must treat this sentinel as
+    absent so the rich-reply and sent-store fallbacks can recover the real
+    content, instead of injecting ``[object Object]`` as the reply-to text.
+    """
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    msg = _make_message(
+        text="What is this?",
+        reply_to_text="[object Object]",
+        quote_text=None,
+    )
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    # The sentinel must NOT be passed through as reply_to_text.
+    # It should be None (no rich-message echo or sent-store entry in this mock)
+    # rather than the literal "[object Object]" string.
+    assert event.reply_to_text != "[object Object]"


### PR DESCRIPTION
## Summary

When a user replies to a rich message (`sendRichMessage`, Bot API 10.1), Telegram echoes the literal string `[object Object]` as `reply_to_message.text` instead of returning empty/None. The adapter accepted this as valid reply text (it's a truthy string), skipping the `_extract_rich_reply_text` and `rich_sent_store.lookup` fallbacks that would have recovered the real content.

This caused the agent to see `[object Object]` as the reply-to context instead of the actual message body — e.g. replying to a cron-delivered morning briefing produced:

```
[Replying to: "[object Object]"]
What is this?
```

## Fix

Add a guard after the `.text` / `.caption` extraction that detects the `[object Object]` sentinel and sets `reply_to_text = None`. This lets the existing fallback chain fire as intended:

1. `_extract_rich_reply_text()` — parses Telegram's native rich-message echo
2. `rich_sent_store.lookup()` — recovers from the local send-time index

## Test Plan

- [x] New test `test_object_object_sentinel_treated_as_absent` verifies the sentinel is not passed through
- [x] Existing reply-quote tests still pass (no regression)

```
tests/gateway/test_telegram_reply_quote.py::test_native_partial_quote_used_as_reply_to_text PASSED
tests/gateway/test_telegram_reply_quote.py::test_full_reply_text_used_when_no_native_quote PASSED
tests/gateway/test_telegram_reply_quote.py::test_caption_fallback_when_no_quote_and_no_text PASSED
tests/gateway/test_telegram_reply_quote.py::test_empty_quote_text_falls_back_to_full_reply PASSED
tests/gateway/test_telegram_reply_quote.py::test_object_object_sentinel_treated_as_absent PASSED
5 passed in 0.35s
```