### PR TITLE
Fix Slack table column settings validation

### DIFF
--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -285,18 +285,19 @@ def _table_block(rows: List[str], sep_line: str) -> Optional[Block]:
         return None
 
     aligns = _parse_alignment(sep_line)
-    column_settings: List[Optional[Dict[str, Any]]] = []
+    column_settings: List[Dict[str, Any]] = []
     for c in range(min(ncols, MAX_TABLE_COLS)):
         align = aligns[c] if c < len(aligns) else "left"
-        # Only emit a setting when it differs from the default (left, no wrap);
-        # use null to skip a column, per the Slack schema.
-        column_settings.append({"align": align} if align != "left" else None)
+        # Slack validates every column_settings entry as an object.  Include
+        # explicit left-alignment placeholders so later center/right settings
+        # retain their positional column mapping without invalid null entries.
+        column_settings.append({"align": align})
 
     block: Block = {
         "type": "table",
         "rows": [[_rich_text_cell(cell) for cell in row] for row in parsed],
     }
-    if any(cs is not None for cs in column_settings):
+    if any(cs["align"] != "left" for cs in column_settings):
         block["column_settings"] = column_settings
     return block
 

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -159,10 +159,12 @@ class TestTables:
         )
         blocks = render_blocks(md)
         cs = blocks[0]["column_settings"]
-        # left is default -> null; center/right emitted
-        assert cs[0] is None
+        # Slack requires every column_settings entry to be an object. Explicit
+        # left placeholders preserve the position of later custom alignments.
+        assert cs[0] == {"align": "left"}
         assert cs[1] == {"align": "center"}
         assert cs[2] == {"align": "right"}
+        assert all(isinstance(setting, dict) for setting in cs)
 
     def test_inline_formatting_inside_cells(self):
         md = (


### PR DESCRIPTION
## What changed

- emit an object for every `column_settings` entry when a Markdown table requests any non-default alignment
- preserve column positions with explicit `{ "align": "left" }` placeholders instead of `null`
- keep omitting `column_settings` when every column uses Slack's default left alignment
- update the table-rendering regression test to enforce object-only settings

## Root cause

The Block Kit renderer used `null` placeholders for default-aligned columns so later center/right settings retained their positions. Slack's current `chat.postMessage` validation rejects those entries with `invalid_blocks` and `must provide an object` at the affected `column_settings` JSON pointer.

## User impact

Mixed-alignment Markdown tables can now be posted as native Slack table blocks instead of failing at delivery time. Tables that use only default left alignment retain the existing payload shape.

## Verification

- `scripts/run_tests.sh tests/gateway/test_slack_block_kit.py tests/gateway/test_slack_block_kit_adapter.py -q`
- 33 tests passed
- reproduced the rejection and successful object-only payload against Slack's Web API in a private DM canary