### PR TITLE
fix(hindsight): persist HINDSIGHT_EMBED_API_DATABASE_URL into embedded profile env

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -54,6 +54,7 @@ Config file: `~/.hermes/hindsight/config.json`
 |-----|---------|-------------|
 | `mode` | `cloud` | `cloud`, `local_embedded`, or `local_external` |
 | `api_url` | `https://api.hindsight.vectorize.io` | API URL (cloud and local_external modes) |
+| `embed_database_url` | — | `local_embedded` mode only. Postgres URL for the embedded daemon's database, overriding the default per-profile pg0 instance. Also settable via the `HINDSIGHT_EMBED_API_DATABASE_URL` env var; this config key takes precedence over the env var when both are set. |
 
 ### Memory Bank
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -517,6 +517,12 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
     current_provider = config.get("llm_provider", "")
     current_model = config.get("llm_model", "")
     current_base_url = config.get("llm_base_url") or os.environ.get("HINDSIGHT_API_LLM_BASE_URL", "")
+    current_database_url = (
+        config.get("embed_database_url")
+        or config.get("database_url")
+        or config.get("HINDSIGHT_EMBED_API_DATABASE_URL")
+        or os.environ.get("HINDSIGHT_EMBED_API_DATABASE_URL", "")
+    )
 
     # The embedded daemon expects OpenAI wire format for these providers.
     daemon_provider = "openai" if current_provider in {"openai_compatible", "openrouter"} else current_provider
@@ -529,6 +535,8 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
     }
     if current_base_url:
         env_values["HINDSIGHT_API_LLM_BASE_URL"] = str(current_base_url)
+    if current_database_url:
+        env_values["HINDSIGHT_EMBED_API_DATABASE_URL"] = str(current_database_url)
 
     idle_timeout = (
         config.get("idle_timeout")
@@ -1007,6 +1015,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
             {"key": "idle_timeout", "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)", "default": _DEFAULT_IDLE_TIMEOUT, "when": {"mode": "local_embedded"}},
             {"key": "port_health_grace_timeout", "description": "Seconds to wait for a slow daemon /health before treating it as stale (raise on busy/low-resource hosts; blank uses the 30s default)", "default": "", "when": {"mode": "local_embedded"}},
+            {"key": "embed_database_url", "description": "Postgres URL for the embedded daemon's database (overrides the default per-profile pg0 instance)", "default": "", "env_var": "HINDSIGHT_EMBED_API_DATABASE_URL", "when": {"mode": "local_embedded"}},
         ]
 
     def _get_client(self):

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -417,6 +417,42 @@ class TestConfig:
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
 
