### PR TITLE
fix(doctor): decode subprocess output as utf-8

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -80,6 +80,18 @@ def _safe_which(cmd: str) -> str | None:
         return None
 
 
+def _run_doctor_text_command(cmd: list[str], **kwargs):
+    """Run a diagnostic command without relying on the system text encoding."""
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        **kwargs,
+    )
+
+
 def _termux_browser_setup_steps(node_installed: bool) -> list[str]:
     steps: list[str] = []
     step = 1
@@ -1642,10 +1654,8 @@ def run_doctor(args):
             cmd += [target, "echo ok"]
             # Try to connect
             try:
-                result = subprocess.run(
+                result = _run_doctor_text_command(
                     cmd,
-                    capture_output=True,
-                    text=True,
                     timeout=15
                 )
             except subprocess.TimeoutExpired:
@@ -1806,10 +1816,10 @@ def run_doctor(args):
             try:
                 # Use resolved absolute path so Windows can execute
                 # npm.cmd (CreateProcessW can't run bare .cmd names).
-                audit_result = subprocess.run(
+                audit_result = _run_doctor_text_command(
                     [_npm_bin, "audit", "--json", *audit_extra],
                     cwd=str(npm_dir),
-                    capture_output=True, text=True, timeout=30,
+                    timeout=30,
                 )
                 import json as _json
                 audit_data = _json.loads(audit_result.stdout) if audit_result.stdout.strip() else {}

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -16,6 +16,24 @@ from hermes_cli import doctor as doctor_mod
 from hermes_cli.doctor import _has_provider_env_config
 
 
+def test_doctor_text_subprocess_decodes_utf8_with_replacement():
+    """Diagnostic commands must not crash on non-UTF-8 Windows locales."""
+    command = [
+        sys.executable,
+        "-c",
+        (
+            "import sys; payload = b'\\xe2\\x80\\x94\\xff'; "
+            "sys.stdout.buffer.write(payload); sys.stderr.buffer.write(payload)"
+        ),
+    ]
+
+    result = doctor_mod._run_doctor_text_command(command)
+
+    assert result.returncode == 0
+    assert result.stdout == "\u2014\ufffd"
+    assert result.stderr == "\u2014\ufffd"
+
+
 class TestDoctorPlatformHints:
     def test_termux_package_hint(self, monkeypatch):
         monkeypatch.setenv("TERMUX_VERSION", "0.118.3")


### PR DESCRIPTION
## Summary

- Decode text output from doctor diagnostic subprocesses explicitly as UTF-8 with replacement for malformed bytes.
- Use the same safe decoding path for SSH connectivity probing and `npm audit --json`.

## Root cause

`subprocess.run(..., text=True)` used the Windows ANSI code page by default. On GBK/CP936 hosts, UTF-8 subprocess output containing bytes invalid in GBK could raise a background-reader `UnicodeDecodeError`, leaving `.stdout` unavailable and causing doctor checks to fail or be silently skipped.

## Testing

- `python -m py_compile hermes_cli/doctor.py tests/hermes_cli/test_doctor.py`
- Added a regression test that runs a child process emitting valid UTF-8 followed by an invalid byte, and verifies both stdout and stderr are decoded as `—�`.
- `scripts/run_tests.sh tests/hermes_cli/test_doctor.py -q` *(blocked locally: no project Python 3.11-3.13 virtual environment is installed; the only available Python is 3.14, which the project explicitly excludes)*

Fixes #49499
