### PR TITLE
fix(tools): skip environment cleanup during interpreter shutdown

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -5,6 +5,10 @@ init_session() failure handling, and the CWD marker contract.
 """
 
 from unittest.mock import MagicMock
+import os
+import subprocess
+import sys
+import textwrap
 
 from tools.environments.base import BaseEnvironment, _BoundedOutputCollector
 
@@ -520,3 +524,63 @@ class TestCwdMarker:
         env1 = _TestableEnv()
         env2 = _TestableEnv()
         assert env1._cwd_marker != env2._cwd_marker
+
+
+class TestDelShutdownGuard:
+    """__del__ must not run cleanup() during interpreter shutdown.
+
+    Once builtins and modules are torn down, cleanup()'s sync_back path
+    raises NameError on `open` and ImportError (sys.meta_path is None).
+    The remote backends only reach sync_back when a prior push committed
+    state, so the failure surfaces on every clean shutdown for them.
+    """
+
+    def test_del_skips_cleanup_when_shutting_down(self, monkeypatch):
+        import sys
+        calls = []
+        env = _TestableEnv()
+        monkeypatch.setattr(env, "cleanup", lambda: calls.append("cleanup"))
+        monkeypatch.setattr(sys, "meta_path", None)
+        env.__del__()
+        assert calls == [], "cleanup() must not run during interpreter shutdown"
+
+    def test_del_runs_cleanup_when_runtime_intact(self, monkeypatch):
+        import sys
+        calls = []
+        env = _TestableEnv()
+        monkeypatch.setattr(env, "cleanup", lambda: calls.append("cleanup"))
+        monkeypatch.setattr(sys, "meta_path", [object()])
+        env.__del__()
+        assert calls == ["cleanup"], "cleanup() should run during normal GC"
+
+    def test_supported_python_shutdown_skips_cleanup(self):
+        """A real interpreter shutdown must not enter cleanup()."""
+        script = textwrap.dedent(
+            """
+            import os
+
+            from tools.environments.base import BaseEnvironment
+
+            class ShutdownEnv(BaseEnvironment):
+                def __init__(self):
+                    super().__init__(cwd="/tmp", timeout=10)
+
+                def cleanup(self, write=os.write):
+                    write(2, b"cleanup-ran-during-shutdown\\n")
+
+            env = ShutdownEnv()
+            """
+        )
+        env = os.environ.copy()
+        env["PYTHONPATH"] = os.getcwd()
+
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=10,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "cleanup-ran-during-shutdown" not in result.stderr

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -13,6 +13,7 @@ import os
 import select
 import shlex
 import subprocess
+import sys
 import threading
 import time
 import uuid
@@ -1114,6 +1115,16 @@ class BaseEnvironment(ABC):
 
     def __del__(self):
         try:
+            # During interpreter shutdown builtins and modules are torn down,
+            # so cleanup()'s best-effort sync_back (tar pipe plus `open` and
+            # lazy imports) raises NameError on `open` and ImportError
+            # ("sys.meta_path is None"). Skip it then: the OS reclaims sockets
+            # and files, and pulling remote changes back to the host at
+            # teardown serves no purpose. Normal GC (env dropped without an
+            # explicit cleanup()) still runs cleanup() while the runtime is
+            # intact.
+            if sys.meta_path is None:
+                return
             self.cleanup()
         except Exception:
             pass


### PR DESCRIPTION
## What does this PR do?

Prevents `BaseEnvironment.__del__` from starting environment cleanup after Python interpreter shutdown has begun.

Remote backends perform `sync_back()` during cleanup. During finalization, Python has already started clearing builtins and import state, so this late work can emit repeated `name 'open' is not defined` / `sys.meta_path is None` failures and sleep through retry backoff during an otherwise clean exit.

`__del__` now returns when `sys.meta_path is None`, Python's shutdown signal. Normal garbage collection still calls `cleanup()` while the runtime is intact. Only finalizer-time cleanup is skipped, when reliable network/file synchronization is no longer possible and process resources are about to be reclaimed.

## Related Issue

Fixes #68531

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/base.py`
  - Skip `cleanup()` from `__del__` once interpreter shutdown sets `sys.meta_path` to `None`.
  - Preserve the existing best-effort cleanup behavior during normal runtime garbage collection.
- `tests/tools/test_base_environment.py`
  - Cover both sides of the shutdown guard.
  - Launch the supported test interpreter in a subprocess and verify finalization does not enter cleanup.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_base_environment.py::TestDelShutdownGuard -q`.
2. Confirm all three shutdown-guard tests pass.
3. With a remote backend that has synchronized files, exit Hermes and confirm no finalizer-time `sync_back` retries appear.

Latest verification after rebasing onto current `main`:

```text
pytest tests/tools/test_base_environment.py::TestDelShutdownGuard -q
3 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused shutdown regression on the final rebased head: 3 passed
- [x] I've added tests for my changes
- [x] I've tested on my platform: Fedora Linux x86_64, Python 3.13.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior and regression are documented in code/tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the guard uses Python interpreter state and no platform-specific API
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
/tmp/hermes-pr-venv/bin/python -m pytest tests/tools/test_base_environment.py::TestDelShutdownGuard -q
3 passed in 0.18s
```