+    def test_embedded_profile_env_includes_database_url_from_config(self):
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+            "embed_database_url": "postgresql://user:pass@db.internal:5432/hindsight",
+        })
+
+        assert env["HINDSIGHT_EMBED_API_DATABASE_URL"] == "postgresql://user:pass@db.internal:5432/hindsight"
+
+    def test_embedded_profile_env_includes_database_url_from_env(self, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_EMBED_API_DATABASE_URL", "postgresql://user:pass@db.internal:5432/hindsight")
+
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        })
+
+        assert env["HINDSIGHT_EMBED_API_DATABASE_URL"] == "postgresql://user:pass@db.internal:5432/hindsight"
+
+    def test_embedded_profile_env_omits_database_url_when_unset(self, monkeypatch):
+        monkeypatch.delenv("HINDSIGHT_EMBED_API_DATABASE_URL", raising=False)
+
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        })
+
+        assert "HINDSIGHT_EMBED_API_DATABASE_URL" not in env
+
+    def test_config_schema_exposes_embed_database_url(self, provider):
+        schema = provider.get_config_schema()
+        entry = next((e for e in schema if e["key"] == "embed_database_url"), None)
+        assert entry is not None, "embed_database_url must be discoverable in get_config_schema()"
+        assert entry.get("env_var") == "HINDSIGHT_EMBED_API_DATABASE_URL"
+        assert entry.get("when") == {"mode": "local_embedded"}
+
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
         captured = {}
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -23,6 +23,7 @@ from plugins.memory.hindsight import (
     RETAIN_SCHEMA,
     _load_config,
     _build_embedded_profile_env,
+    _materialize_embedded_profile_env,
     _normalize_observation_scopes,
     _normalize_retain_tags,
     _resolve_bank_id_template,
@@ -436,6 +437,33 @@ class TestConfig:
 
         assert env["HINDSIGHT_EMBED_API_DATABASE_URL"] == "postgresql://user:pass@db.internal:5432/hindsight"
 
+    def test_embedded_profile_env_config_database_url_wins_over_env(self, monkeypatch):
+        """Regression (review of #68479): the two isolated tests above each
+        exercise only one source at a time, so neither actually verifies the
+        documented precedence -- a regression that swapped the `or` chain's
+        order (making the env var win instead) would still pass both. Set
+        BOTH sources to DIFFERENT values and assert the config value
+        (embed_database_url) is what actually reaches the generated env,
+        not the env var."""
+        monkeypatch.setenv(
+            "HINDSIGHT_EMBED_API_DATABASE_URL",
+            "postgresql://envuser:envpass@env-db.internal:5432/hindsight",
+        )
+
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+            "embed_database_url": "postgresql://cfguser:cfgpass@config-db.internal:5432/hindsight",
+        })
+
+        assert env["HINDSIGHT_EMBED_API_DATABASE_URL"] == (
+            "postgresql://cfguser:cfgpass@config-db.internal:5432/hindsight"
+        ), (
+            "The README documents embed_database_url as taking precedence "
+            "over the env var when both are set -- the config value must "
+            "win, not the env var"
+        )
+
     def test_embedded_profile_env_omits_database_url_when_unset(self, monkeypatch):
         monkeypatch.delenv("HINDSIGHT_EMBED_API_DATABASE_URL", raising=False)
 
@@ -445,6 +473,35 @@ class TestConfig:
         })
 
         assert "HINDSIGHT_EMBED_API_DATABASE_URL" not in env
+
+    def test_materialized_profile_env_file_contains_configured_database_url(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression (review of #68479): the unit-level tests above only
+        check _build_embedded_profile_env()'s returned dict. This exercises
+        the actual materialization path (_materialize_embedded_profile_env(),
+        which both the setup flow and daemon-restart call) end to end --
+        the URL must reach the real written ~/.hindsight/profiles/*.env file,
+        not just an intermediate in-memory dict."""
+        user_home = tmp_path / "user-home"
+        user_home.mkdir()
+        monkeypatch.setenv("HOME", str(user_home))
+        monkeypatch.delenv("HINDSIGHT_EMBED_API_DATABASE_URL", raising=False)
+
+        config = {
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+            "embed_database_url": "postgresql://user:pass@db.internal:5432/hindsight",
+        }
+
+        written_path = _materialize_embedded_profile_env(config)
+
+        assert written_path.is_file()
+        content = written_path.read_text()
+        assert (
+            "HINDSIGHT_EMBED_API_DATABASE_URL="
+            "postgresql://user:pass@db.internal:5432/hindsight" in content
+        ), f"configured database URL missing from materialized profile env file: {content!r}"
 
     def test_config_schema_exposes_embed_database_url(self, provider):
         schema = provider.get_config_schema()


### PR DESCRIPTION
## Context

Ports #21830 forward onto current main.

## Problem

`_build_embedded_profile_env()` included LLM settings but not the embedded DB URL override, so the daemon reconnected to the default per-profile pg0 instance on restart even when `HINDSIGHT_EMBED_API_DATABASE_URL` was set. The lower layer (`DaemonEmbedManager`) already supports the override.

## Fix

Read `HINDSIGHT_EMBED_API_DATABASE_URL` from config or environment and write it into the profile env dict when set. Also exposes `embed_database_url` as a documented, discoverable key in `get_config_schema()` (mode: local_embedded), rather than relying on the undocumented config alias alone.

Reported and diagnosed by @linglichao.

## Verification

6/6 new/updated tests pass in `tests/plugins/memory/test_hindsight_provider.py`.

Fixes #21809