### PR TITLE
fix(tools): preserve /steer marker when enforce_turn_budget replaces a tool result

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -17,11 +17,13 @@ from tools.tool_result_storage import (
     _heredoc_marker,
     _resolve_storage_dir,
     _safe_result_filename,
+    _split_trailing_steer_marker,
     _write_to_sandbox,
     enforce_turn_budget,
     generate_preview,
     maybe_persist_tool_result,
 )
+from agent.prompt_builder import format_steer_marker, STEER_MARKER_OPEN, STEER_MARKER_CLOSE
 
 
 # ── generate_preview ──────────────────────────────────────────────────
@@ -527,6 +529,63 @@ class TestEnforceTurnBudget:
     def test_empty_messages(self):
         result = enforce_turn_budget([], env=None, config=BudgetConfig(turn_budget=200_000))
         assert result == []
+
+    def test_steer_marker_survives_budget_enforcement(self):
+        """Regression (#31524): if apply_pending_steer_to_tool_results() already
+        appended a /steer marker to a tool result before enforce_turn_budget()
+        replaces that same result, the marker must not be silently dropped."""
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        marker = format_steer_marker("check the other file too")
+        msgs = [
+            {"role": "tool", "tool_call_id": "t1", "content": ("x" * 250_000) + marker},
+        ]
+        enforce_turn_budget(msgs, env=env, config=BudgetConfig(turn_budget=200_000))
+        content = msgs[0]["content"]
+        assert PERSISTED_OUTPUT_TAG in content
+        assert STEER_MARKER_OPEN in content and STEER_MARKER_CLOSE in content
+        assert "check the other file too" in content
+
+    def test_steer_marker_survives_inline_truncation_fallback(self):
+        """Same guarantee when no env is available (inline-truncation path)."""
+        marker = format_steer_marker("stop and summarize instead")
+        msgs = [
+            {"role": "tool", "tool_call_id": "t1", "content": ("x" * 250_000) + marker},
+        ]
+        enforce_turn_budget(msgs, env=None, config=BudgetConfig(turn_budget=200_000))
+        content = msgs[0]["content"]
+        assert "Truncated" in content
+        assert STEER_MARKER_OPEN in content and STEER_MARKER_CLOSE in content
+        assert "stop and summarize instead" in content
+
+
+class TestSplitTrailingSteerMarker:
+    def test_no_marker_returns_content_unchanged(self):
+        body, suffix = _split_trailing_steer_marker("plain tool output")
+        assert body == "plain tool output"
+        assert suffix == ""
+
+    def test_trailing_marker_is_split_off(self):
+        marker = format_steer_marker("hi")
+        body, suffix = _split_trailing_steer_marker("tool output" + marker)
+        assert body == "tool output"
+        assert suffix == marker
+
+    def test_non_trailing_marker_is_left_in_place(self):
+        """A marker embedded mid-content (not at the tail) is not a real
+        trailing steer marker — leave content untouched rather than risk
+        misparsing tool output that happens to contain the literal text."""
+        marker = format_steer_marker("hi")
+        content = "tool output" + marker + "\nmore tool output after"
+        body, suffix = _split_trailing_steer_marker(content)
+        assert body == content
+        assert suffix == ""
+
+    def test_non_string_content_returns_unchanged(self):
+        blocks = [{"type": "text", "text": "hi"}]
+        body, suffix = _split_trailing_steer_marker(blocks)
+        assert body is blocks
+        assert suffix == ""
 
 
 # ── Per-tool threshold integration ────────────────────────────────────

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -38,6 +38,40 @@ from tools.budget_config import (
 logger = logging.getLogger(__name__)
 PERSISTED_OUTPUT_TAG = "<persisted-output>"
 PERSISTED_OUTPUT_CLOSING_TAG = "</persisted-output>"
+
+
+def _split_trailing_steer_marker(content: str) -> tuple[str, str]:
+    """Split a trailing /steer marker (see agent.prompt_builder.format_steer_marker)
+    off the end of a tool result, so budget enforcement can persist the tool
+    output alone and re-attach the marker afterward.
+
+    apply_pending_steer_to_tool_results() may run BEFORE enforce_turn_budget()
+    in the per-tool drain (agent/tool_executor.py), appending the marker to a
+    tool result that aggregate budget enforcement later replaces wholesale.
+    Without this split, that replacement silently drops the user's steer text
+    along with the truncated tool output (issue #31524).
+
+    Returns (content_without_marker, marker_suffix). marker_suffix is ""
+    if content is not a string or has no trailing marker.
+    """
+    if not isinstance(content, str):
+        return content, ""
+    from agent.prompt_builder import STEER_MARKER_OPEN, STEER_MARKER_CLOSE
+
+    close_idx = content.rfind(STEER_MARKER_CLOSE)
+    if close_idx == -1:
+        return content, ""
+    open_idx = content.rfind(STEER_MARKER_OPEN, 0, close_idx)
+    if open_idx == -1:
+        return content, ""
+    marker_end = close_idx + len(STEER_MARKER_CLOSE)
+    if content[marker_end:].strip():
+        # Marker isn't trailing (something follows it) — leave content as-is.
+        return content, ""
+    prefix_end = open_idx
+    if content[:prefix_end].endswith("\n\n"):
+        prefix_end -= 2
+    return content[:prefix_end], content[prefix_end:]
 STORAGE_DIR = "/tmp/hermes-results"
 HEREDOC_MARKER = "HERMES_PERSIST_EOF"
 _BUDGET_TOOL_NAME = "__budget_enforcement__"
@@ -234,14 +268,18 @@ def enforce_turn_budget(
         content = msg["content"]
         tool_use_id = msg.get("tool_call_id", f"budget_{idx}")
 
+        body, steer_suffix = _split_trailing_steer_marker(content)
+
         replacement = maybe_persist_tool_result(
-            content=content,
+            content=body,
             tool_name=_BUDGET_TOOL_NAME,
             tool_use_id=tool_use_id,
             env=env,
             config=config,
             threshold=0,
         )
+        if steer_suffix:
+            replacement = replacement + steer_suffix
         if replacement != content:
             total_size -= size
             total_size += len(replacement)


### PR DESCRIPTION
## Context

Ports #31545 forward onto current main per @teknium1's review, which flagged that the original PR predated the current canonical steer-marker format (`agent.prompt_builder.format_steer_marker` / `STEER_MARKER_OPEN` / `STEER_MARKER_CLOSE`) and asked for a forced-budget regression test.

## Problem

`apply_pending_steer_to_tool_results()` can append a /steer marker to a tool result *before* `enforce_turn_budget()` later replaces that same result wholesale (both the concurrent and sequential tool-call paths in `agent/tool_executor.py` drain the per-tool steer before the aggregate budget pass runs). Without a fix, the marker -- and the user's mid-turn steer text -- is silently dropped along with the truncated content (issue #31524).

## Fix

`_split_trailing_steer_marker()` extracts a trailing marker before persisting content; `enforce_turn_budget()` re-attaches it to the replacement, whether the content was persisted to sandbox or inline-truncated.

## Verification

58/58 tests pass in `tests/tools/test_tool_result_storage.py` (52 existing + 6 new): marker survives sandbox persistence, marker survives the no-env inline-truncation fallback, and direct unit coverage of `_split_trailing_steer_marker()`.

Fixes #31524