### PR TITLE
fix(gateway,memory): stabilize local proxy sessions and Windows Hindsight startup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1414,7 +1414,13 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home, get_hermes_home_override
-from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, is_truthy_value
+from utils import (
+    atomic_json_write,
+    atomic_yaml_write,
+    base_url_host_matches,
+    base_url_hostname,
+    is_truthy_value,
+)
 _hermes_home = get_hermes_home()
 
 # Load environment variables from ~/.hermes/.env first.
@@ -2134,6 +2140,47 @@ def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
     }
+
+
+_LOCAL_PROXY_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def _local_proxy_route_is_authoritative() -> bool:
+    """Return whether the configured primary route is a loopback proxy.
+
+    ``OPENAI_BASE_URL`` is intentionally only used here as the endpoint
+    selected by the already-authoritative ``model.provider: openai-api``
+    configuration. This is a route-safety check, not a credential lookup.
+    """
+    try:
+        from hermes_cli.runtime_provider import _get_model_config
+
+        model_cfg = _get_model_config()
+    except Exception:
+        return False
+    if not isinstance(model_cfg, dict):
+        return False
+    provider = str(model_cfg.get("provider") or "").strip().lower()
+    if provider != "openai-api":
+        return False
+    base_url = str(model_cfg.get("base_url") or "").strip()
+    if not base_url:
+        base_url = os.getenv("OPENAI_BASE_URL", "").strip()
+    return base_url_hostname(base_url) in _LOCAL_PROXY_LOOPBACK_HOSTS
+
+
+def _is_stale_direct_codex_override(override: Optional[dict]) -> bool:
+    """Identify a persisted direct-Codex route superseded by the local proxy."""
+    if not _local_proxy_route_is_authoritative() or not isinstance(override, dict):
+        return False
+    provider = str(override.get("provider") or "").strip().lower()
+    if provider != "openai-codex":
+        return False
+    # Older persisted rows may not contain base_url. A provider-only
+    # openai-codex override is still the direct route and must be retired when
+    # the operator has explicitly selected the local proxy as primary.
+    base_url = str(override.get("base_url") or "").strip()
+    return not base_url or base_url_host_matches(base_url, "chatgpt.com")
 
 
 def _credential_pool_for_provider(provider: Optional[str]):
