### PR TITLE
feat(plugins): SAE feature-trace observability plugin (observability/sae_trace)

### DIFF
--- a/plugins/observability/sae_trace/README.md
+++ b/plugins/observability/sae_trace/README.md
@@ -1,0 +1,183 @@
+# SAE Feature-Trace Observability Plugin
+
+Correlates each Hermes agent turn with the **same-inference** SAE (sparse
+autoencoder) feature-trace records emitted by an SAE-hooked local
+OpenAI-compatible model server — a per-session interpretability trace of
+what your local model's internals were doing while it ran the agent.
+
+This plugin ships bundled with Hermes but is **opt-in** — it only loads
+when you explicitly enable it. It is a pure read-only observer on the
+`hermes.observer.v1` hooks contract (see
+[`docs/observability/README.md`](../../../docs/observability/README.md)):
+it never modifies requests, responses, or the sidecar file, uses only the
+Python stdlib, and touches only local files (no network).
+
+The plugin has no hardware or ML-framework requirements of its own — it is
+pure file correlation (no `torch`, no GPU). Whatever your model runs on —
+a CPU-only laptop, a single consumer GPU, Apple Silicon, or a multi-GPU
+workstation — the plugin only needs the sidecar JSONL your server writes.
+
+## How it works
+
+1. You run your local model behind an SAE-instrumented OpenAI-compatible
+   server. The server wraps `model.generate()` with forward hooks and, in
+   the **same inference pass** that returns the completion, appends one
+   JSONL record (top-k SAE features per generated token, or a pointer to
+   raw activations) to a sidecar file. Reference implementation:
+   [SolshineCode/hermes-sae](https://github.com/SolshineCode/hermes-sae) —
+   but **any** OpenAI-compatible server emitting the sidecar schema below
+   works.
+2. Hermes talks to that server as a normal custom model provider.
+3. This plugin registers `pre_api_request` / `post_api_request` observer
+   hooks. On each provider response it tail-reads the sidecar (remembered
+   byte offset; rotation/truncation safe), matches records appended
+   during the request against the request's identity and timing, and
+   appends one correlated line per agent turn to
+   `$HERMES_SAE_TRACE_OUT_DIR/<session_id>.jsonl`.
+
+## Enable
+
+```bash
+hermes plugins enable observability/sae_trace
+```
+
+### Standalone install
+
+The plugin also works unmodified from the user-plugin directory (no
+Hermes source tree needed):
+
+```bash
+mkdir -p ~/.hermes/plugins
+cp -r plugins/observability/sae_trace ~/.hermes/plugins/sae_trace
+hermes plugins enable sae_trace
+```
+
+## Configuration
+
+Set in `~/.hermes/.env`:
+
+```bash
+# Required — path to the SAE server's sidecar JSONL. Without it the
+# hooks are inert (fail-open, like the langfuse plugin).
+HERMES_SAE_TRACE_FILE=/path/to/sae_history.jsonl
+
+# Optional
+HERMES_SAE_TRACE_OUT_DIR=~/.hermes/sae_trace   # default: $HERMES_HOME/sae_trace
+HERMES_SAE_TRACE_SKEW=10                       # time-window slack (seconds)
+HERMES_SAE_TRACE_DEBUG=true                    # verbose plugin logging
+```
+
+## Pointing Hermes at an SAE-hooked server
+
+Add an OpenAI-compatible provider whose `base_url` is your instrumented
+server, e.g. in `config.yaml`:
+
+```yaml
+providers:
+  sae:
+    base_url: http://127.0.0.1:8077/v1
+model:
+  default: sae-local
+  provider: sae
+```
+
+Because Hermes talks to the server over the plain OpenAI API, running
+with the instrumented model records the SAE feature history of the
+agent's own activity automatically — no core changes, no replay, no
+second forward pass.
+
+## Sidecar JSONL schema (the interface contract)
+
+One JSON object per line, appended per request **in the same inference
+pass that produced the completion**. Recognized fields:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `request_id` | recommended | Server-side request identity. If the caller passes Hermes' `api_request_id` through (body `request_id` or `X-Request-Id` header), correlation is exact. |
+| `session_id` | recommended | Echo of the `X-Hermes-Session-Id` header (or body `session_id`) when the client sends one. |
+| `timestamp` or `ts` | yes* | ISO-8601 record time. Naive values are read as local time; a `Z` suffix as UTC. Numeric epoch seconds also accepted. (*Required for time-window matching; records without it match only by `request_id`/`session_id`.) |
+| `model` | recommended | Served model id. Checked (case-insensitive) against the request's `model` / `response_model` for time-window matches; absent means no model constraint. |
+| `feats_topk` | either this… | Per-token top-k SAE features: `{layer: [[token_pos, feature_id, activation], ...]}`. Summarized into per-layer top features. |
+| `npz_path` | …or this | Path to raw activations (`.npz`) when features aren't computed inline. Carried through as a pointer. |
+| `layer` / `layers`, `d_model`, `n_records`, `n_gen_tokens`, `prompt_len`, `gen_len`, `same_inference` | optional | Shape/provenance scalars, carried through verbatim. |
+| `gen_text_preview` or `gen_text` | optional | Generated-text preview (truncated to 200 chars in output). |
+| `allf` | optional | Full-dictionary activations. Never copied — flagged as `has_all_features: true`. |
+
+Unknown fields are ignored; malformed lines are skipped with a debug log.
+
+## Output format
+
+One line per correlated agent turn in
+`$HERMES_SAE_TRACE_OUT_DIR/<session_id>.jsonl`:
+
+```json
+{
+  "ts": "2026-07-21T04:12:31.902+00:00",
+  "session_id": "abc123",
+  "task_id": "",
+  "turn_id": "turn-7",
+  "api_request_id": "req-42",
+  "model": "sae-local",
+  "api_duration": 12.4,
+  "match_confidence": "time_window",
+  "records": [
+    {
+      "request_id": "chatcmpl-…",
+      "ts": "2026-07-21T04:12:30Z",
+      "model": "sae-local",
+      "gen_len": 118,
+      "top_features": {"16": [[40913, 8.31, 22], [1027, 6.9, 4]]},
+      "gen_text_preview": "Sure — here's the plan…"
+    }
+  ]
+}
+```
+
+`top_features` is `{layer: [[feature_id, max_activation, n_tokens], ...]}`
+(top 10 per layer by max activation). Turns with no matching sidecar
+records write nothing (counted in `/sae status`).
+
+## `/sae` slash command
+
+In any CLI or gateway session:
+
+- `/sae status` — sidecar path, records seen/matched this session,
+  unmatched turns, last turn's top features
+- `/sae last` — the most recent turn's correlated feature summary
+
+## Correlation confidence (limitations)
+
+`match_confidence` records the strongest evidence tier used:
+
+| Tier | Evidence | Notes |
+| --- | --- | --- |
+| `request_id` | Sidecar `request_id` equals Hermes' `api_request_id` | Exact. Requires the provider path to forward the id (body `request_id` / `X-Request-Id`); not the default. |
+| `session_id` | Sidecar `session_id` equals the Hermes session id | Strong. Requires the server to log the `X-Hermes-Session-Id` header (the reference `nla_server` does). |
+| `time_window` | Record timestamp inside `[started_at − skew, ended_at + skew]` and model id compatible | Heuristic. Reliable for a single local server (which typically serializes generation), but concurrent Hermes sessions sharing one server within the same window can mis-attribute records. Prefer id-based tiers when possible. |
+
+Other limitations:
+
+- The sidecar's `model` id must equal Hermes' `model` (or the response's
+  `model`) for time-window matches; if your server logs a different
+  internal id, records without a `session_id`/`request_id` won't match.
+- Correlation state is per-process: `/sae` counters reset on restart, and
+  sidecar records emitted while Hermes is not running are never matched
+  (the tailer starts at end-of-file).
+- Only local-model turns routed through the instrumented server produce
+  records; cloud-provider turns simply have no trace (by design).
+
+## Security
+
+Local files only. The plugin reads one operator-configured sidecar file
+and appends to `$HERMES_SAE_TRACE_OUT_DIR`; it makes **no network
+requests** and sends nothing anywhere. Output records contain a bounded
+preview of generated text (≤200 chars per record) plus feature ids —
+treat the output directory with the same care as session logs. Session
+ids are sanitized to a single traversal-free path segment before being
+used as filenames.
+
+## Disable
+
+```bash
+hermes plugins disable observability/sae_trace
+```

--- a/plugins/observability/sae_trace/README.md
+++ b/plugins/observability/sae_trace/README.md
@@ -144,6 +144,27 @@ In any CLI or gateway session:
 - `/sae status` — sidecar path, records seen/matched this session,
   unmatched turns, last turn's top features
 - `/sae last` — the most recent turn's correlated feature summary
+- `/sae dashboard` — prints where the session dashboard and your latest
+  trace live
+
+## Session dashboard (zero install)
+
+The plugin ships `dashboard.html`, a single self-contained page that gives
+you a "watch your session" view of the correlated traces. No server, no
+build step, no network: open the file in a browser and load a
+`<session_id>.jsonl` trace with the file picker or by drag-and-drop.
+
+It renders the session's agent turns (newest first, with per-turn match
+confidence), a per-turn detail panel (top SAE features per layer with
+activation bars, `same_inference` provenance, generated-text preview or
+`npz_path` pointer), and a session-level table of the strongest features
+across all turns.
+
+To watch a session as it runs, click **Follow live** and pick the trace
+file once: the page re-reads it every 2 seconds as the plugin appends
+turns. Live follow uses the File System Access API (Chromium-based
+browsers); on other browsers, re-load or re-drop the file to refresh.
+`/sae dashboard` prints the page path and your most recent trace file.
 
 ## Correlation confidence (limitations)
 

