### PR TITLE
fix(doctor): bound external health checks (#68419)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -65,6 +65,9 @@ _PROVIDER_ENV_HINTS = (
     "TOKENHUB_API_KEY",
 )
 
+_NPM_AUDIT_TIMEOUT_SECONDS = 10
+_ANTHROPIC_PROBE_TIMEOUT_SECONDS = 5
+
 
 from hermes_constants import is_termux as _is_termux
 
@@ -103,6 +106,37 @@ def _safe_which(cmd: str) -> str | None:
         return shutil.which(cmd)
     except Exception:
         return None
+
+
+def _run_npm_audits(
+    audit_targets: list[tuple[Path, str, list[str]]], npm_bin: str
+) -> list[tuple[subprocess.CompletedProcess | None, Exception | None]]:
+    """Run independent npm audits concurrently in stable target order."""
+    import concurrent.futures
+
+    def _run_one(target):
+        npm_dir, _, audit_extra = target
+        try:
+            result = subprocess.run(
+                [npm_bin, "audit", "--json", *audit_extra],
+                cwd=str(npm_dir),
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=_NPM_AUDIT_TIMEOUT_SECONDS,
+            )
+            return result, None
+        except Exception as exc:
+            return None, exc
+
+    if not audit_targets:
+        return []
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=min(4, len(audit_targets)),
+        thread_name_prefix="doctor-npm-audit",
+    ) as executor:
+        return list(executor.map(_run_one, audit_targets))
 
 
 def _termux_browser_setup_steps(node_installed: bool) -> list[str]:
@@ -2019,21 +2053,29 @@ def run_doctor(args):
             (PROJECT_ROOT, "ui-tui workspace", ["--workspace", "ui-tui"]),
             (_whatsapp_bridge_dir, "WhatsApp bridge", []),
         ]
+        eligible_npm_audit_targets = []
         for npm_dir, label, audit_extra in npm_audit_targets:
             # For workspace-scoped audits run from PROJECT_ROOT the
             # node_modules check must use the workspace root; standalone dirs
             # (whatsapp-bridge) check their own node_modules.
             check_dir = PROJECT_ROOT if audit_extra else npm_dir
-            if not (check_dir / "node_modules").exists():
+            if (check_dir / "node_modules").exists():
+                eligible_npm_audit_targets.append((npm_dir, label, audit_extra))
+
+        audit_results = _run_npm_audits(eligible_npm_audit_targets, _npm_bin)
+        for (npm_dir, label, audit_extra), (audit_result, audit_error) in zip(
+            eligible_npm_audit_targets, audit_results
+        ):
+            if isinstance(audit_error, subprocess.TimeoutExpired):
+                check_warn(
+                    f"{label} deps",
+                    f"(npm audit timed out after {_NPM_AUDIT_TIMEOUT_SECONDS}s)",
+                )
+                continue
+            if audit_error is not None:
+                check_warn(f"{label} deps", f"(npm audit failed: {audit_error})")
                 continue
             try:
-                # Use resolved absolute path so Windows can execute
-                # npm.cmd (CreateProcessW can't run bare .cmd names).
-                audit_result = subprocess.run(
-                    [_npm_bin, "audit", "--json", *audit_extra],
-                    cwd=str(npm_dir),
-                    capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=30,
-                )
                 import json as _json
                 audit_data = _json.loads(audit_result.stdout) if audit_result.stdout.strip() else {}
                 vuln_count = audit_data.get("metadata", {}).get("vulnerabilities", {})
@@ -2203,7 +2245,7 @@ def run_doctor(args):
                 headers["x-api-key"] = key
             r = httpx.get(
                 "https://api.anthropic.com/v1/models",
-                headers=headers, timeout=10,
+                headers=headers, timeout=_ANTHROPIC_PROBE_TIMEOUT_SECONDS,
             )
             # Reactive recovery: OAuth subscriptions without 1M context reject the
             # request with 400 "long context beta is not yet available for this
