### PR TITLE
feat: deliver files from remote terminal backends (send_file + transparent MEDIA fetch)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1197,6 +1197,14 @@ def build_environment_hints() -> str:
                 f"them, probe directly with a terminal call like "
                 f"`uname -a && whoami && pwd`."
             )
+        hints.append(
+            f"File delivery from this backend: MEDIA:/absolute/path "
+            f"directives refer to files inside the {backend} environment — "
+            f"they are fetched out of the backend automatically before being "
+            f"sent to the user (subject to a size cap), so you can deliver "
+            f"files you created there. Use the `send_file` tool instead when "
+            f"you want explicit confirmation that the transfer worked."
+        )
 
     if is_wsl():
         hints.append(WSL_ENVIRONMENT_HINT)

--- a/gateway/media_fetch.py
+++ b/gateway/media_fetch.py
@@ -1,0 +1,220 @@
+"""Fetch MEDIA files from remote terminal backends for platform delivery.
+
+``MEDIA:/absolute/path`` directives only deliver when the file exists on the
+machine running the gateway. Remote terminal backends (ssh, modal, daytona,
+managed_modal — and docker/singularity paths outside their bind mounts) put
+the agent's artifacts on a different filesystem, so ``validate_media_delivery_path``
+rejects them and delivery silently fails (issue #466).
+
+This module bridges the gap: when a MEDIA path fails local resolution and a
+remote backend is active, the file is fetched through the backend's
+``fetch_file`` transport into the canonical document cache
+(``~/.hermes/cache/documents``, already in ``MEDIA_DELIVERY_SAFE_ROOTS``) and
+delivered from there. The fetched copy still goes through the normal local
+validation, and the *remote* path is checked against the same credential /
+system-path denylist as local deliveries before any bytes move — a remote
+fetch must not become a bypass of ``_path_under_denied_prefix``.
+"""
+
+import logging
+import os
+import posixpath
+import uuid
+from pathlib import Path, PurePosixPath
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Maximum size fetched out of a backend for delivery. Telegram bot uploads
+# cap at 50 MB; other platforms are in the same order of magnitude. Operators
+# can raise/lower it via the env var.
+MEDIA_FETCH_MAX_BYTES_ENV = "HERMES_MEDIA_FETCH_MAX_BYTES"
+_MEDIA_FETCH_MAX_BYTES_DEFAULT = 50 * 1024 * 1024
+
+
+def media_fetch_max_bytes() -> int:
+    """Return the configured remote-fetch size cap in bytes."""
+    raw = os.environ.get(MEDIA_FETCH_MAX_BYTES_ENV, "").strip()
+    if raw:
+        try:
+            value = int(raw)
+            if value > 0:
+                return value
+        except ValueError:
+            pass
+    return _MEDIA_FETCH_MAX_BYTES_DEFAULT
+
+
+def _format_size(num_bytes: int) -> str:
+    if num_bytes >= 1024 * 1024:
+        return f"{num_bytes / (1024 * 1024):.1f} MB"
+    if num_bytes >= 1024:
+        return f"{num_bytes / 1024:.1f} KB"
+    return f"{num_bytes} bytes"
+
+
+def remote_path_is_denied(path: str, remote_home: Optional[str] = None) -> bool:
+    """Return True when *path* on a backend filesystem must not be fetched.
+
+    Pure string check (the remote filesystem can't be stat'd from here)
+    applying the same denylist as local delivery: system prefixes
+    (``/etc``, ``/proc``, ...), credential directories under the backend
+    home (``~/.ssh``, ``~/.aws``, ...), and the Hermes credential stores
+    (``~/.hermes/.env``, ``auth.json``, ``mcp-tokens/``, ...).
+
+    When *remote_home* is unknown, home-relative entries are matched against
+    ANY path component (conservative: ``/data/.ssh/key`` is denied too).
+    Mirrors the ``/root``-is-home exception of ``_path_under_denied_prefix``:
+    a denied system prefix that IS the backend's own home stays fetchable —
+    its credential subpaths are separate, more-specific entries.
+    """
+    from gateway.platforms.base import (
+        _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS,
+        _MEDIA_DELIVERY_DENIED_PREFIXES,
+        _ROOT_CREDENTIAL_DIRS,
+        _ROOT_CREDENTIAL_FILES,
+    )
+
+    normalized = PurePosixPath(posixpath.normpath(path))
+    if not normalized.is_absolute():
+        return True
+
+    home = PurePosixPath(posixpath.normpath(remote_home)) if remote_home else None
+
+    def _under(candidate: PurePosixPath, root: PurePosixPath) -> bool:
+        return candidate == root or root in candidate.parents
+
+    for prefix in _MEDIA_DELIVERY_DENIED_PREFIXES:
+        root = PurePosixPath(prefix)
+        if home is not None and root == home:
+            continue
+        if _under(normalized, root):
+            return True
+
+    home_relative = list(_MEDIA_DELIVERY_DENIED_HOME_SUBPATHS)
+    home_relative.extend(
+        posixpath.join(".hermes", *PurePosixPath(rel.replace(os.sep, "/")).parts)
+        for rel in (*_ROOT_CREDENTIAL_FILES, *_ROOT_CREDENTIAL_DIRS)
+    )
+
+    if home is not None:
+        for rel in home_relative:
+            if _under(normalized, home / rel):
+                return True
+        return False
+
+    # Unknown home: deny when the denied subpath appears anywhere in the path.
+    parts = normalized.parts
+    for rel in home_relative:
+        rel_parts = PurePosixPath(rel.replace(os.sep, "/")).parts
+        for start in range(len(parts) - len(rel_parts) + 1):
+            if parts[start:start + len(rel_parts)] == rel_parts:
+                return True
+    return False
+
+
+def _active_remote_environment(task_id: Optional[str] = None):
+    """Return (backend_name, env) when a remote terminal backend is active.
+
+    Returns ``(backend, None)`` when the backend is remote but no live
+    environment exists yet (nothing to fetch from), and ``(backend, None)``
+    with backend ``""`` when the configured backend is local.
+    """
+    backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+    from agent.prompt_builder import _REMOTE_TERMINAL_BACKENDS
+
+    if backend not in _REMOTE_TERMINAL_BACKENDS:
+        return "", None
+    try:
+        from tools.terminal_tool import get_active_env
+
+        return backend, get_active_env(task_id or "default")
+    except Exception as exc:
+        logger.debug("Remote media fetch: could not resolve active env: %s", exc)
+        return backend, None
+
+
+def _sanitize_basename(path: str) -> str:
+    name = posixpath.basename(posixpath.normpath(path.replace("\\", "/")))
+    name = "".join(c for c in name if c.isprintable() and c not in '/\\:*?"<>|')
+    return name.strip() or "file"
+
+
+def fetch_remote_media(
+    path: str, task_id: Optional[str] = None
+) -> Tuple[Optional[str], Optional[str]]:
+    """Fetch *path* from the active remote backend into the document cache.
+
+    Returns ``(local_path, None)`` on success — *local_path* already passed
+    ``validate_media_delivery_path`` — or ``(None, reason)`` with a short
+    user-presentable reason on failure. Never raises.
+    """
+    from gateway.platforms.base import (
+        get_document_cache_dir,
+        validate_media_delivery_path,
+    )
+    from tools.environments.base import FileFetchError
+
+    backend, env = _active_remote_environment(task_id)
+    if not backend:
+        return None, "no remote terminal backend is active"
+    if env is None:
+        return None, f"no active {backend} terminal session to fetch from"
+
+    candidate = posixpath.normpath(str(path).strip())
+    remote_home = env.remote_home
+    if candidate == "~" or candidate.startswith("~/"):
+        if not remote_home:
+            return None, "cannot resolve ~ in the backend"
+        candidate = posixpath.normpath(
+            posixpath.join(remote_home, candidate[2:])
+        )
+    if not candidate.startswith("/"):
+        return None, "only absolute paths can be fetched from the backend"
+
+    if remote_path_is_denied(candidate, remote_home):
+        return None, "the path is not allowed for delivery"
+
+    try:
+        # Best-effort symlink resolution so a link planted at an innocuous
+        # path can't smuggle out a denied credential file.
+        resolved = env.fetch_realpath(candidate)
+        if resolved and remote_path_is_denied(resolved, remote_home):
+            return None, "the path is not allowed for delivery"
+
+        size = env.fetch_file_size(resolved or candidate)
+        if size is None:
+            return None, f"the file was not found in the {backend} backend"
+        limit = media_fetch_max_bytes()
+        if size > limit:
+            return None, (
+                f"the file is {_format_size(size)}, above the "
+                f"{_format_size(limit)} delivery limit"
+            )
+
+        dest = get_document_cache_dir() / (
+            f"doc_{uuid.uuid4().hex[:12]}_{_sanitize_basename(candidate)}"
+        )
+        env.fetch_file(resolved or candidate, str(dest))
+    except FileFetchError as exc:
+        return None, str(exc)
+    except Exception as exc:
+        logger.warning(
+            "Remote media fetch failed for %s backend: %s", backend, exc,
+            exc_info=True,
+        )
+        return None, f"fetching from the {backend} backend failed"
+
+    validated = validate_media_delivery_path(str(dest))
+    if not validated:
+        try:
+            Path(dest).unlink()
+        except OSError:
+            pass
+        return None, "the fetched file failed delivery validation"
+
+    logger.info(
+        "Fetched remote media from %s backend: %s (%s)",
+        backend, candidate, _format_size(size),
+    )
+    return validated, None

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1152,57 +1152,63 @@ def _media_delivery_strict_mode() -> bool:
     return raw in ("1", "true", "yes", "on")
 
 
