### PR TITLE
fix(cron): preserve cron job ownership on root saves (#68483)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -911,9 +911,30 @@ def _save_jobs_unlocked(jobs: List[Dict[str, Any]]):
     """Save all jobs to storage. Caller must hold _jobs_lock()."""
     jobs_file = _current_cron_store().jobs_file
     ensure_dirs()
+
+    # Atomic replace normally gives the destination the temporary file's owner.
+    # When a root CLI process edits jobs.json owned by the unprivileged gateway
+    # account, preserve that existing owner on the temp file before replacement.
+    existing_owner = None
+    if hasattr(os, "fchown"):
+        try:
+            current_stat = jobs_file.stat()
+        except FileNotFoundError:
+            pass
+        else:
+            existing_owner = (current_stat.st_uid, current_stat.st_gid)
+
     fd, tmp_path = tempfile.mkstemp(dir=str(jobs_file.parent), suffix='.tmp', prefix='.jobs_')
     try:
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            if existing_owner is not None:
+                process_uid = os.geteuid()  # windows-footgun: ok — existing_owner requires fchown
+                process_owner = (
+                    process_uid,
+                    os.getegid(),  # windows-footgun: ok — existing_owner requires fchown
+                )
+                if process_uid == 0 and existing_owner != process_owner:
+                    os.fchown(f.fileno(), *existing_owner)
             json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
             f.flush()
             os.fsync(f.fileno())

--- a/tests/cron/test_file_permissions.py
+++ b/tests/cron/test_file_permissions.py
@@ -56,6 +56,98 @@ class TestCronFilePermissions(unittest.TestCase):
             file_mode = stat.S_IMODE(os.stat(jobs_file).st_mode)
             self.assertEqual(file_mode, 0o600)
 
+    def test_root_save_preserves_existing_jobs_owner(self):
+        """A root CLI rewrite must keep the gateway account's ownership."""
+        cron_dir = Path(self.tmpdir) / "cron"
+        output_dir = cron_dir / "output"
+        jobs_file = cron_dir / "jobs.json"
+        cron_dir.mkdir(parents=True)
+        jobs_file.write_text('{"jobs": []}', encoding="utf-8")
+        original = jobs_file.stat()
+
+        with (
+            patch("cron.jobs.CRON_DIR", cron_dir),
+            patch("cron.jobs.OUTPUT_DIR", output_dir),
+            patch("cron.jobs.JOBS_FILE", jobs_file),
+            patch("cron.jobs.os.geteuid", return_value=0),
+            patch("cron.jobs.os.fchown") as fchown,
+        ):
+            from cron.jobs import save_jobs
+
+            save_jobs([{"id": "test", "prompt": "hello"}])
+
+        fchown.assert_called_once()
+        fd, uid, gid = fchown.call_args.args
+        self.assertIsInstance(fd, int)
+        self.assertEqual((uid, gid), (original.st_uid, original.st_gid))
+        self.assertTrue(jobs_file.exists())
+
+    def test_owner_preservation_failure_keeps_existing_jobs_file(self):
+        """Fail closed before replace if ownership cannot be restored."""
+        cron_dir = Path(self.tmpdir) / "cron"
+        output_dir = cron_dir / "output"
+        jobs_file = cron_dir / "jobs.json"
+        cron_dir.mkdir(parents=True)
+        original = b'{"jobs": [{"id": "keep-me"}]}'
+        jobs_file.write_bytes(original)
+
+        with (
+            patch("cron.jobs.CRON_DIR", cron_dir),
+            patch("cron.jobs.OUTPUT_DIR", output_dir),
+            patch("cron.jobs.JOBS_FILE", jobs_file),
+            patch("cron.jobs.os.geteuid", return_value=0),
+            patch("cron.jobs.os.fchown", side_effect=PermissionError("denied")),
+            self.assertRaises(PermissionError),
+        ):
+            from cron.jobs import save_jobs
+
+            save_jobs([{"id": "replacement"}])
+
+        self.assertEqual(jobs_file.read_bytes(), original)
+        self.assertEqual(list(cron_dir.glob(".jobs_*.tmp")), [])
+
+    def test_first_save_does_not_attempt_owner_preservation(self):
+        cron_dir = Path(self.tmpdir) / "cron"
+        output_dir = cron_dir / "output"
+        jobs_file = cron_dir / "jobs.json"
+
+        with (
+            patch("cron.jobs.CRON_DIR", cron_dir),
+            patch("cron.jobs.OUTPUT_DIR", output_dir),
+            patch("cron.jobs.JOBS_FILE", jobs_file),
+            patch("cron.jobs.os.geteuid", return_value=0),
+            patch("cron.jobs.os.fchown") as fchown,
+        ):
+            from cron.jobs import save_jobs
+
+            save_jobs([{"id": "first"}])
+
+        fchown.assert_not_called()
+        self.assertTrue(jobs_file.exists())
+
+    def test_unprivileged_save_does_not_chown_existing_jobs_file(self):
+        """Only a privileged writer should preserve another account's owner."""
+        cron_dir = Path(self.tmpdir) / "cron"
+        output_dir = cron_dir / "output"
+        jobs_file = cron_dir / "jobs.json"
+        cron_dir.mkdir(parents=True)
+        jobs_file.write_text('{"jobs": []}', encoding="utf-8")
+        different_uid = jobs_file.stat().st_uid + 1
+
+        with (
+            patch("cron.jobs.CRON_DIR", cron_dir),
+            patch("cron.jobs.OUTPUT_DIR", output_dir),
+            patch("cron.jobs.JOBS_FILE", jobs_file),
+            patch("cron.jobs.os.geteuid", return_value=different_uid),
+            patch("cron.jobs.os.fchown") as fchown,
+        ):
+            from cron.jobs import save_jobs
+
+            save_jobs([{"id": "recovered"}])
+
+        fchown.assert_not_called()
+        self.assertTrue(jobs_file.exists())
+
     def test_save_job_output_sets_0600(self):
         output_dir = Path(self.tmpdir) / "output"
         with patch("cron.jobs.OUTPUT_DIR", output_dir), \

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -327,6 +327,22 @@ def test_cron_status_reports_running_gateway(monkeypatch, capsys):
     assert "2026-05-31T12:00:00Z" in out
 
 
+def test_cron_status_reports_live_but_consistently_failing_ticker(monkeypatch, capsys):
+    """A fresh heartbeat must not hide a stale last-success marker."""
+    monkeypatch.setattr(cron_cli, "_active_cron_provider_name", lambda: "builtin")
+    monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [1234])
+    monkeypatch.setattr("cron.jobs.get_ticker_heartbeat_age", lambda: 5.0)
+    monkeypatch.setattr("cron.jobs.get_ticker_success_age", lambda: 600.0)
+    monkeypatch.setattr("cron.jobs.list_jobs", lambda include_disabled=False: [])
+
+    cron_cli.cron_status()
+
+    out = capsys.readouterr().out
+    assert "no tick has succeeded in 600s" in out
+    assert "ticks may be failing" in out
+    assert "cron jobs will fire automatically" not in out
+
+
 def test_cron_tick_invokes_scheduler_tick_with_verbose(monkeypatch):
     calls = []
     monkeypatch.setattr("cron.scheduler.tick", lambda verbose=False: calls.append(verbose))


