### PR TITLE
feat(mcp): add playwright preset to hermes mcp add

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -11,7 +11,9 @@ configuration in ~/.hermes/config.yaml under the ``mcp_servers`` key.
 import asyncio
 import logging
 import os
+import platform
 import re
+import sys
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -33,10 +35,46 @@ logger = logging.getLogger(__name__)
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
+def _playwright_browser_args() -> list[str]:
+    """Return extra CLI args for @playwright/mcp based on the runtime environment.
+
+    Playwright MCP defaults to system Chrome. When no system browser is found
+    on the current platform, we add --browser=chromium so Playwright falls back
+    to its own bundled Chromium rather than failing silently.
+
+    On Linux running as root (VPS, Docker, CI), Chrome refuses to launch
+    without --no-sandbox, so we add that flag when euid == 0.
+
+    Browser detection reuses hermes_cli.browser_connect.get_chrome_debug_candidates(),
+    the same platform-aware resolver used for CDP attach — it checks PATH names,
+    standard Linux install paths, macOS .app bundles, and Windows install
+    directories (including WSL's /mnt/c mirror), rather than a single hard-coded
+    path that would misclassify most real installs as "browser absent".
+    """
+    from hermes_cli.browser_connect import get_chrome_debug_candidates
+
+    extra: list[str] = []
+
+    # Root/AppArmor safety flag (Linux-only).
+    if sys.platform == "linux" and os.geteuid() == 0:
+        extra.append("--no-sandbox")
+
+    # Browser availability: if we cannot find a system browser, tell Playwright
+    # MCP to use its own bundled Chromium instead of the default (system Chrome).
+    if not get_chrome_debug_candidates(platform.system()):
+        extra.append("--browser=chromium")
+
+    return extra
+
+
 _MCP_PRESETS: Dict[str, Dict[str, Any]] = {
     "codex": {
         "command": "codex",
         "args": ["mcp-server"],
+    },
+    "playwright": {
+        "command": "npx",
+        "args": ["-y", "@playwright/mcp@latest", "--headless"] + _playwright_browser_args(),
     },
 }
 

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -56,7 +56,7 @@ def _playwright_browser_args() -> list[str]:
     extra: list[str] = []
 
     # Root/AppArmor safety flag (Linux-only).
-    if sys.platform == "linux" and os.geteuid() == 0:
+    if sys.platform == "linux" and hasattr(os, "geteuid") and os.geteuid() == 0:
         extra.append("--no-sandbox")
 
     # Browser availability: if we cannot find a system browser, tell Playwright

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -1049,3 +1049,90 @@ class TestMcpReauth:
         cmd_mcp_reauth(_make_args(name="ghost", all=False))
         out = capsys.readouterr().out
         assert "not found" in out
