### PR TITLE
fix(browser): validate Camofox health responses

### DIFF
--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -3,7 +3,9 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
 
+import tools.browser_camofox as browser_camofox
 from tools.browser_camofox import (
     camofox_back,
     camofox_click,
@@ -48,9 +50,63 @@ class TestCamofoxMode:
         monkeypatch.setenv("BROWSER_CDP_URL", "  ")
         assert is_camofox_mode() is True
 
-    def test_health_check_unreachable(self, monkeypatch):
+    @patch("tools.browser_camofox.requests.get")
+    def test_health_check_unreachable(self, mock_get, monkeypatch):
         monkeypatch.setenv("CAMOFOX_URL", "http://localhost:19999")
+        mock_get.side_effect = browser_camofox.requests.ConnectionError("boom")
         assert check_camofox_available() is False
+
+    @patch("tools.browser_camofox.requests.get")
+    def test_health_check_rejects_html_response(self, mock_get, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:19999")
+        mock_get.return_value = _mock_health_response(
+            body="<html><body>Netdata</body></html>",
+            content_type="text/html; charset=utf-8",
+            json_side_effect=ValueError("Expecting value: line 1 column 1 (char 0)"),
+        )
+
+        assert check_camofox_available() is False
+
+    @patch("tools.browser_camofox.requests.get")
+    def test_health_check_rejects_malformed_json_response(self, mock_get, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:19999")
+        mock_get.return_value = _mock_health_response(
+            body="not-json",
+            content_type="application/json",
+            json_side_effect=ValueError("No JSON object could be decoded"),
+        )
+
+        assert check_camofox_available() is False
+
+    @patch("tools.browser_camofox.requests.get")
+    def test_health_check_accepts_json_without_vnc_port(self, mock_get, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_get.return_value = _mock_health_response(
+            json_data={
+                "ok": True,
+                "engine": "camoufox",
+                "browserConnected": True,
+                "browserRunning": True,
+                "activeTabs": 0,
+            },
+        )
+
+        assert check_camofox_available() is True
+        assert browser_camofox.get_vnc_url() is None
+
+    @patch("tools.browser_camofox.requests.get")
+    def test_health_check_accepts_json_with_null_vnc_port(self, mock_get, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_get.return_value = _mock_health_response(
+            json_data={
+                "ok": True,
+                "engine": "camoufox",
+                "vncPort": None,
+            },
+        )
+
+        assert check_camofox_available() is True
+        assert browser_camofox.get_vnc_url() is None
 
 
 # ---------------------------------------------------------------------------
@@ -69,6 +125,26 @@ def _mock_response(status=200, json_data=None):
     resp.content = b"\x89PNG\r\n\x1a\nfake"
     resp.raise_for_status = MagicMock()
     return resp
+
+
+def _mock_health_response(*, status=200, json_data=None, body="", content_type="application/json", json_side_effect=None):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.headers = {"Content-Type": content_type}
+    resp.text = body
+    resp.content = body.encode()
+    if json_side_effect is not None:
+        resp.json.side_effect = json_side_effect
+    else:
+        resp.json.return_value = json_data or {}
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+@pytest.fixture(autouse=True)
+def reset_camofox_health_cache(monkeypatch):
+    monkeypatch.setattr(browser_camofox, "_vnc_url", None)
+    monkeypatch.setattr(browser_camofox, "_vnc_url_checked", False)
 
 
 # ---------------------------------------------------------------------------
@@ -171,8 +247,10 @@ class TestCamofoxNavigate:
         assert result["success"] is True
         assert result["url"] == "https://b.com"
 
-    def test_connection_error_returns_helpful_message(self, monkeypatch):
+    @patch("tools.browser_camofox.requests.post")
+    def test_connection_error_returns_helpful_message(self, mock_post, monkeypatch):
         monkeypatch.setenv("CAMOFOX_URL", "http://localhost:19999")
+        mock_post.side_effect = browser_camofox.requests.ConnectionError("boom")
         result = json.loads(camofox_navigate("https://example.com", task_id="t_err"))
         assert result["success"] is False
         assert "Cannot connect" in result["error"]

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -93,6 +93,66 @@ def get_camofox_url() -> str:
     return os.getenv("CAMOFOX_URL", "").rstrip("/")
 
 
+def _camofox_health_payload_is_valid(data: Any) -> bool:
+    """Return True when a /health payload looks like a Camofox response.
+
+    Camofox health responses are JSON objects. Current releases return fields
+    such as ``ok``, ``engine``, ``browserConnected``, ``browserRunning``, and
+    ``activeTabs``; ``vncPort`` is optional and may be absent.
+    """
+    if not isinstance(data, dict):
+        return False
+
+    seen_marker = False
+
+    if "ok" in data:
+        seen_marker = True
+        if not bool(data["ok"]):
+            return False
+
+    if "browserConnected" in data:
+        seen_marker = True
+        if not bool(data["browserConnected"]):
+            return False
+
+    if "browserRunning" in data:
+        seen_marker = True
+        if not bool(data["browserRunning"]):
+            return False
+
+    if "status" in data:
+        seen_marker = True
+        status = str(data["status"]).strip().lower()
+        if status in {"down", "error", "failed", "fail", "degraded", "unhealthy"}:
+            return False
+
+    if "vncPort" in data:
+        seen_marker = True
+        vnc_port = data["vncPort"]
+        if vnc_port is not None and (not isinstance(vnc_port, int) or not (1 <= vnc_port <= 65535)):
+            return False
+
+    if "engine" in data or "activeTabs" in data:
+        seen_marker = True
+
+    return seen_marker
+
+
+def _camofox_health_response_vnc_url(data: Any, url: str) -> Optional[str]:
+    """Extract a VNC URL from a validated health payload, if present."""
+    if not isinstance(data, dict):
+        return None
+    vnc_port = data.get("vncPort")
+    if not isinstance(vnc_port, int) or not (1 <= vnc_port <= 65535):
+        return None
+
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url)
+    host = parsed.hostname or "localhost"
+    return f"http://{host}:{vnc_port}"
+
+
 def _config_cdp_url() -> str:
     """Persistent ``browser.cdp_url`` from config.yaml, or empty string.
 
@@ -138,19 +198,21 @@ def check_camofox_available() -> bool:
         return False
     try:
         resp = requests.get(f"{url}/health", timeout=5)
-        if resp.status_code == 200 and not _vnc_url_checked:
-            try:
-                data = resp.json()
-                vnc_port = data.get("vncPort")
-                if isinstance(vnc_port, int) and 1 <= vnc_port <= 65535:
-                    from urllib.parse import urlparse
-                    parsed = urlparse(url)
-                    host = parsed.hostname or "localhost"
-                    _vnc_url = f"http://{host}:{vnc_port}"
-            except (ValueError, KeyError):
-                pass
+        if resp.status_code != 200:
+            return False
+
+        try:
+            data: Any = resp.json()
+        except (ValueError, json.JSONDecodeError):
+            return False
+
+        if not _camofox_health_payload_is_valid(data):
+            return False
+
+        if not _vnc_url_checked:
+            _vnc_url = _camofox_health_response_vnc_url(data, url)
             _vnc_url_checked = True
-        return resp.status_code == 200
+        return True
     except Exception:
         return False
 


### PR DESCRIPTION
## What does this PR do?

Make Camofox availability checks reject arbitrary HTTP 200 responses and make Camofox unreachable tests deterministic.

The previous test setup used `CAMOFOX_URL=http://localhost:19999` as an assumed-unreachable endpoint. On hosts running Netdata, `localhost:19999/health` can return `200 text/html`, so `check_camofox_available()` incorrectly treated the wrong service as a healthy Camofox server because it only checked `status_code == 200`.

This patch validates that `/health` returns a JSON object with Camofox-shaped health markers before reporting Camofox as available. It keeps `vncPort` optional.

## Related Issue

No exact duplicate found.

Related overlap checked: #51907, #51910, #56568, #56573, #57135.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/browser_camofox.py`
  - require a `200` JSON object health response,
  - reject HTML or malformed JSON responses,
  - accept known Camofox health markers such as `ok`, `engine`, `browserConnected`, `browserRunning`, and `activeTabs`,
  - preserve optional VNC URL extraction when `vncPort` is present and valid.
- `tests/tools/test_browser_camofox.py`
  - mock Camofox health requests instead of hitting a real localhost port,
  - add coverage for unreachable endpoint, HTML response, malformed JSON response, and valid JSON health without `vncPort`,
  - reset cached Camofox health state between tests.

## How to Test

1. Run focused Camofox tests directly:

   ```text
   /home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_browser_camofox.py -q -o 'addopts=' --tb=short
   # 33 passed
   ```

2. Run the same file through the canonical runner:

   ```text
   scripts/run_tests.sh tests/tools/test_browser_camofox.py -q -- --tb=short
   # Summary: 1 files, 33 tests passed, 0 failed
   ```

3. Run Ruff on changed Python files:

   ```text
   /home/hermes/.hermes/hermes-agent/venv/bin/python -m ruff check tools/browser_camofox.py tests/tools/test_browser_camofox.py
   # All checks passed
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Targeted Camofox tests were run instead; full suite was not run for this narrow browser-health patch.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (noble), x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - N/A: no user-facing docs changed.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - N/A: no config keys changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - N/A: no architecture/workflow docs changed.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - Health validation is platform-neutral; tests mock HTTP calls rather than relying on a platform-specific localhost port state.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
  - N/A: no tool schemas changed.

## Screenshots / Logs

```text
/home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_browser_camofox.py -q -o 'addopts=' --tb=short
.................................                                        [100%]
33 passed in 2.83s

scripts/run_tests.sh tests/tools/test_browser_camofox.py -q -- --tb=short
=== Summary: 1 files, 33 tests passed, 0 failed (100% complete) in 3.9s (16 workers) ===

/home/hermes/.hermes/hermes-agent/venv/bin/python -m ruff check tools/browser_camofox.py tests/tools/test_browser_camofox.py
All checks passed!
```