### PR TITLE
fix(desktop): truncate long composer model labels

### DIFF
--- a/apps/desktop/src/app/chat/composer/model-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.tsx
@@ -16,7 +16,7 @@ import { $currentModelSource, setModelPickerOpen } from '@/store/session'
 import type { ChatBarState } from './types'
 
 const PILL = cn(
-  'h-(--composer-control-size) max-w-40 shrink-0 gap-1 rounded-md px-2 text-xs font-normal',
+  'h-(--composer-control-size) max-w-40 shrink-0 gap-1 overflow-hidden rounded-md px-2 text-xs font-normal',
   'text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-foreground'
 )
 
@@ -68,7 +68,7 @@ export function ModelPill({
   ) : (
     <>
       {currentModel.trim() ? (
-        <span className="truncate">{formatModelStatusLabel(currentModel, { fastMode, reasoningEffort })}</span>
+        <span className="min-w-0 truncate">{formatModelStatusLabel(currentModel, { fastMode, reasoningEffort })}</span>
       ) : (
         <GlyphSpinner className="opacity-50" spinner="braille" />
       )}


### PR DESCRIPTION
## What does this PR do?

Prevents long model/status labels from wrapping inside the desktop composer model pill.

The label already uses Tailwind's `truncate` utility, but its flex item was missing `min-w-0`, and the parent button did not explicitly clip overflow. Adding those constraints keeps the composer controls on one line and ellipsizes the label while preserving the chevron and pinned indicator.

This supersedes #63607 with the same focused production fix rebased onto current `main` as a single commit.

## Related Issue

Fixes #63601

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `overflow-hidden` to the model pill button in `apps/desktop/src/app/chat/composer/model-pill.tsx`.
- Added `min-w-0` to the label flex child so `truncate` can ellipsize constrained text.

## How to Test

1. Open the Hermes desktop chat UI and select a model with a long display name.
2. Enable Fast mode and a named reasoning effort, such as Ultra.
3. Narrow the window until the composer controls are constrained.
4. Confirm the model/status label remains on one line and truncates with an ellipsis while the chevron remains visible.

Local verification:
- `git diff --check`
- Direct comparison against the reviewed production diff from #63607

The class-token assertion from the earlier PR is intentionally omitted because review on #63607 identified it as implementation-coupled rather than a behavioral layout test. Current CI will run the desktop TypeScript and test checks against this rebased branch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## Screenshots / Logs

No screenshot included because the reproduction contains captured desktop content. The linked issue documents the reproduction steps, and CI results are attached to this PR.
