### PR TITLE
fix(gateway): retry restart notification on transient send-path failures

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16231,10 +16231,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return True
 
     async def _send_restart_notification(self) -> Optional[tuple[str, str, Optional[str]]]:
-        """Notify the chat that initiated /restart that the gateway is back."""
+        """Notify the chat that initiated /restart that the gateway is back.
+
+        Retries on transient send-path failures (e.g. ``send_path_degraded``
+        while the platform adapter is still settling after reconnect) so the
+        notification isn't permanently lost when the adapter isn't ready yet.
+        """
         notify_path = _hermes_home / ".restart_notify.json"
         if not notify_path.exists():
             return None
+
+        _RESTART_NOTIFY_MAX_RETRIES = 5
+        _RESTART_NOTIFY_RETRY_DELAY = 1.0
 
         try:
             data = json.loads(notify_path.read_text())
@@ -16272,35 +16280,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 reply_to_message_id=message_id,
                 adapter=adapter,
             )
-            result = await adapter.send(
-                str(chat_id),
-                "♻ Gateway restarted successfully. Your session continues.",
-                metadata=_non_conversational_metadata(metadata, platform=platform),
-            )
-            # adapter.send() catches provider errors (e.g. "Chat not found")
-            # and returns SendResult(success=False) rather than raising, so
-            # we must inspect the result before claiming success — otherwise
-            # the log line is misleading and hides real delivery failures.
-            if result is not None and getattr(result, "success", True) is False:
+
+            for attempt in range(1, _RESTART_NOTIFY_MAX_RETRIES + 1):
+                result = await adapter.send(
+                    str(chat_id),
+                    "♻ Gateway restarted successfully. Your session continues.",
+                    metadata=_non_conversational_metadata(metadata, platform=platform),
+                )
+                if result is None or getattr(result, "success", True):
+                    logger.info(
+                        "Sent restart notification to %s:%s",
+                        platform_str,
+                        chat_id,
+                    )
+                    return str(platform_str), str(chat_id), str(thread_id) if thread_id else None
+
+                error = getattr(result, "error", "send returned success=False")
+                is_transient = getattr(result, "retryable", False) or error == "send_path_degraded"
+                if is_transient and attempt < _RESTART_NOTIFY_MAX_RETRIES:
+                    logger.debug(
+                        "Restart notification to %s:%s transient failure (attempt %d/%d): %s — retrying in %.1fs",
+                        platform_str, chat_id, attempt, _RESTART_NOTIFY_MAX_RETRIES,
+                        error, _RESTART_NOTIFY_RETRY_DELAY,
+                    )
+                    await asyncio.sleep(_RESTART_NOTIFY_RETRY_DELAY)
+                    continue
+
                 logger.warning(
-                    "Restart notification to %s:%s was not delivered: %s",
+                    "Restart notification to %s:%s was not delivered after %d attempt(s): %s",
                     platform_str,
                     chat_id,
-                    getattr(result, "error", "send returned success=False"),
+                    attempt,
+                    error,
                 )
                 return None
 
-            logger.info(
-                "Sent restart notification to %s:%s",
-                platform_str,
-                chat_id,
-            )
-            return str(platform_str), str(chat_id), str(thread_id) if thread_id else None
         except Exception as e:
             logger.warning("Restart notification failed: %s", e)
-            return None
         finally:
             notify_path.unlink(missing_ok=True)
+        return None
+
 
     async def _send_home_channel_startup_notifications(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16361,37 +16361,55 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     home.thread_id,
                     adapter=adapter,
                 )
-                if metadata:
-                    result = await adapter.send(
-                        str(home.chat_id),
-                        message,
-                        metadata=_non_conversational_metadata(metadata, platform=platform),
-                    )
-                else:
-                    _startup_meta = _non_conversational_metadata(platform=platform)
-                    if _startup_meta:
+
+                _STARTUP_NOTIFY_MAX_RETRIES = 5
+                _STARTUP_NOTIFY_RETRY_DELAY = 1.0
+
+                for attempt in range(1, _STARTUP_NOTIFY_MAX_RETRIES + 1):
+                    if metadata:
                         result = await adapter.send(
                             str(home.chat_id),
                             message,
-                            metadata=_startup_meta,
+                            metadata=_non_conversational_metadata(metadata, platform=platform),
                         )
                     else:
-                        result = await adapter.send(str(home.chat_id), message)
-                if result is not None and getattr(result, "success", True) is False:
+                        _startup_meta = _non_conversational_metadata(platform=platform)
+                        if _startup_meta:
+                            result = await adapter.send(
+                                str(home.chat_id),
+                                message,
+                                metadata=_startup_meta,
+                            )
+                        else:
+                            result = await adapter.send(str(home.chat_id), message)
+
+                    if result is None or getattr(result, "success", True):
+                        delivered.add(target)
+                        logger.info(
+                            "Sent home-channel startup notification to %s:%s",
+                            platform.value,
+                            home.chat_id,
+                        )
+                        break
+
+                    error = getattr(result, "error", "send returned success=False")
+                    is_transient = getattr(result, "retryable", False) or error == "send_path_degraded"
+                    if is_transient and attempt < _STARTUP_NOTIFY_MAX_RETRIES:
+                        logger.debug(
+                            "Home-channel startup notification to %s:%s transient (attempt %d/%d): %s — retrying in %.1fs",
+                            platform.value, home.chat_id, attempt,
+                            _STARTUP_NOTIFY_MAX_RETRIES, error, _STARTUP_NOTIFY_RETRY_DELAY,
+                        )
+                        await asyncio.sleep(_STARTUP_NOTIFY_RETRY_DELAY)
+                        continue
+
                     logger.warning(
-                        "Home-channel startup notification failed for %s:%s: %s",
+                        "Home-channel startup notification failed for %s:%s after %d attempt(s): %s",
                         platform.value,
                         home.chat_id,
-                        getattr(result, "error", "send returned success=False"),
+                        attempt,
+                        error,
                     )
-                    continue
-
-                delivered.add(target)
-                logger.info(
-                    "Sent home-channel startup notification to %s:%s",
-                    platform.value,
-                    home.chat_id,
-                )
             except Exception as exc:
                 logger.warning(
                     "Home-channel startup notification failed for %s:%s: %s",

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2043,7 +2043,14 @@ class TelegramAdapter(BasePlatformAdapter):
         self._polling_generation = getattr(self, "_polling_generation", 0) + 1
         self._polling_progress_event = asyncio.Event()
         self._polling_progress_accepting = True
-        self._send_path_degraded = True
+        # Don't proactively mark the send path as degraded when a new
+        # polling generation starts.  The flag gets set on actual errors
+        # (network failures, conflicts) and cleared after a successful
+        # getUpdates.  Marking it True here blocks all sends — including
+        # lifecycle notifications (restart, startup) — until the first
+        # getUpdates completes, which can take up to the long-poll timeout
+        # (~30 s).  The Bot API's sendMessage uses a separate connection,
+        # so sends are safe even while a getUpdates is in-flight.
         return self._polling_generation, self._polling_progress_event
 
     def _record_polling_progress(self, generation: int) -> None:


### PR DESCRIPTION
## Problem

Two related issues cause gateway restart/startup notifications to silently fail on Telegram:

### 1. Notifications fire before adapter is ready
After gateway restart, `_send_restart_notification()` and `_send_home_channel_startup_notifications()` fire during startup, but the Telegram adapter may not be fully ready. The notification file is deleted on failure, permanently losing the message.

### 2. `_send_path_degraded` is set prematurely  
`_begin_polling_generation()` sets `_send_path_degraded = True` proactively, blocking ALL sends through the live adapter until the first `getUpdates` completes. Since `getUpdates` is a long-poll with up to ~30s timeout, this blocks lifecycle notifications for up to 30 seconds. The flag should only reflect actual errors, not the "still initializing" state.

## Fix

1. **Retry on transient failures**: Both `_send_restart_notification()` and `_send_home_channel_startup_notifications()` now retry up to 5 times (1s delay) on transient errors like `send_path_degraded`.

2. **Remove proactive degraded flag**: `_begin_polling_generation()` no longer sets `_send_path_degraded = True`. The flag is only set on actual network errors and cleared after successful `getUpdates`. The Bot API's `sendMessage` uses a separate connection from `getUpdates`, so sends are safe during polling startup.
