### PR TITLE
fix(desktop): list all shipped memory providers in the settings dropdown

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -250,7 +250,21 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   // Built-in memory is not a provider plugin: the empty sentinel renders as
   // "Built-in only" and a legacy literal `builtin` value is only kept visible
   // via enumOptionsFor's current-value passthrough (#49513).
-  'memory.provider': ['', 'honcho', 'hindsight'],
+  // Keep this in sync with the shipped provider plugins under plugins/memory/
+  // (see plugins/memory/__init__.py::list_memory_provider_names). A dynamic
+  // fetch from the backend would remove the need to touch this on every new
+  // provider — tracked as a follow-up in #68528.
+  'memory.provider': [
+    '',
+    'byterover',
+    'hindsight',
+    'holographic',
+    'honcho',
+    'mem0',
+    'openviking',
+    'retaindb',
+    'supermemory',
+  ],
   // Terminal execution backends — kept in sync with the dispatch ladder in
   // tools/terminal_tool.py::_create_environment (local/docker/singularity/
   // modal/daytona/ssh). Remote backends need extra env (image, tokens, host).

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -19,14 +19,36 @@ describe('settings helpers', () => {
     const options = enumOptionsFor('memory.provider', '', {})
 
     // Built-in memory is not a provider plugin; the empty sentinel is the
-    // only built-in-shaped entry (#49513).
-    expect(options).toEqual(['', 'honcho', 'hindsight'])
+    // only built-in-shaped entry (#49513). The rest are the shipped provider
+    // plugins under plugins/memory/, in directory order (#68528).
+    expect(options).toEqual([
+      '',
+      'byterover',
+      'hindsight',
+      'holographic',
+      'honcho',
+      'mem0',
+      'openviking',
+      'retaindb',
+      'supermemory',
+    ])
   })
 
   it('keeps a legacy literal builtin value visible as the current selection', () => {
     const options = enumOptionsFor('memory.provider', 'builtin', {})
 
-    expect(options).toEqual(['', 'honcho', 'hindsight', 'builtin'])
+    expect(options).toEqual([
+      '',
+      'byterover',
+      'hindsight',
+      'holographic',
+      'honcho',
+      'mem0',
+      'openviking',
+      'retaindb',
+      'supermemory',
+      'builtin',
+    ])
   })
 
   describe('isExternalMemoryProvider', () => {


### PR DESCRIPTION
## Problem

The desktop settings page hardcodes the `memory.provider` dropdown to only 3 options in `apps/desktop/src/app/settings/constants.ts:253`:

```typescript
'memory.provider': ['', 'honcho', 'hindsight'],
```

But the backend ships **8** memory provider plugins under `plugins/memory/` (`byterover`, `hindsight`, `holographic`, `honcho`, `mem0`, `openviking`, `retaindb`, `supermemory`). The other providers are undiscoverable from the GUI — reachable only via `hermes memory setup`, and even then the dropdown does not list them (#68528). The `enumOptionsFor` current-value passthrough is why a CLI-configured provider still *shows* as the active selection, but it does not make the others selectable.

## Fix (minimal)

Replace the 3-entry list with all 8 shipped providers, in directory order to match `plugins/memory/__init__.py::list_memory_provider_names()`:

```typescript
'memory.provider': [
  '',
  'byterover', 'hindsight', 'holographic', 'honcho',
  'mem0', 'openviking', 'retaindb', 'supermemory',
],
```

A code comment notes the sync requirement and points at the backend discovery function.

## Verification

- Updated the two `helpers.test.ts` assertions that pin the declared order (`enumOptionsFor('memory.provider', ...)`).
- **RED-verified**: reverting `constants.ts` to the 3-entry list fails exactly those 2 tests; the fix restores all 30 tests in the file.
- `bun run typecheck` (tsc, all 3 projects) ✅
- `bun run eslint` on the changed files ✅

## Follow-up (not in this PR)

A dynamic fetch from the backend (the `list_memory_provider_names()` directory scan already exists and is explicitly safe to call at import time) would remove the need to touch this list on every new provider. I kept this PR to the minimal data fix to stay in scope, but happy to open a follow-up that wires the dropdown to a backend endpoint if you want.

Fixes #68528
