### PR TITLE
fix(doctor): detect wheel-installed virtualenv entry points

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -6,6 +6,7 @@ Diagnoses issues with Hermes Agent setup.
 
 import os
 import sys
+import sysconfig
 import subprocess
 import shutil
 from pathlib import Path
@@ -1492,11 +1493,34 @@ def run_doctor(args):
         _section("Command Installation")
         # Determine the venv entry point location
         _venv_bin = None
+        _uses_environment_entry_point = False
         for _venv_name in ("venv", ".venv"):
             _candidate = PROJECT_ROOT / _venv_name / "bin" / "hermes"
             if _candidate.exists():
                 _venv_bin = _candidate
                 break
+
+        # A wheel-installed virtualenv keeps the console script under the
+        # environment's scripts directory while PROJECT_ROOT points inside
+        # site-packages.  The source-checkout candidates above cannot describe
+        # that layout, so consult Python's platform-aware install scheme before
+        # reporting a missing entry point (#49529).
+        _active_venv = sys.prefix != getattr(sys, "base_prefix", sys.prefix)
+        _environment_scripts_dir = None
+        if _active_venv:
+            try:
+                _scripts_path = sysconfig.get_path("scripts")
+                if _scripts_path:
+                    _environment_scripts_dir = Path(_scripts_path)
+            except (KeyError, TypeError, ValueError):
+                pass
+        if _venv_bin is None and _environment_scripts_dir is not None:
+            _candidate = _environment_scripts_dir / "hermes"
+            if _candidate.exists():
+                _venv_bin = _candidate
+                _uses_environment_entry_point = True
+
+        _source_checkout = (PROJECT_ROOT / "pyproject.toml").is_file()
 
         # Determine the expected command link directory (mirrors install.sh logic)
         _prefix = os.environ.get("PREFIX", "")
@@ -1510,18 +1534,38 @@ def run_doctor(args):
         _cmd_link = _cmd_link_dir / "hermes"
 
         if _venv_bin is None:
-            check_warn(
-                "Venv entry point not found",
-                "(hermes not in venv/bin/ or .venv/bin/ — reinstall with pip install -e '.[all]')"
-            )
-            manual_issues.append(
-                f"Reinstall entry point: cd {PROJECT_ROOT} && source venv/bin/activate && pip install -e '.[all]'"
-            )
+            if _active_venv and not _source_checkout:
+                _expected_dir = _environment_scripts_dir or Path(sys.prefix) / "bin"
+                _reinstall_cmd = (
+                    f"{sys.executable} -m pip install --force-reinstall hermes-agent"
+                )
+                check_warn(
+                    "Venv entry point not found",
+                    f"(hermes not in {_expected_dir} — reinstall with {_reinstall_cmd})",
+                )
+                manual_issues.append(f"Reinstall entry point: {_reinstall_cmd}")
+            else:
+                check_warn(
+                    "Venv entry point not found",
+                    "(hermes not in venv/bin/ or .venv/bin/ — reinstall with pip install -e '.[all]')"
+                )
+                manual_issues.append(
+                    f"Reinstall entry point: cd {PROJECT_ROOT} && source venv/bin/activate && pip install -e '.[all]'"
+                )
         else:
-            check_ok(f"Venv entry point exists ({_venv_bin.relative_to(PROJECT_ROOT)})")
+            try:
+                _venv_bin_display = _venv_bin.relative_to(PROJECT_ROOT)
+            except ValueError:
+                _venv_bin_display = _venv_bin
+            check_ok(f"Venv entry point exists ({_venv_bin_display})")
 
-            # Check the symlink at the command link location
-            if _cmd_link.is_symlink():
+            # A wheel's console script is already installed in the active
+            # environment.  Requiring a second global link would turn a
+            # healthy isolated venv into a false failure and make --fix leak
+            # that environment into the user's global command path.
+            if _uses_environment_entry_point and not _source_checkout:
+                check_ok("Active environment entry point needs no global symlink")
+            elif _cmd_link.is_symlink():
                 _target = _cmd_link.resolve()
                 _expected = _venv_bin.resolve()
                 if _target == _expected:

--- a/tests/hermes_cli/test_doctor_command_install.py
+++ b/tests/hermes_cli/test_doctor_command_install.py
@@ -1,6 +1,7 @@
 """Tests for the Command Installation check in hermes doctor."""
 
 import sys
+import sysconfig
 import types
 from argparse import Namespace
 from pathlib import Path
