### PR TITLE
feat(provider): extend Anthropic compatibility

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -342,9 +342,22 @@ _FAST_MODE_BETA = "fast-mode-2026-02-01"
 
 # Additional beta headers required for OAuth/subscription auth.
 # Matches what Claude Code (and pi-ai / OpenCode) send.
+# Claude Code sends 14 betas total. The common betas plus these OAuth-only
+# betas match the JS SDK fingerprint. Keep fine-grained tool streaming enabled
+# because Hermes's OAuth transport and replay tests rely on it.
 _OAUTH_ONLY_BETAS = [
     "claude-code-20250219",
     "oauth-2025-04-20",
+    _TOOL_STREAMING_BETA,
+    "thinking-token-count-2026-05-13",
+    "context-management-2025-06-27",
+    "prompt-caching-scope-2026-01-05",
+    "mid-conversation-system-2026-04-07",
+    "advisor-tool-2026-03-01",
+    "advanced-tool-use-2025-11-20",
+    "effort-2025-11-24",
+    "extended-cache-ttl-2025-04-11",
+    "cache-diagnosis-2026-04-07",
 ]
 
 # Claude Code identity — required for OAuth requests to be routed correctly.
@@ -380,7 +393,7 @@ def _detect_claude_code_version() -> str:
     return _CLAUDE_CODE_VERSION_FALLBACK
 
 
-_CLAUDE_CODE_SYSTEM_PREFIX = "You are Claude Code, Anthropic's official CLI for Claude."
+_CLAUDE_CODE_SYSTEM_PREFIX = "You are a Claude agent, built on Anthropic's Claude Agent SDK."
 _MCP_TOOL_PREFIX = "mcp__"
 
 
