### PR TITLE
fix(agent): reject router timeout shim in validate_response

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -18,6 +18,32 @@ from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
 
 
+_ROUTER_TIMEOUT_SHIM = "Connect timeout, please try again later."
+
+
+def _has_positive_completion_tokens(usage: Any) -> bool:
+    """Return whether a response usage object proves text was generated."""
+    for field in ("completion_tokens", "output_tokens"):
+        value = usage.get(field) if isinstance(usage, dict) else getattr(usage, field, None)
+        if isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0:
+            return True
+    return False
+
+
+def _is_router_timeout_shim(response: Any) -> bool:
+    """Recognize a router failure encoded as a successful ChatCompletion."""
+    choices = getattr(response, "choices", None)
+    if not isinstance(choices, list) or len(choices) != 1:
+        return False
+    message = getattr(choices[0], "message", None)
+    content = getattr(message, "content", None)
+    if not isinstance(content, str) or content.strip() != _ROUTER_TIMEOUT_SHIM:
+        return False
+    if getattr(message, "tool_calls", None):
+        return False
+    return not _has_positive_completion_tokens(getattr(response, "usage", None))
+
+
 def _reasoning_config_for_model(model: str, reasoning_config: dict | None) -> dict | None:
     """Return the model's wire-compatible reasoning config."""
     if not isinstance(reasoning_config, dict):
@@ -769,12 +795,14 @@ class ChatCompletionsTransport(ProviderTransport):
         )
 
     def validate_response(self, response: Any) -> bool:
-        """Check that response has valid choices."""
+        """Check that response has valid choices and is not a router failure shim."""
         if response is None:
             return False
         if not hasattr(response, "choices") or response.choices is None:
             return False
         if not response.choices:
+            return False
+        if _is_router_timeout_shim(response):
             return False
         return True
 

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -886,6 +886,44 @@ class TestChatCompletionsValidate:
         r = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="hi"))])
         assert transport.validate_response(r) is True
 
+    @pytest.mark.parametrize("usage", [None, SimpleNamespace(completion_tokens=0)])
+    def test_rejects_known_router_timeout_shim_without_generated_tokens(self, transport, usage):
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(
+                content="Connect timeout, please try again later.",
+                tool_calls=None,
+            ))],
+            usage=usage,
+        )
+
+        assert transport.validate_response(response) is False
+
+    def test_accepts_timeout_text_with_generated_tokens(self, transport):
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(
+                content="Connect timeout, please try again later.",
+                tool_calls=None,
+            ))],
+            usage=SimpleNamespace(completion_tokens=1),
+        )
+
+        assert transport.validate_response(response) is True
+
+    @pytest.mark.parametrize(
+        ("content", "tool_calls"),
+        [
+            ("The router said: Connect timeout, please try again later.", None),
+            ("Connect timeout, please try again later.", [SimpleNamespace()]),
+        ],
+    )
+    def test_accepts_non_shim_timeout_text(self, transport, content, tool_calls):
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=content, tool_calls=tool_calls))],
+            usage=None,
+        )
+
+        assert transport.validate_response(response) is True
+
 
 class TestChatCompletionsNormalize:
 


### PR DESCRIPTION
## Summary

Fixes #68396. OpenAI-compatible routers can return `Connect timeout, please try again later.` inside an HTTP-200 ChatCompletion envelope. When that response has no tool calls and no positive generated-token evidence, Hermes previously treated it as normal assistant text. This change classifies only that exact shim as invalid, so the existing retry/fallback path handles it.

## Changes
- `agent/transports/chat_completions.py`: Reject exact router timeout shim when it has one choice, no tool calls, and no positive completion_tokens/output_tokens.
- `tests/agent/transports/test_chat_completions.py`: Cover missing/zero usage rejection and positive controls.

## Verification
All 96 tests pass. Ruff check and ty check pass.