### PR TITLE
fix(desktop): keep long tool sessions responsive

### DIFF
--- a/apps/desktop/src/app/chat/long-tool-session.repro.test.tsx
+++ b/apps/desktop/src/app/chat/long-tool-session.repro.test.tsx
@@ -1,0 +1,237 @@
+// @vitest-environment jsdom
+import { AssistantRuntimeProvider, type ThreadMessage } from '@assistant-ui/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ChatBar } from '@/app/chat/composer'
+import { useRuntimeMessageRepository } from '@/app/chat/runtime-repository'
+import { Thread } from '@/components/assistant-ui/thread'
+import type { ChatMessage, ChatMessagePart } from '@/lib/chat-messages'
+import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
+
+const TARGET_CONTENT_CHARS = 650_451
+const MESSAGE_COUNT = 266
+const TOOL_CALL_COUNT = 143
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+vi.stubGlobal('CSS', { escape: (value: string) => value })
+vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => window.setTimeout(() => callback(performance.now()), 0))
+vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+
+Element.prototype.scrollTo = function scrollTo() {}
+
+Element.prototype.animate = function animate() {
+  return { cancel: () => {}, finished: Promise.resolve() } as unknown as Animation
+}
+
+function partChars(part: ChatMessagePart): number {
+  if (part.type === 'text' || part.type === 'reasoning') {
+    return part.text.length
+  }
+
+  if (part.type === 'tool-call') {
+    const output = (part.result as { output?: unknown } | undefined)?.output
+
+    return typeof output === 'string' ? output.length : 0
+  }
+
+  return 0
+}
+
+function makeFixture(): ChatMessage[] {
+  const messages: ChatMessage[] = []
+  let toolIndex = 0
+
+  for (let turn = 0; turn < MESSAGE_COUNT / 2; turn += 1) {
+    messages.push({
+      id: `fixture-user-${turn}`,
+      role: 'user',
+      parts: [{ type: 'text', text: `Inspect module ${turn} and explain the observed behavior without omitting evidence.` }],
+      timestamp: turn * 2
+    })
+
+    const parts: ChatMessagePart[] = []
+    const toolsThisTurn = turn < 10 ? 2 : 1
+
+    for (let index = 0; index < toolsThisTurn; index += 1) {
+      const id = `fixture-tool-${toolIndex++}`
+      parts.push({
+        type: 'tool-call',
+        toolCallId: id,
+        toolName: toolIndex % 3 === 0 ? 'terminal' : toolIndex % 3 === 1 ? 'search_files' : 'read_file',
+        args: { path: `/workspace/synthetic/module-${turn}.ts`, query: `symbol-${toolIndex}` },
+        argsText: JSON.stringify({ path: `/workspace/synthetic/module-${turn}.ts`, query: `symbol-${toolIndex}` }),
+        result: { output: `${id}\n${'deterministic tool output '.repeat(165)}` },
+        isError: false
+      })
+    }
+
+    parts.push({
+      type: 'text',
+      text: `Turn ${turn} complete. The fixture keeps all durable history while exercising markdown and tool rendering.\n\n\`\`\`ts\nexport const turn = ${turn}\n\`\`\``
+    })
+
+    messages.push({
+      id: `fixture-assistant-${turn}`,
+      role: 'assistant',
+      parts,
+      timestamp: turn * 2 + 1,
+      pending: false
+    })
+  }
+
+  const chars = messages.reduce((sum, message) => sum + message.parts.reduce((n, part) => n + partChars(part), 0), 0)
+  const pad = TARGET_CONTENT_CHARS - chars
+
+  if (pad < 0) {
+    throw new Error(`fixture exceeded target by ${-pad} chars`)
+  }
+
+  const last = messages.at(-1)
+  const text = last?.parts.at(-1)
+
+  if (!last || !text || text.type !== 'text') {
+    throw new Error('fixture tail missing')
+  }
+
+  last.parts[last.parts.length - 1] = { ...text, text: `${text.text}${'x'.repeat(pad)}` }
+
+  return messages
+}
+
+function makeSingleHeavyTurnFixture(): ChatMessage[] {
+  const parts: ChatMessagePart[] = Array.from({ length: TOOL_CALL_COUNT }, (_, index) => {
+    const id = `single-turn-tool-${index}`
+
+    return {
+      type: 'tool-call',
+      toolCallId: id,
+      toolName: index === 0 ? 'image_generate' : index % 2 === 0 ? 'read_file' : 'search_files',
+      args: { path: `/workspace/synthetic/heavy-${index}.ts` },
+      argsText: JSON.stringify({ path: `/workspace/synthetic/heavy-${index}.ts` }),
+      result: { output: `${id}\n${'single-turn tool output '.repeat(180)}` },
+      isError: false
+    }
+  })
+
+  const usedChars = parts.reduce((sum, part) => sum + partChars(part), 0)
+
+  parts.push({ type: 'text', text: `All tools complete.${'x'.repeat(TARGET_CONTENT_CHARS - usedChars - 19)}` })
+
+  return [
+    { id: 'single-turn-user', role: 'user', parts: [{ type: 'text', text: 'Inspect every result.' }], timestamp: 0 },
+    { id: 'single-turn-assistant', role: 'assistant', parts, timestamp: 1, pending: false }
+  ]
+}
+
+function Harness({ messages, onSubmit }: { messages: ChatMessage[]; onSubmit: (text: string) => boolean }) {
+  const repository = useRuntimeMessageRepository(messages)
+
+  const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({
+    messageRepository: repository,
+    isRunning: false,
+    onNew: async () => {},
+    setMessages: () => {}
+  })
+
+  return (
+    <MemoryRouter>
+      <AssistantRuntimeProvider runtime={runtime}>
+        <div style={{ height: 800, position: 'relative' }}>
+          <Thread clampToComposer sessionId="runtime-fixture" sessionKey="stored-fixture" />
+          <ChatBar
+            busy={false}
+            cwd="/workspace/synthetic"
+            disabled={false}
+            focusKey="runtime-fixture"
+            onCancel={() => {}}
+            onSubmit={onSubmit}
+            sessionId="runtime-fixture"
+            state={{
+              model: { canSwitch: true, model: 'synthetic-model', provider: 'custom' },
+              tools: { enabled: true, label: 'Add context' },
+              voice: { active: false, enabled: false }
+            }}
+          />
+        </div>
+      </AssistantRuntimeProvider>
+    </MemoryRouter>
+  )
+}
+
+afterEach(cleanup)
+
+describe('representative long tool-heavy session contract (#68467)', () => {
+  it('keeps the idle composer editable/sendable and bounds mounted history DOM', async () => {
+    const messages = makeFixture()
+    const toolCalls = messages.flatMap(message => message.parts).filter(part => part.type === 'tool-call')
+    const chars = messages.reduce((sum, message) => sum + message.parts.reduce((n, part) => n + partChars(part), 0), 0)
+    const onSubmit = vi.fn(() => true)
+
+    expect(messages).toHaveLength(MESSAGE_COUNT)
+    expect(toolCalls).toHaveLength(TOOL_CALL_COUNT)
+    expect(chars).toBe(TARGET_CONTENT_CHARS)
+
+    const view = render(<Harness messages={messages} onSubmit={onSubmit} />)
+
+    const editor = screen.getByRole('textbox', { name: /message/i })
+    expect(editor.getAttribute('contenteditable')).toBe('true')
+
+    editor.textContent = 'continue this session'
+    fireEvent.input(editor)
+    fireEvent.keyDown(editor, { key: 'Enter', code: 'Enter' })
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('continue this session', expect.anything()))
+    await act(async () => new Promise(resolve => window.setTimeout(resolve, 25)))
+
+    const mountedToolRows = view.container.querySelectorAll('[data-tool-row]').length
+    const mountedTurnGroups = view.container.querySelectorAll('[data-slot="aui_turn-pair"]').length
+    const showEarlier = screen.getByRole('button', { name: /earlier/i })
+
+    expect(showEarlier).toBeTruthy()
+    expect(showEarlier.getAttribute('type')).toBe('button')
+    expect(mountedToolRows).toBeLessThan(TOOL_CALL_COUNT)
+    expect(mountedTurnGroups).toBeLessThan(MESSAGE_COUNT / 2)
+
+    fireEvent.click(showEarlier)
+
+    await waitFor(() =>
+      expect(view.container.querySelectorAll('[data-slot="aui_turn-pair"]').length).toBeGreaterThan(mountedTurnGroups)
+    )
+    expect(view.container.querySelectorAll('[data-tool-row]').length).toBeGreaterThan(mountedToolRows)
+    expect(messages).toHaveLength(MESSAGE_COUNT)
+    expect(toolCalls).toHaveLength(TOOL_CALL_COUNT)
+  })
+
+  it('keeps one tool-heavy turn bounded by the existing tool-group window', async () => {
+    const messages = makeSingleHeavyTurnFixture()
+    const view = render(<Harness messages={messages} onSubmit={() => true} />)
+
+    await act(async () => new Promise(resolve => window.setTimeout(resolve, 25)))
+
+    expect(screen.getByRole('textbox', { name: /message/i }).getAttribute('contenteditable')).toBe('true')
+    const initialRows = view.container.querySelectorAll('[data-tool-row]').length
+    const showEarlier = screen.getByRole('button', { name: /earlier/i })
+
+    expect(initialRows).toBeLessThan(TOOL_CALL_COUNT)
+    expect(showEarlier.getAttribute('type')).toBe('button')
+    fireEvent.click(showEarlier)
+    expect(view.container.querySelectorAll('[data-tool-row]').length).toBeGreaterThan(initialRows)
+
+    while (screen.queryByRole('button', { name: /earlier/i })) {
+      fireEvent.click(screen.getByRole('button', { name: /earlier/i }))
+    }
+
+    expect(view.container.querySelectorAll('[data-tool-row]')).toHaveLength(TOOL_CALL_COUNT - 1)
+    expect(messages.flatMap(message => message.parts).filter(part => part.type === 'tool-call')).toHaveLength(
+      TOOL_CALL_COUNT
+    )
+  })
+})

--- a/apps/desktop/src/app/chat/long-tool-session.repro.test.tsx
+++ b/apps/desktop/src/app/chat/long-tool-session.repro.test.tsx
@@ -23,7 +23,9 @@ class TestResizeObserver {
 
 vi.stubGlobal('ResizeObserver', TestResizeObserver)
 vi.stubGlobal('CSS', { escape: (value: string) => value })
-vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => window.setTimeout(() => callback(performance.now()), 0))
+vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+  window.setTimeout(() => callback(performance.now()), 0)
+)
 vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
 
 Element.prototype.scrollTo = function scrollTo() {}
@@ -54,7 +56,9 @@ function makeFixture(): ChatMessage[] {
     messages.push({
       id: `fixture-user-${turn}`,
       role: 'user',
-      parts: [{ type: 'text', text: `Inspect module ${turn} and explain the observed behavior without omitting evidence.` }],
+      parts: [
+        { type: 'text', text: `Inspect module ${turn} and explain the observed behavior without omitting evidence.` }
+      ],
       timestamp: turn * 2
     })
 
@@ -185,7 +189,11 @@ function makeMinimalTurns(count: number, withLatestHeavyTools = 0): ChatMessage[
         : [{ type: 'text', text: `Answer ${turn}` }]
 
     return [
-      { id: `minimal-user-${turn}`, role: 'user' as const, parts: [{ type: 'text' as const, text: `Question ${turn}` }] },
+      {
+        id: `minimal-user-${turn}`,
+        role: 'user' as const,
+        parts: [{ type: 'text' as const, text: `Question ${turn}` }]
+      },
       { id: `minimal-assistant-${turn}`, role: 'assistant' as const, parts: assistantParts, pending: false }
     ]
   }).flat()

--- a/apps/desktop/src/app/chat/long-tool-session.repro.test.tsx
+++ b/apps/desktop/src/app/chat/long-tool-session.repro.test.tsx
@@ -9,6 +9,7 @@ import { useRuntimeMessageRepository } from '@/app/chat/runtime-repository'
 import { Thread } from '@/components/assistant-ui/thread'
 import type { ChatMessage, ChatMessagePart } from '@/lib/chat-messages'
 import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
+import { $previewStatusBySession, clearPreviewArtifacts } from '@/store/preview-status'
 
 const TARGET_CONTENT_CHARS = 650_451
 const MESSAGE_COUNT = 266
@@ -131,6 +132,65 @@ function makeSingleHeavyTurnFixture(): ChatMessage[] {
   ]
 }
 