@@ -167,6 +168,8 @@ class TestDoctorCommandInstallation:
         monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
         monkeypatch.setattr(doctor_mod, "_DHH", str(home))
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(sys, "prefix", str(tmp_path / "system-python"))
+        monkeypatch.setattr(sys, "base_prefix", str(tmp_path / "system-python"))
 
         fake_model_tools = types.SimpleNamespace(
             check_tool_availability=lambda *a, **kw: ([], []),
@@ -188,6 +191,84 @@ class TestDoctorCommandInstallation:
         out = _run_doctor(fix=False)
         assert "Command Installation" in out
         assert "Venv entry point not found" in out
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Symlink check is Unix-only")
+    @pytest.mark.parametrize("fix", [False, True])
+    def test_wheel_virtualenv_entry_point_needs_no_global_symlink(
+        self, monkeypatch, tmp_path, fix
+    ):
+        """A wheel venv is healthy without a global command symlink."""
+        _setup_doctor_env(monkeypatch, tmp_path)
+        venv = tmp_path / "wheel-venv"
+        scripts = venv / "bin"
+        scripts.mkdir(parents=True)
+        hermes_bin = scripts / "hermes"
+        hermes_bin.write_text("#!/usr/bin/env python\n# wheel entry point\n")
+        hermes_bin.chmod(0o755)
+
+        site_packages = venv / "lib" / "python3.11" / "site-packages"
+        site_packages.mkdir(parents=True)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", site_packages)
+        monkeypatch.setattr(sys, "prefix", str(venv))
+        monkeypatch.setattr(sys, "base_prefix", str(tmp_path / "base-python"))
+        real_get_path = sysconfig.get_path
+        monkeypatch.setattr(
+            sysconfig,
+            "get_path",
+            lambda name, *args, **kwargs: (
+                str(scripts)
+                if name == "scripts"
+                else real_get_path(name, *args, **kwargs)
+            ),
+        )
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out = _run_doctor(fix=fix)
+
+        assert "Venv entry point exists" in out
+        assert str(hermes_bin) in out
+        assert "Venv entry point not found" not in out
+        assert "Active environment entry point needs no global symlink" in out
+        assert "~/.local/bin/hermes not found" not in out
+        assert "Missing ~/.local/bin/hermes symlink" not in out
+        command_link = tmp_path / ".local" / "bin" / "hermes"
+        assert not command_link.exists()
+        assert not command_link.is_symlink()
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Symlink check is Unix-only")
+    def test_wheel_virtualenv_missing_entry_point_avoids_editable_fix(
+        self, monkeypatch, tmp_path
+    ):
+        """Wheel installs must not be repaired as source checkouts."""
+        _setup_doctor_env(monkeypatch, tmp_path)
+        venv = tmp_path / "wheel-venv"
+        scripts = venv / "bin"
+        scripts.mkdir(parents=True)
+        site_packages = venv / "lib" / "python3.11" / "site-packages"
+        site_packages.mkdir(parents=True)
+
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", site_packages)
+        monkeypatch.setattr(sys, "prefix", str(venv))
+        monkeypatch.setattr(sys, "base_prefix", str(tmp_path / "base-python"))
+        monkeypatch.setattr(sys, "executable", str(scripts / "python"))
+        real_get_path = sysconfig.get_path
+        monkeypatch.setattr(
+            sysconfig,
+            "get_path",
+            lambda name, *args, **kwargs: (
+                str(scripts)
+                if name == "scripts"
+                else real_get_path(name, *args, **kwargs)
+            ),
+        )
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out = _run_doctor(fix=True)
+
+        assert "Venv entry point not found" in out
+        assert "pip install -e" not in out
+        assert "-m pip install --force-reinstall hermes-agent" in out
 
     @pytest.mark.skipif(sys.platform == "win32", reason="Symlink check is Unix-only")
     def test_dot_venv_dir_is_found(self, monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- Detect the `hermes` console script from the active Python environment's platform-aware scripts directory.
- Treat a healthy wheel-installed virtualenv entry point as self-contained instead of requiring or creating a global `~/.local/bin/hermes` symlink.
- Preserve the existing source-checkout candidates, global-link checks, and remediation.
- For a wheel layout with a missing script, recommend reinstalling the package with the active interpreter instead of suggesting an editable install from `site-packages`.

## Root cause and impact

For a wheel install, `PROJECT_ROOT` resolves inside `site-packages`, but the console script lives in the virtualenv's scripts directory. The doctor check only searched `PROJECT_ROOT/venv` and `PROJECT_ROOT/.venv`, so a healthy ordinary virtualenv produced a false `Venv entry point not found` warning. Its remediation also assumed a source checkout and suggested `pip install -e` from `site-packages`.

After locating the active environment's console script, the source-oriented global symlink check must also be skipped. Otherwise the original false warning is merely replaced with `~/.local/bin/hermes not found`, and `doctor --fix` leaks an isolated wheel venv into the user's global command path.

The updated check uses `sysconfig.get_path("scripts")` only when Python reports an active virtualenv, keeps the existing source layout behavior, skips the global link requirement only for an external wheel environment, and safely falls back when the environment path cannot be resolved.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_doctor.py tests/hermes_cli/test_doctor_command_install.py tests/hermes_cli/test_doctor_dedicated_provider_skip.py` — 89 passed
- `ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor_command_install.py` — passed
- Built the changed wheel, installed it into a fresh Python 3.11 virtualenv, and ran `hermes doctor` with an isolated HOME. Doctor reported the venv entry point as present and did not create or request `~/.local/bin/hermes`.
- Regression coverage runs both `doctor` and `doctor --fix` against a wheel layout with no global link and verifies neither mode creates one.
- Full `scripts/run_tests.sh -j 8` from the earlier revision — 43,564 passed; 49 unrelated failures across 20 files plus 2 unrelated provider test files timed out on this macOS host. Failures were in existing platform/tooling paths such as systemd, missing Node, macOS `/tmp` resolution, and network safety fixtures; none touched the changed doctor code or tests.

Addresses the ordinary PyPI wheel + virtualenv doctor facet of #49529.

This intentionally does not change the separate optional-skills packaging facet tracked in the same issue.
