### PR TITLE
Default Slack tool progress to off

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -78,8 +78,11 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "telegram":    _TIER_HIGH,
     "discord":     _TIER_HIGH,
 
+    # Slack is frequently workspace-facing and even edited progress messages are
+    # still visible to everyone in the channel/thread, so default it quieter.
+    "slack":           _TIER_LOW,
+
     # Tier 2 — edit support, often customer/workspace channels
-    "slack":           _TIER_MEDIUM,
     "mattermost":      _TIER_MEDIUM,
     "matrix":          _TIER_MEDIUM,
     "feishu":          _TIER_MEDIUM,

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -186,17 +186,17 @@ class TestPlatformDefaults:
             assert resolve_display_setting({}, plat, "tool_progress") == "all", plat
 
     def test_medium_tier_platforms(self):
-        """Slack, Mattermost, Matrix default to 'new' tool progress."""
+        """Mattermost, Matrix, Feishu, and WhatsApp default to 'new' tool progress."""
         from gateway.display_config import resolve_display_setting
 
-        for plat in ("slack", "mattermost", "matrix", "feishu", "whatsapp"):
+        for plat in ("mattermost", "matrix", "feishu", "whatsapp"):
             assert resolve_display_setting({}, plat, "tool_progress") == "new", plat
 
     def test_low_tier_platforms(self):
-        """Signal, BlueBubbles, etc. default to 'off' tool progress."""
+        """Slack, Signal, BlueBubbles, etc. default to 'off' tool progress."""
         from gateway.display_config import resolve_display_setting
 
-        for plat in ("signal", "bluebubbles", "weixin", "wecom", "dingtalk"):
+        for plat in ("slack", "signal", "bluebubbles", "weixin", "wecom", "dingtalk"):
             assert resolve_display_setting({}, plat, "tool_progress") == "off", plat
 
     def test_minimal_tier_platforms(self):

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -206,6 +206,7 @@ async def test_run_agent_progress_does_not_use_event_message_id_for_telegram_dm(
 async def test_run_agent_progress_uses_event_message_id_for_slack_dm(monkeypatch, tmp_path):
     """Slack DM progress should keep event ts fallback threading."""
     monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+    import yaml
 
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
@@ -218,6 +219,10 @@ async def test_run_agent_progress_uses_event_message_id_for_slack_dm(monkeypatch
     adapter = ProgressCaptureAdapter(platform=Platform.SLACK)
     runner = _make_runner(adapter)
     gateway_run = importlib.import_module("gateway.run")
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump({"display": {"platforms": {"slack": {"tool_progress": "all"}}}}),
+        encoding="utf-8",
+    )
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
 

--- a/tests/gateway/test_verbose_command.py
+++ b/tests/gateway/test_verbose_command.py
@@ -134,7 +134,7 @@ class TestVerboseCommand:
         """Cycling /verbose on Telegram doesn't change Slack's setting.
 
         Without a global tool_progress, each platform uses its built-in
-        default: Telegram = 'all' (high tier), Slack = 'new' (medium tier).
+        default: Telegram = 'all' (high tier), Slack = 'off' (quiet-by-default).
         """
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()
@@ -161,8 +161,8 @@ class TestVerboseCommand:
         platforms = saved["display"]["platforms"]
         # Telegram: all -> verbose (high tier default = all)
         assert platforms["telegram"]["tool_progress"] == "verbose"
-        # Slack: new -> all (medium tier default = new, cycle to all)
-        assert platforms["slack"]["tool_progress"] == "all"
+        # Slack: off -> new (quiet-by-default)
+        assert platforms["slack"]["tool_progress"] == "new"
 
     @pytest.mark.asyncio
     async def test_no_config_file_returns_disabled(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- default Slack gateway tool progress to `off` so Slack chats stay quiet by default
- keep other medium-tier platforms unchanged
- update gateway tests for the quieter Slack default and explicitly opt into progress where the Slack threading test needs it

## Testing
- source venv/bin/activate && python -m pytest tests/gateway/test_display_config.py tests/gateway/test_verbose_command.py tests/gateway/test_run_progress_topics.py::test_run_agent_progress_uses_event_message_id_for_slack_dm -q