### PR TITLE
fix(termux): resolve NameError in _print_fast_version_info before PROJECT_ROOT definition

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -362,9 +362,11 @@ def _read_openai_version_fast() -> str | None:
 
 def _print_fast_version_info() -> None:
     from hermes_cli import __release_date__, __version__
+    from pathlib import Path
 
+    project_root = Path(__file__).parent.parent.resolve()
     print(f"Hermes Agent v{__version__} ({__release_date__})")
-    print(f"Install directory: {PROJECT_ROOT}")
+    print(f"Install directory: {project_root}")
 
     print(f"Python: {sys.version.split()[0]}")
 


### PR DESCRIPTION
On Termux (Android), running `hermes --version` triggers `_try_termux_ultrafast_version()` which calls `_print_fast_version_info()` at module import time — before `PROJECT_ROOT` is defined on line 461. The function now computes the project root inline via `Path(__file__)`, avoiding the forward reference.

Fixes a startup crash on Android/Termux where every hermes invocation failed with:
```
NameError: name PROJECT_ROOT is not defined
```