### PR TITLE
fix(web): handle broken symlinks in managed files listing

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2199,10 +2199,23 @@ def _managed_file_entry(policy: ManagedFilesPolicy, target: Path) -> Dict[str, A
 
     try:
         st = resolved.stat()
-    except OSError as exc:
-        raise HTTPException(status_code=500, detail=f"Could not stat path: {exc}")
+        is_dir = resolved.is_dir()
+    except OSError:
+        # Broken symlink — target doesn't exist. Use lstat for symlink's own
+        # metadata so the entry still appears in listings with partial info.
+        try:
+            st = target.lstat()
+        except OSError:
+            return {
+                "name": target.name,
+                "path": str(resolved),
+                "is_directory": False,
+                "size": None,
+                "mtime": None,
+                "mime_type": None,
+            }
+        is_dir = target.is_dir()
 
-    is_dir = resolved.is_dir()
     mime_type = None if is_dir else (mimetypes.guess_type(resolved.name)[0] or "application/octet-stream")
     return {
         "name": target.name or resolved.name or str(resolved),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2622,10 +2622,23 @@ def _managed_file_entry(policy: ManagedFilesPolicy, target: Path) -> Dict[str, A
 
     try:
         st = resolved.stat()
-    except OSError as exc:
-        raise HTTPException(status_code=500, detail=f"Could not stat path: {exc}")
+        is_dir = resolved.is_dir()
+    except OSError:
+        # Broken symlink — target doesn't exist. Use lstat for symlink's own
+        # metadata so the entry still appears in listings with partial info.
+        try:
+            st = target.lstat()
+        except OSError:
+            return {
+                "name": target.name,
+                "path": str(resolved),
+                "is_directory": False,
+                "size": None,
+                "mtime": None,
+                "mime_type": None,
+            }
+        is_dir = target.is_dir()
 
-    is_dir = resolved.is_dir()
     mime_type = None if is_dir else (mimetypes.guess_type(resolved.name)[0] or "application/octet-stream")
     return {
         "name": target.name or resolved.name or str(resolved),

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -302,3 +302,28 @@ def test_credential_dir_trees_blocked_on_subdir_descent(forced_files_client):
     assert [e["name"] for e in mcp_listing.json()["entries"]] == []
 
 
+def test_dangling_symlink_listing_returns_partial_entry(forced_files_client):
+    """Regression: broken symlinks caused HTTP 500 in managed files listing
+    because _managed_file_entry called resolved.stat() which follows the
+    link. Must return 200 with nullable metadata for the dangling entry."""
+    client, root = forced_files_client
+    root.mkdir(parents=True, exist_ok=True)
+
+    link = root / "broken"
+    try:
+        link.symlink_to("ghost")
+    except OSError:
+        pytest.skip("filesystem does not support symlinks")
+
+    listing = client.get("/api/files", params={"path": str(root)})
+    assert listing.status_code == 200
+
+    entries = listing.json()["entries"]
+    broken = [e for e in entries if e["name"] == "broken"]
+    assert len(broken) == 1
+
+    entry = broken[0]
+    assert entry["is_directory"] is False
+    assert entry["size"] == 5
+    assert entry["mtime"] is not None
+    assert entry["mime_type"] is not None

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -311,7 +311,7 @@ def test_dangling_symlink_listing_returns_partial_entry(forced_files_client):
 
     link = root / "broken"
     try:
-        link.symlink_to("ghost")
+        link.symlink_to("ghost")  # relative — stays inside root so security check passes
     except OSError:
         pytest.skip("filesystem does not support symlinks")
 
@@ -324,6 +324,7 @@ def test_dangling_symlink_listing_returns_partial_entry(forced_files_client):
 
     entry = broken[0]
     assert entry["is_directory"] is False
-    assert entry["size"] == 5
+    # Broken symlink still has valid lstat metadata (size = target name length)
+    assert entry["size"] == 5  # "ghost" is 5 chars
     assert entry["mtime"] is not None
     assert entry["mime_type"] is not None

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -384,7 +384,7 @@ def test_dangling_symlink_listing_returns_partial_entry(forced_files_client):
 
     link = root / "broken"
     try:
-        link.symlink_to("ghost")
+        link.symlink_to("ghost")  # relative — stays inside root so security check passes
     except OSError:
         pytest.skip("filesystem does not support symlinks")
 
@@ -397,6 +397,7 @@ def test_dangling_symlink_listing_returns_partial_entry(forced_files_client):
 
     entry = broken[0]
     assert entry["is_directory"] is False
-    assert entry["size"] == 5
+    # Broken symlink still has valid lstat metadata (size = target name length)
+    assert entry["size"] == 5  # "ghost" is 5 chars
     assert entry["mtime"] is not None
     assert entry["mime_type"] is not None

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -375,3 +375,28 @@ def test_credential_dir_trees_blocked_on_subdir_descent(forced_files_client):
     assert [e["name"] for e in mcp_listing.json()["entries"]] == []
 
 
+def test_dangling_symlink_listing_returns_partial_entry(forced_files_client):
+    """Regression: broken symlinks caused HTTP 500 in managed files listing
+    because _managed_file_entry called resolved.stat() which follows the
+    link. Must return 200 with nullable metadata for the dangling entry."""
+    client, root = forced_files_client
+    root.mkdir(parents=True, exist_ok=True)
+
+    link = root / "broken"
+    try:
+        link.symlink_to("ghost")
+    except OSError:
+        pytest.skip("filesystem does not support symlinks")
+
+    listing = client.get("/api/files", params={"path": str(root)})
+    assert listing.status_code == 200
+
+    entries = listing.json()["entries"]
+    broken = [e for e in entries if e["name"] == "broken"]
+    assert len(broken) == 1
+
+    entry = broken[0]
+    assert entry["is_directory"] is False
+    assert entry["size"] == 5
+    assert entry["mtime"] is not None
+    assert entry["mime_type"] is not None


### PR DESCRIPTION
## What does this PR do?

When the Desktop Files page browses into a directory containing broken symlinks (e.g. Steam's `linux32/` or `ubuntu12_32/`), `_managed_file_entry()` calls `resolved.stat()` which follows the symlink and fails with `OSError: [Errno 2] No such file or directory`, producing an HTTP 500 that breaks the entire directory listing.

This fix catches the `OSError` on `stat()` and falls back to `target.lstat()` to get the symlink's own metadata. If even `lstat()` fails (race condition), returns a partial entry with `None` fields instead of crashing.

## How to test

1. Find or create a directory with a broken symlink: `ln -s /nonexistent /tmp/testdir/broken`
2. In Hermes Desktop, browse into that directory via Files page
3. Before: HTTP 500 "Could not stat path" error
4. After: directory lists with broken symlink shown (size/mtime may be null)

## Checklist

- [x] Bug fix (non-breaking change fixing an issue)
- [x] Extends existing code (first rung of the footprint ladder)
- [ ] Breaking change (would break existing functionality)
- [ ] Requires documentation update