### PR TITLE
feat(gateway): add capability-scoped security contexts for plugins

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2356,6 +2356,23 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     if not isinstance(function_args, dict):
         function_args = {}
 
+    # Capability-scoped sessions get an exact-name dispatch check immediately
+    # before any middleware, built-in shortcut or registry call can execute.
+    try:
+        from gateway.security_context import enforce_agent_tool_dispatch
+        enforce_agent_tool_dispatch(agent, function_name)
+    except PermissionError as exc:
+        logger.warning(
+            "Capability-scoped tool dispatch denied: session=%s tool=%s reason=%s",
+            getattr(agent, "session_id", "") or "",
+            function_name,
+            exc,
+        )
+        return json.dumps(
+            {"error": "tool_denied_by_capability", "tool": function_name},
+            ensure_ascii=False,
+        )
+
     _tool_middleware_trace = list(tool_request_middleware_trace or [])
     try:
         from hermes_cli.middleware import apply_tool_request_middleware

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -382,6 +382,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
 
     # ── Parse args + pre-execution bookkeeping ───────────────────────
     parsed_calls = []  # list of (tool_call, function_name, function_args, middleware_trace, block_result, blocked_by_guardrail)
+    capability_denied_call_ids: set[str] = set()
     for tool_call in tool_calls:
         function_name = tool_call.function.name
 
@@ -401,12 +402,6 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 )
             )
             continue
-
-        # Reset nudge counters only for a structurally valid invocation.
-        if function_name == "memory":
-            agent._turns_since_memory = 0
-        elif function_name == "skill_manage":
-            agent._iters_since_skill = 0
 
         # ── Tool Search unwrap ────────────────────────────────────────
         # When the model invokes the tool_call bridge, peel it open so
@@ -442,6 +437,37 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         }, ensure_ascii=False)
         except Exception:
             pass
+
+        # Exact capability and live provenance validation must precede every
+        # middleware, plugin hook, guardrail, checkpoint, callback, or counter.
+        # The lower dispatch checks again to close the preflight-to-worker race.
+        if _ts_scope_block is None:
+            try:
+                from gateway.security_context import enforce_agent_tool_dispatch
+
+                enforce_agent_tool_dispatch(agent, function_name)
+            except PermissionError:
+                capability_denied_call_ids.add(
+                    getattr(tool_call, "id", "") or ""
+                )
+                parsed_calls.append((
+                    tool_call,
+                    function_name,
+                    function_args,
+                    [],
+                    json.dumps(
+                        {"error": "tool_denied_by_capability", "tool": function_name},
+                        ensure_ascii=False,
+                    ),
+                    False,
+                ))
+                continue
+
+        # Reset nudge counters only for an authorized invocation.
+        if function_name == "memory":
+            agent._turns_since_memory = 0
+        elif function_name == "skill_manage":
+            agent._iters_since_skill = 0
 
         function_args, middleware_trace = _apply_tool_request_middleware_for_agent(
             agent,
@@ -548,10 +574,22 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         parsed_calls.append((tool_call, function_name, function_args, middleware_trace, block_result, blocked_by_guardrail))
 
     # ── Logging / callbacks ──────────────────────────────────────────
-    tool_names_str = ", ".join(name for _, name, _, _, _, _ in parsed_calls)
-    if not agent.quiet_mode and getattr(agent, "tool_progress_mode", "all") != "off":
-        print(f"  ⚡ Concurrent: {num_tools} tool calls — {tool_names_str}")
+    authorized_names = [
+        name
+        for _, name, _, _, block_result, _ in parsed_calls
+        if block_result is None
+    ]
+    tool_names_str = ", ".join(authorized_names)
+    runnable_count = len(authorized_names)
+    if (
+        runnable_count
+        and not agent.quiet_mode
+        and getattr(agent, "tool_progress_mode", "all") != "off"
+    ):
+        print(f"  ⚡ Concurrent: {runnable_count} tool calls — {tool_names_str}")
         for i, (tc, name, args, middleware_trace, block_result, blocked_by_guardrail) in enumerate(parsed_calls, 1):
+            if block_result is not None:
+                continue
             display_args = _redact_tool_args_for_display(name, args) or args
             args_str = json.dumps(display_args, ensure_ascii=False)
             if agent.verbose_logging:
@@ -589,10 +627,13 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         if block_result is not None:
             results[i] = (name, args, block_result, 0.0, True, True, middleware_trace)
 
-    # Touch activity before launching workers so the gateway knows
-    # we're executing tools (not stuck).
-    agent._current_tool = tool_names_str
-    agent._touch_activity(f"executing {num_tools} tools concurrently: {tool_names_str}")
+    # Only executable calls participate in agent activity. Capability-denied
+    # names must not become observable state, including denied-only batches.
+    if runnable_count:
+        agent._current_tool = tool_names_str
+        agent._touch_activity(
+            f"executing {runnable_count} tools concurrently: {tool_names_str}"
+        )
 
     def _run_tool(index, tool_call, function_name, function_args, middleware_trace):
         """Worker function executed in a thread."""
@@ -678,9 +719,14 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             except Exception:
                 pass
 
-    # Start spinner for CLI mode (skip when TUI handles tool progress)
+    # Start spinner for CLI mode (skip when TUI handles tool progress). A
+    # denied-only batch is an error-reporting path, not active tool work.
     spinner = None
-    if agent._should_emit_quiet_tool_messages() and agent._should_start_quiet_spinner():
+    if (
+        runnable_count
+        and agent._should_emit_quiet_tool_messages()
+        and agent._should_start_quiet_spinner()
+    ):
         face = random.choice(KawaiiSpinner.get_waiting_faces())
         spinner = KawaiiSpinner(f"{face} ⚡ running {num_tools} tools concurrently", spinner_type='dots', print_fn=agent._print_fn)
         spinner.start()
@@ -963,8 +1009,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 response_preview = _preview_str[:agent.log_prefix_chars] + "..." if len(_preview_str) > agent.log_prefix_chars else _preview_str
                 print(f"  ✅ Tool {i+1} completed in {tool_duration:.2f}s - {response_preview}")
 
-        agent._current_tool = None
-        agent._touch_activity(f"tool completed: {name} ({tool_duration:.1f}s)")
+        if (getattr(tc, "id", "") or "") not in capability_denied_call_ids:
+            agent._current_tool = None
+            agent._touch_activity(f"tool completed: {name} ({tool_duration:.1f}s)")
 
         if not blocked and agent.tool_complete_callback:
             try:
@@ -1122,13 +1169,43 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         except Exception:
             pass
 
-        function_args, middleware_trace = _apply_tool_request_middleware_for_agent(
-            agent,
-            function_name=function_name,
-            function_args=function_args,
-            effective_task_id=effective_task_id,
-            tool_call_id=getattr(tool_call, "id", "") or "",
-        )
+        # Authorize the exact post-unwrapping name before middleware, hooks,
+        # checkpoints, callbacks, or any agent-level shortcut can execute.
+        _capability_scope_block: Optional[str] = None
+        try:
+            from gateway.security_context import enforce_agent_tool_dispatch
+            enforce_agent_tool_dispatch(agent, function_name)
+        except PermissionError:
+            _capability_scope_block = "tool_denied_by_capability"
+
+        if _capability_scope_block is not None:
+            # Capability denial is not a tool lifecycle event. Preserve the
+            # model-visible error for the original call id, but do not enter
+            # middleware, hooks, guardrails, checkpointing, callbacks,
+            # activity state, persistence helpers, or dispatch bookkeeping.
+            messages.append(
+                make_tool_result_message(
+                    function_name,
+                    json.dumps(
+                        {"error": _capability_scope_block, "tool": function_name},
+                        ensure_ascii=False,
+                    ),
+                    tool_call.id,
+                    effect_disposition="none",
+                )
+            )
+            continue
+
+        if _ts_scope_block is None:
+            function_args, middleware_trace = _apply_tool_request_middleware_for_agent(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+            )
+        else:
+            middleware_trace = []
 
         # Check plugin hooks for a block directive before executing.
         _block_msg: Optional[str] = None

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -11,6 +11,8 @@ Handles loading and validating configuration for:
 import logging
 import os
 import json
+import importlib
+import sys
 from pathlib import Path
 from dataclasses import asdict, dataclass, field, is_dataclass
 from typing import Dict, List, Optional, Any, Callable
@@ -821,6 +823,60 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
 }
 
 
+@dataclass(frozen=True)
+class SecurityContextTrustGrant:
+    """Host-owned allowlist entry for one exact security adapter implementation."""
+
+    platform: str
+    adapter_module: str
+    adapter_class: str
+    plugin_name: str = ""
+
+    @classmethod
+    def from_dict(cls, value: Any) -> Optional["SecurityContextTrustGrant"]:
+        if not isinstance(value, dict):
+            return None
+        fields = {
+            name: str(value.get(name, "") or "").strip()
+            for name in ("platform", "adapter_module", "adapter_class", "plugin_name")
+        }
+        if not all(fields[name] for name in ("platform", "adapter_module", "adapter_class")):
+            return None
+        return cls(**fields)
+
+    def to_dict(self) -> Dict[str, str]:
+        result = {
+            "platform": self.platform,
+            "adapter_module": self.adapter_module,
+            "adapter_class": self.adapter_class,
+        }
+        if self.plugin_name:
+            result["plugin_name"] = self.plugin_name
+        return result
+
+    def matches(self, adapter: Any, entry: Any) -> bool:
+        adapter_type = type(adapter)
+        entry_plugin = str(getattr(entry, "plugin_name", "") or "")
+        try:
+            module = sys.modules.get(self.adapter_module) or importlib.import_module(
+                self.adapter_module
+            )
+            configured_type: Any = module
+            for component in self.adapter_class.split("."):
+                if not component or component == "<locals>":
+                    return False
+                configured_type = getattr(configured_type, component)
+        except (ImportError, AttributeError):
+            return False
+        return bool(
+            self.platform == str(getattr(entry, "name", "") or "")
+            and self.platform
+            == str(getattr(getattr(adapter, "platform", None), "value", "") or "")
+            and configured_type is adapter_type
+            and self.plugin_name == entry_plugin
+        )
+
+
 @dataclass
 class GatewayConfig:
     """
@@ -899,6 +955,10 @@ class GatewayConfig:
     # different profiles. See gateway/profile_routing.py. Each entry is a
     # dict with: name, platform, profile, and optional guild_id/chat_id/thread_id.
     profile_routes: list = field(default_factory=list)
+
+    # Host-owned trust grants for adapters allowed to originate SecurityContext.
+    # Legacy plugin registration flags are intentionally not consulted.
+    security_context_trust_grants: tuple[SecurityContextTrustGrant, ...] = ()
 
     def __post_init__(self) -> None:
         self.systemd_watchdog_seconds = coerce_systemd_watchdog_seconds(
@@ -1023,6 +1083,9 @@ class GatewayConfig:
                 asdict(r) if is_dataclass(r) and not isinstance(r, type) else r
                 for r in self.profile_routes
             ],
+            "security_context_trust_grants": [
+                grant.to_dict() for grant in self.security_context_trust_grants
+            ],
         }
     
     @classmethod
@@ -1128,6 +1191,15 @@ class GatewayConfig:
         from gateway.profile_routing import parse_profile_routes
         profile_routes = parse_profile_routes(data.get("profile_routes") or [])
 
+        raw_trust_grants = data.get("security_context_trust_grants", ())
+        if not isinstance(raw_trust_grants, (list, tuple)):
+            raw_trust_grants = ()
+        security_context_trust_grants = tuple(
+            grant
+            for raw in raw_trust_grants
+            if (grant := SecurityContextTrustGrant.from_dict(raw)) is not None
+        )
+
         return cls(
             platforms=platforms,
             default_reset_policy=default_policy,
@@ -1152,6 +1224,7 @@ class GatewayConfig:
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
             profile_routes=profile_routes,
+            security_context_trust_grants=security_context_trust_grants,
         )
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
@@ -1306,6 +1379,10 @@ def load_gateway_config() -> GatewayConfig:
                 if "systemd_watchdog_seconds" in gateway_section:
                     gw_data["systemd_watchdog_seconds"] = gateway_section[
                         "systemd_watchdog_seconds"
+                    ]
+                if "security_context_trust_grants" in gateway_section:
+                    gw_data["security_context_trust_grants"] = gateway_section[
+                        "security_context_trust_grants"
                     ]
 
             if "max_concurrent_sessions" in yaml_cfg:

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -29,6 +29,8 @@ Usage (gateway side):
 """
 
 import logging
+import threading
+import weakref
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Optional
 
@@ -96,6 +98,11 @@ class PlatformEntry:
     # ── Privacy ──
     # If True, session descriptions redact PII (phone numbers, etc.)
     pii_safe: bool = False
+
+    # Deprecated compatibility field. Registration is plugin-controlled, so
+    # this value is never authority. Host config SecurityContextTrustGrant is
+    # the sole trust source; retaining the field avoids breaking old plugins.
+    trusted_security_context: bool = False
 
     # ── Display ──
     # Emoji for CLI/gateway display (e.g. "💬")
@@ -167,6 +174,7 @@ class PlatformRegistry:
     """
 
     def __init__(self) -> None:
+        self._lock = threading.RLock()
         self._entries: dict[str, PlatformEntry] = {}
         # Deferred platform loaders: name -> zero-arg callable that imports the
         # owning plugin module (which calls register() and populates _entries).
@@ -181,6 +189,9 @@ class PlatformRegistry:
         # actually asks for that platform (gateway start, cron delivery,
         # `hermes setup`/`gateway status`, send_message).
         self._deferred: dict[str, Callable[[], None]] = {}
+        # Host-owned creation provenance. Plugin-controlled adapter attributes
+        # are never accepted as evidence that a factory produced an instance.
+        self._adapter_origins: dict[int, tuple[weakref.ReferenceType, PlatformEntry]] = {}
 
     # -- deferred loading ----------------------------------------------------
 
@@ -235,28 +246,58 @@ class PlatformRegistry:
         wins -- this lets plugins override built-in adapters if desired).
         """
         # A concrete registration supersedes any pending deferred loader.
-        self._deferred.pop(entry.name, None)
-        if entry.name in self._entries:
-            prev = self._entries[entry.name]
-            logger.info(
-                "Platform '%s' re-registered (was %s, now %s)",
-                entry.name,
-                prev.source,
-                entry.source,
-            )
-        self._entries[entry.name] = entry
+        with self._lock:
+            self._deferred.pop(entry.name, None)
+            if entry.name in self._entries:
+                prev = self._entries[entry.name]
+                logger.info(
+                    "Platform '%s' re-registered (was %s, now %s)",
+                    entry.name,
+                    prev.source,
+                    entry.source,
+                )
+            self._entries[entry.name] = entry
         logger.debug("Registered platform adapter: %s (%s)", entry.name, entry.source)
 
     def unregister(self, name: str) -> bool:
         """Remove a platform entry.  Returns True if it existed."""
