### PR TITLE
fix(feishu): route markdown through Card 2.0 interactive cards (v0.18.2 port)

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -152,9 +152,14 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _MARKDOWN_HINT_RE = re.compile(
-    r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)",
+    r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)|(^\s*\|.+\|\s*$)",
     re.MULTILINE,
 )
+_MARKDOWN_HR_RE = re.compile(r"^\s*-+\s*$")
+_MARKDOWN_HEADER_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+_MARKDOWN_UL_RE = re.compile(r"^(\s*)[-*+]\s+(.*)$")
+_MARKDOWN_OL_RE = re.compile(r"^(\s*)(\d+)\.\s+(.*)$")
+_MARKDOWN_BQ_RE = re.compile(r"^>\s?(.*)$")
 # Detect markdown tables: a line starting with | followed by a separator line.
 # Feishu post-type 'md' elements do not render tables, so we force text mode.
 _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
@@ -163,7 +168,7 @@ _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
-_POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+_POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect|invalid (post|card|interactive) content|invalid content format", re.IGNORECASE)
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -560,6 +565,28 @@ def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
 # ---------------------------------------------------------------------------
 # Post payload builders and parsers
 # ---------------------------------------------------------------------------
+
+
+def _build_interactive_card_payload(content: str) -> str:
+    """Wrap markdown content in a Feishu interactive card v2.0.
+
+    The card body uses ``tag: "markdown"`` which is Feishu's full markdown
+    renderer -- it supports real tables (with borders and column alignment),
+    fenced code blocks, lists, headings, bold, italic, links, and the rest
+    of the CommonMark surface. In contrast, the ``tag: "md"`` post element
+    only renders links and partial bold; the post element has no table
+    primitive and silently drops most other markdown.
+    """
+    card = {
+        "schema": "2.0",
+        "config": {"width_mode": "fill"},
+        "body": {
+            "elements": [
+                {"tag": "markdown", "content": content},
+            ],
+        },
+    }
+    return json.dumps(card, ensure_ascii=False)
 
 
 def _build_markdown_post_payload(content: str) -> str:
@@ -1911,9 +1938,9 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
+                    if msg_type not in ("post", "interactive") or not _POST_CONTENT_INVALID_RE.search(str(exc)):
                         raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                    logger.warning("[Feishu] Invalid %s payload rejected by API; falling back to plain text", msg_type)
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
                         msg_type="text",
@@ -1922,7 +1949,7 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 if (
-                    msg_type == "post"
+                    msg_type in ("post", "interactive")
                     and not self._response_succeeded(response)
                     and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
                 ):
@@ -1960,8 +1987,8 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_update_message_request(message_id=message_id, request_body=body)
             response = await self._run_blocking(self._client.im.v1.message.update, request)
             result = self._finalize_send_result(response, "update failed")
-            if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
-                logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
+            if not result.success and msg_type in ("post", "interactive") and _POST_CONTENT_INVALID_RE.search(result.error or ""):
+                logger.warning("[Feishu] Invalid %s update payload rejected by API; falling back to plain text", msg_type)
                 fallback_body = self._build_update_message_body(
                     msg_type="text",
                     content=json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
@@ -4527,14 +4554,13 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+        # Markdown content is sent as a Feishu interactive card (v2.0) using
+        # ``tag: "markdown"`` in the card body. The card's markdown renderer
+        # supports real tables (borders, column alignment), fenced code
+        # blocks, lists, headings, bold, italic, and links -- none of which
+        # the older ``tag: "md"`` post element renders correctly.
         if _MARKDOWN_HINT_RE.search(content):
-            return "post", _build_markdown_post_payload(content)
+            return "interactive", _build_interactive_card_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)
 
@@ -4830,7 +4856,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 return response
             except Exception as exc:
                 last_error = exc
-                if msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(exc)):
+                if msg_type in ("post", "interactive") and _POST_CONTENT_INVALID_RE.search(str(exc)):
                     raise
                 if attempt >= _FEISHU_SEND_ATTEMPTS - 1:
                     raise

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -561,7 +561,7 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["calls"][0].request_body.msg_type, "post")
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
         self.assertEqual(captured["calls"][1].request_body.msg_type, "text")
         self.assertEqual(
             captured["calls"][1].request_body.content,
@@ -2726,10 +2726,14 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
         payload = json.loads(captured["request"].request_body.content)
-        elements = payload["zh_cn"]["content"][0]
-        self.assertEqual(elements, [{"tag": "md", "text": "可以用 **粗体** 和 *斜体*。"}])
+        # Card 2.0 wraps the original markdown content in a single
+        # ``tag:"markdown"`` element. The card's renderer (not the gateway) is
+        # responsible for splitting it into bold/italic runs.
+        self.assertEqual(payload["schema"], "2.0")
+        rendered = payload["body"]["elements"][0]["content"]
+        self.assertEqual(rendered, "可以用 **粗体** 和 *斜体*。")
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_splits_fenced_code_blocks_into_separate_post_rows(self):
@@ -2777,22 +2781,16 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["request"].request_body.msg_type, "post")
-        payload = json.loads(captured["request"].request_body.content)
-        rows = payload["zh_cn"]["content"]
-        self.assertEqual(
-            rows,
-            [
-                [
-                    {
-                        "tag": "md",
-                        "text": "确认已入库 ✓\n文件路径：`/root/.hermes/profiles/agent_cto/cron/jobs.json`\n**解码后的内容：**",
-                    }
-                ],
-                [{"tag": "md", "text": "```json\n{\"cron\": \"list\"}\n```"}],
-                [{"tag": "md", "text": "后续说明仍应保留。"}],
-            ],
-        )
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
+        card = json.loads(captured["request"].request_body.content)
+        # The whole content is wrapped in one card. The card's markdown
+        # renderer (not the gateway) is now responsible for splitting
+        # code blocks from surrounding paragraphs.
+        rendered = card["body"]["elements"][0]["content"]
+        self.assertIn("确认已入库 ✓", rendered)
+        self.assertIn("```json", rendered)
+        self.assertIn('"cron": "list"', rendered)
+        self.assertIn("后续说明仍应保留。", rendered)
 
     @patch.dict(os.environ, {}, clear=True)
     def test_build_post_payload_keeps_fence_like_code_lines_inside_code_block(self):