+
+
+class TestPlaywrightMcpPreset:
+    """Regression coverage for the platform-aware @playwright/mcp preset
+    (issue history: PR #19768 hard-coded a single /opt/google/chrome/chrome
+    path and misclassified PATH/macOS/Windows installs as absent; this
+    reuses hermes_cli.browser_connect.get_chrome_debug_candidates(), the
+    same resolver CDP-attach uses, instead of a bespoke check)."""
+
+    def test_codex_preset_preserved_alongside_playwright(self):
+        from hermes_cli.mcp_config import _MCP_PRESETS
+        assert "codex" in _MCP_PRESETS
+        assert _MCP_PRESETS["codex"]["command"] == "codex"
+        assert "playwright" in _MCP_PRESETS
+
+    def test_playwright_preset_uses_npx_command(self):
+        from hermes_cli.mcp_config import _MCP_PRESETS
+        preset = _MCP_PRESETS["playwright"]
+        assert preset["command"] == "npx"
+        assert preset["args"][:3] == ["-y", "@playwright/mcp@latest", "--headless"]
+
+    def test_no_sandbox_added_on_linux_root(self, monkeypatch):
+        from hermes_cli import mcp_config
+        monkeypatch.setattr(mcp_config.sys, "platform", "linux")
+        monkeypatch.setattr(mcp_config.os, "geteuid", lambda: 0, raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.browser_connect.get_chrome_debug_candidates",
+            lambda system: ["/usr/bin/google-chrome"],
+        )
+        args = mcp_config._playwright_browser_args()
+        assert "--no-sandbox" in args
+
+    def test_no_sandbox_not_added_on_macos(self, monkeypatch):
+        from hermes_cli import mcp_config
+        monkeypatch.setattr(mcp_config.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            "hermes_cli.browser_connect.get_chrome_debug_candidates",
+            lambda system: ["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"],
+        )
+        args = mcp_config._playwright_browser_args()
+        assert "--no-sandbox" not in args
+
+    def test_no_sandbox_not_added_for_non_root_linux(self, monkeypatch):
+        from hermes_cli import mcp_config
+        monkeypatch.setattr(mcp_config.sys, "platform", "linux")
+        monkeypatch.setattr(mcp_config.os, "geteuid", lambda: 1000, raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.browser_connect.get_chrome_debug_candidates",
+            lambda system: ["/usr/bin/google-chrome"],
+        )
+        args = mcp_config._playwright_browser_args()
+        assert "--no-sandbox" not in args
+
+    def test_browser_chromium_fallback_when_no_system_browser_found(self, monkeypatch):
+        from hermes_cli import mcp_config
+        monkeypatch.setattr(mcp_config.sys, "platform", "linux")
+        monkeypatch.setattr(mcp_config.os, "geteuid", lambda: 1000, raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.browser_connect.get_chrome_debug_candidates",
+            lambda system: [],
+        )
+        args = mcp_config._playwright_browser_args()
+        assert "--browser=chromium" in args
+
+    def test_no_chromium_fallback_when_system_browser_found(self, monkeypatch):
+        from hermes_cli import mcp_config
+        monkeypatch.setattr(mcp_config.sys, "platform", "linux")
+        monkeypatch.setattr(mcp_config.os, "geteuid", lambda: 1000, raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.browser_connect.get_chrome_debug_candidates",
+            lambda system: ["/usr/bin/google-chrome"],
+        )
+        args = mcp_config._playwright_browser_args()
+        assert "--browser=chromium" not in args
+
+    def test_macos_app_bundle_counts_as_system_browser(self, monkeypatch):
+        """The platform-aware resolver (unlike a bare shutil.which() name
+        list) must find a macOS .app bundle install."""
+        from hermes_cli import mcp_config
+        monkeypatch.setattr(mcp_config.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            "hermes_cli.browser_connect.get_chrome_debug_candidates",
+            lambda system: ["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"],
+        )
+        args = mcp_config._playwright_browser_args()
+        assert "--browser=chromium" not in args
+

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -1136,3 +1136,17 @@ class TestPlaywrightMcpPreset:
         args = mcp_config._playwright_browser_args()
         assert "--browser=chromium" not in args
 
+    def test_windows_install_dir_counts_as_system_browser(self, monkeypatch):
+        """Regression (review of #63771): the platform-aware resolver must
+        also find a standard Windows install directory (unlike a bare
+        shutil.which() name list, which only matches PATH entries and would
+        misclassify most real Windows Chrome installs as absent)."""
+        from hermes_cli import mcp_config
+        monkeypatch.setattr(mcp_config.sys, "platform", "win32")
+        monkeypatch.setattr(
+            "hermes_cli.browser_connect.get_chrome_debug_candidates",
+            lambda system: [r"C:\Program Files\Google\Chrome\Application\chrome.exe"],
+        )
+        args = mcp_config._playwright_browser_args()
+        assert "--browser=chromium" not in args
+

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -361,6 +361,7 @@ For well-known MCP servers, `hermes mcp add` accepts a `--preset` flag that fill
 | Preset | What it wires up |
 |---|---|
 | `codex` | The Codex CLI's MCP server (`codex mcp-server` over stdio). Requires the `codex` CLI on PATH. |
+| `playwright` | [@playwright/mcp](https://github.com/microsoft/playwright-mcp) browser automation over stdio (`npx -y @playwright/mcp@latest --headless`). Uses a system Chrome/Chromium install if found; falls back to Playwright's bundled Chromium otherwise. Adds `--no-sandbox` automatically when running as root (VPS/Docker/CI). |
 
 ```bash
 # Add Codex CLI as an MCP server in one line


### PR DESCRIPTION
## Context

Ports #63771 forward onto current main per @teknium1's review.

## Fix

Adds `@playwright/mcp` to the built-in MCP preset registry alongside the existing `codex` preset. Browser detection now reuses `hermes_cli.browser_connect.get_chrome_debug_candidates()` -- the same platform-aware resolver CDP-attach uses -- instead of a bespoke `shutil.which()` name list, so macOS `.app` bundles and Windows install directories (including the WSL `/mnt/c` mirror) are correctly detected rather than misclassified as absent.

- `codex` preset preserved alongside `playwright`
- `--no-sandbox` added only on Linux when `euid==0` (root/VPS/Docker)
- `--browser=chromium` fallback added only when no system browser is found
- Dropped the incorrect `Fixes #19760` reference (unrelated, closed Nix build issue)

## Verification

9/9 new tests pass in `TestPlaywrightMcpPreset`; 67/67 in the full `tests/hermes_cli/test_mcp_config.py` file.