### PR TITLE
feat(session_search): add citations and rerank empty anchors (rebased 2026-07-21)

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -255,6 +255,103 @@ class TestDiscoveryShape:
         assert "s_newest" not in sids
 
 
+# =========================================================================
+# Citation layer (per-result provenance block)
+# =========================================================================
+
+class TestCitation:
+    """Every discovery result should include a 'citation' block with:
+       exact_quote, speaker, decided_at, reply_quote (optional), context_url.
+       Title-match path should also include it.
+    """
+
+    def test_citation_present_on_discovery_result(self, db):
+        _seed_modpack_sessions(db)
+        result = json.loads(session_search(query="modpack", limit=3, db=db))
+        assert result["count"] >= 1
+        for hit in result["results"]:
+            assert "citation" in hit, f"missing citation in hit {hit.get('session_id')}"
+            cit = hit["citation"]
+            assert "exact_quote" in cit
+            assert "speaker" in cit
+            assert "decided_at" in cit
+            assert "context_url" in cit
+
+    def test_exact_quote_matches_anchor_message(self, db):
+        _seed_modpack_sessions(db)
+        result = json.loads(session_search(query="modpack", limit=3, db=db))
+        for hit in result["results"]:
+            anchor_id = hit["match_message_id"]
+            anchor_msg = next(m for m in hit["messages"] if m["id"] == anchor_id)
+            assert hit["citation"]["exact_quote"] == anchor_msg["content"]
+
+    def test_speaker_is_anchor_role(self, db):
+        _seed_modpack_sessions(db)
+        result = json.loads(session_search(query="modpack", limit=3, db=db))
+        for hit in result["results"]:
+            anchor_id = hit["match_message_id"]
+            anchor_msg = next(m for m in hit["messages"] if m["id"] == anchor_id)
+            assert hit["citation"]["speaker"] == anchor_msg["role"]
+
+    def test_reply_quote_for_user_anchor_picks_assistant_reply(self, db):
+        _seed_modpack_sessions(db)
+        result = json.loads(session_search(query="modpack", limit=3, db=db))
+        user_hit = next(
+            (h for h in result["results"]
+             if next((m for m in h["messages"] if m["id"] == h["match_message_id"]), {}).get("role") == "user"),
+            None,
+        )
+        if user_hit is None:
+            pytest.skip("no user-role anchor in seeded data")
+        reply = user_hit["citation"].get("reply_quote")
+        assert reply is not None
+        window_ids_in_order = sorted(
+            (m["id"], m) for m in user_hit["messages"] if m["id"] > user_hit["match_message_id"]
+        )
+        if window_ids_in_order:
+            next_msg = window_ids_in_order[0][1]
+            if next_msg["role"] == "assistant":
+                assert reply == next_msg["content"]
+
+    def test_reply_quote_none_when_no_neighbour(self, db):
+        db.create_session("s_solo", source="cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+            (int(time.time()), "Solo Modpack Thought", "s_solo"),
+        )
+        db.append_message("s_solo", role="user", content="I really should build a modpack")
+        db._conn.commit()
+
+        result = json.loads(session_search(query="modpack", db=db))
+        if result["count"] >= 1:
+            hit = next((h for h in result["results"] if h["session_id"] == "s_solo"), None)
+            if hit:
+                assert hit["citation"].get("reply_quote") is None
+
+    def test_context_url_is_pasteable_recipe(self, db):
+        _seed_modpack_sessions(db)
+        result = json.loads(session_search(query="modpack", limit=1, db=db))
+        hit = result["results"][0]
+        ctx = hit["citation"]["context_url"]
+        assert "session_search" in ctx
+        assert hit["session_id"] in ctx
+        assert str(hit["match_message_id"]) in ctx
+
+    def test_citation_present_on_title_match(self, db):
+        db.create_session("s_fingerprint", source="cli")
+        db.set_session_title("s_fingerprint", "fingerprint-login")
+        db.append_message("s_fingerprint", role="user", content="PAM auth setup")
+
+        result = json.loads(session_search(query="fingerprint-login", db=db))
+        assert result["count"] == 1
+        hit = result["results"][0]
+        assert hit["matched_role"] == "session_title"
+        assert "citation" in hit
+        cit = hit["citation"]
+        assert cit["exact_quote"]
+        assert cit["speaker"] == "user"
+
+
 class TestDiscoverySort:
     def test_sort_newest_orders_by_recency(self, db):
         _seed_modpack_sessions(db)

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -352,6 +352,94 @@ class TestCitation:
         assert cit["speaker"] == "user"
 
 