-        self._deferred.pop(name, None)
-        return self._entries.pop(name, None) is not None
+        with self._lock:
+            self._deferred.pop(name, None)
+            return self._entries.pop(name, None) is not None
+
+    def adapter_matches_entry(self, adapter: Any, entry: PlatformEntry) -> bool:
+        """Return whether this exact live instance was created by this entry."""
+        with self._lock:
+            origin = self._adapter_origins.get(id(adapter))
+            return bool(
+                origin
+                and origin[0]() is adapter
+                and origin[1] is entry
+                and self._entries.get(entry.name) is entry
+            )
+
+    def adapter_matches_current_entry(
+        self, adapter: Any, name: str
+    ) -> Optional[PlatformEntry]:
+        """Atomically return the current exact origin entry, else ``None``."""
+        with self._lock:
+            entry = self._entries.get(name)
+            origin = self._adapter_origins.get(id(adapter))
+            if (
+                entry is not None
+                and origin
+                and origin[0]() is adapter
+                and origin[1] is entry
+            ):
+                return entry
+            return None
 
     def get(self, name: str) -> Optional[PlatformEntry]:
         """Look up a platform entry by name."""
         if name not in self._entries:
             self._resolve(name)
-        return self._entries.get(name)
+        with self._lock:
+            return self._entries.get(name)
 
     def all_entries(self) -> list[PlatformEntry]:
         """Return all registered platform entries."""
@@ -317,6 +358,29 @@ class PlatformRegistry:
 
         try:
             adapter = entry.adapter_factory(config)
