### PR TITLE
feat(auth): support multiple OpenAI/Codex subscriptions

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3620,9 +3620,9 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: 
         _save_auth_store(auth_store)
 
 
-def _recover_codex_tokens_from_cli(reason: str) -> Optional[Dict[str, str]]:
+def _recover_codex_tokens_from_cli(reason: str, auth_path: Optional[str] = None) -> Optional[Dict[str, str]]:
     """Adopt a valid Codex CLI token pair into Hermes auth, if available."""
-    imported = _import_codex_cli_tokens()
+    imported = _import_codex_cli_tokens(auth_path)
     # Require BOTH tokens before adopting: persisting a payload without a
     # usable refresh_token would only break the next refresh cycle.
     if not (
@@ -3814,20 +3814,27 @@ def _refresh_codex_auth_tokens(
     return updated_tokens
 
 
-def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
+def _import_codex_cli_tokens(auth_path: Optional[str] = None) -> Optional[Dict[str, str]]:
     """Try to read tokens from ~/.codex/auth.json (Codex CLI shared file).
-    
+
     Returns tokens dict if valid and not expired, None otherwise.
     Does NOT write to the shared file.
+
+    When ``auth_path`` is provided, reads from that path instead of the
+    default ``~/.codex/auth.json``. This enables importing multiple Codex
+    accounts from separate auth files (e.g. after logging out of Account A
+    and logging into Account B in the Codex CLI).
     """
-    codex_home = os.getenv("CODEX_HOME", "").strip()
-    if not codex_home:
-        codex_home = str(Path.home() / ".codex")
-    auth_path = Path(codex_home).expanduser() / "auth.json"
-    if not auth_path.is_file():
+    if auth_path is None:
+        codex_home = os.getenv("CODEX_HOME", "").strip()
+        if not codex_home:
+            codex_home = str(Path.home() / ".codex")
+        auth_path = str(Path(codex_home).expanduser() / "auth.json")
+    path = Path(auth_path).expanduser()
+    if not path.is_file():
         return None
     try:
-        payload = json.loads(auth_path.read_text(encoding="utf-8"))
+        payload = json.loads(path.read_text(encoding="utf-8"))
         tokens = payload.get("tokens")
         if not isinstance(tokens, dict):
             return None
@@ -3840,12 +3847,90 @@ def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
         # but no working credentials.
         if _codex_access_token_is_expiring(access_token, 0):
             logger.debug(
-                "Codex CLI tokens at %s are expired — skipping import.", auth_path,
+                "Codex CLI tokens at %s are expired — skipping import.", path,
             )
             return None
         return dict(tokens)
     except Exception:
         return None
+
+
+def _codex_chatgpt_account_id(access_token: Any) -> Optional[str]:
+    """Best-effort ``chatgpt_account_id`` claim from a Codex OAuth JWT.
+
+    Returns None when the token is not a JWT or carries no account claim.
+    """
+    auth_claims = _decode_jwt_claims(access_token).get("https://api.openai.com/auth")
+    if not isinstance(auth_claims, dict):
+        return None
+    account_id = auth_claims.get("chatgpt_account_id")
+    if isinstance(account_id, str) and account_id.strip():
+        return account_id.strip()
+    return None
+
+
+def codex_credential_identity(tokens: Dict[str, str]) -> str:
+    """Stable identity for a Codex credential, for de-duplication.
+
+    Prefers the JWT's ``chatgpt_account_id`` so two auth files holding
+    *different* token pairs for the same ChatGPT account still collapse to
+    one credential. Falls back to the refresh token — the material that
+    actually must not be duplicated, since Codex refresh tokens are
+    single-use — and then to the access token.
+    """
+    account_id = _codex_chatgpt_account_id(tokens.get("access_token"))
+    if account_id:
+        return f"account:{account_id}"
+    refresh_token = (tokens.get("refresh_token") or "").strip()
+    if refresh_token:
+        return f"refresh:{refresh_token}"
+    return f"access:{(tokens.get('access_token') or '').strip()}"
+
+
+def _import_codex_cli_tokens_from_directory(directory: str) -> list[Dict[str, str]]:
+    """Import all valid Codex token pairs from a directory of auth files.
+
+    Scans ``directory`` for ``auth*.json`` files (e.g. ``auth.json``,
+    ``auth.account-a.json``, ``auth.account-b.json``) and imports each
+    valid, non-expired token pair found. Returns a list of token dicts
+    (each with ``access_token`` and ``refresh_token``), **one per distinct
+    account**.
+
+    This enables the multi-account workflow: the user logs into Account A
+    in the Codex CLI (``~/.codex/auth.json``), copies it to
+    ``~/.codex/auth.account-a.json``, logs into Account B
+    (``~/.codex/auth.json``), and Hermes imports both.
+
+    That workflow routinely leaves the *same* account in two files — the
+    live ``auth.json`` plus the labelled copy the user kept of it. Returning
+    it twice would create two pool entries sharing one refresh token, and
+    Codex refresh tokens are single-use: the first rotation consumes the
+    pair and strands the duplicate on dead credentials. So results are
+    de-duplicated by ``codex_credential_identity()``, keeping whichever
+    file sorts first — for a labelled copy that is ``auth.<label>.json``,
+    which sorts ahead of the bare ``auth.json``.
+    """
+    dir_path = Path(directory).expanduser()
+    if not dir_path.is_dir():
+        return []
+    results: list[Dict[str, str]] = []
+    seen: set[str] = set()
+    for auth_file in sorted(dir_path.glob("auth*.json")):
+        tokens = _import_codex_cli_tokens(str(auth_file))
+        if tokens is None:
+            continue
+        identity = codex_credential_identity(tokens)
+        if identity in seen:
+            logger.debug(
+                "Codex import: %s duplicates an account already read from "
+                "this directory — skipping.", auth_file.name,
+            )
+            continue
+        seen.add(identity)
+        # Tag the entry with the source filename for debugging
+        tokens["_source_file"] = auth_file.name
+        results.append(tokens)
+    return results
 
 
 def resolve_codex_runtime_credentials(
@@ -4094,14 +4179,9 @@ def _probe_codex_quota_restored(
         }
         # Best-effort ChatGPT-Account-Id from the JWT (the backend requires it
         # for some account shapes; harmless to omit for others).
-        claims = _decode_jwt_claims(token)
-        account_id = (
-            claims.get("https://api.openai.com/auth", {}).get("chatgpt_account_id")
-            if isinstance(claims.get("https://api.openai.com/auth"), dict)
-            else None
-        )
-        if isinstance(account_id, str) and account_id.strip():
-            headers["ChatGPT-Account-Id"] = account_id.strip()
+        account_id = _codex_chatgpt_account_id(token)
+        if account_id:
+            headers["ChatGPT-Account-Id"] = account_id
         with httpx.Client(timeout=10.0) as client:
             response = client.get(_codex_usage_probe_url(base_url), headers=headers)
         if response.status_code == 200:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -308,6 +308,95 @@ def auth_add_command(args) -> None:
         return
 
     if provider == "openai-codex":
+        # Multi-account import: if the user points us at a directory of
+        # auth*.json files (e.g. ~/.codex/), import every valid account
+        # found. This supports the "log in Account A → copy auth.json →
+        # log in Account B" workflow without running the device-code flow
+        # per account.
+        codex_dir = (getattr(args, "codex_dir", None) or "").strip()
+        if codex_dir:
+            imported = auth_mod._import_codex_cli_tokens_from_directory(codex_dir)
+            if not imported:
+                raise SystemExit(
+                    f"No valid Codex tokens found in {codex_dir}. "
+                    "Expected auth*.json files with access_token + refresh_token."
+                )
+            # Accounts already in the pool are skipped so re-running the
+            # import (or pointing at a directory overlapping an earlier one)
+            # doesn't append a second entry for the same account. Two entries
+            # sharing one single-use Codex refresh token strand each other on
+            # the first rotation.
+            existing = {
+                auth_mod.codex_credential_identity({
+                    "access_token": e.access_token or "",
+                    "refresh_token": e.refresh_token or "",
+                })
+                for e in pool.entries()
+            }
+            added = 0
+            skipped = 0
+            for tokens in imported:
+                if auth_mod.codex_credential_identity(tokens) in existing:
+                    skipped += 1
+                    continue
+                label = (getattr(args, "label", None) or "").strip() or label_from_token(
+                    tokens["access_token"],
+                    _oauth_default_label(provider, len(pool.entries()) + 1),
+                )
+                entry = PooledCredential(
+                    provider=provider,
+                    id=uuid.uuid4().hex[:6],
+                    label=label,
+                    auth_type=AUTH_TYPE_OAUTH,
+                    priority=0,
+                    source=SOURCE_MANUAL_DEVICE_CODE,
+                    access_token=tokens["access_token"],
+                    refresh_token=tokens["refresh_token"],
+                    base_url=tokens.get("base_url"),
+                    last_refresh=tokens.get("last_refresh"),
+                )
+                pool.add_entry(entry)
+                added += 1
+            if added:
+                auth_mod.mark_provider_active_if_unset(provider)
+            summary = f'Imported {added} {provider} OAuth credential(s) from {codex_dir}'
+            if skipped:
+                summary += f' ({skipped} already in the pool)'
+            print(summary)
+            return
+
+        # Single-file import: --auth-file points at one auth.json to adopt.
+        auth_file = (getattr(args, "auth_file", None) or "").strip()
+        if auth_file:
+            tokens = auth_mod._import_codex_cli_tokens(auth_file)
+            if tokens is None:
+                raise SystemExit(
+                    f"No valid Codex tokens found at {auth_file}. "
+                    "File must contain access_token + refresh_token and not be expired."
+                )
+            label = (getattr(args, "label", None) or "").strip() or label_from_token(
+                tokens["access_token"],
+                _oauth_default_label(provider, len(pool.entries()) + 1),
+            )
+            entry = PooledCredential(
+                provider=provider,
+                id=uuid.uuid4().hex[:6],
+                label=label,
+                auth_type=AUTH_TYPE_OAUTH,
+                priority=0,
+                source=SOURCE_MANUAL_DEVICE_CODE,
+                access_token=tokens["access_token"],
+                refresh_token=tokens["refresh_token"],
+                base_url=tokens.get("base_url"),
+                last_refresh=tokens.get("last_refresh"),
+            )
+            first_credential = not pool.entries()
+            pool.add_entry(entry)
+            if first_credential:
+                auth_mod.mark_provider_active_if_unset(provider)
+            print(f'Imported {provider} OAuth credential: "{entry.label}"')
+            return
+
         creds = auth_mod._codex_device_code_login()
         label = (getattr(args, "label", None) or "").strip() or label_from_token(
             creds["tokens"]["access_token"],

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -49,6 +49,16 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
         help="Disable TLS verification for OAuth login",
     )
     auth_add.add_argument("--ca-bundle", help="Custom CA bundle for OAuth login")
+    auth_add.add_argument(
+        "--auth-file",
+        help="Import Codex OAuth tokens from a specific auth.json file "
+             "(e.g. ~/.codex/auth.account-b.json). Only for openai-codex.",
+    )
+    auth_add.add_argument(
+        "--codex-dir",
+        help="Import all valid Codex OAuth tokens from a directory of "
+             "auth*.json files (e.g. ~/.codex). Only for openai-codex.",
+    )
     auth_list = auth_subparsers.add_parser("list", help="List pooled credentials")
     auth_list.add_argument("provider", nargs="?", help="Optional provider filter")
     auth_remove = auth_subparsers.add_parser(

--- a/tests/hermes_cli/test_auth_codex_self_heal.py
+++ b/tests/hermes_cli/test_auth_codex_self_heal.py
@@ -38,7 +38,7 @@ def test_self_heals_on_stale_refresh_token(monkeypatch):
         )
 
     monkeypatch.setattr(auth, "refresh_codex_oauth_pure", _rejected)
-    monkeypatch.setattr(auth, "_import_codex_cli_tokens", lambda: dict(fresh))
+    monkeypatch.setattr(auth, "_import_codex_cli_tokens", lambda *a, **k: dict(fresh))
     monkeypatch.setattr(auth, "_save_codex_tokens", lambda t, *a, **k: saved.update(t))
 
     out = _refresh_codex_auth_tokens(STALE, 20.0)

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -26,6 +26,18 @@ def _jwt_with_email(email: str) -> str:
     return f"{header}.{payload}.signature"
 
 
+def _jwt_with_account(email: str, account_id: str) -> str:
+    """JWT carrying the ``chatgpt_account_id`` claim Codex identity keys on."""
+    header = base64.urlsafe_b64encode(b'{"alg":"RS256","typ":"JWT"}').rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(
+        json.dumps({
+            "email": email,
+            "https://api.openai.com/auth": {"chatgpt_account_id": account_id},
+        }).encode()
+    ).rstrip(b"=").decode()
+    return f"{header}.{payload}.signature"
+
+
 def _codex_pool_only_store(*, exhausted: bool = False) -> dict:
     entry = {
         "id": "codex-1",
@@ -769,3 +781,308 @@ def test_auth_remove_copilot_suppresses_all_variants(tmp_path, monkeypatch):
     assert is_source_suppressed("copilot", "env:GITHUB_TOKEN")
 
 
+def test_auth_add_codex_auth_file_imports_single_account(tmp_path, monkeypatch):
+    """`hermes auth add openai-codex --auth-file <path>` imports a single
+    Codex account from a specific auth.json file instead of running the
+    device-code flow. Enables the multi-account workflow where the user
+    copies auth.json between logins."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    # Create a fake Codex CLI auth.json with valid tokens
+    codex_auth = tmp_path / "auth.account-b.json"
+    codex_auth.write_text(json.dumps({
+        "tokens": {
+            "access_token": _jwt_with_email("account-b@example.com"),
+            "refresh_token": "refresh-token-b",
+        },
+    }))
+
+    from types import SimpleNamespace
+    from hermes_cli.auth_commands import auth_add_command
+
+    auth_add_command(SimpleNamespace(
+        provider="openai-codex",
+        auth_type="oauth",
+        api_key=None,
+        label=None,
+        auth_file=str(codex_auth),
+        codex_dir=None,
+    ))
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["openai-codex"]
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["source"] == "manual:device_code"
+    assert entry["access_token"] == _jwt_with_email("account-b@example.com")
+    assert entry["refresh_token"] == "refresh-token-b"
+    assert payload["active_provider"] == "openai-codex"
+
+
+def test_auth_add_codex_auth_file_rejects_expired_tokens(tmp_path, monkeypatch):
+    """`--auth-file` rejects expired tokens — importing stale tokens leaves
+    the user stuck with "Login successful!" but no working credentials."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    # Create an expired token (exp in the past)
+    import time
+    expired_jwt = (
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+        "eyJzdWIiOiIxMjM0NTY3ODkwIiwiZW1haWwiOiJleHBpcmVkQGV4YW1wbGUuY29tIiwiZXhwIjoxNjAwMDAwMDAwfQ."
+        "invalid-signature"
+    )
+    codex_auth = tmp_path / "auth.expired.json"
+    codex_auth.write_text(json.dumps({
+        "tokens": {
+            "access_token": expired_jwt,
+            "refresh_token": "refresh-token",
+        },
+    }))
+
+    from types import SimpleNamespace
+    from hermes_cli.auth_commands import auth_add_command
+
+    with pytest.raises(SystemExit, match="No valid Codex tokens"):
+        auth_add_command(SimpleNamespace(
+            provider="openai-codex",
+            auth_type="oauth",
+            api_key=None,
+            label=None,
+            auth_file=str(codex_auth),
+            codex_dir=None,
+        ))
+
+
+def test_auth_add_codex_dir_imports_multiple_accounts(tmp_path, monkeypatch):
+    """`hermes auth add openai-codex --codex-dir <dir>` imports all valid
+    Codex accounts from a directory of auth*.json files. Supports the
+    "log in A → copy auth.json → log in B" workflow."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    (codex_dir / "auth.json").write_text(json.dumps({
+        "tokens": {
+            "access_token": _jwt_with_email("account-a@example.com"),
+            "refresh_token": "refresh-a",
+        },
+    }))
+    (codex_dir / "auth.account-b.json").write_text(json.dumps({
+        "tokens": {
+            "access_token": _jwt_with_email("account-b@example.com"),
+            "refresh_token": "refresh-b",
+        },
+    }))
+
+    from types import SimpleNamespace
+    from hermes_cli.auth_commands import auth_add_command
+
+    auth_add_command(SimpleNamespace(
+        provider="openai-codex",
+        auth_type="oauth",
+        api_key=None,
+        label=None,
+        auth_file=None,
+        codex_dir=str(codex_dir),
+    ))
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["openai-codex"]
+    assert len(entries) == 2
+    labels = {e["label"] for e in entries}
+    assert "account-a@example.com" in labels
+    assert "account-b@example.com" in labels
+    assert payload["active_provider"] == "openai-codex"
+
+
+def test_auth_add_codex_dir_dedupes_same_account_across_files(tmp_path, monkeypatch):
+    """The documented workflow leaves one account in two files.
+
+    After "log in A -> copy auth.json -> log in B", a user who also keeps a
+    labelled copy of B ends up with auth.json (B), auth.account-a.json (A)
+    and auth.account-b.json (B). That must yield two pool entries, not
+    three: Codex refresh tokens are single-use, so two entries sharing a
+    pair strand each other on the first rotation.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    account_b = json.dumps({
+        "tokens": {
+            "access_token": _jwt_with_email("account-b@example.com"),
+            "refresh_token": "refresh-b",
+        },
+    })
+    (codex_dir / "auth.json").write_text(account_b)
+    (codex_dir / "auth.account-b.json").write_text(account_b)
+    (codex_dir / "auth.account-a.json").write_text(json.dumps({
+        "tokens": {
+            "access_token": _jwt_with_email("account-a@example.com"),
+            "refresh_token": "refresh-a",
+        },
+    }))
+
+    from types import SimpleNamespace
+    from hermes_cli.auth_commands import auth_add_command
+
+    auth_add_command(SimpleNamespace(
+        provider="openai-codex",
+        auth_type="oauth",
+        api_key=None,
+        label=None,
+        auth_file=None,
+        codex_dir=str(codex_dir),
+    ))
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["openai-codex"]
+    assert len(entries) == 2
+    assert {e["label"] for e in entries} == {
+        "account-a@example.com", "account-b@example.com",
+    }
+    # The single-use refresh tokens must each appear exactly once.
+    assert sorted(e["refresh_token"] for e in entries) == ["refresh-a", "refresh-b"]
+
+
+def test_auth_add_codex_dir_dedupes_by_account_id_not_just_token(tmp_path, monkeypatch):
+    """Same account re-authenticated in two files = different token pairs.
+
+    Keying only on the refresh token would let this through, so identity
+    prefers the JWT's chatgpt_account_id claim.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    (codex_dir / "auth.json").write_text(json.dumps({
+        "tokens": {
+            "access_token": _jwt_with_account("same@example.com", "acct-1"),
+            "refresh_token": "refresh-newer",
+        },
+    }))
+    (codex_dir / "auth.older.json").write_text(json.dumps({
+        "tokens": {
+            "access_token": _jwt_with_account("same@example.com", "acct-1"),
+            "refresh_token": "refresh-older",
+        },
+    }))
+
+    from types import SimpleNamespace
+    from hermes_cli.auth_commands import auth_add_command
+
+    auth_add_command(SimpleNamespace(
+        provider="openai-codex",
+        auth_type="oauth",
+        api_key=None,
+        label=None,
+        auth_file=None,
+        codex_dir=str(codex_dir),
+    ))
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert len(payload["credential_pool"]["openai-codex"]) == 1
+
+
+def test_auth_add_codex_dir_rerun_does_not_duplicate_pool_entries(tmp_path, monkeypatch):
+    """Re-running the import is idempotent - accounts already pooled are skipped."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    (codex_dir / "auth.json").write_text(json.dumps({
+        "tokens": {
+            "access_token": _jwt_with_email("account-a@example.com"),
+            "refresh_token": "refresh-a",
+        },
+    }))
+
+    from types import SimpleNamespace
+    from hermes_cli.auth_commands import auth_add_command
+
+    args = SimpleNamespace(
+        provider="openai-codex",
+        auth_type="oauth",
+        api_key=None,
+        label=None,
+        auth_file=None,
+        codex_dir=str(codex_dir),
+    )
+    auth_add_command(args)
+    auth_add_command(args)
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert len(payload["credential_pool"]["openai-codex"]) == 1
+
+
+def test_auth_add_codex_dir_rejects_empty_directory(tmp_path, monkeypatch):
+    """`--codex-dir` with no valid auth*.json files returns an error."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    (codex_dir / "auth.empty.json").write_text(json.dumps({
+        "tokens": {"access_token": "", "refresh_token": ""},
+    }))
+
+    from types import SimpleNamespace
+    from hermes_cli.auth_commands import auth_add_command
+
+    with pytest.raises(SystemExit, match="No valid Codex tokens"):
+        auth_add_command(SimpleNamespace(
+            provider="openai-codex",
+            auth_type="oauth",
+            api_key=None,
+            label=None,
+            auth_file=None,
+            codex_dir=str(codex_dir),
+        ))
+
+
+def test_auth_add_codex_auth_file_and_dir_are_mutually_exclusive(tmp_path, monkeypatch):
+    """`--auth-file` and `--codex-dir` should not be used together; when both
+    are provided, `--codex-dir` takes precedence (it is the broader import)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    (codex_dir / "auth.json").write_text(json.dumps({
+        "tokens": {
+            "access_token": _jwt_with_email("dir-account@example.com"),
+            "refresh_token": "refresh-dir",
+        },
+    }))
+
+    single_file = tmp_path / "auth.single.json"
+    single_file.write_text(json.dumps({
+        "tokens": {
+            "access_token": _jwt_with_email("single@example.com"),
+            "refresh_token": "refresh-single",
+        },
+    }))
+
+    from types import SimpleNamespace
+    from hermes_cli.auth_commands import auth_add_command
+
+    auth_add_command(SimpleNamespace(
+        provider="openai-codex",
+        auth_type="oauth",
+        api_key=None,
+        label=None,
+        auth_file=str(single_file),
+        codex_dir=str(codex_dir),
+    ))
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["openai-codex"]
+    # --codex-dir wins: only the directory account is imported
+    assert len(entries) == 1
+    assert entries[0]["label"] == "dir-account@example.com"

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -543,6 +543,37 @@ hermes auth spotify                                      # Authenticate Hermes w
 
 Subcommands: `add`, `list`, `remove`, `reset`, `status`, `logout`, `spotify`. When called with no subcommand, launches the interactive management wizard.
 
+### Importing multiple Codex subscriptions
+
+`hermes auth add openai-codex` accepts two flags for adopting ChatGPT Codex
+credentials that the Codex CLI already holds, so a second subscription can be
+pooled without running the device-code flow again:
+
+| Option | Description |
+|--------|-------------|
+| `--auth-file <path>` | Import one account from a specific `auth.json` (e.g. `~/.codex/auth.account-b.json`). |
+| `--codex-dir <dir>` | Import every account found in a directory of `auth*.json` files (e.g. `~/.codex`). |
+
+```bash
+# Adopt a single saved account
+hermes auth add openai-codex --auth-file ~/.codex/auth.account-b.json
+
+# Adopt every account in ~/.codex at once
+hermes auth add openai-codex --codex-dir ~/.codex
+```
+
+`--codex-dir` takes precedence when both are given. Expired tokens are rejected
+at import time, since they can no longer be refreshed. Each imported account
+becomes its own pool entry, so the usual rotation strategies handle rate-limit
+failover between subscriptions.
+
+Duplicates are collapsed: the copy-then-relogin workflow routinely leaves the
+same account in both `auth.json` and a labelled copy of it, and re-running the
+import would otherwise append a second entry for an account already pooled.
+Because Codex refresh tokens are single-use, two entries sharing one token
+would strand each other on the first rotation, so accounts are de-duplicated by
+their `chatgpt_account_id` (falling back to the refresh token).
+
 ## `hermes status`
 
 ```bash


### PR DESCRIPTION
## Problem

Currently only a single OpenAI ChatGPT Codex subscription is supported. When rate limit hits, users cannot switch to another active subscription.

Each Codex CLI has a `~/.codex/auth.json`, which one can import (functionality already exists). But importing multiple accounts requires running the device-code OAuth flow for each account — even when the user already has valid auth.json files.

## Solution

Multi-account import support for `openai-codex`:

| Command | Behavior |
|---------|----------|
| `hermes auth add openai-codex` | Device-code OAuth flow (unchanged) |
| `hermes auth add openai-codex --auth-file <path>` | Import a single account from a specific auth.json file |
| `hermes auth add openai-codex --codex-dir <dir>` | Import all valid accounts from a directory of `auth*.json` files |

### Multi-account workflow

```bash
# Log in Account A in Codex CLI
# Copy: ~/.codex/auth.json → ~/.codex/auth.account-a.json
# Log out, log in Account B in Codex CLI
# Copy: ~/.codex/auth.json → ~/.codex/auth.account-b.json

hermes auth add openai-codex --codex-dir ~/.codex
# Imports both accounts as distinct pool entries
```

Each imported account becomes a distinct, self-contained `manual:device_code` pool entry — the same pattern already used by xai-oauth, qwen-oauth, and minimax-oauth. The credential pool's round-robin / fill-first / least-used rotation strategies then handle rate-limit failover automatically.

## Safety

- Expired tokens are rejected at import time (they cannot be refreshed)
- `_import_codex_cli_tokens` now accepts an optional `auth_path` parameter for reading from non-default locations
- `_import_codex_cli_tokens_from_directory` scans a directory for `auth*.json` files

## Tests

Added 5 new tests in `tests/hermes_cli/test_auth_commands.py`:
- Single-file import (`--auth-file`)
- Multi-account directory import (`--codex-dir`)
- Expired token rejection
- Empty directory rejection
- `--auth-file` vs `--codex-dir` precedence

All 58 tests pass.

Fixes #65735
