### PR TITLE
fix(gateway): mark current session in listings

### DIFF
--- a/contributors/emails/xuezhao@gmail.com
+++ b/contributors/emails/xuezhao@gmail.com
@@ -1,0 +1,2 @@
+xuezhaolan
+# PR #68556 contributor attribution

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4000,6 +4000,7 @@ class GatewaySlashCommandsMixin:
             getattr(self._session_db, "_db", self._session_db),
             source=source.platform.value if source.platform else None,
             current_session_id=current_entry.session_id,
+            include_current_session=True,
             include_all_sources=cross_origin,
             include_unnamed=include_unnamed,
             search_query=search_query,

--- a/hermes_cli/session_listing.py
+++ b/hermes_cli/session_listing.py
@@ -47,6 +47,7 @@ def query_session_listing(
     *,
     source: str | None,
     current_session_id: str | None = None,
+    include_current_session: bool = False,
     include_all_sources: bool = False,
     include_unnamed: bool = False,
     search_query: str | None = None,
@@ -57,7 +58,8 @@ def query_session_listing(
 
     This is the shared selection policy behind CLI/gateway session browsing:
     source-scoped by default, optionally global, hide unnamed sessions unless
-    the caller asks for a full listing, and never include the current session.
+    the caller asks for a full listing, and hide the current session unless the
+    caller asks to show it with an ``is_current_session`` marker.
     With ``search_query``, rows are filtered by title/id match (SQL-level, see
     ``SessionDB.list_sessions_rich``) and ordered by most-recent activity;
     unnamed sessions stay visible since an id match may be the only handle.
@@ -74,10 +76,14 @@ def query_session_listing(
     )
     result: list[dict[str, Any]] = []
     for row in rows:
-        if current_session_id and row.get("id") == current_session_id:
+        is_current = bool(current_session_id and row.get("id") == current_session_id)
+        if is_current and not include_current_session:
             continue
-        if not include_unnamed and not row.get("title") and not search:
+        if not include_unnamed and not row.get("title") and not search and not is_current:
             continue
+        if is_current:
+            row = dict(row)
+            row["is_current_session"] = True
         result.append(row)
         if len(result) >= limit:
             break
@@ -102,11 +108,12 @@ def format_gateway_session_listing(
     for idx, row in enumerate(rows, start=1):
         session_id = str(row.get("id") or "")
         title_text = str(row.get("title") or "—")
+        current_part = " (current)" if row.get("is_current_session") else ""
         preview = str(row.get("preview") or "")[:40]
         source = str(row.get("source") or "")
         source_part = f" `{source}`" if include_source and source else ""
         preview_part = f" — _{preview}_" if preview else ""
-        lines.append(f"{idx}. **{title_text}**{source_part} — `{session_id}`{preview_part}")
+        lines.append(f"{idx}. **{title_text}**{current_part}{source_part} — `{session_id}`{preview_part}")
     lines.append("")
     lines.append("Resume: `/resume <session id>` or `/resume <number>` from `/resume`.")
     lines.append("More: `/sessions all`, `/sessions full`, `/sessions search <query>`.")

--- a/tests/hermes_cli/test_session_listing.py
+++ b/tests/hermes_cli/test_session_listing.py
@@ -3,6 +3,7 @@
 import pytest
 
 from hermes_cli.session_listing import (
+    format_gateway_session_listing,
     parse_session_listing_args,
     query_session_listing,
 )
@@ -97,3 +98,33 @@ class TestQuerySessionListingSearch:
 
     def test_plain_listing_still_hides_unnamed(self, db):
         assert self._ids(db, source="telegram") == ["sess_an94"]
+
+    def test_current_session_is_hidden_by_default(self, db):
+        rows = query_session_listing(db, source="telegram", current_session_id="sess_an94")
+        assert [r["id"] for r in rows] == []
+
+    def test_current_session_can_be_listed_with_marker(self, db):
+        rows = query_session_listing(
+            db,
+            source="telegram",
+            current_session_id="sess_an94",
+            include_current_session=True,
+        )
+
+        assert [r["id"] for r in rows] == ["sess_an94"]
+        assert rows[0]["is_current_session"] is True
+
+
+class TestFormatGatewaySessionListing:
+    def test_marks_current_session(self):
+        listing = format_gateway_session_listing(
+            [
+                {
+                    "id": "sess_an94",
+                    "title": "AN-94 Prestige Barrel Build #2",
+                    "is_current_session": True,
+                }
+            ]
+        )
+
+        assert "**AN-94 Prestige Barrel Build #2** (current)" in listing


### PR DESCRIPTION
## Summary
- adds an opt-in `include_current_session` path for shared session listings
- marks the active gateway `/sessions` row as `(current)` instead of hiding it
- preserves existing default behavior for `/resume` and other callers so numeric resume lists remain stable

Fixes #68547

## Test Plan
- `uv run --with pytest python -m pytest tests/hermes_cli/test_session_listing.py -q -o 'addopts='`
- `python3 -m compileall hermes_cli/session_listing.py gateway/slash_commands.py tests/hermes_cli/test_session_listing.py`
- `git diff --check`
- static added-line secret/dangerous-pattern scan
- independent Codex read-only diff review