### PR TITLE
feat(desktop): add custom endpoint quick-edit card to API Keys page

### DIFF
--- a/apps/desktop/src/app/settings/custom-endpoints-settings.test.tsx
+++ b/apps/desktop/src/app/settings/custom-endpoints-settings.test.tsx
@@ -1,0 +1,122 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { CustomEndpoint, CustomEndpointsResponse } from '@/types/hermes'
+
+const activateCustomEndpoint = vi.fn()
+const deleteCustomEndpoint = vi.fn()
+const getCustomEndpoints = vi.fn()
+const saveCustomEndpoint = vi.fn()
+const validateCustomEndpoint = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  activateCustomEndpoint: (id: string) => activateCustomEndpoint(id),
+  deleteCustomEndpoint: (id: string, source?: string) => deleteCustomEndpoint(id, source),
+  getCustomEndpoints: () => getCustomEndpoints(),
+  saveCustomEndpoint: (endpoint: unknown) => saveCustomEndpoint(endpoint),
+  validateCustomEndpoint: (endpoint: unknown) => validateCustomEndpoint(endpoint)
+}))
+
+vi.mock('@/lib/haptics', () => ({ triggerHaptic: vi.fn() }))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+function endpoint(id: string, source: string, patch: Partial<CustomEndpoint> = {}): CustomEndpoint {
+  return {
+    base_url: `https://${id}.example/v1`,
+    discover_models: true,
+    has_api_key: false,
+    id,
+    model: `${id}/model`,
+    models: [`${id}/model`],
+    name: id,
+    source,
+    ...patch
+  }
+}
+
+function response(endpoints: CustomEndpoint[]): CustomEndpointsResponse {
+  return {
+    current: { base_url: '', model: '', provider: '' },
+    endpoints
+  }
+}
+
+beforeEach(() => {
+  activateCustomEndpoint.mockResolvedValue({ model: 'modern/model', ok: true, provider: 'modern' })
+  deleteCustomEndpoint.mockResolvedValue(response([]))
+  saveCustomEndpoint.mockResolvedValue(response([]))
+  validateCustomEndpoint.mockResolvedValue({ message: '', models: [], ok: true, reachable: true })
+  vi.spyOn(window, 'confirm').mockReturnValue(true)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+})
+
+async function renderSettings() {
+  const { CustomEndpointsSettings } = await import('./custom-endpoints-settings')
+
+  return render(<CustomEndpointsSettings />)
+}
+
+describe('CustomEndpointsSettings', () => {
+  it('renders legacy custom_providers entries as delete-only summaries and refreshes after deletion', async () => {
+    const legacy = endpoint('legacy-0-abcd1234', 'custom_providers', {
+      api_key_preview: 'sk-...1234',
+      base_url: 'https://legacy-proxy.example/v1',
+      has_api_key: true,
+      is_current: true,
+      model: 'legacy-proxy/model',
+      name: 'Legacy Proxy'
+    })
+
+    getCustomEndpoints.mockResolvedValueOnce(response([legacy])).mockResolvedValueOnce(response([]))
+
+    await renderSettings()
+
+    expect(await screen.findByText('Legacy config')).toBeTruthy()
+    expect(screen.getByText('https://legacy-proxy.example/v1')).toBeTruthy()
+    expect(screen.getByText('legacy-proxy/model')).toBeTruthy()
+    expect(screen.getByText('sk-...1234')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /^Legacy Proxy/ })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Use' })).toBeNull()
+    expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Legacy Proxy' }))
+
+    await waitFor(() => expect(deleteCustomEndpoint).toHaveBeenCalledWith('legacy-0-abcd1234', 'custom_providers'))
+    await waitFor(() => expect(getCustomEndpoints).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(screen.queryByText('Legacy config')).toBeNull())
+  })
+
+  it('keeps modern and direct-config endpoints selectable with their existing actions', async () => {
+    const modern = endpoint('modern', 'providers', { name: 'Modern Proxy' })
+    const direct = endpoint('custom', 'direct-config', { name: 'Direct Custom' })
+    getCustomEndpoints.mockResolvedValue(response([modern, direct]))
+
+    await renderSettings()
+    await screen.findByText('Modern Proxy')
+
+    fireEvent.click(screen.getByRole('button', { name: 'New endpoint' }))
+    fireEvent.click(screen.getByRole('button', { name: /^Direct Custom/ }))
+    expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('Direct Custom')
+
+    fireEvent.click(screen.getByRole('button', { name: 'New endpoint' }))
+    fireEvent.click(screen.getByRole('button', { name: /^Modern Proxy/ }))
+    expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('Modern Proxy')
+
+    expect(screen.getAllByRole('button', { name: 'Use' })).toHaveLength(2)
+    expect(screen.getByRole('button', { name: 'Delete Modern Proxy' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Delete Direct Custom' })).toBeNull()
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Use' })[0])
+    await waitFor(() => expect(activateCustomEndpoint).toHaveBeenCalledWith('modern'))
+    await waitFor(() => expect(getCustomEndpoints).toHaveBeenCalledTimes(2))
+  })
+})

--- a/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
+++ b/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
@@ -58,6 +58,33 @@ function formFromEndpoint(endpoint: CustomEndpoint): EndpointForm {
   }
 }
 
+function isLegacyEndpoint(endpoint: CustomEndpoint) {
+  return endpoint.source === 'custom_providers'
+}
+
+function EndpointSummary({ endpoint }: { endpoint: CustomEndpoint }) {
+  return (
+    <>
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="truncate text-sm font-medium">{endpoint.name}</span>
+        {endpoint.is_current && (
+          <Pill tone="primary">
+            <Check className="size-3" />
+            Active
+          </Pill>
+        )}
+        {isLegacyEndpoint(endpoint) && <Pill tone="warn">Legacy config</Pill>}
+        {endpoint.source === 'direct-config' && <Pill>config.yaml</Pill>}
+      </div>
+      <div className="mt-1 truncate font-mono text-[0.7rem] text-muted-foreground">{endpoint.base_url}</div>
+      <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted-foreground">
+        <span>{endpoint.model}</span>
+        {endpoint.has_api_key && <span>{endpoint.api_key_preview ?? 'API key set'}</span>}
+      </div>
+    </>
+  )
+}
+
 function toPayload(form: EndpointForm): CustomEndpointUpdate {
   const contextLength = Number.parseInt(form.contextLength, 10)
 
@@ -100,7 +127,8 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
         }
 
         setEndpoints(data.endpoints)
-        const current = data.endpoints.find(endpoint => endpoint.is_current) ?? data.endpoints[0]
+        const editableEndpoints = data.endpoints.filter(endpoint => !isLegacyEndpoint(endpoint))
+        const current = editableEndpoints.find(endpoint => endpoint.is_current) ?? editableEndpoints[0]
 
         if (current) {
           setForm(formFromEndpoint(current))
@@ -200,8 +228,8 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
 
     try {
       setDeleting(endpoint.id)
-      const response = await deleteCustomEndpoint(endpoint.id)
-      setEndpoints(response.endpoints)
+      await deleteCustomEndpoint(endpoint.id, endpoint.source)
+      await refresh()
 
       if (form.id === endpoint.id) {
         setForm(EMPTY_FORM)
@@ -231,59 +259,59 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
           <SectionHeading icon={Globe} meta={`${endpoints.length}`} title="Custom Endpoints" />
           <div className="divide-y divide-border/40 rounded-md border border-border/50">
             {endpoints.length ? (
-              endpoints.map(endpoint => (
-                <div className="grid gap-3 p-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center" key={endpoint.id}>
-                  <button
-                    className="min-w-0 text-left"
-                    onClick={() => {
-                      setForm(formFromEndpoint(endpoint))
-                      setDiscoveredModels(endpoint.models)
-                    }}
-                    type="button"
+              endpoints.map(endpoint => {
+                const isLegacy = isLegacyEndpoint(endpoint)
+
+                return (
+                  <div
+                    className="grid gap-3 p-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
+                    key={`${endpoint.source ?? 'unknown'}:${endpoint.id}`}
                   >
-                    <div className="flex min-w-0 items-center gap-2">
-                      <span className="truncate text-sm font-medium">{endpoint.name}</span>
-                      {endpoint.is_current && (
-                        <Pill tone="primary">
-                          <Check className="size-3" />
-                          Active
-                        </Pill>
-                      )}
-                      {endpoint.source === 'direct-config' && <Pill>config.yaml</Pill>}
-                    </div>
-                    <div className="mt-1 truncate font-mono text-[0.7rem] text-muted-foreground">
-                      {endpoint.base_url}
-                    </div>
-                    <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted-foreground">
-                      <span>{endpoint.model}</span>
-                      {endpoint.has_api_key && <span>{endpoint.api_key_preview ?? 'API key set'}</span>}
-                    </div>
-                  </button>
-                  <div className="flex items-center gap-2 sm:justify-end">
-                    <Button
-                      disabled={endpoint.is_current || activating === endpoint.id}
-                      onClick={() => void handleActivate(endpoint)}
-                      size="sm"
-                      variant="outline"
-                    >
-                      {activating === endpoint.id ? <Loader2 className="animate-spin" /> : <Zap />}
-                      Use
-                    </Button>
-                    {endpoint.source !== 'direct-config' && (
-                      <Button
-                        className="hover:text-destructive"
-                        disabled={deleting === endpoint.id}
-                        onClick={() => void handleDelete(endpoint)}
-                        size="icon-sm"
-                        title="Delete endpoint"
-                        variant="ghost"
+                    {isLegacy ? (
+                      <div className="min-w-0">
+                        <EndpointSummary endpoint={endpoint} />
+                      </div>
+                    ) : (
+                      <button
+                        className="min-w-0 text-left"
+                        onClick={() => {
+                          setForm(formFromEndpoint(endpoint))
+                          setDiscoveredModels(endpoint.models)
+                        }}
+                        type="button"
                       >
-                        {deleting === endpoint.id ? <Loader2 className="animate-spin" /> : <Trash2 />}
-                      </Button>
+                        <EndpointSummary endpoint={endpoint} />
+                      </button>
                     )}
+                    <div className="flex items-center gap-2 sm:justify-end">
+                      {!isLegacy && (
+                        <Button
+                          disabled={endpoint.is_current || activating === endpoint.id}
+                          onClick={() => void handleActivate(endpoint)}
+                          size="sm"
+                          variant="outline"
+                        >
+                          {activating === endpoint.id ? <Loader2 className="animate-spin" /> : <Zap />}
+                          Use
+                        </Button>
+                      )}
+                      {endpoint.source !== 'direct-config' && (
+                        <Button
+                          aria-label={`Delete ${endpoint.name}`}
+                          className="hover:text-destructive"
+                          disabled={deleting === endpoint.id}
+                          onClick={() => void handleDelete(endpoint)}
+                          size="icon-sm"
+                          title="Delete endpoint"
+                          variant="ghost"
+                        >
+                          {deleting === endpoint.id ? <Loader2 className="animate-spin" /> : <Trash2 />}
+                        </Button>
+                      )}
+                    </div>
                   </div>
-                </div>
-              ))
+                )
+              })
             ) : (
               <EmptyState description="Add an OpenAI-compatible endpoint below." title="No custom endpoints" />
             )}

--- a/apps/desktop/src/app/settings/providers-settings.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.tsx
@@ -13,9 +13,10 @@ import {
   sortProviders
 } from '@/components/onboarding'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { RowButton } from '@/components/ui/row-button'
 import { SearchField } from '@/components/ui/search-field'
-import { disconnectOAuthProvider, listOAuthProviders } from '@/hermes'
+import { deleteCustomEndpoint, disconnectOAuthProvider, getCustomEndpoints, listOAuthProviders, saveCustomEndpoint } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { Check, ChevronDown, ChevronRight, KeyRound, Loader2, Terminal, Trash2 } from '@/lib/icons'
 import { normalize } from '@/lib/text'
@@ -24,11 +25,11 @@ import { notify, notifyError } from '@/store/notifications'
 import { $desktopOnboarding, startManualLocalEndpoint, startManualProviderOAuth } from '@/store/onboarding'
 import type { EnvVarInfo, OAuthProvider } from '@/types/hermes'
 
-import { isKeyVar, ProviderKeyRows } from './credential-key-ui'
+import { CREDENTIAL_CONTROL_CLASS, isKeyVar, ProviderKeyRows } from './credential-key-ui'
 import { CustomEndpointsSettings } from './custom-endpoints-settings'
 import { SettingsCategoryHeading, useEnvCredentials } from './env-credentials'
 import { providerGroup, providerMeta, providerPriority } from './helpers'
-import { SettingsContent, SettingsSkeleton } from './primitives'
+import { ListRow, SettingsContent, SettingsSkeleton } from './primitives'
 
 // The embedded terminal (and thus the "run disconnect command" path) only
 // exists in the Electron desktop shell, not the web dashboard.
@@ -331,6 +332,228 @@ function LocalEndpointRow({ onOpen }: { onOpen: (reason: null | string) => void 
   )
 }
 
+function CustomEndpointKeyCard() {
+  const { t } = useI18n()
+  const ce = t.settings.providers.customEndpoint
+  const [expanded, setExpanded] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [savedBaseUrl, setSavedBaseUrl] = useState('')
+  const [baseUrlDraft, setBaseUrlDraft] = useState('')
+  const [apiKeyDraft, setApiKeyDraft] = useState<string | null>(null)
+  const [apiKeySet, setApiKeySet] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    void getCustomEndpoints()
+      .then(response => {
+        if (cancelled) return
+        const current = response.endpoints.find(e => e.is_current) ?? response.endpoints[0]
+        if (current) {
+          setSavedBaseUrl(current.base_url ?? '')
+          setBaseUrlDraft(current.base_url ?? '')
+          setApiKeySet(current.has_api_key)
+        }
+      })
+      .catch(err => notifyError(err, ce.failedLoad))
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [])
+
+  const keyEditing = apiKeyDraft !== null
+  const baseUrlDirty = baseUrlDraft.trim() !== savedBaseUrl
+  const apiKeyDirty = Boolean(apiKeyDraft?.trim())
+  const dirty = baseUrlDirty || apiKeyDirty
+
+  async function save() {
+    if (!baseUrlDraft.trim() || !dirty) return
+    setSaving(true)
+    try {
+      const response = await getCustomEndpoints()
+      const current = response.endpoints.find(e => e.is_current) ?? response.endpoints[0]
+      if (!current) {
+        notifyError(new Error('No endpoint'), ce.failedSave)
+        return
+      }
+      const updated = await saveCustomEndpoint({
+        ...(apiKeyDirty ? { api_key: apiKeyDraft!.trim() } : {}),
+        base_url: baseUrlDraft.trim(),
+        context_length: current.context_length ?? undefined,
+        discover_models: current.discover_models,
+        id: current.id,
+        make_default: current.is_current,
+        model: current.model,
+        name: current.name
+      })
+      setSavedBaseUrl(current.base_url ?? '')
+      setBaseUrlDraft(current.base_url ?? '')
+      setApiKeySet(apiKeyDirty || updated.endpoints.some(e => e.id === current.id && e.has_api_key))
+      setApiKeyDraft(null)
+      notify({ kind: 'success', message: ce.saved })
+    } catch (err) {
+      notifyError(err, ce.failedSave)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function removeApiKey() {
+    if (!window.confirm(ce.removeConfirm)) return
+    setSaving(true)
+    try {
+      const response = await getCustomEndpoints()
+      const current = response.endpoints.find(e => e.is_current) ?? response.endpoints[0]
+      if (!current) return
+      await saveCustomEndpoint({ api_key: '', base_url: savedBaseUrl, id: current.id, model: current.model, name: current.name })
+      setApiKeyDraft(null)
+      setApiKeySet(false)
+      notify({ kind: 'success', message: ce.apiKeyRemoved })
+    } catch (err) {
+      notifyError(err, ce.failedRemove)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function deleteEndpoint() {
+    if (!window.confirm(ce.removeConfirm)) return
+    setSaving(true)
+    try {
+      const response = await getCustomEndpoints()
+      const current = response.endpoints.find(e => e.is_current) ?? response.endpoints[0]
+      if (!current) return
+      await deleteCustomEndpoint(current.id)
+      setSavedBaseUrl('')
+      setBaseUrlDraft('')
+      setApiKeyDraft(null)
+      setApiKeySet(false)
+      notify({ kind: 'success', message: ce.apiKeyRemoved })
+    } catch (err) {
+      notifyError(err, ce.failedRemove)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) return null
+
+  const busy = saving
+
+  return (
+    <div
+      className={cn(
+        '@container group/card rounded-[6px] p-3 transition-colors',
+        !expanded && 'row-hover',
+        expanded && 'bg-(--ui-bg-quaternary) ring-1 ring-(--ui-stroke-secondary)'
+      )}
+      onClick={() => setExpanded(v => !v)}
+      onKeyDown={e => {
+        if (e.target !== e.currentTarget) return
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setExpanded(v => !v) }
+      }}
+      role="button"
+      tabIndex={0}
+    >
+      <div className="grid grid-cols-1 items-start gap-x-3 gap-y-1.5 @2xl:grid-cols-[minmax(0,1fr)_minmax(15rem,22rem)] @2xl:gap-y-3">
+        <div className="flex h-8 min-w-0 items-center gap-2">
+          <span className={cn('size-2 shrink-0 rounded-full', savedBaseUrl ? 'bg-primary' : 'bg-(--ui-stroke-secondary)')} />
+          <span className="min-w-0 truncate text-[length:var(--conversation-text-font-size)] font-medium text-foreground">
+            {ce.title}
+          </span>
+          <ChevronDown className={cn('size-3.5 shrink-0 text-muted-foreground transition', expanded ? 'rotate-180' : 'opacity-0 group-hover/card:opacity-100')} />
+        </div>
+
+        <div className="min-w-0" onClick={e => e.stopPropagation()}>
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2">
+            {apiKeySet && !keyEditing ? (
+              <Input
+                className={cn(CREDENTIAL_CONTROL_CLASS, !expanded && 'border-0! bg-transparent! shadow-none! h-auto! p-0! @2xl:h-8! @2xl:px-2.5! @2xl:py-1.5!', 'cursor-pointer text-muted-foreground')}
+                onFocus={() => setApiKeyDraft('')}
+                readOnly
+                value="••••••••"
+              />
+            ) : (
+              <Input
+                autoFocus={keyEditing}
+                className={cn(CREDENTIAL_CONTROL_CLASS, !expanded && 'border-0! bg-transparent! shadow-none! h-auto! p-0! @2xl:h-8! @2xl:px-2.5! @2xl:py-1.5!')}
+                onChange={e => setApiKeyDraft(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && apiKeyDirty) void save()
+                  if (e.key === 'Escape') { e.preventDefault(); setApiKeyDraft(null) }
+                }}
+                placeholder={ce.pasteApiKey}
+                type="password"
+                value={apiKeyDraft ?? ''}
+              />
+            )}
+            <div className="flex items-center gap-1">
+              {keyEditing && (apiKeySet || apiKeyDirty) && (
+                <>
+                  {apiKeySet && (
+                    <Button aria-label={ce.removeApiKey} className="text-muted-foreground hover:text-destructive" disabled={busy} onClick={() => void removeApiKey()} size="icon-xs" title={ce.removeApiKey} type="button" variant="ghost">
+                      <Trash2 />
+                    </Button>
+                  )}
+                  {dirty && (
+                    <Button className="h-8" disabled={busy || !baseUrlDraft.trim()} onClick={() => void save()} size="sm">
+                      {busy ? <Loader2 className="animate-spin" /> : <Check />}
+                      {t.common.save}
+                    </Button>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {expanded && (
+          <div className="grid gap-3 @2xl:col-span-2" onClick={e => e.stopPropagation()}>
+            <p className="text-[length:var(--conversation-caption-font-size)] leading-(--conversation-caption-line-height) text-(--ui-text-tertiary)">
+              {ce.description}
+            </p>
+            <ListRow
+              action={
+                <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2">
+                  <Input
+                    className={CREDENTIAL_CONTROL_CLASS}
+                    onChange={e => setBaseUrlDraft(e.target.value)}
+                    onKeyDown={e => { if (e.key === 'Enter' && baseUrlDirty) void save() }}
+                    placeholder="http://127.0.0.1:11434/v1"
+                    value={loading ? '' : baseUrlDraft}
+                  />
+                  {savedBaseUrl && (
+                    <Button
+                      aria-label={t.common.remove}
+                      className="text-muted-foreground hover:text-destructive"
+                      disabled={busy}
+                      onClick={() => void deleteEndpoint()}
+                      size="icon-xs"
+                      title={t.common.remove}
+                      type="button"
+                      variant="ghost"
+                    >
+                      <Trash2 />
+                    </Button>
+                  )}
+                </div>
+              }
+              title={ce.baseUrlLabel}
+            />
+            {baseUrlDirty && !keyEditing && (
+              <div>
+                <Button className="h-8" disabled={busy || !baseUrlDraft.trim()} onClick={() => void save()} size="sm">
+                  {busy ? <Loader2 className="animate-spin" /> : <Check />}
+                  {t.common.save}
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
 export function ProvidersSettings({
   onClose,
   onConfigSaved,
@@ -455,6 +678,7 @@ export function ProvidersSettings({
     return (
       <SettingsContent>
         <LocalEndpointRow onOpen={startManualLocalEndpoint} />
+        <CustomEndpointKeyCard />
         {keyGroups.length > 0 ? (
           <div className="grid gap-3">
             <SearchField

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -7,6 +7,7 @@ import {
   AUDIO_TRANSCRIBE_MIN_REQUEST_TIMEOUT_MS,
   audioSpeakRequestTimeoutMs,
   audioTranscribeRequestTimeoutMs,
+  deleteCustomEndpoint,
   getCronJobs,
   getGlobalModelInfo,
   getGlobalModelOptions,
@@ -304,6 +305,22 @@ describe('Hermes REST helpers', () => {
       await call()
       expect(api).toHaveBeenCalledWith(expect.objectContaining({ path, timeoutMs: 60_000 }))
     }
+  })
+
+  it('uses a source-qualified query route only for legacy custom endpoints', async () => {
+    await deleteCustomEndpoint('legacy-2-a/b', 'custom_providers')
+
+    expect(api).toHaveBeenLastCalledWith({
+      method: 'DELETE',
+      path: '/api/providers/custom-endpoints?endpoint_id=legacy-2-a%2Fb&source=custom_providers'
+    })
+
+    await deleteCustomEndpoint('modern', 'providers')
+
+    expect(api).toHaveBeenLastCalledWith({
+      method: 'DELETE',
+      path: '/api/providers/custom-endpoints/modern'
+    })
   })
 
   it('keeps the liveness poll on the short default so a dead backend fails fast', async () => {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -765,7 +765,16 @@ export function activateCustomEndpoint(id: string): Promise<{ ok: boolean; provi
   })
 }
 
-export function deleteCustomEndpoint(id: string): Promise<CustomEndpointsResponse> {
+export function deleteCustomEndpoint(id: string, source?: string): Promise<CustomEndpointsResponse> {
+  if (source === 'custom_providers') {
+    const params = new URLSearchParams({ endpoint_id: id, source })
+
+    return window.hermesDesktop.api<CustomEndpointsResponse>({
+      path: `/api/providers/custom-endpoints?${params.toString()}`,
+      method: 'DELETE'
+    })
+  }
+
   return window.hermesDesktop.api<CustomEndpointsResponse>({
     path: `/api/providers/custom-endpoints/${encodeURIComponent(id)}`,
     method: 'DELETE'

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -829,6 +829,19 @@ export const en: Translations = {
         title: 'Local / custom endpoint',
         description: 'Point Hermes at any OpenAI-compatible endpoint (Zyphra, vLLM, llama.cpp, Ollama, etc).'
       },
+      customEndpoint: {
+        title: 'Custom Endpoint',
+        description: 'Point Hermes at any OpenAI-compatible endpoint (Ollama, vLLM, etc).',
+        baseUrlLabel: 'Endpoint URL',
+        pasteApiKey: 'Paste API key',
+        removeApiKey: 'Remove API key',
+        removeConfirm: 'Remove API key?',
+        saved: 'Custom endpoint saved.',
+        apiKeyRemoved: 'API key removed.',
+        failedLoad: 'Failed to load custom endpoint',
+        failedSave: 'Failed to save custom endpoint',
+        failedRemove: 'Failed to remove API key'
+      },
       loading: 'Loading providers...'
     },
     sessions: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -710,6 +710,19 @@ export interface Translations {
         title: string
         description: string
       }
+      customEndpoint: {
+        title: string
+        description: string
+        baseUrlLabel: string
+        pasteApiKey: string
+        removeApiKey: string
+        removeConfirm: string
+        saved: string
+        apiKeyRemoved: string
+        failedLoad: string
+        failedSave: string
+        failedRemove: string
+      }
       loading: string
     }
     sessions: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1029,6 +1029,19 @@ export const zh: Translations = {
         title: '本地 / 自定义端点',
         description: '将 Hermes 指向任意 OpenAI 兼容端点（Zyphra、vLLM、llama.cpp、Ollama 等）。'
       },
+      customEndpoint: {
+        title: '自定义端点',
+        description: '将 Hermes 指向任意 OpenAI 兼容端点（Ollama、vLLM 等）。',
+        baseUrlLabel: '端点 URL',
+        pasteApiKey: '粘贴 API 密钥',
+        removeApiKey: '移除 API 密钥',
+        removeConfirm: '确定移除 API 密钥？',
+        saved: '自定义端点已保存。',
+        apiKeyRemoved: 'API 密钥已移除。',
+        failedLoad: '加载自定义端点失败',
+        failedSave: '保存自定义端点失败',
+        failedRemove: '移除 API 密钥失败'
+      },
       loading: '正在加载提供方...'
     },
     sessions: {

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -72,11 +72,13 @@ from hermes_cli.config import (
     check_config_version,
     detect_install_method,
     format_docker_update_message,
+    get_compatible_custom_providers,
     recommended_update_command_for_method,
     redact_key,
     write_platform_config_field,
     _deep_merge,
 )
+from hermes_cli.providers import custom_provider_slug
 from plugins.memory.config_schema import (
     ProviderConfigSchema,
     ProviderField,
@@ -7213,6 +7215,104 @@ def _models_from_custom_endpoint_entry(entry: Dict[str, Any]) -> List[str]:
     return [model for model in models if model and not (model in seen or seen.add(model))]
 
 
+def _canonical_endpoint_url(raw_url: str) -> str:
+    """Normalize URL components that are case-insensitive by specification."""
+    value = raw_url.strip()
+    try:
+        parsed = urllib.parse.urlsplit(value)
+        hostname = parsed.hostname
+        if not parsed.scheme or not hostname:
+            return value.rstrip("/")
+
+        host = f"[{hostname.lower()}]" if ":" in hostname else hostname.lower()
+        port = parsed.port
+        if port is not None and not (
+            (parsed.scheme.lower() == "http" and port == 80)
+            or (parsed.scheme.lower() == "https" and port == 443)
+        ):
+            host = f"{host}:{port}"
+
+        return urllib.parse.urlunsplit((
+            parsed.scheme.lower(),
+            host,
+            parsed.path.rstrip("/"),
+            parsed.query,
+            "",
+        ))
+    except ValueError:
+        return value.rstrip("/")
+
+
+def _custom_endpoint_signature(name: str, base_url: str, model: str) -> Tuple[str, str, str]:
+    """Return the compatibility identity used to deduplicate endpoint rows."""
+    return (
+        name.strip().lower(),
+        _canonical_endpoint_url(base_url),
+        model.strip(),
+    )
+
+
+def _legacy_custom_endpoint_id(index: int, name: str, base_url: str, model: str) -> str:
+    """Build a path-safe management ID for one legacy list entry.
+
+    The runtime slug is not suitable here: different names can normalize to
+    the same slug, and slashes in a name do not survive a single-segment REST
+    route. Including the list position and a non-secret content fingerprint
+    also lets deletion reject a stale row after the config has changed.
+    """
+    identity = "\0".join(_custom_endpoint_signature(name, base_url, model))
+    digest = hashlib.blake2s(identity.encode("utf-8"), digest_size=6).hexdigest()
+    return f"legacy-{index}-{digest}"
+
+
+def _legacy_custom_endpoint_rows(cfg: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Project valid legacy ``custom_providers`` entries into Desktop rows."""
+    raw_entries = cfg.get("custom_providers")
+    if not isinstance(raw_entries, list):
+        return []
+
+    rows: List[Dict[str, Any]] = []
+    for index, raw_entry in enumerate(raw_entries):
+        if not isinstance(raw_entry, dict):
+            continue
+        # Use the public compatibility path so aliases and model-list shapes
+        # stay aligned with runtime resolution. Pass a copy because the
+        # normalizer accepts camelCase aliases by materialising snake_case keys.
+        normalized = get_compatible_custom_providers({
+            "custom_providers": [dict(raw_entry)],
+        })
+        if not normalized:
+            continue
+        entry = normalized[0]
+        name = str(entry.get("name") or "").strip()
+        base_url = str(entry.get("base_url") or "").strip()
+        if not name or not base_url:
+            continue
+        models = _models_from_custom_endpoint_entry(entry)
+        model = str(entry.get("model") or (models[0] if models else "")).strip()
+        api_key = str(entry.get("api_key") or "").strip()
+        rows.append({
+            "id": _legacy_custom_endpoint_id(index, name, base_url, model),
+            "_config_index": index,
+            "name": name,
+            "base_url": base_url,
+            "model": model,
+            "models": models,
+            "context_length": entry.get("context_length"),
+            "discover_models": bool(entry.get("discover_models", True)),
+            "has_api_key": bool(api_key),
+            "api_key_preview": redact_key(api_key) if api_key else None,
+            "source": "custom_providers",
+        })
+    return rows
+
+
+def _endpoint_url_matches(left: str, right: str) -> bool:
+    return bool(left.strip() and right.strip()) and (
+        _canonical_endpoint_url(left) == _canonical_endpoint_url(right)
+    )
+
+
 def _custom_endpoint_response(cfg: Dict[str, Any]) -> Dict[str, Any]:
     model_cfg = cfg.get("model", {}) if isinstance(cfg.get("model"), dict) else {}
     current_provider = str(model_cfg.get("provider", "") or "")
@@ -7220,6 +7320,7 @@ def _custom_endpoint_response(cfg: Dict[str, Any]) -> Dict[str, Any]:
     current_base_url = str(model_cfg.get("base_url", "") or "")
 
     endpoints: List[Dict[str, Any]] = []
+    modern_by_signature: Dict[Tuple[str, str, str], Dict[str, Any]] = {}
     providers = cfg.get("providers")
     if isinstance(providers, dict):
         for provider_id, raw_entry in providers.items():
@@ -7230,10 +7331,15 @@ def _custom_endpoint_response(cfg: Dict[str, Any]) -> Dict[str, Any]:
                 continue
             endpoint_id = str(provider_id)
             models = _models_from_custom_endpoint_entry(raw_entry)
-            endpoint_model = str(raw_entry.get("model") or raw_entry.get("default_model") or (models[0] if models else ""))
-            endpoints.append({
+            endpoint_model = str(
+                raw_entry.get("model")
+                or raw_entry.get("default_model")
+                or (models[0] if models else "")
+            ).strip()
+            name = str(raw_entry.get("name") or endpoint_id).strip() or endpoint_id
+            endpoint = {
                 "id": endpoint_id,
-                "name": str(raw_entry.get("name") or endpoint_id),
+                "name": name,
                 "base_url": base_url,
                 "model": endpoint_model,
                 "models": models,
@@ -7243,9 +7349,49 @@ def _custom_endpoint_response(cfg: Dict[str, Any]) -> Dict[str, Any]:
                 "api_key_preview": redact_key(str(raw_entry.get("api_key", "") or "")) if raw_entry.get("api_key") else None,
                 "is_current": endpoint_id == current_provider,
                 "source": "providers",
-            })
+            }
+            endpoints.append(endpoint)
+            modern_by_signature[
+                _custom_endpoint_signature(name, base_url, endpoint_model)
+            ] = endpoint
 
-    if current_provider.lower() == "custom" and current_base_url and not any(e["id"] == "custom" for e in endpoints):
+    for legacy_row in _legacy_custom_endpoint_rows(cfg):
+        endpoint = {
+            key: value
+            for key, value in legacy_row.items()
+            if key != "_config_index"
+        }
+        signature = _custom_endpoint_signature(
+            endpoint["name"], endpoint["base_url"], endpoint["model"]
+        )
+        current_provider_lower = current_provider.strip().lower()
+        endpoint["is_current"] = (
+            current_provider_lower
+            in {
+                custom_provider_slug(endpoint["name"]).lower(),
+                endpoint["name"].strip().lower(),
+            }
+            or (
+                current_provider_lower == "custom"
+                and _endpoint_url_matches(current_base_url, endpoint["base_url"])
+            )
+        )
+        if signature in modern_by_signature:
+            if endpoint["is_current"]:
+                modern_by_signature[signature]["is_current"] = True
+            continue
+        endpoints.append(endpoint)
+
+    if (
+        current_provider.lower() == "custom"
+        and current_base_url
+        and not any(e["id"] == "custom" for e in endpoints)
+        and not any(
+            e["source"] == "custom_providers"
+            and _endpoint_url_matches(current_base_url, e["base_url"])
+            for e in endpoints
+        )
+    ):
         endpoints.insert(0, {
             "id": "custom",
             "name": "Custom",
@@ -7270,7 +7416,13 @@ def _custom_endpoint_response(cfg: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def _detach_main_model_from_provider(cfg: Dict[str, Any], provider_key: str) -> None:
+def _detach_main_model_from_provider(
+    cfg: Dict[str, Any],
+    provider_key: str,
+    *,
+    base_urls: Tuple[str, ...] = (),
+    provider_aliases: Tuple[str, ...] = (),
+) -> None:
     """Drop the main-slot mirror of a provider that no longer exists.
 
     ``activate_custom_endpoint`` copies the endpoint's ``base_url`` and
@@ -7286,10 +7438,17 @@ def _detach_main_model_from_provider(cfg: Dict[str, Any], provider_key: str) -> 
     model_cfg = cfg.get("model")
     if not isinstance(model_cfg, dict):
         return
-    if str(model_cfg.get("provider") or "").strip().lower() != provider_key:
+    current_provider = str(model_cfg.get("provider") or "").strip().lower()
+    identities = {provider_key.strip().lower()}
+    identities.update(alias.strip().lower() for alias in provider_aliases if alias.strip())
+    if current_provider == "custom":
+        current_base_url = str(model_cfg.get("base_url") or "")
+        if not any(_endpoint_url_matches(current_base_url, url) for url in base_urls):
+            return
+    elif current_provider not in identities:
         return
-    for field in ("provider", "base_url", "api_key"):
-        model_cfg.pop(field, None)
+    model_cfg.pop("provider", None)
+    clear_model_endpoint_credentials(model_cfg, clear_base_url=True)
     cfg["model"] = model_cfg
 
 
@@ -7415,18 +7574,60 @@ def activate_custom_endpoint(endpoint_id: str):
         raise HTTPException(status_code=500, detail="Failed to activate custom endpoint")
 
 
+@app.delete("/api/providers/custom-endpoints")
 @app.delete("/api/providers/custom-endpoints/{endpoint_id}")
-def delete_custom_endpoint(endpoint_id: str):
-    """Remove a configured custom endpoint from ``providers``."""
+def delete_custom_endpoint(endpoint_id: str, source: Optional[str] = None):
+    """Remove a configured custom endpoint from either supported schema."""
     try:
         cfg = load_config()
         provider_key = _custom_endpoint_id(endpoint_id)
         providers = cfg.get("providers")
-        if not isinstance(providers, dict) or provider_key not in providers:
-            raise HTTPException(status_code=404, detail="custom endpoint not found")
-        providers.pop(provider_key, None)
-        cfg["providers"] = providers
-        _detach_main_model_from_provider(cfg, provider_key)
+        requested_id = endpoint_id.strip()
+        if source not in {None, "providers", "custom_providers"}:
+            raise HTTPException(status_code=400, detail="unsupported custom endpoint source")
+        modern_provider_key: Optional[str] = None
+        if source != "custom_providers" and isinstance(providers, dict):
+            if requested_id in providers:
+                modern_provider_key = requested_id
+            elif not requested_id.lower().startswith("custom:") and provider_key in providers:
+                modern_provider_key = provider_key
+        if isinstance(providers, dict) and modern_provider_key is not None:
+            providers.pop(modern_provider_key, None)
+            cfg["providers"] = providers
+            _detach_main_model_from_provider(
+                cfg,
+                modern_provider_key,
+                provider_aliases=(
+                    custom_provider_slug(modern_provider_key),
+                ),
+            )
+        else:
+            if source != "custom_providers":
+                raise HTTPException(status_code=404, detail="custom endpoint not found")
+            raw_legacy = cfg.get("custom_providers")
+            if not isinstance(raw_legacy, list):
+                raise HTTPException(status_code=404, detail="custom endpoint not found")
+
+            legacy_rows = _legacy_custom_endpoint_rows(cfg)
+            matched_rows = [row for row in legacy_rows if row["id"] == requested_id]
+            if not matched_rows:
+                raise HTTPException(status_code=404, detail="custom endpoint not found")
+            if len(matched_rows) > 1:
+                raise HTTPException(status_code=409, detail="custom endpoint id is ambiguous")
+
+            matched_row = matched_rows[0]
+            matched_index = matched_row["_config_index"]
+            cfg["custom_providers"] = [
+                raw_entry
+                for index, raw_entry in enumerate(raw_legacy)
+                if index != matched_index
+            ]
+            _detach_main_model_from_provider(
+                cfg,
+                custom_provider_slug(matched_row["name"]),
+                base_urls=(matched_row["base_url"],),
+                provider_aliases=(matched_row["name"],),
+            )
         save_config(cfg)
         response = _custom_endpoint_response(cfg)
         response["ok"] = True

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4230,6 +4230,174 @@ class TestWebServerEndpoints:
         assert data["endpoints"][0]["source"] == "direct-config"
         assert data["endpoints"][0]["has_api_key"] is True
 
+    def test_custom_endpoints_list_includes_legacy_entries_and_redacts_keys(self):
+        from hermes_cli.config import save_config
+
+        save_config({
+            "model": {
+                "provider": "custom:acme-legacy",
+                "default": "acme/model-1",
+                "base_url": "https://legacy.acme.test/v1",
+            },
+            "custom_providers": [
+                {
+                    "name": "Acme Legacy",
+                    "api": "https://legacy.acme.test/v1",
+                    "api_key": "sk-super-secret-value",
+                    "model": "acme/model-1",
+                    "models": ["acme/model-1", "acme/model-2"],
+                    "discover_models": False,
+                },
+                {"name": "Broken", "base_url": "not-a-url"},
+            ],
+        })
+
+        resp = self.client.get("/api/providers/custom-endpoints")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["endpoints"]) == 1
+        endpoint = data["endpoints"][0]
+        assert endpoint["id"].startswith("legacy-0-")
+        assert endpoint["source"] == "custom_providers"
+        assert endpoint["models"] == ["acme/model-1", "acme/model-2"]
+        assert endpoint["discover_models"] is False
+        assert endpoint["has_api_key"] is True
+        assert endpoint["api_key_preview"] == redact_key("sk-super-secret-value")
+        assert endpoint["is_current"] is True
+        assert "sk-super-secret-value" not in resp.text
+
+    def _delete_legacy_endpoint(self, name: str):
+        endpoints = self.client.get(
+            "/api/providers/custom-endpoints"
+        ).json()["endpoints"]
+        endpoint = next(
+            row
+            for row in endpoints
+            if row["source"] == "custom_providers" and row["name"] == name
+        )
+        return self.client.request(
+            "DELETE",
+            "/api/providers/custom-endpoints",
+            params={"endpoint_id": endpoint["id"], "source": endpoint["source"]},
+        )
+
+    def test_custom_endpoints_deduplicates_legacy_equivalent_of_provider_entry(self):
+        from hermes_cli.config import load_config, save_config
+
+        save_config({
+            "model": {
+                "provider": "custom:acme",
+                "default": "acme/m1",
+                "base_url": "https://llm.acme.test/v1",
+                "api_key": "model-secret",
+                "api_mode": "codex_responses",
+            },
+            "custom_providers": [{
+                "name": "Acme",
+                "base_url": "https://llm.acme.test/v1/",
+                "model": "acme/m1",
+                "api_key": "legacy-secret",
+            }],
+            "providers": {"acme": {
+                "name": " Acme ",
+                "api": "https://llm.acme.test/v1",
+                "default_model": " acme/m1 ",
+                "api_key": "modern-secret",
+            }},
+        })
+
+        endpoints = self.client.get("/api/providers/custom-endpoints").json()["endpoints"]
+
+        assert [(row["id"], row["source"]) for row in endpoints] == [
+            ("acme", "providers")
+        ]
+        assert endpoints[0]["is_current"] is True
+        assert endpoints[0]["name"] == "Acme"
+        assert endpoints[0]["model"] == "acme/m1"
+        assert "legacy-secret" not in json.dumps(endpoints)
+        assert "modern-secret" not in json.dumps(endpoints)
+
+        resp = self.client.request("DELETE", "/api/providers/custom-endpoints/acme")
+
+        assert resp.status_code == 200
+        cfg = load_config()
+        assert cfg["providers"] == {}
+        assert cfg["custom_providers"] == [{
+            "name": "Acme",
+            "base_url": "https://llm.acme.test/v1/",
+            "model": "acme/m1",
+            "api_key": "legacy-secret",
+        }]
+        model_cfg = cfg["model"]
+        for field in ("provider", "base_url", "api_key", "api", "api_mode"):
+            assert field not in model_cfg
+        assert [row["source"] for row in resp.json()["endpoints"]] == ["custom_providers"]
+
+    def test_legacy_management_id_excludes_url_credentials_and_fragment(self):
+        from hermes_cli.config import save_config
+
+        def endpoint_id(base_url: str) -> str:
+            save_config({
+                "custom_providers": [{
+                    "name": "Acme",
+                    "base_url": base_url,
+                    "model": "acme/m1",
+                }],
+            })
+            return self.client.get(
+                "/api/providers/custom-endpoints"
+            ).json()["endpoints"][0]["id"]
+
+        first_id = endpoint_id("https://user:first-secret@LLM.ACME.TEST:443/v1#first")
+        second_id = endpoint_id("https://user:second-secret@llm.acme.test/v1#second")
+
+        assert first_id == second_id
+        assert "secret" not in first_id
+
+    def test_custom_endpoint_identity_preserves_url_path_and_model_case(self):
+        from hermes_cli.config import load_config, save_config
+
+        save_config({
+            "providers": {"acme": {
+                "name": "Acme",
+                "base_url": "HTTPS://LLM.ACME.TEST:443/v1/Alpha",
+                "model": "acme/Model",
+            }},
+            "custom_providers": [
+                {
+                    "name": "Acme",
+                    "base_url": "https://llm.acme.test/v1/alpha",
+                    "model": "acme/Model",
+                },
+                {
+                    "name": "Acme",
+                    "base_url": "https://llm.acme.test/v1/Alpha",
+                    "model": "acme/model",
+                },
+            ],
+        })
+
+        endpoints = self.client.get(
+            "/api/providers/custom-endpoints"
+        ).json()["endpoints"]
+
+        assert [(row["source"], row["base_url"], row["model"]) for row in endpoints] == [
+            ("providers", "HTTPS://LLM.ACME.TEST:443/v1/Alpha", "acme/Model"),
+            ("custom_providers", "https://llm.acme.test/v1/alpha", "acme/Model"),
+            ("custom_providers", "https://llm.acme.test/v1/Alpha", "acme/model"),
+        ]
+
+        resp = self.client.request(
+            "DELETE", "/api/providers/custom-endpoints/acme"
+        )
+
+        assert resp.status_code == 200
+        assert [row["model"] for row in load_config()["custom_providers"]] == [
+            "acme/Model",
+            "acme/model",
+        ]
+
     def test_custom_endpoint_upsert_persists_provider_and_sets_default(self):
         """Desktop can persist an OpenAI-compatible proxy in providers and make
         it the default for new chats.
@@ -4464,6 +4632,245 @@ class TestWebServerEndpoints:
         assert model_cfg.get("provider") == "other"
         assert model_cfg.get("api_key") == "sk-other"
         assert model_cfg.get("base_url") == "https://llm.other.corp/v1"
+
+    def test_deleting_active_legacy_endpoint_scrubs_all_model_credentials(self):
+        from hermes_cli.config import load_config, save_config
+
+        save_config({
+            "model": {
+                "provider": "custom:acme-legacy",
+                "default": "acme/m1",
+                "base_url": "https://legacy.acme.test/v1",
+                "api_key": "new-alias-secret",
+                "api": "old-alias-secret",
+                "api_mode": "anthropic_messages",
+            },
+            "custom_providers": [
+                {
+                    "name": "Acme Legacy",
+                    "base_url": "https://legacy.acme.test/v1",
+                    "api_key": "provider-secret",
+                    "model": "acme/m1",
+                },
+                {
+                    "name": "Keep Me",
+                    "base_url": "https://keep.example/v1",
+                    "api_key": "keep-secret",
+                },
+            ],
+        })
+
+        resp = self._delete_legacy_endpoint("Acme Legacy")
+
+        assert resp.status_code == 200
+        cfg = load_config()
+        assert [row["name"] for row in cfg["custom_providers"]] == ["Keep Me"]
+        model_cfg = cfg["model"]
+        for field in ("provider", "base_url", "api_key", "api", "api_mode"):
+            assert field not in model_cfg
+        assert model_cfg["default"] == "acme/m1"
+        assert "provider-secret" not in resp.text
+
+    def test_deleting_inactive_legacy_endpoint_preserves_active_model(self):
+        from hermes_cli.config import load_config, save_config
+
+        active_model = {
+            "provider": "other",
+            "default": "other/m1",
+            "base_url": "https://other.example/v1",
+            "api_key": "other-secret",
+            "api": "other-old-secret",
+            "api_mode": "chat_completions",
+        }
+        save_config({
+            "model": dict(active_model),
+            "custom_providers": [{
+                "name": "Acme Legacy",
+                "base_url": "https://legacy.acme.test/v1",
+                "api_key": "provider-secret",
+            }],
+        })
+
+        resp = self._delete_legacy_endpoint("Acme Legacy")
+
+        assert resp.status_code == 200
+        assert load_config()["model"] == active_model
+
+    def test_deleting_unknown_legacy_endpoint_returns_404_without_changes(self):
+        from hermes_cli.config import load_config, save_config
+
+        original = {
+            "model": {"provider": "nous", "default": "hermes-4"},
+            "custom_providers": [{
+                "name": "Acme Legacy",
+                "base_url": "https://legacy.acme.test/v1",
+            }],
+        }
+        save_config(original)
+        before = load_config()
+
+        resp = self.client.request(
+            "DELETE",
+            "/api/providers/custom-endpoints",
+            params={
+                "endpoint_id": "legacy-99-does-not-exist",
+                "source": "custom_providers",
+            },
+        )
+
+        assert resp.status_code == 404
+        assert load_config() == before
+
+    def test_bare_custom_legacy_delete_only_detaches_matching_base_url(self):
+        from hermes_cli.config import load_config, save_config
+
+        model_cfg = {
+            "provider": "custom",
+            "default": "other/m1",
+            "base_url": "https://other.example/v1",
+            "api_key": "other-secret",
+            "api": "other-old-secret",
+            "api_mode": "chat_completions",
+        }
+        save_config({
+            "model": dict(model_cfg),
+            "custom_providers": [{
+                "name": "Acme Legacy",
+                "base_url": "https://legacy.acme.test/v1",
+                "api_key": "provider-secret",
+            }],
+        })
+
+        resp = self._delete_legacy_endpoint("Acme Legacy")
+
+        assert resp.status_code == 200
+        assert load_config()["model"] == model_cfg
+
+    def test_bare_custom_legacy_delete_detaches_matching_base_url(self):
+        from hermes_cli.config import load_config, save_config
+
+        save_config({
+            "model": {
+                "provider": "custom",
+                "default": "acme/m1",
+                "base_url": "https://legacy.acme.test/v1/",
+                "api_key": "new-alias-secret",
+                "api": "old-alias-secret",
+                "api_mode": "chat_completions",
+            },
+            "custom_providers": [{
+                "name": "Acme Legacy",
+                "base_url": "https://legacy.acme.test/v1",
+                "api_key": "provider-secret",
+            }],
+        })
+
+        resp = self._delete_legacy_endpoint("Acme Legacy")
+
+        assert resp.status_code == 200
+        model_cfg = load_config()["model"]
+        for field in ("provider", "base_url", "api_key", "api", "api_mode"):
+            assert field not in model_cfg
+
+    def test_bare_custom_legacy_delete_preserves_case_distinct_active_url(self):
+        from hermes_cli.config import load_config, save_config
+
+        model_cfg = {
+            "provider": "custom",
+            "default": "other/m1",
+            "base_url": "https://legacy.acme.test/v1/Alpha",
+            "api_key": "other-secret",
+            "api_mode": "chat_completions",
+        }
+        save_config({
+            "model": dict(model_cfg),
+            "custom_providers": [{
+                "name": "Acme Legacy",
+                "base_url": "https://LEGACY.ACME.TEST:443/v1/alpha",
+                "api_key": "provider-secret",
+            }],
+        })
+
+        resp = self._delete_legacy_endpoint("Acme Legacy")
+
+        assert resp.status_code == 200
+        assert load_config()["model"] == model_cfg
+
+    def test_legacy_delete_distinguishes_modern_id_and_colliding_legacy_slugs(self):
+        from hermes_cli.config import load_config, save_config
+
+        save_config({
+            "model": {"provider": "other", "default": "other/m1"},
+            "providers": {
+                "custom:foo-bar": {
+                    "name": "Modern Foo",
+                    "base_url": "https://modern.example/v1",
+                    "model": "modern/m1",
+                }
+            },
+            "custom_providers": [
+                {
+                    "name": "Foo Bar",
+                    "base_url": "https://first.example/v1",
+                    "model": "first/m1",
+                },
+                {
+                    "name": "foo-bar",
+                    "base_url": "https://second.example/v1",
+                    "model": "second/m1",
+                },
+            ],
+        })
+
+        endpoints = self.client.get(
+            "/api/providers/custom-endpoints"
+        ).json()["endpoints"]
+        legacy_rows = [row for row in endpoints if row["source"] == "custom_providers"]
+        assert len({row["id"] for row in legacy_rows}) == 2
+
+        target = next(row for row in legacy_rows if row["name"] == "Foo Bar")
+        resp = self.client.request(
+            "DELETE",
+            "/api/providers/custom-endpoints",
+            params={"endpoint_id": target["id"], "source": target["source"]},
+        )
+
+        assert resp.status_code == 200
+        cfg = load_config()
+        assert "custom:foo-bar" in cfg["providers"]
+        assert [row["name"] for row in cfg["custom_providers"]] == ["foo-bar"]
+
+    def test_legacy_delete_accepts_slash_in_display_name_without_path_routing(self):
+        from hermes_cli.config import load_config, save_config
+
+        save_config({
+            "custom_providers": [{
+                "name": "Acme/Proxy",
+                "base_url": "https://slash.example/v1",
+                "model": "slash/m1",
+            }],
+        })
+
+        resp = self._delete_legacy_endpoint("Acme/Proxy")
+
+        assert resp.status_code == 200
+        assert load_config()["custom_providers"] == []
+
+    def test_legacy_delete_requires_source_qualified_management_id(self):
+        from hermes_cli.config import load_config, save_config
+
+        original = {
+            "custom_providers": [
+                {"name": "Foo Bar", "base_url": "https://first.example/v1"},
+                {"name": "foo-bar", "base_url": "https://second.example/v1"},
+            ],
+        }
+        save_config(original)
+
+        resp = self.client.request("DELETE", "/api/providers/custom-endpoints/custom:foo-bar")
+
+        assert resp.status_code == 404
+        assert load_config()["custom_providers"] == original["custom_providers"]
 
     def test_set_model_main_preserves_base_url_for_named_custom_provider(self):
         """Selecting a named custom endpoint from the Desktop model picker


### PR DESCRIPTION
## Summary

Adds a compact inline card under the LocalEndpointRow in the API Keys page, giving users a quick-edit affordance for their active custom endpoint's base_url and api_key without leaving the page.

This sits on top of [PR #69258](https://github.com/NousResearch/hermes-agent/pull/69258) which adds legacy `custom_providers:` management to the existing full Custom Endpoints settings page. That page (preserved as-is) handles multi-endpoint CRUD, API compatibility mode, and legacy entries; the new card is just a faster inline shortcut for the common single-endpoint case.

## Changes

### New `CustomEndpointKeyCard` component (`providers-settings.tsx`)
- Inline card directly under `<LocalEndpointRow />` in the API Keys view
- Edit `base_url` and `api_key` in place
- Uses the same plural `/api/providers/custom-endpoints` REST surface as upstream main
- Resolves the active endpoint via `getCustomEndpoints()` and passes its `id/name/model` through `saveCustomEndpoint()` on every save
- Falls back to the existing `<LocalEndpointRow />` → full page for new endpoints / multiple endpoints / legacy entries

### i18n
- Added `customEndpoint` translation block (en + zh + types)

## Out of scope (already handled by #69258)
- Legacy `custom_providers:` entry listing and deletion
- API compatibility mode (tracked in #69824)
- Multi-endpoint CRUD flows

## Design notes
- Plural API only — no single-endpoint route divergence from upstream
- Reads the current endpoint's identity from `getCustomEndpoints()` so backend writes stay scoped to a known `provider` key (no orphan `name` derivation)
- Backend `web_server.py` is unchanged from #69258's branch