### PR TITLE
fix(config): check credential pool in get_env_value (#68003)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -8179,14 +8179,60 @@ def reload_env() -> int:
 
 
 def get_env_value(key: str) -> Optional[str]:
-    """Get a value from ~/.hermes/.env or environment."""
+    """Get a value from ~/.hermes/.env, environment, or credential pool.
+
+    Resolution order:
+        1. os.environ
+        2. ~/.hermes/.env
+        3. Credential pool (for keys stored via ``hermes auth add``)
+
+    The credential pool fallback maps env var names to providers by
+    scanning ``providers.<name>.key_env`` in config.yaml, then reading
+    the pool entry for that provider.  This fixes STT/TTS and other
+    tools that bypass the full provider resolver path (#68003).
+    """
     # Check environment first
     if key in os.environ:
         return os.environ[key]
 
     # Then check .env file
     env_vars = load_env()
-    return env_vars.get(key)
+    val = env_vars.get(key)
+    if val:
+        return val
+
+    # Finally check credential pool — find provider that uses this env var
+    try:
+        cfg = load_config()
+        providers = cfg.get("providers") or {}
+        if isinstance(providers, dict):
+            for provider_name, provider_cfg in providers.items():
+                if not isinstance(provider_cfg, dict):
+                    continue
+                provider_key_env = (
+                    provider_cfg.get("key_env")
+                    or provider_cfg.get("api_key_env")
+                    or ""
+                ).strip()
+                if provider_key_env == key:
+                    # Found the provider — check credential pool
+                    try:
+                        from hermes_cli.auth import read_credential_pool
+
+                        pool_entries = read_credential_pool(provider_name)
+                        if pool_entries and isinstance(pool_entries, list):
+                            for entry in pool_entries:
+                                if isinstance(entry, dict):
+                                    api_key = entry.get("api_key") or entry.get("access_token")
+                                    if api_key:
+                                        return str(api_key)
+                    except Exception:
+                        pass
+                    break
+    except Exception:
+        pass
+
+    return None
 
 
 def get_env_value_prefer_dotenv(key: str) -> Optional[str]:


### PR DESCRIPTION
## Summary

When API keys are stored exclusively in the credential pool (`hermes auth add`) and removed from `.env` and shell environment, STT/TTS tools fail because `get_env_value()` only checks `os.environ` and `.env`.

## Root Cause

`get_env_value()` in `hermes_cli/config.py` has no knowledge of the credential pool. The main chat path uses the full provider resolver (`agent.runtime_provider` / `agent.chat_completion_helpers`) which maps `providers.mistral.key_env: MISTRAL_API_KEY` to the credential pool entry `custom:mistral`. STT/TTS tools bypass this entirely.

## Fix

Extend `get_env_value()` to also check the credential pool as a fallback:

1. Check `os.environ`
2. Check `~/.hermes/.env`
3. **NEW**: Scan `providers.<name>.key_env` in config.yaml to find which provider uses the requested env var, then read the credential pool entry for that provider

This is a generic fix — any tool using `get_env_value()` (including STT, TTS, and future tools) automatically benefits.

## Testing

```python
# Before fix: STT fails with "MISTRAL_API_KEY not set"
# After fix: get_env_value("MISTRAL_API_KEY") finds key in credential pool
```

Fixes #68003
