### PR TITLE
fix(tests): skip pytest-less virtualenv candidates

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -41,26 +41,47 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Probe local venvs first; fall back to the Nix devShell's editable venv
 # (HERMES_PYTHON is exported by the devShell hook and ships [dev] extras:
 # pytest, pytest-asyncio, pytest-timeout, ruff, ty).
-VENV=""
+python_has_pytest() {
+  "$1" -c 'import pytest' >/dev/null 2>&1
+}
+
+SKIPPED_PYTHON_HINTS=()
+PYTHON=""
+
 for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
-  if [ -f "$candidate/bin/activate" ]; then
-    VENV="$candidate"
-    break
+  candidate_python="$candidate/bin/python"
+  if [ -f "$candidate/bin/activate" ] && [ -x "$candidate_python" ]; then
+    if python_has_pytest "$candidate_python"; then
+      PYTHON="$candidate_python"
+      break
+    fi
+    echo "⚠ skipping ${candidate##*/}: $candidate_python cannot import pytest" >&2
+    SKIPPED_PYTHON_HINTS+=("${candidate##*/}: $candidate_python cannot import pytest")
   fi
 done
 
-if [ -n "$VENV" ]; then
-  PYTHON="$VENV/bin/python"
-elif [ -n "${HERMES_PYTHON:-}" ] && [ -x "$HERMES_PYTHON" ] \
-    && "$HERMES_PYTHON" -c 'import pytest' 2>/dev/null; then
+if [ -z "$PYTHON" ] && [ -n "${HERMES_PYTHON:-}" ] && [ -x "$HERMES_PYTHON" ]; then
   # Guard with an import check: HERMES_PYTHON may point at the RELEASE
   # venv (no pytest) when inherited from a wrapped `hermes` binary rather
   # than the devShell hook.
