### PR TITLE
fix(windows): prevent helper process console flashes

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -765,32 +765,47 @@ def _spawn_gateway_restart_watcher(old_pid: int, run_argv: list[str]) -> bool:
         windows_detach_popen_kwargs,
     )
 
-    # On Windows the incoming ``run_argv`` leads with the venv's console
-    # ``python.exe`` (from ``get_python_path()``).  Respawning the gateway
-    # with that interpreter — even under CREATE_NO_WINDOW — leaves a
-    # persistent console window, because uv's venv launcher re-execs the
-    # base console interpreter, which allocates its own conhost.  Rewrite
-    # the argv to the windowless ``pythonw.exe`` (mirroring the clean-start
-    # ``_spawn_detached`` path) and capture the cwd + env overlay the base
-    # interpreter needs to resolve imports without the venv launcher.
-    # No-op on POSIX.  See gateway_windows.windowless_gateway_restart_spec.
+    # On Windows both the incoming ``run_argv`` and the watcher itself lead
+    # with a venv console ``python.exe``.  Even under CREATE_NO_WINDOW, uv's
+    # launcher re-execs the base console interpreter and allocates a conhost.
+    # Rewrite both legs to the base ``pythonw.exe`` and carry the cwd + env
+    # overlay it needs to resolve imports without the venv launcher.  No-op
+    # on POSIX.  See gateway_windows.windowless_gateway_restart_spec.
     respawn_cwd = ""
     respawn_env_overlay: dict[str, str] = {}
+    watcher_python = sys.executable
+    watcher_cwd = ""
+    watcher_env_overlay: dict[str, str] = {}
     if sys.platform == "win32":
         try:
             from hermes_cli.gateway_windows import (
                 windowless_gateway_restart_spec,
             )
-
-            run_argv, respawn_cwd, respawn_env_overlay = (
-                windowless_gateway_restart_spec(list(run_argv))
-            )
         except Exception:
-            # Best-effort: if the rewrite fails for any reason, fall back to
-            # the original argv.  A visible window is worse than nothing, but
-            # a failed respawn is worse still — keep the gateway coming back.
-            respawn_cwd = ""
-            respawn_env_overlay = {}
+            windowless_gateway_restart_spec = None
+
+        if windowless_gateway_restart_spec is not None:
+            try:
+                run_argv, respawn_cwd, respawn_env_overlay = (
+                    windowless_gateway_restart_spec(list(run_argv))
+                )
+            except Exception:
+                # Best-effort: a visible window is worse than nothing, but a
+                # failed respawn is worse still — keep the gateway coming back.
+                respawn_cwd = ""
+                respawn_env_overlay = {}
+
+            try:
+                watcher_argv_head, watcher_cwd, watcher_env_overlay = (
+                    windowless_gateway_restart_spec([sys.executable])
+                )
+                if watcher_argv_head:
+                    watcher_python = watcher_argv_head[0]
+            except Exception:
+                # The watcher must still start when interpreter discovery fails.
+                watcher_python = sys.executable
+                watcher_cwd = ""
+                watcher_env_overlay = {}
 
     # Serialized as JSON literals embedded in the watcher source so the
     # inner respawn can apply cwd= / env= without extra argv plumbing.
