### PR TITLE
fix(models): drop unavailable models from probe_api_models catalog

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3733,6 +3733,28 @@ def github_model_reasoning_efforts(
     return _github_reasoning_efforts_for_model_id(str(model_id or normalized))
 
 
+# Statuses an OpenAI-compatible /models endpoint may set on an entry to say the
+# model is no longer servable (Volcengine ARK and similar catalogs flag retiring
+# and decommissioned models this way). Standard OpenAI responses have no status
+# field, so entries without one are always kept.
+_UNAVAILABLE_MODEL_STATUSES = frozenset(
+    {"shutdown", "retiring", "deprecated", "disabled", "end_of_life", "eol"}
+)
+
+
+def _is_unavailable_model(entry: Any) -> bool:
+    """True when a catalog entry explicitly declares itself unavailable.
+
+    Only matches known ``status`` values that mean "not servable" so a provider
+    using a non-standard but active status (e.g. ``Running``) is never dropped.
+    Entries with no ``status`` field pass through unchanged.
+    """
+    if not isinstance(entry, dict):
+        return False
+    status = str(entry.get("status") or "").strip().lower()
+    return bool(status) and status in _UNAVAILABLE_MODEL_STATUSES
+
+
 def probe_api_models(
     api_key: Optional[str],
     base_url: Optional[str],
@@ -3802,7 +3824,11 @@ def probe_api_models(
             with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
                 return {
-                    "models": [m.get("id", "") for m in data.get("data", [])],
+                    "models": [
+                        m.get("id", "")
+                        for m in data.get("data", [])
+                        if not _is_unavailable_model(m)
+                    ],
                     "probed_url": url,
                     "resolved_base_url": candidate_base.rstrip("/"),
                     "suggested_base_url": alternate_base if alternate_base != candidate_base else normalized,

--- a/tests/hermes_cli/test_probe_api_models_status_filter.py
+++ b/tests/hermes_cli/test_probe_api_models_status_filter.py
@@ -1,0 +1,98 @@
+"""probe_api_models() must drop catalog entries the endpoint itself flags as
+unavailable (status: Shutdown/Retiring/etc.), while keeping standard entries
+that carry no status field. Regression test for the /model picker flooding with
+dead models on OpenAI-compatible catalogs that populate ``status``.
+"""
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+from hermes_cli.models import probe_api_models
+
+
+class _MixedStatusModelsHandler(BaseHTTPRequestHandler):
+    # Mixed catalog: a few servable, several explicitly unavailable.
+    CATALOG: list[dict[str, Any]] = [
+        {"id": "glm-5-2-active"},  # no status field -> keep
+        {"id": "ark-code-latest", "status": "Running"},  # non-standard active -> keep
+        {"id": "dead-shutdown", "status": "Shutdown"},  # drop
+        {"id": "soon-retiring", "status": "Retiring"},  # drop
+        {"id": "old-deprecated", "status": "deprecated"},  # drop (case-insensitive)
+        {"id": "off-disabled", "status": "Disabled"},  # drop
+        {"id": "vision-only", "status": "ACTIVE"},  # active variant -> keep
+    ]
+
+    def do_GET(self):
+        body = json.dumps({"data": type(self).CATALOG}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format, *_args):
+        pass
+
+
+def _serve(handler_cls):
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def test_probe_api_models_drops_unavailable_status_entries():
+    server = _serve(_MixedStatusModelsHandler)
+    try:
+        result = probe_api_models(
+            api_key="provider-key",
+            base_url=f"http://127.0.0.1:{server.server_port}/v1",
+            timeout=3,
+        )
+    finally:
+        server.shutdown()
+
+    models = result["models"]
+    # Servable entries survive regardless of whether status is absent, an active
+    # variant, or a non-standard active value.
+    assert "glm-5-2-active" in models
+    assert "ark-code-latest" in models
+    assert "vision-only" in models
+    # Every entry the endpoint flagged unavailable is filtered out.
+    assert "dead-shutdown" not in models
+    assert "soon-retiring" not in models
+    assert "old-deprecated" not in models
+    assert "off-disabled" not in models
+    # Ordering of the kept entries is preserved.
+    assert models == ["glm-5-2-active", "ark-code-latest", "vision-only"]
+
+
+def test_probe_api_models_keeps_all_entries_without_status():
+    """A standard OpenAI-style response (no status field anywhere) is unchanged."""
+
+    class _NoStatusHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            body = json.dumps(
+                {"data": [{"id": "gpt-x"}, {"id": "gpt-y"}, {"id": "gpt-z"}]}
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format, *_args):
+            pass
+
+    server = _serve(_NoStatusHandler)
+    try:
+        result = probe_api_models(
+            api_key="provider-key",
+            base_url=f"http://127.0.0.1:{server.server_port}/v1",
+            timeout=3,
+        )
+    finally:
+        server.shutdown()
+
+    assert result["models"] == ["gpt-x", "gpt-y", "gpt-z"]


### PR DESCRIPTION
OpenAI-compatible /models endpoints that populate a status field flood the /model picker with dead entries. On Volcengine ARK, for example, the endpoint returns 126 models but 90 of them are flagged Shutdown/Retiring, so the picker is dominated by models that cannot actually serve a request (issue #68536).

probe_api_models() extracted every id from the data array with no filtering at all. This change skips catalog entries whose status explicitly declares the model not servable — shutdown, retiring, deprecated, disabled, end_of_life, eol — matched case-insensitively.

It is deliberately conservative: entries with no status field (the standard OpenAI response shape) and entries using a non-standard but active status like "Running" are kept untouched, so only models the endpoint itself flags as unavailable get dropped. I kept the filter to the status check rather than also gating on domain/task_type, since domain filtering is more opinionated and not every endpoint populates it — that can be a follow-up if you want it.

Added a regression test that stands up a mixed local catalog (servable, non-standard-active, and several unavailable statuses) and asserts the unavailable ones are filtered while the rest survive in order, plus a second test confirming a status-free OpenAI-style response comes back unchanged.