### PR TITLE
fix(weixin): bridge cron delivery across event loops via run_coroutine_threadsafe

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -2280,6 +2280,41 @@ class WeixinAdapter(BasePlatformAdapter):
         return _wrap_copy_friendly_lines_for_weixin(_normalize_markdown_blocks(content))
 
 
+async def _live_send_impl(
+    adapter: "WeixinAdapter",
+    chat_id: str,
+    message: str,
+    media_files: Optional[List[Tuple[str, bool]]] = None,
+) -> Dict[str, Any]:
+    """Send text + media through a live WeixinAdapter.
+
+    Returns a dict with ``success``, ``platform``, ``chat_id``, and
+    optionally ``message_id`` on success, or ``error`` on failure.
+    """
+    last_result: Optional[SendResult] = None
+    cleaned = adapter.format_message(message)
+    if cleaned:
+        last_result = await adapter.send(chat_id, cleaned)
+        if not last_result.success:
+            return {"error": f"Weixin send failed: {last_result.error}"}
+
+    for media_path, _is_voice in media_files or []:
+        ext = Path(media_path).suffix.lower()
+        if ext in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}:
+            last_result = await adapter.send_image_file(chat_id, media_path)
+        else:
+            last_result = await adapter.send_document(chat_id, media_path)
+        if not last_result.success:
+            return {"error": f"Weixin media send failed: {last_result.error}"}
+
+    return {
+        "success": True,
+        "platform": "weixin",
+        "chat_id": chat_id,
+        "message_id": last_result.message_id if last_result else None,
+    }
+
+
 async def send_weixin_direct(
     *,
     extra: Dict[str, Any],
@@ -2306,34 +2341,35 @@ async def send_weixin_direct(
     token_store.restore(account_id)
     context_token = token_store.get(account_id, chat_id)
 
+    # Reuse the gateway's live WeixinAdapter when available.  The live
+    # adapter maintains the long-poll session that iLink requires for
+    # accepting outbound messages — creating a bare cold adapter (the
+    # fallback below) omits that session and iLink rejects its sends
+    # with ret=-2 (rate limit).
     live_adapter = _LIVE_ADAPTERS.get(resolved_token)
     send_session = getattr(live_adapter, '_send_session', None)
-    if (live_adapter is not None and send_session is not None
-            and not send_session.closed
-            and send_session._loop is asyncio.get_running_loop()):
-        last_result: Optional[SendResult] = None
-        cleaned = live_adapter.format_message(message)
-        if cleaned:
-            last_result = await live_adapter.send(chat_id, cleaned)
-            if not last_result.success:
-                return {"error": f"Weixin send failed: {last_result.error}"}
-
-        for media_path, _is_voice in media_files or []:
-            ext = Path(media_path).suffix.lower()
-            if ext in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}:
-                last_result = await live_adapter.send_image_file(chat_id, media_path)
+    if live_adapter is not None and send_session is not None and not send_session.closed:
+        loop = send_session._loop
+        if loop is not None and not loop.is_closed():
+            coro = _live_send_impl(live_adapter, chat_id, message, media_files)
+            if loop is asyncio.get_running_loop():
+                # Fast path: same event loop (live gateway send_message).
+                result = await coro
             else:
-                last_result = await live_adapter.send_document(chat_id, media_path)
-            if not last_result.success:
-                return {"error": f"Weixin media send failed: {last_result.error}"}
+                # Bridge path: different event loop (cron standalone
+                # delivery via asyncio.run()).  Schedule on the gateway's
+                # loop and wait for the result.
+                result = await asyncio.wrap_future(
+                    asyncio.run_coroutine_threadsafe(coro, loop)
+                )
+            if "success" in result and "context_token_used" not in result:
+                result["context_token_used"] = bool(context_token)
+            return result
 
-        return {
-            "success": True,
-            "platform": "weixin",
-            "chat_id": chat_id,
-            "message_id": last_result.message_id if last_result else None,
-            "context_token_used": bool(context_token),
-        }
+    # Fallback: no live adapter — create a one-shot adapter.  This path
+    # is used when the gateway is not running (e.g. CLI send_message or
+    # the web-server scheduler provider).  It does NOT have an active
+    # iLink long-poll session and may be rate-limited by the server.
 
     async with aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector()) as session:
         adapter = WeixinAdapter(


### PR DESCRIPTION
## Problem

Cron standalone delivery runs in its own asyncio event loop via asyncio.run(), which differs from the gateway's long-poll loop. send_weixin_direct() required send_session._loop IS get_running_loop(), causing cron sends to fall through to the cold adapter path. Without an active iLink long-poll session, cold adapters get rejected with ret=-2 (rate limit).

This is why cron deliveries to WeChat consistently fail with iLink rate limited errors — not because of actual rate limits, but because the adapter has no active session.

## Fix

- Extract _live_send_impl() as a reusable coroutine
- Relax the loop check to loop.is_closed() only
- Add a bridge path using run_coroutine_threadsafe() for cross-event-loop delivery
- Improve comments explaining the cold adapter fallback

## Testing

Tested with cron standalone delivery via asyncio.run() — messages now successfully bridge to the live adapter's event loop.