@@ -2221,7 +2263,7 @@ def run_doctor(args):
                 )
                 r = httpx.get(
                     "https://api.anthropic.com/v1/models",
-                    headers=headers, timeout=10,
+                    headers=headers, timeout=_ANTHROPIC_PROBE_TIMEOUT_SECONDS,
                 )
             if r.status_code == 200:
                 return _ConnectivityResult(

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1410,3 +1410,196 @@ class TestDoctorDeprecatedConfigAndEnv:
         assert "Deprecated: delegation.max_async_children" in out
         assert "Deprecated: HERMES_TOOL_PROGRESS_MODE" in out
         assert "⚠" in out or "Deprecated" in out
+
+
+def test_run_doctor_reports_one_audit_timeout_and_other_results(monkeypatch, tmp_path):
+    """One stalled workspace stays visible without suppressing completed audits."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    project = tmp_path / "project"
+    (project / "node_modules").mkdir(parents=True)
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(
+        doctor_mod.shutil, "which", lambda cmd: "/usr/bin/npm" if cmd == "npm" else None
+    )
+
+    def mock_run(cmd, **kwargs):
+        if "audit" in cmd:
+            assert kwargs["timeout"] == 10
+            if "--workspace" in cmd and "web" in cmd:
+                raise doctor_mod.subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+            if "--workspace" in cmd and "ui-tui" in cmd:
+                raise OSError("npm unavailable")
+            payload = (
+                '{"metadata": {"vulnerabilities": '
+                '{"critical": 0, "high": 0, "moderate": 0}}}'
+            )
+            return SimpleNamespace(returncode=0, stdout=payload, stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(doctor_mod.subprocess, "run", mock_run)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "web workspace deps" in out
+    assert "npm audit timed out after 10s" in out
+    assert "Browser tools (agent-browser) deps" in out
+    assert "ui-tui workspace deps" in out
+    assert "npm audit failed: npm unavailable" in out
+
+
+def test_npm_audits_start_concurrently_and_keep_target_order(monkeypatch, tmp_path):
+    """A degraded npm registry must cost one bounded wait, not one per workspace."""
+    import threading
+
+    barrier = threading.Barrier(4)
+
+    def mock_run(cmd, **kwargs):
+        barrier.wait(timeout=5)
+        return SimpleNamespace(returncode=0, stdout=cmd[-1], stderr="")
+
+    monkeypatch.setattr(doctor_mod.subprocess, "run", mock_run)
+    targets = [
+        (tmp_path, "root", ["root"]),
+        (tmp_path, "web", ["web"]),
+        (tmp_path, "ui-tui", ["ui-tui"]),
+        (tmp_path, "WhatsApp", ["whatsapp"]),
+    ]
+
+    results = doctor_mod._run_npm_audits(targets, "npm")
+
+    assert [result.stdout for result, error in results if error is None] == [
+        "root",
+        "web",
+        "ui-tui",
+        "whatsapp",
+    ]
+
+
+@pytest.mark.parametrize("outcome", ["success", "timeout"])
+def test_run_doctor_bounds_stale_anthropic_probe(monkeypatch, tmp_path, outcome):
+    """A configured but unreachable Anthropic credential must not stall doctor."""
+    import httpx
+    import hermes_cli.auth as auth_mod
+
+    home = tmp_path / ".hermes"
+    project = tmp_path / "project"
+    home.mkdir()
+    project.mkdir()
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod.shutil, "which", lambda _cmd: None)
+    monkeypatch.setattr(auth_mod, "get_anthropic_key", lambda: "sk-ant-test")
+    for env_name in doctor_mod._PROVIDER_ENV_HINTS:
+        monkeypatch.delenv(env_name, raising=False)
+    for env_name in (
+        "AWS_ACCESS_KEY_ID",
+        "AWS_PROFILE",
+        "AZURE_CLIENT_ID",
+        "AZURE_TENANT_ID",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
+
+    anthropic_timeouts = []
+
+    class Response:
+        status_code = 200
+        text = "{}"
+
+        @staticmethod
+        def json():
+            return {}
+
+    def fake_get(url, **kwargs):
+        if url == "https://api.anthropic.com/v1/models":
+            anthropic_timeouts.append(kwargs["timeout"])
+            if outcome == "timeout":
+                raise httpx.TimeoutException("probe timed out")
+        return Response()
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: (_ for _ in ()).throw(SystemExit(0)),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf), pytest.raises(SystemExit):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    assert anthropic_timeouts == [5]
+    assert "Anthropic API" in buf.getvalue()
+    if outcome == "timeout":
+        assert "probe timed out" in buf.getvalue()
+
+
+def test_doctor_reports_oauth_retry_receives_bound_timeout(monkeypatch, tmp_path):
+    """OAuth retry (long-context 400) must also receive the 5-second timeout."""
+    import httpx
+    import hermes_cli.auth as auth_mod
+
+    home = tmp_path / ".hermes"
+    project = tmp_path / "project"
+    home.mkdir()
+    project.mkdir()
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod.shutil, "which", lambda _cmd: None)
+    # OAuth setup tokens use the sk-ant-oat-* form.
+    monkeypatch.setattr(auth_mod, "get_anthropic_key", lambda: "sk-ant-oat-test12345")
+    for env_name in doctor_mod._PROVIDER_ENV_HINTS:
+        monkeypatch.delenv(env_name, raising=False)
+    for env_name in (
+        "AWS_ACCESS_KEY_ID",
+        "AWS_PROFILE",
+        "AZURE_CLIENT_ID",
+        "AZURE_TENANT_ID",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
+
+    anthropic_timeouts = []
+    call_count = [0]
+
+    class LongContextResponse:
+        status_code = 400
+        text = "long context beta is not yet available for this subscription"
+
+        @staticmethod
+        def json():
+            return {}
+
+    class SuccessResponse:
+        status_code = 200
+        text = "{}"
+
+        @staticmethod
+        def json():
+            return {}
+
+    def fake_get(url, **kwargs):
+        if url == "https://api.anthropic.com/v1/models":
+            anthropic_timeouts.append(kwargs["timeout"])
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return LongContextResponse()
+            return SuccessResponse()
+        return SuccessResponse()
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: (_ for _ in ()).throw(SystemExit(0)),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf), pytest.raises(SystemExit):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    # Both the initial call and the OAuth retry must use the bound timeout
+    assert anthropic_timeouts == [5, 5]
+    assert "Anthropic API" in buf.getvalue()


### PR DESCRIPTION
## Summary

- run eligible root, web, ui-tui, and WhatsApp `npm audit` checks concurrently while preserving declaration-order output
- bound each diagnostic npm audit to 10 seconds and surface per-target timeout/subprocess warnings without hiding successful siblings
- bound both Anthropic connectivity requests to 5 seconds, including the OAuth long-context retry

This reduces the issue-specific worst case from roughly 130 seconds to about 15 seconds for the usual single Anthropic request (20 seconds if the reactive Anthropic retry is needed).

Fixes #68419

## Verification

- Focused production-path regressions: **4 passed**
- Nearby doctor suite: **78 passed**
- `ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor.py`: passed
- `py_compile`: passed
- `git diff --check`: passed
- Branch topology after final rebase: **0 behind, 1 ahead** of `upstream/main`

`ruff format --check` reports broad pre-existing formatting drift in both touched files on `upstream/main`; applying it would introduce unrelated churn. New blocks were kept consistent with the formatter.

## Competing work

No open PR was found by issue number, same author/head, timeline cross-reference, or distinctive topic terms. PR #44772 touches doctor/npm dependency handling but addresses dependency pruning rather than audit/probe latency.

Auto-published by Moonsong via Path B automated pipeline.