### PR TITLE
feat(desktop): add scoped Nattpasset mission launcher

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -102,6 +102,7 @@ import {
   type AppView,
   ARTIFACTS_ROUTE,
   MESSAGING_ROUTE,
+  NATTPASSET_ROUTE,
   SIDEBAR_NAV_AREA,
   type SidebarNavContribution,
   SKILLS_ROUTE
@@ -167,6 +168,12 @@ const SIDEBAR_NAV: SidebarNavItem[] = [
     icon: props => <Codicon name="files" {...props} />,
     route: ARTIFACTS_ROUTE,
     keybindActionId: 'nav.artifacts'
+  },
+  {
+    id: 'nattpasset',
+    label: '',
+    icon: props => <Codicon name="run-all" {...props} />,
+    route: NATTPASSET_ROUTE
   }
 ]
 

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -183,6 +183,7 @@ export const ChatRoutesSurface = memo(function ChatRoutesSurface({
       <Route element={null} path="agents" />
       <Route element={null} path="command-center" />
       <Route element={null} path="cron" />
+      <Route element={null} path="nattpasset" />
       <Route element={null} path="profiles" />
       <Route element={null} path="settings" />
       <Route element={null} path="starmap" />

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -30,8 +30,20 @@ import { latestSessionTodos } from '@/lib/todos'
 import { setCronFocusJobId } from '@/store/cron'
 import { $pinnedSessionIds, pinSession, restoreWorktree, unpinSession } from '@/store/layout'
 import { $filePreviewTarget, $previewTarget } from '@/store/preview'
-import { $activeGatewayProfile, $freshSessionRequest, $profileScope, refreshActiveProfile } from '@/store/profile'
-import { $startWorkSessionRequest, followActiveSessionCwd, resolveNewSessionCwd } from '@/store/projects'
+import {
+  $activeGatewayProfile,
+  $freshSessionRequest,
+  $profileScope,
+  normalizeProfileKey,
+  refreshActiveProfile
+} from '@/store/profile'
+import {
+  $activeProjectId,
+  $projects,
+  $startWorkSessionRequest,
+  followActiveSessionCwd,
+  resolveNewSessionCwd
+} from '@/store/projects'
 import {
   $activeSessionId,
   $connection,
@@ -68,11 +80,16 @@ import { useGatewayRequest } from '../gateway/hooks/use-gateway-request'
 import { useKeybinds } from '../hooks/use-keybinds'
 import { ModelPickerOverlay } from '../model-picker-overlay'
 import { ModelVisibilityOverlay } from '../model-visibility-overlay'
+import {
+  launchNattpassMission,
+  nattpassLaunchContextMatches,
+  nattpassProjectWorkspace
+} from '../nattpasset'
 import { PetGenerateOverlay } from '../pet-generate/pet-generate-overlay'
 import { FileActionDialogs } from '../right-sidebar/file-actions'
 import { RemoteFolderPicker } from '../right-sidebar/files/remote-picker'
 import { PersistentTerminal } from '../right-sidebar/terminal/persistent'
-import { CRON_ROUTE, routeSessionId, sessionRoute, SETTINGS_ROUTE, syncWorkspaceIsPage } from '../routes'
+import { CRON_ROUTE, NEW_CHAT_ROUTE, routeSessionId, sessionRoute, SETTINGS_ROUTE, syncWorkspaceIsPage } from '../routes'
 import { SessionPickerOverlay } from '../session-picker-overlay'
 import { SessionSwitcher } from '../session-switcher'
 import { useBackgroundQueueDrain } from '../session/hooks/use-background-queue-drain'
@@ -108,6 +125,7 @@ import type { WiringActions, WiringApi } from './types'
 const AgentsView = lazy(async () => ({ default: (await import('../agents')).AgentsView }))
 const CommandCenterView = lazy(async () => ({ default: (await import('../command-center')).CommandCenterView }))
 const CronView = lazy(async () => ({ default: (await import('../cron')).CronView }))
+const NattpassetView = lazy(async () => ({ default: (await import('../nattpasset')).NattpassetView }))
 const ProfilesView = lazy(async () => ({ default: (await import('../profiles')).ProfilesView }))
 const SettingsView = lazy(async () => ({ default: (await import('../settings')).SettingsView }))
 const StarmapView = lazy(async () => ({ default: (await import('../starmap')).StarmapView }))
@@ -138,6 +156,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
   const messagingSessions = useStore($messagingSessions)
   const profileScope = useStore($profileScope)
+  const projects = useStore($projects)
+  const activeProjectId = useStore($activeProjectId)
 
   const routedSessionId = routeSessionId(location.pathname)
   const routedSessionIdRef = useRef(routedSessionId)
@@ -147,6 +167,21 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const routeTokenRef = useRef(routeToken)
   routeTokenRef.current = routeToken
   const getRouteToken = useCallback(() => routeTokenRef.current, [])
+  const freshDraftRouteWaitersRef = useRef<Array<() => void>>([])
+
+  useEffect(() => {
+    if (location.pathname !== NEW_CHAT_ROUTE || freshDraftRouteWaitersRef.current.length === 0) {
+      return
+    }
+
+    const waiters = freshDraftRouteWaitersRef.current.splice(0)
+    waiters.forEach(resolve => resolve())
+  }, [location.pathname])
+
+  const waitForFreshDraftRoute = useCallback(
+    () => new Promise<void>(resolve => freshDraftRouteWaitersRef.current.push(resolve)),
+    []
+  )
 
   const getRoutedStoredSessionId = useCallback(() => routedSessionIdRef.current, [])
 
@@ -168,6 +203,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     commandCenterInitialSection,
     commandCenterOpen,
     cronOpen,
+    nattpassetOpen,
     currentView,
     openAgents,
     openCommandCenterSection,
@@ -950,6 +986,52 @@ export function ContribWiring({ children }: { children: ReactNode }) {
           <CronView
             onClose={closeOverlayToPreviousRoute}
             onOpenSession={sessionId => navigate(sessionRoute(sessionId))}
+          />
+        </Suspense>
+      )}
+
+      {nattpassetOpen && (
+        <Suspense fallback={null}>
+          <NattpassetView
+            activeProjectId={activeProjectId}
+            onClose={closeOverlayToPreviousRoute}
+            onLaunch={(mission, isCurrent) => {
+              const expectedActiveProjectId = $activeProjectId.get()
+              const expectedProfile = normalizeProfileKey($activeGatewayProfile.get())
+              const expectedWorkspace = nattpassProjectWorkspace(mission.project)
+
+              const expectedContext = {
+                activeProjectId: expectedActiveProjectId,
+                profile: expectedProfile,
+                projectId: mission.project.id,
+                workspace: expectedWorkspace
+              }
+
+              return launchNattpassMission(
+                mission,
+                workspace => startFreshSessionDraft({ workspaceTarget: workspace }),
+                waitForFreshDraftRoute,
+                submitText,
+                () => {
+                  const currentProject = $projects.get().find(project => project.id === mission.project.id)
+
+                  return (
+                    isCurrent() &&
+                    nattpassLaunchContextMatches(expectedContext, {
+                      activeProjectId: $activeProjectId.get(),
+                      cwd: $currentCwd.get(),
+                      freshDraftReady: $freshDraftReady.get(),
+                      onFreshDraftRoute: routeTokenRef.current.startsWith(`${NEW_CHAT_ROUTE}:`),
+                      profile: normalizeProfileKey($activeGatewayProfile.get()),
+                      project: currentProject ?? null,
+                      runtimeSessionId: $activeSessionId.get(),
+                      storedSessionId: $selectedStoredSessionId.get()
+                    })
+                  )
+                }
+              )
+            }}
+            projects={projects}
           />
         </Suspense>
       )}

--- a/apps/desktop/src/app/nattpasset/index.test.tsx
+++ b/apps/desktop/src/app/nattpasset/index.test.tsx
@@ -1,0 +1,194 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { ProjectInfo } from '@/types/hermes'
+
+import { buildNattpassMission, launchNattpassMission, NattpassetView, nattpassLaunchContextMatches } from '.'
+
+const project: ProjectInfo = {
+  archived: false,
+  board_slug: null,
+  color: null,
+  created_at: 1,
+  description: null,
+  folders: [],
+  icon: null,
+  id: 'p_hermes',
+  name: 'Hermes Agent',
+  primary_path: '/work/hermes-agent',
+  slug: 'hermes-agent'
+}
+
+afterEach(cleanup)
+
+describe('buildNattpassMission', () => {
+  it('makes project identity verification and evidence-classified delivery mandatory', () => {
+    const prompt = buildNattpassMission({
+      acceptanceCriteria: ['Focused tests pass', 'The launch state is honest'],
+      goal: 'Ship the first Nattpasset slice',
+      project
+    })
+
+    expect(prompt).toContain('Project id: p_hermes')
+    expect(prompt).toContain('Expected workspace: /work/hermes-agent')
+    expect(prompt).toMatch(/verify.*cwd.*repository.*remote.*branch.*status/is)
+    expect(prompt).toMatch(/stop.*decision/is)
+    expect(prompt).toContain('Focused tests pass')
+    expect(prompt).toContain('KLART')
+    expect(prompt).toContain('VERIFIERAT')
+    expect(prompt).toContain('KVAR')
+    expect(prompt).toContain('BESLUT KRÄVS')
+    expect(prompt).toMatch(/existing.*todo.*delegation.*Kanban.*cron/is)
+  })
+})
+
+describe('launchNattpassMission', () => {
+  it('captures the verified workspace in a fresh session before submitting to the backend', async () => {
+    const trace: string[] = []
+
+    const accepted = await launchNattpassMission(
+      { project, prompt: 'mission' },
+      path => trace.push(`draft:${path}`),
+      async () => {
+        trace.push('ready')
+      },
+      async prompt => {
+        trace.push(`submit:${prompt}`)
+
+        return true
+      },
+      () => true
+    )
+
+    expect(accepted).toBe(true)
+    expect(trace).toEqual(['draft:/work/hermes-agent', 'ready', 'submit:mission'])
+  })
+
+  it.each(['project', 'profile', 'session'])('fails closed when the %s identity changes while routing', async field => {
+    const expected = {
+      activeProjectId: 'p_hermes',
+      profile: 'default',
+      projectId: project.id,
+      workspace: '/work/hermes-agent'
+    }
+
+    const current: Parameters<typeof nattpassLaunchContextMatches>[1] = {
+      activeProjectId: 'p_hermes',
+      cwd: '/work/hermes-agent',
+      freshDraftReady: true,
+      onFreshDraftRoute: true,
+      profile: 'default',
+      project,
+      runtimeSessionId: null,
+      storedSessionId: null
+    }
+
+    let releaseRoute!: () => void
+
+    const routeReady = new Promise<void>(resolve => {
+      releaseRoute = resolve
+    })
+
+    const submitPrompt = vi.fn(async () => true)
+
+    const pending = launchNattpassMission(
+      { project, prompt: 'mission' },
+      () => undefined,
+      () => routeReady,
+      submitPrompt,
+      () => nattpassLaunchContextMatches(expected, current)
+    )
+
+    if (field === 'project') {
+      current.activeProjectId = 'p_other'
+    } else if (field === 'profile') {
+      current.profile = 'other'
+    } else {
+      current.runtimeSessionId = 'runtime-other'
+    }
+
+    releaseRoute()
+
+    await expect(pending).resolves.toBe(false)
+    expect(submitPrompt).not.toHaveBeenCalled()
+  })
+})
+
+describe('NattpassetView', () => {
+  it('launches a real mission only after goal, acceptance criteria, and scope confirmation', () => {
+    const onLaunch = vi.fn(async () => true)
+
+    render(<NattpassetView activeProjectId="p_hermes" onClose={vi.fn()} onLaunch={onLaunch} projects={[project]} />)
+
+    expect(screen.getByText(/live Hermes session/i)).toBeTruthy()
+    expect(screen.getByText(/not yet durable across app or runtime restarts/i)).toBeTruthy()
+
+    const launch = screen.getByRole('button', { name: 'Start Nattpasset' }) as HTMLButtonElement
+    expect(launch.disabled).toBe(true)
+
+    fireEvent.change(screen.getByLabelText('What should be different by morning?'), {
+      target: { value: 'Ship the first Nattpasset slice' }
+    })
+    fireEvent.change(screen.getByLabelText('How will we know it is done?'), {
+      target: { value: 'Focused tests pass\nThe launch state is honest' }
+    })
+
+    expect(launch.disabled).toBe(true)
+    fireEvent.click(screen.getByRole('checkbox', { name: /Hermes Agent.*\/work\/hermes-agent/i }))
+    expect(launch.disabled).toBe(false)
+
+    fireEvent.click(launch)
+
+    expect(onLaunch).toHaveBeenCalledTimes(1)
+    expect(onLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        project,
+        prompt: expect.stringContaining('Ship the first Nattpasset slice')
+      }),
+      expect.any(Function)
+    )
+  })
+
+  it('fails closed when no project with a workspace is available', () => {
+    render(<NattpassetView activeProjectId={null} onClose={vi.fn()} onLaunch={vi.fn()} projects={[]} />)
+
+    expect(screen.getByText(/Create or select a project with a workspace/i)).toBeTruthy()
+    expect((screen.getByRole('button', { name: 'Start Nattpasset' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('ignores an older failed launch after a newer launch succeeds', async () => {
+    const secondProject = { ...project, id: 'p_two', name: 'Second Project', primary_path: '/work/two' }
+    let resolveFirst!: (accepted: boolean) => void
+
+    const first = new Promise<boolean>(resolve => {
+      resolveFirst = resolve
+    })
+
+    const onLaunch = vi.fn().mockReturnValueOnce(first).mockResolvedValueOnce(true)
+
+    render(
+      <NattpassetView
+        activeProjectId="p_hermes"
+        onClose={vi.fn()}
+        onLaunch={onLaunch}
+        projects={[project, secondProject]}
+      />
+    )
+    fireEvent.change(screen.getByLabelText('What should be different by morning?'), { target: { value: 'First goal' } })
+    fireEvent.change(screen.getByLabelText('How will we know it is done?'), { target: { value: 'Done' } })
+    fireEvent.click(screen.getByRole('checkbox', { name: /Hermes Agent.*\/work\/hermes-agent/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Start Nattpasset' }))
+
+    fireEvent.click(screen.getByRole('button', { name: /Second Project/i }))
+    fireEvent.click(screen.getByRole('checkbox', { name: /Second Project.*\/work\/two/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Start Nattpasset' }))
+    await act(async () => undefined)
+
+    expect(onLaunch).toHaveBeenCalledTimes(2)
+    expect(screen.getByRole('button', { name: 'Starting…' })).toBeTruthy()
+
+    await act(async () => resolveFirst(false))
+
+    expect(screen.getByRole('button', { name: 'Starting…' })).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/nattpasset/index.tsx
+++ b/apps/desktop/src/app/nattpasset/index.tsx
@@ -1,0 +1,282 @@
+import { useMemo, useRef, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { useI18n } from '@/i18n'
+import type { ProjectInfo } from '@/types/hermes'
+
+import { Panel, PanelHeader } from '../overlays/panel'
+
+interface NattpassMissionInput {
+  acceptanceCriteria: string[]
+  goal: string
+  project: ProjectInfo
+}
+
+interface NattpassLaunch extends NattpassMissionInput {
+  prompt: string
+}
+
+interface NattpassetViewProps {
+  activeProjectId: null | string
+  onClose: () => void
+  onLaunch: (mission: NattpassLaunch, isCurrent: () => boolean) => Promise<boolean> | boolean
+  projects: ProjectInfo[]
+}
+
+export function nattpassProjectWorkspace(project: ProjectInfo): string {
+  return (project.primary_path || project.folders.find(folder => folder.is_primary)?.path || '').trim()
+}
+
+export interface NattpassLaunchContext {
+  activeProjectId: null | string
+  cwd: string
+  freshDraftReady: boolean
+  onFreshDraftRoute: boolean
+  profile: string
+  project: null | ProjectInfo
+  runtimeSessionId: null | string
+  storedSessionId: null | string
+}
+
+export interface ExpectedNattpassLaunchContext {
+  activeProjectId: null | string
+  profile: string
+  projectId: string
+  workspace: string
+}
+
+export function nattpassLaunchContextMatches(
+  expected: ExpectedNattpassLaunchContext,
+  current: NattpassLaunchContext
+): boolean {
+  return Boolean(
+    current.activeProjectId === expected.activeProjectId &&
+    current.profile === expected.profile &&
+    current.project?.id === expected.projectId &&
+    !current.project.archived &&
+    nattpassProjectWorkspace(current.project) === expected.workspace &&
+    current.runtimeSessionId === null &&
+    current.storedSessionId === null &&
+    current.freshDraftReady &&
+    current.cwd === expected.workspace &&
+    current.onFreshDraftRoute
+  )
+}
+
+export function buildNattpassMission({ acceptanceCriteria, goal, project }: NattpassMissionInput): string {
+  const workspace = nattpassProjectWorkspace(project)
+  const criteria = acceptanceCriteria.map((criterion, index) => `${index + 1}. ${criterion}`).join('\n')
+
+  return `NATTPASSET — LIVE OPERATOR MISSION
+
+Mission
+${goal.trim()}
+
+Acceptance criteria
+${criteria}
+
+Scope identity supplied by Hermes Desktop
+- Project: ${project.name}
+- Project id: ${project.id}
+- Expected workspace: ${workspace}
+
+Mandatory scope gate — do this before any work
+Verify the actual cwd, repository identity, git remotes, branch, and worktree status against the scope above. If the identity is missing, ambiguous, stale, dirty in a way that makes the mission unsafe, or does not match, STOP before editing or launching subagents and ask for a decision under BESLUT KRÄVS. Never silently retarget the mission.
+
+Execution contract
+- Restate the mission and acceptance criteria in plain language, then create a concrete todo plan.
+- Perform the work through Hermes' existing todo, delegation, Kanban, and cron capabilities as appropriate. Do not create or pretend there is a second agent system.
+- Keep working until the acceptance criteria have been exercised with real evidence. Do not substitute mock or demo runtime data for execution.
+- This launch is a live session, not durable overnight execution. If the mission must survive a runtime restart, say so and use an existing durable mechanism such as cron where it genuinely fits; otherwise list that limitation under KVAR.
+- Surface blockers as soon as they prevent safe progress. Do not claim success for work that was not run or verified.
+
+Final handoff
+End with exactly these headings and put every claim under one of them:
+KLART — what was actually delivered.
+VERIFIERAT — concrete checks run and their observed results.
+KVAR — incomplete work or limitations, including durability.
+BESLUT KRÄVS — only decisions that require the operator; write “Inget” when none are needed.
+`
+}
+
+export async function launchNattpassMission(
+  mission: Pick<NattpassLaunch, 'project' | 'prompt'>,
+  startFreshSessionDraft: (workspace: string) => void,
+  waitForFreshDraftRoute: () => Promise<void>,
+  submitPrompt: (prompt: string) => Promise<boolean> | boolean,
+  isLaunchContextCurrent: () => boolean
+): Promise<boolean> {
+  const workspace = nattpassProjectWorkspace(mission.project)
+
+  if (!workspace) {
+    return false
+  }
+
+  startFreshSessionDraft(workspace)
+  await waitForFreshDraftRoute()
+
+  if (!isLaunchContextCurrent()) {
+    return false
+  }
+
+  return submitPrompt(mission.prompt)
+}
+
+export function NattpassetView({ activeProjectId, onClose, onLaunch, projects }: NattpassetViewProps) {
+  const { t } = useI18n()
+  const copy = t.nattpasset
+
+  const eligibleProjects = useMemo(
+    () => projects.filter(project => !project.archived && Boolean(nattpassProjectWorkspace(project))),
+    [projects]
+  )
+
+  const initialProject = eligibleProjects.some(project => project.id === activeProjectId)
+    ? activeProjectId
+    : eligibleProjects.length === 1
+      ? eligibleProjects[0].id
+      : null
+
+  const [projectId, setProjectId] = useState<null | string>(initialProject)
+  const [goal, setGoal] = useState('')
+  const [criteriaText, setCriteriaText] = useState('')
+  const [scopeConfirmed, setScopeConfirmed] = useState(false)
+  const [launching, setLaunching] = useState(false)
+  const launchGenerationRef = useRef(0)
+
+  const selectedProject = eligibleProjects.find(project => project.id === projectId) ?? null
+
+  const criteria = criteriaText
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+
+  const canLaunch = Boolean(selectedProject && goal.trim() && criteria.length && scopeConfirmed && !launching)
+
+  const invalidatePendingLaunch = () => {
+    if (launching) {
+      launchGenerationRef.current += 1
+      setLaunching(false)
+    }
+  }
+
+  const launch = async () => {
+    if (!selectedProject || !canLaunch) {
+      return
+    }
+
+    const requestId = launchGenerationRef.current + 1
+    launchGenerationRef.current = requestId
+    setLaunching(true)
+    const mission = { acceptanceCriteria: criteria, goal: goal.trim(), project: selectedProject }
+    let accepted = false
+
+    try {
+      accepted = await onLaunch(
+        { ...mission, prompt: buildNattpassMission(mission) },
+        () => launchGenerationRef.current === requestId
+      )
+    } catch {
+      accepted = false
+    }
+
+    if (launchGenerationRef.current === requestId && !accepted) {
+      setLaunching(false)
+    }
+  }
+
+  return (
+    <Panel closeLabel={copy.close} contentClassName="max-w-3xl self-center" onClose={onClose}>
+      <PanelHeader subtitle={copy.subtitle} title={copy.title} />
+      <div className="min-h-0 flex-1 overflow-y-auto px-1 pb-1">
+        <p className="mb-5 text-sm text-(--ui-text-secondary)">{copy.intro}</p>
+
+        <section className="mb-5">
+          <h3 className="mb-1 text-xs font-semibold text-foreground">{copy.goalLabel}</h3>
+          <Textarea
+            aria-label={copy.goalQuestion}
+            onChange={event => {
+              invalidatePendingLaunch()
+              setGoal(event.target.value)
+            }}
+            placeholder={copy.goalPlaceholder}
+            value={goal}
+          />
+        </section>
+
+        <section className="mb-5">
+          <h3 className="mb-1 text-xs font-semibold text-foreground">{copy.criteriaLabel}</h3>
+          <Textarea
+            aria-label={copy.criteriaQuestion}
+            onChange={event => {
+              invalidatePendingLaunch()
+              setCriteriaText(event.target.value)
+            }}
+            placeholder={copy.criteriaPlaceholder}
+            value={criteriaText}
+          />
+          <p className="mt-1 text-xs text-(--ui-text-tertiary)">{copy.criteriaHint}</p>
+        </section>
+
+        <section className="mb-5">
+          <h3 className="mb-1 text-xs font-semibold text-foreground">{copy.scopeLabel}</h3>
+          {eligibleProjects.length ? (
+            <div className="space-y-1">
+              {eligibleProjects.map(project => {
+                const workspace = nattpassProjectWorkspace(project)
+                const selected = project.id === projectId
+
+                return (
+                  <button
+                    aria-pressed={selected}
+                    className="row-hover flex w-full cursor-pointer items-start gap-2 rounded-md px-2 py-2 text-left"
+                    key={project.id}
+                    onClick={() => {
+                      invalidatePendingLaunch()
+                      setProjectId(project.id)
+                      setScopeConfirmed(false)
+                    }}
+                    type="button"
+                  >
+                    <span aria-hidden="true" className="mt-1 text-(--ui-text-tertiary)">{selected ? '●' : '○'}</span>
+                    <span className="min-w-0">
+                      <span className="block text-sm font-medium text-foreground">{project.name}</span>
+                      <span className="block truncate text-xs text-(--ui-text-tertiary)">{workspace}</span>
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+          ) : (
+            <p className="text-sm text-(--ui-text-secondary)">{copy.noProject}</p>
+          )}
+
+          {selectedProject ? (
+            <label className="mt-3 flex cursor-pointer items-start gap-2 text-sm text-(--ui-text-secondary)">
+              <input
+                checked={scopeConfirmed}
+                className="mt-0.5"
+                onChange={event => {
+                  invalidatePendingLaunch()
+                  setScopeConfirmed(event.target.checked)
+                }}
+                type="checkbox"
+              />
+              <span>{copy.confirmScope(selectedProject.name, nattpassProjectWorkspace(selectedProject))}</span>
+            </label>
+          ) : null}
+        </section>
+
+        <p className="mb-5 text-xs text-(--ui-text-tertiary)">{copy.liveNotice}</p>
+
+        <div className="flex justify-end gap-2">
+          <Button onClick={onClose} variant="secondary">{copy.cancel}</Button>
+          <Button disabled={!canLaunch} onClick={() => void launch()}>
+            {launching ? copy.launching : copy.launch}
+          </Button>
+        </div>
+      </div>
+    </Panel>
+  )
+}

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -14,6 +14,7 @@ export const CRON_ROUTE = '/cron'
 export const PROFILES_ROUTE = '/profiles'
 export const AGENTS_ROUTE = '/agents'
 export const STARMAP_ROUTE = '/starmap'
+export const NATTPASSET_ROUTE = '/nattpasset'
 
 export type AppView =
   | 'agents'
@@ -27,6 +28,7 @@ export type AppView =
   // session-title dropdown while a plugin page was showing.
   | 'extension'
   | 'messaging'
+  | 'nattpasset'
   | 'profiles'
   | 'settings'
   | 'skills'
@@ -38,6 +40,7 @@ export type AppRouteId =
   | 'command-center'
   | 'cron'
   | 'messaging'
+  | 'nattpasset'
   | 'new'
   | 'profiles'
   | 'settings'
@@ -56,6 +59,7 @@ export const APP_ROUTES = [
   { id: 'command-center', path: COMMAND_CENTER_ROUTE, view: 'command-center' },
   { id: 'skills', path: SKILLS_ROUTE, view: 'skills' },
   { id: 'messaging', path: MESSAGING_ROUTE, view: 'messaging' },
+  { id: 'nattpasset', path: NATTPASSET_ROUTE, view: 'nattpasset' },
   { id: 'artifacts', path: ARTIFACTS_ROUTE, view: 'artifacts' },
   { id: 'cron', path: CRON_ROUTE, view: 'cron' },
   { id: 'profiles', path: PROFILES_ROUTE, view: 'profiles' },
@@ -119,6 +123,7 @@ export const OVERLAY_VIEWS: ReadonlySet<AppView> = new Set([
   'agents',
   'command-center',
   'cron',
+  'nattpasset',
   'profiles',
   'settings',
   'starmap'

--- a/apps/desktop/src/app/shell/hooks/use-overlay-routing.ts
+++ b/apps/desktop/src/app/shell/hooks/use-overlay-routing.ts
@@ -23,6 +23,7 @@ export function useOverlayRouting() {
   const agentsOpen = currentView === 'agents'
   const starmapOpen = currentView === 'starmap'
   const cronOpen = currentView === 'cron'
+  const nattpassetOpen = currentView === 'nattpasset'
   const profilesOpen = currentView === 'profiles'
   const chatOpen = currentView === 'chat'
   const overlayOpen = isOverlayView(currentView)
@@ -70,6 +71,7 @@ export function useOverlayRouting() {
     commandCenterInitialSection,
     commandCenterOpen,
     cronOpen,
+    nattpassetOpen,
     currentView,
     openAgents,
     openCommandCenterSection,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1440,6 +1440,28 @@ export const en: Translations = {
     failedRename: 'Failed to rename profile'
   },
 
+  nattpasset: {
+    close: 'Close Nattpasset',
+    title: 'Nattpasset',
+    subtitle: 'Define the outcome. Hermes handles the implementation.',
+    intro: 'Answer two questions, confirm the project, and start a real operator mission.',
+    goalLabel: '1. Outcome',
+    goalQuestion: 'What should be different by morning?',
+    goalPlaceholder: 'Describe the result in your own words…',
+    criteriaLabel: '2. Done means',
+    criteriaQuestion: 'How will we know it is done?',
+    criteriaPlaceholder: 'One observable result per line…',
+    criteriaHint: 'Use things you can see or verify. You do not need to describe the implementation.',
+    scopeLabel: '3. Project and scope',
+    noProject: 'Create or select a project with a workspace before starting Nattpasset.',
+    confirmScope: (name, path) => `I confirm that ${name} at ${path} is the intended project.`,
+    liveNotice:
+      'This first slice starts now in a live Hermes session. It is not yet durable across app or runtime restarts; Hermes will report that honestly under KVAR.',
+    cancel: 'Cancel',
+    launch: 'Start Nattpasset',
+    launching: 'Starting…'
+  },
+
   cron: {
     close: 'Close cron',
     title: 'Scheduled jobs',
@@ -1597,7 +1619,8 @@ export const en: Translations = {
       'new-session': 'New session',
       skills: 'Capabilities',
       messaging: 'Messaging',
-      artifacts: 'Artifacts'
+      artifacts: 'Artifacts',
+      nattpasset: 'Nattpasset'
     },
     searchAria: 'Search sessions',
     searchPlaceholder: 'Search sessions…',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1368,6 +1368,28 @@ export const ja = defineLocale({
     failedRename: 'プロファイルの名前変更に失敗しました'
   },
 
+  nattpasset: {
+    close: 'Nattpasset を閉じる',
+    title: 'Nattpasset',
+    subtitle: '成果を定義すれば、実装は Hermes が進めます。',
+    intro: '2 つの質問に答え、プロジェクトを確認して、実際のオペレーターミッションを開始します。',
+    goalLabel: '1. 成果',
+    goalQuestion: '朝までに何が変わっていてほしいですか？',
+    goalPlaceholder: '望む結果を自分の言葉で説明してください…',
+    criteriaLabel: '2. 完了の条件',
+    criteriaQuestion: '完了したとどう判断しますか？',
+    criteriaPlaceholder: '確認できる結果を 1 行に 1 つ…',
+    criteriaHint: '見たり確認したりできる条件を書いてください。実装方法の説明は不要です。',
+    scopeLabel: '3. プロジェクトと範囲',
+    noProject: 'Nattpasset を開始する前に、ワークスペースのあるプロジェクトを作成または選択してください。',
+    confirmScope: (name, path) => `${path} の ${name} が対象プロジェクトであることを確認します。`,
+    liveNotice:
+      'この最初のスライスは、実際の Hermes セッションですぐに開始します。アプリやランタイムの再起動をまたぐ耐久性はまだなく、Hermes は KVAR で正直に報告します。',
+    cancel: 'キャンセル',
+    launch: 'Nattpasset を開始',
+    launching: '開始中…'
+  },
+
   cron: {
     close: 'Cron を閉じる',
     title: 'スケジュール済みジョブ',
@@ -1526,7 +1548,8 @@ export const ja = defineLocale({
       'new-session': '新しいセッション',
       skills: 'スキルとツール',
       messaging: 'メッセージング',
-      artifacts: 'アーティファクト'
+      artifacts: 'アーティファクト',
+      nattpasset: 'Nattpasset'
     },
     searchAria: 'セッションを検索',
     searchPlaceholder: 'セッションを検索…',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1210,6 +1210,27 @@ export interface Translations {
     failedRename: string
   }
 
+  nattpasset: {
+    close: string
+    title: string
+    subtitle: string
+    intro: string
+    goalLabel: string
+    goalQuestion: string
+    goalPlaceholder: string
+    criteriaLabel: string
+    criteriaQuestion: string
+    criteriaPlaceholder: string
+    criteriaHint: string
+    scopeLabel: string
+    noProject: string
+    confirmScope: (name: string, path: string) => string
+    liveNotice: string
+    cancel: string
+    launch: string
+    launching: string
+  }
+
   cron: {
     close: string
     title: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1321,6 +1321,28 @@ export const zhHant = defineLocale({
     failedRename: '重新命名設定檔失敗'
   },
 
+  nattpasset: {
+    close: '關閉 Nattpasset',
+    title: 'Nattpasset',
+    subtitle: '定義成果，Hermes 負責實作。',
+    intro: '回答兩個問題、確認專案，然後啟動真實的操作任務。',
+    goalLabel: '1. 成果',
+    goalQuestion: '到了早上，什麼應該有所不同？',
+    goalPlaceholder: '用你自己的話描述想要的結果…',
+    criteriaLabel: '2. 完成代表',
+    criteriaQuestion: '我們如何知道它已完成？',
+    criteriaPlaceholder: '每行寫一個可觀察的結果…',
+    criteriaHint: '請使用你能看到或驗證的條件，不需要描述實作方式。',
+    scopeLabel: '3. 專案與範圍',
+    noProject: '啟動 Nattpasset 前，請建立或選擇一個有工作區的專案。',
+    confirmScope: (name, path) => `我確認位於 ${path} 的 ${name} 是目標專案。`,
+    liveNotice:
+      '此第一個切片會立即在真實 Hermes 工作階段中啟動。目前尚無法跨應用程式或執行階段重新啟動持久執行；Hermes 會在 KVAR 中如實回報。',
+    cancel: '取消',
+    launch: '啟動 Nattpasset',
+    launching: '正在啟動…'
+  },
+
   cron: {
     close: '關閉排程',
     title: '排程工作',
@@ -1477,7 +1499,8 @@ export const zhHant = defineLocale({
       'new-session': '新工作階段',
       skills: '技能與工具',
       messaging: '訊息平台',
-      artifacts: '成品'
+      artifacts: '成品',
+      nattpasset: 'Nattpasset'
     },
     searchAria: '搜尋工作階段',
     searchPlaceholder: '搜尋工作階段…',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1624,6 +1624,28 @@ export const zh: Translations = {
     failedRename: '重命名配置档案失败'
   },
 
+  nattpasset: {
+    close: '关闭 Nattpasset',
+    title: 'Nattpasset',
+    subtitle: '定义结果，Hermes 负责实施。',
+    intro: '回答两个问题、确认项目，然后启动真实的操作任务。',
+    goalLabel: '1. 结果',
+    goalQuestion: '到早上时，什么应该有所不同？',
+    goalPlaceholder: '用你自己的话描述想要的结果…',
+    criteriaLabel: '2. 完成意味着',
+    criteriaQuestion: '我们如何知道它已完成？',
+    criteriaPlaceholder: '每行写一个可观察的结果…',
+    criteriaHint: '请使用你能看到或验证的条件，无需描述实现方式。',
+    scopeLabel: '3. 项目和范围',
+    noProject: '启动 Nattpasset 前，请创建或选择一个带工作区的项目。',
+    confirmScope: (name, path) => `我确认位于 ${path} 的 ${name} 是目标项目。`,
+    liveNotice:
+      '此首个切片会立即在真实 Hermes 会话中启动。目前尚不能跨应用或运行时重启持久执行；Hermes 会在 KVAR 中如实报告。',
+    cancel: '取消',
+    launch: '启动 Nattpasset',
+    launching: '正在启动…'
+  },
+
   cron: {
     close: '关闭定时任务',
     title: '定时任务',
@@ -1780,7 +1802,8 @@ export const zh: Translations = {
       'new-session': '新建会话',
       skills: '技能与工具',
       messaging: '消息平台',
-      artifacts: '产物'
+      artifacts: '产物',
+      nattpasset: 'Nattpasset'
     },
     searchAria: '搜索会话',
     searchPlaceholder: '搜索会话…',


### PR DESCRIPTION
## Summary
- add a project-scoped Nattpasset mission launcher to Hermes Desktop
- fail closed if project/profile/session identity changes while a fresh draft is routed
- guard overlapping launches with a monotonic generation token

## Verification
- Desktop UI suite: 1,721 passed, 1 skipped
- focused Nattpasset suite: 8 passed
- TypeScript typecheck: passed
- targeted ESLint: passed
- Desktop production build: passed
- git diff --check: passed

Draft pending manual Desktop interaction E2E.