### PR TITLE
fix(cli): handle cua-driver doctor policy denial

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13894,15 +13894,14 @@ def main():
     )
     computer_use_doctor = computer_use_sub.add_parser(
         "doctor",
-        help="Run cua-driver `health_report` and surface the check matrix",
+        help="Run cua-driver diagnostics and surface the check matrix",
         description=(
-            "Drive cua-driver's stable `health_report` MCP tool and render\n"
-            "its check matrix (TCC permissions, bundle identity, version,\n"
-            "platform support, screenshot probe, …) as human-readable\n"
-            "output. cua-driver owns the health model; this command stays\n"
-            "thin so new checks added upstream surface here without code\n"
-            "changes. Exits 0 when overall=ok, 1 when degraded/failed, 2\n"
-            "when the binary is missing or unreachable."
+            "Run cua-driver's diagnostic interface and render its check\n"
+            "matrix as human-readable output. The health_report MCP tool\n"
+            "is preferred; if current driver policy denies that call, the\n"
+            "supported `cua-driver doctor --json` interface is used without\n"
+            "weakening the policy. Exits 0 when healthy, 1 when checks fail,\n"
+            "and 2 when the binary or diagnostic interface is unavailable."
         ),
     )
     computer_use_doctor.add_argument(
@@ -13926,7 +13925,7 @@ def main():
     computer_use_doctor.add_argument(
         "--json",
         action="store_true",
-        help="Emit the raw structured payload as JSON (same shape as `tools/call`).",
+        help="Emit the raw structured payload from the diagnostic interface.",
     )
     computer_use_perms = computer_use_sub.add_parser(
         "permissions",

--- a/tests/computer_use/test_doctor.py
+++ b/tests/computer_use/test_doctor.py
@@ -76,6 +76,25 @@ def _degraded_report() -> dict:
     }
 
 
+def _cli_doctor_report(*, ok: bool = True) -> dict:
+    """Current ``cua-driver doctor --json`` response shape."""
+    return {
+        "ok": ok,
+        "probes": [
+            {
+                "label": "binary",
+                "status": "ok",
+                "message": "cua-driver 0.10.0 (x86_64-windows)",
+            },
+            {
+                "label": "UI Automation",
+                "status": "ok" if ok else "err",
+                "message": "CoCreateInstance(CUIAutomation) succeeded" if ok else "failed",
+            },
+        ],
+    }
+
+
 # ── exit codes ─────────────────────────────────────────────────────────────
 
 
@@ -209,6 +228,84 @@ class TestResponseShapeParsing:
             code = doctor.run_doctor()
         assert code == 2
         assert "method not found" in capsys.readouterr().err
+
+    def test_mcp_error_envelope_falls_back_to_cli_doctor(self):
+        """A policy denial must not be rendered as a successful question-mark report."""
+        from tools.computer_use import doctor
+
+        proc = _fake_proc_with_responses(
+            {"jsonrpc": "2.0", "id": 1, "result": {}},
+            {
+                "jsonrpc": "2.0", "id": 2,
+                "result": {
+                    "isError": True,
+                    "content": [{"type": "text", "text": "Permission denied"}],
+                    "structuredContent": {"exit_code": 1},
+                },
+            },
+        )
+        completed = MagicMock(
+            stdout=json.dumps(_cli_doctor_report()), stderr="", returncode=0
+        )
+        with patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("subprocess.Popen", return_value=proc), \
+             patch("subprocess.run", return_value=completed), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            code = doctor.run_doctor()
+
+        assert code == 0
+        text = out.getvalue()
+        assert "0.10.0" in text
+        assert "win32" in text
+        assert "? on ?" not in text
+
+    def test_cli_doctor_failure_exits_1(self):
+        from tools.computer_use import doctor
+
+        proc = _fake_proc_with_responses(
+            {"jsonrpc": "2.0", "id": 1, "result": {}},
+            {
+                "jsonrpc": "2.0", "id": 2,
+                "result": {
+                    "isError": True,
+                    "content": [{"type": "text", "text": "Permission denied"}],
+                    "structuredContent": {"exit_code": 1},
+                },
+            },
+        )
+        completed = MagicMock(
+            stdout=json.dumps(_cli_doctor_report(ok=False)), stderr="", returncode=1
+        )
+        with patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("subprocess.Popen", return_value=proc), \
+             patch("subprocess.run", return_value=completed), \
+             patch("sys.stdout", new_callable=StringIO):
+            code = doctor.run_doctor()
+        assert code == 1
+
+    def test_non_policy_mcp_error_does_not_fall_back(self, capsys):
+        """A driver/tool failure must remain visible instead of being masked."""
+        from tools.computer_use import doctor
+
+        proc = _fake_proc_with_responses(
+            {"jsonrpc": "2.0", "id": 1, "result": {}},
+            {
+                "jsonrpc": "2.0", "id": 2,
+                "result": {
+                    "isError": True,
+                    "content": [{"type": "text", "text": "driver internal failure"}],
+                    "structuredContent": {"exit_code": 1},
+                },
+            },
+        )
+        with patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("subprocess.Popen", return_value=proc), \
+             patch("subprocess.run") as run:
+            code = doctor.run_doctor()
+
+        assert code == 2
+        run.assert_not_called()
+        assert "driver internal failure" in capsys.readouterr().err
 
 
 # ── args / arg passthrough ─────────────────────────────────────────────────

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -1,11 +1,11 @@
 """
-`hermes computer-use doctor` — thin client for cua-driver's `health_report` MCP tool.
+`hermes computer-use doctor` — diagnostics adapter for cua-driver.
 
 cua-driver owns the health model (#1908 / be761fac on `main`). This module
-just drives the stdio JSON-RPC handshake, calls `health_report`, and
-renders the structured response. When the driver gets new checks, they
-flow through here without code changes on the Hermes side — the only
-contract is the stable `schema_version="1"` payload shape.
+prefers the stable `health_report` MCP tool and renders its structured
+response. Newer cua-driver permission policies can deny that tool before
+dispatch; in that case this module falls back to the driver's supported
+`doctor --json` CLI without bypassing the policy.
 
 Exit code conventions:
 - 0: overall == "ok"
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -35,6 +36,31 @@ _OVERALL_GLYPH = {
     "degraded": "⚠️",
     "failed":   "❌",
 }
+
+
+class _HealthReportPolicyDenied(RuntimeError):
+    """The MCP exchange worked, but policy denied health_report dispatch."""
+
+
+def _is_health_report(value: Any) -> bool:
+    """Return whether *value* satisfies the stable health-report envelope."""
+    return (
+        isinstance(value, dict)
+        and value.get("schema_version") == "1"
+        and isinstance(value.get("platform"), str)
+        and isinstance(value.get("driver_version"), str)
+        and value.get("overall") in _OVERALL_GLYPH
+        and isinstance(value.get("checks"), list)
+    )
+
+
+def _is_cli_doctor_report(value: Any) -> bool:
+    """Return whether *value* is the current `cua-driver doctor --json` shape."""
+    return (
+        isinstance(value, dict)
+        and isinstance(value.get("ok"), bool)
+        and isinstance(value.get("probes"), list)
+    )
 
 
 def _cua_child_env() -> Dict[str, str]:
@@ -152,11 +178,26 @@ def _drive_health_report(
 
     result = resp.get("result") or {}
 
+    # A denied MCP tool call is still a successful JSON-RPC exchange. Current
+    # cua-driver versions encode that denial as result.isError plus a small
+    # structuredContent object (for example {"exit_code": 1}). Never mistake
+    # that error envelope for the documented health-report schema.
+    if result.get("isError"):
+        messages = [
+            str(item.get("text", "")).strip()
+            for item in result.get("content", [])
+            if isinstance(item, dict) and item.get("type") == "text"
+        ]
+        detail = next((message for message in messages if message), "MCP tool call failed")
+        if detail.lower().startswith("permission denied"):
+            raise _HealthReportPolicyDenied(detail)
+        raise RuntimeError(f"health_report MCP tool failed: {detail}")
+
     # Preferred: structuredContent (cua-driver-rs always emits it on the
     # health_report response). Fall back to parsing the first text item
     # as JSON for older cua-driver builds that didn't carry structuredContent.
     sc = result.get("structuredContent")
-    if isinstance(sc, dict):
+    if _is_health_report(sc):
         return sc
 
     for item in result.get("content", []):
@@ -165,7 +206,7 @@ def _drive_health_report(
             try:
                 # Many health_report payloads ship JSON in the text item too.
                 parsed = json.loads(text)
-                if isinstance(parsed, dict) and "schema_version" in parsed:
+                if _is_health_report(parsed):
                     return parsed
             except (ValueError, TypeError):
                 pass
@@ -176,9 +217,93 @@ def _drive_health_report(
     )
 
 
+def _drive_cli_doctor(binary: str, *, timeout: float = 12.0) -> Dict[str, Any]:
+    """Run the driver's supported machine-readable self-diagnostic command."""
+    try:
+        completed = subprocess.run(
+            [binary, "doctor", "--json"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            env=_sanitized_cua_env(),
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        raise RuntimeError(f"cua-driver doctor could not run: {e}") from e
+
+    try:
+        report = json.loads(completed.stdout)
+    except (ValueError, TypeError) as e:
+        stderr = (completed.stderr or "").strip()
+        raise RuntimeError(
+            f"cua-driver doctor returned invalid JSON: {e}; stderr: {stderr or '(empty)'}"
+        ) from e
+
+    if not _is_cli_doctor_report(report):
+        raise RuntimeError(
+            "cua-driver doctor returned an unrecognised payload; "
+            f"keys: {list(report.keys()) if isinstance(report, dict) else type(report).__name__}"
+        )
+    return report
+
+
+def _cli_doctor_identity(report: Dict[str, Any]) -> tuple[str, str]:
+    """Extract version and platform from the driver's stable binary probe."""
+    for probe in report.get("probes", []):
+        if isinstance(probe, dict) and probe.get("label") == "binary":
+            message = str(probe.get("message") or "")
+            match = re.search(r"\bcua-driver\s+(\S+)\s+\([^)]*-(windows|linux|macos)\)", message)
+            if match:
+                platform = {"windows": "win32", "macos": "darwin"}.get(
+                    match.group(2), match.group(2)
+                )
+                return match.group(1), platform
+    return "?", sys.platform
+
+
+def _print_cli_doctor_report(report: Dict[str, Any], color: bool) -> None:
+    """Render the current `cua-driver doctor --json` probe report."""
+    probes = [probe for probe in report.get("probes", []) if isinstance(probe, dict)]
+    has_warning = any(probe.get("status") == "warn" for probe in probes)
+    ok = bool(report.get("ok"))
+    overall = "ok" if ok else "failed"
+    summary = "ok (warnings present)" if ok and has_warning else overall
+    version, platform = _cli_doctor_identity(report)
+    glyph = "✅" if ok else "❌"
+
+    if color:
+        col_red = "\033[31m"
+        col_yellow = "\033[33m"
+        col_green = "\033[32m"
+        col_reset = "\033[0m"
+        col_dim = "\033[2m"
+        header_col = col_yellow if has_warning and ok else (col_green if ok else col_red)
+    else:
+        col_red = col_yellow = col_green = col_reset = col_dim = header_col = ""
+
+    print(f"{glyph} cua-driver {version} on {platform} — {header_col}{summary}{col_reset}")
+    glyphs = {"ok": "✅", "warn": "⚠️", "err": "❌"}
+    colours = {"ok": col_green, "warn": col_yellow, "err": col_red}
+    for probe in probes:
+        status = str(probe.get("status") or "?")
+        label = str(probe.get("label") or "?")
+        message = str(probe.get("message") or "")
+        status_col = colours.get(status, "") if color else ""
+        print(f"  {glyphs.get(status, '•')} {status_col}{label}{col_reset}: {message}")
+        detail = probe.get("detail")
+        if detail:
+            for line in str(detail).splitlines():
+                print(f"      {col_dim}{line}{col_reset}")
+
+
 def _print_text_report(report: Dict[str, Any], color: bool) -> None:
     """Render the report in the same style as `cua-driver call health_report`
     would (one line per check + a summary footer)."""
+    if _is_cli_doctor_report(report):
+        _print_cli_doctor_report(report, color=color)
+        return
+
     schema = report.get("schema_version", "?")
     platform = report.get("platform", "?")
     driver_v = report.get("driver_version", "?")
@@ -270,8 +395,28 @@ def run_doctor(
 
     try:
         report = _drive_health_report(binary, include=include, skip=skip)
-    except RuntimeError as e:
-        print(f"cua-driver health_report failed: {e}", file=sys.stderr)
+    except _HealthReportPolicyDenied as health_error:
+        # Current cua-driver policy can deny health_report before dispatch even
+        # though it is read-only. Its own `doctor --json` command is the
+        # supported local diagnostic path and does not weaken that policy.
+        if include or skip:
+            print(
+                "cua-driver health_report failed and the CLI fallback does not "
+                f"support include/skip filters: {health_error}",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            report = _drive_cli_doctor(binary)
+        except RuntimeError as doctor_error:
+            print(
+                f"cua-driver diagnostics failed: health_report: {health_error}; "
+                f"doctor --json: {doctor_error}",
+                file=sys.stderr,
+            )
+            return 2
+    except RuntimeError as health_error:
+        print(f"cua-driver health_report failed: {health_error}", file=sys.stderr)
         return 2
 
     if json_output:
@@ -281,6 +426,9 @@ def run_doctor(
         if color is None:
             color = sys.stdout.isatty()
         _print_text_report(report, color=bool(color))
+
+    if _is_cli_doctor_report(report):
+        return 0 if report.get("ok") else 1
 
     overall = report.get("overall")
     if overall in ("degraded", "failed"):


### PR DESCRIPTION
> **Status (2026-07-26): Closed as superseded by #68452.** The maintainer confirmed that #68452 covers this case more thoroughly with a multi-probe fallback, real-schema preference, and broader unavailable-report detection. This PR remains as the Windows reproduction and validation record.

## What changed

- validate the `health_report` MCP response before treating `structuredContent` as the documented report schema
- recognize the standard-policy denial returned by cua-driver 0.10.0
- fall back to the supported `cua-driver doctor --json` diagnostic command without weakening the driver's permission mode
- render the CLI doctor probe format in both human-readable and JSON modes
- preserve protocol/tool failures as failures instead of masking them with the fallback
- update the CLI help text and add regression coverage

## Why

On native Windows with cua-driver 0.10.0 running in its default `standard` permission mode, the MCP call returned an error payload whose `structuredContent` contained only an exit code. Hermes accepted that small error object as a valid health report, printed an unknown-status line, and could report success incorrectly.

The fallback uses cua-driver's own machine-readable self-diagnostic interface. It does not enable unrestricted mode, alter policy configuration, or bypass an approval boundary.

## User impact

Users of current cua-driver releases would get real version, platform, installation, interactive-session, UI Automation, and window-enumeration diagnostics instead of a misleading question-mark report.

Older drivers that return the documented `health_report` schema continue using the existing path unchanged.

## Validation

- `scripts/run_tests.sh tests/computer_use/test_doctor.py -q` — 17 passed
- `scripts/check-windows-footguns.py` — no Windows footguns in the three changed files
- manual native Windows verification with cua-driver 0.10.0:
  - `hermes computer-use doctor` reports `cua-driver 0.10.0 on win32 — ok`
  - interactive desktop attached
  - UI Automation available
  - visible windows enumerated
  - daemon remains in `standard` permission mode

## Platform tested

Native Windows 11, Python 3.11, Hermes Agent 0.19.0, cua-driver 0.10.0.