### PR TITLE
fix(gateway): prefix all busy-ack messages with [System]

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5768,9 +5768,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
             if self._queue_during_drain_enabled():
                 self._queue_or_replace_pending_event(session_key, event)
-                message = f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
+                message = f"[System] ⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
             else:
-                message = f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
+                message = f"[System] ⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
 
             await adapter._send_with_retry(
                 chat_id=event.source.chat_id,
@@ -6116,6 +6116,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 mark_seen(_hermes_home / "config.yaml", BUSY_INPUT_FLAG)
         except Exception as _onb_err:
             logger.debug("Failed to apply busy-input onboarding hint: %s", _onb_err)
+
+        # Prefix all busy-ack messages with [System] so the user and the
+        # agent can distinguish automated gateway notices from agent replies.
+        # Applied after the final message is selected (including onboarding hint
+        # append) so every busy mode -- steer, queue, interrupt, subagent, and
+        # compression demotion -- is uniformly prefixed. LINE's
+        # _is_system_bypass() strips this prefix before matching its known
+        # emoji prefixes, so the bypass contract for interrupt/queue/steer
+        # acks continues to work (see plugins/platforms/line/adapter.py).
+        message = "[System] " + message
 
         reply_anchor = self._reply_anchor_for_event(event)
         thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -613,6 +613,12 @@ _SYSTEM_BYPASS_PREFIXES: Tuple[str, ...] = (
 def _is_system_bypass(content: str) -> bool:
     if not content:
         return False
+    # All gateway busy-ack and drain-ack messages are now wrapped with a
+    # "[System] " prefix for user/agent legibility (gateway/run.py). Strip
+    # it before checking so the bypass contract keeps matching regardless
+    # of the wrapper.
+    if content.startswith("[System] "):
+        content = content[len("[System] "):]
     return any(content.startswith(p) for p in _SYSTEM_BYPASS_PREFIXES)
 
 

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -694,6 +694,144 @@ class TestBusySessionAck:
         assert result is False  # not handled, let default path try
 
 
+class TestBusyAckSystemPrefix:
+    """All busy-ack and drain-ack messages must carry a '[System] ' prefix
+    so users/the agent can distinguish automated gateway notices from agent
+    replies, and so LINE's postback-bypass detection (which strips this
+    prefix before matching) keeps working across every mode."""
+
+    def _content_of(self, adapter):
+        call_kwargs = adapter._send_with_retry.call_args
+        return call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
+
+    @pytest.mark.asyncio
+    async def test_interrupt_mode_prefixed(self):
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+        event = _make_event(text="hi")
+        sk = build_session_key(event.source)
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {}
+        runner._running_agents[sk] = agent
+        runner.adapters[event.source.platform] = adapter
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        content = self._content_of(adapter)
+        assert content.startswith("[System] "), content
+        assert "Interrupting" in content
+
+    @pytest.mark.asyncio
+    async def test_queue_mode_prefixed(self):
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+        event = _make_event(text="hi")
+        sk = build_session_key(event.source)
+        runner._running_agents[sk] = MagicMock()
+        runner.adapters[event.source.platform] = adapter
+
+        with patch("gateway.run.merge_pending_message_event"):
+            await runner._handle_active_session_busy_message(event, sk)
+
+        content = self._content_of(adapter)
+        assert content.startswith("[System] "), content
+        assert "Queued for the next turn" in content
+
+    @pytest.mark.asyncio
+    async def test_steer_mode_prefixed(self, monkeypatch):
+        import gateway.run as _gr
+
+        monkeypatch.delenv("HERMES_GATEWAY_BUSY_STEER_ACK_ENABLED", raising=False)
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+        event = _make_event(text="steer this")
+        sk = build_session_key(event.source)
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+        runner.adapters[event.source.platform] = adapter
+
+        with patch("gateway.run.merge_pending_message_event"):
+            await runner._handle_active_session_busy_message(event, sk)
+
+        content = self._content_of(adapter)
+        assert content.startswith("[System] "), content
+        assert "Steered" in content
+
+    @pytest.mark.asyncio
+    async def test_subagent_demotion_prefixed(self, monkeypatch):
+        """interrupt demoted to queue because the running agent has active
+        subagents (#30170) — a distinct message branch from plain queue."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+        event = _make_event(text="hi")
+        sk = build_session_key(event.source)
+        runner._running_agents[sk] = MagicMock()
+        runner.adapters[event.source.platform] = adapter
+        monkeypatch.setattr(
+            type(runner), "_agent_has_active_subagents", staticmethod(lambda _agent: True)
+        )
+
+        with patch("gateway.run.merge_pending_message_event"):
+            await runner._handle_active_session_busy_message(event, sk)
+
+        content = self._content_of(adapter)
+        assert content.startswith("[System] "), content
+        assert "Subagent working" in content
+
+    @pytest.mark.asyncio
+    async def test_compression_demotion_prefixed(self, monkeypatch):
+        """interrupt demoted to queue because compression is in flight (#56391)."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+        event = _make_event(text="hi")
+        sk = build_session_key(event.source)
+        runner._running_agents[sk] = MagicMock()
+        runner.adapters[event.source.platform] = adapter
+        monkeypatch.setattr(
+            type(runner), "_agent_has_active_subagents", staticmethod(lambda _agent: False)
+        )
+
+        async def _compression_in_flight(_sk):
+            return True
+
+        runner._session_has_compression_in_flight = _compression_in_flight
+
+        with patch("gateway.run.merge_pending_message_event"):
+            await runner._handle_active_session_busy_message(event, sk)
+
+        content = self._content_of(adapter)
+        assert content.startswith("[System] "), content
+        assert "Compressing context" in content
+
+    @pytest.mark.asyncio
+    async def test_draining_case_prefixed(self):
+        """The draining-case ack is a separate early-return branch from the
+        busy-mode message selection above; it must also carry the prefix."""
+        runner, sentinel = _make_runner()
+        runner._draining = True
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+        event = _make_event(text="hello")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+        runner._queue_during_drain_enabled = lambda: True
+        runner._status_action_gerund = lambda: "restarting"
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        content = self._content_of(adapter)
+        assert content.startswith("[System] "), content
+        assert "restarting" in content
+
+
 class TestBusySessionOnboardingHint:
     """First-touch hint appended to the busy-ack the first time it fires."""
 

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -324,6 +324,16 @@ class TestSendRouting:
         assert not _is_system_bypass("Hello world")
         assert not _is_system_bypass("")
 
+    def test_system_bypass_recognized_with_system_prefix(self):
+        """gateway/run.py wraps all busy-ack messages with a '[System] '
+        prefix; the bypass check must strip it before matching the known
+        emoji prefixes, or every busy-ack silently stops bypassing the
+        postback cache on LINE."""
+        assert _is_system_bypass("[System] ⚡ Interrupting current run")
+        assert _is_system_bypass("[System] ⏳ Queued — agent is busy")
+        assert _is_system_bypass("[System] ⏩ Steered toward new task")
+        assert not _is_system_bypass("[System] Hello world")
+
     def test_send_uses_reply_when_token_present(self, adapter):
         import time as _time
         adapter._reply_tokens["Uchat"] = ("rt-token", _time.time() + 30)
@@ -376,6 +386,20 @@ class TestSendRouting:
         # Bypass goes through push (no reply token stored)
         adapter._client.push.assert_called_once()
         # And the cache entry is unchanged (still PENDING for the eventual answer)
+        assert adapter._cache.get(rid).state is State.PENDING
+
+    def test_send_system_prefixed_busy_ack_skips_postback_cache(self, adapter):
+        """Regression: gateway/run.py now sends '[System] ⚡ Interrupting...'
+        (not the bare emoji-prefixed string). A pending postback button must
+        not swallow this into the tap-to-reveal cache -- it must still push
+        through as a visible bubble, exactly like the bare-prefix case above."""
+        rid = adapter._cache.register_pending("Uchat")
+        adapter._pending_buttons["Uchat"] = rid
+        result = asyncio.run(
+            adapter.send("Uchat", "[System] ⚡ Interrupting current task. I'll respond to your message shortly.")
+        )
+        assert result.success
+        adapter._client.push.assert_called_once()
         assert adapter._cache.get(rid).state is State.PENDING
 
     def test_send_caps_messages_per_call_at_five(self, adapter):


### PR DESCRIPTION
## Context

Ports #64251 forward onto current main per @teknium1's review.

## Fix

All busy-ack modes (interrupt, queue, steer, subagent demotion, compression demotion) now emit a `[System] ` prefix.

Per review, this addresses two gaps the original port missed:

1. **LINE bypass regression**: `LineAdapter._is_system_bypass()` matched busy-acks via `startswith()` against bare emoji prefixes. With every busy-ack now wrapped in `[System] `, that check silently stopped matching -- a pending postback button would swallow busy-acks into the tap-to-reveal cache instead of surfacing them as visible bubbles. Fixed by stripping the wrapper before the prefix check.
2. **The draining-case acknowledgement** (gateway restarting/stopping) is a separate early-return branch that was never reached by the original single prefix assignment. It now gets the same prefix.

Dropped the incorrect `Fixes #21074` reference (closed, unrelated issue).

## Verification

Replaced source-inspection tests with handler-level `_send_with_retry` content assertions across all 5 busy modes plus draining, and added LINE-side coverage for the prefixed bypass case + a pending-postback behavioral test. 32/32 pass in `test_busy_session_ack.py` (26 existing + 6 new); 78/78 in `test_line_plugin.py` (76 existing + 2 new).