### PR TITLE
fix(gateway): honor profile secret scope in allowlist checks, add missing /status floor command

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -417,7 +417,7 @@ class GatewayAuthorizationMixin:
                 Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
             }.get(source.platform, "")
             if chat_allowlist_env:
-                raw_chat_allowlist = os.getenv(chat_allowlist_env, "").strip()
+                raw_chat_allowlist = _auth_env(chat_allowlist_env)
                 if raw_chat_allowlist:
                     allowed_group_ids = {
                         cid.strip()
@@ -459,7 +459,7 @@ class GatewayAuthorizationMixin:
         }
         if getattr(source, "is_bot", False):
             allow_bots_var = platform_allow_bots_map.get(source.platform)
-            if allow_bots_var and os.getenv(allow_bots_var, "none").lower().strip() in {"mentions", "all"}:
+            if allow_bots_var and _auth_env(allow_bots_var, "none").lower() in {"mentions", "all"}:
                 return True
 
         if not user_id:
@@ -816,13 +816,13 @@ class GatewayAuthorizationMixin:
                 ),
                 Platform.QQBOT: ("QQ_GROUP_ALLOWED_USERS",),
             }
-            if os.getenv(platform_env_map.get(platform, ""), "").strip():
+            if _auth_env(platform_env_map.get(platform, "")):
                 return "ignore"
             for env_key in platform_group_env_map.get(platform, ()):
-                if os.getenv(env_key, "").strip():
+                if _auth_env(env_key):
                     return "ignore"
 
-        if os.getenv("GATEWAY_ALLOWED_USERS", "").strip():
+        if _auth_env("GATEWAY_ALLOWED_USERS"):
             return "ignore"
 
         return "pair"

--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -653,7 +653,7 @@ class PairingStore:
     def _all_platforms(self, suffix: str) -> list:
         """List all platforms that have data files of a given suffix."""
         platforms = []
-        for f in PAIRING_DIR.iterdir():
+        for f in self._dir.iterdir():
             if f.name.endswith(f"-{suffix}.json"):
                 platform = f.name.replace(f"-{suffix}.json", "")
                 if not platform.startswith("_"):

--- a/gateway/slash_access.py
+++ b/gateway/slash_access.py
@@ -50,6 +50,7 @@ from typing import Any, FrozenSet, Iterable, Optional, Tuple
 _ALWAYS_ALLOWED_FOR_USERS: FrozenSet[str] = frozenset({
     "help",
     "whoami",
+    "status",
 })
 
 

--- a/tests/gateway/test_authz_profile_secret_scope.py
+++ b/tests/gateway/test_authz_profile_secret_scope.py
@@ -1,0 +1,127 @@
+"""Regression tests: authz_mixin.py allowlist checks must honor profile-scoped
+secrets (via ``agent.secret_scope``), not just ``os.environ``.
+
+Three call sites in ``GatewayAuthorizationMixin`` read allowlist env vars with
+raw ``os.getenv()`` instead of the module's own ``_auth_env()`` helper, which
+checks the active profile secret scope first. Under multiplexing, an operator
+who sets an allowlist via a profile's ``secret_scope`` (rather than the
+process environment) had that allowlist silently ignored at exactly these
+three spots, while every other allowlist check in the same class correctly
+honored it. Fixed by routing all three through ``_auth_env()``.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import agent.secret_scope as secret_scope
+from gateway.session import Platform, SessionSource
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    for var in (
+        "TELEGRAM_GROUP_ALLOWED_CHATS",
+        "TELEGRAM_ALLOW_BOTS",
+        "TELEGRAM_ALLOWED_USERS",
+        "GATEWAY_ALLOWED_USERS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture
+def scoped_secrets():
+    """Install a profile secret scope, auto-reset after the test."""
+
+    def _install(secrets):
+        secret_scope.set_multiplex_active(True)
+        token = secret_scope.set_secret_scope(secrets)
+        return token
+
+    installed = []
+
+    def _install_and_track(secrets):
+        token = _install(secrets)
+        installed.append(token)
+        return token
+
+    yield _install_and_track
+
+    for token in installed:
+        secret_scope.reset_secret_scope(token)
+    secret_scope.set_multiplex_active(False)
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.pairing_store = SimpleNamespace(is_approved=lambda *_a, **_kw: False)
+    return runner
+
+
+def _group_source(chat_id="grp1", chat_type="group"):
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_type=chat_type,
+        user_id=None,
+        user_name=None,
+        is_bot=False,
+    )
+
+
+def _bot_source():
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="dm1",
+        chat_type="dm",
+        user_id="bot-1",
+        user_name="SomeBot",
+        is_bot=True,
+    )
+
+
+def test_group_chat_allowlist_honors_profile_secret_scope(scoped_secrets):
+    """TELEGRAM_GROUP_ALLOWED_CHATS set only via secret_scope must still authorize."""
+    runner = _make_runner()
+    scoped_secrets({"TELEGRAM_GROUP_ALLOWED_CHATS": "grp1"})
+
+    assert runner._is_user_authorized(_group_source("grp1")) is True
+
+
+def test_group_chat_allowlist_denies_when_not_in_profile_scope(scoped_secrets):
+    """Same var, but the chat id isn't listed — must still deny (not fail open)."""
+    runner = _make_runner()
+    scoped_secrets({"TELEGRAM_GROUP_ALLOWED_CHATS": "some-other-chat"})
+
+    assert runner._is_user_authorized(_group_source("grp1")) is False
+
+
+def test_allow_bots_honors_profile_secret_scope(scoped_secrets):
+    """TELEGRAM_ALLOW_BOTS set only via secret_scope must still admit bots."""
+    runner = _make_runner()
+    scoped_secrets({"TELEGRAM_ALLOW_BOTS": "all"})
+
+    assert runner._is_user_authorized(_bot_source()) is True
+
+
+def test_unauthorized_dm_behavior_honors_profile_secret_scope(scoped_secrets):
+    """A profile-scoped GATEWAY_ALLOWED_USERS must switch the default from
+    'pair' to 'ignore' — sending pairing codes to unknown senders when an
+    allowlist IS configured (just not in os.environ) is exactly the info-leak
+    the default is designed to avoid (see docstring on _get_unauthorized_dm_behavior)."""
+    runner = _make_runner()
+    runner.config = None
+    scoped_secrets({"GATEWAY_ALLOWED_USERS": "owner1"})
+
+    assert runner._get_unauthorized_dm_behavior(Platform.TELEGRAM) == "ignore"
+
+
+def test_unauthorized_dm_behavior_defaults_to_pair_with_no_allowlist_anywhere(scoped_secrets):
+    """Sanity check: with no allowlist configured (scope or env), default stays 'pair'."""
+    runner = _make_runner()
+    runner.config = None
+    scoped_secrets({})
+
+    assert runner._get_unauthorized_dm_behavior(Platform.TELEGRAM) == "pair"