+# The active Hermes profile and shared Hermes root both contain control
+# files and credentials. Only cache subdirectories under them are
+# explicitly allowlisted above (matched BEFORE this denylist in
+# validate_media_delivery_path, so generated media still delivers).
+#
+# These are the per-file credential / secret stores that live at the
+# HERMES_HOME root. The set mirrors the canonical read guard in
+# agent/file_safety.py (get_read_block_error / build_write_denied_*) so the
+# delivery (read/exfil) side can't trail the write side: a credential the
+# agent is forbidden to write or read must also never be auto-attached to a
+# chat reply. Enumerated explicitly per-file rather than denying the whole
+# tree, so skills/, logs/, and ad-hoc agent-written files under ~/.hermes
+# stay deliverable (see #32090, #34425).
+#
+# Module-level (not local to _media_delivery_denied_paths) so the remote-path
+# check in gateway/media_fetch.py applies the same set to backend filesystems.
+_ROOT_CREDENTIAL_FILES = (
+    ".env",
+    "auth.json",
+    "auth.lock",
+    "credentials",
+    "config.yaml",
+    # Anthropic PKCE / OAuth refresh credential store.
+    ".anthropic_oauth.json",
+    # Google Workspace skill: auto-refreshing OAuth token (mtime bumps
+    # every turn, which defeated the strict-mode recency window) plus the
+    # pending-exchange session/verifier file.
+    "google_token.json",
+    "google_oauth_pending.json",
+    os.path.join("auth", "google_oauth.json"),
+    # Webhook subscription HMAC secrets.
+    "webhook_subscriptions.json",
+    # Bitwarden Secrets Manager plaintext disk cache.
+    os.path.join("cache", "bws_cache.json"),
+)
+
+# Directory trees whose every child is credential material.
+#
+# mcp-tokens/ holds live MCP OAuth access tokens (<server>.json) and
+# dynamically-registered client credentials (<server>.client.json); see
+# tools/mcp_oauth.py. Same credential class as auth.json/credentials/.
+# The write side already denies it (file_tools _check_sensitive_path);
+# this pairs the media-delivery (exfil) side so a prompt-injection MEDIA
+# tag can't deliver a live bearer token as a native attachment.
+# (session/kanban SQLite stores are handled by #41071 — kept out here.)
+_ROOT_CREDENTIAL_DIRS = (
+    "pairing",
+    "mcp-tokens",
+)
+
+
 def _media_delivery_denied_paths() -> List[Path]:
     """Return absolute denylist paths under which delivery is never allowed."""
     denied = [Path(p) for p in _MEDIA_DELIVERY_DENIED_PREFIXES]
     home = Path(os.path.expanduser("~"))
     for sub in _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS:
         denied.append(home / sub)
-    # The active Hermes profile and shared Hermes root both contain control
-    # files and credentials. Only cache subdirectories under them are
-    # explicitly allowlisted above (matched BEFORE this denylist in
-    # validate_media_delivery_path, so generated media still delivers).
-    #
-    # These are the per-file credential / secret stores that live at the
-    # HERMES_HOME root. The set mirrors the canonical read guard in
-    # agent/file_safety.py (get_read_block_error / build_write_denied_*) so the
-    # delivery (read/exfil) side can't trail the write side: a credential the
-    # agent is forbidden to write or read must also never be auto-attached to a
-    # chat reply. Enumerated explicitly per-file rather than denying the whole
-    # tree, so skills/, logs/, and ad-hoc agent-written files under ~/.hermes
-    # stay deliverable (see #32090, #34425).
-    _ROOT_CREDENTIAL_FILES = (
-        ".env",
-        "auth.json",
-        "auth.lock",
-        "credentials",
-        "config.yaml",
-        # Anthropic PKCE / OAuth refresh credential store.
-        ".anthropic_oauth.json",
-        # Google Workspace skill: auto-refreshing OAuth token (mtime bumps
-        # every turn, which defeated the strict-mode recency window) plus the
-        # pending-exchange session/verifier file.
-        "google_token.json",
-        "google_oauth_pending.json",
-        os.path.join("auth", "google_oauth.json"),
-        # Webhook subscription HMAC secrets.
-        "webhook_subscriptions.json",
-        # Bitwarden Secrets Manager plaintext disk cache.
-        os.path.join("cache", "bws_cache.json"),
-    )
-    # Directory trees whose every child is credential material.
-    #
-    # mcp-tokens/ holds live MCP OAuth access tokens (<server>.json) and
-    # dynamically-registered client credentials (<server>.client.json); see
-    # tools/mcp_oauth.py. Same credential class as auth.json/credentials/.
-    # The write side already denies it (file_tools _check_sensitive_path);
-    # this pairs the media-delivery (exfil) side so a prompt-injection MEDIA
-    # tag can't deliver a live bearer token as a native attachment.
-    # (session/kanban SQLite stores are handled by #41071 — kept out here.)
-    _ROOT_CREDENTIAL_DIRS = (
-        "pairing",
-        "mcp-tokens",
-    )
     for hermes_root in (_HERMES_HOME, _HERMES_ROOT):
         for rel in _ROOT_CREDENTIAL_FILES:
             denied.append(hermes_root / rel)
@@ -1359,6 +1365,33 @@ _LOG_UNSAFE_CHARS = re.compile(r"[\x00-\x1f\x7f\x85\u2028\u2029]")
 def _log_safe_path(path: str) -> str:
     """Return a single-line, length-bounded path for log output."""
     return _LOG_UNSAFE_CHARS.sub("?", str(path))[:200]
