### PR TITLE
fix(dashboard): warm configured platform SDKs before ready announcement

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19138,6 +19138,32 @@ def _maybe_open_browser(
     threading.Thread(target=_open, daemon=True).start()
 
 
+def _warm_configured_platform_sdks() -> None:
+    """Eagerly import the SDK modules of every *connected* gateway platform.
+
+    Platform adapter modules import their SDKs at module level (lark_oapi,
+    slack_bolt, discord.py, ...). lark_oapi alone is ~11k generated modules,
+    and on Windows with real-time AV scanning that first import blocks the
+    asyncio event loop for 15-60s. It is otherwise triggered lazily inside
+    the first /api/status request — i.e. AFTER uvicorn has announced
+    HERMES_(BACKEND|DASHBOARD)_READY — so the desktop's 15s readiness fetch
+    times out and kills the backend, looping the boot forever (#50209).
+
+    Called between socket bind and the ready announcement: the desktop's
+    port-announce window is 90s, so paying the import cost here is safe, and
+    afterwards the very first probe answers in milliseconds. Best-effort —
+    any failure is logged and ignored; the lazy import path still works.
+    """
+    try:
+        from gateway.config import load_gateway_config
+        from gateway.platform_registry import platform_registry
+
+        for platform in load_gateway_config().get_connected_platforms():
+            platform_registry.get(platform.value)
+    except Exception as exc:  # pragma: no cover - best-effort
+        _log.debug("platform SDK warm-up skipped: %s", exc)
+
+
 def start_server(
     host: str = "127.0.0.1",
     port: int = 9119,
@@ -19336,6 +19362,10 @@ def start_server(
 
             actual_port = _read_bound_port(server, fallback=port)
             app.state.bound_port = actual_port
+
+            # Pay the cold platform-SDK import cost BEFORE announcing
+            # readiness (#50209) — see _warm_configured_platform_sdks.
+            _warm_configured_platform_sdks()
 
             _write_dashboard_ready_file(actual_port)
             # Port-discovery sentinel parsed by the desktop spawn. `serve` is a

--- a/tests/test_web_server_platform_warmup.py
+++ b/tests/test_web_server_platform_warmup.py
@@ -1,0 +1,77 @@
+"""Tests for ``_warm_configured_platform_sdks`` (#50209).
+
+The helper must resolve exactly the *connected* platforms through the
+platform registry (triggering their deferred platform-module imports, which
+is what pulls heavy SDKs like lark_oapi into sys.modules before the ready
+announcement) and must never propagate failures — the lazy import path in
+the request handlers is the fallback.
+"""
+
+import types
+
+import gateway.config as gw_config
+import gateway.platform_registry as gw_registry
+
+from hermes_cli import web_server
+
+
+class _FakePlatform:
+    def __init__(self, value):
+        self.value = value
+
+
+def _patch_gateway_config(monkeypatch, connected):
+    fake_config = types.SimpleNamespace(
+        get_connected_platforms=lambda: connected
+    )
+    monkeypatch.setattr(gw_config, "load_gateway_config", lambda: fake_config)
+
+
+def test_warmup_resolves_each_connected_platform(monkeypatch):
+    _patch_gateway_config(
+        monkeypatch, [_FakePlatform("feishu"), _FakePlatform("telegram")]
+    )
+    calls = []
+    monkeypatch.setattr(
+        gw_registry, "platform_registry", types.SimpleNamespace(get=calls.append)
+    )
+
+    web_server._warm_configured_platform_sdks()
+
+    assert calls == ["feishu", "telegram"]
+
+
+def test_warmup_with_no_connected_platforms_is_noop(monkeypatch):
+    _patch_gateway_config(monkeypatch, [])
+    calls = []
+    monkeypatch.setattr(
+        gw_registry, "platform_registry", types.SimpleNamespace(get=calls.append)
+    )
+
+    web_server._warm_configured_platform_sdks()
+
+    assert calls == []
+
+
+def test_warmup_swallows_config_failures(monkeypatch):
+    def _boom():
+        raise RuntimeError("config unreadable")
+
+    monkeypatch.setattr(gw_config, "load_gateway_config", _boom)
+
+    # Must not raise — a broken config must not block server startup.
+    web_server._warm_configured_platform_sdks()
+
+
+def test_warmup_swallows_registry_failures(monkeypatch):
+    _patch_gateway_config(monkeypatch, [_FakePlatform("feishu")])
+
+    def _boom(name):
+        raise RuntimeError(f"cannot import {name}")
+
+    monkeypatch.setattr(
+        gw_registry, "platform_registry", types.SimpleNamespace(get=_boom)
+    )
+
+    # Must not raise — the request-time lazy import remains as fallback.
+    web_server._warm_configured_platform_sdks()


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows desktop boot failure loop: when a messaging platform with a
heavy SDK (e.g. Feishu/`lark_oapi`) is configured, the desktop never gets
past "Waiting for Hermes backend to become ready" — the backend announces
its port, the readiness probe times out at 15s, the desktop kills the
backend and retries forever.

**Root cause:** the first `/api/status` request after startup lazily
imports the configured platform's adapter module, which imports its SDK at
module level. `lark_oapi` alone is ~11k generated modules (~98 MB); with
Windows Defender (or any real-time AV) scanning each file, that import
blocks the asyncio event loop for 15-60s. The desktop's readiness fetch
times out at 15s (`DEFAULT_FETCH_TIMEOUT_MS`), aborts the request (which
cancels the in-flight import mid-tree), retries — each attempt re-pays the
cost — declares boot failure, kills the backend, and starts over. Because
the backend is killed before ever finishing, the loop never converges.

**Fix:** pay the import cost *before* announcing readiness. Between the
uvicorn socket bind and the `HERMES_(BACKEND|DASHBOARD)_READY` print, the
server now resolves every *connected* platform through the platform
registry (`_warm_configured_platform_sdks()`), which triggers the deferred
platform-module import — the same lazy path the first request would take.
The desktop's port-announce window is 90s (`backend-ready.ts`), so the
announcement still arrives comfortably in time, and the first readiness
probe then answers in milliseconds. The helper is best-effort: any failure
is logged at debug level and ignored, so a broken config can never block
server startup (the lazy request-time path remains as fallback).

This follows the precedent already in the codebase for the same Windows
cold-import problem: `hermes_cli.gateway`'s first import is offloaded to a
thread in `/api/status` (see the comment there about 15-30s cold-import
stalls), and `_lifespan` warms it via `run_in_executor` for the same reason.

## Related Issue

Related to #50209.
Note: #50209 addressed a different root cause for the same symptom; this PR fixes the same Windows cold-import boot-loop issue when the configured messaging platform SDK is lazily imported at the first `/api/status` request.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: add `_warm_configured_platform_sdks()` helper
  and call it in `_serve()` between `_read_bound_port()` and the
  `HERMES_(BACKEND|DASHBOARD)_READY` announcement (both `serve` and
  `dashboard` paths share `_serve()`).
- `tests/test_web_server_platform_warmup.py`: new tests — resolves exactly
  the connected platforms through the registry, no-op when none are
  connected, and swallows config/registry failures.

## How to Test

Reproduction (Windows, Feishu configured in `config.yaml`, cold venv):

1. `python -m hermes_cli.main serve --host 127.0.0.1 --port 0`
2. Immediately `curl http://127.0.0.1:<port>/api/status` on the announced
   port.

Before the fix: the first request hangs 15-60s (py-spy shows the main
thread importing `lark_oapi\api\...\__init__.py`), so the desktop's 15s
readiness fetch times out and boot loops. After the fix:

1. Same `serve` command — the `HERMES_BACKEND_READY` announcement is
   delayed (~23s here) while the SDK import happens *before* it.
2. First `/api/status` probe after the announcement: **HTTP 200 in ~0.2s**.

Desktop end-to-end (`hermes desktop --source`): boot reaches
"Hermes backend is ready. Finalizing desktop startup" instead of the
timeout/respawn loop.

Unit tests: `pytest tests/test_web_server_platform_warmup.py -v` (4 passed),
plus existing `pytest tests/test_web_server.py -q` (4 passed, no
regressions). `ruff check` clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass *(targeted: `test_web_server*.py` — 8 passed)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Python 3.11.15, Electron 40.10.2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A *(change is platform-agnostic; it only front-loads an import that already happens on every platform)*
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (desktop.log, repeating forever):

```
[hermes] HERMES_BACKEND_READY port=59538
[hermes] [boot] Waiting for Hermes backend to become ready
[hermes] [boot] Desktop boot failed: Hermes backend did not become ready:
Timed out connecting to Hermes backend after 15000ms
```

py-spy during the hang (main thread = event loop):

```
<module> (lark_oapi\api\corehr\v2\model\__init__.py:703)
<module> (lark_oapi\api\corehr\v2\__init__.py:1)
<module> (lark_oapi\ws\client.py:21)
...
```

After:

```
HERMES_BACKEND_READY port=53801        # announced after ~23s warm-up
GET /api/status -> HTTP 200 in 0.21s   # first probe, previously 15-60s
[hermes] [boot] Hermes backend is ready. Finalizing desktop startup
```
