### PR TITLE
fix(cronjob): accept bare model string in schema and _resolve_model_override

### DIFF
--- a/contributors/emails/webtecnica@users.noreply.github.com
+++ b/contributors/emails/webtecnica@users.noreply.github.com
@@ -1,0 +1,2 @@
+webtecnica
+# PR #68587 maintainer attribution

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -579,6 +579,38 @@ class TestResolveModelOverride:
         assert provider == "custom:cliproxy"
         assert model == "gpt-5.4"
 
+    # -- bare-string tests (regression for #68380) -----------------------
+
+    def test_bare_string_model_returns_none_provider(self):
+        """Regression: _resolve_model_override("anthropic/claude-haiku-4.5")
+        must return (None, "anthropic/claude-haiku-4.5"), not (None, None)."""
+        provider, model = _resolve_model_override("anthropic/claude-haiku-4.5")
+        assert provider is None
+        assert model == "anthropic/claude-haiku-4.5"
+
+    def test_bare_string_model_whitespace_stripped(self):
+        provider, model = _resolve_model_override("  gpt-4  ")
+        assert provider is None
+        assert model == "gpt-4"
+
+    def test_bare_string_model_empty_returns_none_none(self):
+        provider, model = _resolve_model_override("   ")
+        assert provider is None
+        assert model is None
+
+    def test_dict_model_still_works(self):
+        """Dict path must not be broken by the bare-string addition."""
+        provider, model = _resolve_model_override(
+            {"provider": "nous", "model": "claude-haiku-4.5"}
+        )
+        assert provider == "nous"
+        assert model == "claude-haiku-4.5"
+
+    def test_none_returns_none_none(self):
+        provider, model = _resolve_model_override(None)
+        assert provider is None
+        assert model is None
+
 
 class TestLocalDeliveryNotice:
     """#51568 — TUI/CLI cron jobs are local-only; surface that at create time

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -373,15 +373,25 @@ def _canonical_skills(skill: Optional[str] = None, skills: Optional[Any] = None)
 
 
 
-def _resolve_model_override(model_obj: Optional[Dict[str, Any]]) -> tuple:
-    """Resolve a model override object into (provider, model) for job storage.
+def _resolve_model_override(model_obj: Optional[Union[str, Dict[str, Any]]]) -> tuple:
+    """Resolve a model override into (provider, model) for job storage.
+
+    Accepts both the declared object shape ``{"model": "...", "provider": "..."}``
+    and a bare model string (e.g. ``"gpt-4"``) for the ``action=update`` path
+    where agents typically send flat scalars.
 
     If provider is omitted, pins the current main provider from config so the
     job doesn't drift when the user later changes their default via hermes model.
 
     Returns (provider_str_or_none, model_str_or_none).
     """
-    if not model_obj or not isinstance(model_obj, dict):
+    if not model_obj:
+        return (None, None)
+    if isinstance(model_obj, str):
+        # Agent sent a bare model string instead of the object shape —
+        # treat it as model name with no provider override.
+        return (None, model_obj.strip() or None)
+    if not isinstance(model_obj, dict):
         return (None, None)
     model_name = (model_obj.get("model") or "").strip() or None
     provider_name = (model_obj.get("provider") or "").strip() or None
@@ -1023,19 +1033,16 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "description": "Optional ordered list of skill names to load before executing the cron prompt. On update, pass an empty array to clear attached skills."
             },
             "model": {
-                "type": "object",
-                "description": "Optional per-job model override. If provider is omitted, the current main provider is pinned at creation time so the job stays stable.",
-                "properties": {
-                    "provider": {
-                        "type": "string",
-                        "description": "Provider name (e.g. 'openrouter', 'anthropic', or 'custom:<name>' for a provider defined in custom_providers config — always include the ':<name>' suffix, never pass the bare 'custom'). Omit to use and pin the current provider."
-                    },
-                    "model": {
-                        "type": "string",
-                        "description": "Model name (e.g. 'anthropic/claude-sonnet-4', 'claude-sonnet-4')"
-                    }
-                },
-                "required": ["model"]
+                "type": "string",
+                "description": "Optional per-job model override (e.g. 'anthropic/claude-sonnet-4'). When set on create or update, the model is pinned so the job stays stable across config changes. For create, combine with the ``provider`` param to pin both at once."
+            },
+            "provider": {
+                "type": "string",
+                "description": "Optional per-job provider override (e.g. 'anthropic', 'openai', or 'custom:<name>' for a provider defined in custom_providers config — always include the ':<name>' suffix, never pass the bare 'custom'). When set on create or update, the provider is pinned. Combine with ``model`` to pin both."
+            },
+            "base_url": {
+                "type": "string",
+                "description": "Optional per-job base URL override. Only valid together with a named provider (``provider`` must also be set). Must be an absolute URL (http:// or https://)."
             },
             "script": {
                 "type": "string",


### PR DESCRIPTION
Fixes #68380

## Problem

`cronjob action=update` silently drops the `model` field when the LLM sends a flat string (e.g. `"gpt-4"`) instead of the declared object shape `{"model": "gpt-4"}`. The provider updates fine because it is a top-level string, but `_resolve_model_override` guards on `isinstance(model_obj, dict)` and returns `(None, None)` for strings — the model value is lost entirely while the tool reports success.

## Fix (two parts)

1. **Schema:** Change `model` from `{provider, model}` object to a flat string. Add top-level `provider` and `base_url` string params, matching the function signature and the #59031 guardrail's advertised syntax.

2. **_resolve_model_override:** Accept both shapes:
   - `{"model": "...", "provider": "..."}` — existing object shape (unchanged)
   - `"gpt-4"` — bare string treated as model name, no provider override

## Regression tests (5)

Added 5 new tests to `TestResolveModelOverride` (8 total):

- `test_bare_string_model_returns_none_provider` — `"anthropic/claude-haiku-4.5"` → `(None, "anthropic/claude-haiku-4.5")`
- `test_bare_string_model_whitespace_stripped` — `"  gpt-4  "` → `(None, "gpt-4")`
- `test_bare_string_model_empty_returns_none_none` — `"   "` → `(None, None)`
- `test_dict_model_still_works` — dict path unaffected
- `test_none_returns_none_none` — None path unaffected

All 82 tests in `tests/tools/test_cronjob_tools.py` pass.