+
+
+def _maybe_fetch_remote_media(path: str) -> Tuple[Optional[str], str]:
+    """Try to fetch a locally-unresolvable MEDIA path from the active remote
+    terminal backend. Returns ``(local_path, "")`` on success or
+    ``(None, reason)`` — never raises (delivery must not crash on a fetch bug).
+    """
+    try:
+        from gateway.media_fetch import fetch_remote_media
+
+        local_path, reason = fetch_remote_media(path)
+        return local_path, reason or ""
+    except Exception as exc:
+        logger.warning("Remote media fetch errored: %s", exc, exc_info=True)
+        return None, "remote fetch errored"
+
+
+def undeliverable_media_notice(names: List[str]) -> str:
+    """Short user-facing notice for MEDIA paths that could not be delivered.
+
+    Mirrors the ``send_document`` fallback tone; shows only basenames (never
+    host paths — see send_voice for the rationale).
+    """
+    unique = list(dict.fromkeys(n for n in names if n))
+    if not unique:
+        return "⚠️ Couldn't deliver a file attachment."
+    return f"⚠️ Couldn't deliver: {', '.join(unique)}."
 
 
 SUPPORTED_DOCUMENT_TYPES = {
@@ -3615,16 +3648,39 @@ class BasePlatformAdapter(ABC):
         return validate_media_delivery_path(path)
 
     @staticmethod
-    def filter_media_delivery_paths(media_files) -> List[Tuple[str, bool]]:
-        """Drop unsafe MEDIA paths and normalize accepted paths."""
+    def filter_media_delivery_paths(
+        media_files,
+        undeliverable: Optional[List[str]] = None,
+    ) -> List[Tuple[str, bool]]:
+        """Drop unsafe MEDIA paths and normalize accepted paths.
+
+        A path that fails local resolution is retried against the active
+        remote terminal backend (ssh, modal, daytona, ... — see
+        ``gateway/media_fetch.py``): the file is fetched into the document
+        cache and delivered from there, so ``MEDIA:`` just works for
+        artifacts created inside a sandbox (#466).
+
+        When *undeliverable* is passed, the basename of every path that
+        could not be delivered (either way) is appended to it so callers
+        can surface a "couldn't deliver" notice instead of silence.
+        """
         safe_media: List[Tuple[str, bool]] = []
         for media_path, is_voice in media_files or []:
             raw = str(media_path)
             safe_path = validate_media_delivery_path(raw)
-            if safe_path:
-                safe_media.append((safe_path, bool(is_voice)))
-            else:
-                logger.warning("Skipping unsafe MEDIA directive path: %s", _log_safe_path(raw))
+            if not safe_path:
+                safe_path, fetch_reason = _maybe_fetch_remote_media(raw)
+                if not safe_path:
+                    logger.warning(
+                        "Skipping unsafe MEDIA directive path: %s (%s)",
+                        _log_safe_path(raw), fetch_reason,
+                    )
+                    if undeliverable is not None:
+                        undeliverable.append(
+                            os.path.basename(raw.rstrip("/\\")) or raw
+                        )
+                    continue
+            safe_media.append((safe_path, bool(is_voice)))
         return safe_media
 
     @staticmethod
@@ -5080,7 +5136,15 @@ class BasePlatformAdapter(ABC):
 
                 # Extract MEDIA:<path> tags (from TTS tool) before other processing
                 media_files, response = self.extract_media(response)
-                media_files = self.filter_media_delivery_paths(media_files)
+                _undeliverable_media: List[str] = []
+                media_files = self.filter_media_delivery_paths(
+                    media_files, _undeliverable_media
+                )
+                if _undeliverable_media:
+                    # Surface the failure instead of silently dropping the
+                    # attachment (#466); the tag itself is already stripped.
+                    _notice = undeliverable_media_notice(_undeliverable_media)
+                    response = f"{response}\n\n{_notice}" if response.strip() else _notice
 
                 # Extract image URLs and send them as native platform attachments
                 images, text_content = self.extract_images(response)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14608,7 +14608,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from gateway.platforms.base import BasePlatformAdapter, should_send_media_as_audio
 
             media_files, cleaned = adapter.extract_media(response)
-            media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+            undeliverable_media: list = []
+            media_files = BasePlatformAdapter.filter_media_delivery_paths(
+                media_files, undeliverable_media
+            )
             # Chain the cleaned text through each extractor (extract_media →
             # extract_images → extract_local_files) so MEDIA: tags and image URLs
             # are removed before the bare-path auto-detect runs. Previously the
@@ -14700,6 +14703,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
                 except Exception as e:
                     logger.warning("[%s] Post-stream file delivery failed: %s", adapter.name, e)
+
+            if undeliverable_media:
+                # The streamed text already went out (with the MEDIA tag
+                # stripped), so surface the failure as its own short message
+                # instead of silence (#466).
+                from gateway.platforms.base import undeliverable_media_notice
+                try:
+                    await adapter.send(
+                        chat_id=event.source.chat_id,
+                        content=undeliverable_media_notice(undeliverable_media),
+                        metadata=_thread_meta,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "[%s] Undeliverable-media notice failed: %s", adapter.name, e
+                    )
 
         except Exception as e:
             logger.warning("Post-stream media extraction failed: %s", e)
@@ -14851,8 +14870,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Extract media files from the response
             if response:
                 media_files, response = adapter.extract_media(response)
-                from gateway.platforms.base import BasePlatformAdapter
-                media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+                from gateway.platforms.base import (
+                    BasePlatformAdapter,
+                    undeliverable_media_notice,
+                )
+                undeliverable_media: list = []
+                media_files = BasePlatformAdapter.filter_media_delivery_paths(
+                    media_files, undeliverable_media
+                )
+                if undeliverable_media:
+                    _notice = undeliverable_media_notice(undeliverable_media)
+                    response = f"{response}\n\n{_notice}" if response.strip() else _notice
                 images, text_content = adapter.extract_images(response)
 
                 preview = prompt[:60] + ("..." if len(prompt) > 60 else "")

--- a/tests/gateway/test_remote_media_fetch.py
+++ b/tests/gateway/test_remote_media_fetch.py
@@ -1,0 +1,326 @@
+"""Tests for remote MEDIA fetch (issue #466) — gateway/media_fetch.py.
+
+Covers: the remote-path credential/system denylist, the size cap, the
+transparent fetch through BasePlatformAdapter.filter_media_delivery_paths,
+the undeliverable-notice plumbing, and end-to-end delivery of a fetched
+file through TelegramAdapter.send_document (mirrors
+tests/gateway/test_telegram_documents.py).
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.media_fetch import (
+    MEDIA_FETCH_MAX_BYTES_ENV,
+    fetch_remote_media,
+    media_fetch_max_bytes,
+    remote_path_is_denied,
+)
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    undeliverable_media_notice,
+)
+from tools.environments.base import FileFetchError
+
+
+# ---------------------------------------------------------------------------
+# Test double for a remote environment
+# ---------------------------------------------------------------------------
+
+class _FakeRemoteEnv:
+    """Duck-typed environment: serves files from an in-memory dict."""
+
+    def __init__(self, files=None, home="/home/worker", links=None):
+        self.files = files or {}
+        self.links = links or {}
+        self._remote_home = home
+        self.fetched = []
+
+    @property
+    def remote_home(self):
+        return self._remote_home
+
+    def fetch_realpath(self, remote_path):
+        return self.links.get(remote_path, remote_path)
+
+    def fetch_file_size(self, remote_path):
+        data = self.files.get(remote_path)
+        return None if data is None else len(data)
+
+    def fetch_file(self, remote_path, local_dest):
+        data = self.files.get(remote_path)
+        if data is None:
+            raise FileFetchError(f"{remote_path!r} not found")
+        self.fetched.append(remote_path)
+        with open(local_dest, "wb") as f:
+            f.write(data)
+
+
+@pytest.fixture()
+def remote_backend(tmp_path, monkeypatch):
+    """Activate a fake ssh backend and point the document cache at tmp_path."""
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    cache = tmp_path / "doc_cache"
+    monkeypatch.setattr("gateway.platforms.base.DOCUMENT_CACHE_DIR", cache)
+
+    env = _FakeRemoteEnv(files={"/home/worker/report.pdf": b"%PDF-1.4 remote"})
+
+    def _install(environment=env):
+        monkeypatch.setattr(
+            "tools.terminal_tool.get_active_env", lambda task_id: environment
+        )
+        return environment
+
+    return _install
+
+
+# ---------------------------------------------------------------------------
+# Remote-path denylist (security parity with _path_under_denied_prefix)
+# ---------------------------------------------------------------------------
+
+class TestRemotePathDenylist:
+    @pytest.mark.parametrize("path", [
+        "/etc/passwd",
+        "/proc/self/environ",
+        "/var/log/auth.log",
+        "/home/worker/.ssh/id_rsa",
+        "/home/worker/.aws/credentials",
+        "/home/worker/.hermes/.env",
+        "/home/worker/.hermes/auth.json",
+        "/home/worker/.hermes/credentials/token",
+        "/home/worker/.hermes/mcp-tokens/github.json",
+        "/home/worker/.hermes/auth/google_oauth.json",
+        "/home/worker/.hermes/cache/bws_cache.json",
+        "/home/worker/work/../.ssh/id_rsa",  # traversal is normalized first
+    ])
+    def test_denied_with_known_home(self, path):
+        assert remote_path_is_denied(path, "/home/worker") is True
+
+    @pytest.mark.parametrize("path", [
+        "/home/worker/report.pdf",
+        "/workspace/build/output.zip",
+        "/tmp/chart.png",
+        "/home/worker/.hermes/skills/notes.md",  # skills stay deliverable
+    ])
+    def test_allowed_with_known_home(self, path):
+        assert remote_path_is_denied(path, "/home/worker") is False
+
+    def test_root_home_exception(self):
+        # /root is a denied system prefix, but on a container whose home IS
+        # /root the operator's own artifacts live there (mirrors the local
+        # exception in _path_under_denied_prefix).
+        assert remote_path_is_denied("/root/report.pdf", "/root") is False
+        assert remote_path_is_denied("/root/.ssh/id_rsa", "/root") is True
+        assert remote_path_is_denied("/root/report.pdf", "/home/worker") is True
+
+    def test_unknown_home_is_conservative(self):
+        assert remote_path_is_denied("/data/.ssh/id_rsa", None) is True
+        assert remote_path_is_denied("/srv/app/.hermes/.env", None) is True
+        assert remote_path_is_denied("/srv/app/report.pdf", None) is False
+
+    def test_relative_path_denied(self):
+        assert remote_path_is_denied("workspace/report.pdf", "/root") is True
+
+
+# ---------------------------------------------------------------------------
+# Size cap
+# ---------------------------------------------------------------------------
+
+class TestSizeCap:
+    def test_default_is_50mb(self, monkeypatch):
+        monkeypatch.delenv(MEDIA_FETCH_MAX_BYTES_ENV, raising=False)
+        assert media_fetch_max_bytes() == 50 * 1024 * 1024
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv(MEDIA_FETCH_MAX_BYTES_ENV, "1024")
+        assert media_fetch_max_bytes() == 1024
+
+    def test_invalid_override_falls_back(self, monkeypatch):
+        monkeypatch.setenv(MEDIA_FETCH_MAX_BYTES_ENV, "lots")
+        assert media_fetch_max_bytes() == 50 * 1024 * 1024
+
+    def test_oversized_file_rejected_with_clear_reason(
+        self, remote_backend, monkeypatch
+    ):
+        env = remote_backend()
+        env.files["/home/worker/huge.bin"] = b"x" * 2048
+        monkeypatch.setenv(MEDIA_FETCH_MAX_BYTES_ENV, "1024")
+
+        local_path, reason = fetch_remote_media("/home/worker/huge.bin")
+        assert local_path is None
+        assert "2.0 KB" in reason and "1.0 KB" in reason
+        assert env.fetched == []  # rejected before any bytes moved
+
+
+# ---------------------------------------------------------------------------
+# fetch_remote_media orchestration
+# ---------------------------------------------------------------------------
+
+class TestFetchRemoteMedia:
+    def test_success_lands_in_document_cache(self, remote_backend, tmp_path):
+        env = remote_backend()
+        local_path, reason = fetch_remote_media("/home/worker/report.pdf")
+        assert reason is None
+        assert local_path is not None
+        assert local_path.startswith(str(tmp_path / "doc_cache"))
+        assert "report.pdf" in local_path
+        with open(local_path, "rb") as f:
+            assert f.read() == b"%PDF-1.4 remote"
+        assert env.fetched == ["/home/worker/report.pdf"]
+
+    def test_missing_file_reports_backend(self, remote_backend):
+        remote_backend()
+        local_path, reason = fetch_remote_media("/home/worker/nope.pdf")
+        assert local_path is None
+        assert "ssh" in reason
+
+    def test_denied_remote_path_never_fetches(self, remote_backend):
+        env = remote_backend()
+        env.files["/home/worker/.ssh/id_rsa"] = b"PRIVATE KEY"
+        local_path, reason = fetch_remote_media("/home/worker/.ssh/id_rsa")
+        assert local_path is None
+        assert "not allowed" in reason
+        assert env.fetched == []
+
+    def test_symlink_to_denied_target_rejected(self, remote_backend):
+        env = remote_backend()
+        env.files["/tmp/innocent.txt"] = b"PRIVATE KEY"
+        env.links["/tmp/innocent.txt"] = "/home/worker/.ssh/id_rsa"
+        local_path, reason = fetch_remote_media("/tmp/innocent.txt")
+        assert local_path is None
+        assert "not allowed" in reason
+        assert env.fetched == []
+
+    def test_tilde_resolves_against_remote_home(self, remote_backend):
+        env = remote_backend()
+        local_path, reason = fetch_remote_media("~/report.pdf")
+        assert reason is None
+        assert env.fetched == ["/home/worker/report.pdf"]
+
+    def test_local_backend_does_not_fetch(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        local_path, reason = fetch_remote_media("/anywhere/file.pdf")
+        assert local_path is None
+        assert "no remote terminal backend" in reason
+
+    def test_no_active_session(self, remote_backend, monkeypatch):
+        remote_backend()
+        monkeypatch.setattr("tools.terminal_tool.get_active_env", lambda task_id: None)
+        local_path, reason = fetch_remote_media("/home/worker/report.pdf")
+        assert local_path is None
+        assert "no active ssh terminal session" in reason
+
+
+# ---------------------------------------------------------------------------
+# Transparent MEDIA integration via filter_media_delivery_paths
+# ---------------------------------------------------------------------------
+
+class TestFilterMediaDeliveryPathsRemote:
+    def test_remote_path_is_fetched_and_substituted(self, remote_backend):
+        remote_backend()
+        undeliverable = []
+        safe = BasePlatformAdapter.filter_media_delivery_paths(
+            [("/home/worker/report.pdf", False)], undeliverable
+        )
+        assert len(safe) == 1
+        fetched_path, is_voice = safe[0]
+        assert fetched_path != "/home/worker/report.pdf"
+        assert "report.pdf" in fetched_path
+        assert is_voice is False
+        assert undeliverable == []
+
+    def test_unfetchable_path_lands_in_undeliverable(self, remote_backend):
+        remote_backend()
+        undeliverable = []
+        safe = BasePlatformAdapter.filter_media_delivery_paths(
+            [("/home/worker/ghost.pdf", False)], undeliverable
+        )
+        assert safe == []
+        assert undeliverable == ["ghost.pdf"]
+
+    def test_local_files_still_pass_untouched(self, remote_backend, tmp_path,
+                                              monkeypatch):
+        # A path that resolves locally (e.g. host-side cache) must never
+        # round-trip through the backend — additive behavior only.
+        env = remote_backend()
+        local = tmp_path / "doc_cache"
+        local.mkdir(parents=True, exist_ok=True)
+        host_file = local / "already_local.pdf"
+        host_file.write_bytes(b"%PDF local")
+        safe = BasePlatformAdapter.filter_media_delivery_paths(
+            [(str(host_file), False)]
+        )
+        assert safe == [(str(host_file.resolve()), False)]
+        assert env.fetched == []
+
+    def test_default_call_signature_unchanged(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        assert BasePlatformAdapter.filter_media_delivery_paths([]) == []
+        assert BasePlatformAdapter.filter_media_delivery_paths(
+            [("/nonexistent/x.pdf", True)]
+        ) == []
+
+
+class TestUndeliverableNotice:
+    def test_single_name(self):
+        assert undeliverable_media_notice(["report.pdf"]) == (
+            "⚠️ Couldn't deliver: report.pdf."
+        )
+
+    def test_deduplicates_and_joins(self):
+        notice = undeliverable_media_notice(["a.pdf", "b.csv", "a.pdf"])
+        assert notice == "⚠️ Couldn't deliver: a.pdf, b.csv."
+
+    def test_empty_names_fall_back(self):
+        assert "file attachment" in undeliverable_media_notice([""])
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: fetched file delivered through TelegramAdapter.send_document
+# (mirrors tests/gateway/test_telegram_documents.py)
+# ---------------------------------------------------------------------------
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, telegram_mod)
+
+
+class TestRemoteFetchTelegramDelivery:
+    @pytest.mark.asyncio
+    async def test_remote_media_tag_delivers_as_document(self, remote_backend):
+        _ensure_telegram_mock()
+        from gateway.config import PlatformConfig
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        remote_backend()
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+        mock_msg = MagicMock()
+        mock_msg.message_id = 7
+        adapter._bot = AsyncMock()
+        adapter._bot.send_document = AsyncMock(return_value=mock_msg)
+
+        media_files, cleaned = adapter.extract_media(
+            "Here you go!\nMEDIA:/home/worker/report.pdf"
+        )
+        media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+        assert len(media_files) == 1
+
+        result = await adapter.send_document(
+            chat_id="12345", file_path=media_files[0][0]
+        )
+        assert result.success is True
+        call_kwargs = adapter._bot.send_document.call_args[1]
+        # The uuid-prefixed cache name is what lands on disk; the visible
+        # filename comes from the file on upload.
+        assert call_kwargs["chat_id"] == 12345

--- a/tests/gateway/test_tool_response_drop_recovery.py
+++ b/tests/gateway/test_tool_response_drop_recovery.py
@@ -206,7 +206,8 @@ class TestRecoveryDoesNotLeakMediaFragments:
         # but force the path to be filtered out (unsafe/nonexistent) so we hit
         # the empty-text + no-attachment recovery branch deterministically.
         monkeypatch.setattr(
-            type(adapter), "filter_media_delivery_paths", staticmethod(lambda m: [])
+            type(adapter), "filter_media_delivery_paths",
+            staticmethod(lambda m, undeliverable=None: [])
         )
 
         event = _make_event(Platform.DISCORD)

--- a/tests/tools/test_environment_fetch_file.py
+++ b/tests/tools/test_environment_fetch_file.py
@@ -1,0 +1,298 @@
+"""Tests for the per-backend file extraction API (issue #466).
+
+Covers BaseEnvironment.fetch_file / fetch_file_size (base64-over-exec
+default), the SSH cat-over-ControlMaster override, the Docker bind-mount /
+docker cp override, the Daytona SDK override, and the Local passthrough.
+"""
+
+import base64
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.environments.base import BaseEnvironment, FileFetchError
+
+
+# ---------------------------------------------------------------------------
+# Base implementation (base64 over the exec channel)
+# ---------------------------------------------------------------------------
+
+class _FakeExecEnvironment(BaseEnvironment):
+    """BaseEnvironment with execute() stubbed to canned results."""
+
+    def __init__(self, results):
+        # Skip BaseEnvironment.__init__ side effects — set the attributes
+        # fetch_file/fetch_file_size actually use.
+        self.timeout = 60
+        self._results = list(results)
+        self.commands = []
+
+    def execute(self, command, cwd="", **kwargs):
+        self.commands.append(command)
+        return self._results.pop(0)
+
+    def cleanup(self):
+        pass
+
+
+class TestBaseFetchFile:
+    def test_fetch_file_decodes_marker_fenced_payload(self, tmp_path):
+        payload = b"%PDF-1.4 binary\x00\x01 content"
+        encoded = base64.b64encode(payload).decode()
+
+        def fake_execute(command, cwd="", **kwargs):
+            marker = command.split("echo ")[1].split(" &&")[0]
+            return {"output": f"{marker}\n{encoded}\n{marker}\n", "returncode": 0}
+
+        env = _FakeExecEnvironment([])
+        env.execute = fake_execute
+        dest = tmp_path / "out.pdf"
+        env.fetch_file("/workspace/report.pdf", str(dest))
+        assert dest.read_bytes() == payload
+
+    def test_fetch_file_ignores_noise_outside_markers(self, tmp_path):
+        payload = b"hello world"
+        encoded = base64.b64encode(payload).decode()
+
+        def fake_execute(command, cwd="", **kwargs):
+            marker = command.split("echo ")[1].split(" &&")[0]
+            return {
+                "output": f"motd: welcome!\n{marker}\n{encoded}\n{marker}\ntrailing\n",
+                "returncode": 0,
+            }
+
+        env = _FakeExecEnvironment([])
+        env.execute = fake_execute
+        dest = tmp_path / "out.txt"
+        env.fetch_file("/tmp/hello.txt", str(dest))
+        assert dest.read_bytes() == payload
+
+    def test_fetch_file_missing_file_raises(self, tmp_path):
+        env = _FakeExecEnvironment([{"output": "", "returncode": 1}])
+        with pytest.raises(FileFetchError, match="could not read"):
+            env.fetch_file("/nope.txt", str(tmp_path / "out"))
+
+    def test_fetch_file_corrupt_payload_raises(self, tmp_path):
+        def fake_execute(command, cwd="", **kwargs):
+            marker = command.split("echo ")[1].split(" &&")[0]
+            return {"output": f"{marker}\nnot!!valid@@b64\n{marker}\n", "returncode": 0}
+
+        env = _FakeExecEnvironment([])
+        env.execute = fake_execute
+        with pytest.raises(FileFetchError, match="corrupted"):
+            env.fetch_file("/tmp/x.bin", str(tmp_path / "out"))
+
+    def test_fetch_file_size_parses_last_digit_token(self):
+        env = _FakeExecEnvironment([{"output": "banner\n  1234\n", "returncode": 0}])
+        assert env.fetch_file_size("/tmp/x.bin") == 1234
+
+    def test_fetch_file_size_missing_returns_none(self):
+        env = _FakeExecEnvironment([{"output": "", "returncode": 1}])
+        assert env.fetch_file_size("/nope") is None
+
+    def test_remote_home_defaults_to_none(self):
+        env = _FakeExecEnvironment([])
+        assert env.remote_home is None
+
+
+# ---------------------------------------------------------------------------
+# SSH override (cat over the ControlMaster connection)
+# ---------------------------------------------------------------------------
+
+class TestSSHFetchFile:
+    def _make_env(self):
+        from tools.environments.ssh import SSHEnvironment
+
+        env = SSHEnvironment.__new__(SSHEnvironment)
+        env.host = "example.com"
+        env.user = "worker"
+        env.port = 22
+        env.key_path = ""
+        env.control_socket = Path("/tmp/hermes-ssh/test.sock")
+        return env
+
+    def test_fetch_file_streams_cat_to_dest(self, tmp_path):
+        env = self._make_env()
+        dest = tmp_path / "artifact.bin"
+        payload = b"\x00\x01binary"
+
+        def fake_run(cmd, stdin=None, stdout=None, stderr=None, timeout=None):
+            assert cmd[-1] == "cat /home/worker/artifact.bin"
+            assert any("ControlPath=" in part for part in cmd)
+            stdout.write(payload)
+            return subprocess.CompletedProcess(cmd, 0, stderr=b"")
+
+        with patch("tools.environments.ssh.subprocess.run", side_effect=fake_run):
+            env.fetch_file("/home/worker/artifact.bin", str(dest))
+        assert dest.read_bytes() == payload
+
+    def test_fetch_file_failure_raises_and_removes_partial(self, tmp_path):
+        env = self._make_env()
+        dest = tmp_path / "artifact.bin"
+
+        def fake_run(cmd, stdin=None, stdout=None, stderr=None, timeout=None):
+            stdout.write(b"partial")
+            return subprocess.CompletedProcess(cmd, 1, stderr=b"cat: no such file")
+
+        with patch("tools.environments.ssh.subprocess.run", side_effect=fake_run):
+            with pytest.raises(FileFetchError, match="no such file"):
+                env.fetch_file("/home/worker/missing.bin", str(dest))
+        assert not dest.exists()
+
+    def test_fetch_file_quotes_hostile_remote_path(self, tmp_path):
+        env = self._make_env()
+        seen = {}
+
+        def fake_run(cmd, stdin=None, stdout=None, stderr=None, timeout=None):
+            seen["remote_cmd"] = cmd[-1]
+            return subprocess.CompletedProcess(cmd, 0, stderr=b"")
+
+        with patch("tools.environments.ssh.subprocess.run", side_effect=fake_run):
+            env.fetch_file("/tmp/$(rm -rf ~)/x.txt", str(tmp_path / "x"))
+        assert "$(rm" in seen["remote_cmd"]
+        assert seen["remote_cmd"].startswith("cat '")
+
+
+# ---------------------------------------------------------------------------
+# Docker override (bind-mount view, docker cp fallback)
+# ---------------------------------------------------------------------------
+
+class TestDockerFetchFile:
+    def _make_env(self, home_dir=None, workspace_dir=None):
+        from tools.environments.docker import DockerEnvironment
+
+        env = DockerEnvironment.__new__(DockerEnvironment)
+        env._home_dir = home_dir
+        env._workspace_dir = workspace_dir
+        env._container_id = "cafebabe1234"
+        env._docker_exe = "docker"
+        return env
+
+    def test_bind_mounted_root_path_copies_from_host(self, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "report.pdf").write_bytes(b"%PDF data")
+        env = self._make_env(home_dir=str(home))
+        dest = tmp_path / "out.pdf"
+
+        with patch("tools.environments.docker.subprocess.run") as run_mock:
+            env.fetch_file("/root/report.pdf", str(dest))
+        run_mock.assert_not_called()
+        assert dest.read_bytes() == b"%PDF data"
+
+    def test_traversal_out_of_mount_does_not_map(self, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        env = self._make_env(home_dir=str(home))
+        # /root/../etc/passwd normalizes to /etc/passwd -> no host mapping,
+        # falls through to docker cp.
+        assert env._host_path_for("/root/../etc/passwd") is None
+
+    def test_unmounted_path_uses_docker_cp(self, tmp_path):
+        env = self._make_env()
+        dest = tmp_path / "out.txt"
+
+        def fake_run(cmd, capture_output=None, text=None, timeout=None, stdin=None):
+            assert cmd[:3] == ["docker", "cp", "-L"]
+            assert cmd[3] == "cafebabe1234:/var/tmp/out.txt"
+            Path(cmd[4]).write_bytes(b"copied")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with patch("tools.environments.docker.subprocess.run", side_effect=fake_run):
+            env.fetch_file("/var/tmp/out.txt", str(dest))
+        assert dest.read_bytes() == b"copied"
+
+    def test_docker_cp_failure_raises(self, tmp_path):
+        env = self._make_env()
+
+        def fake_run(cmd, capture_output=None, text=None, timeout=None, stdin=None):
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="no such file")
+
+        with patch("tools.environments.docker.subprocess.run", side_effect=fake_run):
+            with pytest.raises(FileFetchError, match="no such file"):
+                env.fetch_file("/nope.txt", str(tmp_path / "out"))
+
+    def test_docker_cp_directory_result_rejected(self, tmp_path):
+        env = self._make_env()
+        dest = tmp_path / "out"
+
+        def fake_run(cmd, capture_output=None, text=None, timeout=None, stdin=None):
+            Path(cmd[4]).mkdir()
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with patch("tools.environments.docker.subprocess.run", side_effect=fake_run):
+            with pytest.raises(FileFetchError, match="not a regular file"):
+                env.fetch_file("/some/dir", str(dest))
+        assert not dest.exists()
+
+
+# ---------------------------------------------------------------------------
+# Daytona override (SDK download)
+# ---------------------------------------------------------------------------
+
+class TestDaytonaFetchFile:
+    def _make_env(self):
+        from tools.environments.daytona import DaytonaEnvironment
+
+        env = DaytonaEnvironment.__new__(DaytonaEnvironment)
+        env._sandbox = MagicMock()
+        return env
+
+    def test_fetch_file_uses_sdk_download(self, tmp_path):
+        env = self._make_env()
+        dest = tmp_path / "out.csv"
+        env._sandbox.fs.download_file.side_effect = (
+            lambda remote, local: Path(local).write_bytes(b"a,b\n1,2")
+        )
+        env.fetch_file("/home/daytona/data.csv", str(dest))
+        env._sandbox.fs.download_file.assert_called_once_with(
+            "/home/daytona/data.csv", str(dest)
+        )
+        assert dest.read_bytes() == b"a,b\n1,2"
+
+    def test_fetch_file_sdk_error_raises(self, tmp_path):
+        env = self._make_env()
+        env._sandbox.fs.download_file.side_effect = RuntimeError("sandbox stopped")
+        with pytest.raises(FileFetchError, match="sandbox stopped"):
+            env.fetch_file("/home/daytona/data.csv", str(tmp_path / "out"))
+
+
+# ---------------------------------------------------------------------------
+# Local passthrough
+# ---------------------------------------------------------------------------
+
+class TestLocalFetchFile:
+    def _make_env(self):
+        from tools.environments.local import LocalEnvironment
+
+        return LocalEnvironment.__new__(LocalEnvironment)
+
+    def test_fetch_file_copies(self, tmp_path):
+        env = self._make_env()
+        src = tmp_path / "src.txt"
+        src.write_text("hello")
+        dest = tmp_path / "dest.txt"
+        env.fetch_file(str(src), str(dest))
+        assert dest.read_text() == "hello"
+
+    def test_fetch_file_same_path_is_noop(self, tmp_path):
+        env = self._make_env()
+        src = tmp_path / "src.txt"
+        src.write_text("hello")
+        env.fetch_file(str(src), str(src))
+        assert src.read_text() == "hello"
+
+    def test_fetch_file_missing_raises(self, tmp_path):
+        env = self._make_env()
+        with pytest.raises(FileFetchError):
+            env.fetch_file(str(tmp_path / "nope.txt"), str(tmp_path / "out"))
+
+    def test_fetch_file_size(self, tmp_path):
+        env = self._make_env()
+        src = tmp_path / "src.bin"
+        src.write_bytes(b"12345")
+        assert env.fetch_file_size(str(src)) == 5
+        assert env.fetch_file_size(str(tmp_path / "nope")) is None
+        assert env.fetch_file_size(str(tmp_path)) is None

--- a/tests/tools/test_send_file_tool.py
+++ b/tests/tools/test_send_file_tool.py
@@ -1,0 +1,84 @@
+"""Tests for the send_file tool (issue #466)."""
+
+import json
+
+import pytest
+
+from tools.send_file_tool import send_file_tool
+
+
+@pytest.fixture(autouse=True)
+def _local_backend(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+
+class TestSendFileLocal:
+    def test_valid_file_returns_media_tag(self, tmp_path, monkeypatch):
+        f = tmp_path / "report.pdf"
+        f.write_bytes(b"%PDF-1.4")
+        result = json.loads(send_file_tool(str(f)))
+        assert result["success"] is True
+        assert result["media_tag"].startswith("MEDIA:")
+        assert result["file_path"].endswith("report.pdf")
+
+    def test_caption_prepended_to_media_tag(self, tmp_path):
+        f = tmp_path / "data.csv"
+        f.write_text("a,b\n")
+        result = json.loads(send_file_tool(str(f), message="Here's the data"))
+        assert result["media_tag"].startswith("Here's the data\nMEDIA:")
+
+    def test_missing_file_reports_not_found(self, tmp_path):
+        result = json.loads(send_file_tool(str(tmp_path / "nope.pdf")))
+        assert result.get("success") is not True
+        assert "not found" in result["error"].lower()
+
+    def test_denied_local_path_reports_not_allowed(self, tmp_path, monkeypatch):
+        ssh_dir = tmp_path / ".ssh"
+        ssh_dir.mkdir()
+        key = ssh_dir / "id_rsa"
+        key.write_text("PRIVATE")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        result = json.loads(send_file_tool(str(key)))
+        assert result.get("success") is not True
+        assert "not allowed" in result["error"]
+
+    def test_empty_path_rejected(self):
+        result = json.loads(send_file_tool("  "))
+        assert "error" in result
+
+
+class TestSendFileRemote:
+    def test_remote_fetch_success(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        staged = tmp_path / "doc_abc_report.pdf"
+        staged.write_bytes(b"%PDF")
+        monkeypatch.setattr(
+            "gateway.media_fetch.fetch_remote_media",
+            lambda path, task_id=None: (str(staged), None),
+        )
+        result = json.loads(send_file_tool("/home/worker/report.pdf", task_id="t1"))
+        assert result["success"] is True
+        assert result["media_tag"] == f"MEDIA:{staged}"
+
+    def test_remote_fetch_failure_surfaces_reason(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "modal")
+        monkeypatch.setattr(
+            "gateway.media_fetch.fetch_remote_media",
+            lambda path, task_id=None: (None, "the file is 60.0 MB, above the 50.0 MB delivery limit"),
+        )
+        result = json.loads(send_file_tool("/root/huge.zip"))
+        assert result.get("success") is not True
+        assert "modal backend" in result["error"]
+        assert "50.0 MB" in result["error"]
+
+
+class TestRegistration:
+    def test_send_file_registered_in_file_toolset(self):
+        import tools.send_file_tool  # noqa: F401 — self-registers on import
+        from tools.registry import registry
+        from toolsets import resolve_toolset
+
+        entry = registry.get_entry("send_file")
+        assert entry is not None
+        assert entry.toolset == "file"
+        assert "send_file" in resolve_toolset("file")

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -6,6 +6,8 @@ re-sourced before each command. CWD persists via in-band stdout markers (remote)
 or a temp file (local).
 """
 
+import base64
+import binascii
 import codecs
 import json
 import logging
@@ -380,6 +382,20 @@ class _ThreadedProcessHandle:
 
 def _cwd_marker(session_id: str) -> str:
     return f"__HERMES_CWD_{session_id}__"
+
+
+# ---------------------------------------------------------------------------
+# File extraction (backend -> host)
+# ---------------------------------------------------------------------------
+
+
+class FileFetchError(RuntimeError):
+    """A file could not be extracted from the backend filesystem."""
+
+
+# Extraction of a large file over a slow exec channel (base64 on Modal /
+# Singularity) can legitimately outlast the per-command terminal timeout.
+_FETCH_TIMEOUT_SECONDS = 300
 
 
 # ---------------------------------------------------------------------------
@@ -1037,6 +1053,104 @@ class BaseEnvironment(ABC):
         visible inside the container/process.
         """
         pass
+
+    # ------------------------------------------------------------------
+    # File extraction (backend -> host)
+    # ------------------------------------------------------------------
+
+    @property
+    def remote_home(self) -> str | None:
+        """Home directory on the machine where commands actually run, if known.
+
+        Used by delivery-path security checks to resolve ``~``-relative
+        credential locations (``~/.ssh``, ``~/.hermes/.env``) against the
+        backend filesystem. ``None`` means unknown — callers must fall back
+        to conservative matching.
+        """
+        return getattr(self, "_remote_home", None)
+
+    def fetch_file_size(self, remote_path: str) -> int | None:
+        """Return the byte size of *remote_path* in the backend, or ``None``
+        when the path does not exist or is not a regular file.
+
+        Default transport: ``wc -c`` over the exec channel. Backends with a
+        direct filesystem view (local) override this with ``os.stat``.
+        """
+        quoted = shlex.quote(remote_path)
+        result = self.execute(
+            f"[ -f {quoted} ] && wc -c < {quoted}",
+            rewrite_compound_background=False,
+        )
+        if int(result.get("returncode") or 0) != 0:
+            return None
+        # Take the last all-digit token so stray login-shell noise in the
+        # merged stdout/stderr stream can't corrupt the parse.
+        for token in reversed((result.get("output") or "").split()):
+            if token.isdigit():
+                return int(token)
+        return None
+
+    def fetch_realpath(self, remote_path: str) -> str | None:
+        """Resolve symlinks of *remote_path* inside the backend, best-effort.
+
+        Returns the resolved absolute path, or ``None`` when the backend
+        cannot resolve it (missing ``readlink``/``realpath``, dead path).
+        Callers use this to re-run denylist checks on the symlink target so
+        a link planted at an innocuous path can't smuggle out a credential.
+        """
+        quoted = shlex.quote(remote_path)
+        result = self.execute(
+            f"readlink -f {quoted} 2>/dev/null || realpath {quoted} 2>/dev/null",
+            rewrite_compound_background=False,
+        )
+        if int(result.get("returncode") or 0) != 0:
+            return None
+        for line in reversed((result.get("output") or "").splitlines()):
+            line = line.strip()
+            if line.startswith("/"):
+                return line
+        return None
+
+    def fetch_file(self, remote_path: str, local_dest: str) -> None:
+        """Copy *remote_path* from the backend filesystem to *local_dest* on
+        the host. Raises :class:`FileFetchError` on any failure.
+
+        Default transport: base64 over the exec channel — works on any
+        backend that can run ``bash`` (Modal, Singularity, managed Modal).
+        Backends with a cheaper native transport override this: SSH streams
+        over the ControlMaster connection, Docker reads the bind-mount view
+        or ``docker cp``, Daytona uses its SDK download, local copies
+        directly.
+
+        The payload is fenced between unique markers so login-shell noise in
+        the merged stdout/stderr stream can never corrupt the decode.
+        """
+        marker = f"__HERMES_FETCH_{uuid.uuid4().hex[:12]}__"
+        quoted = shlex.quote(remote_path)
+        result = self.execute(
+            f"[ -f {quoted} ] && echo {marker} && "
+            f"base64 < {quoted} 2>/dev/null && echo {marker}",
+            timeout=_FETCH_TIMEOUT_SECONDS,
+            rewrite_compound_background=False,
+        )
+        if int(result.get("returncode") or 0) != 0:
+            raise FileFetchError(
+                f"could not read {remote_path!r} in the backend "
+                f"(missing, not a regular file, or unreadable)"
+            )
+        output = result.get("output") or ""
+        first = output.find(marker)
+        last = output.rfind(marker)
+        if first == -1 or last <= first:
+            raise FileFetchError(f"transfer of {remote_path!r} produced no payload")
+        payload = "".join(output[first + len(marker):last].split())
+        try:
+            data = base64.b64decode(payload, validate=True)
+        except (ValueError, binascii.Error) as exc:
+            raise FileFetchError(
+                f"transfer of {remote_path!r} was corrupted in transit: {exc}"
+            ) from exc
+        Path(local_dest).write_bytes(data)
 
     # ------------------------------------------------------------------
     # Unified execute()

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from tools.environments.base import (
     BaseEnvironment,
+    FileFetchError,
     _ThreadedProcessHandle,
 )
 from tools.environments.file_sync import (
@@ -198,6 +199,18 @@ class DaytonaEnvironment(BaseEnvironment):
     def _daytona_delete(self, remote_paths: list[str]) -> None:
         """Batch-delete remote files via SDK exec."""
         self._sandbox.process.exec(quoted_rm_command(remote_paths))
+
+    def fetch_file(self, remote_path: str, local_dest: str) -> None:
+        """Download a single sandbox file via the Daytona SDK."""
+        try:
+            self._sandbox.fs.download_file(remote_path, local_dest)
+        except Exception as exc:
+            Path(local_dest).unlink(missing_ok=True)
+            raise FileFetchError(
+                f"Daytona download of {remote_path!r} failed: {exc}"
+            ) from exc
+        if not os.path.isfile(local_dest):
+            raise FileFetchError(f"{remote_path!r} is not a regular file")
 
     # ------------------------------------------------------------------
     # Sandbox lifecycle

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -8,6 +8,7 @@ persistence via bind mounts.
 import json
 import logging
 import os
+import posixpath
 import re
 import shutil
 import subprocess
@@ -16,7 +17,12 @@ import uuid
 from pathlib import Path
 from typing import Optional
 
-from tools.environments.base import BaseEnvironment, _popen_bash
+from tools.environments.base import (
+    _FETCH_TIMEOUT_SECONDS,
+    BaseEnvironment,
+    FileFetchError,
+    _popen_bash,
+)
 from tools.environments.local import (
     _HERMES_PROVIDER_ENV_BLOCKLIST,
     _is_hermes_internal_secret,
@@ -815,6 +821,12 @@ class DockerEnvironment(BaseEnvironment):
         # /usr/local/bin is not in PATH (common on macOS gateway/service).
         self._docker_exe = find_docker() or "docker"
 
+        # Best-effort home for delivery-path security checks (remote_home
+        # property): containers run as root unless run_as_host_user remaps
+        # the uid, in which case the in-container home is unknown.
+        if not (run_as_host_user and user_args):
+            self._remote_home = "/root"
+
         # s6-overlay images (e.g. hermes-agent:latest) already use /init as PID 1
         # and exec /run/s6/basedir/bin/init during startup. For those images we
         # must (a) skip Docker's --init (two competing PID-1 inits) and (b) mount
@@ -1076,6 +1088,62 @@ class DockerEnvironment(BaseEnvironment):
             cmd.extend(["bash", "-c", cmd_string])
 
         return _popen_bash(cmd, stdin_data)
+
+    # ------------------------------------------------------------------
+    # File extraction (container -> host)
+    # ------------------------------------------------------------------
+
+    def _host_path_for(self, container_path: str) -> Optional[str]:
+        """Map a container path onto its persistent bind-mount host path.
+
+        Only covers the sandbox-managed /root and /workspace mounts; paths
+        outside them (tmpfs, explicit docker_volumes) return None and go
+        through ``docker cp`` instead. The path is normalized first so
+        ``/root/../etc/passwd`` can't escape the mapped root.
+        """
+        normalized = posixpath.normpath(container_path)
+        for prefix, host_root in (("/root", self._home_dir),
+                                  ("/workspace", self._workspace_dir)):
+            if not host_root:
+                continue
+            if normalized == prefix or normalized.startswith(prefix + "/"):
+                return os.path.join(host_root, normalized[len(prefix):].lstrip("/"))
+        return None
+
+    def fetch_file(self, container_path: str, local_dest: str) -> None:
+        """Copy a file out of the container to *local_dest* on the host.
+
+        Persistent /root and /workspace are bind mounts, so those paths copy
+        straight from the host-side view. Everything else streams through
+        ``docker cp`` (the Archive API). ``-L`` dereferences symlinks inside
+        the container so the copy can never land as a host-side symlink.
+        """
+        host_path = self._host_path_for(container_path)
+        if host_path and os.path.isfile(host_path):
+            shutil.copy2(host_path, local_dest)
+            return
+
+        if not self._container_id:
+            raise FileFetchError("Docker container not started")
+        try:
+            result = subprocess.run(
+                [self._docker_exe, "cp", "-L",
+                 f"{self._container_id}:{container_path}", local_dest],
+                capture_output=True,
+                text=True,
+                timeout=_FETCH_TIMEOUT_SECONDS,
+                stdin=subprocess.DEVNULL,
+            )
+        except subprocess.TimeoutExpired:
+            raise FileFetchError(f"docker cp of {container_path!r} timed out")
+        if result.returncode != 0:
+            raise FileFetchError(
+                f"docker cp of {container_path!r} failed: {result.stderr.strip()}"
+            )
+        if not os.path.isfile(local_dest):
+            # docker cp of a directory materializes a directory — reject it.
+            shutil.rmtree(local_dest, ignore_errors=True)
+            raise FileFetchError(f"{container_path!r} is not a regular file")
 
     # ------------------------------------------------------------------
     # "No such container" recovery (issue #36266)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -13,7 +13,7 @@ import tempfile
 import time
 from pathlib import Path
 
-from tools.environments.base import BaseEnvironment, _pipe_stdin
+from tools.environments.base import BaseEnvironment, FileFetchError, _pipe_stdin
 from hermes_cli._subprocess_compat import windows_hide_flags
 
 _IS_WINDOWS = platform.system() == "Windows"
@@ -1271,7 +1271,24 @@ class LocalEnvironment(BaseEnvironment):
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
         cwd = _resolve_local_initial_cwd(cwd)
         super().__init__(cwd=cwd, timeout=timeout, env=env)
+        self._remote_home = os.path.expanduser("~")
         self.init_session()
+
+    def fetch_file_size(self, remote_path: str) -> int | None:
+        """Direct filesystem view — stat instead of an exec round-trip."""
+        try:
+            if not os.path.isfile(remote_path):
+                return None
+            return os.stat(remote_path).st_size
+        except OSError:
+            return None
+
+    def fetch_file(self, remote_path: str, local_dest: str) -> None:
+        """The file already lives on the host — plain copy."""
+        if not os.path.isfile(remote_path):
+            raise FileFetchError(f"{remote_path!r} is not a regular file")
+        if os.path.abspath(remote_path) != os.path.abspath(local_dest):
+            shutil.copy2(remote_path, local_dest)
 
     def get_temp_dir(self) -> str:
         """Return a shell-safe writable temp dir for local execution.

--- a/tools/environments/managed_modal.py
+++ b/tools/environments/managed_modal.py
@@ -54,6 +54,9 @@ class ManagedModalEnvironment(BaseModalExecutionEnvironment):
     ):
         super().__init__(cwd=cwd, timeout=timeout)
 
+        # Modal sandboxes run as root; exposed via the remote_home property
+        # for delivery-path checks.
+        self._remote_home = "/root"
         self._guard_unsupported_credential_passthrough()
 
         gateway = resolve_managed_tool_gateway("modal")

--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -182,6 +182,9 @@ class ModalEnvironment(BaseEnvironment):
     ):
         super().__init__(cwd=cwd, timeout=timeout)
 
+        # Modal sandboxes always run as root (see _modal_bulk_download);
+        # exposed via the remote_home property for delivery-path checks.
+        self._remote_home = "/root"
         self._persistent = persistent_filesystem
         self._task_id = task_id
         self._sandbox = None

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -9,7 +9,12 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-from tools.environments.base import BaseEnvironment, _popen_bash
+from tools.environments.base import (
+    _FETCH_TIMEOUT_SECONDS,
+    BaseEnvironment,
+    FileFetchError,
+    _popen_bash,
+)
 from tools.environments.file_sync import (
     FileSyncManager,
     iter_sync_files,
@@ -317,6 +322,34 @@ class SSHEnvironment(BaseEnvironment):
             )
         if result.returncode != 0:
             raise RuntimeError(f"SSH bulk download failed: {result.stderr.decode(errors='replace').strip()}")
+
+    def fetch_file(self, remote_path: str, local_dest: str) -> None:
+        """Stream a single remote file over the ControlMaster connection.
+
+        Same transport as _ssh_bulk_download (binary-safe stdout pipe), but
+        ``cat`` instead of ``tar`` so the destination is the bare file. The
+        remote path is shell-quoted — it may originate from model output.
+        """
+        cmd = self._build_ssh_command()
+        cmd.append(f"cat {shlex.quote(remote_path)}")
+        try:
+            with open(local_dest, "wb") as f:
+                result = subprocess.run(
+                    cmd,
+                    stdin=subprocess.DEVNULL,
+                    stdout=f,
+                    stderr=subprocess.PIPE,
+                    timeout=_FETCH_TIMEOUT_SECONDS,
+                )
+        except subprocess.TimeoutExpired:
+            Path(local_dest).unlink(missing_ok=True)
+            raise FileFetchError(f"SSH fetch of {remote_path!r} timed out")
+        if result.returncode != 0:
+            Path(local_dest).unlink(missing_ok=True)
+            raise FileFetchError(
+                f"SSH fetch of {remote_path!r} failed: "
+                f"{result.stderr.decode(errors='replace').strip()}"
+            )
 
     def _ssh_delete(self, remote_paths: list[str]) -> None:
         """Batch-delete remote files in one SSH call."""

--- a/tools/send_file_tool.py
+++ b/tools/send_file_tool.py
@@ -1,0 +1,112 @@
+"""send_file tool — deliver a file from the terminal environment to the user.
+
+Thin explicit wrapper over the MEDIA: delivery pipeline (#466). The MEDIA:
+directive already just works — including transparent fetch from remote
+terminal backends (see gateway/media_fetch.py) — but it is fire-and-forget:
+the agent never learns whether the file was extractable or under the size
+cap. This tool runs the same validation/fetch eagerly and reports the
+outcome, returning a ``media_tag`` for the agent to include in its reply
+(the same contract as text_to_speech).
+"""
+
+import json
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def send_file_tool(path: str, message: str = None, task_id: str = None) -> str:
+    """Validate/fetch *path* for platform delivery and return a MEDIA tag."""
+    path = (path or "").strip()
+    if not path:
+        return tool_error("send_file requires a non-empty 'path'")
+
+    backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+    from agent.prompt_builder import _REMOTE_TERMINAL_BACKENDS
+
+    if backend in _REMOTE_TERMINAL_BACKENDS:
+        from gateway.media_fetch import fetch_remote_media
+
+        local_path, reason = fetch_remote_media(path, task_id=task_id)
+        if not local_path:
+            return tool_error(
+                f"Could not deliver {os.path.basename(path)!r} from the "
+                f"{backend} backend: {reason}"
+            )
+    else:
+        from gateway.platforms.base import validate_media_delivery_path
+
+        local_path = validate_media_delivery_path(path)
+        if not local_path:
+            if not os.path.isfile(os.path.expanduser(path)):
+                return tool_error(
+                    f"File not found on the host: {path!r}. Pass an absolute "
+                    f"path to an existing file."
+                )
+            return tool_error(
+                f"The path {path!r} is not allowed for delivery "
+                f"(credential/system location)."
+            )
+
+    media_tag = f"MEDIA:{local_path}"
+    if message:
+        media_tag = f"{message}\n{media_tag}"
+    return json.dumps({
+        "success": True,
+        "file_path": local_path,
+        "media_tag": media_tag,
+        "note": (
+            "File is staged for delivery. Include the media_tag line "
+            "verbatim in your reply so the platform attaches it."
+        ),
+    }, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+from tools.registry import registry, tool_error
+
+SEND_FILE_SCHEMA = {
+    "name": "send_file",
+    "description": (
+        "Send a file from the terminal environment to the user as a native "
+        "attachment. Works on every terminal backend: when the terminal runs "
+        "in a remote sandbox (ssh, docker, modal, daytona, singularity) the "
+        "file is fetched out of the sandbox first. Returns a media_tag to "
+        "include verbatim in your reply, or a clear error when the file is "
+        "missing, too large, or in a protected location. Plain "
+        "MEDIA:/absolute/path directives do the same implicitly — use this "
+        "tool when you want confirmation that the file is deliverable."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": (
+                    "Absolute path of the file inside the terminal "
+                    "environment (the sandbox filesystem when the backend "
+                    "is remote)."
+                ),
+            },
+            "message": {
+                "type": "string",
+                "description": "Optional caption to send along with the file.",
+            },
+        },
+        "required": ["path"],
+    },
+}
+
+registry.register(
+    name="send_file",
+    toolset="file",
+    schema=SEND_FILE_SCHEMA,
+    handler=lambda args, **kw: send_file_tool(
+        path=args.get("path", ""),
+        message=args.get("message"),
+        task_id=kw.get("task_id")),
+    emoji="📎",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -39,6 +39,8 @@ _HERMES_CORE_TOOLS = [
     "read_terminal", "close_terminal",
     # File manipulation
     "read_file", "write_file", "patch", "search_files",
+    # Deliver a file from the terminal environment to the user
+    "send_file",
     # Vision + image generation
     "vision_analyze", "image_generate",
     # Skills
@@ -190,8 +192,8 @@ TOOLSETS = {
     
 
     "file": {
-        "description": "File manipulation tools: read, write, patch (with fuzzy matching), and search (content + files)",
-        "tools": ["read_file", "write_file", "patch", "search_files"],
+        "description": "File manipulation tools: read, write, patch (with fuzzy matching), search (content + files), and send to the user",
+        "tools": ["read_file", "write_file", "patch", "search_files", "send_file"],
         "includes": []
     },
     


### PR DESCRIPTION
## Description

Fixes: #466

- `MEDIA:` directives pointing at files that only exist inside a remote terminal backend (ssh, modal, daytona, managed modal — and docker/singularity paths outside their bind mounts) were silently dropped by `validate_media_delivery_path`; they are now fetched into the canonical document cache (`~/.hermes/cache/documents`) and delivered natively from there
- adds a `fetch_file` / `fetch_file_size` API on `BaseEnvironment` with a base64-over-exec default (covers modal, singularity, managed modal) and per-backend transports: ssh streams over the existing ControlMaster connection, docker reads the bind-mount host view and falls back to `docker cp -L`, daytona uses its SDK download, local is a plain copy
- remote paths go through the same credential/system denylist as local delivery before any bytes move (`~/.ssh`, `~/.aws`, `~/.hermes/.env`, `mcp-tokens/`, ...), with best-effort symlink resolution on the remote side, and a size cap (`HERMES_MEDIA_FETCH_MAX_BYTES`, default 50 MB) rejected with a clear reason
- deliveries that still fail now surface a short "couldn't deliver <basename>" notice instead of nothing
- adds an explicit `send_file` tool (file toolset) that runs the same validation/fetch eagerly and returns a `media_tag`, and updates the remote-backend system prompt to state that `MEDIA:` paths refer to the backend filesystem and are fetched automatically
- local and existing docker delivery flows are unchanged; the fetch only triggers where delivery previously failed silently
