### PR TITLE
fix(tools): resolve TTS/STT provider keys through credential pool

### DIFF
--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -62,6 +62,30 @@ def get_env_value(name, default=None):
     value = _get_env_value(name)
     return default if value is None else value
 
+
+def _resolve_provider_key(env_var: str, provider_id: str) -> str:
+    """Resolve an API key from env, .env, or the credential pool.
+
+    Used by TTS/STT providers (Mistral, ElevenLabs) that store keys
+    via ``hermes auth add <provider_id>``.
+    """
+    key = get_env_value(env_var)
+    if key:
+        return key
+    try:
+        from agent.credential_pool import load_pool
+        pool = load_pool(provider_id)
+        if pool and pool.has_credentials():
+            entry = pool.peek()
+            if entry:
+                key = getattr(entry, "access_token", "") or getattr(entry, "runtime_api_key", "")
+                key = str(key).strip()
+                if key:
+                    return key
+    except Exception:
+        pass
+    return ""
+
 # ---------------------------------------------------------------------------
 # Optional imports — graceful degradation
 # ---------------------------------------------------------------------------
@@ -804,7 +828,7 @@ def _get_provider(stt_config: dict) -> str:
             return "none"
 
         if provider == "mistral":
-            if _HAS_MISTRAL and get_env_value("MISTRAL_API_KEY"):
+            if _HAS_MISTRAL and _resolve_provider_key("MISTRAL_API_KEY", "mistral"):
                 return "mistral"
             logger.warning(
                 "STT provider 'mistral' configured but mistralai package "
@@ -823,7 +847,7 @@ def _get_provider(stt_config: dict) -> str:
             return "none"
 
         if provider == "elevenlabs":
-            if get_env_value("ELEVENLABS_API_KEY"):
+            if _resolve_provider_key("ELEVENLABS_API_KEY", "elevenlabs"):
                 return "elevenlabs"
             logger.warning(
                 "STT provider 'elevenlabs' configured but ELEVENLABS_API_KEY not set"
@@ -865,7 +889,7 @@ def _get_provider(stt_config: dict) -> str:
     # Only auto-select Mistral if the SDK is already present — don't trigger a
     # lazy-install during passive auto-detection. Explicit `provider: mistral`
     # (above) does lazy-install on first transcription call.
-    if _HAS_MISTRAL and get_env_value("MISTRAL_API_KEY"):
+    if _HAS_MISTRAL and _resolve_provider_key("MISTRAL_API_KEY", "mistral"):
         logger.info("No local STT available, using Mistral Voxtral Transcribe API")
         return "mistral"
     try:
@@ -876,7 +900,7 @@ def _get_provider(stt_config: dict) -> str:
             return "xai"
     except Exception:
         pass
-    if get_env_value("ELEVENLABS_API_KEY"):
+    if _resolve_provider_key("ELEVENLABS_API_KEY", "elevenlabs"):
         logger.info("No local STT available, using ElevenLabs Scribe STT API")
         return "elevenlabs"
     if _HAS_OPENAI and (get_env_value("DEEPINFRA_API_KEY") or "").strip():
@@ -1425,7 +1449,7 @@ def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
     Uses the ``mistralai`` Python SDK to call ``/v1/audio/transcriptions``.
     Requires ``MISTRAL_API_KEY`` environment variable.
     """
-    api_key = get_env_value("MISTRAL_API_KEY")
+    api_key = _resolve_provider_key("MISTRAL_API_KEY", "mistral")
     if not api_key:
         return {"success": False, "transcript": "", "error": "MISTRAL_API_KEY not set"}
 
@@ -1572,7 +1596,7 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
 
 def _transcribe_elevenlabs(file_path: str, model_name: str) -> Dict[str, Any]:
     """Transcribe using ElevenLabs Scribe STT API."""
-    api_key = get_env_value("ELEVENLABS_API_KEY")
+    api_key = _resolve_provider_key("ELEVENLABS_API_KEY", "elevenlabs")
     if not api_key:
         return {"success": False, "transcript": "", "error": "ELEVENLABS_API_KEY not set"}
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -69,6 +69,30 @@ def get_env_value(name, default=None):
         return os.getenv(name, default)
     value = _get_env_value(name)
     return default if value is None else value
+
+
+def _resolve_provider_key(env_var: str, provider_id: str) -> str:
+    """Resolve an API key from env, .env, or the credential pool.
+
+    Used by TTS providers (Mistral, ElevenLabs) that store keys
+    via ``hermes auth add <provider_id>``.
+    """
+    key = get_env_value(env_var)
+    if key:
+        return key
+    try:
+        from agent.credential_pool import load_pool
+        pool = load_pool(provider_id)
+        if pool and pool.has_credentials():
+            entry = pool.peek()
+            if entry:
+                key = getattr(entry, "access_token", "") or getattr(entry, "runtime_api_key", "")
+                key = str(key).strip()
+                if key:
+                    return key
+    except Exception:
+        pass
+    return ""
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
 from tools.tool_backend_helpers import (
     managed_nous_tools_enabled,
@@ -986,7 +1010,7 @@ def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]
     Returns:
         Path to the saved audio file.
     """
-    api_key = (get_env_value("ELEVENLABS_API_KEY") or "")
+    api_key = (_resolve_provider_key("ELEVENLABS_API_KEY", "elevenlabs") or "")
     if not api_key:
         raise ValueError("ELEVENLABS_API_KEY not set. Get one at https://elevenlabs.io/")
 
@@ -1557,7 +1581,7 @@ def _generate_mistral_tts(text: str, output_path: str, tts_config: Dict[str, Any
     and writes the raw bytes to *output_path*.
     Supports native Opus output for Telegram voice bubbles.
     """
-    api_key = (get_env_value("MISTRAL_API_KEY") or "")
+    api_key = (_resolve_provider_key("MISTRAL_API_KEY", "mistral") or "")
     if not api_key:
         raise ValueError("MISTRAL_API_KEY not set. Get one at https://console.mistral.ai/")
 
@@ -2631,7 +2655,7 @@ def check_tts_requirements() -> bool:
             _import_elevenlabs()
         except ImportError:
             return False
-        return bool(get_env_value("ELEVENLABS_API_KEY"))
+        return bool(_resolve_provider_key("ELEVENLABS_API_KEY", "elevenlabs"))
     if provider == "openai":
         try:
             _import_openai_client()
@@ -2660,7 +2684,7 @@ def check_tts_requirements() -> bool:
             _import_mistral_client()
         except ImportError:
             return False
-        return bool(get_env_value("MISTRAL_API_KEY"))
+        return bool(_resolve_provider_key("MISTRAL_API_KEY", "mistral"))
     if provider == "neutts":
         return _check_neutts_available()
     if provider == "kittentts":
@@ -2789,7 +2813,7 @@ def stream_tts_to_speaker(
             {**tts_config, "elevenlabs": {**el_config, "model_id": model_id}},
         )
 
-        api_key = (get_env_value("ELEVENLABS_API_KEY") or "")
+        api_key = (_resolve_provider_key("ELEVENLABS_API_KEY", "elevenlabs") or "")
         if not api_key:
             logger.warning("ELEVENLABS_API_KEY not set; streaming TTS audio disabled")
         else:
@@ -2975,7 +2999,7 @@ if __name__ == "__main__":
     print("\nProvider availability:")
     print(f"  Edge TTS:   {'installed' if _check(_import_edge_tts, 'edge') else 'not installed (pip install edge-tts)'}")
     print(f"  ElevenLabs: {'installed' if _check(_import_elevenlabs, 'el') else 'not installed (pip install elevenlabs)'}")
-    print(f"    API Key:  {'set' if get_env_value('ELEVENLABS_API_KEY') else 'not set'}")
+    print(f"    API Key:  {'set' if _resolve_provider_key('ELEVENLABS_API_KEY', 'elevenlabs') else 'not set'}")
     print(f"  OpenAI:     {'installed' if _check(_import_openai_client, 'oai') else 'not installed'}")
     print(
         "    API Key:  "

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -37,21 +37,6 @@ from utils import is_truthy_value
 logger = logging.getLogger(__name__)
 
 
-# ── Proxy detection ──────────────────────────────────────────
-# Proxy environment variables that indicate the runtime should
-# delegate DNS to a proxy rather than attempting direct resolution.
-_PROXY_ENV_VARS = (
-    "HTTPS_PROXY", "https_proxy",
-    "HTTP_PROXY", "http_proxy",
-    "ALL_PROXY", "all_proxy",
-)
-
-
-def _proxy_is_configured() -> bool:
-    """Return True when at least one HTTP proxy env var is set."""
-    return any(os.environ.get(v) for v in _PROXY_ENV_VARS)
-
-
 def normalize_url_for_request(url: str) -> str:
     """Return an ASCII-safe HTTP URL for Hermes-owned URL tools.
 
@@ -431,21 +416,8 @@ def is_safe_url(url: str) -> bool:
         try:
             addr_info = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
         except socket.gaierror:
-            # DNS resolution failed.  In sandbox / proxy environments
-            # (NVIDIA OpenShell, Docker + Squid, etc.) the host may
-            # block direct DNS — only HTTP(S) through the proxy is
-            # permitted.  When a proxy is configured, delegate DNS to
-            # the proxy rather than blocking the request outright.
-            # The hostname was already checked against
-            # _BLOCKED_HOSTNAMES above so metadata endpoints remain
-            # blocked regardless.
-            if _proxy_is_configured():
-                logger.debug(
-                    "DNS resolution failed for %s — proxy configured, "
-                    "allowing through for proxy-side resolution",
-                    hostname,
-                )
-                return True
+            # DNS resolution failed — fail closed. If DNS can't resolve it,
+            # the HTTP client will also fail, so blocking loses nothing.
             logger.warning("Blocked request — DNS resolution failed for: %s", hostname)
             return False
 

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -37,6 +37,21 @@ from utils import is_truthy_value
 logger = logging.getLogger(__name__)
 
 
+# ── Proxy detection ──────────────────────────────────────────
+# Proxy environment variables that indicate the runtime should
+# delegate DNS to a proxy rather than attempting direct resolution.
+_PROXY_ENV_VARS = (
+    "HTTPS_PROXY", "https_proxy",
+    "HTTP_PROXY", "http_proxy",
+    "ALL_PROXY", "all_proxy",
+)
+
+
+def _proxy_is_configured() -> bool:
+    """Return True when at least one HTTP proxy env var is set."""
+    return any(os.environ.get(v) for v in _PROXY_ENV_VARS)
+
+
 def normalize_url_for_request(url: str) -> str:
     """Return an ASCII-safe HTTP URL for Hermes-owned URL tools.
 
@@ -416,8 +431,21 @@ def is_safe_url(url: str) -> bool:
         try:
             addr_info = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
         except socket.gaierror:
-            # DNS resolution failed — fail closed. If DNS can't resolve it,
-            # the HTTP client will also fail, so blocking loses nothing.
+            # DNS resolution failed.  In sandbox / proxy environments
+            # (NVIDIA OpenShell, Docker + Squid, etc.) the host may
+            # block direct DNS — only HTTP(S) through the proxy is
+            # permitted.  When a proxy is configured, delegate DNS to
+            # the proxy rather than blocking the request outright.
+            # The hostname was already checked against
+            # _BLOCKED_HOSTNAMES above so metadata endpoints remain
+            # blocked regardless.
+            if _proxy_is_configured():
+                logger.debug(
+                    "DNS resolution failed for %s — proxy configured, "
+                    "allowing through for proxy-side resolution",
+                    hostname,
+                )
+                return True
             logger.warning("Blocked request — DNS resolution failed for: %s", hostname)
             return False
 


### PR DESCRIPTION
## Summary

Fixes #68003: TTS/STT providers (Mistral, ElevenLabs) stored via `hermes auth add mistral` / `hermes auth add elevenlabs` were invisible to the transcription and TTS tools — they only checked env vars and `.env` files via `get_env_value()`.

## Root Cause

`transcription_tools.py` and `tts_tool.py` each define their own `get_env_value()` wrapper that reads from env and `.env`. When a key is stored in the credential pool (via `hermes auth add`), it bypasses env entirely and stores in `auth.json`. The tools had no fallback to the pool.

## Fix

Added `_resolve_provider_key(env_var, provider_id)` in both files:

```python
def _resolve_provider_key(env_var: str, provider_id: str) -> str:
    key = get_env_value(env_var)       # env / .env (existing behavior)
    if key:
        return key
    # Fallback: credential pool (hermes auth add <provider_id>)
    from agent.credential_pool import load_pool
    pool = load_pool(provider_id)
    if pool and pool.has_credentials():
        entry = pool.peek()
        if entry:
            return entry.access_token or entry.runtime_api_key
    return ""
```

## Changes

| File | Sites changed |
|------|---------------|
| `tools/transcription_tools.py` | 6 (provider selection + auto-detect + synthesis) |
| `tools/tts_tool.py` | 6 (synthesis + availability check + diagnostic) |

+60 lines, -12 lines across 2 files. No imports changed — `load_pool` is imported lazily. No other files touched.

## Clean PR

This is a clean extraction of just the credential-pool fix from #68011 (which bundles +9662/-55 across 47 files of unrelated work). Per @PRATHAMESH75's [autotriage review](https://github.com/NousResearch/hermes-agent/pull/68011#issuecomment-5021829728): "The credential-pool routing itself is the right approach and worth landing on its own."