### PR TITLE
fix(api): preserve REST fork session isolation

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2450,6 +2450,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "api_server",
             model=source.get("model"),
             system_prompt=source.get("system_prompt"),
+            model_config={"_branched_from": source_id},
             parent_session_id=source_id,
         )
         messages = await asyncio.to_thread(db.get_messages, source_id)

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -1,5 +1,6 @@
 """Focused tests for API server session-control endpoints."""
 
+import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -209,6 +210,20 @@ async def test_session_fork_uses_current_sessiondb_branch_primitives(adapter, se
     assert fork["title"] == "Alternative"
     assert [m["content"] for m in session_db.get_messages(fork["id"])] == ["first path", "answer"]
     assert session_db.get_session(source_id)["end_reason"] == "branched"
+
+    fork_row = session_db.get_session(fork["id"])
+    assert json.loads(fork_row["model_config"]) == {"_branched_from": source_id}
+
+    session_db.append_message(fork["id"], "user", "fork-only")
+    assert session_db.resolve_resume_session_id(source_id) == source_id
+
+    async with TestClient(TestServer(app)) as cli:
+        messages_resp = await cli.get(f"/api/sessions/{source_id}/messages")
+        assert messages_resp.status == 200
+        messages = await messages_resp.json()
+
+    assert messages["session_id"] == source_id
+    assert [message["content"] for message in messages["data"]] == ["first path", "answer"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Mark REST-created fork sessions with `_branched_from`, matching the CLI `/branch` path.
- Keep a forked child from being treated as a compression continuation when the original session is resumed or its messages are queried.

## Root cause

The REST fork endpoint created a child with `parent_session_id` but omitted the lineage marker consumed by `SessionDB.resolve_resume_session_id`. The resolver could therefore follow the fork and return the child's transcript for the original session.

## Testing

- `python -m py_compile gateway/platforms/api_server.py tests/gateway/test_session_api.py`
- `scripts/run_tests.sh tests/gateway/test_session_api.py -q` *(blocked locally: no project Python 3.11-3.13 virtual environment is installed; the only available Python is 3.14, which the project explicitly excludes)*

Fixes #68511
