### PR TITLE
fix(providers): resolve custom:<name> to CustomProfile for reasoning_effort

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1223,7 +1223,10 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         is_kimi=_is_kimi,
         is_tokenhub=_is_tokenhub,
         is_lmstudio=_is_lmstudio,
-        is_custom_provider=agent.provider == "custom",
+        is_custom_provider=(
+            (agent.provider or "").strip().lower() == "custom"
+            or (agent.provider or "").strip().lower().startswith("custom:")
+        ),
         ollama_num_ctx=agent._ollama_num_ctx,
         provider_preferences=_prefs or None,
         openrouter_min_coding_score=agent.openrouter_min_coding_score,

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -66,10 +66,25 @@ def get_provider_profile(name: str) -> ProviderProfile | None:
     """Look up a provider profile by name or alias.
 
     Returns None if the provider has no profile (falls back to generic).
+
+    Named custom endpoints are stored as ``custom:<label>`` (e.g.
+    ``custom:my-proxy``). Those must resolve to the shared ``custom``
+    profile so quirks like top-level ``reasoning_effort`` still apply —
+    otherwise effort is silently dropped and upstream proxies default
+    to medium.
     """
     if not _discovered:
         _discover_providers()
-    canonical = _ALIASES.get(name, name)
+    raw = (name or "").strip()
+    if not raw:
+        return None
+    # custom:<name> / CUSTOM:Foo → custom profile
+    if raw.lower().startswith("custom:"):
+        raw = "custom"
+    canonical = _ALIASES.get(raw, raw)
+    # also try lower-case alias/name for mixed-case provider ids
+    if canonical not in _REGISTRY and raw.lower() != raw:
+        canonical = _ALIASES.get(raw.lower(), raw.lower())
     return _REGISTRY.get(canonical)
 
 

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -21,6 +21,34 @@ class TestRegistry:
 
     def test_unknown_provider_returns_none(self):
         assert get_provider_profile("nonexistent-provider") is None
+        assert get_provider_profile("") is None
+
+    def test_named_custom_provider_resolves_to_custom_profile(self):
+        """Named custom endpoints use provider ids like ``custom:<label>``.
+
+        Runtime stores ``custom:my-proxy`` rather than the bare ``custom``
+        registry key. These must still hit CustomProfile so top-level
+        ``reasoning_effort`` is emitted instead of being silently dropped
+        (upstream then defaults to medium).
+        """
+        bare = get_provider_profile("custom")
+        assert bare is not None
+        assert bare.name == "custom"
+
+        for name in (
+            "custom:my-proxy",
+            "custom:local-vllm",
+            "CUSTOM:Foo",
+            "custom:relay-1",
+        ):
+            p = get_provider_profile(name)
+            assert p is not None, name
+            assert p is bare or p.name == "custom"
+            # CustomProfile must still wire reasoning effort top-level.
+            _eb, tl = p.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": "high"}
+            )
+            assert tl.get("reasoning_effort") == "high", name
 
     def test_all_providers_have_name(self):
         get_provider_profile("nvidia")  # trigger discovery


### PR DESCRIPTION
## Summary
- Named custom endpoints use provider ids like `custom:<label>` (e.g. `custom:my-proxy`), but `get_provider_profile()` only looked up the bare `custom` registry key.
- Result: `CustomProfile` was skipped, top-level `reasoning_effort` was never emitted, and upstream proxies defaulted to **medium** even when Hermes was configured for high/xhigh.
- Fix: map `custom:<label>` → `custom` profile; also treat `custom:*` as custom in the legacy chat-completions kwargs path.
- Tests: registry coverage for named custom lookup + effort emission.

## Context
Related to #55276 (reasoning_effort silently dropped for custom providers). This PR covers the additional failure mode where the runtime provider string is `custom:<name>` rather than bare `custom`.

## Test plan
- [x] Manual: `get_provider_profile("custom:my-proxy")` resolves to `custom` and emits `reasoning_effort=high`
- [x] Manual: before fix, same lookup returned `None` and no effort field was sent
- [x] Added `test_named_custom_provider_resolves_to_custom_profile`
- [ ] CI unit tests
