### PR TITLE
fix(weixin): cross-loop cron delivery via live adapter bypasses iLink rate limit

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -2308,22 +2308,22 @@ async def send_weixin_direct(
 
     live_adapter = _LIVE_ADAPTERS.get(resolved_token)
     send_session = getattr(live_adapter, '_send_session', None)
-    if (live_adapter is not None and send_session is not None
-            and not send_session.closed
-            and send_session._loop is asyncio.get_running_loop()):
+
+    async def _deliver_via_live(adapter: Any) -> Dict[str, Any]:
+        """Send text + media through a live adapter, returning a result dict."""
         last_result: Optional[SendResult] = None
-        cleaned = live_adapter.format_message(message)
+        cleaned = adapter.format_message(message)
         if cleaned:
-            last_result = await live_adapter.send(chat_id, cleaned)
+            last_result = await adapter.send(chat_id, cleaned)
             if not last_result.success:
                 return {"error": f"Weixin send failed: {last_result.error}"}
 
         for media_path, _is_voice in media_files or []:
             ext = Path(media_path).suffix.lower()
             if ext in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}:
-                last_result = await live_adapter.send_image_file(chat_id, media_path)
+                last_result = await adapter.send_image_file(chat_id, media_path)
             else:
-                last_result = await live_adapter.send_document(chat_id, media_path)
+                last_result = await adapter.send_document(chat_id, media_path)
             if not last_result.success:
                 return {"error": f"Weixin media send failed: {last_result.error}"}
 
@@ -2334,6 +2334,28 @@ async def send_weixin_direct(
             "message_id": last_result.message_id if last_result else None,
             "context_token_used": bool(context_token),
         }
+
+    if (live_adapter is not None and send_session is not None
+            and not send_session.closed):
+        if send_session._loop is asyncio.get_running_loop():
+            # Same event loop — send directly (interactive reply path).
+            return await _deliver_via_live(live_adapter)
+        else:
+            # Cross-loop (cron delivery) — submit to the gateway's event
+            # loop so we reuse the persistent iLink connection instead of
+            # creating a fresh HTTP session that iLink rate-limits.
+            try:
+                future = asyncio.run_coroutine_threadsafe(
+                    _deliver_via_live(live_adapter), send_session._loop,
+                )
+                return future.result(timeout=120)
+            except Exception as exc:
+                logger.warning(
+                    "[weixin] cross-loop delivery via live adapter failed: %s; "
+                    "falling back to fresh adapter",
+                    exc,
+                )
+                # Fall through to the fresh-adapter path below as last resort.
 
     async with aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector()) as session:
         adapter = WeixinAdapter(


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where `send_weixin_direct()` fails when triggered by cross-loop cron jobs because it creates a fresh `aiohttp` session instead of reusing the gateway's persistent live adapter, leading to iLink rate limits (`ret=-2`).

### Problem
When `send_weixin_direct()` is executed from a cron job (which runs in a different event loop), `send_session._loop is asyncio.get_running_loop()` evaluates to `False`. This forces a new `aiohttp.ClientSession` to be opened for every message, triggering iLink rate limiting.

### Solution
Submit the send coroutine to the main gateway event loop via `asyncio.run_coroutine_threadsafe()` when event loops differ, reusing the persistent live adapter.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/weixin.py`: Dispatch cross-loop sending to live adapter loop using `asyncio.run_coroutine_threadsafe()`.

## How to Test

1. Configure WeChat adapter in gateway.
2. Trigger `send_weixin_direct()` from a separate event loop (e.g. a scheduled cron task).
3. Verify messages are sent via the live adapter without encountering `ret=-2` rate limit errors.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)