### PR TITLE
feat(mcp): add Talamus local-first memory

### DIFF
--- a/optional-mcps/talamus/manifest.yaml
+++ b/optional-mcps/talamus/manifest.yaml
@@ -1,0 +1,59 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: talamus
+description: Give Hermes durable, cited, local-first project memory with temporal history.
+source: https://github.com/ampres-ai/talamus
+
+# Talamus publishes a standard stdio MCP server on PyPI. uvx keeps the
+# installation isolated and lets Hermes start the server without adding a
+# package to the user's global Python environment.
+transport:
+  type: stdio
+  command: "uvx"
+  # Pinned per catalog dependency policy. 1.0.0 was released 2026-07-03,
+  # beyond the two-week supply-chain cooldown at the time of this submission.
+  args:
+    - "--from"
+    - "talamus[mcp]==1.0.0"
+    - "talamus-mcp"
+  version: "1.0.0"
+
+auth:
+  type: none
+
+# Default to the read-oriented surface. The excluded tools can synthesize
+# answers with a configured LLM, write memory, or apply review decisions.
+# Users can opt into those deliberately with `hermes mcp configure talamus`.
+# `search` stays deterministic as long as its optional `smart` argument is
+# left false (the default).
+tools:
+  default_enabled:
+    - search
+    - read_note
+    - recall
+    - overview
+    - neighbors
+    - history
+    - sources
+    - ontology_status
+    - review_list
+
+post_install: |
+  Talamus resolves its project brain from the directory where Hermes starts.
+  From the project you want Hermes to remember, initialize one once with:
+
+    uvx --from "talamus[mcp]==1.0.0" talamus init
+
+  Then start a new Hermes session from that directory. Notes remain local,
+  human-readable Markdown; derived indexes are local and rebuildable.
+
+  The default tool set is read-oriented. `search` is deterministic while its
+  `smart` argument remains false. Tools such as ask/verify may call the user's
+  configured LLM, and remember/ingest/review tools mutate the brain, so they
+  are disabled until the user opts in with:
+
+    hermes mcp configure talamus
+
+  Re-run the catalog install to update a future pinned Talamus release.

--- a/optional-mcps/talamus/manifest.yaml
+++ b/optional-mcps/talamus/manifest.yaml
@@ -1,0 +1,63 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: talamus
+description: Give Hermes durable, cited, local-first project memory with temporal history.
+source: https://github.com/ampres-ai/talamus
+
+# Talamus publishes a standard stdio MCP server on PyPI. uvx keeps the
+# installation isolated and lets Hermes start the server without adding a
+# package to the user's global Python environment.
+transport:
+  type: stdio
+  command: "uvx"
+  # Exact pins keep the catalog reproducible and avoid resolving the MCP 2.x
+  # API with a Talamus release built for MCP 1.x. Talamus 1.1.1 and MCP
+  # 1.29.0 were released on 2026-07-22 and 2026-07-28 respectively, beyond
+  # the catalog's two-week supply-chain cooldown at this update.
+  args:
+    - "--from"
+    - "talamus[mcp]==1.1.1"
+    - "--with"
+    - "mcp==1.29.0"
+    - "talamus-mcp"
+  version: "1.1.1"
+
+auth:
+  type: none
+
+# Default to the read-oriented surface. The excluded tools can synthesize
+# answers with a configured LLM, write memory, or apply review decisions.
+# Users can opt into those deliberately with `hermes mcp configure talamus`.
+# `search` stays deterministic as long as its optional `smart` argument is
+# left false (the default).
+tools:
+  default_enabled:
+    - search
+    - read_note
+    - recall
+    - overview
+    - neighbors
+    - history
+    - sources
+    - ontology_status
+    - review_list
+
+post_install: |
+  Talamus resolves its project brain from the directory where Hermes starts.
+  From the project you want Hermes to remember, initialize one once with:
+
+    uvx --from "talamus==1.1.1" talamus init
+
+  Then start a new Hermes session from that directory. Notes remain local,
+  human-readable Markdown; derived indexes are local and rebuildable.
+
+  The default tool set is read-oriented. `search` is deterministic while its
+  `smart` argument remains false. Tools such as ask/verify may call the user's
+  configured LLM, and remember/ingest/review tools mutate the brain, so they
+  are disabled until the user opts in with:
+
+    hermes mcp configure talamus
+
+  Re-run the catalog install to update a future pinned Talamus release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,6 +334,7 @@ locales = ["locales/*.yaml"]
 # entry; tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>.
 "optional-mcps/linear" = ["optional-mcps/linear/manifest.yaml"]
 "optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
+"optional-mcps/talamus" = ["optional-mcps/talamus/manifest.yaml"]
 
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]


### PR DESCRIPTION
## Summary
- add Talamus to the Nous-approved MCP catalog as an isolated `uvx` server
- default to nine read-oriented tools; LLM-backed and mutating tools remain opt-in
- keep the change to one source-tree manifest, with no `pyproject.toml` packaging change

## Why it fits Hermes
Talamus provides inspectable project memory through local Markdown, source provenance, temporal history, deterministic retrieval, and review-gated corrections. It uses stdio MCP, needs no hosted account or mandatory API key, and adds no core tool-schema footprint.

## Reproducible pins
- `talamus[mcp]==1.1.1` — released 2026-07-22
- `mcp==1.29.0` — released 2026-07-28

Both pins are beyond the catalog's two-week cooldown. The explicit MCP 1.x pin prevents Talamus 1.1.1 from resolving MCP 2.x.

## Validation
- `scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py -q` — 25 passed
- `uvx --from "talamus[mcp]==1.1.1" --with "mcp==1.29.0" talamus-mcp --help` — passed
- stdio MCP smoke — initialized and discovered 16 tools
- PR diff — only `optional-mcps/talamus/manifest.yaml`

## Safety defaults
The default set is read-oriented: `search`, `read_note`, `recall`, `overview`, `neighbors`, `history`, `sources`, `ontology_status`, and `review_list`. LLM-backed and mutating tools remain disabled until the user opts in with `hermes mcp configure talamus`.

_Disclosure: I maintain Talamus._