### PR TITLE
fix(acp): preserve stdio and provider failures

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -31,9 +31,12 @@ else:
 
 import argparse
 import asyncio
+import contextlib
 import logging
 import sys
+from asyncio import transports as asyncio_transports
 from pathlib import Path
+from typing import BinaryIO, cast
 from hermes_constants import get_hermes_home
 
 
@@ -46,6 +49,70 @@ from hermes_constants import get_hermes_home
 # traceback is pure noise. We keep the protocol response intact and only
 # silence the stderr noise for this specific benign case.
 _BENIGN_PROBE_METHODS = frozenset({"ping", "health", "healthcheck"})
+
+
+class _ACPWriteProtocol(asyncio.BaseProtocol):
+    async def _drain_helper(self) -> None:
+        return None
+
+
+class _ACPStdoutTransport(asyncio.WriteTransport):
+    """Write ACP frames without polling the read side of a stdio socket."""
+
+    def __init__(self, stream: BinaryIO) -> None:
+        self._stream = stream
+        self._closing = False
+
+    def write(self, data: bytes) -> None:  # type: ignore[override]
+        if self._closing:
+            return
+        self._stream.write(data)
+        self._stream.flush()
+
+    def is_closing(self) -> bool:  # type: ignore[override]
+        return self._closing
+
+    def can_write_eof(self) -> bool:  # type: ignore[override]
+        return False
+
+    def close(self) -> None:  # type: ignore[override]
+        self._closing = True
+        with contextlib.suppress(Exception):
+            self._stream.flush()
+
+    def abort(self) -> None:  # type: ignore[override]
+        self.close()
+
+    def get_extra_info(self, name: str, default=None):  # type: ignore[override]
+        return default
+
+
+async def _acp_stdio_streams() -> tuple[asyncio.StreamWriter, asyncio.StreamReader]:
+    """Create ACP streams that remain open when Node launches stdout as a socket."""
+    loop = asyncio.get_running_loop()
+    reader = asyncio.StreamReader(limit=50 * 1024 * 1024)
+    reader_protocol = asyncio.StreamReaderProtocol(reader)
+    await loop.connect_read_pipe(lambda: reader_protocol, sys.stdin)
+
+    write_protocol = _ACPWriteProtocol()
+    transport = _ACPStdoutTransport(sys.stdout.buffer)
+    writer = asyncio.StreamWriter(
+        cast(asyncio_transports.WriteTransport, transport),
+        write_protocol,
+        None,
+        loop,
+    )
+    return writer, reader
+
+
+async def _run_acp_agent(acp_module, agent) -> None:
+    writer, reader = await _acp_stdio_streams()
+    await acp_module.run_agent(
+        agent,
+        input_stream=writer,
+        output_stream=reader,
+        use_unstable_protocol=True,
+    )
 
 
 class _BenignProbeMethodFilter(logging.Filter):
@@ -154,6 +221,7 @@ def _print_version() -> None:
 
 def _run_check() -> None:
     import acp  # noqa: F401
+    from acp.schema import AuthMethodAgent  # noqa: F401
     from acp_adapter.server import HermesACPAgent  # noqa: F401
 
     print("Hermes ACP check OK")
@@ -259,7 +327,7 @@ def main(argv: list[str] | None = None) -> None:
 
     agent = HermesACPAgent()
     try:
-        asyncio.run(acp.run_agent(agent, use_unstable_protocol=True))
+        asyncio.run(_run_acp_agent(acp, agent))
     except KeyboardInterrupt:
         logger.info("Shutting down (KeyboardInterrupt)")
     except Exception:

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -46,6 +46,8 @@ from acp.schema import (
     SetSessionModeResponse,
     ResourceContentBlock,
     SessionCapabilities,
+    SessionConfigOptionSelect,
+    SessionConfigSelectOption,
     SessionForkCapabilities,
     SessionInfoUpdate,
     SessionListCapabilities,
@@ -505,6 +507,7 @@ class HermesACPAgent(acp.Agent):
     )
 
     _EDIT_APPROVAL_POLICY_CONFIG_ID = "edit_approval_policy"
