### PR TITLE
fix(mcp): add self-alias and granular MCP toolset control for delegate_task

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -573,14 +573,48 @@ def _expand_parent_toolsets(parent_toolsets: set) -> set:
     return expanded
 
 
+def _normalize_mcp_toolset_name(name: str) -> str:
+    """Strip 'mcp-' prefix if present, return the bare server name."""
+    if name.startswith("mcp-"):
+        return name[4:]
+    return name
+
+
 def _preserve_parent_mcp_toolsets(
-    child_toolsets: List[str], parent_toolsets: set[str]
+    child_toolsets: List[str],
+    parent_toolsets: set[str],
+    requested_mcp: Optional[List[str]] = None,
 ) -> List[str]:
-    """Append any parent MCP toolsets that are missing from a narrowed child."""
+    """Append parent MCP toolsets that are missing from a narrowed child.
+
+    When *requested_mcp* is provided (non-empty list of explicit MCP toolset
+    names), only those toolsets are preserved.  When it is ``None``, all
+    parent MCP toolsets are preserved (backward-compatible default).
+
+    This gives callers granular control: requesting ``toolsets=["web"]``
+    alone strips MCP tools, while ``toolsets=["web", "mcp-obsidian"]``
+    preserves only the explicitly named MCP server.
+
+    Name matching is normalized: ``mcp-obsidian`` matches parent toolset
+    ``obsidian`` and vice-versa, because platform tools may register
+    MCP servers without the ``mcp-`` prefix.
+    """
+    # Build a normalized set of requested MCP server names (without mcp- prefix)
+    requested_normalized: Optional[set[str]] = None
+    if requested_mcp is not None:
+        requested_normalized = {_normalize_mcp_toolset_name(t) for t in requested_mcp}
+
     preserved = list(child_toolsets)
     for toolset_name in sorted(parent_toolsets):
-        if _is_mcp_toolset_name(toolset_name) and toolset_name not in preserved:
-            preserved.append(toolset_name)
+        is_mcp = _is_mcp_toolset_name(toolset_name)
+        # Also treat bare server names as MCP if the user explicitly requested them
+        bare_name = _normalize_mcp_toolset_name(toolset_name)
+        if not is_mcp and requested_normalized and bare_name in requested_normalized:
+            is_mcp = True
+
+        if is_mcp and toolset_name not in preserved:
+            if requested_normalized is None or bare_name in requested_normalized:
+                preserved.append(toolset_name)
     return preserved
 
 