@@ -724,6 +737,50 @@ def _build_anthropic_client_with_bearer_hook(
     return _anthropic_sdk.Anthropic(**kwargs)
 
 
+def _build_oauth_impersonation_http_client(
+    api_key: str,
+    *,
+    timeout,
+    anthropic_beta: str = "",
+) -> "httpx.Client":
+    """Build an httpx client that rewrites headers to match Claude Code's JS SDK.
+
+    The Anthropic Python SDK adds X-Stainless and User-Agent headers after
+    default_headers, so default_headers cannot override the Python SDK
+    fingerprint. A request hook can.
+    """
+    from httpx import Client, Limits, Timeout
+
+    cc_version = _get_claude_code_version()
+
+    def _rewrite_headers(request):
+        request.headers["user-agent"] = f"claude-code/{cc_version}"
+        request.headers["x-stainless-lang"] = "js"
+        request.headers["x-stainless-runtime"] = "node"
+        request.headers["x-stainless-runtime-version"] = "v26.3.0"
+        request.headers["x-stainless-package-version"] = "0.94.0"
+        request.headers["x-stainless-timeout"] = "600"
+        request.headers["x-stainless-async"] = "false"
+        request.headers["x-stainless-helper-method"] = "stream"
+        request.headers["x-stainless-stream-helper"] = "messages"
+        request.headers["x-app"] = "cli"
+        request.headers["x-anthropic-billing-header"] = (
+            f"cc_version={cc_version}; cc_entrypoint=sdk-cli; cch=00000;"
+        )
+        request.headers["anthropic-dangerous-direct-browser-access"] = "true"
+        if anthropic_beta:
+            request.headers["anthropic-beta"] = anthropic_beta
+        request.headers["authorization"] = f"Bearer {api_key}"
+        request.headers.pop("x-api-key", None)
+
+    http_timeout = timeout if isinstance(timeout, Timeout) else Timeout(timeout=900.0, connect=10.0)
+    return Client(
+        timeout=http_timeout,
+        limits=Limits(max_keepalive_connections=5, max_connections=10),
+        event_hooks={"request": [_rewrite_headers]},
+    )
+
+
 def build_anthropic_client(
     api_key,
     base_url: str = None,
@@ -834,15 +891,24 @@ def build_anthropic_client(
         if common_betas:
             kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
     elif _is_oauth_token(api_key):
-        # OAuth access token / setup-token → Bearer auth + Claude Code identity.
-        # Anthropic routes OAuth requests based on user-agent and headers;
-        # without Claude Code's fingerprint, requests get intermittent 500s.
+        # OAuth access token / setup-token -> Bearer auth + Claude Code identity.
+        # The Python SDK fingerprints itself in headers, so use a request hook
+        # to rewrite the wire request to Claude Code's JS SDK shape.
         all_betas = common_betas + _OAUTH_ONLY_BETAS
+        beta_header = ",".join(dict.fromkeys(all_betas))
         kwargs["auth_token"] = api_key
+        kwargs["http_client"] = _build_oauth_impersonation_http_client(
+            api_key,
+            timeout=kwargs.get("timeout"),
+            anthropic_beta=beta_header,
+        )
         kwargs["default_headers"] = {
-            "anthropic-beta": ",".join(all_betas),
-            "user-agent": f"claude-code/{_get_claude_code_version()} (external, cli)",
+            "anthropic-beta": beta_header,
+            "user-agent": f"claude-code/{_get_claude_code_version()}",
             "x-app": "cli",
+            "x-anthropic-billing-header": (
+                f"cc_version={_get_claude_code_version()}; cc_entrypoint=sdk-cli; cch=00000;"
+            ),
         }
     else:
         # Regular API key → x-api-key header + common betas
@@ -2129,7 +2195,7 @@ def _convert_user_message(content: Any) -> Dict[str, Any]:
     if isinstance(content, list):
         converted_blocks = _convert_content_to_anthropic(content)
         if not converted_blocks or all(
-            (b.get("text") or "").strip() == ""
+            b.get("text", "").strip() == ""
             for b in converted_blocks
             if isinstance(b, dict) and b.get("type") == "text"
         ):
@@ -2552,14 +2618,22 @@ def build_anthropic_kwargs(
 
     # ── OAuth: Claude Code identity ──────────────────────────────────
     if is_oauth:
-        # 1. Prepend Claude Code system prompt identity
+        # 1. Prepend billing attribution as system prompt block[0], then the
+        # Claude Code/SDK identity. Claude Code carries this in the body.
+        billing_block = {
+            "type": "text",
+            "text": (
+                f"x-anthropic-billing-header: cc_version={_get_claude_code_version()}; "
+                "cc_entrypoint=sdk-cli; cch=00000;"
+            ),
+        }
         cc_block = {"type": "text", "text": _CLAUDE_CODE_SYSTEM_PREFIX}
         if isinstance(system, list):
-            system = [cc_block] + system
+            system = [billing_block, cc_block] + system
         elif isinstance(system, str) and system:
-            system = [cc_block, {"type": "text", "text": system}]
+            system = [billing_block, cc_block, {"type": "text", "text": system}]
         else:
-            system = [cc_block]
+            system = [billing_block, cc_block]
 
         # 2. Sanitize system prompt — replace product name references
         #    to avoid Anthropic's server-side content filters.
@@ -2626,17 +2700,19 @@ def build_anthropic_kwargs(
 
     if anthropic_tools:
         kwargs["tools"] = anthropic_tools
-        # Map OpenAI tool_choice to Anthropic format
-        if tool_choice == "auto" or tool_choice is None:
-            kwargs["tool_choice"] = {"type": "auto"}
-        elif tool_choice == "required":
-            kwargs["tool_choice"] = {"type": "any"}
-        elif tool_choice == "none":
-            # Anthropic has no tool_choice "none" — omit tools entirely to prevent use
-            kwargs.pop("tools", None)
-        elif isinstance(tool_choice, str):
-            # Specific tool name
-            kwargs["tool_choice"] = {"type": "tool", "name": tool_choice}
+        # Map OpenAI tool_choice to Anthropic format. OAuth impersonation omits
+        # tool_choice because Claude Code's native SDK does not send it.
+        if not is_oauth:
+            if tool_choice == "auto" or tool_choice is None:
+                kwargs["tool_choice"] = {"type": "auto"}
+            elif tool_choice == "required":
+                kwargs["tool_choice"] = {"type": "any"}
+            elif tool_choice == "none":
+                # Anthropic has no tool_choice "none" — omit tools entirely to prevent use
+                kwargs.pop("tools", None)
+            elif isinstance(tool_choice, str):
+                # Specific tool name
+                kwargs["tool_choice"] = {"type": "tool", "name": tool_choice}
 
     # Map reasoning_config to Anthropic's thinking parameter.
     # Claude 4.6+ models use adaptive thinking + output_config.effort.
@@ -2661,10 +2737,13 @@ def build_anthropic_kwargs(
             effort = str(reasoning_config.get("effort", "medium")).lower()
             budget = THINKING_BUDGET.get(effort, 8000)
             if _supports_adaptive_thinking(model):
-                kwargs["thinking"] = {
-                    "type": "adaptive",
-                    "display": "summarized",
-                }
+                if is_oauth:
+                    kwargs["thinking"] = {"type": "adaptive"}
+                else:
+                    kwargs["thinking"] = {
+                        "type": "adaptive",
+                        "display": "summarized",
+                    }
                 adaptive_effort = ADAPTIVE_EFFORT_MAP.get(effort, "medium")
                 # Downgrade xhigh→max on models that don't list xhigh as a
                 # supported level (Opus/Sonnet 4.6). Opus 4.7+ keeps xhigh.
@@ -2710,6 +2789,24 @@ def build_anthropic_kwargs(
             betas.extend(_OAUTH_ONLY_BETAS)
         betas.append(_FAST_MODE_BETA)
         kwargs["extra_headers"] = {"anthropic-beta": ",".join(betas)}
+
+    # ── OAuth: extra body fields matching Claude Code's JS SDK ──────
+    if is_oauth:
+        kwargs.setdefault("extra_body", {})
+        if kwargs.get("thinking"):
+            kwargs["extra_body"]["context_management"] = {
+                "edits": [
+                    {"type": "clear_thinking_20251015", "keep": "all"},
+                ],
+            }
+        kwargs["extra_body"]["metadata"] = {
+            "user_id": json.dumps({
+                "device_id": "0000000000000000000000000000000000000000000000000000000000000000",
+                "account_uuid": "00000000-0000-0000-0000-000000000000",
+                "session_id": "00000000-0000-0000-0000-000000000000",
+            }),
+        }
+        kwargs["extra_body"]["diagnostics"] = {"previous_message_id": None}
 
     return kwargs
 


### PR DESCRIPTION
## Summary

Ports the Anthropic portion of TrueNix's compatibility patch onto current `NousResearch/hermes-agent` main.

Source gist (reviewed revision `45ade785239855d728df1cd212d281d0121cc0c4`):
https://gist.github.com/TrueNix/e48aab4ab9b85af12edc76f7f4776682

This PR intentionally excludes the gist's Gemini adapter and Gemini tests.

The Anthropic port adds:

- expanded Anthropic Messages/OAuth compatibility and credential handling
- Claude Code-compatible OAuth request headers and beta negotiation
- third-party Anthropic endpoint handling, including Kimi/DeepSeek/MiniMax/Azure/Foundry cases
- thinking-block replay and request-shaping updates

Current-main reconciliation performed during the port:

- keeps the required `claude-code/<version>` user-agent prefix
- preserves `fine-grained-tool-streaming-2025-05-14` for OAuth requests
- deduplicates the final OAuth beta list

## Important account/ToS caveat

The OAuth path intentionally rewrites Python SDK headers to a Claude Code-compatible identity, including `user-agent`, `x-stainless-*`, `x-app`, and billing metadata. This can carry provider Terms-of-Service, subscription-routing, credential-revocation, or account-ban risk even when technically functional. Users and maintainers should make an explicit policy decision before enabling that behavior.

## Verification

- Gist Anthropic source: syntax checked
- Ruff: passed
- Current-main Anthropic adapter tests: **243 passed**
- Clean three-way port onto current upstream main: succeeded without conflicts