@@ -862,7 +877,7 @@ def _spawn_gateway_restart_watcher(old_pid: int, run_argv: list[str]) -> bool:
     )
 
     watcher_argv = [
-        sys.executable,
+        watcher_python,
         "-c",
         watcher,
         str(old_pid),
@@ -871,11 +886,18 @@ def _spawn_gateway_restart_watcher(old_pid: int, run_argv: list[str]) -> bool:
 
     # Same platform-aware detach for the watcher process itself — so
     # closing the user's terminal doesn't kill the watcher.
+    watcher_popen_kwargs: dict = {
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+    }
+    if watcher_cwd:
+        watcher_popen_kwargs["cwd"] = watcher_cwd
+    if watcher_env_overlay:
+        watcher_popen_kwargs["env"] = {**os.environ, **watcher_env_overlay}
     try:
         subprocess.Popen(
             watcher_argv,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            **watcher_popen_kwargs,
             **windows_detach_popen_kwargs(),
         )
     except OSError:
@@ -885,15 +907,14 @@ def _spawn_gateway_restart_watcher(old_pid: int, run_argv: list[str]) -> bool:
         # ``start_new_session=True`` cannot raise OSError — so the
         # fallback is only meaningful on Windows.
         try:
-            fallback_kwargs: dict = (
+            fallback_kwargs = dict(watcher_popen_kwargs)
+            fallback_kwargs.update(
                 {"creationflags": windows_detach_flags_without_breakaway()}
                 if sys.platform == "win32"
                 else {"start_new_session": True}
             )
             subprocess.Popen(
                 watcher_argv,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
                 **fallback_kwargs,
             )
         except OSError:

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -766,6 +766,37 @@ def _prepend_pythonpath(env_overlay: dict[str, str], entries: list[str]) -> None
     env_overlay["PYTHONPATH"] = os.pathsep.join(clean_entries)
 
 
+def _windowless_python_spawn_spec(
+    python_exe: str,
+    project_root: str | Path,
+) -> tuple[str, dict[str, str]]:
+    """Return a windowless interpreter and import env for a Python child.
+
+    The base ``pythonw.exe`` used for uv-created venvs does not inherit the
+    venv launcher's import configuration, so callers must provide both the
+    venv marker and import paths.  On non-Windows, or when resolution fails,
+    preserve the original interpreter and environment unchanged.
+    """
+    if sys.platform != "win32":
+        return python_exe, {}
+
+    try:
+        windowless_python, venv_dir, extra_pythonpath = _resolve_detached_python(
+            python_exe
+        )
+    except Exception:
+        return python_exe, {}
+
+    env_overlay = {"VIRTUAL_ENV": str(venv_dir)}
+    _prepend_pythonpath(
+        env_overlay,
+        [str(project_root), *extra_pythonpath]
+        if extra_pythonpath
+        else [str(project_root)],
+    )
+    return windowless_python, env_overlay
+
+
 def _build_gateway_argv() -> tuple[list[str], str, dict[str, str]]:
     """Build (argv, working_dir, env_overlay) for the gateway subprocess.
 
@@ -850,33 +881,28 @@ def windowless_gateway_restart_spec(
     # interpreter we can find a windowless sibling for.  If a caller passed
     # something else (a captured argv whose argv[0] is already pythonw, or a
     # non-python launcher), leave it alone.
-    try:
-        windowless_python, venv_dir, extra_pythonpath = _resolve_detached_python(
-            python_exe
-        )
-    except Exception:
+    windowless_python, python_env_overlay = _windowless_python_spawn_spec(
+        python_exe,
+        PROJECT_ROOT,
+    )
+    if not python_env_overlay:
         return run_argv, "", {}
 
     new_argv = [windowless_python, *rest]
 
     working_dir = _stable_gateway_working_dir(PROJECT_ROOT)
-    project_root = str(PROJECT_ROOT)
     try:
         hermes_home = str(Path(get_hermes_home()).resolve())
     except Exception:
         hermes_home = ""
 
     env_overlay: dict[str, str] = {
+        **python_env_overlay,
         "PYTHONIOENCODING": "utf-8",
         "HERMES_GATEWAY_DETACHED": "1",
-        "VIRTUAL_ENV": str(venv_dir),
     }
     if hermes_home:
         env_overlay["HERMES_HOME"] = hermes_home
-    _prepend_pythonpath(
-        env_overlay,
-        [project_root, *extra_pythonpath] if extra_pythonpath else [project_root],
-    )
     return new_argv, working_dir, env_overlay
 
 

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -656,6 +656,150 @@ def test_gateway_restart_on_windows_preserves_failure_fallback(monkeypatch):
     assert calls == ["restart", "stop", "wait", "run"]
 
 
+def test_windows_restart_watcher_uses_uv_base_pythonw_and_profile_env(
+    monkeypatch, tmp_path
+):
+    import hermes_cli._subprocess_compat as subprocess_compat
+    import hermes_cli.gateway_windows as gateway_windows
+
+    captured = []
+    project_root = tmp_path / "project"
+    venv_dir = tmp_path / "venv"
+    scripts_dir = venv_dir / "Scripts"
+    site_packages = venv_dir / "Lib" / "site-packages"
+    uv_python_dir = tmp_path / "uv-python"
+    profile_home = tmp_path / ".hermes" / "profiles" / "work"
+    scripts_dir.mkdir(parents=True)
+    site_packages.mkdir(parents=True)
+    uv_python_dir.mkdir(parents=True)
+    profile_home.mkdir(parents=True)
+    original_python = scripts_dir / "python.exe"
+    (scripts_dir / "pythonw.exe").touch()
+    base_pythonw = uv_python_dir / "pythonw.exe"
+    base_pythonw.touch()
+    (venv_dir / "pyvenv.cfg").write_text(
+        f"home = {uv_python_dir}\nuv = 0.11.29\n",
+        encoding="utf-8",
+    )
+    stable_cwd = r"C:\Users\me\.hermes"
+
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+    monkeypatch.setattr(gateway.sys, "executable", str(original_python))
+    monkeypatch.setattr(gateway, "PROJECT_ROOT", project_root)
+    monkeypatch.setattr(
+        gateway_windows,
+        "_stable_gateway_working_dir",
+        lambda _root: stable_cwd,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.get_hermes_home",
+        lambda: profile_home,
+    )
+    monkeypatch.setattr(
+        subprocess_compat,
+        "windows_detach_popen_kwargs",
+        lambda: {"creationflags": 0x08000208},
+    )
+    monkeypatch.setattr(
+        gateway.subprocess,
+        "Popen",
+        lambda cmd, **kwargs: captured.append((cmd, kwargs)) or SimpleNamespace(),
+    )
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+
+    assert gateway._spawn_gateway_restart_watcher(
+        4321,
+        [str(original_python), "-m", "hermes_cli.main", "gateway", "run"],
+    )
+
+    watcher_argv, kwargs = captured[0]
+    assert watcher_argv[0] == str(base_pythonw)
+    assert watcher_argv[4:] == [
+        str(base_pythonw),
+        "-m",
+        "hermes_cli.main",
+        "gateway",
+        "run",
+    ]
+    assert kwargs["creationflags"] == 0x08000208
+    assert kwargs["cwd"] == stable_cwd
+    assert kwargs["env"]["VIRTUAL_ENV"] == str(venv_dir)
+    assert kwargs["env"]["HERMES_HOME"] == str(profile_home.resolve())
+    pythonpath = kwargs["env"]["PYTHONPATH"].split(gateway_windows.os.pathsep)
+    assert str(project_root) in pythonpath
+    assert str(site_packages) in pythonpath
+
+
+def test_windows_restart_watcher_falls_back_when_pythonw_resolution_fails(
+    monkeypatch,
+):
+    import hermes_cli._subprocess_compat as subprocess_compat
+    import hermes_cli.gateway_windows as gateway_windows
+
+    captured = []
+    original_python = r"C:\venv\Scripts\python.exe"
+
+    def fail_resolution(_python):
+        raise OSError("missing pyvenv.cfg")
+
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+    monkeypatch.setattr(gateway.sys, "executable", original_python)
+    monkeypatch.setattr(gateway_windows, "_resolve_detached_python", fail_resolution)
+    monkeypatch.setattr(
+        subprocess_compat,
+        "windows_detach_popen_kwargs",
+        lambda: {"creationflags": 0x08000208},
+    )
+    monkeypatch.setattr(
+        gateway.subprocess,
+        "Popen",
+        lambda cmd, **kwargs: captured.append((cmd, kwargs)) or SimpleNamespace(),
+    )
+
+    assert gateway._spawn_gateway_restart_watcher(
+        4321,
+        [original_python, "-m", "hermes_cli.main", "gateway", "run"],
+    )
+
+    watcher_argv, kwargs = captured[0]
+    assert watcher_argv[0] == original_python
+    assert watcher_argv[4] == original_python
+    assert "cwd" not in kwargs
+    assert "env" not in kwargs
+
+
+def test_non_windows_restart_watcher_keeps_sys_executable(monkeypatch):
+    import hermes_cli._subprocess_compat as subprocess_compat
+
+    captured = []
+    original_python = "/venv/bin/python"
+
+    monkeypatch.setattr(gateway.sys, "platform", "darwin")
+    monkeypatch.setattr(gateway.sys, "executable", original_python)
+    monkeypatch.setattr(
+        subprocess_compat,
+        "windows_detach_popen_kwargs",
+        lambda: {"start_new_session": True},
+    )
+    monkeypatch.setattr(
+        gateway.subprocess,
+        "Popen",
+        lambda cmd, **kwargs: captured.append((cmd, kwargs)) or SimpleNamespace(),
+    )
+
+    assert gateway._spawn_gateway_restart_watcher(
+        4321,
+        [original_python, "-m", "hermes_cli.main", "gateway", "run"],
+    )
+
+    watcher_argv, kwargs = captured[0]
+    assert watcher_argv[0] == original_python
+    assert watcher_argv[4] == original_python
+    assert kwargs["start_new_session"] is True
+    assert "cwd" not in kwargs
+    assert "env" not in kwargs
+
+
 def test_systemd_status_warns_when_linger_disabled(monkeypatch, tmp_path, capsys):
     unit_path = tmp_path / "hermes-gateway.service"
     unit_path.write_text("[Unit]\n")
@@ -1107,7 +1251,7 @@ def test_reap_unsupervised_orphans_sigterms_then_sigkills_survivor(monkeypatch):
 
     assert gateway._reap_unsupervised_gateway_orphans() is True
     assert (708, signal.SIGTERM) in sent
-    assert (708, signal.SIGKILL) in sent
+    assert (708, getattr(signal, "SIGKILL", signal.SIGTERM)) in sent
 
 
 def test_reap_unsupervised_orphans_returns_false_when_none_found(monkeypatch):
@@ -1123,10 +1267,19 @@ def test_reap_unsupervised_orphans_returns_false_when_none_found(monkeypatch):
 def test_scan_gateway_pids_detects_windows_hermes_exe_case_variants(monkeypatch):
     monkeypatch.setattr(gateway, "is_windows", lambda: True)
     monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
-    monkeypatch.setattr(gateway.shutil, "which", lambda name: "wmic.exe" if name == "wmic" else None)
+    monkeypatch.setattr(
+        gateway.shutil,
+        "which",
+        lambda name: "wmic.exe" if name == "wmic" else None,  # windows-footgun: ok
+    )
 
     def fake_run(cmd, **kwargs):
-        if cmd[:4] == ["wmic.exe", "process", "get", "ProcessId,CommandLine"]:
+        if cmd[:4] == [
+            "wmic.exe",  # windows-footgun: ok
+            "process",
+            "get",
+            "ProcessId,CommandLine",
+        ]:
             return SimpleNamespace(
                 returncode=0,
                 stdout=(

--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -628,10 +628,28 @@ def test_skills_hub_gh_token_hides_windows(monkeypatch):
     assert captured[0][1]["creationflags"] == _CREATE_NO_WINDOW
 
 
-def test_tui_slash_worker_hides_python_window(monkeypatch):
+def test_tui_slash_worker_uses_uv_base_pythonw_with_profile_env(monkeypatch, tmp_path):
     from tui_gateway import server
+    import hermes_cli._subprocess_compat as subprocess_compat
+    import hermes_cli.gateway_windows as gateway_windows
 
     captured = []
+    venv_dir = tmp_path / "venv"
+    scripts_dir = venv_dir / "Scripts"
+    site_packages = venv_dir / "Lib" / "site-packages"
+    uv_python_dir = tmp_path / "uv-python"
+    scripts_dir.mkdir(parents=True)
+    site_packages.mkdir(parents=True)
+    uv_python_dir.mkdir(parents=True)
+    venv_python = scripts_dir / "python.exe"
+    (scripts_dir / "pythonw.exe").touch()
+    base_pythonw = uv_python_dir / "pythonw.exe"
+    base_pythonw.touch()
+    (venv_dir / "pyvenv.cfg").write_text(
+        f"home = {uv_python_dir}\nuv = 0.11.29\n",
+        encoding="utf-8",
+    )
+    profile_home = r"C:\Users\me\.hermes\profiles\work"
 
     class _Proc:
         stdin = SimpleNamespace()
@@ -642,17 +660,98 @@ def test_tui_slash_worker_hides_python_window(monkeypatch):
         captured.append((cmd, kwargs))
         return _Proc()
 
+    monkeypatch.setattr(server.sys, "platform", "win32")
+    monkeypatch.setattr(server.sys, "executable", str(venv_python))
+    monkeypatch.setattr(
+        server,
+        "hermes_subprocess_env",
+        lambda **_kwargs: {"PATH": r"C:\Windows"},
+    )
     monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(server.threading, "Thread", lambda *a, **k: SimpleNamespace(start=lambda: None))
-
-    import hermes_cli._subprocess_compat as subprocess_compat
-
     monkeypatch.setattr(subprocess_compat, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+
+    server._SlashWorker("session-key", "model-x", profile_home=profile_home)
+
+    argv, kwargs = captured[0]
+    assert argv[:3] == [str(base_pythonw), "-m", "tui_gateway.slash_worker"]
+    assert kwargs["creationflags"] == _CREATE_NO_WINDOW
+    assert kwargs["env"]["VIRTUAL_ENV"] == str(venv_dir)
+    pythonpath = kwargs["env"]["PYTHONPATH"].split(gateway_windows.os.pathsep)
+    assert str(Path(server.__file__).parent.parent) in pythonpath
+    assert str(site_packages) in pythonpath
+    assert kwargs["env"]["HERMES_HOME"] == profile_home
+
+
+def test_tui_slash_worker_falls_back_when_windowless_resolution_fails(monkeypatch):
+    from tui_gateway import server
+    import hermes_cli.gateway_windows as gateway_windows
+
+    captured = []
+    original_python = r"C:\venv\Scripts\python.exe"
+
+    class _Proc:
+        stdin = SimpleNamespace()
+        stdout = []
+        stderr = []
+
+    def fail_resolution(_python):
+        raise OSError("missing pyvenv.cfg")
+
+    monkeypatch.setattr(server.sys, "platform", "win32")
+    monkeypatch.setattr(server.sys, "executable", original_python)
+    monkeypatch.setattr(gateway_windows, "_resolve_detached_python", fail_resolution)
+    monkeypatch.setattr(
+        server,
+        "hermes_subprocess_env",
+        lambda **_kwargs: {"PATH": r"C:\Windows"},
+    )
+    monkeypatch.setattr(
+        server.subprocess,
+        "Popen",
+        lambda cmd, **kwargs: captured.append((cmd, kwargs)) or _Proc(),
+    )
+    monkeypatch.setattr(
+        server.threading,
+        "Thread",
+        lambda *a, **k: SimpleNamespace(start=lambda: None),
+    )
 
     server._SlashWorker("session-key", "model-x")
 
-    assert captured[0][0][:3] == [server.sys.executable, "-m", "tui_gateway.slash_worker"]
-    assert captured[0][1]["creationflags"] == _CREATE_NO_WINDOW
+    argv, kwargs = captured[0]
+    assert argv[0] == original_python
+    assert "VIRTUAL_ENV" not in kwargs["env"]
+
+
+def test_tui_slash_worker_non_windows_keeps_sys_executable(monkeypatch):
+    from tui_gateway import server
+
+    captured = []
+    original_python = "/venv/bin/python"
+
+    class _Proc:
+        stdin = SimpleNamespace()
+        stdout = []
+        stderr = []
+
+    monkeypatch.setattr(server.sys, "platform", "darwin")
+    monkeypatch.setattr(server.sys, "executable", original_python)
+    monkeypatch.setattr(
+        server.subprocess,
+        "Popen",
+        lambda cmd, **kwargs: captured.append((cmd, kwargs)) or _Proc(),
+    )
+    monkeypatch.setattr(
+        server.threading,
+        "Thread",
+        lambda *a, **k: SimpleNamespace(start=lambda: None),
+    )
+
+    server._SlashWorker("session-key", "model-x")
+
+    assert captured[0][0][0] == original_python
 
 
 # ── #56747 GUI-reachable exec paths + provider transports (PR #56877) ──────

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -315,8 +315,26 @@ class _SlashWorker:
         self.stderr_tail: list[str] = []
         self.stdout_queue: queue.Queue[dict | None] = queue.Queue()
 
+        python_exe = sys.executable
+        python_env_overlay: dict[str, str] = {}
+        if sys.platform == "win32":
+            try:
+                from hermes_cli.gateway_windows import (
+                    _windowless_python_spawn_spec,
+                )
+
+                python_exe, python_env_overlay = _windowless_python_spawn_spec(
+                    sys.executable,
+                    Path(__file__).parent.parent,
+                )
+            except Exception:
+                # Keep slash commands available even if the windowless
+                # interpreter cannot be resolved on an unusual install.
+                python_exe = sys.executable
+                python_env_overlay = {}
+
         argv = [
-            sys.executable,
+            python_exe,
             "-m",
             "tui_gateway.slash_worker",
             "--session-key",
@@ -331,6 +349,7 @@ class _SlashWorker:
         # slash_worker runs the Hermes agent → needs provider credentials.
         # Tier-1 secrets (gateway/GitHub/infra) are still stripped (#29157).
         env = hermes_subprocess_env(inherit_credentials=True)
+        env.update(python_env_overlay)
         if profile_home:
             # Global-remote / multi-profile sessions: the worker must resolve
             # config/skills/state against the session's profile home, not the


### PR DESCRIPTION
## What does this PR do?

Prevents visible console flashes from the two remaining helper-process spawn paths on Windows installations created by uv.

The venv `python.exe` launcher re-execs the base console interpreter, so `CREATE_NO_WINDOW` on the launcher cannot suppress the second `conhost`. This change reuses the existing uv-aware interpreter resolution to launch both the TUI slash worker and the gateway restart watcher with the base `pythonw.exe`. It also supplies the `VIRTUAL_ENV` and `PYTHONPATH` overlay required by the base interpreter, while preserving profile-specific `HERMES_HOME` and safe fallback behavior.

## Related Issue

Fixes #68457

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added a private reusable windowless-Python spawn specification in `hermes_cli/gateway_windows.py`.
- Updated `tui_gateway/server.py` so `_SlashWorker` launches uv environments through the base `pythonw.exe` and retains its profile environment.
- Updated `hermes_cli/gateway.py` so the restart watcher itself, not only the gateway it later respawns, uses `pythonw.exe` with the required cwd and environment.
- Added behavioral coverage for real uv `pyvenv.cfg` resolution, profile propagation, non-Windows behavior, and resolution-failure fallback.

## Validation

After rebasing onto current `main` (including #56747's additional Windows hide-flag paths and tests):

- `HERMES_PYTHON=/path/to/python scripts/run_tests.sh tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_windows.py tests/gateway/test_restart_drain.py tests/test_tui_gateway_server.py tests/test_windows_subprocess_no_window_flags.py tests/tui_gateway/test_slash_worker_profile_home.py` — **589 passed**
- `ruff check hermes_cli/gateway.py hermes_cli/gateway_windows.py tui_gateway/server.py tests/hermes_cli/test_gateway.py tests/test_windows_subprocess_no_window_flags.py` — passed
- `python scripts/check-windows-footguns.py --diff upstream/main` — passed across all five changed files
- `git diff --check upstream/main...HEAD` — passed

The spawn-path tests construct a real uv-style `pyvenv.cfg`, base `pythonw.exe`, and venv site-packages so the resolver is exercised end to end. Non-Windows behavior and resolution failure retain the original `sys.executable` fallback. The upstream #56747 regression coverage for the six other GUI-reachable spawn sites remains intact.

I also attempted the full suite. It reached 37% before I stopped it after unrelated host/environment failures, including a Linux systemd abstract-socket test on macOS and Discord fixture URLs resolving to an SSRF-blocked reserved address. All suites covering the changed paths passed.

## Checklist

- [x] Read the contribution guidance
- [x] Conventional commit and GitHub-linked author identity
- [x] Searched for duplicate PRs
- [x] Only scoped files are changed
- [x] Added behavioral regression coverage
- [x] Considered Windows and non-Windows behavior
- [x] No public API or configuration keys added

## Screenshots / Logs

Not applicable: this is process-launch behavior covered by subprocess-spawn assertions and real uv-layout resolver fixtures.