+            try:
+                adapter_id = id(adapter)
+                origin = (
+                    weakref.ref(
+                        adapter,
+                        lambda _ref, key=adapter_id: self._adapter_origins.pop(key, None),
+                    ),
+                    entry,
+                )
+                # Provenance is first-writer-wins for the lifetime of an exact
+                # instance. A replacement factory returning a captured adapter
+                # cannot relabel it as originating from the spoofed entry.
+                with self._lock:
+                    existing = self._adapter_origins.get(adapter_id)
+                    if (
+                        self._entries.get(name) is entry
+                        and (existing is None or existing[0]() is None)
+                    ):
+                        self._adapter_origins[adapter_id] = origin
+            except TypeError:
+                # Non-weak-referenceable legacy adapters keep working, but can
+                # never satisfy the stronger SecurityContext trust boundary.
+                pass
             return adapter
         except Exception as e:
             logger.error(

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -21,6 +21,7 @@ from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
 from utils import normalize_proxy_url
+from gateway.security_context import SecurityContext
 
 logger = logging.getLogger(__name__)
 
@@ -1819,6 +1820,15 @@ class MessageEvent:
     # particular key existing.
     metadata: Dict[str, Any] = field(default_factory=dict)
 
+    # Immutable per-message capability envelope.  Only registry-declared
+    # trusted adapters may supply this; gateway/run.py rejects every other
+    # source before model invocation.
+    security_context: Optional[SecurityContext] = None
+
+    # Gateway-stamped, wire-invisible provenance. Adapters must not populate
+    # this themselves; GatewayRunner overwrites it in its per-instance handler.
+    _adapter_security_capability: Any = field(default=None, repr=False, compare=False)
+
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
     
@@ -2211,6 +2221,7 @@ _RETRYABLE_ERROR_PATTERNS = (
 # reply), an ``EphemeralReply`` to opt the reply into auto-deletion, or
 # ``None`` when the response was already delivered (e.g. via streaming).
 MessageHandler = Callable[[MessageEvent], Awaitable[Optional[Union[str, "EphemeralReply"]]]]
+SecurityPreflight = Callable[[MessageEvent], Awaitable[Optional[MessageEvent]]]
 
 
 def resolve_channel_prompt(
@@ -2439,6 +2450,9 @@ class BasePlatformAdapter(ABC):
         self.config = config
         self.platform = platform
         self._message_handler: Optional[MessageHandler] = None
+        # Host-owned intake gate for an exact live-trusted adapter instance.
+        # Legacy adapters leave this unset and retain their existing behavior.
+        self._security_preflight: Optional[SecurityPreflight] = None
         # Optional hook (e.g. Telegram DM topic recovery) that rewrites
         # ``event.source.thread_id`` before session keying. Returns the
         # corrected thread_id or None to leave the source untouched.
@@ -2893,6 +2907,18 @@ class BasePlatformAdapter(ABC):
         an optional response string.
         """
         self._message_handler = handler
+
+    def set_security_preflight(
+        self, preflight: Optional[SecurityPreflight]
+    ) -> None:
+        """Install the host-owned gate that runs before all adapter effects."""
+        self._security_preflight = preflight
+
+    async def revalidate_security_context(
+        self, context: SecurityContext, tool_name: str
+    ) -> None:
+        """Live effect/read authorization hook for reviewed secure adapters."""
+        raise PermissionError("adapter does not support security revalidation")
 
     def set_topic_recovery_fn(
         self,
@@ -4769,6 +4795,24 @@ class BasePlatformAdapter(ABC):
         """
         if not self._message_handler:
             return
+
+        # This is deliberately the first operation after the inert handler
+        # presence check. A trusted-adapter denial must precede command
+        # coercion, topic/session recovery, guard healing, queue/debounce
+        # mutation, lifecycle tasks, hooks, typing and delivery.
+        security_preflight = getattr(self, "_security_preflight", None)
+        if security_preflight is not None:
+            try:
+                event = await security_preflight(event)
+            except PermissionError as exc:
+                logger.warning(
+                    "[%s] Trusted adapter security preflight denied message: %s",
+                    self.name,
+                    exc,
+                )
+                return
+            if event is None:
+                return
 
         coerce_plaintext_gateway_command(event)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8247,7 +8247,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # A future internal handoff capability must be explicit rather than
         # silently manufacturing provenance here.
         if (
-            getattr(adapter, "_host_security_context_trusted_instance", False)
+            getattr(adapter, "_host_security_context_trusted_instance", False) is True
             or self._adapter_has_live_security_trust(adapter)
         ):
             from gateway.security_context import SecurityContextError

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5826,18 +5826,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _approval_handler = self._handle_approve_command
                     _normalized_args = "session"
                 if _approval_handler is not None:
-                    # Synthesize the canonical "/approve [args]" / "/deny"
-                    # command text so the slash handlers parse modifiers via
-                    # event.get_command_args().  Always use a literal "/" —
-                    # MessageEvent.is_command()/get_command_args() only
-                    # recognize the "/" prefix, not the per-platform display
-                    # prefix ("!" on Slack/Matrix).
                     _verb = "approve" if _approval_handler is self._handle_approve_command else "deny"
+                    _approval_denied = await self._authorize_security_action(
+                        event, self._command_security_action(_verb)
+                    )
+                    # Synthesize only after authorization so a denial cannot
+                    # mutate event state or signal the waiting approval.
                     _synth = f"/{_verb}"
                     if _normalized_args:
                         _synth = f"{_synth} {_normalized_args}"
-                    event.text = _synth
-                    _reply = await _approval_handler(event)
+                    if _approval_denied is None:
+                        event.text = _synth
+                        _reply = await _approval_handler(event)
+                    else:
+                        _reply = _approval_denied
                     logger.info(
                         "Approval response via plain text: session=%s verb=%s args=%r",
                         session_key, _verb, _normalized_args,
@@ -7679,7 +7681,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 continue
             
             # Set up message + fatal error handlers
-            adapter.set_message_handler(self._handle_message)
+            self._install_adapter_security_preflight(adapter)
+            adapter.set_message_handler(self._make_adapter_message_handler(adapter))
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
@@ -8238,6 +8241,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 f"platform '{platform_name}' is not active in this gateway"
             )
 
+        # Trusted adapters require an adapter-bound context at intake. A CLI
+        # handoff has no such live inbound context, so fail closed before thread
+        # creation, session lookup/switch, cache eviction, or worker release.
+        # A future internal handoff capability must be explicit rather than
+        # silently manufacturing provenance here.
+        if (
+            getattr(adapter, "_host_security_context_trusted_instance", False)
+            or self._adapter_has_live_security_trust(adapter)
+        ):
+            from gateway.security_context import SecurityContextError
+
+            raise SecurityContextError("handoff_security_context_missing")
+
         # Home channel must be configured
         home = self.config.get_home_channel(platform)
         if not home or not home.chat_id:
@@ -8652,7 +8668,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         del self._failed_platforms[platform]
                         continue
 
-                    adapter.set_message_handler(self._handle_message)
+                    self._install_adapter_security_preflight(adapter)
+                    adapter.set_message_handler(self._make_adapter_message_handler(adapter))
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
@@ -9522,7 +9539,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         platform: Platform,
     ) -> None:
         """Install the profile-scoped handlers shared by startup and reconnect."""
-        adapter.set_message_handler(self._make_profile_message_handler(profile_name))
+        self._install_adapter_security_preflight(adapter)
+        adapter.set_message_handler(
+            self._make_profile_message_handler(profile_name, adapter)
+        )
         adapter.set_fatal_error_handler(
             self._make_profile_fatal_error_handler(profile_name, platform)
         )
@@ -9701,7 +9721,174 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Reconnect is scoped to the profile's own config and secret mapping;
         # never rebuild a secondary adapter with the default profile's credentials.
 
-    def _make_profile_message_handler(self, profile_name: str):
+    async def _authorize_security_action(self, event, action: str) -> Optional[str]:
+        """Fail closed for secure contexts; preserve legacy command behaviour."""
+        from gateway.security_context import require_action_for_context
+
+        context = getattr(event, "security_context", None)
+        if context is None:
+            context = getattr(getattr(event, "source", None), "security_context", None)
+        try:
+            await require_action_for_context(context, action)
+        except PermissionError as exc:
+            logger.warning("Secure gateway action denied: action=%s reason=%s", action, exc)
+            return f"Action denied by capability: `{action}`."
+        return None
+
+    @staticmethod
+    def _command_security_action(command_name: str) -> str:
+        # /new and /reset share one destructive session-boundary capability.
+        canonical = str(command_name or "").strip().lower()
+        if canonical == "new":
+            canonical = "reset"
+        return f"command.{canonical}" if canonical else "command.unknown"
+
+    def _adapter_has_live_security_trust(self, adapter) -> bool:
+        """Check exact adapter provenance against current registry and grants."""
+        from gateway.platform_registry import platform_registry
+
+        platform_name = str(getattr(getattr(adapter, "platform", None), "value", ""))
+        entry = platform_registry.adapter_matches_current_entry(adapter, platform_name)
+        if entry is None:
+            return False
+        grants = tuple(
+            getattr(self.config, "security_context_trust_grants", ()) or ()
+        )
+        return any(grant.matches(adapter, entry) for grant in grants)
+
+    def _issue_live_adapter_security_capability(self, adapter):
+        """Issue a capability whose callback consults live host state."""
+        from gateway.security_context import (
+            SecurityContextError,
+            issue_adapter_security_capability,
+        )
+
+        if not self._adapter_has_live_security_trust(adapter):
+            raise SecurityContextError("security_adapter_not_trusted")
+
+        async def _live_revalidate(context, dispatch_name):
+            if not self._adapter_has_live_security_trust(adapter):
+                raise SecurityContextError("security_adapter_trust_revoked")
+            if context.platform != adapter.platform.value:
+                raise SecurityContextError("security_platform_drift")
+            await adapter.revalidate_security_context(context, dispatch_name)
+
+        return issue_adapter_security_capability(
+            adapter,
+            asyncio.get_running_loop(),
+            _live_revalidate,
+        )
+
+    @staticmethod
+    def _preflight_command_name(event) -> str | None:
+        """Resolve command authority without mutating the inbound event."""
+        from gateway.platforms.base import coerce_plaintext_gateway_command
+        from hermes_cli.commands import resolve_command
+
+        probe = dataclasses.replace(event)
+        coerce_plaintext_gateway_command(probe)
+        command = probe.get_command()
+        definition = resolve_command(command) if command else None
+        return definition.name if definition is not None else command
+
+    def _install_adapter_security_preflight(self, adapter) -> None:
+        """Install the earliest intake gate only on this exact trusted instance."""
+        from gateway.security_context import (
+            AdapterSecurityCapability,
+            SecurityContext,
+            SecurityContextError,
+            bind_context_to_adapter,
+            require_action_for_context,
+        )
+
+        try:
+            capability = self._issue_live_adapter_security_capability(adapter)
+        except PermissionError:
+            setter = getattr(adapter, "set_security_preflight", None)
+            if callable(setter):
+                setter(None)
+            return
+
+        # Permanent for this adapter object: later grant removal or registry
+        # replacement must revoke trust, not downgrade the instance into the
+        # legacy context-free handoff path.
+        adapter._host_security_context_trusted_instance = True
+
+        async def _preflight(event):
+            if not self._adapter_has_live_security_trust(adapter):
+                capability.revoke()
+                raise SecurityContextError("security_adapter_trust_revoked")
+            context = getattr(event, "security_context", None)
+            if not isinstance(context, SecurityContext) or not isinstance(
+                capability, AdapterSecurityCapability
+            ):
+                raise SecurityContextError("security_context_missing")
+            if not capability.belongs_to_adapter_source(event.source):
+                raise SecurityContextError("security_adapter_source_mismatch")
+
+            context = bind_context_to_adapter(context, capability)
+            context.verify()
+            await capability.revalidate_async(context, "intake")
+            if context.platform != event.source.platform.value:
+                raise SecurityContextError("security_platform_drift")
+            if context.principal_id != str(event.source.user_id or ""):
+                raise SecurityContextError("security_principal_drift")
+            if context.denied:
+                raise SecurityContextError("security_context_denied")
+
+            command = self._preflight_command_name(event)
+            if command:
+                await require_action_for_context(
+                    context, self._command_security_action(command)
+                )
+
+            source = dataclasses.replace(event.source, security_context=context)
+            return dataclasses.replace(
+                event,
+                source=source,
+                security_context=context,
+                _adapter_security_capability=capability,
+            )
+
+        setter = getattr(adapter, "set_security_preflight", None)
+        if not callable(setter):
+            raise PermissionError("trusted adapter lacks security preflight boundary")
+        setter(_preflight)
+
+    def _make_adapter_message_handler(
+        self, adapter, profile_name: str | None = None
+    ):
+        """Bind inbound events to one exact adapter instance."""
+        try:
+            capability = self._issue_live_adapter_security_capability(adapter)
+        except PermissionError:
+            capability = None
+
+        async def _handler(event):
+            stamped_capability = getattr(
+                event, "_adapter_security_capability", None
+            ) or capability
+            if stamped_capability is not None and not self._adapter_has_live_security_trust(adapter):
+                stamped_capability.revoke()
+                stamped_capability = None
+            # Always overwrite provenance; event kwargs are not authority.
+            event = dataclasses.replace(
+                event, _adapter_security_capability=stamped_capability
+            )
+            try:
+                if (
+                    profile_name
+                    and getattr(event, "source", None) is not None
+                    and not event.source.profile
+                ):
+                    event.source.profile = profile_name
+            except Exception:
+                pass
+            return await self._handle_message(event)
+
+        return _handler
+
+    def _make_profile_message_handler(self, profile_name: str, adapter=None):
         """Return a message handler that stamps source.profile then delegates.
 
         Auth runs inside ``_handle_message`` *before* the agent-turn scope is
@@ -9715,6 +9902,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             profile_home = get_profile_dir(profile_name)
         except Exception:
             profile_home = None
+        secured_handler = (
+            self._make_adapter_message_handler(adapter, profile_name=profile_name)
+            if adapter is not None
+            else self._handle_message
+        )
 
         async def _handler(event):
             try:
@@ -9724,8 +9916,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
             if profile_home is not None:
                 with _profile_runtime_scope(profile_home):
-                    return await self._handle_message(event)
-            return await self._handle_message(event)
+                    return await secured_handler(event)
+            return await secured_handler(event)
 
         return _handler
 
@@ -9974,18 +10166,71 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         await adapter.send(source.chat_id, content, metadata=metadata)
 
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
-        """
-        Handle an incoming message from any platform.
-        
-        This is the core message processing pipeline:
-        1. Check user authorization
-        2. Check for commands (/new, /reset, etc.)
-        3. Check for running agent and interrupt if needed
-        4. Get or create session
-        5. Build context for agent
-        6. Run agent conversation
-        7. Return response
-        """
+        """Validate provenance, bind security context, then enter the pipeline."""
+        from gateway.security_context import (
+            AdapterSecurityCapability,
+            SecurityContext,
+            bind_context_to_adapter,
+            bind_security_context,
+            reset_security_context,
+        )
+
+        source = event.source
+        context = getattr(event, "security_context", None)
+        capability = getattr(event, "_adapter_security_capability", None)
+        if context is not None:
+            if not isinstance(context, SecurityContext) or not isinstance(
+                capability, AdapterSecurityCapability
+            ):
+                logger.error("Unprovenanced security context; message denied")
+                return None
+            if not capability.belongs_to_adapter_source(source):
+                logger.error("Security adapter/source mismatch; message denied")
+                return None
+            try:
+                context = bind_context_to_adapter(context, capability)
+                context.verify()
+                # Re-entered queued/steered/retried/goal events carry the
+                # original opaque capability. Revalidate it against live host
+                # registry/config state before any command or session effect.
+                await capability.revalidate_async(context, "intake")
+            except PermissionError:
+                logger.error("Invalid security context; message denied", exc_info=True)
+                return None
+            if context.platform != source.platform.value:
+                logger.error("Security platform/source mismatch; message denied")
+                return None
+            if context.principal_id != str(source.user_id or ""):
+                logger.error("Security principal/source mismatch; message denied")
+                return None
+            if context.denied:
+                # Must stop before slash-command handling or session creation.
+                logger.info("Denied security context stopped at gateway intake")
+                return None
+            source = dataclasses.replace(source, security_context=context)
+            event = dataclasses.replace(event, source=source, security_context=context)
+        elif capability is not None:
+            # A trusted adapter must produce a context for every inbound event.
+            logger.error("Trusted security adapter omitted context; message denied")
+            return None
+        else:
+            # Direct synthetic callers (handoff, startup resume, completion and
+            # other internal paths) do not pass through the per-adapter handler.
+            # They must not turn omission of both envelope fields into a legacy
+            # downgrade for a platform currently registered as trusted.
+            adapter = self._adapter_for_source(source)
+            if adapter is not None and self._adapter_has_live_security_trust(adapter):
+                logger.error("Trusted platform event omitted security context; message denied")
+                return None
+
+        token = bind_security_context(context)
+        try:
+            return await self._handle_message_impl(event)
+        finally:
+            reset_security_context(token)
+
+    async def _handle_message_impl(self, event: MessageEvent) -> Optional[str]:
+        """Core message processing pipeline after security intake."""
         source = event.source
 
         # 🔴 Cross-session leak guard. This handler runs inside a per-message
@@ -10067,6 +10312,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     break
 
         if is_internal:
+            pass
+        elif getattr(source, "security_context", None) is not None:
+            # Authentication and authorization were completed by the trusted
+            # adapter and bound into the immutable security context.
             pass
         elif source.user_id is None:
             # Messages with no user identity (Telegram service messages,
@@ -10355,9 +10604,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._release_running_agent_state(_quick_key)
 
         if _quick_key in self._running_agents:
-            if event.get_command() == "status":
-                return await self._handle_status_command(event)
-
             # Resolve the command once for all early-intercept checks below.
             from hermes_cli.commands import (
                 ACTIVE_SESSION_BYPASS_COMMANDS as _DEDICATED_HANDLERS,
@@ -10365,6 +10611,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             _evt_cmd = event.get_command()
             _cmd_def_inner = _resolve_cmd_inner(_evt_cmd) if _evt_cmd else None
+
+            if _evt_cmd:
+                _security_command = (
+                    _cmd_def_inner.name if _cmd_def_inner is not None else _evt_cmd
+                )
+                _security_denied = await self._authorize_security_action(
+                    event, self._command_security_action(_security_command)
+                )
+                if _security_denied is not None:
+                    return _security_denied
+
+            if _cmd_def_inner and _cmd_def_inner.name == "status":
+                return await self._handle_status_command(event)
 
             # Slash command access control on the running-agent fast-path.
             # Mirrors the cold-path gate further below so non-admin users
@@ -10451,6 +10710,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         reply_to_is_own_message=event.reply_to_is_own_message,
                         auto_skill=event.auto_skill,
                         channel_prompt=event.channel_prompt,
+                        security_context=getattr(event, "security_context", None),
+                        _adapter_security_capability=getattr(
+                            event, "_adapter_security_capability", None
+                        ),
                         internal=event.internal,
                         timestamp=event.timestamp,
                     )
@@ -10480,6 +10743,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             source=event.source,
                             message_id=event.message_id,
                             channel_prompt=event.channel_prompt,
+                            security_context=getattr(event, "security_context", None),
+                            _adapter_security_capability=getattr(
+                                event, "_adapter_security_capability", None
+                            ),
                         )
                         adapter._pending_messages[_quick_key] = queued_event
                     return "Agent still starting — /steer queued for the next turn."
@@ -10502,6 +10769,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         source=event.source,
                         message_id=event.message_id,
                         channel_prompt=event.channel_prompt,
+                        security_context=getattr(event, "security_context", None),
+                        _adapter_security_capability=getattr(
+                            event, "_adapter_security_capability", None
+                        ),
                     )
                     adapter._pending_messages[_quick_key] = queued_event
                 return "No active agent — /steer queued for the next turn."
@@ -10789,6 +11060,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _cmd_def = _resolve_cmd(command) if command else None
                         canonical = _cmd_def.name if _cmd_def else command
 
+        # Secure contexts require one exact action grant before command hooks,
+        # built-ins, plugin handlers, quick-command exec, or skill expansion.
+        if command:
+            _security_denied = await self._authorize_security_action(
+                event, self._command_security_action(canonical or command or "")
+            )
+            if _security_denied is not None:
+                return _security_denied
+
         # Per-platform slash command access control. Only kicks in when the
         # operator has set ``allow_admin_from`` for the source's scope (DM
         # vs group). When unset → backward-compat: every allowed user can
@@ -10853,6 +11133,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     command = event.get_command()
                     _cmd_def = _resolve_cmd(command) if command else None
                     canonical = _cmd_def.name if _cmd_def else command
+                    _rewrite_denied = await self._authorize_security_action(
+                        event, self._command_security_action(canonical or command or "")
+                    )
+                    if _rewrite_denied is not None:
+                        return _rewrite_denied
                     break
 
         if canonical == "new":
@@ -12155,6 +12440,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         # Set session context variables for tools (task-local, concurrency-safe)
         _session_env_tokens = self._set_session_env(context)
+        from gateway.security_context import bind_security_context
+        _security_context_token = bind_security_context(
+            getattr(source, "security_context", None)
+        )
         
         # Read privacy.redact_pii from config (re-read per message)
         _redact_pii = False
@@ -13655,7 +13944,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "Try again or use /reset to start a fresh session."
             )
         finally:
-            # Restore session context variables to their pre-handler state
+            # Restore session context variables to their pre-handler state.
+            from gateway.security_context import reset_security_context
+            reset_security_context(_security_context_token)
             self._clear_session_env(_session_env_tokens)
 
     def _reset_notice_session_info(self, source: SessionSource) -> str:
@@ -14222,12 +14513,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter = self._adapter_for_source(source)
             _quick_key = self._session_key_for_source(source)
             if adapter and _quick_key:
+                _security_context = getattr(source, "security_context", None)
                 cont_event = MessageEvent(
                     text=prompt,
                     message_type=MessageType.TEXT,
                     source=source,
                     message_id=None,
                     channel_prompt=None,
+                    security_context=_security_context,
+                    _adapter_security_capability=getattr(
+                        _security_context, "_adapter_capability", None
+                    ),
                 )
                 self._enqueue_fifo(_quick_key, cont_event, adapter)
         except Exception as exc:
@@ -15709,8 +16005,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         confirm_id = f"{next(counter)}"
 
         # Register the pending confirm FIRST so a super-fast button click
-        # cannot race the send_slash_confirm return.
-        _slash_confirm_mod.register(session_key, confirm_id, command, handler)
+        # cannot race the send_slash_confirm return. Re-check the exact command
+        # action when the callback actually dispatches; a grant or registry
+        # entry may have been revoked while the prompt was waiting.
+        async def _authorized_handler(choice: str):
+            denied = await self._authorize_security_action(
+                event, self._command_security_action(command)
+            )
+            if denied is not None:
+                return denied
+            return await handler(choice)
+
+        _slash_confirm_mod.register(
+            session_key, confirm_id, command, _authorized_handler
+        )
 
         adapter = self._adapter_for_source(source)
         metadata = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
@@ -19967,6 +20275,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # channel_overrides system_prompt (or global ephemeral), and gateway
             # ephemeral prompt from _get_system_prompt_for_channel.
             combined_ephemeral = context_prompt or ""
+            _security_context = getattr(source, "security_context", None)
+            from gateway.security_context import agent_context_options
+            _agent_context_options = agent_context_options(_security_context)
+            if _security_context is not None:
+                from gateway.security_context import build_security_context_prompt
+                combined_ephemeral = (
+                    combined_ephemeral
+                    + "\n\n"
+                    + build_security_context_prompt(_security_context)
+                ).strip()
             event_channel_prompt = (channel_prompt or "").strip()
             if event_channel_prompt:
                 combined_ephemeral = (combined_ephemeral + "\n\n" + event_channel_prompt).strip()
@@ -20368,10 +20686,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     chat_type=source.chat_type,
                     thread_id=source.thread_id,
                     gateway_session_key=session_key,
+                    skip_context_files=_agent_context_options["skip_context_files"],
+                    load_soul_identity=_agent_context_options["load_soul_identity"],
+                    skip_memory=_agent_context_options["skip_memory"],
                     session_db=getattr(self._session_db, "_db", self._session_db),
                     # Reload from disk — do not reuse the startup snapshot (#60955).
                     fallback_model=self._refresh_fallback_model(),
                 )
+                if _security_context is not None:
+                    from gateway.security_context import apply_security_context_to_agent
+                    apply_security_context_to_agent(agent, _security_context)
                 if _cache_lock and _cache is not None:
                     with _cache_lock:
                         # Record the session_id the snapshot was taken for
@@ -20384,6 +20708,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
                         self._enforce_agent_cache_cap()
                 logger.debug("Created new agent for session %s (sig=%s)", session_key, _sig)
+
+            # Bind and verify the exact authority envelope on every turn,
+            # including cached-agent reuse. Hash or provenance drift fails closed.
+            if _security_context is not None:
+                from gateway.security_context import apply_security_context_to_agent
+                apply_security_context_to_agent(agent, _security_context)
 
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.

--- a/gateway/security_context.py
+++ b/gateway/security_context.py
@@ -1,0 +1,479 @@
+"""Immutable per-message capability boundary for trusted gateway adapters.
+
+A :class:`SecurityContext` is data, not provenance.  The gateway binds it to an
+opaque, per-adapter capability at intake and tool execution revalidates through
+that same capability.  Platform strings and mutable registry entries are never
+used as proof of origin.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import contextvars
+import hashlib
+import json
+import re
+import threading
+import weakref
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Iterable, Mapping, Sequence
+
+_SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@-]{0,255}$")
+_SAFE_HASH = re.compile(r"^[a-f0-9]{64}$")
+_CURRENT_SECURITY_CONTEXT: contextvars.ContextVar["SecurityContext | None"] = contextvars.ContextVar(
+    "gateway_security_context", default=None
+)
+
+
+class SecurityContextError(PermissionError):
+    """Raised when a capability envelope is absent, malformed or exceeded."""
+
+
+SecurityRevalidator = Callable[["SecurityContext", str], Awaitable[None]]
+_CAPABILITY_SENTINEL = object()
+
+
+DEFAULT_REVALIDATION_TIMEOUT_SECONDS = 10.0
+MAX_SECURITY_CONTEXT_AGE_SECONDS = 300.0
+MAX_SECURITY_CONTEXT_CLOCK_SKEW_SECONDS = 30.0
+
+
+
+def require_fresh_security_context(
+    context: "SecurityContext", *, now: datetime | None = None
+) -> None:
+    """Reject stale or implausibly future-dated capability evidence."""
+    current = now or datetime.now(timezone.utc)
+    age = (current - context.authenticated_at).total_seconds()
+    if age > MAX_SECURITY_CONTEXT_AGE_SECONDS:
+        raise SecurityContextError("security_context_expired")
+    if age < -MAX_SECURITY_CONTEXT_CLOCK_SKEW_SECONDS:
+        raise SecurityContextError("security_context_from_future")
+
+
+class AdapterSecurityCapability:
+    """Opaque identity binding one live adapter to its gateway revalidator."""
+
+    __slots__ = (
+        "_adapter_ref", "_platform", "_loop", "_revalidator", "_active",
+        "_revalidation_timeout_seconds",
+    )
+
+    def __init__(
+        self,
+        sentinel: object,
+        adapter: Any,
+        loop: asyncio.AbstractEventLoop,
+        revalidator: SecurityRevalidator,
+        revalidation_timeout_seconds: float,
+    ) -> None:
+        if sentinel is not _CAPABILITY_SENTINEL:
+            raise TypeError("AdapterSecurityCapability cannot be constructed directly")
+        self._adapter_ref = weakref.ref(adapter)
+        self._platform = str(getattr(getattr(adapter, "platform", None), "value", ""))
+        self._loop = loop
+        self._revalidator = revalidator
+        self._active = True
+        self._revalidation_timeout_seconds = revalidation_timeout_seconds
+
+    def belongs_to(self, adapter: Any) -> bool:
+        return self._active and self._adapter_ref() is adapter
+
+    def belongs_to_adapter_source(self, source: Any) -> bool:
+        return bool(
+            self._active
+            and self._adapter_ref() is not None
+            and self._platform
+            == str(getattr(getattr(source, "platform", None), "value", ""))
+        )
+
+    def revoke(self) -> None:
+        self._active = False
+
+    async def revalidate_async(
+        self, context: "SecurityContext", dispatch_name: str
+    ) -> None:
+        require_fresh_security_context(context)
+        if not self._active or self._adapter_ref() is None or self._loop.is_closed():
+            raise SecurityContextError("security_adapter_unavailable")
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        if running is not self._loop:
+            raise SecurityContextError("security_revalidation_off_gateway_loop")
+        try:
+            await asyncio.wait_for(
+                self._revalidator(context, dispatch_name),
+                timeout=self._revalidation_timeout_seconds,
+            )
+            require_fresh_security_context(context)
+        except asyncio.TimeoutError as exc:
+            raise SecurityContextError("security_revalidation_timeout") from exc
+        except PermissionError:
+            raise
+        except Exception as exc:
+            raise SecurityContextError("security_revalidation_failed") from exc
+
+    def revalidate_sync(self, context: "SecurityContext", tool_name: str) -> None:
+        require_fresh_security_context(context)
+        if not self._active or self._adapter_ref() is None or self._loop.is_closed():
+            raise SecurityContextError("security_adapter_unavailable")
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        if running is self._loop:
+            # Tool dispatch is intentionally synchronous and must run in the
+            # gateway executor. Blocking its own loop would deadlock.
+            raise SecurityContextError("security_revalidation_on_gateway_loop")
+        future = asyncio.run_coroutine_threadsafe(
+            self._revalidator(context, tool_name), self._loop
+        )
+        try:
+            future.result(timeout=self._revalidation_timeout_seconds)
+            require_fresh_security_context(context)
+        except concurrent.futures.TimeoutError as exc:
+            future.cancel()
+            raise SecurityContextError("security_revalidation_timeout") from exc
+        except PermissionError:
+            raise
+        except Exception as exc:
+            raise SecurityContextError("security_revalidation_failed") from exc
+
+
+def issue_adapter_security_capability(
+    adapter: Any,
+    loop: asyncio.AbstractEventLoop,
+    revalidator: SecurityRevalidator,
+    *,
+    revalidation_timeout_seconds: float = DEFAULT_REVALIDATION_TIMEOUT_SECONDS,
+) -> AdapterSecurityCapability:
+    """Issue an opaque capability for one exact adapter instance.
+
+    GatewayRunner calls this while wiring a reviewed adapter.  The returned
+    object is checked by identity; names, registry entries and event metadata
+    cannot substitute for it.
+    """
+    if (
+        adapter is None
+        or not callable(revalidator)
+        or loop is None
+        or isinstance(revalidation_timeout_seconds, bool)
+        or not isinstance(revalidation_timeout_seconds, (int, float))
+        or revalidation_timeout_seconds <= 0
+    ):
+        raise SecurityContextError("invalid_security_adapter_binding")
+    return AdapterSecurityCapability(
+        _CAPABILITY_SENTINEL,
+        adapter,
+        loop,
+        revalidator,
+        float(revalidation_timeout_seconds),
+    )
+
+
+def bind_context_to_adapter(
+    context: "SecurityContext", capability: AdapterSecurityCapability
+) -> "SecurityContext":
+    if not isinstance(context, SecurityContext):
+        raise SecurityContextError("untrusted_security_context_type")
+    if not isinstance(capability, AdapterSecurityCapability):
+        raise SecurityContextError("missing_adapter_security_capability")
+    require_fresh_security_context(context)
+    existing = context._adapter_capability
+    if existing is not None and existing is not capability:
+        raise SecurityContextError("security_context_provenance_mismatch")
+    return context if existing is capability else replace(context, _adapter_capability=capability)
+
+
+def _clean_set(values: Iterable[str], *, field_name: str) -> frozenset[str]:
+    if isinstance(values, (str, bytes)):
+        raise SecurityContextError(f"{field_name}_must_be_sequence")
+    result: set[str] = set()
+    for raw in values:
+        value = str(raw)
+        if value != value.strip() or not value or not _SAFE_ID.fullmatch(value):
+            raise SecurityContextError(f"invalid_{field_name}")
+        result.add(value)
+    return frozenset(result)
+
+
+def canonical_capability_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class SecurityContext:
+    principal_id: str
+    tenant_id: str
+    platform: str
+    authority: str
+    domains: frozenset[str] = field(default_factory=frozenset)
+    capability_bundle: str = "denied"
+    capability_hash: str = ""
+    allowed_toolsets: frozenset[str] = field(default_factory=frozenset)
+    allowed_tools: frozenset[str] = field(default_factory=frozenset)
+    denied_tools: frozenset[str] = field(default_factory=frozenset)
+    allowed_actions: frozenset[str] = field(default_factory=frozenset)
+    expose_private_context: bool = False
+    expose_memory: bool = False
+    expose_identity: bool = True
+    policy_revision: str = ""
+    authenticated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    evidence_source: str = "live"
+    _adapter_capability: AdapterSecurityCapability | None = field(
+        default=None, repr=False, compare=False
+    )
+
+    def __post_init__(self) -> None:
+        for name in (
+            "principal_id", "tenant_id", "platform", "authority",
+            "capability_bundle", "policy_revision", "evidence_source",
+        ):
+            value = str(getattr(self, name))
+            if value != value.strip() or not value or not _SAFE_ID.fullmatch(value):
+                raise SecurityContextError(f"invalid_{name}")
+        for name in (
+            "domains", "allowed_toolsets", "allowed_tools", "denied_tools",
+            "allowed_actions",
+        ):
+            object.__setattr__(self, name, _clean_set(getattr(self, name), field_name=name))
+        if self.allowed_tools & self.denied_tools:
+            raise SecurityContextError("tool_allow_deny_overlap")
+        for name in (
+            "expose_private_context", "expose_memory", "expose_identity",
+        ):
+            if not isinstance(getattr(self, name), bool):
+                raise SecurityContextError(f"invalid_{name}")
+        when = self.authenticated_at
+        if not isinstance(when, datetime) or when.tzinfo is None:
+            raise SecurityContextError("authenticated_at_must_be_timezone_aware")
+        expected = self.derive_capability_hash()
+        supplied = str(self.capability_hash or "")
+        if supplied and (not _SAFE_HASH.fullmatch(supplied) or supplied != expected):
+            raise SecurityContextError("capability_hash_mismatch")
+        object.__setattr__(self, "capability_hash", expected)
+
+    def authority_payload(self) -> Mapping[str, Any]:
+        """Canonical projection of deterministic effective authority.
+
+        Authentication timestamps and evidence labels are freshness metadata.
+        They are verified independently and intentionally do not split sessions.
+        """
+        return {
+            "principal_id": self.principal_id,
+            "tenant_id": self.tenant_id,
+            "platform": self.platform,
+            "authority": self.authority,
+            "domains": sorted(self.domains),
+            "capability_bundle": self.capability_bundle,
+            "allowed_toolsets": sorted(self.allowed_toolsets),
+            "allowed_tools": sorted(self.allowed_tools),
+            "denied_tools": sorted(self.denied_tools),
+            "allowed_actions": sorted(self.allowed_actions),
+            "expose_private_context": self.expose_private_context,
+            "expose_memory": self.expose_memory,
+            "expose_identity": self.expose_identity,
+            "policy_revision": self.policy_revision,
+        }
+
+    def derive_capability_hash(self) -> str:
+        return canonical_capability_hash(self.authority_payload())
+
+    def verify(self) -> None:
+        if self.capability_hash != self.derive_capability_hash():
+            raise SecurityContextError("capability_hash_mismatch")
+
+    @property
+    def denied(self) -> bool:
+        return self.authority == "denied" or self.capability_bundle == "denied"
+
+    def permits_tool(self, tool_name: str) -> bool:
+        name = str(tool_name or "")
+        return bool(not self.denied and name in self.allowed_tools and name not in self.denied_tools)
+
+    def permits_action(self, action: str) -> bool:
+        name = str(action or "")
+        return bool(not self.denied and name and ("*" in self.allowed_actions or name in self.allowed_actions))
+
+    def public_summary(self) -> Mapping[str, Any]:
+        return {
+            "principal_id": self.principal_id,
+            "tenant_id": self.tenant_id,
+            "platform": self.platform,
+            "authority": self.authority,
+            "domains": sorted(self.domains),
+            "capability_bundle": self.capability_bundle,
+            "capability_hash": self.capability_hash,
+            "expose_private_context": self.expose_private_context,
+            "expose_memory": self.expose_memory,
+            "expose_identity": self.expose_identity,
+            "policy_revision": self.policy_revision,
+            "evidence_source": self.evidence_source,
+        }
+
+
+def agent_context_options(context: SecurityContext | None) -> dict[str, bool]:
+    """Translate explicit exposure capabilities into ``AIAgent`` options.
+
+    A missing security context is the legacy gateway path and retains the
+    agent's existing context, identity, and memory defaults.
+    """
+    if context is None:
+        return {
+            "skip_context_files": False,
+            "load_soul_identity": False,
+            "skip_memory": False,
+        }
+    if not isinstance(context, SecurityContext):
+        raise SecurityContextError("untrusted_security_context_type")
+    context.verify()
+    return {
+        "skip_context_files": not context.expose_private_context,
+        "load_soul_identity": context.expose_identity,
+        "skip_memory": not context.expose_memory,
+    }
+
+
+def bind_security_context(context: SecurityContext | None) -> contextvars.Token:
+    if context is not None:
+        if not isinstance(context, SecurityContext):
+            raise SecurityContextError("untrusted_security_context_type")
+        context.verify()
+    return _CURRENT_SECURITY_CONTEXT.set(context)
+
+
+def reset_security_context(token: contextvars.Token) -> None:
+    _CURRENT_SECURITY_CONTEXT.reset(token)
+
+
+def current_security_context(*, required: bool = False) -> SecurityContext | None:
+    context = _CURRENT_SECURITY_CONTEXT.get()
+    if required and context is None:
+        raise SecurityContextError("missing_security_context")
+    return context
+
+
+def require_action(action: str, *, domains: Iterable[str] = ()) -> SecurityContext:
+    context = current_security_context(required=True)
+    assert context is not None
+    context.verify()
+    if not context.permits_action(action):
+        raise SecurityContextError("action_denied")
+    if not _clean_set(domains, field_name="required_domains").issubset(context.domains):
+        raise SecurityContextError("domain_denied")
+    return context
+
+
+async def require_action_for_context(
+    context: SecurityContext | None,
+    action: str,
+    *,
+    domains: Iterable[str] = (),
+) -> SecurityContext | None:
+    """Authorize an exact control action and live-revalidate provenance.
+
+    ``None`` is a legacy context and preserves existing gateway behaviour.
+    Secure contexts never inherit wildcard command authority.
+    """
+    if context is None:
+        return None
+    if not isinstance(context, SecurityContext):
+        raise SecurityContextError("untrusted_security_context_type")
+    context.verify()
+    name = str(action or "")
+    if not name or context.denied or name not in context.allowed_actions:
+        raise SecurityContextError("action_denied")
+    if not _clean_set(domains, field_name="required_domains").issubset(context.domains):
+        raise SecurityContextError("domain_denied")
+    capability = context._adapter_capability
+    if not isinstance(capability, AdapterSecurityCapability):
+        raise SecurityContextError("missing_adapter_security_capability")
+    await capability.revalidate_async(context, f"action:{name}")
+    return context
+
+
+def filter_tool_schemas(
+    schemas: Sequence[Mapping[str, Any]], context: SecurityContext
+) -> list[dict[str, Any]]:
+    context.verify()
+    if context.denied:
+        return []
+    filtered: list[dict[str, Any]] = []
+    for schema in schemas or ():
+        try:
+            name = str(schema["function"]["name"])
+        except (KeyError, TypeError):
+            continue
+        if context.permits_tool(name):
+            filtered.append(dict(schema))
+    return filtered
+
+
+def build_security_context_prompt(context: SecurityContext) -> str:
+    context.verify()
+    summary = context.public_summary()
+    return (
+        "## Authenticated Channel Security Boundary\n\n"
+        f"Authority: `{summary['authority']}`. "
+        f"Capability bundle: `{summary['capability_bundle']}`. "
+        f"Domains: `{', '.join(summary['domains']) or 'none'}`. "
+        f"Policy revision: `{summary['policy_revision']}`.\n\n"
+        "The gateway has already filtered context and tools. Do not claim access "
+        "outside this boundary. Explain denials naturally. Never request, reveal, "
+        "or transport credentials or secret values through this channel."
+    )
+
+
+def apply_security_context_to_agent(agent: Any, context: SecurityContext) -> None:
+    """Bind/revalidate a capability-scoped agent and narrow its current tools."""
+    context.verify()
+    existing = getattr(agent, "_security_context", None)
+    if existing is not None:
+        if not isinstance(existing, SecurityContext):
+            raise SecurityContextError("invalid_agent_security_context")
+        existing.verify()
+        if existing.capability_hash != context.capability_hash:
+            raise SecurityContextError("cached_agent_capability_mismatch")
+        if existing._adapter_capability is not context._adapter_capability:
+            raise SecurityContextError("cached_agent_provenance_mismatch")
+    agent.tools = filter_tool_schemas(getattr(agent, "tools", ()) or (), context)
+    agent.valid_tool_names = {
+        str(item["function"]["name"]) for item in agent.tools
+        if isinstance(item, dict) and isinstance(item.get("function"), dict)
+    }
+    agent._security_context = context
+    agent._capability_allowed_tools = frozenset(agent.valid_tool_names)
+
+
+def enforce_agent_tool_dispatch(agent: Any, tool_name: str) -> None:
+    """Exact check and live revalidation immediately before dispatch."""
+    context = getattr(agent, "_security_context", None)
+    if context is None:
+        return
+    if not isinstance(context, SecurityContext):
+        raise SecurityContextError("invalid_agent_security_context")
+    context.verify()
+    if context.denied:
+        raise SecurityContextError("context_denied")
+    if tool_name not in getattr(agent, "_capability_allowed_tools", frozenset()):
+        raise SecurityContextError("tool_denied")
+    if not context.permits_tool(tool_name):
+        raise SecurityContextError("tool_denied")
+    capability = context._adapter_capability
+    if not isinstance(capability, AdapterSecurityCapability):
+        raise SecurityContextError("missing_adapter_security_capability")
+    capability.revalidate_sync(context, tool_name)
+
+
+def reapply_security_context_after_tool_refresh(agent: Any) -> None:
+    """Re-filter a rebuilt tool snapshot before it is published to a turn."""
+    context = getattr(agent, "_security_context", None)
+    if context is not None:
+        apply_security_context_to_agent(agent, context)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -17,7 +17,7 @@ import threading
 import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
@@ -203,6 +203,12 @@ class SessionSource:
     # deliberately excluded from ``to_dict``/``from_dict`` so a peer can never
     # forge it across the wire or have it restored from persistence.
     delivered_via_upstream_relay: bool = False
+
+    # Internal, wire-INVISIBLE capability envelope supplied by a trusted
+    # platform adapter.  Excluded from to_dict/from_dict so persisted or relayed
+    # message data cannot manufacture authority.  build_session_key consumes
+    # only its non-secret capability discriminator.
+    security_context: Any = field(default=None, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         # D-Q2.5 dual-field reconciliation: `scope_id` is canonical, `guild_id`
@@ -936,6 +942,30 @@ def build_session_key(
       - Without identifiers, messages fall back to one session per platform/chat_type.
     """
     ns = _session_key_namespace(profile)
+
+    def _scoped(key: str) -> str:
+        security_context = getattr(source, "security_context", None)
+        if security_context is None:
+            return key
+        from gateway.security_context import SecurityContext, SecurityContextError
+        if not isinstance(security_context, SecurityContext):
+            raise SecurityContextError("invalid_source_security_context")
+        # Use canonical JSON hashed to a fixed-width discriminator. Delimiter
+        # characters inside principal/tenant IDs can never create aliasing.
+        scope_payload = {
+            "principal_id": security_context.principal_id,
+            "tenant_id": security_context.tenant_id,
+            "capability_hash": security_context.capability_hash,
+        }
+        scope_hash = hashlib.sha256(
+            json.dumps(
+                scope_payload,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+            ).encode("utf-8")
+        ).hexdigest()
+        return f"{key}:security:{scope_hash}"
     platform = source.platform.value
     if source.chat_type == "dm":
         dm_chat_id = source.chat_id
@@ -944,8 +974,8 @@ def build_session_key(
 
         if dm_chat_id:
             if source.thread_id:
-                return f"{ns}:{platform}:dm:{dm_chat_id}:{source.thread_id}"
-            return f"{ns}:{platform}:dm:{dm_chat_id}"
+                return _scoped(f"{ns}:{platform}:dm:{dm_chat_id}:{source.thread_id}")
+            return _scoped(f"{ns}:{platform}:dm:{dm_chat_id}")
         # No chat_id — fall back to the sender's own identifier before the
         # bare per-platform sink.  Without this, every DM from every user that
         # arrives without a chat_id (non-standard adapters / synthetic sources)
@@ -960,11 +990,11 @@ def build_session_key(
             )
         if dm_participant_id:
             if source.thread_id:
-                return f"{ns}:{platform}:dm:{dm_participant_id}:{source.thread_id}"
-            return f"{ns}:{platform}:dm:{dm_participant_id}"
+                return _scoped(f"{ns}:{platform}:dm:{dm_participant_id}:{source.thread_id}")
+            return _scoped(f"{ns}:{platform}:dm:{dm_participant_id}")
         if source.thread_id:
-            return f"{ns}:{platform}:dm:{source.thread_id}"
-        return f"{ns}:{platform}:dm"
+            return _scoped(f"{ns}:{platform}:dm:{source.thread_id}")
+        return _scoped(f"{ns}:{platform}:dm")
 
     participant_id = source.user_id_alt or source.user_id
     if participant_id and source.platform == Platform.WHATSAPP:
@@ -989,7 +1019,7 @@ def build_session_key(
     if isolate_user and participant_id:
         key_parts.append(str(participant_id))
 
-    return ":".join(key_parts)
+    return _scoped(":".join(key_parts))
 
 
 class _SessionFlight:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2302,6 +2302,10 @@ class GatewaySlashCommandsMixin:
             source=source,
             raw_message=event.raw_message,
             channel_prompt=event.channel_prompt,
+            security_context=getattr(event, "security_context", None),
+            _adapter_security_capability=getattr(
+                event, "_adapter_security_capability", None
+            ),
         )
         
         # Let the normal message handler process it
@@ -2434,6 +2438,10 @@ class GatewaySlashCommandsMixin:
                     source=event.source,
                     message_id=event.message_id,
                     channel_prompt=event.channel_prompt,
+                    security_context=getattr(event, "security_context", None),
+                    _adapter_security_capability=getattr(
+                        event, "_adapter_security_capability", None
+                    ),
                 )
                 self._enqueue_fifo(_quick_key, kickoff_event, adapter)
             except Exception as exc:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -962,7 +962,9 @@ class PluginContext:
         """
         from gateway.platform_registry import platform_registry, PlatformEntry
 
-        entry_kwargs.setdefault("plugin_name", self.manifest.name)
+        # Registration metadata is host-owned. A plugin must not impersonate a
+        # different manifest identity through forwarded PlatformEntry kwargs.
+        entry_kwargs["plugin_name"] = self.manifest.name
         entry = PlatformEntry(
             name=name,
             label=label,

--- a/tests/gateway/test_platform_registry.py
+++ b/tests/gateway/test_platform_registry.py
@@ -5,7 +5,7 @@ import pytest
 from unittest.mock import MagicMock
 
 from gateway.platform_registry import PlatformRegistry, PlatformEntry
-from gateway.config import Platform, GatewayConfig
+from gateway.config import Platform, GatewayConfig, SecurityContextTrustGrant
 
 
 # ── Platform enum dynamic members ─────────────────────────────────────────
@@ -200,6 +200,43 @@ class TestPlatformRegistry:
         reg.register(entry2)
         assert reg.get("dup").label == "Dup v2"
 
+    def test_reregistration_cannot_relabel_existing_adapter_provenance(self):
+        reg = PlatformRegistry()
+        adapter = MagicMock()
+        first = PlatformEntry(
+            name="dup", label="First", adapter_factory=lambda cfg: adapter,
+            check_fn=lambda: True, source="plugin", plugin_name="trusted",
+        )
+        replacement = PlatformEntry(
+            name="dup", label="Replacement", adapter_factory=lambda cfg: adapter,
+            check_fn=lambda: True, source="plugin", plugin_name="trusted",
+        )
+        reg.register(first)
+        assert reg.create_adapter("dup", object()) is adapter
+        assert reg.adapter_matches_entry(adapter, first)
+        reg.register(replacement)
+        assert reg.create_adapter("dup", object()) is adapter
+        assert not reg.adapter_matches_entry(adapter, replacement)
+
+    def test_plugin_context_owns_plugin_identity_even_if_plugin_spoofs_kwarg(self):
+        from hermes_cli.plugins import PluginContext, PluginManifest
+        from gateway.platform_registry import platform_registry as global_registry
+
+        manager = MagicMock()
+        manager._plugin_platform_names = set()
+        ctx = PluginContext(PluginManifest(name="real-plugin"), manager)
+        try:
+            ctx.register_platform(
+                name="identity-test",
+                label="Identity Test",
+                adapter_factory=lambda cfg: MagicMock(),
+                check_fn=lambda: True,
+                plugin_name="spoofed-plugin",
+            )
+            assert global_registry.get("identity-test").plugin_name == "real-plugin"
+        finally:
+            global_registry.unregister("identity-test")
+
 
 # ── GatewayConfig integration ────────────────────────────────────────────
 
@@ -218,6 +255,56 @@ class TestGatewayConfigPluginPlatform:
         platform_values = {p.value for p in cfg.platforms}
         assert "telegram" in platform_values
         assert "irc" in platform_values
+
+    def test_security_context_trust_grants_parse_exact_identity_and_drop_malformed(self):
+        cfg = GatewayConfig.from_dict({
+            "security_context_trust_grants": [
+                {
+                    "platform": "telegram",
+                    "adapter_module": "secure.adapter",
+                    "adapter_class": "TeamsAdapter",
+                    "plugin_name": "secure-plugin",
+                },
+                {"platform": "telegram", "adapter_module": "missing-class"},
+                "not-a-mapping",
+            ]
+        })
+        assert cfg.security_context_trust_grants == (
+            SecurityContextTrustGrant(
+                platform="telegram",
+                adapter_module="secure.adapter",
+                adapter_class="TeamsAdapter",
+                plugin_name="secure-plugin",
+            ),
+        )
+        round_trip = GatewayConfig.from_dict(cfg.to_dict())
+        assert round_trip.security_context_trust_grants == cfg.security_context_trust_grants
+
+    def test_security_context_trust_grants_load_from_host_gateway_yaml(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "gateway:\n"
+            "  security_context_trust_grants:\n"
+            "    - platform: telegram\n"
+            "      adapter_module: secure.adapter\n"
+            "      adapter_class: TeamsAdapter\n"
+            "      plugin_name: secure-plugin\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        from gateway.config import load_gateway_config
+
+        assert load_gateway_config().security_context_trust_grants == (
+            SecurityContextTrustGrant(
+                platform="telegram",
+                adapter_module="secure.adapter",
+                adapter_class="TeamsAdapter",
+                plugin_name="secure-plugin",
+            ),
+        )
 
     def test_get_connected_platforms_includes_registered_plugin(self):
         """Plugin platform with registry entry passes get_connected_platforms."""

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -1,7 +1,6 @@
 """Tests for gateway /reasoning command and hot reload behavior."""
 
 import asyncio
-import inspect
 import sys
 import types
 from unittest.mock import AsyncMock, MagicMock
@@ -78,8 +77,11 @@ class TestReasoningCommand:
         assert "level" in result and "show" in result and "hide" in result
 
     def test_reasoning_is_known_command(self):
-        source = inspect.getsource(gateway_run.GatewayRunner._handle_message)
-        assert '"reasoning"' in source
+        from hermes_cli.commands import is_gateway_known_command, resolve_command
+
+        definition = resolve_command("reasoning")
+        assert definition is not None and definition.name == "reasoning"
+        assert is_gateway_known_command(definition.name)
 
     def test_parse_reasoning_command_args_accepts_ascii_and_smart_global_flags(self):
         assert gateway_run.GatewayRunner._parse_reasoning_command_args("high --global") == ("high", True)

--- a/tests/gateway/test_security_context.py
+++ b/tests/gateway/test_security_context.py
@@ -1,0 +1,962 @@
+import asyncio
+from contextlib import nullcontext
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+import gateway.security_context as security_module
+from gateway.config import (
+    GatewayConfig,
+    HomeChannel,
+    Platform,
+    PlatformConfig,
+    SecurityContextTrustGrant,
+)
+from gateway.platform_registry import PlatformEntry, platform_registry
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.security_context import (
+    SecurityContext,
+    SecurityContextError,
+    apply_security_context_to_agent,
+    bind_context_to_adapter,
+    bind_security_context,
+    current_security_context,
+    enforce_agent_tool_dispatch,
+    issue_adapter_security_capability,
+    reset_security_context,
+    require_action_for_context,
+)
+from gateway.session import SessionSource, build_session_key
+
+_AUTH_TIME = datetime.now(timezone.utc)
+
+
+def _context(
+    *,
+    principal="user-a",
+    tenant="tenant-a",
+    platform="telegram",
+    tools=("web_search",),
+    denied=(),
+    revision="r1",
+    authority="tier1_staff",
+    bundle="tier1_staff",
+    domains=("daily",),
+    toolsets=("web",),
+    actions=("teams.reply",),
+    expose_private_context=False,
+    expose_memory=False,
+    expose_identity=True,
+    authenticated_at=None,
+    evidence_source="test",
+):
+    return SecurityContext(
+        principal_id=principal,
+        tenant_id=tenant,
+        platform=platform,
+        authority=authority,
+        domains=frozenset(domains),
+        capability_bundle=bundle,
+        allowed_toolsets=frozenset(toolsets),
+        allowed_tools=frozenset(tools),
+        denied_tools=frozenset(denied),
+        allowed_actions=frozenset(actions),
+        expose_private_context=expose_private_context,
+        expose_memory=expose_memory,
+        expose_identity=expose_identity,
+        policy_revision=revision,
+        authenticated_at=authenticated_at or datetime.now(timezone.utc),
+        evidence_source=evidence_source,
+    )
+
+
+class _Adapter:
+    platform = Platform.TELEGRAM
+
+    def __init__(self):
+        self.revalidated = []
+
+    async def revalidate_security_context(self, context, tool_name):
+        self.revalidated.append((context.capability_hash, tool_name))
+
+
+class _OtherAdapter(_Adapter):
+    pass
+
+
+class _LiveTrustedAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(
+            PlatformConfig(enabled=True, token="test-token"), Platform.TELEGRAM
+        )
+        self.effects = []
+
+    async def connect(self, *, is_reconnect: bool = False):
+        return None
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, text, **kwargs):
+        self.effects.append(("send", chat_id, text))
+        return SendResult(success=True, message_id="sent")
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+    async def revalidate_security_context(self, context, tool_name):
+        self.effects.append(("revalidate", tool_name))
+
+
+def _grant(
+    adapter_class: type = _Adapter,
+    *,
+    platform="telegram",
+    plugin_name="secure-plugin",
+):
+    return SecurityContextTrustGrant(
+        platform=platform,
+        adapter_module=adapter_class.__module__,
+        adapter_class=adapter_class.__qualname__,
+        plugin_name=plugin_name,
+    )
+
+
+def _entry(adapter, *, plugin_name="secure-plugin", trusted=False):
+    return PlatformEntry(
+        name="telegram",
+        label="Test",
+        adapter_factory=lambda cfg: adapter,
+        check_fn=lambda: True,
+        source="plugin",
+        plugin_name=plugin_name,
+        trusted_security_context=trusted,
+    )
+
+
+def test_capability_hash_ignores_freshness_metadata():
+    base = _context(authenticated_at=_AUTH_TIME)
+    refreshed = _context(
+        authenticated_at=_AUTH_TIME + timedelta(minutes=10),
+        evidence_source="graph-live-refresh",
+    )
+    assert refreshed.capability_hash == base.capability_hash
+    source = dict(
+        platform=Platform.TELEGRAM, chat_id="room", chat_type="group", user_id="user-a"
+    )
+    assert build_session_key(SessionSource(**source, security_context=refreshed)) == (
+        build_session_key(SessionSource(**source, security_context=base))
+    )
+
+
+@pytest.mark.asyncio
+async def test_context_freshness_is_enforced_at_admission_and_dispatch():
+    adapter = _Adapter()
+    capability = issue_adapter_security_capability(
+        adapter, asyncio.get_running_loop(), adapter.revalidate_security_context
+    )
+    stale = _context(
+        authenticated_at=datetime.now(timezone.utc) - timedelta(minutes=6)
+    )
+
+    with pytest.raises(SecurityContextError, match="security_context_expired"):
+        bind_context_to_adapter(stale, capability)
+
+    future = _context(
+        authenticated_at=datetime.now(timezone.utc) + timedelta(seconds=31)
+    )
+    with pytest.raises(SecurityContextError, match="security_context_from_future"):
+        bind_context_to_adapter(future, capability)
+
+    bound = bind_context_to_adapter(_context(), capability)
+    stale_after_admission = replace(
+        bound,
+        authenticated_at=datetime.now(timezone.utc) - timedelta(minutes=6),
+    )
+    with pytest.raises(SecurityContextError, match="security_context_expired"):
+        await capability.revalidate_async(stale_after_admission, "web_search")
+    with pytest.raises(SecurityContextError, match="security_context_expired"):
+        capability.revalidate_sync(stale_after_admission, "web_search")
+
+
+@pytest.mark.asyncio
+async def test_context_expiring_during_revalidation_denies_async_and_sync_dispatch(
+    monkeypatch,
+):
+    adapter = _Adapter()
+    capability = issue_adapter_security_capability(
+        adapter, asyncio.get_running_loop(), adapter.revalidate_security_context
+    )
+    bound = bind_context_to_adapter(_context(), capability)
+
+    async_freshness = Mock(
+        side_effect=[None, SecurityContextError("security_context_expired")]
+    )
+    monkeypatch.setattr(
+        security_module, "require_fresh_security_context", async_freshness
+    )
+    with pytest.raises(SecurityContextError, match="security_context_expired"):
+        await capability.revalidate_async(bound, "teams.reply")
+
+    sync_freshness = Mock(
+        side_effect=[None, SecurityContextError("security_context_expired")]
+    )
+    monkeypatch.setattr(
+        security_module, "require_fresh_security_context", sync_freshness
+    )
+    with pytest.raises(SecurityContextError, match="security_context_expired"):
+        await asyncio.to_thread(capability.revalidate_sync, bound, "web_search")
+
+
+def test_context_freshness_exact_age_and_clock_skew_boundaries():
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    security_module.require_fresh_security_context(
+        _context(authenticated_at=now - timedelta(seconds=300)), now=now
+    )
+    security_module.require_fresh_security_context(
+        _context(authenticated_at=now + timedelta(seconds=30)), now=now
+    )
+    with pytest.raises(SecurityContextError, match="security_context_expired"):
+        security_module.require_fresh_security_context(
+            _context(authenticated_at=now - timedelta(seconds=300, microseconds=1)),
+            now=now,
+        )
+    with pytest.raises(SecurityContextError, match="security_context_from_future"):
+        security_module.require_fresh_security_context(
+            _context(authenticated_at=now + timedelta(seconds=30, microseconds=1)),
+            now=now,
+        )
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"principal": "user-b"},
+        {"tenant": "tenant-b"},
+        {"platform": "discord"},
+        {"authority": "tier2"},
+        {"domains": ("daily", "restricted")},
+        {"bundle": "tier2"},
+        {"toolsets": ("web", "files")},
+        {"tools": ("web_extract",)},
+        {"denied": ("terminal",)},
+        {"actions": ("teams.reply", "teams.delete")},
+        {"expose_private_context": True},
+        {"expose_memory": True},
+        {"expose_identity": False},
+        {"revision": "r2"},
+    ],
+)
+def test_capability_hash_changes_for_every_effective_policy_field(change):
+    base = _context()
+    assert len(base.capability_hash) == 64
+    assert _context(**change).capability_hash != base.capability_hash
+
+
+def test_capability_hash_rejects_stale_supplied_digest():
+    base = _context()
+    with pytest.raises(SecurityContextError, match="capability_hash_mismatch"):
+        replace(base, capability_hash="0" * 64, policy_revision="r2")
+
+
+@pytest.mark.parametrize(
+    "field", ["expose_private_context", "expose_memory", "expose_identity"]
+)
+def test_exposure_capabilities_require_booleans(field):
+    with pytest.raises(SecurityContextError, match=f"invalid_{field}"):
+        _context(**{field: "yes"})
+
+
+def test_agent_context_options_are_explicit_and_legacy_context_is_unchanged():
+    from gateway.security_context import agent_context_options
+
+    assert agent_context_options(None) == {
+        "skip_context_files": False,
+        "load_soul_identity": False,
+        "skip_memory": False,
+    }
+    assert agent_context_options(
+        _context(
+            authority="arbitrary-label",
+            bundle="arbitrary-bundle",
+            expose_private_context=True,
+            expose_memory=True,
+            expose_identity=False,
+        )
+    ) == {
+        "skip_context_files": False,
+        "load_soul_identity": False,
+        "skip_memory": False,
+    }
+    assert agent_context_options(
+        _context(
+            authority="another-label",
+            bundle="another-bundle",
+            expose_private_context=False,
+            expose_memory=False,
+            expose_identity=True,
+        )
+    ) == {
+        "skip_context_files": True,
+        "load_soul_identity": True,
+        "skip_memory": True,
+    }
+
+
+def test_session_key_isolated_with_collision_free_security_discriminator():
+    base = dict(platform=Platform.TELEGRAM, chat_id="room", chat_type="group")
+    contexts = (
+        _context(principal="user-a"),
+        _context(principal="user-b"),
+        _context(principal="user-a", tools=("web_extract",)),
+        _context(principal="a:tenant:b", tenant="c"),
+        _context(principal="a", tenant="b:tenant:c"),
+    )
+    keys = {
+        build_session_key(
+            SessionSource(**base, user_id=context.principal_id, security_context=context)
+        )
+        for context in contexts
+    }
+    assert len(keys) == len(contexts)
+    assert all(":security:" in key and len(key.rsplit(":", 1)[-1]) == 64 for key in keys)
+
+
+def test_security_context_is_wire_invisible():
+    context = _context()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="dm",
+        user_id="user-a",
+        security_context=context,
+    )
+    encoded = source.to_dict()
+    assert "security_context" not in encoded
+    assert SessionSource.from_dict(encoded).security_context is None
+
+
+def test_apply_context_intersects_tool_schemas_and_denies_exact_other_name():
+    agent = SimpleNamespace(
+        tools=[
+            {"type": "function", "function": {"name": "web_search"}},
+            {"type": "function", "function": {"name": "terminal"}},
+        ],
+        valid_tool_names={"web_search", "terminal"},
+    )
+    apply_security_context_to_agent(agent, _context())
+    assert agent.valid_tool_names == {"web_search"}
+    with pytest.raises(SecurityContextError, match="tool_denied"):
+        enforce_agent_tool_dispatch(agent, "terminal")
+
+
+@pytest.mark.asyncio
+async def test_allowed_dispatch_revalidates_on_gateway_loop_from_executor():
+    adapter = _Adapter()
+    capability = issue_adapter_security_capability(
+        adapter, asyncio.get_running_loop(), adapter.revalidate_security_context
+    )
+    context = bind_context_to_adapter(_context(), capability)
+    agent = SimpleNamespace(
+        tools=[{"type": "function", "function": {"name": "web_search"}}],
+        valid_tool_names={"web_search"},
+    )
+    apply_security_context_to_agent(agent, context)
+    await asyncio.to_thread(enforce_agent_tool_dispatch, agent, "web_search")
+    assert adapter.revalidated == [(context.capability_hash, "web_search")]
+
+
+@pytest.mark.asyncio
+async def test_live_revalidation_times_out_and_cancels_hung_callback():
+    cancelled = asyncio.Event()
+
+    class HungAdapter(_Adapter):
+        async def revalidate_security_context(self, context, tool_name):
+            try:
+                await asyncio.Future()
+            finally:
+                cancelled.set()
+
+    adapter = HungAdapter()
+    capability = issue_adapter_security_capability(
+        adapter,
+        asyncio.get_running_loop(),
+        adapter.revalidate_security_context,
+        revalidation_timeout_seconds=0.02,
+    )
+    context = bind_context_to_adapter(_context(), capability)
+    agent = SimpleNamespace(
+        tools=[{"type": "function", "function": {"name": "web_search"}}],
+        valid_tool_names={"web_search"},
+    )
+    apply_security_context_to_agent(agent, context)
+    with pytest.raises(SecurityContextError, match="security_revalidation_timeout"):
+        await asyncio.to_thread(enforce_agent_tool_dispatch, agent, "web_search")
+    await asyncio.wait_for(cancelled.wait(), timeout=1)
+
+
+def test_capability_change_or_provenance_change_cannot_mutate_cached_agent():
+    agent = SimpleNamespace(
+        tools=[{"type": "function", "function": {"name": "web_search"}}],
+        valid_tool_names={"web_search"},
+    )
+    apply_security_context_to_agent(agent, _context())
+    with pytest.raises(SecurityContextError, match="cached_agent_capability_mismatch"):
+        apply_security_context_to_agent(agent, _context(tools=("web_extract",), revision="r2"))
+
+
+def test_contextvar_binding_resets_without_leak():
+    context = _context()
+    token = bind_security_context(context)
+    try:
+        assert current_security_context(required=True) is context
+    finally:
+        reset_security_context(token)
+    assert current_security_context() is None
+
+
+def test_invalid_overlapping_and_denied_contexts_fail_closed():
+    with pytest.raises(SecurityContextError):
+        _context(principal="bad principal")
+    with pytest.raises(SecurityContextError, match="tool_allow_deny_overlap"):
+        _context(tools=("terminal",), denied=("terminal",))
+    denied = _context(authority="denied", bundle="denied", tools=())
+    assert denied.denied
+    assert not denied.permits_tool("web_search")
+
+
+def test_platform_trust_flag_defaults_false():
+    entry = PlatformEntry(
+        name="example",
+        label="Example",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+    )
+    assert entry.trusted_security_context is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "grant,registered_class,entry_plugin,source_platform",
+    [
+        (None, _Adapter, "secure-plugin", Platform.TELEGRAM),
+        (replace(_grant(), adapter_module="wrong.module"), _Adapter, "secure-plugin", Platform.TELEGRAM),
+        (replace(_grant(), adapter_class="WrongAdapter"), _Adapter, "secure-plugin", Platform.TELEGRAM),
+        (_grant(plugin_name="other-plugin"), _Adapter, "secure-plugin", Platform.TELEGRAM),
+        (_grant(platform="discord"), _Adapter, "secure-plugin", Platform.TELEGRAM),
+        (_grant(), _OtherAdapter, "secure-plugin", Platform.TELEGRAM),
+        (_grant(), _Adapter, "other-plugin", Platform.TELEGRAM),
+        (_grant(), _Adapter, "secure-plugin", Platform.DISCORD),
+    ],
+)
+async def test_gateway_trust_requires_exact_host_registry_class_plugin_and_platform(
+    grant, registered_class, entry_plugin, source_platform
+):
+    from gateway.run import GatewayRunner
+
+    prior = platform_registry.get("telegram")
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        security_context_trust_grants=(() if grant is None else (grant,))
+    )
+    runner._startup_restore_in_progress = True
+    runner._queue_startup_restore_event = lambda event: pytest.fail("untrusted event queued")
+    try:
+        registered = registered_class()
+        platform_registry.register(
+            _entry(registered, plugin_name=entry_plugin, trusted=True)
+        )
+        adapter = platform_registry.create_adapter("telegram", object())
+        assert adapter is registered
+        handler = runner._make_adapter_message_handler(adapter)
+        source = SessionSource(
+            platform=source_platform, chat_id="dm", user_id="user-a"
+        )
+        assert await handler(
+            MessageEvent(text="hello", source=source, security_context=_context())
+        ) is None
+    finally:
+        platform_registry.unregister("telegram")
+        if prior is not None:
+            platform_registry.register(prior)
+
+
+@pytest.mark.asyncio
+async def test_gateway_binds_exact_adapter_and_registry_reregistration_cannot_spoof():
+    from gateway.run import GatewayRunner
+
+    prior = platform_registry.get("telegram")
+    queued = []
+    runner = object.__new__(GatewayRunner)
+    runner._startup_restore_in_progress = True
+    runner._queue_startup_restore_event = queued.append
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="dm", user_id="user-a")
+    context = _context()
+    adapter = _Adapter()
+    runner.config = GatewayConfig(security_context_trust_grants=(_grant(),))
+    try:
+        # Direct/unprovenanced invocation is denied even if a plugin self-asserts trust.
+        platform_registry.register(_entry(adapter, trusted=True))
+        assert await runner._handle_message(
+            MessageEvent(text="hello", source=source, security_context=context)
+        ) is None
+        assert queued == []
+
+        assert platform_registry.create_adapter("telegram", object()) is adapter
+        handler = runner._make_adapter_message_handler(adapter)
+        await handler(MessageEvent(text="hello", source=source, security_context=context))
+        assert len(queued) == 1
+        assert queued[0].source.security_context._adapter_capability.belongs_to(adapter)
+        queued.clear()
+
+        # Re-registering/spoofing the same platform after the adapter was created
+        # invalidates both newly-created and already-issued handler provenance.
+        platform_registry.register(_entry(_OtherAdapter(), plugin_name="attacker"))
+        spoofed_handler = runner._make_adapter_message_handler(adapter)
+        assert await spoofed_handler(
+            MessageEvent(text="hello", source=source, security_context=context)
+        ) is None
+        assert queued == []
+        assert await handler(
+            MessageEvent(text="hello", source=source, security_context=context)
+        ) is None
+        assert queued == []
+
+        # Even an exact-identity replacement entry cannot claim an already
+        # created instance (registry creation provenance is first-writer-wins).
+        platform_registry.register(_entry(adapter))
+        assert platform_registry.create_adapter("telegram", object()) is adapter
+        replacement_handler = runner._make_adapter_message_handler(adapter)
+        assert await replacement_handler(
+            MessageEvent(text="hello", source=source, security_context=context)
+        ) is None
+        assert queued == []
+        assert await handler(
+            MessageEvent(text="hello", source=source, security_context=context)
+        ) is None
+        assert queued == []
+    finally:
+        platform_registry.unregister("telegram")
+        if prior is not None:
+            platform_registry.register(prior)
+
+
+@pytest.mark.asyncio
+async def test_denied_and_principal_mismatch_stop_before_session_or_command_paths():
+    from gateway.run import GatewayRunner
+
+    prior = platform_registry.get("telegram")
+    runner = object.__new__(GatewayRunner)
+    runner._startup_restore_in_progress = True
+    runner._queue_startup_restore_event = lambda event: pytest.fail("must stop before queue")
+    adapter = _Adapter()
+    runner.config = GatewayConfig(security_context_trust_grants=(_grant(),))
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="dm", user_id="user-a")
+    try:
+        platform_registry.register(_entry(adapter))
+        platform_registry.create_adapter("telegram", object())
+        handler = runner._make_adapter_message_handler(adapter)
+        assert await handler(MessageEvent(
+            text="/reset", source=source,
+            security_context=_context(authority="denied", bundle="denied", tools=()),
+        )) is None
+        assert await handler(MessageEvent(
+            text="hello", source=source,
+            security_context=_context(principal="someone-else"),
+        )) is None
+    finally:
+        platform_registry.unregister("telegram")
+        if prior is not None:
+            platform_registry.register(prior)
+
+
+@pytest.mark.asyncio
+async def test_direct_synthetic_entry_cannot_bypass_trusted_adapter_context(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    prior = platform_registry.get("telegram")
+    runner = object.__new__(GatewayRunner)
+    adapter = _Adapter()
+    runner.config = GatewayConfig(security_context_trust_grants=(_grant(),))
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    entered = []
+
+    async def impl(_event):
+        entered.append(True)
+        return "unsafe"
+
+    monkeypatch.setattr(runner, "_handle_message_impl", impl)
+    try:
+        platform_registry.register(_entry(adapter))
+        assert platform_registry.create_adapter("telegram", object()) is adapter
+        event = MessageEvent(
+            text="internal continuation",
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                user_id="user-1",
+                chat_id="chat-1",
+            ),
+            internal=True,
+        )
+        assert await runner._handle_message(event) is None
+        assert entered == []
+    finally:
+        platform_registry.unregister("telegram")
+        if prior is not None:
+            platform_registry.register(prior)
+
+
+@pytest.mark.asyncio
+async def test_trusted_adapter_handoff_denies_before_destination_mutation():
+    """A context-free handoff must fail before creating or rebinding its lane."""
+    from gateway.run import GatewayRunner
+
+    prior = platform_registry.get("telegram")
+    adapter = _LiveTrustedAdapter()
+    adapter.create_handoff_thread = AsyncMock(return_value="new-thread")
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                token="test-token",
+                home_channel=HomeChannel(
+                    platform=Platform.TELEGRAM,
+                    chat_id="home-chat",
+                    name="Home",
+                ),
+            )
+        },
+        security_context_trust_grants=(
+            _grant(adapter_class=_LiveTrustedAdapter),
+        ),
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.session_store = object()
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=AsyncMock(),
+        switch_session=AsyncMock(),
+    )
+    runner._evict_cached_agent = Mock()
+    runner._release_running_agent_state = Mock()
+
+    try:
+        platform_registry.register(
+            PlatformEntry(
+                name="telegram",
+                label="Trusted Base Test",
+                adapter_factory=lambda cfg: adapter,
+                check_fn=lambda: True,
+                source="plugin",
+                plugin_name="secure-plugin",
+                trusted_security_context=True,
+            )
+        )
+        assert platform_registry.create_adapter("telegram", object()) is adapter
+        runner._install_adapter_security_preflight(adapter)
+
+        handoff = {
+            "id": "cli-session",
+            "title": "CLI work",
+            "handoff_platform": "telegram",
+        }
+        with pytest.raises(
+            SecurityContextError, match="handoff_security_context_missing"
+        ):
+            await runner._process_handoff(handoff)
+
+        runner.config = replace(
+            runner.config, security_context_trust_grants=()
+        )
+        with pytest.raises(
+            SecurityContextError, match="handoff_security_context_missing"
+        ):
+            await runner._process_handoff(handoff)
+
+        platform_registry.register(
+            PlatformEntry(
+                name="telegram",
+                label="Replacement",
+                adapter_factory=lambda cfg: _OtherAdapter(),
+                check_fn=lambda: True,
+                source="plugin",
+                plugin_name="replacement",
+                trusted_security_context=False,
+            )
+        )
+        with pytest.raises(
+            SecurityContextError, match="handoff_security_context_missing"
+        ):
+            await runner._process_handoff(handoff)
+
+        adapter.create_handoff_thread.assert_not_awaited()
+        runner.async_session_store.get_or_create_session.assert_not_awaited()
+        runner.async_session_store.switch_session.assert_not_awaited()
+        runner._evict_cached_agent.assert_not_called()
+        runner._release_running_agent_state.assert_not_called()
+    finally:
+        platform_registry.unregister("telegram")
+        if prior is not None:
+            platform_registry.register(prior)
+
+
+@pytest.mark.asyncio
+async def test_action_requires_exact_grant_and_live_revalidation_before_effect():
+    adapter = _Adapter()
+    capability = issue_adapter_security_capability(
+        adapter, asyncio.get_running_loop(), adapter.revalidate_security_context
+    )
+    context = bind_context_to_adapter(
+        _context(actions=("command.reset",)), capability
+    )
+    with pytest.raises(SecurityContextError, match="action_denied"):
+        await require_action_for_context(context, "command.restart")
+    assert adapter.revalidated == []
+
+    await require_action_for_context(context, "command.reset")
+    assert adapter.revalidated == [(context.capability_hash, "action:command.reset")]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_revalidation_uses_live_registry_and_live_runner_grants():
+    from gateway.run import GatewayRunner
+
+    prior = platform_registry.get("telegram")
+    runner = object.__new__(GatewayRunner)
+    adapter = _Adapter()
+    runner.config = GatewayConfig(security_context_trust_grants=(_grant(),))
+    try:
+        entry = _entry(adapter)
+        platform_registry.register(entry)
+        assert platform_registry.create_adapter("telegram", object()) is adapter
+        capability = runner._issue_live_adapter_security_capability(adapter)
+        context = bind_context_to_adapter(
+            _context(actions=("command.reset",)), capability
+        )
+
+        await require_action_for_context(context, "command.reset")
+        runner.config = GatewayConfig(security_context_trust_grants=())
+        with pytest.raises(SecurityContextError):
+            await require_action_for_context(context, "command.reset")
+
+        runner.config = GatewayConfig(security_context_trust_grants=(_grant(),))
+        platform_registry.register(_entry(_OtherAdapter(), plugin_name="attacker"))
+        with pytest.raises(SecurityContextError):
+            await require_action_for_context(context, "command.reset")
+    finally:
+        platform_registry.unregister("telegram")
+        if prior is not None:
+            platform_registry.register(prior)
+
+
+def test_registry_provenance_reads_are_race_safe_during_replacement():
+    import threading
+
+    prior = platform_registry.get("telegram")
+    adapter = _Adapter()
+    entry = _entry(adapter)
+    failures = []
+    try:
+        platform_registry.register(entry)
+        assert platform_registry.create_adapter("telegram", object()) is adapter
+
+        def replace_entries():
+            for _ in range(200):
+                platform_registry.register(_entry(_OtherAdapter(), plugin_name="attacker"))
+                platform_registry.register(entry)
+
+        thread = threading.Thread(target=replace_entries)
+        thread.start()
+        while thread.is_alive():
+            try:
+                matched = platform_registry.adapter_matches_current_entry(
+                    adapter, "telegram"
+                )
+                assert matched is entry or matched is None
+            except BaseException as exc:  # pragma: no cover - regression evidence
+                failures.append(exc)
+                break
+        thread.join()
+        assert failures == []
+    finally:
+        platform_registry.unregister("telegram")
+        if prior is not None:
+            platform_registry.register(prior)
+
+
+@pytest.mark.parametrize("text", ["stop", "new", "reset"])
+def test_security_preflight_preserves_ordinary_plaintext_conversation(text):
+    from gateway.run import GatewayRunner
+
+    event = MessageEvent(
+        text=text,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="user-1",
+            chat_id="chat-1",
+            chat_type="dm",
+        ),
+    )
+    assert GatewayRunner._preflight_command_name(event) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("command", ["/stop", "/new"])
+async def test_revoked_live_adapter_preflight_denies_active_session_command_before_effects(
+    command,
+):
+    """The real Base adapter must not begin its command handoff after revocation."""
+    from gateway.run import GatewayRunner
+
+    prior = platform_registry.get("telegram")
+    adapter = _LiveTrustedAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        security_context_trust_grants=(
+            _grant(adapter_class=_LiveTrustedAdapter),
+        )
+    )
+    context = _context(
+        actions=("command.stop", "command.reset"),
+        tools=("web_search",),
+    )
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="dm",
+        chat_type="dm",
+        user_id=context.principal_id,
+    )
+    event = MessageEvent(
+        text=command,
+        message_type=MessageType.TEXT,
+        source=source,
+        security_context=context,
+    )
+    session_key = build_session_key(source)
+    worker = asyncio.create_task(asyncio.Event().wait())
+    guard = asyncio.Event()
+    pending = MessageEvent(text="pending", source=source)
+    debounce = object()
+    handler_calls = []
+    hook_calls = []
+
+    async def handler(inbound):
+        handler_calls.append(inbound.text)
+        return "must not send"
+
+    try:
+        platform_registry.register(
+            PlatformEntry(
+                name="telegram",
+                label="Trusted Base Test",
+                adapter_factory=lambda cfg: adapter,
+                check_fn=lambda: True,
+                source="plugin",
+                plugin_name="secure-plugin",
+                trusted_security_context=True,
+            )
+        )
+        assert platform_registry.create_adapter("telegram", object()) is adapter
+        adapter.set_message_handler(handler)
+        runner._install_adapter_security_preflight(adapter)
+        adapter._topic_recovery_fn = lambda _event: hook_calls.append("topic")
+        adapter._active_sessions[session_key] = guard
+        adapter._session_tasks[session_key] = worker
+        adapter._pending_messages[session_key] = pending
+        adapter._text_debounce[session_key] = debounce
+
+        # Revoke after the exact live adapter and callback were installed.
+        runner.config = GatewayConfig(security_context_trust_grants=())
+        adapter.effects.clear()
+
+        await adapter.handle_message(event)
+        await asyncio.sleep(0)
+
+        assert adapter._active_sessions == {session_key: guard}
+        assert adapter._session_tasks == {session_key: worker}
+        assert adapter._pending_messages == {session_key: pending}
+        assert adapter._text_debounce == {session_key: debounce}
+        assert not worker.cancelled() and not worker.done()
+        assert event.text == command
+        assert handler_calls == []
+        assert hook_calls == []
+        assert adapter.effects == []
+        assert adapter._background_tasks == set()
+    finally:
+        worker.cancel()
+        await asyncio.gather(worker, return_exceptions=True)
+        platform_registry.unregister("telegram")
+        if prior is not None:
+            platform_registry.register(prior)
+
+
+@pytest.mark.asyncio
+async def test_multiplex_profile_configuration_preserves_trusted_preflight(
+    monkeypatch,
+):
+    """The upstream multiplex helper must not bypass adapter provenance binding."""
+    from gateway.run import GatewayRunner
+
+    prior = platform_registry.get("telegram")
+    adapter = _LiveTrustedAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        security_context_trust_grants=(
+            _grant(adapter_class=_LiveTrustedAdapter),
+        )
+    )
+    runner.session_store = object()
+    runner._handle_active_session_busy_message = object()
+    runner._recover_telegram_topic_thread_id = object()
+    runner._busy_text_mode = "queue"
+    runner._make_adapter_auth_check = lambda platform, profile_name=None: object()
+    seen = []
+
+    async def handle(inbound):
+        seen.append((inbound.source.profile, inbound.security_context))
+        return "ok"
+
+    runner._handle_message = handle
+    monkeypatch.setattr(
+        "gateway.run._profile_runtime_scope", lambda _home: nullcontext()
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir", lambda _name: object()
+    )
+    context = _context(tools=("web_search",))
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="dm",
+            chat_type="dm",
+            user_id=context.principal_id,
+        ),
+        security_context=context,
+    )
+    try:
+        platform_registry.register(
+            PlatformEntry(
+                name="telegram",
+                label="Trusted Multiplex Test",
+                adapter_factory=lambda cfg: adapter,
+                check_fn=lambda: True,
+                source="plugin",
+                plugin_name="secure-plugin",
+                trusted_security_context=True,
+            )
+        )
+        assert platform_registry.create_adapter("telegram", object()) is adapter
+        runner._configure_profile_adapter(adapter, "coder", Platform.TELEGRAM)
+        assert callable(adapter._security_preflight)
+        stamped = await adapter._security_preflight(event)
+        assert stamped is not None
+        assert await adapter._message_handler(stamped) == "ok"
+        assert seen == [("coder", stamped.security_context)]
+    finally:
+        platform_registry.unregister("telegram")
+        if prior is not None:
+            platform_registry.register(prior)