@@ -17477,7 +17524,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         when the store has nothing persisted (e.g. the user ran /new, which
         clears both the in-memory dict and the persisted field).
         """
-        if session_key in self._session_model_overrides:
+        in_memory = self._session_model_overrides.get(session_key)
+        if in_memory is not None:
+            if _is_stale_direct_codex_override(in_memory):
+                self._session_model_overrides.pop(session_key, None)
+                store = getattr(self, "session_store", None)
+                if store is not None:
+                    try:
+                        store.set_model_override(session_key, None)
+                    except Exception:
+                        logger.debug(
+                            "Failed to clear stale in-memory model override",
+                            exc_info=True,
+                        )
+                logger.warning(
+                    "Discarded direct Codex model override for local proxy session=%s",
+                    session_key,
+                )
             return
         store = getattr(self, "session_store", None)
         if store is None:
@@ -17490,6 +17553,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return
         if not persisted:
+            return
+        if _is_stale_direct_codex_override(persisted):
+            try:
+                store.set_model_override(session_key, None)
+            except Exception:
+                logger.debug(
+                    "Failed to clear stale persisted model override", exc_info=True
+                )
+            logger.warning(
+                "Discarded stale persisted direct Codex override for local proxy "
+                "session=%s",
+                session_key,
+            )
             return
         override: Dict[str, Any] = {
             "model": persisted.get("model"),

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -140,6 +140,101 @@ def _check_local_runtime() -> tuple[bool, str | None]:
         return False, str(exc)
 
 
+_WINDOWS_HINDSIGHT_BOOTSTRAP = """\
+import os
+import runpy
+import site
+import subprocess
+import sys
+
+venv_root = sys.argv.pop(1)
+site_packages = sys.argv.pop(1)
+os.environ["VIRTUAL_ENV"] = venv_root
+site.addsitedir(site_packages)
+
+_original_popen = subprocess.Popen
+
+class _HiddenPopen(_original_popen):
+    def __init__(self, *args, **kwargs):
+        flags = kwargs.get("creationflags", 0)
+        if not flags & subprocess.CREATE_NEW_CONSOLE:
+            kwargs["creationflags"] = flags | subprocess.CREATE_NO_WINDOW
+        super().__init__(*args, **kwargs)
+
+subprocess.Popen = _HiddenPopen
+runpy.run_module("hindsight_api.main", run_name="__main__")
+"""
+
+
+def _patch_windows_hindsight_daemon_launcher() -> None:
+    """Keep Hindsight's embedded daemon and its children console-less on Windows.
+
+    uv-created ``Scripts/pythonw.exe`` files are launchers. On Windows they
+    respawn the base console ``python.exe``, which makes Windows Terminal open
+    a persistent blank tab despite Hindsight's detached-process flags. Replace
+    only that command with the real base ``pythonw.exe`` and a small bootstrap
+    that activates the venv packages and hides console-subsystem children such
+    as pg0 and PostgreSQL helpers.
+    """
+    if sys.platform != "win32":
+        return
+
+    try:
+        manager_module = importlib.import_module("hindsight_embed.daemon_embed_manager")
+        manager_class = manager_module.DaemonEmbedManager
+        original_find_api_command = manager_class._find_api_command
+    except (AttributeError, ImportError):
+        return
+
+    if getattr(manager_class, "_hermes_uv_safe_launcher", False):
+        return
+
+    def _find_api_command(self):
+        from pathlib import Path
+
+        command = list(original_find_api_command(self))
+        if len(command) < 3 or command[1:3] != ["-m", "hindsight_api.main"]:
+            return command
+
+        launcher = Path(command[0])
+        if (
+            launcher.name.casefold() != "pythonw.exe"
+            or launcher.parent.name.casefold() != "scripts"
+        ):
+            return command
+
+        venv_root = launcher.parent.parent
+        config_path = venv_root / "pyvenv.cfg"
+        site_packages = venv_root / "Lib" / "site-packages"
+        try:
+            config = {}
+            for line in config_path.read_text(encoding="utf-8").splitlines():
+                key, separator, value = line.partition("=")
+                if separator:
+                    config[key.strip().casefold()] = value.strip().strip('"')
+        except OSError:
+            return command
+
+        if "uv" not in config or not config.get("home"):
+            return command
+
+        base_pythonw = Path(config["home"]) / "pythonw.exe"
+        if not base_pythonw.exists() or not site_packages.is_dir():
+            return command
+
+        return [
+            str(base_pythonw),
+            "-c",
+            _WINDOWS_HINDSIGHT_BOOTSTRAP,
+            str(venv_root),
+            str(site_packages),
+            *command[3:],
+        ]
+
+    manager_class._find_api_command = _find_api_command
+    manager_class._hermes_uv_safe_launcher = True
+
+
 def _ensure_cloud_client_dependency() -> None:
     """Install the Hindsight cloud client lazily before importing it."""
     try:
@@ -1026,6 +1121,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     pass
                 except Exception as _e:
                     raise ImportError(str(_e))
+                _patch_windows_hindsight_daemon_launcher()
                 from hindsight import HindsightEmbedded
                 HindsightEmbedded.__del__ = lambda self: None
                 llm_provider = self._config.get("llm_provider", "")

--- a/tests/gateway/test_local_proxy_session_override.py
+++ b/tests/gateway/test_local_proxy_session_override.py
@@ -1,0 +1,130 @@
+"""Regression tests for stale direct-Codex session overrides.
+
+When Hermes is configured to use a loopback OpenAI-compatible proxy, a
+persisted ``/model`` override that still points at the direct ChatGPT Codex
+endpoint must not resurrect that route after a gateway restart.
+"""
+
+from gateway.run import GatewayRunner
+
+
+class _Store:
+    def __init__(self, override):
+        self.override = override
+        self.cleared = []
+
+    def get_model_override(self, _session_key):
+        return self.override
+
+    def set_model_override(self, session_key, override):
+        self.cleared.append((session_key, override))
+
+
+def test_rehydrate_clears_stale_direct_codex_override_for_local_proxy(
+    monkeypatch,
+):
+    """A local-proxy primary must win over a persisted direct-Codex route."""
+
+    session_key = "agent:main:telegram:dm:test-user"
+    store = _Store(
+        {
+            "model": "gpt-5.6-sol",
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        }
+    )
+    runner = object.__new__(GatewayRunner)
+    runner._session_model_overrides = {}
+    runner.session_store = store
+
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:52533/v1")
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider._get_model_config",
+        lambda: {"default": "gpt-5.6-sol", "provider": "openai-api"},
+    )
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+        lambda _provider: {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "test-only",
+            "api_mode": "codex_responses",
+        },
+    )
+
+    runner._rehydrate_session_model_override(session_key)
+
+    assert session_key not in runner._session_model_overrides
+    assert store.cleared == [(session_key, None)]
+
+
+def test_rehydrate_keeps_direct_codex_override_without_local_proxy(monkeypatch):
+    """A direct-Codex choice remains valid when no local proxy is configured."""
+
+    session_key = "agent:main:telegram:dm:test-user"
+    store = _Store(
+        {
+            "model": "gpt-5.6-sol",
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        }
+    )
+    runner = object.__new__(GatewayRunner)
+    runner._session_model_overrides = {}
+    runner.session_store = store
+
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider._get_model_config",
+        lambda: {"default": "gpt-5.6-sol", "provider": "openai-codex"},
+    )
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+        lambda _provider: {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "test-only",
+            "api_mode": "codex_responses",
+        },
+    )
+
+    runner._rehydrate_session_model_override(session_key)
+
+    assert runner._session_model_overrides[session_key]["provider"] == "openai-codex"
+    assert store.cleared == []
+
+
+def test_rehydrate_keeps_non_codex_override_with_local_proxy(monkeypatch):
+    """The local-proxy guard must not erase unrelated intentional overrides."""
+
+    session_key = "agent:main:telegram:dm:test-user"
+    store = _Store(
+        {
+            "model": "claude-sonnet-4.6",
+            "provider": "anthropic",
+            "base_url": "https://api.anthropic.com",
+        }
+    )
+    runner = object.__new__(GatewayRunner)
+    runner._session_model_overrides = {}
+    runner.session_store = store
+
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:52533/v1")
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider._get_model_config",
+        lambda: {"default": "gpt-5.6-sol", "provider": "openai-api"},
+    )
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+        lambda _provider: {
+            "provider": "anthropic",
+            "base_url": "https://api.anthropic.com",
+            "api_key": "test-only",
+            "api_mode": "anthropic_messages",
+        },
+    )
+
+    runner._rehydrate_session_model_override(session_key)
+
+    assert runner._session_model_overrides[session_key]["provider"] == "anthropic"
+    assert store.cleared == []

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import plugins.memory.hindsight as hindsight_plugin
 from hermes_cli.memory_setup import _CANCELLED
 from plugins.memory.hindsight import (
     HindsightMemoryProvider,
@@ -28,6 +29,99 @@ from plugins.memory.hindsight import (
     _resolve_bank_id_template,
     _sanitize_bank_segment,
 )
+
+
+class TestWindowsDaemonLauncher:
+    def test_uv_venv_pythonw_uses_base_gui_python_with_hidden_child_bootstrap(
+        self, tmp_path, monkeypatch
+    ):
+        """uv's pythonw launcher must not respawn console python.exe."""
+        venv_root = tmp_path / "hindsight-runtime"
+        scripts = venv_root / "Scripts"
+        site_packages = venv_root / "Lib" / "site-packages"
+        base = tmp_path / "uv" / "python" / "cpython-3.11-windows-x86_64-none"
+        scripts.mkdir(parents=True)
+        site_packages.mkdir(parents=True)
+        base.mkdir(parents=True)
+
+        venv_pythonw = scripts / "pythonw.exe"
+        base_pythonw = base / "pythonw.exe"
+        venv_pythonw.write_bytes(b"")
+        base_pythonw.write_bytes(b"")
+        (venv_root / "pyvenv.cfg").write_text(
+            f"home = {base}\nimplementation = CPython\nuv = 0.11.14\n",
+            encoding="utf-8",
+        )
+
+        class FakeDaemonEmbedManager:
+            def _find_api_command(self):
+                return [
+                    str(venv_pythonw),
+                    "-m",
+                    "hindsight_api.main",
+                    "--existing-option",
+                ]
+
+        fake_manager_module = SimpleNamespace(DaemonEmbedManager=FakeDaemonEmbedManager)
+        real_import_module = hindsight_plugin.importlib.import_module
+
+        def fake_import_module(name):
+            if name == "hindsight_embed.daemon_embed_manager":
+                return fake_manager_module
+            return real_import_module(name)
+
+        monkeypatch.setattr(hindsight_plugin.sys, "platform", "win32")
+        monkeypatch.setattr(
+            hindsight_plugin.importlib, "import_module", fake_import_module
+        )
+
+        hindsight_plugin._patch_windows_hindsight_daemon_launcher()
+        command = FakeDaemonEmbedManager()._find_api_command()
+
+        assert command[0] == str(base_pythonw)
+        assert command[1] == "-c"
+        assert "CREATE_NO_WINDOW" in command[2]
+        assert str(venv_root) in command
+        assert str(site_packages) in command
+        assert command[-1] == "--existing-option"
+        assert str(venv_pythonw) not in command
+
+    def test_hidden_child_bootstrap_keeps_popen_subclassable(
+        self, tmp_path, monkeypatch
+    ):
+        """asyncio.windows_utils subclasses Popen while Hindsight imports."""
+        import runpy
+        import subprocess
+
+        calls = []
+
+        class RecordingPopen:
+            def __init__(self, *args, **kwargs):
+                calls.append((args, kwargs))
+
+        monkeypatch.setattr(subprocess, "Popen", RecordingPopen)
+        monkeypatch.setattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
+        monkeypatch.setattr(subprocess, "CREATE_NEW_CONSOLE", 0x00000010)
+        monkeypatch.setattr(runpy, "run_module", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["-c", str(tmp_path), str(tmp_path / "site-packages")],
+        )
+
+        exec(hindsight_plugin._WINDOWS_HINDSIGHT_BOOTSTRAP, {})
+
+        class AsyncioStylePopen(subprocess.Popen):
+            pass
+
+        subprocess.Popen(["hidden-child"])
+        subprocess.Popen(
+            ["explicit-console"], creationflags=subprocess.CREATE_NEW_CONSOLE
+        )
+
+        assert issubclass(AsyncioStylePopen, RecordingPopen)
+        assert calls[0][1]["creationflags"] & subprocess.CREATE_NO_WINDOW
+        assert calls[1][1]["creationflags"] == subprocess.CREATE_NEW_CONSOLE
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- discard a persisted direct `openai-codex` session override when the configured default route is an OpenAI-compatible localhost proxy
- keep legitimate non-Codex and non-local-proxy session overrides unchanged
- launch uv-managed Hindsight runtimes through the real base `pythonw.exe` while bootstrapping the venv `site-packages`
- apply `CREATE_NO_WINDOW` to Hindsight/pg0 child processes without breaking `subprocess.Popen` subclassing

## Root causes

1. Gateway session rehydration restored an old direct Codex provider/base URL after restart, silently bypassing the configured local OpenAI-compatible proxy.
2. On Windows, uv's venv `pythonw.exe` launcher re-executed the console base `python.exe`. Hindsight's detached flags therefore still created a visible Windows Terminal/console host.

## Verification

- `pytest tests/gateway/test_local_proxy_session_override.py tests/plugins/memory/test_hindsight_provider.py::TestWindowsDaemonLauncher -q` - **5 passed**
- affected gateway/Hindsight group excluding three unchanged Windows `HOME`/`Path.home()` setup tests - **117 passed, 1 skipped, 3 deselected**
- `ruff check` on all four changed files - passed
- `py_compile` on all four changed files - passed
- `git diff --check` - passed
- live Windows Hindsight process: `/health` reports `healthy`, database `connected`; isolated 50-second high-frequency observation produced **0** new `OpenConsole.exe` processes