### PR TITLE
docs(contributing): fix stale project-structure diagram

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,7 +254,7 @@ hermes-agent/
 │   ├── code_execution_tool.py    # Sandboxed Python with RPC tool access
 │   ├── session_search_tool.py    # Search past conversations with FTS5 + anchored windows
 │   ├── cronjob_tools.py          # Scheduled task management
-│   ├── skill_tools.py            # Skill search, load, manage
+│   ├── skills_tool.py             # Skill search, load, manage
 │   └── environments/             # Terminal execution backends
 │       ├── base.py                   # BaseEnvironment ABC
 │       ├── local.py, docker.py, ssh.py, singularity.py, modal.py, daytona.py
@@ -262,9 +262,10 @@ hermes-agent/
 ├── gateway/                  # Messaging gateway
 │   ├── run.py                    # GatewayRunner — platform lifecycle, message routing, cron
 │   ├── config.py                 # Platform configuration resolution
-│   ├── session.py                # Session store, context prompts, reset policies
-│   └── platforms/                # Platform adapters
-│       ├── telegram.py, discord_adapter.py, slack.py, whatsapp.py
+│   └── session.py                # Session store, context prompts, reset policies
+│
+├── plugins/platforms/        # Channel adapters (telegram, discord, slack, whatsapp, etc.)
+│   └── <platform>/adapter.py     # One subdirectory per platform, e.g. plugins/platforms/telegram/adapter.py
 │
 ├── scripts/                  # Installer and bridge scripts
 │   ├── install.sh                # Linux/macOS installer


### PR DESCRIPTION
## What does this PR do?

Fixes two stale entries in `CONTRIBUTING.md`'s project-structure diagram that no longer match the actual file layout — a new contributor following the diagram would look in the wrong place.

## Related Issue

Fixes # (none filed — small stale-docs fix, confirmed by checking the actual file paths on disk)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `CONTRIBUTING.md` — `tools/skill_tools.py` → `tools/skills_tool.py` (the actual filename on disk).
- `CONTRIBUTING.md` — the `gateway/platforms/` entry (listing `telegram.py, discord_adapter.py, slack.py, whatsapp.py`) no longer exists; channel adapters now live under `plugins/platforms/<name>/adapter.py` (e.g. `plugins/platforms/telegram/adapter.py`, `plugins/platforms/discord/adapter.py`). Replaced the stale entry with a `plugins/platforms/` entry describing the current layout.

## How to Test

```
ls tools/skills_tool.py                      # exists
ls gateway/platforms/ 2>&1                    # No such file or directory
ls plugins/platforms/telegram/adapter.py      # exists
ls plugins/platforms/discord/adapter.py       # exists
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`docs(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] N/A — docs-only change, no code paths affected
- [x] N/A — docs-only change, no tests applicable
- [x] I've tested on my platform: Linux (Debian trixie) — N/A for a docs-only change

### Documentation & Housekeeping

- [x] I've updated relevant documentation — this PR *is* the documentation update
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture changed, just correcting stale docs
- [x] I've considered cross-platform impact — N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
