### PR TITLE
fix(lsp): wrap Unix shell script LSP launchers on Windows

### DIFF
--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -50,6 +50,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import shlex
+import shutil
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -280,11 +282,42 @@ class LSPClient:
 
     @staticmethod
     def _win_wrap_cmd(cmd: List[str]) -> List[str]:
-        """On Windows, wrap .cmd/.bat shims so CreateProcess can run them."""
+        """On Windows, wrap .cmd/.bat shims and Unix shell scripts so
+        CreateProcess can run them.
+
+        npm/npx-installed LSP servers often place a Unix shell script
+        (no .exe/.cmd/.bat extension, '#!/bin/sh' shebang) as the launcher
+        -- e.g. pyright-langserver under ~/.hermes/lsp/bin/. CreateProcess
+        cannot execute these directly and fails with WinError 193
+        ("%1 is not a valid Win32 application") (issue #49470).
+        """
         exe = cmd[0]
-        if exe.lower().endswith((".cmd", ".bat")):
+        lower = exe.lower()
+        if lower.endswith((".cmd", ".bat")):
             return ["cmd.exe", "/c", *cmd]
-        return cmd
+        if lower.endswith((".exe", ".com", ".msi", ".ps1")):
+            return cmd
+        # Heuristic: any other extensionless/unknown-extension executable on
+        # Windows is most likely a Unix shell script shim (or has no
+        # extension at all). Try to detect a shebang to avoid wrapping a
+        # genuine native binary that just lacks a recognized suffix.
+        try:
+            with open(exe, "rb") as f:
+                head = f.read(2)
+            if head != b"#!":
+                return cmd
+        except OSError:
+            return cmd
+        bash = shutil.which("bash")
+        if not bash:
+            logger.warning(
+                "[lsp] '%s' looks like a Unix shell script but 'bash' is not "
+                "on PATH; spawn will likely fail with WinError 193. Install "
+                "Git for Windows (provides Git Bash) to run this LSP server.",
+                exe,
+            )
+            return cmd
+        return [bash, "-c", " ".join(shlex.quote(a) for a in cmd)]
 
     async def _spawn(self) -> None:
         env = dict(os.environ)

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -303,11 +303,52 @@ class LSPClient:
         # genuine native binary that just lacks a recognized suffix.
         try:
             with open(exe, "rb") as f:
-                head = f.read(2)
-            if head != b"#!":
+                # A shebang line can legitimately be much longer than 2
+                # bytes (e.g. "#!/usr/bin/env node"); read enough to parse
+                # the interpreter, not just the "#!" marker.
+                head_line = f.readline(512)
+            if not head_line.startswith(b"#!"):
                 return cmd
         except OSError:
             return cmd