### PR DESCRIPTION
## Summary

- preserve the existing `jobs.json` UID/GID when a root process performs an atomic cron-store rewrite
- apply ownership to the open temporary descriptor before replacement, so a failed `fchown` leaves the original file untouched
- keep first-save, non-root, no-`fchown`, fsync, atomic replacement, and `0600` hardening behavior unchanged
- pin the already-correct stale-success CLI status as `interrupted`

## Root cause

`mkstemp()` creates the replacement file as the effective user. When `hermes cron` ran as root, `atomic_replace()` swapped that root-owned inode over the gateway user's `jobs.json`, leaving the unprivileged scheduler unable to read future job state.

## Verification

- RED proof before the production fix: **2 failed, 2 passed**
- focused ownership/status regressions after the fix: **4 passed**
- nearby cron/CLI suite: **131 passed**
- final permissions + CLI rerun: **29 passed**
- `python scripts/check-windows-footguns.py --all`: passed (**788 files scanned**)
- `ruff check` on all changed Python files: passed
- `git diff --check`: passed

## Related work

#68504 targets the same report, but its head contains unrelated history and restores ownership only after replacement. This patch instead `fchown`s the temporary descriptor before replacement, preserving the original file on failure, and adds root, first-save, non-root, cleanup, and status regression coverage.

Fixes #68483