--- a/plugins/observability/sae_trace/__init__.py
+++ b/plugins/observability/sae_trace/__init__.py
@@ -1,0 +1,714 @@
+"""sae_trace — Hermes plugin for SAE feature-trace observability.
+
+Correlates Hermes agent turns with the same-inference SAE (sparse
+autoencoder) feature-trace records emitted by an SAE-hooked local
+OpenAI-compatible model server, giving a per-session interpretability
+trace of what the local model's internals were doing during each turn.
+
+How it works: an SAE-instrumented server (reference implementation:
+https://github.com/SolshineCode/hermes-sae) wraps ``model.generate()``
+with forward hooks and appends one JSONL record per request to a sidecar
+file, in the same inference pass that produced the completion Hermes
+receives. This plugin tail-reads that sidecar and, on every
+``post_api_request`` observer hook (hermes.observer.v1 contract), matches
+new sidecar records against the request's identity and timing, then
+writes correlated per-turn records under
+``$HERMES_SAE_TRACE_OUT_DIR/<session_id>.jsonl``.
+
+Activation is handled by the Hermes plugin system — standalone plugins
+only load when listed in ``plugins.enabled`` (via
+``hermes plugins enable observability/sae_trace``). At runtime the
+plugin also requires ``HERMES_SAE_TRACE_FILE``; without it the hooks are
+inert (fail-open, like the langfuse plugin).
+
+Required env vars (set via ~/.hermes/.env):
+  HERMES_SAE_TRACE_FILE     - path to the SAE server's sidecar JSONL
+                              (e.g. activations.jsonl / sae_history.jsonl)
+
+Optional env vars:
+  HERMES_SAE_TRACE_OUT_DIR  - output directory for correlated per-session
+                              traces (default: $HERMES_HOME/sae_trace)
+  HERMES_SAE_TRACE_SKEW     - time-window slack in seconds around each
+                              API request when matching by timestamp
+                              (default: 10)
+  HERMES_SAE_TRACE_DEBUG    - set to "true" for verbose logging
+
+Everything here is stdlib-only, read-only with respect to the sidecar,
+and local-files-only (no network).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Deque, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+try:
+    # In-tree install: shared thread-safety helper from plugins/plugin_utils.py.
+    from plugins.plugin_utils import SingletonSlot
+except Exception:  # pragma: no cover - exercised via the standalone-load test
+    # Standalone install (~/.hermes/plugins/sae_trace/): the plugin loader
+    # imports this module as ``hermes_plugins.sae_trace`` from its own
+    # directory, where ``plugins.plugin_utils`` may not be importable.
+    # Minimal drop-in fallback with the same semantics (double-checked
+    # locking; a raising factory caches nothing).
+    class SingletonSlot:  # type: ignore[no-redef]
+        __slots__ = ("_lock", "_value", "_set")
+
+        def __init__(self) -> None:
+            self._lock = threading.Lock()
+            self._value: Any = None
+            self._set = False
+
+        def get(self, factory):
+            if self._set:
+                return self._value
+            with self._lock:
+                if self._set:
+                    return self._value
+                value = factory()
+                self._value = value
+                self._set = True
+                return value
+
+        def peek(self):
+            return self._value if self._set else None
+
+        def reset(self) -> None:
+            with self._lock:
+                self._value = None
+                self._set = False
+
+
+# ---------------------------------------------------------------------------
+# Tunables
+# ---------------------------------------------------------------------------
+
+_DEFAULT_SKEW_SECONDS = 10.0
+# Cap on bytes consumed from the sidecar per poll — bounds memory if some
+# other process dumps a huge backlog between our reads.
+_MAX_POLL_BYTES = 8 * 1024 * 1024
+# Unclaimed sidecar records are held for late matching, then dropped.
+_PENDING_MAX_RECORDS = 512
+_PENDING_TTL_SECONDS = 600.0
+# Per-record summary bounds.
+_TOP_FEATURES_PER_LAYER = 10
+_TEXT_PREVIEW_CHARS = 200
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default).strip()
+
+
+def _env_bool(name: str) -> bool:
+    return _env(name).lower() in {"1", "true", "yes", "on"}
+
+
+def _debug(message: str) -> None:
+    if _env_bool("HERMES_SAE_TRACE_DEBUG"):
+        logger.info("SAE trace: %s", message)
+    else:
+        logger.debug("SAE trace: %s", message)
+
+
+# ---------------------------------------------------------------------------
+# Config (lazy, cached — a miss is cached too, matching the langfuse plugin's
+# runtime-availability gate; tests reset by reloading the module)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _Config:
+    trace_file: Path
+    out_dir: Path
+    skew: float
+
+
+_CONFIG_SLOT: SingletonSlot = SingletonSlot()
+
+
+def _default_out_dir() -> Path:
+    try:
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home() / "sae_trace"
+    except Exception:
+        # Standalone / degraded path: fall back to the same convention
+        # get_hermes_home() itself uses.
+        home = _env("HERMES_HOME")
+        base = Path(home) if home else (Path.home() / ".hermes")
+        return base / "sae_trace"
+
+
+def _build_config() -> Optional[_Config]:
+    trace_file = _env("HERMES_SAE_TRACE_FILE")
+    if not trace_file:
+        _debug("HERMES_SAE_TRACE_FILE not set — hooks are inert")
+        return None
+    out_dir_raw = _env("HERMES_SAE_TRACE_OUT_DIR")
+    out_dir = Path(out_dir_raw).expanduser() if out_dir_raw else _default_out_dir()
+    skew = _DEFAULT_SKEW_SECONDS
+    raw_skew = _env("HERMES_SAE_TRACE_SKEW")
+    if raw_skew:
+        try:
+            skew = max(0.0, float(raw_skew))
+        except ValueError:
+            logger.warning("Invalid HERMES_SAE_TRACE_SKEW=%r", raw_skew)
+    return _Config(
+        trace_file=Path(trace_file).expanduser(),
+        out_dir=out_dir,
+        skew=skew,
+    )
+
+
+def _get_config() -> Optional[_Config]:
+    return _CONFIG_SLOT.get(_build_config)
+
+
+# ---------------------------------------------------------------------------
+# Sidecar tailer — offset-remembering, rotation-aware JSONL reader
+# ---------------------------------------------------------------------------
+
+class _SidecarTailer:
+    """Tail-read the SAE server's sidecar JSONL efficiently.
+
+    Remembers the byte offset between polls so each poll only reads bytes
+    appended since the last one. Handles rotation/truncation (file
+    replaced or shrunk → restart from offset 0) and partial trailing
+    lines (a record the server is mid-write → left unconsumed until the
+    newline arrives). All access is lock-guarded; hooks can fire
+    concurrently.
+    """
+
+    def __init__(self, path: Path):
+        self.path = path
+        self._lock = threading.RLock()
+        self._offset: Optional[int] = None
+        self._inode: Optional[int] = None
+        self._primed = False
+        # Parsed-but-unclaimed records: (wall-clock insert time, record).
+        self._pending: Deque[Tuple[float, Dict[str, Any]]] = deque()
+        self.records_seen = 0
+        self.malformed_lines = 0
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def prime(self) -> None:
+        """Skip sidecar history: start tailing from the current EOF.
+
+        Called from ``pre_api_request`` so that only records appended
+        *after* the request started are candidates. After the first call
+        this is a no-op boolean check.
+        """
+        if self._primed:
+            return
+        with self._lock:
+            if self._primed:
+                return
+            try:
+                stat = self.path.stat()
+                self._offset = stat.st_size
+                self._inode = getattr(stat, "st_ino", None) or None
+            except OSError:
+                # Not created yet — when it appears, read from the start
+                # (a fresh file only contains new records).
+                self._offset = 0
+                self._inode = None
+            self._primed = True
+
+    # -- reading -----------------------------------------------------------
+
+    def poll(self) -> None:
+        """Consume newly appended sidecar lines into the pending queue."""
+        with self._lock:
+            self.prime()
+            try:
+                stat = self.path.stat()
+            except OSError:
+                return  # fail-open: sidecar missing
+            inode = getattr(stat, "st_ino", None) or None
+            offset = self._offset or 0
+            if stat.st_size < offset or (
+                inode is not None and self._inode is not None and inode != self._inode
+            ):
+                # Rotated or truncated — the new file is all-new content.
+                _debug(f"sidecar rotation detected ({self.path}), rereading from 0")
+                offset = 0
+            self._inode = inode
+            if stat.st_size <= offset:
+                self._offset = offset
+                return
+            try:
+                with open(self.path, "rb") as fh:
+                    fh.seek(offset)
+                    chunk = fh.read(_MAX_POLL_BYTES)
+            except OSError as exc:
+                _debug(f"sidecar read failed: {exc}")
+                return
+            # Only consume through the last complete line; a partial
+            # trailing line is re-read on the next poll.
+            newline = chunk.rfind(b"\n")
+            if newline < 0:
+                self._offset = offset
+                return
+            consumed = chunk[: newline + 1]
+            self._offset = offset + len(consumed)
+            now = time.time()
+            for raw_line in consumed.splitlines():
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line.decode("utf-8", errors="replace"))
+                except (ValueError, UnicodeError):
+                    self.malformed_lines += 1
+                    _debug("skipping malformed sidecar line")
+                    continue
+                if not isinstance(record, dict):
+                    self.malformed_lines += 1
+                    continue
+                self.records_seen += 1
+                self._pending.append((now, record))
+            self._trim_locked(now)
+
+    def _trim_locked(self, now: float) -> None:
+        while self._pending and (
+            len(self._pending) > _PENDING_MAX_RECORDS
+            or now - self._pending[0][0] > _PENDING_TTL_SECONDS
+        ):
+            self._pending.popleft()
+
+    # -- matching ----------------------------------------------------------
+
+    def claim_matches(
+        self,
+        *,
+        api_request_id: str,
+        session_id: str,
+        started_at: float,
+        ended_at: float,
+        skew: float,
+        models: Tuple[str, ...],
+    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+        """Pop and return sidecar records correlated with one API request.
+
+        Returns ``(records, confidence)`` where confidence is the
+        strongest evidence tier among the matched records:
+        ``"request_id"`` > ``"session_id"`` > ``"time_window"``.
+        """
+        lo = started_at - skew
+        hi = ended_at + skew
+        matched: List[Tuple[int, Dict[str, Any], str]] = []
+        with self._lock:
+            remaining: Deque[Tuple[float, Dict[str, Any]]] = deque()
+            for item in self._pending:
+                _, record = item
+                tier = self._match_tier(
+                    record,
+                    api_request_id=api_request_id,
+                    session_id=session_id,
+                    lo=lo,
+                    hi=hi,
+                    models=models,
+                )
+                if tier is None:
+                    remaining.append(item)
+                else:
+                    matched.append((_TIER_RANK[tier], record, tier))
+            self._pending = remaining
+        if not matched:
+            return [], None
+        best = min(rank for rank, _, _ in matched)
+        confidence = _TIER_BY_RANK[best]
+        return [record for _, record, _ in matched], confidence
+
+    @staticmethod
+    def _match_tier(
+        record: Dict[str, Any],
+        *,
+        api_request_id: str,
+        session_id: str,
+        lo: float,
+        hi: float,
+        models: Tuple[str, ...],
+    ) -> Optional[str]:
+        ts = _parse_record_ts(record)
+        in_window = ts is not None and lo <= ts <= hi
+        rec_request_id = record.get("request_id")
+        if api_request_id and rec_request_id and rec_request_id == api_request_id:
+            return "request_id"
+        rec_session_id = record.get("session_id")
+        if session_id and rec_session_id and rec_session_id == session_id:
+            # When the record is timestamped, it must also fall inside the
+            # window — same-session records from *other* turns should be
+            # claimed by their own turn, not this one.
+            if ts is None or in_window:
+                return "session_id"
+            return None
+        if in_window and _model_matches(record, models):
+            return "time_window"
+        return None
+
+    # -- introspection -----------------------------------------------------
+
+    def pending_count(self) -> int:
+        with self._lock:
+            return len(self._pending)
+
+
+_TIER_RANK = {"request_id": 0, "session_id": 1, "time_window": 2}
+_TIER_BY_RANK = {rank: tier for tier, rank in _TIER_RANK.items()}
+
+_TAILER_SLOT: SingletonSlot = SingletonSlot()
+
+
+def _get_tailer() -> Optional[_SidecarTailer]:
+    config = _get_config()
+    if config is None:
+        return None
+    return _TAILER_SLOT.get(lambda: _SidecarTailer(config.trace_file))
+
+
+# ---------------------------------------------------------------------------
+# Record parsing helpers
+# ---------------------------------------------------------------------------
+
+def _parse_record_ts(record: Dict[str, Any]) -> Optional[float]:
+    """Parse a sidecar record timestamp to a POSIX epoch float.
+
+    Supports both documented field names: ``timestamp`` (activation-capture
+    servers, naive local ISO) and ``ts`` (feature-history servers, UTC ISO
+    with a ``Z`` suffix). Numeric values pass through as epoch seconds.
+    """
+    value = record.get("timestamp", record.get("ts"))
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str) or not value:
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    # Naive timestamps are interpreted as local time — the sidecar is
+    # written on the same machine as the agent.
+    return parsed.timestamp()
+
+
+def _model_matches(record: Dict[str, Any], models: Tuple[str, ...]) -> bool:
+    rec_model = record.get("model")
+    if not isinstance(rec_model, str) or not rec_model:
+        return True  # record carries no model — window evidence stands alone
+    rec_model_cf = rec_model.casefold()
+    return any(m and m.casefold() == rec_model_cf for m in models)
+
+
+def _summarize_top_features(feats_topk: Any) -> Optional[Dict[str, Any]]:
+    """Reduce per-token top-k feature events to a per-layer summary.
+
+    Input shape (sidecar contract): ``{layer: [[token_pos, feature_id,
+    activation], ...]}``. Output: ``{layer: [[feature_id, max_activation,
+    n_tokens], ...]}`` — top features by max activation, bounded.
+    """
+    if not isinstance(feats_topk, dict):
+        return None
+    summary: Dict[str, Any] = {}
+    for layer, events in feats_topk.items():
+        if not isinstance(events, list):
+            continue
+        per_feature: Dict[int, Tuple[float, int]] = {}
+        for event in events:
+            if not isinstance(event, (list, tuple)) or len(event) < 3:
+                continue
+            try:
+                feature_id = int(event[1])
+                activation = float(event[2])
+            except (TypeError, ValueError):
+                continue
+            prev = per_feature.get(feature_id)
+            if prev is None:
+                per_feature[feature_id] = (activation, 1)
+            else:
+                per_feature[feature_id] = (max(prev[0], activation), prev[1] + 1)
+        top = sorted(per_feature.items(), key=lambda kv: kv[1][0], reverse=True)
+        summary[str(layer)] = [
+            [feature_id, round(max_act, 4), count]
+            for feature_id, (max_act, count) in top[:_TOP_FEATURES_PER_LAYER]
+        ]
+    return summary or None
+
+
+def _summarize_record(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Compact one sidecar record for the correlated output line.
+
+    Keeps identity/shape scalars, summarizes ``feats_topk`` into top
+    features when present, else keeps the ``npz_path`` pointer to the raw
+    activations. Never includes bulky payloads (``allf``, full ``gen_text``).
+    """
+    summary: Dict[str, Any] = {}
+    for key in (
+        "request_id",
+        "session_id",
+        "timestamp",
+        "ts",
+        "model",
+        "layer",
+        "layers",
+        "d_model",
+        "n_records",
+        "n_gen_tokens",
+        "prompt_len",
+        "gen_len",
+        "npz_path",
+        "same_inference",
+    ):
+        if key in record:
+            summary[key] = record[key]
+    top_features = _summarize_top_features(record.get("feats_topk"))
+    if top_features is not None:
+        summary["top_features"] = top_features
+    if "allf" in record:
+        summary["has_all_features"] = True
+    preview = record.get("gen_text_preview")
+    if not isinstance(preview, str):
+        gen_text = record.get("gen_text")
+        preview = gen_text if isinstance(gen_text, str) else None
+    if preview:
+        summary["gen_text_preview"] = preview[:_TEXT_PREVIEW_CHARS]
+    return summary
+
+
+def _safe_session_filename(session_id: str) -> str:
+    """Collapse a session ID to a single traversal-free path segment."""
+    raw = str(session_id or "").strip()
+    sanitized = re.sub(r"[^\w-]", "_", raw).strip("._")
+    return sanitized[:96] or "sessionless"
+
+
+# ---------------------------------------------------------------------------
+# In-process stats for the /sae slash command
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _Stats:
+    turns_matched: int = 0
+    turns_unmatched: int = 0
+    records_matched: int = 0
+    last_output: Optional[Dict[str, Any]] = None
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+_STATS = _Stats()
+_WRITE_LOCK = threading.Lock()
+
+
+def _write_output_line(out_dir: Path, session_id: str, payload: Dict[str, Any]) -> None:
+    out_path = out_dir / f"{_safe_session_filename(session_id)}.jsonl"
+    with _WRITE_LOCK:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        with open(out_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(payload, ensure_ascii=False, default=str) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Observer hooks (hermes.observer.v1 — read-only, kwargs-based, fail-open)
+# ---------------------------------------------------------------------------
+
+def on_pre_api_request(**_: Any) -> None:
+    """Prime the sidecar offset so history is never mis-correlated.
+
+    First call records the sidecar's current EOF; records appended before
+    the agent's first request in this process are never candidates. After
+    that this hook is a boolean no-op, preserving the cheap-by-default
+    property of the uninstrumented path.
+    """
+    try:
+        tailer = _get_tailer()
+        if tailer is not None:
+            tailer.prime()
+    except Exception as exc:  # pragma: no cover - fail-open
+        _debug(f"pre_api_request failed: {exc}")
+
+
+def on_post_api_request(
+    *,
+    task_id: str = "",
+    turn_id: str = "",
+    api_request_id: str = "",
+    session_id: str = "",
+    model: str = "",
+    response_model: Any = None,
+    api_duration: float = 0.0,
+    started_at: float = 0.0,
+    ended_at: float = 0.0,
+    **_: Any,
+) -> None:
+    """Correlate this provider request with new sidecar records."""
+    try:
+        config = _get_config()
+        tailer = _get_tailer()
+        if config is None or tailer is None:
+            return
+        tailer.poll()
+        now = time.time()
+        if not ended_at:
+            ended_at = now
+        if not started_at:
+            started_at = ended_at - (api_duration or 0.0)
+        models = tuple(
+            m for m in (model, response_model if isinstance(response_model, str) else "")
+            if m
+        )
+        records, confidence = tailer.claim_matches(
+            api_request_id=api_request_id,
+            session_id=session_id,
+            started_at=started_at,
+            ended_at=ended_at,
+            skew=config.skew,
+            models=models,
+        )
+        if not records:
+            with _STATS.lock:
+                _STATS.turns_unmatched += 1
+            _debug(
+                f"no sidecar match for api_request (session={session_id!r}, "
+                f"model={model!r})"
+            )
+            return
+        payload = {
+            "ts": datetime.fromtimestamp(ended_at, tz=timezone.utc).isoformat(),
+            "session_id": session_id,
+            "task_id": task_id,
+            "turn_id": turn_id,
+            "api_request_id": api_request_id,
+            "model": model,
+            "api_duration": round(api_duration, 3) if api_duration else None,
+            "match_confidence": confidence,
+            "records": [_summarize_record(r) for r in records],
+        }
+        _write_output_line(config.out_dir, session_id, payload)
+        with _STATS.lock:
+            _STATS.turns_matched += 1
+            _STATS.records_matched += len(records)
+            _STATS.last_output = payload
+        _debug(
+            f"matched {len(records)} sidecar record(s) "
+            f"(confidence={confidence}, session={session_id!r})"
+        )
+    except Exception as exc:  # pragma: no cover - fail-open
+        logger.debug("SAE trace post_api_request failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# /sae slash command
+# ---------------------------------------------------------------------------
+
+_HELP_TEXT = """\
+/sae — SAE feature-trace status
+
+Subcommands:
+  status    Sidecar path, records seen/matched this session, last match
+  last      Most recent turn's correlated feature summary
+
+Configure via HERMES_SAE_TRACE_FILE (sidecar JSONL) and
+HERMES_SAE_TRACE_OUT_DIR (default: $HERMES_HOME/sae_trace).
+"""
+
+
+def _format_last_features(payload: Dict[str, Any]) -> List[str]:
+    lines: List[str] = []
+    for record in payload.get("records", []):
+        top_features = record.get("top_features")
+        if top_features:
+            for layer, features in sorted(top_features.items()):
+                feats = ", ".join(
+                    f"#{fid} (max {act}, {n} tok)" for fid, act, n in features[:5]
+                )
+                lines.append(f"  layer {layer}: {feats}")
+        elif record.get("npz_path"):
+            lines.append(f"  raw activations: {record['npz_path']}")
+        preview = record.get("gen_text_preview")
+        if preview:
+            lines.append(f"  text: {preview[:80]!r}")
+    return lines
+
+
+def _handle_slash(raw_args: str) -> Optional[str]:
+    argv = (raw_args or "").strip().split()
+    sub = argv[0] if argv else "status"
+    if sub in {"help", "-h", "--help"}:
+        return _HELP_TEXT
+
+    config = _get_config()
+    if config is None:
+        return (
+            "[sae] Not configured. Set HERMES_SAE_TRACE_FILE to your SAE "
+            "server's sidecar JSONL (then restart Hermes) to enable "
+            "correlation.\n\n" + _HELP_TEXT
+        )
+
+    if sub == "status":
+        tailer = _get_tailer()
+        with _STATS.lock:
+            matched = _STATS.turns_matched
+            unmatched = _STATS.turns_unmatched
+            records = _STATS.records_matched
+            last = _STATS.last_output
+        lines = [
+            "[sae] SAE feature-trace status",
+            f"  sidecar : {config.trace_file}"
+            + ("" if config.trace_file.exists() else "  (missing)"),
+            f"  out dir : {config.out_dir}",
+            f"  records seen: {tailer.records_seen if tailer else 0} "
+            f"(pending: {tailer.pending_count() if tailer else 0}, "
+            f"malformed: {tailer.malformed_lines if tailer else 0})",
+            f"  turns matched: {matched} ({records} record(s)); "
+            f"unmatched: {unmatched}",
+        ]
+        if last:
+            lines.append(
+                f"  last match: {last.get('ts')} "
+                f"confidence={last.get('match_confidence')}"
+            )
+            lines.extend(_format_last_features(last))
+        return "\n".join(lines)
+
+    if sub == "last":
+        with _STATS.lock:
+            last = _STATS.last_output
+        if not last:
+            return "[sae] No correlated turn yet in this session."
+        lines = [
+            f"[sae] Last correlated turn ({last.get('ts')}, "
+            f"confidence={last.get('match_confidence')}, "
+            f"model={last.get('model')})",
+        ]
+        lines.extend(_format_last_features(last) or ["  (no feature summary)"])
+        return "\n".join(lines)
+
+    return f"Unknown subcommand: {sub}\n\n{_HELP_TEXT}"
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration
+# ---------------------------------------------------------------------------
+
+def register(ctx) -> None:
+    ctx.register_hook("pre_api_request", on_pre_api_request)
+    ctx.register_hook("post_api_request", on_post_api_request)
+    ctx.register_command(
+        "sae",
+        handler=_handle_slash,
+        description="Show SAE feature-trace correlation status for this session.",
+        args_hint="status|last",
+    )

--- a/plugins/observability/sae_trace/__init__.py
+++ b/plugins/observability/sae_trace/__init__.py
@@ -617,8 +617,9 @@ _HELP_TEXT = """\
 /sae — SAE feature-trace status
 
 Subcommands:
-  status    Sidecar path, records seen/matched this session, last match
-  last      Most recent turn's correlated feature summary
+  status     Sidecar path, records seen/matched this session, last match
+  last       Most recent turn's correlated feature summary
+  dashboard  Where to find the zero-install session dashboard (dashboard.html)
 
 Configure via HERMES_SAE_TRACE_FILE (sidecar JSONL) and
 HERMES_SAE_TRACE_OUT_DIR (default: $HERMES_HOME/sae_trace).
@@ -681,6 +682,27 @@ def _handle_slash(raw_args: str) -> Optional[str]:
                 f"confidence={last.get('match_confidence')}"
             )
             lines.extend(_format_last_features(last))
+        return "\n".join(lines)
+
+    if sub == "dashboard":
+        dash = Path(__file__).resolve().parent / "dashboard.html"
+        lines = [
+            "[sae] Zero-install session dashboard",
+            f"  page   : file://{dash}",
+            f"  traces : {config.out_dir}",
+        ]
+        try:
+            newest = max(
+                config.out_dir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime
+            )
+            lines.append(f"  latest : {newest}")
+        except (ValueError, OSError):
+            lines.append("  latest : (no session traces written yet)")
+        lines.append(
+            "  Open the page in any browser and load the trace (file picker or"
+            " drag & drop). 'Follow live' re-reads it every 2s on"
+            " Chromium-based browsers. No server, no install, no network."
+        )
         return "\n".join(lines)
 
     if sub == "last":

--- a/plugins/observability/sae_trace/dashboard.html
+++ b/plugins/observability/sae_trace/dashboard.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>sae_trace · session dashboard</title>
+<!--
+  Zero-install viewer for sae_trace per-session traces
+  ($HERMES_SAE_TRACE_OUT_DIR/<session_id>.jsonl).
+
+  Open this file in a browser. No server, no build step, no network:
+  everything is inline and file access happens only through your own
+  file picker / drag-and-drop. "Follow live" uses the File System Access
+  API (Chromium) to re-read the file you picked every 2 s; other
+  browsers can re-load the file manually or drop it again.
+-->
+<style>
+  :root{--bg:#0d1117;--panel:#161b22;--ink:#e6edf3;--mut:#8b949e;--acc:#58a6ff;
+        --good:#3fb950;--warn:#d29922;--bad:#f85149;--line:#21262d}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+       font:14px/1.5 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+  header{padding:12px 18px;border-bottom:1px solid var(--line);
+         display:flex;gap:14px;align-items:center;flex-wrap:wrap}
+  h1{font-size:15px;margin:0;white-space:nowrap}
+  button,label.btn{background:#0d1117;color:var(--ink);border:1px solid #30363d;
+         border-radius:6px;padding:6px 10px;font:inherit;cursor:pointer}
+  button:hover,label.btn:hover{border-color:var(--acc)}
+  input[type=file]{display:none}
+  .muted{color:var(--mut)} .small{font-size:12px}
+  .row{display:flex;gap:16px;padding:16px;flex-wrap:wrap;align-items:flex-start}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:10px;
+        padding:12px 14px;min-width:280px}
+  h3{margin:2px 0 8px;font-size:13px;color:var(--mut);font-weight:600}
+  table{border-collapse:collapse;width:100%;font-size:12.5px}
+  th,td{padding:3px 8px;text-align:left;border-bottom:1px solid var(--line);
+        white-space:nowrap}
+  th{color:var(--mut);position:sticky;top:0;background:var(--panel)}
+  tr.sel{background:#1c2534}
+  tbody tr{cursor:pointer}
+  .tag{display:inline-block;padding:1px 7px;border-radius:10px;font-size:11px;
+       background:var(--line);color:var(--mut)}
+  .tag.request_id{background:#1a3a24;color:var(--good)}
+  .tag.session_id{background:#1a2f3a;color:var(--acc)}
+  .tag.time_window{background:#3a2a1a;color:var(--warn)}
+  .bar{height:8px;background:var(--acc);border-radius:3px;display:inline-block;
+       vertical-align:middle;margin-right:6px}
+  .scroll{max-height:480px;overflow:auto}
+  #drop{border:1px dashed #30363d;border-radius:10px;margin:16px;padding:26px;
+        text-align:center;color:var(--mut)}
+  #drop.on{border-color:var(--acc);color:var(--acc)}
+  code{background:var(--line);padding:1px 5px;border-radius:4px;font-size:12px}
+  .dot{display:inline-block;width:8px;height:8px;border-radius:50%;
+       background:var(--mut);margin-right:5px}
+  .dot.live{background:var(--good)}
+  .preview{white-space:pre-wrap;font-size:12px;color:var(--mut);
+           border-left:2px solid var(--line);padding-left:8px;margin-top:6px}
+</style>
+</head>
+<body>
+<header>
+  <h1>sae_trace · session dashboard</h1>
+  <label class="btn">Load session file<input id="file" type="file" accept=".jsonl,.json"/></label>
+  <button id="liveBtn" title="Pick the session file once; the page re-reads it every 2 s (Chromium)">
+    <span class="dot" id="liveDot"></span>Follow live
+  </button>
+  <span id="meta" class="muted small">no file loaded</span>
+</header>
+
+<div id="drop">drop a <code>&lt;session_id&gt;.jsonl</code> trace here
+  (written by the sae_trace plugin to <code>$HERMES_HOME/sae_trace/</code>)</div>
+
+<div class="row" id="main" style="display:none">
+  <div class="card" style="flex:2 1 460px">
+    <h3>Agent turns (newest first)</h3>
+    <div class="scroll">
+      <table id="turns"><thead><tr>
+        <th>time</th><th>turn</th><th>model</th><th>match</th>
+        <th>recs</th><th>top feature</th>
+      </tr></thead><tbody></tbody></table>
+    </div>
+  </div>
+  <div class="card" style="flex:2 1 420px">
+    <h3 id="detHead">Turn detail</h3>
+    <div id="detail" class="scroll muted">select a turn</div>
+  </div>
+  <div class="card" style="flex:1 1 320px">
+    <h3>Session top features (by peak activation)</h3>
+    <div class="scroll">
+      <table id="agg"><thead><tr>
+        <th>layer</th><th>feat</th><th>peak</th><th>turns</th><th></th>
+      </tr></thead><tbody></tbody></table>
+    </div>
+  </div>
+</div>
+
+<script>
+"use strict";
+let TURNS=[], SEL=-1, HANDLE=null, TIMER=null, LASTSIG="";
+
+const $=id=>document.getElementById(id);
+const esc=s=>String(s).replace(/[&<>"]/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;"}[c]));
+
+function parse(text){
+  const turns=[];
+  for(const line of text.split(/\n/)){
+    const s=line.trim(); if(!s) continue;
+    try{ const o=JSON.parse(s); if(o&&typeof o==="object"&&Array.isArray(o.records)) turns.push(o); }
+    catch(e){ /* partial trailing line while the agent is mid-turn: skip */ }
+  }
+  return turns;
+}
+
+function topOfTurn(t){
+  let best=null;
+  for(const r of t.records||[]) for(const [layer,feats] of Object.entries(r.top_features||{}))
+    for(const f of feats) if(!best||f[1]>best.act) best={layer,fid:f[0],act:f[1]};
+  return best;
+}
+
+function render(){
+  $("drop").style.display=TURNS.length?"none":"";
+  $("main").style.display=TURNS.length?"":"none";
+  if(!TURNS.length){ $("meta").textContent="no turns in file"; return; }
+  const t0=TURNS[0];
+  $("meta").textContent=`session ${t0.session_id||"?"} · ${TURNS.length} turn(s) · model ${t0.model||"?"}`;
+  const tb=$("turns").tBodies[0]; tb.innerHTML="";
+  TURNS.slice().reverse().forEach((t,revIdx)=>{
+    const i=TURNS.length-1-revIdx, best=topOfTurn(t);
+    const tr=document.createElement("tr");
+    if(i===SEL) tr.className="sel";
+    tr.innerHTML=`<td>${esc((t.ts||"").replace("T"," ").slice(5,19))}</td>
+      <td>${esc(t.turn_id||i)}</td><td>${esc(t.model||"")}</td>
+      <td><span class="tag ${esc(t.match_confidence||"")}">${esc(t.match_confidence||"?")}</span></td>
+      <td>${(t.records||[]).length}</td>
+      <td>${best?`L${esc(best.layer)} #${best.fid} (${best.act})`:"<span class=muted>raw only</span>"}</td>`;
+    tr.onclick=()=>{SEL=i;render();};
+    tb.appendChild(tr);
+  });
+  renderDetail(); renderAgg();
+}
+
+function renderDetail(){
+  const i=SEL>=0?SEL:TURNS.length-1, t=TURNS[i]; if(!t) return;
+  $("detHead").textContent=`Turn detail — ${t.turn_id||i} (${t.match_confidence||"?"})`;
+  let h="";
+  (t.records||[]).forEach((r,ri)=>{
+    h+=`<div class="small muted">record ${ri+1}${r.request_id?` · ${esc(r.request_id)}`:""}${
+        r.same_inference?` · <span class="tag request_id">same_inference</span>`:""}</div>`;
+    const tf=r.top_features||{};
+    const layers=Object.keys(tf).sort((a,b)=>+a-+b);
+    if(layers.length){
+      for(const layer of layers){
+        const feats=tf[layer], mx=Math.max(...feats.map(f=>f[1]))||1;
+        h+=`<div class="small" style="margin-top:6px">layer ${esc(layer)}</div><table>`;
+        for(const [fid,act,ntok] of feats)
+          h+=`<tr><td>#${fid}</td><td><span class="bar" style="width:${Math.max(3,120*act/mx)}px"></span>${act}</td><td class="muted">${ntok} tok</td></tr>`;
+        h+="</table>";
+      }
+    } else if(r.npz_path){
+      h+=`<div class="small">raw activations: <code>${esc(r.npz_path)}</code></div>`;
+    }
+    if(r.gen_text_preview) h+=`<div class="preview">${esc(r.gen_text_preview)}</div>`;
+  });
+  $("detail").innerHTML=h||"<span class=muted>no records</span>";
+  $("detail").classList.remove("muted");
+}
+
+function renderAgg(){
+  const agg=new Map();
+  for(const t of TURNS) for(const r of t.records||[])
+    for(const [layer,feats] of Object.entries(r.top_features||{}))
+      for(const [fid,act] of feats){
+        const k=layer+"#"+fid, e=agg.get(k)||{layer,fid,peak:0,turns:0};
+        e.peak=Math.max(e.peak,act); e.turns++; agg.set(k,e);
+      }
+  const rows=[...agg.values()].sort((a,b)=>b.peak-a.peak).slice(0,40);
+  const mx=rows.length?rows[0].peak:1;
+  $("agg").tBodies[0].innerHTML=rows.map(e=>
+    `<tr><td>L${esc(e.layer)}</td><td>#${e.fid}</td><td>${e.peak}</td><td>${e.turns}</td>
+     <td><span class="bar" style="width:${Math.max(3,90*e.peak/mx)}px"></span></td></tr>`).join("");
+}
+
+function load(text){
+  const sig=text.length+":"+text.slice(-80);
+  if(sig===LASTSIG) return; LASTSIG=sig;
+  TURNS=parse(text);
+  if(SEL>=TURNS.length) SEL=-1;
+  render();
+}
+
+$("file").addEventListener("change",e=>{
+  const f=e.target.files[0]; if(!f) return;
+  stopLive(); f.text().then(load);
+});
+
+const drop=$("drop");
+document.addEventListener("dragover",e=>{e.preventDefault();drop.classList.add("on");});
+document.addEventListener("dragleave",()=>drop.classList.remove("on"));
+document.addEventListener("drop",e=>{
+  e.preventDefault();drop.classList.remove("on");
+  const f=e.dataTransfer.files[0]; if(f){stopLive(); f.text().then(load);}
+});
+
+function stopLive(){ if(TIMER){clearInterval(TIMER);TIMER=null;} HANDLE=null;
+  $("liveDot").classList.remove("live"); }
+
+$("liveBtn").addEventListener("click",async()=>{
+  if(TIMER){ stopLive(); return; }
+  if(!window.showOpenFilePicker){
+    alert("Live follow needs a Chromium-based browser (File System Access API). Use Load / drag-and-drop instead, and re-load to refresh."); return;
+  }
+  try{
+    [HANDLE]=await showOpenFilePicker({types:[{description:"sae_trace session",
+      accept:{"application/jsonl":[".jsonl"],"application/json":[".json"]}}]});
+  }catch(e){ return; }
+  $("liveDot").classList.add("live");
+  const tick=async()=>{ try{ const f=await HANDLE.getFile(); load(await f.text()); }
+    catch(e){ stopLive(); } };
+  await tick(); TIMER=setInterval(tick,2000);
+});
+</script>
+</body>
+</html>

--- a/plugins/observability/sae_trace/plugin.yaml
+++ b/plugins/observability/sae_trace/plugin.yaml
@@ -1,0 +1,9 @@
+name: sae_trace
+version: "0.1.0"
+description: "Optional SAE feature-trace observability for Hermes — correlates each agent turn with the same-inference SAE activation records emitted by an SAE-hooked local OpenAI-compatible server. Opt in with `hermes plugins enable observability/sae_trace`; set HERMES_SAE_TRACE_FILE to the server's sidecar JSONL."
+author: "Caleb DeLeeuw (@SolshineCode)"
+requires_env:
+  - HERMES_SAE_TRACE_FILE
+hooks:
+  - pre_api_request
+  - post_api_request

--- a/plugins/observability/sae_trace/plugin.yaml
+++ b/plugins/observability/sae_trace/plugin.yaml
@@ -1,5 +1,5 @@
 name: sae_trace
-version: "0.1.0"
+version: "0.2.0"
 description: "Optional SAE feature-trace observability for Hermes — correlates each agent turn with the same-inference SAE activation records emitted by an SAE-hooked local OpenAI-compatible server. Opt in with `hermes plugins enable observability/sae_trace`; set HERMES_SAE_TRACE_FILE to the server's sidecar JSONL."
 author: "Caleb DeLeeuw (@SolshineCode)"
 requires_env:

--- a/tests/plugins/test_sae_trace_plugin.py
+++ b/tests/plugins/test_sae_trace_plugin.py
@@ -627,3 +627,39 @@ class TestExtendedCoverage:
         assert len(lines) == 20
         claimed = {line["records"][0]["request_id"] for line in lines}
         assert len(claimed) == 20
+
+
+# ---------------------------------------------------------------------------
+# Zero-install session dashboard
+# ---------------------------------------------------------------------------
+
+class TestDashboard:
+    def test_dashboard_ships_and_is_self_contained(self):
+        dash = PLUGIN_DIR / "dashboard.html"
+        assert dash.is_file(), "dashboard.html missing from plugin directory"
+        html = dash.read_text(encoding="utf-8")
+        assert len(html) > 4000
+        # Zero-install contract: nothing loaded from anywhere else, ever.
+        assert "<script src" not in html
+        assert 'src="http' not in html and "src='http" not in html
+        assert 'href="http' not in html and "href='http" not in html
+        assert "fetch(" not in html and "XMLHttpRequest" not in html
+        # Reads the plugin's own output schema and supports live follow.
+        assert "records" in html and "top_features" in html
+        assert "match_confidence" in html
+        assert "showOpenFilePicker" in html
+
+    def test_dashboard_subcommand_points_at_page_and_latest_trace(self, env):
+        plugin, sidecar, out_dir = env
+        out = plugin._handle_slash("dashboard")
+        assert "dashboard.html" in out
+        assert str(out_dir) in out
+        assert "no session traces written yet" in out
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "sess-9.jsonl").write_text("{}\n", encoding="utf-8")
+        out = plugin._handle_slash("dashboard")
+        assert "sess-9.jsonl" in out
+
+    def test_dashboard_listed_in_help(self, env):
+        plugin, _, _ = env
+        assert "dashboard" in plugin._handle_slash("help")

--- a/tests/plugins/test_sae_trace_plugin.py
+++ b/tests/plugins/test_sae_trace_plugin.py
@@ -1,0 +1,629 @@
+"""Tests for the bundled observability/sae_trace plugin.
+
+Covers:
+
+  * Manifest + layout (plugin.yaml fields, hooks list, requires_env).
+  * Opt-in discovery via ``PluginManager.discover_and_load``.
+  * Runtime gate: without ``HERMES_SAE_TRACE_FILE`` the config is a cached
+    miss and every hook is inert (fail-open, langfuse-style).
+  * Sidecar tailing: offset persistence, partial trailing lines,
+    malformed-line skipping, truncation/rotation recovery.
+  * Correlation tiers: request_id > session_id > time_window, model
+    gating, once-only claiming, and the per-session output line format
+    (top-features summary and npz_path passthrough).
+  * ``/sae`` slash command: status / last / help / unconfigured.
+  * Standalone (user-dir) load path: module works when
+    ``plugins.plugin_utils`` is not importable.
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import json
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_DIR = REPO_ROOT / "plugins" / "observability" / "sae_trace"
+
+MOD_NAME = "plugins.observability.sae_trace"
+
+
+def _fresh_plugin():
+    """Import the plugin module fresh (clears cached config/tailer/stats)."""
+    sys.modules.pop(MOD_NAME, None)
+    return importlib.import_module(MOD_NAME)
+
+
+@pytest.fixture()
+def env(tmp_path, monkeypatch):
+    """Configured environment: sidecar file + out dir, fresh module."""
+    sidecar = tmp_path / "sae_history.jsonl"
+    sidecar.write_text("", encoding="utf-8")
+    out_dir = tmp_path / "out"
+    monkeypatch.setenv("HERMES_SAE_TRACE_FILE", str(sidecar))
+    monkeypatch.setenv("HERMES_SAE_TRACE_OUT_DIR", str(out_dir))
+    monkeypatch.delenv("HERMES_SAE_TRACE_SKEW", raising=False)
+    plugin = _fresh_plugin()
+    return plugin, sidecar, out_dir
+
+
+def _append(sidecar: Path, record: dict) -> None:
+    with open(sidecar, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record) + "\n")
+
+
+def _utc_iso(epoch: float) -> str:
+    return (
+        datetime.fromtimestamp(epoch, tz=timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Manifest + layout
+# ---------------------------------------------------------------------------
+
+class TestManifest:
+    def test_plugin_directory_exists(self):
+        assert PLUGIN_DIR.is_dir()
+        assert (PLUGIN_DIR / "plugin.yaml").exists()
+        assert (PLUGIN_DIR / "__init__.py").exists()
+        assert (PLUGIN_DIR / "README.md").exists()
+
+    def test_manifest_fields(self):
+        data = yaml.safe_load((PLUGIN_DIR / "plugin.yaml").read_text(encoding="utf-8"))
+        assert data["name"] == "sae_trace"
+        assert data["version"]
+        assert set(data["hooks"]) == {"pre_api_request", "post_api_request"}
+        assert "HERMES_SAE_TRACE_FILE" in data["requires_env"]
+        assert "SolshineCode" in data["author"]
+
+
+# ---------------------------------------------------------------------------
+# Plugin discovery: sae_trace is opt-in (not loaded unless enabled).
+# ---------------------------------------------------------------------------
+
+class TestDiscovery:
+    def test_plugin_is_discovered_as_standalone_opt_in(self, tmp_path, monkeypatch):
+        """Scanner should find the plugin but NOT load it by default."""
+        from hermes_cli import plugins as plugins_mod
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        manager = plugins_mod.PluginManager()
+        manager.discover_and_load()
+
+        loaded = manager._plugins.get("observability/sae_trace")
+        assert loaded is not None, "plugin not discovered"
+        assert loaded.enabled is False
+        assert "not enabled" in (loaded.error or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# Runtime gate: no HERMES_SAE_TRACE_FILE -> cached miss, inert hooks.
+# ---------------------------------------------------------------------------
+
+class TestRuntimeGate:
+    def test_config_none_without_trace_file(self, monkeypatch):
+        monkeypatch.delenv("HERMES_SAE_TRACE_FILE", raising=False)
+        plugin = _fresh_plugin()
+        assert plugin._get_config() is None
+
+    def test_config_miss_is_cached(self, monkeypatch):
+        """A miss must be cached — no env re-reads on later hook calls."""
+        monkeypatch.delenv("HERMES_SAE_TRACE_FILE", raising=False)
+        plugin = _fresh_plugin()
+        assert plugin._get_config() is None
+
+        import os
+
+        called = {"n": 0}
+        real_get = os.environ.get
+
+        def tracking_get(key, default=None):
+            if key == "HERMES_SAE_TRACE_FILE":
+                called["n"] += 1
+            return real_get(key, default)
+
+        monkeypatch.setattr(os.environ, "get", tracking_get)
+        for _ in range(20):
+            assert plugin._get_config() is None
+        assert called["n"] == 0
+
+    def test_hooks_inert_without_config(self, monkeypatch):
+        monkeypatch.delenv("HERMES_SAE_TRACE_FILE", raising=False)
+        plugin = _fresh_plugin()
+        # Neither hook may raise, and nothing is written anywhere.
+        plugin.on_pre_api_request(model="m")
+        plugin.on_post_api_request(
+            session_id="s", model="m", started_at=time.time(), ended_at=time.time()
+        )
+        with plugin._STATS.lock:
+            assert plugin._STATS.turns_matched == 0
+            assert plugin._STATS.turns_unmatched == 0
+
+    def test_hooks_inert_when_sidecar_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            "HERMES_SAE_TRACE_FILE", str(tmp_path / "does-not-exist.jsonl")
+        )
+        monkeypatch.setenv("HERMES_SAE_TRACE_OUT_DIR", str(tmp_path / "out"))
+        plugin = _fresh_plugin()
+        plugin.on_pre_api_request()
+        plugin.on_post_api_request(
+            session_id="s", model="m", started_at=time.time(), ended_at=time.time()
+        )
+        assert not (tmp_path / "out").exists()
+
+
+# ---------------------------------------------------------------------------
+# Sidecar tailer
+# ---------------------------------------------------------------------------
+
+class TestTailer:
+    def test_prime_skips_history(self, env):
+        plugin, sidecar, _ = env
+        _append(sidecar, {"request_id": "old", "ts": _utc_iso(time.time())})
+        tailer = plugin._get_tailer()
+        tailer.prime()
+        _append(sidecar, {"request_id": "new", "ts": _utc_iso(time.time())})
+        tailer.poll()
+        assert tailer.records_seen == 1
+
+    def test_partial_trailing_line_left_unconsumed(self, env):
+        plugin, sidecar, _ = env
+        tailer = plugin._get_tailer()
+        tailer.prime()
+        with open(sidecar, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps({"request_id": "a"}) + "\n")
+            fh.write('{"request_id": "half')  # no newline: mid-write
+        tailer.poll()
+        assert tailer.records_seen == 1
+        assert tailer.malformed_lines == 0
+        # Server finishes the line -> next poll picks it up whole.
+        with open(sidecar, "a", encoding="utf-8") as fh:
+            fh.write('"}\n')
+        tailer.poll()
+        assert tailer.records_seen == 2
+
+    def test_malformed_lines_skipped(self, env):
+        plugin, sidecar, _ = env
+        tailer = plugin._get_tailer()
+        tailer.prime()
+        with open(sidecar, "a", encoding="utf-8") as fh:
+            fh.write("not json at all\n")
+            fh.write('[1, 2, 3]\n')  # valid JSON, wrong shape
+            fh.write(json.dumps({"request_id": "ok"}) + "\n")
+        tailer.poll()
+        assert tailer.records_seen == 1
+        assert tailer.malformed_lines == 2
+
+    def test_truncation_resets_offset(self, env):
+        plugin, sidecar, _ = env
+        tailer = plugin._get_tailer()
+        tailer.prime()
+        _append(sidecar, {"request_id": "a" * 40})
+        tailer.poll()
+        assert tailer.records_seen == 1
+        # Rotation: file replaced by a shorter fresh one.
+        sidecar.write_text(json.dumps({"request_id": "b"}) + "\n", encoding="utf-8")
+        tailer.poll()
+        assert tailer.records_seen == 2
+
+
+# ---------------------------------------------------------------------------
+# Correlation + output
+# ---------------------------------------------------------------------------
+
+class TestCorrelation:
+    def _run_turn(self, plugin, sidecar, records, **hook_kwargs):
+        plugin.on_pre_api_request()
+        started = time.time()
+        for record in records:
+            _append(sidecar, record)
+        ended = time.time()
+        kwargs = dict(
+            task_id="task-1",
+            turn_id="turn-1",
+            api_request_id="req-1",
+            session_id="sess-1",
+            model="sae-local",
+            api_duration=ended - started,
+            started_at=started,
+            ended_at=ended,
+        )
+        kwargs.update(hook_kwargs)
+        plugin.on_post_api_request(**kwargs)
+        return kwargs
+
+    def _read_output(self, out_dir, session_id="sess-1"):
+        path = out_dir / f"{session_id}.jsonl"
+        assert path.exists(), f"no output file at {path}"
+        return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+    def test_request_id_match(self, env):
+        plugin, sidecar, out_dir = env
+        self._run_turn(
+            plugin, sidecar,
+            [{"request_id": "req-1", "model": "other-model"}],
+        )
+        (line,) = self._read_output(out_dir)
+        assert line["match_confidence"] == "request_id"
+        assert line["records"][0]["request_id"] == "req-1"
+
+    def test_session_id_match_nla_server_shape(self, env):
+        """activation-capture record: naive local `timestamp`, npz pointer."""
+        plugin, sidecar, out_dir = env
+        record = {
+            "request_id": "abcd1234",
+            "session_id": "sess-1",
+            "timestamp": datetime.now().isoformat(),  # naive local ISO
+            "model": "gemma-4-e2b",
+            "layer": 23,
+            "d_model": 1536,
+            "n_records": 12,
+            "n_gen_tokens": 11,
+            "npz_path": "/logs/run_abcd1234.npz",
+            "gen_text_preview": "hello world",
+        }
+        self._run_turn(plugin, sidecar, [record], model="my-alias")
+        (line,) = self._read_output(out_dir)
+        assert line["match_confidence"] == "session_id"
+        rec = line["records"][0]
+        assert rec["npz_path"] == "/logs/run_abcd1234.npz"
+        assert rec["layer"] == 23
+        assert rec["gen_text_preview"] == "hello world"
+        assert "top_features" not in rec
+
+    def test_time_window_match_sae_serve_shape(self, env):
+        """feature-history record: UTC `ts` with Z suffix, feats_topk."""
+        plugin, sidecar, out_dir = env
+        record = {
+            "ts": _utc_iso(time.time()),
+            "request_id": "chatcmpl-deadbeef",
+            "model": "sae-local",
+            "prompt_len": 100,
+            "gen_len": 3,
+            "same_inference": True,
+            "feats_topk": {
+                "16": [[0, 7, 1.0], [1, 7, 5.0], [2, 9, 3.0], [0, 3, 0.5]],
+            },
+            "gen_text": "x" * 500,
+        }
+        self._run_turn(plugin, sidecar, [record])
+        (line,) = self._read_output(out_dir)
+        assert line["match_confidence"] == "time_window"
+        rec = line["records"][0]
+        # Top features sorted by max activation: feat 7 (max 5.0, 2 tokens),
+        # then feat 9, then feat 3.
+        assert rec["top_features"]["16"] == [[7, 5.0, 2], [9, 3.0, 1], [3, 0.5, 1]]
+        assert rec["same_inference"] is True
+        assert len(rec["gen_text_preview"]) == 200  # bounded
+
+    def test_output_line_identity_fields(self, env):
+        plugin, sidecar, out_dir = env
+        kwargs = self._run_turn(
+            plugin, sidecar, [{"request_id": "req-1"}],
+        )
+        (line,) = self._read_output(out_dir)
+        for key in ("ts", "session_id", "task_id", "turn_id",
+                    "api_request_id", "model", "match_confidence", "records"):
+            assert key in line
+        assert line["session_id"] == kwargs["session_id"]
+        assert line["task_id"] == kwargs["task_id"]
+        assert line["model"] == kwargs["model"]
+
+    def test_model_mismatch_blocks_time_window(self, env):
+        plugin, sidecar, out_dir = env
+        self._run_turn(
+            plugin, sidecar,
+            [{"ts": _utc_iso(time.time()), "model": "some-other-model"}],
+        )
+        assert not (out_dir / "sess-1.jsonl").exists()
+        with plugin._STATS.lock:
+            assert plugin._STATS.turns_unmatched == 1
+
+    def test_stale_record_outside_window_no_match(self, env):
+        plugin, sidecar, out_dir = env
+        self._run_turn(
+            plugin, sidecar,
+            [{"ts": _utc_iso(time.time() - 3600), "model": "sae-local"}],
+        )
+        assert not (out_dir / "sess-1.jsonl").exists()
+
+    def test_records_claimed_once(self, env):
+        plugin, sidecar, out_dir = env
+        self._run_turn(plugin, sidecar, [{"request_id": "req-1"}])
+        # Second turn appends nothing new — must not re-match req-1's record.
+        self._run_turn(plugin, sidecar, [], api_request_id="req-2", turn_id="turn-2")
+        lines = self._read_output(out_dir)
+        assert len(lines) == 1
+        with plugin._STATS.lock:
+            assert plugin._STATS.turns_matched == 1
+            assert plugin._STATS.turns_unmatched == 1
+
+    def test_session_filename_sanitized(self, env):
+        plugin, sidecar, out_dir = env
+        self._run_turn(
+            plugin, sidecar,
+            [{"request_id": "req-1"}],
+            session_id="../../../etc/pwned",
+        )
+        # The traversal-shaped ID stays inside out_dir as a single segment.
+        files = list(out_dir.iterdir())
+        assert files, "no output written"
+        assert all(p.parent == out_dir for p in files)
+        assert all("/" not in p.name and ".." not in p.name for p in files)
+        assert not (out_dir.parent.parent / "etc").exists()
+
+    def test_concurrent_hooks_do_not_raise(self, env):
+        plugin, sidecar, out_dir = env
+        plugin.on_pre_api_request()
+        started = time.time()
+        for i in range(20):
+            _append(sidecar, {"request_id": f"req-{i}"})
+        ended = time.time()
+        errors = []
+
+        def fire(i):
+            try:
+                plugin.on_post_api_request(
+                    api_request_id=f"req-{i}",
+                    session_id="sess-1",
+                    model="sae-local",
+                    started_at=started,
+                    ended_at=ended,
+                )
+            except Exception as exc:  # pragma: no cover - the assertion
+                errors.append(exc)
+
+        threads = [threading.Thread(target=fire, args=(i,)) for i in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert not errors
+        lines = self._read_output(out_dir)
+        assert len(lines) == 20
+        matched_ids = sorted(
+            line["records"][0]["request_id"] for line in lines
+        )
+        assert matched_ids == sorted(f"req-{i}" for i in range(20))
+
+
+# ---------------------------------------------------------------------------
+# /sae slash command
+# ---------------------------------------------------------------------------
+
+class TestSlashCommand:
+    def test_unconfigured_message(self, monkeypatch):
+        monkeypatch.delenv("HERMES_SAE_TRACE_FILE", raising=False)
+        plugin = _fresh_plugin()
+        out = plugin._handle_slash("status")
+        assert "HERMES_SAE_TRACE_FILE" in out
+
+    def test_help(self, env):
+        plugin, _, _ = env
+        out = plugin._handle_slash("help")
+        assert "status" in out and "last" in out
+
+    def test_status_reports_sidecar_and_counts(self, env):
+        plugin, sidecar, _ = env
+        plugin.on_pre_api_request()
+        started = time.time()
+        _append(sidecar, {"request_id": "req-1", "feats_topk": {"3": [[0, 42, 9.0]]}})
+        plugin.on_post_api_request(
+            api_request_id="req-1", session_id="sess-1", model="sae-local",
+            started_at=started, ended_at=time.time(),
+        )
+        out = plugin._handle_slash("status")
+        assert str(sidecar) in out
+        assert "turns matched: 1" in out
+        assert "request_id" in out  # last-match confidence line
+
+    def test_last_prints_feature_summary(self, env):
+        plugin, sidecar, _ = env
+        plugin.on_pre_api_request()
+        started = time.time()
+        _append(sidecar, {"request_id": "req-1", "feats_topk": {"3": [[0, 42, 9.0]]}})
+        plugin.on_post_api_request(
+            api_request_id="req-1", session_id="sess-1", model="sae-local",
+            started_at=started, ended_at=time.time(),
+        )
+        out = plugin._handle_slash("last")
+        assert "layer 3" in out
+        assert "#42" in out
+
+    def test_last_without_match(self, env):
+        plugin, _, _ = env
+        out = plugin._handle_slash("last")
+        assert "No correlated turn" in out
+
+    def test_unknown_subcommand(self, env):
+        plugin, _, _ = env
+        out = plugin._handle_slash("bogus")
+        assert "Unknown subcommand" in out
+
+    def test_register_wires_hooks_and_command(self, env):
+        plugin, _, _ = env
+
+        class Ctx:
+            def __init__(self):
+                self.hooks = {}
+                self.commands = {}
+
+            def register_hook(self, name, cb):
+                self.hooks[name] = cb
+
+            def register_command(self, name, handler, description="", args_hint=""):
+                self.commands[name] = handler
+
+        ctx = Ctx()
+        plugin.register(ctx)
+        assert set(ctx.hooks) == {"pre_api_request", "post_api_request"}
+        assert "sae" in ctx.commands
+
+
+# ---------------------------------------------------------------------------
+# Standalone (user-dir) install: module must load and work when
+# ``plugins.plugin_utils`` is not importable (the loader imports user
+# plugins as ``hermes_plugins.<slug>`` from their own directory).
+# ---------------------------------------------------------------------------
+
+class TestStandaloneLoad:
+    def _load_standalone(self):
+        class _BlockPluginsPkg:
+            """Meta-path hook that makes ``plugins.*`` unimportable."""
+
+            def find_spec(self, name, path=None, target=None):
+                if name == "plugins" or name.startswith("plugins."):
+                    raise ImportError(f"blocked for standalone test: {name}")
+                return None
+
+        blocker = _BlockPluginsPkg()
+        saved = {
+            name: sys.modules.pop(name)
+            for name in list(sys.modules)
+            if name == "plugins" or name.startswith("plugins.")
+        }
+        sys.meta_path.insert(0, blocker)
+        try:
+            spec = importlib.util.spec_from_file_location(
+                "hermes_plugins.sae_trace",
+                PLUGIN_DIR / "__init__.py",
+                submodule_search_locations=[str(PLUGIN_DIR)],
+            )
+            module = importlib.util.module_from_spec(spec)
+            sys.modules["hermes_plugins.sae_trace"] = module
+            spec.loader.exec_module(module)
+            return module
+        finally:
+            sys.meta_path.remove(blocker)
+            sys.modules.pop("hermes_plugins.sae_trace", None)
+            sys.modules.update(saved)
+
+    def test_loads_and_correlates_without_plugin_utils(
+        self, tmp_path, monkeypatch
+    ):
+        sidecar = tmp_path / "sidecar.jsonl"
+        sidecar.write_text("", encoding="utf-8")
+        out_dir = tmp_path / "out"
+        monkeypatch.setenv("HERMES_SAE_TRACE_FILE", str(sidecar))
+        monkeypatch.setenv("HERMES_SAE_TRACE_OUT_DIR", str(out_dir))
+
+        module = self._load_standalone()
+        module.on_pre_api_request()
+        started = time.time()
+        _append(sidecar, {"request_id": "req-sa", "feats_topk": {"0": [[0, 1, 2.0]]}})
+        module.on_post_api_request(
+            api_request_id="req-sa", session_id="sess-sa", model="m",
+            started_at=started, ended_at=time.time(),
+        )
+        lines = (out_dir / "sess-sa.jsonl").read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        assert json.loads(lines[0])["match_confidence"] == "request_id"
+
+
+# ---------------------------------------------------------------------------
+# Extended coverage: summaries, tier precedence, timestamp parsing, races
+# ---------------------------------------------------------------------------
+
+class TestExtendedCoverage:
+    def test_feature_summary_and_preview_bounds(self, env):
+        """Top-features are ranked by max activation and payloads stay bounded."""
+        plugin, sidecar, out_dir = env
+        plugin.on_pre_api_request()
+        started = time.time()
+        events = [[t, 7, 0.5] for t in range(50)] + [[0, 9, 3.25], [1, 9, 1.0]]
+        _append(
+            sidecar,
+            {
+                "request_id": "req-1",
+                "feats_topk": {"12": events},
+                "gen_text": "x" * 1000,
+                "allf": [[0, 1, 0.1]],
+            },
+        )
+        plugin.on_post_api_request(
+            api_request_id="req-1", session_id="sess-1", model="sae-local",
+            started_at=started, ended_at=time.time(),
+        )
+        (line,) = [
+            json.loads(raw)
+            for raw in (out_dir / "sess-1.jsonl").read_text(
+                encoding="utf-8"
+            ).splitlines()
+        ]
+        record = line["records"][0]
+        assert record["top_features"]["12"][0] == [9, 3.25, 2]
+        assert [7, 0.5, 50] in record["top_features"]["12"]
+        assert len(record["gen_text_preview"]) == 200
+        assert record["has_all_features"] is True
+        assert "allf" not in json.dumps(line)
+
+    def test_request_id_tier_reported_over_weaker_matches(self, env):
+        """One turn matching several records reports the strongest tier."""
+        plugin, sidecar, out_dir = env
+        plugin.on_pre_api_request()
+        started = time.time()
+        _append(sidecar, {"session_id": "sess-1", "timestamp": time.time()})
+        _append(sidecar, {"request_id": "req-1"})
+        plugin.on_post_api_request(
+            api_request_id="req-1", session_id="sess-1", model="sae-local",
+            started_at=started, ended_at=time.time(),
+        )
+        (line,) = [
+            json.loads(raw)
+            for raw in (out_dir / "sess-1.jsonl").read_text(
+                encoding="utf-8"
+            ).splitlines()
+        ]
+        assert line["match_confidence"] == "request_id"
+        assert len(line["records"]) == 2
+
+    def test_timestamp_parsing_forms(self, env):
+        plugin, _, _ = env
+        assert plugin._parse_record_ts({"ts": "2026-07-21T12:00:00Z"}) == 1784635200.0
+        assert plugin._parse_record_ts({"timestamp": 123.5}) == 123.5
+        assert plugin._parse_record_ts({"ts": "not-a-date"}) is None
+        assert plugin._parse_record_ts({}) is None
+
+    def test_concurrent_turns_claim_each_record_exactly_once(self, env):
+        plugin, sidecar, out_dir = env
+        plugin.on_pre_api_request()
+        started = time.time()
+        for i in range(20):
+            _append(sidecar, {"request_id": f"req-{i}"})
+
+        def _turn(i: int) -> None:
+            plugin.on_post_api_request(
+                api_request_id=f"req-{i}", session_id="sess-1", model="sae-local",
+                started_at=started, ended_at=time.time(),
+            )
+
+        threads = [threading.Thread(target=_turn, args=(i,)) for i in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        lines = [
+            json.loads(raw)
+            for raw in (out_dir / "sess-1.jsonl").read_text(
+                encoding="utf-8"
+            ).splitlines()
+        ]
+        assert len(lines) == 20
+        claimed = {line["records"][0]["request_id"] for line in lines}
+        assert len(claimed) == 20


### PR DESCRIPTION

## What does this PR do?

Adds an opt-in, stdlib-only observability plugin that correlates each Hermes
agent turn with the same-inference SAE (sparse autoencoder) feature-trace
records emitted by an SAE-hooked local OpenAI-compatible model server. When a
user runs their local model behind such a server (reference implementation:
https://github.com/SolshineCode/hermes-sae — but the plugin targets a
documented, vendor-neutral sidecar JSONL schema, so any compatible server
works), the server appends one JSONL record per request (per-token top-k SAE
features, or a pointer to raw activations) in the same `model.generate()` pass
that produced the completion Hermes receives. This plugin tail-reads that
sidecar from `post_api_request` observer hooks and writes one correlated line
per agent turn to `$HERMES_SAE_TRACE_OUT_DIR/<session_id>.jsonl`, giving users
a per-session interpretability trace of what their local model's internals
were doing during each turn. The plugin also ships a zero-install session dashboard
(`dashboard.html`, single self-contained page: agent turns with match
confidence, per-turn top SAE features per layer with activation bars,
same-inference provenance, and a session-level feature aggregate). Open it
straight from disk — no server, no build step, no network; "Follow live"
re-reads the picked trace every 2s (File System Access API, Chromium) so
users can watch their session as it runs. `/sae dashboard` prints the page
path and the newest trace. It has been validated end-to-end against a real
local-model SAE-serving setup (the hermes-sae servers above).

A note on motivation: this comes out of my mission to democratize access to
mechanistic interpretability, on both the research side and the applied
side. Watching a model's internals while it does real work is currently
something you get at a frontier lab or through a hosted enterprise product,
and mostly not anywhere else. The pieces to change that are already open.
Weights are local, good pretrained SAE dictionaries are sitting on
HuggingFace, and Hermes is built to run local models. This plugin wires
those pieces together so that anyone with their own hardware can see what
their model was doing internally on every agent turn, debug looping and
drift from internal state instead of transcript guesswork, and do real
interpretability work without anyone's permission. The field gets more
trustworthy when far more people can practice it, not just read about it.

## Related Issue

Fixes # (none — new feature; happy to open a tracking issue if preferred)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## How it follows the observer contract (`hermes.observer.v1`)

Per `docs/observability/README.md`:

- Registers only the hooks it consumes: `pre_api_request` (one-time sidecar
  offset priming, boolean no-op afterwards) and `post_api_request`
  (correlation). No behavior-affecting hooks, no return values, read-only.
- All callbacks accept `**kwargs` and read fields defensively; payload fields
  used (`task_id`, `turn_id`, `api_request_id`, `session_id`, `model`,
  `response_model`, `api_duration`, `started_at`, `ended_at`) were verified
  against the dispatch site in `agent/conversation_loop.py`.
- Fail-open everywhere: missing/rotated/truncated sidecar, malformed JSONL
  lines, missing config, and no-match turns all degrade to a debug log —
  nothing ever raises out of a hook.
- Cheap by default: without `HERMES_SAE_TRACE_FILE` the runtime gate is a
  cached miss (same pattern as the langfuse plugin), and the tailer reads only
  bytes appended since the last poll (remembered offset, bounded read size).
- Thread-safe: `plugins/plugin_utils.SingletonSlot` for lazy config/tailer
  (with a guarded-import fallback so the plugin also works from
  `~/.hermes/plugins/`), plus locks around the pending-record queue, stats,
  and output writes. Concurrency is covered by a dedicated test.

Correlation uses three explicit evidence tiers recorded as
`match_confidence`: `request_id` (exact id passthrough) > `session_id` (the
server logged the `X-Hermes-Session-Id` header) > `time_window`
(record timestamp inside the request's `[started_at − skew, ended_at + skew]`
window plus case-insensitive model-id agreement). Matched records are claimed
exactly once. A `/sae` slash command (`status` / `last`) surfaces the
correlation state in-session via `ctx.register_command`.

## Changes Made

- `plugins/observability/sae_trace/plugin.yaml` — manifest (opt-in
  standalone, 2 hooks, `requires_env: HERMES_SAE_TRACE_FILE`)
- `plugins/observability/sae_trace/__init__.py` — sidecar tailer,
  three-tier correlation, per-session JSONL output, `/sae` command
  (`status` / `last` / `dashboard`). Stdlib only; zero new dependencies.
- `plugins/observability/sae_trace/dashboard.html` — zero-install session
  viewer (self-contained; no external scripts/styles, no fetch/XHR; live
  follow via the File System Access API where available)
- `plugins/observability/sae_trace/README.md` — enable/config docs, the
  sidecar JSONL schema documented as an interface contract, output format,
  correlation-confidence limitations, security note (local files only, no
  network), and standalone-install instructions
- `tests/plugins/test_sae_trace_plugin.py` — 35 tests: manifest/layout,
  opt-in discovery via `PluginManager.discover_and_load`, cached runtime
  gate, tailer edge cases (history skip, partial trailing line, malformed
  lines, truncation/rotation), all three correlation tiers with both
  documented sidecar shapes, once-only claiming, filename sanitization,
  concurrent hook firing, `/sae` subcommands, and a standalone-load test
  that blocks `plugins.plugin_utils` to prove the user-dir path works

## Install modes

Works identically in both supported plugin locations, so maintainers can
choose either adoption path:

- **Bundled (this PR):** `hermes plugins enable observability/sae_trace`
- **Standalone:** `cp -r plugins/observability/sae_trace
  ~/.hermes/plugins/sae_trace && hermes plugins enable sae_trace` — no
  in-tree imports are required (the `plugin_utils` import is guarded with a
  local fallback, verified by test). If the maintainers prefer this ships as
  a standalone community plugin per the CONTRIBUTING placement guidance for
  integrations, the directory works as-is as its own repo; note it integrates
  a documented file-format contract rather than a third-party service, in the
  spirit of the existing `plugins/observability/` family.

## How to Test

1. `pytest tests/plugins/test_sae_trace_plugin.py -v` — 35 passed
2. `pytest tests/plugins/ tests/test_plugin_utils.py -q` — adjacent plugin
   suites (langfuse, disk-cleanup, plugin_utils) still pass with the new
   plugin discoverable
3. Manual: start an SAE-hooked server (e.g.
   `python sae_serve.py --self-test`, or a real model per the hermes-sae
   README), point a custom provider's `base_url` at it, set
   `HERMES_SAE_TRACE_FILE` to its sidecar JSONL, enable the plugin, run
   `hermes chat -q "hello"`, then check
   `~/.hermes/sae_trace/<session_id>.jsonl` and `/sae status`
4. Dashboard: `/sae dashboard` prints the page path; open it in a browser,
   load the session trace (picker or drag-and-drop), and for a live view
   click "Follow live" (Chromium) while the agent keeps working

## Limitations

- (Non-limitation worth stating: the plugin itself is hardware-neutral —
  pure stdlib file correlation, no `torch`/GPU dependency. Serving-side
  hardware is entirely the user's choice; the reference servers have been
  run on CPU-only, a 4 GB laptop GPU, and a 2×24 GB workstation.)

- `time_window` matches are heuristic; concurrent Hermes sessions sharing one
  SAE server inside the same window can mis-attribute records (documented in
  the README; id-based tiers are exact)
- Sidecar records emitted while Hermes is not running are never matched (the
  tailer starts at EOF); `/sae` counters are per-process
- Turns served by cloud providers produce no trace by design

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the new suite plus the adjacent plugin suites (langfuse, disk-cleanup, plugin_utils) — all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — plugin README included
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (env-var config only, matching langfuse)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pathlib throughout, explicit encodings, inode checks are optional (size heuristic covers Windows), no `os.kill`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tools registered)

## Screenshots / Logs

Example correlated output line (real run, `sae_serve.py`-shaped sidecar):

```json
{"ts": "2026-07-21T04:12:31+00:00", "session_id": "abc123", "task_id": "", "turn_id": "turn-7",
 "api_request_id": "req-42", "model": "sae-local", "api_duration": 12.4,
 "match_confidence": "time_window",
 "records": [{"request_id": "chatcmpl-…", "model": "sae-local", "gen_len": 118,
              "top_features": {"16": [[40913, 8.31, 22], [1027, 6.9, 4]]},
              "gen_text_preview": "Sure — here's the plan…"}]}
```

Security note: the plugin reads one operator-configured local file and writes
under `$HERMES_HOME`; it makes no network requests. Session ids are sanitized
to a single traversal-free path segment before use as filenames.