+
+        # Parse the interpreter the shebang actually names. A shebang can
+        # name Node, Python, Perl, or any other interpreter -- not just a
+        # shell -- and routing those through `bash -c` is wrong: bash would
+        # try to execute the target's source as shell script under the
+        # wrong interpreter and fail (or worse, partially "succeed" on
+        # lines that happen to parse as valid shell).
+        try:
+            shebang_text = head_line[2:].decode("utf-8", errors="replace").strip()
+        except Exception:
+            shebang_text = ""
+        shebang_parts = shebang_text.split()
+        # "#!/usr/bin/env node" -> interpreter is the env argument, not env
+        # itself. "#!/bin/sh" -> interpreter is the direct path.
+        if shebang_parts and Path(shebang_parts[0]).stem.lower() == "env" and len(shebang_parts) > 1:
+            interpreter_name = Path(shebang_parts[1]).stem.lower()
+        elif shebang_parts:
+            interpreter_name = Path(shebang_parts[0]).stem.lower()
+        else:
+            interpreter_name = ""
+
+        _SHELL_INTERPRETER_NAMES = {"sh", "bash", "dash", "zsh", "ash", "ksh"}
+        if interpreter_name and interpreter_name not in _SHELL_INTERPRETER_NAMES:
+            # A real, non-shell interpreter (node, python3, perl, ...) --
+            # spawn the script through that interpreter directly rather
+            # than bash. Resolve it via PATH the same way a Unix shell
+            # would when honoring the shebang.
+            resolved_interpreter = shutil.which(interpreter_name)
+            if resolved_interpreter:
+                return [resolved_interpreter, *cmd]
+            logger.warning(
+                "[lsp] '%s' has a non-shell shebang naming '%s', but that "
+                "interpreter is not on PATH; spawn will likely fail with "
+                "WinError 193.",
+                exe, interpreter_name,
+            )
+            return cmd
+
         bash = shutil.which("bash")
         if not bash:
             logger.warning(

--- a/tests/agent/lsp/test_win_wrap_cmd.py
+++ b/tests/agent/lsp/test_win_wrap_cmd.py
@@ -1,0 +1,69 @@
+"""Unit tests for LSPClient._win_wrap_cmd (issue #49470).
+
+npm/npx-installed LSP servers often place a Unix shell script (no
+.exe/.cmd/.bat extension, '#!/bin/sh' shebang) as the launcher -- e.g.
+pyright-langserver under ~/.hermes/lsp/bin/. On Windows, CreateProcess
+cannot execute these directly and fails with WinError 193. _win_wrap_cmd()
+detects the shebang and wraps the command with 'bash -c' when bash is
+available on PATH.
+"""
+from unittest.mock import patch
+
+from agent.lsp.client import LSPClient
+
+
+def _write_shebang_script(tmp_path, name="pyright-langserver"):
+    script = tmp_path / name
+    script.write_bytes(b"#!/bin/sh\nexec node \"$(dirname \"$0\")/pyright.js\" \"$@\"\n")
+    return script
+
+
+class TestWinWrapCmdShebangDetection:
+    def test_shebang_script_wrapped_with_bash_when_available(self, tmp_path):
+        script = _write_shebang_script(tmp_path)
+        with patch("shutil.which", return_value="/usr/bin/bash"):
+            result = LSPClient._win_wrap_cmd([str(script), "--stdio"])
+        assert result[0] == "/usr/bin/bash"
+        assert result[1] == "-c"
+        assert str(script) in result[2]
+        assert "--stdio" in result[2]
+
+    def test_shebang_script_falls_through_unchanged_when_bash_absent(self, tmp_path, caplog):
+        script = _write_shebang_script(tmp_path)
+        with patch("shutil.which", return_value=None):
+            with caplog.at_level("WARNING", logger="agent.lsp.client"):
+                result = LSPClient._win_wrap_cmd([str(script), "--stdio"])
+        assert result == [str(script), "--stdio"]
+        assert any("bash" in r.getMessage().lower() for r in caplog.records)
+
+    def test_non_shebang_extensionless_file_left_unchanged(self, tmp_path):
+        """A genuine native binary without a recognized extension must not
+        be wrapped -- only files that actually start with '#!' are."""
+        native = tmp_path / "some-native-tool"
+        native.write_bytes(b"\x7fELF\x02\x01\x01\x00")  # ELF magic, not a shebang
+        with patch("shutil.which", return_value="/usr/bin/bash"):
+            result = LSPClient._win_wrap_cmd([str(native), "--stdio"])
+        assert result == [str(native), "--stdio"]
+
+    def test_nonexistent_file_left_unchanged(self, tmp_path):
+        missing = tmp_path / "does-not-exist"
+        result = LSPClient._win_wrap_cmd([str(missing), "--stdio"])
+        assert result == [str(missing), "--stdio"]
+
+
+class TestWinWrapCmdExistingBehaviorPreserved:
+    def test_cmd_extension_still_wrapped_with_cmd_exe(self):
+        result = LSPClient._win_wrap_cmd(["C:\\tools\\server.cmd", "--stdio"])
+        assert result == ["cmd.exe", "/c", "C:\\tools\\server.cmd", "--stdio"]
+
+    def test_bat_extension_still_wrapped_with_cmd_exe(self):
+        result = LSPClient._win_wrap_cmd(["C:\\tools\\server.bat"])
+        assert result == ["cmd.exe", "/c", "C:\\tools\\server.bat"]
+
+    def test_exe_extension_passed_through_unchanged(self):
+        result = LSPClient._win_wrap_cmd(["C:\\tools\\server.exe", "--stdio"])
+        assert result == ["C:\\tools\\server.exe", "--stdio"]
+
+    def test_ps1_extension_passed_through_unchanged(self):
+        result = LSPClient._win_wrap_cmd(["C:\\tools\\server.ps1"])
+        assert result == ["C:\\tools\\server.ps1"]

--- a/tests/agent/lsp/test_win_wrap_cmd.py
+++ b/tests/agent/lsp/test_win_wrap_cmd.py
@@ -50,6 +50,70 @@ class TestWinWrapCmdShebangDetection:
         result = LSPClient._win_wrap_cmd([str(missing), "--stdio"])
         assert result == [str(missing), "--stdio"]
 
+    def test_env_node_shebang_spawns_via_node_not_bash(self, tmp_path):
+        """Regression (review of #68494): a shebang naming a non-shell
+        interpreter (Node, via the common '#!/usr/bin/env node' form) must
+        NOT be routed through bash -c -- bash would try to execute the
+        JS source as shell script under the wrong interpreter and fail.
+        It must spawn via the actual named interpreter, resolved from PATH."""
+        script = tmp_path / "some-js-launcher"
+        script.write_bytes(b"#!/usr/bin/env node\nconsole.log('hi');\n")
+        with patch(
+            "shutil.which",
+            side_effect=lambda name: (
+                "/usr/bin/node" if name == "node" else "/usr/bin/bash"
+            ),
+        ):
+            result = LSPClient._win_wrap_cmd([str(script), "--stdio"])
+        assert result[0] == "/usr/bin/node"
+        assert result[1] == str(script)
+        assert result[2] == "--stdio"
+        assert "bash" not in result
+
+    def test_direct_python_shebang_spawns_via_python_not_bash(self, tmp_path):
+        """Same regression, direct-path shebang form (no /usr/bin/env
+        indirection): '#!/usr/bin/python3'."""
+        script = tmp_path / "some-py-launcher"
+        script.write_bytes(b"#!/usr/bin/python3\nprint('hi')\n")
+        with patch(
+            "shutil.which",
+            side_effect=lambda name: (
+                "/usr/bin/python3" if name == "python3" else "/usr/bin/bash"
+            ),
+        ):
+            result = LSPClient._win_wrap_cmd([str(script), "--stdio"])
+        assert result[0] == "/usr/bin/python3"
+        assert result[1] == str(script)
+        assert "bash" not in result
+
+    def test_non_shell_interpreter_not_on_path_falls_through_with_warning(
+        self, tmp_path, caplog
+    ):
+        """If the named non-shell interpreter isn't resolvable, fall
+        through unchanged (matching the existing no-bash-found behavior)
+        rather than silently misrouting through bash."""
+        script = tmp_path / "some-js-launcher"
+        script.write_bytes(b"#!/usr/bin/env node\nconsole.log('hi');\n")
+        with patch("shutil.which", return_value=None):
+            with caplog.at_level("WARNING", logger="agent.lsp.client"):
+                result = LSPClient._win_wrap_cmd([str(script), "--stdio"])
+        assert result == [str(script), "--stdio"]
+        assert any("node" in r.getMessage().lower() for r in caplog.records)
+
+    def test_shell_shebang_variants_still_use_bash(self, tmp_path):
+        """Sanity: this fix must not regress the original supported cases --
+        sh, bash, zsh, dash shebangs (direct or via /usr/bin/env) must still
+        route through bash -c as before."""
+        for i, shebang in enumerate(
+            (b"#!/bin/sh\n", b"#!/bin/bash\n", b"#!/usr/bin/env bash\n", b"#!/usr/bin/env sh\n")
+        ):
+            script = tmp_path / f"shell-script-{i}"
+            script.write_bytes(shebang + b"exec node real.js \"$@\"\n")
+            with patch("shutil.which", return_value="/usr/bin/bash"):
+                result = LSPClient._win_wrap_cmd([str(script), "--stdio"])
+            assert result[0] == "/usr/bin/bash", (shebang, result)
+            assert result[1] == "-c", (shebang, result)
+
 
 class TestWinWrapCmdExistingBehaviorPreserved:
     def test_cmd_extension_still_wrapped_with_cmd_exe(self):


### PR DESCRIPTION
## Context

Ports #49501 forward onto current main per @teknium1's review.

## Problem

npm/npx-installed LSP servers often place a Unix shell script (no .exe/.cmd/.bat extension, shebang) as launcher -- e.g. pyright-langserver. CreateProcess fails with WinError 193 (issue #49470).

## Fix

`_win_wrap_cmd()` detects a shebang and wraps with `bash -c` (shlex.quote). Falls through if bash not on PATH, logging a warning. `.exe/.com/.msi/.ps1` untouched; `.cmd/.bat` keep the existing wrap.

## Verification

Added unit tests for the static helper: shebang detection with bash found/absent, non-shebang extensionless binary left unwrapped, nonexistent-path no-op, and preservation of existing `.cmd/.bat/.exe/.ps1` behavior. 8/8 pass.