### PR TITLE
fix(codex): send ChatGPT-Account-Id on /models probes

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -4,6 +4,7 @@ Pure utility functions with no AIAgent dependency. Used by ContextCompressor
 and run_agent.py for pre-flight context checks.
 """
 
+import base64
 import hashlib
 import ipaddress
 import json
@@ -1933,6 +1934,34 @@ def _codex_oauth_token_fingerprint(access_token: str) -> str:
     return hashlib.sha256(access_token.encode("utf-8")).hexdigest()[:16]
 
 
+def _extract_chatgpt_account_id(access_token: str) -> Optional[str]:
+    """Extract ``chatgpt_account_id`` from the Codex OAuth JWT.
+
+    The Codex ``/backend-api/codex/models`` endpoint returns the per-account
+    catalog only when the ``ChatGPT-Account-Id`` header is present; without
+    it, the endpoint returns ``{"models":[]}`` (HTTP 200) and the context
+    probe falls back to the hardcoded defaults — which can be stale or
+    wrong for the active account's plan. Mirrors the same extraction done
+    in ``auxiliary_client.py`` for the request path.
+
+    Returns ``None`` on any parse error rather than raising, so a bad
+    token still surfaces as a normal probe failure instead of crashing
+    the metadata resolver.
+    """
+    try:
+        parts = access_token.split(".")
+        if len(parts) < 2:
+            return None
+        payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload_b64))
+        if not isinstance(claims, dict):
+            return None
+        acct_id = claims.get("https://api.openai.com/auth", {}).get("chatgpt_account_id")
+        return acct_id if isinstance(acct_id, str) and acct_id else None
+    except Exception:
+        return None
+
+
 def _fetch_codex_oauth_context_lengths_with_source(
     access_token: str,
 ) -> Tuple[Dict[str, int], bool]:
@@ -1953,10 +1982,15 @@ def _fetch_codex_oauth_context_lengths_with_source(
         if now - cached_at < _CODEX_OAUTH_CONTEXT_CACHE_TTL:
             return cached_models, False
 
+    headers = {"Authorization": f"Bearer {access_token}"}
+    acct_id = _extract_chatgpt_account_id(access_token)
+    if acct_id:
+        headers["ChatGPT-Account-Id"] = acct_id
+
     try:
         resp = requests.get(
             "https://chatgpt.com/backend-api/codex/models?client_version=1.0.0",
-            headers={"Authorization": f"Bearer {access_token}"},
+            headers=headers,
             timeout=(5, 10),
             verify=_resolve_requests_verify(),
         )

--- a/contributors/emails/tars@users.noreply.github.com
+++ b/contributors/emails/tars@users.noreply.github.com
@@ -1,0 +1,1 @@
+MLcogTech

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 from pathlib import Path
@@ -93,13 +94,47 @@ def _add_forward_compat_models(model_ids: List[str]) -> List[str]:
     return ordered
 
 
+def _extract_chatgpt_account_id(access_token: str) -> Optional[str]:
+    """Best-effort extraction of ``chatgpt_account_id`` from the OAuth JWT.
+
+    The Codex backend requires the ``ChatGPT-Account-Id`` header for the
+    per-account catalog. Without it, ``GET /backend-api/codex/models``
+    returns ``{"models":[]}`` (HTTP 200) — which masquerades as "no
+    models available" and silently degrades the picker to the curated
+    fallback list. The request-side path in ``auxiliary_client.py``
+    already extracts the same claim; this mirrors that logic here so the
+    probe sees the same catalog the request path will actually use.
+
+    Returns ``None`` on any parse error — the probe then degrades
+    gracefully to the unauthenticated fallback list instead of crashing.
+    """
+    try:
+        parts = access_token.split(".")
+        if len(parts) < 2:
+            return None
+        payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload_b64))
+        acct_id = (
+            claims.get("https://api.openai.com/auth", {}).get("chatgpt_account_id")
+            if isinstance(claims, dict)
+            else None
+        )
+        return acct_id if isinstance(acct_id, str) and acct_id else None
+    except Exception:
+        return None
+
+
 def _fetch_models_from_api(access_token: str) -> List[str]:
     """Fetch available models from the Codex API. Returns visible models sorted by priority."""
     try:
         import httpx
+        headers = {"Authorization": f"Bearer {access_token}"}
+        acct_id = _extract_chatgpt_account_id(access_token)
+        if acct_id:
+            headers["ChatGPT-Account-Id"] = acct_id
         resp = httpx.get(
             "https://chatgpt.com/backend-api/codex/models?client_version=1.0.0",
-            headers={"Authorization": f"Bearer {access_token}"},
+            headers=headers,
             timeout=10,
         )
         if resp.status_code != 200:

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -113,6 +113,83 @@ def test_fetch_from_api_keeps_supported_in_api_false_models(monkeypatch):
     assert "gpt-5-internal" not in models
 
 
+def test_fetch_from_api_sends_chatgpt_account_id_header(monkeypatch):
+    """The Codex /models endpoint only returns the per-account catalog when
+    the ``ChatGPT-Account-Id`` header is present. Without it, the response
+    is ``{"models":[]}`` (HTTP 200), which makes the picker silently
+    degrade to the curated fallback list and send invalid slugs on later
+    requests. Regression test for the upstream bug behind slow first
+    responses and HTTP 520/120s SSE hangs.
+    """
+    import sys
+    from hermes_cli import codex_models
+
+    captured = {}
+
+    class _FakeResp:
+        status_code = 200
+
+        def json(self):
+            return {"models": [{"slug": "gpt-5.6-sol", "priority": 0}]}
+
+    class _FakeHttpx:
+        @staticmethod
+        def get(url, headers=None, timeout=None):
+            captured["url"] = url
+            captured["headers"] = dict(headers or {})
+            return _FakeResp()
+
+    monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+
+    # Hand-crafted JWT carrying the chatgpt_account_id claim.
+    import base64
+    import json
+
+    payload = base64.urlsafe_b64encode(
+        json.dumps(
+            {"https://api.openai.com/auth": {"chatgpt_account_id": "acct-test-123"}}
+        ).encode()
+    ).rstrip(b"=").decode()
+    fake_jwt = f"header.{payload}.sig"
+
+    models = codex_models._fetch_models_from_api(access_token=fake_jwt)
+
+    assert captured["headers"]["Authorization"] == f"Bearer {fake_jwt}"
+    assert captured["headers"].get("ChatGPT-Account-Id") == "acct-test-123"
+    assert "gpt-5.6-sol" in models
+
+
+def test_fetch_from_api_omits_account_id_header_when_jwt_unparseable(monkeypatch):
+    """A malformed token must not crash the probe — it should still send the
+    bearer header and let the upstream decide. We just verify the probe
+    returns ``[]`` cleanly without the optional header.
+    """
+    import sys
+    from hermes_cli import codex_models
+
+    captured = {}
+
+    class _FakeResp:
+        status_code = 200
+
+        def json(self):
+            return {"models": []}
+
+    class _FakeHttpx:
+        @staticmethod
+        def get(url, headers=None, timeout=None):
+            captured["headers"] = dict(headers or {})
+            return _FakeResp()
+
+    monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+
+    models = codex_models._fetch_models_from_api(access_token="not-a-jwt")
+
+    assert "ChatGPT-Account-Id" not in captured["headers"]
+    assert captured["headers"]["Authorization"] == "Bearer not-a-jwt"
+    assert models == []
+
+
 def test_model_command_uses_runtime_access_token_for_codex_list(monkeypatch):
     from hermes_cli.main import _model_flow_openai_codex
 


### PR DESCRIPTION
## Summary
Both Codex OAuth `/models` probe paths now send the `ChatGPT-Account-Id` header (extracted from the OAuth JWT), so the per-account catalog is returned instead of a silent `{"models":[]}` — the model picker and the context-window resolver now see the same catalog the request path actually uses.

Salvages PR #64821 by @MLcogTech (2 commits cherry-picked, authorship preserved) onto current main, on top of the just-merged #68554 cache-revalidation work.

## Root cause
The Codex request path (`agent/auxiliary_client.py`) already extracts `chatgpt_account_id` from the JWT and sends the header, but the two probe-side paths (`hermes_cli/codex_models.py::_fetch_models_from_api` and `agent/model_metadata.py::_fetch_codex_oauth_context_lengths`) sent only the bearer token. The endpoint responds `200 {"models":[]}` without the header, so the picker silently degraded to the curated fallback list and the context probe fell back to hardcoded defaults — stale slugs then caused HTTP 520s and 120s SSE hangs downstream.

## Changes
- `agent/model_metadata.py`: `_extract_chatgpt_account_id()` + header on the context-window probe (merged cleanly with #68554's per-credential source-tracked fetch)
- `hermes_cli/codex_models.py`: same extraction + header on the model-picker probe
- `tests/hermes_cli/test_codex_models.py`: header-presence regression test + malformed-token graceful-degradation test

## Validation
| Scenario | Before | After |
|---|---|---|
| Live probe with valid JWT | `{"models":[]}`, fallback catalog | per-account catalog, header `ChatGPT-Account-Id` sent |
| Malformed token | n/a | header omitted, probe degrades gracefully, no crash |

E2E-tested via real imports against a temp HERMES_HOME: hand-crafted JWT → header captured on the wire → 372K live value resolved through the full `get_model_context_length()` route; malformed token → no header, no crash. Targeted suites green: `tests/agent/test_model_metadata.py`, `tests/hermes_cli/test_codex_models.py`, `tests/agent/test_codex_cloudflare_headers.py` — 162 passed.

Closes #64821 (salvaged with authorship preserved).

## Infographic
![Account-scoped catalog probes](https://v3b.fal.media/files/b/0aa32323/H92bV3QWNYUcamLBADtQ__4o1bBlzc.png)