@@ -2897,7 +2895,7 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["calls"][0].request_body.msg_type, "post")
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
         self.assertEqual(captured["calls"][1].request_body.msg_type, "text")
         self.assertEqual(
             captured["calls"][1].request_body.content,
@@ -2942,7 +2940,7 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["calls"][0].request_body.msg_type, "post")
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
         self.assertEqual(captured["calls"][1].request_body.msg_type, "text")
         self.assertEqual(
             captured["calls"][1].request_body.content,
@@ -2985,13 +2983,12 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["request"].request_body.msg_type, "post")
-        payload = json.loads(captured["request"].request_body.content)
-        rows = payload["zh_cn"]["content"]
-        self.assertEqual(
-            rows,
-            [[{"tag": "md", "text": "---\n1. 第一项\n<u>下划线</u>\n~~删除线~~"}]],
-        )
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
+        card = json.loads(captured["request"].request_body.content)
+        # Card 2.0 with ``tag:"markdown"`` keeps the source content intact and
+        # lets the Feishu renderer render `<u>`, `~~`, ordered lists, hr, etc.
+        rendered = card["body"]["elements"][0]["content"]
+        self.assertEqual(rendered, "---\n1. 第一项\n<u>下划线</u>\n~~删除线~~")
 
 
 @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")


### PR DESCRIPTION
## Summary

Ports the Card 2.0 markdown fix from #45036 to Hermes v0.18.2 via **manual port** (not cherry-pick) per the sweeper review on #45036 comment 4969941933.

The original PR was opened against the 422-line pre-v0.17.0 `gateway/platforms/feishu.py`. After release `9de9c25f6` (and the file-move commit referenced by the sweeper) the active adapter is `plugins/platforms/feishu/adapter.py` (5662 lines in v0.18.2). A cherry-pick of the original commit fails because the source path no longer exists.

## What changed (in `plugins/platforms/feishu/adapter.py`)

- `_build_outbound_payload` now routes markdown through Feishu Card 2.0 (`schema: "2.0"`, `tag: "markdown"`) — the full CommonMark renderer — instead of the stripped-down `tag: "md"` post element that silently drops tables, code blocks, lists, headings, italic, strikethrough, and blockquotes.
- Plain prose (no markdown hints) still goes as plain text — no behavior change for non-markdown messages.
- `_POST_CONTENT_INVALID_RE` extended to detect card-rejection errors (`"invalid card content"` / `"invalid content format"`).
- 3 fallback sites in the send/edit pipeline now treat both `"post"` and `"interactive"` as fallback-eligible (`msg_type in ("post", "interactive")`).

## What was deliberately **not** changed

Per the sweeper review:

- **`_build_markdown_post_rows` is preserved as-is.** It is still live — referenced by `_build_post_payload()` and `_build_media_post_payload()` for media captions. The original PR rewrote it, but the sweeper review flagged this as out of scope. No caption regression test was added because no caption behavior changed.
- `_build_markdown_post_payload` is also untouched; cards are not used for media captions.

## Tests

`pytest tests/gateway/test_feishu.py` → **208 passed** on clean v0.18.2 (HEAD `8e734810d`).

- 6 assertions in `_build_outbound_payload` consumers updated to expect `msg_type="interactive"` and Card 2.0 schema (`{"schema": "2.0", "body": {"elements": [{"tag": "markdown", "content": ...}]}}`) instead of post rows.
- All `_build_post_payload` unit tests untouched (the helper still serves media captions).

## Why a separate PR (vs. reviving #45036)

#45036's diff targets the old `gateway/platforms/feishu.py` path, which no longer exists in main. The fix has been a saturated-cluster casualty (tracking issue #27469, canonical partial fix #12114) — opening a fresh PR with a clean rebase on current main and a body that links the original avoids the duplicate-closure risk and gives maintainers a diff that actually applies.

## Refs

- #45036 — original fix (Mr8rock, still open)
- #27469 — saturated cluster tracker
- #12114 — canonical `"tag:"table""` partial fix