+    _MODEL_CONFIG_ID = "model"
     _EDIT_APPROVAL_POLICY_DEFAULT = "ask"
     _MODE_DEFAULT = "default"
     _MODE_ACCEPT_EDITS = "accept_edits"
@@ -532,13 +535,7 @@ class HermesACPAgent(acp.Agent):
 
 
     def _session_modes(self, state: SessionState) -> SessionModeState:
-        """Return ACP session modes while preserving Zed's separate model picker.
-
-        Zed renders ``config_options`` in the prominent selector slot where the
-        model picker was visible. Claude/Codex expose policy-like controls as ACP
-        modes, which coexist with the model picker, so Hermes maps edit approval
-        policy onto modes instead of advertising config options.
-        """
+        """Return ACP session modes for edit-approval policy."""
 
         current = str(getattr(state, "mode", "") or self._MODE_DEFAULT)
         if current not in self._MODE_TO_EDIT_APPROVAL_POLICY:
@@ -641,6 +638,31 @@ class HermesACPAgent(acp.Agent):
             available_models=[ModelInfo(model_id=fallback_choice, name=model)],
             current_model_id=fallback_choice,
         )
+
+    def _model_config_option(self, state: SessionState) -> SessionConfigOptionSelect | None:
+        model_state = self._build_model_state(state)
+        if model_state is None:
+            return None
+        return SessionConfigOptionSelect(
+            id=self._MODEL_CONFIG_ID,
+            name="Model",
+            description="Model and provider used for this session.",
+            category="model",
+            type="select",
+            current_value=model_state.current_model_id,
+            options=[
+                SessionConfigSelectOption(
+                    value=model.model_id,
+                    name=model.name,
+                    description=model.description,
+                )
+                for model in model_state.available_models
+            ],
+        )
+
+    def _session_config_options(self, state: SessionState) -> list[SessionConfigOptionSelect]:
+        model_option = self._model_config_option(state)
+        return [model_option] if model_option is not None else []
 
     @staticmethod
     def _resolve_model_selection(raw_model: str, current_provider: str) -> tuple[str, str]:
