### PR TITLE
fix(models): resolve custom provider model ids

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -965,6 +965,38 @@ def _configured_provider_matches(
     return matches
 
 
+def _resolve_named_custom_model_id(
+    model_name: str,
+    target_provider: str,
+    custom_providers: Optional[list],
+) -> str:
+    """Map a picker-prefixed custom model selection to its configured ID."""
+    provider = str(target_provider or "").strip().lower()
+    if not provider.startswith("custom:") or "/" not in model_name:
+        return model_name
+
+    prefix, candidate = model_name.split("/", 1)
+    prefix = prefix.strip().lower()
+    candidate = candidate.strip()
+    if not prefix or not candidate:
+        return model_name
+
+    for entry in custom_providers or []:
+        if not isinstance(entry, dict):
+            continue
+        entry_slugs = {
+            custom_provider_slug(str(entry.get(key) or "")).lower()
+            for key in ("name", "provider_key")
+            if str(entry.get(key) or "").strip()
+        }
+        if provider not in entry_slugs or f"custom:{prefix}" not in entry_slugs:
+            continue
+        for model_id in _declared_model_ids(entry.get("models")):
+            if model_id.lower() == candidate.lower():
+                return model_id
+    return model_name
+
+
 # ---------------------------------------------------------------------------
 # Core model-switching pipeline
 # ---------------------------------------------------------------------------
@@ -1447,6 +1479,9 @@ def switch_model(
         api_mode = determine_api_mode(target_provider, base_url)
 
     # --- Normalize model name for target provider ---
+    new_model = _resolve_named_custom_model_id(
+        new_model, target_provider, custom_providers
+    )
     new_model = normalize_model_for_provider(new_model, target_provider)
 
     # --- Validate ---

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -283,6 +283,48 @@ def test_switch_model_accepts_explicit_named_custom_provider(monkeypatch):
     assert result.api_key == "no-key-required"
 
 
+def test_picker_selection_resolves_named_custom_provider_model_id(monkeypatch):
+    """Picker prefixes must not leak into a named custom provider API model id."""
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "test-key",
+            "base_url": "https://token.sensenova.cn/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: _MOCK_VALIDATION,
+    )
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_model_capabilities",
+        lambda *a, **k: None,
+    )
+
+    result = switch_model(
+        raw_input="sensenova/deepseek-v4-flash",
+        current_provider="openai-codex",
+        current_model="gpt-5.4",
+        explicit_provider="custom:sensenova",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "sensenova",
+                "base_url": "https://token.sensenova.cn/v1",
+                "models": [
+                    {"id": "deepseek-v4-flash", "name": "deepseek-v4-flash"}
+                ],
+            }
+        ],
+    )
+
+    assert result.success is True
+    assert result.target_provider == "custom:sensenova"
+    assert result.new_model == "deepseek-v4-flash"
+
+
 def test_list_groups_same_name_custom_providers_into_one_row(monkeypatch):
     """Multiple custom_providers entries sharing a name should produce one row
     with all models collected, not N duplicate rows."""


### PR DESCRIPTION
## Summary

When a `custom_providers` entry lists a model as `{"id": "deepseek-v4-flash", "name": "deepseek-v4-flash"}`, the model picker (`/model sensenova/deepseek-v4-flash`) selects the picker string instead of the configured bare id. The prefixed string then flows through `hermes_cli/model_switch.py::switch_model` → `normalize_model_for_provider` → session persistence → `agent/chat_completion_helpers.py`, where it is sent verbatim as the API `model` parameter. Sensenova (and any other OpenAI-compatible custom provider that does not accept `provider/model`) returns `HTTP 404 model is not found` for the prefixed form, even though the bare id is valid.

The CLI `/model <id> --provider sensenova` workaround succeeds because that path bypasses `switch_model` for a custom provider and stores the bare id directly. The fix maps picker-prefixed selections back to the configured bare id in the shared switch chokepoint so CLI / TUI / desktop / gateway share a single, normalized value.

## Repro

```yaml
custom_providers:
  - name: sensenova
    base_url: https://token.sensenova.cn/v1
    key_env: SENSENOVA_API_KEY
    models:
      - { id: deepseek-v4-flash, name: deepseek-v4-flash }
model:
  default: deepseek-v4-flash
  provider: custom:sensenova
```

1. Pick `sensenova/deepseek-v4-flash` from the model picker.
2. Send a message.
3. Expected: API request body contains `"model": "deepseek-v4-flash"`.
4. Actual: API request body contains `"model": "sensenova/deepseek-v4-flash"` → `HTTP 404 model is not found`.

Verified at the API layer: `POST /v1/chat/completions` with `model=deepseek-v4-flash` returns 200; with `model=sensenova/deepseek-v4-flash` returns 404.

## Fix

In `hermes_cli/model_switch.py::switch_model`, before `normalize_model_for_provider` runs, resolve the picker-prefixed custom selection to the bare configured id when:

- the explicit provider is `custom:<name>`;
- the picker input matches that prefix and the prefix corresponds to a configured custom provider entry;
- the candidate model id (case-insensitive) is actually declared under that entry's `models[].id`.

If any of those checks fail, the original model string is preserved untouched, so bare custom-provider selections, third-party providers, and slash-style model hints are unaffected.

The mapping is intentionally restricted to the picker input prefix -> configured id; downstream `normalize_model_for_provider` continues to handle built-in provider slug normalization.

## Tests

- RED -> GREEN test in `tests/hermes_cli/test_model_switch_custom_providers.py::test_picker_selection_resolves_named_custom_provider_model_id`. RED observed `result.new_model == "sensenova/deepseek-v4-flash"` against expected `"deepseek-v4-flash"`.
- Focused suite: `tests/hermes_cli/test_model_switch_custom_providers.py` -> 52 passed.
- Related: model switch / inventory / gateway / TUI custom-provider persistence -> 20 files, 221 passed, 0 failed.
- `ruff check` clean.
- `git diff --check` clean.

## Scope

Two files, +77 lines. No public schema change, no new env var, no config migration. Sibling surfaces that share `switch_model` (CLI picker, TUI, desktop, gateway) all pick up the same normalization in one place.

Fixes #68347