+function makeInterleavedHeavyTurnFixture(toolCount = 160): ChatMessage[] {
+  const messages: ChatMessage[] = [
+    { id: 'interleaved-user', role: 'user', parts: [{ type: 'text', text: 'Inspect every result.' }], timestamp: 0 }
+  ]
+
+  let toolIndex = 0
+
+  for (let assistantIndex = 0; assistantIndex < 4; assistantIndex += 1) {
+    const parts: ChatMessagePart[] = []
+
+    while (toolIndex < Math.ceil(((assistantIndex + 1) * toolCount) / 4)) {
+      const id = `interleaved-tool-${toolIndex}`
+      parts.push({
+        type: 'tool-call',
+        toolCallId: id,
+        toolName: toolIndex % 2 === 0 ? 'read_file' : 'search_files',
+        args: { path: `/workspace/synthetic/interleaved-${toolIndex}.ts` },
+        argsText: JSON.stringify({ path: `/workspace/synthetic/interleaved-${toolIndex}.ts` }),
+        result: { output: `${id} complete` },
+        isError: false
+      })
+      parts.push({ type: 'text', text: `Narration after tool ${toolIndex}.` })
+      toolIndex += 1
+    }
+
+    messages.push({
+      id: `interleaved-assistant-${assistantIndex}`,
+      role: 'assistant',
+      parts,
+      timestamp: assistantIndex + 1,
+      pending: false
+    })
+  }
+
+  return messages
+}
+
+function makeMinimalTurns(count: number, withLatestHeavyTools = 0): ChatMessage[] {
+  return Array.from({ length: count }, (_, turn) => {
+    const assistantParts: ChatMessagePart[] =
+      turn === count - 1 && withLatestHeavyTools > 0
+        ? Array.from({ length: withLatestHeavyTools }, (__, tool) => ({
+            type: 'tool-call' as const,
+            toolCallId: `minimal-tool-${tool}`,
+            toolName: 'read_file',
+            args: { path: `/workspace/minimal-${tool}.ts` },
+            argsText: JSON.stringify({ path: `/workspace/minimal-${tool}.ts` }),
+            result: { output: `tool ${tool}` },
+            isError: false
+          }))
+        : [{ type: 'text', text: `Answer ${turn}` }]
+
+    return [
+      { id: `minimal-user-${turn}`, role: 'user' as const, parts: [{ type: 'text' as const, text: `Question ${turn}` }] },
+      { id: `minimal-assistant-${turn}`, role: 'assistant' as const, parts: assistantParts, pending: false }
+    ]
+  }).flat()
+}
+
 function Harness({ messages, onSubmit }: { messages: ChatMessage[]; onSubmit: (text: string) => boolean }) {
   const repository = useRuntimeMessageRepository(messages)
 
@@ -193,12 +253,16 @@ describe('representative long tool-heavy session contract (#68467)', () => {
 
     const mountedToolRows = view.container.querySelectorAll('[data-tool-row]').length
     const mountedTurnGroups = view.container.querySelectorAll('[data-slot="aui_turn-pair"]').length
-    const showEarlier = screen.getByRole('button', { name: /earlier/i })
+    const showEarlier = screen.getByRole('button', { name: 'Show earlier messages' })
 
     expect(showEarlier).toBeTruthy()
     expect(showEarlier.getAttribute('type')).toBe('button')
-    expect(mountedToolRows).toBeLessThan(TOOL_CALL_COUNT)
-    expect(mountedTurnGroups).toBeLessThan(MESSAGE_COUNT / 2)
+    expect(mountedToolRows).toBeLessThanOrEqual(20)
+    expect(mountedTurnGroups).toBeLessThanOrEqual(20)
+
+    await act(async () => new Promise(resolve => window.setTimeout(resolve, 25)))
+    expect(view.container.querySelectorAll('[data-tool-row]')).toHaveLength(mountedToolRows)
+    expect(view.container.querySelectorAll('[data-slot="aui_turn-pair"]')).toHaveLength(mountedTurnGroups)
 
     fireEvent.click(showEarlier)
 
@@ -218,20 +282,157 @@ describe('representative long tool-heavy session contract (#68467)', () => {
 
     expect(screen.getByRole('textbox', { name: /message/i }).getAttribute('contenteditable')).toBe('true')
     const initialRows = view.container.querySelectorAll('[data-tool-row]').length
-    const showEarlier = screen.getByRole('button', { name: /earlier/i })
+    const showEarlier = screen.getByRole('button', { name: 'Show earlier tool calls' })
 
     expect(initialRows).toBeLessThan(TOOL_CALL_COUNT)
     expect(showEarlier.getAttribute('type')).toBe('button')
     fireEvent.click(showEarlier)
     expect(view.container.querySelectorAll('[data-tool-row]').length).toBeGreaterThan(initialRows)
 
-    while (screen.queryByRole('button', { name: /earlier/i })) {
-      fireEvent.click(screen.getByRole('button', { name: /earlier/i }))
+    while (screen.queryByRole('button', { name: 'Show earlier tool calls' })) {
+      fireEvent.click(screen.getByRole('button', { name: 'Show earlier tool calls' }))
     }
 
     expect(view.container.querySelectorAll('[data-tool-row]')).toHaveLength(TOOL_CALL_COUNT - 1)
     expect(messages.flatMap(message => message.parts).filter(part => part.type === 'tool-call')).toHaveLength(
       TOOL_CALL_COUNT
     )
+  })
+
+  it('bounds an interleaved multi-message logical turn and progressively restores it in order', async () => {
+    const messages = makeInterleavedHeavyTurnFixture()
+    const view = render(<Harness messages={messages} onSubmit={() => true} />)
+
+    await act(async () => new Promise(resolve => window.setTimeout(resolve, 25)))
+
+    expect(view.container.querySelectorAll('[data-tool-page-key]')).toHaveLength(20)
+    expect(view.container.querySelectorAll('[data-tool-row]')).toHaveLength(20)
+
+    while (screen.queryByRole('button', { name: 'Show earlier tool calls' })) {
+      fireEvent.click(screen.getByRole('button', { name: 'Show earlier tool calls' }))
+    }
+
+    const keys = Array.from(view.container.querySelectorAll<HTMLElement>('[data-tool-page-key]')).map(
+      element => element.dataset.toolPageKey
+    )
+
+    expect(keys).toEqual(
+      Array.from(
+        { length: 160 },
+        (_, index) => `interleaved-assistant-${Math.floor(index / 40)}:interleaved-tool-${index}`
+      )
+    )
+    const firstTool = view.container.querySelector<HTMLElement>('[data-tool-page-key]')
+    const firstToolToggle = firstTool?.querySelector<HTMLButtonElement>('button[aria-expanded]')
+
+    if (!firstToolToggle) {
+      throw new Error('first restored tool is not expandable')
+    }
+
+    fireEvent.click(firstToolToggle)
+    expect(firstTool?.textContent).toContain('interleaved-tool-0 complete')
+    expect(view.container.textContent).toContain('Narration after tool 159.')
+    expect(messages.flatMap(message => message.parts).filter(part => part.type === 'tool-call')).toHaveLength(160)
+  })
+
+  it('keeps the oldest revealed tool stable when the same turn appends another call', async () => {
+    const initial = makeInterleavedHeavyTurnFixture(30)
+    const view = render(<Harness messages={initial} onSubmit={() => true} />)
+    const pager = screen.getByRole('button', { name: 'Show earlier tool calls' })
+
+    pager.focus()
+    fireEvent.click(pager)
+
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Show earlier tool calls' })).toBeNull())
+    const oldest = view.container.querySelector<HTMLElement>('[data-tool-page-key]')
+
+    expect(oldest?.dataset.toolPageKey).toBe('interleaved-assistant-0:interleaved-tool-0')
+    await waitFor(() => expect(globalThis.document.activeElement).toBe(oldest))
+
+    const appended = structuredClone(initial)
+    const lastAssistant = appended.at(-1)
+
+    if (!lastAssistant || lastAssistant.role !== 'assistant') {
+      throw new Error('missing assistant tail')
+    }
+
+    lastAssistant.parts.push({
+      type: 'tool-call',
+      toolCallId: 'interleaved-tool-30',
+      toolName: 'read_file',
+      args: { path: '/workspace/synthetic/interleaved-30.ts' },
+      argsText: JSON.stringify({ path: '/workspace/synthetic/interleaved-30.ts' }),
+      result: { output: 'interleaved-tool-30 complete' },
+      isError: false
+    })
+    view.rerender(<Harness messages={appended} onSubmit={() => true} />)
+
+    await waitFor(() => expect(view.container.querySelectorAll('[data-tool-page-key]')).toHaveLength(31))
+    expect(view.container.querySelector<HTMLElement>('[data-tool-page-key]')?.dataset.toolPageKey).toBe(
+      'interleaved-assistant-0:interleaved-tool-0'
+    )
+  })
+
+  it('keeps revealed history identity stable across append and transfers final pager focus', async () => {
+    const initial = makeMinimalTurns(25)
+    const view = render(<Harness messages={initial} onSubmit={() => true} />)
+    const pager = screen.getByRole('button', { name: 'Show earlier messages' })
+
+    pager.focus()
+    fireEvent.click(pager)
+
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Show earlier messages' })).toBeNull())
+    const oldest = view.container.querySelector<HTMLElement>('[data-history-group-id]')
+
+    expect(oldest?.dataset.historyGroupId).toBe('minimal-user-0')
+    await waitFor(() => expect(globalThis.document.activeElement).toBe(oldest))
+
+    const appended: ChatMessage[] = [
+      ...initial,
+      { id: 'minimal-user-25', role: 'user', parts: [{ type: 'text', text: 'Question 25' }] },
+      { id: 'minimal-assistant-25', role: 'assistant', parts: [{ type: 'text', text: 'Answer 25' }] }
+    ]
+
+    view.rerender(<Harness messages={appended} onSubmit={() => true} />)
+
+    await waitFor(() => expect(view.container.querySelectorAll('[data-history-group-id]')).toHaveLength(26))
+    expect(view.container.querySelector<HTMLElement>('[data-history-group-id]')?.dataset.historyGroupId).toBe(
+      'minimal-user-0'
+    )
+  })
+
+  it('keeps history and tool pagers uniquely named', () => {
+    render(<Harness messages={makeMinimalTurns(25, 25)} onSubmit={() => true} />)
+
+    expect(screen.getByRole('button', { name: 'Show earlier messages' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Show earlier tool calls' })).toBeTruthy()
+  })
+
+  it('registers a hidden preview artifact without mounting its heavy tool row', async () => {
+    clearPreviewArtifacts('runtime-fixture')
+    const messages = makeMinimalTurns(25)
+    const hiddenAssistant = messages[1]
+
+    hiddenAssistant.parts = [
+      {
+        type: 'tool-call',
+        toolCallId: 'hidden-preview-tool',
+        toolName: 'write_file',
+        args: { path: '/workspace/hidden-preview.html' },
+        argsText: JSON.stringify({ path: '/workspace/hidden-preview.html' }),
+        result: { output: 'created' },
+        isError: false
+      }
+    ]
+
+    const view = render(<Harness messages={messages} onSubmit={() => true} />)
+
+    await waitFor(() =>
+      expect($previewStatusBySession.get()['runtime-fixture']?.map(item => item.target)).toContain(
+        '/workspace/hidden-preview.html'
+      )
+    )
+    expect(view.container.querySelector('[data-tool-page-key*="hidden-preview-tool"]')).toBeNull()
+    expect(view.container.querySelectorAll('[data-slot="aui_turn-pair"]')).toHaveLength(20)
   })
 })

--- a/apps/desktop/src/app/chat/long-tool-session.repro.test.tsx
+++ b/apps/desktop/src/app/chat/long-tool-session.repro.test.tsx
@@ -562,6 +562,56 @@ describe('representative long tool-heavy session contract (#68467)', () => {
     unsubscribe()
   })
 
+  it('does not resurrect a dismissed tail preview when a failed rewind restores the timeline', async () => {
+    clearPreviewArtifacts('runtime-fixture')
+    const messages = makeMinimalTurns(2)
+    messages[3].parts = [
+      {
+        type: 'tool-call',
+        toolCallId: 'dismissed-rollback-preview',
+        toolName: 'write_file',
+        args: { path: '/workspace/dismissed-rollback.html' },
+        argsText: JSON.stringify({ path: '/workspace/dismissed-rollback.html' }),
+        result: { output: 'created' },
+        isError: false
+      }
+    ]
+    const view = render(<Harness messages={messages} onSubmit={() => true} />)
+
+    await waitFor(() =>
+      expect($previewStatusBySession.get()['runtime-fixture']?.map(item => item.target)).toEqual([
+        '/workspace/dismissed-rollback.html'
+      ])
+    )
+
+    act(() => dismissPreviewArtifact('runtime-fixture', '/workspace/dismissed-rollback.html'))
+    expect($previewStatusBySession.get()['runtime-fixture']).toBeUndefined()
+
+    act(() => clearPreviewArtifacts('runtime-fixture'))
+    view.rerender(<Harness messages={messages.slice(0, -2)} onSubmit={() => true} />)
+    expect($previewStatusBySession.get()['runtime-fixture']).toBeUndefined()
+
+    view.rerender(<Harness messages={messages} onSubmit={() => true} />)
+    await waitFor(() => expect(screen.getByText('Question 1')).toBeTruthy())
+    expect($previewStatusBySession.get()['runtime-fixture']).toBeUndefined()
+
+    const reproduced = structuredClone(messages)
+    const reproducedPart = reproduced[3].parts[0]
+
+    if (reproducedPart.type !== 'tool-call') {
+      throw new Error('expected the reproduced dismissed preview tool call')
+    }
+
+    reproduced[3].parts = [{ ...reproducedPart, toolCallId: 'reproduced-after-dismissed-rollback' }]
+    view.rerender(<Harness messages={reproduced} onSubmit={() => true} />)
+
+    await waitFor(() =>
+      expect($previewStatusBySession.get()['runtime-fixture']?.map(item => item.target)).toEqual([
+        '/workspace/dismissed-rollback.html'
+      ])
+    )
+  })
+
   it('re-registers the same preview target after a restored timeline produces it again', async () => {
     clearPreviewArtifacts('runtime-fixture')
     const withPreview = makeMinimalTurns(25)

--- a/apps/desktop/src/app/chat/long-tool-session.repro.test.tsx
+++ b/apps/desktop/src/app/chat/long-tool-session.repro.test.tsx
@@ -354,6 +354,32 @@ describe('representative long tool-heavy session contract (#68467)', () => {
     expect(messages.flatMap(message => message.parts).filter(part => part.type === 'tool-call')).toHaveLength(160)
   })
 
+  it('transfers focus through every pager before focusing the final revealed tool', async () => {
+    const view = render(<Harness messages={makeInterleavedHeavyTurnFixture(65)} onSubmit={() => true} />)
+
+    for (const expectedPagerKey of [
+      'interleaved-assistant-1:interleaved-tool-25',
+      'interleaved-assistant-0:interleaved-tool-5'
+    ]) {
+      const pager = screen.getByRole('button', { name: 'Show earlier tool calls' })
+
+      pager.focus()
+      fireEvent.click(pager)
+
+      const nextPager = screen.getByRole('button', { name: 'Show earlier tool calls' })
+      await waitFor(() => expect(globalThis.document.activeElement).toBe(nextPager))
+      expect(nextPager.dataset.toolPagePager).toBe(expectedPagerKey)
+    }
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show earlier tool calls' }))
+
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Show earlier tool calls' })).toBeNull())
+    const firstTool = view.container.querySelector<HTMLElement>('[data-tool-page-key]')
+
+    expect(firstTool?.dataset.toolPageKey).toBe('interleaved-assistant-0:interleaved-tool-0')
+    await waitFor(() => expect(globalThis.document.activeElement).toBe(firstTool))
+  })
+
   it('keeps the oldest revealed tool stable when the same turn appends another call', async () => {
     const initial = makeInterleavedHeavyTurnFixture(30)
     const view = render(<Harness messages={initial} onSubmit={() => true} />)

--- a/apps/desktop/src/app/chat/long-tool-session.repro.test.tsx
+++ b/apps/desktop/src/app/chat/long-tool-session.repro.test.tsx
@@ -469,6 +469,99 @@ describe('representative long tool-heavy session contract (#68467)', () => {
     expect(view.container.querySelectorAll('[data-slot="aui_turn-pair"]')).toHaveLength(20)
   })
 
+  it('reconciles a retained preview when rewind removes only a non-preview tail', async () => {
+    clearPreviewArtifacts('runtime-fixture')
+    const messages = makeMinimalTurns(2)
+    messages[1].parts = [
+      {
+        type: 'tool-call',
+        toolCallId: 'retained-preview',
+        toolName: 'write_file',
+        args: { path: '/workspace/retained.html' },
+        argsText: JSON.stringify({ path: '/workspace/retained.html' }),
+        result: { output: 'created' },
+        isError: false
+      }
+    ]
+    const view = render(<Harness messages={messages} onSubmit={() => true} />)
+
+    await waitFor(() =>
+      expect($previewStatusBySession.get()['runtime-fixture']?.map(item => item.target)).toEqual([
+        '/workspace/retained.html'
+      ])
+    )
+
+    act(() => clearPreviewArtifacts('runtime-fixture'))
+    view.rerender(<Harness messages={messages.slice(0, -2)} onSubmit={() => true} />)
+
+    await waitFor(() =>
+      expect($previewStatusBySession.get()['runtime-fixture']?.map(item => item.target)).toEqual([
+        '/workspace/retained.html'
+      ])
+    )
+  })
+
+  it('restores a failed rewind tail once without replay churn', async () => {
+    clearPreviewArtifacts('runtime-fixture')
+    const messages = makeMinimalTurns(2)
+    messages[1].parts = [
+      {
+        type: 'tool-call',
+        toolCallId: 'rollback-retained-preview',
+        toolName: 'write_file',
+        args: { path: '/workspace/rollback-retained.html' },
+        argsText: JSON.stringify({ path: '/workspace/rollback-retained.html' }),
+        result: { output: 'created' },
+        isError: false
+      }
+    ]
+    messages[3].parts = [
+      {
+        type: 'tool-call',
+        toolCallId: 'rollback-tail-preview',
+        toolName: 'write_file',
+        args: { path: '/workspace/rollback-tail.html' },
+        argsText: JSON.stringify({ path: '/workspace/rollback-tail.html' }),
+        result: { output: 'created' },
+        isError: false
+      }
+    ]
+    const view = render(<Harness messages={messages} onSubmit={() => true} />)
+
+    await waitFor(() => expect($previewStatusBySession.get()['runtime-fixture']).toHaveLength(2))
+
+    let emissions = 0
+
+    const unsubscribe = $previewStatusBySession.subscribe(() => {
+      emissions += 1
+    })
+
+    act(() => clearPreviewArtifacts('runtime-fixture'))
+    view.rerender(<Harness messages={messages.slice(0, -2)} onSubmit={() => true} />)
+
+    await waitFor(() =>
+      expect($previewStatusBySession.get()['runtime-fixture']?.map(item => item.target)).toEqual([
+        '/workspace/rollback-retained.html'
+      ])
+    )
+    expect(emissions).toBe(3)
+
+    view.rerender(<Harness messages={messages} onSubmit={() => true} />)
+
+    await waitFor(() =>
+      expect($previewStatusBySession.get()['runtime-fixture']?.map(item => item.target)).toEqual([
+        '/workspace/rollback-retained.html',
+        '/workspace/rollback-tail.html'
+      ])
+    )
+    expect(emissions).toBe(4)
+
+    view.rerender(<Harness messages={structuredClone(messages)} onSubmit={() => true} />)
+    await waitFor(() => expect(screen.getByText('Question 1')).toBeTruthy())
+    expect(emissions).toBe(4)
+    unsubscribe()
+  })
+
   it('re-registers the same preview target after a restored timeline produces it again', async () => {
     clearPreviewArtifacts('runtime-fixture')
     const withPreview = makeMinimalTurns(25)

--- a/apps/desktop/src/app/chat/long-tool-session.repro.test.tsx
+++ b/apps/desktop/src/app/chat/long-tool-session.repro.test.tsx
@@ -9,7 +9,7 @@ import { useRuntimeMessageRepository } from '@/app/chat/runtime-repository'
 import { Thread } from '@/components/assistant-ui/thread'
 import type { ChatMessage, ChatMessagePart } from '@/lib/chat-messages'
 import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
-import { $previewStatusBySession, clearPreviewArtifacts } from '@/store/preview-status'
+import { $previewStatusBySession, clearPreviewArtifacts, dismissPreviewArtifact } from '@/store/preview-status'
 
 const TARGET_CONTENT_CHARS = 650_451
 const MESSAGE_COUNT = 266
@@ -199,7 +199,15 @@ function makeMinimalTurns(count: number, withLatestHeavyTools = 0): ChatMessage[
   }).flat()
 }
 
-function Harness({ messages, onSubmit }: { messages: ChatMessage[]; onSubmit: (text: string) => boolean }) {
+function Harness({
+  messages,
+  onSubmit,
+  sessionKey = 'stored-fixture'
+}: {
+  messages: ChatMessage[]
+  onSubmit: (text: string) => boolean
+  sessionKey?: string
+}) {
   const repository = useRuntimeMessageRepository(messages)
 
   const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({
@@ -213,7 +221,7 @@ function Harness({ messages, onSubmit }: { messages: ChatMessage[]; onSubmit: (t
     <MemoryRouter>
       <AssistantRuntimeProvider runtime={runtime}>
         <div style={{ height: 800, position: 'relative' }}>
-          <Thread clampToComposer sessionId="runtime-fixture" sessionKey="stored-fixture" />
+          <Thread clampToComposer sessionId="runtime-fixture" sessionKey={sessionKey} />
           <ChatBar
             busy={false}
             cwd="/workspace/synthetic"
@@ -301,7 +309,7 @@ describe('representative long tool-heavy session contract (#68467)', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Show earlier tool calls' }))
     }
 
-    expect(view.container.querySelectorAll('[data-tool-row]')).toHaveLength(TOOL_CALL_COUNT - 1)
+    expect(view.container.querySelectorAll('[data-tool-row]')).toHaveLength(TOOL_CALL_COUNT)
     expect(messages.flatMap(message => message.parts).filter(part => part.type === 'tool-call')).toHaveLength(
       TOOL_CALL_COUNT
     )
@@ -337,7 +345,10 @@ describe('representative long tool-heavy session contract (#68467)', () => {
       throw new Error('first restored tool is not expandable')
     }
 
-    fireEvent.click(firstToolToggle)
+    if (firstToolToggle.getAttribute('aria-expanded') !== 'true') {
+      fireEvent.click(firstToolToggle)
+    }
+
     expect(firstTool?.textContent).toContain('interleaved-tool-0 complete')
     expect(view.container.textContent).toContain('Narration after tool 159.')
     expect(messages.flatMap(message => message.parts).filter(part => part.type === 'tool-call')).toHaveLength(160)
@@ -409,6 +420,20 @@ describe('representative long tool-heavy session contract (#68467)', () => {
     )
   })
 
+  it('resets expanded history when the session key changes', async () => {
+    const messages = makeMinimalTurns(25)
+    const view = render(<Harness messages={messages} onSubmit={() => true} sessionKey="first-session" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show earlier messages' }))
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Show earlier messages' })).toBeNull())
+    expect(view.container.querySelectorAll('[data-history-group-id]')).toHaveLength(25)
+
+    view.rerender(<Harness messages={messages} onSubmit={() => true} sessionKey="second-session" />)
+
+    expect(screen.getByRole('button', { name: 'Show earlier messages' })).toBeTruthy()
+    expect(view.container.querySelectorAll('[data-history-group-id]')).toHaveLength(20)
+  })
+
   it('keeps history and tool pagers uniquely named', () => {
     render(<Harness messages={makeMinimalTurns(25, 25)} onSubmit={() => true} />)
 
@@ -442,5 +467,118 @@ describe('representative long tool-heavy session contract (#68467)', () => {
     )
     expect(view.container.querySelector('[data-tool-page-key*="hidden-preview-tool"]')).toBeNull()
     expect(view.container.querySelectorAll('[data-slot="aui_turn-pair"]')).toHaveLength(20)
+  })
+
+  it('re-registers the same preview target after a restored timeline produces it again', async () => {
+    clearPreviewArtifacts('runtime-fixture')
+    const withPreview = makeMinimalTurns(25)
+    withPreview[1].parts = [
+      {
+        type: 'tool-call',
+        toolCallId: 'preview-before-restore',
+        toolName: 'write_file',
+        args: { path: '/workspace/restored-preview.html' },
+        argsText: JSON.stringify({ path: '/workspace/restored-preview.html' }),
+        result: { output: 'created' },
+        isError: false
+      }
+    ]
+
+    const view = render(<Harness messages={withPreview} onSubmit={() => true} />)
+
+    await waitFor(() =>
+      expect($previewStatusBySession.get()['runtime-fixture']?.map(item => item.target)).toContain(
+        '/workspace/restored-preview.html'
+      )
+    )
+
+    act(() => clearPreviewArtifacts('runtime-fixture'))
+    expect($previewStatusBySession.get()['runtime-fixture']).toBeUndefined()
+
+    const reproduced = structuredClone(withPreview)
+    const reproducedPart = reproduced[1].parts[0]
+
+    if (reproducedPart.type !== 'tool-call') {
+      throw new Error('expected the reproduced preview tool call')
+    }
+
+    reproduced[1].parts = [{ ...reproducedPart, toolCallId: 'preview-after-restore' }]
+    view.rerender(<Harness messages={reproduced} onSubmit={() => true} />)
+
+    await waitFor(() =>
+      expect($previewStatusBySession.get()['runtime-fixture']?.map(item => item.target)).toContain(
+        '/workspace/restored-preview.html'
+      )
+    )
+  })
+
+  it('registers a large historical preview set with one bounded atom update', async () => {
+    clearPreviewArtifacts('runtime-fixture')
+    const messages = makeMinimalTurns(1)
+    messages[1].parts = Array.from({ length: 101 }, (_, index) => ({
+      type: 'tool-call' as const,
+      toolCallId: `preview-${index}`,
+      toolName: 'write_file',
+      args: { path: `/workspace/preview-${index}.html` },
+      argsText: JSON.stringify({ path: `/workspace/preview-${index}.html` }),
+      result: { output: 'created' },
+      isError: false
+    }))
+    let emissions = 0
+
+    const unsubscribe = $previewStatusBySession.subscribe(() => {
+      emissions += 1
+    })
+
+    render(<Harness messages={messages} onSubmit={() => true} />)
+
+    await waitFor(() =>
+      expect($previewStatusBySession.get()['runtime-fixture']?.map(item => item.target)).toEqual([
+        '/workspace/preview-97.html',
+        '/workspace/preview-98.html',
+        '/workspace/preview-99.html',
+        '/workspace/preview-100.html'
+      ])
+    )
+    expect(emissions).toBe(2)
+    unsubscribe()
+  })
+
+  it('does not resurrect a dismissed preview when another target is produced', async () => {
+    clearPreviewArtifacts('runtime-fixture')
+    const initial = makeMinimalTurns(1)
+    initial[1].parts = [
+      {
+        type: 'tool-call',
+        toolCallId: 'dismissed-preview',
+        toolName: 'write_file',
+        args: { path: '/workspace/dismissed.html' },
+        argsText: JSON.stringify({ path: '/workspace/dismissed.html' }),
+        result: { output: 'created' },
+        isError: false
+      }
+    ]
+    const view = render(<Harness messages={initial} onSubmit={() => true} />)
+
+    await waitFor(() => expect($previewStatusBySession.get()['runtime-fixture']).toHaveLength(1))
+    act(() => dismissPreviewArtifact('runtime-fixture', '/workspace/dismissed.html'))
+
+    const appended = structuredClone(initial)
+    appended[1].parts.push({
+      type: 'tool-call',
+      toolCallId: 'new-preview',
+      toolName: 'write_file',
+      args: { path: '/workspace/new.html' },
+      argsText: JSON.stringify({ path: '/workspace/new.html' }),
+      result: { output: 'created' },
+      isError: false
+    })
+    view.rerender(<Harness messages={appended} onSubmit={() => true} />)
+
+    await waitFor(() =>
+      expect($previewStatusBySession.get()['runtime-fixture']?.map(item => item.target)).toEqual([
+        '/workspace/new.html'
+      ])
+    )
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/index.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/index.tsx
@@ -95,8 +95,10 @@ export const Thread: FC<{
       <ThreadMessageList
         clampToComposer={clampToComposer}
         components={messageComponents}
+        cwd={cwd}
         emptyPlaceholder={emptyPlaceholder}
         loadingIndicator={<BackgroundResumeNotice />}
+        sessionId={sessionId}
         sessionKey={sessionKey}
       />
       {loading === 'session' && <CenteredThreadSpinner />}

--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from 'vitest'
 
 import {
   buildGroups,
+  earlierGroupIndex,
   firstVisibleGroupIndex,
   isVirtualizedGroup,
   LIVE_TAIL_GROUPS,
-  type MessageGroup,
-  nextHistoryBudget,
-  shouldAutoBackfill
+  MAX_INITIAL_GROUPS,
+  type MessageGroup
 } from './list'
 
 // Signature rows are `${index}:${id}:${role}:${weight}` (see the useAuiState
@@ -87,6 +87,12 @@ describe('firstVisibleGroupIndex', () => {
   it('returns groups.length for an empty list', () => {
     expect(firstVisibleGroupIndex([], 60)).toBe(0)
   })
+
+  it('applies a literal group cap in addition to the part budget', () => {
+    const groups = Array.from({ length: MAX_INITIAL_GROUPS + 10 }, (_, index) => group(String(index), 1))
+
+    expect(groups.length - firstVisibleGroupIndex(groups, 60)).toBe(MAX_INITIAL_GROUPS)
+  })
 })
 
 describe('isVirtualizedGroup', () => {
@@ -119,26 +125,14 @@ describe('isVirtualizedGroup', () => {
   })
 })
 
-describe('shouldAutoBackfill', () => {
-  const group = (weight: number): MessageGroup => ({ id: String(weight), index: 0, kind: 'standalone', weight })
-
-  it('backfills a bounded transcript after first paint', () => {
-    expect(shouldAutoBackfill([group(300)])).toBe(true)
-  })
-
-  it('keeps a long transcript on explicit history pages', () => {
-    expect(shouldAutoBackfill([group(301)])).toBe(false)
-  })
-})
-
-describe('nextHistoryBudget', () => {
+describe('earlierGroupIndex', () => {
   const group = (id: string, weight: number): MessageGroup => ({ id, index: 0, kind: 'standalone', weight })
 
   it('advances by a bounded page for ordinary history', () => {
-    expect(nextHistoryBudget([group('old', 60), group('new', 60)], 60)).toBe(120)
+    expect(earlierGroupIndex([group('old', 60), group('new', 60)], 1)).toBe(0)
   })
 
   it('always reveals an earlier group after a very heavy visible turn', () => {
-    expect(nextHistoryBudget([group('old', 5), group('huge', 500)], 60)).toBe(505)
+    expect(earlierGroupIndex([group('old', 5), group('huge', 500)], 1)).toBe(0)
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildGroups, firstVisibleGroupIndex, isVirtualizedGroup, LIVE_TAIL_GROUPS, type MessageGroup } from './list'
+import {
+  buildGroups,
+  firstVisibleGroupIndex,
+  isVirtualizedGroup,
+  LIVE_TAIL_GROUPS,
+  type MessageGroup,
+  nextHistoryBudget,
+  shouldAutoBackfill
+} from './list'
 
 // Signature rows are `${index}:${id}:${role}:${weight}` (see the useAuiState
 // selector in list.tsx).
@@ -108,5 +116,29 @@ describe('isVirtualizedGroup', () => {
   it('honors a custom tail size', () => {
     expect(isVirtualizedGroup(5, 10, 3)).toBe(true)
     expect(isVirtualizedGroup(7, 10, 3)).toBe(false)
+  })
+})
+
+describe('shouldAutoBackfill', () => {
+  const group = (weight: number): MessageGroup => ({ id: String(weight), index: 0, kind: 'standalone', weight })
+
+  it('backfills a bounded transcript after first paint', () => {
+    expect(shouldAutoBackfill([group(300)])).toBe(true)
+  })
+
+  it('keeps a long transcript on explicit history pages', () => {
+    expect(shouldAutoBackfill([group(301)])).toBe(false)
+  })
+})
+
+describe('nextHistoryBudget', () => {
+  const group = (id: string, weight: number): MessageGroup => ({ id, index: 0, kind: 'standalone', weight })
+
+  it('advances by a bounded page for ordinary history', () => {
+    expect(nextHistoryBudget([group('old', 60), group('new', 60)], 60)).toBe(120)
+  })
+
+  it('always reveals an earlier group after a very heavy visible turn', () => {
+    expect(nextHistoryBudget([group('old', 5), group('huge', 500)], 60)).toBe(505)
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -47,6 +47,7 @@ const RENDER_BUDGET = 300
 // in a requestAnimationFrame — defers the heavy markdown+syntax-highlight render
 // past the initial commit, so the switch feels instant.
 const FIRST_PAINT_BUDGET = 60
+const HISTORY_PAGE_BUDGET = FIRST_PAINT_BUDGET
 
 interface ThreadMessageListProps {
   clampToComposer: boolean
@@ -134,6 +135,24 @@ export function isVirtualizedGroup(indexInVisible: number, visibleCount: number,
   return indexInVisible < visibleCount - liveTail
 }
 
+export function shouldAutoBackfill(groups: readonly MessageGroup[]): boolean {
+  return groups.reduce((weight, group) => weight + group.weight, 0) <= RENDER_BUDGET
+}
+
+export function nextHistoryBudget(groups: readonly MessageGroup[], budget: number): number {
+  const firstVisible = firstVisibleGroupIndex(groups, budget)
+
+  if (firstVisible <= 0) {
+    return budget
+  }
+
+  const requiredForEarlierGroup = groups
+    .slice(firstVisible - 1)
+    .reduce((weight, group) => weight + group.weight, 0)
+
+  return Math.max(budget + HISTORY_PAGE_BUDGET, requiredForEarlierGroup)
+}
+
 const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   clampToComposer,
   components,
@@ -191,15 +210,13 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     }
   }
 
-  // Backfill from FIRST_PAINT_BUDGET to the full budget after the small
-  // commit painted — as a TRANSITION, so the heavy markdown + syntax
-  // highlight render of the older turns is interruptible instead of one long
-  // synchronous commit that freezes input right after the switch. Route
-  // changes stay urgent (main.tsx disables router transitions); it's exactly
-  // this backfill that belongs at background priority. "Show earlier" pages
-  // (budget > RENDER_BUDGET) never re-enter here.
+  // After first paint, backfill bounded transcripts in a transition.
+  // Long histories stay at the first-paint budget and page on explicit demand,
+  // avoiding a second automatic markdown/tool render that can block typing.
+  const autoBackfill = shouldAutoBackfill(groups)
+
   useEffect(() => {
-    if (renderBudget >= RENDER_BUDGET) {
+    if (renderBudget >= RENDER_BUDGET || !autoBackfill) {
       return
     }
 
@@ -211,7 +228,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     })
 
     return () => cancelAnimationFrame(rafId)
-  }, [renderBudget])
+  }, [autoBackfill, renderBudget])
 
   const hiddenCount = firstVisibleGroupIndex(groups, renderBudget)
   const visibleGroups = hiddenCount > 0 ? groups.slice(hiddenCount) : groups
@@ -319,8 +336,8 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     const el = scrollRef.current
 
     restoreFromBottomRef.current = el ? el.scrollHeight - el.scrollTop : null
-    setRenderBudget(budget => budget + RENDER_BUDGET)
-  }, [scrollRef])
+    setRenderBudget(budget => nextHistoryBudget(groups, budget))
+  }, [groups, scrollRef])
 
   useLayoutEffect(() => {
     const el = scrollRef.current
@@ -373,7 +390,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
           >
             {hiddenCount > 0 && (
               <button
-                className="mx-auto mb-(--conversation-turn-gap) rounded-full border border-border/65 bg-(--composer-fill) px-3 py-1 text-xs text-muted-foreground hover:text-foreground"
+                className="mx-auto mb-(--conversation-turn-gap) rounded-full border border-border/65 bg-(--composer-fill) px-3 py-1 text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 onClick={showEarlier}
                 type="button"
               >

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -16,7 +16,7 @@ import { useStickToBottom } from 'use-stick-to-bottom'
 
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
-import { recordPreviewArtifact } from '@/store/preview-status'
+import { getPreviewClearGeneration, recordPreviewArtifacts } from '@/store/preview-status'
 import {
   onScrollToBottomRequest,
   onThreadEditClose,
@@ -50,6 +50,7 @@ export type MessageGroup = { id: string; weight: number } & (
 const FIRST_PAINT_BUDGET = 60
 const HISTORY_PAGE_BUDGET = FIRST_PAINT_BUDGET
 export const MAX_INITIAL_GROUPS = 20
+const MAX_TRACKED_PREVIEW_SESSIONS = 20
 
 interface ThreadMessageListProps {
   clampToComposer: boolean
@@ -163,13 +164,16 @@ export function earlierGroupIndex(groups: readonly MessageGroup[], firstVisible:
 }
 
 const ToolPreviewRegistrar: FC<{ cwd: string | null; sessionId: string | null | undefined }> = ({ cwd, sessionId }) => {
-  const seenBySessionRef = useRef(new Map<string, Set<string>>())
   const targetCacheRef = useRef(new WeakMap<object, { args: unknown; result: unknown; target: string }>())
+
+  const registrationBySessionRef = useRef(
+    new Map<string, { clearGeneration: number; occurrenceKeys: Set<string> }>()
+  )
 
   const targetsSignature = useAuiState(s =>
     JSON.stringify(
       s.thread.messages.flatMap(message =>
-        message.content.flatMap(part => {
+        message.content.flatMap((part, partIndex) => {
           if (part.type !== 'tool-call' || part.result === undefined) {
             return []
           }
@@ -189,7 +193,9 @@ const ToolPreviewRegistrar: FC<{ cwd: string | null; sessionId: string | null | 
             targetCacheRef.current.set(part, { args: part.args, result: part.result, target })
           }
 
-          return target && isPreviewableTarget(target) ? [target] : []
+          return target && isPreviewableTarget(target)
+            ? [{ key: `${message.id}:${part.toolCallId || `part-${partIndex}`}:${target}`, target }]
+            : []
         })
       )
     )
@@ -200,19 +206,27 @@ const ToolPreviewRegistrar: FC<{ cwd: string | null; sessionId: string | null | 
       return
     }
 
-    let seen = seenBySessionRef.current.get(sessionId)
+    const entries = JSON.parse(targetsSignature) as Array<{ key: string; target: string }>
+    const clearGeneration = getPreviewClearGeneration(sessionId)
+    const previous = registrationBySessionRef.current.get(sessionId)
+    const occurrenceKeys = new Set(entries.map(entry => entry.key))
+    const priorKeys = previous?.clearGeneration === clearGeneration ? previous.occurrenceKeys : new Set<string>()
+    const newTargets = entries.filter(entry => !priorKeys.has(entry.key)).map(entry => entry.target)
 
-    if (!seen) {
-      seen = new Set()
-      seenBySessionRef.current.set(sessionId, seen)
-    }
+    registrationBySessionRef.current.delete(sessionId)
+    registrationBySessionRef.current.set(sessionId, { clearGeneration, occurrenceKeys })
 
-    for (const target of JSON.parse(targetsSignature) as string[]) {
-      if (!seen.has(target)) {
-        seen.add(target)
-        recordPreviewArtifact(sessionId, target, cwd || '')
+    while (registrationBySessionRef.current.size > MAX_TRACKED_PREVIEW_SESSIONS) {
+      const oldestSession = registrationBySessionRef.current.keys().next().value
+
+      if (!oldestSession) {
+        break
       }
+
+      registrationBySessionRef.current.delete(oldestSession)
     }
+
+    recordPreviewArtifacts(sessionId, newTargets, cwd || '')
   }, [cwd, sessionId, targetsSignature])
 
   return null

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -5,10 +5,10 @@ import {
   type FC,
   memo,
   type ReactNode,
-  startTransition,
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState
 } from 'react'
@@ -16,6 +16,7 @@ import { useStickToBottom } from 'use-stick-to-bottom'
 
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
+import { recordPreviewArtifact } from '@/store/preview-status'
 import {
   onScrollToBottomRequest,
   onThreadEditClose,
@@ -26,6 +27,16 @@ import {
 import { isSecondaryWindow } from '@/store/windows'
 
 import { MessageRenderBoundary } from '../message-render-boundary'
+import {
+  isPreviewableTarget,
+  type ToolPart,
+  toolPreviewTargetForPart
+} from '../tool/fallback-model'
+import {
+  toolPartPageKey,
+  ToolTurnPaginationProvider,
+  type TurnToolRef
+} from '../tool/turn-pagination'
 
 type ThreadMessageComponents = ComponentProps<typeof ThreadPrimitive.MessageByIndex>['components']
 
@@ -41,19 +52,20 @@ export type MessageGroup = { id: string; weight: number } & (
 // sticky human bubble never loses its turn. This is the long-session perf lever
 // WITHOUT a virtualizer — pure rendering, never touches scrollTop, so it can't
 // fight use-stick-to-bottom (the single scroll owner).
-const RENDER_BUDGET = 300
-// On session switch, paint a small budget first (enough for the bottom turn(s)
-// the user actually sees after scroll-to-bottom), then bump to the full budget
-// in a requestAnimationFrame — defers the heavy markdown+syntax-highlight render
-// past the initial commit, so the switch feels instant.
+// On session switch, paint only the bottom page the user can see. Earlier
+// history is mounted exclusively after an explicit request; this prevents a
+// post-paint transition from rebuilding the expensive transcript automatically.
 const FIRST_PAINT_BUDGET = 60
 const HISTORY_PAGE_BUDGET = FIRST_PAINT_BUDGET
+export const MAX_INITIAL_GROUPS = 20
 
 interface ThreadMessageListProps {
   clampToComposer: boolean
   components: ThreadMessageComponents
+  cwd?: string | null
   emptyPlaceholder?: ReactNode
   loadingIndicator?: ReactNode
+  sessionId?: string | null
   sessionKey?: string | null
 }
 
@@ -99,14 +111,19 @@ export function buildGroups(signature: string): MessageGroup[] {
 // Walk turns newest-first, summing their part weights until the budget is met;
 // everything before the first kept turn is hidden. Returns the index of that
 // first visible group.
-export function firstVisibleGroupIndex(groups: readonly MessageGroup[], budget: number): number {
+export function firstVisibleGroupIndex(
+  groups: readonly MessageGroup[],
+  budget: number,
+  maxGroups = MAX_INITIAL_GROUPS
+): number {
   let firstVisible = groups.length
 
-  for (let i = groups.length - 1, weight = 0; i >= 0; i--) {
+  for (let i = groups.length - 1, weight = 0, count = 0; i >= 0; i--) {
     weight += groups[i].weight
     firstVisible = i
+    count += 1
 
-    if (weight >= budget) {
+    if (weight >= budget || count >= maxGroups) {
       break
     }
   }
@@ -135,29 +152,87 @@ export function isVirtualizedGroup(indexInVisible: number, visibleCount: number,
   return indexInVisible < visibleCount - liveTail
 }
 
-export function shouldAutoBackfill(groups: readonly MessageGroup[]): boolean {
-  return groups.reduce((weight, group) => weight + group.weight, 0) <= RENDER_BUDGET
-}
+export function earlierGroupIndex(groups: readonly MessageGroup[], firstVisible: number): number {
+  let nextFirst = firstVisible
+  let weight = 0
+  let count = 0
 
-export function nextHistoryBudget(groups: readonly MessageGroup[], budget: number): number {
-  const firstVisible = firstVisibleGroupIndex(groups, budget)
+  for (let i = firstVisible - 1; i >= 0; i--) {
+    weight += groups[i].weight
+    nextFirst = i
+    count += 1
 
-  if (firstVisible <= 0) {
-    return budget
+    if (weight >= HISTORY_PAGE_BUDGET || count >= MAX_INITIAL_GROUPS) {
+      break
+    }
   }
 
-  const requiredForEarlierGroup = groups
-    .slice(firstVisible - 1)
-    .reduce((weight, group) => weight + group.weight, 0)
+  return nextFirst
+}
 
-  return Math.max(budget + HISTORY_PAGE_BUDGET, requiredForEarlierGroup)
+const ToolPreviewRegistrar: FC<{ cwd: string | null; sessionId: string | null | undefined }> = ({ cwd, sessionId }) => {
+  const seenBySessionRef = useRef(new Map<string, Set<string>>())
+  const targetCacheRef = useRef(new WeakMap<object, { args: unknown; result: unknown; target: string }>())
+
+  const targetsSignature = useAuiState(s =>
+    JSON.stringify(
+      s.thread.messages.flatMap(message =>
+        message.content.flatMap(part => {
+          if (part.type !== 'tool-call' || part.result === undefined) {
+            return []
+          }
+
+          const cached = targetCacheRef.current.get(part)
+          let target = cached?.args === part.args && cached.result === part.result ? cached.target : undefined
+
+          if (target === undefined) {
+            target = toolPreviewTargetForPart({
+              args: part.args,
+              isError: part.isError,
+              result: part.result,
+              toolCallId: part.toolCallId,
+              toolName: part.toolName,
+              type: 'tool-call'
+            } satisfies ToolPart)
+            targetCacheRef.current.set(part, { args: part.args, result: part.result, target })
+          }
+
+          return target && isPreviewableTarget(target) ? [target] : []
+        })
+      )
+    )
+  )
+
+  useEffect(() => {
+    if (!sessionId) {
+      return
+    }
+
+    let seen = seenBySessionRef.current.get(sessionId)
+
+    if (!seen) {
+      seen = new Set()
+      seenBySessionRef.current.set(sessionId, seen)
+    }
+
+    for (const target of JSON.parse(targetsSignature) as string[]) {
+      if (!seen.has(target)) {
+        seen.add(target)
+        recordPreviewArtifact(sessionId, target, cwd || '')
+      }
+    }
+  }, [cwd, sessionId, targetsSignature])
+
+  return null
 }
 
 const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   clampToComposer,
   components,
+  cwd = '',
   emptyPlaceholder,
   loadingIndicator,
+  sessionId,
   sessionKey
 }) => {
   const messageSignature = useAuiState(s =>
@@ -166,8 +241,39 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       .join('\n')
   )
 
+  const toolInventorySignature = useAuiState(s =>
+    JSON.stringify(
+      s.thread.messages.map((message, messageIndex) => ({
+        messageIndex,
+        tools: message.content.flatMap((part, partIndex) =>
+          part.type === 'tool-call'
+            ? [
+                {
+                  key: toolPartPageKey(message.id, partIndex, part.toolCallId),
+                  messageId: message.id,
+                  partIndex
+                } satisfies TurnToolRef
+              ]
+            : []
+        )
+      }))
+    )
+  )
+
   const { t } = useI18n()
   const groups = buildGroups(messageSignature)
+
+  const toolsByMessageIndex = useMemo(
+    () =>
+      new Map(
+        (JSON.parse(toolInventorySignature) as Array<{ messageIndex: number; tools: TurnToolRef[] }>).map(item => [
+          item.messageIndex,
+          item.tools
+        ])
+      ),
+    [toolInventorySignature]
+  )
+
   const renderEmpty = groups.length === 0 && Boolean(emptyPlaceholder)
 
   // use-stick-to-bottom owns scrollTop (single writer): follow while locked,
@@ -180,57 +286,35 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     resize: 'instant'
   })
 
-  const [renderBudget, setRenderBudget] = useState(FIRST_PAINT_BUDGET)
-
-  // Cut the budget during RENDER, not in the post-commit layout effect. An
-  // effect-time cut is too late: React would first build the whole tree with
-  // the full budget (up to 300 parts of markdown + syntax highlighting),
-  // commit it, and only then re-render at the small budget. The render-phase
-  // state adjustment restarts this component immediately — before any child
-  // renders — so the heavy commit never happens.
-  //
-  // Two triggers, because the transcript swap arrives differently per path:
-  // a WARM switch publishes sessionKey + messages in one commit (the key
-  // branch), while a COLD switch changes sessionKey with an empty transcript
-  // and the prefetched messages land hundreds of ms later under the SAME key
-  // (the empty→non-empty branch).
+  // The boundary becomes identity-based only after explicit backfill. Before
+  // that, append-only streaming may keep a bounded newest suffix. Once the user
+  // asks for history, its oldest visible group is stable across later appends.
   const hasGroups = groups.length > 0
-  const [budgetSessionKey, setBudgetSessionKey] = useState(sessionKey)
+  const [historyState, setHistoryState] = useState({ expanded: false, oldestVisibleId: null as string | null, sessionKey })
   const [hadGroups, setHadGroups] = useState(hasGroups)
+  const focusAfterRevealRef = useRef<string | null>(null)
+  const focusFrameRef = useRef<number | null>(null)
 
-  if (budgetSessionKey !== sessionKey) {
-    setBudgetSessionKey(sessionKey)
+  if (historyState.sessionKey !== sessionKey) {
+    focusAfterRevealRef.current = null
+    setHistoryState({ expanded: false, oldestVisibleId: null, sessionKey })
     setHadGroups(hasGroups)
-    setRenderBudget(FIRST_PAINT_BUDGET)
   } else if (hadGroups !== hasGroups) {
     setHadGroups(hasGroups)
 
     if (hasGroups) {
-      setRenderBudget(FIRST_PAINT_BUDGET)
+      setHistoryState({ expanded: false, oldestVisibleId: null, sessionKey })
     }
   }
 
-  // After first paint, backfill bounded transcripts in a transition.
-  // Long histories stay at the first-paint budget and page on explicit demand,
-  // avoiding a second automatic markdown/tool render that can block typing.
-  const autoBackfill = shouldAutoBackfill(groups)
+  const normalizedHistoryState =
+    historyState.sessionKey === sessionKey ? historyState : { expanded: false, oldestVisibleId: null, sessionKey }
 
-  useEffect(() => {
-    if (renderBudget >= RENDER_BUDGET || !autoBackfill) {
-      return
-    }
+  const stableBoundaryIndex = normalizedHistoryState.expanded
+    ? groups.findIndex(group => group.id === normalizedHistoryState.oldestVisibleId)
+    : -1
 
-    const rafId = requestAnimationFrame(() => {
-      // Functional max, not a plain set: an urgent "Show earlier" click can
-      // land between scheduling and committing this transition, and a plain
-      // set would rebase over it and shrink the budget back down.
-      startTransition(() => setRenderBudget(budget => Math.max(budget, RENDER_BUDGET)))
-    })
-
-    return () => cancelAnimationFrame(rafId)
-  }, [autoBackfill, renderBudget])
-
-  const hiddenCount = firstVisibleGroupIndex(groups, renderBudget)
+  const hiddenCount = stableBoundaryIndex >= 0 ? stableBoundaryIndex : firstVisibleGroupIndex(groups, FIRST_PAINT_BUDGET)
   const visibleGroups = hiddenCount > 0 ? groups.slice(hiddenCount) : groups
   const restoreFromBottomRef = useRef<number | null>(null)
   // Secondary windows (new-session scratch, subagent watch, cmd-click pop-out)
@@ -251,6 +335,14 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
 
   useEffect(() => setThreadAtBottom(isAtBottom), [isAtBottom])
   useEffect(() => () => resetThreadScroll(), [])
+  useEffect(
+    () => () => {
+      if (focusFrameRef.current != null) {
+        cancelAnimationFrame(focusFrameRef.current)
+      }
+    },
+    []
+  )
 
   // Floating jump button (outside this subtree) → return to the bottom.
   useEffect(() => onScrollToBottomRequest(() => void scrollToBottom()), [scrollToBottom])
@@ -334,10 +426,13 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   // won't fight this manual restore.
   const showEarlier = useCallback(() => {
     const el = scrollRef.current
+    const nextFirst = earlierGroupIndex(groups, hiddenCount)
+    const nextOldestId = groups[nextFirst]?.id ?? null
 
     restoreFromBottomRef.current = el ? el.scrollHeight - el.scrollTop : null
-    setRenderBudget(budget => nextHistoryBudget(groups, budget))
-  }, [groups, scrollRef])
+    focusAfterRevealRef.current = nextFirst === 0 ? nextOldestId : null
+    setHistoryState({ expanded: true, oldestVisibleId: nextOldestId, sessionKey })
+  }, [groups, hiddenCount, scrollRef, sessionKey])
 
   useLayoutEffect(() => {
     const el = scrollRef.current
@@ -346,7 +441,34 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       el.scrollTop = el.scrollHeight - restoreFromBottomRef.current
       restoreFromBottomRef.current = null
     }
-  }, [scrollRef, renderBudget])
+
+    const focusId = focusAfterRevealRef.current
+
+    if (focusId && hiddenCount === 0) {
+      focusAfterRevealRef.current = null
+
+      const target = Array.from(el?.querySelectorAll<HTMLElement>('[data-history-group-id]') ?? []).find(
+        element => element.dataset.historyGroupId === focusId
+      )
+
+      if (focusFrameRef.current != null) {
+        cancelAnimationFrame(focusFrameRef.current)
+      }
+
+      focusFrameRef.current = requestAnimationFrame(() => {
+        focusFrameRef.current = null
+        target?.focus({ preventScroll: true })
+      })
+    }
+  }, [hiddenCount, scrollRef])
+
+  const toolRefsByGroup = new Map(
+    groups.map(group => {
+      const indices = group.kind === 'turn' ? group.indices : [group.index]
+
+      return [group.id, indices.flatMap(index => toolsByMessageIndex.get(index) ?? [])]
+    })
+  )
 
   return (
     <div
@@ -358,6 +480,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
         } as CSSProperties
       }
     >
+      <ToolPreviewRegistrar cwd={cwd} sessionId={sessionId} />
       {secondaryWindow && (
         // Secondary windows hide the titlebar chrome, so the scroller runs to
         // the window's top edge and streamed text slides up under the OS
@@ -394,7 +517,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
                 onClick={showEarlier}
                 type="button"
               >
-                {t.assistant.thread.showEarlier}
+                {t.assistant.thread.showEarlierMessages}
               </button>
             )}
             {visibleGroups.map((group, indexInVisible) => (
@@ -419,22 +542,29 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
                   isVirtualizedGroup(indexInVisible, visibleGroups.length) &&
                     '[contain-intrinsic-size:auto_37.5rem] [content-visibility:auto]'
                 )}
+                data-history-group-id={group.id}
                 key={group.id}
+                tabIndex={-1}
               >
-                <MessageRenderBoundary resetKey={messageSignature}>
-                  {group.kind === 'turn' ? (
-                    <div
-                      className="composer-human-ai-pair-container relative flex min-w-0 flex-col gap-(--conversation-turn-gap)"
-                      data-slot="aui_turn-pair"
-                    >
-                      {group.indices.map(index => (
-                        <ThreadPrimitive.MessageByIndex components={components} index={index} key={index} />
-                      ))}
-                    </div>
-                  ) : (
-                    <ThreadPrimitive.MessageByIndex components={components} index={group.index} />
-                  )}
-                </MessageRenderBoundary>
+                <ToolTurnPaginationProvider
+                  tools={toolRefsByGroup.get(group.id) ?? []}
+                  turnKey={`${sessionKey ?? ''}:${group.id}`}
+                >
+                  <MessageRenderBoundary resetKey={messageSignature}>
+                    {group.kind === 'turn' ? (
+                      <div
+                        className="composer-human-ai-pair-container relative flex min-w-0 flex-col gap-(--conversation-turn-gap)"
+                        data-slot="aui_turn-pair"
+                      >
+                        {group.indices.map(index => (
+                          <ThreadPrimitive.MessageByIndex components={components} index={index} key={index} />
+                        ))}
+                      </div>
+                    ) : (
+                      <ThreadPrimitive.MessageByIndex components={components} index={group.index} />
+                    )}
+                  </MessageRenderBoundary>
+                </ToolTurnPaginationProvider>
               </div>
             ))}
             {loadingIndicator}

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -27,16 +27,8 @@ import {
 import { isSecondaryWindow } from '@/store/windows'
 
 import { MessageRenderBoundary } from '../message-render-boundary'
-import {
-  isPreviewableTarget,
-  type ToolPart,
-  toolPreviewTargetForPart
-} from '../tool/fallback-model'
-import {
-  toolPartPageKey,
-  ToolTurnPaginationProvider,
-  type TurnToolRef
-} from '../tool/turn-pagination'
+import { isPreviewableTarget, type ToolPart, toolPreviewTargetForPart } from '../tool/fallback-model'
+import { toolPartPageKey, ToolTurnPaginationProvider, type TurnToolRef } from '../tool/turn-pagination'
 
 type ThreadMessageComponents = ComponentProps<typeof ThreadPrimitive.MessageByIndex>['components']
 
@@ -290,7 +282,13 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   // that, append-only streaming may keep a bounded newest suffix. Once the user
   // asks for history, its oldest visible group is stable across later appends.
   const hasGroups = groups.length > 0
-  const [historyState, setHistoryState] = useState({ expanded: false, oldestVisibleId: null as string | null, sessionKey })
+
+  const [historyState, setHistoryState] = useState({
+    expanded: false,
+    oldestVisibleId: null as string | null,
+    sessionKey
+  })
+
   const [hadGroups, setHadGroups] = useState(hasGroups)
   const focusAfterRevealRef = useRef<string | null>(null)
   const focusFrameRef = useRef<number | null>(null)
@@ -314,7 +312,9 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     ? groups.findIndex(group => group.id === normalizedHistoryState.oldestVisibleId)
     : -1
 
-  const hiddenCount = stableBoundaryIndex >= 0 ? stableBoundaryIndex : firstVisibleGroupIndex(groups, FIRST_PAINT_BUDGET)
+  const hiddenCount =
+    stableBoundaryIndex >= 0 ? stableBoundaryIndex : firstVisibleGroupIndex(groups, FIRST_PAINT_BUDGET)
+
   const visibleGroups = hiddenCount > 0 ? groups.slice(hiddenCount) : groups
   const restoreFromBottomRef = useRef<number | null>(null)
   // Secondary windows (new-session scratch, subagent watch, cmd-click pop-out)

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -17,7 +17,11 @@ import { useStickToBottom } from 'use-stick-to-bottom'
 
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
-import { $previewClearGenerationBySession, recordPreviewArtifacts } from '@/store/preview-status'
+import {
+  $previewClearGenerationBySession,
+  $previewDismissGenerationBySession,
+  recordPreviewArtifacts
+} from '@/store/preview-status'
 import {
   onScrollToBottomRequest,
   onThreadEditClose,
@@ -172,7 +176,10 @@ const ToolPreviewRegistrar: FC<{ cwd: string | null; sessionId: string | null | 
       string,
       {
         clearGeneration: number
+        dismissGenerations: Record<string, number>
+        dismissedOccurrenceKeys: Set<string>
         occurrenceKeys: Set<string>
+        occurrenceTargets: Map<string, string>
         targetsSignature: string
         timelineSignature: string
       }
@@ -203,6 +210,8 @@ const ToolPreviewRegistrar: FC<{ cwd: string | null; sessionId: string | null | 
 
   const clearGenerationBySession = useStore($previewClearGenerationBySession)
   const clearGeneration = sessionId ? (clearGenerationBySession[sessionId] ?? 0) : 0
+  const dismissGenerationBySession = useStore($previewDismissGenerationBySession)
+  const dismissGenerationSignature = JSON.stringify(sessionId ? (dismissGenerationBySession[sessionId] ?? {}) : {})
 
   const targetsSignature = useAuiState(s =>
     JSON.stringify(
@@ -240,25 +249,46 @@ const ToolPreviewRegistrar: FC<{ cwd: string | null; sessionId: string | null | 
       return
     }
 
+    const dismissGenerations = JSON.parse(dismissGenerationSignature) as Record<string, number>
     const previous = registrationBySessionRef.current.get(sessionId)
     const timelineChanged = previous?.timelineSignature !== timelineSignature
+    const dismissedOccurrenceKeys = new Set(previous?.dismissedOccurrenceKeys)
+
+    // Dismissal belongs to the exact occurrences mounted when the user acted,
+    // not to the normalized target forever. Preserve those tombstones across a
+    // clear/truncate/rollback sequence, while allowing a later occurrence with
+    // a different message/tool-call key to reproduce the same target.
+    if (previous) {
+      for (const [target, generation] of Object.entries(dismissGenerations)) {
+        if (generation <= (previous.dismissGenerations[target] ?? 0)) {
+          continue
+        }
+
+        for (const [key, occurrenceTarget] of previous.occurrenceTargets) {
+          if (occurrenceTarget === target) {
+            dismissedOccurrenceKeys.add(key)
+          }
+        }
+      }
+    }
 
     // A clear invalidates the abandoned timeline, but must not immediately
     // replay that same timeline before restore/edit publishes its optimistic
     // rewind. Keep the old generation until an authoritative timeline change
     // arrives; that change may leave the preview inventory itself unchanged.
     if (previous && previous.clearGeneration !== clearGeneration && !timelineChanged) {
+      previous.dismissGenerations = dismissGenerations
+      previous.dismissedOccurrenceKeys = dismissedOccurrenceKeys
+
       return
     }
 
     // Ordinary non-preview streaming/tail updates do not need inventory work.
     // Remember the latest timeline identity so a later clear can distinguish
     // the actual rewind from the generation-only notification.
-    if (
-      previous &&
-      previous.clearGeneration === clearGeneration &&
-      previous.targetsSignature === targetsSignature
-    ) {
+    if (previous && previous.clearGeneration === clearGeneration && previous.targetsSignature === targetsSignature) {
+      previous.dismissGenerations = dismissGenerations
+      previous.dismissedOccurrenceKeys = dismissedOccurrenceKeys
       previous.timelineSignature = timelineSignature
 
       return
@@ -267,12 +297,18 @@ const ToolPreviewRegistrar: FC<{ cwd: string | null; sessionId: string | null | 
     const entries = JSON.parse(targetsSignature) as Array<{ key: string; target: string }>
     const occurrenceKeys = new Set(entries.map(entry => entry.key))
     const priorKeys = previous?.clearGeneration === clearGeneration ? previous.occurrenceKeys : new Set<string>()
-    const newTargets = entries.filter(entry => !priorKeys.has(entry.key)).map(entry => entry.target)
+
+    const newTargets = entries
+      .filter(entry => !priorKeys.has(entry.key) && !dismissedOccurrenceKeys.has(entry.key))
+      .map(entry => entry.target)
 
     registrationBySessionRef.current.delete(sessionId)
     registrationBySessionRef.current.set(sessionId, {
       clearGeneration,
+      dismissGenerations,
+      dismissedOccurrenceKeys,
       occurrenceKeys,
+      occurrenceTargets: new Map(entries.map(entry => [entry.key, entry.target])),
       targetsSignature,
       timelineSignature
     })
@@ -288,7 +324,7 @@ const ToolPreviewRegistrar: FC<{ cwd: string | null; sessionId: string | null | 
     }
 
     recordPreviewArtifacts(sessionId, newTargets, cwd || '')
-  }, [clearGeneration, cwd, sessionId, targetsSignature, timelineSignature])
+  }, [clearGeneration, cwd, dismissGenerationSignature, sessionId, targetsSignature, timelineSignature])
 
   return null
 }

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -1,4 +1,5 @@
 import { ThreadPrimitive, useAuiEvent, useAuiState } from '@assistant-ui/react'
+import { useStore } from '@nanostores/react'
 import {
   type ComponentProps,
   type CSSProperties,
@@ -16,7 +17,7 @@ import { useStickToBottom } from 'use-stick-to-bottom'
 
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
-import { getPreviewClearGeneration, recordPreviewArtifacts } from '@/store/preview-status'
+import { $previewClearGenerationBySession, recordPreviewArtifacts } from '@/store/preview-status'
 import {
   onScrollToBottomRequest,
   onThreadEditClose,
@@ -167,8 +168,41 @@ const ToolPreviewRegistrar: FC<{ cwd: string | null; sessionId: string | null | 
   const targetCacheRef = useRef(new WeakMap<object, { args: unknown; result: unknown; target: string }>())
 
   const registrationBySessionRef = useRef(
-    new Map<string, { clearGeneration: number; occurrenceKeys: Set<string> }>()
+    new Map<
+      string,
+      {
+        clearGeneration: number
+        occurrenceKeys: Set<string>
+        targetsSignature: string
+        timelineSignature: string
+      }
+    >()
   )
+
+  const timelinePartIdsRef = useRef(new WeakMap<object, number>())
+  const nextTimelinePartIdRef = useRef(0)
+
+  const timelineSignature = useAuiState(s =>
+    s.thread.messages
+      .map(message => {
+        const partIds = message.content.map(part => {
+          let id = timelinePartIdsRef.current.get(part)
+
+          if (id === undefined) {
+            id = nextTimelinePartIdRef.current++
+            timelinePartIdsRef.current.set(part, id)
+          }
+
+          return id
+        })
+
+        return `${message.id}:${partIds.join(',')}`
+      })
+      .join('|')
+  )
+
+  const clearGenerationBySession = useStore($previewClearGenerationBySession)
+  const clearGeneration = sessionId ? (clearGenerationBySession[sessionId] ?? 0) : 0
 
   const targetsSignature = useAuiState(s =>
     JSON.stringify(
@@ -206,15 +240,42 @@ const ToolPreviewRegistrar: FC<{ cwd: string | null; sessionId: string | null | 
       return
     }
 
-    const entries = JSON.parse(targetsSignature) as Array<{ key: string; target: string }>
-    const clearGeneration = getPreviewClearGeneration(sessionId)
     const previous = registrationBySessionRef.current.get(sessionId)
+    const timelineChanged = previous?.timelineSignature !== timelineSignature
+
+    // A clear invalidates the abandoned timeline, but must not immediately
+    // replay that same timeline before restore/edit publishes its optimistic
+    // rewind. Keep the old generation until an authoritative timeline change
+    // arrives; that change may leave the preview inventory itself unchanged.
+    if (previous && previous.clearGeneration !== clearGeneration && !timelineChanged) {
+      return
+    }
+
+    // Ordinary non-preview streaming/tail updates do not need inventory work.
+    // Remember the latest timeline identity so a later clear can distinguish
+    // the actual rewind from the generation-only notification.
+    if (
+      previous &&
+      previous.clearGeneration === clearGeneration &&
+      previous.targetsSignature === targetsSignature
+    ) {
+      previous.timelineSignature = timelineSignature
+
+      return
+    }
+
+    const entries = JSON.parse(targetsSignature) as Array<{ key: string; target: string }>
     const occurrenceKeys = new Set(entries.map(entry => entry.key))
     const priorKeys = previous?.clearGeneration === clearGeneration ? previous.occurrenceKeys : new Set<string>()
     const newTargets = entries.filter(entry => !priorKeys.has(entry.key)).map(entry => entry.target)
 
     registrationBySessionRef.current.delete(sessionId)
-    registrationBySessionRef.current.set(sessionId, { clearGeneration, occurrenceKeys })
+    registrationBySessionRef.current.set(sessionId, {
+      clearGeneration,
+      occurrenceKeys,
+      targetsSignature,
+      timelineSignature
+    })
 
     while (registrationBySessionRef.current.size > MAX_TRACKED_PREVIEW_SESSIONS) {
       const oldestSession = registrationBySessionRef.current.keys().next().value
@@ -227,7 +288,7 @@ const ToolPreviewRegistrar: FC<{ cwd: string | null; sessionId: string | null | 
     }
 
     recordPreviewArtifacts(sessionId, newTargets, cwd || '')
-  }, [cwd, sessionId, targetsSignature])
+  }, [clearGeneration, cwd, sessionId, targetsSignature, timelineSignature])
 
   return null
 }

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
@@ -724,6 +724,18 @@ function toolPreviewTarget(toolName: string, args: Record<string, unknown>, resu
   return ''
 }
 
+/** Lightweight preview metadata extraction for the authoritative transcript.
+ * Keep this independent of buildToolView so paginated tool rows do not need to
+ * mount (or stringify their full result) before the composer can surface an
+ * artifact produced by a completed tool call. */
+export function toolPreviewTargetForPart(part: ToolPart): string {
+  if (part.result === undefined) {
+    return ''
+  }
+
+  return toolPreviewTarget(part.toolName, parseMaybeObject(part.args), parseMaybeObject(part.result))
+}
+
 function toolImageUrl(args: Record<string, unknown>, result: Record<string, unknown>): string {
   const candidate =
     firstStringField(result, ['image_url', 'url', 'path', 'image_path']) ||

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -37,8 +37,6 @@ import { AlertCircle, CheckCircle2 } from '@/lib/icons'
 import { normalize } from '@/lib/text'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
-import { recordPreviewArtifact } from '@/store/preview-status'
-import { $activeSessionId, $currentCwd } from '@/store/session'
 import { $toolInlineDiff } from '@/store/tool-diffs'
 import { $toolRowDismissed, dismissToolRow } from '@/store/tool-dismiss'
 import { $toolDisclosureOpen, $toolViewMode, setToolDisclosureOpen } from '@/store/tool-view'
@@ -51,7 +49,6 @@ import {
   countDiffLineStats,
   inlineDiffFromResult,
   isFileEditTool,
-  isPreviewableTarget,
   looksRedundant,
   type SearchResultRow,
   selectMessageRunning,
@@ -62,6 +59,7 @@ import {
   type ToolStatus,
   type ToolTitleAction
 } from './fallback-model'
+import { toolPartPageKey, useToolTurnPagination } from './turn-pagination'
 
 // `true` when a ToolEntry is rendered inside an embedding wrapper that owns
 // the per-row chrome (timer / preview). The flat ToolGroupSlot sets this
@@ -323,26 +321,6 @@ function ToolEntry({ part }: ToolEntryProps) {
     return buildToolView(p, inlineDiff)
   }, [inlineDiff, isPending, result, stablePart])
 
-  // Surface a previewable artifact (HTML file / localhost URL) as a compact link
-  // in the composer status stack rather than a bulky inline card. Uses the same
-  // detected target the old inline card did, keyed to the active session the
-  // stack reads from. Idempotent + dedup'd, so re-renders don't churn.
-  const previewTarget = view.previewTarget
-
-  useEffect(() => {
-    if (isPending || !previewTarget || !isPreviewableTarget(previewTarget)) {
-      return
-    }
-
-    // Read (don't subscribe) session/cwd: this only fires when a previewable
-    // target appears, and subscribing re-rendered every tool row on any session
-    // or cwd change.
-    const activeSessionId = $activeSessionId.get()
-
-    if (activeSessionId) {
-      recordPreviewArtifact(activeSessionId, previewTarget, $currentCwd.get() || '')
-    }
-  }, [isPending, previewTarget])
 
   const detailSections = useMemo(() => {
     if (!view.detail) {
@@ -759,6 +737,7 @@ export const ToolGroupSlot: FC<PropsWithChildren<{ endIndex: number; startIndex:
   const messageId = useAuiState(s => s.message.id)
   const messageRunning = useAuiState(selectMessageRunning)
   const { t } = useI18n()
+  const turnPagination = useToolTurnPagination()
 
   const hasUnboundable = useAuiState(s =>
     s.message.parts
@@ -773,25 +752,56 @@ export const ToolGroupSlot: FC<PropsWithChildren<{ endIndex: number; startIndex:
   const pageKey = `${messageId}:${startIndex}`
   const [page, setPage] = useState({ count: TOOL_GROUP_DOM_PAGE, key: pageKey })
 
+  const partKeysSignature = useAuiState(s =>
+    s.message.parts
+      .slice(Math.max(0, startIndex), endIndex + 1)
+      .map((part, offset) =>
+        part.type === 'tool-call'
+          ? toolPartPageKey(messageId, Math.max(0, startIndex) + offset, part.toolCallId)
+          : ''
+      )
+      .filter(Boolean)
+      .join('\n')
+  )
+
   if (page.key !== pageKey) {
     setPage({ count: TOOL_GROUP_DOM_PAGE, key: pageKey })
   }
 
   const renderCount = page.key === pageKey ? page.count : TOOL_GROUP_DOM_PAGE
-  const hiddenCount = Math.max(0, childArray.length - renderCount)
-  const visibleChildren = hiddenCount > 0 ? childArray.slice(-renderCount) : childArray
+
+  const partKeys = partKeysSignature ? partKeysSignature.split('\n') : []
+  const keyedChildren = childArray.map((child, index) => ({ child, key: partKeys[index] ?? `${pageKey}:${index}` }))
+  const localHiddenCount = Math.max(0, keyedChildren.length - renderCount)
+
+  const visibleChildren = turnPagination
+    ? keyedChildren.filter(item => turnPagination.isVisible(item.key))
+    : localHiddenCount > 0
+      ? keyedChildren.slice(-renderCount)
+      : keyedChildren
+
+  const showTurnPager = Boolean(
+    turnPagination &&
+      turnPagination.hiddenCount > 0 &&
+      visibleChildren.some(item => item.key === turnPagination.pagerKey)
+  )
+
   const { contentRef, faded, onScroll, scrollRef } = useToolWindow(bounded)
 
   return (
     <ToolEmbedContext.Provider value={false}>
       <div className="min-w-0 max-w-full overflow-hidden" data-slot="tool-block" data-tool-group="" ref={enterRef}>
-        {hiddenCount > 0 && (
+        {(showTurnPager || (!turnPagination && localHiddenCount > 0)) && (
           <button
             className="mx-auto mb-1 block rounded-full border border-border/65 bg-(--composer-fill) px-2.5 py-0.5 text-[0.65rem] text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            onClick={() => setPage(current => ({ ...current, count: current.count + TOOL_GROUP_DOM_PAGE }))}
+            onClick={() =>
+              turnPagination
+                ? turnPagination.revealEarlier()
+                : setPage(current => ({ ...current, count: current.count + TOOL_GROUP_DOM_PAGE }))
+            }
             type="button"
           >
-            {t.assistant.thread.showEarlier}
+            {t.assistant.thread.showEarlierToolCalls}
           </button>
         )}
         <div
@@ -803,7 +813,11 @@ export const ToolGroupSlot: FC<PropsWithChildren<{ endIndex: number; startIndex:
           ref={scrollRef}
         >
           <div className="grid min-w-0 max-w-full gap-(--tool-row-gap)" ref={contentRef}>
-            {visibleChildren}
+            {visibleChildren.map(item => (
+              <div data-tool-page-key={item.key} key={item.key} tabIndex={-1}>
+                {item.child}
+              </div>
+            ))}
           </div>
         </div>
       </div>

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -321,7 +321,6 @@ function ToolEntry({ part }: ToolEntryProps) {
     return buildToolView(p, inlineDiff)
   }, [inlineDiff, isPending, result, stablePart])
 
-
   const detailSections = useMemo(() => {
     if (!view.detail) {
       return { body: '', summary: '' }
@@ -756,9 +755,7 @@ export const ToolGroupSlot: FC<PropsWithChildren<{ endIndex: number; startIndex:
     s.message.parts
       .slice(Math.max(0, startIndex), endIndex + 1)
       .map((part, offset) =>
-        part.type === 'tool-call'
-          ? toolPartPageKey(messageId, Math.max(0, startIndex) + offset, part.toolCallId)
-          : ''
+        part.type === 'tool-call' ? toolPartPageKey(messageId, Math.max(0, startIndex) + offset, part.toolCallId) : ''
       )
       .filter(Boolean)
       .join('\n')
@@ -782,8 +779,8 @@ export const ToolGroupSlot: FC<PropsWithChildren<{ endIndex: number; startIndex:
 
   const showTurnPager = Boolean(
     turnPagination &&
-      turnPagination.hiddenCount > 0 &&
-      visibleChildren.some(item => item.key === turnPagination.pagerKey)
+    turnPagination.hiddenCount > 0 &&
+    visibleChildren.some(item => item.key === turnPagination.pagerKey)
   )
 
   const { contentRef, faded, onScroll, scrollRef } = useToolWindow(bounded)

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -791,6 +791,7 @@ export const ToolGroupSlot: FC<PropsWithChildren<{ endIndex: number; startIndex:
         {(showTurnPager || (!turnPagination && localHiddenCount > 0)) && (
           <button
             className="mx-auto mb-1 block rounded-full border border-border/65 bg-(--composer-fill) px-2.5 py-0.5 text-[0.65rem] text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            data-tool-page-pager={turnPagination?.pagerKey ?? undefined}
             onClick={() =>
               turnPagination
                 ? turnPagination.revealEarlier()

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -672,10 +672,11 @@ function TerminalTranscript({ command, exitCode }: TerminalTranscriptProps) {
 // A back-to-back run of this many tool calls collapses into the bounded,
 // auto-scrolling window; fewer than this stays a plain inline stack.
 const TOOL_GROUP_SCROLL_THRESHOLD = 3
+const TOOL_GROUP_DOM_PAGE = 20
 
 // Tools whose body (an interactive form, a full-size image) must never be
-// trapped behind the window's max-height + fade mask. A run holding any of
-// them stays a plain, fully-visible stack no matter how long it is.
+// trapped behind the window's max-height + fade mask. Large runs still page
+// their DOM independently; the newest page contains the active tool.
 export const UNBOUNDABLE_TOOLS = new Set(['clarify', 'image_generate'])
 
 export function shouldBoundToolGroup(childCount: number, hasUnboundable: boolean) {
@@ -757,6 +758,7 @@ export const ToolGroupSlot: FC<PropsWithChildren<{ endIndex: number; startIndex:
 }) => {
   const messageId = useAuiState(s => s.message.id)
   const messageRunning = useAuiState(selectMessageRunning)
+  const { t } = useI18n()
 
   const hasUnboundable = useAuiState(s =>
     s.message.parts
@@ -766,12 +768,32 @@ export const ToolGroupSlot: FC<PropsWithChildren<{ endIndex: number; startIndex:
 
   const enterRef = useEnterAnimation(messageRunning, `tool-group:${messageId}:${startIndex}`)
 
-  const bounded = shouldBoundToolGroup(Children.count(children), hasUnboundable)
+  const childArray = Children.toArray(children)
+  const bounded = shouldBoundToolGroup(childArray.length, hasUnboundable)
+  const pageKey = `${messageId}:${startIndex}`
+  const [page, setPage] = useState({ count: TOOL_GROUP_DOM_PAGE, key: pageKey })
+
+  if (page.key !== pageKey) {
+    setPage({ count: TOOL_GROUP_DOM_PAGE, key: pageKey })
+  }
+
+  const renderCount = page.key === pageKey ? page.count : TOOL_GROUP_DOM_PAGE
+  const hiddenCount = Math.max(0, childArray.length - renderCount)
+  const visibleChildren = hiddenCount > 0 ? childArray.slice(-renderCount) : childArray
   const { contentRef, faded, onScroll, scrollRef } = useToolWindow(bounded)
 
   return (
     <ToolEmbedContext.Provider value={false}>
       <div className="min-w-0 max-w-full overflow-hidden" data-slot="tool-block" data-tool-group="" ref={enterRef}>
+        {hiddenCount > 0 && (
+          <button
+            className="mx-auto mb-1 block rounded-full border border-border/65 bg-(--composer-fill) px-2.5 py-0.5 text-[0.65rem] text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={() => setPage(current => ({ ...current, count: current.count + TOOL_GROUP_DOM_PAGE }))}
+            type="button"
+          >
+            {t.assistant.thread.showEarlier}
+          </button>
+        )}
         <div
           className={cn(
             bounded && 'tool-group-scroll max-h-(--tool-group-scroll-max-h) overflow-y-auto',
@@ -781,7 +803,7 @@ export const ToolGroupSlot: FC<PropsWithChildren<{ endIndex: number; startIndex:
           ref={scrollRef}
         >
           <div className="grid min-w-0 max-w-full gap-(--tool-row-gap)" ref={contentRef}>
-            {children}
+            {visibleChildren}
           </div>
         </div>
       </div>

--- a/apps/desktop/src/components/assistant-ui/tool/turn-pagination.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/turn-pagination.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { firstVisibleToolIndex, TOOL_TURN_PAGE_SIZE, type TurnToolRef } from './turn-pagination'
+
+const tools = (count: number): TurnToolRef[] =>
+  Array.from({ length: count }, (_, index) => ({ key: `tool-${index}`, messageId: 'message', partIndex: index }))
+
+describe('firstVisibleToolIndex', () => {
+  it.each([
+    [0, 0],
+    [1, 0],
+    [TOOL_TURN_PAGE_SIZE - 1, 0],
+    [TOOL_TURN_PAGE_SIZE, 0],
+    [TOOL_TURN_PAGE_SIZE + 1, 1],
+    [TOOL_TURN_PAGE_SIZE * 2, TOOL_TURN_PAGE_SIZE],
+    [TOOL_TURN_PAGE_SIZE * 2 + 1, TOOL_TURN_PAGE_SIZE + 1]
+  ])('keeps exactly one bounded tail for %i tool calls', (count, expected) => {
+    expect(firstVisibleToolIndex(tools(count), null, false)).toBe(expected)
+  })
+
+  it('keeps the oldest revealed tool stable when newer calls append', () => {
+    expect(firstVisibleToolIndex(tools(41), 'tool-10', true)).toBe(10)
+  })
+
+  it('falls back to the bounded tail when the saved tool no longer exists', () => {
+    expect(firstVisibleToolIndex(tools(41), 'removed-tool', true)).toBe(21)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/tool/turn-pagination.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/turn-pagination.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import { createContext, type FC, type PropsWithChildren, useCallback, useContext, useLayoutEffect, useRef, useState } from 'react'
+
+export const TOOL_TURN_PAGE_SIZE = 20
+
+export interface TurnToolRef {
+  key: string
+  messageId: string
+  partIndex: number
+}
+
+interface ToolTurnPaginationState {
+  expanded: boolean
+  oldestVisibleKey: string | null
+  turnKey: string
+}
+
+interface ToolTurnPaginationValue {
+  hiddenCount: number
+  isVisible: (key: string) => boolean
+  pagerKey: string | null
+  revealEarlier: () => void
+}
+
+const ToolTurnPaginationContext = createContext<ToolTurnPaginationValue | null>(null)
+
+export function toolPartPageKey(messageId: string, partIndex: number, toolCallId?: string): string {
+  return `${messageId}:${toolCallId || `part-${partIndex}`}`
+}
+
+export function firstVisibleToolIndex(tools: readonly TurnToolRef[], oldestVisibleKey: string | null, expanded: boolean): number {
+  if (expanded && oldestVisibleKey) {
+    const stableIndex = tools.findIndex(tool => tool.key === oldestVisibleKey)
+
+    if (stableIndex >= 0) {
+      return stableIndex
+    }
+  }
+
+  return Math.max(0, tools.length - TOOL_TURN_PAGE_SIZE)
+}
+
+export const ToolTurnPaginationProvider: FC<
+  PropsWithChildren<{ tools: readonly TurnToolRef[]; turnKey: string }>
+> = ({ children, tools, turnKey }) => {
+  const [state, setState] = useState<ToolTurnPaginationState>({
+    expanded: false,
+    oldestVisibleKey: null,
+    turnKey
+  })
+
+  const rootRef = useRef<HTMLDivElement | null>(null)
+  const focusAfterRevealRef = useRef<string | null>(null)
+
+  if (state.turnKey !== turnKey) {
+    focusAfterRevealRef.current = null
+    setState({ expanded: false, oldestVisibleKey: null, turnKey })
+  }
+
+  const currentState = state.turnKey === turnKey ? state : { expanded: false, oldestVisibleKey: null, turnKey }
+  const firstVisible = firstVisibleToolIndex(tools, currentState.oldestVisibleKey, currentState.expanded)
+  const hiddenCount = firstVisible
+  const visibleKeys = new Set(tools.slice(firstVisible).map(tool => tool.key))
+  const pagerKey = hiddenCount > 0 ? tools[firstVisible]?.key ?? null : null
+
+  const revealEarlier = useCallback(() => {
+    setState(current => {
+      const normalized = current.turnKey === turnKey ? current : { expanded: false, oldestVisibleKey: null, turnKey }
+      const visibleStart = firstVisibleToolIndex(tools, normalized.oldestVisibleKey, normalized.expanded)
+      const nextStart = Math.max(0, visibleStart - TOOL_TURN_PAGE_SIZE)
+      const nextOldest = tools[nextStart]?.key ?? null
+
+      focusAfterRevealRef.current = nextStart === 0 ? nextOldest : null
+
+      return { expanded: true, oldestVisibleKey: nextOldest, turnKey }
+    })
+  }, [tools, turnKey])
+
+  useLayoutEffect(() => {
+    const focusKey = focusAfterRevealRef.current
+
+    if (!focusKey || hiddenCount > 0) {
+      return
+    }
+
+    focusAfterRevealRef.current = null
+
+    const target = Array.from(rootRef.current?.querySelectorAll<HTMLElement>('[data-tool-page-key]') ?? []).find(
+      element => element.dataset.toolPageKey === focusKey
+    )
+
+    const frame = requestAnimationFrame(() => target?.focus({ preventScroll: true }))
+
+    return () => cancelAnimationFrame(frame)
+  }, [hiddenCount])
+
+  const value: ToolTurnPaginationValue = {
+    hiddenCount,
+    isVisible: key => visibleKeys.has(key),
+    pagerKey,
+    revealEarlier
+  }
+
+  return (
+    <ToolTurnPaginationContext.Provider value={value}>
+      <div className="contents" ref={rootRef}>
+        {children}
+      </div>
+    </ToolTurnPaginationContext.Provider>
+  )
+}
+
+export function useToolTurnPagination(): ToolTurnPaginationValue | null {
+  return useContext(ToolTurnPaginationContext)
+}

--- a/apps/desktop/src/components/assistant-ui/tool/turn-pagination.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/turn-pagination.tsx
@@ -1,6 +1,15 @@
 'use client'
 
-import { createContext, type FC, type PropsWithChildren, useCallback, useContext, useLayoutEffect, useRef, useState } from 'react'
+import {
+  createContext,
+  type FC,
+  type PropsWithChildren,
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useRef,
+  useState
+} from 'react'
 
 export const TOOL_TURN_PAGE_SIZE = 20
 
@@ -29,7 +38,11 @@ export function toolPartPageKey(messageId: string, partIndex: number, toolCallId
   return `${messageId}:${toolCallId || `part-${partIndex}`}`
 }
 
-export function firstVisibleToolIndex(tools: readonly TurnToolRef[], oldestVisibleKey: string | null, expanded: boolean): number {
+export function firstVisibleToolIndex(
+  tools: readonly TurnToolRef[],
+  oldestVisibleKey: string | null,
+  expanded: boolean
+): number {
   if (expanded && oldestVisibleKey) {
     const stableIndex = tools.findIndex(tool => tool.key === oldestVisibleKey)
 
@@ -41,9 +54,11 @@ export function firstVisibleToolIndex(tools: readonly TurnToolRef[], oldestVisib
   return Math.max(0, tools.length - TOOL_TURN_PAGE_SIZE)
 }
 
-export const ToolTurnPaginationProvider: FC<
-  PropsWithChildren<{ tools: readonly TurnToolRef[]; turnKey: string }>
-> = ({ children, tools, turnKey }) => {
+export const ToolTurnPaginationProvider: FC<PropsWithChildren<{ tools: readonly TurnToolRef[]; turnKey: string }>> = ({
+  children,
+  tools,
+  turnKey
+}) => {
   const [state, setState] = useState<ToolTurnPaginationState>({
     expanded: false,
     oldestVisibleKey: null,
@@ -62,7 +77,7 @@ export const ToolTurnPaginationProvider: FC<
   const firstVisible = firstVisibleToolIndex(tools, currentState.oldestVisibleKey, currentState.expanded)
   const hiddenCount = firstVisible
   const visibleKeys = new Set(tools.slice(firstVisible).map(tool => tool.key))
-  const pagerKey = hiddenCount > 0 ? tools[firstVisible]?.key ?? null : null
+  const pagerKey = hiddenCount > 0 ? (tools[firstVisible]?.key ?? null) : null
 
   const revealEarlier = useCallback(() => {
     setState(current => {

--- a/apps/desktop/src/components/assistant-ui/tool/turn-pagination.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/turn-pagination.tsx
@@ -80,17 +80,13 @@ export const ToolTurnPaginationProvider: FC<PropsWithChildren<{ tools: readonly 
   const pagerKey = hiddenCount > 0 ? (tools[firstVisible]?.key ?? null) : null
 
   const revealEarlier = useCallback(() => {
-    setState(current => {
-      const normalized = current.turnKey === turnKey ? current : { expanded: false, oldestVisibleKey: null, turnKey }
-      const visibleStart = firstVisibleToolIndex(tools, normalized.oldestVisibleKey, normalized.expanded)
-      const nextStart = Math.max(0, visibleStart - TOOL_TURN_PAGE_SIZE)
-      const nextOldest = tools[nextStart]?.key ?? null
+    const visibleStart = firstVisibleToolIndex(tools, currentState.oldestVisibleKey, currentState.expanded)
+    const nextStart = Math.max(0, visibleStart - TOOL_TURN_PAGE_SIZE)
+    const nextOldest = tools[nextStart]?.key ?? null
 
-      focusAfterRevealRef.current = nextStart === 0 ? nextOldest : null
-
-      return { expanded: true, oldestVisibleKey: nextOldest, turnKey }
-    })
-  }, [tools, turnKey])
+    focusAfterRevealRef.current = nextStart === 0 ? nextOldest : null
+    setState({ expanded: true, oldestVisibleKey: nextOldest, turnKey })
+  }, [currentState.expanded, currentState.oldestVisibleKey, tools, turnKey])
 
   useLayoutEffect(() => {
     const focusKey = focusAfterRevealRef.current

--- a/apps/desktop/src/components/assistant-ui/tool/turn-pagination.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/turn-pagination.tsx
@@ -84,21 +84,23 @@ export const ToolTurnPaginationProvider: FC<PropsWithChildren<{ tools: readonly 
     const nextStart = Math.max(0, visibleStart - TOOL_TURN_PAGE_SIZE)
     const nextOldest = tools[nextStart]?.key ?? null
 
-    focusAfterRevealRef.current = nextStart === 0 ? nextOldest : null
+    focusAfterRevealRef.current = nextOldest
     setState({ expanded: true, oldestVisibleKey: nextOldest, turnKey })
   }, [currentState.expanded, currentState.oldestVisibleKey, tools, turnKey])
 
   useLayoutEffect(() => {
     const focusKey = focusAfterRevealRef.current
 
-    if (!focusKey || hiddenCount > 0) {
+    if (!focusKey) {
       return
     }
 
     focusAfterRevealRef.current = null
 
-    const target = Array.from(rootRef.current?.querySelectorAll<HTMLElement>('[data-tool-page-key]') ?? []).find(
-      element => element.dataset.toolPageKey === focusKey
+    const target = Array.from(
+      rootRef.current?.querySelectorAll<HTMLElement>('[data-tool-page-key], [data-tool-page-pager]') ?? []
+    ).find(element =>
+      hiddenCount > 0 ? element.dataset.toolPagePager === focusKey : element.dataset.toolPageKey === focusKey
     )
 
     const frame = requestAnimationFrame(() => target?.focus({ preventScroll: true }))

--- a/apps/desktop/src/components/chat/shiki-highlighter.dom.test.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.dom.test.tsx
@@ -3,9 +3,21 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import type { ComponentProps } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { ShikiWorkerToken } from './shiki-worker'
+import type { ShikiHighlightJob } from './shiki-worker-client'
+
+interface ActualShikiWorkerClient {
+  getShikiWorkerClientSnapshotForTests: () => {
+    activeGeneration: number | null
+    activeLeases: number
+    pending: number
+  }
+  startShikiHighlight: (code: string, language: string) => ShikiHighlightJob
+}
+
 const CODE = 'export const answer = 42'
 
-const TOKENS = [
+const TOKENS: ShikiWorkerToken[][] = [
   [
     { content: 'export', htmlStyle: { '--shiki-light': '#6E7781', color: '#6E7781' } },
     { content: ' const answer = 42', htmlStyle: { color: '#ff0000' } }
@@ -17,10 +29,12 @@ const { disposeHighlight, startShikiHighlight } = vi.hoisted(() => {
 
   return {
     disposeHighlight,
-    startShikiHighlight: vi.fn(() => ({
-      dispose: disposeHighlight,
-      promise: Promise.resolve(TOKENS)
-    }))
+    startShikiHighlight: vi.fn<(code: string, language: string) => ShikiHighlightJob>(
+      (_code: string, _language: string) => ({
+        dispose: disposeHighlight,
+        promise: Promise.resolve(TOKENS)
+      })
+    )
   }
 })
 
@@ -58,7 +72,7 @@ const components = {
 beforeEach(() => {
   disposeHighlight.mockClear()
   startShikiHighlight.mockClear()
-  startShikiHighlight.mockImplementation(() => ({
+  startShikiHighlight.mockImplementation((_code: string, _language: string) => ({
     dispose: disposeHighlight,
     promise: Promise.resolve(TOKENS)
   }))
@@ -81,10 +95,7 @@ describe('SyntaxHighlighter viewport and worker lifecycle', () => {
     expect(intersectionCallback).not.toBeNull()
 
     act(() => {
-      intersectionCallback?.(
-        [{ isIntersecting: true } as IntersectionObserverEntry],
-        {} as IntersectionObserver
-      )
+      intersectionCallback?.([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver)
     })
 
     await waitFor(() => expect(startShikiHighlight).toHaveBeenCalledWith(CODE, 'ts'))
@@ -98,10 +109,7 @@ describe('SyntaxHighlighter viewport and worker lifecycle', () => {
     render(<SyntaxHighlighter code={CODE} components={components} language="ts" />)
 
     act(() => {
-      intersectionCallback?.(
-        [{ isIntersecting: true } as IntersectionObserverEntry],
-        {} as IntersectionObserver
-      )
+      intersectionCallback?.([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver)
     })
     await waitFor(() => expect(startShikiHighlight).toHaveBeenCalledTimes(1))
 
@@ -121,10 +129,7 @@ describe('SyntaxHighlighter viewport and worker lifecycle', () => {
 
     const view = render(<SyntaxHighlighter code={CODE} components={components} language="ts" />)
     act(() => {
-      intersectionCallback?.(
-        [{ isIntersecting: true } as IntersectionObserverEntry],
-        {} as IntersectionObserver
-      )
+      intersectionCallback?.([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver)
     })
     await waitFor(() => expect(startShikiHighlight).toHaveBeenCalledTimes(1))
 
@@ -197,5 +202,101 @@ describe('SyntaxHighlighter viewport and worker lifecycle', () => {
 
     expect(startShikiHighlight).toHaveBeenCalledTimes(2)
     expect(view.container.querySelector('code')?.textContent).toBe(CODE)
+  })
+
+  it('shares one replacement generation after a transient Worker constructor failure', async () => {
+    vi.stubGlobal('IntersectionObserver', undefined)
+    const constructorCause = new Error('transient constructor detail')
+
+    class ConstructorRetryWorker {
+      static constructorCalls = 0
+      static instances: ConstructorRetryWorker[] = []
+      messages: Array<{ code: string; id: number; language: string }> = []
+      onerror: ((event: ErrorEvent) => void) | null = null
+      onmessage: ((event: MessageEvent) => void) | null = null
+      terminateCalls = 0
+
+      constructor() {
+        ConstructorRetryWorker.constructorCalls += 1
+
+        if (ConstructorRetryWorker.constructorCalls === 1) {
+          throw constructorCause
+        }
+
+        ConstructorRetryWorker.instances.push(this)
+      }
+
+      postMessage(message: { code: string; id: number; language: string }) {
+        this.messages.push(message)
+      }
+
+      terminate() {
+        this.terminateCalls += 1
+      }
+    }
+
+    vi.stubGlobal('Worker', ConstructorRetryWorker)
+    const client = await vi.importActual<ActualShikiWorkerClient>('./shiki-worker-client')
+    startShikiHighlight.mockImplementation(client.startShikiHighlight)
+
+    const view = render(
+      <>
+        <SyntaxHighlighter code="first block" components={components} language="ts" />
+        <SyntaxHighlighter code="second block" components={components} language="ts" />
+      </>
+    )
+
+    await waitFor(() => expect(ConstructorRetryWorker.instances).toHaveLength(1))
+    const worker = ConstructorRetryWorker.instances[0]
+    await waitFor(() => expect(worker.messages).toHaveLength(2))
+
+    for (const message of worker.messages) {
+      worker.onmessage?.({ data: { id: message.id, tokens: TOKENS } } as MessageEvent)
+    }
+
+    await waitFor(() => expect(view.container.querySelectorAll('span[style*="#57606a"]')).toHaveLength(2))
+    expect(ConstructorRetryWorker.constructorCalls).toBe(2)
+    expect(client.getShikiWorkerClientSnapshotForTests()).toMatchObject({ activeLeases: 2, pending: 0 })
+
+    view.unmount()
+
+    expect(worker.terminateCalls).toBe(1)
+    expect(client.getShikiWorkerClientSnapshotForTests()).toEqual({
+      activeGeneration: null,
+      activeLeases: 0,
+      pending: 0
+    })
+  })
+
+  it('falls back without looping when both Worker constructor attempts fail', async () => {
+    vi.stubGlobal('IntersectionObserver', undefined)
+    const constructorCauses = [new Error('first constructor detail'), new Error('second constructor detail')]
+
+    class AlwaysFailingConstructorWorker {
+      static constructorCalls = 0
+
+      constructor() {
+        const cause = constructorCauses[AlwaysFailingConstructorWorker.constructorCalls]
+        AlwaysFailingConstructorWorker.constructorCalls += 1
+        throw cause
+      }
+    }
+
+    vi.stubGlobal('Worker', AlwaysFailingConstructorWorker)
+    const client = await vi.importActual<ActualShikiWorkerClient>('./shiki-worker-client')
+    startShikiHighlight.mockImplementation(client.startShikiHighlight)
+
+    const view = render(<SyntaxHighlighter code={CODE} components={components} language="ts" />)
+
+    await waitFor(() => expect(AlwaysFailingConstructorWorker.constructorCalls).toBe(2))
+    await act(async () => Promise.resolve())
+
+    expect(AlwaysFailingConstructorWorker.constructorCalls).toBe(2)
+    expect(view.container.querySelector('code')?.textContent).toBe(CODE)
+    expect(client.getShikiWorkerClientSnapshotForTests()).toEqual({
+      activeGeneration: null,
+      activeLeases: 0,
+      pending: 0
+    })
   })
 })

--- a/apps/desktop/src/components/chat/shiki-highlighter.dom.test.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.dom.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ComponentProps } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const CODE = 'export const answer = 42'
+
+const TOKENS = [
+  [
+    { content: 'export', htmlStyle: { '--shiki-light': '#6E7781', color: '#6E7781' } },
+    { content: ' const answer = 42', htmlStyle: { color: '#ff0000' } }
+  ]
+]
+
+const { disposeHighlight, startShikiHighlight } = vi.hoisted(() => {
+  const disposeHighlight = vi.fn()
+
+  return {
+    disposeHighlight,
+    startShikiHighlight: vi.fn(() => ({
+      dispose: disposeHighlight,
+      promise: Promise.resolve(TOKENS)
+    }))
+  }
+})
+
+vi.mock('@/components/chat/shiki-worker-client', () => ({ startShikiHighlight }))
+
+import { SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
+
+let intersectionCallback: IntersectionObserverCallback | null = null
+
+class TestIntersectionObserver {
+  constructor(callback: IntersectionObserverCallback) {
+    intersectionCallback = callback
+  }
+
+  disconnect() {}
+  observe() {}
+  takeRecords() {
+    return []
+  }
+  unobserve() {}
+  root = null
+  rootMargin = '300px 0px'
+  thresholds = [0]
+}
+
+const components = {
+  Code: ({ node: _node, ...props }: ComponentProps<'code'> & { node?: unknown }) => <code {...props} />,
+  Pre: ({ node: _node, ...props }: ComponentProps<'pre'> & { node?: unknown }) => <pre {...props} />
+}
+
+beforeEach(() => {
+  disposeHighlight.mockClear()
+  startShikiHighlight.mockClear()
+  startShikiHighlight.mockImplementation(() => ({
+    dispose: disposeHighlight,
+    promise: Promise.resolve(TOKENS)
+  }))
+  intersectionCallback = null
+  vi.stubGlobal('IntersectionObserver', TestIntersectionObserver)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('SyntaxHighlighter viewport and worker lifecycle', () => {
+  it('keeps complete off-screen code plain, then highlights it near the viewport', async () => {
+    const view = render(<SyntaxHighlighter code={CODE} components={components} language="ts" />)
+
+    expect(view.container.textContent).toContain(CODE)
+    expect(startShikiHighlight).not.toHaveBeenCalled()
+    expect(intersectionCallback).not.toBeNull()
+
+    act(() => {
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+    })
+
+    await waitFor(() => expect(startShikiHighlight).toHaveBeenCalledWith(CODE, 'ts'))
+    await waitFor(() => expect(view.container.querySelector('code')?.textContent).toBe(CODE))
+    expect(view.container.querySelector('span[style*="#57606a"]')?.textContent).toBe('export')
+  })
+
+  it('copies the complete original code after worker highlighting', async () => {
+    const writeClipboard = vi.fn(async () => {})
+    Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: { writeClipboard } })
+    render(<SyntaxHighlighter code={CODE} components={components} language="ts" />)
+
+    act(() => {
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+    })
+    await waitFor(() => expect(startShikiHighlight).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByRole('button', { name: /copy code/i }))
+
+    await waitFor(() => expect(writeClipboard).toHaveBeenCalledWith(CODE))
+  })
+
+  it('disposes the worker lease and ignores a late result after unmount', async () => {
+    let resolveTokens: (tokens: typeof TOKENS) => void = () => {}
+    startShikiHighlight.mockImplementationOnce(() => ({
+      dispose: disposeHighlight,
+      promise: new Promise(resolve => {
+        resolveTokens = resolve
+      })
+    }))
+
+    const view = render(<SyntaxHighlighter code={CODE} components={components} language="ts" />)
+    act(() => {
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      )
+    })
+    await waitFor(() => expect(startShikiHighlight).toHaveBeenCalledTimes(1))
+
+    view.unmount()
+    expect(disposeHighlight).toHaveBeenCalledTimes(1)
+
+    await act(async () => resolveTokens(TOKENS))
+  })
+
+  it('keeps plain code usable when Worker support is unavailable', async () => {
+    vi.stubGlobal('IntersectionObserver', undefined)
+    startShikiHighlight.mockImplementationOnce(() => ({
+      dispose: disposeHighlight,
+      promise: Promise.reject(new Error('Web Workers are unavailable'))
+    }))
+
+    const view = render(<SyntaxHighlighter code={CODE} components={components} language="ts" />)
+
+    await waitFor(() => expect(startShikiHighlight).toHaveBeenCalledTimes(1))
+    expect(view.container.querySelector('code')?.textContent).toBe(CODE)
+  })
+})

--- a/apps/desktop/src/components/chat/shiki-highlighter.dom.test.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.dom.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import type { ComponentProps } from 'react'
+import { type ComponentProps, useLayoutEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ShikiWorkerToken } from './shiki-worker'
@@ -69,6 +69,18 @@ const components = {
   Pre: ({ node: _node, ...props }: ComponentProps<'pre'> & { node?: unknown }) => <pre {...props} />
 }
 
+function CommitProbe({ code, onCommit }: { code: string; onCommit: (visibleCode: null | string) => void }) {
+  const ref = useRef<HTMLDivElement | null>(null)
+
+  useLayoutEffect(() => onCommit(ref.current?.querySelector('code')?.textContent ?? null), [code, onCommit])
+
+  return (
+    <div ref={ref}>
+      <SyntaxHighlighter code={code} components={components} language="ts" />
+    </div>
+  )
+}
+
 beforeEach(() => {
   disposeHighlight.mockClear()
   startShikiHighlight.mockClear()
@@ -116,6 +128,35 @@ describe('SyntaxHighlighter viewport and worker lifecycle', () => {
     fireEvent.click(screen.getByRole('button', { name: /copy code/i }))
 
     await waitFor(() => expect(writeClipboard).toHaveBeenCalledWith(CODE))
+  })
+
+  it('never commits tokens from the previous code after props change', async () => {
+    vi.stubGlobal('IntersectionObserver', undefined)
+
+    const staleTokens: ShikiWorkerToken[][] = [
+      [{ content: 'stale highlighted code', htmlStyle: { color: '#ff0000' } }]
+    ]
+
+    let resolveStaleTokens: (tokens: ShikiWorkerToken[][]) => void = () => {}
+    startShikiHighlight.mockImplementationOnce(() => ({
+      dispose: disposeHighlight,
+      promise: new Promise(resolve => {
+        resolveStaleTokens = resolve
+      })
+    }))
+    startShikiHighlight.mockImplementationOnce(() => ({
+      dispose: disposeHighlight,
+      promise: new Promise(() => {})
+    }))
+    const onCommit = vi.fn()
+    const view = render(<CommitProbe code={CODE} onCommit={onCommit} />)
+
+    await act(async () => resolveStaleTokens(staleTokens))
+    await waitFor(() => expect(view.container.querySelector('code')?.textContent).toBe('stale highlighted code'))
+
+    view.rerender(<CommitProbe code="const replacement = true" onCommit={onCommit} />)
+
+    expect(onCommit).toHaveBeenLastCalledWith('const replacement = true')
   })
 
   it('disposes the worker lease and ignores a late result after unmount', async () => {

--- a/apps/desktop/src/components/chat/shiki-highlighter.dom.test.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.dom.test.tsx
@@ -24,7 +24,11 @@ const { disposeHighlight, startShikiHighlight } = vi.hoisted(() => {
   }
 })
 
-vi.mock('@/components/chat/shiki-worker-client', () => ({ startShikiHighlight }))
+vi.mock('@/components/chat/shiki-worker-client', () => ({
+  isShikiWorkerRetryableError: (error: unknown) =>
+    error instanceof Error && 'retryable' in error && error.retryable === true,
+  startShikiHighlight
+}))
 
 import { SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
 
@@ -140,6 +144,58 @@ describe('SyntaxHighlighter viewport and worker lifecycle', () => {
     const view = render(<SyntaxHighlighter code={CODE} components={components} language="ts" />)
 
     await waitFor(() => expect(startShikiHighlight).toHaveBeenCalledTimes(1))
+    expect(view.container.querySelector('code')?.textContent).toBe(CODE)
+  })
+
+  it('retries all mounted blocks once after a shared worker failure', async () => {
+    vi.stubGlobal('IntersectionObserver', undefined)
+    const retryable = Object.assign(new Error('shared worker crashed'), { retryable: true })
+    const initialRejects: Array<(error: Error) => void> = []
+    const retryResolves: Array<(tokens: typeof TOKENS) => void> = []
+
+    startShikiHighlight.mockImplementation(() => {
+      const call = startShikiHighlight.mock.calls.length
+
+      return {
+        dispose: disposeHighlight,
+        promise:
+          call <= 2
+            ? new Promise((_resolve, reject) => initialRejects.push(reject))
+            : new Promise(resolve => retryResolves.push(resolve))
+      }
+    })
+
+    const view = render(
+      <>
+        <SyntaxHighlighter code="first block" components={components} language="ts" />
+        <SyntaxHighlighter code="second block" components={components} language="ts" />
+      </>
+    )
+
+    await waitFor(() => expect(startShikiHighlight).toHaveBeenCalledTimes(2))
+    await act(async () => initialRejects.forEach(reject => reject(retryable)))
+    await waitFor(() => expect(startShikiHighlight).toHaveBeenCalledTimes(4))
+    await act(async () => retryResolves.forEach(resolve => resolve(TOKENS)))
+
+    await waitFor(() => expect(view.container.querySelectorAll('span[style*="#57606a"]')).toHaveLength(2))
+    expect(startShikiHighlight).toHaveBeenCalledTimes(4)
+  })
+
+  it('falls back to complete plain code after the bounded retry also fails', async () => {
+    vi.stubGlobal('IntersectionObserver', undefined)
+    const retryable = Object.assign(new Error('persistent worker failure'), { retryable: true })
+
+    startShikiHighlight.mockImplementation(() => ({
+      dispose: disposeHighlight,
+      promise: Promise.reject(retryable)
+    }))
+
+    const view = render(<SyntaxHighlighter code={CODE} components={components} language="ts" />)
+
+    await waitFor(() => expect(startShikiHighlight).toHaveBeenCalledTimes(2))
+    await act(async () => Promise.resolve())
+
+    expect(startShikiHighlight).toHaveBeenCalledTimes(2)
     expect(view.container.querySelector('code')?.textContent).toBe(CODE)
   })
 })

--- a/apps/desktop/src/components/chat/shiki-highlighter.dom.test.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.dom.test.tsx
@@ -133,9 +133,7 @@ describe('SyntaxHighlighter viewport and worker lifecycle', () => {
   it('never commits tokens from the previous code after props change', async () => {
     vi.stubGlobal('IntersectionObserver', undefined)
 
-    const staleTokens: ShikiWorkerToken[][] = [
-      [{ content: 'stale highlighted code', htmlStyle: { color: '#ff0000' } }]
-    ]
+    const staleTokens: ShikiWorkerToken[][] = [[{ content: 'stale highlighted code', htmlStyle: { color: '#ff0000' } }]]
 
     let resolveStaleTokens: (tokens: ShikiWorkerToken[][]) => void = () => {}
     startShikiHighlight.mockImplementationOnce(() => ({

--- a/apps/desktop/src/components/chat/shiki-highlighter.test.ts
+++ b/apps/desktop/src/components/chat/shiki-highlighter.test.ts
@@ -2,10 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { chunkByLines, exceedsHighlightBudget } from '@/components/chat/shiki-highlighter'
 import { tokenizeShikiCode } from '@/components/chat/shiki-worker'
-import {
-  getShikiWorkerClientSnapshotForTests,
-  startShikiHighlight
-} from '@/components/chat/shiki-worker-client'
+import { getShikiWorkerClientSnapshotForTests, startShikiHighlight } from '@/components/chat/shiki-worker-client'
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -46,6 +43,34 @@ describe('chunkByLines', () => {
 })
 
 describe('Shiki worker client lifecycle', () => {
+  it('normalizes constructor failures without exposing their message', async () => {
+    const constructorCause = new Error('secret-bearing constructor detail')
+
+    class ThrowingWorker {
+      constructor() {
+        throw constructorCause
+      }
+    }
+
+    vi.stubGlobal('Worker', ThrowingWorker)
+    const job = startShikiHighlight('const a = 1', 'ts')
+    const error = await job.promise.catch(reason => reason)
+
+    expect(error).toMatchObject({
+      cause: constructorCause,
+      message: 'Shiki worker construction failed',
+      name: 'ShikiWorkerRetryableError',
+      retryable: true
+    })
+    expect(error.message).not.toContain(constructorCause.message)
+    expect(getShikiWorkerClientSnapshotForTests()).toEqual({
+      activeGeneration: null,
+      activeLeases: 0,
+      pending: 0
+    })
+    expect(() => job.dispose()).not.toThrow()
+  })
+
   it('shares one worker and terminates it after the final consumer disposes', async () => {
     class TestWorker {
       static instances: TestWorker[] = []

--- a/apps/desktop/src/components/chat/shiki-highlighter.test.ts
+++ b/apps/desktop/src/components/chat/shiki-highlighter.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { chunkByLines, exceedsHighlightBudget } from '@/components/chat/shiki-highlighter'
+import { startShikiHighlight } from '@/components/chat/shiki-worker-client'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 describe('exceedsHighlightBudget', () => {
   it('highlights normal-sized blocks', () => {
@@ -33,5 +38,97 @@ describe('chunkByLines', () => {
     expect(chunks).toHaveLength(5)
     expect(chunks.map(chunk => chunk.text).join('\n')).toBe(code)
     expect(chunks.reduce((sum, chunk) => sum + chunk.lines, 0)).toBe(1000)
+  })
+})
+
+describe('Shiki worker client lifecycle', () => {
+  it('shares one worker and terminates it after the final consumer disposes', async () => {
+    class TestWorker {
+      static instances: TestWorker[] = []
+      messages: Array<{ code: string; id: number; language: string }> = []
+      onerror: ((event: ErrorEvent) => void) | null = null
+      onmessage: ((event: MessageEvent) => void) | null = null
+      terminated = false
+
+      constructor() {
+        TestWorker.instances.push(this)
+      }
+
+      postMessage(message: { code: string; id: number; language: string }) {
+        this.messages.push(message)
+      }
+
+      terminate() {
+        this.terminated = true
+      }
+    }
+
+    vi.stubGlobal('Worker', TestWorker)
+    const first = startShikiHighlight('const a = 1', 'ts')
+    const second = startShikiHighlight('print(1)', 'python')
+    const worker = TestWorker.instances[0]
+
+    expect(TestWorker.instances).toHaveLength(1)
+    expect(worker.messages).toHaveLength(2)
+
+    for (const message of worker.messages) {
+      worker.onmessage?.({ data: { id: message.id, tokens: [[{ content: message.code }]] } } as MessageEvent)
+    }
+
+    await expect(first.promise).resolves.toEqual([[{ content: 'const a = 1' }]])
+    await expect(second.promise).resolves.toEqual([[{ content: 'print(1)' }]])
+
+    first.dispose()
+    expect(worker.terminated).toBe(false)
+    second.dispose()
+    expect(worker.terminated).toBe(true)
+  })
+
+  it('returns a plain-code-compatible rejection when Worker is unavailable', async () => {
+    vi.stubGlobal('Worker', undefined)
+    const job = startShikiHighlight('const a = 1', 'ts')
+
+    await expect(job.promise).rejects.toThrow('Web Workers are unavailable')
+    expect(() => job.dispose()).not.toThrow()
+  })
+
+  it('rejects pending jobs and recreates the worker after a runtime error', async () => {
+    class FailingWorker {
+      static instances: FailingWorker[] = []
+      messages: Array<{ code: string; id: number; language: string }> = []
+      onerror: ((event: ErrorEvent) => void) | null = null
+      onmessage: ((event: MessageEvent) => void) | null = null
+
+      constructor() {
+        FailingWorker.instances.push(this)
+      }
+
+      postMessage(message: { code: string; id: number; language: string }) {
+        this.messages.push(message)
+      }
+
+      terminate() {}
+    }
+
+    vi.stubGlobal('Worker', FailingWorker)
+    const first = startShikiHighlight('const a = 1', 'ts')
+    const second = startShikiHighlight('print(1)', 'python')
+    const failedWorker = FailingWorker.instances[0]
+    const firstRejection = expect(first.promise).rejects.toThrow('worker crashed')
+    const secondRejection = expect(second.promise).rejects.toThrow('worker crashed')
+
+    failedWorker.onerror?.({ message: 'worker crashed' } as ErrorEvent)
+    await Promise.all([firstRejection, secondRejection])
+    first.dispose()
+    second.dispose()
+
+    const recovered = startShikiHighlight('echo ok', 'bash')
+    const recoveredWorker = FailingWorker.instances[1]
+    const message = recoveredWorker.messages[0]
+
+    expect(FailingWorker.instances).toHaveLength(2)
+    recoveredWorker.onmessage?.({ data: { id: message.id, tokens: [[{ content: message.code }]] } } as MessageEvent)
+    await expect(recovered.promise).resolves.toEqual([[{ content: 'echo ok' }]])
+    recovered.dispose()
   })
 })

--- a/apps/desktop/src/components/chat/shiki-highlighter.test.ts
+++ b/apps/desktop/src/components/chat/shiki-highlighter.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { chunkByLines, exceedsHighlightBudget } from '@/components/chat/shiki-highlighter'
-import { startShikiHighlight } from '@/components/chat/shiki-worker-client'
+import { tokenizeShikiCode } from '@/components/chat/shiki-worker'
+import {
+  getShikiWorkerClientSnapshotForTests,
+  startShikiHighlight
+} from '@/components/chat/shiki-worker-client'
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -130,5 +134,84 @@ describe('Shiki worker client lifecycle', () => {
     recoveredWorker.onmessage?.({ data: { id: message.id, tokens: [[{ content: message.code }]] } } as MessageEvent)
     await expect(recovered.promise).resolves.toEqual([[{ content: 'echo ok' }]])
     recovered.dispose()
+  })
+
+  it('cancels one of two jobs, ignores its late reply, and terminates after the final lease', async () => {
+    class ConcurrentWorker {
+      static instances: ConcurrentWorker[] = []
+      messages: Array<{ code: string; id: number; language: string }> = []
+      onerror: ((event: ErrorEvent) => void) | null = null
+      onmessage: ((event: MessageEvent) => void) | null = null
+      terminateCalls = 0
+
+      constructor() {
+        ConcurrentWorker.instances.push(this)
+      }
+
+      postMessage(message: { code: string; id: number; language: string }) {
+        this.messages.push(message)
+      }
+
+      terminate() {
+        this.terminateCalls += 1
+      }
+    }
+
+    vi.stubGlobal('Worker', ConcurrentWorker)
+    const first = startShikiHighlight('first', 'text')
+    const second = startShikiHighlight('second', 'text')
+    const worker = ConcurrentWorker.instances[0]
+    const [firstMessage, secondMessage] = worker.messages
+    const lateHandler = worker.onmessage
+    let firstOutcome = 'pending'
+
+    void first.promise.then(
+      () => {
+        firstOutcome = 'resolved'
+      },
+      () => {
+        firstOutcome = 'rejected'
+      }
+    )
+
+    expect(getShikiWorkerClientSnapshotForTests()).toMatchObject({ activeLeases: 2, pending: 2 })
+
+    first.dispose()
+    await Promise.resolve()
+
+    expect(firstOutcome).toBe('rejected')
+    expect(getShikiWorkerClientSnapshotForTests()).toMatchObject({ activeLeases: 1, pending: 1 })
+    expect(worker.terminateCalls).toBe(0)
+
+    lateHandler?.({ data: { id: firstMessage.id, tokens: [[{ content: 'late first' }]] } } as MessageEvent)
+    expect(getShikiWorkerClientSnapshotForTests()).toMatchObject({ activeLeases: 1, pending: 1 })
+
+    worker.onmessage?.({
+      data: { id: secondMessage.id, tokens: [[{ content: secondMessage.code }]] }
+    } as MessageEvent)
+    await expect(second.promise).resolves.toEqual([[{ content: 'second' }]])
+    expect(getShikiWorkerClientSnapshotForTests().pending).toBe(0)
+
+    second.dispose()
+    first.dispose()
+    second.dispose()
+
+    expect(worker.terminateCalls).toBe(1)
+    expect(getShikiWorkerClientSnapshotForTests()).toEqual({ activeGeneration: null, activeLeases: 0, pending: 0 })
+  })
+})
+
+describe('Shiki embedded language loading', () => {
+  it.each([
+    ['markdown', '```python\ndef greet():\n    return 42\n```', 'def'],
+    ['vue', '<script lang="ts">\nconst answer: number = 42\n</script>', 'const']
+  ])('tokenizes embedded code in %s', async (language, code, keyword) => {
+    const tokens = await tokenizeShikiCode(code, language)
+    const keywordTokens = tokens.flat().filter(token => token.content === keyword)
+    const reconstructed = tokens.map(line => line.map(token => token.content).join('')).join('\n')
+
+    expect(reconstructed).toBe(code)
+    expect(keywordTokens).toHaveLength(1)
+    expect(keywordTokens[0].htmlStyle).toBeTruthy()
   })
 })

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -17,7 +17,7 @@ import { useI18n } from '@/i18n'
 import { codiconForLanguage, isLikelyProseCodeBlock, sanitizeLanguageTag } from '@/lib/markdown-code'
 
 import type { ShikiWorkerToken } from './shiki-worker'
-import { startShikiHighlight } from './shiki-worker-client'
+import { isShikiWorkerRetryableError, startShikiHighlight } from './shiki-worker-client'
 
 /**
  * Streamdown's code adapter renders header + body as inline siblings, so we
@@ -100,22 +100,41 @@ function useWorkerHighlight(code: string, enabled: boolean, language: string) {
       return
     }
 
-    const job = startShikiHighlight(code, language)
     let active = true
+    let activeJob: ReturnType<typeof startShikiHighlight> | null = null
 
-    void job.promise
-      .then(result => {
-        if (active) {
-          setTokens(result)
+    const highlight = async () => {
+      for (let attempt = 0; attempt < 2 && active; attempt += 1) {
+        const job = startShikiHighlight(code, language)
+        activeJob = job
+
+        try {
+          const result = await job.promise
+
+          if (active) {
+            setTokens(result)
+          }
+
+          return
+        } catch (error) {
+          job.dispose()
+
+          if (activeJob === job) {
+            activeJob = null
+          }
+
+          if (!active || attempt > 0 || !isShikiWorkerRetryableError(error)) {
+            return
+          }
         }
-      })
-      .catch(() => {
-        // Plain code is the intentional fallback when a grammar/worker fails.
-      })
+      }
+    }
+
+    void highlight()
 
     return () => {
       active = false
-      job.dispose()
+      activeJob?.dispose()
     }
   }, [code, enabled, language])
 

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import type { SyntaxHighlighterProps } from '@assistant-ui/react-streamdown'
-import { type FC, useMemo } from 'react'
-import ShikiHighlighter from 'react-shiki'
+import { type CSSProperties, type FC, useEffect, useMemo, useRef, useState } from 'react'
 
 import {
   CodeCard,
@@ -17,13 +16,17 @@ import { CopyButton } from '@/components/ui/copy-button'
 import { useI18n } from '@/i18n'
 import { codiconForLanguage, isLikelyProseCodeBlock, sanitizeLanguageTag } from '@/lib/markdown-code'
 
+import type { ShikiWorkerToken } from './shiki-worker'
+import { startShikiHighlight } from './shiki-worker-client'
+
 /**
  * Streamdown's code adapter renders header + body as inline siblings, so we
  * own the wrapping `<CodeCard>` here and neutralize the upstream
  * `data-streamdown="code-block"` chrome from styles.css. Anything that wants
  * a card-shaped code surface should compose `CodeCard*` directly.
  *
- * `react-shiki` full bundle so all `bundledLanguages` work; theme switches
+ * Shiki runs in a shared, lazily-created worker so all bundled languages remain
+ * available without putting grammar work on the renderer thread. Theme switches
  * follow the document `color-scheme` via `defaultColor="light-dark()"`.
  */
 interface HermesSyntaxHighlighterProps extends SyntaxHighlighterProps {
@@ -51,6 +54,113 @@ const MAX_HIGHLIGHT_CHARS = 150_000
 const MAX_HIGHLIGHT_LINES = 3_000
 const CHUNK_LINES = 200
 const EST_LINE_PX = 16
+
+function useNearViewportHighlight(enabled: boolean) {
+  const ref = useRef<HTMLDivElement | null>(null)
+  const [nearViewport, setNearViewport] = useState(() => typeof IntersectionObserver === 'undefined')
+
+  useEffect(() => {
+    const target = ref.current
+
+    if (!enabled || nearViewport || !target) {
+      return
+    }
+
+    if (typeof IntersectionObserver === 'undefined') {
+      setNearViewport(true)
+
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      entries => {
+        if (entries.some(entry => entry.isIntersecting)) {
+          setNearViewport(true)
+          observer.disconnect()
+        }
+      },
+      { rootMargin: '300px 0px' }
+    )
+
+    observer.observe(target)
+
+    return () => observer.disconnect()
+  }, [enabled, nearViewport])
+
+  return { nearViewport, ref }
+}
+
+function useWorkerHighlight(code: string, enabled: boolean, language: string) {
+  const [tokens, setTokens] = useState<ShikiWorkerToken[][] | null>(null)
+
+  useEffect(() => {
+    setTokens(null)
+
+    if (!enabled) {
+      return
+    }
+
+    const job = startShikiHighlight(code, language)
+    let active = true
+
+    void job.promise
+      .then(result => {
+        if (active) {
+          setTokens(result)
+        }
+      })
+      .catch(() => {
+        // Plain code is the intentional fallback when a grammar/worker fails.
+      })
+
+    return () => {
+      active = false
+      job.dispose()
+    }
+  }, [code, enabled, language])
+
+  return tokens
+}
+
+function tokenStyle(style: Record<string, string> | undefined): CSSProperties | undefined {
+  if (!style) {
+    return undefined
+  }
+
+  return Object.fromEntries(
+    Object.entries(style).map(([property, value]) => {
+      // Dual-theme Shiki tokens put the light color in both `color:
+      // light-dark(...)` and `--shiki-light`. Never rewrite `--shiki-dark`:
+      // color replacements are intentionally theme-scoped.
+      const adjusted =
+        property === 'color' || property === '--shiki-light'
+          ? Object.entries(SHIKI_COLOR_REPLACEMENTS['github-light-default']).reduce(
+              (next, [from, to]) => next.replaceAll(from.toLowerCase(), to),
+              value.toLowerCase()
+            )
+          : value
+
+      return [property, adjusted]
+    })
+  ) as CSSProperties
+}
+
+function HighlightedCode({ tokens }: { tokens: ShikiWorkerToken[][] }) {
+  return (
+    <code className="block whitespace-pre">
+      {tokens.map((line, lineIndex) => (
+        <span key={lineIndex}>
+          {line.map((token, tokenIndex) => (
+            <span key={tokenIndex} style={tokenStyle(token.htmlStyle)}>
+              {token.content}
+            </span>
+          ))}
+          {lineIndex < tokens.length - 1 ? '\n' : null}
+        </span>
+      ))}
+    </code>
+  )
+}
 
 export function exceedsHighlightBudget(code: string): boolean {
   if (code.length > MAX_HIGHLIGHT_CHARS) {
@@ -123,6 +233,9 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
 }) => {
   const { t } = useI18n()
   const trimmed = (code ?? '').replace(/^\n+/, '').trimEnd()
+  const overBudget = exceedsHighlightBudget(trimmed)
+  const { nearViewport, ref } = useNearViewportHighlight(!defer && !overBudget && Boolean(trimmed.trim()))
+  const highlighted = useWorkerHighlight(trimmed, !defer && !overBudget && nearViewport, language || 'text')
 
   // Streaming may hand us empty/incomplete fences — render nothing rather
   // than a transient empty card.
@@ -136,10 +249,9 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
 
   const cleanLanguage = sanitizeLanguageTag(language || '')
   const label = cleanLanguage && cleanLanguage !== 'unknown' ? cleanLanguage : ''
-  const plain = defer || exceedsHighlightBudget(trimmed)
 
   return (
-    <CodeCard data-streaming={defer ? 'true' : undefined}>
+    <CodeCard data-streaming={defer ? 'true' : undefined} ref={ref}>
       <CodeCardHeader>
         <CodeCardTitle>
           <CodeCardIcon name={codiconForLanguage(label)} />
@@ -158,22 +270,7 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
       <CodeCardBody>
         <ExpandableBlock>
           <Pre className="aui-shiki m-0 overflow-hidden bg-transparent p-0">
-            {plain ? (
-              <PlainCode code={trimmed} />
-            ) : (
-              <ShikiHighlighter
-                addDefaultStyles={false}
-                as="div"
-                colorReplacements={SHIKI_COLOR_REPLACEMENTS}
-                defaultColor="light-dark()"
-                delay={120}
-                language={language || 'text'}
-                showLanguage={false}
-                theme={SHIKI_THEME}
-              >
-                {trimmed}
-              </ShikiHighlighter>
-            )}
+            {highlighted ? <HighlightedCode tokens={highlighted} /> : <PlainCode code={trimmed} />}
           </Pre>
         </ExpandableBlock>
       </CodeCardBody>

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -91,10 +91,14 @@ function useNearViewportHighlight(enabled: boolean) {
 }
 
 function useWorkerHighlight(code: string, enabled: boolean, language: string) {
-  const [tokens, setTokens] = useState<ShikiWorkerToken[][] | null>(null)
+  const [highlight, setHighlight] = useState<{
+    code: string
+    language: string
+    tokens: ShikiWorkerToken[][]
+  } | null>(null)
 
   useEffect(() => {
-    setTokens(null)
+    setHighlight(null)
 
     if (!enabled) {
       return
@@ -112,7 +116,7 @@ function useWorkerHighlight(code: string, enabled: boolean, language: string) {
           const result = await job.promise
 
           if (active) {
-            setTokens(result)
+            setHighlight({ code, language, tokens: result })
           }
 
           return
@@ -138,7 +142,7 @@ function useWorkerHighlight(code: string, enabled: boolean, language: string) {
     }
   }, [code, enabled, language])
 
-  return tokens
+  return enabled && highlight?.code === code && highlight.language === language ? highlight.tokens : null
 }
 
 function tokenStyle(style: Record<string, string> | undefined): CSSProperties | undefined {

--- a/apps/desktop/src/components/chat/shiki-worker-client.ts
+++ b/apps/desktop/src/components/chat/shiki-worker-client.ts
@@ -1,0 +1,113 @@
+import type { ShikiWorkerRequest, ShikiWorkerResponse, ShikiWorkerToken } from './shiki-worker'
+
+export interface ShikiHighlightJob {
+  dispose: () => void
+  promise: Promise<ShikiWorkerToken[][]>
+}
+
+let nextRequestId = 0
+let worker: Worker | null = null
+let consumers = 0
+
+const pending = new Map<
+  number,
+  { reject: (reason?: unknown) => void; resolve: (tokens: ShikiWorkerToken[][]) => void }
+>()
+
+function rejectPending(error: Error) {
+  for (const request of pending.values()) {
+    request.reject(error)
+  }
+
+  pending.clear()
+}
+
+function terminateWorker(error: Error) {
+  const activeWorker = worker
+  worker = null
+
+  if (activeWorker) {
+    activeWorker.onmessage = null
+    activeWorker.onerror = null
+    activeWorker.terminate()
+  }
+
+  rejectPending(error)
+}
+
+function getWorker(): Worker {
+  if (worker) {
+    return worker
+  }
+
+  worker = new Worker(new URL('./shiki-worker.ts', import.meta.url), { type: 'module' })
+
+  worker.onmessage = (event: MessageEvent<ShikiWorkerResponse>) => {
+    const request = pending.get(event.data.id)
+
+    if (!request) {
+      return
+    }
+
+    pending.delete(event.data.id)
+
+    if (event.data.error || !event.data.tokens) {
+      request.reject(new Error(event.data.error || 'Shiki worker returned no tokens'))
+    } else {
+      request.resolve(event.data.tokens)
+    }
+  }
+
+  worker.onerror = event => {
+    terminateWorker(new Error(event.message || 'Shiki worker failed'))
+  }
+
+  return worker
+}
+
+export function startShikiHighlight(code: string, language: string): ShikiHighlightJob {
+  if (typeof Worker === 'undefined') {
+    return {
+      dispose: () => {},
+      promise: Promise.reject(new Error('Web Workers are unavailable'))
+    }
+  }
+
+  const id = ++nextRequestId
+  consumers += 1
+  let disposed = false
+
+  const promise = new Promise<ShikiWorkerToken[][]>((resolve, reject) => {
+    pending.set(id, { reject, resolve })
+
+    try {
+      getWorker().postMessage({ code, id, language } satisfies ShikiWorkerRequest)
+    } catch (error) {
+      pending.delete(id)
+      reject(error)
+    }
+  })
+
+  return {
+    promise,
+    dispose: () => {
+      if (disposed) {
+        return
+      }
+
+      disposed = true
+      const request = pending.get(id)
+
+      if (request) {
+        pending.delete(id)
+        request.reject(new Error('Shiki highlight cancelled'))
+      }
+
+      consumers = Math.max(0, consumers - 1)
+
+      if (consumers === 0) {
+        terminateWorker(new Error('Shiki worker has no active consumers'))
+      }
+    }
+  }
+}

--- a/apps/desktop/src/components/chat/shiki-worker-client.ts
+++ b/apps/desktop/src/components/chat/shiki-worker-client.ts
@@ -21,6 +21,11 @@ interface PendingRequest {
 
 export class ShikiWorkerRetryableError extends Error {
   readonly retryable = true
+
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'ShikiWorkerRetryableError'
+  }
 }
 
 let nextGenerationId = 0
@@ -59,12 +64,20 @@ function retireGeneration(generation: WorkerGeneration, error: Error) {
 }
 
 function createGeneration(): WorkerGeneration {
+  let worker: Worker
+
+  try {
+    worker = new Worker(new URL('./shiki-worker.ts', import.meta.url), { type: 'module' })
+  } catch (cause) {
+    throw new ShikiWorkerRetryableError('Shiki worker construction failed', { cause })
+  }
+
   const generation: WorkerGeneration = {
     id: ++nextGenerationId,
     leases: 0,
     pendingIds: new Set(),
     retired: false,
-    worker: new Worker(new URL('./shiki-worker.ts', import.meta.url), { type: 'module' })
+    worker
   }
 
   generation.worker.onmessage = (event: MessageEvent<ShikiWorkerResponse>) => {
@@ -98,8 +111,10 @@ function getGeneration(): WorkerGeneration {
 }
 
 export function isShikiWorkerRetryableError(error: unknown): error is ShikiWorkerRetryableError {
-  return error instanceof ShikiWorkerRetryableError ||
+  return (
+    error instanceof ShikiWorkerRetryableError ||
     (error instanceof Error && 'retryable' in error && error.retryable === true)
+  )
 }
 
 /** Narrow behavior seam for lifecycle tests; never exposes worker instances. */
@@ -138,10 +153,7 @@ export function startShikiHighlight(code: string, language: string): ShikiHighli
     try {
       generation.worker.postMessage({ code, id, language } satisfies ShikiWorkerRequest)
     } catch (error) {
-      retireGeneration(
-        generation,
-        new ShikiWorkerRetryableError(error instanceof Error ? error.message : String(error))
-      )
+      retireGeneration(generation, new ShikiWorkerRetryableError('Shiki worker postMessage failed', { cause: error }))
     }
   })
 

--- a/apps/desktop/src/components/chat/shiki-worker-client.ts
+++ b/apps/desktop/src/components/chat/shiki-worker-client.ts
@@ -5,51 +5,77 @@ export interface ShikiHighlightJob {
   promise: Promise<ShikiWorkerToken[][]>
 }
 
+interface WorkerGeneration {
+  id: number
+  leases: number
+  pendingIds: Set<number>
+  retired: boolean
+  worker: Worker
+}
+
+interface PendingRequest {
+  generation: WorkerGeneration
+  reject: (reason?: unknown) => void
+  resolve: (tokens: ShikiWorkerToken[][]) => void
+}
+
+export class ShikiWorkerRetryableError extends Error {
+  readonly retryable = true
+}
+
+let nextGenerationId = 0
 let nextRequestId = 0
-let worker: Worker | null = null
-let consumers = 0
+let currentGeneration: WorkerGeneration | null = null
+const pending = new Map<number, PendingRequest>()
 
-const pending = new Map<
-  number,
-  { reject: (reason?: unknown) => void; resolve: (tokens: ShikiWorkerToken[][]) => void }
->()
+function rejectGenerationPending(generation: WorkerGeneration, error: Error) {
+  for (const id of generation.pendingIds) {
+    const request = pending.get(id)
 
-function rejectPending(error: Error) {
-  for (const request of pending.values()) {
-    request.reject(error)
+    if (request?.generation === generation) {
+      pending.delete(id)
+      request.reject(error)
+    }
   }
 
-  pending.clear()
+  generation.pendingIds.clear()
 }
 
-function terminateWorker(error: Error) {
-  const activeWorker = worker
-  worker = null
-
-  if (activeWorker) {
-    activeWorker.onmessage = null
-    activeWorker.onerror = null
-    activeWorker.terminate()
+function retireGeneration(generation: WorkerGeneration, error: Error) {
+  if (generation.retired) {
+    return
   }
 
-  rejectPending(error)
+  generation.retired = true
+
+  if (currentGeneration === generation) {
+    currentGeneration = null
+  }
+
+  generation.worker.onmessage = null
+  generation.worker.onerror = null
+  generation.worker.terminate()
+  rejectGenerationPending(generation, error)
 }
 
-function getWorker(): Worker {
-  if (worker) {
-    return worker
+function createGeneration(): WorkerGeneration {
+  const generation: WorkerGeneration = {
+    id: ++nextGenerationId,
+    leases: 0,
+    pendingIds: new Set(),
+    retired: false,
+    worker: new Worker(new URL('./shiki-worker.ts', import.meta.url), { type: 'module' })
   }
 
-  worker = new Worker(new URL('./shiki-worker.ts', import.meta.url), { type: 'module' })
-
-  worker.onmessage = (event: MessageEvent<ShikiWorkerResponse>) => {
+  generation.worker.onmessage = (event: MessageEvent<ShikiWorkerResponse>) => {
     const request = pending.get(event.data.id)
 
-    if (!request) {
+    if (!request || request.generation !== generation) {
       return
     }
 
     pending.delete(event.data.id)
+    generation.pendingIds.delete(event.data.id)
 
     if (event.data.error || !event.data.tokens) {
       request.reject(new Error(event.data.error || 'Shiki worker returned no tokens'))
@@ -58,11 +84,31 @@ function getWorker(): Worker {
     }
   }
 
-  worker.onerror = event => {
-    terminateWorker(new Error(event.message || 'Shiki worker failed'))
+  generation.worker.onerror = event => {
+    retireGeneration(generation, new ShikiWorkerRetryableError(event.message || 'Shiki worker failed'))
   }
 
-  return worker
+  currentGeneration = generation
+
+  return generation
+}
+
+function getGeneration(): WorkerGeneration {
+  return currentGeneration ?? createGeneration()
+}
+
+export function isShikiWorkerRetryableError(error: unknown): error is ShikiWorkerRetryableError {
+  return error instanceof ShikiWorkerRetryableError ||
+    (error instanceof Error && 'retryable' in error && error.retryable === true)
+}
+
+/** Narrow behavior seam for lifecycle tests; never exposes worker instances. */
+export function getShikiWorkerClientSnapshotForTests() {
+  return {
+    activeGeneration: currentGeneration?.id ?? null,
+    activeLeases: currentGeneration?.leases ?? 0,
+    pending: pending.size
+  }
 }
 
 export function startShikiHighlight(code: string, language: string): ShikiHighlightJob {
@@ -73,18 +119,29 @@ export function startShikiHighlight(code: string, language: string): ShikiHighli
     }
   }
 
+  let generation: WorkerGeneration
+
+  try {
+    generation = getGeneration()
+  } catch (error) {
+    return { dispose: () => {}, promise: Promise.reject(error) }
+  }
+
   const id = ++nextRequestId
-  consumers += 1
+  generation.leases += 1
   let disposed = false
 
   const promise = new Promise<ShikiWorkerToken[][]>((resolve, reject) => {
-    pending.set(id, { reject, resolve })
+    pending.set(id, { generation, reject, resolve })
+    generation.pendingIds.add(id)
 
     try {
-      getWorker().postMessage({ code, id, language } satisfies ShikiWorkerRequest)
+      generation.worker.postMessage({ code, id, language } satisfies ShikiWorkerRequest)
     } catch (error) {
-      pending.delete(id)
-      reject(error)
+      retireGeneration(
+        generation,
+        new ShikiWorkerRetryableError(error instanceof Error ? error.message : String(error))
+      )
     }
   })
 
@@ -98,15 +155,16 @@ export function startShikiHighlight(code: string, language: string): ShikiHighli
       disposed = true
       const request = pending.get(id)
 
-      if (request) {
+      if (request?.generation === generation) {
         pending.delete(id)
+        generation.pendingIds.delete(id)
         request.reject(new Error('Shiki highlight cancelled'))
       }
 
-      consumers = Math.max(0, consumers - 1)
+      generation.leases = Math.max(0, generation.leases - 1)
 
-      if (consumers === 0) {
-        terminateWorker(new Error('Shiki worker has no active consumers'))
+      if (generation.leases === 0 && !generation.retired) {
+        retireGeneration(generation, new Error('Shiki worker has no active consumers'))
       }
     }
   }

--- a/apps/desktop/src/components/chat/shiki-worker.ts
+++ b/apps/desktop/src/components/chat/shiki-worker.ts
@@ -1,4 +1,4 @@
-import { type BundledLanguage, getSingletonHighlighter } from 'shiki'
+import { type BundledLanguage, getSingletonHighlighter, guessEmbeddedLanguages } from 'shiki'
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
 
 export interface ShikiWorkerRequest {
@@ -20,35 +20,49 @@ export interface ShikiWorkerResponse {
 
 const engine = createJavaScriptRegexEngine({ forgiving: true })
 
-self.onmessage = async (event: MessageEvent<ShikiWorkerRequest>) => {
-  const { code, id, language } = event.data
+export async function tokenizeShikiCode(code: string, language: string): Promise<ShikiWorkerToken[][]> {
+  const lang = (language || 'text') as BundledLanguage
 
-  try {
-    const lang = (language || 'text') as BundledLanguage
+  const highlighterOptions = {
+    engine,
+    langs: [lang],
+    themes: ['github-dark-dimmed', 'github-light-default']
+  }
 
-    const highlighterOptions = {
-      engine,
-      langs: [lang],
-      themes: ['github-dark-dimmed', 'github-light-default']
+  const highlighter = await getSingletonHighlighter(highlighterOptions)
+  const embeddedLanguages = guessEmbeddedLanguages(code, lang, highlighter) as BundledLanguage[]
+
+  if (embeddedLanguages.length > 0) {
+    await highlighter.loadLanguage(...embeddedLanguages)
+  }
+
+  const result = highlighter.codeToTokens(code, {
+    defaultColor: 'light-dark()',
+    lang,
+    themes: { dark: 'github-dark-dimmed', light: 'github-light-default' }
+  })
+
+  return result.tokens.map(line =>
+    line.map(token => ({
+      content: token.content,
+      ...(token.htmlStyle ? { htmlStyle: token.htmlStyle as Record<string, string> } : {})
+    }))
+  )
+}
+
+if (typeof self !== 'undefined') {
+  self.onmessage = async (event: MessageEvent<ShikiWorkerRequest>) => {
+    const { code, id, language } = event.data
+
+    try {
+      const tokens = await tokenizeShikiCode(code, language)
+
+      self.postMessage({ id, tokens } satisfies ShikiWorkerResponse)
+    } catch (error) {
+      self.postMessage({
+        id,
+        error: error instanceof Error ? error.message : String(error)
+      } satisfies ShikiWorkerResponse)
     }
-
-    const highlighter = await getSingletonHighlighter(highlighterOptions)
-
-    const result = highlighter.codeToTokens(code, {
-      defaultColor: 'light-dark()',
-      lang,
-      themes: { dark: 'github-dark-dimmed', light: 'github-light-default' }
-    })
-
-    const tokens = result.tokens.map(line =>
-      line.map(token => ({
-        content: token.content,
-        ...(token.htmlStyle ? { htmlStyle: token.htmlStyle as Record<string, string> } : {})
-      }))
-    )
-
-    self.postMessage({ id, tokens } satisfies ShikiWorkerResponse)
-  } catch (error) {
-    self.postMessage({ id, error: error instanceof Error ? error.message : String(error) } satisfies ShikiWorkerResponse)
   }
 }

--- a/apps/desktop/src/components/chat/shiki-worker.ts
+++ b/apps/desktop/src/components/chat/shiki-worker.ts
@@ -1,0 +1,54 @@
+import { type BundledLanguage, getSingletonHighlighter } from 'shiki'
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
+
+export interface ShikiWorkerRequest {
+  code: string
+  id: number
+  language: string
+}
+
+export interface ShikiWorkerToken {
+  content: string
+  htmlStyle?: Record<string, string>
+}
+
+export interface ShikiWorkerResponse {
+  error?: string
+  id: number
+  tokens?: ShikiWorkerToken[][]
+}
+
+const engine = createJavaScriptRegexEngine({ forgiving: true })
+
+self.onmessage = async (event: MessageEvent<ShikiWorkerRequest>) => {
+  const { code, id, language } = event.data
+
+  try {
+    const lang = (language || 'text') as BundledLanguage
+
+    const highlighterOptions = {
+      engine,
+      langs: [lang],
+      themes: ['github-dark-dimmed', 'github-light-default']
+    }
+
+    const highlighter = await getSingletonHighlighter(highlighterOptions)
+
+    const result = highlighter.codeToTokens(code, {
+      defaultColor: 'light-dark()',
+      lang,
+      themes: { dark: 'github-dark-dimmed', light: 'github-light-default' }
+    })
+
+    const tokens = result.tokens.map(line =>
+      line.map(token => ({
+        content: token.content,
+        ...(token.htmlStyle ? { htmlStyle: token.htmlStyle as Record<string, string> } : {})
+      }))
+    )
+
+    self.postMessage({ id, tokens } satisfies ShikiWorkerResponse)
+  } catch (error) {
+    self.postMessage({ id, error: error instanceof Error ? error.message : String(error) } satisfies ShikiWorkerResponse)
+  }
+}

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2238,7 +2238,8 @@ export const ar = defineLocale({
   assistant: {
     thread: {
       loadingSession: 'جار تحميل الجلسة...',
-      showEarlier: 'عرض الرسائل الأقدم',
+      showEarlierMessages: 'عرض الرسائل الأقدم',
+      showEarlierToolCalls: 'عرض استدعاءات الأدوات الأقدم',
       loadingResponse: 'جار تحميل الرد...',
       resumeWhenBackgroundDone: count =>
         count === 1 ? 'سيُستأنف عند انتهاء المهمة الخلفية' : `سيُستأنف عند انتهاء ${count} مهام خلفية`,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2608,7 +2608,8 @@ export const en: Translations = {
   assistant: {
     thread: {
       loadingSession: 'Loading session',
-      showEarlier: 'Show earlier messages',
+      showEarlierMessages: 'Show earlier messages',
+      showEarlierToolCalls: 'Show earlier tool calls',
       loadingResponse: 'Hermes is loading a response',
       resumeWhenBackgroundDone: count =>
         count === 1

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2475,7 +2475,8 @@ export const ja = defineLocale({
   assistant: {
     thread: {
       loadingSession: 'セッションを読み込み中',
-      showEarlier: '以前のメッセージを表示',
+      showEarlierMessages: '以前のメッセージを表示',
+      showEarlierToolCalls: '以前のツール呼び出しを表示',
       loadingResponse: 'Hermes が応答を読み込み中',
       resumeWhenBackgroundDone: count =>
         count === 1

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2212,7 +2212,8 @@ export interface Translations {
   assistant: {
     thread: {
       loadingSession: string
-      showEarlier: string
+      showEarlierMessages: string
+      showEarlierToolCalls: string
       loadingResponse: string
       resumeWhenBackgroundDone: (count: number) => string
       thinking: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2399,7 +2399,8 @@ export const zhHant = defineLocale({
   assistant: {
     thread: {
       loadingSession: '正在載入工作階段',
-      showEarlier: '顯示較早的訊息',
+      showEarlierMessages: '顯示較早的訊息',
+      showEarlierToolCalls: '顯示較早的工具呼叫',
       loadingResponse: 'Hermes 正在載入回覆',
       resumeWhenBackgroundDone: count =>
         count === 1 ? '背景工作完成後將自動繼續' : `${count} 個背景工作完成後將自動繼續`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2782,7 +2782,8 @@ export const zh: Translations = {
   assistant: {
     thread: {
       loadingSession: '正在加载会话',
-      showEarlier: '显示更早的消息',
+      showEarlierMessages: '显示更早的消息',
+      showEarlierToolCalls: '显示更早的工具调用',
       loadingResponse: 'Hermes 正在加载回复',
       resumeWhenBackgroundDone: count =>
         count === 1 ? '后台任务完成后将自动继续' : `${count} 个后台任务完成后将自动继续`,

--- a/apps/desktop/src/store/preview-status.test.ts
+++ b/apps/desktop/src/store/preview-status.test.ts
@@ -4,7 +4,9 @@ import {
   $previewStatusBySession,
   clearPreviewArtifacts,
   dismissPreviewArtifact,
-  recordPreviewArtifact
+  getPreviewClearGeneration,
+  recordPreviewArtifact,
+  recordPreviewArtifacts
 } from './preview-status'
 
 beforeEach(() => $previewStatusBySession.set({}))
@@ -29,6 +31,41 @@ describe('recordPreviewArtifact', () => {
     expect(list[3].label).toBe('p5.html')
   })
 
+  it('records a large batch atomically and keeps only its newest unique targets', () => {
+    let emissions = 0
+
+    const unsubscribe = $previewStatusBySession.subscribe(() => {
+      emissions += 1
+    })
+
+    recordPreviewArtifacts(
+      's1',
+      [...Array.from({ length: 100 }, (_, index) => `/a/p${index}.html`), '/a/p99.html'],
+      '/work'
+    )
+
+    expect($previewStatusBySession.get().s1.map(item => item.id)).toEqual([
+      '/a/p96.html',
+      '/a/p97.html',
+      '/a/p98.html',
+      '/a/p99.html'
+    ])
+    expect(emissions).toBe(2)
+    unsubscribe()
+  })
+
+  it('preserves sequential eviction semantics within one batch', () => {
+    recordPreviewArtifacts('s1', ['/a/a.html', '/a/b.html', '/a/c.html', '/a/d.html'], '/work')
+    recordPreviewArtifacts('s1', ['/a/e.html', '/a/a.html'], '/work')
+
+    expect($previewStatusBySession.get().s1.map(item => item.id)).toEqual([
+      '/a/c.html',
+      '/a/d.html',
+      '/a/e.html',
+      '/a/a.html'
+    ])
+  })
+
   it('dismiss and clear remove rows', () => {
     recordPreviewArtifact('s1', '/a/index.html', '/work')
     recordPreviewArtifact('s1', '/a/about.html', '/work')
@@ -37,5 +74,15 @@ describe('recordPreviewArtifact', () => {
 
     clearPreviewArtifacts('s1')
     expect($previewStatusBySession.get().s1).toBeUndefined()
+  })
+
+  it('advances the reconciliation generation only when the timeline is cleared', () => {
+    const before = getPreviewClearGeneration('s1')
+    recordPreviewArtifact('s1', '/a/index.html', '/work')
+    dismissPreviewArtifact('s1', '/a/index.html')
+
+    expect(getPreviewClearGeneration('s1')).toBe(before)
+    clearPreviewArtifacts('s1')
+    expect(getPreviewClearGeneration('s1')).toBe(before + 1)
   })
 })

--- a/apps/desktop/src/store/preview-status.test.ts
+++ b/apps/desktop/src/store/preview-status.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
+  $previewClearGenerationBySession,
   $previewStatusBySession,
   clearPreviewArtifacts,
   dismissPreviewArtifact,
@@ -9,7 +10,10 @@ import {
   recordPreviewArtifacts
 } from './preview-status'
 
-beforeEach(() => $previewStatusBySession.set({}))
+beforeEach(() => {
+  $previewClearGenerationBySession.set({})
+  $previewStatusBySession.set({})
+})
 
 describe('recordPreviewArtifact', () => {
   it('appends new targets newest-last and is idempotent', () => {
@@ -84,5 +88,6 @@ describe('recordPreviewArtifact', () => {
     expect(getPreviewClearGeneration('s1')).toBe(before)
     clearPreviewArtifacts('s1')
     expect(getPreviewClearGeneration('s1')).toBe(before + 1)
+    expect($previewClearGenerationBySession.get().s1).toBe(before + 1)
   })
 })

--- a/apps/desktop/src/store/preview-status.test.ts
+++ b/apps/desktop/src/store/preview-status.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
   $previewClearGenerationBySession,
+  $previewDismissGenerationBySession,
   $previewStatusBySession,
   clearPreviewArtifacts,
   dismissPreviewArtifact,
@@ -12,6 +13,7 @@ import {
 
 beforeEach(() => {
   $previewClearGenerationBySession.set({})
+  $previewDismissGenerationBySession.set({})
   $previewStatusBySession.set({})
 })
 

--- a/apps/desktop/src/store/preview-status.ts
+++ b/apps/desktop/src/store/preview-status.ts
@@ -22,6 +22,7 @@ export interface PreviewArtifact {
 }
 
 const MAX_PER_SESSION = 4
+const clearGenerationBySession = new Map<string, number>()
 
 export const $previewStatusBySession = atom<Record<string, PreviewArtifact[]>>({})
 
@@ -44,24 +45,38 @@ const writePreviews = (sid: string, items: PreviewArtifact[]) => {
 }
 
 /**
- * Record a detected artifact, newest last, capped. Idempotent: a target already
- * in the list keeps its slot (transcript reconciliation may see it repeatedly,
- * so this must not churn the atom or reorder rows).
+ * Record detected artifacts in one atom update, newest last and capped.
+ * Idempotent: a target already in the list keeps its slot (transcript
+ * reconciliation may see it repeatedly, so this must not churn or reorder).
  */
+export function recordPreviewArtifacts(sid: string, targets: readonly string[], cwd: string) {
+  if (!sid) {
+    return
+  }
+
+  let next = $previewStatusBySession.get()[sid] ?? []
+  let changed = false
+
+  for (const target of targets) {
+    const raw = target.trim()
+
+    if (!raw || next.some(item => item.id === raw)) {
+      continue
+    }
+
+    changed = true
+    next = [...next, { cwd, id: raw, label: previewName(raw), target: raw }].slice(-MAX_PER_SESSION)
+  }
+
+  if (!changed) {
+    return
+  }
+
+  writePreviews(sid, next)
+}
+
 export function recordPreviewArtifact(sid: string, target: string, cwd: string) {
-  const raw = target.trim()
-
-  if (!sid || !raw) {
-    return
-  }
-
-  const list = $previewStatusBySession.get()[sid] ?? []
-
-  if (list.some(item => item.id === raw)) {
-    return
-  }
-
-  writePreviews(sid, [...list, { cwd, id: raw, label: previewName(raw), target: raw }].slice(-MAX_PER_SESSION))
+  recordPreviewArtifacts(sid, [target], cwd)
 }
 
 export function dismissPreviewArtifact(sid: string, id: string) {
@@ -76,5 +91,10 @@ export function dismissPreviewArtifact(sid: string, id: string) {
 }
 
 export function clearPreviewArtifacts(sid: string) {
+  clearGenerationBySession.set(sid, (clearGenerationBySession.get(sid) ?? 0) + 1)
   writePreviews(sid, [])
+}
+
+export function getPreviewClearGeneration(sid: string): number {
+  return clearGenerationBySession.get(sid) ?? 0
 }

--- a/apps/desktop/src/store/preview-status.ts
+++ b/apps/desktop/src/store/preview-status.ts
@@ -8,8 +8,9 @@ import { previewName } from '@/lib/preview-targets'
  * NOT auto-opened and NOT a bulky inline card. Click opens the rail preview or
  * the browser; both are manual.
  *
- * Fed from the tool row itself (see tool-fallback.tsx) using the same detected
- * target the inline card used, so detection parity is exact.
+ * Fed from the authoritative thread collection using the same lightweight
+ * target extractor as tool rendering, so paginated rows remain discoverable
+ * without mounting their expensive visual subtree.
  */
 export interface PreviewArtifact {
   /** cwd captured at detection so a relative path still resolves on click. */
@@ -44,8 +45,8 @@ const writePreviews = (sid: string, items: PreviewArtifact[]) => {
 
 /**
  * Record a detected artifact, newest last, capped. Idempotent: a target already
- * in the list keeps its slot (the tool row re-registers on every render, so this
- * must not churn the atom or reorder rows).
+ * in the list keeps its slot (transcript reconciliation may see it repeatedly,
+ * so this must not churn the atom or reorder rows).
  */
 export function recordPreviewArtifact(sid: string, target: string, cwd: string) {
   const raw = target.trim()

--- a/apps/desktop/src/store/preview-status.ts
+++ b/apps/desktop/src/store/preview-status.ts
@@ -25,6 +25,7 @@ const MAX_PER_SESSION = 4
 
 export const $previewStatusBySession = atom<Record<string, PreviewArtifact[]>>({})
 export const $previewClearGenerationBySession = atom<Record<string, number>>({})
+export const $previewDismissGenerationBySession = atom<Record<string, Record<string, number>>>({})
 
 const writePreviews = (sid: string, items: PreviewArtifact[]) => {
   const current = $previewStatusBySession.get()
@@ -83,10 +84,20 @@ export function dismissPreviewArtifact(sid: string, id: string) {
   const list = $previewStatusBySession.get()[sid]
 
   if (list) {
-    writePreviews(
-      sid,
-      list.filter(item => item.id !== id)
-    )
+    const next = list.filter(item => item.id !== id)
+
+    if (next.length === list.length) {
+      return
+    }
+
+    const generations = $previewDismissGenerationBySession.get()
+    const sessionGenerations = generations[sid] ?? {}
+
+    $previewDismissGenerationBySession.set({
+      ...generations,
+      [sid]: { ...sessionGenerations, [id]: (sessionGenerations[id] ?? 0) + 1 }
+    })
+    writePreviews(sid, next)
   }
 }
 

--- a/apps/desktop/src/store/preview-status.ts
+++ b/apps/desktop/src/store/preview-status.ts
@@ -22,9 +22,9 @@ export interface PreviewArtifact {
 }
 
 const MAX_PER_SESSION = 4
-const clearGenerationBySession = new Map<string, number>()
 
 export const $previewStatusBySession = atom<Record<string, PreviewArtifact[]>>({})
+export const $previewClearGenerationBySession = atom<Record<string, number>>({})
 
 const writePreviews = (sid: string, items: PreviewArtifact[]) => {
   const current = $previewStatusBySession.get()
@@ -91,10 +91,12 @@ export function dismissPreviewArtifact(sid: string, id: string) {
 }
 
 export function clearPreviewArtifacts(sid: string) {
-  clearGenerationBySession.set(sid, (clearGenerationBySession.get(sid) ?? 0) + 1)
+  const generations = $previewClearGenerationBySession.get()
+
+  $previewClearGenerationBySession.set({ ...generations, [sid]: (generations[sid] ?? 0) + 1 })
   writePreviews(sid, [])
 }
 
 export function getPreviewClearGeneration(sid: string): number {
-  return clearGenerationBySession.get(sid) ?? 0
+  return $previewClearGenerationBySession.get()[sid] ?? 0
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #68467 by keeping Hermes Desktop responsive when opening long, tool-heavy sessions without deleting, truncating, or mutating persisted transcript data.

The reviewed branch is based on `760112adb6458417da8614d2269e5325f0739ed5`. During finalization, `main` advanced by one unrelated relay/gateway commit to `ebab890ae5676fc297461b6e069df5b54cbbefce`; the changed paths do not overlap and `git merge-tree` is clean. The branch restores the complete continuation from #69275 after both earlier branches became conflicted: the first three commits retain Jakub Wolniewicz's authorship, the review-driven hardening commit retains `iwillwill` as author, and three final Jakub-authored commits fix preview reconciliation, preserve dismissals across failed rewind rollback, and maintain keyboard focus through multi-page tool history.

## Related Issue

Fixes #68467.

Supersedes the conflicted continuation #69275 while preserving all of its implementation, hardening, tests, and attribution.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- Bounds initial history to at most 20 complete semantic groups and progressively reveals older groups.
- Applies one turn-wide tool budget across interleaved narration and assistant messages.
- Preserves live-tail virtualization, oldest-visible identity, scroll position, and pager focus.
- Reconciles preview targets from authoritative transcript state without mounting hidden heavy tool rows, including restore/reproduce and dismiss behavior.
- Renders complete plain/copyable code immediately, then viewport-gates Shiki enhancement in a shared lazy Web Worker.
- Bounds worker retry, cancellation, late replies, generation retirement, and stale-prop token handling.
- Preserves current locale parity, including the Arabic catalog added after the earlier branch point.

## How to Test

Focused regression contract on CachyOS Linux / Node 25:

```bash
NODE_ENV=test NODE_OPTIONS='--max-old-space-size=8192 --localstorage-file=/tmp/hermes-long-session.json' \
  npm --workspace apps/desktop exec -- vitest run --project ui \
  src/app/chat/long-tool-session.repro.test.tsx \
  src/components/assistant-ui/thread/list.test.ts \
  src/components/assistant-ui/tool/turn-pagination.test.ts \
  src/components/chat/shiki-highlighter.test.ts \
  src/components/chat/shiki-highlighter.dom.test.tsx \
  src/store/preview-status.test.ts
# 6 files, 67 passed

NODE_ENV=test npm --workspace apps/desktop run typecheck
NODE_ENV=test npm --workspace apps/desktop run lint
NODE_ENV=production npm --workspace apps/desktop run build
git diff --check origin/main...HEAD
```

Results:

- final focused candidate regression: **67/67 passed**;
- retained-preview, failed-rewind, dismissed-preview rollback, and multi-page keyboard-focus regressions fail before their follow-up fixes and pass afterward;
- typecheck: passed;
- lint: 0 errors (existing warnings only);
- production build: passed, including emitted lazy Shiki worker;
- `git diff --check`: passed.

The complete Desktop suite is not fully green on either ref in this Node 25/shared-localStorage environment. Candidate run: **2,958 passed, 6 failed, 3 skipped**; untouched current `main`: **2,917 passed, 5 failed, 3 skipped**. Shared baseline failures cover locale/Intl, billing, and an existing truncation assertion. The one additional order-dependent preview-routing failure passes **5/5** when isolated. Final exact HEAD was rechecked with focused tests, typecheck, lint, and build after the small current-main locale/import adaptations.

The committed performance threshold is also stale against current `main`, so the meaningful same-machine comparison is candidate vs base:

| Metric | current `main` | candidate |
|---|---:|---:|
| Transcript mount | 376.5 ms | 211.7 ms |
| Total long-task time | 514 ms | 252 ms |
| Max long task | 238 ms | 177 ms |

No same-machine regression against current `main` was observed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Existing and competing PRs were searched and linked
- [x] The PR contains only long-session Desktop rendering changes and tests
- [x] Relevant focused/static/build checks pass
- [x] Regression coverage covers pagination, previews, and worker lifecycle
- [x] Tested on CachyOS Linux

### Documentation & Housekeeping

- [x] Relevant docs — N/A; no user-facing config/API change
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — standard Worker/IntersectionObserver paths retain plain-code/error fallback
- [x] Tool descriptions/schemas — N/A

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

No visual contract change or private transcript fixture is committed. The synthetic regression reproduces the 266-message / 143-tool-call class from #68467 without private data.
