### PR TITLE
fix(update): handle git stash no-op for staged gitlinks

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6712,9 +6712,11 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         "hermes-update-autostash-%Y%m%d-%H%M%S"
     )
     print("→ Local changes detected — stashing before update...")
-    subprocess.run(
+    stash_push = subprocess.run(
         git_cmd + ["stash", "push", "--include-untracked", "-m", stash_name],
         cwd=cwd,
+        capture_output=True,
+        text=True,
         check=True,
     )
     stash_ref = subprocess.run(
@@ -6722,9 +6724,21 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         cwd=cwd,
         capture_output=True,
         text=True,
-        check=True,
-    ).stdout.strip()
-    return stash_ref
+        check=False,
+    )
+    if stash_ref.returncode == 0:
+        return stash_ref.stdout.strip()
+
+    print("⚠ Git reported local changes, but `git stash` did not create a stash entry.")
+    stash_message = (stash_push.stdout or stash_push.stderr).strip()
+    if stash_message:
+        print(f"  git stash said: {stash_message.splitlines()[0]}")
+    print("  Leaving those changes in place for the update.")
+    print("  This commonly happens with staged embedded git repositories / gitlinks.")
+    print(
+        "  If a later checkout/pull step fails, inspect `git status` and commit, remove, or convert that nested repo before retrying."
+    )
+    return None
 
 
 def _resolve_stash_selector(

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -304,22 +304,70 @@ def test_restore_stashed_changes_auto_resets_non_interactive(monkeypatch, tmp_pa
     assert len(reset_calls) == 1
 
 
-def test_stash_local_changes_if_needed_raises_when_stash_ref_missing(monkeypatch, tmp_path):
+def test_stash_local_changes_if_needed_warns_and_continues_when_stash_ref_missing(
+    monkeypatch, tmp_path, capsys
+):
     def fake_run(cmd, **kwargs):
         if cmd[-2:] == ["status", "--porcelain"]:
             return SimpleNamespace(stdout=" M hermes_cli/main.py\n", returncode=0)
         if cmd[-2:] == ["ls-files", "--unmerged"]:
             return SimpleNamespace(stdout="", returncode=0)
         if cmd[1:4] == ["stash", "push", "--include-untracked"]:
-            return SimpleNamespace(stdout="Saved working directory\n", returncode=0)
+            return SimpleNamespace(stdout="No local changes to save\n", stderr="", returncode=0)
         if cmd[-3:] == ["rev-parse", "--verify", "refs/stash"]:
-            raise CalledProcessError(returncode=128, cmd=cmd)
+            return SimpleNamespace(stdout="", stderr="fatal: Needed a single revision\n", returncode=128)
         raise AssertionError(f"unexpected command: {cmd}")
 
     monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
 
-    with pytest.raises(CalledProcessError):
-        hermes_main._stash_local_changes_if_needed(["git"], Path(tmp_path))
+    stash_ref = hermes_main._stash_local_changes_if_needed(["git"], Path(tmp_path))
+
+    assert stash_ref is None
+    out = capsys.readouterr().out
+    assert "did not create a stash entry" in out
+    assert "No local changes to save" in out
+    assert "embedded git repositories / gitlinks" in out
+
+
+def test_stash_local_changes_if_needed_real_git_embedded_repo_addition(tmp_path, capsys):
+    """Real git regression: `git stash` ignores staged embedded repos / gitlinks."""
+    import shutil
+    import subprocess
+
+    if shutil.which("git") is None:
+        pytest.skip("git not available")
+
+    def git(*args, cwd=tmp_path):
+        return subprocess.run(
+            ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+        )
+
+    git("init", "-q")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "t")
+    (tmp_path / "README.md").write_text("root\n")
+    git("add", "README.md")
+    git("commit", "-qm", "init")
+
+    child = tmp_path / "child"
+    child.mkdir()
+    git("init", "-q", cwd=child)
+    git("config", "user.email", "t@example.com", cwd=child)
+    git("config", "user.name", "t", cwd=child)
+    (child / "sub.txt").write_text("sub\n")
+    git("add", "sub.txt", cwd=child)
+    git("commit", "-qm", "subinit", cwd=child)
+
+    git("add", "child")
+
+    stash_ref = hermes_main._stash_local_changes_if_needed(["git"], Path(tmp_path))
+
+    assert stash_ref is None
+    out = capsys.readouterr().out
+    assert "did not create a stash entry" in out
+    assert "Leaving those changes in place" in out
+    status = git("status", "--porcelain").stdout
+    assert "A  child" in status
 
 
 def test_discard_lockfile_churn_skips_lock_when_package_json_dirty(tmp_path):


### PR DESCRIPTION
## Bug Description

`hermes update` could crash during autostash when Git reported local changes but
`git stash push` produced no stash entry for a staged embedded repository/gitlink.

## Root Cause

The update flow assumed that any dirty worktree would always yield `refs/stash`.
For staged embedded repositories/gitlinks, Git can print `No local changes to save`
while still reporting a dirty status, so `git rev-parse --verify refs/stash` failed.

## Fix

- capture the `git stash push` output during autostash
- treat a missing `refs/stash` as a warning path instead of a hard failure
- keep the local changes in place and print guidance about embedded repos/gitlinks
- add regression coverage, including a real-git test for staged embedded repos

## How to Verify

1. Run `python -m pytest tests/hermes_cli/test_update_autostash.py -q`
2. Run `python -m pytest tests/hermes_cli/test_update_yes_flag.py -q`
3. Run `python -m ruff check hermes_cli/main.py tests/hermes_cli/test_update_autostash.py`

## Test Plan

- [x] Added regression test for this bug
- [x] Existing targeted tests still pass
- [ ] Manual verification of the full update flow

## Risk Assessment

Low — the change only affects the autostash path when Git fails to create a stash
entry, and the default successful stash path is unchanged.