--- a/tests/gateway/test_title_command.py
+++ b/tests/gateway/test_title_command.py
@@ -241,11 +241,12 @@ class TestTitleInHelp:
         assert "/title" in result
 
     def test_title_is_known_command(self):
-        """The /title command is in the _known_commands set."""
-        from gateway.run import GatewayRunner
-        import inspect
-        source = inspect.getsource(GatewayRunner._handle_message)
-        assert '"title"' in source
+        """The registry resolves /title as a gateway-dispatchable command."""
+        from hermes_cli.commands import is_gateway_known_command, resolve_command
+
+        definition = resolve_command("title")
+        assert definition is not None and definition.name == "title"
+        assert is_gateway_known_command(definition.name)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -922,10 +922,9 @@ class TestUpdateInHelp:
         assert "/update" in result
 
     def test_update_is_known_command(self):
-        """The /update command is in the help text (proxy for _known_commands)."""
-        # _known_commands is local to _handle_message, so we verify by
-        # checking the help output includes it.
-        from gateway.run import GatewayRunner
-        import inspect
-        source = inspect.getsource(GatewayRunner._handle_message)
-        assert '"update"' in source
+        """The registry resolves /update as a gateway-dispatchable command."""
+        from hermes_cli.commands import is_gateway_known_command, resolve_command
+
+        definition = resolve_command("update")
+        assert definition is not None and definition.name == "update"
+        assert is_gateway_known_command(definition.name)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2375,6 +2375,63 @@ class TestFormatToolsForSystemMessage:
 
 
 class TestExecuteToolCalls:
+    def test_sequential_capability_denial_has_no_executor_side_effects(
+        self, agent, monkeypatch
+    ):
+        tc = _mock_tool_call(name="todo", arguments="{}", call_id="denied-1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        effects = []
+        original_current_tool = object()
+        agent._current_tool = original_current_tool
+        agent._touch_activity = lambda desc: effects.append(("activity", desc))
+        agent.tool_progress_callback = lambda *a, **kw: effects.append(("progress", a))
+        agent.tool_start_callback = lambda *a, **kw: effects.append(("start", a))
+        agent.tool_complete_callback = lambda *a, **kw: effects.append(("complete", a))
+        agent._tool_guardrails.before_call = lambda *a, **kw: effects.append(
+            ("guardrail", a)
+        )
+        agent._checkpoint_mgr.enabled = True
+        agent._checkpoint_mgr.ensure_checkpoint = lambda *a, **kw: effects.append(
+            ("checkpoint", a)
+        )
+        agent._record_file_mutation_result = lambda *a, **kw: effects.append(
+            ("mutation", a)
+        )
+
+        monkeypatch.setattr(
+            "gateway.security_context.enforce_agent_tool_dispatch",
+            lambda _agent, _name: (_ for _ in ()).throw(PermissionError("denied")),
+        )
+        monkeypatch.setattr(
+            "agent.tool_executor._apply_tool_request_middleware_for_agent",
+            lambda *a, **kw: effects.append(("request_middleware", kw)) or ({}, []),
+        )
+        monkeypatch.setattr(
+            "agent.tool_executor._run_agent_tool_execution_middleware",
+            lambda *a, **kw: effects.append(("execution_middleware", kw)),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda *a, **kw: effects.append(("pre_hook", a)),
+        )
+        monkeypatch.setattr(
+            "model_tools._emit_post_tool_call_hook",
+            lambda **kw: effects.append(("post_hook", kw)),
+        )
+        monkeypatch.setattr(
+            "run_agent.handle_function_call",
+            lambda *a, **kw: effects.append(("dispatch", a)),
+        )
+
+        agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        assert effects == []
+        assert agent._current_tool is original_current_tool
+        assert json.loads(messages[0]["content"])["error"] == (
+            "tool_denied_by_capability"
+        )
+
     def test_single_tool_executed(self, agent):
         tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
@@ -2662,6 +2719,115 @@ class TestRetryAfterCap:
 
 class TestConcurrentToolExecution:
     """Tests for _execute_tool_calls_concurrent and dispatch logic."""
+
+    def test_denied_capability_runs_no_concurrent_preflight_or_callbacks(
+        self, agent, monkeypatch
+    ):
+        tc1 = _mock_tool_call("terminal", '{"command":"touch denied"}', "c1")
+        tc2 = _mock_tool_call("web_search", '{"query":"allowed"}', "c2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+        observed = []
+
+        def enforce(_agent, name):
+            observed.append(("authorize", name))
+            if name == "terminal":
+                raise PermissionError("tool_denied")
+
+        monkeypatch.setattr(
+            "gateway.security_context.enforce_agent_tool_dispatch", enforce
+        )
+        monkeypatch.setattr(
+            "agent.tool_executor._apply_tool_request_middleware_for_agent",
+            lambda *a, **kw: (
+                observed.append(("middleware", kw["function_name"]))
+                or (kw["function_args"], [])
+            ),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda name, *a, **kw: observed.append(("hook", name)),
+        )
+        agent._tool_guardrails.before_call = lambda name, args: (
+            observed.append(("guardrail", name))
+            or SimpleNamespace(allows_execution=True)
+        )
+        agent.tool_progress_callback = lambda event, name, *a, **kw: observed.append(("progress", name))
+        agent.tool_start_callback = lambda call_id, name, args: observed.append(("start", name))
+        monkeypatch.setattr(
+            "run_agent.handle_function_call",
+            lambda name, *a, **kw: observed.append(("dispatch", name)) or "ok",
+        )
+
+        agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        assert ("authorize", "terminal") in observed
+        assert not any(
+            name == "terminal" and stage != "authorize" for stage, name in observed
+        )
+        assert ("dispatch", "web_search") in observed
+
+    def test_denied_only_concurrent_batch_does_not_mutate_activity(
+        self, agent, monkeypatch
+    ):
+        calls = [
+            _mock_tool_call("terminal", "{}", "d1"),
+            _mock_tool_call("write_file", "{}", "d2"),
+        ]
+        mock_msg = _mock_assistant_msg(content="", tool_calls=calls)
+        messages = []
+        activity = []
+        original_current_tool = object()
+        agent._current_tool = original_current_tool
+        agent._touch_activity = activity.append
+        monkeypatch.setattr(
+            "gateway.security_context.enforce_agent_tool_dispatch",
+            lambda _agent, _name: (_ for _ in ()).throw(PermissionError("denied")),
+        )
+
+        agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        assert activity == []
+        assert agent._current_tool is original_current_tool
+        assert len(messages) == 2
+
+    def test_mixed_concurrent_activity_names_only_authorized_calls(
+        self, agent, monkeypatch
+    ):
+        calls = [
+            _mock_tool_call("terminal", "{}", "d1"),
+            _mock_tool_call("web_search", '{"query":"ok"}', "a1"),
+        ]
+        mock_msg = _mock_assistant_msg(content="", tool_calls=calls)
+        messages = []
+        activity = []
+        observed_current_tools = []
+
+        def touch(description):
+            activity.append(description)
+            observed_current_tools.append(agent._current_tool)
+
+        def enforce(_agent, name):
+            if name == "terminal":
+                raise PermissionError("denied")
+
+        agent._touch_activity = touch
+        monkeypatch.setattr(
+            "gateway.security_context.enforce_agent_tool_dispatch", enforce
+        )
+        monkeypatch.setattr(
+            "run_agent.handle_function_call", lambda *a, **kw: "allowed result"
+        )
+
+        agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        assert activity
+        assert all("terminal" not in description for description in activity)
+        assert all(
+            current is None or "terminal" not in str(current)
+            for current in observed_current_tools
+        )
+        assert any("web_search" in description for description in activity)
 
     def test_single_tool_uses_sequential_path(self, agent):
         """Single tool call should use sequential path, not concurrent."""

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -10,8 +10,10 @@ freezing any particular tool list.
 
 import threading
 import types
+from datetime import datetime, timezone
 
 from tools import mcp_tool
+from gateway.security_context import SecurityContext, apply_security_context_to_agent
 
 
 def _tool(name):
@@ -25,6 +27,24 @@ def _agent(tool_names, *, enabled=None, disabled=None):
     a.enabled_toolsets = enabled
     a.disabled_toolsets = disabled
     return a
+
+
+def _security_context(*tool_names):
+    return SecurityContext(
+        principal_id="security-review-user",
+        tenant_id="security-review-tenant",
+        platform="telegram",
+        authority="tier1_staff",
+        domains=frozenset({"daily"}),
+        capability_bundle="review",
+        allowed_toolsets=frozenset({"coding", "mcp-security-ceiling"}),
+        allowed_tools=frozenset(tool_names),
+        denied_tools=frozenset(),
+        allowed_actions=frozenset({"command.reload-mcp"}),
+        policy_revision="review-1",
+        authenticated_at=datetime.now(timezone.utc),
+        evidence_source="test",
+    )
 
 
 def test_refresh_adds_late_landing_tools(monkeypatch):
@@ -42,6 +62,59 @@ def test_refresh_adds_late_landing_tools(monkeypatch):
     assert added == {"mcp_granola_get_account_info"}
     assert "mcp_granola_get_account_info" in agent.valid_tool_names
     assert len(agent.tools) == 3
+
+
+def test_real_mcp_registration_refresh_cannot_widen_security_scoped_agent():
+    """A live MCP registry mutation cannot exceed the cached agent's ceiling."""
+    from tools.registry import registry
+
+    server_name = "security-ceiling"
+    allowed_late = mcp_tool.mcp_prefixed_tool_name(server_name, "late_allowed")
+    denied_late = mcp_tool.mcp_prefixed_tool_name(server_name, "late_denied")
+    agent = _agent(["read_file"])
+    apply_security_context_to_agent(
+        agent, _security_context("read_file", allowed_late)
+    )
+    server = types.SimpleNamespace(
+        _tools=[
+            types.SimpleNamespace(
+                name="late_allowed",
+                description="late allowed tool",
+                inputSchema={"type": "object", "properties": {}},
+            ),
+            types.SimpleNamespace(
+                name="late_denied",
+                description="late denied tool",
+                inputSchema={"type": "object", "properties": {}},
+            ),
+        ],
+        tool_timeout=1,
+        session=object(),
+    )
+
+    try:
+        with mcp_tool._lock:
+            mcp_tool._servers[server_name] = server
+        registered = mcp_tool._register_server_tools(
+            server_name,
+            server,
+            {"tools": {"include": ["late_allowed", "late_denied"]}},
+        )
+        assert set(registered) == {allowed_late, denied_late}
+
+        mcp_tool.refresh_agent_mcp_tools(agent, quiet_mode=True)
+
+        assert agent.valid_tool_names == {"read_file"}
+        assert {tool["function"]["name"] for tool in agent.tools} == {
+            "read_file"
+        }
+        assert agent._capability_allowed_tools == frozenset({"read_file"})
+    finally:
+        with mcp_tool._lock:
+            mcp_tool._servers.pop(server_name, None)
+        for name in (allowed_late, denied_late):
+            registry.deregister(name)
+            mcp_tool._forget_mcp_tool_server(name)
 
 
 def test_refresh_no_change_returns_empty_and_leaves_agent_untouched(monkeypatch):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5603,6 +5603,28 @@ def refresh_agent_mcp_tools(
     # this rebuild actually appended (matching agent_init's dedup-aware add).
     staged_engine_names = _reinject_post_build_tools(agent, new_defs, new_names)
 
+    # Capability-scoped agents must never publish the unfiltered registry
+    # snapshot, including late MCP discovery and /reload-mcp rebuilds.
+    _security_context = getattr(agent, "_security_context", None)
+    if _security_context is not None:
+        from gateway.security_context import filter_tool_schemas
+        new_defs = filter_tool_schemas(new_defs, _security_context)
+        # A cached secure agent's executable/schema ceiling is the exact
+        # intersection established when the context was first bound. Dynamic
+        # registry discovery and /reload-mcp may remove names, but must never
+        # add a previously absent name even when the broader envelope permits
+        # it; a fresh authority-scoped agent is required for widening.
+        _security_ceiling = getattr(
+            agent, "_capability_allowed_tools", frozenset()
+        )
+        new_defs = [
+            tool
+            for tool in new_defs
+            if tool.get("function", {}).get("name") in _security_ceiling
+        ]
+        new_names = {t["function"]["name"] for t in new_defs}
+        staged_engine_names.intersection_update(new_names)
+
     # Single atomic read-diff-publish so the returned ``added`` is consistent
     # with what was actually published, even under concurrent callers, and a
     # stale (older-generation) rebuild can't overwrite a newer published one.

--- a/website/docs/developer-guide/adding-platform-adapters.md
+++ b/website/docs/developer-guide/adding-platform-adapters.md
@@ -458,6 +458,79 @@ See `plugins/platforms/irc/` in the repo for a complete working example — a fu
 
 ---
 
+## Security-context trust grants
+
+Adapters that originate `SecurityContext` objects require an explicit,
+host-owned trust grant. A plugin's registration metadata (including the legacy
+`trusted_security_context` flag) is not authority by itself. Without an exact
+host grant, the gateway treats the adapter as untrusted and rejects security
+contexts from it.
+
+Configure grants under `gateway.security_context_trust_grants` in
+`~/.hermes/config.yaml`:
+
+```yaml
+gateway:
+  security_context_trust_grants:
+    - platform: my-platform
+      adapter_module: my_plugin.adapter
+      adapter_class: MyPlatformAdapter
+      plugin_name: my-plugin
+```
+
+Each list item has this schema:
+
+| Field | Required | Meaning |
+|---|---:|---|
+| `platform` | yes | Exact platform registry name and `adapter.platform.value`. |
+| `adapter_module` | yes | Importable Python module containing the adapter class. |
+| `adapter_class` | yes | Exact class qualified name within that module. Nested classes use their dotted `__qualname__`; local classes are rejected. |
+| `plugin_name` | no | Exact owning `PlatformEntry.plugin_name`. Omit it only for entries whose plugin name is empty. |
+
+Validation is fail-closed at two stages. Configuration parsing drops entries
+that are not mappings or that omit a required field. At runtime Hermes imports
+`adapter_module`, resolves every component of `adapter_class`, and requires the
+resolved object to be the adapter's exact type (subclasses do not match). It
+also requires an exact platform, plugin name, current registry entry, and
+host-recorded factory provenance match. Replacing or re-registering the entry
+revokes the match. Restart the gateway after changing a grant, then verify that
+trusted traffic succeeds and a deliberately mismatched grant is denied.
+
+To discover values rather than guessing them:
+
+1. Run `hermes plugins list --plain` to find the enabled plugin's canonical
+   name; use that as `plugin_name`.
+2. Open the plugin's platform-registration call and note its `PlatformEntry`
+   `name` and the concrete class returned by `adapter_factory`.
+3. In Python, the exact values are `type(adapter).__module__` and
+   `type(adapter).__qualname__` for the factory-created adapter instance. These
+   become `adapter_module` and `adapter_class` respectively.
+4. Compare the configured round trip without printing credentials:
+
+   ```bash
+   uv run python - <<'PY'
+   from gateway.config import load_gateway_config
+   for grant in load_gateway_config().security_context_trust_grants:
+       print(grant.to_dict())
+   PY
+   ```
+
+A trusted adapter must attach a context to every event. Its context should use
+neutral, explicit exposure capabilities: `expose_private_context`,
+`expose_memory`, and `expose_identity`. These booleans are included in the
+canonical capability hash. The secure defaults are `false`, `false`, and
+`true`; adapters must opt in explicitly before exposing private context files
+or memory. Authority and capability-bundle labels are descriptive and do not
+implicitly grant any of these exposures.
+
+Every trusted context is also subject to the gateway's shared freshness contract.
+`authenticated_at` must be timezone-aware, no more than five minutes old, and
+no more than 30 seconds in the future. Hermes enforces this at adapter admission
+and again before capability revalidation/tool dispatch. Adapter-specific live
+revalidation remains mandatory; it does not extend or replace the generic age
+limit. Refreshing authentication evidence may update `authenticated_at` without
+changing the canonical capability hash.
+
 ## Step-by-Step Checklist (Built-in Path)
 
 :::note


### PR DESCRIPTION
## Summary

- add host-owned capability-scoped security contexts for trusted plugin adapters
- bind adapter provenance, identity, tenant, session/tool ceilings and external-action authority
- revalidate trusted contexts at dispatch time and fail closed on trust drift or handoff
- keep built-in platform behaviour unchanged; trust is granted explicitly by host configuration
- require an explicit trusted-instance boolean latch so test doubles and arbitrary truthy attributes cannot trigger the trusted-adapter path

## Why

Out-of-tree messaging adapters need a core-owned way to establish and preserve security provenance without adding each adapter to the built-in `Platform` enum. The boundary must remain owned by the gateway: plugins may present evidence, but they cannot grant themselves authority.

## Verification

- `812 passed` across the focused gateway, agent-runtime and MCP-tool suites
- `9,840 passed` across the aggregate gateway suite; two unrelated health-version assertions fail identically on current upstream `main` because editable package metadata reports `version=null`
- `52 passed` in an external plugin activation/compatibility suite
- plugin discovery/import and Python compilation passed against the frozen candidate tree
- no tests removed, skipped or marked `xfail`

## Security properties

- exact adapter class/module and current registry entry must match a host trust grant
- identity, tenant and recipient authority are immutable within a context
- tool availability is intersected with the context ceiling
- tool dispatch and external replies are revalidated against current trust/config state
- stale, revoked, mismatched or unavailable evidence fails closed
- trusted-adapter handoff without a fresh bound context is denied
