### PR TITLE
fix(cli): pass conversation_history to prevent session duplication on cold resume (#68454)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7149,7 +7149,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if self.agent:
                 try:
                     self.agent._flush_messages_to_session_db(
-                        self.conversation_history
+                        self.conversation_history,
+                        conversation_history=self.conversation_history,
                     )
                 except Exception:
                     pass  # best-effort

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -758,7 +758,8 @@ class CLICommandsMixin:
         if self.agent:
             try:
                 self.agent._flush_messages_to_session_db(
-                    self.conversation_history
+                    self.conversation_history,
+                    conversation_history=self.conversation_history,
                 )
             except Exception:
                 pass
@@ -919,7 +920,8 @@ class CLICommandsMixin:
         if self.agent:
             try:
                 self.agent._flush_messages_to_session_db(
-                    self.conversation_history
+                    self.conversation_history,
+                    conversation_history=self.conversation_history,
                 )
             except Exception:
                 pass


### PR DESCRIPTION
## Summary

When `/new`, `/resume`, or `/branch` is called immediately after a cold resume (before any turn runs), `_flush_messages_to_session_db()` sees an empty `history_ids` set and treats every restored row as new — re-appending the entire transcript to the old session.

This is the same bug class as #68196 (fixed in #68205 for the preflight compression path), but at three different call sites.

## Fix

Pass `conversation_history=self.conversation_history` at all three call sites so the identity-based skip path correctly recognizes the restored rows as already persisted:

1. `cli.py:7151` — `/new` command
2. `hermes_cli/cli_commands_mixin.py:760` — `/resume` command
3. `hermes_cli/cli_commands_mixin.py:921` — `/branch` command

This mirrors the fix applied in #68205 for the preflight compression rotation path.

## Testing

```python
# Before fix: cold resume + /new duplicates transcript
# After fix: /new correctly ends session without duplication
```

Fixes #68454
