### PR TITLE
fix(gateway): surface apply_yaml_config_fn validation errors

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1549,6 +1549,17 @@ def load_gateway_config() -> GatewayConfig:
                         continue
                     try:
                         seeded = entry.apply_yaml_config_fn(yaml_cfg, platform_cfg)
+                    except ValueError as e:
+                        # Validation errors (e.g. duplicate app_id, exceeding
+                        # app limits) must be visible — the platform will be
+                        # silently disabled if we just continue.  Log at ERROR
+                        # so the user sees it in gateway logs.
+                        logger.error(
+                            "Configuration error for %s: %s — this platform "
+                            "will be disabled.",
+                            entry.name, e,
+                        )
+                        continue
                     except Exception as e:
                         logger.debug(
                             "apply_yaml_config_fn for %s raised: %s",

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1551,12 +1551,14 @@ def load_gateway_config() -> GatewayConfig:
                         seeded = entry.apply_yaml_config_fn(yaml_cfg, platform_cfg)
                     except ValueError as e:
                         # Validation errors (e.g. duplicate app_id, exceeding
-                        # app limits) must be visible — the platform will be
-                        # silently disabled if we just continue.  Log at ERROR
-                        # so the user sees it in gateway logs.
+                        # app limits) must be visible. The YAML bridge is
+                        # skipped, but env overrides may still enable the
+                        # platform downstream — so the message describes the
+                        # bridge failure, not a guaranteed disable.
                         logger.error(
-                            "Configuration error for %s: %s — this platform "
-                            "will be disabled.",
+                            "Configuration error in %s's YAML bridge: %s "
+                            "— YAML config was skipped; the platform may still "
+                            "be enabled via environment variables.",
                             entry.name, e,
                         )
                         continue

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -130,7 +130,8 @@ class PlatformEntry:
     # and before ``_apply_env_overrides``.  Mutating ``os.environ`` is allowed
     # (use ``not os.getenv(...)`` guards to preserve env > YAML precedence);
     # any returned dict is merged into ``PlatformConfig.extra``.  Exceptions
-    # are caught and logged at debug level.
+    # ``ValueError`` is logged at ERROR level (visible to the user) so they
+    # can fix misconfiguration; all other exceptions are logged at debug level.
     # See website/docs/developer-guide/adding-platform-adapters.md for the
     # full contract and a worked example.
     apply_yaml_config_fn: Optional[Callable[[dict, dict], Optional[dict]]] = None

--- a/tests/gateway/test_apply_yaml_config_errors.py
+++ b/tests/gateway/test_apply_yaml_config_errors.py
@@ -1,0 +1,105 @@
+"""Tests for apply_yaml_config_fn ValueError surfacing.
+
+Verifies that ValueError raised by a platform's apply_yaml_config_fn
+is logged at ERROR level (not silently swallowed at debug), so the
+user knows why a platform was disabled.
+"""
+
+import logging
+import os
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+class TestApplyYamlConfigValidationError:
+    """Validation errors from apply_yaml_config_fn must be visible."""
+
+    @pytest.fixture
+    def temp_hermes_home(self, monkeypatch, tmp_path):
+        """Isolate HERMES_HOME for E2E config tests."""
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        return home
+
+    def test_value_error_logged_at_error_level(
+        self, temp_hermes_home, caplog
+    ):
+        """ValueError from apply_yaml_config_fn is caught by the
+        ValueError-specific handler and logged at ERROR level.
+
+        We mock the platform registry to inject a fake
+        apply_yaml_config_fn that raises ValueError, simulating a
+        platform validation failure (e.g. duplicate app_id, exceeding
+        app limits). This is provider-agnostic — the fix applies to
+        ALL platforms that use apply_yaml_config_fn.
+        """
+        import yaml
+
+        config_path = temp_hermes_home / "config.yaml"
+        with open(config_path, "w", encoding="utf-8") as f:
+            yaml.dump({"test_platform": {"some_key": "val"}}, f)
+
+        mock_entry = MagicMock()
+        mock_entry.name = "test_platform"
+        mock_entry.apply_yaml_config_fn = MagicMock(
+            side_effect=ValueError("too many apps configured: limit is 10")
+        )
+        mock_registry = MagicMock()
+        mock_registry.is_registered.return_value = False
+        mock_registry.all_entries.return_value = [mock_entry]
+        mock_registry.get.return_value = mock_entry
+
+        with patch("gateway.platform_registry.platform_registry", mock_registry):
+            from gateway.config import load_gateway_config
+
+            with caplog.at_level(logging.ERROR):
+                load_gateway_config()
+
+        # The ValueError was logged at ERROR, not swallowed at debug
+        assert any(
+            "Configuration error" in record.message
+            and record.levelno == logging.ERROR
+            for record in caplog.records
+        ), (
+            "Expected ERROR log for ValueError from apply_yaml_config_fn, "
+            f"got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_generic_exception_still_handled_at_debug(
+        self, temp_hermes_home, caplog
+    ):
+        """Non-ValueError exceptions are still caught by the generic
+        except Exception handler — backward compatibility preserved.
+        """
+        import yaml
+
+        config_path = temp_hermes_home / "config.yaml"
+        with open(config_path, "w", encoding="utf-8") as f:
+            yaml.dump({"broken_platform": {"some_key": "val"}}, f)
+
+        mock_entry = MagicMock()
+        mock_entry.name = "broken_platform"
+        mock_entry.apply_yaml_config_fn = MagicMock(
+            side_effect=RuntimeError("unexpected internal error")
+        )
+        mock_registry = MagicMock()
+        mock_registry.is_registered.return_value = False
+        mock_registry.all_entries.return_value = [mock_entry]
+        mock_registry.get.return_value = mock_entry
+
+        with patch("gateway.platform_registry.platform_registry", mock_registry):
+            from gateway.config import load_gateway_config
+
+            # Should NOT raise — generic handler catches it
+            gw_config = load_gateway_config()
+            assert gw_config is not None
+
+        # RuntimeError was NOT logged at ERROR (only ValueError gets ERROR)
+        assert not any(
+            record.levelno == logging.ERROR
+            and "broken_platform" in record.message
+            for record in caplog.records
+        )

--- a/tests/gateway/test_apply_yaml_config_errors.py
+++ b/tests/gateway/test_apply_yaml_config_errors.py
@@ -61,6 +61,7 @@ class TestApplyYamlConfigValidationError:
         # The ValueError was logged at ERROR, not swallowed at debug
         assert any(
             "Configuration error" in record.message
+            and "YAML bridge" in record.message
             and record.levelno == logging.ERROR
             for record in caplog.records
         ), (
@@ -93,13 +94,30 @@ class TestApplyYamlConfigValidationError:
         with patch("gateway.platform_registry.platform_registry", mock_registry):
             from gateway.config import load_gateway_config
 
-            # Should NOT raise — generic handler catches it
-            gw_config = load_gateway_config()
-            assert gw_config is not None
+            # Capture gateway.config at DEBUG to verify the generic
+            # exception handler still fires.
+            with caplog.at_level(logging.DEBUG, logger="gateway.config"):
+                # Should NOT raise — generic handler catches it
+                gw_config = load_gateway_config()
+                assert gw_config is not None
 
         # RuntimeError was NOT logged at ERROR (only ValueError gets ERROR)
         assert not any(
             record.levelno == logging.ERROR
             and "broken_platform" in record.message
             for record in caplog.records
+        ), (
+            "RuntimeError should NOT produce an ERROR log — "
+            f"got: {[(r.levelname, r.message) for r in caplog.records]}"
+        )
+
+        # The generic-exception debug message WAS logged (backward compat)
+        assert any(
+            record.levelno == logging.DEBUG
+            and "apply_yaml_config_fn" in record.message
+            and "broken_platform" in record.message
+            for record in caplog.records
+        ), (
+            "Expected DEBUG log for generic exception from "
+            f"apply_yaml_config_fn, got: {[(r.levelname, r.message) for r in caplog.records]}"
         )

--- a/website/docs/developer-guide/adding-platform-adapters.md
+++ b/website/docs/developer-guide/adding-platform-adapters.md
@@ -277,7 +277,7 @@ def register(ctx):
 
 The hook is invoked during `load_gateway_config()` after the generic shared-key loop (which handles common keys like `unauthorized_dm_behavior`, `notice_delivery`, `reply_prefix`, `require_mention`, etc.) and before `_apply_env_overrides()`, so your plugin only needs to bridge **platform-specific** keys.
 
-Exceptions raised by the hook are swallowed and logged at debug level — a misbehaving plugin never aborts gateway config load.
+``ValueError`` raised by the hook is caught and logged at **ERROR** level so the user can fix misconfiguration. All other exceptions are caught and logged at debug level — a misbehaving plugin never aborts gateway config load.
 
 
 ## Cron Delivery


### PR DESCRIPTION
## Problem

`load_gateway_config()` catches all exceptions from `apply_yaml_config_fn` at `debug` level, silently disabling the platform on `ValueError` (e.g. duplicate app_id, exceeding app limits). Users have no feedback — the platform just doesn't work.

## Fix

Add a `ValueError`-specific `except` branch that logs at `ERROR` level with a clear *"this platform will be disabled"* message. Non-`ValueError` exceptions keep the existing debug-level handler for backward compat.

```python
except ValueError as e:
    logger.error(
        "Configuration error for %s: %s — this platform will be disabled.",
        entry.name, e,
    )
    continue
except Exception as e:
    logger.debug("apply_yaml_config_fn for %s raised: %s", entry.name, e)
    continue
```

## Testing

- `test_value_error_logged_at_error_level` — verifies ValueError is logged at ERROR
- `test_generic_exception_still_handled_at_debug` — verifies RuntimeError stays at debug (backward compat)

Provider-agnostic fix — applies to all platforms using `apply_yaml_config_fn` (Slack, Feishu, etc.).