+# =========================================================================
+# Rerank + transcript expansion (anchor promotion when FTS5 lands on empty)
+# =========================================================================
+
+class TestRerank:
+    """When FTS5 ranks an empty/tool-only message at the top, the rerank
+    pass should promote the nearest substantive user/assistant message to
+    the anchor, so citation surfaces real content instead of empty quotes.
+    """
+
+    def test_substantive_anchor_unchanged(self, db):
+        _seed_modpack_sessions(db)
+        result = json.loads(session_search(query="modpack", limit=3, db=db))
+        for hit in result["results"]:
+            anchor_id = hit["match_message_id"]
+            anchor_msg = next((m for m in hit["messages"] if m["id"] == anchor_id), None)
+            if anchor_msg and len((anchor_msg.get("content") or "").strip()) >= 20:
+                # Substantive anchors must not shift
+                assert hit["effective_anchor_id"] == anchor_id
+
+    def test_effective_anchor_present_on_every_result(self, db):
+        _seed_modpack_sessions(db)
+        result = json.loads(session_search(query="modpack", limit=3, db=db))
+        for hit in result["results"]:
+            assert "effective_anchor_id" in hit
+            assert hit["effective_anchor_id"] is not None
+            # Effective anchor must be flagged in the window
+            assert any(m.get("anchor") for m in hit["messages"])
+
+    def test_empty_anchor_promoted_to_substantive(self, db):
+        """Seed a session where a tool-only message sits between two
+        substantive messages. When FTS5 ranks the tool-only message,
+        the rerank should promote one of the substantive neighbours."""
+        db.create_session("s_tool", source="cli")
+        # Substantive user prompt
+        db.append_message("s_tool", role="user", content="Let's discuss the modpack build pipeline in detail")
+        # Empty tool-call message (the kind that often ranks top in FTS5)
+        db.append_message("s_tool", role="assistant", content="", tool_name="write_file")
+        # Substantive assistant answer
+        db.append_message("s_tool", role="assistant", content="The modpack build pipeline uses NeoForge 1.21.1 with tier-0 mods")
+        db._conn.commit()
+
+        # FTS5 will match on "modpack" — likely on the empty assistant (depends on
+        # whether tool_name / arguments index it). Verify effective_anchor_id
+        # is NOT the empty one.
+        result = json.loads(session_search(query="modpack", db=db))
+        if result["count"] >= 1:
+            hit = result["results"][0]
+            effective = hit["effective_anchor_id"]
+            effective_msg = next((m for m in hit["messages"] if m["id"] == effective), None)
+            if effective_msg:
+                assert len((effective_msg.get("content") or "").strip()) >= 20, \
+                    f"effective_anchor_id={effective} landed on empty content; rerank failed"
+
+    def test_no_substantive_falls_back_to_fts_anchor(self, db):
+        """When the candidate pool has no substantive message (very edge case),
+        the rerank should return the original FTS5 anchor id unchanged."""
+        # Direct test of the helper
+        from tools.session_search_tool import _rerank_anchor
+        view = {
+            "window": [
+                {"id": 1, "role": "assistant", "content": ""},
+                {"id": 2, "role": "tool", "content": "json output"},
+            ],
+            "bookend_start": [],
+            "bookend_end": [],
+        }
+        assert _rerank_anchor(view, fts_anchor_id=1) == 1
+        assert _rerank_anchor(view, fts_anchor_id=2) == 2
+
+    def test_picks_nearest_substantive_by_id_distance(self, db):
+        """When FTS5 anchor is empty, rerank picks the substantive message
+        with smallest id-distance, not the first in window order."""
+        from tools.session_search_tool import _rerank_anchor
+        view = {
+            "window": [
+                {"id": 10, "role": "user", "content": "earlier substantive"},
+                {"id": 20, "role": "assistant", "content": ""},  # FTS5 anchor (empty)
+                {"id": 21, "role": "assistant", "content": "adjacent substantive (1 away)"},
+                {"id": 30, "role": "user", "content": "later substantive (10 away)"},
+            ],
+            "bookend_start": [],
+            "bookend_end": [],
+        }
+        # Anchor 20 is empty. Nearest substantive by id-distance is 21 (dist=1), not 10 (dist=10).
+        assert _rerank_anchor(view, fts_anchor_id=20) == 21
+
+
 class TestDiscoverySort:
     def test_sort_newest_orders_by_recency(self, db):
         _seed_modpack_sessions(db)

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -141,6 +141,55 @@ def _shape_message(m: Dict[str, Any], anchor_id: Optional[int] = None) -> Dict[s
     return {k: v for k, v in entry.items() if v is not None or k in ("content",)}
 
 
+def _build_citation(
+    messages: List[Dict[str, Any]],
+    anchor_id: Optional[int],
+    session_id: str,
+) -> Dict[str, Any]:
+    """Derive a citation block from the existing anchored window.
+
+    Pure derivation — the anchor message is already flagged via
+    ``_shape_message(m, anchor_id=...)`` setting ``entry["anchor"] = True``.
+    No new DB calls. Reply is taken from the same window: the next message
+    in id order if anchor is user (the assistant answer), or the previous
+    message if anchor is assistant (the user prompt that prompted it).
+
+    Returns a citation dict suitable for inclusion in a discovery entry.
+    Empty dict if anchor can't be located.
+    """
+    if anchor_id is None or not messages:
+        return {}
+
+    anchor = next((m for m in messages if m.get("id") == anchor_id), None)
+    if not anchor:
+        return {}
+
+    # Find a neighbour in the same window: prefer the next message by id,
+    # fall back to the previous. Filter to a different role (assistant reply
+    # to user prompt, or vice versa) — pure same-role continuation is noise.
+    neighbours = [m for m in messages if m.get("id") != anchor_id]
+    next_neighbour = next((m for m in neighbours if m.get("id", 0) > anchor_id), None)
+    prev_neighbour = next(
+        (m for m in reversed(neighbours) if m.get("id", 0) < anchor_id), None
+    )
+    reply = None
+    for candidate in (next_neighbour, prev_neighbour):
+        if candidate and candidate.get("role") != anchor.get("role") and candidate.get("content"):
+            reply = candidate["content"]
+            break
+
+    return {
+        "exact_quote": anchor.get("content", ""),
+        "speaker": anchor.get("role"),
+        "decided_at": _format_timestamp(anchor.get("timestamp")),
+        "reply_quote": reply,
+        "context_url": (
+            f'session_search(session_id="{session_id}", '
+            f"around_message_id={anchor_id}, window=10)"
+        ),
+    }
+
+
 def _resolve_profile_db(profile: str):
     """Open another profile's ``state.db`` read-only, or None for the current one.
 
@@ -484,6 +533,11 @@ def _title_match_result(
         "matched_role": "session_title",
         "match_message_id": anchor_id,
         "snippet": f"Session title matched: {session_meta.get('title') or title_query}",
+        "citation": _build_citation(
+            [_shape_message(m, anchor_id=anchor_id) for m in (view.get("window") or messages[:5])],
+            anchor_id,
+            session_id,
+        ),
         "bookend_start": [_shape_message(m) for m in (view.get("bookend_start") or messages[:3])],
         "messages": [_shape_message(m, anchor_id=anchor_id) for m in (view.get("window") or messages[:5])],
         "bookend_end": [_shape_message(m) for m in (view.get("bookend_end") or messages[-3:])],
@@ -596,6 +650,11 @@ def _discover(
             "matched_role": match_info.get("role"),
             "match_message_id": msg_id,
             "snippet": match_info.get("snippet") or "",
+            "citation": _build_citation(
+                [_shape_message(m, anchor_id=msg_id) for m in (view.get("window") or [])],
+                msg_id,
+                hit_sid,
+            ),
             "bookend_start": [_shape_message(m) for m in (view.get("bookend_start") or [])],
             "messages": [_shape_message(m, anchor_id=msg_id) for m in (view.get("window") or [])],
             "bookend_end": [_shape_message(m) for m in (view.get("bookend_end") or [])],
@@ -780,6 +839,13 @@ SESSION_SEARCH_SCHEMA = {
         "       - bookend_end: last 3 user+assistant messages of the session "
         "(the resolution / decisions)\n"
         "       - match_message_id, messages_before, messages_after\n"
+        "     Each discovery result also carries a 'citation' block — exact_quote "
+        "(the matched message's verbatim content), speaker (user/assistant), "
+        "decided_at (timestamp of the match), reply_quote (the neighbour "
+        "message in the same window when one exists), and a context_url recipe "
+        "the model can paste into a follow-up session_search(...) call to "
+        "expand context. Use the citation block to attribute decisions "
+        "verbatim when answering the user.\n"
         "     Bookends + window together let you reconstruct goal → match → resolution "
         "without paying for the whole transcript.\n\n"
         "  2) SCROLL — pass `session_id` + `around_message_id`:\n"

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -141,6 +141,52 @@ def _shape_message(m: Dict[str, Any], anchor_id: Optional[int] = None) -> Dict[s
     return {k: v for k, v in entry.items() if v is not None or k in ("content",)}
 
 
+def _rerank_anchor(
+    raw_view: Dict[str, Any],
+    fts_anchor_id: int,
+    min_content_len: int = 20,
+) -> int:
+    """Promote the nearest substantive message to anchor if FTS5 hit is empty.
+
+    Pure derivation — no new DB calls. Uses the same view's window +
+    bookends as the candidate pool, so we never look up data we haven't
+    already fetched.
+
+    A message is "substantive" if:
+      - role is user or assistant (NOT tool)
+      - stripped content length >= min_content_len
+
+    Stable: if the FTS5 anchor is already substantive, returns it unchanged.
+    Fallback: if no substantive message exists in the candidate pool,
+    returns the FTS5 anchor id (best we can do).
+    """
+    candidates = (
+        list(raw_view.get("window") or [])
+        + list(raw_view.get("bookend_start") or [])
+        + list(raw_view.get("bookend_end") or [])
+    )
+    if not candidates:
+        return fts_anchor_id
+
+    def is_substantive(m: Dict[str, Any]) -> bool:
+        return (
+            m.get("role") in ("user", "assistant")
+            and len((m.get("content") or "").strip()) >= min_content_len
+        )
+
+    # If FTS5 anchor is already substantive, leave it
+    anchor_msg = next((m for m in candidates if m.get("id") == fts_anchor_id), None)
+    if anchor_msg and is_substantive(anchor_msg):
+        return fts_anchor_id
+
+    # Otherwise find the nearest substantive message by id-distance
+    substantive = [m for m in candidates if is_substantive(m)]
+    if not substantive:
+        return fts_anchor_id
+    nearest = min(substantive, key=lambda m: abs(m.get("id", 0) - fts_anchor_id))
+    return nearest["id"]
+
+
 def _build_citation(
     messages: List[Dict[str, Any]],
     anchor_id: Optional[int],
@@ -634,11 +680,16 @@ def _discover(
             logging.warning("get_anchored_view failed for %s/%s: %s", hit_sid, msg_id, e, exc_info=True)
             continue
 
+        # Rerank: if FTS5 anchor landed on an empty/tool-only message,
+        # promote the nearest substantive user/assistant message to anchor.
+        effective_anchor_id = _rerank_anchor(view, msg_id)
+
         try:
             session_meta = db.get_session(lineage_root) or {}
         except Exception:
             session_meta = {}
 
+        shaped_window = [_shape_message(m, anchor_id=effective_anchor_id) for m in (view.get("window") or [])]
         entry = {
             "session_id": hit_sid,
             "when": _format_timestamp(
@@ -649,14 +700,11 @@ def _discover(
             "title": session_meta.get("title") or None,
             "matched_role": match_info.get("role"),
             "match_message_id": msg_id,
+            "effective_anchor_id": effective_anchor_id,
             "snippet": match_info.get("snippet") or "",
-            "citation": _build_citation(
-                [_shape_message(m, anchor_id=msg_id) for m in (view.get("window") or [])],
-                msg_id,
-                hit_sid,
-            ),
+            "citation": _build_citation(shaped_window, effective_anchor_id, hit_sid),
             "bookend_start": [_shape_message(m) for m in (view.get("bookend_start") or [])],
-            "messages": [_shape_message(m, anchor_id=msg_id) for m in (view.get("window") or [])],
+            "messages": shaped_window,
             "bookend_end": [_shape_message(m) for m in (view.get("bookend_end") or [])],
             "messages_before": view.get("messages_before", 0),
             "messages_after": view.get("messages_after", 0),


### PR DESCRIPTION
## Summary
- Add per-result citation provenance for session-search discovery results.
- Rerank empty/tool-only FTS5 anchors to the nearest substantive user/assistant message.
- Preserve the raw FTS match while exposing the effective anchor used for citation.
- Rebased onto current upstream `main` (1745+ commits ahead of original base).

## Validation
- Targeted: `scripts/run_tests.sh tests/tools/test_session_search.py -q` — 65 passed.
- `git diff --check` against current `origin/main` — clean.

## Notes
- Replaces the earlier PR #67994 (pre-rebase). This branch is rebased onto the current upstream `main`; the earlier PR had a stale, pre-upstream base.
- Independent reviews of the prior PR #67994 concluded ship-ready; same code is now rebased onto current main.
- Two unrelated, environment/dependency test failures remain in the broader suite (Bedrock default-region; Feishu SDK extra_ua_tags parameter). Neither file is touched by this PR.