### PR TITLE
fix(cli): filter decommissioned models out of the /model picker probe

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3865,6 +3865,31 @@ def github_model_reasoning_efforts(
     return _github_reasoning_efforts_for_model_id(str(model_id or normalized))
 
 
+# Catalog entries whose ``status`` marks them unusable (case-insensitive).
+# ARK-style providers (e.g. Volcengine) tag decommissioned models with
+# ``Shutdown``/``Retiring`` but keep returning them from ``/models``; passing
+# them through floods the ``/model`` picker with entries that fail on use
+# (#68536). Entries with no ``status`` field (OpenAI-style catalogs) are
+# always kept.
+_UNAVAILABLE_MODEL_STATUSES = frozenset({"shutdown", "retiring", "retired"})
+
+
+def _is_model_entry_available(entry: Any) -> bool:
+    """Return True when a ``/models`` catalog entry is usable for the picker.
+
+    Drops entries without a non-empty ``id`` (malformed rows previously
+    surfaced as ``""``) and entries whose ``status`` is a known
+    decommissioned marker. Unknown or absent statuses pass through — the
+    filter must never hide a working model.
+    """
+    if not isinstance(entry, dict) or not entry.get("id"):
+        return False
+    status = entry.get("status")
+    if isinstance(status, str) and status.strip().lower() in _UNAVAILABLE_MODEL_STATUSES:
+        return False
+    return True
+
+
 def probe_api_models(
     api_key: Optional[str],
     base_url: Optional[str],
@@ -3934,7 +3959,11 @@ def probe_api_models(
             with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
                 return {
-                    "models": [m.get("id", "") for m in data.get("data", [])],
+                    "models": [
+                        m["id"]
+                        for m in data.get("data", [])
+                        if _is_model_entry_available(m)
+                    ],
                     "probed_url": url,
                     "resolved_base_url": candidate_base.rstrip("/"),
                     "suggested_base_url": alternate_base if alternate_base != candidate_base else normalized,

--- a/tests/hermes_cli/test_probe_api_models_filter.py
+++ b/tests/hermes_cli/test_probe_api_models_filter.py
@@ -1,0 +1,85 @@
+"""Tests for probe_api_models() catalog filtering (#68536).
+
+ARK-style providers (e.g. Volcengine) keep returning decommissioned models
+from ``/models`` with ``status: "Shutdown"`` / ``"Retiring"``. The probe used
+to map ``data[].id`` straight through, flooding the ``/model`` picker with
+unusable entries (and surfacing malformed rows as ``""``).
+"""
+
+import io
+import json
+from unittest.mock import patch
+
+from hermes_cli.models import _is_model_entry_available, probe_api_models
+
+
+class _FakeResponse(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+
+def _probe_with_catalog(entries):
+    payload = json.dumps({"data": entries}).encode()
+    with patch(
+        "hermes_cli.models._urlopen_model_catalog_request",
+        return_value=_FakeResponse(payload),
+    ):
+        return probe_api_models("sk-test", "https://ark.example.com/api/v3")
+
+
+def test_shutdown_and_retiring_models_are_filtered():
+    result = _probe_with_catalog(
+        [
+            {"id": "doubao-pro", "status": "Active"},
+            {"id": "old-model-1", "status": "Shutdown"},
+            {"id": "old-model-2", "status": "Retiring"},
+            {"id": "old-model-3", "status": "Retired"},
+        ]
+    )
+    assert result["models"] == ["doubao-pro"]
+
+
+def test_status_matching_is_case_insensitive():
+    result = _probe_with_catalog(
+        [
+            {"id": "gone-1", "status": "SHUTDOWN"},
+            {"id": "gone-2", "status": "retiring "},
+            {"id": "kept", "status": "active"},
+        ]
+    )
+    assert result["models"] == ["kept"]
+
+
+def test_entries_without_status_pass_through():
+    """OpenAI-style catalogs carry no status field — never filter those."""
+    result = _probe_with_catalog([{"id": "gpt-5.5"}, {"id": "gpt-5.5-mini"}])
+    assert result["models"] == ["gpt-5.5", "gpt-5.5-mini"]
+
+
+def test_unknown_status_values_pass_through():
+    """The filter must never hide a working model on an unrecognized tag."""
+    result = _probe_with_catalog(
+        [{"id": "beta-model", "status": "Preview"}, {"id": "kept", "status": ""}]
+    )
+    assert result["models"] == ["beta-model", "kept"]
+
+
+def test_malformed_entries_are_dropped():
+    """Missing/empty ids used to surface as '' in the picker."""
+    result = _probe_with_catalog(
+        [{"status": "Active"}, {"id": ""}, "not-a-dict", None, {"id": "kept"}]
+    )
+    assert result["models"] == ["kept"]
+
+
+def test_predicate_directly():
+    assert _is_model_entry_available({"id": "m"}) is True
+    assert _is_model_entry_available({"id": "m", "status": None}) is True
+    assert _is_model_entry_available({"id": "m", "status": "Shutdown"}) is False
+    assert _is_model_entry_available({"id": ""}) is False
+    assert _is_model_entry_available({}) is False
+    assert _is_model_entry_available(["id"]) is False


### PR DESCRIPTION
## What does this PR do?

When a provider's `/models` endpoint tags decommissioned models with `status: "Shutdown"` / `"Retiring"` (ARK-style catalogs, e.g. Volcengine), `probe_api_models()` mapped `data[].id` straight through with **zero filtering** — flooding the `/model` picker with entries that fail on use. Malformed rows (missing `id`) also surfaced as empty strings.

This PR filters the single parse site through a small availability predicate, `_is_model_entry_available()`:

- drops entries whose `status` (case-insensitive, whitespace-stripped) is `Shutdown` / `Retiring` / `Retired`;
- drops entries with a missing/empty `id`;
- **always keeps** entries with no `status` field (OpenAI-style catalogs) or an unrecognized status (`Preview`, `active`, …) — the filter must never hide a working model on an unknown tag.

## Related Issue

Fixes #68536

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models.py` — `_UNAVAILABLE_MODEL_STATUSES` + `_is_model_entry_available()`; applied at `probe_api_models()`'s parse site (the one place `data[].id` is extracted, so `/model` picker, saved-model probe, and custom-provider flows all inherit the fix).
- `tests/hermes_cli/test_probe_api_models_filter.py` — new: filtered statuses, case-insensitivity/whitespace, status-absent passthrough, unknown-status passthrough, malformed-entry dropping, and the predicate directly.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_probe_api_models_filter.py -q`
2. Manual repro (from the issue): configure an ARK-style provider whose `/models` returns `Shutdown`/`Retiring` entries → `/model` now lists only usable models; previously every decommissioned id appeared.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (topic search + issue timeline: none)
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the probe-related suites (`test_probe_api_models_filter`, `test_custom_provider_model_switch`, `test_cli_provider_resolution`, `test_minimax_model_validation`) — failure set identical to clean `main` on my platform (pre-existing Windows-environment failures; zero new failures), new suite 6/6
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Docstrings document the predicate's never-hide-working-models contract — or N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure parsing logic); `scripts/check-windows-footguns.py --diff` is clean
- [x] Tool descriptions/schemas — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
