### PR TITLE
fix(url_safety): allow DNS failure in proxy/sandbox environments

### DIFF
--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -37,6 +37,21 @@ from utils import is_truthy_value
 logger = logging.getLogger(__name__)
 
 
+# ── Proxy detection ──────────────────────────────────────────
+# Proxy environment variables that indicate the runtime should
+# delegate DNS to a proxy rather than attempting direct resolution.
+_PROXY_ENV_VARS = (
+    "HTTPS_PROXY", "https_proxy",
+    "HTTP_PROXY", "http_proxy",
+    "ALL_PROXY", "all_proxy",
+)
+
+
+def _proxy_is_configured() -> bool:
+    """Return True when at least one HTTP proxy env var is set."""
+    return any(os.environ.get(v) for v in _PROXY_ENV_VARS)
+
+
 def normalize_url_for_request(url: str) -> str:
     """Return an ASCII-safe HTTP URL for Hermes-owned URL tools.
 
@@ -416,8 +431,21 @@ def is_safe_url(url: str) -> bool:
         try:
             addr_info = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
         except socket.gaierror:
-            # DNS resolution failed — fail closed. If DNS can't resolve it,
-            # the HTTP client will also fail, so blocking loses nothing.
+            # DNS resolution failed.  In sandbox / proxy environments
+            # (NVIDIA OpenShell, Docker + Squid, etc.) the host may
+            # block direct DNS — only HTTP(S) through the proxy is
+            # permitted.  When a proxy is configured, delegate DNS to
+            # the proxy rather than blocking the request outright.
+            # The hostname was already checked against
+            # _BLOCKED_HOSTNAMES above so metadata endpoints remain
+            # blocked regardless.
+            if _proxy_is_configured():
+                logger.debug(
+                    "DNS resolution failed for %s — proxy configured, "
+                    "allowing through for proxy-side resolution",
+                    hostname,
+                )
+                return True
             logger.warning("Blocked request — DNS resolution failed for: %s", hostname)
             return False
 


### PR DESCRIPTION
## Summary

Fixes #32217 — SSRF check blocks web tools inside Docker + Squid / NVIDIA OpenShell sandboxes where DNS is intentionally unavailable.

## Root Cause

`tools/url_safety.py` `is_safe_url()` requires DNS resolution (`socket.getaddrinfo`) before allowing any outbound request. In proxy-only environments, DNS is blocked at the network level — only HTTP/HTTPS traffic through the proxy is permitted. The function fails closed on DNS error, blocking all web tools.

## Fix

When `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` (or lowercase variants) is set, skip the pre-flight DNS + IP check and let the proxy handle hostname resolution and egress policy enforcement.

**The blocked-hostname check (cloud metadata endpoints) runs BEFORE the DNS skip, so those remain blocked regardless.**

```python
_proxy_env = (
    os.environ.get("HTTP_PROXY", "")
    or os.environ.get("HTTPS_PROXY", "")
    or os.environ.get("http_proxy", "")
    or os.environ.get("https_proxy", "")
    or os.environ.get("ALL_PROXY", "")
    or os.environ.get("all_proxy", "")
)
if not _proxy_env:
    # existing DNS + IP check (unchanged)
```

## Security properties preserved

- Cloud metadata endpoints (169.254.169.254, metadata.google.internal) remain **always blocked** — checked before the proxy skip
- `security.allow_private_urls: true` still honored
- Non-proxy environments: behavior unchanged (full DNS + IP check)

## Environments fixed

- Docker + Squid proxy (`HTTP_PROXY=http://ssrf_proxy:3128`)
- NVIDIA OpenShell (`HTTPS_PROXY=http://10.200.0.1:3128`)
- Corporate egress proxies
- Any environment where DNS is intentionally disabled in favor of proxy-only egress