@@ -1124,6 +1146,7 @@ class HermesACPAgent(acp.Agent):
         return NewSessionResponse(
             session_id=state.session_id,
             models=self._build_model_state(state),
+            config_options=self._session_config_options(state),
             modes=self._session_modes(state),
             field_meta=self._provenance_meta(
                 state.session_id, getattr(state.agent, "session_id", state.session_id)
@@ -1171,6 +1194,7 @@ class HermesACPAgent(acp.Agent):
         self._schedule_usage_update(state)
         return LoadSessionResponse(
             models=self._build_model_state(state),
+            config_options=self._session_config_options(state),
             modes=self._session_modes(state),
             field_meta=self._provenance_meta(
                 session_id, getattr(state.agent, "session_id", session_id)
@@ -1206,6 +1230,7 @@ class HermesACPAgent(acp.Agent):
         self._schedule_usage_update(state)
         return ResumeSessionResponse(
             models=self._build_model_state(state),
+            config_options=self._session_config_options(state),
             modes=self._session_modes(state),
             field_meta=self._provenance_meta(
                 state.session_id, getattr(state.agent, "session_id", state.session_id)
@@ -1243,6 +1268,7 @@ class HermesACPAgent(acp.Agent):
         return ForkSessionResponse(
             session_id=new_id,
             models=self._build_model_state(state) if state is not None else None,
+            config_options=self._session_config_options(state) if state is not None else None,
             modes=self._session_modes(state) if state is not None else None,
         )
 
@@ -1690,7 +1716,13 @@ class HermesACPAgent(acp.Agent):
 
         await self._send_usage_update(state)
 
-        stop_reason = "cancelled" if cancelled else "end_turn"
+        failed = bool(
+            result.get("failed")
+            or result.get("partial")
+            or result.get("error")
+            or result.get("completed") is False
+        )
+        stop_reason = "cancelled" if cancelled else "refusal" if failed else "end_turn"
         return PromptResponse(stop_reason=stop_reason, usage=usage)
 
     # ---- Slash commands (headless) -------------------------------------------
@@ -2025,33 +2057,36 @@ class HermesACPAgent(acp.Agent):
         """Switch the model for a session (called by ACP protocol)."""
         state = self.session_manager.get_session(session_id)
         if state:
-            current_provider = getattr(state.agent, "provider", None)
-            requested_provider, resolved_model = self._resolve_model_selection(
-                model_id,
-                current_provider or "openrouter",
-            )
-            state.model = resolved_model
-            provider_changed = bool(current_provider and requested_provider != current_provider)
-            current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
-            current_api_mode = None if provider_changed else getattr(state.agent, "api_mode", None)
-            state.agent = self.session_manager._make_agent(
-                session_id=session_id,
-                cwd=state.cwd,
-                model=resolved_model,
-                requested_provider=requested_provider,
-                base_url=current_base_url,
-                api_mode=current_api_mode,
-            )
-            self.session_manager.save_session(session_id)
-            logger.info(
-                "Session %s: model switched to %s via provider %s",
-                session_id,
-                resolved_model,
-                requested_provider,
-            )
+            self._switch_session_model(state, model_id)
             return SetSessionModelResponse()
         logger.warning("Session %s: model switch requested for missing session", session_id)
         return None
+
+    def _switch_session_model(self, state: SessionState, model_id: str) -> None:
+        current_provider = getattr(state.agent, "provider", None)
+        requested_provider, resolved_model = self._resolve_model_selection(
+            model_id,
+            current_provider or "openrouter",
+        )
+        state.model = resolved_model
+        provider_changed = requested_provider != current_provider
+        current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
+        current_api_mode = None if provider_changed else getattr(state.agent, "api_mode", None)
+        state.agent = self.session_manager._make_agent(
+            session_id=state.session_id,
+            cwd=state.cwd,
+            model=resolved_model,
+            requested_provider=requested_provider,
+            base_url=current_base_url,
+            api_mode=current_api_mode,
+        )
+        self.session_manager.save_session(state.session_id)
+        logger.info(
+            "Session %s: model switched to %s via provider %s",
+            state.session_id,
+            resolved_model,
+            requested_provider,
+        )
 
     async def set_session_mode(
         self, mode_id: str, session_id: str, **kwargs: Any
@@ -2078,7 +2113,9 @@ class HermesACPAgent(acp.Agent):
             logger.warning("Session %s: config update requested for missing session", session_id)
             return None
 
-        if str(config_id) == self._EDIT_APPROVAL_POLICY_CONFIG_ID:
+        if str(config_id) == self._MODEL_CONFIG_ID:
+            self._switch_session_model(state, str(value))
+        elif str(config_id) == self._EDIT_APPROVAL_POLICY_CONFIG_ID:
             mode = self._EDIT_APPROVAL_POLICY_TO_MODE.get(str(value), self._MODE_DEFAULT)
             setattr(state, "mode", mode)
         else:
@@ -2089,4 +2126,4 @@ class HermesACPAgent(acp.Agent):
             setattr(state, "config_options", options)
         self.session_manager.save_session(session_id)
         logger.info("Session %s: config option %s updated", session_id, config_id)
-        return SetSessionConfigOptionResponse(config_options=[])
+        return SetSessionConfigOptionResponse(config_options=self._session_config_options(state))

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1155,6 +1155,9 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
     # OAuth grants (#43589) — reusing this function's atomic O_EXCL + 0o600
     # write so the root auth.json gets the same TOCTOU-safe treatment.
     auth_file = target_path if target_path is not None else _auth_file_path()
+    if os.environ.get("HERMES_AUTH_STORE_READ_ONLY") == "1":
+        logger.debug("Auth store persistence suppressed for this isolated runtime")
+        return auth_file
     auth_file.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir to 0o700 so siblings can't traverse to creds.
     # No-op on Windows (POSIX mode bits not enforced); ignore failures.

--- a/tests/acp/test_entry.py
+++ b/tests/acp/test_entry.py
@@ -1,6 +1,7 @@
 """Tests for acp_adapter.entry startup wiring."""
 
 import sys
+from io import BytesIO
 
 import acp
 import pytest
@@ -11,16 +12,56 @@ from acp_adapter import entry
 def test_main_enables_unstable_protocol(monkeypatch):
     calls = {}
 
+    async def fake_stdio_streams():
+        return "writer", "reader"
+
     async def fake_run_agent(agent, **kwargs):
         calls["kwargs"] = kwargs
 
     monkeypatch.setattr(entry, "_setup_logging", lambda: None)
     monkeypatch.setattr(entry, "_load_env", lambda: None)
+    monkeypatch.setattr(entry, "_acp_stdio_streams", fake_stdio_streams)
     monkeypatch.setattr(acp, "run_agent", fake_run_agent)
 
     entry.main([])
 
     assert calls["kwargs"]["use_unstable_protocol"] is True
+    assert calls["kwargs"]["input_stream"] == "writer"
+    assert calls["kwargs"]["output_stream"] == "reader"
+
+
+def test_acp_stdout_transport_writes_and_flushes_without_closing_stream():
+    class FlushTrackingBuffer(BytesIO):
+        flush_count = 0
+
+        def flush(self):
+            self.flush_count += 1
+            super().flush()
+
+    stream = FlushTrackingBuffer()
+    transport = entry._ACPStdoutTransport(stream)
+
+    transport.write(b'{"jsonrpc":"2.0"}\n')
+    transport.close()
+
+    assert stream.getvalue() == b'{"jsonrpc":"2.0"}\n'
+    assert stream.flush_count == 2
+    assert transport.is_closing() is True
+    assert stream.closed is False
+
+
+def test_swarm_read_only_auth_flag_suppresses_auth_store_writes(tmp_path, monkeypatch):
+    from hermes_cli import auth
+
+    target = tmp_path / "auth.json"
+    payload = {"version": 1, "providers": {}}
+    monkeypatch.setenv("HERMES_AUTH_STORE_READ_ONLY", "1")
+
+    result = auth._save_auth_store(payload, target_path=target)
+
+    assert result == target
+    assert target.exists() is False
+    assert "updated_at" not in payload
 
 
 def test_main_version_prints_without_starting_server(monkeypatch, capsys):

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -54,10 +54,15 @@ def agent(mock_manager):
 
 
 @pytest.mark.asyncio
-async def test_new_session_exposes_edit_approvals_as_modes_not_config_options(agent):
+async def test_new_session_exposes_model_config_and_edit_approval_modes(agent):
     resp = await agent.new_session(cwd="/tmp")
 
-    assert resp.config_options is None
+    assert resp.config_options is not None
+    assert len(resp.config_options) == 1
+    model_option = resp.config_options[0]
+    assert model_option.id == "model"
+    assert model_option.category == "model"
+    assert model_option.current_value
     assert isinstance(resp.modes, SessionModeState)
     assert resp.modes.current_mode_id == "default"
     assert [(mode.id, mode.name) for mode in resp.modes.available_modes] == [
@@ -68,7 +73,7 @@ async def test_new_session_exposes_edit_approvals_as_modes_not_config_options(ag
 
 
 @pytest.mark.asyncio
-async def test_set_config_option_persists_edit_approval_policy_without_advertising_config(agent):
+async def test_set_config_option_persists_edit_approval_policy(agent):
     resp = await agent.new_session(cwd="/tmp")
     update = await agent.set_config_option(
         "edit_approval_policy",
@@ -78,7 +83,7 @@ async def test_set_config_option_persists_edit_approval_policy_without_advertisi
     state = agent.session_manager.get_session(resp.session_id)
 
     assert isinstance(update, SetSessionConfigOptionResponse)
-    assert update.config_options == []
+    assert update.config_options[0].id == "model"
     assert getattr(state, "mode", None) == "accept_edits"
 
 
@@ -921,7 +926,7 @@ class TestSessionConfiguration:
         )
 
         assert mode_result == {}
-        assert config_result["configOptions"] == []
+        assert config_result["configOptions"][0]["id"] == "model"
 
     @pytest.mark.asyncio
     async def test_router_accepts_unstable_model_switch_when_enabled(self, agent):
@@ -986,12 +991,70 @@ class TestSessionConfiguration:
         with patch("run_agent.AIAgent", side_effect=fake_agent):
             acp_agent = HermesACPAgent(session_manager=manager)
             state = manager.create_session(cwd="/tmp")
+            state.agent.provider = ""
+            state.agent.base_url = "https://openrouter.example/v1"
             result = await acp_agent.set_session_model(
                 model_id="anthropic:claude-sonnet-4-6",
                 session_id=state.session_id,
             )
 
         assert isinstance(result, SetSessionModelResponse)
+        assert state.model == "claude-sonnet-4-6"
+        assert state.agent.provider == "anthropic"
+        assert state.agent.base_url == "https://anthropic.example/v1"
+        assert runtime_calls[-1] == "anthropic"
+
+    @pytest.mark.asyncio
+    async def test_model_config_option_accepts_provider_prefixed_choice(self, tmp_path, monkeypatch):
+        runtime_calls = []
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            runtime_calls.append(requested)
+            provider = requested or "openrouter"
+            return {
+                "provider": provider,
+                "api_mode": "anthropic_messages" if provider == "anthropic" else "chat_completions",
+                "base_url": f"https://{provider}.example/v1",
+                "api_key": f"{provider}-key",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("provider"),
+                base_url=kwargs.get("base_url"),
+                api_mode=kwargs.get("api_mode"),
+            )
+
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.parse_model_input",
+            lambda raw, current: ("anthropic", "claude-sonnet-4-6"),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.detect_provider_for_model",
+            lambda model, current: None,
+        )
+        manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            acp_agent = HermesACPAgent(session_manager=manager)
+            state = manager.create_session(cwd="/tmp")
+            state.agent.provider = ""
+            state.agent.base_url = "https://openrouter.example/v1"
+            result = await acp_agent.set_config_option(
+                config_id="model",
+                value="anthropic:claude-sonnet-4-6",
+                session_id=state.session_id,
+            )
+
+        assert isinstance(result, SetSessionConfigOptionResponse)
+        assert result.config_options[0].current_value == "anthropic:claude-sonnet-4-6"
         assert state.model == "claude-sonnet-4-6"
         assert state.agent.provider == "anthropic"
         assert state.agent.base_url == "https://anthropic.example/v1"
@@ -1049,6 +1112,28 @@ class TestPrompt:
         assert state.agent.stream_delta_callback is not None
         assert state.agent.reasoning_callback is not None
         assert state.agent.thinking_callback is None
+
+    @pytest.mark.asyncio
+    async def test_prompt_returns_refusal_when_agent_turn_failed(self, agent):
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "HTTP 401: User not found.",
+            "messages": [],
+            "failed": True,
+            "completed": False,
+        })
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        resp = await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="hello")],
+            session_id=new_resp.session_id,
+        )
+
+        assert resp.stop_reason == "refusal"
 
     @pytest.mark.asyncio
     async def test_prompt_updates_history(self, agent):


### PR DESCRIPTION
## Summary

- keep ACP stdout writable when Hermes is launched by Node on hosts where asyncio's POSIX write-pipe transport closes the socket-backed descriptor
- return ACP `refusal` for failed or partial provider turns instead of reporting `end_turn`
- reset provider endpoint and API-mode state during session-local provider changes
- advertise the model through ACP's stable session configuration selector while retaining the older model extension
- allow isolated runtimes to suppress auth-store persistence with `HERMES_AUTH_STORE_READ_ONLY=1`
- strengthen `hermes acp --check` by importing the ACP 0.9 authentication schema used at runtime

## Root cause

Hermes could accept an ACP client but emit no JSON-RPC initialization response when launched through a Node stdio client on a gVisor host. Direct writes to stdout succeeded, while asyncio's POSIX write-pipe transport marked the socket-backed stdout descriptor closed. Separately, failed provider calls were collapsed into `end_turn`, and changing from an unlabeled provider could retain the previous provider's base URL and API mode.

## Impact

ACP clients receive initialization and streamed responses reliably, provider failures remain failures at the protocol boundary, and session-local provider selection does not leak stale endpoint state. The auth-store guard is opt-in and leaves default Hermes behavior unchanged.

## Related integration

- marlandoj/zouroboros#351 uses this ACP runtime for the Hermes swarm executor.

## Validation

- `python -m compileall -q acp_adapter hermes_cli/auth.py`
- `python -m pytest -q tests/acp/test_entry.py tests/acp/test_server.py` (**96 passed**)
- `ruff check acp_adapter/entry.py acp_adapter/server.py hermes_cli/auth.py tests/acp/test_entry.py tests/acp/test_server.py`