--- a/tests/gateway/test_slash_access.py
+++ b/tests/gateway/test_slash_access.py
@@ -207,7 +207,7 @@ class TestPolicyForSource:
                     enabled=True,
                     extra={
                         "allow_admin_from": ["111"],
-                        "user_allowed_commands": ["status"],
+                        "user_allowed_commands": ["history"],
                         "group_allow_admin_from": ["222"],
                         "group_user_allowed_commands": ["help"],
                     },
@@ -220,10 +220,15 @@ class TestPolicyForSource:
         p = policy_for_source(cfg, grp_src)
         assert p.is_admin("222") is True
         assert p.is_admin("111") is False  # DM admin, not group admin
-        # In group scope, the only listed user command is "help"; "status"
-        # is not in the group list and should be denied for non-admins.
+        # In group scope, the only explicitly listed user command is "help".
+        # "status" is NOT in that list but must still be allowed — it's part
+        # of the always-allowed floor (_ALWAYS_ALLOWED_FOR_USERS), which
+        # applies regardless of scope per the module docstring. "history" is
+        # neither listed for this scope nor part of that floor, so it must
+        # still be denied — this is what actually exercises the group list.
         assert p.can_run("999", "help") is True
-        assert p.can_run("999", "status") is False
+        assert p.can_run("999", "status") is True
+        assert p.can_run("999", "history") is False
 
     def test_channel_thread_chat_types_treated_as_group_scope(self):
         # Discord channels and threads are group-scoped, not DM-scoped.


### PR DESCRIPTION
## What does this PR do?

Fixes three allowlist checks in `GatewayAuthorizationMixin` (`gateway/authz_mixin.py`) that read `os.getenv()` directly instead of the module's own `_auth_env()` helper — which checks the active profile `secret_scope` (multiplexing) before falling back to the process environment. Under a multiplex profile whose allowlist lives in the profile's `secret_scope` rather than process `os.environ`, these three checks silently behave as if no allowlist were configured.