-  PYTHON="$HERMES_PYTHON"
-  echo "▶ no local venv — using Nix dev venv via HERMES_PYTHON: $PYTHON"
-else
-  echo "error: no virtualenv found in $REPO_ROOT/.venv or $REPO_ROOT/venv," >&2
-  echo "       and HERMES_PYTHON is not a python with pytest (enter the Nix devShell or create a venv)" >&2
+  if python_has_pytest "$HERMES_PYTHON"; then
+    PYTHON="$HERMES_PYTHON"
+    echo "▶ no local test-ready venv — using Nix dev venv via HERMES_PYTHON: $PYTHON"
+  else
+    echo "⚠ skipping HERMES_PYTHON: $HERMES_PYTHON cannot import pytest" >&2
+    SKIPPED_PYTHON_HINTS+=("HERMES_PYTHON: $HERMES_PYTHON cannot import pytest")
+  fi
+fi
+
+if [ -z "$PYTHON" ]; then
+  echo "error: no test-ready virtualenv found" >&2
+  if [ ${#SKIPPED_PYTHON_HINTS[@]} -gt 0 ]; then
+    echo "       checked:" >&2
+    for hint in "${SKIPPED_PYTHON_HINTS[@]}"; do
+      echo "         - $hint" >&2
+    done
+  fi
+  echo "       create a venv with pytest installed or enter the Nix devShell" >&2
   exit 1
 fi
 

--- a/tests/test_run_tests_sh_pytest_probe.py
+++ b/tests/test_run_tests_sh_pytest_probe.py
@@ -1,0 +1,170 @@
+"""Regression tests for scripts/run_tests.sh virtualenv selection."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="bash runner probe")
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+def _write_fake_python(path: Path, label: str, has_pytest: bool) -> None:
+    _write_executable(
+        path,
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${{1-}}" == "-c" && "${{2-}}" == "import pytest" ]]; then
+  if [[ {1 if has_pytest else 0} -eq 1 ]]; then
+    exit 0
+  fi
+  printf '%s\n' 'No module named pytest' >&2
+  exit 1
+fi
+
+if [[ "${{1-}}" == "-m" && "${{2-}}" == "compileall" ]]; then
+  exit 0
+fi
+
+if [[ "${{1-}}" == *"run_tests_parallel.py" ]]; then
+  printf '%s\n' "fake-python:{label}:${{1-}}"
+  exit 0
+fi
+
+printf '%s\n' "unexpected invocation: $*" >&2
+exit 42
+""",
+    )
+
+
+def _make_fake_repo(tmp_path: Path, *, local_venv_has_pytest: bool, local_dotvenv_has_pytest: bool) -> Path:
+    repo_root = tmp_path / "repo"
+    scripts_dir = repo_root / "scripts"
+    scripts_dir.mkdir(parents=True)
+
+    project_root = Path(__file__).resolve().parent.parent
+    shutil.copy2(project_root / "scripts" / "run_tests.sh", scripts_dir / "run_tests.sh")
+    shutil.copy2(
+        project_root / "scripts" / "run_tests_parallel.py",
+        scripts_dir / "run_tests_parallel.py",
+    )
+
+    (repo_root / "tracked.py").write_text("print('tracked')\n", encoding="utf-8")
+
+    subprocess.run(["git", "init"], cwd=repo_root, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    subprocess.run(
+        ["git", "add", "tracked.py", "scripts/run_tests.sh", "scripts/run_tests_parallel.py"],
+        cwd=repo_root,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    for name, has_pytest in ((".venv", local_dotvenv_has_pytest), ("venv", local_venv_has_pytest)):
+        venv_dir = repo_root / name / "bin"
+        venv_dir.mkdir(parents=True)
+        (venv_dir / "activate").write_text("# fake activate\n", encoding="utf-8")
+        _write_fake_python(venv_dir / "python", name, has_pytest)
+
+    return repo_root
+
+
+def _run_run_tests(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    script = repo_root / "scripts" / "run_tests.sh"
+    return subprocess.run(
+        ["bash", str(script), *args],
+        cwd=repo_root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+
+def _make_home_hermes_venv(home: Path, *, has_pytest: bool) -> Path:
+    venv_dir = home / ".hermes" / "hermes-agent" / "venv" / "bin"
+    venv_dir.mkdir(parents=True)
+    (venv_dir / "activate").write_text("# fake activate\n", encoding="utf-8")
+    _write_fake_python(venv_dir / "python", "home-hermes-venv", has_pytest)
+    return venv_dir.parent
+
+
+def test_run_tests_sh_skips_pytestless_dotvenv_and_uses_venv(tmp_path: Path) -> None:
+    repo_root = _make_fake_repo(
+        tmp_path,
+        local_venv_has_pytest=True,
+        local_dotvenv_has_pytest=False,
+    )
+
+    proc = _run_run_tests(repo_root, "tests/test_widget.py")
+
+    assert proc.returncode == 0, proc.stdout
+    assert "skipping .venv" in proc.stdout
+    assert "fake-python:venv" in proc.stdout
+    assert "fake-python:.venv" not in proc.stdout
+
+
+def test_run_tests_sh_falls_back_to_home_hermes_venv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo_root = _make_fake_repo(
+        tmp_path,
+        local_venv_has_pytest=False,
+        local_dotvenv_has_pytest=False,
+    )
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    _make_home_hermes_venv(home, has_pytest=True)
+
+    proc = _run_run_tests(repo_root, "tests/test_widget.py")
+
+    assert proc.returncode == 0, proc.stdout
+    assert "skipping .venv" in proc.stdout
+    assert "skipping venv" in proc.stdout
+    assert "fake-python:home-hermes-venv" in proc.stdout
+
+
+def test_run_tests_sh_prefers_dotvenv_when_both_are_ready(tmp_path: Path) -> None:
+    repo_root = _make_fake_repo(
+        tmp_path,
+        local_venv_has_pytest=True,
+        local_dotvenv_has_pytest=True,
+    )
+
+    proc = _run_run_tests(repo_root, "tests/test_widget.py")
+
+    assert proc.returncode == 0, proc.stdout
+    assert "skipping .venv" not in proc.stdout
+    assert "fake-python:.venv" in proc.stdout
+    assert "fake-python:venv" not in proc.stdout
+
+
+def test_run_tests_sh_fails_cleanly_when_no_candidate_has_pytest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = _make_fake_repo(
+        tmp_path,
+        local_venv_has_pytest=False,
+        local_dotvenv_has_pytest=False,
+    )
+    monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+
+    proc = _run_run_tests(repo_root, "tests/test_widget.py")
+
+    assert proc.returncode == 1
+    assert "skipping .venv" in proc.stdout
+    assert "skipping venv" in proc.stdout
+    assert "no test-ready virtualenv found" in proc.stdout
+    assert "launching test runner" not in proc.stdout


### PR DESCRIPTION
## What does this PR do?

Make `scripts/run_tests.sh` skip virtualenv candidates that cannot import `pytest` instead of selecting the first existing candidate blindly.

This preserves the existing candidate order — repo `.venv`, repo `venv`, then `$HOME/.hermes/hermes-agent/venv` — but changes “candidate env exists” into “candidate env is test-ready”. Without this, a stale `.venv` missing dev/test extras can make the canonical runner launch every test file under an interpreter that immediately fails with:

```text
No module named pytest
```

The runner now falls through to a working repo `venv`, `$HOME/.hermes/hermes-agent/venv`, or `HERMES_PYTHON` when available, and fails early with actionable diagnostics when no test-ready interpreter exists.

## Related Issue

No exact duplicate found.

Related overlap checked: #66496, #19758, #22401, #22767, #65237.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/run_tests.sh`
  - add a `python_has_pytest()` readiness probe,
  - probe repo `.venv`, repo `venv`, then `$HOME/.hermes/hermes-agent/venv` in the existing order,
  - skip candidates whose Python cannot `import pytest`,
  - apply the same readiness check to `HERMES_PYTHON`,
  - print skipped-candidate diagnostics and fail before launching the per-file runner when no test-ready interpreter exists.
- `tests/test_run_tests_sh_pytest_probe.py`
  - cover `.venv` missing pytest while `venv` works,
  - cover both candidates working with `.venv` still preferred,
  - cover fallback to `$HOME/.hermes/hermes-agent/venv`,
  - cover no candidate working and the runner failing cleanly before test launch.

## How to Test

1. Run the focused regression tests:

   ```text
   /home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_run_tests_sh_pytest_probe.py -q -o 'addopts=' --tb=short
   # 4 passed
   ```

2. Run the same tests through the canonical shell runner using a known test-ready interpreter:

   ```text
   HERMES_PYTHON=/home/hermes/.hermes/hermes-agent/venv/bin/python bash scripts/run_tests.sh tests/test_run_tests_sh_pytest_probe.py -q -- --tb=short
   # Summary: 1 files, 4 tests passed, 0 failed
   ```

3. Run syntax/lint checks:

   ```text
   bash -n scripts/run_tests.sh
   /home/hermes/.hermes/hermes-agent/venv/bin/python -m ruff check tests/test_run_tests_sh_pytest_probe.py
   # All checks passed
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Targeted tests were run instead; full suite was not run for this narrow runner patch.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (noble), x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - N/A: no user-facing docs changed.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - N/A: no config keys changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - N/A: no architecture/workflow docs changed.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - This patch touches the Bash runner path; native Windows runner work is being handled separately in #66496.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
  - N/A: no tool schemas changed.

## Screenshots / Logs

```text
/home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_run_tests_sh_pytest_probe.py -q -o 'addopts=' --tb=short
...                                                                      [100%]
4 passed in 0.71s

HERMES_PYTHON=/home/hermes/.hermes/hermes-agent/venv/bin/python bash scripts/run_tests.sh tests/test_run_tests_sh_pytest_probe.py -q -- --tb=short
=== Summary: 1 files, 4 tests passed, 0 failed (100% complete) in 1.7s (16 workers) ===

bash -n scripts/run_tests.sh
/home/hermes/.hermes/hermes-agent/venv/bin/python -m ruff check tests/test_run_tests_sh_pytest_probe.py
All checks passed!
```