@@ -1144,11 +1178,21 @@ def _build_child_agent(
         # Intersect with parent — subagent must not gain tools the parent lacks.
         # Expand composite toolsets (e.g. hermes-cli) so that individual
         # toolset names (e.g. web, terminal) are recognised during intersection.
+        #
+        # MCP toolsets (mcp-xxx) are handled separately: they are not in
+        # TOOLSETS dict (registered dynamically at runtime), so they would
+        # be filtered out by the intersection.  We extract them first and
+        # let _preserve_parent_mcp_toolsets decide which ones to keep.
         expanded_parent = _expand_parent_toolsets(parent_toolsets)
-        child_toolsets = [t for t in toolsets if t in expanded_parent]
+        requested_mcp = [t for t in toolsets if _is_mcp_toolset_name(t)]
+        regular_toolsets = [t for t in toolsets if not _is_mcp_toolset_name(t)]
+        child_toolsets = [t for t in regular_toolsets if t in expanded_parent]
         if _get_inherit_mcp_toolsets():
+            # Preserve only explicitly requested MCP toolsets.
+            # When requested_mcp is empty list → strip all MCP toolsets.
+            # When requested_mcp has values → keep only those MCP toolsets.
             child_toolsets = _preserve_parent_mcp_toolsets(
-                child_toolsets, parent_toolsets
+                child_toolsets, parent_toolsets, requested_mcp=requested_mcp
             )
         child_toolsets = _strip_blocked_tools(child_toolsets)
     elif parent_agent and parent_enabled is not None:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5124,6 +5124,12 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
 
     if registered_names:
         registry.register_toolset_alias(name, toolset_name)
+        # Also register the canonical name as a self-alias so that
+        # validate_toolset("mcp-<name>") resolves correctly.  Without
+        # this, child agents that receive "mcp-obsidian" in their
+        # enabled_toolsets (via _preserve_parent_mcp_toolsets) hit
+        # validate_toolset → False and the tools are silently dropped.
+        registry.register_toolset_alias(toolset_name, toolset_name)
 
     return registered_names
 


### PR DESCRIPTION
# Pull Request: fix MCP toolset self-alias + granular delegation control

## Description

Two small bugs in MCP toolset resolution that cause silent tool loss during `delegate_task`.

### 1. `tools/mcp_tool.py` — self-alias fix

**Problem:** `validate_toolset("mcp-<name>")` always returns `False`.

When an MCP server registers, `_register_server_tools` calls:
```python
registry.register_toolset_alias("obsidian", "mcp-obsidian")
# → aliases dict = {"obsidian": "mcp-obsidian"}
```
But `validate_toolset(name)` (`toolsets.py:882`) checks `name in _get_registry_toolset_aliases()` — it looks at **keys**, not values. So `"mcp-obsidian"` is never found and validation fails.

**Fix:** Register a self-alias so the canonical `mcp-<name>` form validates:
```python
registry.register_toolset_alias(toolset_name, toolset_name)
# → aliases dict = {"obsidian": "mcp-obsidian", "mcp-obsidian": "mcp-obsidian"}
```

**Impact:** Without this, `toolsets=["web", "mcp-obsidian"]` in `delegate_task` silently drops the MCP tools — the child agent never gets them and no warning is emitted.

### 2. `tools/delegate_tool.py` — granular MCP toolset control

**Problem:** When `delegate_task` is called with explicit toolsets like `toolsets=["web"]`, MCP tools are still injected into the child because `_preserve_parent_mcp_toolsets` always preserves ALL parent MCP toolsets. There is no way to restrict which MCP servers a child should get.

The existing `inherit_mcp_toolsets: false` config is all-or-nothing — it strips ALL MCP tools, even the ones the child legitimately needs.

**Fix:** Two changes in `_build_child_agent`:
1. Separate MCP toolsets from regular toolsets before intersection:
   - `requested_mcp` = toolsets that look like `mcp-<name>`
   - `regular_toolsets` = everything else
2. Only preserve MCP toolsets that are explicitly requested (not all of them)

Plus `_normalize_mcp_toolset_name()` to handle `mcp-` prefix matching (platform may use bare name `"obsidian"` while user passes `"mcp-obsidian"`).

**New behavior:**

| `toolsets` parameter | Result |
|---|---|
| `None` | Inherit all tools including MCP (unchanged) |
| `["web"]` | Only web tools, no MCP (was: web + ALL MCP) |
| `["web", "mcp-obsidian"]` | web + Obsidian MCP only (was: validate_toolset failed on `mcp-obsidian`) |
| `["mcp-obsidian"]` | Only Obsidian MCP tools (new capability) |
| `[]` | Inherit all (same as None) |

---

## Files changed

| File | Insertions | Deletions |
|---|---|---|
| `tools/mcp_tool.py` | 6 | 0 |
| `tools/delegate_tool.py` | 56 | 6 |

### Diff

```diff
# tools/mcp_tool.py
@@ -5124,6 +5124,12 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
 
     if registered_names:
         registry.register_toolset_alias(name, toolset_name)
+        # Also register the canonical name as a self-alias so that
+        # validate_toolset("mcp-<name>") resolves correctly. Without
+        # this, child agents that receive "mcp-obsidian" in their
+        # enabled_toolsets (via _preserve_parent_mcp_toolsets) hit
+        # validate_toolset → False and the tools are silently dropped.
+        registry.register_toolset_alias(toolset_name, toolset_name)
 
     return registered_names
```

```diff
# tools/delegate_tool.py
@@ -573,14 +573,48 @@ def _expand_parent_toolsets(parent_toolsets: set) -> set:
     return expanded
 
 
+def _normalize_mcp_toolset_name(name: str) -> str:
+    """Strip 'mcp-' prefix if present, return the bare server name."""
+    if name.startswith("mcp-"):
+        return name[4:]
+    return name
+
+
 def _preserve_parent_mcp_toolsets(
-    child_toolsets: List[str], parent_toolsets: set[str]
+    child_toolsets: List[str],
+    parent_toolsets: set[str],
+    requested_mcp: Optional[List[str]] = None,
 ) -> List[str]:
-    """Append any parent MCP toolsets that are missing from a narrowed child."""
+    """Append parent MCP toolsets that are missing from a narrowed child.
+
+    When *requested_mcp* is provided (non-empty list of explicit MCP toolset
+    names), only those toolsets are preserved. When it is ``None``, all
+    parent MCP toolsets are preserved (backward-compatible default).
+
+    This gives callers granular control: requesting ``toolsets=["web"]``
+    alone strips MCP tools, while ``toolsets=["web", "mcp-obsidian"]``
+    preserves only the explicitly named MCP server.
+
+    Name matching is normalized: ``mcp-obsidian`` matches parent toolset
+    ``obsidian`` and vice-versa, because platform tools may register
+    MCP servers without the ``mcp-`` prefix.
+    """
+    # Build a normalized set of requested MCP server names (without mcp- prefix)
+    requested_normalized: Optional[set[str]] = None
+    if requested_mcp is not None:
+        requested_normalized = {_normalize_mcp_toolset_name(t) for t in requested_mcp}
+
     preserved = list(child_toolsets)
     for toolset_name in sorted(parent_toolsets):
-        if _is_mcp_toolset_name(toolset_name) and toolset_name not in preserved:
-            preserved.append(toolset_name)
+        is_mcp = _is_mcp_toolset_name(toolset_name)
+        # Also treat bare server names as MCP if the user explicitly requested them
+        bare_name = _normalize_mcp_toolset_name(toolset_name)
+        if not is_mcp and requested_normalized and bare_name in requested_normalized:
+            is_mcp = True
+
+        if is_mcp and toolset_name not in preserved:
+            if requested_normalized is None or bare_name in requested_normalized:
+                preserved.append(toolset_name)
     return preserved
 
 
@@ -1144,11 +1178,21 @@ def _build_child_agent(
         # Intersect with parent — subagent must not gain tools the parent lacks.
         # Expand composite toolsets (e.g. hermes-cli) so that individual
         # toolset names (e.g. web, terminal) are recognised during intersection.
+        #
+        # MCP toolsets (mcp-xxx) are handled separately: they are not in
+        # TOOLSETS dict (registered dynamically at runtime), so they would
+        # be filtered out by the intersection. We extract them first and
+        # let _preserve_parent_mcp_toolsets decide which ones to keep.
         expanded_parent = _expand_parent_toolsets(parent_toolsets)
-        child_toolsets = [t for t in toolsets if t in expanded_parent]
+        requested_mcp = [t for t in toolsets if _is_mcp_toolset_name(t)]
+        regular_toolsets = [t for t in toolsets if not _is_mcp_toolset_name(t)]
+        child_toolsets = [t for t in regular_toolsets if t in expanded_parent]
         if _get_inherit_mcp_toolsets():
+            # Preserve only explicitly requested MCP toolsets.
+            # When requested_mcp is empty list → strip all MCP toolsets.
+            # When requested_mcp has values → keep only those MCP toolsets.
             child_toolsets = _preserve_parent_mcp_toolsets(
-                child_toolsets, parent_toolsets
+                child_toolsets, parent_toolsets, requested_mcp=requested_mcp
             )
         child_toolsets = _strip_blocked_tools(child_toolsets)
     elif parent_agent and parent_enabled is not None:
```

---

## How to submit this PR (via GitHub Web)

1. Fork https://github.com/NousResearch/hermes-agent
2. Create branch: `fix/mcp-toolset-self-alias-and-granular-delegation`
3. Apply both diffs above
4. Push to your fork
5. Open PR against `NousResearch/hermes-agent:main`

---

## Related issues

- https://github.com/NousResearch/hermes-agent/issues/30563 — MCP server name collision
- https://github.com/NousResearch/hermes-agent/issues/14986 — MCP tools not available in ACP sessions
- https://github.com/NousResearch/hermes-agent/issues/21658 — Subagent tool delegation inconsistent
- https://github.com/NousResearch/hermes-agent/issues/32668 — per-agent toolset restriction

## Checklist

- [x] Code compiles (Python 3.11)
- [x] E2E tested:
  - `toolsets=None` → inherit all ✅
  - `toolsets=["web"]` → web only, no MCP ✅
  - `toolsets=["web", "mcp-obsidian"]` → web + Obsidian MCP ✅
  - `toolsets=["mcp-obsidian"]` → Obsidian MCP only ✅
  - `validate_toolset("mcp-obsidian")` → True ✅