Also fixes a matching bug in `gateway/pairing.py` (`PairingStore._all_platforms()` reads the global `PAIRING_DIR` instead of the profile-scoped `self._dir` every other method on the class correctly uses — breaks the class's documented per-profile isolation), and adds `status` to `gateway/slash_access.py`'s `_ALWAYS_ALLOWED_FOR_USERS` floor, which the module's own docstring already names as intended but the actual frozenset was missing.

**Why this wasn't already covered by #65629:** PR #65629 (merged, closing #59739/#59662) introduced `_auth_env()` and converted the platform-allow-all, platform/global allowlist, and `GATEWAY_ALLOW_ALL_USERS` checks inside `_is_user_authorized()` to use it. I checked its diff directly (`gh pr diff 65629`) before writing this fix, specifically to rule out duplicating that work. The diff's last hunk in `_is_user_authorized()` ends right before the chat-scoped allowlist block (`TELEGRAM_GROUP_ALLOWED_CHATS`/`QQ_GROUP_ALLOWED_USERS`) and the `{PLATFORM}_ALLOW_BOTS` block — both still on raw `os.getenv()` on current `main`. `_get_unauthorized_dm_behavior()` wasn't touched by that PR at all. This PR picks up exactly those three remaining spots.

## Related Issue

Fixes # (none filed — found via an automated first-pass code scan, then personally verified line-by-line against current `main` and against PR #65629's actual diff before writing this fix)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/authz_mixin.py` — `_is_user_authorized()`: chat-scoped allowlist check (line ~350) and `{PLATFORM}_ALLOW_BOTS` check (line ~374) now go through `_auth_env()` instead of raw `os.getenv()`. `_get_unauthorized_dm_behavior()`: per-platform, per-platform-group, and `GATEWAY_ALLOWED_USERS` presence checks (lines ~716-722) now go through `_auth_env()`.
- `gateway/pairing.py` — `PairingStore._all_platforms()` now reads `self._dir` instead of the module-level `PAIRING_DIR` constant, matching every other path-building method on the class.
- `gateway/slash_access.py` — added `"status"` to `_ALWAYS_ALLOWED_FOR_USERS`, matching the module docstring's stated intent (`"...no way to see what state the agent is in (`/status`)"`).
- `tests/gateway/test_authz_profile_secret_scope.py` (new) — 5 regression tests covering the three previously-broken call sites under an active profile `secret_scope`.
- `tests/gateway/test_slash_access.py` — **one existing assertion changed**, flagging this explicitly per this repo's own guidance on plausible-but-wrong fixes: `test_group_chat_type_resolves_to_group_scope` asserted `can_run("999", "status")` should be `False` in group scope. That assertion matched the pre-fix (buggy) behavior — `_ALWAYS_ALLOWED_FOR_USERS`'s own docstring says these commands "MUST stay reachable for any allowed user, even when slash gating is enabled... regardless of scope," naming `/status` specifically, and `can_run()` applies the floor uniformly with no scope-specific carve-out anywhere in the function. I could not find any comment, commit, or code path suggesting `/status` was deliberately excluded from group scope specifically — the rest of this file is heavily commented for every other deliberate design decision, and this one has no such comment. My read: the test was written to match the implementation as it stood (missing `/status`), not derived independently from the stated invariant. **If I'm wrong and there's a reason `/status` should stay group-scope-restricted, please say so — happy to revert just that piece.** I updated the test to assert `status` is now allowed (floor) and swapped in `history` (a real, non-floor command) as the negative case, so the test still actually exercises group-scope command-list restriction rather than just passing vacuously.

## How to Test

1. `pytest tests/gateway/test_authz_profile_secret_scope.py tests/gateway/test_pairing_allowlist_bypass.py tests/gateway/test_pairing.py tests/gateway/test_slash_access.py tests/gateway/test_slash_access_dispatch.py -v` — 110/110 pass.
2. `pytest tests/gateway/ -q` — 9,704 passed, 30 failed. I checked all 30 by hand: none touch `authz_mixin.py`, `pairing.py`, or `slash_access.py` (grepped each failing file for those module names — one false-positive hit was just a comment mentioning an unrelated function name). They're restart/update-command/telegram-escaping/wecom/whatsapp-pidfile tests that look environment-specific to the sandboxed container I ran them in (no systemd, no macOS, library-version-sensitive escaping) rather than caused by this change — consistent with #4443's own PR description noting a similar baseline of ~10 pre-existing unrelated failures in this directory.
3. Manual repro of the original bug: install a `TELEGRAM_GROUP_ALLOWED_CHATS` value only via `secret_scope.set_secret_scope(...)` (not `os.environ`) under `set_multiplex_active(True)`, then call `_is_user_authorized()` with a matching group `SessionSource` — fails (returns `False`) before this fix, passes after. Same for `_get_unauthorized_dm_behavior()` returning `"pair"` instead of `"ignore"` with a scoped `GATEWAY_ALLOWED_USERS`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for existing PRs — found and read #64461/#65629 (the actual prior fix in this area) in full before writing this, to confirm no duplication; details above.
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/gateway/ -q` and reviewed every failure — see How to Test #2
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Debian trixie, Docker container) — cross-platform impact is nil, this is pure env-var resolution logic with no OS-specific behavior

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, no docstring/behavior claims changed (the docstrings already described the intended behavior; the code just didn't match them)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A, no OS-specific code touched
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Test run (targeted files):
```
110 passed in 2.44s
```

Full `tests/gateway/` run: `9704 passed, 30 failed, 61 skipped, 279 warnings in 410.37s` — 30 failures individually checked, none touch the changed files (see How to Test #2 for detail).
