### PR TITLE
fix(credential-pool): exhaust all entries sharing a failed API key on 402

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1715,6 +1715,23 @@ class CredentialPool:
                 return None
             _label = entry.label or entry.id[:8]
             self._mark_exhausted(entry, status_code, error_context)
+            # A 402/429/401 is an API-key–level failure: the account is out of
+            # balance, rate-limited, or its key is rejected.  The same key can
+            # back more than one pool entry (e.g. an explicit pool entry plus a
+            # ``model_config`` entry auto-seeded from ``model.api_key`` — both
+            # carry the identical ``runtime_api_key``).  Marking only the first
+            # match leaves the sibling entries OK, so ``_select_unlocked()``
+            # keeps handing back the same depleted key and rotation never
+            # converges — the caller ``continue``s forever until the client
+            # disconnects (a ~2.5min hang with no error surfaced to the user).
+            # Mark every entry sharing the failed key so the pool can reach the
+            # "no available entries" state and let the error propagate.
+            if api_key_hint:
+                for sibling in self._entries:
+                    if sibling.id == entry.id:
+                        continue
+                    if sibling.runtime_api_key == api_key_hint:
+                        self._mark_exhausted(sibling, status_code, error_context)
             # Re-read the updated entry to log the correct terminal state.
             updated_entry = next(
                 (e for e in self._entries if e.id == entry.id), entry,

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -379,6 +379,70 @@ def test_mark_exhausted_and_rotate_persists_status(tmp_path, monkeypatch):
     assert persisted["last_error_code"] == 402
 
 
+def test_billing_rotation_marks_all_entries_sharing_failed_key(tmp_path, monkeypatch):
+    """A 402 must exhaust every pool entry backed by the same API key.
+
+    Regression: the same key can back more than one pool entry — e.g. an
+    explicit pool entry plus a ``model_config`` entry auto-seeded from
+    ``model.api_key`` (both carry the identical ``runtime_api_key``).  When
+    ``mark_exhausted_and_rotate`` is called with ``api_key_hint`` it matched
+    only the *first* such entry, leaving the sibling OK.  ``_select_unlocked()``
+    then kept handing back the same depleted key, so the billing-recovery
+    ``continue`` loop in the conversation retry path never converged — the
+    request hung ~2.5min until the client disconnected, with no 402 ever
+    surfaced to the user.  All entries sharing the failed key must be
+    exhausted so the pool reaches "no available entries" and the error
+    propagates immediately.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    shared_key = "sk-deepseek-shared"
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "custom": [
+                    {
+                        "id": "cred-explicit",
+                        "label": "520555",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": shared_key,
+                        "base_url": "https://api.deepseek.com",
+                    },
+                    {
+                        "id": "cred-model-config",
+                        "label": "model_config",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": shared_key,
+                        "base_url": "https://api.deepseek.com",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool, STATUS_EXHAUSTED
+
+    pool = load_pool("custom")
+
+    # First 402 on the shared key: rotation must NOT hand back a sibling
+    # entry that wraps the same depleted key — it must converge to None.
+    next_entry = pool.mark_exhausted_and_rotate(
+        status_code=402,
+        api_key_hint=shared_key,
+    )
+    assert next_entry is None
+
+    # Both entries are now exhausted (not just the first match).
+    statuses = {entry.id: entry.last_status for entry in pool.entries()}
+    assert statuses["cred-explicit"] == STATUS_EXHAUSTED
+    assert statuses["cred-model-config"] == STATUS_EXHAUSTED
+
+
 def test_token_invalidated_marks_credential_dead(tmp_path, monkeypatch):
     """OpenAI Codex token_invalidated must mark the credential DEAD, not exhausted.
 


### PR DESCRIPTION
## What does this PR do?

Fixes an unbounded credential-rotation loop that hangs a streaming request (~2.5min observed) instead of surfacing an HTTP 402 to the client.

A `402`/`429`/`401` is an **API-key–level** failure (account out of balance, rate-limited, or key rejected). But the same key can back **more than one pool entry** — for example an explicit pool entry plus a `model_config` entry auto-seeded from `model.api_key` (both carry the identical `runtime_api_key`).

`CredentialPool.mark_exhausted_and_rotate(api_key_hint=...)` matched only the **first** entry with that key and marked just that one exhausted. `_select_unlocked()` then handed back the sibling entry — which wraps the *same depleted key* — so the billing-recovery `continue` loop in `conversation_loop.py` never converged. The request emitted only `response.created` and hung until the client disconnected, with no 402 ever reaching the user.

The fix marks **every** entry sharing the failed key so the pool can reach the "no available entries" state and the error propagates immediately.

## Related Issue

Follow-up to #58738, which introduced the `api_key_hint` attribution (matching the failing key instead of the shared `current()` pointer). That change fixed mis-attribution to a healthy key, but surfaced this convergence bug: when a single key backs more than one entry, only the first match is exhausted, so rotation never converges. This PR completes that path.

No separate issue filed; happy to open one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/credential_pool.py` — in `mark_exhausted_and_rotate`, when `api_key_hint` is provided, also mark all sibling entries whose `runtime_api_key` matches the failed key as exhausted.
- `tests/agent/test_credential_pool.py` — regression test `test_billing_rotation_marks_all_entries_sharing_failed_key`: two entries backed by the same key; a 402 must exhaust both and rotation must converge to `None`.

## How to Test

1. Configure a `custom` provider whose key is out of balance, with the key present in both an explicit pool entry and via `model.api_key` (so it seeds a `model_config` sibling).
2. Send a streaming `/v1/responses` request. **Before:** stream stalls after `response.created`; agent log shows repeated `marking … exhausted (status=402), rotating → rotated to …` for minutes until the client disconnects. **After:** the 402 surfaces promptly as a `response.failed` event.
3. `pytest tests/agent/test_credential_pool.py -q` — 100 passed (99 existing + 1 new).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass (`tests/agent/test_credential_pool*.py`, fallback/interrupt suites — 118 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.3)

### Documentation & Housekeeping

- [x] Documentation — N/A (internal recovery-path behavior; covered by inline comment)
- [x] `cli-config.yaml.example` — N/A (no config keys changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact — N/A (pure Python, no platform-specific calls)
- [x] Tool descriptions/schemas — N/A
